### PR TITLE
require go1.10 minimum

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ master    | [![CircleCI](https://circleci.com/gh/cosmos/cosmos-sdk/tree/master.s
 
 **WARNING**: the libraries are still undergoing breaking changes as we get better ideas and start building out the Apps.
 
-**Note**: Requires [Go 1.9+](https://golang.org/dl/)
+**Note**: Requires [Go 1.10+](https://golang.org/dl/)
 
 
 ## Overview


### PR DESCRIPTION
ref #1009

we require go1.10 elsewhere so might as well update it here.