### PR TITLE
gaiacli: Improve error messages for `send` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ FEATURES
   - You can now use a Ledger with `gaiacli --ledger` for all key-related commands
   - Ledger keys can be named and tracked locally in the key DB
 * [gaiacli] added an --async flag to the cli to deliver transactions without waiting for a tendermint response
+* [gaiacli] improve error messages on `send` and `account` commands
 
 FIXES
 * [gaia] Added self delegation for validators in the genesis creation

--- a/x/auth/client/cli/account.go
+++ b/x/auth/client/cli/account.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -54,7 +55,7 @@ func GetAccountCmd(storeName string, cdc *wire.Codec, decoder auth.AccountDecode
 
 			// Check if account was found
 			if res == nil {
-				return sdk.ErrUnknownAddress("No account with address " + addr +
+				return errors.New("No account with address " + addr +
 					" was found in the state.\nAre you sure there has been a transaction involving it?")
 			}
 


### PR DESCRIPTION
Now provides better error messages when the account you're sending
from has no money, or it has insufficient funds. (Avoids making
the user interpret ABCI errors)

closes #1489

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺ 
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes. 
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  --> 

* [ ] Updated all relevant documentation in docs
* [x] Updated all code comments where relevant
* [ ] Wrote tests
* [x] Updated CHANGELOG.md
* [ ] Updated Gaia/Examples
* [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
* [x] Added appropriate labels to PR (ex. wip, ready-for-review, docs)
