### PR TITLE
Strongly typed transactions in handlers

### DIFF
--- a/examples/dummy/main.go
+++ b/examples/dummy/main.go
@@ -62,9 +62,14 @@ func main() {
 
 func DummyHandler(storeKey sdk.StoreKey) sdk.Handler {
 	return func(ctx sdk.Context, msg sdk.Msg) sdk.Result {
+		dTx, ok := msg.(dummyTx)
+		if !ok {
+			panic("DummyHandler should only receive dummyTx")
+		}
+
 		// tx is already unmarshalled
-		key := msg.Get("key").([]byte)
-		value := msg.Get("value").([]byte)
+		key := dTx.key
+		value := dTx.value
 
 		store := ctx.KVStore(storeKey)
 		store.Set(key, value)

--- a/examples/dummy/tx.go
+++ b/examples/dummy/tx.go
@@ -56,6 +56,8 @@ func (tx dummyTx) GetFeePayer() crypto.Address {
 	return nil
 }
 
+// takes raw transaction bytes and decodes them into an sdk.Tx. An sdk.Tx has
+// all the signatures and can be used to authenticate.
 func decodeTx(txBytes []byte) (sdk.Tx, sdk.Error) {
 	var tx sdk.Tx
 


### PR DESCRIPTION
During transaction processing we retrieve the type of msg and based on
that we get the applicable handler from the router. This means that the
router should only receive messages that it knows how to handle. Instead
of using Get interfaces, we should cast to the actual type of
transaction and then access the transaction details that way.
It's okay to panic here, because if the DummyHandler receives a message
that it cannot cast to the expected type it means something is wrong
with the router. Instead of retrieving an arbitrary key by chance we
should panic.