### PR TITLE
Loading config into BaseApp with server.Context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ BREAKING CHANGES
     * go-crypto, abci, tmlibs have been merged into Tendermint
     * Various other fixes
 * [auth] Signers of a transaction now only sign over their own account and sequence number
-* [auth] Removed MsgChangePubKey 
+* [auth] Removed MsgChangePubKey
 * [auth] Removed SetPubKey from account mapper
 * [auth] AltBytes renamed to Memo, now a string, max 100 characters, costs a bit of gas
 * [types] `GetMsg()` -> `GetMsgs()` as txs wrap many messages
@@ -41,6 +41,8 @@ BREAKING CHANGES
 * [x/stake] most index keys nolonger hold a value - inputs are rearranged to form the desired key
 * [lcd] Switch key creation output to return bech32
 * [x/stake] store-value for delegation, validator, ubd, and red do not hold duplicate information contained store-key
+* [server] Moved server.Context to types.ServerContext
+* [baseapp] NewBaseApp and related constructors take ServerContext instead of Logger
 
 DEPRECATED
 * [cli] Deprecate `--name` flag in commands that send txs, in favor of `--from`

--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -8,6 +8,7 @@ import (
 	"github.com/pkg/errors"
 
 	abci "github.com/tendermint/tendermint/abci/types"
+	cfg "github.com/tendermint/tendermint/config"
 	cmn "github.com/tendermint/tendermint/libs/common"
 	dbm "github.com/tendermint/tendermint/libs/db"
 	"github.com/tendermint/tendermint/libs/log"
@@ -41,6 +42,7 @@ const (
 type BaseApp struct {
 	// initialized on creation
 	Logger     log.Logger
+	Config     *cfg.Config
 	name       string               // application name from abci.Info
 	cdc        *wire.Codec          // Amino codec
 	db         dbm.DB               // common DB backend
@@ -73,9 +75,10 @@ var _ abci.Application = (*BaseApp)(nil)
 
 // Create and name new BaseApp
 // NOTE: The db is used to store the version number for now.
-func NewBaseApp(name string, cdc *wire.Codec, logger log.Logger, db dbm.DB) *BaseApp {
+func NewBaseApp(name string, cdc *wire.Codec, ctx *sdk.ServerContext, db dbm.DB) *BaseApp {
 	app := &BaseApp{
-		Logger:     logger,
+		Logger:     ctx.Logger,
+		Config:     ctx.Config,
 		name:       name,
 		cdc:        cdc,
 		db:         db,

--- a/client/lcd/test_helpers.go
+++ b/client/lcd/test_helpers.go
@@ -101,11 +101,12 @@ func InitializeTestLCD(t *testing.T, nValidators int, initAddrs []sdk.Address) (
 
 	logger := log.NewTMLogger(log.NewSyncWriter(os.Stdout))
 	logger = log.NewFilter(logger, log.AllowDebug())
+	ctx := sdk.NewServerContext(config, logger)
 	privValidatorFile := config.PrivValidatorFile()
 	privVal := pvm.LoadOrGenFilePV(privValidatorFile)
 	privVal.Reset()
 	db := dbm.NewMemDB()
-	app := gapp.NewGaiaApp(logger, db)
+	app := gapp.NewGaiaApp(ctx, db)
 	cdc = gapp.MakeCodec()
 
 	genesisFile := config.GenesisFile()

--- a/cmd/gaia/app/app.go
+++ b/cmd/gaia/app/app.go
@@ -7,7 +7,6 @@ import (
 	abci "github.com/tendermint/tendermint/abci/types"
 	cmn "github.com/tendermint/tendermint/libs/common"
 	dbm "github.com/tendermint/tendermint/libs/db"
-	"github.com/tendermint/tendermint/libs/log"
 	tmtypes "github.com/tendermint/tendermint/types"
 
 	bam "github.com/cosmos/cosmos-sdk/baseapp"
@@ -55,12 +54,12 @@ type GaiaApp struct {
 	govKeeper           gov.Keeper
 }
 
-func NewGaiaApp(logger log.Logger, db dbm.DB) *GaiaApp {
+func NewGaiaApp(ctx *sdk.ServerContext, db dbm.DB) *GaiaApp {
 	cdc := MakeCodec()
 
 	// create your application object
 	var app = &GaiaApp{
-		BaseApp:          bam.NewBaseApp(appName, cdc, logger, db),
+		BaseApp:          bam.NewBaseApp(appName, cdc, ctx, db),
 		cdc:              cdc,
 		keyMain:          sdk.NewKVStoreKey("main"),
 		keyAccount:       sdk.NewKVStoreKey("acc"),

--- a/cmd/gaia/cmd/gaiad/main.go
+++ b/cmd/gaia/cmd/gaiad/main.go
@@ -5,19 +5,19 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/cosmos/cosmos-sdk/server"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/libs/cli"
 	dbm "github.com/tendermint/tendermint/libs/db"
-	"github.com/tendermint/tendermint/libs/log"
 	tmtypes "github.com/tendermint/tendermint/types"
 
 	"github.com/cosmos/cosmos-sdk/cmd/gaia/app"
-	"github.com/cosmos/cosmos-sdk/server"
 )
 
 func main() {
 	cdc := app.MakeCodec()
-	ctx := server.NewDefaultContext()
+	ctx := sdk.NewDefaultServerContext()
 	cobra.EnableCommandSorting = false
 	rootCmd := &cobra.Command{
 		Use:               "gaiad",
@@ -38,11 +38,11 @@ func main() {
 	}
 }
 
-func newApp(logger log.Logger, db dbm.DB) abci.Application {
-	return app.NewGaiaApp(logger, db)
+func newApp(ctx *sdk.ServerContext, db dbm.DB) abci.Application {
+	return app.NewGaiaApp(ctx, db)
 }
 
-func exportAppStateAndTMValidators(logger log.Logger, db dbm.DB) (json.RawMessage, []tmtypes.GenesisValidator, error) {
-	gapp := app.NewGaiaApp(logger, db)
+func exportAppStateAndTMValidators(ctx *sdk.ServerContext, db dbm.DB) (json.RawMessage, []tmtypes.GenesisValidator, error) {
+	gapp := app.NewGaiaApp(ctx, db)
 	return gapp.ExportAppStateAndValidators()
 }

--- a/cmd/gaia/cmd/gaiadebug/hack.go
+++ b/cmd/gaia/cmd/gaiadebug/hack.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 	abci "github.com/tendermint/tendermint/abci/types"
+	cfg "github.com/tendermint/tendermint/config"
 	"github.com/tendermint/tendermint/crypto"
 	cmn "github.com/tendermint/tendermint/libs/common"
 	dbm "github.com/tendermint/tendermint/libs/db"
@@ -39,12 +40,14 @@ func runHackCmd(cmd *cobra.Command, args []string) error {
 
 	// load the app
 	logger := log.NewTMLogger(log.NewSyncWriter(os.Stdout))
+	config := cfg.DefaultConfig()
+	ctx := sdk.NewServerContext(config, logger)
 	db, err := dbm.NewGoLevelDB("gaia", dataDir)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}
-	app := NewGaiaApp(logger, db)
+	app := NewGaiaApp(ctx, db)
 
 	// print some info
 	id := app.LastCommitID()
@@ -140,12 +143,12 @@ type GaiaApp struct {
 	slashingKeeper      slashing.Keeper
 }
 
-func NewGaiaApp(logger log.Logger, db dbm.DB) *GaiaApp {
+func NewGaiaApp(ctx *sdk.ServerContext, db dbm.DB) *GaiaApp {
 	cdc := MakeCodec()
 
 	// create your application object
 	var app = &GaiaApp{
-		BaseApp:     bam.NewBaseApp(appName, cdc, logger, db),
+		BaseApp:     bam.NewBaseApp(appName, cdc, ctx, db),
 		cdc:         cdc,
 		keyMain:     sdk.NewKVStoreKey("main"),
 		keyAccount:  sdk.NewKVStoreKey("acc"),

--- a/docs/core/app1.md
+++ b/docs/core/app1.md
@@ -420,11 +420,11 @@ documentation](https://godoc.org/github.com/cosmos/cosmos-sdk/baseapp) for more 
 Here is the complete setup for App1:
 
 ```go
-func NewApp1(logger log.Logger, db dbm.DB) *bapp.BaseApp {
+func NewApp1(ctx *sdk.ServerContext, db dbm.DB) *bapp.BaseApp {
     cdc := wire.NewCodec()
 
     // Create the base application object.
-    app := bapp.NewBaseApp(app1Name, cdc, logger, db)
+    app := bapp.NewBaseApp(app1Name, cdc, ctx, db)
 
     // Create a capability key for accessing the account store.
     keyAccount := sdk.NewKVStoreKey("acc")

--- a/docs/core/app2.md
+++ b/docs/core/app2.md
@@ -2,7 +2,7 @@
 
 In the previous app we built a simple `bank` with one message type for sending
 coins and one store for storing accounts.
-Here we build `App2`, which expands on `App1` by introducing 
+Here we build `App2`, which expands on `App1` by introducing
 
 - a new message type for issuing new coins
 - a new store for coin metadata (like who can issue coins)
@@ -38,7 +38,7 @@ methods for `MsgIssue` are similar to `MsgSend`.
 ## Handler
 
 We'll need a new handler to support the new message type. It just checks if the
-sender of the `MsgIssue` is the correct issuer for the given coin type, as per the information 
+sender of the `MsgIssue` is the correct issuer for the given coin type, as per the information
 in the issuer store:
 
 ```go
@@ -107,11 +107,11 @@ but that's left as an excercise for the reader :).
 
 ## Amino
 
-Now that we have two implementations of `Msg`, we won't know before hand 
+Now that we have two implementations of `Msg`, we won't know before hand
 which type is contained in a serialized `Tx`. Ideally, we would use the
 `Msg` interface inside our `Tx` implementation, but the JSON decoder can't
-decode into interface types. In fact, there's no standard way to unmarshal 
-into interfaces in Go. This is one of the primary reasons we built 
+decode into interface types. In fact, there's no standard way to unmarshal
+into interfaces in Go. This is one of the primary reasons we built
 [Amino](https://github.com/tendermint/go-amino) :).
 
 While SDK developers can encode transactions and state objects however they
@@ -121,7 +121,7 @@ excludes the `oneof` keyword.
 
 While `oneof` provides union types, Amino aims to provide interfaces.
 The main difference being that with union types, you have to know all the types
-up front. But anyone can implement an interface type whenever and however 
+up front. But anyone can implement an interface type whenever and however
 they like.
 
 To implement interface types, Amino allows any concrete implementation of an
@@ -160,7 +160,7 @@ Now that we're using Amino, we can embed the `Msg` interface directly in our
 // Simple tx to wrap the Msg.
 type app2Tx struct {
     sdk.Msg
-    
+
     PubKey    crypto.PubKey
     Signature crypto.Signature
 }
@@ -176,7 +176,7 @@ Amino codec!
 
 ## AnteHandler
 
-Now that we have an implementation of `Tx` that includes more than just the Msg, 
+Now that we have an implementation of `Tx` that includes more than just the Msg,
 we need to specify how that extra information is validated and processed. This
 is the role of the `AnteHandler`. The word `ante` here denotes "before", as the
 `AnteHandler` is run before a `Handler`. While an app can have many Handlers,
@@ -196,7 +196,7 @@ according to whatever capability keys it was granted. Instead of a `Msg`,
 however, it takes a `Tx`.
 
 Like Handler, AnteHandler returns a `Result` type, but it also returns a new
-`Context` and an `abort bool`. 
+`Context` and an `abort bool`.
 
 For `App2`, we simply check if the PubKey matches the Address, and the Signature validates with the PubKey:
 
@@ -244,12 +244,12 @@ func antehandler(ctx sdk.Context, tx sdk.Tx) (_ sdk.Context, _ sdk.Result, abort
 Let's put it all together now to get App2:
 
 ```go
-func NewApp2(logger log.Logger, db dbm.DB) *bapp.BaseApp {
+func NewApp2(ctx *sdk.ServerContext, db dbm.DB) *bapp.BaseApp {
 
 	cdc := NewCodec()
 
 	// Create the base application object.
-	app := bapp.NewBaseApp(app2Name, cdc, logger, db)
+	app := bapp.NewBaseApp(app2Name, cdc, ctx, db)
 
 	// Create a key for accessing the account store.
 	keyAccount := sdk.NewKVStoreKey("acc")

--- a/docs/core/app5.md
+++ b/docs/core/app5.md
@@ -1,7 +1,7 @@
 # App5 - Basecoin
 
 As we've seen, the SDK provides a flexible yet comprehensive framework for building state
-machines and defining their transitions, including authenticating transactions, 
+machines and defining their transitions, including authenticating transactions,
 executing messages, controlling access to stores, and updating the validator set.
 
 Until now, we have focused on building only isolated ABCI applications to
@@ -17,11 +17,11 @@ TODO
 
 ## Tendermint Node
 
-Since the Cosmos-SDK is written in Go, Cosmos-SDK applications can be compiled 
+Since the Cosmos-SDK is written in Go, Cosmos-SDK applications can be compiled
 with Tendermint into a single binary. Of course, like any ABCI application, they
 can also run as separate processes that communicate with Tendermint via socket.
 
-For more details on what's involved in starting a Tendermint full node, see the 
+For more details on what's involved in starting a Tendermint full node, see the
 [NewNode](https://godoc.org/github.com/tendermint/tendermint/node#NewNode)
 function in `github.com/tendermint/tendermint/node`.
 
@@ -52,19 +52,19 @@ func main() {
 	executor.Execute()
 }
 
-func newApp(logger log.Logger, db dbm.DB) abci.Application {
-	return app.NewBasecoinApp(logger, db)
+func newApp(ctx *sdk.ServerContext, db dbm.DB) abci.Application {
+	return app.NewBasecoinApp(ctx, db)
 }
 ```
 
-Note we utilize the popular [cobra library](https://github.com/spf13/cobra) 
-for the CLI, in concert with the [viper library](https://github.com/spf13/library) 
+Note we utilize the popular [cobra library](https://github.com/spf13/cobra)
+for the CLI, in concert with the [viper library](https://github.com/spf13/library)
 for managing configuration. See our [cli library](https://github.com/tendermint/blob/master/tmlibs/cli/setup.go)
 for more details.
 
 TODO: compile and run the binary
 
-Options for running the `basecoind` binary are effectively the same as for `tendermint`. 
+Options for running the `basecoind` binary are effectively the same as for `tendermint`.
 See [Using Tendermint](TODO) for more details.
 
 ## Clients

--- a/docs/core/examples/app1.go
+++ b/docs/core/examples/app1.go
@@ -5,7 +5,6 @@ import (
 
 	cmn "github.com/tendermint/tendermint/libs/common"
 	dbm "github.com/tendermint/tendermint/libs/db"
-	"github.com/tendermint/tendermint/libs/log"
 
 	bapp "github.com/cosmos/cosmos-sdk/baseapp"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -16,12 +15,12 @@ const (
 	app1Name = "App1"
 )
 
-func NewApp1(logger log.Logger, db dbm.DB) *bapp.BaseApp {
+func NewApp1(ctx *sdk.ServerContext, db dbm.DB) *bapp.BaseApp {
 
 	cdc := wire.NewCodec()
 
 	// Create the base application object.
-	app := bapp.NewBaseApp(app1Name, cdc, logger, db)
+	app := bapp.NewBaseApp(app1Name, cdc, ctx, db)
 
 	// Create a key for accessing the account store.
 	keyAccount := sdk.NewKVStoreKey("acc")

--- a/docs/core/examples/app2.go
+++ b/docs/core/examples/app2.go
@@ -8,7 +8,6 @@ import (
 	"github.com/tendermint/tendermint/crypto"
 	cmn "github.com/tendermint/tendermint/libs/common"
 	dbm "github.com/tendermint/tendermint/libs/db"
-	"github.com/tendermint/tendermint/libs/log"
 
 	bapp "github.com/cosmos/cosmos-sdk/baseapp"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -32,12 +31,12 @@ func NewCodec() *wire.Codec {
 	return cdc
 }
 
-func NewApp2(logger log.Logger, db dbm.DB) *bapp.BaseApp {
+func NewApp2(ctx *sdk.ServerContext, db dbm.DB) *bapp.BaseApp {
 
 	cdc := NewCodec()
 
 	// Create the base application object.
-	app := bapp.NewBaseApp(app2Name, cdc, logger, db)
+	app := bapp.NewBaseApp(app2Name, cdc, ctx, db)
 
 	// Create a key for accessing the account store.
 	keyAccount := sdk.NewKVStoreKey("acc")

--- a/docs/core/examples/app3.go
+++ b/docs/core/examples/app3.go
@@ -3,7 +3,6 @@ package app
 import (
 	cmn "github.com/tendermint/tendermint/libs/common"
 	dbm "github.com/tendermint/tendermint/libs/db"
-	"github.com/tendermint/tendermint/libs/log"
 
 	bapp "github.com/cosmos/cosmos-sdk/baseapp"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -15,13 +14,13 @@ const (
 	app3Name = "App3"
 )
 
-func NewApp3(logger log.Logger, db dbm.DB) *bapp.BaseApp {
+func NewApp3(ctx *sdk.ServerContext, db dbm.DB) *bapp.BaseApp {
 
 	// Create the codec with registered Msg types
 	cdc := NewCodec()
 
 	// Create the base application object.
-	app := bapp.NewBaseApp(app3Name, cdc, logger, db)
+	app := bapp.NewBaseApp(app3Name, cdc, ctx, db)
 
 	// Create a key for accessing the account store.
 	keyAccount := sdk.NewKVStoreKey("acc")

--- a/docs/core/examples/app4.go
+++ b/docs/core/examples/app4.go
@@ -4,7 +4,6 @@ import (
 	abci "github.com/tendermint/tendermint/abci/types"
 	cmn "github.com/tendermint/tendermint/libs/common"
 	dbm "github.com/tendermint/tendermint/libs/db"
-	"github.com/tendermint/tendermint/libs/log"
 
 	bapp "github.com/cosmos/cosmos-sdk/baseapp"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -17,12 +16,12 @@ const (
 	app4Name = "App4"
 )
 
-func NewApp4(logger log.Logger, db dbm.DB) *bapp.BaseApp {
+func NewApp4(ctx *sdk.ServerContext, db dbm.DB) *bapp.BaseApp {
 
 	cdc := NewCodec()
 
 	// Create the base application object.
-	app := bapp.NewBaseApp(app3Name, cdc, logger, db)
+	app := bapp.NewBaseApp(app3Name, cdc, ctx, db)
 
 	// Create a key for accessing the account store.
 	keyAccount := sdk.NewKVStoreKey("acc")

--- a/examples/basecoin/app/app.go
+++ b/examples/basecoin/app/app.go
@@ -13,7 +13,6 @@ import (
 	abci "github.com/tendermint/tendermint/abci/types"
 	cmn "github.com/tendermint/tendermint/libs/common"
 	dbm "github.com/tendermint/tendermint/libs/db"
-	"github.com/tendermint/tendermint/libs/log"
 	tmtypes "github.com/tendermint/tendermint/types"
 )
 
@@ -46,14 +45,14 @@ type BasecoinApp struct {
 // In addition, all necessary mappers and keepers are created, routes
 // registered, and finally the stores being mounted along with any necessary
 // chain initialization.
-func NewBasecoinApp(logger log.Logger, db dbm.DB) *BasecoinApp {
+func NewBasecoinApp(ctx *sdk.ServerContext, db dbm.DB) *BasecoinApp {
 	// create and register app-level codec for TXs and accounts
 	cdc := MakeCodec()
 
 	// create your application type
 	var app = &BasecoinApp{
 		cdc:        cdc,
-		BaseApp:    bam.NewBaseApp(appName, cdc, logger, db),
+		BaseApp:    bam.NewBaseApp(appName, cdc, ctx, db),
 		keyMain:    sdk.NewKVStoreKey("main"),
 		keyAccount: sdk.NewKVStoreKey("acc"),
 		keyIBC:     sdk.NewKVStoreKey("ibc"),

--- a/examples/basecoin/app/app_test.go
+++ b/examples/basecoin/app/app_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/auth"
 	"github.com/stretchr/testify/require"
 	abci "github.com/tendermint/tendermint/abci/types"
+	cfg "github.com/tendermint/tendermint/config"
 	"github.com/tendermint/tendermint/crypto"
 	dbm "github.com/tendermint/tendermint/libs/db"
 	"github.com/tendermint/tendermint/libs/log"
@@ -38,8 +39,10 @@ func setGenesis(baseApp *BasecoinApp, accounts ...*types.AppAccount) (types.Gene
 
 func TestGenesis(t *testing.T) {
 	logger := log.NewTMLogger(log.NewSyncWriter(os.Stdout)).With("module", "sdk/app")
+	config := cfg.DefaultConfig()
+	sctx := sdk.NewServerContext(config, logger)
 	db := dbm.NewMemDB()
-	baseApp := NewBasecoinApp(logger, db)
+	baseApp := NewBasecoinApp(sctx, db)
 
 	// construct a pubkey and an address for the test account
 	pubkey := crypto.GenPrivKeyEd25519().PubKey()
@@ -65,7 +68,7 @@ func TestGenesis(t *testing.T) {
 	require.Equal(t, appAcct, res)
 
 	// reload app and ensure the account is still there
-	baseApp = NewBasecoinApp(logger, db)
+	baseApp = NewBasecoinApp(sctx, db)
 
 	stateBytes, err := wire.MarshalJSONIndent(baseApp.cdc, genState)
 	require.Nil(t, err)

--- a/examples/basecoin/cmd/basecoind/main.go
+++ b/examples/basecoin/cmd/basecoind/main.go
@@ -6,17 +6,17 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/examples/basecoin/app"
 	"github.com/cosmos/cosmos-sdk/server"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/spf13/cobra"
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/libs/cli"
 	dbm "github.com/tendermint/tendermint/libs/db"
-	"github.com/tendermint/tendermint/libs/log"
 	tmtypes "github.com/tendermint/tendermint/types"
 )
 
 func main() {
 	cdc := app.MakeCodec()
-	ctx := server.NewDefaultContext()
+	ctx := sdk.NewDefaultServerContext()
 
 	rootCmd := &cobra.Command{
 		Use:               "basecoind",
@@ -39,11 +39,11 @@ func main() {
 	}
 }
 
-func newApp(logger log.Logger, db dbm.DB) abci.Application {
-	return app.NewBasecoinApp(logger, db)
+func newApp(ctx *sdk.ServerContext, db dbm.DB) abci.Application {
+	return app.NewBasecoinApp(ctx, db)
 }
 
-func exportAppStateAndTMValidators(logger log.Logger, db dbm.DB) (json.RawMessage, []tmtypes.GenesisValidator, error) {
-	bapp := app.NewBasecoinApp(logger, db)
+func exportAppStateAndTMValidators(ctx *sdk.ServerContext, db dbm.DB) (json.RawMessage, []tmtypes.GenesisValidator, error) {
+	bapp := app.NewBasecoinApp(ctx, db)
 	return bapp.ExportAppStateAndValidators()
 }

--- a/examples/democoin/app/app.go
+++ b/examples/democoin/app/app.go
@@ -6,7 +6,6 @@ import (
 	abci "github.com/tendermint/tendermint/abci/types"
 	cmn "github.com/tendermint/tendermint/libs/common"
 	dbm "github.com/tendermint/tendermint/libs/db"
-	"github.com/tendermint/tendermint/libs/log"
 	tmtypes "github.com/tendermint/tendermint/types"
 
 	bam "github.com/cosmos/cosmos-sdk/baseapp"
@@ -51,14 +50,14 @@ type DemocoinApp struct {
 	accountMapper auth.AccountMapper
 }
 
-func NewDemocoinApp(logger log.Logger, db dbm.DB) *DemocoinApp {
+func NewDemocoinApp(ctx *sdk.ServerContext, db dbm.DB) *DemocoinApp {
 
 	// Create app-level codec for txs and accounts.
 	var cdc = MakeCodec()
 
 	// Create your application object.
 	var app = &DemocoinApp{
-		BaseApp:            bam.NewBaseApp(appName, cdc, logger, db),
+		BaseApp:            bam.NewBaseApp(appName, cdc, ctx, db),
 		cdc:                cdc,
 		capKeyMainStore:    sdk.NewKVStoreKey("main"),
 		capKeyAccountStore: sdk.NewKVStoreKey("acc"),

--- a/examples/democoin/app/app_test.go
+++ b/examples/democoin/app/app_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/auth"
 	"github.com/stretchr/testify/require"
 	abci "github.com/tendermint/tendermint/abci/types"
+	cfg "github.com/tendermint/tendermint/config"
 	"github.com/tendermint/tendermint/crypto"
 	dbm "github.com/tendermint/tendermint/libs/db"
 	"github.com/tendermint/tendermint/libs/log"
@@ -42,8 +43,10 @@ func setGenesis(bapp *DemocoinApp, trend string, accs ...auth.BaseAccount) error
 
 func TestGenesis(t *testing.T) {
 	logger := log.NewTMLogger(log.NewSyncWriter(os.Stdout)).With("module", "sdk/app")
+	config := cfg.DefaultConfig()
+	sctx := sdk.NewServerContext(config, logger)
 	db := dbm.NewMemDB()
-	bapp := NewDemocoinApp(logger, db)
+	bapp := NewDemocoinApp(sctx, db)
 
 	// Construct some genesis bytes to reflect democoin/types/AppAccount
 	pk := crypto.GenPrivKeyEd25519().PubKey()
@@ -64,7 +67,7 @@ func TestGenesis(t *testing.T) {
 	require.Equal(t, acc, res1)
 
 	// reload app and ensure the account is still there
-	bapp = NewDemocoinApp(logger, db)
+	bapp = NewDemocoinApp(sctx, db)
 	bapp.InitChain(abci.RequestInitChain{AppStateBytes: []byte("{}")})
 	ctx = bapp.BaseApp.NewContext(true, abci.Header{})
 	res1 = bapp.accountMapper.GetAccount(ctx, baseAcc.Address)

--- a/examples/democoin/cmd/democoind/main.go
+++ b/examples/democoin/cmd/democoind/main.go
@@ -9,11 +9,11 @@ import (
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/libs/cli"
 	dbm "github.com/tendermint/tendermint/libs/db"
-	"github.com/tendermint/tendermint/libs/log"
 	tmtypes "github.com/tendermint/tendermint/types"
 
 	"github.com/cosmos/cosmos-sdk/examples/democoin/app"
 	"github.com/cosmos/cosmos-sdk/server"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/wire"
 )
 
@@ -50,18 +50,18 @@ func CoolAppGenState(cdc *wire.Codec, appGenTxs []json.RawMessage) (appState jso
 	return
 }
 
-func newApp(logger log.Logger, db dbm.DB) abci.Application {
-	return app.NewDemocoinApp(logger, db)
+func newApp(ctx *sdk.ServerContext, db dbm.DB) abci.Application {
+	return app.NewDemocoinApp(ctx, db)
 }
 
-func exportAppStateAndTMValidators(logger log.Logger, db dbm.DB) (json.RawMessage, []tmtypes.GenesisValidator, error) {
-	dapp := app.NewDemocoinApp(logger, db)
+func exportAppStateAndTMValidators(ctx *sdk.ServerContext, db dbm.DB) (json.RawMessage, []tmtypes.GenesisValidator, error) {
+	dapp := app.NewDemocoinApp(ctx, db)
 	return dapp.ExportAppStateAndValidators()
 }
 
 func main() {
 	cdc := app.MakeCodec()
-	ctx := server.NewDefaultContext()
+	ctx := sdk.NewDefaultServerContext()
 
 	rootCmd := &cobra.Command{
 		Use:               "democoind",

--- a/examples/kvstore/main.go
+++ b/examples/kvstore/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/tendermint/tendermint/abci/server"
+	cfg "github.com/tendermint/tendermint/config"
 	"github.com/tendermint/tendermint/libs/cli"
 	cmn "github.com/tendermint/tendermint/libs/common"
 	dbm "github.com/tendermint/tendermint/libs/db"
@@ -20,6 +21,8 @@ import (
 func main() {
 
 	logger := log.NewTMLogger(log.NewSyncWriter(os.Stdout)).With("module", "main")
+	config := cfg.DefaultConfig()
+	ctx := sdk.NewServerContext(config, logger)
 
 	rootDir := viper.GetString(cli.HomeFlag)
 	db, err := dbm.NewGoLevelDB("basecoind", filepath.Join(rootDir, "data"))
@@ -32,7 +35,7 @@ func main() {
 	var capKeyMainStore = sdk.NewKVStoreKey("main")
 
 	// Create BaseApp.
-	var baseApp = bam.NewBaseApp("kvstore", nil, logger, db)
+	var baseApp = bam.NewBaseApp("kvstore", nil, ctx, db)
 
 	// Set mounts for BaseApp's MultiStore.
 	baseApp.MountStoresIAVL(capKeyMainStore)

--- a/server/constructors.go
+++ b/server/constructors.go
@@ -4,40 +4,40 @@ import (
 	"encoding/json"
 	"path/filepath"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	abci "github.com/tendermint/tendermint/abci/types"
 	dbm "github.com/tendermint/tendermint/libs/db"
-	"github.com/tendermint/tendermint/libs/log"
 	tmtypes "github.com/tendermint/tendermint/types"
 )
 
 // AppCreator lets us lazily initialize app, using home dir
 // and other flags (?) to start
-type AppCreator func(string, log.Logger) (abci.Application, error)
+type AppCreator func(string, *sdk.ServerContext) (abci.Application, error)
 
 // AppExporter dumps all app state to JSON-serializable structure and returns the current validator set
-type AppExporter func(home string, log log.Logger) (json.RawMessage, []tmtypes.GenesisValidator, error)
+type AppExporter func(home string, ctx *sdk.ServerContext) (json.RawMessage, []tmtypes.GenesisValidator, error)
 
 // ConstructAppCreator returns an application generation function
-func ConstructAppCreator(appFn func(log.Logger, dbm.DB) abci.Application, name string) AppCreator {
-	return func(rootDir string, logger log.Logger) (abci.Application, error) {
+func ConstructAppCreator(appFn func(*sdk.ServerContext, dbm.DB) abci.Application, name string) AppCreator {
+	return func(rootDir string, ctx *sdk.ServerContext) (abci.Application, error) {
 		dataDir := filepath.Join(rootDir, "data")
 		db, err := dbm.NewGoLevelDB(name, dataDir)
 		if err != nil {
 			return nil, err
 		}
-		app := appFn(logger, db)
+		app := appFn(ctx, db)
 		return app, nil
 	}
 }
 
 // ConstructAppExporter returns an application export function
-func ConstructAppExporter(appFn func(log.Logger, dbm.DB) (json.RawMessage, []tmtypes.GenesisValidator, error), name string) AppExporter {
-	return func(rootDir string, logger log.Logger) (json.RawMessage, []tmtypes.GenesisValidator, error) {
+func ConstructAppExporter(appFn func(*sdk.ServerContext, dbm.DB) (json.RawMessage, []tmtypes.GenesisValidator, error), name string) AppExporter {
+	return func(rootDir string, ctx *sdk.ServerContext) (json.RawMessage, []tmtypes.GenesisValidator, error) {
 		dataDir := filepath.Join(rootDir, "data")
 		db, err := dbm.NewGoLevelDB(name, dataDir)
 		if err != nil {
 			return nil, nil, err
 		}
-		return appFn(logger, db)
+		return appFn(ctx, db)
 	}
 }

--- a/server/export.go
+++ b/server/export.go
@@ -7,18 +7,19 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/wire"
 	tmtypes "github.com/tendermint/tendermint/types"
 )
 
 // ExportCmd dumps app state to JSON
-func ExportCmd(ctx *Context, cdc *wire.Codec, appExporter AppExporter) *cobra.Command {
+func ExportCmd(ctx *sdk.ServerContext, cdc *wire.Codec, appExporter AppExporter) *cobra.Command {
 	return &cobra.Command{
 		Use:   "export",
 		Short: "Export state to JSON",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			home := viper.GetString("home")
-			appState, validators, err := appExporter(home, ctx.Logger)
+			appState, validators, err := appExporter(home, ctx)
 			if err != nil {
 				return errors.Errorf("error exporting state: %v\n", err)
 			}

--- a/server/init.go
+++ b/server/init.go
@@ -63,7 +63,7 @@ type InitConfig struct {
 }
 
 // get cmd to initialize all files for tendermint and application
-func GenTxCmd(ctx *Context, cdc *wire.Codec, appInit AppInit) *cobra.Command {
+func GenTxCmd(ctx *sdk.ServerContext, cdc *wire.Codec, appInit AppInit) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "gen-tx",
 		Short: "Create genesis transaction file (under [--home]/config/gentx/gentx-[nodeID].json)",
@@ -153,7 +153,7 @@ func gentxWithConfig(cdc *wire.Codec, appInit AppInit, config *cfg.Config, genTx
 }
 
 // get cmd to initialize all files for tendermint and application
-func InitCmd(ctx *Context, cdc *wire.Codec, appInit AppInit) *cobra.Command {
+func InitCmd(ctx *sdk.ServerContext, cdc *wire.Codec, appInit AppInit) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "init",
 		Short: "Initialize genesis config, priv-validator file, and p2p-node file",

--- a/server/init_test.go
+++ b/server/init_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/tendermint/tendermint/libs/log"
 
 	"github.com/cosmos/cosmos-sdk/server/mock"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/wire"
 	tcmd "github.com/tendermint/tendermint/cmd/tendermint/commands"
 )
@@ -19,7 +20,7 @@ func TestInitCmd(t *testing.T) {
 	logger := log.NewNopLogger()
 	cfg, err := tcmd.ParseConfig()
 	require.Nil(t, err)
-	ctx := NewContext(cfg, logger)
+	ctx := sdk.NewServerContext(cfg, logger)
 	cdc := wire.NewCodec()
 	appInit := AppInit{
 		AppGenState: mock.AppGenState,

--- a/server/mock/app.go
+++ b/server/mock/app.go
@@ -8,7 +8,6 @@ import (
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/crypto"
 	dbm "github.com/tendermint/tendermint/libs/db"
-	"github.com/tendermint/tendermint/libs/log"
 	tmtypes "github.com/tendermint/tendermint/types"
 
 	bam "github.com/cosmos/cosmos-sdk/baseapp"
@@ -20,7 +19,7 @@ import (
 // NewApp creates a simple mock kvstore app for testing. It should work
 // similar to a real app. Make sure rootDir is empty before running the test,
 // in order to guarantee consistent results
-func NewApp(rootDir string, logger log.Logger) (abci.Application, error) {
+func NewApp(rootDir string, ctx *sdk.ServerContext) (abci.Application, error) {
 	db, err := dbm.NewGoLevelDB("mock", filepath.Join(rootDir, "data"))
 	if err != nil {
 		return nil, err
@@ -30,7 +29,7 @@ func NewApp(rootDir string, logger log.Logger) (abci.Application, error) {
 	capKeyMainStore := sdk.NewKVStoreKey("main")
 
 	// Create BaseApp.
-	baseApp := bam.NewBaseApp("kvstore", nil, logger, db)
+	baseApp := bam.NewBaseApp("kvstore", nil, ctx, db)
 
 	// Set mounts for BaseApp's MultiStore.
 	baseApp.MountStoresIAVL(capKeyMainStore)

--- a/server/mock/helpers.go
+++ b/server/mock/helpers.go
@@ -5,7 +5,9 @@ import (
 	"io/ioutil"
 	"os"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	abci "github.com/tendermint/tendermint/abci/types"
+	cfg "github.com/tendermint/tendermint/config"
 	"github.com/tendermint/tendermint/libs/log"
 )
 
@@ -14,6 +16,8 @@ import (
 func SetupApp() (abci.Application, func(), error) {
 	logger := log.NewTMLogger(log.NewSyncWriter(os.Stdout)).
 		With("module", "mock")
+	config := cfg.DefaultConfig()
+	ctx := sdk.NewServerContext(config, logger)
 	rootDir, err := ioutil.TempDir("", "mock-sdk")
 	if err != nil {
 		return nil, nil, err
@@ -26,6 +30,6 @@ func SetupApp() (abci.Application, func(), error) {
 		}
 	}
 
-	app, err := NewApp(rootDir, logger)
+	app, err := NewApp(rootDir, ctx)
 	return app, cleanup, err
 }

--- a/server/start.go
+++ b/server/start.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/tendermint/tendermint/abci/server"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	tcmd "github.com/tendermint/tendermint/cmd/tendermint/commands"
 	cmn "github.com/tendermint/tendermint/libs/common"
 	"github.com/tendermint/tendermint/node"
@@ -21,7 +22,7 @@ const (
 
 // StartCmd runs the service passed in, either
 // stand-alone, or in-process with tendermint
-func StartCmd(ctx *Context, appCreator AppCreator) *cobra.Command {
+func StartCmd(ctx *sdk.ServerContext, appCreator AppCreator) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "start",
 		Short: "Run the full node",
@@ -45,11 +46,11 @@ func StartCmd(ctx *Context, appCreator AppCreator) *cobra.Command {
 	return cmd
 }
 
-func startStandAlone(ctx *Context, appCreator AppCreator) error {
+func startStandAlone(ctx *sdk.ServerContext, appCreator AppCreator) error {
 	// Generate the app in the proper dir
 	addr := viper.GetString(flagAddress)
 	home := viper.GetString("home")
-	app, err := appCreator(home, ctx.Logger)
+	app, err := appCreator(home, ctx)
 	if err != nil {
 		return err
 	}
@@ -75,10 +76,10 @@ func startStandAlone(ctx *Context, appCreator AppCreator) error {
 	return nil
 }
 
-func startInProcess(ctx *Context, appCreator AppCreator) (*node.Node, error) {
+func startInProcess(ctx *sdk.ServerContext, appCreator AppCreator) (*node.Node, error) {
 	cfg := ctx.Config
 	home := cfg.RootDir
-	app, err := appCreator(home, ctx.Logger)
+	app, err := appCreator(home, ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/server/start_test.go
+++ b/server/start_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/cosmos/cosmos-sdk/server/mock"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/wire"
 	"github.com/tendermint/tendermint/abci/server"
 	tcmd "github.com/tendermint/tendermint/cmd/tendermint/commands"
@@ -25,7 +26,7 @@ func TestStartStandAlone(t *testing.T) {
 	logger := log.NewNopLogger()
 	cfg, err := tcmd.ParseConfig()
 	require.Nil(t, err)
-	ctx := NewContext(cfg, logger)
+	ctx := sdk.NewServerContext(cfg, logger)
 	cdc := wire.NewCodec()
 	appInit := AppInit{
 		AppGenState: mock.AppGenState,
@@ -35,7 +36,7 @@ func TestStartStandAlone(t *testing.T) {
 	err = initCmd.RunE(nil, nil)
 	require.NoError(t, err)
 
-	app, err := mock.NewApp(home, logger)
+	app, err := mock.NewApp(home, ctx)
 	require.Nil(t, err)
 	svrAddr, _, err := FreeTCPAddr()
 	require.Nil(t, err)

--- a/server/testnet.go
+++ b/server/testnet.go
@@ -11,6 +11,7 @@ import (
 
 	"os"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/wire"
 	"github.com/spf13/viper"
 	cfg "github.com/tendermint/tendermint/config"
@@ -28,7 +29,7 @@ var (
 const nodeDirPerm = 0755
 
 // get cmd to initialize all files for tendermint testnet and application
-func TestnetFilesCmd(ctx *Context, cdc *wire.Codec, appInit AppInit) *cobra.Command {
+func TestnetFilesCmd(ctx *sdk.ServerContext, cdc *wire.Codec, appInit AppInit) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "testnet",
 		Short: "Initialize files for a Gaiad testnet",

--- a/server/tm_cmds.go
+++ b/server/tm_cmds.go
@@ -14,7 +14,7 @@ import (
 )
 
 // ShowNodeIDCmd - ported from Tendermint, dump node ID to stdout
-func ShowNodeIDCmd(ctx *Context) *cobra.Command {
+func ShowNodeIDCmd(ctx *sdk.ServerContext) *cobra.Command {
 	return &cobra.Command{
 		Use:   "show_node_id",
 		Short: "Show this node's ID",
@@ -31,7 +31,7 @@ func ShowNodeIDCmd(ctx *Context) *cobra.Command {
 }
 
 // ShowValidator - ported from Tendermint, show this node's validator info
-func ShowValidatorCmd(ctx *Context) *cobra.Command {
+func ShowValidatorCmd(ctx *sdk.ServerContext) *cobra.Command {
 	flagJSON := "json"
 	cmd := cobra.Command{
 		Use:   "show_validator",
@@ -66,7 +66,7 @@ func ShowValidatorCmd(ctx *Context) *cobra.Command {
 }
 
 // UnsafeResetAllCmd - extension of the tendermint command, resets initialization
-func UnsafeResetAllCmd(ctx *Context) *cobra.Command {
+func UnsafeResetAllCmd(ctx *sdk.ServerContext) *cobra.Command {
 	return &cobra.Command{
 		Use:   "unsafe_reset_all",
 		Short: "Reset blockchain database, priv_validator.json file, and the logger",

--- a/server/util.go
+++ b/server/util.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/cosmos/cosmos-sdk/client"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/version"
 	"github.com/cosmos/cosmos-sdk/wire"
 	tcmd "github.com/tendermint/tendermint/cmd/tendermint/commands"
@@ -20,29 +21,12 @@ import (
 	"github.com/tendermint/tendermint/libs/log"
 )
 
-// server context
-type Context struct {
-	Config *cfg.Config
-	Logger log.Logger
-}
-
-func NewDefaultContext() *Context {
-	return NewContext(
-		cfg.DefaultConfig(),
-		log.NewTMLogger(log.NewSyncWriter(os.Stdout)),
-	)
-}
-
-func NewContext(config *cfg.Config, logger log.Logger) *Context {
-	return &Context{config, logger}
-}
-
 //___________________________________________________________________________________
 
 // PersistentPreRunEFn returns a PersistentPreRunE function for cobra
 // that initailizes the passed in context with a properly configured
-// logger and config objecy
-func PersistentPreRunEFn(context *Context) func(*cobra.Command, []string) error {
+// logger and config object
+func PersistentPreRunEFn(context *sdk.ServerContext) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
 		if cmd.Name() == version.VersionCmd.Name() {
 			return nil
@@ -92,7 +76,7 @@ func interceptLoadConfig() (conf *cfg.Config, err error) {
 
 // add server commands
 func AddCommands(
-	ctx *Context, cdc *wire.Codec,
+	ctx *sdk.ServerContext, cdc *wire.Codec,
 	rootCmd *cobra.Command, appInit AppInit,
 	appCreator AppCreator, appExport AppExporter) {
 

--- a/types/servercontext.go
+++ b/types/servercontext.go
@@ -1,0 +1,24 @@
+package types
+
+import (
+	cfg "github.com/tendermint/tendermint/config"
+	"github.com/tendermint/tendermint/libs/log"
+	"os"
+)
+
+// server context
+type ServerContext struct {
+	Config *cfg.Config
+	Logger log.Logger
+}
+
+func NewDefaultServerContext() *ServerContext {
+	return NewServerContext(
+		cfg.DefaultConfig(),
+		log.NewTMLogger(log.NewSyncWriter(os.Stdout)),
+	)
+}
+
+func NewServerContext(config *cfg.Config, logger log.Logger) *ServerContext {
+	return &ServerContext{config, logger}
+}

--- a/x/mock/app.go
+++ b/x/mock/app.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/wire"
 	"github.com/cosmos/cosmos-sdk/x/auth"
 	abci "github.com/tendermint/tendermint/abci/types"
+	cfg "github.com/tendermint/tendermint/config"
 	"github.com/tendermint/tendermint/crypto"
 	dbm "github.com/tendermint/tendermint/libs/db"
 	"github.com/tendermint/tendermint/libs/log"
@@ -33,6 +34,8 @@ type App struct {
 // testing.
 func NewApp() *App {
 	logger := log.NewTMLogger(log.NewSyncWriter(os.Stdout)).With("module", "sdk/app")
+	config := cfg.DefaultConfig()
+	ctx := sdk.NewServerContext(config, logger)
 	db := dbm.NewMemDB()
 
 	// Create the cdc with some standard codecs
@@ -43,7 +46,7 @@ func NewApp() *App {
 
 	// Create your application object
 	app := &App{
-		BaseApp:    bam.NewBaseApp("mock", cdc, logger, db),
+		BaseApp:    bam.NewBaseApp("mock", cdc, ctx, db),
 		Cdc:        cdc,
 		KeyMain:    sdk.NewKVStoreKey("main"),
 		KeyAccount: sdk.NewKVStoreKey("acc"),


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺ 
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes. 
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  --> 

This PR replaces the Logger in calls to NewBaseApp and other App constructors with an instance of server.Context, which contains both the logger and the config object. To avoid dependency cycles related to server.mock, the server.Context struct has been moved to types.ServerContext.

This should allow loading of runtime configuration without resorting to calls to viper in sdk code.
(needed for #1533)

* [x] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [x] Updated CHANGELOG.md
* [ ] Updated Gaia/Examples
* [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
* [ ] Added appropriate labels to PR (ex. wip, ready-for-review, docs)
