### PR TITLE
types: Switch table driven test error messages to new format

### DIFF
--- a/types/coin_test.go
+++ b/types/coin_test.go
@@ -17,9 +17,9 @@ func TestIsPositiveCoin(t *testing.T) {
 		{NewCoin("a", -1), false},
 	}
 
-	for _, tc := range cases {
+	for tcIndex, tc := range cases {
 		res := tc.inputOne.IsPositive()
-		require.Equal(t, tc.expected, res)
+		require.Equal(t, tc.expected, res, "%s positivity is incorrect. tc #%d", tc.inputOne.String(), tcIndex)
 	}
 }
 
@@ -33,9 +33,9 @@ func TestIsNotNegativeCoin(t *testing.T) {
 		{NewCoin("a", -1), false},
 	}
 
-	for _, tc := range cases {
+	for tcIndex, tc := range cases {
 		res := tc.inputOne.IsNotNegative()
-		require.Equal(t, tc.expected, res)
+		require.Equal(t, tc.expected, res, "%s not-negativity is incorrect. tc #%d", tc.inputOne.String(), tcIndex)
 	}
 }
 
@@ -52,9 +52,9 @@ func TestSameDenomAsCoin(t *testing.T) {
 		{NewCoin("steak", -11), NewCoin("steak", 10), true},
 	}
 
-	for _, tc := range cases {
+	for tcIndex, tc := range cases {
 		res := tc.inputOne.SameDenomAs(tc.inputTwo)
-		require.Equal(t, tc.expected, res)
+		require.Equal(t, tc.expected, res, "Coin denominations didn't match. tc #%d", tcIndex)
 	}
 }
 
@@ -70,9 +70,9 @@ func TestIsGTECoin(t *testing.T) {
 		{NewCoin("a", 1), NewCoin("b", 1), false},
 	}
 
-	for _, tc := range cases {
+	for tcIndex, tc := range cases {
 		res := tc.inputOne.IsGTE(tc.inputTwo)
-		require.Equal(t, tc.expected, res)
+		require.Equal(t, tc.expected, res, "Coin GTE relation is incorrect. tc #%d", tcIndex)
 	}
 }
 
@@ -89,9 +89,9 @@ func TestIsEqualCoin(t *testing.T) {
 		{NewCoin("steak", -11), NewCoin("steak", 10), false},
 	}
 
-	for _, tc := range cases {
+	for tcIndex, tc := range cases {
 		res := tc.inputOne.IsEqual(tc.inputTwo)
-		require.Equal(t, tc.expected, res)
+		require.Equal(t, tc.expected, res, "Coin equality relation is incorrect. tc #%d", tcIndex)
 	}
 }
 
@@ -106,9 +106,9 @@ func TestPlusCoin(t *testing.T) {
 		{NewCoin("asdf", -4), NewCoin("asdf", 5), NewCoin("asdf", 1)},
 	}
 
-	for _, tc := range cases {
+	for tcIndex, tc := range cases {
 		res := tc.inputOne.Plus(tc.inputTwo)
-		require.Equal(t, tc.expected, res)
+		require.Equal(t, tc.expected, res, "Sum of coins is incorrect. tc #%d", tcIndex)
 	}
 
 	tc := struct {
@@ -132,9 +132,9 @@ func TestMinusCoin(t *testing.T) {
 		{NewCoin("asdf", 10), NewCoin("asdf", 1), NewCoin("asdf", 9)},
 	}
 
-	for _, tc := range cases {
+	for tcIndex, tc := range cases {
 		res := tc.inputOne.Minus(tc.inputTwo)
-		require.Equal(t, tc.expected, res)
+		require.Equal(t, tc.expected, res, "Difference of coins is incorrect. tc #%d", tcIndex)
 	}
 
 	tc := struct {
@@ -212,10 +212,10 @@ func TestPlusCoins(t *testing.T) {
 		{Coins{{"A", negone}, {"B", zero}}, Coins{{"A", zero}, {"B", zero}}, Coins{{"A", negone}}},
 	}
 
-	for _, tc := range cases {
+	for tcIndex, tc := range cases {
 		res := tc.inputOne.Plus(tc.inputTwo)
 		assert.True(t, res.IsValid())
-		require.Equal(t, tc.expected, res)
+		require.Equal(t, tc.expected, res, "Sum of coins is incorrect. tc #%d", tcIndex)
 	}
 }
 
@@ -242,12 +242,12 @@ func TestParse(t *testing.T) {
 		{"5foo-bar", false, nil},              // once more, only letters in coin name
 	}
 
-	for _, tc := range cases {
+	for tcIndex, tc := range cases {
 		res, err := ParseCoins(tc.input)
 		if !tc.valid {
-			require.NotNil(t, err, "%s: %#v", tc.input, res)
+			require.NotNil(t, err, "%s: %#v. tc #%d", tc.input, res, tcIndex)
 		} else if assert.Nil(t, err, "%s: %+v", tc.input, err) {
-			require.Equal(t, tc.expected, res)
+			require.Equal(t, tc.expected, res, "Coin parsing was incorrect. tc #%d", tcIndex)
 		}
 	}
 
@@ -296,10 +296,10 @@ func TestSortCoins(t *testing.T) {
 		{dup, false, false},
 	}
 
-	for _, tc := range cases {
-		require.Equal(t, tc.before, tc.coins.IsValid())
+	for tcIndex, tc := range cases {
+		require.Equal(t, tc.before, tc.coins.IsValid(), "Coin validity is incorrect before sorting. tc #%d", tcIndex)
 		tc.coins.Sort()
-		require.Equal(t, tc.after, tc.coins.IsValid())
+		require.Equal(t, tc.after, tc.coins.IsValid(), "Coin validity is incorrect after sorting. tc #%d", tcIndex)
 	}
 }
 

--- a/types/coin_test.go
+++ b/types/coin_test.go
@@ -19,7 +19,7 @@ func TestIsPositiveCoin(t *testing.T) {
 
 	for tcIndex, tc := range cases {
 		res := tc.inputOne.IsPositive()
-		require.Equal(t, tc.expected, res, "%s positivity is incorrect. tc #%d", tc.inputOne.String(), tcIndex)
+		require.Equal(t, tc.expected, res, "%s positivity is incorrect, tc #%d", tc.inputOne.String(), tcIndex)
 	}
 }
 
@@ -35,7 +35,7 @@ func TestIsNotNegativeCoin(t *testing.T) {
 
 	for tcIndex, tc := range cases {
 		res := tc.inputOne.IsNotNegative()
-		require.Equal(t, tc.expected, res, "%s not-negativity is incorrect. tc #%d", tc.inputOne.String(), tcIndex)
+		require.Equal(t, tc.expected, res, "%s not-negativity is incorrect, tc #%d", tc.inputOne.String(), tcIndex)
 	}
 }
 
@@ -54,7 +54,7 @@ func TestSameDenomAsCoin(t *testing.T) {
 
 	for tcIndex, tc := range cases {
 		res := tc.inputOne.SameDenomAs(tc.inputTwo)
-		require.Equal(t, tc.expected, res, "Coin denominations didn't match. tc #%d", tcIndex)
+		require.Equal(t, tc.expected, res, "coin denominations didn't match, tc #%d", tcIndex)
 	}
 }
 
@@ -72,7 +72,7 @@ func TestIsGTECoin(t *testing.T) {
 
 	for tcIndex, tc := range cases {
 		res := tc.inputOne.IsGTE(tc.inputTwo)
-		require.Equal(t, tc.expected, res, "Coin GTE relation is incorrect. tc #%d", tcIndex)
+		require.Equal(t, tc.expected, res, "coin GTE relation is incorrect, tc #%d", tcIndex)
 	}
 }
 
@@ -91,7 +91,7 @@ func TestIsEqualCoin(t *testing.T) {
 
 	for tcIndex, tc := range cases {
 		res := tc.inputOne.IsEqual(tc.inputTwo)
-		require.Equal(t, tc.expected, res, "Coin equality relation is incorrect. tc #%d", tcIndex)
+		require.Equal(t, tc.expected, res, "coin equality relation is incorrect, tc #%d", tcIndex)
 	}
 }
 
@@ -108,7 +108,7 @@ func TestPlusCoin(t *testing.T) {
 
 	for tcIndex, tc := range cases {
 		res := tc.inputOne.Plus(tc.inputTwo)
-		require.Equal(t, tc.expected, res, "Sum of coins is incorrect. tc #%d", tcIndex)
+		require.Equal(t, tc.expected, res, "sum of coins is incorrect, tc #%d", tcIndex)
 	}
 
 	tc := struct {
@@ -134,7 +134,7 @@ func TestMinusCoin(t *testing.T) {
 
 	for tcIndex, tc := range cases {
 		res := tc.inputOne.Minus(tc.inputTwo)
-		require.Equal(t, tc.expected, res, "Difference of coins is incorrect. tc #%d", tcIndex)
+		require.Equal(t, tc.expected, res, "difference of coins is incorrect, tc #%d", tcIndex)
 	}
 
 	tc := struct {
@@ -215,7 +215,7 @@ func TestPlusCoins(t *testing.T) {
 	for tcIndex, tc := range cases {
 		res := tc.inputOne.Plus(tc.inputTwo)
 		assert.True(t, res.IsValid())
-		require.Equal(t, tc.expected, res, "Sum of coins is incorrect. tc #%d", tcIndex)
+		require.Equal(t, tc.expected, res, "sum of coins is incorrect, tc #%d", tcIndex)
 	}
 }
 
@@ -247,7 +247,7 @@ func TestParse(t *testing.T) {
 		if !tc.valid {
 			require.NotNil(t, err, "%s: %#v. tc #%d", tc.input, res, tcIndex)
 		} else if assert.Nil(t, err, "%s: %+v", tc.input, err) {
-			require.Equal(t, tc.expected, res, "Coin parsing was incorrect. tc #%d", tcIndex)
+			require.Equal(t, tc.expected, res, "coin parsing was incorrect, tc #%d", tcIndex)
 		}
 	}
 
@@ -297,9 +297,9 @@ func TestSortCoins(t *testing.T) {
 	}
 
 	for tcIndex, tc := range cases {
-		require.Equal(t, tc.before, tc.coins.IsValid(), "Coin validity is incorrect before sorting. tc #%d", tcIndex)
+		require.Equal(t, tc.before, tc.coins.IsValid(), "coin validity is incorrect before sorting, tc #%d", tcIndex)
 		tc.coins.Sort()
-		require.Equal(t, tc.after, tc.coins.IsValid(), "Coin validity is incorrect after sorting. tc #%d", tcIndex)
+		require.Equal(t, tc.after, tc.coins.IsValid(), "coin validity is incorrect after sorting, tc #%d", tcIndex)
 	}
 }
 

--- a/types/rational.go
+++ b/types/rational.go
@@ -234,7 +234,7 @@ func (r *Rat) UnmarshalAmino(text string) (err error) {
 //___________________________________________________________________________________
 // helpers
 
-// test if two rat arrays are the equal
+// test if two rat arrays are equal
 func RatsEqual(r1s, r2s []Rat) bool {
 	if len(r1s) != len(r2s) {
 		return false

--- a/types/rational_test.go
+++ b/types/rational_test.go
@@ -51,19 +51,19 @@ func TestNewFromDecimal(t *testing.T) {
 	for tcIndex, tc := range tests {
 		res, err := NewRatFromDecimal(tc.decimalStr, 4)
 		if tc.expErr {
-			require.NotNil(t, err, tc.decimalStr, "Did not error where expected. tc #%d", tcIndex)
+			require.NotNil(t, err, tc.decimalStr, "error expected, tc #%d", tcIndex)
 		} else {
-			require.Nil(t, err, tc.decimalStr, "Unexpectedly errored. tc #%d", tcIndex)
-			require.True(t, res.Equal(tc.exp), tc.decimalStr, "Equality was incorrect. tc #%d", tcIndex)
+			require.Nil(t, err, tc.decimalStr, "unexpected error, tc #%d", tcIndex)
+			require.True(t, res.Equal(tc.exp), tc.decimalStr, "equality was incorrect, tc #%d", tcIndex)
 		}
 
 		// negative tc
 		res, err = NewRatFromDecimal("-"+tc.decimalStr, 4)
 		if tc.expErr {
-			require.NotNil(t, err, tc.decimalStr, "Did not error where expected (negative case). tc #%d", tcIndex)
+			require.NotNil(t, err, tc.decimalStr, "error expected (negative case), tc #%d", tcIndex)
 		} else {
-			require.Nil(t, err, tc.decimalStr, "Unexpectedly errored (negative case). tc #%d", tcIndex)
-			require.True(t, res.Equal(tc.exp.Mul(NewRat(-1))), tc.decimalStr, "Equality was incorrect (negative case). tc #%d", tcIndex)
+			require.Nil(t, err, tc.decimalStr, "unexpected error (negative case), tc #%d", tcIndex)
+			require.True(t, res.Equal(tc.exp.Mul(NewRat(-1))), tc.decimalStr, "equality was incorrect (negative case), tc #%d", tcIndex)
 		}
 	}
 }
@@ -100,9 +100,9 @@ func TestEqualities(t *testing.T) {
 	}
 
 	for tcIndex, tc := range tests {
-		require.Equal(t, tc.gt, tc.r1.GT(tc.r2), "GT result is incorrect. tc #%d", tcIndex)
-		require.Equal(t, tc.lt, tc.r1.LT(tc.r2), "LT result is incorrect. tc #%d", tcIndex)
-		require.Equal(t, tc.eq, tc.r1.Equal(tc.r2), "Equality result is incorrect. tc #%d", tcIndex)
+		require.Equal(t, tc.gt, tc.r1.GT(tc.r2), "GT result is incorrect, tc #%d", tcIndex)
+		require.Equal(t, tc.lt, tc.r1.LT(tc.r2), "LT result is incorrect, tc #%d", tcIndex)
+		require.Equal(t, tc.eq, tc.r1.Equal(tc.r2), "equality result is incorrect, tc #%d", tcIndex)
 	}
 
 }
@@ -193,9 +193,9 @@ func TestRound(t *testing.T) {
 	}
 
 	for tcIndex, tc := range tests {
-		require.Equal(t, tc.res, tc.r.Round(tc.precFactor), "%v", tc.r, "Incorrect rounding. tc #%d", tcIndex)
+		require.Equal(t, tc.res, tc.r.Round(tc.precFactor), "%v", tc.r, "incorrect rounding, tc #%d", tcIndex)
 		negR1, negRes := tc.r.Mul(NewRat(-1)), tc.res.Mul(NewRat(-1))
-		require.Equal(t, negRes, negR1.Round(tc.precFactor), "%v", negR1, "Incorrect rounding (negative case). tc #%d", tcIndex)
+		require.Equal(t, negRes, negR1.Round(tc.precFactor), "%v", negR1, "incorrect rounding (negative case), tc #%d", tcIndex)
 	}
 }
 
@@ -212,7 +212,7 @@ func TestToLeftPadded(t *testing.T) {
 		{NewRat(1000, 3), 12, "000000000333"},
 	}
 	for tcIndex, tc := range tests {
-		require.Equal(t, tc.res, tc.rat.ToLeftPadded(tc.digits), "Incorrect left padding. tc #%d", tcIndex)
+		require.Equal(t, tc.res, tc.rat.ToLeftPadded(tc.digits), "incorrect left padding, tc #%d", tcIndex)
 	}
 }
 
@@ -301,8 +301,8 @@ func TestRatsEqual(t *testing.T) {
 	}
 
 	for tcIndex, tc := range tests {
-		require.Equal(t, tc.eq, RatsEqual(tc.r1s, tc.r2s), "Equality of rational arrays is incorrect. tc #%d", tcIndex)
-		require.Equal(t, tc.eq, RatsEqual(tc.r2s, tc.r1s), "Equality of rational arrays is incorrect (converse). tc #%d", tcIndex)
+		require.Equal(t, tc.eq, RatsEqual(tc.r1s, tc.r2s), "equality of rational arrays is incorrect, tc #%d", tcIndex)
+		require.Equal(t, tc.eq, RatsEqual(tc.r2s, tc.r1s), "equality of rational arrays is incorrect (converse), tc #%d", tcIndex)
 	}
 
 }

--- a/types/rational_test.go
+++ b/types/rational_test.go
@@ -48,22 +48,22 @@ func TestNewFromDecimal(t *testing.T) {
 		{"0.foobar.", true, Rat{}},
 	}
 
-	for _, tc := range tests {
+	for tcIndex, tc := range tests {
 		res, err := NewRatFromDecimal(tc.decimalStr, 4)
 		if tc.expErr {
-			require.NotNil(t, err, tc.decimalStr)
+			require.NotNil(t, err, tc.decimalStr, "Did not error where expected. tc #%d", tcIndex)
 		} else {
-			require.Nil(t, err, tc.decimalStr)
-			require.True(t, res.Equal(tc.exp), tc.decimalStr)
+			require.Nil(t, err, tc.decimalStr, "Unexpectedly errored. tc #%d", tcIndex)
+			require.True(t, res.Equal(tc.exp), tc.decimalStr, "Equality was incorrect. tc #%d", tcIndex)
 		}
 
 		// negative tc
 		res, err = NewRatFromDecimal("-"+tc.decimalStr, 4)
 		if tc.expErr {
-			require.NotNil(t, err, tc.decimalStr)
+			require.NotNil(t, err, tc.decimalStr, "Did not error where expected (negative case). tc #%d", tcIndex)
 		} else {
-			require.Nil(t, err, tc.decimalStr)
-			require.True(t, res.Equal(tc.exp.Mul(NewRat(-1))), tc.decimalStr)
+			require.Nil(t, err, tc.decimalStr, "Unexpectedly errored (negative case). tc #%d", tcIndex)
+			require.True(t, res.Equal(tc.exp.Mul(NewRat(-1))), tc.decimalStr, "Equality was incorrect (negative case). tc #%d", tcIndex)
 		}
 	}
 }
@@ -99,10 +99,10 @@ func TestEqualities(t *testing.T) {
 		{NewRat(-1, 7), NewRat(-3, 7), true, false, false},
 	}
 
-	for _, tc := range tests {
-		require.Equal(t, tc.gt, tc.r1.GT(tc.r2))
-		require.Equal(t, tc.lt, tc.r1.LT(tc.r2))
-		require.Equal(t, tc.eq, tc.r1.Equal(tc.r2))
+	for tcIndex, tc := range tests {
+		require.Equal(t, tc.gt, tc.r1.GT(tc.r2), "GT result is incorrect. tc #%d", tcIndex)
+		require.Equal(t, tc.lt, tc.r1.LT(tc.r2), "LT result is incorrect. tc #%d", tcIndex)
+		require.Equal(t, tc.eq, tc.r1.Equal(tc.r2), "Equality result is incorrect. tc #%d", tcIndex)
 	}
 
 }
@@ -135,15 +135,15 @@ func TestArithmetic(t *testing.T) {
 		{NewRat(100), NewRat(1, 7), NewRat(100, 7), NewRat(700), NewRat(701, 7), NewRat(699, 7)},
 	}
 
-	for _, tc := range tests {
-		require.True(t, tc.resMul.Equal(tc.r1.Mul(tc.r2)), "r1 %v, r2 %v", tc.r1.Rat, tc.r2.Rat)
-		require.True(t, tc.resAdd.Equal(tc.r1.Add(tc.r2)), "r1 %v, r2 %v", tc.r1.Rat, tc.r2.Rat)
-		require.True(t, tc.resSub.Equal(tc.r1.Sub(tc.r2)), "r1 %v, r2 %v", tc.r1.Rat, tc.r2.Rat)
+	for tcIndex, tc := range tests {
+		require.True(t, tc.resMul.Equal(tc.r1.Mul(tc.r2)), "r1 %v, r2 %v. tc #%d", tc.r1.Rat, tc.r2.Rat, tcIndex)
+		require.True(t, tc.resAdd.Equal(tc.r1.Add(tc.r2)), "r1 %v, r2 %v. tc #%d", tc.r1.Rat, tc.r2.Rat, tcIndex)
+		require.True(t, tc.resSub.Equal(tc.r1.Sub(tc.r2)), "r1 %v, r2 %v. tc #%d", tc.r1.Rat, tc.r2.Rat, tcIndex)
 
 		if tc.r2.Num().IsZero() { // panic for divide by zero
 			require.Panics(t, func() { tc.r1.Quo(tc.r2) })
 		} else {
-			require.True(t, tc.resDiv.Equal(tc.r1.Quo(tc.r2)), "r1 %v, r2 %v", tc.r1.Rat, tc.r2.Rat)
+			require.True(t, tc.resDiv.Equal(tc.r1.Quo(tc.r2)), "r1 %v, r2 %v. tc #%d", tc.r1.Rat, tc.r2.Rat, tcIndex)
 		}
 	}
 }
@@ -168,9 +168,9 @@ func TestEvaluate(t *testing.T) {
 		{NewRat(113, 12), 9},
 	}
 
-	for _, tc := range tests {
-		require.Equal(t, tc.res, tc.r1.RoundInt64(), "%v", tc.r1)
-		require.Equal(t, tc.res*-1, tc.r1.Mul(NewRat(-1)).RoundInt64(), "%v", tc.r1.Mul(NewRat(-1)))
+	for tcIndex, tc := range tests {
+		require.Equal(t, tc.res, tc.r1.RoundInt64(), "%v. tc #%d", tc.r1, tcIndex)
+		require.Equal(t, tc.res*-1, tc.r1.Mul(NewRat(-1)).RoundInt64(), "%v. tc #%d", tc.r1.Mul(NewRat(-1)), tcIndex)
 	}
 }
 
@@ -192,10 +192,10 @@ func TestRound(t *testing.T) {
 		{NewRat(1, 2), NewRat(1, 2), 1000},
 	}
 
-	for _, tc := range tests {
-		require.Equal(t, tc.res, tc.r.Round(tc.precFactor), "%v", tc.r)
+	for tcIndex, tc := range tests {
+		require.Equal(t, tc.res, tc.r.Round(tc.precFactor), "%v", tc.r, "Incorrect rounding. tc #%d", tcIndex)
 		negR1, negRes := tc.r.Mul(NewRat(-1)), tc.res.Mul(NewRat(-1))
-		require.Equal(t, negRes, negR1.Round(tc.precFactor), "%v", negR1)
+		require.Equal(t, negRes, negR1.Round(tc.precFactor), "%v", negR1, "Incorrect rounding (negative case). tc #%d", tcIndex)
 	}
 }
 
@@ -211,8 +211,8 @@ func TestToLeftPadded(t *testing.T) {
 		{NewRat(1000, 3), 8, "00000333"},
 		{NewRat(1000, 3), 12, "000000000333"},
 	}
-	for _, tc := range tests {
-		require.Equal(t, tc.res, tc.rat.ToLeftPadded(tc.digits))
+	for tcIndex, tc := range tests {
+		require.Equal(t, tc.res, tc.rat.ToLeftPadded(tc.digits), "Incorrect left padding. tc #%d", tcIndex)
 	}
 }
 
@@ -296,11 +296,13 @@ func TestRatsEqual(t *testing.T) {
 		{[]Rat{NewRat(1), NewRat(0)}, []Rat{NewRat(1), NewRat(0)}, true},
 		{[]Rat{NewRat(1), NewRat(0)}, []Rat{NewRat(0), NewRat(1)}, false},
 		{[]Rat{NewRat(1), NewRat(0)}, []Rat{NewRat(1)}, false},
+		{[]Rat{NewRat(1), NewRat(2)}, []Rat{NewRat(2), NewRat(4)}, false},
+		{[]Rat{NewRat(3), NewRat(18)}, []Rat{NewRat(1), NewRat(6)}, false},
 	}
 
-	for _, tc := range tests {
-		require.Equal(t, tc.eq, RatsEqual(tc.r1s, tc.r2s))
-		require.Equal(t, tc.eq, RatsEqual(tc.r2s, tc.r1s))
+	for tcIndex, tc := range tests {
+		require.Equal(t, tc.eq, RatsEqual(tc.r1s, tc.r2s), "Equality of rational arrays is incorrect. tc #%d", tcIndex)
+		require.Equal(t, tc.eq, RatsEqual(tc.r2s, tc.r1s), "Equality of rational arrays is incorrect (converse). tc #%d", tcIndex)
 	}
 
 }

--- a/types/utils_test.go
+++ b/types/utils_test.go
@@ -29,10 +29,10 @@ func TestSortJSON(t *testing.T) {
 			wantErr: false},
 	}
 
-	for _, tc := range cases {
+	for tcIndex, tc := range cases {
 		got, err := SortJSON([]byte(tc.unsortedJSON))
 		if tc.wantErr != (err != nil) {
-			t.Fatalf("got %t, want: %t, err=%s", err != nil, tc.wantErr, err)
+			t.Fatalf("got %t, want: %t, tc #%d, err=%s", err != nil, tc.wantErr, tcIndex, err)
 		}
 		require.Equal(t, string(got), tc.want)
 	}


### PR DESCRIPTION
Make table driven tests in /types follow the format described in #1664

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺ 
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes. 
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  --> 

* [ ] Updated all relevant documentation (`docs/`)
* [x] Updated all relevant code comments
* [x] Wrote tests
* [X] Updated `CHANGELOG.md` - not an end user facing change
* [x] Updated `cmd/gaia` and `examples/`
___________________________________
For Admin Use:
* [ ] Added appropriate labels to PR (ex. wip, ready-for-review, docs)
* [ ] Reviewers Assigned 
* [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
