### PR TITLE
server: Use differing defaults from tendermint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ FEATURES
   * Delegators delegate votes to validator by default but can override (for their stake)
 * [tools] make get_tools installs tendermint's linter, and gometalinter
 * [tools] Switch gometalinter to the stable version
+* [server] Default config now creates a profiler at port 6060, and increase p2p send/recv rates
 
 FIXES
 * \#1259 - fix bug where certain tests that could have a nil pointer in defer


### PR DESCRIPTION
When loading the config file, this now checks in the sdk if the file
already exists. If not, it writes a config with different defaults.
The defaults differ by having the profiler listen address set,
and increasing the receive / send rates.

Closes #1098 

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺ 
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes. 
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  --> 

* [ ] Updated all relevant documentation in docs - not sure what documentation I should be changing
* [X] Updated all code comments where relevant
* [ ] Wrote tests - are they needed here?
* [X] Updated CHANGELOG.md
* [X] Updated Gaia/Examples
* [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
