### PR TITLE
WIP fix gen-tx

### DIFF
--- a/PENDING.md
+++ b/PENDING.md
@@ -51,3 +51,4 @@ BUG FIXES
 *  \#1797 Fix off-by-one error in slashing for downtime
 *  \#1787 Fixed bug where Tally fails due to revoked/unbonding validator
 *  \#1766 Fixes bad example for keybase identity
+*  \#1804 Fixes gen-tx genesis generation logic temporarily until upstream updates

--- a/server/init.go
+++ b/server/init.go
@@ -48,9 +48,10 @@ var (
 
 // genesis piece structure for creating combined genesis
 type GenesisTx struct {
-	NodeID   string          `json:"node_id"`
-	IP       string          `json:"ip"`
-	AppGenTx json.RawMessage `json:"app_gen_tx"`
+	NodeID    string                   `json:"node_id"`
+	IP        string                   `json:"ip"`
+	Validator tmtypes.GenesisValidator `json:"validator"`
+	AppGenTx  json.RawMessage          `json:"app_gen_tx"`
 }
 
 // Storage for init command input parameters
@@ -120,15 +121,16 @@ func gentxWithConfig(cdc *wire.Codec, appInit AppInit, config *cfg.Config, genTx
 	nodeID := string(nodeKey.ID())
 	pubKey := readOrCreatePrivValidator(config)
 
-	appGenTx, cliPrint, _, err := appInit.AppGenTx(cdc, pubKey, genTxConfig)
+	appGenTx, cliPrint, validator, err := appInit.AppGenTx(cdc, pubKey, genTxConfig)
 	if err != nil {
 		return
 	}
 
 	tx := GenesisTx{
-		NodeID:   nodeID,
-		IP:       genTxConfig.IP,
-		AppGenTx: appGenTx,
+		NodeID:    nodeID,
+		IP:        genTxConfig.IP,
+		Validator: validator,
+		AppGenTx:  appGenTx,
 	}
 	bz, err := wire.MarshalJSONIndent(cdc, tx)
 	if err != nil {
@@ -310,6 +312,7 @@ func processGenTxs(genTxsDir string, cdc *wire.Codec) (
 		genTx := genTxs[nodeID]
 
 		// combine some stuff
+		validators = append(validators, genTx.Validator)
 		appGenTxs = append(appGenTxs, genTx.AppGenTx)
 
 		// Add a persistent peer


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺ 
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes. 
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  --> 
This PR should close #1804

breaking changes were made in #1373 which broke the `gen-tx` mechanism in init. 

Example commands which demonstrate the break:
```
gaiad init gen-tx --name=foo --home=$HOME/foobar                                           
 .............. > respond with some JSON indicating success 
gaiad init --gen-txs -o --home=$HOME/foobar
ERROR: Error{The genesis file must have at least one validator}
```
That final error should not be occurring. (basically non of the validators from any `gen-tx` are being processed and added to the genesis.json)

The current roll-back (aka my first commit here) has the Tendermint validators in the genesis file, which I think we've already removed? Not totally sure, I'm assuming that still needs to be updated in this PR @mossid 

- [ ] Linked to github-issue with discussion and accepted design
- [ ] Updated all relevant documentation (`docs/`)
- [ ] Updated all relevant code comments
- [ ] Wrote tests
- [ ] Added entries in `PENDING.md`
- [ ] Updated `cmd/gaia` and `examples/`
___________________________________
For Admin Use:
- [ ] Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- [ ] Reviewers Assigned 
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
