### PR TITLE
Change to go-wire UnmarshalJSON for bank transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Pending
+
+BREAKING CHANGES
+
+FEATURES
+
+IMPROVEMENTS
+* bank module uses go-wire codec instead of 'encoding/json'
+
+FIXES
+
 ## 0.18.1
 
 BREAKING CHANGES

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ FEATURES
 
 IMPROVEMENTS
 * bank module uses go-wire codec instead of 'encoding/json'
+* auth module uses go-wire codec instead of 'encoding/json'
 
 FIXES
 

--- a/x/auth/msgs.go
+++ b/x/auth/msgs.go
@@ -1,8 +1,6 @@
 package auth
 
 import (
-	"encoding/json"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	crypto "github.com/tendermint/go-crypto"
 )
@@ -30,7 +28,7 @@ func (msg MsgChangeKey) ValidateBasic() sdk.Error {
 
 // Implements Msg.
 func (msg MsgChangeKey) GetSignBytes() []byte {
-	b, err := json.Marshal(msg) // XXX: ensure some canonical form
+	b, err := msgCdc.MarshalJSON(msg) // XXX: ensure some canonical form
 	if err != nil {
 		panic(err)
 	}

--- a/x/auth/stdtx.go
+++ b/x/auth/stdtx.go
@@ -1,8 +1,6 @@
 package auth
 
 import (
-	"encoding/json"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	crypto "github.com/tendermint/go-crypto"
 )
@@ -70,7 +68,7 @@ func (fee StdFee) Bytes() []byte {
 	if len(fee.Amount) == 0 {
 		fee.Amount = sdk.Coins{}
 	}
-	bz, err := json.Marshal(fee) // TODO
+	bz, err := msgCdc.MarshalJSON(fee) // TODO
 	if err != nil {
 		panic(err)
 	}
@@ -95,7 +93,7 @@ type StdSignDoc struct {
 // StdSignBytes returns the bytes to sign for a transaction.
 // TODO: change the API to just take a chainID and StdTx ?
 func StdSignBytes(chainID string, sequences []int64, fee StdFee, msg sdk.Msg) []byte {
-	bz, err := json.Marshal(StdSignDoc{
+	bz, err := msgCdc.MarshalJSON(StdSignDoc{
 		ChainID:   chainID,
 		Sequences: sequences,
 		FeeBytes:  fee.Bytes(),

--- a/x/auth/wire.go
+++ b/x/auth/wire.go
@@ -10,3 +10,9 @@ func RegisterWire(cdc *wire.Codec) {
 	cdc.RegisterConcrete(&BaseAccount{}, "auth/Account", nil)
 	cdc.RegisterConcrete(MsgChangeKey{}, "auth/ChangeKey", nil)
 }
+
+var msgCdc = wire.NewCodec()
+
+func init() {
+	RegisterWire(msgCdc)
+}

--- a/x/auth/wire.go
+++ b/x/auth/wire.go
@@ -15,4 +15,5 @@ var msgCdc = wire.NewCodec()
 
 func init() {
 	RegisterWire(msgCdc)
+	wire.RegisterCrypto(msgCdc)
 }

--- a/x/bank/client/rest/sendtx.go
+++ b/x/bank/client/rest/sendtx.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/context"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/wire"
+	"github.com/cosmos/cosmos-sdk/x/bank"
 	"github.com/cosmos/cosmos-sdk/x/bank/client"
 )
 
@@ -30,6 +31,12 @@ type sendBody struct {
 	Sequence         int64     `json:"sequence"`
 }
 
+var msgCdc = wire.NewCodec()
+
+func init() {
+	bank.RegisterWire(msgCdc)
+}
+
 // SendRequestHandlerFn - http request handler to send coins to a address
 func SendRequestHandlerFn(cdc *wire.Codec, kb keys.Keybase, ctx context.CoreContext) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -44,7 +51,7 @@ func SendRequestHandlerFn(cdc *wire.Codec, kb keys.Keybase, ctx context.CoreCont
 			w.Write([]byte(err.Error()))
 			return
 		}
-		err = json.Unmarshal(body, &m)
+		err = msgCdc.UnmarshalJSON(body, &m)
 		if err != nil {
 			w.WriteHeader(http.StatusBadRequest)
 			w.Write([]byte(err.Error()))

--- a/x/bank/msgs.go
+++ b/x/bank/msgs.go
@@ -53,8 +53,7 @@ func (msg MsgSend) ValidateBasic() sdk.Error {
 
 // Implements Msg.
 func (msg MsgSend) GetSignBytes() []byte {
-	cdc := getCodec()
-	b, err := cdc.MarshalJSON(msg) // XXX: ensure some canonical form
+	b, err := msgCdc.MarshalJSON(msg) // XXX: ensure some canonical form
 	if err != nil {
 		panic(err)
 	}
@@ -103,8 +102,7 @@ func (msg MsgIssue) ValidateBasic() sdk.Error {
 
 // Implements Msg.
 func (msg MsgIssue) GetSignBytes() []byte {
-	cdc := getCodec()
-	b, err := cdc.MarshalJSON(msg) // XXX: ensure some canonical form
+	b, err := msgCdc.MarshalJSON(msg) // XXX: ensure some canonical form
 	if err != nil {
 		panic(err)
 	}

--- a/x/bank/msgs.go
+++ b/x/bank/msgs.go
@@ -1,8 +1,6 @@
 package bank
 
 import (
-	"encoding/json"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -55,7 +53,8 @@ func (msg MsgSend) ValidateBasic() sdk.Error {
 
 // Implements Msg.
 func (msg MsgSend) GetSignBytes() []byte {
-	b, err := json.Marshal(msg) // XXX: ensure some canonical form
+	cdc := getCodec()
+	b, err := cdc.MarshalJSON(msg) // XXX: ensure some canonical form
 	if err != nil {
 		panic(err)
 	}
@@ -104,7 +103,8 @@ func (msg MsgIssue) ValidateBasic() sdk.Error {
 
 // Implements Msg.
 func (msg MsgIssue) GetSignBytes() []byte {
-	b, err := json.Marshal(msg) // XXX: ensure some canonical form
+	cdc := getCodec()
+	b, err := cdc.MarshalJSON(msg) // XXX: ensure some canonical form
 	if err != nil {
 		panic(err)
 	}

--- a/x/bank/msgs_test.go
+++ b/x/bank/msgs_test.go
@@ -186,8 +186,15 @@ func TestMsgSendGetSignBytes(t *testing.T) {
 		Outputs: []Output{NewOutput(addr2, coins)},
 	}
 	res := msg.GetSignBytes()
+
+	cdc := getCodec()
+	unmarshaledMsg := &MsgSend{}
+	cdc.UnmarshalJSON(res, unmarshaledMsg)
+	assert.Equal(t, &msg, unmarshaledMsg)
+
 	// TODO bad results
-	assert.Equal(t, string(res), `{"inputs":[{"address":"696E707574","coins":[{"denom":"atom","amount":10}]}],"outputs":[{"address":"6F7574707574","coins":[{"denom":"atom","amount":10}]}]}`)
+	expected := `{"type":"EAFDE32A2C87F8","value":{"inputs":[{"address":"696E707574","coins":[{"denom":"atom","amount":10}]}],"outputs":[{"address":"6F7574707574","coins":[{"denom":"atom","amount":10}]}]}}`
+	assert.Equal(t, expected, string(res))
 }
 
 func TestMsgSendGetSigners(t *testing.T) {
@@ -255,8 +262,15 @@ func TestMsgIssueGetSignBytes(t *testing.T) {
 		Outputs: []Output{NewOutput(addr, coins)},
 	}
 	res := msg.GetSignBytes()
+
+	cdc := getCodec()
+	unmarshaledMsg := &MsgIssue{}
+	cdc.UnmarshalJSON(res, unmarshaledMsg)
+	assert.Equal(t, &msg, unmarshaledMsg)
+
 	// TODO bad results
-	assert.Equal(t, string(res), `{"banker":"696E707574","outputs":[{"address":"6C6F616E2D66726F6D2D62616E6B","coins":[{"denom":"atom","amount":10}]}]}`)
+	expected := `{"type":"72E617C06ABAD0","value":{"banker":"696E707574","outputs":[{"address":"6C6F616E2D66726F6D2D62616E6B","coins":[{"denom":"atom","amount":10}]}]}}`
+	assert.Equal(t, expected, string(res))
 }
 
 func TestMsgIssueGetSigners(t *testing.T) {

--- a/x/bank/msgs_test.go
+++ b/x/bank/msgs_test.go
@@ -187,9 +187,8 @@ func TestMsgSendGetSignBytes(t *testing.T) {
 	}
 	res := msg.GetSignBytes()
 
-	cdc := getCodec()
 	unmarshaledMsg := &MsgSend{}
-	cdc.UnmarshalJSON(res, unmarshaledMsg)
+	msgCdc.UnmarshalJSON(res, unmarshaledMsg)
 	assert.Equal(t, &msg, unmarshaledMsg)
 
 	// TODO bad results
@@ -263,9 +262,8 @@ func TestMsgIssueGetSignBytes(t *testing.T) {
 	}
 	res := msg.GetSignBytes()
 
-	cdc := getCodec()
 	unmarshaledMsg := &MsgIssue{}
-	cdc.UnmarshalJSON(res, unmarshaledMsg)
+	msgCdc.UnmarshalJSON(res, unmarshaledMsg)
 	assert.Equal(t, &msg, unmarshaledMsg)
 
 	// TODO bad results

--- a/x/bank/wire.go
+++ b/x/bank/wire.go
@@ -10,8 +10,8 @@ func RegisterWire(cdc *wire.Codec) {
 	cdc.RegisterConcrete(MsgIssue{}, "cosmos-sdk/Issue", nil)
 }
 
-func getCodec() *wire.Codec {
-	cdc := wire.NewCodec()
-	RegisterWire(cdc)
-	return cdc
+var msgCdc = wire.NewCodec()
+
+func init() {
+	RegisterWire(msgCdc)
 }

--- a/x/bank/wire.go
+++ b/x/bank/wire.go
@@ -9,3 +9,9 @@ func RegisterWire(cdc *wire.Codec) {
 	cdc.RegisterConcrete(MsgSend{}, "cosmos-sdk/Send", nil)
 	cdc.RegisterConcrete(MsgIssue{}, "cosmos-sdk/Issue", nil)
 }
+
+func getCodec() *wire.Codec {
+	cdc := wire.NewCodec()
+	RegisterWire(cdc)
+	return cdc
+}

--- a/x/stake/msg.go
+++ b/x/stake/msg.go
@@ -1,10 +1,7 @@
 package stake
 
 import (
-	"encoding/json"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/cosmos/cosmos-sdk/wire"
 	crypto "github.com/tendermint/go-crypto"
 )
 
@@ -19,12 +16,6 @@ const StakingToken = "steak"
 
 //Verify interface at compile time
 var _, _, _, _ sdk.Msg = &MsgDeclareCandidacy{}, &MsgEditCandidacy{}, &MsgDelegate{}, &MsgUnbond{}
-
-var msgCdc = wire.NewCodec()
-
-func init() {
-	wire.RegisterCrypto(msgCdc)
-}
 
 //______________________________________________________________________
 
@@ -94,7 +85,7 @@ func (msg MsgEditCandidacy) GetSigners() []sdk.Address { return []sdk.Address{ms
 
 // get the bytes for the message signer to sign on
 func (msg MsgEditCandidacy) GetSignBytes() []byte {
-	b, err := json.Marshal(msg)
+	b, err := msgCdc.MarshalJSON(msg)
 	if err != nil {
 		panic(err)
 	}
@@ -136,7 +127,7 @@ func (msg MsgDelegate) GetSigners() []sdk.Address { return []sdk.Address{msg.Del
 
 // get the bytes for the message signer to sign on
 func (msg MsgDelegate) GetSignBytes() []byte {
-	b, err := json.Marshal(msg)
+	b, err := msgCdc.MarshalJSON(msg)
 	if err != nil {
 		panic(err)
 	}
@@ -183,7 +174,7 @@ func (msg MsgUnbond) GetSigners() []sdk.Address { return []sdk.Address{msg.Deleg
 
 // get the bytes for the message signer to sign on
 func (msg MsgUnbond) GetSignBytes() []byte {
-	b, err := json.Marshal(msg)
+	b, err := msgCdc.MarshalJSON(msg)
 	if err != nil {
 		panic(err)
 	}

--- a/x/stake/params.go
+++ b/x/stake/params.go
@@ -18,8 +18,8 @@ type Params struct {
 }
 
 func (p Params) equal(p2 Params) bool {
-	bz1 := cdcEmpty.MustMarshalBinary(&p)
-	bz2 := cdcEmpty.MustMarshalBinary(&p2)
+	bz1 := msgCdc.MustMarshalBinary(&p)
+	bz2 := msgCdc.MustMarshalBinary(&p2)
 	return bytes.Equal(bz1, bz2)
 }
 

--- a/x/stake/pool.go
+++ b/x/stake/pool.go
@@ -25,8 +25,8 @@ type Pool struct {
 }
 
 func (p Pool) equal(p2 Pool) bool {
-	bz1 := cdcEmpty.MustMarshalBinary(&p)
-	bz2 := cdcEmpty.MustMarshalBinary(&p2)
+	bz1 := msgCdc.MustMarshalBinary(&p)
+	bz2 := msgCdc.MustMarshalBinary(&p2)
 	return bytes.Equal(bz1, bz2)
 }
 

--- a/x/stake/wire.go
+++ b/x/stake/wire.go
@@ -12,4 +12,8 @@ func RegisterWire(cdc *wire.Codec) {
 	cdc.RegisterConcrete(MsgUnbond{}, "cosmos-sdk/MsgUnbond", nil)
 }
 
-var cdcEmpty = wire.NewCodec()
+var msgCdc = wire.NewCodec()
+
+func init() {
+	wire.RegisterCrypto(msgCdc)
+}

--- a/x/stake/wire.go
+++ b/x/stake/wire.go
@@ -15,5 +15,6 @@ func RegisterWire(cdc *wire.Codec) {
 var msgCdc = wire.NewCodec()
 
 func init() {
+	RegisterWire(msgCdc)
 	wire.RegisterCrypto(msgCdc)
 }


### PR DESCRIPTION
The bank and auth modules now uses their own codecs to encode and decode Msgs into JSON. 

This closes #558. The code is adapted from Adrian's PR #534. 