### PR TITLE
tests: cli_tests no longer call `unsafe_reset_all` on local env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,7 @@ BUG FIXES
 * \#1353 - CLI: Show pool shares fractions in human-readable format
 * \#1258 - printing big.rat's can no longer overflow int64
 * \#887  - limit the size of rationals that can be passed in from user input
+* \#1461 - CLI tests now no longer reset your local environment data
 
 ## 0.19.0
 

--- a/cmd/gaia/cli_test/cli_test.go
+++ b/cmd/gaia/cli_test/cli_test.go
@@ -42,11 +42,9 @@ func TestGaiaCLISend(t *testing.T) {
 	tests.WaitForNextHeightTM(port)
 
 	fooAddr, _ := executeGetAddrPK(t, fmt.Sprintf("gaiacli keys show foo --output=json --home=%s", gaiacliHome))
-	fooCech, err := sdk.Bech32ifyAcc(fooAddr)
-	require.NoError(t, err)
+	fooCech := sdk.MustBech32ifyAcc(fooAddr)
 	barAddr, _ := executeGetAddrPK(t, fmt.Sprintf("gaiacli keys show bar --output=json --home=%s", gaiacliHome))
-	barCech, err := sdk.Bech32ifyAcc(barAddr)
-	require.NoError(t, err)
+	barCech := sdk.MustBech32ifyAcc(barAddr)
 
 	fooAcc := executeGetAccount(t, fmt.Sprintf("gaiacli account %v %v", fooCech, flags))
 	require.Equal(t, int64(50), fooAcc.GetCoins().AmountOf("steak").Int64())
@@ -85,13 +83,10 @@ func TestGaiaCLICreateValidator(t *testing.T) {
 	tests.WaitForNextHeightTM(port)
 
 	fooAddr, _ := executeGetAddrPK(t, fmt.Sprintf("gaiacli keys show foo --output=json --home=%s", gaiacliHome))
-	fooCech, err := sdk.Bech32ifyAcc(fooAddr)
-	require.NoError(t, err)
+	fooCech := sdk.MustBech32ifyAcc(fooAddr)
 	barAddr, barPubKey := executeGetAddrPK(t, fmt.Sprintf("gaiacli keys show bar --output=json --home=%s", gaiacliHome))
-	barCech, err := sdk.Bech32ifyAcc(barAddr)
-	require.NoError(t, err)
-	barCeshPubKey, err := sdk.Bech32ifyValPub(barPubKey)
-	require.NoError(t, err)
+	barCech := sdk.MustBech32ifyAcc(barAddr)
+	barCeshPubKey := sdk.MustBech32ifyValPub(barPubKey)
 
 	executeWrite(t, fmt.Sprintf("gaiacli send %v --amount=10steak --to=%v --name=foo", flags, barCech), pass)
 	tests.WaitForNextHeightTM(port)
@@ -145,8 +140,7 @@ func TestGaiaCLISubmitProposal(t *testing.T) {
 	tests.WaitForNextHeightTM(port)
 
 	fooAddr, _ := executeGetAddrPK(t, fmt.Sprintf("gaiacli keys show foo --output=json --home=%s", gaiacliHome))
-	fooCech, err := sdk.Bech32ifyAcc(fooAddr)
-	require.NoError(t, err)
+	fooCech := sdk.MustBech32ifyAcc(fooAddr)
 
 	fooAcc := executeGetAccount(t, fmt.Sprintf("gaiacli account %v %v", fooCech, flags))
 	require.Equal(t, int64(50), fooAcc.GetCoins().AmountOf("steak").Int64())
@@ -186,7 +180,6 @@ func getTestingHomeDirs() (string, string) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	// Users home directory
 	home := usr.HomeDir
 	gaiadHome := fmt.Sprintf("%s%s.test_gaiad", home, string(os.PathSeparator))
 	gaiacliHome := fmt.Sprintf("%s%s.test_gaiacli", home, string(os.PathSeparator))

--- a/cmd/gaia/cli_test/cli_test.go
+++ b/cmd/gaia/cli_test/cli_test.go
@@ -33,7 +33,19 @@ func init() {
 }
 
 func TestGaiaCLISend(t *testing.T) {
-	flags, port, proc := resetTestEnv(t)
+	tests.ExecuteT(t, fmt.Sprintf("gaiad --home=%s unsafe_reset_all", gaiadHome))
+	executeWrite(t, fmt.Sprintf("gaiacli keys delete --home=%s foo", gaiacliHome), pass)
+	executeWrite(t, fmt.Sprintf("gaiacli keys delete --home=%s bar", gaiacliHome), pass)
+	chainID := executeInit(t, "gaiad init -o --name=foo --home="+gaiadHome)
+	executeWrite(t, fmt.Sprintf("gaiacli keys add --home=%s bar", gaiacliHome), pass)
+
+	// get a free port, also setup some common flags
+	servAddr, port, err := server.FreeTCPAddr()
+	require.NoError(t, err)
+	flags := fmt.Sprintf("--home=%s --node=%v --chain-id=%v", gaiacliHome, servAddr, chainID)
+
+	// start gaiad server
+	proc := tests.GoExecuteTWithStdout(t, fmt.Sprintf("gaiad start --home=%s --rpc.laddr=%v", gaiadHome, servAddr))
 
 	defer proc.Stop(false)
 	tests.WaitForTMStart(port)
@@ -75,7 +87,20 @@ func TestGaiaCLISend(t *testing.T) {
 }
 
 func TestGaiaCLICreateValidator(t *testing.T) {
-	flags, port, proc := resetTestEnv(t)
+	tests.ExecuteT(t, fmt.Sprintf("gaiad --home=%s unsafe_reset_all", gaiadHome))
+	executeWrite(t, fmt.Sprintf("gaiacli keys delete --home=%s foo", gaiacliHome), pass)
+	executeWrite(t, fmt.Sprintf("gaiacli keys delete --home=%s bar", gaiacliHome), pass)
+	chainID := executeInit(t, "gaiad init -o --name=foo --home="+gaiadHome)
+	executeWrite(t, fmt.Sprintf("gaiacli keys add --home=%s bar", gaiacliHome), pass)
+
+	// get a free port, also setup some common flags
+	servAddr, port, err := server.FreeTCPAddr()
+	require.NoError(t, err)
+	flags := fmt.Sprintf("--home=%s --node=%v --chain-id=%v", gaiacliHome, servAddr, chainID)
+
+	// start gaiad server
+	proc := tests.GoExecuteTWithStdout(t, fmt.Sprintf("gaiad start --home=%s --rpc.laddr=%v", gaiadHome, servAddr))
+
 	defer proc.Stop(false)
 	tests.WaitForTMStart(port)
 	tests.WaitForNextHeightTM(port)
@@ -132,7 +157,20 @@ func TestGaiaCLICreateValidator(t *testing.T) {
 }
 
 func TestGaiaCLISubmitProposal(t *testing.T) {
-	flags, port, proc := resetTestEnv(t)
+	tests.ExecuteT(t, fmt.Sprintf("gaiad --home=%s unsafe_reset_all", gaiadHome))
+	executeWrite(t, fmt.Sprintf("gaiacli keys delete --home=%s foo", gaiacliHome), pass)
+	executeWrite(t, fmt.Sprintf("gaiacli keys delete --home=%s bar", gaiacliHome), pass)
+	chainID := executeInit(t, "gaiad init -o --name=foo --home="+gaiadHome)
+	executeWrite(t, fmt.Sprintf("gaiacli keys add --home=%s bar", gaiacliHome), pass)
+
+	// get a free port, also setup some common flags
+	servAddr, port, err := server.FreeTCPAddr()
+	require.NoError(t, err)
+	flags := fmt.Sprintf("--home=%s --node=%v --chain-id=%v", gaiacliHome, servAddr, chainID)
+
+	// start gaiad server
+	proc := tests.GoExecuteTWithStdout(t, fmt.Sprintf("gaiad start --home=%s --rpc.laddr=%v", gaiadHome, servAddr))
+
 	defer proc.Stop(false)
 	tests.WaitForTMStart(port)
 	tests.WaitForNextHeightTM(port)
@@ -178,25 +216,6 @@ func getTestingHomeDirs() (string, string) {
 	gaiadHome := fmt.Sprintf("%s%s.test_gaiad", tmpDir, string(os.PathSeparator))
 	gaiacliHome := fmt.Sprintf("%s%s.test_gaiacli", tmpDir, string(os.PathSeparator))
 	return gaiadHome, gaiacliHome
-}
-
-// returns flags, port, process
-func resetTestEnv(t *testing.T) (flags string, port string, proc *tests.Process) {
-	tests.ExecuteT(t, fmt.Sprintf("gaiad --home=%s unsafe_reset_all", gaiadHome))
-	executeWrite(t, fmt.Sprintf("gaiacli keys delete --home=%s foo", gaiacliHome), pass)
-	executeWrite(t, fmt.Sprintf("gaiacli keys delete --home=%s bar", gaiacliHome), pass)
-	chainID := executeInit(t, "gaiad init -o --name=foo --home="+gaiadHome)
-	executeWrite(t, fmt.Sprintf("gaiacli keys add --home=%s bar", gaiacliHome), pass)
-
-	// get a free port, also setup some common flags
-	servAddr, port, err := server.FreeTCPAddr()
-	require.NoError(t, err)
-	flags = fmt.Sprintf("--home=%s --node=%v --chain-id=%v", gaiacliHome, servAddr, chainID)
-
-	// start gaiad server
-	proc = tests.GoExecuteTWithStdout(t, fmt.Sprintf("gaiad start --home=%s --rpc.laddr=%v", gaiadHome, servAddr))
-
-	return flags, port, proc
 }
 
 //___________________________________________________________________________________

--- a/cmd/gaia/cli_test/cli_test.go
+++ b/cmd/gaia/cli_test/cli_test.go
@@ -36,7 +36,7 @@ func TestGaiaCLISend(t *testing.T) {
 	tests.ExecuteT(t, fmt.Sprintf("gaiad --home=%s unsafe_reset_all", gaiadHome))
 	executeWrite(t, fmt.Sprintf("gaiacli keys delete --home=%s foo", gaiacliHome), pass)
 	executeWrite(t, fmt.Sprintf("gaiacli keys delete --home=%s bar", gaiacliHome), pass)
-	chainID := executeInit(t, "gaiad init -o --name=foo --home="+gaiadHome)
+	chainID := executeInit(t, "gaiad init -o --owk --name=foo --home="+gaiadHome)
 	executeWrite(t, fmt.Sprintf("gaiacli keys add --home=%s bar", gaiacliHome), pass)
 
 	// get a free port, also setup some common flags
@@ -90,7 +90,7 @@ func TestGaiaCLICreateValidator(t *testing.T) {
 	tests.ExecuteT(t, fmt.Sprintf("gaiad --home=%s unsafe_reset_all", gaiadHome))
 	executeWrite(t, fmt.Sprintf("gaiacli keys delete --home=%s foo", gaiacliHome), pass)
 	executeWrite(t, fmt.Sprintf("gaiacli keys delete --home=%s bar", gaiacliHome), pass)
-	chainID := executeInit(t, "gaiad init -o --name=foo --home="+gaiadHome)
+	chainID := executeInit(t, "gaiad init -o --owk --name=foo --home="+gaiadHome)
 	executeWrite(t, fmt.Sprintf("gaiacli keys add --home=%s bar", gaiacliHome), pass)
 
 	// get a free port, also setup some common flags
@@ -160,7 +160,7 @@ func TestGaiaCLISubmitProposal(t *testing.T) {
 	tests.ExecuteT(t, fmt.Sprintf("gaiad --home=%s unsafe_reset_all", gaiadHome))
 	executeWrite(t, fmt.Sprintf("gaiacli keys delete --home=%s foo", gaiacliHome), pass)
 	executeWrite(t, fmt.Sprintf("gaiacli keys delete --home=%s bar", gaiacliHome), pass)
-	chainID := executeInit(t, "gaiad init -o --name=foo --home="+gaiadHome)
+	chainID := executeInit(t, "gaiad init -o --owk --name=foo --home="+gaiadHome)
 	executeWrite(t, fmt.Sprintf("gaiacli keys add --home=%s bar", gaiacliHome), pass)
 
 	// get a free port, also setup some common flags

--- a/cmd/gaia/cli_test/cli_test.go
+++ b/cmd/gaia/cli_test/cli_test.go
@@ -36,7 +36,7 @@ func TestGaiaCLISend(t *testing.T) {
 	tests.ExecuteT(t, fmt.Sprintf("gaiad --home=%s unsafe_reset_all", gaiadHome))
 	executeWrite(t, fmt.Sprintf("gaiacli keys delete --home=%s foo", gaiacliHome), pass)
 	executeWrite(t, fmt.Sprintf("gaiacli keys delete --home=%s bar", gaiacliHome), pass)
-	chainID := executeInit(t, fmt.Sprintf("gaiad init -o --owk --name=foo --home=%s --home-client=%s", gaiadHome, gaiacliHome))
+	chainID := executeInit(t, fmt.Sprintf("gaiad init -o --name=foo --home=%s --home-client=%s", gaiadHome, gaiacliHome))
 	executeWrite(t, fmt.Sprintf("gaiacli keys add --home=%s bar", gaiacliHome), pass)
 
 	// get a free port, also setup some common flags
@@ -90,7 +90,7 @@ func TestGaiaCLICreateValidator(t *testing.T) {
 	tests.ExecuteT(t, fmt.Sprintf("gaiad --home=%s unsafe_reset_all", gaiadHome))
 	executeWrite(t, fmt.Sprintf("gaiacli keys delete --home=%s foo", gaiacliHome), pass)
 	executeWrite(t, fmt.Sprintf("gaiacli keys delete --home=%s bar", gaiacliHome), pass)
-	chainID := executeInit(t, fmt.Sprintf("gaiad init -o --owk --name=foo --home=%s --home-client=%s", gaiadHome, gaiacliHome))
+	chainID := executeInit(t, fmt.Sprintf("gaiad init -o --name=foo --home=%s --home-client=%s", gaiadHome, gaiacliHome))
 	executeWrite(t, fmt.Sprintf("gaiacli keys add --home=%s bar", gaiacliHome), pass)
 
 	// get a free port, also setup some common flags
@@ -160,7 +160,7 @@ func TestGaiaCLISubmitProposal(t *testing.T) {
 	tests.ExecuteT(t, fmt.Sprintf("gaiad --home=%s unsafe_reset_all", gaiadHome))
 	executeWrite(t, fmt.Sprintf("gaiacli keys delete --home=%s foo", gaiacliHome), pass)
 	executeWrite(t, fmt.Sprintf("gaiacli keys delete --home=%s bar", gaiacliHome), pass)
-	chainID := executeInit(t, fmt.Sprintf("gaiad init -o --owk --name=foo --home=%s --home-client=%s", gaiadHome, gaiacliHome))
+	chainID := executeInit(t, fmt.Sprintf("gaiad init -o --name=foo --home=%s --home-client=%s", gaiadHome, gaiacliHome))
 	executeWrite(t, fmt.Sprintf("gaiacli keys add --home=%s bar", gaiacliHome), pass)
 
 	// get a free port, also setup some common flags

--- a/cmd/gaia/cli_test/cli_test.go
+++ b/cmd/gaia/cli_test/cli_test.go
@@ -36,7 +36,7 @@ func TestGaiaCLISend(t *testing.T) {
 	tests.ExecuteT(t, fmt.Sprintf("gaiad --home=%s unsafe_reset_all", gaiadHome))
 	executeWrite(t, fmt.Sprintf("gaiacli keys delete --home=%s foo", gaiacliHome), pass)
 	executeWrite(t, fmt.Sprintf("gaiacli keys delete --home=%s bar", gaiacliHome), pass)
-	chainID := executeInit(t, "gaiad init -o --owk --name=foo --home="+gaiadHome)
+	chainID := executeInit(t, fmt.Sprintf("gaiad init -o --owk --name=foo --home=%s --home-client=%s", gaiadHome, gaiacliHome))
 	executeWrite(t, fmt.Sprintf("gaiacli keys add --home=%s bar", gaiacliHome), pass)
 
 	// get a free port, also setup some common flags
@@ -90,7 +90,7 @@ func TestGaiaCLICreateValidator(t *testing.T) {
 	tests.ExecuteT(t, fmt.Sprintf("gaiad --home=%s unsafe_reset_all", gaiadHome))
 	executeWrite(t, fmt.Sprintf("gaiacli keys delete --home=%s foo", gaiacliHome), pass)
 	executeWrite(t, fmt.Sprintf("gaiacli keys delete --home=%s bar", gaiacliHome), pass)
-	chainID := executeInit(t, "gaiad init -o --owk --name=foo --home="+gaiadHome)
+	chainID := executeInit(t, fmt.Sprintf("gaiad init -o --owk --name=foo --home=%s --home-client=%s", gaiadHome, gaiacliHome))
 	executeWrite(t, fmt.Sprintf("gaiacli keys add --home=%s bar", gaiacliHome), pass)
 
 	// get a free port, also setup some common flags
@@ -160,7 +160,7 @@ func TestGaiaCLISubmitProposal(t *testing.T) {
 	tests.ExecuteT(t, fmt.Sprintf("gaiad --home=%s unsafe_reset_all", gaiadHome))
 	executeWrite(t, fmt.Sprintf("gaiacli keys delete --home=%s foo", gaiacliHome), pass)
 	executeWrite(t, fmt.Sprintf("gaiacli keys delete --home=%s bar", gaiacliHome), pass)
-	chainID := executeInit(t, "gaiad init -o --owk --name=foo --home="+gaiadHome)
+	chainID := executeInit(t, fmt.Sprintf("gaiad init -o --owk --name=foo --home=%s --home-client=%s", gaiadHome, gaiacliHome))
 	executeWrite(t, fmt.Sprintf("gaiacli keys add --home=%s bar", gaiacliHome), pass)
 
 	// get a free port, also setup some common flags

--- a/cmd/gaia/cli_test/cli_test.go
+++ b/cmd/gaia/cli_test/cli_test.go
@@ -3,9 +3,7 @@ package clitest
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"os"
-	"os/user"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -176,13 +174,9 @@ func TestGaiaCLISubmitProposal(t *testing.T) {
 // helper methods
 
 func getTestingHomeDirs() (string, string) {
-	usr, err := user.Current()
-	if err != nil {
-		log.Fatal(err)
-	}
-	home := usr.HomeDir
-	gaiadHome := fmt.Sprintf("%s%s.test_gaiad", home, string(os.PathSeparator))
-	gaiacliHome := fmt.Sprintf("%s%s.test_gaiacli", home, string(os.PathSeparator))
+	tmpDir := os.TempDir()
+	gaiadHome := fmt.Sprintf("%s%s.test_gaiad", tmpDir, string(os.PathSeparator))
+	gaiacliHome := fmt.Sprintf("%s%s.test_gaiacli", tmpDir, string(os.PathSeparator))
 	return gaiadHome, gaiacliHome
 }
 


### PR DESCRIPTION
* Makes all cli tests use .test_gaiad, .test_gaiacli instead of the
	same directories as the default binaries
* Abstracts alot of the functionality for setting up the server into
	a single function / file-wide constants. This is to reduce
	code duplication, especially since some of this functionality
	depends on each test setting up the keys in the same way.

Closes #1461, #1557 

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺ 
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes. 
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  --> 

* [X] ~Updated all relevant documentation in docs~
* [X] Updated all code comments where relevant
* [X] ~Wrote tests~
* [X] Updated CHANGELOG.md
* [X] ~Updated Gaia/Examples~
* [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
* [X] Added appropriate labels to PR (ex. wip, ready-for-review, docs)
