### PR TITLE
fix ante. set lcd log to debug

### DIFF
--- a/client/lcd/test_helpers.go
+++ b/client/lcd/test_helpers.go
@@ -100,7 +100,7 @@ func InitializeTestLCD(t *testing.T, nValidators int, initAddrs []sdk.Address) (
 	config.TxIndex.IndexAllTags = true
 
 	logger := log.NewTMLogger(log.NewSyncWriter(os.Stdout))
-	logger = log.NewFilter(logger, log.AllowError())
+	logger = log.NewFilter(logger, log.AllowDebug())
 	privValidatorFile := config.PrivValidatorFile()
 	privVal := pvm.LoadOrGenFilePV(privValidatorFile)
 	privVal.Reset()

--- a/x/auth/ante.go
+++ b/x/auth/ante.go
@@ -73,12 +73,12 @@ func NewAnteHandler(am AccountMapper, fck FeeCollectionKeeper) sdk.AnteHandler {
 		}
 		fee := stdTx.Fee
 		chainID := ctx.ChainID()
-		// XXX: major hack; need to get ChainID
+		// XXX/TODO: major hack; need to get ChainID
 		// into the app right away (#565)
 		if chainID == "" {
 			chainID = viper.GetString("chain-id")
 		}
-		signBytes := StdSignBytes(ctx.ChainID(), accNums, sequences, fee, msg, memo)
+		signBytes := StdSignBytes(chainID, accNums, sequences, fee, msg, memo)
 
 		// Check sig and nonce and collect signer accounts.
 		var signerAccs = make([]Account, len(signerAddrs))


### PR DESCRIPTION
I guess this still needs to be fixed properly by setting ChainID on InitChain.

Also bumped the log level to Debug.

With this change, the signature verification seems to pass, but the test halts because after the first block the sole validator gets unbonded. I.e we see the following in the logs after the first block: 

```
I[06-21|07:34:35.029] Updates to validators                        module=state updates="[{\"address\":\"\",\"pub_key\":\"AT/+aaL1eB0477Mud9JMm8Sh8BIvOYlPGC9KkIUmFaE=\",\"power\":0}]"
```

Maybe a bug in new unbonding ? 
