### PR TITLE
Add Query without proof

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,14 @@
 *.swp
 *.swo
 vendor
-merkleeyes.db
+*.db
 build
+dummy-data
+
 docs/guide/*.sh
 tools/bin/*
 examples/build/*
 
-### Vagrant ###
 .vagrant/
 *.box
 *.log

--- a/app/app.go
+++ b/app/app.go
@@ -191,7 +191,7 @@ func (app *App) Query(req abci.RequestQuery) (res abci.ResponseQuery) {
 	case "/key", "/store":
 		path = "main"
 	default:
-		if strings.HasPrefix(path, "/") {
+		if !strings.HasPrefix(path, "/") {
 			// TODO: better error code
 			return abci.ResponseQuery{Code: 101, Log: "Path must start with /"}
 		}

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -38,7 +38,7 @@ func TestBasic(t *testing.T) {
 	store, storeKeys := newCommitMultiStore()
 
 	// Create app.
-	app := NewApp(t.Name(), store)
+	app := NewApp(t.Name(), store, storeKeys)
 	app.SetTxDecoder(func(txBytes []byte) (sdk.Tx, error) {
 		var ttx testTx
 		fromJSON(txBytes, &ttx)

--- a/examples/basecoin/app/basecoin_app.go
+++ b/examples/basecoin/app/basecoin_app.go
@@ -17,6 +17,7 @@ type BasecoinApp struct {
 	*apm.App
 	cdc        *wire.Codec
 	multiStore sdk.CommitMultiStore
+	storeKeys  map[string]sdk.SubstoreKey
 
 	// The key to access the substores.
 	mainStoreKey *sdk.KVStoreKey
@@ -73,7 +74,7 @@ func (app *BasecoinApp) initKeys() {
 
 // depends on initMultiStore()
 func (app *BasecoinApp) initSDKApp() {
-	app.App = apm.NewApp(appName, app.multiStore)
+	app.App = apm.NewApp(appName, app.multiStore, app.storeKeys)
 }
 
 func (app *BasecoinApp) initCodec() {

--- a/examples/basecoin/app/stores.go
+++ b/examples/basecoin/app/stores.go
@@ -32,8 +32,11 @@ func (app *BasecoinApp) initMultiStore() {
 	multiStore.SetSubstoreLoader(app.mainStoreKey, mainLoader)
 	multiStore.SetSubstoreLoader(app.ibcStoreKey, ibcLoader)
 
-	// Finally,
+	// Finally, set variables on app
 	app.multiStore = multiStore
+	app.storeKeys = map[string]store.SubstoreKey{}
+	app.storeKeys[app.mainStoreKey.Name()] = app.mainStoreKey
+	app.storeKeys[app.ibcStoreKey.Name()] = app.ibcStoreKey
 }
 
 // depends on initKeys()

--- a/examples/dummy/main.go
+++ b/examples/dummy/main.go
@@ -65,12 +65,19 @@ func newDummyApp() (*app.App, error) {
 	// Set Tx decoder
 	app.SetTxDecoder(decodeTx)
 
+	app.SetDefaultAnteHandler(noAnte)
+
 	app.Router().AddRoute("dummy", DummyHandler(mainStoreKey))
 
 	if err := app.LoadLatestVersion(mainStoreKey); err != nil {
 		return nil, err
 	}
 	return app, nil
+}
+
+// noAnte is a noop
+func noAnte(ctx sdk.Context, tx sdk.Tx) (sdk.Context, sdk.Result, bool) {
+	return ctx, sdk.Result{}, false
 }
 
 type dummyTx struct {

--- a/examples/dummy/main.go
+++ b/examples/dummy/main.go
@@ -30,13 +30,16 @@ func main() {
 
 	// key to access the main KVStore
 	var mainStoreKey = sdk.NewKVStoreKey("main")
+	keys := map[string]sdk.SubstoreKey{
+		"main": mainStoreKey,
+	}
 
 	// Create MultiStore
 	multiStore := store.NewCommitMultiStore(db)
 	multiStore.SetSubstoreLoader(mainStoreKey, loader)
 
 	// Set everything on the app and load latest
-	app := app.NewApp("dummy", multiStore)
+	app := app.NewApp("dummy", multiStore, keys)
 
 	// Set Tx decoder
 	app.SetTxDecoder(decodeTx)

--- a/examples/dummy/main_test.go
+++ b/examples/dummy/main_test.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"fmt"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,6 +11,9 @@ import (
 )
 
 func TestQuery(t *testing.T) {
+	// delete all data first
+	os.RemoveAll("./dummy-data")
+
 	app, err := newDummyApp()
 	require.NoError(t, err)
 
@@ -28,7 +31,9 @@ func TestQuery(t *testing.T) {
 
 	// submit a tx and commit
 	txBytes := append(append(k, '='), v...)
-	fmt.Printf("tx: %x\n", txBytes)
+
+	// Note: need to call BeginBlock before DeliverTX or it panics
+	app.BeginBlock(abci.RequestBeginBlock{})
 	dres := app.DeliverTx(txBytes)
 	require.Equal(t, 0, int(dres.Code), dres.Log)
 	cres := app.Commit()

--- a/examples/dummy/main_test.go
+++ b/examples/dummy/main_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	abci "github.com/tendermint/abci/types"
+)
+
+func TestQuery(t *testing.T) {
+	app, err := newDummyApp()
+	require.NoError(t, err)
+
+	k, v := []byte("my-key"), []byte("some-awesome-value")
+
+	// make sure that we reject proof for now
+	badReq := abci.RequestQuery{Data: k, Prove: true, Path: "/store"}
+	res := app.Query(badReq)
+	assert.Equal(t, 500, int(res.Code))
+
+	// check that missing data returns correct code
+	req := abci.RequestQuery{Data: k, Path: "/main"}
+	res = app.Query(req)
+	assert.Equal(t, 404, int(res.Code))
+
+	// submit a tx and commit
+	txBytes := append(append(k, '='), v...)
+	fmt.Printf("tx: %x\n", txBytes)
+	dres := app.DeliverTx(txBytes)
+	require.Equal(t, 0, int(dres.Code), dres.Log)
+	cres := app.Commit()
+	// we want a non-empty hash
+	require.NotEqual(t, 0, len(cres.Data))
+
+	// now try to query for existing data
+	res = app.Query(req)
+	assert.Equal(t, 0, int(res.Code))
+	assert.Equal(t, k, res.Key)
+	assert.Equal(t, v, res.Value)
+}


### PR DESCRIPTION
Fixes #340 

Simplest case, no historical queries, no proofs.
Just uses the non-cached KVStore, which is state after last commit.

Add tests to dummy app to verify it works.