### PR TITLE
simulation: Allow operations to specify future operations

### DIFF
--- a/PENDING.md
+++ b/PENDING.md
@@ -41,6 +41,7 @@ FEATURES
 
 * SDK
   * [querier] added custom querier functionality, so ABCI query requests can be handled by keepers
+  * [simulation] \#1924 allow operations to specify future operations
 
 * Tendermint
 

--- a/cmd/gaia/app/sim_test.go
+++ b/cmd/gaia/app/sim_test.go
@@ -3,7 +3,6 @@ package app
 import (
 	"encoding/json"
 	"flag"
-	"fmt"
 	"math/rand"
 	"testing"
 
@@ -87,7 +86,7 @@ func appStateFn(r *rand.Rand, keys []crypto.PrivKey, accs []sdk.AccAddress) json
 
 func testAndRunTxs(app *GaiaApp) []simulation.Operation {
 	return []simulation.Operation{
-		banksim.TestAndRunSingleInputMsgSend(app.accountMapper),
+		banksim.SimulateSingleInputMsgSend(app.accountMapper),
 		govsim.SimulateMsgSubmitProposal(app.govKeeper, app.stakeKeeper),
 		govsim.SimulateMsgDeposit(app.govKeeper, app.stakeKeeper),
 		govsim.SimulateMsgVote(app.govKeeper, app.stakeKeeper),
@@ -171,11 +170,10 @@ func TestAppStateDeterminism(t *testing.T) {
 				true,
 			)
 			appHash := app.LastCommitID().Hash
-			fmt.Printf(">>> APP HASH: %v, %X\n", appHash, appHash)
 			appHashList[j] = appHash
 		}
 		for k := 1; k < numTimesToRunPerSeed; k++ {
-			require.Equal(t, appHashList[0], appHashList[k])
+			require.Equal(t, appHashList[0], appHashList[k], "appHash list: %v", appHashList)
 		}
 	}
 }

--- a/x/bank/simulation/msgs.go
+++ b/x/bank/simulation/msgs.go
@@ -18,10 +18,10 @@ import (
 	"github.com/tendermint/tendermint/crypto"
 )
 
-// TestAndRunSingleInputMsgSend tests and runs a single msg send, with one input and one output, where both
+// SimulateSingleInputMsgSend tests and runs a single msg send, with one input and one output, where both
 // accounts already exist.
-func TestAndRunSingleInputMsgSend(mapper auth.AccountMapper) simulation.Operation {
-	return func(t *testing.T, r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, keys []crypto.PrivKey, log string, event func(string)) (action string, err sdk.Error) {
+func SimulateSingleInputMsgSend(mapper auth.AccountMapper) simulation.Operation {
+	return func(t *testing.T, r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, keys []crypto.PrivKey, log string, event func(string)) (action string, fOps []simulation.FutureOperation, err sdk.Error) {
 		fromKey := simulation.RandomKey(r, keys)
 		fromAddr := sdk.AccAddress(fromKey.PubKey().Address())
 		toKey := simulation.RandomKey(r, keys)
@@ -36,13 +36,13 @@ func TestAndRunSingleInputMsgSend(mapper auth.AccountMapper) simulation.Operatio
 		initFromCoins := mapper.GetAccount(ctx, fromAddr).GetCoins()
 
 		if len(initFromCoins) == 0 {
-			return "skipping, no coins at all", nil
+			return "skipping, no coins at all", nil, nil
 		}
 
 		denomIndex := r.Intn(len(initFromCoins))
 		amt, goErr := randPositiveInt(r, initFromCoins[denomIndex].Amount)
 		if goErr != nil {
-			return "skipping bank send due to account having no coins of denomination " + initFromCoins[denomIndex].Denom, nil
+			return "skipping bank send due to account having no coins of denomination " + initFromCoins[denomIndex].Denom, nil, nil
 		}
 
 		action = fmt.Sprintf("%s is sending %s %s to %s",
@@ -61,7 +61,7 @@ func TestAndRunSingleInputMsgSend(mapper auth.AccountMapper) simulation.Operatio
 		sendAndVerifyMsgSend(t, app, mapper, msg, ctx, log, []crypto.PrivKey{fromKey})
 		event("bank/sendAndVerifyMsgSend/ok")
 
-		return action, nil
+		return action, nil, nil
 	}
 }
 

--- a/x/bank/simulation/sim_test.go
+++ b/x/bank/simulation/sim_test.go
@@ -34,7 +34,7 @@ func TestBankWithRandomMessages(t *testing.T) {
 	simulation.Simulate(
 		t, mapp.BaseApp, appStateFn,
 		[]simulation.Operation{
-			TestAndRunSingleInputMsgSend(mapper),
+			SimulateSingleInputMsgSend(mapper),
 		},
 		[]simulation.RandSetup{},
 		[]simulation.Invariant{

--- a/x/gov/simulation/msgs.go
+++ b/x/gov/simulation/msgs.go
@@ -20,9 +20,10 @@ const (
 	denom = "steak"
 )
 
-// SimulateMsgSubmitProposal
+// SimulateMsgSubmitProposal simulates a msg Submit Proposal
+// Note: Currently doesn't ensure that the proposal txt is in JSON form
 func SimulateMsgSubmitProposal(k gov.Keeper, sk stake.Keeper) simulation.Operation {
-	return func(t *testing.T, r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, keys []crypto.PrivKey, log string, event func(string)) (action string, err sdk.Error) {
+	return func(t *testing.T, r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, keys []crypto.PrivKey, log string, event func(string)) (action string, fOps []simulation.FutureOperation, err sdk.Error) {
 		key := simulation.RandomKey(r, keys)
 		addr := sdk.AccAddress(key.PubKey().Address())
 		deposit := randomDeposit(r)
@@ -45,18 +46,18 @@ func SimulateMsgSubmitProposal(k gov.Keeper, sk stake.Keeper) simulation.Operati
 		}
 		event(fmt.Sprintf("gov/MsgSubmitProposal/%v", result.IsOK()))
 		action = fmt.Sprintf("TestMsgSubmitProposal: ok %v, msg %s", result.IsOK(), msg.GetSignBytes())
-		return action, nil
+		return action, nil, nil
 	}
 }
 
 // SimulateMsgDeposit
 func SimulateMsgDeposit(k gov.Keeper, sk stake.Keeper) simulation.Operation {
-	return func(t *testing.T, r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, keys []crypto.PrivKey, log string, event func(string)) (action string, err sdk.Error) {
+	return func(t *testing.T, r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, keys []crypto.PrivKey, log string, event func(string)) (action string, fOp []simulation.FutureOperation, err sdk.Error) {
 		key := simulation.RandomKey(r, keys)
 		addr := sdk.AccAddress(key.PubKey().Address())
 		proposalID, ok := randomProposalID(r, k, ctx)
 		if !ok {
-			return "no-operation", nil
+			return "no-operation", nil, nil
 		}
 		deposit := randomDeposit(r)
 		msg := gov.NewMsgDeposit(addr, proposalID, deposit)
@@ -72,18 +73,18 @@ func SimulateMsgDeposit(k gov.Keeper, sk stake.Keeper) simulation.Operation {
 		}
 		event(fmt.Sprintf("gov/MsgDeposit/%v", result.IsOK()))
 		action = fmt.Sprintf("TestMsgDeposit: ok %v, msg %s", result.IsOK(), msg.GetSignBytes())
-		return action, nil
+		return action, nil, nil
 	}
 }
 
 // SimulateMsgVote
 func SimulateMsgVote(k gov.Keeper, sk stake.Keeper) simulation.Operation {
-	return func(t *testing.T, r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, keys []crypto.PrivKey, log string, event func(string)) (action string, err sdk.Error) {
+	return func(t *testing.T, r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, keys []crypto.PrivKey, log string, event func(string)) (action string, fOp []simulation.FutureOperation, err sdk.Error) {
 		key := simulation.RandomKey(r, keys)
 		addr := sdk.AccAddress(key.PubKey().Address())
 		proposalID, ok := randomProposalID(r, k, ctx)
 		if !ok {
-			return "no-operation", nil
+			return "no-operation", nil, nil
 		}
 		option := randomVotingOption(r)
 		msg := gov.NewMsgVote(addr, proposalID, option)
@@ -95,7 +96,7 @@ func SimulateMsgVote(k gov.Keeper, sk stake.Keeper) simulation.Operation {
 		}
 		event(fmt.Sprintf("gov/MsgVote/%v", result.IsOK()))
 		action = fmt.Sprintf("TestMsgVote: ok %v, msg %s", result.IsOK(), msg.GetSignBytes())
-		return action, nil
+		return action, nil, nil
 	}
 }
 

--- a/x/mock/simulation/types.go
+++ b/x/mock/simulation/types.go
@@ -19,10 +19,13 @@ type (
 	// For ease of debugging,
 	// an operation returns a descriptive message "action",
 	// which details what this fuzzed state machine transition actually did.
+	//
+	// Operations can optionally provide a list of "FutureOperations" to run later
+	// These will be ran at the beginning of the corresponding block.
 	Operation func(
 		t *testing.T, r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context,
 		privKeys []crypto.PrivKey, log string, event func(string),
-	) (action string, err sdk.Error)
+	) (action string, futureOperations []FutureOperation, err sdk.Error)
 
 	// RandSetup performs the random setup the mock module needs.
 	RandSetup func(r *rand.Rand, privKeys []crypto.PrivKey)
@@ -35,6 +38,15 @@ type (
 	mockValidator struct {
 		val           abci.Validator
 		livenessState int
+	}
+
+	// FutureOperation is an operation which will be ran at the
+	// beginning of the provided BlockHeight.
+	// In the (likely) event that multiple operations are queued at the same
+	// block height, they will execute in a FIFO pattern.
+	FutureOperation struct {
+		BlockHeight int
+		Op          Operation
 	}
 )
 

--- a/x/slashing/simulation/msgs.go
+++ b/x/slashing/simulation/msgs.go
@@ -17,7 +17,7 @@ import (
 
 // SimulateMsgUnjail
 func SimulateMsgUnjail(k slashing.Keeper) simulation.Operation {
-	return func(t *testing.T, r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, keys []crypto.PrivKey, log string, event func(string)) (action string, err sdk.Error) {
+	return func(t *testing.T, r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, keys []crypto.PrivKey, log string, event func(string)) (action string, fOp []simulation.FutureOperation, err sdk.Error) {
 		key := simulation.RandomKey(r, keys)
 		address := sdk.AccAddress(key.PubKey().Address())
 		msg := slashing.NewMsgUnjail(address)
@@ -29,6 +29,6 @@ func SimulateMsgUnjail(k slashing.Keeper) simulation.Operation {
 		}
 		event(fmt.Sprintf("slashing/MsgUnjail/%v", result.IsOK()))
 		action = fmt.Sprintf("TestMsgUnjail: ok %v, msg %s", result.IsOK(), msg.GetSignBytes())
-		return action, nil
+		return action, nil, nil
 	}
 }

--- a/x/stake/simulation/msgs.go
+++ b/x/stake/simulation/msgs.go
@@ -19,7 +19,7 @@ import (
 
 // SimulateMsgCreateValidator
 func SimulateMsgCreateValidator(m auth.AccountMapper, k stake.Keeper) simulation.Operation {
-	return func(t *testing.T, r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, keys []crypto.PrivKey, log string, event func(string)) (action string, err sdk.Error) {
+	return func(t *testing.T, r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, keys []crypto.PrivKey, log string, event func(string)) (action string, fOp []simulation.FutureOperation, err sdk.Error) {
 		denom := k.GetParams(ctx).BondDenom
 		description := stake.Description{
 			Moniker: simulation.RandStringOfLength(r, 10),
@@ -32,7 +32,7 @@ func SimulateMsgCreateValidator(m auth.AccountMapper, k stake.Keeper) simulation
 			amount = simulation.RandomAmount(r, amount)
 		}
 		if amount.Equal(sdk.ZeroInt()) {
-			return "no-operation", nil
+			return "no-operation", nil, nil
 		}
 		msg := stake.MsgCreateValidator{
 			Description:   description,
@@ -50,13 +50,13 @@ func SimulateMsgCreateValidator(m auth.AccountMapper, k stake.Keeper) simulation
 		event(fmt.Sprintf("stake/MsgCreateValidator/%v", result.IsOK()))
 		// require.True(t, result.IsOK(), "expected OK result but instead got %v", result)
 		action = fmt.Sprintf("TestMsgCreateValidator: ok %v, msg %s", result.IsOK(), msg.GetSignBytes())
-		return action, nil
+		return action, nil, nil
 	}
 }
 
 // SimulateMsgEditValidator
 func SimulateMsgEditValidator(k stake.Keeper) simulation.Operation {
-	return func(t *testing.T, r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, keys []crypto.PrivKey, log string, event func(string)) (action string, err sdk.Error) {
+	return func(t *testing.T, r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, keys []crypto.PrivKey, log string, event func(string)) (action string, fOp []simulation.FutureOperation, err sdk.Error) {
 		description := stake.Description{
 			Moniker:  simulation.RandStringOfLength(r, 10),
 			Identity: simulation.RandStringOfLength(r, 10),
@@ -78,13 +78,13 @@ func SimulateMsgEditValidator(k stake.Keeper) simulation.Operation {
 		}
 		event(fmt.Sprintf("stake/MsgEditValidator/%v", result.IsOK()))
 		action = fmt.Sprintf("TestMsgEditValidator: ok %v, msg %s", result.IsOK(), msg.GetSignBytes())
-		return action, nil
+		return action, nil, nil
 	}
 }
 
 // SimulateMsgDelegate
 func SimulateMsgDelegate(m auth.AccountMapper, k stake.Keeper) simulation.Operation {
-	return func(t *testing.T, r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, keys []crypto.PrivKey, log string, event func(string)) (action string, err sdk.Error) {
+	return func(t *testing.T, r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, keys []crypto.PrivKey, log string, event func(string)) (action string, fOp []simulation.FutureOperation, err sdk.Error) {
 		denom := k.GetParams(ctx).BondDenom
 		validatorKey := simulation.RandomKey(r, keys)
 		validatorAddress := sdk.AccAddress(validatorKey.PubKey().Address())
@@ -95,7 +95,7 @@ func SimulateMsgDelegate(m auth.AccountMapper, k stake.Keeper) simulation.Operat
 			amount = simulation.RandomAmount(r, amount)
 		}
 		if amount.Equal(sdk.ZeroInt()) {
-			return "no-operation", nil
+			return "no-operation", nil, nil
 		}
 		msg := stake.MsgDelegate{
 			DelegatorAddr: delegatorAddress,
@@ -110,13 +110,13 @@ func SimulateMsgDelegate(m auth.AccountMapper, k stake.Keeper) simulation.Operat
 		}
 		event(fmt.Sprintf("stake/MsgDelegate/%v", result.IsOK()))
 		action = fmt.Sprintf("TestMsgDelegate: ok %v, msg %s", result.IsOK(), msg.GetSignBytes())
-		return action, nil
+		return action, nil, nil
 	}
 }
 
 // SimulateMsgBeginUnbonding
 func SimulateMsgBeginUnbonding(m auth.AccountMapper, k stake.Keeper) simulation.Operation {
-	return func(t *testing.T, r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, keys []crypto.PrivKey, log string, event func(string)) (action string, err sdk.Error) {
+	return func(t *testing.T, r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, keys []crypto.PrivKey, log string, event func(string)) (action string, fOp []simulation.FutureOperation, err sdk.Error) {
 		denom := k.GetParams(ctx).BondDenom
 		validatorKey := simulation.RandomKey(r, keys)
 		validatorAddress := sdk.AccAddress(validatorKey.PubKey().Address())
@@ -127,7 +127,7 @@ func SimulateMsgBeginUnbonding(m auth.AccountMapper, k stake.Keeper) simulation.
 			amount = simulation.RandomAmount(r, amount)
 		}
 		if amount.Equal(sdk.ZeroInt()) {
-			return "no-operation", nil
+			return "no-operation", nil, nil
 		}
 		msg := stake.MsgBeginUnbonding{
 			DelegatorAddr: delegatorAddress,
@@ -142,13 +142,13 @@ func SimulateMsgBeginUnbonding(m auth.AccountMapper, k stake.Keeper) simulation.
 		}
 		event(fmt.Sprintf("stake/MsgBeginUnbonding/%v", result.IsOK()))
 		action = fmt.Sprintf("TestMsgBeginUnbonding: ok %v, msg %s", result.IsOK(), msg.GetSignBytes())
-		return action, nil
+		return action, nil, nil
 	}
 }
 
 // SimulateMsgCompleteUnbonding
 func SimulateMsgCompleteUnbonding(k stake.Keeper) simulation.Operation {
-	return func(t *testing.T, r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, keys []crypto.PrivKey, log string, event func(string)) (action string, err sdk.Error) {
+	return func(t *testing.T, r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, keys []crypto.PrivKey, log string, event func(string)) (action string, fOp []simulation.FutureOperation, err sdk.Error) {
 		validatorKey := simulation.RandomKey(r, keys)
 		validatorAddress := sdk.AccAddress(validatorKey.PubKey().Address())
 		delegatorKey := simulation.RandomKey(r, keys)
@@ -165,13 +165,13 @@ func SimulateMsgCompleteUnbonding(k stake.Keeper) simulation.Operation {
 		}
 		event(fmt.Sprintf("stake/MsgCompleteUnbonding/%v", result.IsOK()))
 		action = fmt.Sprintf("TestMsgCompleteUnbonding: ok %v, msg %s", result.IsOK(), msg.GetSignBytes())
-		return action, nil
+		return action, nil, nil
 	}
 }
 
 // SimulateMsgBeginRedelegate
 func SimulateMsgBeginRedelegate(m auth.AccountMapper, k stake.Keeper) simulation.Operation {
-	return func(t *testing.T, r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, keys []crypto.PrivKey, log string, event func(string)) (action string, err sdk.Error) {
+	return func(t *testing.T, r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, keys []crypto.PrivKey, log string, event func(string)) (action string, fOp []simulation.FutureOperation, err sdk.Error) {
 		denom := k.GetParams(ctx).BondDenom
 		sourceValidatorKey := simulation.RandomKey(r, keys)
 		sourceValidatorAddress := sdk.AccAddress(sourceValidatorKey.PubKey().Address())
@@ -185,7 +185,7 @@ func SimulateMsgBeginRedelegate(m auth.AccountMapper, k stake.Keeper) simulation
 			amount = simulation.RandomAmount(r, amount)
 		}
 		if amount.Equal(sdk.ZeroInt()) {
-			return "no-operation", nil
+			return "no-operation", nil, nil
 		}
 		msg := stake.MsgBeginRedelegate{
 			DelegatorAddr:    delegatorAddress,
@@ -201,13 +201,13 @@ func SimulateMsgBeginRedelegate(m auth.AccountMapper, k stake.Keeper) simulation
 		}
 		event(fmt.Sprintf("stake/MsgBeginRedelegate/%v", result.IsOK()))
 		action = fmt.Sprintf("TestMsgBeginRedelegate: %s", msg.GetSignBytes())
-		return action, nil
+		return action, nil, nil
 	}
 }
 
 // SimulateMsgCompleteRedelegate
 func SimulateMsgCompleteRedelegate(k stake.Keeper) simulation.Operation {
-	return func(t *testing.T, r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, keys []crypto.PrivKey, log string, event func(string)) (action string, err sdk.Error) {
+	return func(t *testing.T, r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, keys []crypto.PrivKey, log string, event func(string)) (action string, fOp []simulation.FutureOperation, err sdk.Error) {
 		validatorSrcKey := simulation.RandomKey(r, keys)
 		validatorSrcAddress := sdk.AccAddress(validatorSrcKey.PubKey().Address())
 		validatorDstKey := simulation.RandomKey(r, keys)
@@ -227,7 +227,7 @@ func SimulateMsgCompleteRedelegate(k stake.Keeper) simulation.Operation {
 		}
 		event(fmt.Sprintf("stake/MsgCompleteRedelegate/%v", result.IsOK()))
 		action = fmt.Sprintf("TestMsgCompleteRedelegate: ok %v, msg %s", result.IsOK(), msg.GetSignBytes())
-		return action, nil
+		return action, nil, nil
 	}
 }
 


### PR DESCRIPTION
Addresses one of the points in #1924 

The intent of this is to allow for simulating things like slashing for not
voting on a governance proposal. To test this, you would queue all the validator votes
in future blocks, and keep track of which ones you didn't slash. Then you could add queue a
"check governance slashing operation" after the voting period is over.

I'm saving writing a test for "Check governance slashing operation" for a separate PR. 

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/develop/CONTRIBUTING.md#pr-targeting))

- [X] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`) - simulation docs are postlaunch AFAIK
- [X] Added entries in `PENDING.md` with issue # 

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
