### PR TITLE
MERGE: makefile: dont use sub vendor deps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,6 @@ gaia:
 
 build:
 	@rm -rf examples/basecoin/vendor/
-	cd examples/basecoin && $(MAKE) get_vendor_deps
 	go build $(BUILD_FLAGS) -o build/basecoind ./examples/basecoin/cmd/basecoind/...
 
 dist:


### PR DESCRIPTION
The whole point of things being in one repo is that we dont have to do a zillion glide updates.

So I am going to strongly advocate in favour of just using the top-level vendor dir for all testing and so in the SDK.

Otherwise, every time we break the SDK API, we have to perform glide magic in the examples dir. Madness!