### PR TITLE
ABCI app has a unique AnteHandler

### DIFF
--- a/baseapp/baseapp_test.go
+++ b/baseapp/baseapp_test.go
@@ -44,7 +44,7 @@ func TestBasic(t *testing.T) {
 		return ttx, nil
 	})
 
-	app.SetDefaultAnteHandler(func(ctx sdk.Context, tx sdk.Tx) (newCtx sdk.Context, res sdk.Result, abort bool) { return })
+	app.SetAnteHandler(func(ctx sdk.Context, tx sdk.Tx) (newCtx sdk.Context, res sdk.Result, abort bool) { return })
 	app.Router().AddRoute(msgType, func(ctx sdk.Context, msg sdk.Msg) sdk.Result {
 		// TODO
 		return sdk.Result{}

--- a/examples/basecoin/app/init_handlers.go
+++ b/examples/basecoin/app/init_handlers.go
@@ -17,7 +17,7 @@ func (app *BasecoinApp) initDefaultAnteHandler() {
 	// Deducts fee from payer.
 	// Verifies signatures and nonces.
 	// Sets Signers to ctx.
-	app.BaseApp.SetDefaultAnteHandler(
+	app.BaseApp.SetAnteHandler(
 		auth.NewAnteHandler(app.accountMapper))
 }
 

--- a/examples/dummy/tx.go
+++ b/examples/dummy/tx.go
@@ -3,8 +3,9 @@ package main
 import (
 	"bytes"
 
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	crypto "github.com/tendermint/go-crypto"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 // An sdk.Tx which is its own sdk.Msg.

--- a/types/handler.go
+++ b/types/handler.go
@@ -2,5 +2,8 @@ package types
 
 type Handler func(ctx Context, msg Msg) Result
 
+// AnteHandler is an action that is run no matter whether the transaction
+// succeeds or fails. It should check and do things that are applicable to all
+// transactions. An Ethereum example is to deduct the fees.
 // If newCtx.IsZero(), ctx is used instead.
 type AnteHandler func(ctx Context, tx Tx) (newCtx Context, result Result, abort bool)


### PR DESCRIPTION
Should there be multiple ante handlers per application or is an AnteHandler something that applies to the whole application. If we want multiple AnteHandlers we should reuse the router functionality for it.

My personal take so far is that there should only to be one AnteHandler that applies to the entire
application. 

Also, contains some random formatting changes from reading the code.

ref #377 