### PR TITLE
Match UnmarshalBinaryBare/MarshalBinaryBare (ref #1099)

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -380,7 +380,7 @@
     "ripemd160",
     "salsa20/salsa"
   ]
-  revision = "ab813273cd59e1333f7ae7bff5d027d4aadf528c"
+  revision = "5ba7f63082460102a45837dbd1827e10f9479ac0"
 
 [[projects]]
   branch = "master"

--- a/x/slashing/tick.go
+++ b/x/slashing/tick.go
@@ -20,7 +20,7 @@ func NewBeginBlocker(sk Keeper) sdk.BeginBlocker {
 		// Deal with any equivocation evidence
 		for _, evidence := range req.ByzantineValidators {
 			var pk crypto.PubKey
-			sk.cdc.MustUnmarshalBinary(evidence.PubKey, &pk)
+			sk.cdc.MustUnmarshalBinaryBare(evidence.PubKey, &pk)
 			switch string(evidence.Type) {
 			case tmtypes.DUPLICATE_VOTE:
 				sk.handleDoubleSign(ctx, evidence.Height, evidence.Time, pk)
@@ -33,7 +33,7 @@ func NewBeginBlocker(sk Keeper) sdk.BeginBlocker {
 		absent := make(map[crypto.PubKey]struct{})
 		for _, pubkey := range req.AbsentValidators {
 			var pk crypto.PubKey
-			sk.cdc.MustUnmarshalBinary(pubkey, &pk)
+			sk.cdc.MustUnmarshalBinaryBare(pubkey, &pk)
 			absent[pk] = struct{}{}
 		}
 


### PR DESCRIPTION
Strange, why do we require this now but we didn't previously?