### PR TITLE
transient store missed to implement store type interface

### DIFF
--- a/store/transientstore.go
+++ b/store/transientstore.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	dbm "github.com/tendermint/tendermint/libs/db"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 var _ KVStore = (*transientStore)(nil)
@@ -40,4 +41,9 @@ func (ts *transientStore) Prefix(prefix []byte) KVStore {
 // Implements KVStore
 func (ts *transientStore) Gas(meter GasMeter, config GasConfig) KVStore {
 	return NewGasKVStore(meter, config, ts)
+}
+
+// Implements Store.
+func (st *transientStore) GetStoreType() StoreType {
+	return sdk.StoreTypeTransient
 }

--- a/store/transientstore.go
+++ b/store/transientstore.go
@@ -44,6 +44,6 @@ func (ts *transientStore) Gas(meter GasMeter, config GasConfig) KVStore {
 }
 
 // Implements Store.
-func (st *transientStore) GetStoreType() StoreType {
+func (ts *transientStore) GetStoreType() StoreType {
 	return sdk.StoreTypeTransient
 }


### PR DESCRIPTION
Currently transient store doesn't implement store type interface. As a result, when calculating commitStores, the transient store will also be included, which is unexpected.
```
func commitStores(version int64, storeMap map[StoreKey]CommitStore) commitInfo {
	storeInfos := make([]storeInfo, 0, len(storeMap))

	for key, store := range storeMap {
		// Commit
		commitID := store.Commit()

		if store.GetStoreType() == sdk.StoreTypeTransient {
			continue
		}

		// Record CommitID
		si := storeInfo{}
		si.Name = key.Name()
		si.Core.CommitID = commitID
		// si.Core.StoreType = store.GetStoreType()
		storeInfos = append(storeInfos, si)
	}

	ci := commitInfo{
		Version:    version,
		StoreInfos: storeInfos,
	}
	return ci
}
```
Now, we have two params store. One is IAVL store and another one is transient. 
```
		keyParams:        sdk.NewKVStoreKey("params"),
		tkeyParams:       sdk.NewTransientStoreKey("params"),
```
They have the same name. And the second one should not be included in commitInfo. However, due to the bugs I mentioned above, both the two store are included in commitInfo.
@jaekwon @adrianbrink 