### PR TITLE
R4R: Make response can be read by humans

### DIFF
--- a/PENDING.md
+++ b/PENDING.md
@@ -17,6 +17,7 @@ BREAKING CHANGES
   * `gaiacli gov deposit --depositer`
   * `gaiacli gov vote --voter`
 * [x/gov] Added tags sub-package, changed tags to use dash-case 
+* [client/context] Make response can be read by humans
 
 FEATURES
 * [lcd] Can now query governance proposals by ProposalStatus

--- a/x/gov/handler.go
+++ b/x/gov/handler.go
@@ -3,6 +3,7 @@ package gov
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/gov/tags"
+	"strconv"
 )
 
 // Handle all "gov" type messages.
@@ -31,7 +32,7 @@ func handleMsgSubmitProposal(ctx sdk.Context, keeper Keeper, msg MsgSubmitPropos
 		return err.Result()
 	}
 
-	proposalIDBytes := keeper.cdc.MustMarshalBinaryBare(proposal.GetProposalID())
+	proposalIDBytes := []byte(strconv.FormatInt(proposal.GetProposalID(),10))
 
 	resTags := sdk.NewTags(
 		tags.Action, tags.ActionSubmitProposal,
@@ -81,7 +82,7 @@ func handleMsgVote(ctx sdk.Context, keeper Keeper, msg MsgVote) sdk.Result {
 		return err.Result()
 	}
 
-	proposalIDBytes := keeper.cdc.MustMarshalBinaryBare(msg.ProposalID)
+	proposalIDBytes := []byte(strconv.FormatInt(msg.ProposalID,10))
 
 	resTags := sdk.NewTags(
 		tags.Action, tags.ActionVote,
@@ -105,7 +106,8 @@ func EndBlocker(ctx sdk.Context, keeper Keeper) (resTags sdk.Tags, nonVotingVals
 			continue
 		}
 
-		proposalIDBytes := keeper.cdc.MustMarshalBinaryBare(inactiveProposal.GetProposalID())
+		proposalIDBytes := []byte(strconv.FormatInt(inactiveProposal.GetProposalID(),10))
+
 		keeper.DeleteProposal(ctx, inactiveProposal)
 		resTags.AppendTag(tags.Action, tags.ActionProposalDropped)
 		resTags.AppendTag(tags.ProposalID, proposalIDBytes)
@@ -168,3 +170,4 @@ func shouldPopActiveProposalQueue(ctx sdk.Context, keeper Keeper) bool {
 	}
 	return false
 }
+


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺ 
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes. 
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  --> 
Solve #1604 
For `x/gov`, I cast the `proposal-id` to `[ ]byte` just like other `Tag`, not be serialized by `go-amino`.
In `client/context/helpers.go`, I could make response readable by go-reflect regardless of any structrue.

Response :
```
~ » gaiacli gov  submit-proposal --name=x1 --proposer=cosmosaccaddr14am8zp5k4utgs9507wchxpehhhqzfe56c5k03w --title=I want to be slashed --description=I am crazy --type=Text --deposit=1steak --chain-id=gov-test
** Note --name is deprecated and will be removed next release. Please use --from instead **
Defaulting to account number: 0
Defaulting to next sequence number: 7
Password to sign with 'x1':
Committed at block 293. Hash: 4B560DDFBAF7FA8C96A1F86DFAA1B4E7D60438EC 
Response:
Code : 0
Data : 7
Log : Msg 0:
Info :
GasWanted : 0
GasUsed : 3675
Tags {
    action : submitProposal
    proposer : cosmosaccaddr14am8zp5k4utgs9507wchxpehhhqzfe56c5k03w
    proposalId : 7
}
Fee: {:0}
```

* [ ] Updated all relevant documentation (`docs/`)
* [ ] Updated all relevant code comments
* [ ] Wrote tests
* [X] Added entries in `PENDING.md`
* [ ] Updated `cmd/gaia` and `examples/`
___________________________________
For Admin Use:
* [ ] Added appropriate labels to PR (ex. wip, ready-for-review, docs)
* [ ] Reviewers Assigned 
* [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
