### PR TITLE
Add a Release Process for SDK

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,17 +1,17 @@
-<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺ 
+<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
 v                               ✰  Thanks for creating a PR! ✰    
-v    Before smashing the submit button please review the checkboxes. 
+v    Before smashing the submit button please review the checkboxes.
 v    If a checkbox is n/a - please still include it but + a little note why
-☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  --> 
+☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->
 
 - [ ] Linked to github-issue with discussion and accepted design
 - [ ] Updated all relevant documentation (`docs/`)
 - [ ] Updated all relevant code comments
 - [ ] Wrote tests
-- [ ] Added entries in `PENDING.md`
+- [ ] Added entries in `PENDING.md` that include links to the relevant issue or PR that most accurately describes the change.
 - [ ] Updated `cmd/gaia` and `examples/`
 ___________________________________
 For Admin Use:
 - [ ] Added appropriate labels to PR (ex. wip, ready-for-review, docs)
-- [ ] Reviewers Assigned 
+- [ ] Reviewers Assigned
 - [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -1,0 +1,11 @@
+### `cosmos/cosmos-sdk` Release Process
+
+- [ ] 1. Decide on release designation (are we doing a patch, or minor version bump) and start a P.R. for the release
+- [ ] 2. Add commits/PRs that are desired for this release **that haven’t already been added to develop**
+- [ ] 3. Ensure that `CHANGELOG.md` contains links to issues/PRs for each item
+- [ ] 4. Summarize breaking API changes section under “Breaking Changes” section to the `CHANGELOG.md` to bring attention to any breaking API changes that affect RPC consumers
+- [ ] 5. Tag the commit `{{ .Release.Name }}-rcN`
+- [ ] 6. Kick off 1 day of automated fuzz testing
+- [ ] 7. Release Lead assigns 2 people to perform buddy testing script
+- [ ] 8. If errors are found in either #6 or #7 go back to #2 (*NOTE*: be sure to increment the `rcN`)
+- [ ] 9. After #6 and #7 have successfully completed then merge the release PR and push the final release tag

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -2,8 +2,8 @@
 
 - [ ] 1. Decide on release designation (are we doing a patch, or minor version bump) and start a P.R. for the release
 - [ ] 2. Add commits/PRs that are desired for this release **that haven’t already been added to develop**
-- [ ] 3. Ensure that `CHANGELOG.md` contains links to issues/PRs for each item
-- [ ] 4. Summarize breaking API changes section under “Breaking Changes” section to the `CHANGELOG.md` to bring attention to any breaking API changes that affect RPC consumers
+- [ ] 3. Merge items in `PENDING.md` into the `CHANGELOG.md`. While doing this make sure that each entry contains links to issues/PRs for each item
+- [ ] 4. Summarize breaking API changes section under “Breaking Changes” section to the `CHANGELOG.md` to bring attention to any breaking API changes that affect RPC consumers.
 - [ ] 5. Tag the commit `{{ .Release.Name }}-rcN`
 - [ ] 6. Kick off 1 day of automated fuzz testing
 - [ ] 7. Release Lead assigns 2 people to perform buddy testing script


### PR DESCRIPTION
During a discussion with @jaekwon, @cwgoes, @ValarDragon, @jlandrews today we came up with a possible release checklist to start using when cutting SDK releases. I've added the process we agreed to in a document at `docs/RELEASE_CHECKLIST.md`. I think we should use this process (except the fuzz testing) for the [`v0.23` release](https://github.com/cosmos/cosmos-sdk/pull/1769) as a test run. 

This would mean we need to spend tomorrow using the [Plain English test "script"](https://docs.google.com/document/d/1KJJy1Llg83CxtPnNYdz86G67sUqTvyjcHkm7A3CTQ2A/edit) to ensure the functionality of the release before cutting it.  We would also need buy in on the `CHANGELOG.md` updates proposed in the release process.

Tagging @zmanian and @ebuchman for comment and feedback.