### PR TITLE
Objcap ValidatorSet

### DIFF
--- a/cmd/gaia/app/app.go
+++ b/cmd/gaia/app/app.go
@@ -76,7 +76,7 @@ func NewGaiaApp(logger log.Logger, db dbm.DB) *GaiaApp {
 	app.coinKeeper = bank.NewKeeper(app.accountMapper)
 	app.ibcMapper = ibc.NewMapper(app.cdc, app.keyIBC, app.RegisterCodespace(ibc.DefaultCodespace))
 	app.stakeKeeper = stake.NewKeeper(app.cdc, app.keyStake, app.coinKeeper, app.RegisterCodespace(stake.DefaultCodespace))
-	app.slashingKeeper = slashing.NewKeeper(app.cdc, app.keySlashing, app.stakeKeeper, app.RegisterCodespace(slashing.DefaultCodespace))
+	app.slashingKeeper = slashing.NewKeeper(app.cdc, app.keySlashing, app.stakeKeeper.Full(), app.RegisterCodespace(slashing.DefaultCodespace))
 
 	// register message routes
 	app.Router().

--- a/examples/basecoin/app/app.go
+++ b/examples/basecoin/app/app.go
@@ -73,7 +73,7 @@ func NewBasecoinApp(logger log.Logger, db dbm.DB) *BasecoinApp {
 	app.coinKeeper = bank.NewKeeper(app.accountMapper)
 	app.ibcMapper = ibc.NewMapper(app.cdc, app.keyIBC, app.RegisterCodespace(ibc.DefaultCodespace))
 	app.stakeKeeper = stake.NewKeeper(app.cdc, app.keyStake, app.coinKeeper, app.RegisterCodespace(stake.DefaultCodespace))
-	app.slashingKeeper = slashing.NewKeeper(app.cdc, app.keySlashing, app.stakeKeeper, app.RegisterCodespace(slashing.DefaultCodespace))
+	app.slashingKeeper = slashing.NewKeeper(app.cdc, app.keySlashing, app.stakeKeeper.Full(), app.RegisterCodespace(slashing.DefaultCodespace))
 
 	// register message routes
 	app.Router().

--- a/types/stake.go
+++ b/types/stake.go
@@ -65,6 +65,72 @@ type ValidatorSet interface {
 	Unrevoke(Context, crypto.PubKey)          // unrevoke a validator
 }
 
+// ViewValidatorSet only allows reading validator informations, without slashing/revoking
+type ViewValidatorSet struct {
+	valset ValidatorSet
+}
+
+func NewViewValidatorSet(valset ValidatorSet) ViewValidatorSet {
+	return ViewValidatorSet{
+		valset: valset,
+	}
+}
+
+func (valset ViewValidatorSet) IterateValidators(ctx Context, fn func(int64, Validator) bool) {
+	valset.valset.IterateValidators(ctx, fn)
+}
+
+func (valset ViewValidatorSet) IterateValidatorsBonded(ctx Context, fn func(int64, Validator) bool) {
+	valset.valset.IterateValidatorsBonded(ctx, fn)
+}
+
+func (valset ViewValidatorSet) Validator(ctx Context, addr Address) Validator {
+	return valset.valset.Validator(ctx, addr)
+}
+
+func (valset ViewValidatorSet) TotalPower(ctx Context) Rat {
+	return valset.valset.TotalPower(ctx)
+}
+
+// FullValidatorSet allows all activity on ValidatorSet but prevent type assertion/switching
+type FullValidatorSet struct {
+	valset ValidatorSet
+}
+
+func NewFullValidatorSet(valset ValidatorSet) FullValidatorSet {
+	return FullValidatorSet{
+		valset: valset,
+	}
+}
+
+func (valset FullValidatorSet) IterateValidators(ctx Context, fn func(int64, Validator) bool) {
+	valset.valset.IterateValidators(ctx, fn)
+}
+
+func (valset FullValidatorSet) IterateValidatorsBonded(ctx Context, fn func(int64, Validator) bool) {
+	valset.valset.IterateValidatorsBonded(ctx, fn)
+}
+
+func (valset FullValidatorSet) Validator(ctx Context, addr Address) Validator {
+	return valset.valset.Validator(ctx, addr)
+}
+
+func (valset FullValidatorSet) TotalPower(ctx Context) Rat {
+	return valset.valset.TotalPower(ctx)
+}
+
+func (valset FullValidatorSet) Slash(ctx Context, pubkey crypto.PubKey, height int64, fraction Rat) {
+	valset.valset.Slash(ctx, pubkey, height, fraction)
+}
+
+func (valset FullValidatorSet) Revoke(ctx Context, pubkey crypto.PubKey) {
+	valset.valset.Revoke(ctx, pubkey)
+}
+
+func (valset FullValidatorSet) Unrevoke(ctx Context, pubkey crypto.PubKey) {
+	valset.valset.Unrevoke(ctx, pubkey)
+}
+
 //_______________________________________________________________________________
 
 // delegation bond for a delegated proof of stake system

--- a/x/slashing/keeper.go
+++ b/x/slashing/keeper.go
@@ -12,14 +12,14 @@ import (
 type Keeper struct {
 	storeKey     sdk.StoreKey
 	cdc          *wire.Codec
-	validatorSet sdk.ValidatorSet
+	validatorSet sdk.FullValidatorSet
 
 	// codespace
 	codespace sdk.CodespaceType
 }
 
 // NewKeeper creates a slashing keeper
-func NewKeeper(cdc *wire.Codec, key sdk.StoreKey, vs sdk.ValidatorSet, codespace sdk.CodespaceType) Keeper {
+func NewKeeper(cdc *wire.Codec, key sdk.StoreKey, vs sdk.FullValidatorSet, codespace sdk.CodespaceType) Keeper {
 	keeper := Keeper{
 		storeKey:     key,
 		cdc:          cdc,

--- a/x/slashing/test_common.go
+++ b/x/slashing/test_common.go
@@ -68,7 +68,7 @@ func createTestInput(t *testing.T) (sdk.Context, bank.Keeper, stake.Keeper, Keep
 			{sk.GetParams(ctx).BondDenom, initCoins},
 		})
 	}
-	keeper := NewKeeper(cdc, keySlashing, sk, DefaultCodespace)
+	keeper := NewKeeper(cdc, keySlashing, sk.Full(), DefaultCodespace)
 	return ctx, ck, sk, keeper
 }
 

--- a/x/stake/keeper.go
+++ b/x/stake/keeper.go
@@ -758,6 +758,16 @@ func (k Keeper) TotalPower(ctx sdk.Context) sdk.Rat {
 	return pool.BondedShares
 }
 
+// wrap the keeper to sdk.FullValidatorSet
+func (k Keeper) Full() sdk.FullValidatorSet {
+	return sdk.NewFullValidatorSet(k)
+}
+
+// wrap the keeper to sdk.ViewValidatorSet
+func (k Keeper) View() sdk.ViewValidatorSet {
+	return sdk.NewViewValidatorSet(k)
+}
+
 //__________________________________________________________________________
 
 // Implements DelegationSet


### PR DESCRIPTION
Add two new types, `ViewValidatorSet` and `FullValidatorSet`.

`ViewValidatorSet` can retrieve information about the current validators, but cannot slash or revoke. `FullValidatorSet` reexports all methods from `ValidatorSet` but prevent type switching/assertion to the inner struct.

`slashing.Keeper` now takes `FullValidatorSet` and `stake.Keeper` exports two new methods, `.Full()` and `View()`, which exports `FullValidatorSet` and `ViewValidatorSet` repectively.