### PR TITLE
R4R: Test that localnet-start makes at least 10 blocks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,6 +157,8 @@ jobs:
     environment:
       GOBIN: /home/circleci/.go_workspace/bin
       GOPATH: /home/circleci/.go_workspace/
+      GOOS: linux
+      GOARCH: amd64 
     parallelism: 1
     steps:
       - checkout
@@ -166,7 +168,7 @@ jobs:
             set -x
             make get_tools
             make get_vendor_deps
-            go build GOOS=linux GOARCH=amd64 -o build/gaiad ./cmd/gaia/cmd/gaiad
+            go build -o build/gaiad ./cmd/gaia/cmd/gaiad
             make localnet-start
             docker run -it --network=host jackzampolin/gaiad-poll:latest ./poll.sh 40 5 10 localhost
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,7 +168,7 @@ jobs:
             make get_vendor_deps
             make build-linux
             make localnet-start
-            docker run -it --network=bridge jackzampolin/gaiad-poll:latest ./poll.sh 40 5 10 gaianode0
+            docker run -it --network=host jackzampolin/gaiad-poll:latest ./poll.sh 40 5 10 localhost
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -158,7 +158,7 @@ jobs:
       GOBIN: /home/circleci/.go_workspace/bin
       GOPATH: /home/circleci/.go_workspace/
       GOOS: linux
-      GOARCH: amd64 
+      GOARCH: amd64
     parallelism: 1
     steps:
       - checkout
@@ -168,7 +168,7 @@ jobs:
             set -x
             make get_tools
             make get_vendor_deps
-            go build -o build/gaiad ./cmd/gaia/cmd/gaiad
+            make build-linux
             make localnet-start
             docker run -it --network=host jackzampolin/gaiad-poll:latest ./poll.sh 40 5 10 localhost
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,7 +166,7 @@ jobs:
             set -x
             make get_tools
             make get_vendor_deps
-            make build-linux
+            go build GOOS=linux GOARCH=amd64 -o build/gaiad ./cmd/gaia/cmd/gaiad
             make localnet-start
             docker run -it --network=host jackzampolin/gaiad-poll:latest ./poll.sh 40 5 10 localhost
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,6 +150,26 @@ jobs:
           name: upload
           command: bash <(curl -s https://codecov.io/bash) -f coverage.txt
 
+  localnet:
+    working_directory: /home/circleci/.go_workspace/src/github.com/cosmos/cosmos-sdk
+    machine:
+      image: circleci/classic:latest
+    environment:
+      GOBIN: /home/circleci/.go_workspace/bin
+      GOPATH: /home/circleci/.go_workspace/
+    parallelism: 1
+    steps:
+      - checkout
+      - run:
+          name: run localnet and exit on failure
+          command: |
+            set -x
+            make get_tools
+            make get_vendor_deps
+            make build-linux
+            make localnet-start
+            docker run -it --network=bridge jackzampolin/gaiad-poll:latest ./poll.sh 40 5 10 gaianode0
+
 workflows:
   version: 2
   test-suite:
@@ -165,6 +185,9 @@ workflows:
           requires:
             - setup_dependencies
       - test_cover:
+          requires:
+            - setup_dependencies
+      - localnet:
           requires:
             - setup_dependencies
       - upload_coverage:

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ BUILD_TAGS = netgo ledger
 BUILD_FLAGS = -tags "${BUILD_TAGS}" -ldflags "-X github.com/cosmos/cosmos-sdk/version.GitCommit=${COMMIT_HASH}"
 GCC := $(shell command -v gcc 2> /dev/null)
 LEDGER_ENABLED ?= true
+UNAME_S := $(shell uname -s)
 all: get_tools get_vendor_deps install install_examples install_cosmos-sdk-cli test_lint test
 
 ########################################
@@ -17,12 +18,18 @@ ci: get_tools get_vendor_deps install test_cover test_lint test
 
 check-ledger: 
 ifeq ($(LEDGER_ENABLED),true)
-ifndef GCC
-$(error "gcc not installed for ledger support, please install or set LEDGER_ENABLED to false in the Makefile")
-endif
+   	ifeq ($(UNAME_S),OpenBSD)
+   		$(info "OpenBSD detected, disabling ledger support (https://github.com/cosmos/cosmos-sdk/issues/1988)")
+   	   	TMP_BUILD_TAGS := $(BUILD_TAGS)
+   	   	BUILD_TAGS = $(filter-out ledger, $(TMP_BUILD_TAGS))
+   	else
+   	   	ifndef GCC
+   	   	   $(error "gcc not installed for ledger support, please install or set LEDGER_ENABLED to false in the Makefile")
+   	   	endif
+   	endif
 else
-TMP_BUILD_TAGS := $(BUILD_TAGS)
-BUILD_TAGS = $(filter-out ledger, $(TMP_BUILD_TAGS))
+	TMP_BUILD_TAGS := $(BUILD_TAGS)
+	BUILD_TAGS = $(filter-out ledger, $(TMP_BUILD_TAGS))
 endif
 
 build: check-ledger

--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,7 @@ get_dev_tools:
 
 get_vendor_deps:
 	@echo "--> Running dep ensure"
+	@rm -rf .vendor-new
 	@dep ensure -v
 
 draw_deps:

--- a/Makefile
+++ b/Makefile
@@ -20,16 +20,16 @@ check-ledger:
 ifeq ($(LEDGER_ENABLED),true)
    	ifeq ($(UNAME_S),OpenBSD)
    		$(info "OpenBSD detected, disabling ledger support (https://github.com/cosmos/cosmos-sdk/issues/1988)")
-   	   	TMP_BUILD_TAGS := $(BUILD_TAGS)
-   	   	BUILD_TAGS = $(filter-out ledger, $(TMP_BUILD_TAGS))
+        TMP_BUILD_TAGS := $(BUILD_TAGS)
+        BUILD_TAGS = $(filter-out ledger, $(TMP_BUILD_TAGS))
    	else
    	   	ifndef GCC
    	   	   $(error "gcc not installed for ledger support, please install or set LEDGER_ENABLED to false in the Makefile")
    	   	endif
    	endif
 else
-	TMP_BUILD_TAGS := $(BUILD_TAGS)
-	BUILD_TAGS = $(filter-out ledger, $(TMP_BUILD_TAGS))
+  TMP_BUILD_TAGS := $(BUILD_TAGS)
+  BUILD_TAGS = $(filter-out ledger, $(TMP_BUILD_TAGS))
 endif
 
 build: check-ledger

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ ci: get_tools get_vendor_deps install test_cover test_lint test
 ########################################
 ### Build/Install
 
-check-ledger: 
+check-ledger:
 ifeq ($(LEDGER_ENABLED),true)
    	ifeq ($(UNAME_S),OpenBSD)
    		$(info "OpenBSD detected, disabling ledger support (https://github.com/cosmos/cosmos-sdk/issues/1988)")
@@ -199,7 +199,7 @@ build-docker-gaiadnode:
 # Run a 4-node testnet locally
 localnet-start: localnet-stop
 	@if ! [ -f build/node0/gaiad/config/genesis.json ]; then docker run --rm -v $(CURDIR)/build:/gaiad:Z tendermint/gaiadnode testnet --v 4 --o . --starting-ip-address 192.168.10.2 ; fi
-	docker-compose up
+	docker-compose up -d
 
 # Stop testnet
 localnet-stop:

--- a/PENDING.md
+++ b/PENDING.md
@@ -38,6 +38,7 @@ BREAKING CHANGES
 * [types] sdk.NewCoin now takes sdk.Int, sdk.NewInt64Coin takes int64
 * [cli] #1551: Officially removed `--name` from CLI commands
 * [cli] Genesis/key creation (`init`) now supports user-provided key passwords
+* [cli] unsafe_reset_all, show_validator, and show_node_id have been renamed to unsafe-reset-all, show-validator, and show-node-id
 
 FEATURES
 * [lcd] Can now query governance proposals by ProposalStatus

--- a/PENDING.md
+++ b/PENDING.md
@@ -74,6 +74,7 @@ IMPROVEMENTS
 * [x/stake] \#1815 Sped up the processing of `EditValidator` txs.
 * [server] \#1930 Transactions indexer indexes all tags by default.
 * [x/stake] \#2000 Added tests for new staking endpoints
+* [tools] Make get_vendor_deps deletes `.vendor-new` directories, in case scratch files are present.
 
 BUG FIXES
 *  \#1666 Add intra-tx counter to the genesis validators

--- a/PENDING.md
+++ b/PENDING.md
@@ -77,6 +77,7 @@ IMPROVEMENTS
 * [tools] Make get_vendor_deps deletes `.vendor-new` directories, in case scratch files are present.
 
 BUG FIXES
+*  \#1988 Make us compile on OpenBSD (disable ledger) [#1988] (https://github.com/cosmos/cosmos-sdk/issues/1988)
 *  \#1666 Add intra-tx counter to the genesis validators
 *  \#1797 Fix off-by-one error in slashing for downtime
 *  \#1787 Fixed bug where Tally fails due to revoked/unbonding validator

--- a/cmd/gaia/cli_test/cli_test.go
+++ b/cmd/gaia/cli_test/cli_test.go
@@ -34,7 +34,7 @@ func init() {
 }
 
 func TestGaiaCLISend(t *testing.T) {
-	tests.ExecuteT(t, fmt.Sprintf("gaiad --home=%s unsafe_reset_all", gaiadHome), "")
+	tests.ExecuteT(t, fmt.Sprintf("gaiad --home=%s unsafe-reset-all", gaiadHome), "")
 	executeWrite(t, fmt.Sprintf("gaiacli keys delete --home=%s foo", gaiacliHome), app.DefaultKeyPass)
 	executeWrite(t, fmt.Sprintf("gaiacli keys delete --home=%s bar", gaiacliHome), app.DefaultKeyPass)
 
@@ -87,7 +87,7 @@ func TestGaiaCLISend(t *testing.T) {
 }
 
 func TestGaiaCLICreateValidator(t *testing.T) {
-	tests.ExecuteT(t, fmt.Sprintf("gaiad --home=%s unsafe_reset_all", gaiadHome), "")
+	tests.ExecuteT(t, fmt.Sprintf("gaiad --home=%s unsafe-reset-all", gaiadHome), "")
 	executeWrite(t, fmt.Sprintf("gaiacli keys delete --home=%s foo", gaiacliHome), app.DefaultKeyPass)
 	executeWrite(t, fmt.Sprintf("gaiacli keys delete --home=%s bar", gaiacliHome), app.DefaultKeyPass)
 	chainID := executeInit(t, fmt.Sprintf("gaiad init -o --name=foo --home=%s --home-client=%s", gaiadHome, gaiacliHome))
@@ -153,7 +153,7 @@ func TestGaiaCLICreateValidator(t *testing.T) {
 }
 
 func TestGaiaCLISubmitProposal(t *testing.T) {
-	tests.ExecuteT(t, fmt.Sprintf("gaiad --home=%s unsafe_reset_all", gaiadHome), "")
+	tests.ExecuteT(t, fmt.Sprintf("gaiad --home=%s unsafe-reset-all", gaiadHome), "")
 	executeWrite(t, fmt.Sprintf("gaiacli keys delete --home=%s foo", gaiacliHome), app.DefaultKeyPass)
 	executeWrite(t, fmt.Sprintf("gaiacli keys delete --home=%s bar", gaiacliHome), app.DefaultKeyPass)
 	chainID := executeInit(t, fmt.Sprintf("gaiad init -o --name=foo --home=%s --home-client=%s", gaiadHome, gaiacliHome))

--- a/docs/getting-started/full-node.md
+++ b/docs/getting-started/full-node.md
@@ -41,7 +41,7 @@ First, remove the outdated files and reset the data.
 
 ```bash
 rm $HOME/.gaiad/config/addrbook.json $HOME/.gaiad/config/genesis.json
-gaiad unsafe_reset_all
+gaiad unsafe-reset-all
 ```
 
 Your node is now in a pristine state while keeping the original `priv_validator.json` and `config.toml`. If you had any sentry nodes or full nodes setup before,

--- a/docs/sdk/clients.md
+++ b/docs/sdk/clients.md
@@ -29,7 +29,7 @@ There are three types of key representations that are used:
 
 - `cosmosvalpub`
   - Generated when the node is created with `gaiad init`.
-  - Get this value with `gaiad tendermint show_validator`
+  - Get this value with `gaiad tendermint show-validator`
   - e.g. `cosmosvalpub1zcjduc3qcyj09qc03elte23zwshdx92jm6ce88fgc90rtqhjx8v0608qh5ssp0w94c`
 
 ### Generate Keys
@@ -59,7 +59,7 @@ gaiacli keys list
 View the validator pubkey for your node by typing:
 
 ```bash
-gaiad tendermint show_validator
+gaiad tendermint show-validator
 ```
 
 ::: danger Warning
@@ -120,7 +120,7 @@ On the testnet, we delegate `steak` instead of `atom`. Here's how you can bond t
 ```bash
 gaiacli stake delegate \
   --amount=10steak \
-  --address-validator=$(gaiad tendermint show_validator) \
+  --address-validator=$(gaiad tendermint show-validator) \
   --name=<key_name> \
   --chain-id=gaia-7005
 ```
@@ -137,7 +137,7 @@ If for any reason the validator misbehaves, or you want to unbond a certain amou
 
 ```bash
 gaiacli stake unbond begin \
-  --address-validator=$(gaiad tendermint show_validator) \
+  --address-validator=$(gaiad tendermint show-validator) \
   --shares=MAX \
   --name=<key_name> \
   --chain-id=gaia-7005
@@ -152,7 +152,7 @@ gaiacli account <account_cosmosaccaddr>
 
 gaiacli stake delegation \
   --address-delegator=<account_cosmosaccaddr> \
-  --address-validator=$(gaiad tendermint show_validator) \
+  --address-validator=$(gaiad tendermint show-validator) \
   --chain-id=gaia-7005
 ```
 

--- a/docs/validators/validator-setup.md
+++ b/docs/validators/validator-setup.md
@@ -19,7 +19,7 @@ If you want to become a validator for the Hub's `mainnet`, you should [research 
 Your `cosmosvalpub` can be used to create a new validator by staking tokens. You can find your validator pubkey by running:
 
 ```bash
-gaiad tendermint show_validator
+gaiad tendermint show-validator
 ```
 
 Next, craft your `gaiacli stake create-validator` command:
@@ -31,7 +31,7 @@ Don't use more `steak` thank you have! You can always get more by using the [Fau
 ```bash
 gaiacli stake create-validator \
   --amount=5steak \
-  --pubkey=$(gaiad tendermint show_validator) \
+  --pubkey=$(gaiad tendermint show-validator) \
   --address-validator=<account_cosmosaccaddr>
   --moniker="choose a moniker" \
   --chain-id=gaia-7005 \
@@ -70,7 +70,7 @@ gaiacli stake validator \
 Your validator is active if the following command returns anything:
 
 ```bash
-gaiacli advanced tendermint validator-set | grep "$(gaiad tendermint show_validator)"
+gaiacli advanced tendermint validator-set | grep "$(gaiad tendermint show-validator)"
 ```
 
 You should also be able to see your validator on the [Explorer](https://explorecosmos.network/validators). You are looking for the `bech32` encoded `address` in the `~/.gaiad/config/priv_validator.json` file.

--- a/examples/README.md
+++ b/examples/README.md
@@ -179,7 +179,7 @@ starting this tutorial again or trying something new), the following
 commands are run:
 
 ```
-basecoind unsafe_reset_all
+basecoind unsafe-reset-all
 rm -rf ~/.basecoind
 rm -rf ~/.basecli
 ```

--- a/networks/remote/ansible/roles/upgrade-gaiad/tasks/main.yml
+++ b/networks/remote/ansible/roles/upgrade-gaiad/tasks/main.yml
@@ -24,6 +24,6 @@
 
 - name: Reset network
   when: UNSAFE_RESET_ALL | default(false) | bool
-  command: "sudo -u gaiad gaiad unsafe_reset_all"
+  command: "sudo -u gaiad gaiad unsafe-reset-all"
   notify: restart gaiad
 

--- a/server/tm_cmds.go
+++ b/server/tm_cmds.go
@@ -16,7 +16,7 @@ import (
 // ShowNodeIDCmd - ported from Tendermint, dump node ID to stdout
 func ShowNodeIDCmd(ctx *Context) *cobra.Command {
 	return &cobra.Command{
-		Use:   "show_node_id",
+		Use:   "show-node-id",
 		Short: "Show this node's ID",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg := ctx.Config
@@ -34,7 +34,7 @@ func ShowNodeIDCmd(ctx *Context) *cobra.Command {
 func ShowValidatorCmd(ctx *Context) *cobra.Command {
 	flagJSON := "json"
 	cmd := cobra.Command{
-		Use:   "show_validator",
+		Use:   "show-validator",
 		Short: "Show this node's tendermint validator info",
 		RunE: func(cmd *cobra.Command, args []string) error {
 
@@ -68,7 +68,7 @@ func ShowValidatorCmd(ctx *Context) *cobra.Command {
 // UnsafeResetAllCmd - extension of the tendermint command, resets initialization
 func UnsafeResetAllCmd(ctx *Context) *cobra.Command {
 	return &cobra.Command{
-		Use:   "unsafe_reset_all",
+		Use:   "unsafe-reset-all",
 		Short: "Reset blockchain database, priv_validator.json file, and the logger",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg := ctx.Config


### PR DESCRIPTION
This PR adds the check to the Circle CI script to ensure that the `make localnet-start` command starts a testnet that can produce at least 10 blocks. cc @ValarDragon 