### PR TITLE
Sdk2 basecoinapp init

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @jaekwon

--- a/examples/basecoin/app/app.go
+++ b/examples/basecoin/app/app.go
@@ -31,18 +31,15 @@ func NewBasecoinApp() *BasecoinApp {
 
 	// Create and configure app.
 	var app = &BasecoinApp{}
-	app.initKeys()
-	app.initMultiStore()
-	app.initAppStore()
-	app.initSDKApp()
-	app.initCodec()
-	app.initTxDecoder()
-	app.initAnteHandler()
-	app.initRoutes()
+	app.initCapKeys() // ./capkeys.go
+	app.initStores()  // ./stores.go
+	app.initSDKApp()  // ./sdkapp.go
+	app.initRoutes()  // ./routes.go
 
 	// TODO: Load genesis
 	// TODO: InitChain with validators
 	// TODO: Set the genesis accounts
+
 	app.loadStores()
 
 	return app
@@ -65,29 +62,6 @@ func (app *BasecoinApp) RunForever() {
 	})
 
 }
-
-func (app *BasecoinApp) initKeys() {
-	app.mainStoreKey = sdk.NewKVStoreKey("main")
-	app.ibcStoreKey = sdk.NewKVStoreKey("ibc")
-}
-
-// depends on initMultiStore()
-func (app *BasecoinApp) initSDKApp() {
-	app.App = apm.NewApp(appName, app.multiStore)
-}
-
-func (app *BasecoinApp) initCodec() {
-	app.cdc = wire.NewCodec()
-	app.registerMsgs()
-}
-
-// depends on initSDKApp()
-func (app *BasecoinApp) initTxDecoder() {
-	app.App.SetTxDecoder(app.decodeTx)
-}
-
-// initAnteHandler defined in app/routes.go
-// initRoutes defined in app/routes.go
 
 // Load the stores.
 func (app *BasecoinApp) loadStores() {

--- a/examples/basecoin/app/capkeys.go
+++ b/examples/basecoin/app/capkeys.go
@@ -1,0 +1,16 @@
+package app
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// initCapKeys() happens before initStores(), initSDKApp(), and initRoutes().
+func (app *BasecoinApp) initCapKeys() {
+
+	// All top-level capabilities keys
+	// should be constructed here.
+	// For more information, see http://www.erights.org/elib/capability/ode/ode.pdf.
+	app.mainStoreKey = sdk.NewKVStoreKey("main")
+	app.ibcStoreKey = sdk.NewKVStoreKey("ibc")
+
+}

--- a/examples/basecoin/app/msgs.go
+++ b/examples/basecoin/app/msgs.go
@@ -1,32 +1,22 @@
 package app
 
 import (
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/bank"
 	crypto "github.com/tendermint/go-crypto"
+	wire "github.com/tendermint/go-wire"
 )
 
-// Set via `app.App.SetTxDecoder(app.decodeTx)`
-func (app *BasecoinApp) decodeTx(txBytes []byte) (sdk.Tx, error) {
-	var tx = sdk.StdTx{}
-	err := app.cdc.UnmarshalBinary(txBytes, &tx)
-	return tx, err
-}
+// Wire requires registration of interfaces & concrete types.  All
+// interfaces to be encoded/decoded in a Msg must be registered
+// here, along with all the concrete types that implement them.
+func makeTxCodec() (cdc *wire.Codec) {
+	cdc = wire.NewCodec()
 
-// Wire requires registration of interfaces & concrete types.
-func (app *BasecoinApp) registerMsgs() {
-	cdc := app.cdc
-
-	// Register the crypto
+	// Register crypto.[PubKey,PrivKey,Signature] types.
 	crypto.RegisterWire(cdc)
 
-	// Register the Msg interface.
-	cdc.RegisterInterface((*sdk.Msg)(nil), nil)
-	cdc.RegisterConcrete(bank.SendMsg{}, "cosmos-sdk/SendMsg", nil)   // XXX refactor out
-	cdc.RegisterConcrete(bank.IssueMsg{}, "cosmos-sdk/IssueMsg", nil) // XXX refactor out to bank/msgs.go
-	// more msgs here...
+	// Register bank.[SendMsg,IssueMsg] types.
+	bank.RegisterWire(cdc)
 
-	// All interfaces to be encoded/decoded in a Msg must be
-	// registered here, along with all the concrete types that
-	// implement them.
+	return
 }

--- a/examples/basecoin/app/routes.go
+++ b/examples/basecoin/app/routes.go
@@ -1,22 +1,15 @@
 package app
 
 import (
-	"github.com/cosmos/cosmos-sdk/x/auth"
 	"github.com/cosmos/cosmos-sdk/x/bank"
 )
 
-// Handle charging tx fees and checking signatures.
-func (app *BasecoinApp) initAnteHandler() {
-	var authAnteHandler = auth.NewAnteHandler(app.accStore)
-	app.App.SetDefaultAnteHandler(authAnteHandler)
-}
-
-// Constructs router to route handling of msgs.
+// initRoutes() happens after initCapKeys(), initStores(), and initSDKApp().
 func (app *BasecoinApp) initRoutes() {
 	var router = app.App.Router()
-	// var multiStore = app.multiStore
 	var accStore = app.accStore
 
+	// All handlers must be added here.
+	// The order matters.
 	router.AddRoute("bank", bank.NewHandler(accStore))
-	// more routes here... (order matters)
 }

--- a/examples/basecoin/app/sdkapp.go
+++ b/examples/basecoin/app/sdkapp.go
@@ -1,0 +1,29 @@
+package app
+
+import (
+	apm "github.com/cosmos/cosmos-sdk/app"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/auth"
+)
+
+// initSDKApp() happens after initCapKeys() and initStores().
+// initSDKApp() happens before initRoutes().
+func (app *BasecoinApp) initSDKApp() {
+	app.App = apm.NewApp(appName, app.multiStore)
+	app.initSDKAppTxDecoder()
+	app.initSDKAppAnteHandler()
+}
+
+func (app *BasecoinApp) initSDKAppTxDecoder() {
+	cdc := makeTxCodec()
+	app.App.SetTxDecoder(func(txBytes []byte) (sdk.Tx, error) {
+		var tx = sdk.StdTx{}
+		err := cdc.UnmarshalBinary(txBytes, &tx)
+		return tx, err
+	})
+}
+
+func (app *BasecoinApp) initSDKAppAnteHandler() {
+	var authAnteHandler = auth.NewAnteHandler(app.accStore)
+	app.App.SetDefaultAnteHandler(authAnteHandler)
+}

--- a/examples/basecoin/app/stores.go
+++ b/examples/basecoin/app/stores.go
@@ -10,7 +10,13 @@ import (
 	dbm "github.com/tendermint/tmlibs/db"
 )
 
-// depends on initKeys()
+// initStores() happens after initCapKeys(), but before initSDKApp() and initRoutes().
+func (app *BasecoinApp) initStores() {
+	app.initMultiStore()
+	app.initAccountStore()
+}
+
+// Initialize root MultiStore.
 func (app *BasecoinApp) initMultiStore() {
 
 	// Create the underlying leveldb datastore which will
@@ -36,16 +42,18 @@ func (app *BasecoinApp) initMultiStore() {
 	app.multiStore = multiStore
 }
 
-// depends on initKeys()
-func (app *BasecoinApp) initAppStore() {
+// Initialize the AccountStore, which accesses the MultiStore.
+func (app *BasecoinApp) initAccountStore() {
 	accStore := auth.NewAccountStore(
-		app.mainStoreKey,    // where accounts are persisted.
-		&types.AppAccount{}, // prototype sdk.Account.
+		// where accounts are persisted in the MultiStore.
+		app.mainStoreKey,
+		// prototype sdk.Account.
+		&types.AppAccount{},
 	)
 
-	// If there are additional interfaces & concrete types that need to be
-	// registered w/ wire.Codec, they can be registered here before the
-	// accStore is sealed.
+	// If there are additional interfaces & concrete types that
+	// need to be registered w/ wire.Codec, they can be registered
+	// here before the accStore is sealed.
 	//
 	// cdc := accStore.WireCodec()
 	// cdc.RegisterInterface(...)

--- a/x/auth/account.go
+++ b/x/auth/account.go
@@ -13,7 +13,9 @@ import (
 
 var _ sdk.Account = (*BaseAccount)(nil)
 
-// BaseAccount - coin account structure
+// BaseAccount - base account structure.
+// Extend this by embedding this in your AppAccount.
+// See the examples/basecoin/types/account.go for an example.
 type BaseAccount struct {
 	Address  crypto.Address `json:"address"`
 	Coins    sdk.Coins      `json:"coins"`
@@ -27,22 +29,22 @@ func NewBaseAccountWithAddress(addr crypto.Address) BaseAccount {
 	}
 }
 
-// Implements Account
+// Implements sdk.Account.
 func (acc BaseAccount) Get(key interface{}) (value interface{}, err error) {
 	panic("not implemented yet")
 }
 
-// Implements Account
+// Implements sdk.Account.
 func (acc *BaseAccount) Set(key interface{}, value interface{}) error {
 	panic("not implemented yet")
 }
 
-// Implements Account
+// Implements sdk.Account.
 func (acc BaseAccount) GetAddress() crypto.Address {
 	return acc.Address
 }
 
-// Implements Account
+// Implements sdk.Account.
 func (acc *BaseAccount) SetAddress(addr crypto.Address) error {
 	if len(acc.Address) != 0 {
 		return errors.New("cannot override BaseAccount address")
@@ -51,12 +53,12 @@ func (acc *BaseAccount) SetAddress(addr crypto.Address) error {
 	return nil
 }
 
-// Implements Account
+// Implements sdk.Account.
 func (acc BaseAccount) GetPubKey() crypto.PubKey {
 	return acc.PubKey
 }
 
-// Implements Account
+// Implements sdk.Account.
 func (acc *BaseAccount) SetPubKey(pubKey crypto.PubKey) error {
 	if acc.PubKey != nil {
 		return errors.New("cannot override BaseAccount pubkey")
@@ -65,23 +67,23 @@ func (acc *BaseAccount) SetPubKey(pubKey crypto.PubKey) error {
 	return nil
 }
 
-// Implements Account
+// Implements sdk.Account.
 func (acc *BaseAccount) GetCoins() sdk.Coins {
 	return acc.Coins
 }
 
-// Implements Account
+// Implements sdk.Account.
 func (acc *BaseAccount) SetCoins(coins sdk.Coins) error {
 	acc.Coins = coins
 	return nil
 }
 
-// Implements Account
+// Implements sdk.Account.
 func (acc *BaseAccount) GetSequence() int64 {
 	return acc.Sequence
 }
 
-// Implements Account
+// Implements sdk.Account.
 func (acc *BaseAccount) SetSequence(seq int64) error {
 	acc.Sequence = seq
 	return nil

--- a/x/bank/wire.go
+++ b/x/bank/wire.go
@@ -1,0 +1,11 @@
+package bank
+
+import (
+	"github.com/tendermint/go-wire"
+)
+
+func RegisterWire(cdc *wire.Codec) {
+	// TODO include option to always include prefix bytes.
+	cdc.RegisterConcrete(SendMsg{}, "cosmos-sdk/SendMsg", nil)
+	cdc.RegisterConcrete(IssueMsg{}, "cosmos-sdk/IssueMsg", nil)
+}


### PR DESCRIPTION
Group init functions into 4:

initCapKeys, initStores, initSDKApp, initRoutes.

Makes it clearer where things go, as the top-level init* methods correspond to their filenames.

* To create more capabilities keys, modify initCapKeys in app/capkeys.go
* To create more stores, modify initStores in app/stores.go
* To add more msg handlers, modify app/routes.go
* You probably don't need to touch app/sdkapp.go