### PR TITLE
WIP: EVM module using SputnikVM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,9 @@ draw_deps:
 	go get github.com/RobotsAndPencils/goviz
 	@goviz -i github.com/tendermint/tendermint/cmd/tendermint -d 3 | dot -Tpng -o dependency-graph.png
 
+evm:
+	cd $(GOPATH)/src/github.com/cosmos/cosmos-sdk/vendor/github.com/ethereumproject/sputnikvm-ffi/c && $(MAKE) build
+
 
 ########################################
 ### Documentation
@@ -67,6 +70,9 @@ test_tutorial:
 	@for script in docs/guide/*.sh ; do \
 		bash $$script ; \
 	done
+
+test_evm:
+	CGO_LDFLAGS="$(GOPATH)/src/github.com/cosmos/cosmos-sdk/vendor/github.com/ethereumproject/sputnikvm-ffi/c/libsputnikvm.a -ldl -lresolv" go test ./x/evm
 
 benchmark:
 	@go test -bench=. $(PACKAGES)

--- a/examples/basecoin/LICENSE
+++ b/examples/basecoin/LICENSE
@@ -1,4 +1,4 @@
-Cosmos-SDK
+Cosmos-SDK Basecoin (template)
 License: Apache2.0
 
                                  Apache License
@@ -189,7 +189,7 @@ License: Apache2.0
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2016 All in Bits, Inc
+   Copyright 2018 All in Bits, Inc
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/examples/basecoin/README.md
+++ b/examples/basecoin/README.md
@@ -1,0 +1,19 @@
+This is the "Basecoin" example application built on the Cosmos-SDK.  This
+"Basecoin" is not affiliated with [Coinbase](http://www.getbasecoin.com/), nor
+the [stable coin](http://www.getbasecoin.com/).
+
+You need a recent version of `glide` to install Basecoin's dependencies.
+
+```bash
+> make get_tools
+```
+
+Then, you can build the cmd binaries (NOTE: a work in progress!), or run the tests.
+
+```
+> make get_vendor_deps
+> make build
+> make test
+```
+
+If you want to create a new application, start by copying the Basecoin app.

--- a/examples/basecoin/glide.yaml
+++ b/examples/basecoin/glide.yaml
@@ -1,4 +1,4 @@
 package: github.com/cosmos/cosmos-sdk/examples/basecoin
 import:
 - package: github.com/cosmos/cosmos-sdk
-  version: sdk2
+  version: develop

--- a/examples/basecoin/tools/Makefile
+++ b/examples/basecoin/tools/Makefile
@@ -43,9 +43,6 @@ install: get_vendor_deps
 	
 	@echo "$(ansi_yel)Install gometalinter.v2$(ansi_end)"
 	GOBIN=$(CURDIR)/bin ./bin/go-vendorinstall gopkg.in/alecthomas/gometalinter.v2
-	
-	@echo "$(ansi_yel)Install shelldown$(ansi_end)"
-	GOBIN=$(CURDIR)/bin ./bin/go-vendorinstall github.com/rigelrozanski/shelldown/cmd/shelldown
 
 	@echo "$(ansi_grn)Done installing tools$(ansi_end)"
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: e8435271aa9fdfc49efff9016427eca1fd6b43093a17187619360edda9f265e6
-updated: 2018-01-22T05:53:49.683395197-08:00
+hash: 563d600a0d26653d423f4d7ff830b09ef9bddc61ee3a3ae402ae22ffe6678a0a
+updated: 2018-01-28T18:13:54.132995+01:00
 imports:
 - name: github.com/btcsuite/btcd
   version: 2e60448ffcc6bf78332d1fe590260095f554dd78
@@ -11,6 +11,14 @@ imports:
   - spew
 - name: github.com/ebuchman/fail-test
   version: 95f809107225be108efcf10a3509e4ea6ceef3c4
+- name: github.com/ethereumproject/go-ethereum
+  version: d3deb0eacf635def39f1afd8eca4bcb7172c2568
+  subpackages:
+  - common
+- name: github.com/ethereumproject/sputnikvm-ffi
+  version: a6c914124a94151706443826c8124896ab1473bc
+  subpackages:
+  - go/sputnikvm
 - name: github.com/go-kit/kit
   version: e2b298466b32c7cd5579a9b9b07e968fc9d9452c
   subpackages:
@@ -119,7 +127,7 @@ imports:
   - state
   - types
 - name: github.com/tendermint/tmlibs
-  version: 80029abc6e20f85079cd751e659a05508773288c
+  version: dc2111f0ddc779216e99758660a15ec831135706
   subpackages:
   - cli
   - cli/flags

--- a/glide.yaml
+++ b/glide.yaml
@@ -48,6 +48,11 @@ import:
   - events
   - log
   - logger
+- package: github.com/ethereumproject/sputnikvm-ffi
+  subpackages:
+  - go/sputnikvm
+- package: github.com/ethereumproject/go-ethereum
+  version: ^4.2.1
 testImport:
 - package: github.com/stretchr/testify
   subpackages:

--- a/types/coin.go
+++ b/types/coin.go
@@ -73,6 +73,7 @@ func (coins Coins) IsValid() bool {
 }
 
 // Plus combines two sets of coins
+// CONTRACT: Plus will never return Coins where one Coin has a 0 amount.
 func (coins Coins) Plus(coinsB Coins) Coins {
 	sum := []Coin{}
 	indexA, indexB := 0, 0

--- a/types/coin.go
+++ b/types/coin.go
@@ -72,10 +72,7 @@ func (coins Coins) IsValid() bool {
 	}
 }
 
-// Plus combines to sets of coins
-//
-// TODO: handle empty coins!
-// Currently appends an empty coin ...
+// Plus combines two sets of coins
 func (coins Coins) Plus(coinsB Coins) Coins {
 	sum := []Coin{}
 	indexA, indexB := 0, 0
@@ -110,7 +107,6 @@ func (coins Coins) Plus(coinsB Coins) Coins {
 			indexB++
 		}
 	}
-	return sum
 }
 
 // Negative returns a set of coins with all amount negative

--- a/types/coin_test.go
+++ b/types/coin_test.go
@@ -64,12 +64,13 @@ func TestPlusCoins(t *testing.T) {
 		{Coins{{"A", 0}, {"B", 1}}, Coins{{"A", 0}, {"B", 0}}, Coins{{"B", 1}}},
 		{Coins{{"A", 0}, {"B", 0}}, Coins{{"A", 0}, {"B", 0}}, Coins{}},
 		{Coins{{"A", 1}, {"B", 0}}, Coins{{"A", -1}, {"B", 0}}, Coins{}},
+		{Coins{{"A", -1}, {"B", 0}}, Coins{{"A", 0}, {"B", 0}}, Coins{{"A", -1}}},
 	}
 
 	for _, tc := range cases {
 		res := tc.inputOne.Plus(tc.inputTwo)
 		assert.True(res.IsValid())
-		assert.Equal(res, tc.expected)
+		assert.Equal(tc.expected, res)
 	}
 }
 

--- a/types/coin_test.go
+++ b/types/coin_test.go
@@ -52,7 +52,28 @@ func TestCoins(t *testing.T) {
 
 }
 
-//Test the parse coin and parse coins functionality
+func TestPlusCoins(t *testing.T) {
+	assert := assert.New(t)
+
+	cases := []struct {
+		inputOne Coins
+		inputTwo Coins
+		expected Coins
+	}{
+		{Coins{{"A", 1}, {"B", 1}}, Coins{{"A", 1}, {"B", 1}}, Coins{{"A", 2}, {"B", 2}}},
+		{Coins{{"A", 0}, {"B", 1}}, Coins{{"A", 0}, {"B", 0}}, Coins{{"B", 1}}},
+		{Coins{{"A", 0}, {"B", 0}}, Coins{{"A", 0}, {"B", 0}}, Coins{}},
+		{Coins{{"A", 1}, {"B", 0}}, Coins{{"A", -1}, {"B", 0}}, Coins{}},
+	}
+
+	for _, tc := range cases {
+		res := tc.inputOne.Plus(tc.inputTwo)
+		assert.True(res.IsValid())
+		assert.Equal(res, tc.expected)
+	}
+}
+
+//Test the parsing of Coin and Coins
 func TestParse(t *testing.T) {
 
 	cases := []struct {

--- a/types/coin_test.go
+++ b/types/coin_test.go
@@ -24,7 +24,8 @@ func TestCoins(t *testing.T) {
 		{"GAS", 1},
 		{"MINERAL", 1},
 	}
-	badSort2 := Coins{ // both are after the first one, but the second and third are in the wrong order
+	// both are after the first one, but the second and third are in the wrong order
+	badSort2 := Coins{
 		{"GAS", 1},
 		{"TREE", 1},
 		{"MINERAL", 1},

--- a/x/evm/doc.go
+++ b/x/evm/doc.go
@@ -1,0 +1,1 @@
+package evm

--- a/x/evm/evm.go
+++ b/x/evm/evm.go
@@ -1,0 +1,1 @@
+package evm

--- a/x/evm/evm_test.go
+++ b/x/evm/evm_test.go
@@ -1,0 +1,23 @@
+package evm_test
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/ethereumproject/sputnikvm-ffi/go/sputnikvm"
+)
+
+func TestEVM(t *testing.T) {
+	assert.True(t, true)
+
+	account := sputnikvm.AccountChangeStorageItem{
+		Key:   big.NewInt(100),
+		Value: big.NewInt(19),
+	}
+
+	_ = account
+
+	assert.True(t, true)
+}

--- a/x/web3/doc.go
+++ b/x/web3/doc.go
@@ -1,0 +1,1 @@
+package web3

--- a/x/web3/web3.go
+++ b/x/web3/web3.go
@@ -1,0 +1,1 @@
+package web3

--- a/x/web3/web3_test.go
+++ b/x/web3/web3_test.go
@@ -1,0 +1,1 @@
+package web3


### PR DESCRIPTION
The module lives in `x/evm`. 

You have to have Rust installed in order to compile the underlying `libsputnikvm.a` library. I would recommend [rustup](http://rustup.rs/).

Once you have that you can run `make get_tools && make get_vendor_deps` and this should hopefully grab the latest version of [SputnikVM](https://github.com/ethereumproject/sputnikvm-ffi).

After that you should run `make evm` in order to compile and copy the shared library.

Lastly, you can run `make test_evm` in order to run the tests.


## TODO
- [x] Access SputnikVM's rust code through FFI in Go
- [ ] Define the module internals so that it can work as a handler
- [ ] Cleanup the build process