### PR TITLE
types: Context.GetOp should never crash

### DIFF
--- a/types/context.go
+++ b/types/context.go
@@ -238,7 +238,7 @@ func (pst *thePast) getOp(ver int64) (Op, bool) {
 	pst.mtx.RLock()
 	defer pst.mtx.RUnlock()
 	l := int64(len(pst.ops))
-	if l < ver {
+	if l < ver || ver <= 0 {
 		return Op{}, false
 	} else {
 		return pst.ops[ver-1], true

--- a/types/context_test.go
+++ b/types/context_test.go
@@ -1,0 +1,20 @@
+package types_test
+
+import (
+	"testing"
+
+	"github.com/cosmos/cosmos-sdk/types"
+	abci "github.com/tendermint/abci/types"
+)
+
+func TestContextGetOpShouldNeverPanic(t *testing.T) {
+	var ms types.MultiStore
+	ctx := types.NewContext(ms, abci.Header{}, false, nil)
+	indices := []int64{
+		-10, 1, 0, 10, 20,
+	}
+
+	for _, index := range indices {
+		_, _ = ctx.GetOp(index)
+	}
+}


### PR DESCRIPTION
Ensure that requesting version <= 0 doesn't
cause a runtime out of bounds dereference,
with a simple validation and accompanying tests
to ensure we never regress.

Since GetOp allows int64, it is fair game
that it should except out of range inputs,
plus this is an SDK so is bound to be abused
both unintentionally and intentionally.

Fixes #400