### PR TITLE
Handle unmarshalling failures gracefully in x/stake commands

### DIFF
--- a/PENDING.md
+++ b/PENDING.md
@@ -95,3 +95,4 @@ BUG FIXES
 *  \#1787 Fixed bug where Tally fails due to revoked/unbonding validator
 *  \#1787 Fixed bug where Tally fails due to revoked/unbonding validator
 * [basecoin] Fixes coin transaction failure and account query [discussion](https://forum.cosmos.network/t/unmarshalbinarybare-expected-to-read-prefix-bytes-75fbfab8-since-it-is-registered-concrete-but-got-0a141dfa/664/6)
+* [cli] Handle panics gracefully when `gaiacli stake {delegation,unbond}` fail to unmarshal delegation.

--- a/PENDING.md
+++ b/PENDING.md
@@ -95,4 +95,4 @@ BUG FIXES
 *  \#1787 Fixed bug where Tally fails due to revoked/unbonding validator
 *  \#1787 Fixed bug where Tally fails due to revoked/unbonding validator
 * [basecoin] Fixes coin transaction failure and account query [discussion](https://forum.cosmos.network/t/unmarshalbinarybare-expected-to-read-prefix-bytes-75fbfab8-since-it-is-registered-concrete-but-got-0a141dfa/664/6)
-* [cli] Handle panics gracefully when `gaiacli stake {delegation,unbond}` fail to unmarshal delegation.
+* [cli] \#1997 Handle panics gracefully when `gaiacli stake {delegation,unbond}` fail to unmarshal delegation.

--- a/x/stake/client/cli/query.go
+++ b/x/stake/client/cli/query.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/tendermint/tendermint/libs/cli"
@@ -142,7 +141,7 @@ func GetCmdQueryDelegation(storeName string, cdc *wire.Codec) *cobra.Command {
 			// parse out the delegation
 			delegation, err := types.UnmarshalDelegation(cdc, key, res)
 			if err != nil {
-				return errors.Errorf("%v: %v", types.ErrNoDelegation(types.DefaultCodespace).Data(), err)
+				return err
 			}
 
 			switch viper.Get(cli.OutputFlag) {

--- a/x/stake/client/cli/query.go
+++ b/x/stake/client/cli/query.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/tendermint/tendermint/libs/cli"
@@ -139,7 +140,10 @@ func GetCmdQueryDelegation(storeName string, cdc *wire.Codec) *cobra.Command {
 			}
 
 			// parse out the delegation
-			delegation := types.MustUnmarshalDelegation(cdc, key, res)
+			delegation, err := types.UnmarshalDelegation(cdc, key, res)
+			if err != nil {
+				return errors.Errorf("cannot unmarshal delegation: %v", err)
+			}
 
 			switch viper.Get(cli.OutputFlag) {
 			case "text":

--- a/x/stake/client/cli/query.go
+++ b/x/stake/client/cli/query.go
@@ -142,7 +142,7 @@ func GetCmdQueryDelegation(storeName string, cdc *wire.Codec) *cobra.Command {
 			// parse out the delegation
 			delegation, err := types.UnmarshalDelegation(cdc, key, res)
 			if err != nil {
-				return errors.Errorf("cannot unmarshal delegation: %v", err)
+				return errors.Errorf("%v: %v", types.ErrNoDelegation(types.DefaultCodespace).Data(), err)
 			}
 
 			switch viper.Get(cli.OutputFlag) {

--- a/x/stake/client/cli/tx.go
+++ b/x/stake/client/cli/tx.go
@@ -275,7 +275,7 @@ func getShares(
 		}
 		delegation, err := types.UnmarshalDelegation(cdc, key, resQuery)
 		if err != nil {
-			return sdk.ZeroRat(), errors.Errorf("cannot unmarshal delegation: %v", err)
+			return sdk.ZeroRat(), errors.Errorf("%v: %v", types.ErrNoDelegation(types.DefaultCodespace).Data(), err)
 		}
 		sharesAmount = sharesPercent.Mul(delegation.Shares)
 	}

--- a/x/stake/client/cli/tx.go
+++ b/x/stake/client/cli/tx.go
@@ -273,11 +273,12 @@ func getShares(
 		if err != nil {
 			return sharesAmount, errors.Errorf("cannot find delegation to determine percent Error: %v", err)
 		}
-
-		delegation := types.MustUnmarshalDelegation(cdc, key, resQuery)
+		delegation, err := types.UnmarshalDelegation(cdc, key, resQuery)
+		if err != nil {
+			return sdk.ZeroRat(), errors.Errorf("cannot unmarshal delegation: %v", err)
+		}
 		sharesAmount = sharesPercent.Mul(delegation.Shares)
 	}
-
 	return
 }
 

--- a/x/stake/client/cli/tx.go
+++ b/x/stake/client/cli/tx.go
@@ -275,7 +275,7 @@ func getShares(
 		}
 		delegation, err := types.UnmarshalDelegation(cdc, key, resQuery)
 		if err != nil {
-			return sdk.ZeroRat(), errors.Errorf("%v: %v", types.ErrNoDelegation(types.DefaultCodespace).Data(), err)
+			return sdk.ZeroRat(), err
 		}
 		sharesAmount = sharesPercent.Mul(delegation.Shares)
 	}

--- a/x/stake/types/delegation.go
+++ b/x/stake/types/delegation.go
@@ -143,7 +143,7 @@ func UnmarshalUBD(cdc *wire.Codec, key, value []byte) (ubd UnbondingDelegation, 
 
 	addrs := key[1:] // remove prefix bytes
 	if len(addrs) != 2*sdk.AddrLen {
-		err = fmt.Errorf("%v", ErrBadUnbondingDelegationAddr(DefaultCodespace).Data())
+		err = fmt.Errorf("%v", ErrBadDelegationAddr(DefaultCodespace).Data())
 		return
 	}
 	delAddr := sdk.AccAddress(addrs[:sdk.AddrLen])

--- a/x/stake/types/delegation.go
+++ b/x/stake/types/delegation.go
@@ -2,7 +2,6 @@ package types
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"time"
 
@@ -144,7 +143,7 @@ func UnmarshalUBD(cdc *wire.Codec, key, value []byte) (ubd UnbondingDelegation, 
 
 	addrs := key[1:] // remove prefix bytes
 	if len(addrs) != 2*sdk.AddrLen {
-		err = errors.New("unexpected key length")
+		err = fmt.Errorf("%v", ErrBadUnbondingDelegationAddr(DefaultCodespace).Data())
 		return
 	}
 	delAddr := sdk.AccAddress(addrs[:sdk.AddrLen])
@@ -236,7 +235,7 @@ func UnmarshalRED(cdc *wire.Codec, key, value []byte) (red Redelegation, err err
 
 	addrs := key[1:] // remove prefix bytes
 	if len(addrs) != 3*sdk.AddrLen {
-		err = errors.New("unexpected key length")
+		err = fmt.Errorf("%v", ErrBadRedelegationAddr(DefaultCodespace).Data())
 		return
 	}
 	delAddr := sdk.AccAddress(addrs[:sdk.AddrLen])

--- a/x/stake/types/delegation.go
+++ b/x/stake/types/delegation.go
@@ -48,12 +48,13 @@ func UnmarshalDelegation(cdc *wire.Codec, key, value []byte) (delegation Delegat
 	var storeValue delegationValue
 	err = cdc.UnmarshalBinary(value, &storeValue)
 	if err != nil {
+		err = fmt.Errorf("%v: %v", ErrNoDelegation(DefaultCodespace).Data(), err)
 		return
 	}
 
 	addrs := key[1:] // remove prefix bytes
 	if len(addrs) != 2*sdk.AddrLen {
-		err = errors.New("unexpected key length")
+		err = fmt.Errorf("%v", ErrBadDelegationAddr(DefaultCodespace).Data())
 		return
 	}
 	delAddr := sdk.AccAddress(addrs[:sdk.AddrLen])

--- a/x/stake/types/errors.go
+++ b/x/stake/types/errors.go
@@ -135,7 +135,7 @@ func ErrExistingUnbondingDelegation(codespace sdk.CodespaceType) sdk.Error {
 }
 
 func ErrBadRedelegationAddr(codespace sdk.CodespaceType) sdk.Error {
-	return sdk.NewError(codespace, CodeInvalidInput, "unexpected address length for this (address, srcValidator, dstValidator) triple")
+	return sdk.NewError(codespace, CodeInvalidInput, "unexpected address length for this (address, srcValidator, dstValidator) tuple")
 }
 
 func ErrNoRedelegation(codespace sdk.CodespaceType) sdk.Error {

--- a/x/stake/types/errors.go
+++ b/x/stake/types/errors.go
@@ -17,6 +17,7 @@ const (
 	CodeInvalidDelegation CodeType = 102
 	CodeInvalidInput      CodeType = 103
 	CodeValidatorJailed   CodeType = 104
+	CodeInvalidAddress    CodeType = sdk.CodeInvalidAddress
 	CodeUnauthorized      CodeType = sdk.CodeUnauthorized
 	CodeInternal          CodeType = sdk.CodeInternal
 	CodeUnknownRequest    CodeType = sdk.CodeUnknownRequest
@@ -25,6 +26,10 @@ const (
 //validator
 func ErrNilValidatorAddr(codespace sdk.CodespaceType) sdk.Error {
 	return sdk.NewError(codespace, CodeInvalidInput, "validator address is nil")
+}
+
+func ErrBadValidatorAddr(codespace sdk.CodespaceType) sdk.Error {
+	return sdk.NewError(codespace, CodeInvalidAddress, "validator address is invalid")
 }
 
 func ErrNoValidatorFound(codespace sdk.CodespaceType) sdk.Error {

--- a/x/stake/types/errors.go
+++ b/x/stake/types/errors.go
@@ -73,6 +73,10 @@ func ErrBadDenom(codespace sdk.CodespaceType) sdk.Error {
 	return sdk.NewError(codespace, CodeInvalidDelegation, "invalid coin denomination")
 }
 
+func ErrBadDelegationAddr(codespace sdk.CodespaceType) sdk.Error {
+	return sdk.NewError(codespace, CodeInvalidInput, "unexpected address length for this (address, validator) pair")
+}
+
 func ErrBadDelegationAmount(codespace sdk.CodespaceType) sdk.Error {
 	return sdk.NewError(codespace, CodeInvalidDelegation, "amount must be > 0")
 }

--- a/x/stake/types/errors.go
+++ b/x/stake/types/errors.go
@@ -126,12 +126,20 @@ func ErrNotMature(codespace sdk.CodespaceType, operation, descriptor string, got
 	return sdk.NewError(codespace, CodeUnauthorized, msg)
 }
 
+func ErrBadUnbondingDelegationAddr(codespace sdk.CodespaceType) sdk.Error {
+	return sdk.NewError(codespace, CodeInvalidInput, "unexpected address length for this (address, validator) pair")
+}
+
 func ErrNoUnbondingDelegation(codespace sdk.CodespaceType) sdk.Error {
 	return sdk.NewError(codespace, CodeInvalidDelegation, "no unbonding delegation found")
 }
 
 func ErrExistingUnbondingDelegation(codespace sdk.CodespaceType) sdk.Error {
 	return sdk.NewError(codespace, CodeInvalidDelegation, "existing unbonding delegation found")
+}
+
+func ErrBadRedelegationAddr(codespace sdk.CodespaceType) sdk.Error {
+	return sdk.NewError(codespace, CodeInvalidInput, "unexpected address length for this (address, srcValidator, dstValidator) triple")
 }
 
 func ErrNoRedelegation(codespace sdk.CodespaceType) sdk.Error {

--- a/x/stake/types/errors.go
+++ b/x/stake/types/errors.go
@@ -126,10 +126,6 @@ func ErrNotMature(codespace sdk.CodespaceType, operation, descriptor string, got
 	return sdk.NewError(codespace, CodeUnauthorized, msg)
 }
 
-func ErrBadUnbondingDelegationAddr(codespace sdk.CodespaceType) sdk.Error {
-	return sdk.NewError(codespace, CodeInvalidInput, "unexpected address length for this (address, validator) pair")
-}
-
 func ErrNoUnbondingDelegation(codespace sdk.CodespaceType) sdk.Error {
 	return sdk.NewError(codespace, CodeInvalidDelegation, "no unbonding delegation found")
 }

--- a/x/stake/types/validator.go
+++ b/x/stake/types/validator.go
@@ -2,7 +2,6 @@ package types
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 
 	abci "github.com/tendermint/tendermint/abci/types"
@@ -115,14 +114,13 @@ func MustUnmarshalValidator(cdc *wire.Codec, ownerAddr, value []byte) Validator 
 
 // unmarshal a redelegation from a store key and value
 func UnmarshalValidator(cdc *wire.Codec, ownerAddr, value []byte) (validator Validator, err error) {
+	if len(ownerAddr) != 20 {
+		err = fmt.Errorf("%v", ErrBadValidatorAddr(DefaultCodespace).Data())
+		return
+	}
 	var storeValue validatorValue
 	err = cdc.UnmarshalBinary(value, &storeValue)
 	if err != nil {
-		return
-	}
-
-	if len(ownerAddr) != 20 {
-		err = errors.New("unexpected address length")
 		return
 	}
 

--- a/x/stake/types/validator.go
+++ b/x/stake/types/validator.go
@@ -114,7 +114,7 @@ func MustUnmarshalValidator(cdc *wire.Codec, ownerAddr, value []byte) Validator 
 
 // unmarshal a redelegation from a store key and value
 func UnmarshalValidator(cdc *wire.Codec, ownerAddr, value []byte) (validator Validator, err error) {
-	if len(ownerAddr) != 20 {
+	if len(ownerAddr) != sdk.AddrLen {
 		err = fmt.Errorf("%v", ErrBadValidatorAddr(DefaultCodespace).Data())
 		return
 	}


### PR DESCRIPTION
* Introduce new `Err{NoDelegation,Bad{Redelegation,UnbondingDelegation,Validator}Addr}` functions in stake's types.
* `stake/types.Unmarshal{Validator,UBD,RED}()`:
  - Return consistent errors on address validation failures.
* `stake/types.UnmarshalValidator()`:
  - Perform address validation first to avoid attempting unmarshalling at all if the latter fails.
* Replace `MustUnmarshalDelegation()` with `UnmarshalDelegation()` calls and handle errors gracefully rather than panicking to fix #1831 and #1907.
