### PR TITLE
types/rat: Fix overflowing in printing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ FIXES
 * Fixed bug where chain ID wasn't passed properly in x/bank REST handler
 * Fixed bug where `democli account` didn't decode the account data correctly
 * \#1343 - fixed unnecessary parallelism in CI
+* \#1258 - printing big.rat's can no longer overflow int64
 
 ## 0.19.0
 

--- a/types/rational.go
+++ b/types/rational.go
@@ -115,7 +115,7 @@ func (r Rat) Mul(r2 Rat) Rat    { return Rat{*new(big.Rat).Mul(&(r.Rat), &(r2.Ra
 func (r Rat) Quo(r2 Rat) Rat    { return Rat{*new(big.Rat).Quo(&(r.Rat), &(r2.Rat))} } // Quo - quotient
 func (r Rat) Add(r2 Rat) Rat    { return Rat{*new(big.Rat).Add(&(r.Rat), &(r2.Rat))} } // Add - addition
 func (r Rat) Sub(r2 Rat) Rat    { return Rat{*new(big.Rat).Sub(&(r.Rat), &(r2.Rat))} } // Sub - subtraction
-func (r Rat) String() string    { return fmt.Sprintf("%v/%v", r.Num(), r.Denom()) }
+func (r Rat) String() string    { return r.Rat.String() }
 
 var (
 	zero  = big.NewInt(0)

--- a/types/rational_test.go
+++ b/types/rational_test.go
@@ -100,7 +100,7 @@ func TestEqualities(t *testing.T) {
 
 }
 
-func TestArithmatic(t *testing.T) {
+func TestArithmetic(t *testing.T) {
 	tests := []struct {
 		r1, r2                         Rat
 		resMul, resDiv, resAdd, resSub Rat
@@ -296,4 +296,15 @@ func TestRatsEqual(t *testing.T) {
 		assert.Equal(t, tc.eq, RatsEqual(tc.r2s, tc.r1s))
 	}
 
+}
+
+func TestStringOverflow(t *testing.T) {
+	// two random 64 bit primes
+	rat1 := NewRat(5164315003622678713, 4389711697696177267)
+	rat2 := NewRat(-3179849666053572961, 8459429845579852627)
+	rat3 := rat1.Add(rat2)
+	assert.Equal(t,
+		"29728537197630860939575850336935951464/37134458148982045574552091851127630409",
+		rat3.String(),
+	)
 }


### PR DESCRIPTION
This now uses the underlying golang big.rat's string function,
instead of casting to num and den which are int64s.

Closes #1258

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺ 
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes. 
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  --> 

* [X] Updated all relevant documentation in docs - n/a to my knowledge
* [X] Updated all code comments where relevant
* [X] Wrote tests
* [X] Updated CHANGELOG.md
* [X] Updated Gaia/Examples
* [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
