### PR TITLE
tools: Switch gometalinter to use a config file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ test_cover:
 	@bash tests/test_cover.sh
 
 test_lint:
-	gometalinter.v2 --disable-all --enable='golint' --enable='misspell' --enable='unparam' --enable='unconvert' --enable='ineffassign' --linter='vet:go vet -composites=false:PATH:LINE:MESSAGE' --enable='vet' --deadline=500s --vendor ./...
+	gometalinter.v2 --config=tools/gometalinter.json ./...
 	!(gometalinter.v2 --disable-all --enable='errcheck' --vendor ./... | grep -v "client/")
 	find . -name '*.go' -type f -not -path "./vendor*" -not -path "*.git*" | xargs gofmt -d -s
 

--- a/tools/gometalinter.json
+++ b/tools/gometalinter.json
@@ -1,0 +1,8 @@
+{
+    "Linters": {
+        "vet": "go tool vet -composites=false :PATH:LINE:MESSAGE"
+   },
+    "Enable": ["golint", "vet", "ineffassign", "unparam", "unconvert", "misspell"],
+    "Deadline": "500s",
+    "Vendor": true
+}


### PR DESCRIPTION
The test_lint was getting way too long. (Also there isn't a clean way to adjust the gocyclo parameter without a config file to my knowledge)
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺ 
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes. 
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  --> 

* [ ] Updated all relevant documentation in docs - should I update any?
* [X] ~Updated all code comments where relevant~
* [X] ~Wrote tests~
* [ ] Updated CHANGELOG.md - Should I? Linters are all new this release
* [X] ~Updated Gaia/Examples~
* [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
* [X] Added appropriate labels to PR (ex. wip, ready-for-review, docs)
