### PR TITLE
dep: Fix error with scratch directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,7 @@ get_dev_tools:
 
 get_vendor_deps:
 	@echo "--> Running dep ensure"
+	@rm -rf .vendor-new
 	@dep ensure -v
 
 draw_deps:

--- a/PENDING.md
+++ b/PENDING.md
@@ -73,6 +73,7 @@ IMPROVEMENTS
 * [x/stake] \#1815 Sped up the processing of `EditValidator` txs.
 * [server] \#1930 Transactions indexer indexes all tags by default.
 * [x/stake] \#2000 Added tests for new staking endpoints
+* [tools] Make get_vendor_deps deletes `.vendor-new` directories, in case scratch files are present.
 
 BUG FIXES
 *  \#1666 Add intra-tx counter to the genesis validators


### PR DESCRIPTION
If dep already sees its scratch directory (.vendor-new), dep ensure fails. This rm -rf's that directory so that `make get_vendor_deps` doesn't fail.
___________________________________
For Admin Use:
- [X] Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- [ ] Reviewers Assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
