### PR TITLE
Dash instead of space in version output

### DIFF
--- a/version/command.go
+++ b/version/command.go
@@ -19,7 +19,7 @@ var (
 func getVersion() string {
 	v := Version
 	if GitCommit != "" {
-		v = v + " " + GitCommit
+		v = v + "-" + GitCommit
 	}
 	return v
 }


### PR DESCRIPTION
Per request of @greg-szabo - easier to parse in automated tooling