### PR TITLE
CI: Make CI not update the lock file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ jobs:
           name: dependencies
           command: |
             export PATH="$GOBIN:$PATH"
-            make get_vendor_deps_ci
+            make get_vendor_deps
       - run:
           name: binaries
           command: |
@@ -51,7 +51,7 @@ jobs:
           name: dependencies
           command: |
             export PATH="$GOBIN:$PATH"
-            make get_vendor_deps_ci
+            make get_vendor_deps
       - run:
           name: Get metalinter
           command: |
@@ -74,7 +74,7 @@ jobs:
           name: dependencies
           command: |
             export PATH="$GOBIN:$PATH"
-            make get_vendor_deps_ci
+            make get_vendor_deps
       - run:
           name: Test cli
           command: |
@@ -93,7 +93,7 @@ jobs:
           name: dependencies
           command: |
             export PATH="$GOBIN:$PATH"
-            make get_vendor_deps_ci
+            make get_vendor_deps
       - run:
           name: Test individual module simulations
           command: |
@@ -111,7 +111,7 @@ jobs:
           name: dependencies
           command: |
             export PATH="$GOBIN:$PATH"
-            make get_vendor_deps_ci
+            make get_vendor_deps
       - run:
           name: Test individual module simulations
           command: |
@@ -129,7 +129,7 @@ jobs:
           name: dependencies
           command: |
             export PATH="$GOBIN:$PATH"
-            make get_vendor_deps_ci
+            make get_vendor_deps
       - run:
           name: Test full Gaia simulation
           command: |
@@ -147,7 +147,7 @@ jobs:
           name: dependencies
           command: |
             export PATH="$GOBIN:$PATH"
-            make get_vendor_deps_ci
+            make get_vendor_deps
       - run: mkdir -p /tmp/logs
       - run:
           name: Run tests
@@ -176,7 +176,7 @@ jobs:
           name: dependencies
           command: |
             export PATH="$GOBIN:$PATH"
-            make get_vendor_deps_ci
+            make get_vendor_deps
       - run:
           name: gather
           command: |
@@ -207,7 +207,7 @@ jobs:
             command: |
               set -x
               make get_tools
-              make get_vendor_deps_ci
+              make get_vendor_deps
               make build-linux
               make localnet-start
               ./scripts/localnet-blocks-test.sh 40 5 10 localhost

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ jobs:
           name: dependencies
           command: |
             export PATH="$GOBIN:$PATH"
-            make get_vendor_deps
+            make get_vendor_deps_ci
       - run:
           name: binaries
           command: |
@@ -51,7 +51,7 @@ jobs:
           name: dependencies
           command: |
             export PATH="$GOBIN:$PATH"
-            make get_vendor_deps
+            make get_vendor_deps_ci
       - run:
           name: Get metalinter
           command: |
@@ -74,7 +74,7 @@ jobs:
           name: dependencies
           command: |
             export PATH="$GOBIN:$PATH"
-            make get_vendor_deps
+            make get_vendor_deps_ci
       - run:
           name: Test cli
           command: |
@@ -93,7 +93,7 @@ jobs:
           name: dependencies
           command: |
             export PATH="$GOBIN:$PATH"
-            make get_vendor_deps
+            make get_vendor_deps_ci
       - run:
           name: Test individual module simulations
           command: |
@@ -111,7 +111,7 @@ jobs:
           name: dependencies
           command: |
             export PATH="$GOBIN:$PATH"
-            make get_vendor_deps
+            make get_vendor_deps_ci
       - run:
           name: Test individual module simulations
           command: |
@@ -129,7 +129,7 @@ jobs:
           name: dependencies
           command: |
             export PATH="$GOBIN:$PATH"
-            make get_vendor_deps
+            make get_vendor_deps_ci
       - run:
           name: Test full Gaia simulation
           command: |
@@ -147,7 +147,7 @@ jobs:
           name: dependencies
           command: |
             export PATH="$GOBIN:$PATH"
-            make get_vendor_deps
+            make get_vendor_deps_ci
       - run: mkdir -p /tmp/logs
       - run:
           name: Run tests
@@ -176,7 +176,7 @@ jobs:
           name: dependencies
           command: |
             export PATH="$GOBIN:$PATH"
-            make get_vendor_deps
+            make get_vendor_deps_ci
       - run:
           name: gather
           command: |
@@ -207,7 +207,7 @@ jobs:
             command: |
               set -x
               make get_tools
-              make get_vendor_deps
+              make get_vendor_deps_ci
               make build-linux
               make localnet-start
               ./scripts/localnet-blocks-test.sh 40 5 10 localhost

--- a/Makefile
+++ b/Makefile
@@ -106,14 +106,14 @@ get_dev_tools:
 	cd tools && $(MAKE) get_dev_tools
 
 get_vendor_deps:
+	@echo "--> Generating vendor directory via dep ensure"
+	@rm -rf .vendor-new
+	@dep ensure -v -vendor-only
+
+update_vendor_deps:
 	@echo "--> Running dep ensure"
 	@rm -rf .vendor-new
 	@dep ensure -v
-
-get_vendor_deps_ci:
-	@echo "--> Running dep ensure"
-	@rm -rf .vendor-new
-	@dep ensure -v -vendor-only
 
 draw_deps:
 	@# requires brew install graphviz or apt-get install graphviz

--- a/Makefile
+++ b/Makefile
@@ -110,6 +110,11 @@ get_vendor_deps:
 	@rm -rf .vendor-new
 	@dep ensure -v
 
+get_vendor_deps_ci:
+	@echo "--> Running dep ensure"
+	@rm -rf .vendor-new
+	@dep ensure -v -vendor-only
+
 draw_deps:
 	@# requires brew install graphviz or apt-get install graphviz
 	go get github.com/RobotsAndPencils/goviz

--- a/PENDING.md
+++ b/PENDING.md
@@ -12,6 +12,7 @@ BREAKING CHANGES
     * [cli] \#1983 you can now pass --pubkey or --address to gaiacli keys show to return a plaintext representation of the key's address or public key for use with other commands
     * [cli] \#2061 changed proposalID in governance REST endpoints to proposal-id
     * [cli] \#2014 `gaiacli advanced` no longer exists - to access `ibc`, `rest-server`, and `validator-set` commands use `gaiacli ibc`, `gaiacli rest-server`, and `gaiacli tendermint`, respectively
+    * [makefile] `get_vendor_deps` no longer updates lock file it just updates vendor directory. Use `update_vendor_deps` to update the lock file. [#2152](https://github.com/cosmos/cosmos-sdk/pull/2152)
 
 * Gaia
     * Make the transient store key use a distinct store key. [#2013](https://github.com/cosmos/cosmos-sdk/pull/2013)


### PR DESCRIPTION
We want CI to be running the lock in the repo, not generating a new one.
Linting ensures that the lock file is up to date, so thats not a concern here.

I hope that this will prevent the upload_coverage error in https://circleci.com/gh/cosmos/cosmos-sdk/24023 from happening again.
I believe we discussed doing this previously @cwgoes. 
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/develop/CONTRIBUTING.md#pr-targeting))

- [ ] Added entries in `PENDING.md` with issue #  - I don't think CI changes are relevant to anyone reading our changelog

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
