### PR TITLE
Fix auto-sequencing (closes #950)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ FEATURES:
 
 BUG FIXES
 * Gaia now uses stake, ported from github.com/cosmos/gaia
+* Auto-sequencing now works correctly
 
 ## 0.15.1 (April 29, 2018)
 

--- a/client/context/helpers.go
+++ b/client/context/helpers.go
@@ -158,6 +158,11 @@ func (ctx CoreContext) NextSequence(address []byte) (int64, error) {
 		return 0, err
 	}
 
+	if len(res) == 0 {
+		fmt.Printf("No account found, defaulting to sequence 0\n")
+		return 0, err
+	}
+
 	account, err := ctx.Decoder(res)
 	if err != nil {
 		panic(err)

--- a/client/context/viper.go
+++ b/client/context/viper.go
@@ -36,7 +36,7 @@ func NewCoreContextFromViper() CoreContext {
 		Sequence:        viper.GetInt64(client.FlagSequence),
 		Client:          rpc,
 		Decoder:         nil,
-		AccountStore:    "main",
+		AccountStore:    "acc",
 	}
 }
 
@@ -55,7 +55,8 @@ func defaultChainID() (string, error) {
 
 // EnsureSequence - automatically set sequence number if none provided
 func EnsureSequence(ctx CoreContext) (CoreContext, error) {
-	if viper.IsSet(client.FlagSequence) {
+	// Should be viper.IsSet, but this does not work - https://github.com/spf13/viper/pull/331
+	if viper.GetInt64(client.FlagSequence) != 0 {
 		return ctx, nil
 	}
 	from, err := ctx.GetFromAddress()

--- a/cmd/gaia/cli_test/cli_test.go
+++ b/cmd/gaia/cli_test/cli_test.go
@@ -48,6 +48,15 @@ func TestGaiaCLISend(t *testing.T) {
 	assert.Equal(t, int64(10), barAcc.GetCoins().AmountOf("steak"))
 	fooAcc = executeGetAccount(t, fmt.Sprintf("gaiacli account %v %v", fooAddr, flags))
 	assert.Equal(t, int64(40), fooAcc.GetCoins().AmountOf("steak"))
+
+	// test autosequencing
+	executeWrite(t, fmt.Sprintf("gaiacli send %v --amount=10steak --to=%v --name=foo", flags, barAddr), pass)
+	time.Sleep(time.Second * 3) // waiting for some blocks to pass
+
+	barAcc = executeGetAccount(t, fmt.Sprintf("gaiacli account %v %v", barAddr, flags))
+	assert.Equal(t, int64(20), barAcc.GetCoins().AmountOf("steak"))
+	fooAcc = executeGetAccount(t, fmt.Sprintf("gaiacli account %v %v", fooAddr, flags))
+	assert.Equal(t, int64(30), fooAcc.GetCoins().AmountOf("steak"))
 }
 
 func TestGaiaCLIDeclareCandidacy(t *testing.T) {


### PR DESCRIPTION
Ref https://github.com/cosmos/cosmos-sdk/issues/950

Maybe we want to add this to the go-bash tests?