### PR TITLE
Expose NewContext, so I can initialize accounts

### DIFF
--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -298,7 +298,7 @@ func (app *BaseApp) runTx(isCheckTx bool, txBytes []byte, tx sdk.Tx) (result sdk
 	}
 
 	// Construct a Context.
-	var ctx = app.newContext(isCheckTx, txBytes)
+	var ctx = app.NewContext(isCheckTx, txBytes)
 
 	// TODO: override default ante handler w/ custom ante handler.
 

--- a/baseapp/context.go
+++ b/baseapp/context.go
@@ -2,10 +2,10 @@ package baseapp
 
 import sdk "github.com/cosmos/cosmos-sdk/types"
 
-// Returns a new Context suitable for AnteHandler (and indirectly Handler) processing.
+// NewContext returns a new Context suitable for AnteHandler (and indirectly Handler) processing.
 // NOTE: txBytes may be nil to support TestApp.RunCheckTx
 // and TestApp.RunDeliverTx.
-func (app *BaseApp) newContext(isCheckTx bool, txBytes []byte) sdk.Context {
+func (app *BaseApp) NewContext(isCheckTx bool, txBytes []byte) sdk.Context {
 	var store sdk.MultiStore
 	if isCheckTx {
 		store = app.msCheck


### PR DESCRIPTION
While working on testing app logic in https://github.com/tendermint/clearchain/tree/cosmos-sdk
I needed a way to actually set the initial state. As a flexible, yet simple, approach to exposing write access to the database, I wished to expose NewContext to the app constructor, so it may be used in the main function.

Example usage here: https://github.com/tendermint/clearchain/blob/cosmos-sdk/app/app.go#L66-L70

This can be called by test code init, or init from genesis file. A more complex solution may be added, but some general way to access the data store from main is always helpful.