### PR TITLE
WIP: Creating a randomized module testing framework

### DIFF
--- a/mock/TestModules.go
+++ b/mock/TestModules.go
@@ -1,0 +1,112 @@
+package mock
+
+import (
+	"github.com/stretchr/testify/assert"
+	"math/rand"
+	"strconv"
+	"testing"
+	"time"
+	// "github.com/stretchr/testify/require"
+	// "github.com/cosmos/cosmos-sdk/baseapp"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/cosmos/cosmos-sdk/wire"
+	"github.com/cosmos/cosmos-sdk/x/auth"
+	abci "github.com/tendermint/abci/types"
+)
+
+func SingleModuleTest(t *testing.T, module TestModule, keeper interface{}, size []int) {
+	maxSize := getMaxValue(size)
+	keys, addrs := GenerateNPrivKeyAddressPairs(maxSize)
+	blocksize := 20 // Arbitrary. Later replace this with some sort of normal distribution
+	numblocks := 20 // Same as above
+	numRuns := 10
+	cdc := wire.NewCodec()
+	wire.RegisterCrypto(cdc)
+	module.RegisterWire(cdc)
+
+	for i := 0; i < numRuns; i++ {
+		app, cleanup, err := setupMockApp()
+		app.Cdc = cdc
+		assert.Nil(t, err)
+		time := time.Now().UnixNano()
+		log := "Starting SingleModuleTest with randomness created with seed " + strconv.Itoa(int(time))
+		r := rand.New(rand.NewSource(time))
+
+		keeperStore := make(map[string]KeeperStorage)
+		moduleKey := module.RandomSetup(t, r, app, size, keys, keeperStore)
+
+		app.MountStoresIAVL(app.KeyMain, app.KeyAccountStore, keeperStore[moduleKey].Key)
+		// TODO: Eventually abstract the following to support more ante handlers.
+		app.SetAnteHandler(auth.NewAnteHandler(app.AccountMapper, app.FeeCollectionKeeper))
+		// TODO: Randomize number of denominatioons
+		app.SetInitChainer(createInitChain(r, app, addrs, []string{"FooCoin"},
+			[]TestModule{module}, keeperStore))
+
+		// sanity check. Must allow no-transition invariant assertion
+		module.AssertInvariants(t, log, keeper)
+
+		header := abci.Header{
+			AppHash: []byte("apphash"),
+			Height:  0,
+		}
+		for i := 0; i < numblocks; i++ {
+			app.BeginBlock(abci.RequestBeginBlock{})
+
+			ctx := app.NewContext(false, header)
+			for j := 0; j < blocksize; j++ {
+				tx, newLog := module.RandOperation(r)(module, r, ctx, keeperStore[moduleKey].Keeper)
+				app.Deliver(tx)
+				module.AssertInvariants(t, log, keeper)
+				log += newLog + "\n"
+			}
+			app.EndBlock(abci.RequestEndBlock{})
+			app.Commit()
+			incrementHeight(header)
+
+			// sanity check. Must allow no-transition invariant assertion
+			module.AssertInvariants(t, log, keeper)
+		}
+
+		cleanup()
+	}
+}
+
+func createInitChain(r *rand.Rand, app *MockApp, addrs []sdk.Address, coinDenoms []string,
+	mods []TestModule, keeperStore map[string]KeeperStorage) sdk.InitChainer {
+	return func(ctx sdk.Context, req abci.RequestInitChain) abci.ResponseInitChain {
+		accts := CreateRandomGenesisAccounts(r, addrs, coinDenoms)
+		for _, act := range accts {
+			app.AccountMapper.SetAccount(ctx, &act)
+		}
+
+		// Application specific genesis handling
+		for _, mod := range mods {
+			err := mod.InitGenesis(ctx, keeperStore)
+			if err != nil {
+				panic(err)
+			}
+		}
+		return abci.ResponseInitChain{}
+	}
+}
+
+func MasterTest(t *testing.T, modules []TestModule, sizes [][]int, coinDenoms []string, numValidators int) {
+
+}
+
+// func initChain(bapp *baseapp.BaseApp, accs [])
+
+func incrementHeight(head abci.Header) {
+	head.Height++
+}
+
+func getMaxValue(vals []int) int {
+	m := vals[0]
+	for _, e := range vals {
+		if e < m {
+			m = e
+		}
+	}
+	return m
+}

--- a/mock/app_test.go
+++ b/mock/app_test.go
@@ -9,6 +9,8 @@ import (
 	abci "github.com/tendermint/abci/types"
 )
 
+var expectedStorePath = "/store/mock/key"
+
 // TestInitApp makes sure we can initialize this thing without an error
 func TestInitApp(t *testing.T) {
 	// set up an app
@@ -33,7 +35,7 @@ func TestInitApp(t *testing.T) {
 
 	// make sure we can query these values
 	query := abci.RequestQuery{
-		Path: "/store/main/key",
+		Path: expectedStorePath,
 		Data: []byte("foo"),
 	}
 	qres := app.Query(query)
@@ -69,7 +71,7 @@ func TestDeliverTx(t *testing.T) {
 
 	// make sure we can query these values
 	query := abci.RequestQuery{
-		Path: "/store/main/key",
+		Path: expectedStorePath,
 		Data: []byte(key),
 	}
 	qres := app.Query(query)

--- a/mock/helpers.go
+++ b/mock/helpers.go
@@ -5,23 +5,56 @@ import (
 	"os"
 
 	abci "github.com/tendermint/abci/types"
+	dbm "github.com/tendermint/tmlibs/db"
 	"github.com/tendermint/tmlibs/log"
+	"path/filepath"
+
+	bam "github.com/cosmos/cosmos-sdk/baseapp"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/wire"
+	"github.com/cosmos/cosmos-sdk/x/auth"
 )
 
-// SetupApp returns an application as well as a clean-up function
+// setupMockApp returns an application as well as a clean-up function
 // to be used to quickly setup a test case with an app
-func SetupApp() (abci.Application, func(), error) {
+// TODO Fix name ambiguity
+func setupMockApp() (*MockApp, func(), error) {
 	logger := log.NewTMLogger(log.NewSyncWriter(os.Stdout)).
 		With("module", "mock")
 	rootDir, err := ioutil.TempDir("", "mock-sdk")
 	if err != nil {
-		return nil, nil, err
+		return &MockApp{}, nil, err
 	}
 
 	cleanup := func() {
 		os.RemoveAll(rootDir)
 	}
 
-	app, err := NewApp(rootDir, logger)
-	return app, cleanup, err
+	app, err := newApp(rootDir, logger)
+	return app.(*MockApp), cleanup, err
+}
+
+// NewApp sets up everything it can without knowing what modules will be loaded.
+// TODO: Fix this name ambiguity
+func newApp(rootDir string, logger log.Logger) (abci.Application, error) {
+	db, err := dbm.NewGoLevelDB("mock", filepath.Join(rootDir, "data"))
+	if err != nil {
+		return nil, err
+	}
+
+	// Create MockApp.
+	mApp := &MockApp{
+		BaseApp:         bam.NewBaseApp("mockApp", nil, logger, db),
+		Cdc:             wire.NewCodec(),
+		KeyMain:         sdk.NewKVStoreKey("mock"),
+		KeyAccountStore: sdk.NewKVStoreKey("acc"),
+	}
+
+	// Define the accountMapper.
+	mApp.AccountMapper = auth.NewAccountMapper(
+		mApp.Cdc,
+		mApp.KeyAccountStore, // target store
+		&auth.BaseAccount{},  // prototype
+	)
+	return mApp, nil
 }

--- a/mock/test_utils.go
+++ b/mock/test_utils.go
@@ -1,0 +1,75 @@
+package mock
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/require"
+	crypto "github.com/tendermint/go-crypto"
+	"math/rand"
+	"testing"
+
+	"github.com/cosmos/cosmos-sdk/baseapp"
+	"github.com/cosmos/cosmos-sdk/x/auth"
+	abci "github.com/tendermint/abci/types"
+)
+
+func GenerateNPrivKeys(N int) (keys []crypto.PrivKey) {
+	// TODO Randomize this between ed255 and secp
+	keys = make([]crypto.PrivKey, N, N)
+	for i := 0; i < N; i++ {
+		keys[i] = crypto.GenPrivKeyEd25519()
+	}
+	return
+}
+
+func GenerateNPrivKeyAddressPairs(N int) (keys []crypto.PrivKey, addrs []sdk.Address) {
+	keys = make([]crypto.PrivKey, N, N)
+	addrs = make([]sdk.Address, N, N)
+	for i := 0; i < N; i++ {
+		keys[i] = crypto.GenPrivKeyEd25519()
+		addrs[i] = keys[i].PubKey().Address()
+	}
+	return
+}
+
+func CreateRandomGenesisAccounts(r *rand.Rand, addrs []sdk.Address, denoms []string) []auth.BaseAccount {
+	accts := make([]auth.BaseAccount, len(addrs), len(addrs))
+	maxNumCoins := 2 << 50
+	for i := 0; i < len(accts); i++ {
+		coins := make([]sdk.Coin, len(denoms), len(denoms))
+		for j := 0; j < len(denoms); j++ {
+			coins[j] = sdk.Coin{Denom: denoms[j], Amount: int64(r.Intn(maxNumCoins))}
+		}
+		accts[i] = auth.NewBaseAccountWithAddress(addrs[i])
+		accts[i].SetCoins(coins)
+	}
+	return accts
+}
+
+// TODO describe the use of this function
+func CheckDeliver(t *testing.T, bapp *baseapp.BaseApp, tx sdk.Tx, expPass bool) sdk.Result {
+	// Run a Check
+	res := bapp.Check(tx)
+	if expPass {
+		require.Equal(t, sdk.ABCICodeOK, res.Code, res.Log)
+	} else {
+		require.NotEqual(t, sdk.ABCICodeOK, res.Code, res.Log)
+	}
+
+	// Simulate a Block
+	bapp.BeginBlock(abci.RequestBeginBlock{})
+	res = bapp.Deliver(tx)
+	if expPass {
+		require.Equal(t, sdk.ABCICodeOK, res.Code, res.Log)
+	} else {
+		require.NotEqual(t, sdk.ABCICodeOK, res.Code, res.Log)
+	}
+	bapp.EndBlock(abci.RequestEndBlock{})
+	//bapp.Commit()
+	return res
+}
+
+func CreateRandOperation(ops []Operation) func(r *rand.Rand) Operation {
+	return func(r *rand.Rand) Operation {
+		return ops[r.Intn(len(ops))]
+	}
+}

--- a/mock/types.go
+++ b/mock/types.go
@@ -1,0 +1,45 @@
+package mock
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	// "github.com/stretchr/testify/require"
+	// bap "github.com/cosmos/cosmos-sdk/baseapp"
+	// "github.com/cosmos/cosmos-sdk/x/auth"
+	// abci "github.com/tendermint/abci/types"
+	"github.com/cosmos/cosmos-sdk/wire"
+	crypto "github.com/tendermint/go-crypto"
+	"math/rand"
+	"testing"
+)
+
+// any operation that transforms state takes in RNG instance, and its keeper.
+// returns msg to include in block, and meaningful message for log.
+type Operation func(mod TestModule, r *rand.Rand, ctx sdk.Context, keeper interface{}) (sdk.Tx, string)
+
+type KeeperStorage struct {
+	Keeper interface{}
+	Key    *sdk.KVStoreKey
+
+	Other []interface{}
+}
+
+type TestModule interface {
+	AssertInvariants(t *testing.T, log string, keeper interface{}) (bool, string)
+	// Sets keeper and needed interfaces in KeeperStore. Don't mutate privKeyList
+	RandomSetup(t *testing.T, r *rand.Rand, app *MockApp, size []int, privkeyList []crypto.PrivKey,
+		keeperStore map[string]KeeperStorage) (name string)
+	RandOperation(r *rand.Rand) Operation
+	RegisterWire(cdc *wire.Codec)
+	// Optional
+	InitGenesis(ctx sdk.Context, keeperStore map[string]KeeperStorage) sdk.Error
+}
+
+var modules = []TestModule{}
+
+func RegisterModule(module TestModule) {
+	modules = append(modules, module)
+}
+
+func ClearModules() {
+	modules = []TestModule{}
+}


### PR DESCRIPTION
This basically converts mockApp to an application we use for testing. The currently envisioned process for adding a module to testing is you create a 'TestModule' struct. This will have an init function, and a function to check all of the things you're app needs in order to be valid. You also define operations which will randomly produce a message of the given type. This testmodule interface is in `mock/types.go`. I am still working on making staking implement this, just making a WIP PR upon request.

<!-- Thanks for filing a PR! Before hitting the button, please check the following items.-->

* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG.md
* [ ] Add the code for testing multiple modules together
* [ ] Make default modules implement this
* [ ] Show an example of this in democoin
* [ ] Reduce code reuse in application app_tests
* [ ] Fix the weird two sets of 'new / setup' commands in MockApp that I made
* [ ] Create meta-tests