### PR TITLE
crypto/keys: Reduce bcrypt parameter in tests

### DIFF
--- a/crypto/keys/keybase_test.go
+++ b/crypto/keys/keybase_test.go
@@ -13,6 +13,10 @@ import (
 	dbm "github.com/tendermint/tendermint/libs/db"
 )
 
+func init() {
+	BcryptSecurityParameter = 1
+}
+
 // TestKeyManagement makes sure we can manipulate these keys well
 func TestKeyManagement(t *testing.T) {
 	// make the storage with reasonable defaults


### PR DESCRIPTION
Currently the crypto/keys tests take 2 minutes in circle CI.
A significant portion of this time is due to the bcrypt security
parameter. Changing it for these tests should reduce the time significantly.

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

- [X] Added entries in `PENDING.md` that include links to the relevant issue or PR that most accurately describes the change. - not user facing
___________________________________
For Admin Use:
- [X] Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- [X] Reviewers Assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
