### PR TITLE
Encapsulate Get Passphrase Logic in Builder

### DIFF
--- a/client/builder/builder.go
+++ b/client/builder/builder.go
@@ -124,11 +124,23 @@ func SignAndBuild(name, passphrase string, msg sdk.Msg, cdc *wire.Codec) ([]byte
 }
 
 // sign and build the transaction from the msg
-func SignBuildBroadcast(name string, passphrase string, msg sdk.Msg, cdc *wire.Codec) (*ctypes.ResultBroadcastTxCommit, error) {
+func SignBuildBroadcast(name string, msg sdk.Msg, cdc *wire.Codec) (*ctypes.ResultBroadcastTxCommit, error) {
+	passphrase, err := GetPassphraseFromStdin(name)
+	if err != nil {
+		return nil, err
+	}
+
 	txBytes, err := SignAndBuild(name, passphrase, msg, cdc)
 	if err != nil {
 		return nil, err
 	}
 
 	return BroadcastTx(txBytes)
+}
+
+// get passphrase from std input
+func GetPassphraseFromStdin(name string) (pass string, err error) {
+	buf := client.BufferStdin()
+	prompt := fmt.Sprintf("Password to sign with '%s':", name)
+	return client.GetPassword(prompt, buf)
 }

--- a/examples/basecoin/x/cool/commands/tx.go
+++ b/examples/basecoin/x/cool/commands/tx.go
@@ -36,16 +36,8 @@ func QuizTxCmd(cdc *wire.Codec) *cobra.Command {
 			// get account name
 			name := viper.GetString(client.FlagName)
 
-			// get password
-			buf := client.BufferStdin()
-			prompt := fmt.Sprintf("Password to sign with '%s':", name)
-			passphrase, err := client.GetPassword(prompt, buf)
-			if err != nil {
-				return err
-			}
-
 			// build and sign the transaction, then broadcast to Tendermint
-			res, err := builder.SignBuildBroadcast(name, passphrase, msg, cdc)
+			res, err := builder.SignBuildBroadcast(name, msg, cdc)
 			if err != nil {
 				return err
 			}
@@ -75,19 +67,11 @@ func SetTrendTxCmd(cdc *wire.Codec) *cobra.Command {
 			// get account name
 			name := viper.GetString(client.FlagName)
 
-			// get password
-			buf := client.BufferStdin()
-			prompt := fmt.Sprintf("Password to sign with '%s':", name)
-			passphrase, err := client.GetPassword(prompt, buf)
-			if err != nil {
-				return err
-			}
-
 			// create the message
 			msg := cool.NewSetTrendMsg(from, args[0])
 
 			// build and sign the transaction, then broadcast to Tendermint
-			res, err := builder.SignBuildBroadcast(name, passphrase, msg, cdc)
+			res, err := builder.SignBuildBroadcast(name, msg, cdc)
 			if err != nil {
 				return err
 			}

--- a/x/bank/commands/sendtx.go
+++ b/x/bank/commands/sendtx.go
@@ -62,19 +62,11 @@ func (c Commander) sendTxCmd(cmd *cobra.Command, args []string) error {
 	// get account name
 	name := viper.GetString(client.FlagName)
 
-	// get password
-	buf := client.BufferStdin()
-	prompt := fmt.Sprintf("Password to sign with '%s':", name)
-	passphrase, err := client.GetPassword(prompt, buf)
-	if err != nil {
-		return err
-	}
-
 	// build message
 	msg := BuildMsg(from, to, coins)
 
 	// build and sign the transaction, then broadcast to Tendermint
-	res, err := builder.SignBuildBroadcast(name, passphrase, msg, c.Cdc)
+	res, err := builder.SignBuildBroadcast(name, msg, c.Cdc)
 	if err != nil {
 		return err
 	}

--- a/x/ibc/commands/ibctx.go
+++ b/x/ibc/commands/ibctx.go
@@ -53,14 +53,8 @@ func (c sendCommander) sendIBCTransfer(cmd *cobra.Command, args []string) error 
 
 	// get password
 	name := viper.GetString(client.FlagName)
-	buf := client.BufferStdin()
-	prompt := fmt.Sprintf("Password to sign with '%s':", name)
-	passphrase, err := client.GetPassword(prompt, buf)
-	if err != nil {
-		return err
-	}
 
-	res, err := builder.SignBuildBroadcast(name, passphrase, msg, c.cdc)
+	res, err := builder.SignBuildBroadcast(name, msg, c.cdc)
 	if err != nil {
 		return err
 	}

--- a/x/ibc/commands/relay.go
+++ b/x/ibc/commands/relay.go
@@ -27,7 +27,7 @@ const (
 type relayCommander struct {
 	cdc       *wire.Codec
 	address   sdk.Address
-	decoder    sdk.AccountDecoder
+	decoder   sdk.AccountDecoder
 	mainStore string
 	ibcStore  string
 }
@@ -35,7 +35,7 @@ type relayCommander struct {
 func IBCRelayCmd(cdc *wire.Codec) *cobra.Command {
 	cmdr := relayCommander{
 		cdc:       cdc,
-		decoder:    authcmd.GetAccountDecoder(cdc),
+		decoder:   authcmd.GetAccountDecoder(cdc),
 		ibcStore:  "ibc",
 		mainStore: "main",
 	}
@@ -80,9 +80,7 @@ func (c relayCommander) runIBCRelay(cmd *cobra.Command, args []string) {
 func (c relayCommander) loop(fromChainID, fromChainNode, toChainID, toChainNode string) {
 	// get password
 	name := viper.GetString(client.FlagName)
-	buf := client.BufferStdin()
-	prompt := fmt.Sprintf("Password to sign with '%s':", name)
-	passphrase, err := client.GetPassword(prompt, buf)
+	passphrase, err := builder.GetPassphraseFromStdin(name)
 	if err != nil {
 		panic(err)
 	}

--- a/x/staking/commands/commands.go
+++ b/x/staking/commands/commands.go
@@ -94,14 +94,7 @@ func (co commander) unbondTxCmd(cmd *cobra.Command, args []string) error {
 
 func (co commander) sendMsg(msg sdk.Msg) error {
 	name := viper.GetString(client.FlagName)
-	buf := client.BufferStdin()
-	prompt := fmt.Sprintf("Password to sign with '%s':", name)
-	passphrase, err := client.GetPassword(prompt, buf)
-	if err != nil {
-		return err
-	}
-
-	res, err := builder.SignBuildBroadcast(name, passphrase, msg, co.cdc)
+	res, err := builder.SignBuildBroadcast(name, msg, co.cdc)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
It makes no sense to have passphrase as the parameter to builder which generates a lot of duplicate code.