### PR TITLE
add link to new docs location

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,54 +6,7 @@
 Welcome to the Cosmos SDK!
 ==========================
 
-.. image:: graphics/cosmos-sdk-image.png
-   :height: 250px
-   :width: 500px
-   :align: center
+This location for our documentation has been deprecated, please see:
 
-SDK
----
-
-.. toctree::
-   :maxdepth: 1
-   
-   sdk/install.rst
-   sdk/key-management.rst
-.. sdk/overview.rst # needs to be updated
-.. old/glossary.rst # not completely up to date but has good content
-
-.. Basecoin
-.. --------
-
-.. .. toctree::
-   :maxdepth: 2
-
-.. old/basecoin/basics.rst # has a decent getting-start tutorial that's relatively up to date, should be consolidated with the other getting started doc
-
-.. Extensions
-.. ----------
-
-.. old/basecoin/extensions.rst # probably not worth salvaging
-
-.. Replay Protection
-.. ~~~~~~~~~~~~~~~~~
-
-..   old/replay-protection.rst # not sure if worth salvaging
-
-
-Staking
-~~~~~~~
-
-.. toctree::
-   :maxdepth: 1
-
-   staking/testnet.rst
-.. staking/intro.rst
-.. staking/key-management.rst
-.. staking/local-testnet.rst
-.. staking/public-testnet.rst
-
-.. IBC
-.. ---
-
-.. old/ibc.rst # needs to be updated
+- https://cosmos.network/docs/
+- 


### PR DESCRIPTION
With forthcoming new docs website, we need to deprecate RTD. This PR is meant to be to master because develop lost all the RTD build stuff. DO NOT MERGE until the new docs site is up and running. But it also must be merged before the next SDK release.

* [x] Updated all relevant documentation in docs
* [x] Updated all code comments where relevant
* [N/A] Wrote tests
* [] Updated CHANGELOG.md
* [N/A] Updated Gaia/Examples
* [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
* [ ] Added appropriate labels to PR (ex. wip, ready-for-review, docs)
