### PR TITLE
Windows compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@ TUTORIALS=$(shell find docs/guide -name "*md" -type f)
 EXAMPLES := counter eyes basecoin
 INSTALL_EXAMPLES := $(addprefix install_,${EXAMPLES})
 TEST_EXAMPLES := $(addprefix testex_,${EXAMPLES})
-
-LINKER_FLAGS:="-X github.com/cosmos/cosmos-sdk/client/commands.CommitHash=`git rev-parse --short HEAD`"
+COMMIT_HASH := $(shell git rev-parse --short HEAD)
+LINKER_FLAGS:="-X github.com/cosmos/cosmos-sdk/client/commands.CommitHash=${COMMIT_HASH}"
 
 all: get_vendor_deps install test
 

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ INSTALL_EXAMPLES := $(addprefix install_,${EXAMPLES})
 TEST_EXAMPLES := $(addprefix testex_,${EXAMPLES})
 COMMIT_HASH := $(shell git rev-parse --short HEAD)
 LINKER_FLAGS:="-X github.com/cosmos/cosmos-sdk/client/commands.CommitHash=${COMMIT_HASH}"
+NOVENDOR := $(shell glide novendor)
 
 all: get_vendor_deps install test
 
@@ -21,7 +22,7 @@ $(TEST_EXAMPLES): testex_%:
 	cd ./examples/$* && make test_cli
 
 install: $(INSTALL_EXAMPLES)
-	@go install -ldflags $(LINKER_FLAGS) ./cmd/...
+	go install -ldflags $(LINKER_FLAGS) ./cmd/...
 
 dist:
 	@bash publish/dist.sh
@@ -34,7 +35,7 @@ benchmark:
 test: test_unit test_cli
 
 test_unit:
-	@go test `glide novendor`
+	@go test $(NOVENDOR)
 
 test_cli: $(TEST_EXAMPLES)
 	# sudo apt-get install jq

--- a/examples/basecoin/Makefile
+++ b/examples/basecoin/Makefile
@@ -1,5 +1,6 @@
 COMMIT_HASH := $(shell git rev-parse --short HEAD)
 LINKER_FLAGS:="-X github.com/cosmos/cosmos-sdk/client/commands.CommitHash=${COMMIT_HASH}"
+NOVENDOR := $(shell glide novendor)
 
 install:
 	@go install -ldflags $(LINKER_FLAGS) ./cmd/...
@@ -7,7 +8,7 @@ install:
 test: test_unit test_cli
 
 test_unit:
-	@go test `glide novendor`
+	@go test $(NOVENDOR)
 
 test_cli:
 	./tests/cli/keys.sh

--- a/examples/basecoin/Makefile
+++ b/examples/basecoin/Makefile
@@ -2,7 +2,7 @@ COMMIT_HASH := $(shell git rev-parse --short HEAD)
 LINKER_FLAGS:="-X github.com/cosmos/cosmos-sdk/client/commands.CommitHash=${COMMIT_HASH}"
 
 install:
-	go install -ldflags $(LINKER_FLAGS) ./cmd/...
+	@go install -ldflags $(LINKER_FLAGS) ./cmd/...
 
 test: test_unit test_cli
 

--- a/examples/basecoin/Makefile
+++ b/examples/basecoin/Makefile
@@ -1,7 +1,8 @@
-LINKER_FLAGS:="-X github.com/cosmos/cosmos-sdk/client/commands.CommitHash=`git rev-parse --short HEAD`"
+COMMIT_HASH := $(shell git rev-parse --short HEAD)
+LINKER_FLAGS:="-X github.com/cosmos/cosmos-sdk/client/commands.CommitHash=${COMMIT_HASH}"
 
 install:
-	@go install -ldflags $(LINKER_FLAGS) ./cmd/...
+	go install -ldflags $(LINKER_FLAGS) ./cmd/...
 
 test: test_unit test_cli
 

--- a/examples/counter/Makefile
+++ b/examples/counter/Makefile
@@ -1,4 +1,5 @@
-LINKER_FLAGS:="-X github.com/cosmos/cosmos-sdk/client/commands.CommitHash=`git rev-parse --short HEAD`"
+COMMIT_HASH := $(shell git rev-parse --short HEAD)
+LINKER_FLAGS:="-X github.com/cosmos/cosmos-sdk/client/commands.CommitHash=${COMMIT_HASH}"
 
 install:
 	@go install -ldflags $(LINKER_FLAGS) ./cmd/...

--- a/examples/counter/Makefile
+++ b/examples/counter/Makefile
@@ -1,5 +1,6 @@
 COMMIT_HASH := $(shell git rev-parse --short HEAD)
 LINKER_FLAGS:="-X github.com/cosmos/cosmos-sdk/client/commands.CommitHash=${COMMIT_HASH}"
+NOVENDOR := $(shell glide novendor)
 
 install:
 	@go install -ldflags $(LINKER_FLAGS) ./cmd/...
@@ -7,7 +8,7 @@ install:
 test: test_unit test_cli
 
 test_unit:
-	@go test `glide novendor`
+	@go test $(NOVENDOR)
 
 test_cli:
 	./tests/cli/counter.sh

--- a/examples/eyes/Makefile
+++ b/examples/eyes/Makefile
@@ -1,5 +1,6 @@
 COMMIT_HASH := $(shell git rev-parse --short HEAD)
 LINKER_FLAGS:="-X github.com/cosmos/cosmos-sdk/client/commands.CommitHash=${COMMIT_HASH}"
+NOVENDOR := $(shell glide novendor)
 
 install:
 	@go install -ldflags $(LINKER_FLAGS) ./cmd/...
@@ -7,7 +8,7 @@ install:
 test: test_unit test_cli
 
 test_unit:
-	@go test `glide novendor`
+	@go test $(NOVENDOR)
 
 test_cli:
 	./tests/cli/eyes.sh

--- a/examples/eyes/Makefile
+++ b/examples/eyes/Makefile
@@ -1,4 +1,5 @@
-LINKER_FLAGS:="-X github.com/cosmos/cosmos-sdk/client/commands.CommitHash=`git rev-parse --short HEAD`"
+COMMIT_HASH := $(shell git rev-parse --short HEAD)
+LINKER_FLAGS:="-X github.com/cosmos/cosmos-sdk/client/commands.CommitHash=${COMMIT_HASH}"
 
 install:
 	@go install -ldflags $(LINKER_FLAGS) ./cmd/...


### PR DESCRIPTION
Make basecoin compile again.

Just took out a few unix-isms from the Makefiles so it is more generic