### PR TITLE
Sort all genesis transaction by node id

### DIFF
--- a/cmd/gaia/app/genesis.go
+++ b/cmd/gaia/app/genesis.go
@@ -66,8 +66,9 @@ func GaiaAppInit() server.AppInit {
 
 	fsAppGenTx := pflag.NewFlagSet("", pflag.ContinueOnError)
 	fsAppGenTx.String(flagName, "", "validator moniker, if left blank, do not add validator")
-	fsAppGenTx.String(flagClientHome, DefaultCLIHome, "home directory for the client, used for key generation")
-	fsAppGenTx.Bool(flagOWK, false, "overwrite the for the accounts created")
+	fsAppGenTx.String(flagClientHome, DefaultCLIHome,
+		"home directory for the client, used for key generation")
+	fsAppGenTx.Bool(flagOWK, false, "overwrite the accounts created")
 
 	return server.AppInit{
 		FlagsAppGenState: fsAppGenState,

--- a/server/init.go
+++ b/server/init.go
@@ -244,17 +244,18 @@ func processGenTxs(genTxsDir string, cdc *wire.Codec, appInit AppInit) (
 	sort.Strings(nodeIDs)
 
 	for _, nodeID := range nodeIDs {
+		genTx := genTxs[nodeID]
+
 		// combine some stuff
-		validators = append(validators, genTxs[nodeID].Validator)
-		appGenTxs = append(appGenTxs, genTxs[nodeID].AppGenTx)
+		validators = append(validators, genTx.Validator)
+		appGenTxs = append(appGenTxs, genTx.AppGenTx)
 
 		// Add a persistent peer
 		comma := ","
 		if len(persistentPeers) == 0 {
 			comma = ""
 		}
-		persistentPeers += fmt.Sprintf("%s%s@%s:46656", comma, genTxs[nodeID].NodeID,
-			genTxs[nodeID].IP)
+		persistentPeers += fmt.Sprintf("%s%s@%s:46656", comma, genTx.NodeID, genTx.IP)
 	}
 
 	return

--- a/server/init.go
+++ b/server/init.go
@@ -222,7 +222,7 @@ func processGenTxs(genTxsDir string, cdc *wire.Codec, appInit AppInit) (
 	for _, fo := range fos {
 		filename := path.Join(genTxsDir, fo.Name())
 		if !fo.IsDir() && (path.Ext(filename) != ".json") {
-			return
+			continue
 		}
 
 		// get the genTx


### PR DESCRIPTION
This ensures that users can rename the genesis transactions and they
will still be in the same order.

<!-- Thanks for filing a PR! Before hitting the button, please check the following items.-->

* [x] Updated all relevant documentation in docs
* [x] Updated all code comments where relevant
* [x] Wrote tests
* [x] Updated CHANGELOG.md

ref #940 #987
