### PR TITLE
Add basic Dockerfile to build all binaries and export gaiad

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+Dockerfile
+Vagrantfile
+
+build/
+coverage.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,8 @@
 
 FROM alpine:edge
 
-# Install minimum necessary dependencies
-
+# Set up dependencies
 ENV PACKAGES go glide make git libc-dev bash
-RUN apk add --no-cache $PACKAGES
 
 # Set up GOPATH & PATH
 
@@ -20,20 +18,17 @@ ENV PATH         $GOPATH/bin:$PATH
 
 # Link expected Go repo path
 
-RUN mkdir -p $WORKDIR $GOPATH/pkg $ $GOPATH/bin $BASE_PATH && ln -sf $WORKDIR $REPO_PATH
+RUN mkdir -p $WORKDIR $GOPATH/pkg $ $GOPATH/bin $BASE_PATH
 
 # Add source files
 
-ADD . $WORKDIR
+ADD . $REPO_PATH
 
-# Build cosmos-sdk
-
-RUN cd $REPO_PATH && make get_tools && make get_vendor_deps && make all && make install
-
-# Remove packages
-
-RUN apk del $PACKAGES
+# Install minimum necessary dependencies, build Cosmos SDK, remove packages
+RUN apk add --no-cache $PACKAGES && \
+    cd $REPO_PATH && make get_tools && make get_vendor_deps && make all && make install && \
+    apk del $PACKAGES
 
 # Set entrypoint
 
-ENTRYPOINT ["/root/go/bin/gaiad"]
+ENTRYPOINT ["gaiad"]


### PR DESCRIPTION
One step towards easier testnet setup. CC @martindale - this should eliminate dealing with GOPATH on testnet servers.

Instructions at the top of the Dockerfile. Designed to be built locally after cloning the repository - we could also set up [automated builds](https://docs.docker.com/docker-hub/builds/) if that would be helpful for validators.

Changes nothing else, can be reviewed & merged.