### PR TITLE
R4R: Ensure Legacy Validator Delegation Invariants

### DIFF
--- a/PENDING.md
+++ b/PENDING.md
@@ -59,6 +59,7 @@ IMPROVEMENTS
 * Gaia
     * [x/stake] [#2023](https://github.com/cosmos/cosmos-sdk/pull/2023) Terminate iteration loop in `UpdateBondedValidators` and `UpdateBondedValidatorsFull` when the first revoked validator is encountered and perform a sanity check.
     * [x/auth] Signature verification's gas cost now accounts for pubkey type. [#2046](https://github.com/tendermint/tendermint/pull/2046)
+    * [x/stake] [x/slashing] Ensure delegation invariants to jailed validators [#1883](https://github.com/cosmos/cosmos-sdk/issues/1883).
 
 * SDK
     * [tools] Make get_vendor_deps deletes `.vendor-new` directories, in case scratch files are present.

--- a/examples/democoin/mock/validator.go
+++ b/examples/democoin/mock/validator.go
@@ -135,3 +135,8 @@ func (vs *ValidatorSet) Jail(ctx sdk.Context, pubkey crypto.PubKey) {
 func (vs *ValidatorSet) Unjail(ctx sdk.Context, pubkey crypto.PubKey) {
 	panic("not implemented")
 }
+
+// Implements sdk.ValidatorSet
+func (vs *ValidatorSet) Delegation(ctx sdk.Context, addrDel, addrVal sdk.AccAddress) sdk.Delegation {
+	panic("not implemented")
+}

--- a/types/stake.go
+++ b/types/stake.go
@@ -76,6 +76,8 @@ type ValidatorSet interface {
 	Jail(Context, crypto.PubKey)   // jail a validator
 	Unjail(Context, crypto.PubKey) // unjail a validator
 
+	// Delegation allows for getting a particular delegation for a given validator
+	// and delegator outside the scope of the staking module.
 	Delegation(Context, AccAddress, AccAddress) Delegation
 }
 

--- a/types/stake.go
+++ b/types/stake.go
@@ -75,6 +75,8 @@ type ValidatorSet interface {
 	Slash(Context, crypto.PubKey, int64, int64, Dec)
 	Jail(Context, crypto.PubKey)   // jail a validator
 	Unjail(Context, crypto.PubKey) // unjail a validator
+
+	Delegation(Context, AccAddress, AccAddress) Delegation
 }
 
 //_______________________________________________________________________________

--- a/x/slashing/errors.go
+++ b/x/slashing/errors.go
@@ -12,20 +12,28 @@ const (
 	// Default slashing codespace
 	DefaultCodespace sdk.CodespaceType = 10
 
-	CodeInvalidValidator   CodeType = 101
-	CodeValidatorJailed    CodeType = 102
-	CodeValidatorNotJailed CodeType = 103
+	CodeInvalidValidator      CodeType = 101
+	CodeValidatorJailed       CodeType = 102
+	CodeValidatorNotJailed    CodeType = 103
+	CodeMissingSelfDelegation CodeType = 104
 )
 
 func ErrNoValidatorForAddress(codespace sdk.CodespaceType) sdk.Error {
 	return sdk.NewError(codespace, CodeInvalidValidator, "that address is not associated with any known validator")
 }
+
 func ErrBadValidatorAddr(codespace sdk.CodespaceType) sdk.Error {
 	return sdk.NewError(codespace, CodeInvalidValidator, "validator does not exist for that address")
 }
+
 func ErrValidatorJailed(codespace sdk.CodespaceType) sdk.Error {
 	return sdk.NewError(codespace, CodeValidatorJailed, "validator still jailed, cannot yet be unjailed")
 }
+
 func ErrValidatorNotJailed(codespace sdk.CodespaceType) sdk.Error {
 	return sdk.NewError(codespace, CodeValidatorNotJailed, "validator not jailed, cannot be unjailed")
+}
+
+func ErrMissingSelfDelegation(codespace sdk.CodespaceType) sdk.Error {
+	return sdk.NewError(codespace, CodeMissingSelfDelegation, "validator has no self-delegation, cannot be unjailed")
 }

--- a/x/slashing/errors.go
+++ b/x/slashing/errors.go
@@ -35,5 +35,5 @@ func ErrValidatorNotJailed(codespace sdk.CodespaceType) sdk.Error {
 }
 
 func ErrMissingSelfDelegation(codespace sdk.CodespaceType) sdk.Error {
-	return sdk.NewError(codespace, CodeMissingSelfDelegation, "validator has no self-delegation, cannot be unjailed")
+	return sdk.NewError(codespace, CodeMissingSelfDelegation, "validator has no self-delegation; cannot be unjailed")
 }

--- a/x/slashing/handler.go
+++ b/x/slashing/handler.go
@@ -19,11 +19,15 @@ func NewHandler(k Keeper) sdk.Handler {
 // Validators must submit a transaction to unjail itself after
 // having been jailed (and thus unbonded) for downtime
 func handleMsgUnjail(ctx sdk.Context, msg MsgUnjail, k Keeper) sdk.Result {
-
-	// Validator must exist
 	validator := k.validatorSet.Validator(ctx, msg.ValidatorAddr)
 	if validator == nil {
 		return ErrNoValidatorForAddress(k.codespace).Result()
+	}
+
+	// cannot be unjailed if no self-delegation exists
+	selfDel := k.validatorSet.Delegation(ctx, msg.ValidatorAddr, msg.ValidatorAddr)
+	if selfDel == nil {
+		return ErrMissingSelfDelegation(k.codespace).Result()
 	}
 
 	if !validator.GetJailed() {
@@ -32,22 +36,21 @@ func handleMsgUnjail(ctx sdk.Context, msg MsgUnjail, k Keeper) sdk.Result {
 
 	addr := sdk.ValAddress(validator.GetPubKey().Address())
 
-	// Signing info must exist
 	info, found := k.getValidatorSigningInfo(ctx, addr)
 	if !found {
 		return ErrNoValidatorForAddress(k.codespace).Result()
 	}
 
-	// Cannot be unjailed until out of jail
+	// cannot be unjailed until out of jail
 	if ctx.BlockHeader().Time.Before(info.JailedUntil) {
 		return ErrValidatorJailed(k.codespace).Result()
 	}
 
-	// Update the starting height (so the validator can't be immediately jailed again)
+	// update the starting height so the validator can't be immediately jailed
+	// again
 	info.StartHeight = ctx.BlockHeight()
 	k.setValidatorSigningInfo(ctx, addr, info)
 
-	// Unjail the validator
 	k.validatorSet.Unjail(ctx, validator.GetPubKey())
 
 	tags := sdk.NewTags("action", []byte("unjail"), "validator", []byte(msg.ValidatorAddr.String()))

--- a/x/slashing/handler_test.go
+++ b/x/slashing/handler_test.go
@@ -40,7 +40,6 @@ func TestJailedValidatorDelegations(t *testing.T) {
 	amount := int64(10)
 	valAddr, valPubKey, bondAmount := addrs[0], pks[0], sdk.NewInt(amount)
 	msgCreateVal := newTestMsgCreateValidator(valAddr, valPubKey, bondAmount)
-
 	got := stake.NewHandler(stakeKeeper)(ctx, msgCreateVal)
 	require.True(t, got.IsOK(), "expected create validator msg to be ok, got: %v", got)
 
@@ -56,21 +55,21 @@ func TestJailedValidatorDelegations(t *testing.T) {
 	// delegate tokens to the validator
 	delAddr := addrs[1]
 	msgDelegate := newTestMsgDelegate(delAddr, valAddr, bondAmount)
-
 	got = stake.NewHandler(stakeKeeper)(ctx, msgDelegate)
 	require.True(t, got.IsOK(), "expected delegation to be ok, got %v", got)
 
-	// unbond validator total self-delegations (which should jail the validator)
 	unbondShares := sdk.NewDec(10)
-	msgBeginUnbonding := stake.NewMsgBeginUnbonding(valAddr, valAddr, unbondShares)
-	msgCompleteUnbonding := stake.NewMsgCompleteUnbonding(valAddr, valAddr)
 
+	// unbond validator total self-delegations (which should jail the validator)
+	msgBeginUnbonding := stake.NewMsgBeginUnbonding(valAddr, valAddr, unbondShares)
 	got = stake.NewHandler(stakeKeeper)(ctx, msgBeginUnbonding)
 	require.True(t, got.IsOK(), "expected begin unbonding validator msg to be ok, got: %v", got)
 
+	msgCompleteUnbonding := stake.NewMsgCompleteUnbonding(valAddr, valAddr)
 	got = stake.NewHandler(stakeKeeper)(ctx, msgCompleteUnbonding)
 	require.True(t, got.IsOK(), "expected complete unbonding validator msg to be ok, got: %v", got)
 
+	// verify validator still exists and is jailed
 	validator, found := stakeKeeper.GetValidator(ctx, valAddr)
 	require.True(t, found)
 	require.True(t, validator.GetJailed())
@@ -81,7 +80,6 @@ func TestJailedValidatorDelegations(t *testing.T) {
 
 	// self-delegate to validator
 	msgSelfDelegate := newTestMsgDelegate(valAddr, valAddr, bondAmount)
-
 	got = stake.NewHandler(stakeKeeper)(ctx, msgSelfDelegate)
 	require.True(t, got.IsOK(), "expected delegation to not be ok, got %v", got)
 

--- a/x/slashing/handler_test.go
+++ b/x/slashing/handler_test.go
@@ -2,6 +2,7 @@ package slashing
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -26,4 +27,65 @@ func TestCannotUnjailUnlessJailed(t *testing.T) {
 	got = slh(ctx, NewMsgUnjail(addr))
 	require.False(t, got.IsOK(), "allowed unjail of non-jailed validator")
 	require.Equal(t, sdk.ToABCICode(DefaultCodespace, CodeValidatorNotJailed), got.Code)
+}
+
+func TestJailedValidatorDelegations(t *testing.T) {
+	ctx, _, stakeKeeper, _, slashingKeeper := createTestInput(t)
+
+	stakeParams := stakeKeeper.GetParams(ctx)
+	stakeParams.UnbondingTime = 0
+	stakeKeeper.SetParams(ctx, stakeParams)
+
+	// create a validator
+	amount := int64(10)
+	valAddr, valPubKey, bondAmount := addrs[0], pks[0], sdk.NewInt(amount)
+	msgCreateVal := newTestMsgCreateValidator(valAddr, valPubKey, bondAmount)
+
+	got := stake.NewHandler(stakeKeeper)(ctx, msgCreateVal)
+	require.True(t, got.IsOK(), "expected create validator msg to be ok, got: %v", got)
+
+	// set dummy signing info
+	newInfo := ValidatorSigningInfo{
+		StartHeight:         int64(0),
+		IndexOffset:         int64(0),
+		JailedUntil:         time.Unix(0, 0),
+		SignedBlocksCounter: int64(0),
+	}
+	slashingKeeper.setValidatorSigningInfo(ctx, sdk.ValAddress(valAddr), newInfo)
+
+	// delegate tokens to the validator
+	delAddr := addrs[1]
+	msgDelegate := newTestMsgDelegate(delAddr, valAddr, bondAmount)
+
+	got = stake.NewHandler(stakeKeeper)(ctx, msgDelegate)
+	require.True(t, got.IsOK(), "expected delegation to be ok, got %v", got)
+
+	// unbond validator total self-delegations (which should jail the validator)
+	unbondShares := sdk.NewDec(10)
+	msgBeginUnbonding := stake.NewMsgBeginUnbonding(valAddr, valAddr, unbondShares)
+	msgCompleteUnbonding := stake.NewMsgCompleteUnbonding(valAddr, valAddr)
+
+	got = stake.NewHandler(stakeKeeper)(ctx, msgBeginUnbonding)
+	require.True(t, got.IsOK(), "expected begin unbonding validator msg to be ok, got: %v", got)
+
+	got = stake.NewHandler(stakeKeeper)(ctx, msgCompleteUnbonding)
+	require.True(t, got.IsOK(), "expected complete unbonding validator msg to be ok, got: %v", got)
+
+	validator, found := stakeKeeper.GetValidator(ctx, valAddr)
+	require.True(t, found)
+	require.True(t, validator.GetJailed())
+
+	// verify the validator cannot unjail itself
+	got = NewHandler(slashingKeeper)(ctx, NewMsgUnjail(valAddr))
+	require.False(t, got.IsOK(), "expected jailed validator to not be able to unjail, got: %v", got)
+
+	// self-delegate to validator
+	msgSelfDelegate := newTestMsgDelegate(valAddr, valAddr, bondAmount)
+
+	got = stake.NewHandler(stakeKeeper)(ctx, msgSelfDelegate)
+	require.True(t, got.IsOK(), "expected delegation to not be ok, got %v", got)
+
+	// verify the validator can now unjail itself
+	got = NewHandler(slashingKeeper)(ctx, NewMsgUnjail(valAddr))
+	require.True(t, got.IsOK(), "expected jailed validator to be able to unjail, got: %v", got)
 }

--- a/x/slashing/test_common.go
+++ b/x/slashing/test_common.go
@@ -4,6 +4,7 @@ import (
 	"encoding/hex"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -61,7 +62,7 @@ func createTestInput(t *testing.T) (sdk.Context, bank.Keeper, stake.Keeper, para
 	ms.MountStoreWithDB(keyParams, sdk.StoreTypeIAVL, db)
 	err := ms.LoadLatestVersion()
 	require.Nil(t, err)
-	ctx := sdk.NewContext(ms, abci.Header{}, false, log.NewTMLogger(os.Stdout))
+	ctx := sdk.NewContext(ms, abci.Header{Time: time.Unix(0, 0)}, false, log.NewTMLogger(os.Stdout))
 	cdc := createTestCodec()
 	accountMapper := auth.NewAccountMapper(cdc, keyAcc, auth.ProtoBaseAccount)
 	ck := bank.NewKeeper(accountMapper)
@@ -106,5 +107,13 @@ func newTestMsgCreateValidator(address sdk.AccAddress, pubKey crypto.PubKey, amt
 		ValidatorAddr: address,
 		PubKey:        pubKey,
 		Delegation:    sdk.Coin{"steak", amt},
+	}
+}
+
+func newTestMsgDelegate(delAddr, valAddr sdk.AccAddress, delAmount sdk.Int) stake.MsgDelegate {
+	return stake.MsgDelegate{
+		DelegatorAddr: delAddr,
+		ValidatorAddr: valAddr,
+		Delegation:    sdk.Coin{"steak", delAmount},
 	}
 }

--- a/x/stake/handler_test.go
+++ b/x/stake/handler_test.go
@@ -193,6 +193,97 @@ func TestDuplicatesMsgCreateValidatorOnBehalfOf(t *testing.T) {
 	require.False(t, got.IsOK(), "%v", got)
 }
 
+func TestLegacyValidatorDelegations(t *testing.T) {
+	ctx, _, keeper := keep.CreateTestInput(t, false, int64(1000))
+	setInstantUnbondPeriod(keeper, ctx)
+
+	bondAmount := int64(10)
+	valAddr, valPubKey := keep.Addrs[0], keep.PKs[0]
+	delAddr := keep.Addrs[1]
+
+	// create validator
+	msgCreateVal := newTestMsgCreateValidator(valAddr, valPubKey, bondAmount)
+	got := handleMsgCreateValidator(ctx, msgCreateVal, keeper)
+	require.True(t, got.IsOK(), "expected create validator msg to be ok, got %v", got)
+
+	// verify the validator exists and has the correct attributes
+	validator, found := keeper.GetValidator(ctx, valAddr)
+	require.True(t, found)
+	require.Equal(t, sdk.Bonded, validator.Status)
+	require.Equal(t, bondAmount, validator.DelegatorShares.RoundInt64())
+	require.Equal(t, bondAmount, validator.BondedTokens().RoundInt64())
+
+	// delegate tokens to the validator
+	msgDelegate := newTestMsgDelegate(delAddr, valAddr, bondAmount)
+	got = handleMsgDelegate(ctx, msgDelegate, keeper)
+	require.True(t, got.IsOK(), "expected delegation to be ok, got %v", got)
+
+	// verify validator bonded shares
+	validator, found = keeper.GetValidator(ctx, valAddr)
+	require.True(t, found)
+	require.Equal(t, bondAmount*2, validator.DelegatorShares.RoundInt64())
+	require.Equal(t, bondAmount*2, validator.BondedTokens().RoundInt64())
+
+	// unbond validator total self-delegations (which should jail the validator)
+	unbondShares := sdk.NewDec(10)
+	msgBeginUnbonding := NewMsgBeginUnbonding(valAddr, valAddr, unbondShares)
+	msgCompleteUnbonding := NewMsgCompleteUnbonding(valAddr, valAddr)
+
+	got = handleMsgBeginUnbonding(ctx, msgBeginUnbonding, keeper)
+	require.True(t, got.IsOK(), "expected begin unbonding validator msg to be ok, got %v", got)
+
+	got = handleMsgCompleteUnbonding(ctx, msgCompleteUnbonding, keeper)
+	require.True(t, got.IsOK(), "expected complete unbonding validator msg to be ok, got %v", got)
+
+	// verify the validator record still exists, is jailed, and has correct tokens
+	validator, found = keeper.GetValidator(ctx, valAddr)
+	require.True(t, found)
+	require.True(t, validator.Jailed)
+	require.Equal(t, sdk.NewDec(10), validator.Tokens)
+
+	// verify delegation still exists
+	bond, found := keeper.GetDelegation(ctx, delAddr, valAddr)
+	require.True(t, found)
+	require.Equal(t, bondAmount, bond.Shares.RoundInt64())
+	require.Equal(t, bondAmount, validator.DelegatorShares.RoundInt64())
+
+	// verify a delegator cannot create a new delegation to the now jailed validator
+	msgDelegate = newTestMsgDelegate(delAddr, valAddr, bondAmount)
+	got = handleMsgDelegate(ctx, msgDelegate, keeper)
+	require.False(t, got.IsOK(), "expected delegation to not be ok, got %v", got)
+
+	// verify the validator can still self-delegate
+	msgSelfDelegate := newTestMsgDelegate(valAddr, valAddr, bondAmount)
+	got = handleMsgDelegate(ctx, msgSelfDelegate, keeper)
+	require.True(t, got.IsOK(), "expected delegation to not be ok, got %v", got)
+
+	// verify validator bonded shares
+	validator, found = keeper.GetValidator(ctx, valAddr)
+	require.True(t, found)
+	require.Equal(t, bondAmount*2, validator.DelegatorShares.RoundInt64())
+	require.Equal(t, bondAmount*2, validator.Tokens.RoundInt64())
+
+	// unjail the validator now that is has non-zero self-delegated shares
+	keeper.Unjail(ctx, valPubKey)
+
+	// verify the validator can now accept delegations
+	msgDelegate = newTestMsgDelegate(delAddr, valAddr, bondAmount)
+	got = handleMsgDelegate(ctx, msgDelegate, keeper)
+	require.True(t, got.IsOK(), "expected delegation to be ok, got %v", got)
+
+	// verify validator bonded shares
+	validator, found = keeper.GetValidator(ctx, valAddr)
+	require.True(t, found)
+	require.Equal(t, bondAmount*3, validator.DelegatorShares.RoundInt64())
+	require.Equal(t, bondAmount*3, validator.Tokens.RoundInt64())
+
+	// verify new delegation
+	bond, found = keeper.GetDelegation(ctx, delAddr, valAddr)
+	require.True(t, found)
+	require.Equal(t, bondAmount*2, bond.Shares.RoundInt64())
+	require.Equal(t, bondAmount*3, validator.DelegatorShares.RoundInt64())
+}
+
 func TestIncrementsMsgDelegate(t *testing.T) {
 	initBond := int64(1000)
 	ctx, accMapper, keeper := keep.CreateTestInput(t, false, initBond)

--- a/x/stake/keeper/delegation.go
+++ b/x/stake/keeper/delegation.go
@@ -287,6 +287,7 @@ func (k Keeper) unbond(ctx sdk.Context, delegatorAddr, validatorAddr sdk.AccAddr
 		if bytes.Equal(delegation.DelegatorAddr, validator.Operator) && validator.Jailed == false {
 			validator.Jailed = true
 		}
+
 		k.RemoveDelegation(ctx, delegation)
 	} else {
 		// Update height

--- a/x/stake/keeper/delegation.go
+++ b/x/stake/keeper/delegation.go
@@ -307,7 +307,7 @@ func (k Keeper) unbond(ctx sdk.Context, delegatorAddr, validatorAddr sdk.AccAddr
 		k.RemoveValidator(ctx, validator.Operator)
 	}
 
-	return
+	return amount, nil
 }
 
 //______________________________________________________________________________________________________


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

* Add `Delegation` to `ValidatorSet` type. The motivation was to be able to determine
if a validator has a self-delegation in the unjail message handler.
	* Note, the keeper implementing the `ValidatorSet` interface already has `Delegation` defined.
* Update `handleMsgUnjail` to not allow a validator to unjail itself if it has no
self-bonded delegation (it may have other delegated power).
* Update `handleMsgDelegate` to allow a validator to self-bond when jailed.
* Added unit tests to ensure the following:

When a validator removes it's final self-bonded share:
* the validator is jailed (existing behavior)
* delegators cannot delegate to said validator
* the validator CAN self-delegate to itself
* validator cannot unjail themselves UNLESS they have self self-bonded
* after self-bonding and unjailing themselves - the validator should be able to accept delegations again

closes: #1883 

----

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/develop/CONTRIBUTING.md#pr-targeting))

- [x] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [x] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [x] Added entries in `PENDING.md` with issue # 
- [x] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
