### PR TITLE
gov/client: rename submitproposal to submit-proposal

### DIFF
--- a/cmd/gaia/cli_test/cli_test.go
+++ b/cmd/gaia/cli_test/cli_test.go
@@ -181,7 +181,7 @@ func TestGaiaCLISubmitProposal(t *testing.T) {
 	fooAcc := executeGetAccount(t, fmt.Sprintf("gaiacli account %v %v", fooCech, flags))
 	require.Equal(t, int64(50), fooAcc.GetCoins().AmountOf("steak").Int64())
 
-	executeWrite(t, fmt.Sprintf("gaiacli gov submitproposal %v --proposer=%v --deposit=5steak --type=Text --title=Test --description=test --from=foo", flags, fooCech), pass)
+	executeWrite(t, fmt.Sprintf("gaiacli gov submit-proposal %v --proposer=%v --deposit=5steak --type=Text --title=Test --description=test --from=foo", flags, fooCech), pass)
 	tests.WaitForNextHeightTM(port)
 
 	fooAcc = executeGetAccount(t, fmt.Sprintf("gaiacli account %v %v", fooCech, flags))

--- a/x/gov/client/cli/tx.go
+++ b/x/gov/client/cli/tx.go
@@ -29,7 +29,7 @@ const (
 // submit a proposal tx
 func GetCmdSubmitProposal(cdc *wire.Codec) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "submitproposal",
+		Use:   "submit-proposal",
 		Short: "Submit a proposal along with an initial deposit",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			title := viper.GetString(flagTitle)


### PR DESCRIPTION
It is standard in the sdk to use a dash for subcommands / flags
with multiple words. This makes submitproposal comply with that.

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺ 
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes. 
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  --> 

* [ ] Updated all relevant documentation in docs - none exist to my knowledge?
* [X] ~Updated all code comments where relevant~
* [X] Wrote tests
* [X] Updated CHANGELOG.md - not needed, since gov is added in this release
* [X] Updated Gaia/Examples
* [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
* [X] Added appropriate labels to PR (ex. wip, ready-for-review, docs)
