### PR TITLE
Swap x/slashing to sdk.ValidatorSet

### DIFF
--- a/x/slashing/handler.go
+++ b/x/slashing/handler.go
@@ -21,7 +21,7 @@ func NewHandler(k Keeper) sdk.Handler {
 func handleMsgUnrevoke(ctx sdk.Context, msg MsgUnrevoke, k Keeper) sdk.Result {
 
 	// Validator must exist
-	validator := k.stakeKeeper.Validator(ctx, msg.ValidatorAddr)
+	validator := k.validatorSet.Validator(ctx, msg.ValidatorAddr)
 	if validator == nil {
 		return ErrNoValidatorForAddress(k.codespace).Result()
 	}
@@ -48,7 +48,7 @@ func handleMsgUnrevoke(ctx sdk.Context, msg MsgUnrevoke, k Keeper) sdk.Result {
 	k.setValidatorSigningInfo(ctx, addr, info)
 
 	// Unrevoke the validator
-	k.stakeKeeper.Unrevoke(ctx, validator.GetPubKey())
+	k.validatorSet.Unrevoke(ctx, validator.GetPubKey())
 
 	tags := sdk.NewTags("action", []byte("unrevoke"), "validator", msg.ValidatorAddr.Bytes())
 

--- a/x/slashing/tick.go
+++ b/x/slashing/tick.go
@@ -41,7 +41,7 @@ func BeginBlocker(ctx sdk.Context, req abci.RequestBeginBlock, sk Keeper) (tags 
 	}
 
 	// Iterate over all the validators which *should* have signed this block
-	sk.stakeKeeper.IterateValidatorsBonded(ctx, func(_ int64, validator sdk.Validator) (stop bool) {
+	sk.validatorSet.IterateValidatorsBonded(ctx, func(_ int64, validator sdk.Validator) (stop bool) {
 		pubkey := validator.GetPubKey()
 		present := true
 		if _, ok := absent[pubkey]; ok {


### PR DESCRIPTION
Closes https://github.com/cosmos/cosmos-sdk/issues/1114

Slashing tests still reference staking for now (they need to create validators), perhaps those can be moved to a common testsuite later.