### PR TITLE
keys: Keybase.Update no longer asks for newpass if oldpass is incorrect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Pending
+
+BREAKING CHANGES
+- [keys] Keybase.Update function now takes in a function to get the newpass, rather than the password itself
+
+BUG FIXES
+- [keys] \#1629 - updating password no longer asks for a new password when the first entered password was incorrect
+
 ## 0.20.0
 
 *July 10th, 2018*

--- a/crypto/keys/keybase.go
+++ b/crypto/keys/keybase.go
@@ -330,8 +330,9 @@ func (kb dbKeybase) Delete(name, passphrase string) error {
 // encrypted.
 //
 // oldpass must be the current passphrase used for encryption,
-// newpass will be the only valid passphrase from this time forward.
-func (kb dbKeybase) Update(name, oldpass, newpass string) error {
+// getNewpass is a function to get the passphrase to permanently replace
+// the current passphrase
+func (kb dbKeybase) Update(name, oldpass string, getNewpass func() (string, error)) error {
 	info, err := kb.Get(name)
 	if err != nil {
 		return err
@@ -340,6 +341,10 @@ func (kb dbKeybase) Update(name, oldpass, newpass string) error {
 	case localInfo:
 		linfo := info.(localInfo)
 		key, err := unarmorDecryptPrivKey(linfo.PrivKeyArmor, oldpass)
+		if err != nil {
+			return err
+		}
+		newpass, err := getNewpass()
 		if err != nil {
 			return err
 		}

--- a/crypto/keys/keybase_test.go
+++ b/crypto/keys/keybase_test.go
@@ -167,9 +167,10 @@ func TestSignVerify(t *testing.T) {
 }
 
 func assertPassword(t *testing.T, cstore Keybase, name, pass, badpass string) {
-	err := cstore.Update(name, badpass, pass)
+	getNewpass := func() (string, error) { return pass, nil }
+	err := cstore.Update(name, badpass, getNewpass)
 	require.NotNil(t, err)
-	err = cstore.Update(name, pass, pass)
+	err = cstore.Update(name, pass, getNewpass)
 	require.Nil(t, err, "%+v", err)
 }
 
@@ -265,12 +266,13 @@ func TestAdvancedKeyManagement(t *testing.T) {
 	assertPassword(t, cstore, n1, p1, p2)
 
 	// update password requires the existing password
-	err = cstore.Update(n1, "jkkgkg", p2)
+	getNewpass := func() (string, error) { return p2, nil }
+	err = cstore.Update(n1, "jkkgkg", getNewpass)
 	require.NotNil(t, err)
 	assertPassword(t, cstore, n1, p1, p2)
 
 	// then it changes the password when correct
-	err = cstore.Update(n1, p1, p2)
+	err = cstore.Update(n1, p1, getNewpass)
 	require.NoError(t, err)
 	// p2 is now the proper one!
 	assertPassword(t, cstore, n1, p2, p1)

--- a/crypto/keys/types.go
+++ b/crypto/keys/types.go
@@ -34,7 +34,7 @@ type Keybase interface {
 	CreateOffline(name string, pubkey crypto.PubKey) (info Info, err error)
 
 	// The following operations will *only* work on locally-stored keys
-	Update(name, oldpass, newpass string) error
+	Update(name, oldpass string, getNewpass func() (string, error)) error
 	Import(name string, armor string) (err error)
 	ImportPubKey(name string, armor string) (err error)
 	Export(name string) (armor string, err error)


### PR DESCRIPTION
Achieved by refactoring the parameter newpass as follows:

* (newpass string) -> (getNewpass func() (string, error))

Closes #1629

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺ 
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes. 
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  --> 

* [X] Updated all relevant documentation in docs - updated godoc
* [X] Updated all code comments where relevant - updated godoc
* [X] Wrote tests
* [X] Updated CHANGELOG.md
* [X] ~Updated Gaia/Examples~
* [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
* [X] Added appropriate labels to PR (ex. wip, ready-for-review, docs)
