### PR TITLE
types: remove GetMemo from Tx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ BREAKING CHANGES
 * Signers of a transaction now only sign over their account and sequence number
 * Removed MsgChangePubKey from auth
 * Removed setPubKey from account mapper
+* Removed GetMemo from Tx (it is still on StdTx)
 
 FEATURES
 * [gaiacli] You can now attach a simple text-only memo to any transaction, with the `--memo` flag

--- a/types/tx_msg.go
+++ b/types/tx_msg.go
@@ -31,9 +31,6 @@ type Tx interface {
 
 	// Gets the Msg.
 	GetMsgs() []Msg
-
-	// Gets the memo.
-	GetMemo() string
 }
 
 //__________________________________________________________

--- a/x/auth/ante.go
+++ b/x/auth/ante.go
@@ -38,7 +38,7 @@ func NewAnteHandler(am AccountMapper, fck FeeCollectionKeeper) sdk.AnteHandler {
 				true
 		}
 
-		memo := tx.GetMemo()
+		memo := stdTx.GetMemo()
 
 		if len(memo) > maxMemoCharacters {
 			return ctx,
@@ -85,7 +85,7 @@ func NewAnteHandler(am AccountMapper, fck FeeCollectionKeeper) sdk.AnteHandler {
 			signerAddr, sig := signerAddrs[i], sigs[i]
 
 			// check signature, return account with incremented nonce
-			signBytes := StdSignBytes(ctx.ChainID(), accNums[i], sequences[i], fee, msgs, tx.GetMemo())
+			signBytes := StdSignBytes(ctx.ChainID(), accNums[i], sequences[i], fee, msgs, stdTx.GetMemo())
 			signerAcc, res := processSig(
 				ctx, am,
 				signerAddr, sig, signBytes,


### PR DESCRIPTION
This method is an unneccessary requirement on Tx. Auth casts the Tx
to StdTx, so the memo can be obtained in previous usecases from
StdTx. This also makes it more clear for when something is
implementing StdTx vs Tx.

Resolves #1375

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺ 
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes. 
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  --> 

* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [x] Updated CHANGELOG.md
* [ ] Updated Gaia/Examples
* [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
