### PR TITLE
Refactored gaiacli and gaiad commands into subcommands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Pending
 
 BREAKING CHANGES
+* [cli] rearranged commands under subcommands
 
 FEATURES
 

--- a/client/rpc/block.go
+++ b/client/rpc/block.go
@@ -16,7 +16,7 @@ const (
 	flagSelect = "select"
 )
 
-func blockCommand() *cobra.Command {
+func BlockCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "block [height]",
 		Short: "Get verified data for a the block at given height",

--- a/client/rpc/block.go
+++ b/client/rpc/block.go
@@ -16,6 +16,7 @@ const (
 	flagSelect = "select"
 )
 
+//BlockCommand returns the verified block data for a given heights
 func BlockCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "block [height]",

--- a/client/rpc/root.go
+++ b/client/rpc/root.go
@@ -26,8 +26,6 @@ func AddCommands(cmd *cobra.Command) {
 	cmd.AddCommand(
 		initClientCommand(),
 		statusCommand(),
-		blockCommand(),
-		validatorCommand(),
 	)
 }
 

--- a/client/rpc/validators.go
+++ b/client/rpc/validators.go
@@ -14,7 +14,7 @@ import (
 
 // TODO these next two functions feel kinda hacky based on their placement
 
-func validatorCommand() *cobra.Command {
+func ValidatorCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "validatorset [height]",
 		Short: "Get the full validator set at given height",

--- a/client/rpc/validators.go
+++ b/client/rpc/validators.go
@@ -18,7 +18,7 @@ import (
 func ValidatorCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "validatorset [height]",
-		Short: "Get the full validator set at given height",
+		Short: "Get the full tendermint validator set at given height",
 		Args:  cobra.MaximumNArgs(1),
 		RunE:  printValidators,
 	}

--- a/client/rpc/validators.go
+++ b/client/rpc/validators.go
@@ -14,6 +14,7 @@ import (
 
 // TODO these next two functions feel kinda hacky based on their placement
 
+//ValidatorCommand returns the validator set for a given height
 func ValidatorCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "validatorset [height]",

--- a/cmd/gaia/cli_test/cli_test.go
+++ b/cmd/gaia/cli_test/cli_test.go
@@ -22,7 +22,7 @@ import (
 
 func TestGaiaCLISend(t *testing.T) {
 
-	tests.ExecuteT(t, "gaiad tendermint unsafe_reset_all")
+	tests.ExecuteT(t, "gaiad unsafe_reset_all")
 	pass := "1234567890"
 	executeWrite(t, "gaiacli keys delete foo", pass)
 	executeWrite(t, "gaiacli keys delete bar", pass)
@@ -69,7 +69,7 @@ func TestGaiaCLISend(t *testing.T) {
 
 func TestGaiaCLICreateValidator(t *testing.T) {
 
-	tests.ExecuteT(t, "gaiad tendermint unsafe_reset_all")
+	tests.ExecuteT(t, "gaiad unsafe_reset_all")
 	pass := "1234567890"
 	executeWrite(t, "gaiacli keys delete foo", pass)
 	executeWrite(t, "gaiacli keys delete bar", pass)

--- a/cmd/gaia/cli_test/cli_test.go
+++ b/cmd/gaia/cli_test/cli_test.go
@@ -22,7 +22,7 @@ import (
 
 func TestGaiaCLISend(t *testing.T) {
 
-	tests.ExecuteT(t, "gaiad unsafe_reset_all")
+	tests.ExecuteT(t, "gaiad tendermint unsafe_reset_all")
 	pass := "1234567890"
 	executeWrite(t, "gaiacli keys delete foo", pass)
 	executeWrite(t, "gaiacli keys delete bar", pass)
@@ -69,7 +69,7 @@ func TestGaiaCLISend(t *testing.T) {
 
 func TestGaiaCLICreateValidator(t *testing.T) {
 
-	tests.ExecuteT(t, "gaiad unsafe_reset_all")
+	tests.ExecuteT(t, "gaiad tendermint unsafe_reset_all")
 	pass := "1234567890"
 	executeWrite(t, "gaiacli keys delete foo", pass)
 	executeWrite(t, "gaiacli keys delete bar", pass)
@@ -104,7 +104,7 @@ func TestGaiaCLICreateValidator(t *testing.T) {
 	assert.Equal(t, int64(40), fooAcc.GetCoins().AmountOf("steak"))
 
 	// create validator
-	cvStr := fmt.Sprintf("gaiacli create-validator %v", flags)
+	cvStr := fmt.Sprintf("gaiacli stake create-validator %v", flags)
 	cvStr += fmt.Sprintf(" --name=%v", "bar")
 	cvStr += fmt.Sprintf(" --address-validator=%v", barCech)
 	cvStr += fmt.Sprintf(" --pubkey=%v", barCeshPubKey)
@@ -117,12 +117,12 @@ func TestGaiaCLICreateValidator(t *testing.T) {
 	barAcc = executeGetAccount(t, fmt.Sprintf("gaiacli account %v %v", barCech, flags))
 	require.Equal(t, int64(8), barAcc.GetCoins().AmountOf("steak"), "%v", barAcc)
 
-	validator := executeGetValidator(t, fmt.Sprintf("gaiacli validator %v --output=json %v", barCech, flags))
+	validator := executeGetValidator(t, fmt.Sprintf("gaiacli stake validator %v --output=json %v", barCech, flags))
 	assert.Equal(t, validator.Owner, barAddr)
 	assert.Equal(t, "2/1", validator.PoolShares.Amount.String())
 
 	// unbond a single share
-	unbondStr := fmt.Sprintf("gaiacli unbond %v", flags)
+	unbondStr := fmt.Sprintf("gaiacli stake unbond %v", flags)
 	unbondStr += fmt.Sprintf(" --name=%v", "bar")
 	unbondStr += fmt.Sprintf(" --address-validator=%v", barCech)
 	unbondStr += fmt.Sprintf(" --address-delegator=%v", barCech)
@@ -135,7 +135,7 @@ func TestGaiaCLICreateValidator(t *testing.T) {
 
 	barAcc = executeGetAccount(t, fmt.Sprintf("gaiacli account %v %v", barCech, flags))
 	require.Equal(t, int64(9), barAcc.GetCoins().AmountOf("steak"), "%v", barAcc)
-	validator = executeGetValidator(t, fmt.Sprintf("gaiacli validator %v --output=json %v", barCech, flags))
+	validator = executeGetValidator(t, fmt.Sprintf("gaiacli stake validator %v --output=json %v", barCech, flags))
 	assert.Equal(t, "1/1", validator.PoolShares.Amount.String())
 }
 

--- a/cmd/gaia/cli_test/cli_test.go
+++ b/cmd/gaia/cli_test/cli_test.go
@@ -96,7 +96,7 @@ func TestGaiaCLICreateValidator(t *testing.T) {
 	require.NoError(t, err)
 
 	executeWrite(t, fmt.Sprintf("gaiacli send %v --amount=10steak --to=%v --name=foo", flags, barCech), pass)
-	time.Sleep(time.Second * 2) // waiting for some blocks to pass
+	time.Sleep(time.Second * 3) // waiting for some blocks to pass
 
 	barAcc := executeGetAccount(t, fmt.Sprintf("gaiacli account %v %v", barCech, flags))
 	assert.Equal(t, int64(10), barAcc.GetCoins().AmountOf("steak"))

--- a/cmd/gaia/cmd/gaiacli/main.go
+++ b/cmd/gaia/cmd/gaiacli/main.go
@@ -39,15 +39,15 @@ func main() {
 	rpc.AddCommands(rootCmd)
 
 	//Add state commands
-	stateCmd := &cobra.Command{
-		Use:   "state",
-		Short: "State querying subcommands (validators, blocks, transactions)",
+	tendermintCmd := &cobra.Command{
+		Use:   "tendermint",
+		Short: "Tendermint state querying subcommands",
 	}
-	stateCmd.AddCommand(
+	tendermintCmd.AddCommand(
 		rpc.BlockCommand(),
 		rpc.ValidatorCommand(),
 	)
-	tx.AddCommands(stateCmd, cdc)
+	tx.AddCommands(tendermintCmd, cdc)
 
 	//Add IBC commands
 	ibcCmd := &cobra.Command{
@@ -66,7 +66,7 @@ func main() {
 	}
 
 	advancedCmd.AddCommand(
-		stateCmd,
+		tendermintCmd,
 		ibcCmd,
 		lcd.ServeCommand(cdc),
 	)

--- a/cmd/gaia/cmd/gaiacli/main.go
+++ b/cmd/gaia/cmd/gaiacli/main.go
@@ -37,7 +37,6 @@ func main() {
 
 	// add standard rpc commands
 	rpc.AddCommands(rootCmd)
-	rootCmd.AddCommand(client.LineBreak)
 
 	//Add state commands
 	stateCmd := &cobra.Command{
@@ -49,8 +48,30 @@ func main() {
 		rpc.ValidatorCommand(),
 	)
 	tx.AddCommands(stateCmd, cdc)
-	rootCmd.AddCommand(
+
+	//Add IBC commands
+	ibcCmd := &cobra.Command{
+		Use:   "ibc",
+		Short: "Inter-Blockchain Communication subcommands",
+	}
+	ibcCmd.AddCommand(
+		client.PostCommands(
+			ibccmd.IBCTransferCmd(cdc),
+			ibccmd.IBCRelayCmd(cdc),
+		)...)
+
+	advancedCmd := &cobra.Command{
+		Use:   "advanced",
+		Short: "Advanced subcommands",
+	}
+
+	advancedCmd.AddCommand(
 		stateCmd,
+		ibcCmd,
+		lcd.ServeCommand(cdc),
+	)
+	rootCmd.AddCommand(
+		advancedCmd,
 		client.LineBreak,
 	)
 
@@ -75,22 +96,6 @@ func main() {
 		)...)
 	rootCmd.AddCommand(
 		stakeCmd,
-		client.LineBreak,
-	)
-
-	//Add IBC commands
-	ibcCmd := &cobra.Command{
-		Use:   "ibc",
-		Short: "Inter-Blockchain Communication subcommands",
-	}
-	ibcCmd.AddCommand(
-		client.PostCommands(
-			ibccmd.IBCTransferCmd(cdc),
-			ibccmd.IBCRelayCmd(cdc),
-		)...)
-	rootCmd.AddCommand(
-		ibcCmd,
-		client.LineBreak,
 	)
 
 	//Add auth and bank commands
@@ -105,8 +110,6 @@ func main() {
 
 	// add proxy, version and key info
 	rootCmd.AddCommand(
-		client.LineBreak,
-		lcd.ServeCommand(cdc),
 		keys.Commands(),
 		client.LineBreak,
 		version.VersionCmd,

--- a/cmd/gaia/cmd/gaiacli/main.go
+++ b/cmd/gaia/cmd/gaiacli/main.go
@@ -35,30 +35,72 @@ func main() {
 	// the below functions and eliminate global vars, like we do
 	// with the cdc
 
-	// add standard rpc, and tx commands
+	// add standard rpc commands
 	rpc.AddCommands(rootCmd)
 	rootCmd.AddCommand(client.LineBreak)
-	tx.AddCommands(rootCmd, cdc)
-	rootCmd.AddCommand(client.LineBreak)
 
-	// add query/post commands (custom to binary)
+	//Add state commands
+	stateCmd := &cobra.Command{
+		Use:   "state",
+		Short: "State querying subcommands (validators, blocks, transactions)",
+	}
+	stateCmd.AddCommand(
+		rpc.BlockCommand(),
+		rpc.ValidatorCommand(),
+	)
+	tx.AddCommands(stateCmd, cdc)
 	rootCmd.AddCommand(
+		stateCmd,
+		client.LineBreak,
+	)
+
+	//Add stake commands
+	stakeCmd := &cobra.Command{
+		Use:   "stake",
+		Short: "Stake and validation subcommands",
+	}
+	stakeCmd.AddCommand(
 		client.GetCommands(
-			authcmd.GetAccountCmd("acc", cdc, authcmd.GetAccountDecoder(cdc)),
 			stakecmd.GetCmdQueryValidator("stake", cdc),
 			stakecmd.GetCmdQueryValidators("stake", cdc),
 			stakecmd.GetCmdQueryDelegation("stake", cdc),
 			stakecmd.GetCmdQueryDelegations("stake", cdc),
 		)...)
-	rootCmd.AddCommand(
+	stakeCmd.AddCommand(
 		client.PostCommands(
-			bankcmd.SendTxCmd(cdc),
-			ibccmd.IBCTransferCmd(cdc),
-			ibccmd.IBCRelayCmd(cdc),
 			stakecmd.GetCmdCreateValidator(cdc),
 			stakecmd.GetCmdEditValidator(cdc),
 			stakecmd.GetCmdDelegate(cdc),
 			stakecmd.GetCmdUnbond(cdc),
+		)...)
+	rootCmd.AddCommand(
+		stakeCmd,
+		client.LineBreak,
+	)
+
+	//Add IBC commands
+	ibcCmd := &cobra.Command{
+		Use:   "ibc",
+		Short: "Inter-Blockchain Communication subcommands",
+	}
+	ibcCmd.AddCommand(
+		client.PostCommands(
+			ibccmd.IBCTransferCmd(cdc),
+			ibccmd.IBCRelayCmd(cdc),
+		)...)
+	rootCmd.AddCommand(
+		ibcCmd,
+		client.LineBreak,
+	)
+
+	//Add auth and bank commands
+	rootCmd.AddCommand(
+		client.GetCommands(
+			authcmd.GetAccountCmd("acc", cdc, authcmd.GetAccountDecoder(cdc)),
+		)...)
+	rootCmd.AddCommand(
+		client.PostCommands(
+			bankcmd.SendTxCmd(cdc),
 		)...)
 
 	// add proxy, version and key info

--- a/cmd/gaia/cmd/gaiad/main.go
+++ b/cmd/gaia/cmd/gaiad/main.go
@@ -17,6 +17,7 @@ import (
 func main() {
 	cdc := app.MakeCodec()
 	ctx := server.NewDefaultContext()
+	cobra.EnableCommandSorting = false
 	rootCmd := &cobra.Command{
 		Use:               "gaiad",
 		Short:             "Gaia Daemon (server)",

--- a/server/util.go
+++ b/server/util.go
@@ -73,12 +73,12 @@ func AddCommands(
 
 	rootCmd.PersistentFlags().String("log_level", ctx.Config.LogLevel, "Log level")
 
-	tendCmd := &cobra.Command{
+	tendermintCmd := &cobra.Command{
 		Use:   "tendermint",
 		Short: "Tendermint subcommands",
 	}
 
-	tendCmd.AddCommand(
+	tendermintCmd.AddCommand(
 		UnsafeResetAllCmd(ctx),
 		ShowNodeIDCmd(ctx),
 		ShowValidatorCmd(ctx),
@@ -88,7 +88,7 @@ func AddCommands(
 		InitCmd(ctx, cdc, appInit),
 		StartCmd(ctx, appCreator),
 		client.LineBreak,
-		tendCmd,
+		tendermintCmd,
 		client.LineBreak,
 		ExportCmd(ctx, cdc, appExport),
 		client.LineBreak,

--- a/server/util.go
+++ b/server/util.go
@@ -79,7 +79,6 @@ func AddCommands(
 	}
 
 	tendermintCmd.AddCommand(
-		UnsafeResetAllCmd(ctx),
 		ShowNodeIDCmd(ctx),
 		ShowValidatorCmd(ctx),
 	)
@@ -87,6 +86,7 @@ func AddCommands(
 	rootCmd.AddCommand(
 		InitCmd(ctx, cdc, appInit),
 		StartCmd(ctx, appCreator),
+		UnsafeResetAllCmd(ctx),
 		client.LineBreak,
 		tendermintCmd,
 		ExportCmd(ctx, cdc, appExport),

--- a/server/util.go
+++ b/server/util.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
+	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/version"
 	"github.com/cosmos/cosmos-sdk/wire"
 	tcmd "github.com/tendermint/tendermint/cmd/tendermint/commands"
@@ -72,13 +73,25 @@ func AddCommands(
 
 	rootCmd.PersistentFlags().String("log_level", ctx.Config.LogLevel, "Log level")
 
-	rootCmd.AddCommand(
-		InitCmd(ctx, cdc, appInit),
-		StartCmd(ctx, appCreator),
+	tendCmd := &cobra.Command{
+		Use:   "tendermint",
+		Short: "Tendermint subcommands",
+	}
+
+	tendCmd.AddCommand(
 		UnsafeResetAllCmd(ctx),
 		ShowNodeIDCmd(ctx),
 		ShowValidatorCmd(ctx),
+	)
+
+	rootCmd.AddCommand(
+		InitCmd(ctx, cdc, appInit),
+		StartCmd(ctx, appCreator),
+		client.LineBreak,
+		tendCmd,
+		client.LineBreak,
 		ExportCmd(ctx, cdc, appExport),
+		client.LineBreak,
 		version.VersionCmd,
 	)
 }

--- a/server/util.go
+++ b/server/util.go
@@ -89,7 +89,6 @@ func AddCommands(
 		StartCmd(ctx, appCreator),
 		client.LineBreak,
 		tendermintCmd,
-		client.LineBreak,
 		ExportCmd(ctx, cdc, appExport),
 		client.LineBreak,
 		version.VersionCmd,


### PR DESCRIPTION
Implementation of #1068 

Old:



```
- gaiad
  - export
  - help
  - init
  - show_node_id
  - show_validator
  - start
  - unsafe_reset_all
  - version
- gaiacli
  - init
  - status
  - block
  - validatorset
  - txs
  - tx
  - account
  - validator
  - validators
  - delegation
  - delegations
  - send
  - transfer
  - relay
  - create-validator
  - edit-validator
  - delegate
  - unbond
  - rest-server
  - keys
  - version
  - help
```
New:

```
- gaiad
  - init
  - start
  - tendermint
    - unsafe_reset_all
    - show_node_id
    - show_validator
  - export
  - version
  - help
- gaiacli
  - init
  - status
  - state
    - block
    - validatorset
    - txs
    - tx
  - stake
    - validator
    - validators
    - delegation
    - delegations
    - create-validator
    - edit-validator
    - delegate
    - unbond
  - ibc
    - transfer
    - relay
  - account
  - send
  - rest-server
  - keys
  - version
  - help
```
