### PR TITLE
stake: register auth.BaseAccount, not basecoin AppAccount

### DIFF
--- a/x/stake/test_common.go
+++ b/x/stake/test_common.go
@@ -11,7 +11,6 @@ import (
 	oldwire "github.com/tendermint/go-wire"
 	dbm "github.com/tendermint/tmlibs/db"
 
-	"github.com/cosmos/cosmos-sdk/examples/basecoin/types"
 	"github.com/cosmos/cosmos-sdk/store"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/wire"
@@ -83,7 +82,7 @@ func makeTestCodec() *wire.Codec {
 	const accTypeApp = 0x1
 	var _ = oldwire.RegisterInterface(
 		struct{ sdk.Account }{},
-		oldwire.ConcreteType{&types.AppAccount{}, accTypeApp},
+		oldwire.ConcreteType{&auth.BaseAccount{}, accTypeApp},
 	)
 	cdc := wire.NewCodec()
 


### PR DESCRIPTION
None of the modules should be importing from basecoin!