### PR TITLE
R4R: Implement generate-only option for commands that create txs

### DIFF
--- a/PENDING.md
+++ b/PENDING.md
@@ -44,6 +44,7 @@ FEATURES
 * Gaia REST API (`gaiacli advanced rest-server`)
   * [lcd] Endpoints to query staking pool and params
   * [lcd] \#2110 Add support for `simulate=true` requests query argument to endpoints that send txs to run simulations of transactions
+  * [lcd] \#966 Add support for `generate_only=true` query argument to generate offline unsigned transactions
 
 * Gaia CLI  (`gaiacli`)
   * [cli] Cmds to query staking pool and params

--- a/PENDING.md
+++ b/PENDING.md
@@ -53,6 +53,7 @@ FEATURES
   * [cli] \#2047 Setting the --gas flag value to 0 triggers a simulation of the tx before the actual execution. The gas estimate obtained via the simulation will be used as gas limit in the actual execution.
   * [cli] \#2047 The --gas-adjustment flag can be used to adjust the estimate obtained via the simulation triggered by --gas=0.
   * [cli] \#2110 Add --dry-run flag to perform a simulation of a transaction without broadcasting it. The --gas flag is ignored as gas would be automatically estimated.
+  * [cli] \#966 Add --generate-only flag to build an unsigned transaction and write it to STDOUT.
 
 * Gaia
   * [cli] #2170 added ability to show the node's address via `gaiad tendermint show-address`

--- a/client/context/context.go
+++ b/client/context/context.go
@@ -3,10 +3,11 @@ package context
 import (
 	"bytes"
 	"fmt"
+	"io"
+
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/wire"
 	"github.com/cosmos/cosmos-sdk/x/auth"
-	"io"
 
 	"github.com/spf13/viper"
 
@@ -38,6 +39,7 @@ type CLIContext struct {
 	PrintResponse   bool
 	Certifier       tmlite.Certifier
 	DryRun          bool
+	GenerateOnly    bool
 }
 
 // NewCLIContext returns a new initialized CLIContext with parameters from the
@@ -65,6 +67,7 @@ func NewCLIContext() CLIContext {
 		PrintResponse:   viper.GetBool(client.FlagPrintResponse),
 		Certifier:       createCertifier(),
 		DryRun:          viper.GetBool(client.FlagDryRun),
+		GenerateOnly:    viper.GetBool(client.FlagGenerateOnly),
 	}
 }
 

--- a/client/flags.go
+++ b/client/flags.go
@@ -27,6 +27,7 @@ const (
 	FlagJson          = "json"
 	FlagPrintResponse = "print-response"
 	FlagDryRun        = "dry-run"
+	FlagGenerateOnly  = "generate-only"
 )
 
 // LineBreak can be included in a command list to provide a blank line
@@ -64,6 +65,7 @@ func PostCommands(cmds ...*cobra.Command) []*cobra.Command {
 		c.Flags().Bool(FlagPrintResponse, true, "return tx response (only works with async = false)")
 		c.Flags().Bool(FlagTrustNode, true, "Don't verify proofs for query responses")
 		c.Flags().Bool(FlagDryRun, false, "ignore the --gas flag and perform a simulation of a transaction, but don't broadcast it")
+		c.Flags().Bool(FlagGenerateOnly, false, "build an unsigned transaction and write it to STDOUT")
 	}
 	return cmds
 }

--- a/client/lcd/lcd_test.go
+++ b/client/lcd/lcd_test.go
@@ -326,6 +326,7 @@ func TestCoinSendGenerateOnly(t *testing.T) {
 	require.Equal(t, len(msg.Msgs), 1)
 	require.Equal(t, msg.Msgs[0].Type(), "bank")
 	require.Equal(t, msg.Msgs[0].GetSigners(), []sdk.AccAddress{addr})
+	require.Equal(t, 0, len(msg.Signatures))
 }
 
 func TestTxs(t *testing.T) {

--- a/client/lcd/lcd_test.go
+++ b/client/lcd/lcd_test.go
@@ -313,6 +313,21 @@ func TestIBCTransfer(t *testing.T) {
 	// TODO: query ibc egress packet state
 }
 
+func TestCoinSendGenerateOnly(t *testing.T) {
+	name, password := "test", "1234567890"
+	addr, seed := CreateAddr(t, "test", password, GetKeyBase(t))
+	cleanup, _, port := InitializeTestLCD(t, 1, []sdk.AccAddress{addr})
+	defer cleanup()
+	// create TX
+	res, body, _ := doSendWithGas(t, port, seed, name, password, addr, 0, 0, "?generate_only=true")
+	require.Equal(t, http.StatusOK, res.StatusCode, body)
+	var msg auth.StdTx
+	require.Nil(t, cdc.UnmarshalJSON([]byte(body), &msg))
+	require.Equal(t, len(msg.Msgs), 1)
+	require.Equal(t, msg.Msgs[0].Type(), "bank")
+	require.Equal(t, msg.Msgs[0].GetSigners(), []sdk.AccAddress{addr})
+}
+
 func TestTxs(t *testing.T) {
 	name, password := "test", "1234567890"
 	addr, seed := CreateAddr(t, "test", password, GetKeyBase(t))

--- a/cmd/gaia/cli_test/cli_test.go
+++ b/cmd/gaia/cli_test/cli_test.go
@@ -164,6 +164,7 @@ func TestGaiaCLICreateValidator(t *testing.T) {
 	msg := unmarshalStdTx(t, stdout)
 	require.NotZero(t, msg.Fee.Gas)
 	require.Equal(t, len(msg.Msgs), 1)
+	require.Equal(t, 0, len(msg.GetSignatures()))
 
 	// Test --dry-run
 	success = executeWrite(t, cvStr+" --dry-run", app.DefaultKeyPass)
@@ -240,6 +241,7 @@ func TestGaiaCLISubmitProposal(t *testing.T) {
 	msg := unmarshalStdTx(t, stdout)
 	require.NotZero(t, msg.Fee.Gas)
 	require.Equal(t, len(msg.Msgs), 1)
+	require.Equal(t, 0, len(msg.GetSignatures()))
 
 	// Test --dry-run
 	success = executeWrite(t, spStr+" --dry-run", app.DefaultKeyPass)
@@ -271,6 +273,7 @@ func TestGaiaCLISubmitProposal(t *testing.T) {
 	msg = unmarshalStdTx(t, stdout)
 	require.NotZero(t, msg.Fee.Gas)
 	require.Equal(t, len(msg.Msgs), 1)
+	require.Equal(t, 0, len(msg.GetSignatures()))
 
 	executeWrite(t, depositStr, app.DefaultKeyPass)
 	tests.WaitForNextNBlocksTM(2, port)
@@ -294,6 +297,7 @@ func TestGaiaCLISubmitProposal(t *testing.T) {
 	msg = unmarshalStdTx(t, stdout)
 	require.NotZero(t, msg.Fee.Gas)
 	require.Equal(t, len(msg.Msgs), 1)
+	require.Equal(t, 0, len(msg.GetSignatures()))
 
 	executeWrite(t, voteStr, app.DefaultKeyPass)
 	tests.WaitForNextNBlocksTM(2, port)
@@ -350,6 +354,7 @@ func TestGaiaCLISendGenerateOnly(t *testing.T) {
 	msg := unmarshalStdTx(t, stdout)
 	require.Equal(t, msg.Fee.Gas, int64(client.DefaultGasLimit))
 	require.Equal(t, len(msg.Msgs), 1)
+	require.Equal(t, 0, len(msg.GetSignatures()))
 
 	// Test generate sendTx, estimate gas
 	success, stdout, stderr = executeWriteRetStdStreams(t, fmt.Sprintf(
@@ -370,6 +375,7 @@ func TestGaiaCLISendGenerateOnly(t *testing.T) {
 	msg = unmarshalStdTx(t, stdout)
 	require.Equal(t, msg.Fee.Gas, int64(100))
 	require.Equal(t, len(msg.Msgs), 1)
+	require.Equal(t, 0, len(msg.GetSignatures()))
 }
 
 //___________________________________________________________________________________

--- a/cmd/gaia/cli_test/cli_test.go
+++ b/cmd/gaia/cli_test/cli_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/tendermint/tendermint/crypto"
 	cmn "github.com/tendermint/tendermint/libs/common"
 
+	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/keys"
 	"github.com/cosmos/cosmos-sdk/cmd/gaia/app"
 	"github.com/cosmos/cosmos-sdk/server"
@@ -155,8 +156,17 @@ func TestGaiaCLICreateValidator(t *testing.T) {
 
 	initialPool.BondedTokens = initialPool.BondedTokens.Add(sdk.NewDec(1))
 
+	// Test --generate-only
+	success, stdout, stderr := executeWriteRetStdStreams(t, cvStr+" --generate-only", app.DefaultKeyPass)
+	require.True(t, success)
+	require.True(t, success)
+	require.Empty(t, stderr)
+	msg := unmarshalStdTx(t, stdout)
+	require.NotZero(t, msg.Fee.Gas)
+	require.Equal(t, len(msg.Msgs), 1)
+
 	// Test --dry-run
-	success := executeWrite(t, cvStr+" --dry-run", app.DefaultKeyPass)
+	success = executeWrite(t, cvStr+" --dry-run", app.DefaultKeyPass)
 	require.True(t, success)
 
 	executeWrite(t, cvStr, app.DefaultKeyPass)
@@ -222,8 +232,17 @@ func TestGaiaCLISubmitProposal(t *testing.T) {
 	spStr += fmt.Sprintf(" --title=%s", "Test")
 	spStr += fmt.Sprintf(" --description=%s", "test")
 
+	// Test generate only
+	success, stdout, stderr := executeWriteRetStdStreams(t, spStr+" --generate-only", app.DefaultKeyPass)
+	require.True(t, success)
+	require.True(t, success)
+	require.Empty(t, stderr)
+	msg := unmarshalStdTx(t, stdout)
+	require.NotZero(t, msg.Fee.Gas)
+	require.Equal(t, len(msg.Msgs), 1)
+
 	// Test --dry-run
-	success := executeWrite(t, spStr+" --dry-run", app.DefaultKeyPass)
+	success = executeWrite(t, spStr+" --dry-run", app.DefaultKeyPass)
 	require.True(t, success)
 
 	executeWrite(t, spStr, app.DefaultKeyPass)
@@ -244,6 +263,15 @@ func TestGaiaCLISubmitProposal(t *testing.T) {
 	depositStr += fmt.Sprintf(" --deposit=%s", "10steak")
 	depositStr += fmt.Sprintf(" --proposal-id=%s", "1")
 
+	// Test generate only
+	success, stdout, stderr = executeWriteRetStdStreams(t, depositStr+" --generate-only", app.DefaultKeyPass)
+	require.True(t, success)
+	require.True(t, success)
+	require.Empty(t, stderr)
+	msg = unmarshalStdTx(t, stdout)
+	require.NotZero(t, msg.Fee.Gas)
+	require.Equal(t, len(msg.Msgs), 1)
+
 	executeWrite(t, depositStr, app.DefaultKeyPass)
 	tests.WaitForNextNBlocksTM(2, port)
 
@@ -257,6 +285,15 @@ func TestGaiaCLISubmitProposal(t *testing.T) {
 	voteStr += fmt.Sprintf(" --from=%s", "foo")
 	voteStr += fmt.Sprintf(" --proposal-id=%s", "1")
 	voteStr += fmt.Sprintf(" --option=%s", "Yes")
+
+	// Test generate only
+	success, stdout, stderr = executeWriteRetStdStreams(t, voteStr+" --generate-only", app.DefaultKeyPass)
+	require.True(t, success)
+	require.True(t, success)
+	require.Empty(t, stderr)
+	msg = unmarshalStdTx(t, stdout)
+	require.NotZero(t, msg.Fee.Gas)
+	require.Equal(t, len(msg.Msgs), 1)
 
 	executeWrite(t, voteStr, app.DefaultKeyPass)
 	tests.WaitForNextNBlocksTM(2, port)
@@ -291,6 +328,50 @@ func TestGaiaCLISubmitProposal(t *testing.T) {
 	require.Equal(t, "  2 - Apples", proposalsQuery)
 }
 
+func TestGaiaCLISendGenerateOnly(t *testing.T) {
+	chainID, servAddr, port := initializeFixtures(t)
+	flags := fmt.Sprintf("--home=%s --node=%v --chain-id=%v", gaiacliHome, servAddr, chainID)
+
+	// start gaiad server
+	proc := tests.GoExecuteTWithStdout(t, fmt.Sprintf("gaiad start --home=%s --rpc.laddr=%v", gaiadHome, servAddr))
+
+	defer proc.Stop(false)
+	tests.WaitForTMStart(port)
+	tests.WaitForNextNBlocksTM(2, port)
+
+	barAddr, _ := executeGetAddrPK(t, fmt.Sprintf("gaiacli keys show bar --output=json --home=%s", gaiacliHome))
+
+	// Test generate sendTx with default gas
+	success, stdout, stderr := executeWriteRetStdStreams(t, fmt.Sprintf(
+		"gaiacli send %v --amount=10steak --to=%s --from=foo --generate-only",
+		flags, barAddr), []string{}...)
+	require.True(t, success)
+	require.Empty(t, stderr)
+	msg := unmarshalStdTx(t, stdout)
+	require.Equal(t, msg.Fee.Gas, int64(client.DefaultGasLimit))
+	require.Equal(t, len(msg.Msgs), 1)
+
+	// Test generate sendTx, estimate gas
+	success, stdout, stderr = executeWriteRetStdStreams(t, fmt.Sprintf(
+		"gaiacli send %v --amount=10steak --to=%s --from=foo --gas=0 --generate-only",
+		flags, barAddr), []string{}...)
+	require.True(t, success)
+	require.NotEmpty(t, stderr)
+	msg = unmarshalStdTx(t, stdout)
+	require.NotZero(t, msg.Fee.Gas)
+	require.Equal(t, len(msg.Msgs), 1)
+
+	// Test generate sendTx with --gas=$amount
+	success, stdout, stderr = executeWriteRetStdStreams(t, fmt.Sprintf(
+		"gaiacli send %v --amount=10steak --to=%s --from=foo --gas=100 --generate-only",
+		flags, barAddr), []string{}...)
+	require.True(t, success)
+	require.Empty(t, stderr)
+	msg = unmarshalStdTx(t, stdout)
+	require.Equal(t, msg.Fee.Gas, int64(100))
+	require.Equal(t, len(msg.Msgs), 1)
+}
+
 //___________________________________________________________________________________
 // helper methods
 
@@ -312,6 +393,12 @@ func initializeFixtures(t *testing.T) (chainID, servAddr, port string) {
 	// get a free port, also setup some common flags
 	servAddr, port, err := server.FreeTCPAddr()
 	require.NoError(t, err)
+	return
+}
+
+func unmarshalStdTx(t *testing.T, s string) (stdTx auth.StdTx) {
+	cdc := app.MakeCodec()
+	require.Nil(t, cdc.UnmarshalJSON([]byte(s), &stdTx))
 	return
 }
 

--- a/crypto/keys/keybase.go
+++ b/crypto/keys/keybase.go
@@ -224,9 +224,9 @@ func (kb dbKeybase) Sign(name, passphrase string, msg []byte) (sig []byte, pub t
 		}
 	case offlineInfo:
 		linfo := info.(offlineInfo)
-		fmt.Printf("Bytes to sign:\n%s", msg)
+		fmt.Fprintf(os.Stderr, "Bytes to sign:\n%s", msg)
 		buf := bufio.NewReader(os.Stdin)
-		fmt.Printf("\nEnter Amino-encoded signature:\n")
+		fmt.Fprintf(os.Stderr, "\nEnter Amino-encoded signature:\n")
 		// Will block until user inputs the signature
 		signed, err := buf.ReadString('\n')
 		if err != nil {

--- a/docs/sdk/clients.md
+++ b/docs/sdk/clients.md
@@ -139,6 +139,17 @@ gaiacli send \
   --dry-run
 ```
 
+Furthermore, you can build a transaction and print its JSON format to STDOUT by appending `--generate-only` to the list of the command line arguments:
+
+```bash
+gaiacli send \
+  --amount=10faucetToken \
+  --chain-id=<chain_id> \
+  --name=<key_name> \
+  --to=<destination_cosmosaccaddr> \
+  --generate-only
+```
+
 ### Staking
 
 #### Set up a Validator

--- a/x/auth/stdtx.go
+++ b/x/auth/stdtx.go
@@ -143,12 +143,12 @@ func StdSignBytes(chainID string, accnum int64, sequence int64, fee StdFee, msgs
 // a Msg with the other requirements for a StdSignDoc before
 // it is signed. For use in the CLI.
 type StdSignMsg struct {
-	ChainID       string
-	AccountNumber int64
-	Sequence      int64
-	Fee           StdFee
-	Msgs          []sdk.Msg
-	Memo          string
+	ChainID       string    `json:"chain_id"`
+	AccountNumber int64     `json:"account_number"`
+	Sequence      int64     `json:"sequence"`
+	Fee           StdFee    `json:"fee"`
+	Msgs          []sdk.Msg `json:"msgs"`
+	Memo          string    `json:"memo"`
 }
 
 // get message bytes

--- a/x/bank/client/cli/sendtx.go
+++ b/x/bank/client/cli/sendtx.go
@@ -68,6 +68,9 @@ func SendTxCmd(cdc *wire.Codec) *cobra.Command {
 
 			// build and sign the transaction, then broadcast to Tendermint
 			msg := client.BuildMsg(from, to, coins)
+			if cliCtx.GenerateOnly {
+				return utils.PrintUnsignedStdTx(txCtx, cliCtx, []sdk.Msg{msg})
+			}
 
 			return utils.SendTx(txCtx, cliCtx, []sdk.Msg{msg})
 		},

--- a/x/bank/client/rest/sendtx.go
+++ b/x/bank/client/rest/sendtx.go
@@ -107,6 +107,11 @@ func SendRequestHandlerFn(cdc *wire.Codec, kb keys.Keybase, cliCtx context.CLICo
 			txCtx = newCtx
 		}
 
+		if utils.HasGenerateOnlyArg(r) {
+			utils.WriteGenerateStdTxResponse(w, txCtx, []sdk.Msg{msg})
+			return
+		}
+
 		txBytes, err := txCtx.BuildAndSign(m.LocalAccountName, m.Password, []sdk.Msg{msg})
 		if err != nil {
 			utils.WriteErrorResponse(w, http.StatusUnauthorized, err.Error())

--- a/x/gov/client/cli/tx.go
+++ b/x/gov/client/cli/tx.go
@@ -99,6 +99,9 @@ $ gaiacli gov submit-proposal --title="Test Proposal" --description="My awesome 
 			}
 
 			msg := gov.NewMsgSubmitProposal(proposal.Title, proposal.Description, proposalType, fromAddr, amount)
+			if cliCtx.GenerateOnly {
+				return utils.PrintUnsignedStdTx(txCtx, cliCtx, []sdk.Msg{msg})
+			}
 
 			err = msg.ValidateBasic()
 			if err != nil {
@@ -177,7 +180,9 @@ func GetCmdDeposit(cdc *wire.Codec) *cobra.Command {
 			}
 
 			msg := gov.NewMsgDeposit(depositerAddr, proposalID, amount)
-
+			if cliCtx.GenerateOnly {
+				return utils.PrintUnsignedStdTx(txCtx, cliCtx, []sdk.Msg{msg})
+			}
 			err = msg.ValidateBasic()
 			if err != nil {
 				return err
@@ -221,7 +226,9 @@ func GetCmdVote(cdc *wire.Codec) *cobra.Command {
 			}
 
 			msg := gov.NewMsgVote(voterAddr, proposalID, byteVoteOption)
-
+			if cliCtx.GenerateOnly {
+				return utils.PrintUnsignedStdTx(txCtx, cliCtx, []sdk.Msg{msg})
+			}
 			err = msg.ValidateBasic()
 			if err != nil {
 				return err

--- a/x/gov/client/cli/tx.go
+++ b/x/gov/client/cli/tx.go
@@ -99,13 +99,13 @@ $ gaiacli gov submit-proposal --title="Test Proposal" --description="My awesome 
 			}
 
 			msg := gov.NewMsgSubmitProposal(proposal.Title, proposal.Description, proposalType, fromAddr, amount)
-			if cliCtx.GenerateOnly {
-				return utils.PrintUnsignedStdTx(txCtx, cliCtx, []sdk.Msg{msg})
-			}
-
 			err = msg.ValidateBasic()
 			if err != nil {
 				return err
+			}
+
+			if cliCtx.GenerateOnly {
+				return utils.PrintUnsignedStdTx(txCtx, cliCtx, []sdk.Msg{msg})
 			}
 
 			// Build and sign the transaction, then broadcast to Tendermint
@@ -180,12 +180,13 @@ func GetCmdDeposit(cdc *wire.Codec) *cobra.Command {
 			}
 
 			msg := gov.NewMsgDeposit(depositerAddr, proposalID, amount)
-			if cliCtx.GenerateOnly {
-				return utils.PrintUnsignedStdTx(txCtx, cliCtx, []sdk.Msg{msg})
-			}
 			err = msg.ValidateBasic()
 			if err != nil {
 				return err
+			}
+
+			if cliCtx.GenerateOnly {
+				return utils.PrintUnsignedStdTx(txCtx, cliCtx, []sdk.Msg{msg})
 			}
 
 			// Build and sign the transaction, then broadcast to a Tendermint
@@ -226,12 +227,13 @@ func GetCmdVote(cdc *wire.Codec) *cobra.Command {
 			}
 
 			msg := gov.NewMsgVote(voterAddr, proposalID, byteVoteOption)
-			if cliCtx.GenerateOnly {
-				return utils.PrintUnsignedStdTx(txCtx, cliCtx, []sdk.Msg{msg})
-			}
 			err = msg.ValidateBasic()
 			if err != nil {
 				return err
+			}
+
+			if cliCtx.GenerateOnly {
+				return utils.PrintUnsignedStdTx(txCtx, cliCtx, []sdk.Msg{msg})
 			}
 
 			fmt.Printf("Vote[Voter:%s,ProposalID:%d,Option:%s]",

--- a/x/gov/client/rest/util.go
+++ b/x/gov/client/rest/util.go
@@ -96,6 +96,12 @@ func signAndBuild(w http.ResponseWriter, r *http.Request, cliCtx context.CLICont
 		}
 		txCtx = newCtx
 	}
+
+	if utils.HasGenerateOnlyArg(r) {
+		utils.WriteGenerateStdTxResponse(w, txCtx, []sdk.Msg{msg})
+		return
+	}
+
 	txBytes, err := txCtx.BuildAndSign(baseReq.Name, baseReq.Password, []sdk.Msg{msg})
 	if err != nil {
 		utils.WriteErrorResponse(w, http.StatusUnauthorized, err.Error())

--- a/x/gov/msgs.go
+++ b/x/gov/msgs.go
@@ -12,11 +12,11 @@ const MsgType = "gov"
 //-----------------------------------------------------------
 // MsgSubmitProposal
 type MsgSubmitProposal struct {
-	Title          string         //  Title of the proposal
-	Description    string         //  Description of the proposal
-	ProposalType   ProposalKind   //  Type of proposal. Initial set {PlainTextProposal, SoftwareUpgradeProposal}
-	Proposer       sdk.AccAddress //  Address of the proposer
-	InitialDeposit sdk.Coins      //  Initial deposit paid by sender. Must be strictly positive.
+	Title          string         `json:"title"`           //  Title of the proposal
+	Description    string         `json:"description"`     //  Description of the proposal
+	ProposalType   ProposalKind   `json:"proposal_type"`   //  Type of proposal. Initial set {PlainTextProposal, SoftwareUpgradeProposal}
+	Proposer       sdk.AccAddress `json:"proposer"`        //  Address of the proposer
+	InitialDeposit sdk.Coins      `json:"initial_deposit"` //  Initial deposit paid by sender. Must be strictly positive.
 }
 
 func NewMsgSubmitProposal(title string, description string, proposalType ProposalKind, proposer sdk.AccAddress, initialDeposit sdk.Coins) MsgSubmitProposal {

--- a/x/ibc/client/cli/ibctx.go
+++ b/x/ibc/client/cli/ibctx.go
@@ -43,6 +43,9 @@ func IBCTransferCmd(cdc *wire.Codec) *cobra.Command {
 			if err != nil {
 				return err
 			}
+			if cliCtx.GenerateOnly {
+				return utils.PrintUnsignedStdTx(txCtx, cliCtx, []sdk.Msg{msg})
+			}
 
 			return utils.SendTx(txCtx, cliCtx, []sdk.Msg{msg})
 		},

--- a/x/ibc/client/rest/transfer.go
+++ b/x/ibc/client/rest/transfer.go
@@ -98,6 +98,11 @@ func TransferRequestHandlerFn(cdc *wire.Codec, kb keys.Keybase, cliCtx context.C
 			txCtx = newCtx
 		}
 
+		if utils.HasGenerateOnlyArg(r) {
+			utils.WriteGenerateStdTxResponse(w, txCtx, []sdk.Msg{msg})
+			return
+		}
+
 		txBytes, err := txCtx.BuildAndSign(m.LocalAccountName, m.Password, []sdk.Msg{msg})
 		if err != nil {
 			utils.WriteErrorResponse(w, http.StatusUnauthorized, err.Error())

--- a/x/ibc/types.go
+++ b/x/ibc/types.go
@@ -22,11 +22,11 @@ func init() {
 // IBCPacket defines a piece of data that can be send between two separate
 // blockchains.
 type IBCPacket struct {
-	SrcAddr   sdk.AccAddress
-	DestAddr  sdk.AccAddress
-	Coins     sdk.Coins
-	SrcChain  string
-	DestChain string
+	SrcAddr   sdk.AccAddress `json:"src_addr"`
+	DestAddr  sdk.AccAddress `json:"dest_addr"`
+	Coins     sdk.Coins      `json:"coins"`
+	SrcChain  string         `json:"src_chain"`
+	DestChain string         `json:"dest_chain"`
 }
 
 func NewIBCPacket(srcAddr sdk.AccAddress, destAddr sdk.AccAddress, coins sdk.Coins,

--- a/x/slashing/client/cli/tx.go
+++ b/x/slashing/client/cli/tx.go
@@ -33,7 +33,9 @@ func GetCmdUnjail(cdc *wire.Codec) *cobra.Command {
 			}
 
 			msg := slashing.NewMsgUnjail(sdk.ValAddress(valAddr))
-
+			if cliCtx.GenerateOnly {
+				return utils.PrintUnsignedStdTx(txCtx, cliCtx, []sdk.Msg{msg})
+			}
 			return utils.SendTx(txCtx, cliCtx, []sdk.Msg{msg})
 		},
 	}

--- a/x/slashing/client/rest/tx.go
+++ b/x/slashing/client/rest/tx.go
@@ -99,6 +99,11 @@ func unjailRequestHandlerFn(cdc *wire.Codec, kb keys.Keybase, cliCtx context.CLI
 			txCtx = newCtx
 		}
 
+		if utils.HasGenerateOnlyArg(r) {
+			utils.WriteGenerateStdTxResponse(w, txCtx, []sdk.Msg{msg})
+			return
+		}
+
 		txBytes, err := txCtx.BuildAndSign(m.LocalAccountName, m.Password, []sdk.Msg{msg})
 		if err != nil {
 			utils.WriteErrorResponse(w, http.StatusUnauthorized, "Must use own validator address")

--- a/x/stake/client/cli/tx.go
+++ b/x/stake/client/cli/tx.go
@@ -77,7 +77,9 @@ func GetCmdCreateValidator(cdc *wire.Codec) *cobra.Command {
 			} else {
 				msg = stake.NewMsgCreateValidator(sdk.ValAddress(valAddr), pk, amount, description)
 			}
-
+			if cliCtx.GenerateOnly {
+				return utils.PrintUnsignedStdTx(txCtx, cliCtx, []sdk.Msg{msg})
+			}
 			// build and sign the transaction, then broadcast to Tendermint
 			return utils.SendTx(txCtx, cliCtx, []sdk.Msg{msg})
 		},
@@ -117,6 +119,9 @@ func GetCmdEditValidator(cdc *wire.Codec) *cobra.Command {
 
 			msg := stake.NewMsgEditValidator(sdk.ValAddress(valAddr), description)
 
+			if cliCtx.GenerateOnly {
+				return utils.PrintUnsignedStdTx(txCtx, cliCtx, []sdk.Msg{msg})
+			}
 			// build and sign the transaction, then broadcast to Tendermint
 			return utils.SendTx(txCtx, cliCtx, []sdk.Msg{msg})
 		},
@@ -156,6 +161,9 @@ func GetCmdDelegate(cdc *wire.Codec) *cobra.Command {
 
 			msg := stake.NewMsgDelegate(delAddr, valAddr, amount)
 
+			if cliCtx.GenerateOnly {
+				return utils.PrintUnsignedStdTx(txCtx, cliCtx, []sdk.Msg{msg})
+			}
 			// build and sign the transaction, then broadcast to Tendermint
 			return utils.SendTx(txCtx, cliCtx, []sdk.Msg{msg})
 		},
@@ -225,6 +233,9 @@ func GetCmdBeginRedelegate(storeName string, cdc *wire.Codec) *cobra.Command {
 
 			msg := stake.NewMsgBeginRedelegate(delAddr, valSrcAddr, valDstAddr, sharesAmount)
 
+			if cliCtx.GenerateOnly {
+				return utils.PrintUnsignedStdTx(txCtx, cliCtx, []sdk.Msg{msg})
+			}
 			// build and sign the transaction, then broadcast to Tendermint
 			return utils.SendTx(txCtx, cliCtx, []sdk.Msg{msg})
 		},
@@ -313,6 +324,9 @@ func GetCmdCompleteRedelegate(cdc *wire.Codec) *cobra.Command {
 
 			msg := stake.NewMsgCompleteRedelegate(delAddr, valSrcAddr, valDstAddr)
 
+			if cliCtx.GenerateOnly {
+				return utils.PrintUnsignedStdTx(txCtx, cliCtx, []sdk.Msg{msg})
+			}
 			// build and sign the transaction, then broadcast to Tendermint
 			return utils.SendTx(txCtx, cliCtx, []sdk.Msg{msg})
 		},
@@ -374,6 +388,9 @@ func GetCmdBeginUnbonding(storeName string, cdc *wire.Codec) *cobra.Command {
 
 			msg := stake.NewMsgBeginUnbonding(delAddr, valAddr, sharesAmount)
 
+			if cliCtx.GenerateOnly {
+				return utils.PrintUnsignedStdTx(txCtx, cliCtx, []sdk.Msg{msg})
+			}
 			// build and sign the transaction, then broadcast to Tendermint
 			return utils.SendTx(txCtx, cliCtx, []sdk.Msg{msg})
 		},
@@ -409,6 +426,9 @@ func GetCmdCompleteUnbonding(cdc *wire.Codec) *cobra.Command {
 
 			msg := stake.NewMsgCompleteUnbonding(delAddr, valAddr)
 
+			if cliCtx.GenerateOnly {
+				return utils.PrintUnsignedStdTx(txCtx, cliCtx, []sdk.Msg{msg})
+			}
 			// build and sign the transaction, then broadcast to Tendermint
 			return utils.SendTx(txCtx, cliCtx, []sdk.Msg{msg})
 		},

--- a/x/stake/client/rest/tx.go
+++ b/x/stake/client/rest/tx.go
@@ -297,6 +297,11 @@ func delegationsRequestHandlerFn(cdc *wire.Codec, kb keys.Keybase, cliCtx contex
 				txCtx = newCtx
 			}
 
+			if utils.HasGenerateOnlyArg(r) {
+				utils.WriteGenerateStdTxResponse(w, txCtx, []sdk.Msg{msg})
+				return
+			}
+
 			txBytes, err := txCtx.BuildAndSign(m.LocalAccountName, m.Password, []sdk.Msg{msg})
 			if err != nil {
 				utils.WriteErrorResponse(w, http.StatusUnauthorized, err.Error())


### PR DESCRIPTION
The new CLI `--generate-only` flag builds an unsigned transaction and writes it to STDOUT. Likewise, REST clients can now append `generate_only=true` to a request's query arguments list and expect a JSON response carrying the unsigned transaction.

Closes: #966

- [x] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [x] Wrote tests
- [x] Updated relevant documentation (`docs/`)
- [x] Added entries in `PENDING.md` with issue # 
- [x] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
