### PR TITLE
tests: Move cli tests behind a build flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
-PACKAGES=$(shell go list ./... | grep -v '/vendor/')
-PACKAGES_NOCLITEST=$(shell go list ./... | grep -v '/vendor/' | grep -v '/simulation' | grep -v github.com/cosmos/cosmos-sdk/cmd/gaia/cli_test)
-PACKAGES_SIMTEST=$(shell go list ./... | grep -v '/vendor/' | grep '/simulation')
+PACKAGES_NOSIMULATION=$(shell go list ./... | grep -v '/simulation')
+PACKAGES_SIMTEST=$(shell go list ./... | grep '/simulation')
 COMMIT_HASH := $(shell git rev-parse --short HEAD)
 BUILD_TAGS = netgo ledger
 BUILD_FLAGS = -tags "${BUILD_TAGS}" -ldflags "-X github.com/cosmos/cosmos-sdk/version.GitCommit=${COMMIT_HASH}"
@@ -123,13 +122,13 @@ godocs:
 test: test_unit
 
 test_cli:
-	@go test -count 1 -p 1 `go list github.com/cosmos/cosmos-sdk/cmd/gaia/cli_test`
+	@go test -count 1 -p 1 `go list github.com/cosmos/cosmos-sdk/cmd/gaia/cli_test` -tags=cli_test
 
 test_unit:
-	@go test $(PACKAGES_NOCLITEST)
+	@go test $(PACKAGES_NOSIMULATION)
 
 test_race:
-	@go test -race $(PACKAGES_NOCLITEST)
+	@go test -race $(PACKAGES_NOSIMULATION)
 
 test_sim:
 	@echo "Running individual module simulations."
@@ -156,7 +155,7 @@ format:
 	find . -name '*.go' -type f -not -path "./vendor*" -not -path "*.git*" | xargs misspell -w
 
 benchmark:
-	@go test -bench=. $(PACKAGES_NOCLITEST)
+	@go test -bench=. $(PACKAGES_NOSIMULATION)
 
 
 ########################################

--- a/PENDING.md
+++ b/PENDING.md
@@ -45,6 +45,7 @@ IMPROVEMENTS
 * [x/gov] Votes on a proposal can now be queried
 * [x/bank] Unit tests are now table-driven
 * [tests] Fixes ansible scripts to work with AWS too
+* [tests] \#1806 CLI tests are now behind the build flag 'cli_test', so go test works on a new repo
 
 BUG FIXES
 *  \#1666 Add intra-tx counter to the genesis validators

--- a/cmd/gaia/cli_test/cli_test.go
+++ b/cmd/gaia/cli_test/cli_test.go
@@ -1,3 +1,5 @@
+// +build cli_test
+
 package clitest
 
 import (

--- a/cmd/gaia/cli_test/doc.go
+++ b/cmd/gaia/cli_test/doc.go
@@ -1,0 +1,3 @@
+package clitest
+
+// package clitest runs integration tests which make use of CLI commands.


### PR DESCRIPTION
This is done to make go test ./... work for people using the sdk as a sdk.
Closes #1806

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺ 
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes. 
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  --> 

- [x] Linked to github-issue with discussion and accepted design
- [ ] Updated all relevant documentation (`docs/`)
- [ ] Updated all relevant code comments
- [ ] Wrote tests
- [x] Added entries in `PENDING.md`
- [x] Updated `cmd/gaia` and `examples/`
___________________________________
For Admin Use:
- [x] Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- [x] Reviewers Assigned 
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
