### PR TITLE
Update to the latest dependencies and remove references to sdk2

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,18 +1,18 @@
-hash: e8435271aa9fdfc49efff9016427eca1fd6b43093a17187619360edda9f265e6
-updated: 2018-01-22T05:53:49.683395197-08:00
+hash: 7f005d15e06d3de1db4aad2ee36133286c8b7f3d433d2b2f40946924a6d4a53b
+updated: 2018-01-29T10:40:35.952763+01:00
 imports:
 - name: github.com/btcsuite/btcd
-  version: 2e60448ffcc6bf78332d1fe590260095f554dd78
+  version: 9aa9e79ebf7f11f1f70533c100e5c835a6af8c0f
   subpackages:
   - btcec
 - name: github.com/davecgh/go-spew
-  version: 04cdfd42973bb9c8589fd6a731800cf222fde1a9
+  version: ecdeabc65495df2dec95d7c4a4c3e021903035e5
   subpackages:
   - spew
 - name: github.com/ebuchman/fail-test
   version: 95f809107225be108efcf10a3509e4ea6ceef3c4
 - name: github.com/go-kit/kit
-  version: e2b298466b32c7cd5579a9b9b07e968fc9d9452c
+  version: 953e747656a7bbb5e1f998608b460458958b70cc
   subpackages:
   - log
   - log/level
@@ -20,7 +20,7 @@ imports:
 - name: github.com/go-logfmt/logfmt
   version: 390ab7935ee28ec6b286364bba9b4dd6410cb3d5
 - name: github.com/go-stack/stack
-  version: 817915b46b97fd7bb80e8ab6b69f01a53ac3eebf
+  version: 259ab82a6cad3992b4e21ff5cac294ccb06474bc
 - name: github.com/gogo/protobuf
   version: 342cbe0a04158f6dcb03ca0079991a51a4248c02
   subpackages:
@@ -31,7 +31,7 @@ imports:
   - sortkeys
   - types
 - name: github.com/golang/protobuf
-  version: 1e59b77b52bf8e4b449a57e6f79f21226d571845
+  version: 925541529c1fa6821df4e44ce2723319eb2be768
   subpackages:
   - proto
   - ptypes
@@ -41,7 +41,7 @@ imports:
 - name: github.com/golang/snappy
   version: 553a641470496b2327abcac10b36396bd98e45c9
 - name: github.com/gorilla/websocket
-  version: 292fd08b2560ad524ee37396253d71570339a821
+  version: 91f589db023d66e4aba7112d44cc0d2fb091c553
 - name: github.com/jmhodges/levigo
   version: c42d9e0ca023e2198120196f842701bb4c55d7b9
 - name: github.com/kr/logfmt
@@ -49,17 +49,17 @@ imports:
 - name: github.com/pkg/errors
   version: 645ef00459ed84a119197bfb8d8205042c6df63d
 - name: github.com/rcrowley/go-metrics
-  version: e181e095bae94582363434144c61a9653aff6e50
+  version: 8732c616f52954686704c8645fe1a9d59e9df7c1
 - name: github.com/rigelrozanski/common
   version: f691f115798593d783b9999b1263c2f4ffecc439
 - name: github.com/spf13/cobra
   version: 7b2c5ac9fc04fc5efafb60700713d4fa609b777b
 - name: github.com/spf13/pflag
-  version: 97afa5e7ca8a08a383cb259e06636b5e2cc7897f
+  version: 4c012f6dcd9546820e378d0bdda4d8fc772cdfea
 - name: github.com/spf13/viper
-  version: 25b30aa063fc18e48662b86996252eabdcf2f0c7
+  version: aafc9e6bc7b7bb53ddaa75a5ef49a17d6e654be5
 - name: github.com/syndtr/goleveldb
-  version: b89cc31ef7977104127d34c1bd31ebd1a9db2199
+  version: 211f780988068502fe874c44dae530528ebd840f
   subpackages:
   - leveldb
   - leveldb/cache
@@ -91,7 +91,7 @@ imports:
   subpackages:
   - keys
 - name: github.com/tendermint/go-wire
-  version: c7801c1586f51bb28028cd420c599516d7ac9c36
+  version: e723d95ac2838b7ae9919ada25004859236c32ff
   subpackages:
   - data
 - name: github.com/tendermint/iavl
@@ -119,7 +119,7 @@ imports:
   - state
   - types
 - name: github.com/tendermint/tmlibs
-  version: 80029abc6e20f85079cd751e659a05508773288c
+  version: dc2111f0ddc779216e99758660a15ec831135706
   subpackages:
   - cli
   - cli/flags
@@ -133,7 +133,7 @@ imports:
   - pubsub
   - pubsub/query
 - name: golang.org/x/crypto
-  version: edd5e9b0879d13ee6970a50153d85b8fec9f7686
+  version: 1875d0a70c90e57f11972aefd42276df65e895b9
   subpackages:
   - curve25519
   - nacl/box
@@ -144,7 +144,7 @@ imports:
   - ripemd160
   - salsa20/salsa
 - name: golang.org/x/net
-  version: 5ccada7d0a7ba9aeb5d3aca8d3501b4c2a509fec
+  version: 0ed95abb35c445290478a5348a7b38bb154135fd
   subpackages:
   - context
   - http2
@@ -154,14 +154,14 @@ imports:
   - lex/httplex
   - trace
 - name: golang.org/x/text
-  version: c01e4764d870b77f8abe5096ee19ad20d80e8075
+  version: e19ae1496984b1c655b8044a65c0300a3c878dd3
   subpackages:
   - secure/bidirule
   - transform
   - unicode/bidi
   - unicode/norm
 - name: google.golang.org/genproto
-  version: a8101f21cf983e773d0c1133ebc5424792003214
+  version: 4eb30f4778eed4c258ba66527a0d4f9ec8a36c45
   subpackages:
   - googleapis/rpc/status
 - name: google.golang.org/grpc
@@ -185,11 +185,11 @@ imports:
   - transport
 testImports:
 - name: github.com/pmezard/go-difflib
-  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
+  version: 792786c7400a136282c1664665ae0a8db921c6c2
   subpackages:
   - difflib
 - name: github.com/stretchr/testify
-  version: b91bfb9ebec76498946beb6af7c0230c7cc7ba6c
+  version: 87b1dfb5b2fa649f52695dd9eae19abe404a4308
   subpackages:
   - assert
   - require

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,55 +1,44 @@
 package: github.com/cosmos/cosmos-sdk
 import:
+- package: github.com/golang/protobuf
+  version: ^1.0.0
+  subpackages:
+  - proto
 - package: github.com/gorilla/websocket
+  version: ^1.2.0
 - package: github.com/pkg/errors
   version: ^0.8.0
-- package: github.com/spf13/cobra
-- package: github.com/spf13/pflag
-- package: github.com/spf13/viper
+- package: github.com/rigelrozanski/common
 - package: github.com/tendermint/abci
-  version: sdk2
+  version: ^0.9.0
   subpackages:
   - server
   - types
 - package: github.com/tendermint/go-crypto
-  version: sdk2
-  subpackages:
-  - keys
+  version: 45b71f7d11214c35ae63dfb81f42c0da8db9e69e
 - package: github.com/tendermint/go-wire
   version: develop
-  subpackages:
-  - data
-- package: github.com/tendermint/light-client
+- package: github.com/tendermint/iavl
+  version: af6896e646a30733615a9b85364ec73396e5a6a5
+- package: github.com/tendermint/tendermint
   version: develop
   subpackages:
-  - proofs
-  - certifiers
-  - certifiers/client
-  - certifiers/files
-- package: github.com/tendermint/iavl
-  version: sdk2
-- package: github.com/tendermint/tendermint
-  version: sdk2
-  subpackages:
-  - config
-  - node
-  - proxy
-  - rpc/client
   - rpc/core/types
   - rpc/lib/client
   - rpc/lib/types
-  - types
 - package: github.com/tendermint/tmlibs
-  version: sdk2-hashers-and-simple-map
+  version: cbc63518e589d6b0069f9750127fa83dd6ea5ee3
   subpackages:
-  - cli
-  - cli/flags
   - common
-  - events
+  - db
   - log
-  - logger
+  - merkle
+- package: golang.org/x/crypto
+  subpackages:
+  - ripemd160
 testImport:
 - package: github.com/stretchr/testify
+  version: ^1.2.1
   subpackages:
   - assert
   - require

--- a/glide.yaml
+++ b/glide.yaml
@@ -16,7 +16,7 @@ import:
   subpackages:
   - keys
 - package: github.com/tendermint/go-wire
-  version: sdk2
+  version: develop
   subpackages:
   - data
 - package: github.com/tendermint/light-client


### PR DESCRIPTION
Sdk2 branch was deleted and hence glide.yaml was invalid.

Reference: https://github.com/tendermint/go-wire/pull/91