### PR TITLE
Update bech32 human readable spec

### DIFF
--- a/docs/spec/other/bech32.md
+++ b/docs/spec/other/bech32.md
@@ -9,10 +9,10 @@ In the Cosmos network, keys and addresses may refer to a number of different rol
 
 | HRP           | Definition |
 | ------------- |:-------------:|
-| `cosa`        | Cosmos Account Address     |
-| `cosapub`     | Cosmos Account Public Key  |
-| `cosv`        | Cosmos Validator Consensus Address   |
-| `cosvpub`     | Cosmos Validator Consensus Public Key|
+| `cosmos`      | Cosmos Account Address     |
+| `cosmospub`   | Cosmos Account Public Key  |
+| `cosmosval`   | Cosmos Validator Consensus Address   |
+| `cosmosval`   | Cosmos Validator Consensus Public Key|
 
 ## Encoding
 

--- a/docs/spec/other/bech32.md
+++ b/docs/spec/other/bech32.md
@@ -7,12 +7,12 @@ In the Cosmos network, keys and addresses may refer to a number of different rol
 
 ## HRP table     
 
-| HRP        | Definition |
+| HRP           | Definition |
 | ------------- |:-------------:|
-| `cosmosaccaddr`     | Cosmos Account Address     |
-| `cosmosaccpub`      | Cosmos Account Public Key  |
-| `cosmosvaladdr`     | Cosmos Consensus Address   |
-| `cosmosvalpub`      | Cosmos Consensus Public Key|
+| `cosa`        | Cosmos Account Address     |
+| `cosapub`     | Cosmos Account Public Key  |
+| `cosv`        | Cosmos Validator Consensus Address   |
+| `cosvpub`     | Cosmos Validator Consensus Public Key|
 
 ## Encoding
 


### PR DESCRIPTION
The existing bech32 human readable prefix is too long esp for user accounts.  This shortens them.

For employee accounts, we need to ensure that we convert correctly by first decoding using the old prefix, then encoding again with the new prefix, as it changes the last few base32 checksum characters.