### PR TITLE
ParseAccount -> AccountDecoder; check for empty bytes

### DIFF
--- a/examples/basecoin/app/app.go
+++ b/examples/basecoin/app/app.go
@@ -122,11 +122,15 @@ func MakeCodec() *wire.Codec {
 func (app *BasecoinApp) txDecoder(txBytes []byte) (sdk.Tx, sdk.Error) {
 	var tx = sdk.StdTx{}
 
+	if len(txBytes) == 0 {
+		return nil, sdk.ErrTxDecode("txBytes are empty")
+	}
+
 	// StdTx.Msg is an interface. The concrete types
 	// are registered by MakeTxCodec in bank.RegisterWire.
 	err := app.cdc.UnmarshalBinary(txBytes, &tx)
 	if err != nil {
-		return nil, sdk.ErrTxParse("").TraceCause(err, "")
+		return nil, sdk.ErrTxDecode("").TraceCause(err, "")
 	}
 	return tx, nil
 }

--- a/examples/basecoin/cmd/basecli/main.go
+++ b/examples/basecoin/cmd/basecli/main.go
@@ -56,7 +56,7 @@ func main() {
 	// add query/post commands (custom to binary)
 	basecliCmd.AddCommand(
 		client.GetCommands(
-			authcmd.GetAccountCmd("main", cdc, types.GetParseAccount(cdc)),
+			authcmd.GetAccountCmd("main", cdc, types.GetAccountDecoder(cdc)),
 		)...)
 	basecliCmd.AddCommand(
 		client.PostCommands(

--- a/examples/basecoin/types/account.go
+++ b/examples/basecoin/types/account.go
@@ -25,6 +25,9 @@ func (acc *AppAccount) SetName(name string) { acc.Name = name }
 // Get the AccountDecoder function for the custom AppAccount
 func GetAccountDecoder(cdc *wire.Codec) sdk.AccountDecoder {
 	return func(accBytes []byte) (res sdk.Account, err error) {
+		if len(accBytes) == 0 {
+			return nil, sdk.ErrTxDecode("accBytes are empty")
+		}
 		acct := new(AppAccount)
 		err = cdc.UnmarshalBinary(accBytes, &acct)
 		if err != nil {

--- a/examples/basecoin/types/account.go
+++ b/examples/basecoin/types/account.go
@@ -22,8 +22,8 @@ type AppAccount struct {
 func (acc AppAccount) GetName() string      { return acc.Name }
 func (acc *AppAccount) SetName(name string) { acc.Name = name }
 
-// Get the ParseAccount function for the custom AppAccount
-func GetParseAccount(cdc *wire.Codec) sdk.ParseAccount {
+// Get the AccountDecoder function for the custom AppAccount
+func GetAccountDecoder(cdc *wire.Codec) sdk.AccountDecoder {
 	return func(accBytes []byte) (res sdk.Account, err error) {
 		acct := new(AppAccount)
 		err = cdc.UnmarshalBinary(accBytes, &acct)

--- a/examples/kvstore/tx.go
+++ b/examples/kvstore/tx.go
@@ -64,7 +64,7 @@ func decodeTx(txBytes []byte) (sdk.Tx, sdk.Error) {
 		k, v := split[0], split[1]
 		tx = kvstoreTx{k, v, txBytes}
 	} else {
-		return nil, sdk.ErrTxParse("too many =")
+		return nil, sdk.ErrTxDecode("too many =")
 	}
 
 	return tx, nil

--- a/mock/tx.go
+++ b/mock/tx.go
@@ -77,7 +77,7 @@ func decodeTx(txBytes []byte) (sdk.Tx, sdk.Error) {
 		k, v := split[0], split[1]
 		tx = kvstoreTx{k, v, txBytes}
 	} else {
-		return nil, sdk.ErrTxParse("too many =")
+		return nil, sdk.ErrTxDecode("too many =")
 	}
 
 	return tx, nil

--- a/store/iavlstore.go
+++ b/store/iavlstore.go
@@ -141,7 +141,7 @@ func (st *iavlStore) ReverseIterator(start, end []byte) Iterator {
 func (st *iavlStore) Query(req abci.RequestQuery) (res abci.ResponseQuery) {
 	if len(req.Data) == 0 {
 		msg := "Query cannot be zero length"
-		return sdk.ErrTxParse(msg).Result().ToQuery()
+		return sdk.ErrTxDecode(msg).Result().ToQuery()
 	}
 
 	tree := st.tree

--- a/types/account.go
+++ b/types/account.go
@@ -35,5 +35,5 @@ type AccountMapper interface {
 	SetAccount(ctx Context, acc Account)
 }
 
-// Application function variable used to unmarshal account
-type ParseAccount func([]byte) (Account, error)
+// AccountDecoder unmarshals account bytes
+type AccountDecoder func(accountBytes []byte) (Account, error)

--- a/types/errors.go
+++ b/types/errors.go
@@ -21,7 +21,7 @@ func (code CodeType) IsOK() bool {
 const (
 	CodeOK                CodeType = 0
 	CodeInternal          CodeType = 1
-	CodeTxParse           CodeType = 2
+	CodeTxDecode           CodeType = 2
 	CodeInvalidSequence   CodeType = 3
 	CodeUnauthorized      CodeType = 4
 	CodeInsufficientFunds CodeType = 5
@@ -40,7 +40,7 @@ func CodeToDefaultMsg(code CodeType) string {
 	switch code {
 	case CodeInternal:
 		return "Internal error"
-	case CodeTxParse:
+	case CodeTxDecode:
 		return "Tx parse error"
 	case CodeGenesisParse:
 		return "Genesis parse error"
@@ -75,8 +75,8 @@ func CodeToDefaultMsg(code CodeType) string {
 func ErrInternal(msg string) Error {
 	return newError(CodeInternal, msg)
 }
-func ErrTxParse(msg string) Error {
-	return newError(CodeTxParse, msg)
+func ErrTxDecode(msg string) Error {
+	return newError(CodeTxDecode, msg)
 }
 func ErrGenesisParse(msg string) Error {
 	return newError(CodeGenesisParse, msg)

--- a/types/errors_test.go
+++ b/types/errors_test.go
@@ -9,7 +9,7 @@ import (
 
 var codeTypes = []CodeType{
 	CodeInternal,
-	CodeTxParse,
+	CodeTxDecode,
 	CodeInvalidSequence,
 	CodeUnauthorized,
 	CodeInsufficientFunds,
@@ -23,7 +23,7 @@ type errFn func(msg string) Error
 
 var errFns = []errFn{
 	ErrInternal,
-	ErrTxParse,
+	ErrTxDecode,
 	ErrInvalidSequence,
 	ErrUnauthorized,
 	ErrInsufficientFunds,

--- a/types/tx_msg.go
+++ b/types/tx_msg.go
@@ -153,7 +153,7 @@ func (msg StdSignMsg) Bytes() []byte {
 
 //__________________________________________________________
 
-// Application function variable used to unmarshal transaction bytes
+// TxDeocder unmarshals transaction bytes
 type TxDecoder func(txBytes []byte) (Tx, Error)
 
 //__________________________________________________________

--- a/x/auth/commands/account.go
+++ b/x/auth/commands/account.go
@@ -16,10 +16,10 @@ import (
 
 // GetAccountCmd for the auth.BaseAccount type
 func GetAccountCmdDefault(storeName string, cdc *wire.Codec) *cobra.Command {
-	return GetAccountCmd(storeName, cdc, GetParseAccount(cdc))
+	return GetAccountCmd(storeName, cdc, GetAccountDecoder(cdc))
 }
 
-func GetParseAccount(cdc *wire.Codec) sdk.ParseAccount {
+func GetAccountDecoder(cdc *wire.Codec) sdk.AccountDecoder {
 	return func(accBytes []byte) (sdk.Account, error) {
 		acct := new(auth.BaseAccount)
 		err := cdc.UnmarshalBinary(accBytes, &acct)
@@ -32,7 +32,7 @@ func GetParseAccount(cdc *wire.Codec) sdk.ParseAccount {
 
 // GetAccountCmd returns a query account that will display the
 // state of the account at a given address
-func GetAccountCmd(storeName string, cdc *wire.Codec, parser sdk.ParseAccount) *cobra.Command {
+func GetAccountCmd(storeName string, cdc *wire.Codec, parser sdk.AccountDecoder) *cobra.Command {
 	cmdr := commander{
 		storeName,
 		cdc,
@@ -48,7 +48,7 @@ func GetAccountCmd(storeName string, cdc *wire.Codec, parser sdk.ParseAccount) *
 type commander struct {
 	storeName string
 	cdc       *wire.Codec
-	parser    sdk.ParseAccount
+	parser    sdk.AccountDecoder
 }
 
 func (c commander) getAccountCmd(cmd *cobra.Command, args []string) error {

--- a/x/auth/commands/account.go
+++ b/x/auth/commands/account.go
@@ -32,11 +32,11 @@ func GetAccountDecoder(cdc *wire.Codec) sdk.AccountDecoder {
 
 // GetAccountCmd returns a query account that will display the
 // state of the account at a given address
-func GetAccountCmd(storeName string, cdc *wire.Codec, parser sdk.AccountDecoder) *cobra.Command {
+func GetAccountCmd(storeName string, cdc *wire.Codec, decoder sdk.AccountDecoder) *cobra.Command {
 	cmdr := commander{
 		storeName,
 		cdc,
-		parser,
+		decoder,
 	}
 	return &cobra.Command{
 		Use:   "account <address>",
@@ -48,7 +48,7 @@ func GetAccountCmd(storeName string, cdc *wire.Codec, parser sdk.AccountDecoder)
 type commander struct {
 	storeName string
 	cdc       *wire.Codec
-	parser    sdk.AccountDecoder
+	decoder   sdk.AccountDecoder
 }
 
 func (c commander) getAccountCmd(cmd *cobra.Command, args []string) error {
@@ -66,8 +66,8 @@ func (c commander) getAccountCmd(cmd *cobra.Command, args []string) error {
 
 	res, err := builder.Query(key, c.storeName)
 
-	// parse out the value
-	account, err := c.parser(res)
+	// decode the value
+	account, err := c.decoder(res)
 	if err != nil {
 		return err
 	}

--- a/x/auth/commands/account.go
+++ b/x/auth/commands/account.go
@@ -65,6 +65,9 @@ func (c commander) getAccountCmd(cmd *cobra.Command, args []string) error {
 	key := sdk.Address(bz)
 
 	res, err := builder.Query(key, c.storeName)
+	if err != nil {
+		return err
+	}
 
 	// decode the value
 	account, err := c.decoder(res)

--- a/x/auth/rest/query.go
+++ b/x/auth/rest/query.go
@@ -16,10 +16,10 @@ import (
 type commander struct {
 	storeName string
 	cdc       *wire.Codec
-	parser    sdk.ParseAccount
+	parser    sdk.AccountDecoder
 }
 
-func QueryAccountRequestHandler(storeName string, cdc *wire.Codec, parser sdk.ParseAccount) func(http.ResponseWriter, *http.Request) {
+func QueryAccountRequestHandler(storeName string, cdc *wire.Codec, parser sdk.AccountDecoder) func(http.ResponseWriter, *http.Request) {
 	c := commander{storeName, cdc, parser}
 	return func(w http.ResponseWriter, r *http.Request) {
 		vars := mux.Vars(r)

--- a/x/auth/rest/query.go
+++ b/x/auth/rest/query.go
@@ -16,11 +16,11 @@ import (
 type commander struct {
 	storeName string
 	cdc       *wire.Codec
-	parser    sdk.AccountDecoder
+	decoder    sdk.AccountDecoder
 }
 
-func QueryAccountRequestHandler(storeName string, cdc *wire.Codec, parser sdk.AccountDecoder) func(http.ResponseWriter, *http.Request) {
-	c := commander{storeName, cdc, parser}
+func QueryAccountRequestHandler(storeName string, cdc *wire.Codec, decoder sdk.AccountDecoder) func(http.ResponseWriter, *http.Request) {
+	c := commander{storeName, cdc, decoder}
 	return func(w http.ResponseWriter, r *http.Request) {
 		vars := mux.Vars(r)
 		addr := vars["address"]
@@ -46,8 +46,8 @@ func QueryAccountRequestHandler(storeName string, cdc *wire.Codec, parser sdk.Ac
 			return
 		}
 
-		// parse out the value
-		account, err := c.parser(res)
+		// decode the value
+		account, err := c.decoder(res)
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 			w.Write([]byte(fmt.Sprintf("Could't parse query result. Result: %s. Error: %s", res, err.Error())))

--- a/x/auth/rest/root.go
+++ b/x/auth/rest/root.go
@@ -7,5 +7,5 @@ import (
 )
 
 func RegisterRoutes(r *mux.Router, cdc *wire.Codec, storeName string) {
-	r.HandleFunc("/accounts/{address}", QueryAccountRequestHandler(storeName, cdc, auth.GetParseAccount(cdc))).Methods("GET")
+	r.HandleFunc("/accounts/{address}", QueryAccountRequestHandler(storeName, cdc, auth.GetAccountDecoder(cdc))).Methods("GET")
 }

--- a/x/ibc/commands/relay.go
+++ b/x/ibc/commands/relay.go
@@ -27,7 +27,7 @@ const (
 type relayCommander struct {
 	cdc       *wire.Codec
 	address   sdk.Address
-	parser    sdk.AccountDecoder
+	decoder    sdk.AccountDecoder
 	mainStore string
 	ibcStore  string
 }
@@ -35,7 +35,7 @@ type relayCommander struct {
 func IBCRelayCmd(cdc *wire.Codec) *cobra.Command {
 	cmdr := relayCommander{
 		cdc:       cdc,
-		parser:    authcmd.GetAccountDecoder(cdc),
+		decoder:    authcmd.GetAccountDecoder(cdc),
 		ibcStore:  "ibc",
 		mainStore: "main",
 	}
@@ -162,7 +162,7 @@ func (c relayCommander) getSequence(node string) int64 {
 	if err != nil {
 		panic(err)
 	}
-	account, err := c.parser(res)
+	account, err := c.decoder(res)
 	if err != nil {
 		panic(err)
 	}

--- a/x/ibc/commands/relay.go
+++ b/x/ibc/commands/relay.go
@@ -27,7 +27,7 @@ const (
 type relayCommander struct {
 	cdc       *wire.Codec
 	address   sdk.Address
-	parser    sdk.ParseAccount
+	parser    sdk.AccountDecoder
 	mainStore string
 	ibcStore  string
 }
@@ -35,7 +35,7 @@ type relayCommander struct {
 func IBCRelayCmd(cdc *wire.Codec) *cobra.Command {
 	cmdr := relayCommander{
 		cdc:       cdc,
-		parser:    authcmd.GetParseAccount(cdc),
+		parser:    authcmd.GetAccountDecoder(cdc),
 		ibcStore:  "ibc",
 		mainStore: "main",
 	}


### PR DESCRIPTION
Parse is for Human Readable
Decode is for Machine Readable

https://github.com/cosmos/cosmos-sdk/issues/651

also fixes #649 

Decoders need to check for empty bytes. 