### PR TITLE
Add Proper query to BaseApp and rootMultiStore

### DIFF
--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -201,12 +201,12 @@ func (app *BaseApp) InitChain(req abci.RequestInitChain) (res abci.ResponseInitC
 // Implements ABCI.
 // Delegates to CommitMultiStore if it implements Queryable
 func (app *BaseApp) Query(req abci.RequestQuery) (res abci.ResponseQuery) {
-	query, ok := app.cms.(sdk.Queryable)
+	queryable, ok := app.cms.(sdk.Queryable)
 	if !ok {
 		msg := "application doesn't support queries"
 		return sdk.ErrUnknownRequest(msg).Result().ToQuery()
 	}
-	return query.Query(req)
+	return queryable.Query(req)
 }
 
 // Implements ABCI.

--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -199,9 +199,14 @@ func (app *BaseApp) InitChain(req abci.RequestInitChain) (res abci.ResponseInitC
 }
 
 // Implements ABCI.
+// Delegates to CommitMultiStore if it implements Queryable
 func (app *BaseApp) Query(req abci.RequestQuery) (res abci.ResponseQuery) {
-	// TODO: See app/query.go
-	return
+	query, ok := app.cms.(sdk.Queryable)
+	if !ok {
+		msg := "application doesn't support queries"
+		return sdk.ErrUnknownRequest(msg).Result().ToQuery()
+	}
+	return query.Query(req)
 }
 
 // Implements ABCI.

--- a/store/cachemultistore.go
+++ b/store/cachemultistore.go
@@ -72,16 +72,3 @@ func (cms cacheMultiStore) GetStore(key StoreKey) Store {
 func (cms cacheMultiStore) GetKVStore(key StoreKey) KVStore {
 	return cms.stores[key].(KVStore)
 }
-
-// GetStoreByName will first convert the original name to
-// a special key, before looking up the CommitStore.
-// This is not exposed to the extensions (which will need the
-// StoreKey), but is useful in main, and particularly app.Query,
-// in order to convert human strings into CommitStores.
-func (cms cacheMultiStore) GetStoreByName(name string) Store {
-	key := cms.keysByName[name]
-	if key == nil {
-		return nil
-	}
-	return cms.stores[key].(Store)
-}

--- a/store/rootmultistore.go
+++ b/store/rootmultistore.go
@@ -230,7 +230,7 @@ func parsePath(path string) (storeName string, subpath string, err sdk.Error) {
 	paths := strings.SplitN(path[1:], "/", 2)
 	storeName = paths[0]
 	if len(paths) == 2 {
-		subpath = paths[1]
+		subpath = "/" + paths[1]
 	}
 	return
 }

--- a/store/rootmultistore.go
+++ b/store/rootmultistore.go
@@ -176,12 +176,12 @@ func (rs *rootMultiStore) GetKVStore(key StoreKey) KVStore {
 	return rs.stores[key].(KVStore)
 }
 
-// GetStoreByName will first convert the original name to
+// getStoreByName will first convert the original name to
 // a special key, before looking up the CommitStore.
 // This is not exposed to the extensions (which will need the
 // StoreKey), but is useful in main, and particularly app.Query,
 // in order to convert human strings into CommitStores.
-func (rs *rootMultiStore) GetStoreByName(name string) Store {
+func (rs *rootMultiStore) getStoreByName(name string) Store {
 	key := rs.keysByName[name]
 	if key == nil {
 		return nil
@@ -199,7 +199,7 @@ func (rs *rootMultiStore) Query(req abci.RequestQuery) abci.ResponseQuery {
 		return err.Result().ToQuery()
 	}
 
-	store := rs.GetStoreByName(storeName)
+	store := rs.getStoreByName(storeName)
 	if store == nil {
 		msg := fmt.Sprintf("no such store: %s", storeName)
 		return sdk.ErrUnknownRequest(msg).Result().ToQuery()

--- a/store/rootmultistore_test.go
+++ b/store/rootmultistore_test.go
@@ -21,11 +21,11 @@ func TestMultistoreCommitLoad(t *testing.T) {
 	checkStore(t, store, commitID, commitID)
 
 	// make sure we can get stores by name
-	s1 := store.GetStoreByName("store1")
+	s1 := store.getStoreByName("store1")
 	assert.NotNil(t, s1)
-	s3 := store.GetStoreByName("store3")
+	s3 := store.getStoreByName("store3")
 	assert.NotNil(t, s3)
-	s77 := store.GetStoreByName("store77")
+	s77 := store.getStoreByName("store77")
 	assert.Nil(t, s77)
 
 	// make a few commits and check them

--- a/store/rootmultistore_test.go
+++ b/store/rootmultistore_test.go
@@ -20,6 +20,14 @@ func TestMultistoreCommitLoad(t *testing.T) {
 	commitID := CommitID{}
 	checkStore(t, store, commitID, commitID)
 
+	// make sure we can get stores by name
+	s1 := store.GetStoreByName("store1")
+	assert.NotNil(t, s1)
+	s3 := store.GetStoreByName("store3")
+	assert.NotNil(t, s3)
+	s77 := store.GetStoreByName("store77")
+	assert.Nil(t, s77)
+
 	// make a few commits and check them
 	nCommits := int64(3)
 	for i := int64(0); i < nCommits; i++ {
@@ -60,6 +68,27 @@ func TestMultistoreCommitLoad(t *testing.T) {
 	assert.Nil(t, err)
 	commitID = getExpectedCommitID(store, ver+1)
 	checkStore(t, store, commitID, commitID)
+}
+
+func TestParsePath(t *testing.T) {
+	_, _, err := parsePath("foo")
+	assert.Error(t, err)
+
+	store, subpath, err := parsePath("/foo")
+	assert.NoError(t, err)
+	assert.Equal(t, store, "foo")
+	assert.Equal(t, subpath, "")
+
+	store, subpath, err = parsePath("/fizz/bang/baz")
+	assert.NoError(t, err)
+	assert.Equal(t, store, "fizz")
+	assert.Equal(t, subpath, "/bang/baz")
+
+	substore, subsubpath, err := parsePath(subpath)
+	assert.NoError(t, err)
+	assert.Equal(t, substore, "bang")
+	assert.Equal(t, subsubpath, "/baz")
+
 }
 
 //-----------------------------------------------------------------------

--- a/store/types.go
+++ b/store/types.go
@@ -19,3 +19,4 @@ type CacheWrap = types.CacheWrap
 type CommitID = types.CommitID
 type StoreKey = types.StoreKey
 type StoreType = types.StoreType
+type Queryable = types.Queryable

--- a/types/errors.go
+++ b/types/errors.go
@@ -2,8 +2,9 @@ package types
 
 import (
 	"fmt"
-	"github.com/tendermint/go-crypto"
 	"runtime"
+
+	"github.com/tendermint/go-crypto"
 )
 
 type CodeType uint32

--- a/types/result.go
+++ b/types/result.go
@@ -38,3 +38,11 @@ type Result struct {
 func (res Result) IsOK() bool {
 	return res.Code.IsOK()
 }
+
+// ToQuery allows us to return sdk.Error.Result() in query responses
+func (res Result) ToQuery() abci.ResponseQuery {
+	return abci.ResponseQuery{
+		Code: uint32(res.Code),
+		Log:  res.Log,
+	}
+}

--- a/types/store.go
+++ b/types/store.go
@@ -39,6 +39,8 @@ type MultiStore interface {
 	// Convenience for fetching substores.
 	GetStore(StoreKey) Store
 	GetKVStore(StoreKey) KVStore
+
+	GetStoreByName(string) Store
 }
 
 // From MultiStore.CacheMultiStore()....

--- a/types/store.go
+++ b/types/store.go
@@ -48,8 +48,6 @@ type MultiStore interface {
 	// Convenience for fetching substores.
 	GetStore(StoreKey) Store
 	GetKVStore(StoreKey) KVStore
-
-	GetStoreByName(string) Store
 }
 
 // From MultiStore.CacheMultiStore()....

--- a/types/store.go
+++ b/types/store.go
@@ -3,6 +3,7 @@ package types
 import (
 	"fmt"
 
+	abci "github.com/tendermint/abci/types"
 	dbm "github.com/tendermint/tmlibs/db"
 )
 
@@ -23,6 +24,14 @@ type Committer interface {
 type CommitStore interface {
 	Committer
 	Store
+}
+
+// Queryable allows a Store to expose internal state to the abci.Query
+// interface. Multistore can route requests to the proper Store.
+//
+// This is an optional, but useful extension to any CommitStore
+type Queryable interface {
+	Query(abci.RequestQuery) abci.ResponseQuery
 }
 
 //----------------------------------------


### PR DESCRIPTION
Add a Queryable interface, implemented by both rootMultiStore and iavlStore.
Path is assumed to be "/_storename_/_subpath_"

Multistore will look up the store by name, and if it is registered, and implements Queryable,
then it delegates the query to the substore.
iavlStore implements Query as the old sdk did in the application level. Tested it works directly on the iavlStore as expected.