### PR TITLE
x/stake: Speed up handleMsgEditValidator

### DIFF
--- a/PENDING.md
+++ b/PENDING.md
@@ -50,6 +50,7 @@ IMPROVEMENTS
 * [tests] Fixes ansible scripts to work with AWS too
 * [tests] \#1806 CLI tests are now behind the build flag 'cli_test', so go test works on a new repo
 * [x/gov] Initial governance parameters can now be set in the genesis file
+* [x/stake] \#1815 Sped up the processing of `EditValidator` txs. 
 
 BUG FIXES
 *  \#1666 Add intra-tx counter to the genesis validators

--- a/x/stake/handler.go
+++ b/x/stake/handler.go
@@ -111,7 +111,9 @@ func handleMsgEditValidator(ctx sdk.Context, msg types.MsgEditValidator, k keepe
 	}
 	validator.Description = description
 
-	k.UpdateValidator(ctx, validator)
+	// We don't need to run through all the power update logic within k.UpdateValidator
+	// We just need to override the entry in state, since only the description has changed.
+	k.SetValidator(ctx, validator)
 	tags := sdk.NewTags(
 		tags.Action, tags.ActionEditValidator,
 		tags.DstValidator, []byte(msg.ValidatorAddr.String()),

--- a/x/stake/keeper/validator.go
+++ b/x/stake/keeper/validator.go
@@ -191,9 +191,9 @@ func (k Keeper) ClearTendermintUpdates(ctx sdk.Context) {
 
 //___________________________________________________________________________
 
-// Perfom all the nessisary steps for when a validator changes its power.  This
+// Perfom all the necessary steps for when a validator changes its power. This
 // function updates all validator stores as well as tendermint update store.
-// It may kick out validators if new validator is entering the bonded validator
+// It may kick out validators if a new validator is entering the bonded validator
 // group.
 //
 // nolint: gocyclo


### PR DESCRIPTION
This removes running the power update logic on handleMsgEditValidator,
as its unnecessary.

Closes #1815

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

- [X] Linked to github-issue with discussion and accepted design
- [ ] Updated all relevant documentation (`docs/`) - n/a??
- [X] Updated all relevant code comments
- [ ] Wrote tests - n/a?
- [X] Added entries in `PENDING.md` that include links to the relevant issue or PR that most accurately describes the change.
- [X] Updated `cmd/gaia` and `examples/` - n/a
___________________________________
For Admin Use:
- [X] Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- [X] Reviewers Assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
