### PR TITLE
crypto.Address -> sdk.Address

### DIFF
--- a/baseapp/baseapp_test.go
+++ b/baseapp/baseapp_test.go
@@ -327,8 +327,8 @@ func (tx testUpdatePowerTx) Get(key interface{}) (value interface{}) { return ni
 func (tx testUpdatePowerTx) GetMsg() sdk.Msg                         { return tx }
 func (tx testUpdatePowerTx) GetSignBytes() []byte                    { return nil }
 func (tx testUpdatePowerTx) ValidateBasic() sdk.Error                { return nil }
-func (tx testUpdatePowerTx) GetSigners() []crypto.Address            { return nil }
-func (tx testUpdatePowerTx) GetFeePayer() crypto.Address             { return nil }
+func (tx testUpdatePowerTx) GetSigners() []sdk.Address            { return nil }
+func (tx testUpdatePowerTx) GetFeePayer() sdk.Address             { return nil }
 func (tx testUpdatePowerTx) GetSignatures() []sdk.StdSignature       { return nil }
 
 func TestValidatorChange(t *testing.T) {

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -42,7 +42,7 @@ type Msg interface {
 	// Signers returns the addrs of signers that must sign.
 	// CONTRACT: All signatures must be present to be valid.
 	// CONTRACT: Returns addrs in some deterministic order.
-	GetSigners() []crypto.Address
+	GetSigners() []Address
 }
 
 ```
@@ -75,7 +75,7 @@ type SendMsg struct {
 }
 
 type IssueMsg struct {
-	Banker  crypto.Address `json:"banker"`
+	Banker  sdk.Address `json:"banker"`
 	Outputs []Output       `json:"outputs"`
 }
 ```
@@ -83,16 +83,16 @@ type IssueMsg struct {
 Each specifies the addresses that must sign the message:
 
 ```golang
-func (msg SendMsg) GetSigners() []crypto.Address {
-	addrs := make([]crypto.Address, len(msg.Inputs))
+func (msg SendMsg) GetSigners() []sdk.Address {
+	addrs := make([]sdk.Address, len(msg.Inputs))
 	for i, in := range msg.Inputs {
 		addrs[i] = in.Address
 	}
 	return addrs
 }
 
-func (msg IssueMsg) GetSigners() []crypto.Address {
-	return []crypto.Address{msg.Banker}
+func (msg IssueMsg) GetSigners() []sdk.Address {
+	return []sdk.Address{msg.Banker}
 }
 ```
 
@@ -107,7 +107,7 @@ type Tx interface {
 
 	// The address that pays the base fee for this message.  The fee is
 	// deducted before the Msg is processed.
-	GetFeePayer() crypto.Address
+	GetFeePayer() Address
 
 	// Get the canonical byte representation of the Tx.
 	// Includes any signatures (or empty slots).

--- a/docs/sdk/overview.rst
+++ b/docs/sdk/overview.rst
@@ -156,7 +156,7 @@ implementing the ``Msg`` interface:
     	// Signers returns the addrs of signers that must sign.
     	// CONTRACT: All signatures must be present to be valid.
     	// CONTRACT: Returns addrs in some deterministic order.
-    	GetSigners() []crypto.Address
+    	GetSigners() []Address
     }
 
 Messages must specify their type via the ``Type()`` method. The type should
@@ -188,7 +188,7 @@ For instance, the ``Basecoin`` message types are defined in ``x/bank/tx.go``:
     }
     
     type IssueMsg struct {
-    	Banker  crypto.Address `json:"banker"`
+    	Banker  sdk.Address `json:"banker"`
     	Outputs []Output       `json:"outputs"`
     }
 
@@ -196,16 +196,16 @@ Each specifies the addresses that must sign the message:
 
 ::
 
-    func (msg SendMsg) GetSigners() []crypto.Address {
-    	addrs := make([]crypto.Address, len(msg.Inputs))
+    func (msg SendMsg) GetSigners() []sdk.Address {
+    	addrs := make([]sdk.Address, len(msg.Inputs))
     	for i, in := range msg.Inputs {
     		addrs[i] = in.Address
     	}
     	return addrs
     }
     
-    func (msg IssueMsg) GetSigners() []crypto.Address {
-    	return []crypto.Address{msg.Banker}
+    func (msg IssueMsg) GetSigners() []sdk.Address {
+    	return []sdk.Address{msg.Banker}
     }
 
 Transactions
@@ -221,7 +221,7 @@ A transaction is a message with additional information for authentication:
     
     	// The address that pays the base fee for this message.  The fee is
     	// deducted before the Msg is processed.
-    	GetFeePayer() crypto.Address
+    	GetFeePayer() Address
     
     	// Get the canonical byte representation of the Tx.
     	// Includes any signatures (or empty slots).

--- a/examples/basecoin/app/app_test.go
+++ b/examples/basecoin/app/app_test.go
@@ -33,14 +33,14 @@ func TestSendMsg(t *testing.T) {
 	var msg = bank.SendMsg{
 		Inputs: []bank.Input{
 			{
-				Address:  crypto.Address([]byte("input")),
+				Address:  sdk.Address([]byte("input")),
 				Coins:    sdk.Coins{{"atom", 10}},
 				Sequence: 1,
 			},
 		},
 		Outputs: []bank.Output{
 			{
-				Address: crypto.Address([]byte("output")),
+				Address: sdk.Address([]byte("output")),
 				Coins:   sdk.Coins{{"atom", 10}},
 			},
 		},
@@ -155,14 +155,14 @@ func TestSendMsgWithAccounts(t *testing.T) {
 	var msg = bank.SendMsg{
 		Inputs: []bank.Input{
 			{
-				Address:  crypto.Address(addr1),
+				Address:  sdk.Address(addr1),
 				Coins:    sdk.Coins{{"foocoin", 10}},
 				Sequence: 1,
 			},
 		},
 		Outputs: []bank.Output{
 			{
-				Address: crypto.Address(addr2),
+				Address: sdk.Address(addr2),
 				Coins:   sdk.Coins{{"foocoin", 10}},
 			},
 		},

--- a/examples/basecoin/types/account.go
+++ b/examples/basecoin/types/account.go
@@ -3,7 +3,6 @@ package types
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/auth"
-	crypto "github.com/tendermint/go-crypto"
 	wire "github.com/tendermint/go-wire"
 )
 
@@ -41,9 +40,9 @@ type GenesisState struct {
 
 // GenesisAccount doesn't need pubkey or sequence
 type GenesisAccount struct {
-	Name    string         `json:"name"`
-	Address crypto.Address `json:"address"`
-	Coins   sdk.Coins      `json:"coins"`
+	Name    string      `json:"name"`
+	Address sdk.Address `json:"address"`
+	Coins   sdk.Coins   `json:"coins"`
 }
 
 func NewGenesisAccount(aa *AppAccount) *GenesisAccount {

--- a/examples/kvstore/tx.go
+++ b/examples/kvstore/tx.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	crypto "github.com/tendermint/go-crypto"
 )
 
 // An sdk.Tx which is its own sdk.Msg.
@@ -44,7 +43,7 @@ func (tx kvstoreTx) ValidateBasic() sdk.Error {
 	return nil
 }
 
-func (tx kvstoreTx) GetSigners() []crypto.Address {
+func (tx kvstoreTx) GetSigners() []sdk.Address {
 	return nil
 }
 
@@ -52,7 +51,7 @@ func (tx kvstoreTx) GetSignatures() []sdk.StdSignature {
 	return nil
 }
 
-func (tx kvstoreTx) GetFeePayer() crypto.Address {
+func (tx kvstoreTx) GetFeePayer() sdk.Address {
 	return nil
 }
 

--- a/mock/tx.go
+++ b/mock/tx.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	crypto "github.com/tendermint/go-crypto"
 )
 
 // An sdk.Tx which is its own sdk.Msg.
@@ -57,7 +56,7 @@ func (tx kvstoreTx) ValidateBasic() sdk.Error {
 	return nil
 }
 
-func (tx kvstoreTx) GetSigners() []crypto.Address {
+func (tx kvstoreTx) GetSigners() []sdk.Address {
 	return nil
 }
 
@@ -65,7 +64,7 @@ func (tx kvstoreTx) GetSignatures() []sdk.StdSignature {
 	return nil
 }
 
-func (tx kvstoreTx) GetFeePayer() crypto.Address {
+func (tx kvstoreTx) GetFeePayer() sdk.Address {
 	return nil
 }
 

--- a/server/init.go
+++ b/server/init.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	crypto "github.com/tendermint/go-crypto"
 	"github.com/tendermint/go-crypto/keys"
 	"github.com/tendermint/go-crypto/keys/words"
 	cmn "github.com/tendermint/tmlibs/common"
@@ -17,6 +16,8 @@ import (
 	tcmd "github.com/tendermint/tendermint/cmd/tendermint/commands"
 	cfg "github.com/tendermint/tendermint/config"
 	tmtypes "github.com/tendermint/tendermint/types"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 // InitCmd will initialize all files for tendermint,
@@ -45,7 +46,7 @@ type GenOptions func(args []string) (json.RawMessage, error)
 // along with the secret phrase to recover the private key.
 // You can give coins to this address and return the recovery
 // phrase to the user to access them.
-func GenerateCoinKey() (crypto.Address, string, error) {
+func GenerateCoinKey() (sdk.Address, string, error) {
 	// construct an in-memory key store
 	codec, err := words.LoadCodec("english")
 	if err != nil {

--- a/types/account.go
+++ b/types/account.go
@@ -2,13 +2,16 @@ package types
 
 import (
 	crypto "github.com/tendermint/go-crypto"
+	cmn "github.com/tendermint/tmlibs/common"
 )
+
+type Address = cmn.HexBytes
 
 // Account is a standard account using a sequence number for replay protection
 // and a pubkey for authentication.
 type Account interface {
-	GetAddress() crypto.Address
-	SetAddress(crypto.Address) error // errors if already set.
+	GetAddress() Address
+	SetAddress(Address) error // errors if already set.
 
 	GetPubKey() crypto.PubKey // can return nil.
 	SetPubKey(crypto.PubKey) error
@@ -26,8 +29,8 @@ type Account interface {
 // AccountMapper stores and retrieves accounts from stores
 // retrieved from the context.
 type AccountMapper interface {
-	NewAccountWithAddress(ctx Context, addr crypto.Address) Account
-	GetAccount(ctx Context, addr crypto.Address) Account
+	NewAccountWithAddress(ctx Context, addr Address) Account
+	GetAccount(ctx Context, addr Address) Account
 	SetAccount(ctx Context, acc Account)
 }
 

--- a/types/errors.go
+++ b/types/errors.go
@@ -3,8 +3,6 @@ package types
 import (
 	"fmt"
 	"runtime"
-
-	"github.com/tendermint/go-crypto"
 )
 
 // ABCI Response Code
@@ -86,7 +84,7 @@ func ErrInsufficientFunds(msg string) Error {
 func ErrUnknownRequest(msg string) Error {
 	return newError(CodeUnknownRequest, msg)
 }
-func ErrUnrecognizedAddress(addr crypto.Address) Error {
+func ErrUnrecognizedAddress(addr Address) Error {
 	return newError(CodeUnrecognizedAddress, addr.String())
 }
 func ErrInvalidSequence(msg string) Error {

--- a/types/tx_msg.go
+++ b/types/tx_msg.go
@@ -1,9 +1,5 @@
 package types
 
-import (
-	crypto "github.com/tendermint/go-crypto"
-)
-
 // Transactions messages must fulfill the Msg
 type Msg interface {
 
@@ -24,7 +20,7 @@ type Msg interface {
 	// Signers returns the addrs of signers that must sign.
 	// CONTRACT: All signatures must be present to be valid.
 	// CONTRACT: Returns addrs in some deterministic order.
-	GetSigners() []crypto.Address
+	GetSigners() []Address
 }
 
 // Transactions objects must fulfill the Tx
@@ -35,7 +31,7 @@ type Tx interface {
 
 	// The address that pays the base fee for this message.  The fee is
 	// deducted before the Msg is processed.
-	GetFeePayer() crypto.Address
+	GetFeePayer() Address
 
 	// Signatures returns the signature of signers who signed the Msg.
 	// CONTRACT: Length returned is same as length of
@@ -65,7 +61,7 @@ func NewStdTx(msg Msg, sigs []StdSignature) StdTx {
 
 //nolint
 func (tx StdTx) GetMsg() Msg                   { return tx.Msg }
-func (tx StdTx) GetFeePayer() crypto.Address   { return tx.Signatures[0].PubKey.Address() } // XXX but PubKey is optional!
+func (tx StdTx) GetFeePayer() Address          { return tx.Signatures[0].PubKey.Address() } // XXX but PubKey is optional!
 func (tx StdTx) GetSignatures() []StdSignature { return tx.Signatures }
 
 //-------------------------------------

--- a/x/auth/baseaccount.go
+++ b/x/auth/baseaccount.go
@@ -17,13 +17,13 @@ var _ sdk.Account = (*BaseAccount)(nil)
 // Extend this by embedding this in your AppAccount.
 // See the examples/basecoin/types/account.go for an example.
 type BaseAccount struct {
-	Address  crypto.Address `json:"address"`
+	Address  sdk.Address `json:"address"`
 	Coins    sdk.Coins      `json:"coins"`
 	PubKey   crypto.PubKey  `json:"public_key"`
 	Sequence int64          `json:"sequence"`
 }
 
-func NewBaseAccountWithAddress(addr crypto.Address) BaseAccount {
+func NewBaseAccountWithAddress(addr sdk.Address) BaseAccount {
 	return BaseAccount{
 		Address: addr,
 	}
@@ -40,12 +40,12 @@ func (acc *BaseAccount) Set(key interface{}, value interface{}) error {
 }
 
 // Implements sdk.Account.
-func (acc BaseAccount) GetAddress() crypto.Address {
+func (acc BaseAccount) GetAddress() sdk.Address {
 	return acc.Address
 }
 
 // Implements sdk.Account.
-func (acc *BaseAccount) SetAddress(addr crypto.Address) error {
+func (acc *BaseAccount) SetAddress(addr sdk.Address) error {
 	if len(acc.Address) != 0 {
 		return errors.New("cannot override BaseAccount address")
 	}

--- a/x/auth/commands/account.go
+++ b/x/auth/commands/account.go
@@ -8,7 +8,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
-	crypto "github.com/tendermint/go-crypto"
 	wire "github.com/tendermint/go-wire"
 
 	"github.com/cosmos/cosmos-sdk/client"
@@ -61,7 +60,7 @@ func (c commander) getAccountCmd(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	key := crypto.Address(bz)
+	key := sdk.Address(bz)
 
 	res, err := client.Query(key, c.storeName)
 

--- a/x/auth/mapper.go
+++ b/x/auth/mapper.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"reflect"
 
-	crypto "github.com/tendermint/go-crypto"
 	wire "github.com/tendermint/go-wire"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -66,14 +65,14 @@ func (am accountMapper) Seal() sealedAccountMapper {
 }
 
 // Implements sdk.AccountMapper.
-func (am accountMapper) NewAccountWithAddress(ctx sdk.Context, addr crypto.Address) sdk.Account {
+func (am accountMapper) NewAccountWithAddress(ctx sdk.Context, addr sdk.Address) sdk.Account {
 	acc := am.clonePrototype()
 	acc.SetAddress(addr)
 	return acc
 }
 
 // Implements sdk.AccountMapper.
-func (am accountMapper) GetAccount(ctx sdk.Context, addr crypto.Address) sdk.Account {
+func (am accountMapper) GetAccount(ctx sdk.Context, addr sdk.Address) sdk.Account {
 	store := ctx.KVStore(am.key)
 	bz := store.Get(addr)
 	if bz == nil {

--- a/x/bank/commands/sendtx.go
+++ b/x/bank/commands/sendtx.go
@@ -8,7 +8,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	crypto "github.com/tendermint/go-crypto"
 	wire "github.com/tendermint/go-wire"
 
 	"github.com/cosmos/cosmos-sdk/client"
@@ -105,7 +104,7 @@ func (c commander) buildTx() ([]byte, error) {
 	return txBytes, nil
 }
 
-func buildMsg(from crypto.Address) (sdk.Msg, error) {
+func buildMsg(from sdk.Address) (sdk.Msg, error) {
 
 	// parse coins
 	amount := viper.GetString(flagAmount)
@@ -120,7 +119,7 @@ func buildMsg(from crypto.Address) (sdk.Msg, error) {
 	if err != nil {
 		return nil, err
 	}
-	to := crypto.Address(bz)
+	to := sdk.Address(bz)
 
 	input := bank.NewInput(from, coins)
 	output := bank.NewOutput(to, coins)

--- a/x/bank/mapper.go
+++ b/x/bank/mapper.go
@@ -3,8 +3,6 @@ package bank
 import (
 	"fmt"
 
-	crypto "github.com/tendermint/go-crypto"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -19,7 +17,7 @@ func NewCoinKeeper(am sdk.AccountMapper) CoinKeeper {
 }
 
 // SubtractCoins subtracts amt from the coins at the addr.
-func (ck CoinKeeper) SubtractCoins(ctx sdk.Context, addr crypto.Address, amt sdk.Coins) (sdk.Coins, sdk.Error) {
+func (ck CoinKeeper) SubtractCoins(ctx sdk.Context, addr sdk.Address, amt sdk.Coins) (sdk.Coins, sdk.Error) {
 	acc := ck.am.GetAccount(ctx, addr)
 	if acc == nil {
 		return amt, sdk.ErrUnrecognizedAddress(addr)
@@ -37,7 +35,7 @@ func (ck CoinKeeper) SubtractCoins(ctx sdk.Context, addr crypto.Address, amt sdk
 }
 
 // AddCoins adds amt to the coins at the addr.
-func (ck CoinKeeper) AddCoins(ctx sdk.Context, addr crypto.Address, amt sdk.Coins) (sdk.Coins, sdk.Error) {
+func (ck CoinKeeper) AddCoins(ctx sdk.Context, addr sdk.Address, amt sdk.Coins) (sdk.Coins, sdk.Error) {
 	acc := ck.am.GetAccount(ctx, addr)
 	if acc == nil {
 		acc = ck.am.NewAccountWithAddress(ctx, addr)

--- a/x/bank/tx.go
+++ b/x/bank/tx.go
@@ -73,8 +73,8 @@ func (msg SendMsg) GetSignBytes() []byte {
 }
 
 // Implements Msg.
-func (msg SendMsg) GetSigners() []crypto.Address {
-	addrs := make([]crypto.Address, len(msg.Inputs))
+func (msg SendMsg) GetSigners() []sdk.Address {
+	addrs := make([]sdk.Address, len(msg.Inputs))
 	for i, in := range msg.Inputs {
 		addrs[i] = in.Address
 	}
@@ -86,12 +86,12 @@ func (msg SendMsg) GetSigners() []crypto.Address {
 
 // IssueMsg - high level transaction of the coin module
 type IssueMsg struct {
-	Banker  crypto.Address `json:"banker"`
+	Banker  sdk.Address `json:"banker"`
 	Outputs []Output       `json:"outputs"`
 }
 
 // NewIssueMsg - construct arbitrary multi-in, multi-out send msg.
-func NewIssueMsg(banker crypto.Address, out []Output) IssueMsg {
+func NewIssueMsg(banker sdk.Address, out []Output) IssueMsg {
 	return IssueMsg{Banker: banker, Outputs: out}
 }
 
@@ -131,15 +131,15 @@ func (msg IssueMsg) GetSignBytes() []byte {
 }
 
 // Implements Msg.
-func (msg IssueMsg) GetSigners() []crypto.Address {
-	return []crypto.Address{msg.Banker}
+func (msg IssueMsg) GetSigners() []sdk.Address {
+	return []sdk.Address{msg.Banker}
 }
 
 //----------------------------------------
 // Input
 
 type Input struct {
-	Address  crypto.Address `json:"address"`
+	Address  sdk.Address `json:"address"`
 	Coins    sdk.Coins      `json:"coins"`
 	Sequence int64          `json:"sequence"`
 
@@ -168,7 +168,7 @@ func (in Input) String() string {
 }
 
 // NewInput - create a transaction input, used with SendMsg
-func NewInput(addr crypto.Address, coins sdk.Coins) Input {
+func NewInput(addr sdk.Address, coins sdk.Coins) Input {
 	input := Input{
 		Address: addr,
 		Coins:   coins,
@@ -177,7 +177,7 @@ func NewInput(addr crypto.Address, coins sdk.Coins) Input {
 }
 
 // NewInputWithSequence - create a transaction input, used with SendMsg
-func NewInputWithSequence(addr crypto.Address, coins sdk.Coins, seq int64) Input {
+func NewInputWithSequence(addr sdk.Address, coins sdk.Coins, seq int64) Input {
 	input := NewInput(addr, coins)
 	input.Sequence = seq
 	return input
@@ -187,7 +187,7 @@ func NewInputWithSequence(addr crypto.Address, coins sdk.Coins, seq int64) Input
 // Output
 
 type Output struct {
-	Address crypto.Address `json:"address"`
+	Address sdk.Address `json:"address"`
 	Coins   sdk.Coins      `json:"coins"`
 }
 
@@ -210,7 +210,7 @@ func (out Output) String() string {
 }
 
 // NewOutput - create a transaction output, used with SendMsg
-func NewOutput(addr crypto.Address, coins sdk.Coins) Output {
+func NewOutput(addr sdk.Address, coins sdk.Coins) Output {
 	output := Output{
 		Address: addr,
 		Coins:   coins,

--- a/x/bank/tx_test.go
+++ b/x/bank/tx_test.go
@@ -6,8 +6,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	crypto "github.com/tendermint/go-crypto"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -18,14 +16,14 @@ func TestSendMsgType(t *testing.T) {
 	var msg = SendMsg{
 		Inputs: []Input{
 			{
-				Address:  crypto.Address([]byte("input")),
+				Address:  sdk.Address([]byte("input")),
 				Coins:    sdk.Coins{{"atom", 10}},
 				Sequence: 1,
 			},
 		},
 		Outputs: []Output{
 			{
-				Address: crypto.Address([]byte("output")),
+				Address: sdk.Address([]byte("output")),
 				Coins:   sdk.Coins{{"atom", 10}},
 			},
 		},
@@ -36,12 +34,12 @@ func TestSendMsgType(t *testing.T) {
 }
 
 func TestInputValidation(t *testing.T) {
-	addr1 := crypto.Address([]byte{1, 2})
-	addr2 := crypto.Address([]byte{7, 8})
+	addr1 := sdk.Address([]byte{1, 2})
+	addr2 := sdk.Address([]byte{7, 8})
 	someCoins := sdk.Coins{{"atom", 123}}
 	multiCoins := sdk.Coins{{"atom", 123}, {"eth", 20}}
 
-	var emptyAddr crypto.Address
+	var emptyAddr sdk.Address
 	emptyCoins := sdk.Coins{}
 	emptyCoins2 := sdk.Coins{{"eth", 0}}
 	someEmptyCoins := sdk.Coins{{"eth", 10}, {"atom", 0}}
@@ -80,12 +78,12 @@ func TestInputValidation(t *testing.T) {
 }
 
 func TestOutputValidation(t *testing.T) {
-	addr1 := crypto.Address([]byte{1, 2})
-	addr2 := crypto.Address([]byte{7, 8})
+	addr1 := sdk.Address([]byte{1, 2})
+	addr2 := sdk.Address([]byte{7, 8})
 	someCoins := sdk.Coins{{"atom", 123}}
 	multiCoins := sdk.Coins{{"atom", 123}, {"eth", 20}}
 
-	var emptyAddr crypto.Address
+	var emptyAddr sdk.Address
 	emptyCoins := sdk.Coins{}
 	emptyCoins2 := sdk.Coins{{"eth", 0}}
 	someEmptyCoins := sdk.Coins{{"eth", 10}, {"atom", 0}}
@@ -122,8 +120,8 @@ func TestOutputValidation(t *testing.T) {
 }
 
 func TestSendMsgValidation(t *testing.T) {
-	addr1 := crypto.Address([]byte{1, 2})
-	addr2 := crypto.Address([]byte{7, 8})
+	addr1 := sdk.Address([]byte{1, 2})
+	addr2 := sdk.Address([]byte{7, 8})
 	atom123 := sdk.Coins{{"atom", 123}}
 	atom124 := sdk.Coins{{"atom", 124}}
 	eth123 := sdk.Coins{{"eth", 123}}
@@ -136,7 +134,7 @@ func TestSendMsgValidation(t *testing.T) {
 	output3 := NewOutput(addr2, eth123)
 	outputMulti := NewOutput(addr2, atom123eth123)
 
-	var emptyAddr crypto.Address
+	var emptyAddr sdk.Address
 
 	cases := []struct {
 		valid bool
@@ -194,14 +192,14 @@ func TestSendMsgString(t *testing.T) {
 	var msg = SendMsg{
 		Inputs: []Input{
 			{
-				Address:  crypto.Address([]byte("input")),
+				Address:  sdk.Address([]byte("input")),
 				Coins:    sdk.Coins{{"atom", 10}},
 				Sequence: 1,
 			},
 		},
 		Outputs: []Output{
 			{
-				Address: crypto.Address([]byte("output")),
+				Address: sdk.Address([]byte("output")),
 				Coins:   sdk.Coins{{"atom", 10}},
 			},
 		},
@@ -215,14 +213,14 @@ func TestSendMsgGet(t *testing.T) {
 	var msg = SendMsg{
 		Inputs: []Input{
 			{
-				Address:  crypto.Address([]byte("input")),
+				Address:  sdk.Address([]byte("input")),
 				Coins:    sdk.Coins{{"atom", 10}},
 				Sequence: 1,
 			},
 		},
 		Outputs: []Output{
 			{
-				Address: crypto.Address([]byte("output")),
+				Address: sdk.Address([]byte("output")),
 				Coins:   sdk.Coins{{"atom", 10}},
 			},
 		},
@@ -235,14 +233,14 @@ func TestSendMsgGetSignBytes(t *testing.T) {
 	var msg = SendMsg{
 		Inputs: []Input{
 			{
-				Address:  crypto.Address([]byte("input")),
+				Address:  sdk.Address([]byte("input")),
 				Coins:    sdk.Coins{{"atom", 10}},
 				Sequence: 1,
 			},
 		},
 		Outputs: []Output{
 			{
-				Address: crypto.Address([]byte("output")),
+				Address: sdk.Address([]byte("output")),
 				Coins:   sdk.Coins{{"atom", 10}},
 			},
 		},
@@ -256,13 +254,13 @@ func TestSendMsgGetSigners(t *testing.T) {
 	var msg = SendMsg{
 		Inputs: []Input{
 			{
-				Address: crypto.Address([]byte("input1")),
+				Address: sdk.Address([]byte("input1")),
 			},
 			{
-				Address: crypto.Address([]byte("input2")),
+				Address: sdk.Address([]byte("input2")),
 			},
 			{
-				Address: crypto.Address([]byte("input3")),
+				Address: sdk.Address([]byte("input3")),
 			},
 		},
 	}
@@ -273,7 +271,7 @@ func TestSendMsgGetSigners(t *testing.T) {
 /*
 // what to do w/ this test?
 func TestSendMsgSigners(t *testing.T) {
-	signers := []crypto.Address{
+	signers := []sdk.Address{
 		{1, 2, 3},
 		{4, 5, 6},
 		{7, 8, 9},
@@ -300,10 +298,10 @@ func TestNewIssueMsg(t *testing.T) {
 func TestIssueMsgType(t *testing.T) {
 	// Construct an IssueMsg
 	var msg = IssueMsg{
-		Banker: crypto.Address([]byte("input")),
+		Banker: sdk.Address([]byte("input")),
 		Outputs: []Output{
 			{
-				Address: crypto.Address([]byte("loan-from-bank")),
+				Address: sdk.Address([]byte("loan-from-bank")),
 				Coins:   sdk.Coins{{"atom", 10}},
 			},
 		},
@@ -320,10 +318,10 @@ func TestIssueMsgValidation(t *testing.T) {
 func TestIssueMsgString(t *testing.T) {
 	// Construct a IssueMsg
 	var msg = IssueMsg{
-		Banker: crypto.Address([]byte("input")),
+		Banker: sdk.Address([]byte("input")),
 		Outputs: []Output{
 			{
-				Address: crypto.Address([]byte("loan-from-bank")),
+				Address: sdk.Address([]byte("loan-from-bank")),
 				Coins:   sdk.Coins{{"atom", 10}},
 			},
 		},
@@ -334,10 +332,10 @@ func TestIssueMsgString(t *testing.T) {
 
 func TestIssueMsgGet(t *testing.T) {
 	var msg = IssueMsg{
-		Banker: crypto.Address([]byte("input")),
+		Banker: sdk.Address([]byte("input")),
 		Outputs: []Output{
 			{
-				Address: crypto.Address([]byte("loan-from-bank")),
+				Address: sdk.Address([]byte("loan-from-bank")),
 				Coins:   sdk.Coins{{"atom", 10}},
 			},
 		},
@@ -348,10 +346,10 @@ func TestIssueMsgGet(t *testing.T) {
 
 func TestIssueMsgGetSignBytes(t *testing.T) {
 	var msg = IssueMsg{
-		Banker: crypto.Address([]byte("input")),
+		Banker: sdk.Address([]byte("input")),
 		Outputs: []Output{
 			{
-				Address: crypto.Address([]byte("loan-from-bank")),
+				Address: sdk.Address([]byte("loan-from-bank")),
 				Coins:   sdk.Coins{{"atom", 10}},
 			},
 		},
@@ -363,7 +361,7 @@ func TestIssueMsgGetSignBytes(t *testing.T) {
 
 func TestIssueMsgGetSigners(t *testing.T) {
 	var msg = IssueMsg{
-		Banker: crypto.Address([]byte("onlyone")),
+		Banker: sdk.Address([]byte("onlyone")),
 	}
 	res := msg.GetSigners()
 	assert.Equal(t, fmt.Sprintf("%v", res), "[6F6E6C796F6E65]")


### PR DESCRIPTION
Reduce dependence on go-crypto across the codebase by making a type alias in `types`