### PR TITLE
Install python3 as a necessary dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ ADD . $REPO_PATH
 # Install minimum necessary dependencies, build Cosmos SDK, remove packages
 RUN apk add --no-cache $PACKAGES && \
     cd $REPO_PATH && make get_tools && make get_vendor_deps && make build && make install && \
+    apk add python3 && \
     apk del $PACKAGES
 
 # Set entrypoint


### PR DESCRIPTION
Very useful for people who run Docker images on GCP. It fixes the liveness probe check.

<!-- Thanks for filing a PR! Before hitting the button, please check the following items.-->

* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG.md
