### PR TITLE
tools: Add ineffassign linter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,6 @@ jobs:
           command: |
             export PATH="$GOBIN:$PATH"
             make get_tools
-            go get -u github.com/client9/misspell/cmd/misspell
       - run:
           name: Lint source
           command: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ FEATURES
   * gofmt
   * go vet -composites=false
   * unconvert
+  * ineffassign
 * [server] Default config now creates a profiler at port 6060, and increase p2p send/recv rates
 * [tests] Add WaitForNextNBlocksTM helper method
 * [types] Switches internal representation of Int/Uint/Rat to use pointers

--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ test_cover:
 	@bash tests/test_cover.sh
 
 test_lint:
-	gometalinter.v2 --disable-all --enable='golint' --enable='misspell' --enable='unconvert' --linter='vet:go vet -composites=false:PATH:LINE:MESSAGE' --enable='vet' --vendor ./...
+	gometalinter.v2 --disable-all --enable='golint' --enable='misspell' --enable='unconvert' --enable='ineffassign' --linter='vet:go vet -composites=false:PATH:LINE:MESSAGE' --enable='vet' --deadline=500s --vendor ./...
 	find . -name '*.go' -type f -not -path "./vendor*" -not -path "*.git*" | xargs gofmt -d -s
 
 benchmark:

--- a/examples/democoin/app/app_test.go
+++ b/examples/democoin/app/app_test.go
@@ -43,6 +43,7 @@ func TestGenesis(t *testing.T) {
 		},
 	}
 	stateBytes, err := json.MarshalIndent(genesisState, "", "\t")
+	require.Nil(t, err)
 
 	vals := []abci.Validator{}
 	bapp.InitChain(abci.RequestInitChain{Validators: vals, AppStateBytes: stateBytes})

--- a/examples/democoin/cmd/democoind/main.go
+++ b/examples/democoin/cmd/democoind/main.go
@@ -34,6 +34,9 @@ func CoolAppGenState(cdc *wire.Codec, appGenTxs []json.RawMessage) (appState jso
         "trend": "ice-cold"
       }`)
 	appState, err = server.AppendJSON(cdc, appState, key, value)
+	if err != nil {
+		return
+	}
 	key = "pow"
 	value = json.RawMessage(`{
         "difficulty": 1,

--- a/examples/democoin/x/simplestake/keeper_test.go
+++ b/examples/democoin/x/simplestake/keeper_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	abci "github.com/tendermint/abci/types"
 	crypto "github.com/tendermint/go-crypto"
@@ -79,6 +80,7 @@ func TestBonding(t *testing.T) {
 	assert.Nil(t, err)
 
 	power, err := stakeKeeper.bondWithoutCoins(ctx, addr, pubKey, sdk.NewCoin("steak", 10))
+	require.Nil(t, err)
 	assert.Equal(t, int64(20), power)
 
 	pk, _, err := stakeKeeper.unbondWithoutCoins(ctx, addr)

--- a/store/iavlstore_test.go
+++ b/store/iavlstore_test.go
@@ -155,7 +155,7 @@ func TestIAVLSubspaceIterator(t *testing.T) {
 	iavlStore.Set([]byte{byte(255), byte(255), byte(1)}, []byte("test4"))
 	iavlStore.Set([]byte{byte(255), byte(255), byte(255)}, []byte("test4"))
 
-	i := 0
+	var i int
 
 	iter := sdk.KVStorePrefixIterator(iavlStore, []byte("test"))
 	expected := []string{"test1", "test2", "test3"}
@@ -214,7 +214,7 @@ func TestIAVLReverseSubspaceIterator(t *testing.T) {
 	iavlStore.Set([]byte{byte(255), byte(255), byte(1)}, []byte("test4"))
 	iavlStore.Set([]byte{byte(255), byte(255), byte(255)}, []byte("test4"))
 
-	i := 0
+	var i int
 
 	iter := sdk.KVStoreReversePrefixIterator(iavlStore, []byte("test"))
 	expected := []string{"test3", "test2", "test1"}

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -8,11 +8,13 @@ DEP = github.com/golang/dep/cmd/dep
 GOLINT = github.com/tendermint/lint/golint
 GOMETALINTER = gopkg.in/alecthomas/gometalinter.v2
 UNCONVERT = github.com/mdempsky/unconvert
+INEFFASSIGN = github.com/gordonklaus/ineffassign
 
 DEP_CHECK := $(shell command -v dep 2> /dev/null)
 GOLINT_CHECK := $(shell command -v golint 2> /dev/null)
 GOMETALINTER_CHECK := $(shell command -v gometalinter.v2 2> /dev/null)
 UNCONVERT_CHECK := $(shell command -v unconvert 2> /dev/null)
+INEFFASSIGN_CHECK := $(shell command -v ineffassign 2> /dev/null)
 
 check_tools:
 ifndef DEP_CHECK
@@ -34,6 +36,11 @@ ifndef UNCONVERT_CHECK
 	@echo "No unconvert in path.  Install with 'make get_tools'."
 else
 	@echo "Found unconvert in path."
+endif
+ifndef INEFFASSIGN_CHECK
+	@echo "No ineffassign in path.  Install with 'make get_tools'."
+else
+	@echo "Found ineffassign in path."
 endif
 
 get_tools:
@@ -61,6 +68,12 @@ else
 	@echo "Installing unconvert"
 	go get -v $(UNCONVERT)
 endif
+ifdef INEFFASSIGN_CHECK
+	@echo "Ineffassign is already installed.  Run 'make update_tools' to update."
+else
+	@echo "Installing ineffassign"
+	go get -v $(UNCONVERT)
+endif
 
 update_tools:
 	@echo "Updating dep"
@@ -71,6 +84,8 @@ update_tools:
 	go get -u -v $(GOMETALINTER)
 	@echo "Updating unconvert"
 	go get -u -v $(UNCONVERT)
+	@echo "Updating ineffassign"
+	go get -u -v $(INEFFASSIGN)
 
 # To avoid unintended conflicts with file names, always add to .PHONY
 # unless there is a reason not to.

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -9,12 +9,14 @@ GOLINT = github.com/tendermint/lint/golint
 GOMETALINTER = gopkg.in/alecthomas/gometalinter.v2
 UNCONVERT = github.com/mdempsky/unconvert
 INEFFASSIGN = github.com/gordonklaus/ineffassign
+MISSPELL = github.com/client9/misspell/cmd/misspell
 
 DEP_CHECK := $(shell command -v dep 2> /dev/null)
 GOLINT_CHECK := $(shell command -v golint 2> /dev/null)
 GOMETALINTER_CHECK := $(shell command -v gometalinter.v2 2> /dev/null)
 UNCONVERT_CHECK := $(shell command -v unconvert 2> /dev/null)
 INEFFASSIGN_CHECK := $(shell command -v ineffassign 2> /dev/null)
+MISSPELL_CHECK := $(shell command -v misspell 2> /dev/null)
 
 check_tools:
 ifndef DEP_CHECK
@@ -41,6 +43,11 @@ ifndef INEFFASSIGN_CHECK
 	@echo "No ineffassign in path.  Install with 'make get_tools'."
 else
 	@echo "Found ineffassign in path."
+endif
+ifndef MISSPELL_CHECK
+	@echo "No misspell in path.  Install with 'make get_tools'."
+else
+	@echo "Found misspell in path."
 endif
 
 get_tools:
@@ -72,7 +79,13 @@ ifdef INEFFASSIGN_CHECK
 	@echo "Ineffassign is already installed.  Run 'make update_tools' to update."
 else
 	@echo "Installing ineffassign"
-	go get -v $(UNCONVERT)
+	go get -v $(INEFFASSIGN)
+endif
+ifdef MISSPELL_CHECK
+	@echo "misspell is already installed.  Run 'make update_tools' to update."
+else
+	@echo "Installing misspell"
+	go get -v $(MISSPELL)
 endif
 
 update_tools:
@@ -86,6 +99,8 @@ update_tools:
 	go get -u -v $(UNCONVERT)
 	@echo "Updating ineffassign"
 	go get -u -v $(INEFFASSIGN)
+	@echo "Updating misspell"
+	go get -u -v $(MISSPELL)
 
 # To avoid unintended conflicts with file names, always add to .PHONY
 # unless there is a reason not to.

--- a/x/stake/client/cli/tx.go
+++ b/x/stake/client/cli/tx.go
@@ -117,6 +117,9 @@ func GetCmdDelegate(cdc *wire.Codec) *cobra.Command {
 			}
 
 			delegatorAddr, err := sdk.GetAccAddressBech32(viper.GetString(FlagAddressDelegator))
+			if err != nil {
+				return err
+			}
 			validatorAddr, err := sdk.GetAccAddressBech32(viper.GetString(FlagAddressValidator))
 			if err != nil {
 				return err
@@ -259,7 +262,13 @@ func GetCmdCompleteRedelegate(cdc *wire.Codec) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			delegatorAddr, err := sdk.GetAccAddressBech32(viper.GetString(FlagAddressDelegator))
+			if err != nil {
+				return err
+			}
 			validatorSrcAddr, err := sdk.GetAccAddressBech32(viper.GetString(FlagAddressValidatorSrc))
+			if err != nil {
+				return err
+			}
 			validatorDstAddr, err := sdk.GetAccAddressBech32(viper.GetString(FlagAddressValidatorDst))
 			if err != nil {
 				return err
@@ -351,6 +360,9 @@ func GetCmdCompleteUnbonding(cdc *wire.Codec) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			delegatorAddr, err := sdk.GetAccAddressBech32(viper.GetString(FlagAddressDelegator))
+			if err != nil {
+				return err
+			}
 			validatorAddr, err := sdk.GetAccAddressBech32(viper.GetString(FlagAddressValidator))
 			if err != nil {
 				return err

--- a/x/stake/keeper/delegation.go
+++ b/x/stake/keeper/delegation.go
@@ -321,6 +321,9 @@ func (k Keeper) BeginRedelegation(ctx sdk.Context, delegatorAddr, validatorSrcAd
 		return types.ErrBadRedelegationDst(k.Codespace())
 	}
 	sharesCreated, err := k.Delegate(ctx, delegatorAddr, returnCoin, dstValidator)
+	if err != nil {
+		return err
+	}
 
 	// create the unbonding delegation
 	minTime := ctx.BlockHeader().Time + params.UnbondingTime

--- a/x/stake/keeper/inflation_test.go
+++ b/x/stake/keeper/inflation_test.go
@@ -212,7 +212,7 @@ func TestLargeBond(t *testing.T) {
 	keeper.SetParams(ctx, params)
 
 	// validator[9] will be bonded, bringing us from 25% to ~50% (bonding 400,000,000 tokens)
-	pool, validator, _, _ = types.OpBondOrUnbond(r, pool, validator)
+	pool, _, _, _ = types.OpBondOrUnbond(r, pool, validator)
 	keeper.SetPool(ctx, pool)
 
 	// process provisions after the bonding, to compare the difference in expProvisions and expInflation

--- a/x/stake/keeper/validator_test.go
+++ b/x/stake/keeper/validator_test.go
@@ -34,6 +34,7 @@ func TestSetValidator(t *testing.T) {
 	// Check each store for being saved
 	resVal, found := keeper.GetValidator(ctx, addrVals[0])
 	assert.True(ValEq(t, validator, resVal))
+	assert.True(t, found)
 
 	resVals := keeper.GetValidatorsBonded(ctx)
 	require.Equal(t, 1, len(resVals))
@@ -87,6 +88,7 @@ func TestUpdateValidatorByPowerIndex(t *testing.T) {
 
 	pool = keeper.GetPool(ctx)
 	validator, found = keeper.GetValidator(ctx, addrVals[0])
+	assert.True(t, found)
 	power = GetValidatorsByPowerIndexKey(validator, pool)
 	assert.True(t, keeper.validatorByPowerIndexExists(ctx, power))
 }


### PR DESCRIPTION
This errors on assignments that don't actually do anything. i.e.

x, err := myFunc(1)
y, err = myFunc(2)

This will call out that the first function's call error was never
used.

In this commit, I've sometimes made the second variable actually used, causing a greater changelog, though I think it was the correct update.

Ref #1417 

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺ 
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes. 
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  --> 

* [ ] Updated all relevant documentation in docs
* [X] Updated all code comments where relevant
* [X] Wrote tests - n/a
* [X] Updated CHANGELOG.md
* [X] Updated Gaia/Examples
* [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
* [x] Added appropriate labels to PR (ex. wip, ready-for-review, docs)
