### PR TITLE
update signing info endpoint

### DIFF
--- a/PENDING.md
+++ b/PENDING.md
@@ -25,6 +25,7 @@ BREAKING CHANGES
   * `gaiacli gov vote --voter`
 * [x/gov] Added tags sub-package, changed tags to use dash-case 
 * [x/gov] Governance parameters are now stored in globalparams store
+* [lcd] \#1866 Updated lcd /slashing/signing_info endpoint to take cosmosvalpub instead of cosmosvaladdr
 
 FEATURES
 * [lcd] Can now query governance proposals by ProposalStatus

--- a/client/lcd/lcd_test.go
+++ b/client/lcd/lcd_test.go
@@ -526,7 +526,7 @@ func TestUnrevoke(t *testing.T) {
 
 	// XXX: any less than this and it fails
 	tests.WaitForHeight(3, port)
-  pkString, _ := sdk.Bech32ifyValPub(pks[0])
+	pkString, _ := sdk.Bech32ifyValPub(pks[0])
 	signingInfo := getSigningInfo(t, port, pkString)
 	tests.WaitForHeight(4, port)
 	require.Equal(t, true, signingInfo.IndexOffset > 0)

--- a/client/lcd/lcd_test.go
+++ b/client/lcd/lcd_test.go
@@ -526,8 +526,8 @@ func TestUnrevoke(t *testing.T) {
 
 	// XXX: any less than this and it fails
 	tests.WaitForHeight(3, port)
-
-	signingInfo := getSigningInfo(t, port, sdk.ValAddress(pks[0].Address()))
+  pkString, _ := sdk.Bech32ifyValPub(pks[0])
+	signingInfo := getSigningInfo(t, port, pkString)
 	tests.WaitForHeight(4, port)
 	require.Equal(t, true, signingInfo.IndexOffset > 0)
 	require.Equal(t, int64(0), signingInfo.JailedUntil)
@@ -710,8 +710,8 @@ func doIBCTransfer(t *testing.T, port, seed, name, password string, addr sdk.Acc
 	return resultTx
 }
 
-func getSigningInfo(t *testing.T, port string, validatorAddr sdk.ValAddress) slashing.ValidatorSigningInfo {
-	res, body := Request(t, port, "GET", fmt.Sprintf("/slashing/signing_info/%s", validatorAddr), nil)
+func getSigningInfo(t *testing.T, port string, validatorPubKey string) slashing.ValidatorSigningInfo {
+	res, body := Request(t, port, "GET", fmt.Sprintf("/slashing/signing_info/%s", validatorPubKey), nil)
 	require.Equal(t, http.StatusOK, res.StatusCode, body)
 	var signingInfo slashing.ValidatorSigningInfo
 	err := cdc.UnmarshalJSON([]byte(body), &signingInfo)

--- a/x/slashing/client/rest/query.go
+++ b/x/slashing/client/rest/query.go
@@ -26,12 +26,12 @@ func signingInfoHandlerFn(ctx context.CoreContext, storeName string, cdc *wire.C
 		// read parameters
 		vars := mux.Vars(r)
 
-                pk, err := sdk.GetValPubKeyBech32(vars["validator"])
-                        if err != nil {
+		pk, err := sdk.GetValPubKeyBech32(vars["validator"])
+		if err != nil {
 			w.WriteHeader(http.StatusBadRequest)
 			w.Write([]byte(err.Error()))
 			return
-                }
+		}
 
 		key := slashing.GetValidatorSigningInfoKey(sdk.ValAddress(pk.Address()))
 		res, err := ctx.QueryStore(key, storeName)

--- a/x/slashing/client/rest/query.go
+++ b/x/slashing/client/rest/query.go
@@ -25,16 +25,15 @@ func signingInfoHandlerFn(ctx context.CoreContext, storeName string, cdc *wire.C
 
 		// read parameters
 		vars := mux.Vars(r)
-		bech32validator := vars["validator"]
 
-		validatorAddr, err := sdk.ValAddressFromBech32(bech32validator)
-		if err != nil {
+                pk, err := sdk.GetValPubKeyBech32(vars["validator"])
+                        if err != nil {
 			w.WriteHeader(http.StatusBadRequest)
 			w.Write([]byte(err.Error()))
 			return
-		}
+                }
 
-		key := slashing.GetValidatorSigningInfoKey(validatorAddr)
+		key := slashing.GetValidatorSigningInfoKey(sdk.ValAddress(pk.Address()))
 		res, err := ctx.QueryStore(key, storeName)
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)


### PR DESCRIPTION
- [x] Linked to github-issue with discussion and accepted design
- [x] Updated all relevant documentation (`docs/`) - (/slashing/signing-info endpoint does not appear to exist in spec, or api docs)
- [x] Updated all relevant code comments
- [x] Wrote tests (updated existing test)
- [z] Added entries in `PENDING.md` that include links to the relevant issue or PR that most accurately describes the change.
- [n/a] Updated `cmd/gaia` and `examples/`

As discussed in #1866, REST endpoint `/slashing/signing-info/{ validator }` should take `cosmosValPub` rather than existing `cosmosVallAddr` in order to maintain consistency between REST and CLI interfaces.
___________________________________
For Admin Use:
- [ ] Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- [ ] Reviewers Assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
