### PR TITLE
Change delegation amount from int64 to sdk.Int

### DIFF
--- a/cmd/gaia/app/genesis.go
+++ b/cmd/gaia/app/genesis.go
@@ -25,7 +25,7 @@ const DefaultKeyPass = "12345678"
 
 var (
 	// bonded tokens given to genesis validators/accounts
-	freeFermionVal  = sdk.NewInt(100)
+	freeFermionVal  = int64(100)
 	freeFermionsAcc = sdk.NewInt(50)
 )
 
@@ -152,7 +152,7 @@ func GaiaAppGenTxNF(cdc *wire.Codec, pk crypto.PubKey, addr sdk.AccAddress, name
 
 	validator = tmtypes.GenesisValidator{
 		PubKey: pk,
-		Power:  freeFermionVal.Int64(),
+		Power:  freeFermionVal,
 	}
 	return
 }
@@ -195,11 +195,11 @@ func GaiaAppGenState(cdc *wire.Codec, appGenTxs []json.RawMessage) (genesisState
 			validator := stake.NewValidator(genTx.Address,
 				sdk.MustGetAccPubKeyBech32(genTx.PubKey), desc)
 
-			stakeData.Pool.LooseTokens = stakeData.Pool.LooseTokens.Add(sdk.NewDecFromInt(freeFermionVal)) // increase the supply
+			stakeData.Pool.LooseTokens = stakeData.Pool.LooseTokens.Add(sdk.NewDec(freeFermionVal)) // increase the supply
 
 			// add some new shares to the validator
 			var issuedDelShares sdk.Dec
-			validator, stakeData.Pool, issuedDelShares = validator.AddTokensFromDel(stakeData.Pool, freeFermionVal)
+			validator, stakeData.Pool, issuedDelShares = validator.AddTokensFromDel(stakeData.Pool, sdk.NewInt(freeFermionVal))
 			stakeData.Validators = append(stakeData.Validators, validator)
 
 			// create the self-delegation from the issuedDelShares

--- a/cmd/gaia/app/genesis.go
+++ b/cmd/gaia/app/genesis.go
@@ -199,7 +199,7 @@ func GaiaAppGenState(cdc *wire.Codec, appGenTxs []json.RawMessage) (genesisState
 
 			// add some new shares to the validator
 			var issuedDelShares sdk.Dec
-			validator, stakeData.Pool, issuedDelShares = validator.AddTokensFromDel(stakeData.Pool, freeFermionVal)
+			validator, stakeData.Pool, issuedDelShares = validator.AddTokensFromDel(stakeData.Pool, sdk.NewInt(freeFermionVal))
 			stakeData.Validators = append(stakeData.Validators, validator)
 
 			// create the self-delegation from the issuedDelShares

--- a/cmd/gaia/app/genesis.go
+++ b/cmd/gaia/app/genesis.go
@@ -25,8 +25,8 @@ const DefaultKeyPass = "12345678"
 
 var (
 	// bonded tokens given to genesis validators/accounts
-	freeFermionVal  = int64(100)
-	freeFermionsAcc = int64(50)
+	freeFermionVal  = sdk.NewInt(100)
+	freeFermionsAcc = sdk.NewInt(50)
 )
 
 // State to Unmarshal
@@ -152,7 +152,7 @@ func GaiaAppGenTxNF(cdc *wire.Codec, pk crypto.PubKey, addr sdk.AccAddress, name
 
 	validator = tmtypes.GenesisValidator{
 		PubKey: pk,
-		Power:  freeFermionVal,
+		Power:  freeFermionVal.Int64(),
 	}
 	return
 }
@@ -183,11 +183,11 @@ func GaiaAppGenState(cdc *wire.Codec, appGenTxs []json.RawMessage) (genesisState
 		accAuth := auth.NewBaseAccountWithAddress(genTx.Address)
 		accAuth.Coins = sdk.Coins{
 			{genTx.Name + "Token", sdk.NewInt(1000)},
-			{"steak", sdk.NewInt(freeFermionsAcc)},
+			{"steak", freeFermionsAcc},
 		}
 		acc := NewGenesisAccount(&accAuth)
 		genaccs[i] = acc
-		stakeData.Pool.LooseTokens = stakeData.Pool.LooseTokens.Add(sdk.NewDec(freeFermionsAcc)) // increase the supply
+		stakeData.Pool.LooseTokens = stakeData.Pool.LooseTokens.Add(sdk.NewDecFromInt(freeFermionsAcc)) // increase the supply
 
 		// add the validator
 		if len(genTx.Name) > 0 {
@@ -195,11 +195,11 @@ func GaiaAppGenState(cdc *wire.Codec, appGenTxs []json.RawMessage) (genesisState
 			validator := stake.NewValidator(genTx.Address,
 				sdk.MustGetAccPubKeyBech32(genTx.PubKey), desc)
 
-			stakeData.Pool.LooseTokens = stakeData.Pool.LooseTokens.Add(sdk.NewDec(freeFermionVal)) // increase the supply
+			stakeData.Pool.LooseTokens = stakeData.Pool.LooseTokens.Add(sdk.NewDecFromInt(freeFermionVal)) // increase the supply
 
 			// add some new shares to the validator
 			var issuedDelShares sdk.Dec
-			validator, stakeData.Pool, issuedDelShares = validator.AddTokensFromDel(stakeData.Pool, sdk.NewInt(freeFermionVal))
+			validator, stakeData.Pool, issuedDelShares = validator.AddTokensFromDel(stakeData.Pool, freeFermionVal)
 			stakeData.Validators = append(stakeData.Validators, validator)
 
 			// create the self-delegation from the issuedDelShares

--- a/x/stake/keeper/delegation.go
+++ b/x/stake/keeper/delegation.go
@@ -239,7 +239,7 @@ func (k Keeper) Delegate(ctx sdk.Context, delegatorAddr sdk.AccAddress, bondAmt 
 	}
 
 	pool := k.GetPool(ctx)
-	validator, pool, newShares = validator.AddTokensFromDel(pool, bondAmt.Amount.Int64())
+	validator, pool, newShares = validator.AddTokensFromDel(pool, bondAmt.Amount)
 	delegation.Shares = delegation.Shares.Add(newShares)
 
 	// Update delegation height

--- a/x/stake/keeper/delegation_test.go
+++ b/x/stake/keeper/delegation_test.go
@@ -16,11 +16,11 @@ func TestDelegation(t *testing.T) {
 	pool := keeper.GetPool(ctx)
 
 	//construct the validators
-	amts := []int64{9, 8, 7}
+	amts := []sdk.Int{sdk.NewInt(9), sdk.NewInt(8), sdk.NewInt(7)}
 	var validators [3]types.Validator
 	for i, amt := range amts {
 		validators[i] = types.NewValidator(addrVals[i], PKs[i], types.Description{})
-		validators[i], pool, _ = validators[i].AddTokensFromDel(pool, sdk.NewInt(amt))
+		validators[i], pool, _ = validators[i].AddTokensFromDel(pool, amt)
 	}
 
 	keeper.SetPool(ctx, pool)

--- a/x/stake/keeper/delegation_test.go
+++ b/x/stake/keeper/delegation_test.go
@@ -20,7 +20,7 @@ func TestDelegation(t *testing.T) {
 	var validators [3]types.Validator
 	for i, amt := range amts {
 		validators[i] = types.NewValidator(addrVals[i], PKs[i], types.Description{})
-		validators[i], pool, _ = validators[i].AddTokensFromDel(pool, amt)
+		validators[i], pool, _ = validators[i].AddTokensFromDel(pool, sdk.NewInt(amt))
 	}
 
 	keeper.SetPool(ctx, pool)
@@ -146,7 +146,7 @@ func TestUnbondDelegation(t *testing.T) {
 
 	//create a validator and a delegator to that validator
 	validator := types.NewValidator(addrVals[0], PKs[0], types.Description{})
-	validator, pool, issuedShares := validator.AddTokensFromDel(pool, 10)
+	validator, pool, issuedShares := validator.AddTokensFromDel(pool, sdk.NewInt(10))
 	require.Equal(t, int64(10), issuedShares.RoundInt64())
 	keeper.SetPool(ctx, pool)
 	validator = keeper.UpdateValidator(ctx, validator)

--- a/x/stake/keeper/slash_test.go
+++ b/x/stake/keeper/slash_test.go
@@ -24,7 +24,7 @@ func setupHelper(t *testing.T, amt int64) (sdk.Context, Keeper, types.Params) {
 	// add numVals validators
 	for i := 0; i < numVals; i++ {
 		validator := types.NewValidator(addrVals[i], PKs[i], types.Description{})
-		validator, pool, _ = validator.AddTokensFromDel(pool, amt)
+		validator, pool, _ = validator.AddTokensFromDel(pool, sdk.NewInt(amt))
 		keeper.SetPool(ctx, pool)
 		validator = keeper.UpdateValidator(ctx, validator)
 		keeper.SetValidatorByPubKeyIndex(ctx, validator)

--- a/x/stake/keeper/validator_test.go
+++ b/x/stake/keeper/validator_test.go
@@ -18,7 +18,7 @@ func TestSetValidator(t *testing.T) {
 
 	// test how the validator is set from a purely unbonbed pool
 	validator := types.NewValidator(addrVals[0], PKs[0], types.Description{})
-	validator, pool, _ = validator.AddTokensFromDel(pool, 10)
+	validator, pool, _ = validator.AddTokensFromDel(pool, sdk.NewInt(10))
 	require.Equal(t, sdk.Unbonded, validator.Status)
 	assert.True(sdk.DecEq(t, sdk.NewDec(10), validator.Tokens))
 	assert.True(sdk.DecEq(t, sdk.NewDec(10), validator.DelegatorShares))
@@ -61,7 +61,7 @@ func TestUpdateValidatorByPowerIndex(t *testing.T) {
 
 	// add a validator
 	validator := types.NewValidator(addrVals[0], PKs[0], types.Description{})
-	validator, pool, delSharesCreated := validator.AddTokensFromDel(pool, 100)
+	validator, pool, delSharesCreated := validator.AddTokensFromDel(pool, sdk.NewInt(100))
 	require.Equal(t, sdk.Unbonded, validator.Status)
 	require.Equal(t, int64(100), validator.Tokens.RoundInt64())
 	keeper.SetPool(ctx, pool)
@@ -112,7 +112,7 @@ func TestUpdateBondedValidatorsDecreaseCliff(t *testing.T) {
 		val := types.NewValidator(Addrs[i], PKs[i], types.Description{Moniker: moniker})
 		val.BondHeight = int64(i)
 		val.BondIntraTxCounter = int16(i)
-		val, pool, _ = val.AddTokensFromDel(pool, int64((i+1)*10))
+		val, pool, _ = val.AddTokensFromDel(pool, sdk.NewInt(int64((i+1)*10)))
 
 		keeper.SetPool(ctx, pool)
 		val = keeper.UpdateValidator(ctx, val)
@@ -175,7 +175,7 @@ func TestCliffValidatorChange(t *testing.T) {
 		val := types.NewValidator(Addrs[i], PKs[i], types.Description{Moniker: moniker})
 		val.BondHeight = int64(i)
 		val.BondIntraTxCounter = int16(i)
-		val, pool, _ = val.AddTokensFromDel(pool, int64((i+1)*10))
+		val, pool, _ = val.AddTokensFromDel(pool, sdk.NewInt(int64((i+1)*10)))
 
 		keeper.SetPool(ctx, pool)
 		val = keeper.UpdateValidator(ctx, val)
@@ -184,7 +184,7 @@ func TestCliffValidatorChange(t *testing.T) {
 
 	// add a large amount of tokens to current cliff validator
 	currCliffVal := validators[numVals-maxVals]
-	currCliffVal, pool, _ = currCliffVal.AddTokensFromDel(pool, 200)
+	currCliffVal, pool, _ = currCliffVal.AddTokensFromDel(pool, sdk.NewInt(200))
 	keeper.SetPool(ctx, pool)
 	currCliffVal = keeper.UpdateValidator(ctx, currCliffVal)
 
@@ -197,7 +197,7 @@ func TestCliffValidatorChange(t *testing.T) {
 	require.Equal(t, GetValidatorsByPowerIndexKey(newCliffVal, pool), cliffPower)
 
 	// add small amount of tokens to new current cliff validator
-	newCliffVal, pool, _ = newCliffVal.AddTokensFromDel(pool, 1)
+	newCliffVal, pool, _ = newCliffVal.AddTokensFromDel(pool, sdk.NewInt(1))
 	keeper.SetPool(ctx, pool)
 	newCliffVal = keeper.UpdateValidator(ctx, newCliffVal)
 
@@ -207,7 +207,7 @@ func TestCliffValidatorChange(t *testing.T) {
 	require.Equal(t, GetValidatorsByPowerIndexKey(newCliffVal, pool), cliffPower)
 
 	// add enough power to cliff validator to be equal in rank to next validator
-	newCliffVal, pool, _ = newCliffVal.AddTokensFromDel(pool, 9)
+	newCliffVal, pool, _ = newCliffVal.AddTokensFromDel(pool, sdk.NewInt(9))
 	keeper.SetPool(ctx, pool)
 	newCliffVal = keeper.UpdateValidator(ctx, newCliffVal)
 
@@ -227,7 +227,7 @@ func TestSlashToZeroPowerRemoved(t *testing.T) {
 
 	// add a validator
 	validator := types.NewValidator(addrVals[0], PKs[0], types.Description{})
-	validator, pool, _ = validator.AddTokensFromDel(pool, 100)
+	validator, pool, _ = validator.AddTokensFromDel(pool, sdk.NewInt(100))
 	require.Equal(t, sdk.Unbonded, validator.Status)
 	require.Equal(t, int64(100), validator.Tokens.RoundInt64())
 	keeper.SetPool(ctx, pool)
@@ -254,7 +254,7 @@ func TestValidatorBasics(t *testing.T) {
 		validators[i] = types.NewValidator(addrVals[i], PKs[i], types.Description{})
 		validators[i].Status = sdk.Unbonded
 		validators[i].Tokens = sdk.ZeroDec()
-		validators[i], pool, _ = validators[i].AddTokensFromDel(pool, amt)
+		validators[i], pool, _ = validators[i].AddTokensFromDel(pool, sdk.NewInt(amt))
 		keeper.SetPool(ctx, pool)
 	}
 	assert.True(sdk.DecEq(t, sdk.NewDec(9), validators[0].Tokens))
@@ -480,7 +480,7 @@ func TestGetValidatorsEdgeCases(t *testing.T) {
 		pool := keeper.GetPool(ctx)
 		moniker := fmt.Sprintf("val#%d", int64(i))
 		validators[i] = types.NewValidator(Addrs[i], PKs[i], types.Description{Moniker: moniker})
-		validators[i], pool, _ = validators[i].AddTokensFromDel(pool, amt)
+		validators[i], pool, _ = validators[i].AddTokensFromDel(pool, sdk.NewInt(amt))
 		keeper.SetPool(ctx, pool)
 		validators[i] = keeper.UpdateValidator(ctx, validators[i])
 	}
@@ -495,7 +495,7 @@ func TestGetValidatorsEdgeCases(t *testing.T) {
 	assert.True(ValEq(t, validators[3], resValidators[1]))
 
 	pool := keeper.GetPool(ctx)
-	validators[0], pool, _ = validators[0].AddTokensFromDel(pool, 500)
+	validators[0], pool, _ = validators[0].AddTokensFromDel(pool, sdk.NewInt(500))
 	keeper.SetPool(ctx, pool)
 	validators[0] = keeper.UpdateValidator(ctx, validators[0])
 	resValidators = keeper.GetValidatorsByPower(ctx)
@@ -512,7 +512,7 @@ func TestGetValidatorsEdgeCases(t *testing.T) {
 
 	validators[3], found = keeper.GetValidator(ctx, validators[3].Operator)
 	require.True(t, found)
-	validators[3], pool, _ = validators[3].AddTokensFromDel(pool, 1)
+	validators[3], pool, _ = validators[3].AddTokensFromDel(pool, sdk.NewInt(1))
 	keeper.SetPool(ctx, pool)
 	validators[3] = keeper.UpdateValidator(ctx, validators[3])
 	resValidators = keeper.GetValidatorsByPower(ctx)
@@ -530,7 +530,7 @@ func TestGetValidatorsEdgeCases(t *testing.T) {
 	assert.True(ValEq(t, validators[2], resValidators[1]))
 
 	// validator 4 does not get spot back
-	validators[3], pool, _ = validators[3].AddTokensFromDel(pool, 200)
+	validators[3], pool, _ = validators[3].AddTokensFromDel(pool, sdk.NewInt(200))
 	keeper.SetPool(ctx, pool)
 	validators[3] = keeper.UpdateValidator(ctx, validators[3])
 	resValidators = keeper.GetValidatorsByPower(ctx)
@@ -557,9 +557,9 @@ func TestValidatorBondHeight(t *testing.T) {
 	validators[1] = types.NewValidator(Addrs[1], PKs[1], types.Description{})
 	validators[2] = types.NewValidator(Addrs[2], PKs[2], types.Description{})
 
-	validators[0], pool, _ = validators[0].AddTokensFromDel(pool, 200)
-	validators[1], pool, _ = validators[1].AddTokensFromDel(pool, 100)
-	validators[2], pool, _ = validators[2].AddTokensFromDel(pool, 100)
+	validators[0], pool, _ = validators[0].AddTokensFromDel(pool, sdk.NewInt(200))
+	validators[1], pool, _ = validators[1].AddTokensFromDel(pool, sdk.NewInt(100))
+	validators[2], pool, _ = validators[2].AddTokensFromDel(pool, sdk.NewInt(100))
 	keeper.SetPool(ctx, pool)
 
 	validators[0] = keeper.UpdateValidator(ctx, validators[0])
@@ -577,8 +577,8 @@ func TestValidatorBondHeight(t *testing.T) {
 
 	assert.True(ValEq(t, validators[0], resValidators[0]))
 	assert.True(ValEq(t, validators[1], resValidators[1]))
-	validators[1], pool, _ = validators[1].AddTokensFromDel(pool, 50)
-	validators[2], pool, _ = validators[2].AddTokensFromDel(pool, 50)
+	validators[1], pool, _ = validators[1].AddTokensFromDel(pool, sdk.NewInt(50))
+	validators[2], pool, _ = validators[2].AddTokensFromDel(pool, sdk.NewInt(50))
 	keeper.SetPool(ctx, pool)
 	validators[2] = keeper.UpdateValidator(ctx, validators[2])
 	resValidators = keeper.GetValidatorsByPower(ctx)
@@ -601,7 +601,7 @@ func TestFullValidatorSetPowerChange(t *testing.T) {
 	for i, amt := range amts {
 		pool := keeper.GetPool(ctx)
 		validators[i] = types.NewValidator(Addrs[i], PKs[i], types.Description{})
-		validators[i], pool, _ = validators[i].AddTokensFromDel(pool, amt)
+		validators[i], pool, _ = validators[i].AddTokensFromDel(pool, sdk.NewInt(amt))
 		keeper.SetPool(ctx, pool)
 		keeper.UpdateValidator(ctx, validators[i])
 	}
@@ -622,7 +622,7 @@ func TestFullValidatorSetPowerChange(t *testing.T) {
 
 	// test a swap in voting power
 	pool := keeper.GetPool(ctx)
-	validators[0], pool, _ = validators[0].AddTokensFromDel(pool, 600)
+	validators[0], pool, _ = validators[0].AddTokensFromDel(pool, sdk.NewInt(600))
 	keeper.SetPool(ctx, pool)
 	validators[0] = keeper.UpdateValidator(ctx, validators[0])
 	resValidators = keeper.GetValidatorsByPower(ctx)
@@ -640,7 +640,7 @@ func TestClearTendermintUpdates(t *testing.T) {
 	for i, amt := range amts {
 		pool := keeper.GetPool(ctx)
 		validators[i] = types.NewValidator(Addrs[i], PKs[i], types.Description{})
-		validators[i], pool, _ = validators[i].AddTokensFromDel(pool, amt)
+		validators[i], pool, _ = validators[i].AddTokensFromDel(pool, sdk.NewInt(amt))
 		keeper.SetPool(ctx, pool)
 		keeper.UpdateValidator(ctx, validators[i])
 	}
@@ -660,7 +660,7 @@ func TestGetTendermintUpdatesAllNone(t *testing.T) {
 	for i, amt := range amts {
 		pool := keeper.GetPool(ctx)
 		validators[i] = types.NewValidator(Addrs[i], PKs[i], types.Description{})
-		validators[i], pool, _ = validators[i].AddTokensFromDel(pool, amt)
+		validators[i], pool, _ = validators[i].AddTokensFromDel(pool, sdk.NewInt(amt))
 		keeper.SetPool(ctx, pool)
 	}
 
@@ -699,7 +699,7 @@ func TestGetTendermintUpdatesIdentical(t *testing.T) {
 	for i, amt := range amts {
 		pool := keeper.GetPool(ctx)
 		validators[i] = types.NewValidator(Addrs[i], PKs[i], types.Description{})
-		validators[i], pool, _ = validators[i].AddTokensFromDel(pool, amt)
+		validators[i], pool, _ = validators[i].AddTokensFromDel(pool, sdk.NewInt(amt))
 		keeper.SetPool(ctx, pool)
 	}
 	validators[0] = keeper.UpdateValidator(ctx, validators[0])
@@ -722,7 +722,7 @@ func TestGetTendermintUpdatesSingleValueChange(t *testing.T) {
 	for i, amt := range amts {
 		pool := keeper.GetPool(ctx)
 		validators[i] = types.NewValidator(Addrs[i], PKs[i], types.Description{})
-		validators[i], pool, _ = validators[i].AddTokensFromDel(pool, amt)
+		validators[i], pool, _ = validators[i].AddTokensFromDel(pool, sdk.NewInt(amt))
 		keeper.SetPool(ctx, pool)
 	}
 	validators[0] = keeper.UpdateValidator(ctx, validators[0])
@@ -750,7 +750,7 @@ func TestGetTendermintUpdatesMultipleValueChange(t *testing.T) {
 	for i, amt := range amts {
 		pool := keeper.GetPool(ctx)
 		validators[i] = types.NewValidator(Addrs[i], PKs[i], types.Description{})
-		validators[i], pool, _ = validators[i].AddTokensFromDel(pool, amt)
+		validators[i], pool, _ = validators[i].AddTokensFromDel(pool, sdk.NewInt(amt))
 		keeper.SetPool(ctx, pool)
 	}
 	validators[0] = keeper.UpdateValidator(ctx, validators[0])
@@ -761,8 +761,8 @@ func TestGetTendermintUpdatesMultipleValueChange(t *testing.T) {
 	// test multiple value change
 	//  tendermintUpdate set: {c1, c3} -> {c1', c3'}
 	pool := keeper.GetPool(ctx)
-	validators[0], pool, _ = validators[0].AddTokensFromDel(pool, 190)
-	validators[1], pool, _ = validators[1].AddTokensFromDel(pool, 80)
+	validators[0], pool, _ = validators[0].AddTokensFromDel(pool, sdk.NewInt(190))
+	validators[1], pool, _ = validators[1].AddTokensFromDel(pool, sdk.NewInt(80))
 	keeper.SetPool(ctx, pool)
 	validators[0] = keeper.UpdateValidator(ctx, validators[0])
 	validators[1] = keeper.UpdateValidator(ctx, validators[1])
@@ -781,7 +781,7 @@ func TestGetTendermintUpdatesInserted(t *testing.T) {
 	for i, amt := range amts {
 		pool := keeper.GetPool(ctx)
 		validators[i] = types.NewValidator(Addrs[i], PKs[i], types.Description{})
-		validators[i], pool, _ = validators[i].AddTokensFromDel(pool, amt)
+		validators[i], pool, _ = validators[i].AddTokensFromDel(pool, sdk.NewInt(amt))
 		keeper.SetPool(ctx, pool)
 	}
 	validators[0] = keeper.UpdateValidator(ctx, validators[0])
@@ -824,7 +824,7 @@ func TestGetTendermintUpdatesWithCliffValidator(t *testing.T) {
 	for i, amt := range amts {
 		pool := keeper.GetPool(ctx)
 		validators[i] = types.NewValidator(Addrs[i], PKs[i], types.Description{})
-		validators[i], pool, _ = validators[i].AddTokensFromDel(pool, amt)
+		validators[i], pool, _ = validators[i].AddTokensFromDel(pool, sdk.NewInt(amt))
 		keeper.SetPool(ctx, pool)
 	}
 	validators[0] = keeper.UpdateValidator(ctx, validators[0])
@@ -844,7 +844,7 @@ func TestGetTendermintUpdatesWithCliffValidator(t *testing.T) {
 	require.Equal(t, 0, len(keeper.GetTendermintUpdates(ctx)))
 
 	pool := keeper.GetPool(ctx)
-	validators[2], pool, _ = validators[2].AddTokensFromDel(pool, 10)
+	validators[2], pool, _ = validators[2].AddTokensFromDel(pool, sdk.NewInt(10))
 	keeper.SetPool(ctx, pool)
 	validators[2] = keeper.UpdateValidator(ctx, validators[2])
 
@@ -862,7 +862,7 @@ func TestGetTendermintUpdatesPowerDecrease(t *testing.T) {
 	for i, amt := range amts {
 		pool := keeper.GetPool(ctx)
 		validators[i] = types.NewValidator(Addrs[i], PKs[i], types.Description{})
-		validators[i], pool, _ = validators[i].AddTokensFromDel(pool, amt)
+		validators[i], pool, _ = validators[i].AddTokensFromDel(pool, sdk.NewInt(amt))
 		keeper.SetPool(ctx, pool)
 	}
 	validators[0] = keeper.UpdateValidator(ctx, validators[0])

--- a/x/stake/types/validator.go
+++ b/x/stake/types/validator.go
@@ -376,11 +376,11 @@ func (v Validator) RemoveTokens(pool Pool, tokens sdk.Dec) (Validator, Pool) {
 //_________________________________________________________________________________________________________
 
 // AddTokensFromDel adds tokens to a validator
-func (v Validator) AddTokensFromDel(pool Pool, amount int64) (Validator, Pool, sdk.Dec) {
+func (v Validator) AddTokensFromDel(pool Pool, amount sdk.Int) (Validator, Pool, sdk.Dec) {
 
 	// bondedShare/delegatedShare
 	exRate := v.DelegatorShareExRate()
-	amountDec := sdk.NewDec(amount)
+	amountDec := sdk.NewDecFromInt(amount)
 
 	if v.Status == sdk.Bonded {
 		pool = pool.looseTokensToBonded(amountDec)

--- a/x/stake/types/validator_test.go
+++ b/x/stake/types/validator_test.go
@@ -109,7 +109,7 @@ func TestAddTokensValidatorBonded(t *testing.T) {
 	pool.LooseTokens = sdk.NewDec(10)
 	validator := NewValidator(addr1, pk1, Description{})
 	validator, pool = validator.UpdateStatus(pool, sdk.Bonded)
-	validator, pool, delShares := validator.AddTokensFromDel(pool, 10)
+	validator, pool, delShares := validator.AddTokensFromDel(pool, sdk.NewInt(10))
 
 	require.Equal(t, sdk.OneDec(), validator.DelegatorShareExRate())
 
@@ -122,7 +122,7 @@ func TestAddTokensValidatorUnbonding(t *testing.T) {
 	pool.LooseTokens = sdk.NewDec(10)
 	validator := NewValidator(addr1, pk1, Description{})
 	validator, pool = validator.UpdateStatus(pool, sdk.Unbonding)
-	validator, pool, delShares := validator.AddTokensFromDel(pool, 10)
+	validator, pool, delShares := validator.AddTokensFromDel(pool, sdk.NewInt(10))
 
 	require.Equal(t, sdk.OneDec(), validator.DelegatorShareExRate())
 
@@ -136,7 +136,7 @@ func TestAddTokensValidatorUnbonded(t *testing.T) {
 	pool.LooseTokens = sdk.NewDec(10)
 	validator := NewValidator(addr1, pk1, Description{})
 	validator, pool = validator.UpdateStatus(pool, sdk.Unbonded)
-	validator, pool, delShares := validator.AddTokensFromDel(pool, 10)
+	validator, pool, delShares := validator.AddTokensFromDel(pool, sdk.NewInt(10))
 
 	require.Equal(t, sdk.OneDec(), validator.DelegatorShareExRate())
 
@@ -206,7 +206,7 @@ func TestUpdateStatus(t *testing.T) {
 	pool.LooseTokens = sdk.NewDec(100)
 
 	validator := NewValidator(addr1, pk1, Description{})
-	validator, pool, _ = validator.AddTokensFromDel(pool, 100)
+	validator, pool, _ = validator.AddTokensFromDel(pool, sdk.NewInt(100))
 	require.Equal(t, sdk.Unbonded, validator.Status)
 	require.Equal(t, int64(100), validator.Tokens.RoundInt64())
 	require.Equal(t, int64(0), pool.BondedTokens.RoundInt64())
@@ -243,7 +243,7 @@ func TestPossibleOverflow(t *testing.T) {
 	}
 	tokens := int64(71)
 	msg := fmt.Sprintf("validator %#v", validator)
-	newValidator, _, _ := validator.AddTokensFromDel(pool, tokens)
+	newValidator, _, _ := validator.AddTokensFromDel(pool, sdk.NewInt(tokens))
 
 	msg = fmt.Sprintf("Added %d tokens to %s", tokens, msg)
 	require.False(t, newValidator.DelegatorShareExRate().LT(sdk.ZeroDec()),


### PR DESCRIPTION
Now when we delegate out token, we have to conver token amount from sdk.Int to int64.
```
validator, pool, newShares = validator.AddTokensFromDel(pool, bondAmt.Amount.Int64())
```
```
// AddTokensFromDel adds tokens to a validator
func (v Validator) AddTokensFromDel(pool Pool, amount int64) (Validator, Pool, sdk.Dec) {
```

However, I think this is not reasonable. Because this may take a risk of overflow. Besides, using int64 as amount in AddTokensFromDel is weird, we just do a weird data type covertion:
```
sdk.Int -> int64 -> sdk.Dec
```
```
type Int struct {
	i *big.Int
}
```
```
type Dec struct {
	*big.Int `json:"int"`
}
```
Both sdk.Int and sdk.Dec are big int. Why we need to truncate amount from sdk.Int to int64 and extend to sdk.Dec again?