### PR TITLE
CI: Reduce log output

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,9 +118,9 @@ jobs:
           command: |
             export PATH="$GOBIN:$PATH"
             make install
-            for pkg in $(go list github.com/cosmos/cosmos-sdk/... | grep -v /vendor/ | grep -v github.com/cosmos/cosmos-sdk/cmd/gaia/cli_test | circleci tests split --split-by=timings); do
+            for pkg in $(go list github.com/cosmos/cosmos-sdk/... | grep -v github.com/cosmos/cosmos-sdk/cmd/gaia/cli_test | circleci tests split --split-by=timings); do
               id=$(basename "$pkg")
-              GOCACHE=off go test -v -timeout 8m -race -coverprofile=/tmp/workspace/profiles/$id.out -covermode=atomic "$pkg" | tee "/tmp/logs/$id-$RANDOM.log"
+              GOCACHE=off go test -timeout 8m -race -coverprofile=/tmp/workspace/profiles/$id.out -covermode=atomic "$pkg" | tee "/tmp/logs/$id-$RANDOM.log"
             done
       - persist_to_workspace:
           root: /tmp/workspace


### PR DESCRIPTION
This commit makes it such that circle CI only shows the module whose
tests it is currently running in the log, unless a test fails. For each
failing test, it will display the test name and all of the log output. This is done to make
our log output far more scrollable. We lose no information in debugging.

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

- [ ] Linked to github-issue with discussion and accepted design - I think its far easier to judge this with sample log outputs from the CI run on this commit.
- [x] Updated all relevant documentation (`docs/`) - n/a
- [x] Updated all relevant code comments - n/a
- [x] Wrote tests - n/a
- [ ] Added entries in `PENDING.md` that include links to the relevant issue or PR that most accurately describes the change. - not user facing change, only affects CI
- [x] Updated `cmd/gaia` and `examples/` - n/a
___________________________________
For Admin Use:
- [X] Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- [ ] Reviewers Assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
