### PR TITLE
tests: add method to wait for n blocks to pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ FEATURES
 * [tools] Switch gometalinter to the stable version
 * [tools] Add checking for misspellings and for incorrectly formatted files in circle CI
 * [server] Default config now creates a profiler at port 6060, and increase p2p send/recv rates
+* [tests] Add WaitForNextNBlocksTM helper method
 
 FIXES
 * \#1259 - fix bug where certain tests that could have a nil pointer in defer

--- a/tests/util.go
+++ b/tests/util.go
@@ -15,13 +15,19 @@ import (
 // Wait for the next tendermint block from the Tendermint RPC
 // on localhost
 func WaitForNextHeightTM(port string) {
+	WaitForNextNBlocksTM(1, port)
+}
+
+// Wait for N tendermint blocks to pass using the Tendermint RPC
+// on localhost
+func WaitForNextNBlocksTM(n int64, port string) {
 	url := fmt.Sprintf("http://localhost:%v", port)
 	cl := tmclient.NewHTTP(url, "/websocket")
 	resBlock, err := cl.Block(nil)
 	if err != nil {
 		panic(err)
 	}
-	waitForHeightTM(resBlock.Block.Height+1, url)
+	waitForHeightTM(resBlock.Block.Height+n, url)
 }
 
 // Wait for the given height from the Tendermint RPC


### PR DESCRIPTION
Adds a helper method to tests/util.go for waiting for N blocks to
pass. This is useful for situations when you need to wait for
multiple blocks to pass, but don't know the current block number.
In general, this is safer than using "wait for height", since the
block height could have advanced further than expected while the
test was running.

Resolves remaining point in #1283

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺ 
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes. 
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  --> 

* [ ] Updated all relevant documentation in docs - do we have docs for testing API yet?
* [x] Updated all code comments where relevant - I don't think any were needed heree
* [X] Wrote tests - n/a
* [X] Updated CHANGELOG.md - not entirely sure if this belongs in the changelog, but put it anyway.
* [X] Updated Gaia/Examples
* [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
