### PR TITLE
RootMultiStore test helper bugfix

### DIFF
--- a/store/rootmultistore_test.go
+++ b/store/rootmultistore_test.go
@@ -133,6 +133,11 @@ func TestMultiStoreQuery(t *testing.T) {
 	cid = multi.Commit()
 	ver := cid.Version
 
+	// Reload multistore from database
+	multi = newMultiStoreWithMounts(db)
+	err = multi.LoadLatestVersion()
+	require.Nil(t, err)
+
 	// Test bad path.
 	query := abci.RequestQuery{Path: "/key", Data: k, Height: ver}
 	qres := multi.Query(query)

--- a/store/rootmultistore_test.go
+++ b/store/rootmultistore_test.go
@@ -178,11 +178,11 @@ func TestMultiStoreQuery(t *testing.T) {
 func newMultiStoreWithMounts(db dbm.DB) *rootMultiStore {
 	store := NewCommitMultiStore(db)
 	store.MountStoreWithDB(
-		sdk.NewKVStoreKey("store1"), sdk.StoreTypeIAVL, db)
+		sdk.NewKVStoreKey("store1"), sdk.StoreTypeIAVL, nil)
 	store.MountStoreWithDB(
-		sdk.NewKVStoreKey("store2"), sdk.StoreTypeIAVL, db)
+		sdk.NewKVStoreKey("store2"), sdk.StoreTypeIAVL, nil)
 	store.MountStoreWithDB(
-		sdk.NewKVStoreKey("store3"), sdk.StoreTypeIAVL, db)
+		sdk.NewKVStoreKey("store3"), sdk.StoreTypeIAVL, nil)
 	return store
 }
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

The helper function `newMultiStoreWithMounts` in `rootmultistore_test.go` creates 3 substores for use in tests. It currently passes in a `db` parameter with each store, which causes them to share the db and overwrite each other's nodedbs. On current tests this doesn't fail because none of them reload the multistore from db. I've added a few lines which do this in one test, and it fails non-deterministically with different errors depending on the map iterator order in `commitStores`, with the last store written overwriting values of the previous stores, for things such as root hash.

Switching `newMultiStoreWithMounts` to pass in `nil` to each store causes it to use a prefix store on the db in the `rootMultiStore` which solves the problem and seems like the intended behavior of the helper function.  

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Updated all relevant documentation (`docs/`)
- [ ] Updated all relevant code comments
- [ ] Wrote tests
- [ ] Added entries in `PENDING.md` that include links to the relevant issue or PR that most accurately describes the change.
- [ ] Updated `cmd/gaia` and `examples/`
___________________________________
For Admin Use:
- [ ] Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- [ ] Reviewers Assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
