### PR TITLE
baseapp: Allow alphanumerics in routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## PENDING
+
+IMPROVEMENTS
+* [baseapp] Allow any alphanumeric character in route
+
 ## 0.22.0
 
 *July 16th, 2018*

--- a/baseapp/baseapp_test.go
+++ b/baseapp/baseapp_test.go
@@ -290,7 +290,7 @@ func (tx txTest) GetMsgs() []sdk.Msg { return tx.Msgs }
 
 const (
 	typeMsgCounter  = "msgCounter"
-	typeMsgCounter2 = "msgCounterTwo" // NOTE: no numerics (?)
+	typeMsgCounter2 = "msgCounter2"
 )
 
 // ValidateBasic() fails on negative counters.

--- a/baseapp/router.go
+++ b/baseapp/router.go
@@ -31,12 +31,12 @@ func NewRouter() *router {
 	}
 }
 
-var isAlpha = regexp.MustCompile(`^[a-zA-Z]+$`).MatchString
+var isAlphaNumeric = regexp.MustCompile(`^[a-zA-Z0-9]+$`).MatchString
 
 // AddRoute - TODO add description
 func (rtr *router) AddRoute(r string, h sdk.Handler) Router {
-	if !isAlpha(r) {
-		panic("route expressions can only contain alphabet characters")
+	if !isAlphaNumeric(r) {
+		panic("route expressions can only contain alphanumeric characters")
 	}
 	rtr.routes = append(rtr.routes, route{r, h})
 


### PR DESCRIPTION
Previously only alphabetic characters were allowed.

Closes #1587

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺ 
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes. 
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  --> 

* [X] Updated all relevant documentation (`docs/`) - current docs are correct
* [X] Updated all relevant code comments
* [ ] Wrote tests - numeric usage is already covered in a test vector
* [X] Updated `CHANGELOG.md`
* [ ] Updated `cmd/gaia` and `examples/`
___________________________________
For Admin Use:
* [X] Added appropriate labels to PR (ex. wip, ready-for-review, docs)
* [ ] Reviewers Assigned 
* [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
