### PR TITLE
Rename stake Validator.Owner -> .Operator

### DIFF
--- a/PENDING.md
+++ b/PENDING.md
@@ -40,6 +40,9 @@ BREAKING CHANGES
 * [cli] #1551: Officially removed `--name` from CLI commands
 * [cli] Genesis/key creation (`init`) now supports user-provided key passwords
 * [cli] unsafe_reset_all, show_validator, and show_node_id have been renamed to unsafe-reset-all, show-validator, and show-node-id
+* [cli] \#1901 Flag --address-validator renamed to --validator in stake and slashing commands
+* [types] \#1901 Validator interface's GetOwner() renamed to GetOperator()
+* [x/stake] \#1901 Validator type's Owner field renamed to Operator; Validator's GetOwner() renamed accordingly to comply with the SDK's Validator interface.
 
 FEATURES
 * [lcd] Can now query governance proposals by ProposalStatus

--- a/client/lcd/lcd_test.go
+++ b/client/lcd/lcd_test.go
@@ -361,13 +361,13 @@ func TestValidatorsQuery(t *testing.T) {
 	validators := getValidators(t, port)
 	require.Equal(t, len(validators), 1)
 
-	// make sure all the validators were found (order unknown because sorted by owner addr)
+	// make sure all the validators were found (order unknown because sorted by operator addr)
 	foundVal := false
 	pkBech := sdk.MustBech32ifyValPub(pks[0])
 	if validators[0].PubKey == pkBech {
 		foundVal = true
 	}
-	require.True(t, foundVal, "pkBech %v, owner %v", pkBech, validators[0].Owner)
+	require.True(t, foundVal, "pkBech %v, operator %v", pkBech, validators[0].Operator)
 }
 
 func TestValidatorQuery(t *testing.T) {
@@ -375,9 +375,9 @@ func TestValidatorQuery(t *testing.T) {
 	defer cleanup()
 	require.Equal(t, 1, len(pks))
 
-	validator1Owner := sdk.AccAddress(pks[0].Address())
-	validator := getValidator(t, port, validator1Owner)
-	assert.Equal(t, validator.Owner, validator1Owner, "The returned validator does not hold the correct data")
+	validator1Operator := sdk.AccAddress(pks[0].Address())
+	validator := getValidator(t, port, validator1Operator)
+	assert.Equal(t, validator.Operator, validator1Operator, "The returned validator does not hold the correct data")
 }
 
 func TestBonding(t *testing.T) {
@@ -386,10 +386,11 @@ func TestBonding(t *testing.T) {
 	cleanup, pks, port := InitializeTestLCD(t, 1, []sdk.AccAddress{addr})
 	defer cleanup()
 
-	validator1Owner := sdk.AccAddress(pks[0].Address())
-	validator := getValidator(t, port, validator1Owner)
+	validator1Operator := sdk.AccAddress(pks[0].Address())
+	validator := getValidator(t, port, validator1Operator)
 
-	resultTx := doDelegate(t, port, seed, name, password, addr, validator1Owner, 60)
+	// create bond TX
+	resultTx := doDelegate(t, port, seed, name, password, addr, validator1Operator, 60)
 	tests.WaitForHeight(resultTx.Height+1, port)
 
 	require.Equal(t, uint32(0), resultTx.CheckTx.Code)
@@ -400,7 +401,8 @@ func TestBonding(t *testing.T) {
 
 	require.Equal(t, int64(40), coins.AmountOf(denom).Int64())
 
-	bond := getDelegation(t, port, addr, validator1Owner)
+	// query validator
+	bond := getDelegation(t, port, addr, validator1Operator)
 	require.Equal(t, "60.0000000000", bond.Shares)
 
 	summary := getDelegationSummary(t, port, addr)
@@ -411,16 +413,17 @@ func TestBonding(t *testing.T) {
 
 	bondedValidators := getDelegatorValidators(t, port, addr)
 	require.Len(t, bondedValidators, 1)
-	require.Equal(t, validator1Owner, bondedValidators[0].Owner)
+	require.Equal(t, validator1Operator, bondedValidators[0].Operator)
 	require.Equal(t, validator.DelegatorShares.Add(sdk.NewDec(60)).String(), bondedValidators[0].DelegatorShares.String())
 
-	bondedValidator := getDelegatorValidator(t, port, addr, validator1Owner)
-	require.Equal(t, validator1Owner, bondedValidator.Owner)
+	bondedValidator := getDelegatorValidator(t, port, addr, validator1Operator)
+	require.Equal(t, validator1Operator, bondedValidator.Operator)
 
 	//////////////////////
 	// testing unbonding
 
-	resultTx = doBeginUnbonding(t, port, seed, name, password, addr, validator1Owner, 60)
+	// create unbond TX
+	resultTx = doBeginUnbonding(t, port, seed, name, password, addr, validator1Operator, 60)
 	tests.WaitForHeight(resultTx.Height+1, port)
 
 	require.Equal(t, uint32(0), resultTx.CheckTx.Code)
@@ -431,7 +434,7 @@ func TestBonding(t *testing.T) {
 	coins = acc.GetCoins()
 	require.Equal(t, int64(40), coins.AmountOf("steak").Int64())
 
-	unbondings := getUndelegations(t, port, addr, validator1Owner)
+	unbondings := getUndelegations(t, port, addr, validator1Operator)
 	require.Len(t, unbondings, 1, "Unbondings holds all unbonding-delegations")
 	require.Equal(t, "60", unbondings[0].Balance.Amount.String())
 

--- a/cmd/gaia/app/genesis.go
+++ b/cmd/gaia/app/genesis.go
@@ -202,8 +202,8 @@ func GaiaAppGenState(cdc *wire.Codec, appGenTxs []json.RawMessage) (genesisState
 
 			// create the self-delegation from the issuedDelShares
 			delegation := stake.Delegation{
-				DelegatorAddr: validator.Owner,
-				ValidatorAddr: validator.Owner,
+				DelegatorAddr: validator.Operator,
+				ValidatorAddr: validator.Operator,
 				Shares:        issuedDelShares,
 				Height:        0,
 			}

--- a/cmd/gaia/cli_test/cli_test.go
+++ b/cmd/gaia/cli_test/cli_test.go
@@ -131,7 +131,7 @@ func TestGaiaCLICreateValidator(t *testing.T) {
 	require.Equal(t, int64(8), barAcc.GetCoins().AmountOf("steak").Int64(), "%v", barAcc)
 
 	validator := executeGetValidator(t, fmt.Sprintf("gaiacli stake validator %s --output=json %v", barAddr, flags))
-	require.Equal(t, validator.Owner, barAddr)
+	require.Equal(t, validator.Operator, barAddr)
 	require.True(sdk.DecEq(t, sdk.NewDec(2), validator.Tokens))
 
 	// unbond a single share

--- a/cmd/gaia/cli_test/cli_test.go
+++ b/cmd/gaia/cli_test/cli_test.go
@@ -137,7 +137,7 @@ func TestGaiaCLICreateValidator(t *testing.T) {
 	// unbond a single share
 	unbondStr := fmt.Sprintf("gaiacli stake unbond begin %v", flags)
 	unbondStr += fmt.Sprintf(" --from=%s", "bar")
-	unbondStr += fmt.Sprintf(" --address-validator=%s", barAddr)
+	unbondStr += fmt.Sprintf(" --validator=%s", barAddr)
 	unbondStr += fmt.Sprintf(" --shares-amount=%v", "1")
 
 	success := executeWrite(t, unbondStr, app.DefaultKeyPass)

--- a/docs/sdk/clients.md
+++ b/docs/sdk/clients.md
@@ -120,9 +120,9 @@ On the testnet, we delegate `steak` instead of `atom`. Here's how you can bond t
 ```bash
 gaiacli stake delegate \
   --amount=10steak \
-  --address-validator=$(gaiad tendermint show-validator) \
+  --validator=$(gaiad tendermint show-validator) \
   --name=<key_name> \
-  --chain-id=gaia-7005
+  --chain-id=gaia-6002
 ```
 
 While tokens are bonded, they are pooled with all the other bonded tokens in the network. Validators and delegators obtain a percentage of shares that equal their stake in this pool.
@@ -137,9 +137,9 @@ If for any reason the validator misbehaves, or you want to unbond a certain amou
 
 ```bash
 gaiacli stake unbond begin \
-  --address-validator=$(gaiad tendermint show-validator) \
+  --validator=$(gaiad tendermint show-validator) \
   --shares=MAX \
-  --name=<key_name> \
+  --from=<key_name> \
   --chain-id=gaia-7005
 ```
 
@@ -152,7 +152,7 @@ gaiacli account <account_cosmosaccaddr>
 
 gaiacli stake delegation \
   --address-delegator=<account_cosmosaccaddr> \
-  --address-validator=$(gaiad tendermint show-validator) \
+  --validator=$(gaiad tendermint show-validator) \
   --chain-id=gaia-7005
 ```
 

--- a/docs/spec/staking/transactions.md
+++ b/docs/spec/staking/transactions.md
@@ -1,7 +1,7 @@
 ## Transaction Overview
 
 In this section we describe the processing of the transactions and the
-corresponding updates to the state. Transactions: 
+corresponding updates to the state. Transactions:
  - TxCreateValidator
  - TxEditValidator
  - TxDelegation
@@ -19,7 +19,7 @@ Other notes:
  - `getXxx`, `setXxx`, and `removeXxx` functions are used to retrieve and
     modify objects from the store
  - `sdk.Dec` refers to a decimal type specified by the SDK.
- 
+
 ### TxCreateValidator
 
  - triggers: `distribution.CreateValidatorDistribution`
@@ -28,39 +28,39 @@ A validator is created using the `TxCreateValidator` transaction.
 
 ```golang
 type TxCreateValidator struct {
-	OwnerAddr           sdk.Address
+	Operator            sdk.Address
     ConsensusPubKey     crypto.PubKey
     GovernancePubKey    crypto.PubKey
-    SelfDelegation      coin.Coin       
+    SelfDelegation      coin.Coin
 
     Description         Description
     Commission          sdk.Dec
     CommissionMax       sdk.Dec 
     CommissionMaxChange sdk.Dec 
 }
-	
+
 
 createValidator(tx TxCreateValidator):
-    validator = getValidator(tx.OwnerAddr)
+    validator = getValidator(tx.Operator)
     if validator != nil return // only one validator per address
-   	
-    validator = NewValidator(OwnerAddr, ConsensusPubKey, GovernancePubKey, Description)
+
+    validator = NewValidator(operatorAddr, ConsensusPubKey, GovernancePubKey, Description)
     init validator poolShares, delegatorShares set to 0
     init validator commision fields from tx
     validator.PoolShares = 0
-   	
+
     setValidator(validator)
-   
-    txDelegate = TxDelegate(tx.OwnerAddr, tx.OwnerAddr, tx.SelfDelegation) 
+
+    txDelegate = TxDelegate(tx.Operator, tx.Operator, tx.SelfDelegation)
     delegate(txDelegate, validator) // see delegate function in [TxDelegate](TxDelegate)
     return
-``` 
+```
 
 ### TxEditValidator
 
 If either the `Description` (excluding `DateBonded` which is constant),
 `Commission`, or the `GovernancePubKey` need to be updated, the
-`TxEditCandidacy` transaction should be sent from the owner account:
+`TxEditCandidacy` transaction should be sent from the operator account:
 
 ```golang
 type TxEditCandidacy struct {
@@ -68,34 +68,34 @@ type TxEditCandidacy struct {
     Commission          sdk.Dec
     Description         Description
 }
- 
+
 editCandidacy(tx TxEditCandidacy):
     validator = getValidator(tx.ValidatorAddr)
-    
-    if tx.Commission > CommissionMax ||  tx.Commission < 0 then fail 
+
+    if tx.Commission > CommissionMax ||  tx.Commission < 0 then fail
     if rateChange(tx.Commission) > CommissionMaxChange then fail
     validator.Commission = tx.Commission
 
     if tx.GovernancePubKey != nil validator.GovernancePubKey = tx.GovernancePubKey
     if tx.Description != nil validator.Description = tx.Description
-    
+
     setValidator(store, validator)
     return
 ```
-     	
+
 ### TxDelegate
- 
+
  - triggers: `distribution.CreateOrModDelegationDistribution`
 
 Within this transaction the delegator provides coins, and in return receives
 some amount of their validator's delegator-shares that are assigned to
-`Delegation.Shares`. 
+`Delegation.Shares`.
 
 ```golang
 type TxDelegate struct {
-	DelegatorAddr sdk.Address 
-	ValidatorAddr sdk.Address 
-	Amount        sdk.Coin  
+	DelegatorAddr sdk.Address
+	ValidatorAddr sdk.Address
+	Amount        sdk.Coin
 }
 
 delegate(tx TxDelegate):
@@ -104,14 +104,14 @@ delegate(tx TxDelegate):
 
     delegation = getDelegatorBond(DelegatorAddr, ValidatorAddr)
     if delegation == nil then delegation = NewDelegation(DelegatorAddr, ValidatorAddr)
-	
+
     validator, pool, issuedDelegatorShares = validator.addTokensFromDel(tx.Amount, pool)
     delegation.Shares += issuedDelegatorShares
-    
+
     setDelegation(delegation)
     updateValidator(validator)
     setPool(pool)
-    return 
+    return
 ```
 
 ### TxStartUnbonding
@@ -120,28 +120,28 @@ Delegator unbonding is defined with the following transaction:
 
 ```golang
 type TxStartUnbonding struct {
-	DelegatorAddr sdk.Address 
-	ValidatorAddr sdk.Address 
-	Shares        string      
+	DelegatorAddr sdk.Address
+	ValidatorAddr sdk.Address
+	Shares        string
 }
 
-startUnbonding(tx TxStartUnbonding):    
+startUnbonding(tx TxStartUnbonding):
     delegation, found = getDelegatorBond(store, sender, tx.PubKey)
-    if !found == nil return 
-    
+    if !found == nil return
+
 		if bond.Shares < tx.Shares
 			return ErrNotEnoughBondShares
 
 	validator, found = GetValidator(tx.ValidatorAddr)
 	if !found {
-		return err 
+		return err
 
 	bond.Shares -= tx.Shares
 
 	revokeCandidacy = false
 	if bond.Shares.IsZero() {
 
-		if bond.DelegatorAddr == validator.Owner && validator.Revoked == false 
+		if bond.DelegatorAddr == validator.Operator && validator.Revoked == false
 			revokeCandidacy = true
 
 		removeDelegation( bond)
@@ -162,7 +162,7 @@ startUnbonding(tx TxStartUnbonding):
 	validator = updateValidator(validator)
 
 	if validator.DelegatorShares == 0 {
-		removeValidator(validator.Owner)
+		removeValidator(validator.Operator)
 
     return
 ```
@@ -185,7 +185,7 @@ redelegationComplete(tx TxRedelegate):
         returnTokens = ExpectedTokens * tx.startSlashRatio/validator.SlashRatio
 	    AddCoins(unbonding.DelegatorAddr, returnTokens)
         removeUnbondingDelegation(unbonding)
-    return     
+    return
 ```
 
 ### TxRedelegation
@@ -206,20 +206,20 @@ type TxRedelegate struct {
 redelegate(tx TxRedelegate):
 
     pool = getPool()
-    delegation = getDelegatorBond(tx.DelegatorAddr, tx.ValidatorFrom.Owner)
+    delegation = getDelegatorBond(tx.DelegatorAddr, tx.ValidatorFrom.Operator)
     if delegation == nil
-        return 
-    
-    if delegation.Shares < tx.Shares 
-        return 
+        return
+
+    if delegation.Shares < tx.Shares
+        return
     delegation.shares -= Tx.Shares
     validator, pool, createdCoins = validator.RemoveShares(pool, tx.Shares)
     setPool(pool)
-    
-    redelegation = newRedelegation(tx.DelegatorAddr, tx.validatorFrom, 
+
+    redelegation = newRedelegation(tx.DelegatorAddr, tx.validatorFrom,
         tx.validatorTo, tx.Shares, createdCoins, tx.CompletedTime)
     setRedelegation(redelegation)
-    return     
+    return
 ```
 
 ### TxCompleteRedelegation
@@ -239,7 +239,7 @@ redelegationComplete(tx TxRedelegate):
     redelegation = getRedelegation(tx.DelegatorAddr, tx.validatorFrom, tx.validatorTo)
     if redelegation.CompleteTime >= CurrentBlockTime && redelegation.CompleteHeight >= CurrentBlockHeight
         removeRedelegation(redelegation)
-    return     
+    return
 ```
 
 ### Update Validators
@@ -273,11 +273,11 @@ updateBondedValidators(newValidator Validator) (updatedVal Validator)
 		// use the validator provided because it has not yet been updated
 		// in the main validator store
 
-		ownerAddr = iterator.Value()
-		if bytes.Equal(ownerAddr, newValidator.Owner) {
+		operatorAddr = iterator.Value()
+		if bytes.Equal(operatorAddr, newValidator.Operator) {
 			validator = newValidator
         else
-			validator = getValidator(ownerAddr)
+			validator = getValidator(operatorAddr)
 
 		// if not previously a validator (and unrevoked),
 		// kick the cliff validator / bond this new validator
@@ -285,7 +285,7 @@ updateBondedValidators(newValidator Validator) (updatedVal Validator)
 			kickCliffValidator = true
 
 			validator = bondValidator(ctx, store, validator)
-			if bytes.Equal(ownerAddr, newValidator.Owner) {
+			if bytes.Equal(operatorAddr, newValidator.Operator) {
 				updatedVal = validator
 
 		bondedValidatorsCount++
@@ -316,7 +316,7 @@ unbondValidator(ctx Context, store KVStore, validator Validator)
 }
 
 // perform all the store operations for when a validator status becomes bonded
-bondValidator(ctx Context, store KVStore, validator Validator) Validator 
+bondValidator(ctx Context, store KVStore, validator Validator) Validator
 	pool = GetPool(ctx)
 
 	// set the status

--- a/docs/validators/validator-setup.md
+++ b/docs/validators/validator-setup.md
@@ -31,8 +31,13 @@ Don't use more `steak` thank you have! You can always get more by using the [Fau
 ```bash
 gaiacli stake create-validator \
   --amount=5steak \
+<<<<<<< HEAD
   --pubkey=$(gaiad tendermint show-validator) \
   --address-validator=<account_cosmosaccaddr>
+=======
+  --pubkey=$(gaiad tendermint show_validator) \
+  --validator=<account_cosmosaccaddr>
+>>>>>>> 6f19f2ed... Rename --address-validator flag to --validator
   --moniker="choose a moniker" \
   --chain-id=gaia-7005 \
   --name=<key_name>
@@ -46,7 +51,7 @@ The `--identity` can be used as to verify identity with systems like Keybase or 
 
 ```bash
 gaiacli stake edit-validator
-  --address-validator=<account_cosmosaccaddr>
+  --validator=<account_cosmosaccaddr>
   --moniker="choose a moniker" \
   --website="https://cosmos.network" \
   --identity=6A0D65E29A4CBC8E
@@ -61,8 +66,13 @@ View the validator's information with this command:
 
 ```bash
 gaiacli stake validator \
+<<<<<<< HEAD
   --address-validator=<account_cosmosaccaddr> \
   --chain-id=gaia-7005
+=======
+  --validator=<account_cosmosaccaddr> \
+  --chain-id=gaia-6002
+>>>>>>> 6f19f2ed... Rename --address-validator flag to --validator
 ```
 
 ### Confirm Your Validator is Running

--- a/examples/democoin/mock/validator.go
+++ b/examples/democoin/mock/validator.go
@@ -19,7 +19,7 @@ func (v Validator) GetStatus() sdk.BondStatus {
 }
 
 // Implements sdk.Validator
-func (v Validator) GetOwner() sdk.AccAddress {
+func (v Validator) GetOperator() sdk.AccAddress {
 	return v.Address
 }
 

--- a/types/stake.go
+++ b/types/stake.go
@@ -40,7 +40,7 @@ type Validator interface {
 	GetRevoked() bool         // whether the validator is revoked
 	GetMoniker() string       // moniker of the validator
 	GetStatus() BondStatus    // status of the validator
-	GetOwner() AccAddress     // owner AccAddress to receive/return validators coins
+	GetOperator() AccAddress  // owner AccAddress to receive/return validators coins
 	GetPubKey() crypto.PubKey // validation pubkey
 	GetPower() Dec            // validation power
 	GetTokens() Dec           // validation tokens

--- a/x/gov/tally.go
+++ b/x/gov/tally.go
@@ -24,8 +24,8 @@ func tally(ctx sdk.Context, keeper Keeper, proposal Proposal) (passes bool, tall
 	currValidators := make(map[string]validatorGovInfo)
 
 	keeper.vs.IterateValidatorsBonded(ctx, func(index int64, validator sdk.Validator) (stop bool) {
-		currValidators[validator.GetOwner().String()] = validatorGovInfo{
-			Address:         validator.GetOwner(),
+		currValidators[validator.GetOperator().String()] = validatorGovInfo{
+			Address:         validator.GetOperator(),
 			Power:           validator.GetPower(),
 			DelegatorShares: validator.GetDelegatorShares(),
 			Minus:           sdk.ZeroDec(),

--- a/x/slashing/app_test.go
+++ b/x/slashing/app_test.go
@@ -107,7 +107,7 @@ func TestSlashingMsgs(t *testing.T) {
 	mapp.BeginBlock(abci.RequestBeginBlock{})
 
 	validator := checkValidator(t, mapp, stakeKeeper, addr1, true)
-	require.Equal(t, addr1, validator.Owner)
+	require.Equal(t, addr1, validator.Operator)
 	require.Equal(t, sdk.Bonded, validator.Status)
 	require.True(sdk.DecEq(t, sdk.NewDec(10), validator.BondedTokens()))
 	unrevokeMsg := MsgUnrevoke{ValidatorAddr: sdk.AccAddress(validator.PubKey.Address())}

--- a/x/slashing/client/cli/flags.go
+++ b/x/slashing/client/cli/flags.go
@@ -2,5 +2,5 @@ package cli
 
 // nolint
 const (
-	FlagAddressValidator = "address-validator"
+	FlagAddressValidator = "validator"
 )

--- a/x/stake/app_test.go
+++ b/x/stake/app_test.go
@@ -136,7 +136,7 @@ func TestStakeMsgs(t *testing.T) {
 	mApp.BeginBlock(abci.RequestBeginBlock{})
 
 	validator := checkValidator(t, mApp, keeper, addr1, true)
-	require.Equal(t, addr1, validator.Owner)
+	require.Equal(t, addr1, validator.Operator)
 	require.Equal(t, sdk.Bonded, validator.Status)
 	require.True(sdk.DecEq(t, sdk.NewDec(10), validator.BondedTokens()))
 
@@ -148,7 +148,7 @@ func TestStakeMsgs(t *testing.T) {
 	mApp.BeginBlock(abci.RequestBeginBlock{})
 
 	validator = checkValidator(t, mApp, keeper, addr2, true)
-	require.Equal(t, addr2, validator.Owner)
+	require.Equal(t, addr2, validator.Operator)
 	require.Equal(t, sdk.Bonded, validator.Status)
 	require.True(sdk.DecEq(t, sdk.NewDec(10), validator.Tokens))
 

--- a/x/stake/client/cli/flags.go
+++ b/x/stake/client/cli/flags.go
@@ -9,7 +9,7 @@ import (
 // nolint
 const (
 	FlagAddressDelegator    = "address-delegator"
-	FlagAddressValidator    = "address-validator"
+	FlagAddressValidator    = "validator"
 	FlagAddressValidatorSrc = "addr-validator-source"
 	FlagAddressValidatorDst = "addr-validator-dest"
 	FlagPubKey              = "pubkey"

--- a/x/stake/client/rest/query.go
+++ b/x/stake/client/rest/query.go
@@ -114,7 +114,7 @@ func delegatorHandlerFn(cliCtx context.CLIContext, cdc *wire.Codec) http.Handler
 		}
 
 		for _, validator := range validators {
-			validatorAddr = validator.Owner
+			validatorAddr = validator.Operator
 
 			// Delegations
 			delegations, statusCode, errMsg, err := getDelegatorDelegations(cliCtx, cdc, delegatorAddr, validatorAddr)
@@ -400,7 +400,7 @@ func delegatorValidatorsHandlerFn(cliCtx context.CLIContext, cdc *wire.Codec) ht
 
 		for _, validator := range validators {
 			// get all transactions from the delegator to val and append
-			validatorAccAddr = validator.Owner
+			validatorAccAddr = validator.Operator
 
 			validator, statusCode, errMsg, errRes := getDelegatorValidator(cliCtx, cdc, delegatorAddr, validatorAccAddr)
 			if errRes != nil {

--- a/x/stake/handler_test.go
+++ b/x/stake/handler_test.go
@@ -136,13 +136,13 @@ func TestDuplicatesMsgCreateValidator(t *testing.T) {
 
 	require.True(t, found)
 	assert.Equal(t, sdk.Bonded, validator.Status)
-	assert.Equal(t, addr1, validator.Owner)
+	assert.Equal(t, addr1, validator.Operator)
 	assert.Equal(t, pk1, validator.PubKey)
 	assert.Equal(t, sdk.NewDec(10), validator.BondedTokens())
 	assert.Equal(t, sdk.NewDec(10), validator.DelegatorShares)
 	assert.Equal(t, Description{}, validator.Description)
 
-	// two validators can't have the same owner address
+	// two validators can't have the same operator address
 	msgCreateValidator2 := newTestMsgCreateValidator(addr1, pk2, 10)
 	got = handleMsgCreateValidator(ctx, msgCreateValidator2, keeper)
 	require.False(t, got.IsOK(), "%v", got)
@@ -152,7 +152,7 @@ func TestDuplicatesMsgCreateValidator(t *testing.T) {
 	got = handleMsgCreateValidator(ctx, msgCreateValidator3, keeper)
 	require.False(t, got.IsOK(), "%v", got)
 
-	// must have different pubkey and owner
+	// must have different pubkey and operator
 	msgCreateValidator4 := newTestMsgCreateValidator(addr2, pk2, 10)
 	got = handleMsgCreateValidator(ctx, msgCreateValidator4, keeper)
 	require.True(t, got.IsOK(), "%v", got)
@@ -160,7 +160,7 @@ func TestDuplicatesMsgCreateValidator(t *testing.T) {
 
 	require.True(t, found)
 	assert.Equal(t, sdk.Bonded, validator.Status)
-	assert.Equal(t, addr2, validator.Owner)
+	assert.Equal(t, addr2, validator.Operator)
 	assert.Equal(t, pk2, validator.PubKey)
 	assert.True(sdk.DecEq(t, sdk.NewDec(10), validator.Tokens))
 	assert.True(sdk.DecEq(t, sdk.NewDec(10), validator.DelegatorShares))
@@ -180,7 +180,7 @@ func TestDuplicatesMsgCreateValidatorOnBehalfOf(t *testing.T) {
 
 	require.True(t, found)
 	assert.Equal(t, sdk.Bonded, validator.Status)
-	assert.Equal(t, validatorAddr, validator.Owner)
+	assert.Equal(t, validatorAddr, validator.Operator)
 	assert.Equal(t, pk, validator.PubKey)
 	assert.True(sdk.DecEq(t, sdk.NewDec(10), validator.Tokens))
 	assert.True(sdk.DecEq(t, sdk.NewDec(10), validator.DelegatorShares))

--- a/x/stake/keeper/_store.md
+++ b/x/stake/keeper/_store.md
@@ -4,18 +4,18 @@ This document provided a bit more insight as to the purpose of several related
 prefixed areas of the staking store which are accessed in `x/stake/keeper.go`.
 
 
-## Validators 
+## Validators
  - Prefix Key Space:    ValidatorsKey
- - Key/Sort:            Validator Owner Address
+ - Key/Sort:            Validator Operator Address
  - Value:               Validator Object
  - Contains:            All Validator records independent of being bonded or not
- - Used For:            Retrieve validator from owner address, general validator retrieval 
+ - Used For:            Retrieve validator from operator address, general validator retrieval
 
 ## Validators By Power
  - Prefix Key Space:    ValidatorsByPowerKey
  - Key/Sort:            Validator Power (equivalent bonded shares) then Block
                         Height then Transaction Order
- - Value:               Validator Owner Address
+ - Value:               Validator Operator Address
  - Contains:            All Validator records independent of being bonded or not
  - Used For:            Determining who the top validators are whom should be bonded
 
@@ -26,19 +26,19 @@ prefixed areas of the staking store which are accessed in `x/stake/keeper.go`.
  - Contains:            The cliff validator (ex. 100th validator) power
  - Used For:            Efficient updates to validator status
 
-## Validators Bonded 
+## Validators Bonded
  - Prefix Key Space:    ValidatorsBondedKey
  - Key/Sort:            Validator PubKey Address (NOTE same as Tendermint)
- - Value:               Validator Owner Address
+ - Value:               Validator Operator Address
  - Contains:            Only currently bonded Validators
- - Used For:            Retrieving the list of all currently bonded validators when updating 
-                        for a new validator entering the validator set we may want to loop 
+ - Used For:            Retrieving the list of all currently bonded validators when updating
+                        for a new validator entering the validator set we may want to loop
                         through this set to determine who we've kicked out.
                         retrieving validator by tendermint index
 
 ## Tendermint Updates
  - Prefix Key Space:    TendermintUpdatesKey
- - Key/Sort:            Validator Owner Address
+ - Key/Sort:            Validator Operator Address
  - Value:               Tendermint ABCI Validator
  - Contains:            Validators are queued to affect the consensus validation set in Tendermint
  - Used For:            Informing Tendermint of the validator set updates, is used only intra-block, as the

--- a/x/stake/keeper/delegation.go
+++ b/x/stake/keeper/delegation.go
@@ -221,11 +221,11 @@ func (k Keeper) Delegate(ctx sdk.Context, delegatorAddr sdk.AccAddress, bondAmt 
 	validator types.Validator, subtractAccount bool) (newShares sdk.Dec, err sdk.Error) {
 
 	// Get or create the delegator delegation
-	delegation, found := k.GetDelegation(ctx, delegatorAddr, validator.Owner)
+	delegation, found := k.GetDelegation(ctx, delegatorAddr, validator.Operator)
 	if !found {
 		delegation = types.Delegation{
 			DelegatorAddr: delegatorAddr,
-			ValidatorAddr: validator.Owner,
+			ValidatorAddr: validator.Operator,
 			Shares:        sdk.ZeroDec(),
 		}
 	}
@@ -282,9 +282,9 @@ func (k Keeper) unbond(ctx sdk.Context, delegatorAddr, validatorAddr sdk.AccAddr
 	// remove the delegation
 	if delegation.Shares.IsZero() {
 
-		// if the delegation is the owner of the validator then
+		// if the delegation is the operator of the validator then
 		// trigger a revoke validator
-		if bytes.Equal(delegation.DelegatorAddr, validator.Owner) && validator.Revoked == false {
+		if bytes.Equal(delegation.DelegatorAddr, validator.Operator) && validator.Revoked == false {
 			validator.Revoked = true
 		}
 		k.RemoveDelegation(ctx, delegation)
@@ -303,7 +303,7 @@ func (k Keeper) unbond(ctx sdk.Context, delegatorAddr, validatorAddr sdk.AccAddr
 	// update then remove validator if necessary
 	validator = k.UpdateValidator(ctx, validator)
 	if validator.DelegatorShares.IsZero() {
-		k.RemoveValidator(ctx, validator.Owner)
+		k.RemoveValidator(ctx, validator.Operator)
 	}
 
 	return

--- a/x/stake/keeper/slash.go
+++ b/x/stake/keeper/slash.go
@@ -43,7 +43,7 @@ func (k Keeper) Slash(ctx sdk.Context, pubkey crypto.PubKey, infractionHeight in
 			pubkey.Address()))
 		return
 	}
-	ownerAddress := validator.GetOwner()
+	operatorAddress := validator.GetOperator()
 
 	// Track remaining slash amount for the validator
 	// This will decrease when we slash unbondings and
@@ -68,7 +68,7 @@ func (k Keeper) Slash(ctx sdk.Context, pubkey crypto.PubKey, infractionHeight in
 	case infractionHeight < ctx.BlockHeight():
 
 		// Iterate through unbonding delegations from slashed validator
-		unbondingDelegations := k.GetUnbondingDelegationsFromValidator(ctx, ownerAddress)
+		unbondingDelegations := k.GetUnbondingDelegationsFromValidator(ctx, operatorAddress)
 		for _, unbondingDelegation := range unbondingDelegations {
 			amountSlashed := k.slashUnbondingDelegation(ctx, unbondingDelegation, infractionHeight, slashFactor)
 			if amountSlashed.IsZero() {
@@ -78,7 +78,7 @@ func (k Keeper) Slash(ctx sdk.Context, pubkey crypto.PubKey, infractionHeight in
 		}
 
 		// Iterate through redelegations from slashed validator
-		redelegations := k.GetRedelegationsFromValidator(ctx, ownerAddress)
+		redelegations := k.GetRedelegationsFromValidator(ctx, operatorAddress)
 		for _, redelegation := range redelegations {
 			amountSlashed := k.slashRedelegation(ctx, validator, redelegation, infractionHeight, slashFactor)
 			if amountSlashed.IsZero() {
@@ -103,7 +103,7 @@ func (k Keeper) Slash(ctx sdk.Context, pubkey crypto.PubKey, infractionHeight in
 	validator = k.UpdateValidator(ctx, validator)
 	// remove validator if it has been reduced to zero shares
 	if validator.Tokens.IsZero() {
-		k.RemoveValidator(ctx, validator.Owner)
+		k.RemoveValidator(ctx, validator.Operator)
 	}
 
 	// Log that a slash occurred!

--- a/x/stake/keeper/validator_test.go
+++ b/x/stake/keeper/validator_test.go
@@ -128,7 +128,7 @@ func TestCliffValidatorChange(t *testing.T) {
 
 	// assert new cliff validator to be set to the second lowest bonded validator by power
 	newCliffVal := validators[numVals-maxVals+1]
-	require.Equal(t, newCliffVal.Owner, sdk.AccAddress(keeper.GetCliffValidator(ctx)))
+	require.Equal(t, newCliffVal.Operator, sdk.AccAddress(keeper.GetCliffValidator(ctx)))
 
 	// assert cliff validator power should have been updated
 	cliffPower := keeper.GetCliffValidatorPower(ctx)
@@ -141,7 +141,7 @@ func TestCliffValidatorChange(t *testing.T) {
 
 	// assert cliff validator has not change but increased in power
 	cliffPower = keeper.GetCliffValidatorPower(ctx)
-	require.Equal(t, newCliffVal.Owner, sdk.AccAddress(keeper.GetCliffValidator(ctx)))
+	require.Equal(t, newCliffVal.Operator, sdk.AccAddress(keeper.GetCliffValidator(ctx)))
 	require.Equal(t, GetValidatorsByPowerIndexKey(newCliffVal, pool), cliffPower)
 }
 
@@ -240,7 +240,7 @@ func TestValidatorBasics(t *testing.T) {
 	assert.True(ValEq(t, validators[2], resVals[2]))
 
 	// remove a record
-	keeper.RemoveValidator(ctx, validators[1].Owner)
+	keeper.RemoveValidator(ctx, validators[1].Operator)
 	_, found = keeper.GetValidator(ctx, addrVals[1])
 	require.False(t, found)
 }
@@ -269,11 +269,11 @@ func GetValidatorSortingUnmixed(t *testing.T) {
 	assert.Equal(t, sdk.NewDec(100), resValidators[2].BondedTokens(), "%v", resValidators)
 	assert.Equal(t, sdk.NewDec(1), resValidators[3].BondedTokens(), "%v", resValidators)
 	assert.Equal(t, sdk.NewDec(0), resValidators[4].BondedTokens(), "%v", resValidators)
-	assert.Equal(t, validators[3].Owner, resValidators[0].Owner, "%v", resValidators)
-	assert.Equal(t, validators[4].Owner, resValidators[1].Owner, "%v", resValidators)
-	assert.Equal(t, validators[1].Owner, resValidators[2].Owner, "%v", resValidators)
-	assert.Equal(t, validators[2].Owner, resValidators[3].Owner, "%v", resValidators)
-	assert.Equal(t, validators[0].Owner, resValidators[4].Owner, "%v", resValidators)
+	assert.Equal(t, validators[3].Operator, resValidators[0].Operator, "%v", resValidators)
+	assert.Equal(t, validators[4].Operator, resValidators[1].Operator, "%v", resValidators)
+	assert.Equal(t, validators[1].Operator, resValidators[2].Operator, "%v", resValidators)
+	assert.Equal(t, validators[2].Operator, resValidators[3].Operator, "%v", resValidators)
+	assert.Equal(t, validators[0].Operator, resValidators[4].Operator, "%v", resValidators)
 
 	// test a basic increase in voting power
 	validators[3].Tokens = sdk.NewDec(500)
@@ -380,11 +380,11 @@ func GetValidatorSortingMixed(t *testing.T) {
 	assert.Equal(t, sdk.NewDec(100), resValidators[2].BondedTokens(), "%v", resValidators)
 	assert.Equal(t, sdk.NewDec(1), resValidators[3].BondedTokens(), "%v", resValidators)
 	assert.Equal(t, sdk.NewDec(0), resValidators[4].BondedTokens(), "%v", resValidators)
-	assert.Equal(t, validators[3].Owner, resValidators[0].Owner, "%v", resValidators)
-	assert.Equal(t, validators[4].Owner, resValidators[1].Owner, "%v", resValidators)
-	assert.Equal(t, validators[1].Owner, resValidators[2].Owner, "%v", resValidators)
-	assert.Equal(t, validators[2].Owner, resValidators[3].Owner, "%v", resValidators)
-	assert.Equal(t, validators[0].Owner, resValidators[4].Owner, "%v", resValidators)
+	assert.Equal(t, validators[3].Operator, resValidators[0].Operator, "%v", resValidators)
+	assert.Equal(t, validators[4].Operator, resValidators[1].Operator, "%v", resValidators)
+	assert.Equal(t, validators[1].Operator, resValidators[2].Operator, "%v", resValidators)
+	assert.Equal(t, validators[2].Operator, resValidators[3].Operator, "%v", resValidators)
+	assert.Equal(t, validators[0].Operator, resValidators[4].Operator, "%v", resValidators)
 }
 
 // TODO separate out into multiple tests
@@ -409,7 +409,7 @@ func TestGetValidatorsEdgeCases(t *testing.T) {
 		validators[i] = keeper.UpdateValidator(ctx, validators[i])
 	}
 	for i := range amts {
-		validators[i], found = keeper.GetValidator(ctx, validators[i].Owner)
+		validators[i], found = keeper.GetValidator(ctx, validators[i].Operator)
 		require.True(t, found)
 	}
 	resValidators := keeper.GetValidatorsByPower(ctx)
@@ -433,7 +433,7 @@ func TestGetValidatorsEdgeCases(t *testing.T) {
 	// validator 3 enters bonded validator set
 	ctx = ctx.WithBlockHeight(40)
 
-	validators[3], found = keeper.GetValidator(ctx, validators[3].Owner)
+	validators[3], found = keeper.GetValidator(ctx, validators[3].Operator)
 	require.True(t, found)
 	validators[3], pool, _ = validators[3].AddTokensFromDel(pool, 1)
 	keeper.SetPool(ctx, pool)
@@ -460,7 +460,7 @@ func TestGetValidatorsEdgeCases(t *testing.T) {
 	require.Equal(t, nMax, uint16(len(resValidators)))
 	assert.True(ValEq(t, validators[0], resValidators[0]))
 	assert.True(ValEq(t, validators[2], resValidators[1]))
-	validator, exists := keeper.GetValidator(ctx, validators[3].Owner)
+	validator, exists := keeper.GetValidator(ctx, validators[3].Operator)
 	require.Equal(t, exists, true)
 	require.Equal(t, int64(40), validator.BondHeight)
 }
@@ -530,7 +530,7 @@ func TestFullValidatorSetPowerChange(t *testing.T) {
 	}
 	for i := range amts {
 		var found bool
-		validators[i], found = keeper.GetValidator(ctx, validators[i].Owner)
+		validators[i], found = keeper.GetValidator(ctx, validators[i].Operator)
 		require.True(t, found)
 	}
 	assert.Equal(t, sdk.Unbonded, validators[0].Status)
@@ -603,8 +603,8 @@ func TestGetTendermintUpdatesAllNone(t *testing.T) {
 	keeper.ClearTendermintUpdates(ctx)
 	require.Equal(t, 0, len(keeper.GetTendermintUpdates(ctx)))
 
-	keeper.RemoveValidator(ctx, validators[0].Owner)
-	keeper.RemoveValidator(ctx, validators[1].Owner)
+	keeper.RemoveValidator(ctx, validators[0].Operator)
+	keeper.RemoveValidator(ctx, validators[1].Operator)
 
 	updates = keeper.GetTendermintUpdates(ctx)
 	assert.Equal(t, 2, len(updates))

--- a/x/stake/types/validator_test.go
+++ b/x/stake/types/validator_test.go
@@ -72,7 +72,7 @@ func TestABCIValidatorZero(t *testing.T) {
 func TestRemoveTokens(t *testing.T) {
 
 	validator := Validator{
-		Owner:           addr1,
+		Operator:        addr1,
 		PubKey:          pk1,
 		Status:          sdk.Bonded,
 		Tokens:          sdk.NewDec(100),
@@ -148,7 +148,7 @@ func TestAddTokensValidatorUnbonded(t *testing.T) {
 // TODO refactor to make simpler like the AddToken tests above
 func TestRemoveDelShares(t *testing.T) {
 	valA := Validator{
-		Owner:           addr1,
+		Operator:        addr1,
 		PubKey:          pk1,
 		Status:          sdk.Bonded,
 		Tokens:          sdk.NewDec(100),
@@ -176,7 +176,7 @@ func TestRemoveDelShares(t *testing.T) {
 	poolTokens := sdk.NewDec(5102)
 	delShares := sdk.NewDec(115)
 	validator := Validator{
-		Owner:           addr1,
+		Operator:        addr1,
 		PubKey:          pk1,
 		Status:          sdk.Bonded,
 		Tokens:          poolTokens,
@@ -229,7 +229,7 @@ func TestPossibleOverflow(t *testing.T) {
 	poolTokens := sdk.NewDec(2159)
 	delShares := sdk.NewDec(391432570689183511).Quo(sdk.NewDec(40113011844664))
 	validator := Validator{
-		Owner:           addr1,
+		Operator:        addr1,
 		PubKey:          pk1,
 		Status:          sdk.Bonded,
 		Tokens:          poolTokens,


### PR DESCRIPTION
- [**cli**] Flag `--address-validator` renamed to `--validator`
- [**types**] `Validator` interface's `GetOwner()` renamed to `GetOperator()`
- [**x/stake**] `Validator.Owner` renamed to `Validator.Operator`


Relevant issue: #1901 