### PR TITLE
Add async flag and functionality to gaiacli send

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ FEATURES
 * [types] Switches internal representation of Int/Uint/Rat to use pointers
 * [gaiad] unsafe_reset_all now resets addrbook.json
 * [democoin] add x/oracle, x/assoc
+* [gaiacli] added an --async flag to the cli to deliver transactions without waiting for a tendermint response
 
 FIXES 
 * [gaia] Added self delegation for validators in the genesis creation

--- a/client/context/helpers.go
+++ b/client/context/helpers.go
@@ -176,8 +176,7 @@ func (ctx CoreContext) SignAndBuild(name, passphrase string, msgs []sdk.Msg, cdc
 }
 
 // sign and build the transaction from the msg
-func (ctx CoreContext) EnsureSignBuildBroadcast(name string, msgs []sdk.Msg, cdc *wire.Codec) (res *ctypes.ResultBroadcastTxCommit, err error) {
-
+func (ctx CoreContext) ensureSignBuild(name string, msgs []sdk.Msg, cdc *wire.Codec) (tyBytes []byte, err error) {
 	ctx, err = EnsureAccountNumber(ctx)
 	if err != nil {
 		return nil, err
@@ -194,6 +193,17 @@ func (ctx CoreContext) EnsureSignBuildBroadcast(name string, msgs []sdk.Msg, cdc
 	}
 
 	txBytes, err := ctx.SignAndBuild(name, passphrase, msgs, cdc)
+	if err != nil {
+		return nil, err
+	}
+
+	return txBytes, err
+}
+
+// sign and build the transaction from the msg
+func (ctx CoreContext) EnsureSignBuildBroadcast(name string, msgs []sdk.Msg, cdc *wire.Codec) (res *ctypes.ResultBroadcastTxCommit, err error) {
+
+	txBytes, err := ctx.ensureSignBuild(name, msgs, cdc)
 	if err != nil {
 		return nil, err
 	}
@@ -201,25 +211,10 @@ func (ctx CoreContext) EnsureSignBuildBroadcast(name string, msgs []sdk.Msg, cdc
 	return ctx.BroadcastTx(txBytes)
 }
 
-// sign and build the transaction from the msg
+// sign and build the async transaction from the msg
 func (ctx CoreContext) EnsureSignBuildBroadcastAsync(name string, msgs []sdk.Msg, cdc *wire.Codec) (res *ctypes.ResultBroadcastTx, err error) {
 
-	ctx, err = EnsureAccountNumber(ctx)
-	if err != nil {
-		return nil, err
-	}
-	// default to next sequence number if none provided
-	ctx, err = EnsureSequence(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	passphrase, err := ctx.GetPassphraseFromStdin(name)
-	if err != nil {
-		return nil, err
-	}
-
-	txBytes, err := ctx.SignAndBuild(name, passphrase, msgs, cdc)
+	txBytes, err := ctx.ensureSignBuild(name, msgs, cdc)
 	if err != nil {
 		return nil, err
 	}

--- a/client/context/viper.go
+++ b/client/context/viper.go
@@ -56,7 +56,7 @@ func defaultChainID() (string, error) {
 	return doc.ChainID, nil
 }
 
-// EnsureSequence - automatically set sequence number if none provided
+// EnsureAccount - automatically set account number if none provided
 func EnsureAccountNumber(ctx CoreContext) (CoreContext, error) {
 	// Should be viper.IsSet, but this does not work - https://github.com/spf13/viper/pull/331
 	if viper.GetInt64(client.FlagAccountNumber) != 0 {

--- a/x/bank/client/cli/sendtx.go
+++ b/x/bank/client/cli/sendtx.go
@@ -54,7 +54,7 @@ func SendTxCmd(cdc *wire.Codec) *cobra.Command {
 				if err != nil {
 					return err
 				}
-				fmt.Println("Async tx send. tx hash: ", res.Hash)
+				fmt.Println("Async tx sent. tx hash: ", res.Hash.String())
 				return nil
 			}
 			res, err := ctx.EnsureSignBuildBroadcast(ctx.FromAddressName, []sdk.Msg{msg}, cdc)

--- a/x/bank/client/cli/sendtx.go
+++ b/x/bank/client/cli/sendtx.go
@@ -16,6 +16,7 @@ import (
 const (
 	flagTo     = "to"
 	flagAmount = "amount"
+	flagAsync  = "async"
 )
 
 // SendTxCommand will create a send tx and sign it with the given key
@@ -47,16 +48,28 @@ func SendTxCmd(cdc *wire.Codec) *cobra.Command {
 
 			// build and sign the transaction, then broadcast to Tendermint
 			msg := client.BuildMsg(from, to, coins)
+
+			if viper.GetBool(flagAsync) {
+				res, err := ctx.EnsureSignBuildBroadcastAsync(ctx.FromAddressName, []sdk.Msg{msg}, cdc)
+				if err != nil {
+					return err
+				}
+				fmt.Println("Async tx send. tx hash: ", res.Hash)
+				return nil
+			}
 			res, err := ctx.EnsureSignBuildBroadcast(ctx.FromAddressName, []sdk.Msg{msg}, cdc)
 			if err != nil {
 				return err
 			}
 			fmt.Printf("Committed at block %d. Hash: %s\n", res.Height, res.Hash.String())
 			return nil
+
 		},
 	}
 
 	cmd.Flags().String(flagTo, "", "Address to send coins")
 	cmd.Flags().String(flagAmount, "", "Amount of coins to send")
+	cmd.Flags().Bool(flagAsync, false, "Pass the async flag to send a tx without waiting for the tx to be included in a block")
+
 	return cmd
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺ 
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes. 
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  --> 

* [x] ~~Updated all relevant documentation in docs~~ didnt see anywhere to add it 
* [x] Updated all code comments where relevant
* [x] ~~Wrote tests~~  - no new funcs to test, only cli
* [x] Updated CHANGELOG.md
* [x] Updated Gaia/Examples
* [x] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))

This PR addresses https://github.com/cosmos/cosmos-sdk/issues/1193.

It adds an async flag to gaiacli send, to allow for many async txs in the same block. 

For now, sequence will have to be supplied from a script with --sequence if you want to send a lot of txs very quickly. Otherwise it will grab the first sequence from tendermint, but then it will continue to try the same sequence number. This can be updated once there is a way to store sequences locally (see comments in #1193) 

I don't think tests are needed, since this is just a cli call that uses funcs that already exist. I have tested it on a local testnet with branch develop and it works. 

Once you guys approve the changes, I will add in the async flag to democoin and basecoin, update changelog, and see if any docs need to be changed. Then it should be mergable @ValarDragon @cwgoes 