### PR TITLE
Setup for internal testnet before gaia-7000

### DIFF
--- a/cmd/gaia/testnets/internal-7000/README.md
+++ b/cmd/gaia/testnets/internal-7000/README.md
@@ -1,0 +1,59 @@
+# internal-7000 testnet
+
+This is a testnet only for internal testing. 
+
+## Install golang
+
+One way to install golang on an Ubuntu server is to use [gvm](https://github.com/moovweb/gvm).
+
+You can use whatever way works best for you, just make sure that it is correctly installed.
+
+## Install Gaia
+
+```bash
+go get github.com/cosmos/cosmos-sdk
+
+cd $GOPATH/src/github.com/cosmos/cosmos-sdk
+
+git checkout 0d94c5a2559f9b117a67327b1813c2926c5fa6bf
+
+make get_tools
+
+make get_vendor_deps
+
+make install
+
+gaiad version -> 0.20.0-dev-0d94c5a2
+
+gaiacli version -> 0.20.0-dev-0d94c5a2
+```
+
+## Generating a genesis transaction
+
+```bash
+gaiad init gentx --name=<some_name>
+
+cat $HOME/.gaiad/config/gentx/... -> there is a single json file, add it as your_name.json into the `internal-7000` folder
+```
+
+## Starting the testnet
+
+```bash
+rm -r $HOME/.gaiad/config/gentx
+
+cd $GOPATH/src/github.com/cosmos/cosmos-sdk
+
+git checkout develop
+
+git pull origin develop
+
+cp -r $GOPATH/src/github.com/cosmos/cosmos-sdk/cmd/gaia/testnets/internal-7000 $HOME/.gaiad/config/gentx
+
+gaiad init --gen-txs --chain-id=internal-7000
+
+gaiad start
+```
+
+## Testing the testnet
+
+Go nuts, try everything. 

--- a/cmd/gaia/testnets/internal-7000/README.md
+++ b/cmd/gaia/testnets/internal-7000/README.md
@@ -15,7 +15,7 @@ go get github.com/cosmos/cosmos-sdk
 
 cd $GOPATH/src/github.com/cosmos/cosmos-sdk
 
-git checkout 0d94c5a2559f9b117a67327b1813c2926c5fa6bf
+git checkout <next RC>
 
 make get_tools
 

--- a/cmd/gaia/testnets/internal-7000/adrian.json
+++ b/cmd/gaia/testnets/internal-7000/adrian.json
@@ -1,0 +1,17 @@
+{
+    "node_id": "3fd8883a674b4bb61f30db104fc69ec43ad93a25",
+    "ip": "35.234.110.230",
+    "validator": {
+      "pub_key": {
+        "type": "tendermint/PubKeyEd25519",
+        "value": "KlrYo0xdvewpviVeuNBit6Gkjjpd2dxeIITZ0v+RFto="
+      },
+      "power": "100",
+      "name": ""
+    },
+    "app_gen_tx": {
+      "name": "adrian",
+      "address": "cosmosaccaddr1r2n59xe4wf52rmz7r78ea0k7nqmewfc29r7klq",
+      "pub_key": "cosmosaccpub1zcjduepq9fdd3g6vtk77c2d7y40t35rzk7s6fr36thvach3qsnva9lu3zmdqquh96m"
+    }
+  }


### PR DESCRIPTION
This PR is waiting on cutting a release candidate.

This PR creates the folder that we use to collect all the genesis transactions for the setup of `internal-7000`. The readme explains how to generate your own genesis transaction and how to eventually start a node.

Let's test `next RC` for a couple of days internally. Afterwards we will release this to the public as `gaia-7000`. 

@cwgoes @zmanian @jolesbi @faboweb @ValarDragon @jackzampolin @ebuchman @jlandrews @sunnya97 @melekes @mossid  Please ping anyone else that I may have forgotten. Everyone should ideally join.

The goal is to get the testnet running by Tuesday (2018/07/10) 23:59 UTC. Anyone else that didn't have the chance to include their genesis transaction can ask for steak and join as a validator afterwards.