### PR TITLE
WIP: Gaiacli tests

### DIFF
--- a/tests/gobash.go
+++ b/tests/gobash.go
@@ -5,7 +5,6 @@ import (
 	"os/exec"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -34,7 +33,6 @@ func ExecuteT(t *testing.T, command string) (out string) {
 	}
 	require.NoError(t, err, string(bz))
 	out = strings.Trim(string(bz), "\n") //trim any new lines
-	time.Sleep(time.Second)
 	return out
 }
 
@@ -46,6 +44,5 @@ func GoExecuteT(t *testing.T, command string) (cmd *exec.Cmd, pipeIn io.WriteClo
 	pipeOut, err = cmd.StdoutPipe()
 	require.NoError(t, err)
 	cmd.Start()
-	time.Sleep(time.Second)
 	return cmd, pipeIn, pipeOut
 }


### PR DESCRIPTION
This tries to fix the Gaiacli tests. So far, this fixes a panic caused by trying to send messages to `gaiad` before its finished initializing. It also fixes the broken pipes that are caused by an incorrect number of password parameters being added when a new key is created. 

There are a few errors / things left that are confusing. Theres some race condition on lines 58-61 that cause the second send message to take an extra `100` seconds. If these lines are commented, the test takes ~20-30 seconds. And after the second send message in the test for sending, if those getAccount lines are uncommented, it causes errors. I think this is somehow being caused by race conditions.