### PR TITLE
WIP: Software upgrade spec

### DIFF
--- a/docs/spec/governance/README.md
+++ b/docs/spec/governance/README.md
@@ -2,9 +2,14 @@
 
 ## Abstract
 
-This paper specifies the Governance module of the Cosmos-SDK, which was first described in the [Cosmos Whitepaper](https://cosmos.network/about/whitepaper) in June 2016. 
+This paper specifies the Governance module of the Cosmos-SDK, which was first
+described in the [Cosmos Whitepaper](https://cosmos.network/about/whitepaper)
+in June 2016. 
 
-The module enables Cosmos-SDK based blockchain to support an on-chain governance system. In this system, holders of the native staking token of the chain can vote on proposals on a 1 token 1 vote basis. Next is a list of features the module currently supports:
+The module enables Cosmos-SDK based blockchain to support an on-chain
+governance system. In this system, holders of the native staking token of the
+chain can vote on proposals on a 1 token 1 vote basis. Next is a list of
+features the module currently supports:
 
 - **Proposal submission:** Users can submit proposals with a deposit. Once the minimum deposit is reached, proposal enters voting period
 - **Vote:** Participants can vote on proposals that reached MinDeposit
@@ -12,14 +17,18 @@ The module enables Cosmos-SDK based blockchain to support an on-chain governance
 - **Signal and switch:** If a proposal of type `SoftwareUpgradeProposal` is accepted, validators can signal it and switch once enough validators have signalled.
 - **Claiming deposit:** Users that deposited on proposals can recover their deposits if the proposal was accepted OR if the proposal never entered voting period.
 
-Features that may be added in the future are described in [Future improvements](future_improvements.md)
+Features that may be added in the future are described in [Future
+improvements](future_improvements.md)
 
-This module will be used in the Cosmos Hub, the first Hub in the Cosmos network.
+This module will be used in the Cosmos Hub, the first Hub in the Cosmos
+network.
 
 
 ## Contents
 
-The following specification uses *Atom* as the native staking token. The module can be adapted to any Proof-Of-Stake blockchain by replacing *Atom* with the native staking token of the chain.
+The following specification uses *Atom* as the native staking token. The module
+can be adapted to any Proof-Of-Stake blockchain by replacing *Atom* with the
+native staking token of the chain.
 
 1.  **[Design overview](overview.md)**
 2.  **Implementation**
@@ -32,4 +41,5 @@ The following specification uses *Atom* as the native staking token. The module 
         2.  Deposit
         3.  Claim Deposit
         4.  Vote
-3.  **[Future improvements](future_improvements.md)**
+3.  **[Software Upgrade](software_upgrade.md)**
+4.  **[Future improvements](future_improvements.md)**

--- a/docs/spec/governance/overview.md
+++ b/docs/spec/governance/overview.md
@@ -46,18 +46,15 @@ Then, deposits will automatically be refunded to their respective depositer.
 
 ### Proposal types
 
-In the initial version of the governance module, there are two types of 
+In the initial version of the governance module, there is only one type of
 proposal:
-* `PlainTextProposal` All the proposals that do not involve a modification of 
-  the source code go under this type. For example, an opinion poll would use a 
-  proposal of type `PlainTextProposal`.
-* `SoftwareUpgradeProposal`. If accepted, validators are expected to update 
-  their software in accordance with the proposal. They must do so by following 
-  a 2-steps process described in the [Software Upgrade](#software-upgrade) 
-  section below. Software upgrade roadmap may be discussed and agreed on via 
-  `PlainTextProposals`, but actual software upgrades must be performed via 
-  `SoftwareUpgradeProposals`.
 
+* `PlainTextProposal` All the proposals that do not involve a modification of
+  the source code go under this type. For example, an opinion poll would use a
+proposal of type `PlainTextProposal`.
+
+For information about software upgrades, see the [Software Upgrade
+Spec](software_upgrade.md).
 
 ## Vote
 
@@ -161,32 +158,3 @@ making it mechanically impossible for some validators to vote on it.
 ### Governance address
 
 Later, we may add permissionned keys that could only sign txs from certain modules. For the MVP, the `Governance address` will be the main validator address generated at account creation. This address corresponds to a different PrivKey than the Tendermint PrivKey which is responsible for signing consensus messages. Validators thus do not have to sign governance transactions with the sensitive Tendermint PrivKey.
-
-## Software Upgrade
-
-If proposals are of type `SoftwareUpgradeProposal`, then nodes need to upgrade 
-their software to the new version that was voted. This process is divided in 
-two steps.
-
-### Signal
-
-After a `SoftwareUpgradeProposal` is accepted, validators are expected to 
-download and install the new version of the software while continuing to run 
-the previous version. Once a validator has downloaded and installed the 
-upgrade, it will start signaling to the network that it is ready to switch by 
-including the proposal's `proposalID` in its *precommits*.(*Note: Confirmation 
-that we want it in the precommit?*)
-
-Note: There is only one signal slot per *precommit*. If several 
-`SoftwareUpgradeProposals` are accepted in a short timeframe, a pipeline will 
-form and they will be implemented one after the other in the order that they 
-were accepted.
-
-### Switch
-
-Once a block contains more than 2/3rd *precommits* where a common 
-`SoftwareUpgradeProposal` is signaled, all the nodes (including validator 
-nodes, non-validating full nodes and light-nodes) are expected to switch to the
-new version of the software. 
-
-*Note: Not clear how the flip is handled programatically*

--- a/docs/spec/governance/software_upgrade.md
+++ b/docs/spec/governance/software_upgrade.md
@@ -1,0 +1,1 @@
+This is the software upgrade spec.

--- a/docs/spec/governance/software_upgrade.md
+++ b/docs/spec/governance/software_upgrade.md
@@ -1,1 +1,133 @@
-This is the software upgrade spec.
+## Software Upgrade
+
+Software is upgraded according to a 4-step process.
+
+1. Agree on software upgrade plan via governance (currently via a plaintext proposal).
+2. Once the upgrade plan is accepted, validators each update their software according to proposal from step 1.
+3. Each upgraded validator submits a transaction to the SoftwareUpgradeKeeper.
+4. Once a sufficient quorum of validators has completed step 3, new logic kicks
+   in in the form of a special parameter.
+
+### Step 1: Agree on the Upgrade Plan
+
+First, an English plaintext proposal should be submitted based on the following template:
+
+```
+# SOFTWARE UPGRADE PROPOSAL
+
+This is a proposal to upgrade the software.
+
+## Outline:
+
+* Current version: [XXX]
+* Current version commit hash: [XXX]
+* New version Github URL: https://github.com/...
+* New version: [XXX]
+* New version commit hash: [XXX]
+* Upgrade prepared by:
+ - <name/handle> on <date>; commit signature: https://github.com/...
+* Audited by:
+ - <name/handle> on <date>; report: https://github.com/...
+ - <name/handle> on <date>; report: https://github.com/...
+
+## Description:
+
+Describe the purpose of the upgrade and other details.
+
+- [ ] Link to any previous discussions
+- [ ] Link to any alternative proposals
+
+## Requirements:
+
+Describe any requirements
+
+- [ ] Any new hardware requirements?
+- [ ] Any new bandwidth requirements?
+- [ ] Any dependencies on other proposals?
+
+## Procedure:
+
+* Deadline: By 2 weeks from after the proposal has been accepted.
+
+Once this proposal has been accepted, validators should upgrade to the new
+software as described above by the deadline.  Once the new software is
+deployed, the new software will automaticaly submit a message to the
+SoftwareUpgradeKeeper.  The SoftwareUpgradeKeeper ensures that a sufficient
+quorum of validators (SOFTWARE_UPGRADE_QUORUM parameter) is running a specific
+version of the blockchain software.
+
+Once a sufficient quorum has been reached, the "SOFTWARE_UPGRADE_[XXX]_ENABLED"
+parameter will get set to true, thus switching on the new logic.
+
+## Conflict Resolution
+
+In case there are conflicting proposals, the most recent proposal to get
+accepted should be followed.  In other words, if another proposal gets accepted
+after this proposal does which conflicts with this proposal, the new proposal
+should be heeded instead of the process declared here.
+```
+
+It is recommended that all links point to Github for now, for accountability.
+
+This proposal template assumes that much discussion about the upgrade has
+already taken place elsewhere.  To gauge interest in a proposed upgrade,
+users should instead submit a survey proposal with the following template:
+
+Notethat the `Procedure` section has already been filled out.  Do not change
+this section unless there is a good reason to do so.
+
+```
+# SOFTWARE UPGRADE SURVEY
+
+THIS IS A NONBINDING SURVEY.  VOTES HERE ARE ONLY INTENDED TO GUAGE INTEREST.
+IF THIS PROPOSAL MANDATES ANY ACTION, IT IS THE VOTER'S DUTY TO VOTE "NO".
+
+<fill out as much as possible from the SOFTWARE UPGRADE PROPOSAL template>
+```
+
+### Step 2: Validators upgrade their software
+
+Once the proposal from step 1 has been accepted, validators should upgrade
+their software.  For the standard upgrade procedure, it is OK for non-validator
+full nodes to upgrade as well.
+
+### Step 3: Update the SoftwareUpgradeKeeper
+
+The new version of the software should automatically include a (single) signed
+message to the SoftwareUpgradeKeeper w/ the new version of software that the
+validator is running.  Even if a validator were to change their software
+version multiple times, the SoftwareUpgradeKeeper ensures that nothing happens
+until a quorum (SOFTWARE_UPGRADE_QUORUM) are on an identical version of the
+software.
+
+Only validators can vote here, as delegators do not actually run the validation
+software.  Delegators should make sure to vote NO or veto objectionable
+software upgrade proposals in the first step of this process.
+
+### Step 4: Auto-switch to new logic
+
+Once a quorum has been reached, the SoftwareUpgradeKeeper sets a new parameter
+SOFTWARE_UPGRADE_[XXX]_ENABLED=true, where XXX is the commit hash of the new
+software.
+
+### Contingincies
+
+TODO: What happens when there are two conflicting software upgrade proposals?
+Currently the SoftwareUpgradeKeeper ensures that only one upgrade happens at a
+time, but the only protocol that ensures accountability in the face of
+conflicting software upgrade proposals is the "Conflict Resolution" section.
+We should have a constitution that acts as a human-level protocol spec that
+defines how to deal with conflicting proposals in general.
+
+TODO: Document more edge cases.
+
+### Future improvement
+
+Any convention/template that develops in the plaintext proposal could be
+codified as a "SoftwareUpgradeProposal", which more or less acts as the
+plaintext proposal does here in step 1.  The special categorization signals to
+the greater ecosystem (e.g. non-validator full node operators) that an upgrade
+is being considered.
+
+In the future, the Cosmos Hub can include logic for hosting proposal
+discussions even before they reach the deposit requirement.


### PR DESCRIPTION
This spec proposal requires a new SoftwareUpgradeKeeper because the mechanics of that keeper should be different than the governance keeper.

For example, only validators can "vote" (though it should be automatic), and the acceptable values are not yes/no/abstain/veto, but the specific commit hash that the validator already upgraded to.