### PR TITLE
Change to go-wire UnmarshalJSON for bank transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Pending
+
+BREAKING CHANGES
+
+FEATURES
+
+IMPROVEMENTS
+* bank module uses go-wire codec instead of 'encoding/json'
+
+FIXES
+
 ## 0.11.0 (March 1, 2017)
 
 BREAKING CHANGES

--- a/x/bank/tx.go
+++ b/x/bank/tx.go
@@ -1,7 +1,6 @@
 package bank
 
 import (
-	"encoding/json"
 	"fmt"
 
 	crypto "github.com/tendermint/go-crypto"
@@ -65,7 +64,8 @@ func (msg SendMsg) Get(key interface{}) (value interface{}) {
 
 // Implements Msg.
 func (msg SendMsg) GetSignBytes() []byte {
-	b, err := json.Marshal(msg) // XXX: ensure some canonical form
+	cdc := getCodec()
+	b, err := cdc.MarshalJSON(msg) // XXX: ensure some canonical form
 	if err != nil {
 		panic(err)
 	}
@@ -123,7 +123,8 @@ func (msg IssueMsg) Get(key interface{}) (value interface{}) {
 
 // Implements Msg.
 func (msg IssueMsg) GetSignBytes() []byte {
-	b, err := json.Marshal(msg) // XXX: ensure some canonical form
+	cdc := getCodec()
+	b, err := cdc.MarshalJSON(msg) // XXX: ensure some canonical form
 	if err != nil {
 		panic(err)
 	}

--- a/x/bank/tx_test.go
+++ b/x/bank/tx_test.go
@@ -248,8 +248,14 @@ func TestSendMsgGetSignBytes(t *testing.T) {
 		},
 	}
 	res := msg.GetSignBytes()
+
+	cdc := getCodec()
+	unmarshaledMsg := &SendMsg{}
+	cdc.UnmarshalJSON(res, unmarshaledMsg)
+
+	assert.Equal(t, &msg, unmarshaledMsg)
 	// TODO bad results
-	assert.Equal(t, string(res), `{"inputs":[{"address":"696E707574","coins":[{"denom":"atom","amount":10}],"sequence":1}],"outputs":[{"address":"6F7574707574","coins":[{"denom":"atom","amount":10}]}]}`)
+	assert.Equal(t, string(res), `{"_df":"3CAAA78D13BAE4","_v":{"inputs":[{"address":"696E707574","coins":[{"denom":"atom","amount":10}],"sequence":1}],"outputs":[{"address":"6F7574707574","coins":[{"denom":"atom","amount":10}]}]}}`)
 }
 
 func TestSendMsgGetSigners(t *testing.T) {
@@ -357,8 +363,15 @@ func TestIssueMsgGetSignBytes(t *testing.T) {
 		},
 	}
 	res := msg.GetSignBytes()
+
+	cdc := getCodec()
+	unmarshaledMsg := &IssueMsg{}
+	cdc.UnmarshalJSON(res, unmarshaledMsg)
+
+	assert.Equal(t, &msg, unmarshaledMsg)
+
 	// TODO bad results
-	assert.Equal(t, string(res), `{"banker":"696E707574","outputs":[{"address":"6C6F616E2D66726F6D2D62616E6B","coins":[{"denom":"atom","amount":10}]}]}`)
+	assert.Equal(t, string(res), `{"_df":"B5D562E578B450","_v":{"banker":"696E707574","outputs":[{"address":"6C6F616E2D66726F6D2D62616E6B","coins":[{"denom":"atom","amount":10}]}]}}`)
 }
 
 func TestIssueMsgGetSigners(t *testing.T) {

--- a/x/bank/wire.go
+++ b/x/bank/wire.go
@@ -9,3 +9,9 @@ func RegisterWire(cdc *wire.Codec) {
 	cdc.RegisterConcrete(SendMsg{}, "cosmos-sdk/SendMsg", nil)
 	cdc.RegisterConcrete(IssueMsg{}, "cosmos-sdk/IssueMsg", nil)
 }
+
+func getCodec() *wire.Codec {
+	cdc := wire.NewCodec()
+	RegisterWire(cdc)
+	return cdc
+}


### PR DESCRIPTION
The bank module now uses it's own codec to encode and decode Bank Msgs
into JSON.