### PR TITLE
Use bech32 encoding for msg.GetSignBytes()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 BREAKING CHANGES
+* msg.GetSignBytes() now returns bech32-encoded addresses in all cases
 
 FEATURES
 

--- a/types/account.go
+++ b/types/account.go
@@ -98,15 +98,6 @@ func GetAccAddressBech32(address string) (addr Address, err error) {
 	return Address(bz), nil
 }
 
-// must create an Address from a string
-func MustGetAccAddressBech32(address string) Address {
-	addr, err := GetAccAddressBech32(address)
-	if err != nil {
-		panic(err)
-	}
-	return addr
-}
-
 // create a Pubkey from a string
 func GetAccPubKeyBech32(address string) (pk crypto.PubKey, err error) {
 	bz, err := getFromBech32(address, Bech32PrefixAccPub)
@@ -120,15 +111,6 @@ func GetAccPubKeyBech32(address string) (pk crypto.PubKey, err error) {
 	}
 
 	return pk, nil
-}
-
-// must create a Pubkey from a string
-func MustGetAccPubkeyBec32(address string) crypto.PubKey {
-	pk, err := GetAccPubKeyBech32(address)
-	if err != nil {
-		panic(err)
-	}
-	return pk
 }
 
 // create an Address from a hex string
@@ -152,15 +134,6 @@ func GetValAddressBech32(address string) (addr Address, err error) {
 	return Address(bz), nil
 }
 
-// must create an Address from a bech32 string
-func MustGetValAddressBech32(address string) Address {
-	addr, err := GetValAddressBech32(address)
-	if err != nil {
-		panic(err)
-	}
-	return addr
-}
-
 // decode a validator public key into a PubKey
 func GetValPubKeyBech32(pubkey string) (pk crypto.PubKey, err error) {
 	bz, err := getFromBech32(pubkey, Bech32PrefixValPub)
@@ -174,15 +147,6 @@ func GetValPubKeyBech32(pubkey string) (pk crypto.PubKey, err error) {
 	}
 
 	return pk, nil
-}
-
-// must decode a validator public key into a PubKey
-func MustGetValPubKeyBech32(pubkey string) crypto.PubKey {
-	pk, err := GetValPubKeyBech32(pubkey)
-	if err != nil {
-		panic(err)
-	}
-	return pk
 }
 
 func getFromBech32(bech32str, prefix string) ([]byte, error) {

--- a/types/account.go
+++ b/types/account.go
@@ -62,6 +62,15 @@ func GetAccAddressBech32(address string) (addr Address, err error) {
 	return Address(bz), nil
 }
 
+// must create an Address from a string
+func MustGetAccAddressBech32(address string) Address {
+	addr, err := GetAccAddressBech32(address)
+	if err != nil {
+		panic(err)
+	}
+	return addr
+}
+
 // create a Pubkey from a string
 func GetAccPubKeyBech32(address string) (pk crypto.PubKey, err error) {
 	bz, err := getFromBech32(address, Bech32PrefixAccPub)
@@ -75,6 +84,15 @@ func GetAccPubKeyBech32(address string) (pk crypto.PubKey, err error) {
 	}
 
 	return pk, nil
+}
+
+// must create a Pubkey from a string
+func MustGetAccPubkeyBec32(address string) crypto.PubKey {
+	pk, err := GetAccPubKeyBech32(address)
+	if err != nil {
+		panic(err)
+	}
+	return pk
 }
 
 // create an Address from a hex string
@@ -98,7 +116,16 @@ func GetValAddressBech32(address string) (addr Address, err error) {
 	return Address(bz), nil
 }
 
-//Decode a validator publickey into a public key
+// must create an Address from a bech32 string
+func MustGetValAddressBech32(address string) Address {
+	addr, err := GetValAddressBech32(address)
+	if err != nil {
+		panic(err)
+	}
+	return addr
+}
+
+// decode a validator public key into a PubKey
 func GetValPubKeyBech32(pubkey string) (pk crypto.PubKey, err error) {
 	bz, err := getFromBech32(pubkey, Bech32PrefixValPub)
 	if err != nil {
@@ -111,6 +138,15 @@ func GetValPubKeyBech32(pubkey string) (pk crypto.PubKey, err error) {
 	}
 
 	return pk, nil
+}
+
+// must decode a validator public key into a PubKey
+func MustGetValPubKeyBech32(pubkey string) crypto.PubKey {
+	pk, err := GetValPubKeyBech32(pubkey)
+	if err != nil {
+		panic(err)
+	}
+	return pk
 }
 
 func getFromBech32(bech32str, prefix string) ([]byte, error) {

--- a/types/account.go
+++ b/types/account.go
@@ -26,9 +26,27 @@ func Bech32ifyAcc(addr Address) (string, error) {
 	return bech32.ConvertAndEncode(Bech32PrefixAccAddr, addr.Bytes())
 }
 
+// MustBech32ifyAcc panics on bech32-encoding failure
+func MustBech32ifyAcc(addr Address) string {
+	enc, err := Bech32ifyAcc(addr)
+	if err != nil {
+		panic(err)
+	}
+	return enc
+}
+
 // Bech32ifyAccPub takes AccountPubKey and returns the bech32 encoded string
 func Bech32ifyAccPub(pub crypto.PubKey) (string, error) {
 	return bech32.ConvertAndEncode(Bech32PrefixAccPub, pub.Bytes())
+}
+
+// MustBech32ifyAccPub panics on bech32-encoding failure
+func MustBech32ifyAccPub(pub crypto.PubKey) string {
+	enc, err := Bech32ifyAccPub(pub)
+	if err != nil {
+		panic(err)
+	}
+	return enc
 }
 
 // Bech32ifyVal returns the bech32 encoded string for a validator address
@@ -36,9 +54,27 @@ func Bech32ifyVal(addr Address) (string, error) {
 	return bech32.ConvertAndEncode(Bech32PrefixValAddr, addr.Bytes())
 }
 
+// MustBech32ifyVal panics on bech32-encoding failure
+func MustBech32ifyVal(addr Address) string {
+	enc, err := Bech32ifyVal(addr)
+	if err != nil {
+		panic(err)
+	}
+	return enc
+}
+
 // Bech32ifyValPub returns the bech32 encoded string for a validator pubkey
 func Bech32ifyValPub(pub crypto.PubKey) (string, error) {
 	return bech32.ConvertAndEncode(Bech32PrefixValPub, pub.Bytes())
+}
+
+// MustBech32ifyValPub pancis on bech32-encoding failure
+func MustBech32ifyValPub(pub crypto.PubKey) string {
+	enc, err := Bech32ifyValPub(pub)
+	if err != nil {
+		panic(err)
+	}
+	return enc
 }
 
 // create an Address from a string

--- a/x/auth/stdtx.go
+++ b/x/auth/stdtx.go
@@ -1,6 +1,8 @@
 package auth
 
 import (
+	"encoding/json"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	crypto "github.com/tendermint/go-crypto"
 )
@@ -83,11 +85,11 @@ func (fee StdFee) Bytes() []byte {
 // and the Sequence numbers for each signature (prevent
 // inchain replay and enforce tx ordering per account).
 type StdSignDoc struct {
-	ChainID   string  `json:"chain_id"`
-	Sequences []int64 `json:"sequences"`
-	FeeBytes  []byte  `json:"fee_bytes"`
-	MsgBytes  []byte  `json:"msg_bytes"`
-	AltBytes  []byte  `json:"alt_bytes"`
+	ChainID   string          `json:"chain_id"`
+	Sequences []int64         `json:"sequences"`
+	FeeBytes  json.RawMessage `json:"fee_bytes"`
+	MsgBytes  json.RawMessage `json:"msg_bytes"`
+	AltBytes  json.RawMessage `json:"alt_bytes"`
 }
 
 // StdSignBytes returns the bytes to sign for a transaction.
@@ -96,8 +98,8 @@ func StdSignBytes(chainID string, sequences []int64, fee StdFee, msg sdk.Msg) []
 	bz, err := msgCdc.MarshalJSON(StdSignDoc{
 		ChainID:   chainID,
 		Sequences: sequences,
-		FeeBytes:  fee.Bytes(),
-		MsgBytes:  msg.GetSignBytes(),
+		FeeBytes:  json.RawMessage(fee.Bytes()),
+		MsgBytes:  json.RawMessage(msg.GetSignBytes()),
 	})
 	if err != nil {
 		panic(err)

--- a/x/bank/msgs.go
+++ b/x/bank/msgs.go
@@ -150,6 +150,7 @@ type Input struct {
 	Coins   sdk.Coins   `json:"coins"`
 }
 
+// Return bytes to sign for Input
 func (in Input) GetSignBytes() []byte {
 	bin, err := msgCdc.MarshalJSON(struct {
 		Address string    `json:"address"`
@@ -196,6 +197,7 @@ type Output struct {
 	Coins   sdk.Coins   `json:"coins"`
 }
 
+// Return bytes to sign for Output
 func (out Output) GetSignBytes() []byte {
 	bin, err := msgCdc.MarshalJSON(struct {
 		Address string    `json:"address"`

--- a/x/bank/msgs_test.go
+++ b/x/bank/msgs_test.go
@@ -187,12 +187,14 @@ func TestMsgSendGetSignBytes(t *testing.T) {
 	}
 	res := msg.GetSignBytes()
 
-	unmarshaledMsg := &MsgSend{}
-	msgCdc.UnmarshalJSON(res, unmarshaledMsg)
-	assert.Equal(t, &msg, unmarshaledMsg)
+	// TODO Why did we assert this?
+	/*
+		unmarshaledMsg := &MsgSend{}
+		msgCdc.UnmarshalJSON(res, unmarshaledMsg)
+		assert.Equal(t, &msg, unmarshaledMsg)
+	*/
 
-	// TODO bad results
-	expected := `{"type":"EAFDE32A2C87F8","value":{"inputs":[{"address":"696E707574","coins":[{"denom":"atom","amount":10}]}],"outputs":[{"address":"6F7574707574","coins":[{"denom":"atom","amount":10}]}]}}`
+	expected := `{"inputs":[{"address":"cosmosaccaddr1d9h8qat5e4ehc5","coins":[{"denom":"atom","amount":10}]}],"outputs":[{"address":"cosmosaccaddr1da6hgur4wse3jx32","coins":[{"denom":"atom","amount":10}]}]}`
 	assert.Equal(t, expected, string(res))
 }
 

--- a/x/bank/msgs_test.go
+++ b/x/bank/msgs_test.go
@@ -187,13 +187,6 @@ func TestMsgSendGetSignBytes(t *testing.T) {
 	}
 	res := msg.GetSignBytes()
 
-	// TODO Why did we assert this?
-	/*
-		unmarshaledMsg := &MsgSend{}
-		msgCdc.UnmarshalJSON(res, unmarshaledMsg)
-		assert.Equal(t, &msg, unmarshaledMsg)
-	*/
-
 	expected := `{"inputs":[{"address":"cosmosaccaddr1d9h8qat5e4ehc5","coins":[{"denom":"atom","amount":10}]}],"outputs":[{"address":"cosmosaccaddr1da6hgur4wse3jx32","coins":[{"denom":"atom","amount":10}]}]}`
 	assert.Equal(t, expected, string(res))
 }

--- a/x/bank/msgs_test.go
+++ b/x/bank/msgs_test.go
@@ -257,12 +257,7 @@ func TestMsgIssueGetSignBytes(t *testing.T) {
 	}
 	res := msg.GetSignBytes()
 
-	unmarshaledMsg := &MsgIssue{}
-	msgCdc.UnmarshalJSON(res, unmarshaledMsg)
-	assert.Equal(t, &msg, unmarshaledMsg)
-
-	// TODO bad results
-	expected := `{"type":"72E617C06ABAD0","value":{"banker":"696E707574","outputs":[{"address":"6C6F616E2D66726F6D2D62616E6B","coins":[{"denom":"atom","amount":10}]}]}}`
+	expected := `{"banker":"cosmosaccaddr1d9h8qat5e4ehc5","outputs":[{"address":"cosmosaccaddr1d3hkzm3dveex7mfdvfsku6cwsauqd","coins":[{"denom":"atom","amount":10}]}]}`
 	assert.Equal(t, expected, string(res))
 }
 

--- a/x/ibc/types.go
+++ b/x/ibc/types.go
@@ -41,6 +41,7 @@ func NewIBCPacket(srcAddr sdk.Address, destAddr sdk.Address, coins sdk.Coins,
 	}
 }
 
+//nolint
 func (p IBCPacket) GetSignBytes() []byte {
 	b, err := msgCdc.MarshalJSON(struct {
 		SrcAddr   string
@@ -62,11 +63,11 @@ func (p IBCPacket) GetSignBytes() []byte {
 }
 
 // validator the ibc packey
-func (ibcp IBCPacket) ValidateBasic() sdk.Error {
-	if ibcp.SrcChain == ibcp.DestChain {
+func (p IBCPacket) ValidateBasic() sdk.Error {
+	if p.SrcChain == p.DestChain {
 		return ErrIdenticalChains(DefaultCodespace).Trace("")
 	}
-	if !ibcp.Coins.IsValid() {
+	if !p.Coins.IsValid() {
 		return sdk.ErrInvalidCoins("")
 	}
 	return nil

--- a/x/slashing/msg.go
+++ b/x/slashing/msg.go
@@ -30,7 +30,11 @@ func (msg MsgUnrevoke) GetSigners() []sdk.Address { return []sdk.Address{msg.Val
 
 // get the bytes for the message signer to sign on
 func (msg MsgUnrevoke) GetSignBytes() []byte {
-	b, err := cdc.MarshalJSON(msg)
+	b, err := cdc.MarshalJSON(struct {
+		ValidatorAddr string `json:"address"`
+	}{
+		ValidatorAddr: sdk.MustBech32ifyAcc(msg.ValidatorAddr),
+	})
 	if err != nil {
 		panic(err)
 	}

--- a/x/slashing/msg.go
+++ b/x/slashing/msg.go
@@ -33,7 +33,7 @@ func (msg MsgUnrevoke) GetSignBytes() []byte {
 	b, err := cdc.MarshalJSON(struct {
 		ValidatorAddr string `json:"address"`
 	}{
-		ValidatorAddr: sdk.MustBech32ifyAcc(msg.ValidatorAddr),
+		ValidatorAddr: sdk.MustBech32ifyVal(msg.ValidatorAddr),
 	})
 	if err != nil {
 		panic(err)

--- a/x/slashing/msg_test.go
+++ b/x/slashing/msg_test.go
@@ -1,0 +1,16 @@
+package slashing
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+func TestMsgUnrevokeGetSignBytes(t *testing.T) {
+	addr := sdk.Address("abcd")
+	msg := NewMsgUnrevoke(addr)
+	bytes := msg.GetSignBytes()
+	assert.Equal(t, string(bytes), `{"address":"cosmosvaladdr1v93xxeqamr0mv"}`)
+}

--- a/x/stake/msg.go
+++ b/x/stake/msg.go
@@ -45,7 +45,20 @@ func (msg MsgCreateValidator) GetSigners() []sdk.Address {
 
 // get the bytes for the message signer to sign on
 func (msg MsgCreateValidator) GetSignBytes() []byte {
-	return msgCdc.MustMarshalBinary(msg)
+	b, err := msgCdc.MarshalJSON(struct {
+		Description
+		ValidatorAddr string   `json:"address"`
+		PubKey        string   `json:"pubkey"`
+		Bond          sdk.Coin `json:"bond"`
+	}{
+		Description:   msg.Description,
+		ValidatorAddr: sdk.MustBech32ifyVal(msg.ValidatorAddr),
+		PubKey:        sdk.MustBech32ifyValPub(msg.PubKey),
+	})
+	if err != nil {
+		panic(err)
+	}
+	return b
 }
 
 // quick validity check
@@ -89,7 +102,13 @@ func (msg MsgEditValidator) GetSigners() []sdk.Address {
 
 // get the bytes for the message signer to sign on
 func (msg MsgEditValidator) GetSignBytes() []byte {
-	b, err := msgCdc.MarshalJSON(msg)
+	b, err := msgCdc.MarshalJSON(struct {
+		Description
+		ValidatorAddr string `json:"address"`
+	}{
+		Description:   msg.Description,
+		ValidatorAddr: sdk.MustBech32ifyVal(msg.ValidatorAddr),
+	})
 	if err != nil {
 		panic(err)
 	}
@@ -133,7 +152,15 @@ func (msg MsgDelegate) GetSigners() []sdk.Address {
 
 // get the bytes for the message signer to sign on
 func (msg MsgDelegate) GetSignBytes() []byte {
-	b, err := msgCdc.MarshalJSON(msg)
+	b, err := msgCdc.MarshalJSON(struct {
+		DelegatorAddr string   `json:"delegator_addr"`
+		ValidatorAddr string   `json:"validator_addr"`
+		Bond          sdk.Coin `json:"bond"`
+	}{
+		DelegatorAddr: sdk.MustBech32ifyAcc(msg.DelegatorAddr),
+		ValidatorAddr: sdk.MustBech32ifyVal(msg.ValidatorAddr),
+		Bond:          msg.Bond,
+	})
 	if err != nil {
 		panic(err)
 	}
@@ -180,7 +207,15 @@ func (msg MsgUnbond) GetSigners() []sdk.Address { return []sdk.Address{msg.Deleg
 
 // get the bytes for the message signer to sign on
 func (msg MsgUnbond) GetSignBytes() []byte {
-	b, err := msgCdc.MarshalJSON(msg)
+	b, err := msgCdc.MarshalJSON(struct {
+		DelegatorAddr string `json:"delegator_addr"`
+		ValidatorAddr string `json:"validator_addr"`
+		Shares        string `json:"shares"`
+	}{
+		DelegatorAddr: sdk.MustBech32ifyAcc(msg.DelegatorAddr),
+		ValidatorAddr: sdk.MustBech32ifyVal(msg.ValidatorAddr),
+		Shares:        msg.Shares,
+	})
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Closes https://github.com/cosmos/cosmos-sdk/issues/1150.

* [x] Updated all relevant documentation in docs
* [x] Updated all code comments where relevant
* [x] Wrote tests
* [x] Updated CHANGELOG.md
