### PR TITLE
store: Setting default back to archive mode / no pruning

### DIFF
--- a/store/iavlstore.go
+++ b/store/iavlstore.go
@@ -16,7 +16,7 @@ import (
 const (
 	defaultIAVLCacheSize  = 10000
 	defaultIAVLNumRecent  = 100
-	defaultIAVLStoreEvery = 10000
+	defaultIAVLStoreEvery = 1
 )
 
 // load the iavl store


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺ 
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes. 
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  --> 

For testnets at least we should have the default be to keep all history so that bug hunting is easier.
Once other PRs (#1533 and #1580) come in we can have config / command line options to enable pruning manually for those that want to run lower disk usage nodes.

* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated CHANGELOG.md
* [ ] Updated Gaia/Examples
* [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
* [ ] Added appropriate labels to PR (ex. wip, ready-for-review, docs)
