### PR TITLE
changelog: Reorder items in the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,9 @@ BREAKING CHANGES
     * Default ports changed from 466xx to 266xx
     * Amino JSON uses type names instead of prefix bytes
     * ED25519 addresses are the first 20-bytes of the SHA256 of the raw 32-byte
-      pubkey
+      pubkey (Instead of RIPEMD160)
     * go-crypto, abci, tmlibs have been merged into Tendermint
+      * The keys sub-module is now in the SDK
     * Various other fixes
 * [auth] Signers of a transaction now only sign over their own account and sequence number
 * [auth] Removed MsgChangePubKey 
@@ -25,14 +26,6 @@ BREAKING CHANGES
 * [types] renamed rational.Evaluate to rational.Round{Int64, Int}
 * [keys] Keybase and Ledger support from go-crypto merged into the SDK in the `crypto` folder
 * [cli] Rearranged commands under subcommands
-* [x/gov] Gov module REST endpoints changed to be more RESTful
-* [x/stake] Remove Tick and add EndBlocker
-* [x/stake] Introduce concept of unbonding for delegations and validators
-  * `gaiacli stake unbond` replaced with `gaiacli stake begin-unbonding`
-  * Introduced:
-    * `gaiacli stake complete-unbonding`
-    * `gaiacli stake begin-redelegation`
-    * `gaiacli stake complete-redelegation`
 * [x/slashing] Update slashing for unbonding period
   * Slash according to power at time of infraction instead of power at
     time of discovery
@@ -40,25 +33,38 @@ BREAKING CHANGES
     to an infraction, slash them proportional to their stake at the time
   * Add REST endpoint to unrevoke a validator previously revoked for downtime
   * Add REST endpoint to retrieve liveness signing information for a validator
-* [types] renamed rational.Evaluate to rational.Round{Int64, Int}
+* [x/stake] Remove Tick and add EndBlocker
 * [x/stake] most index keys nolonger hold a value - inputs are rearranged to form the desired key
-* [lcd] Switch key creation output to return bech32
 * [x/stake] store-value for delegation, validator, ubd, and red do not hold duplicate information contained store-key
-* [gaiad] genesis transactions now use bech32 addresses / pubkeys
+* [x/stake] Introduce concept of unbonding for delegations and validators
+  * `gaiacli stake unbond` replaced with `gaiacli stake begin-unbonding`
+  * Introduced:
+    * `gaiacli stake complete-unbonding`
+    * `gaiacli stake begin-redelegation`
+    * `gaiacli stake complete-redelegation`
+* [lcd] Switch key creation output to return bech32
 * [lcd] Removed shorthand CLI flags (`a`, `c`, `n`, `o`)
+* [gaiad] genesis transactions now use bech32 addresses / pubkeys
 
 DEPRECATED
-* [cli] Deprecate `--name` flag in commands that send txs, in favor of `--from`
+* [cli] Deprecated `--name` flag in commands that send txs, in favor of `--from`
 
 FEATURES
-* [gaiacli] You can now attach a simple text-only memo to any transaction, with the `--memo` flag
-* [lcd] Queried TXs now include the tx hash to identify each tx
-* [mockapp] CompleteSetup() no longer takes a testing parameter
 * [x/gov] Implemented MVP
   * Supported proposal types: just binary (pass/fail) TextProposals for now
   * Proposals need deposits to be votable; deposits are burned if proposal fails
   * Delegators delegate votes to validator by default but can override (for their stake)
-* Add benchmarks for signing and delivering a block with a single bank transaction
+* [gaiacli] Ledger support added
+  - You can now use a Ledger with `gaiacli --ledger` for all key-related commands
+  - Ledger keys can be named and tracked locally in the key DB
+* [gaiacli] You can now attach a simple text-only memo to any transaction, with the `--memo` flag
+* [gaiacli] added the following flags for commands that post transactions to the chain:
+  * async -- send the tx without waiting for a tendermint response
+  * json  -- return the output in json format for increased readability
+  * print-response -- return the tx response. (includes fields like gas cost)
+* [lcd] Queried TXs now include the tx hash to identify each tx
+* [mockapp] CompleteSetup() no longer takes a testing parameter
+* [x/bank] Add benchmarks for signing and delivering a block with a single bank transaction
   * Run with `cd x/bank && go test --bench=.`
 * [tools] make get_tools installs tendermint's linter, and gometalinter
 * [tools] Switch gometalinter to the stable version
@@ -71,26 +77,21 @@ FEATURES
   * errcheck
   * unparam
   * gocyclo
-* [tools] Add `make format` command to automate fixing misspell and gofmt errors.
+* [tools] Added `make format` command to automate fixing misspell and gofmt errors.
 * [server] Default config now creates a profiler at port 6060, and increase p2p send/recv rates
-* [tests] Add WaitForNextNBlocksTM helper method
 * [types] Switches internal representation of Int/Uint/Rat to use pointers
+* [types] Added MinInt and MinUint functions
 * [gaiad] `unsafe_reset_all` now resets addrbook.json
 * [democoin] add x/oracle, x/assoc
-* [gaiacli] Ledger support added
-  - You can now use a Ledger with `gaiacli --ledger` for all key-related commands
-  - Ledger keys can be named and tracked locally in the key DB
-* [testing] created a randomized testing framework. 
+* [tests] created a randomized testing framework. 
   - Currently bank has limited functionality in the framework
   - Auth has its invariants checked within the framework
-* [gaiacli] added the following flags for commands that post transactions to the chain:
-  * async -- send the tx without waiting for a tendermint response
-  * json  -- return the output in json format for increased readability
-  * print-response -- return the tx response. (includes fields like gas cost)
+* [tests] Add WaitForNextNBlocksTM helper method
+* [keys] New keys now have 24 word recovery keys, for heightened security
 
 IMPROVEMENTS
-* bank module uses go-wire codec instead of 'encoding/json'
-* auth module uses go-wire codec instead of 'encoding/json'
+* [x/bank] Now uses go-wire codec instead of 'encoding/json'
+* [x/auth] Now uses go-wire codec instead of 'encoding/json'
 * revised use of endblock and beginblock
 * [stake] module reorganized to include `types` and `keeper` package
 * [stake] keeper always loads the store (instead passing around which doesn't really boost efficiency)
@@ -105,24 +106,25 @@ BUG FIXES
 * [x/slashing] \#1510 Unrevoked validators cannot un-revoke themselves
 * [x/stake] \#1513 Validators slashed to zero power are unbonded and removed from the store
 * [x/stake] \#1567 Validators decreased in power but not unbonded are now updated in Tendermint
+* [x/stake] error strings lower case
+* [x/stake] pool loose tokens now accounts for unbonding and unbonding tokens not associated with any validator
+* [x/stake] fix revoke bytes ordering (was putting revoked candidates at the top of the list)
+* [x/stake] bond count was counting revoked validators as bonded, fixed
 * [gaia] Added self delegation for validators in the genesis creation
 * [lcd] tests now don't depend on raw json text
-* [stake] error strings lower case
-* [stake] pool loose tokens now accounts for unbonding and unbonding tokens not associated with any validator
-* \#1259 - fix bug where certain tests that could have a nil pointer in defer
-* \#1052 - Make all now works
 * Retry on HTTP request failure in CLI tests, add option to retry tests in Makefile
 * Fixed bug where chain ID wasn't passed properly in x/bank REST handler, removed Viper hack from ante handler
 * Fixed bug where `democli account` didn't decode the account data correctly
-* \#1343 - fixed unnecessary parallelism in CI
-* \#1367 - set ChainID in InitChain
-* \#1353 - CLI: Show pool shares fractions in human-readable format
-* \#1258 - printing big.rat's can no longer overflow int64
+* \#872  - recovery phrases no longer all end in `abandon`
 * \#887  - limit the size of rationals that can be passed in from user input
+* \#1052 - Make all now works
+* \#1258 - printing big.rat's can no longer overflow int64
+* \#1259 - fix bug where certain tests that could have a nil pointer in defer
+* \#1343 - fixed unnecessary parallelism in CI
+* \#1353 - CLI: Show pool shares fractions in human-readable format
+* \#1367 - set ChainID in InitChain
 * \#1461 - CLI tests now no longer reset your local environment data
 * \#1505 - `gaiacli stake validator` no longer panics if validator doesn't exist
-* [x/stake] fix revoke bytes ordering (was putting revoked candidates at the top of the list)
-* [x/stake] bond count was counting revoked validators as bonded, fixed
 * \#1565 - fix cliff validator persisting when validator set shrinks from max
 
 ## 0.19.0


### PR DESCRIPTION
I've reordered the entries to have entries tagged under the same module put together. (I think it was kinda weird with them not together before)

Additionally I've added the following entries:

* Added MinInt and MinUint functions

     * The keys sub-module is now in the sdk

* [keys] New keys now have 24 word recovery keys, for heightened security

* \#872  - recovery phrases no longer all end in `abandon`

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺ 
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes. 
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  --> 

* [ ] ~Updated all relevant documentation in docs~
* [ ] ~Updated all code comments where relevant~
* [ ]~ Wrote tests~
* [ ] ~Updated CHANGELOG.md~
* [ ] ~Updated Gaia/Examples~
* [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
* [X] Added appropriate labels to PR (ex. wip, ready-for-review, docs)

Feel free to close this issue though, if there was some ordering, or we think that any sort of ordering doesn't matter. I don't feel strongly about it