### PR TITLE
tools: Fix makefile install scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,11 @@ FEATURES
   * Supported proposal types: just binary (pass/fail) TextProposals for now
   * Proposals need deposits to be votable; deposits are burned if proposal fails
   * Delegators delegate votes to validator by default but can override (for their stake)
+* [tools] make get_tools installs tendermint's linter, and gometalinter
 
 FIXES
 * \#1259 - fix bug where certain tests that could have a nil pointer in defer
+* \#1052 - Make all now works
 * Retry on HTTP request failure in CLI tests, add option to retry tests in Makefile
 * Fixed bug where chain ID wasn't passed properly in x/bank REST handler
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PACKAGES_NOCLITEST=$(shell go list ./... | grep -v '/vendor/' | grep -v github.c
 COMMIT_HASH := $(shell git rev-parse --short HEAD)
 BUILD_FLAGS = -tags netgo -ldflags "-X github.com/cosmos/cosmos-sdk/version.GitCommit=${COMMIT_HASH}"
 
-all: check_tools get_vendor_deps install install_examples test_lint test
+all: get_tools get_vendor_deps install install_examples test_lint test
 
 ########################################
 ### CI
@@ -36,11 +36,11 @@ else
 	go build $(BUILD_FLAGS) -o build/democli ./examples/democoin/cmd/democli
 endif
 
-install: 
+install:
 	go install $(BUILD_FLAGS) ./cmd/gaia/cmd/gaiad
 	go install $(BUILD_FLAGS) ./cmd/gaia/cmd/gaiacli
 
-install_examples: 
+install_examples:
 	go install $(BUILD_FLAGS) ./examples/basecoin/cmd/basecoind
 	go install $(BUILD_FLAGS) ./examples/basecoin/cmd/basecli
 	go install $(BUILD_FLAGS) ./examples/democoin/cmd/democoind
@@ -89,7 +89,7 @@ godocs:
 
 test: test_unit
 
-test_cli: 
+test_cli:
 	@go test -count 1 -p 1 `go list github.com/cosmos/cosmos-sdk/cmd/gaia/cli_test`
 
 test_cli_retry:

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -32,28 +32,28 @@ get_tools:
 ifdef DEP_CHECK
 	@echo "Dep is already installed.  Run 'make update_tools' to update."
 else
-	@echo "$(ansi_grn)Installing dep$(ansi_end)"
+	@echo "Installing dep"
 	go get -v $(DEP)
 endif
 ifdef GOLINT_CHECK
 	@echo "Golint is already installed.  Run 'make update_tools' to update."
 else
-	@echo "$(ansi_grn)Installing golint$(ansi_end)"
+	@echo "Installing golint"
 	go get -v $(GOLINT)
 endif
 ifdef GOMETALINTER_CHECK
 	@echo "Gometalinter is already installed.  Run 'make update_tools' to update."
 else
-	@echo "$(ansi_grn)Installing gometalinter$(ansi_end)"
+	@echo "Installing gometalinter"
 	go get -v $(GOMETALINTER)
 endif
 
 update_tools:
-	@echo "$(ansi_grn)Updating dep$(ansi_end)"
+	@echo "Updating dep"
 	go get -u -v $(DEP)
-	@echo "$(ansi_grn)Updating tendermint/golint $(ansi_end)"
+	@echo "Updating tendermint/golint"
 	go get -u -v $(GOLINT)
-	@echo "$(ansi_grn)Updating gometalinter $(ansi_end)"
+	@echo "Updating gometalinter"
 	go get -u -v $(GOMETALINTER)
 
 
@@ -67,24 +67,14 @@ get_vendor_deps: check_tools
 	@dep ensure -v
 
 install: get_vendor_deps
-	@echo "$(ansi_grn)Installing tools$(ansi_end)"
-	@echo "$(ansi_yel)Install go-vendorinstall$(ansi_end)"
+	@echo "Installing tools"
+	@echo "Install go-vendorinstall"
 	go build -o bin/go-vendorinstall go-vendorinstall/*.go
 
-	@echo "$(ansi_yel)Install gometalinter.v2$(ansi_end)"
+	@echo "Install gometalinter.v2"
 	GOBIN="$(CURDIR)/bin" ./bin/go-vendorinstall github.com/alecthomas/gometalinter
 
-	@echo "$(ansi_grn)Done installing tools$(ansi_end)"
-
-
-########################################
-# ANSI colors
-
-ansi_red=\033[0;31m
-ansi_grn=\033[0;32m
-ansi_yel=\033[0;33m
-ansi_end=\033[0m
-
+	@echo "Done installing tools"
 
 # To avoid unintended conflicts with file names, always add to .PHONY
 # unless there is a reason not to.

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -5,13 +5,27 @@ all: install
 ### DEP
 
 DEP = github.com/golang/dep/cmd/dep
+GOLINT = github.com/tendermint/lint/golint
+GOMETALINTER = github.com/alecthomas/gometalinter
 DEP_CHECK := $(shell command -v dep 2> /dev/null)
+GOLINT_CHECK := $(shell command -v golint 2> /dev/null)
+GOMETALINTER_CHECK := $(shell command -v gometalinter 2> /dev/null)
 
 check_tools:
 ifndef DEP_CHECK
 	@echo "No dep in path.  Install with 'make get_tools'."
 else
 	@echo "Found dep in path."
+endif
+ifndef GOLINT_CHECK
+	@echo "No golint in path.  Install with 'make get_tools'."
+else
+	@echo "Found golint in path."
+endif
+ifndef GOMETALINTER_CHECK
+	@echo "No gometalinter in path.  Install with 'make get_tools'."
+else
+	@echo "Found gometalinter in path."
 endif
 
 get_tools:
@@ -21,10 +35,26 @@ else
 	@echo "$(ansi_grn)Installing dep$(ansi_end)"
 	go get -v $(DEP)
 endif
+ifdef GOLINT_CHECK
+	@echo "Golint is already installed.  Run 'make update_tools' to update."
+else
+	@echo "$(ansi_grn)Installing golint$(ansi_end)"
+	go get -v $(GOLINT)
+endif
+ifdef GOMETALINTER_CHECK
+	@echo "Gometalinter is already installed.  Run 'make update_tools' to update."
+else
+	@echo "$(ansi_grn)Installing gometalinter$(ansi_end)"
+	go get -v $(GOMETALINTER)
+endif
 
 update_tools:
 	@echo "$(ansi_grn)Updating dep$(ansi_end)"
 	go get -u -v $(DEP)
+	@echo "$(ansi_grn)Updating tendermint/golint $(ansi_end)"
+	go get -u -v $(GOLINT)
+	@echo "$(ansi_grn)Updating gometalinter $(ansi_end)"
+	go get -u -v $(GOMETALINTER)
 
 
 ########################################


### PR DESCRIPTION
Previously, the install scripts weren't installing golint and gometalinter.
This commit fixes this, and installs tendermint's linter, and the HEAD of
the gometalinter repository. Now `make all` should work.
Closes #1052 , Closes #1190 

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺ 
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes. 
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  --> 

* [ ] Updated all relevant documentation in docs - I dont know of any documentation on this
* [X] Updated all code comments where relevant
* [X] Wrote tests - n/a
* [X] Updated CHANGELOG.md
* [X] Updated Gaia/Examples - n/a
* [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
