### PR TITLE
types: Reduce size of TestImmutability<Arith\U>Int tests

### DIFF
--- a/types/int_test.go
+++ b/types/int_test.go
@@ -345,7 +345,7 @@ func intarithraw(uifn func(Int, int64) Int, bifn func(*big.Int, *big.Int, *big.I
 }
 
 func TestImmutabilityArithInt(t *testing.T) {
-	size := 1000
+	size := 500
 
 	ops := []intop{
 		intarith(Int.Add, (*big.Int).Add),
@@ -358,7 +358,7 @@ func TestImmutabilityArithInt(t *testing.T) {
 		intarithraw(Int.DivRaw, (*big.Int).Div),
 	}
 
-	for i := 0; i < 1000; i++ {
+	for i := 0; i < 100; i++ {
 		uis := make([]Int, size)
 		bis := make([]*big.Int, size)
 
@@ -443,7 +443,7 @@ func uintarithraw(uifn func(Uint, uint64) Uint, bifn func(*big.Int, *big.Int, *b
 }
 
 func TestImmutabilityArithUint(t *testing.T) {
-	size := 1000
+	size := 500
 
 	ops := []uintop{
 		uintarith(Uint.Add, (*big.Int).Add, false),
@@ -456,7 +456,7 @@ func TestImmutabilityArithUint(t *testing.T) {
 		uintarithraw(Uint.DivRaw, (*big.Int).Div, false),
 	}
 
-	for i := 0; i < 1000; i++ {
+	for i := 0; i < 100; i++ {
 		uis := make([]Uint, size)
 		bis := make([]*big.Int, size)
 


### PR DESCRIPTION
Currently they take ~1 minute on circle CI. There isn't a significant reason
for this to delay all our tests. This commit reduces the time spent on these
tests by a factor of 20.

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

- [x] Added entries in `PENDING.md` that include links to the relevant issue or PR that most accurately describes the change. - not user facing
___________________________________
For Admin Use:
- [X] Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- [ ] Reviewers Assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
