### PR TITLE
gaiad: Genesis txs now use bech32 encoding of address and pubkey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ BREAKING CHANGES
 * [x/stake] most index keys nolonger hold a value - inputs are rearranged to form the desired key
 * [lcd] Switch key creation output to return bech32
 * [x/stake] store-value for delegation, validator, ubd, and red do not hold duplicate information contained store-key
+* [gaiad] genesis transactions now use bech32 addresses / pubkeys
 
 DEPRECATED
 * [cli] Deprecate `--name` flag in commands that send txs, in favor of `--from`

--- a/client/lcd/test_helpers.go
+++ b/client/lcd/test_helpers.go
@@ -132,7 +132,7 @@ func InitializeTestLCD(t *testing.T, nValidators int, initAddrs []sdk.Address) (
 	for _, gdValidator := range genDoc.Validators {
 		pk := gdValidator.PubKey
 		validatorsPKs = append(validatorsPKs, pk) // append keys for output
-		appGenTx, _, _, err := gapp.GaiaAppGenTxNF(cdc, pk, pk.Address(), "test_val1")
+		appGenTx, _, _, err := gapp.GaiaAppGenTxNF(cdc, pk, sdk.MustBech32ifyAcc(pk.Address()), "test_val1")
 		require.NoError(t, err)
 		appGenTxs = append(appGenTxs, appGenTx)
 	}

--- a/cmd/gaia/app/genesis.go
+++ b/cmd/gaia/app/genesis.go
@@ -30,20 +30,20 @@ type GenesisState struct {
 
 // GenesisAccount doesn't need pubkey or sequence
 type GenesisAccount struct {
-	Address sdk.Address `json:"address"`
-	Coins   sdk.Coins   `json:"coins"`
+	Address string    `json:"address"`
+	Coins   sdk.Coins `json:"coins"`
 }
 
 func NewGenesisAccount(acc *auth.BaseAccount) GenesisAccount {
 	return GenesisAccount{
-		Address: acc.Address,
+		Address: sdk.MustBech32ifyAcc(acc.Address),
 		Coins:   acc.Coins,
 	}
 }
 
 func NewGenesisAccountI(acc auth.Account) GenesisAccount {
 	return GenesisAccount{
-		Address: acc.GetAddress(),
+		Address: sdk.MustBech32ifyAcc(acc.GetAddress()),
 		Coins:   acc.GetCoins(),
 	}
 }
@@ -51,7 +51,7 @@ func NewGenesisAccountI(acc auth.Account) GenesisAccount {
 // convert GenesisAccount to auth.BaseAccount
 func (ga *GenesisAccount) ToAccount() (acc *auth.BaseAccount) {
 	return &auth.BaseAccount{
-		Address: ga.Address,
+		Address: sdk.MustGetAccAddressBech32(ga.Address),
 		Coins:   ga.Coins.Sort(),
 	}
 }
@@ -76,9 +76,9 @@ func GaiaAppInit() server.AppInit {
 
 // simple genesis tx
 type GaiaGenTx struct {
-	Name    string        `json:"name"`
-	Address sdk.Address   `json:"address"`
-	PubKey  crypto.PubKey `json:"pub_key"`
+	Name    string `json:"name"`
+	Address string `json:"address"`
+	PubKey  string `json:"pub_key"`
 }
 
 // Generate a gaia genesis transaction with flags
@@ -88,7 +88,7 @@ func GaiaAppGenTx(cdc *wire.Codec, pk crypto.PubKey, genTxConfig config.GenTx) (
 		return nil, nil, tmtypes.GenesisValidator{}, errors.New("Must specify --name (validator moniker)")
 	}
 
-	var addr sdk.Address
+	var addr string
 	var secret string
 	addr, secret, err = server.GenerateSaveCoinKey(genTxConfig.CliRoot, genTxConfig.Name, "1234567890", genTxConfig.Overwrite)
 	if err != nil {
@@ -108,14 +108,14 @@ func GaiaAppGenTx(cdc *wire.Codec, pk crypto.PubKey, genTxConfig config.GenTx) (
 }
 
 // Generate a gaia genesis transaction without flags
-func GaiaAppGenTxNF(cdc *wire.Codec, pk crypto.PubKey, addr sdk.Address, name string) (
+func GaiaAppGenTxNF(cdc *wire.Codec, pk crypto.PubKey, addr string, name string) (
 	appGenTx, cliPrint json.RawMessage, validator tmtypes.GenesisValidator, err error) {
 
 	var bz []byte
 	gaiaGenTx := GaiaGenTx{
 		Name:    name,
 		Address: addr,
-		PubKey:  pk,
+		PubKey:  sdk.MustBech32ifyAccPub(pk),
 	}
 	bz, err = wire.MarshalJSONIndent(cdc, gaiaGenTx)
 	if err != nil {
@@ -153,7 +153,7 @@ func GaiaAppGenState(cdc *wire.Codec, appGenTxs []json.RawMessage) (genesisState
 		}
 
 		// create the genesis account, give'm few steaks and a buncha token with there name
-		accAuth := auth.NewBaseAccountWithAddress(genTx.Address)
+		accAuth := auth.NewBaseAccountWithAddress(sdk.MustGetAccAddressBech32(genTx.Address))
 		accAuth.Coins = sdk.Coins{
 			{genTx.Name + "Token", sdk.NewInt(1000)},
 			{"steak", sdk.NewInt(freeFermionsAcc)},
@@ -165,7 +165,8 @@ func GaiaAppGenState(cdc *wire.Codec, appGenTxs []json.RawMessage) (genesisState
 		// add the validator
 		if len(genTx.Name) > 0 {
 			desc := stake.NewDescription(genTx.Name, "", "", "")
-			validator := stake.NewValidator(genTx.Address, genTx.PubKey, desc)
+			validator := stake.NewValidator(sdk.MustGetAccAddressBech32(genTx.Address),
+				sdk.MustGetAccPubKeyBech32(genTx.PubKey), desc)
 
 			stakeData.Pool.LooseTokens = stakeData.Pool.LooseTokens + freeFermionVal // increase the supply
 

--- a/server/init.go
+++ b/server/init.go
@@ -376,22 +376,22 @@ var DefaultAppInit = AppInit{
 
 // simple genesis tx
 type SimpleGenTx struct {
-	Addr sdk.Address `json:"addr"`
+	Addr string `json:"addr"`
 }
 
 // Generate a genesis transaction
 func SimpleAppGenTx(cdc *wire.Codec, pk crypto.PubKey, genTxConfig serverconfig.GenTx) (
 	appGenTx, cliPrint json.RawMessage, validator tmtypes.GenesisValidator, err error) {
 
-	var addr sdk.Address
+	var bech32Addr string
 	var secret string
-	addr, secret, err = GenerateCoinKey()
+	bech32Addr, secret, err = GenerateCoinKey()
 	if err != nil {
 		return
 	}
 
 	var bz []byte
-	simpleGenTx := SimpleGenTx{addr}
+	simpleGenTx := SimpleGenTx{bech32Addr}
 	bz, err = cdc.MarshalJSON(simpleGenTx)
 	if err != nil {
 		return
@@ -436,7 +436,7 @@ func SimpleAppGenState(cdc *wire.Codec, appGenTxs []json.RawMessage) (appState j
       }
     ]
   }]
-}`, genTx.Addr.String()))
+}`, genTx.Addr))
 	return
 }
 
@@ -444,7 +444,7 @@ func SimpleAppGenState(cdc *wire.Codec, appGenTxs []json.RawMessage) (appState j
 
 // GenerateCoinKey returns the address of a public key, along with the secret
 // phrase to recover the private key.
-func GenerateCoinKey() (sdk.Address, string, error) {
+func GenerateCoinKey() (string, string, error) {
 
 	// construct an in-memory key store
 	keybase := keys.New(
@@ -454,35 +454,35 @@ func GenerateCoinKey() (sdk.Address, string, error) {
 	// generate a private key, with recovery phrase
 	info, secret, err := keybase.CreateMnemonic("name", keys.English, "pass", keys.Secp256k1)
 	if err != nil {
-		return nil, "", err
+		return "", "", err
 	}
 	addr := info.GetPubKey().Address()
-	return sdk.Address(addr), secret, nil
+	return sdk.MustBech32ifyAcc(sdk.Address(addr)), secret, nil
 }
 
 // GenerateSaveCoinKey returns the address of a public key, along with the secret
 // phrase to recover the private key.
-func GenerateSaveCoinKey(clientRoot, keyName, keyPass string, overwrite bool) (sdk.Address, string, error) {
+func GenerateSaveCoinKey(clientRoot, keyName, keyPass string, overwrite bool) (string, string, error) {
 
 	// get the keystore from the client
 	keybase, err := clkeys.GetKeyBaseFromDir(clientRoot)
 	if err != nil {
-		return nil, "", err
+		return "", "", err
 	}
 
 	// ensure no overwrite
 	if !overwrite {
 		_, err := keybase.Get(keyName)
 		if err == nil {
-			return nil, "", errors.New("key already exists, overwrite is disabled")
+			return "", "", errors.New("key already exists, overwrite is disabled")
 		}
 	}
 
 	// generate a private key, with recovery phrase
 	info, secret, err := keybase.CreateMnemonic(keyName, keys.English, keyPass, keys.Secp256k1)
 	if err != nil {
-		return nil, "", err
+		return "", "", err
 	}
 	addr := info.GetPubKey().Address()
-	return sdk.Address(addr), secret, nil
+	return sdk.MustBech32ifyAcc(sdk.Address(addr)), secret, nil
 }

--- a/types/account.go
+++ b/types/account.go
@@ -102,6 +102,15 @@ func GetAccAddressBech32(address string) (addr Address, err error) {
 	return Address(bz), nil
 }
 
+// create an Address from a string, panics on error
+func MustGetAccAddressBech32(address string) (addr Address) {
+	addr, err := GetAccAddressBech32(address)
+	if err != nil {
+		panic(err)
+	}
+	return addr
+}
+
 // create a Pubkey from a string
 func GetAccPubKeyBech32(address string) (pk crypto.PubKey, err error) {
 	bz, err := GetFromBech32(address, Bech32PrefixAccPub)
@@ -115,6 +124,15 @@ func GetAccPubKeyBech32(address string) (pk crypto.PubKey, err error) {
 	}
 
 	return pk, nil
+}
+
+// create an Pubkey from a string, panics on error
+func MustGetAccPubKeyBech32(address string) (pk crypto.PubKey) {
+	pk, err := GetAccPubKeyBech32(address)
+	if err != nil {
+		panic(err)
+	}
+	return pk
 }
 
 // create an Address from a hex string
@@ -138,6 +156,15 @@ func GetValAddressBech32(address string) (addr Address, err error) {
 	return Address(bz), nil
 }
 
+// create an Address from a string, panics on error
+func MustGetValAddressBech32(address string) (addr Address) {
+	addr, err := GetValAddressBech32(address)
+	if err != nil {
+		panic(err)
+	}
+	return addr
+}
+
 // decode a validator public key into a PubKey
 func GetValPubKeyBech32(pubkey string) (pk crypto.PubKey, err error) {
 	bz, err := GetFromBech32(pubkey, Bech32PrefixValPub)
@@ -151,6 +178,15 @@ func GetValPubKeyBech32(pubkey string) (pk crypto.PubKey, err error) {
 	}
 
 	return pk, nil
+}
+
+// create an Pubkey from a string, panics on error
+func MustGetValPubKeyBech32(address string) (pk crypto.PubKey) {
+	pk, err := GetValPubKeyBech32(address)
+	if err != nil {
+		panic(err)
+	}
+	return pk
 }
 
 // decode a bytestring from a bech32-encoded string


### PR DESCRIPTION
* `gaiad init gen-tx` makes the outputted file use bech32, with acct prefix
* `gaiad init --gen-txs` only reads bech32 with acct prefixes

The reason for using the account prefix is that in principle you could
have genesis transactions for non-validators.

Closes #1475

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺ 
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes. 
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  --> 

* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests - almost no tests are in /server (ref #919 )
* [X] Updated CHANGELOG.md
* [X] Updated Gaia/Examples - Updated Gaia, I don't think examples do genesis stuff
* [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
* [X] Added appropriate labels to PR (ex. wip, ready-for-review, docs)
