### PR TITLE
github: add changelog template to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,7 +7,28 @@ v    If a checkbox is n/a - please still include it but + a little note why
 * [ ] Updated all relevant documentation in docs
 * [ ] Updated all code comments where relevant
 * [ ] Wrote tests
-* [ ] Updated CHANGELOG.md
 * [ ] Updated Gaia/Examples
 * [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
 * [ ] Added appropriate labels to PR (ex. wip, ready-for-review, docs)
+* [ ] Summarized your changes for the changelog
+
+<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺ 
+v    Include a list of changes for the changelog. Each item in the list 
+v    should indicate if its a breaking change, a feature, and improvement,
+v    or a bug fix, and should indicate the pkg it applies to. For instance:
+v   
+v    breaking: [x/stake] MsgCreateValidator includes a DelegatorAddr
+v    breaking: [baseapp] NewBaseApp takes a TxDecoder instead of Codec
+v    feature: [gaiacli] Query for all governance proposals
+v    improvement: [store] Improve performance of MultiStore
+v    bugfix: [gaiacli] Fix panic on empty account 
+v
+v    Of course, your PR should only have a small number of changes!
+☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  --> 
+
+## CHANGELOG
+
+breaking:
+feature:
+improvement:
+bugfix:


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺ 
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes. 
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  --> 

* [ ] Updated all relevant documentation in docs
* [ ] Updated all code comments where relevant
* [ ] Wrote tests
* [ ] Updated Gaia/Examples
* [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
* [ ] Added appropriate labels to PR (ex. wip, ready-for-review, docs)
* [ ] Summarized your changes for the changelog

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺ 
v    Include a list of changes for the changelog. Each item in the list 
v    should indicate if its a breaking change, a feature, and improvement,
v    or a bug fix, and should indicate the pkg it applies to. For instance:
v   
v    breaking: [x/stake] MsgCreateValidator includes a DelegatorAddr
v    breaking: [baseapp] NewBaseApp takes a TxDecoder instead of Codec
v    feature: [gaiacli] Query for all governance proposals
v    improvement: [store] Improve performance of MultiStore
v    bugfix: [gaiacli] Fix panic on empty account 
v
v    Of course, your PR should only have a small number of changes!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  --> 

## CHANGELOG

breaking:
feature:
improvement: [github] Add changelog template to PR template
bugfix:
