### PR TITLE
Rename transient store key to be a unique key.

### DIFF
--- a/PENDING.md
+++ b/PENDING.md
@@ -7,7 +7,7 @@ BREAKING CHANGES
 * Gaia CLI  (`gaiacli`)
 
 * Gaia
-    * Make the transient store key use a distinct store key.
+    * Make the transient store key use a distinct store key. [#2013](https://github.com/cosmos/cosmos-sdk/pull/2013)
     
 * SDK 
 

--- a/PENDING.md
+++ b/PENDING.md
@@ -7,7 +7,8 @@ BREAKING CHANGES
 * Gaia CLI  (`gaiacli`)
 
 * Gaia
-
+    * Make the transient store key use a distinct store key.
+    
 * SDK 
 
 * Tendermint 

--- a/cmd/gaia/app/app.go
+++ b/cmd/gaia/app/app.go
@@ -78,7 +78,7 @@ func NewGaiaApp(logger log.Logger, db dbm.DB, traceStore io.Writer, baseAppOptio
 		keyGov:           sdk.NewKVStoreKey("gov"),
 		keyFeeCollection: sdk.NewKVStoreKey("fee"),
 		keyParams:        sdk.NewKVStoreKey("params"),
-		tkeyParams:       sdk.NewTransientStoreKey("params"),
+		tkeyParams:       sdk.NewTransientStoreKey("transient_params"),
 	}
 
 	// define the accountMapper


### PR DESCRIPTION
This caused an error with non-determinism between nodes with same
gaiad version and genesis. Fixes the issue (we think) for what we saw in internal testnets.
___________________________________
For Admin Use:
- [ ] Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- [ ] Reviewers Assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
