### PR TITLE
Feature/init option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## CHANGES IN DEVELOP
+
+IMPROVEMENTS:
+
+* initialize options for genesis with `--option` flag on `basecoin init` 
+
 ## 0.6.2 (July 27, 2017)
 
 IMPROVEMENTS:

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ GOTOOLS =	github.com/mitchellh/gox \
 			github.com/rigelrozanski/shelldown/cmd/shelldown
 TUTORIALS=$(shell find docs/guide -name "*md" -type f)
 
-EXAMPLES := counter eyes basecoin
+EXAMPLES := counter eyes basecoin 
 INSTALL_EXAMPLES := $(addprefix install_,${EXAMPLES})
 TEST_EXAMPLES := $(addprefix testex_,${EXAMPLES})
 
@@ -37,6 +37,7 @@ test_unit:
 	@go test `glide novendor`
 
 test_cli: $(TEST_EXAMPLES)
+	./tests/cli/init-server.sh
 	# sudo apt-get install jq
 	# wget "https://raw.githubusercontent.com/kward/shunit2/master/source/2.1/src/shunit2"
 

--- a/server/commands/init.go
+++ b/server/commands/init.go
@@ -31,7 +31,7 @@ var (
 
 func init() {
 	InitCmd.Flags().String(FlagChainID, "test_chain_id", "Chain ID")
-	InitCmd.Flags().StringSlice(FlagOption, []string{}, "Genesis option in the format <app>/<option>/<value>")
+	InitCmd.Flags().StringSliceP(FlagOption, "p", []string{}, "Genesis option in the format <app>/<option>/<value>")
 }
 
 // returns 1 iff it set a file, otherwise 0 (so we can add them)
@@ -67,12 +67,13 @@ func initCmd(cmd *cobra.Command, args []string) error {
 		return errors.New("Address must be 20-bytes in hex")
 	}
 
-	var options []string
 	var optionsStr string
-	sep := ",\n      "
 	optionsRaw := viper.GetStringSlice(FlagOption)
 	if len(optionsRaw) > 0 {
-		optionsStr = sep
+
+		var options []string
+		sep := ",\n      "
+
 		for i := 0; i < len(optionsRaw); i++ {
 			s := strings.SplitN(optionsRaw[i], "/", 3)
 			if len(s) != 3 {
@@ -87,8 +88,8 @@ func initCmd(cmd *cobra.Command, args []string) error {
 			option := `"` + s[0] + `/` + s[1] + `", ` + s[2]
 			options = append(options, option)
 		}
+		optionsStr = sep + strings.Join(options[:], sep)
 	}
-	optionsStr += strings.Join(options[:], sep)
 
 	genesis := GetGenesisJSON(viper.GetString(FlagChainID), userAddr, optionsStr)
 	return CreateGenesisValidatorFiles(cfg, genesis, cmd.Root().Name())

--- a/server/commands/init.go
+++ b/server/commands/init.go
@@ -78,7 +78,13 @@ func initCmd(cmd *cobra.Command, args []string) error {
 			if len(s) != 3 {
 				return errors.New("Genesis option must be in the format <app>/<option>/<value>")
 			}
-			option := `"` + s[0] + `/` + s[1] + `", "` + s[2] + `"`
+
+			//Add quotes if the value (s[2]) is not json
+			if !strings.Contains(s[2], "\"") {
+				s[2] = `"` + s[2] + `"`
+			}
+
+			option := `"` + s[0] + `/` + s[1] + `", ` + s[2]
 			options = append(options, option)
 		}
 	}

--- a/server/commands/init.go
+++ b/server/commands/init.go
@@ -82,7 +82,7 @@ func initCmd(cmd *cobra.Command, args []string) error {
 			options = append(options, option)
 		}
 	}
-	optionsStr += strings.Join(options[:], ",\n      ")
+	optionsStr += strings.Join(options[:], sep)
 
 	genesis := GetGenesisJSON(viper.GetString(FlagChainID), userAddr, optionsStr)
 	return CreateGenesisValidatorFiles(cfg, genesis, cmd.Root().Name())

--- a/server/commands/init.go
+++ b/server/commands/init.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -25,10 +26,12 @@ var InitCmd = &cobra.Command{
 //nolint - flags
 var (
 	FlagChainID = "chain-id" //TODO group with other flags or remove? is this already a flag here?
+	FlagOption  = "option"
 )
 
 func init() {
 	InitCmd.Flags().String(FlagChainID, "test_chain_id", "Chain ID")
+	InitCmd.Flags().StringSlice(FlagOption, []string{}, "Genesis option in the format <app>/<option>/<value>")
 }
 
 // returns 1 iff it set a file, otherwise 0 (so we can add them)
@@ -64,7 +67,24 @@ func initCmd(cmd *cobra.Command, args []string) error {
 		return errors.New("Address must be 20-bytes in hex")
 	}
 
-	genesis := GetGenesisJSON(viper.GetString(FlagChainID), userAddr)
+	var options []string
+	var optionsStr string
+	sep := ",\n      "
+	optionsRaw := viper.GetStringSlice(FlagOption)
+	if len(optionsRaw) > 0 {
+		optionsStr = sep
+		for i := 0; i < len(optionsRaw); i++ {
+			s := strings.SplitN(optionsRaw[i], "/", 3)
+			if len(s) != 3 {
+				return errors.New("Genesis option must be in the format <app>/<option>/<value>")
+			}
+			option := `"` + s[0] + `/` + s[1] + `", "` + s[2] + `"`
+			options = append(options, option)
+		}
+	}
+	optionsStr += strings.Join(options[:], ",\n      ")
+
+	genesis := GetGenesisJSON(viper.GetString(FlagChainID), userAddr, optionsStr)
 	return CreateGenesisValidatorFiles(cfg, genesis, cmd.Root().Name())
 }
 
@@ -114,7 +134,7 @@ var PrivValJSON = `{
 // GetGenesisJSON returns a new tendermint genesis with Basecoin app_options
 // that grant a large amount of "mycoin" to a single address
 // TODO: A better UX for generating genesis files
-func GetGenesisJSON(chainID, addr string) string {
+func GetGenesisJSON(chainID, addr string, options string) string {
 	return fmt.Sprintf(`{
   "app_hash": "",
   "chain_id": "%s",
@@ -140,8 +160,8 @@ func GetGenesisJSON(chainID, addr string) string {
       ]
     }],
     "plugin_options": [
-      "coin/issuer", {"app": "sigs", "addr": "%s"}
+      "coin/issuer", {"app": "sigs", "addr": "%s"}%s
     ]
   }
-}`, chainID, addr, addr)
+}`, chainID, addr, addr, options)
 }

--- a/server/commands/root.go
+++ b/server/commands/root.go
@@ -35,6 +35,7 @@ func preRunSetup(cmd *cobra.Command, args []string) (err error) {
 	return nil
 }
 
+// SetUpRoot - initialize the root command
 func SetUpRoot(cmd *cobra.Command) {
 	cmd.PersistentPreRunE = preRunSetup
 	cmd.PersistentFlags().String(FlagLogLevel, defaultLogLevel, "Log level")

--- a/tests/cli/init-server.sh
+++ b/tests/cli/init-server.sh
@@ -8,24 +8,36 @@ test01initOption() {
     rm -rf "$BASE"
     mkdir -p "$BASE"
 
-    SERVER="${BASE}/server"
-    GENESIS_FILE=${SERVER}/genesis.json
+    SERVE_DIR="${BASE}/server"
+    GENESIS_FILE=${SERVE_DIR}/genesis.json
     HEX="deadbeef1234deadbeef1234deadbeef1234aaaa"
 
-    ${SERVER_EXE} init ${HEX} --home="$SERVER" --option=app1/key1/val1 --option=app2/key2/val2 >/dev/null
+    ${SERVER_EXE} init ${HEX} --home="$SERVE_DIR" -p=app1/key1/val1 -p='"app2/key2/{""name"": ""joe"", ""age"": ""100""}"' >/dev/null
     if ! assertTrue "line=${LINENO}" $?; then return 1; fi
 
     OPTION1KEY=$(cat ${GENESIS_FILE} | jq '.app_options.plugin_options[2]')
     OPTION1VAL=$(cat ${GENESIS_FILE} | jq '.app_options.plugin_options[3]')
     OPTION2KEY=$(cat ${GENESIS_FILE} | jq '.app_options.plugin_options[4]')
     OPTION2VAL=$(cat ${GENESIS_FILE} | jq '.app_options.plugin_options[5]')
+    OPTION2VALEXPECTED=$(echo '{"name": "joe", "age": "100"}' | jq '.')
 
     assertEquals "line=${LINENO}" '"app1/key1"' $OPTION1KEY
     assertEquals "line=${LINENO}" '"val1"' $OPTION1VAL
     assertEquals "line=${LINENO}" '"app2/key2"' $OPTION2KEY
-    assertEquals "line=${LINENO}" '"val2"' $OPTION2VAL
+    assertEquals "line=${LINENO}" "$OPTION2VALEXPECTED" "$OPTION2VAL"
+}
+
+test02runServer() {
+    # Attempt to begin the server with the custom genesis
+    SERVER_LOG=$BASE/${SERVER_EXE}.log
+    startServer $SERVE_DIR $SERVER_LOG
+}
+
+oneTimeTearDown() {
+    quickTearDown
 }
 
 # load and run these tests with shunit2!
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )" #get this files directory
-. $DIR/shunit2
+CLI_DIR=$GOPATH/src/github.com/cosmos/cosmos-sdk/tests/cli
+. $CLI_DIR/common.sh
+. $CLI_DIR/shunit2

--- a/tests/cli/init-server.sh
+++ b/tests/cli/init-server.sh
@@ -1,23 +1,31 @@
-" Press ? for help
+#!/bin/bash
 
-.. (up a dir)
-/
-▸ Applications/
-▸ bin/
-▸ cores/
-▸ dev/
-▸ etc/ -> /private/etc/
-▸ home/
-▸ Library/
-▸ net/
-▸ Network/
-▸ opt/
-▸ private/
-▸ sbin/
-▸ System/
-▸ tmp/ -> /private/tmp/
-▸ Users/
-▸ usr/
-▸ var/ -> /private/var/
-▸ Volumes/
-  installer.failurerequests [RO]
+CLIENT_EXE=basecli
+SERVER_EXE=basecoin
+
+test01initOption() {
+    BASE=~/.bc_init_test
+    rm -rf "$BASE"
+    mkdir -p "$BASE"
+
+    SERVER="${BASE}/server"
+    GENESIS_FILE=${SERVER}/genesis.json
+    HEX="deadbeef1234deadbeef1234deadbeef1234aaaa"
+
+    ${SERVER_EXE} init ${HEX} --home="$SERVER" --option=app1/key1/val1 --option=app2/key2/val2 >/dev/null
+    if ! assertTrue "line=${LINENO}" $?; then return 1; fi
+
+    OPTION1KEY=$(cat ${GENESIS_FILE} | jq '.app_options.plugin_options[2]')
+    OPTION1VAL=$(cat ${GENESIS_FILE} | jq '.app_options.plugin_options[3]')
+    OPTION2KEY=$(cat ${GENESIS_FILE} | jq '.app_options.plugin_options[4]')
+    OPTION2VAL=$(cat ${GENESIS_FILE} | jq '.app_options.plugin_options[5]')
+
+    assertEquals "line=${LINENO}" '"app1/key1"' $OPTION1KEY
+    assertEquals "line=${LINENO}" '"val1"' $OPTION1VAL
+    assertEquals "line=${LINENO}" '"app2/key2"' $OPTION2KEY
+    assertEquals "line=${LINENO}" '"val2"' $OPTION2VAL
+}
+
+# load and run these tests with shunit2!
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )" #get this files directory
+. $DIR/shunit2

--- a/tests/cli/init-server.sh
+++ b/tests/cli/init-server.sh
@@ -1,0 +1,23 @@
+" Press ? for help
+
+.. (up a dir)
+/
+▸ Applications/
+▸ bin/
+▸ cores/
+▸ dev/
+▸ etc/ -> /private/etc/
+▸ home/
+▸ Library/
+▸ net/
+▸ Network/
+▸ opt/
+▸ private/
+▸ sbin/
+▸ System/
+▸ tmp/ -> /private/tmp/
+▸ Users/
+▸ usr/
+▸ var/ -> /private/var/
+▸ Volumes/
+  installer.failurerequests [RO]


### PR DESCRIPTION
Closes #241 
The approach was to parse the option flag right into the genesis file as it gets created, the rest of the process train is still the same. Multiple `--option` flags can be used consecutively and it will work. The one problem that seemed to be a huge headache to resolve is to add more complex options that require JSON (such as the existing value to the option `coin/issuer`) This has to do with some the annoying ways which glide likes to parse information, I tried to come up with a solution but it seemed like to much effort for what it's worth... so for the time being this these options only accept non-json strings for the option value.