### PR TITLE
R4R: Implement a simulate-only CLI flag/field for REST endpoints

### DIFF
--- a/PENDING.md
+++ b/PENDING.md
@@ -40,6 +40,7 @@ FEATURES
 
 * Gaia REST API (`gaiacli advanced rest-server`)
   * [lcd] Endpoints to query staking pool and params
+  * [lcd] \#2110 Add support for `simulate=true` requests query argument to endpoints that send txs to run simulations of transactions
 
 * Gaia CLI  (`gaiacli`)
   * [cli] Cmds to query staking pool and params
@@ -48,6 +49,7 @@ FEATURES
   provide desired Bech32 prefix encoding
   * [cli] \#2047 Setting the --gas flag value to 0 triggers a simulation of the tx before the actual execution. The gas estimate obtained via the simulation will be used as gas limit in the actual execution.
   * [cli] \#2047 The --gas-adjustment flag can be used to adjust the estimate obtained via the simulation triggered by --gas=0.
+  * [cli] \#2110 Add --dry-run flag to perform a simulation of a transaction without broadcasting it. The --gas flag is ignored as gas would be automatically estimated.
 
 * Gaia
   * [cli] #2170 added ability to show the node's address via `gaiad tendermint show-address`

--- a/client/context/context.go
+++ b/client/context/context.go
@@ -37,6 +37,7 @@ type CLIContext struct {
 	JSON            bool
 	PrintResponse   bool
 	Certifier       tmlite.Certifier
+	DryRun          bool
 }
 
 // NewCLIContext returns a new initialized CLIContext with parameters from the
@@ -63,6 +64,7 @@ func NewCLIContext() CLIContext {
 		JSON:            viper.GetBool(client.FlagJson),
 		PrintResponse:   viper.GetBool(client.FlagPrintResponse),
 		Certifier:       createCertifier(),
+		DryRun:          viper.GetBool(client.FlagDryRun),
 	}
 }
 

--- a/client/context/context.go
+++ b/client/context/context.go
@@ -159,5 +159,9 @@ func (ctx CLIContext) WithUseLedger(useLedger bool) CLIContext {
 // WithCertifier - return a copy of the context with an updated Certifier
 func (ctx CLIContext) WithCertifier(certifier tmlite.Certifier) CLIContext {
 	ctx.Certifier = certifier
+
+// WithGasAdjustment returns a copy of the context with an updated GasAdjustment flag.
+func (ctx CLIContext) WithGasAdjustment(adjustment float64) CLIContext {
+	ctx.GasAdjustment = adjustment
 	return ctx
 }

--- a/client/context/context.go
+++ b/client/context/context.go
@@ -159,6 +159,8 @@ func (ctx CLIContext) WithUseLedger(useLedger bool) CLIContext {
 // WithCertifier - return a copy of the context with an updated Certifier
 func (ctx CLIContext) WithCertifier(certifier tmlite.Certifier) CLIContext {
 	ctx.Certifier = certifier
+	return ctx
+}
 
 // WithGasAdjustment returns a copy of the context with an updated GasAdjustment flag.
 func (ctx CLIContext) WithGasAdjustment(adjustment float64) CLIContext {

--- a/client/flags.go
+++ b/client/flags.go
@@ -5,7 +5,7 @@ import "github.com/spf13/cobra"
 // nolint
 const (
 	DefaultGasLimit      = 200000
-	DefaultGasAdjustment = 1.2
+	DefaultGasAdjustment = 1.0
 
 	FlagUseLedger     = "ledger"
 	FlagChainID       = "chain-id"
@@ -23,6 +23,7 @@ const (
 	FlagAsync         = "async"
 	FlagJson          = "json"
 	FlagPrintResponse = "print-response"
+	FlagDryRun        = "dry-run"
 )
 
 // LineBreak can be included in a command list to provide a blank line
@@ -54,11 +55,12 @@ func PostCommands(cmds ...*cobra.Command) []*cobra.Command {
 		c.Flags().String(FlagNode, "tcp://localhost:26657", "<host>:<port> to tendermint rpc interface for this chain")
 		c.Flags().Bool(FlagUseLedger, false, "Use a connected Ledger device")
 		c.Flags().Int64(FlagGas, DefaultGasLimit, "gas limit to set per-transaction; set to 0 to calculate required gas automatically")
-		c.Flags().Float64(FlagGasAdjustment, DefaultGasAdjustment, "adjustment factor to be multiplied against the estimate returned by the tx simulation")
+		c.Flags().Float64(FlagGasAdjustment, DefaultGasAdjustment, "adjustment factor to be multiplied against the estimate returned by the tx simulation; if the gas limit is set manually this flag is ignored ")
 		c.Flags().Bool(FlagAsync, false, "broadcast transactions asynchronously")
 		c.Flags().Bool(FlagJson, false, "return output in json format")
 		c.Flags().Bool(FlagPrintResponse, true, "return tx response (only works with async = false)")
 		c.Flags().Bool(FlagTrustNode, true, "Don't verify proofs for query responses")
+		c.Flags().Bool(FlagDryRun, false, "ignore the --gas flag and perform a simulation of a transaction, but don't broadcast it")
 	}
 	return cmds
 }

--- a/client/flags.go
+++ b/client/flags.go
@@ -4,8 +4,11 @@ import "github.com/spf13/cobra"
 
 // nolint
 const (
-	DefaultGasLimit      = 200000
+	// DefaultGasAdjustment is applied to gas estimates to avoid tx
+	// execution failures due to state changes that might
+	// occur between the tx simulation and the actual run.
 	DefaultGasAdjustment = 1.0
+	DefaultGasLimit      = 200000
 
 	FlagUseLedger     = "ledger"
 	FlagChainID       = "chain-id"

--- a/client/lcd/lcd_test.go
+++ b/client/lcd/lcd_test.go
@@ -266,17 +266,21 @@ func TestCoinSend(t *testing.T) {
 	require.Equal(t, int64(1), mycoins.Amount.Int64())
 
 	// test failure with too little gas
-	res, body, _ = doSendWithGas(t, port, seed, name, password, addr, 100, "")
+	res, body, _ = doSendWithGas(t, port, seed, name, password, addr, 100, 0, "")
+	require.Equal(t, http.StatusInternalServerError, res.StatusCode, body)
+
+	// test failure with wrong adjustment
+	res, body, _ = doSendWithGas(t, port, seed, name, password, addr, 0, 0.1, "")
 	require.Equal(t, http.StatusInternalServerError, res.StatusCode, body)
 
 	// run simulation and test success with estimated gas
-	res, body, _ = doSendWithGas(t, port, seed, name, password, addr, 0, "?simulate=true")
+	res, body, _ = doSendWithGas(t, port, seed, name, password, addr, 0, 0, "?simulate=true")
 	require.Equal(t, http.StatusOK, res.StatusCode, body)
 	var responseBody struct {
 		GasEstimate int64 `json:"gas_estimate"`
 	}
 	require.Nil(t, json.Unmarshal([]byte(body), &responseBody))
-	res, body, _ = doSendWithGas(t, port, seed, name, password, addr, responseBody.GasEstimate, "")
+	res, body, _ = doSendWithGas(t, port, seed, name, password, addr, responseBody.GasEstimate, 0, "")
 	require.Equal(t, http.StatusOK, res.StatusCode, body)
 }
 
@@ -727,7 +731,7 @@ func getAccount(t *testing.T, port string, addr sdk.AccAddress) auth.Account {
 	return acc
 }
 
-func doSendWithGas(t *testing.T, port, seed, name, password string, addr sdk.AccAddress, gas int64, queryStr string) (res *http.Response, body string, receiveAddr sdk.AccAddress) {
+func doSendWithGas(t *testing.T, port, seed, name, password string, addr sdk.AccAddress, gas int64, gasAdjustment float64, queryStr string) (res *http.Response, body string, receiveAddr sdk.AccAddress) {
 
 	// create receive address
 	kb := client.MockKeyBase()
@@ -751,22 +755,28 @@ func doSendWithGas(t *testing.T, port, seed, name, password string, addr sdk.Acc
 		"gas":"%v",
 		`, gas)
 	}
+	gasAdjustmentStr := ""
+	if gasAdjustment > 0 {
+		gasStr = fmt.Sprintf(`
+		"gas_adjustment":"%v",
+		`, gasAdjustment)
+	}
 	jsonStr := []byte(fmt.Sprintf(`{
-		%v
+		%v%v
 		"name":"%s",
 		"password":"%s",
 		"account_number":"%d",
 		"sequence":"%d",
 		"amount":[%s],
 		"chain_id":"%s"
-	}`, gasStr, name, password, accnum, sequence, coinbz, chainID))
+	}`, gasStr, gasAdjustmentStr, name, password, accnum, sequence, coinbz, chainID))
 
 	res, body = Request(t, port, "POST", fmt.Sprintf("/accounts/%s/send%v", receiveAddr, queryStr), jsonStr)
 	return
 }
 
 func doSend(t *testing.T, port, seed, name, password string, addr sdk.AccAddress) (receiveAddr sdk.AccAddress, resultTx ctypes.ResultBroadcastTxCommit) {
-	res, body, receiveAddr := doSendWithGas(t, port, seed, name, password, addr, 0, "")
+	res, body, receiveAddr := doSendWithGas(t, port, seed, name, password, addr, 0, 0, "")
 	require.Equal(t, http.StatusOK, res.StatusCode, body)
 
 	err := cdc.UnmarshalJSON([]byte(body), &resultTx)

--- a/client/lcd/lcd_test.go
+++ b/client/lcd/lcd_test.go
@@ -2,6 +2,7 @@ package lcd
 
 import (
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"regexp"
@@ -265,11 +266,17 @@ func TestCoinSend(t *testing.T) {
 	require.Equal(t, int64(1), mycoins.Amount.Int64())
 
 	// test failure with too little gas
-	res, body, _ = doSendWithGas(t, port, seed, name, password, addr, 100)
+	res, body, _ = doSendWithGas(t, port, seed, name, password, addr, 100, "")
 	require.Equal(t, http.StatusInternalServerError, res.StatusCode, body)
 
-	// test success with just enough gas
-	res, body, _ = doSendWithGas(t, port, seed, name, password, addr, 3000)
+	// run simulation and test success with estimated gas
+	res, body, _ = doSendWithGas(t, port, seed, name, password, addr, 0, "?simulate=true")
+	require.Equal(t, http.StatusOK, res.StatusCode, body)
+	var responseBody struct {
+		GasEstimate int64 `json:"gas_estimate"`
+	}
+	require.Nil(t, json.Unmarshal([]byte(body), &responseBody))
+	res, body, _ = doSendWithGas(t, port, seed, name, password, addr, responseBody.GasEstimate, "")
 	require.Equal(t, http.StatusOK, res.StatusCode, body)
 }
 
@@ -720,7 +727,7 @@ func getAccount(t *testing.T, port string, addr sdk.AccAddress) auth.Account {
 	return acc
 }
 
-func doSendWithGas(t *testing.T, port, seed, name, password string, addr sdk.AccAddress, gas int64) (res *http.Response, body string, receiveAddr sdk.AccAddress) {
+func doSendWithGas(t *testing.T, port, seed, name, password string, addr sdk.AccAddress, gas int64, queryStr string) (res *http.Response, body string, receiveAddr sdk.AccAddress) {
 
 	// create receive address
 	kb := client.MockKeyBase()
@@ -754,12 +761,12 @@ func doSendWithGas(t *testing.T, port, seed, name, password string, addr sdk.Acc
 		"chain_id":"%s"
 	}`, gasStr, name, password, accnum, sequence, coinbz, chainID))
 
-	res, body = Request(t, port, "POST", fmt.Sprintf("/accounts/%s/send", receiveAddr), jsonStr)
+	res, body = Request(t, port, "POST", fmt.Sprintf("/accounts/%s/send%v", receiveAddr, queryStr), jsonStr)
 	return
 }
 
 func doSend(t *testing.T, port, seed, name, password string, addr sdk.AccAddress) (receiveAddr sdk.AccAddress, resultTx ctypes.ResultBroadcastTxCommit) {
-	res, body, receiveAddr := doSendWithGas(t, port, seed, name, password, addr, 0)
+	res, body, receiveAddr := doSendWithGas(t, port, seed, name, password, addr, 0, "")
 	require.Equal(t, http.StatusOK, res.StatusCode, body)
 
 	err := cdc.UnmarshalJSON([]byte(body), &resultTx)

--- a/client/utils/rest.go
+++ b/client/utils/rest.go
@@ -1,7 +1,12 @@
 package utils
 
 import (
+	"fmt"
 	"net/http"
+)
+
+const (
+	queryArgDryRun = "simulate"
 )
 
 // WriteErrorResponse prepares and writes a HTTP error
@@ -9,4 +14,17 @@ import (
 func WriteErrorResponse(w *http.ResponseWriter, status int, msg string) {
 	(*w).WriteHeader(status)
 	(*w).Write([]byte(msg))
+}
+
+// WriteGasEstimateResponse prepares and writes an HTTP
+// response for transactions simulations.
+func WriteSimulationResponse(w *http.ResponseWriter, gas int64) {
+	(*w).WriteHeader(http.StatusOK)
+	(*w).Write([]byte(fmt.Sprintf(`{"gas_estimate":%v}`, gas)))
+}
+
+// HasDryRunArg returns true if the request's URL query contains
+// the dry run argument and its value is set to "true".
+func HasDryRunArg(r *http.Request) bool {
+	return r.URL.Query().Get(queryArgDryRun) == "true"
 }

--- a/client/utils/rest.go
+++ b/client/utils/rest.go
@@ -12,16 +12,16 @@ const (
 
 // WriteErrorResponse prepares and writes a HTTP error
 // given a status code and an error message.
-func WriteErrorResponse(w *http.ResponseWriter, status int, msg string) {
-	(*w).WriteHeader(status)
-	(*w).Write([]byte(msg))
+func WriteErrorResponse(w http.ResponseWriter, status int, msg string) {
+	w.WriteHeader(status)
+	w.Write([]byte(msg))
 }
 
 // WriteGasEstimateResponse prepares and writes an HTTP
 // response for transactions simulations.
-func WriteSimulationResponse(w *http.ResponseWriter, gas int64) {
-	(*w).WriteHeader(http.StatusOK)
-	(*w).Write([]byte(fmt.Sprintf(`{"gas_estimate":%v}`, gas)))
+func WriteSimulationResponse(w http.ResponseWriter, gas int64) {
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte(fmt.Sprintf(`{"gas_estimate":%v}`, gas)))
 }
 
 // HasDryRunArg returns true if the request's URL query contains
@@ -32,7 +32,7 @@ func HasDryRunArg(r *http.Request) bool {
 
 // ParseFloat64OrReturnBadRequest converts s to a float64 value. It returns a default
 // value if the string is empty. Write
-func ParseFloat64OrReturnBadRequest(w *http.ResponseWriter, s string, defaultIfEmpty float64) (n float64, ok bool) {
+func ParseFloat64OrReturnBadRequest(w http.ResponseWriter, s string, defaultIfEmpty float64) (n float64, ok bool) {
 	if len(s) == 0 {
 		return defaultIfEmpty, true
 	}

--- a/client/utils/rest.go
+++ b/client/utils/rest.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"fmt"
 	"net/http"
+	"strconv"
 )
 
 const (
@@ -27,4 +28,18 @@ func WriteSimulationResponse(w *http.ResponseWriter, gas int64) {
 // the dry run argument and its value is set to "true".
 func HasDryRunArg(r *http.Request) bool {
 	return r.URL.Query().Get(queryArgDryRun) == "true"
+}
+
+// ParseFloat64OrReturnBadRequest converts s to a float64 value. It returns a default
+// value if the string is empty. Write
+func ParseFloat64OrReturnBadRequest(w *http.ResponseWriter, s string, defaultIfEmpty float64) (n float64, ok bool) {
+	if len(s) == 0 {
+		return defaultIfEmpty, true
+	}
+	n, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		WriteErrorResponse(w, http.StatusBadRequest, err.Error())
+		return n, false
+	}
+	return n, true
 }

--- a/client/utils/utils.go
+++ b/client/utils/utils.go
@@ -12,11 +12,6 @@ import (
 	"github.com/tendermint/tendermint/libs/common"
 )
 
-// DefaultGasAdjustment is applied to gas estimates to avoid tx
-// execution failures due to state changes that might
-// occur between the tx simulation and the actual run.
-const DefaultGasAdjustment = 1.0
-
 // SendTx implements a auxiliary handler that facilitates sending a series of
 // messages in a signed transaction given a TxContext and a QueryContext. It
 // ensures that the account exists, has a proper number and sequence set. In
@@ -91,9 +86,6 @@ func CalculateGas(queryFunc func(string, common.HexBytes) ([]byte, error), cdc *
 }
 
 func adjustGasEstimate(estimate int64, adjustment float64) int64 {
-	if adjustment == 0 {
-		adjustment = DefaultGasAdjustment
-	}
 	return int64(adjustment * float64(estimate))
 }
 

--- a/client/utils/utils.go
+++ b/client/utils/utils.go
@@ -15,7 +15,7 @@ import (
 // DefaultGasAdjustment is applied to gas estimates to avoid tx
 // execution failures due to state changes that might
 // occur between the tx simulation and the actual run.
-const DefaultGasAdjustment = 1.2
+const DefaultGasAdjustment = 1.0
 
 // SendTx implements a auxiliary handler that facilitates sending a series of
 // messages in a signed transaction given a TxContext and a QueryContext. It
@@ -23,47 +23,25 @@ const DefaultGasAdjustment = 1.2
 // addition, it builds and signs a transaction with the supplied messages.
 // Finally, it broadcasts the signed transaction to a node.
 func SendTx(txCtx authctx.TxContext, cliCtx context.CLIContext, msgs []sdk.Msg) error {
-	if err := cliCtx.EnsureAccountExists(); err != nil {
-		return err
-	}
-
-	from, err := cliCtx.GetFromAddress()
+	txCtx, err := prepareTxContext(txCtx, cliCtx)
 	if err != nil {
 		return err
 	}
-
-	// TODO: (ref #1903) Allow for user supplied account number without
-	// automatically doing a manual lookup.
-	if txCtx.AccountNumber == 0 {
-		accNum, err := cliCtx.GetAccountNumber(from)
+	autogas := cliCtx.DryRun || (cliCtx.Gas == 0)
+	if autogas {
+		txCtx, err = EnrichCtxWithGas(txCtx, cliCtx, cliCtx.FromAddressName, msgs)
 		if err != nil {
 			return err
 		}
-
-		txCtx = txCtx.WithAccountNumber(accNum)
+		fmt.Fprintf(os.Stdout, "estimated gas = %v\n", txCtx.Gas)
 	}
-
-	// TODO: (ref #1903) Allow for user supplied account sequence without
-	// automatically doing a manual lookup.
-	if txCtx.Sequence == 0 {
-		accSeq, err := cliCtx.GetAccountSequence(from)
-		if err != nil {
-			return err
-		}
-
-		txCtx = txCtx.WithSequence(accSeq)
+	if cliCtx.DryRun {
+		return nil
 	}
 
 	passphrase, err := keys.GetPassphrase(cliCtx.FromAddressName)
 	if err != nil {
 		return err
-	}
-
-	if cliCtx.Gas == 0 {
-		txCtx, err = EnrichCtxWithGas(txCtx, cliCtx, cliCtx.FromAddressName, passphrase, msgs)
-		if err != nil {
-			return err
-		}
 	}
 
 	// build and sign the transaction
@@ -75,24 +53,24 @@ func SendTx(txCtx authctx.TxContext, cliCtx context.CLIContext, msgs []sdk.Msg) 
 	return cliCtx.EnsureBroadcastTx(txBytes)
 }
 
-// EnrichCtxWithGas calculates the gas estimate that would be consumed by the
-// transaction and set the transaction's respective value accordingly.
-func EnrichCtxWithGas(txCtx authctx.TxContext, cliCtx context.CLIContext, name, passphrase string, msgs []sdk.Msg) (authctx.TxContext, error) {
-	txBytes, err := BuildAndSignTxWithZeroGas(txCtx, name, passphrase, msgs)
+// SimulateMsgs simulates the transaction and returns the gas estimate and the adjusted value.
+func SimulateMsgs(txCtx authctx.TxContext, cliCtx context.CLIContext, name string, msgs []sdk.Msg, gas int64) (estimated, adjusted int64, err error) {
+	txBytes, err := txCtx.WithGas(gas).BuildWithPubKey(name, msgs)
 	if err != nil {
-		return txCtx, err
+		return
 	}
-	estimate, adjusted, err := CalculateGas(cliCtx.Query, cliCtx.Codec, txBytes, cliCtx.GasAdjustment)
-	if err != nil {
-		return txCtx, err
-	}
-	fmt.Fprintf(os.Stderr, "gas: [estimated = %v] [adjusted = %v]\n", estimate, adjusted)
-	return txCtx.WithGas(adjusted), nil
+	estimated, adjusted, err = CalculateGas(cliCtx.Query, cliCtx.Codec, txBytes, cliCtx.GasAdjustment)
+	return
 }
 
-// BuildAndSignTxWithZeroGas builds transactions with GasWanted set to 0.
-func BuildAndSignTxWithZeroGas(txCtx authctx.TxContext, name, passphrase string, msgs []sdk.Msg) ([]byte, error) {
-	return txCtx.WithGas(0).BuildAndSign(name, passphrase, msgs)
+// EnrichCtxWithGas calculates the gas estimate that would be consumed by the
+// transaction and set the transaction's respective value accordingly.
+func EnrichCtxWithGas(txCtx authctx.TxContext, cliCtx context.CLIContext, name string, msgs []sdk.Msg) (authctx.TxContext, error) {
+	_, adjusted, err := SimulateMsgs(txCtx, cliCtx, name, msgs, 0)
+	if err != nil {
+		return txCtx, err
+	}
+	return txCtx.WithGas(adjusted), nil
 }
 
 // CalculateGas simulates the execution of a transaction and returns
@@ -109,13 +87,12 @@ func CalculateGas(queryFunc func(string, common.HexBytes) ([]byte, error), cdc *
 		return
 	}
 	adjusted = adjustGasEstimate(estimate, adjustment)
-	fmt.Fprintf(os.Stderr, "gas: [estimated = %v] [adjusted = %v]\n", estimate, adjusted)
 	return
 }
 
 func adjustGasEstimate(estimate int64, adjustment float64) int64 {
 	if adjustment == 0 {
-		return int64(DefaultGasAdjustment * float64(estimate))
+		adjustment = DefaultGasAdjustment
 	}
 	return int64(adjustment * float64(estimate))
 }
@@ -126,4 +103,36 @@ func parseQueryResponse(cdc *amino.Codec, rawRes []byte) (int64, error) {
 		return 0, err
 	}
 	return simulationResult.GasUsed, nil
+}
+
+func prepareTxContext(txCtx authctx.TxContext, cliCtx context.CLIContext) (authctx.TxContext, error) {
+	if err := cliCtx.EnsureAccountExists(); err != nil {
+		return txCtx, err
+	}
+
+	from, err := cliCtx.GetFromAddress()
+	if err != nil {
+		return txCtx, err
+	}
+
+	// TODO: (ref #1903) Allow for user supplied account number without
+	// automatically doing a manual lookup.
+	if txCtx.AccountNumber == 0 {
+		accNum, err := cliCtx.GetAccountNumber(from)
+		if err != nil {
+			return txCtx, err
+		}
+		txCtx = txCtx.WithAccountNumber(accNum)
+	}
+
+	// TODO: (ref #1903) Allow for user supplied account sequence without
+	// automatically doing a manual lookup.
+	if txCtx.Sequence == 0 {
+		accSeq, err := cliCtx.GetAccountSequence(from)
+		if err != nil {
+			return txCtx, err
+		}
+		txCtx = txCtx.WithSequence(accSeq)
+	}
+	return txCtx, nil
 }

--- a/cmd/gaia/cli_test/cli_test.go
+++ b/cmd/gaia/cli_test/cli_test.go
@@ -58,6 +58,13 @@ func TestGaiaCLISend(t *testing.T) {
 	fooAcc = executeGetAccount(t, fmt.Sprintf("gaiacli account %s %v", fooAddr, flags))
 	require.Equal(t, int64(40), fooAcc.GetCoins().AmountOf("steak").Int64())
 
+	// Test --dry-run
+	success := executeWrite(t, fmt.Sprintf("gaiacli send %v --amount=10steak --to=%s --from=foo --dry-run", flags, barAddr), app.DefaultKeyPass)
+	require.True(t, success)
+	// Check state didn't change
+	fooAcc = executeGetAccount(t, fmt.Sprintf("gaiacli account %s %v", fooAddr, flags))
+	require.Equal(t, int64(40), fooAcc.GetCoins().AmountOf("steak").Int64())
+
 	// test autosequencing
 	executeWrite(t, fmt.Sprintf("gaiacli send %v --amount=10steak --to=%s --from=foo", flags, barAddr), app.DefaultKeyPass)
 	tests.WaitForNextNBlocksTM(2, port)
@@ -148,6 +155,10 @@ func TestGaiaCLICreateValidator(t *testing.T) {
 
 	initialPool.BondedTokens = initialPool.BondedTokens.Add(sdk.NewDec(1))
 
+	// Test --dry-run
+	success := executeWrite(t, cvStr+" --dry-run", app.DefaultKeyPass)
+	require.True(t, success)
+
 	executeWrite(t, cvStr, app.DefaultKeyPass)
 	tests.WaitForNextNBlocksTM(2, port)
 
@@ -164,7 +175,7 @@ func TestGaiaCLICreateValidator(t *testing.T) {
 	unbondStr += fmt.Sprintf(" --validator=%s", sdk.ValAddress(barAddr))
 	unbondStr += fmt.Sprintf(" --shares-amount=%v", "1")
 
-	success := executeWrite(t, unbondStr, app.DefaultKeyPass)
+	success = executeWrite(t, unbondStr, app.DefaultKeyPass)
 	require.True(t, success)
 	tests.WaitForNextNBlocksTM(2, port)
 
@@ -210,6 +221,10 @@ func TestGaiaCLISubmitProposal(t *testing.T) {
 	spStr += fmt.Sprintf(" --type=%s", "Text")
 	spStr += fmt.Sprintf(" --title=%s", "Test")
 	spStr += fmt.Sprintf(" --description=%s", "test")
+
+	// Test --dry-run
+	success := executeWrite(t, spStr+" --dry-run", app.DefaultKeyPass)
+	require.True(t, success)
 
 	executeWrite(t, spStr, app.DefaultKeyPass)
 	tests.WaitForNextNBlocksTM(2, port)

--- a/docs/sdk/clients.md
+++ b/docs/sdk/clients.md
@@ -95,6 +95,8 @@ When you query an account balance with zero tokens, you will get this error: `No
 
 ### Send Tokens
 
+The following command could be used to send coins from one account to another:
+
 ```bash
 gaiacli send \
   --amount=10faucetToken \
@@ -110,7 +112,7 @@ The `--amount` flag accepts the format `--amount=<value|coin_name>`.
 ::: tip Note
 You may want to cap the maximum gas that can be consumed by the transaction via the `--gas` flag.
 If set to 0, the gas limit will be automatically estimated.
-Gas estimate might be inaccurate as state changes could occur in between the end of the simulation and the actual execution of a transaction, thus an adjustment is applied on top of the original estimate in order to ensure the transaction is broadcasted successfully. The adjustment can be controlled via the `--gas-adjustment` flag, whose default value is 1.2.
+Gas estimate might be inaccurate as state changes could occur in between the end of the simulation and the actual execution of a transaction, thus an adjustment is applied on top of the original estimate in order to ensure the transaction is broadcasted successfully. The adjustment can be controlled via the `--gas-adjustment` flag, whose default value is 1.0.
 :::
 
 Now, view the updated balances of the origin and destination accounts:
@@ -124,6 +126,17 @@ You can also check your balance at a given block by using the `--block` flag:
 
 ```bash
 gaiacli account <account_cosmos> --block=<block_height>
+```
+
+You can simulate a transaction without actually broadcasting it by appending the `--dry-run` flag to the command line:
+
+```bash
+gaiacli send \
+  --amount=10faucetToken \
+  --chain-id=<chain_id> \
+  --name=<key_name> \
+  --to=<destination_cosmosaccaddr> \
+  --dry-run
 ```
 
 ### Staking

--- a/examples/democoin/x/cool/app_test.go
+++ b/examples/democoin/x/cool/app_test.go
@@ -88,17 +88,17 @@ func TestMsgQuiz(t *testing.T) {
 	require.Equal(t, acc1, res1)
 
 	// Set the trend, submit a really cool quiz and check for reward
-	mock.SignCheckDeliver(t, mapp.BaseApp, []sdk.Msg{setTrendMsg1}, []int64{0}, []int64{0}, true, priv1)
-	mock.SignCheckDeliver(t, mapp.BaseApp, []sdk.Msg{quizMsg1}, []int64{0}, []int64{1}, true, priv1)
+	mock.SignCheckDeliver(t, mapp.BaseApp, []sdk.Msg{setTrendMsg1}, []int64{0}, []int64{0}, true, true, priv1)
+	mock.SignCheckDeliver(t, mapp.BaseApp, []sdk.Msg{quizMsg1}, []int64{0}, []int64{1}, true, true, priv1)
 	mock.CheckBalance(t, mapp, addr1, sdk.Coins{{"icecold", sdk.NewInt(69)}})
-	mock.SignCheckDeliver(t, mapp.BaseApp, []sdk.Msg{quizMsg2}, []int64{0}, []int64{2}, false, priv1) // result without reward
+	mock.SignCheckDeliver(t, mapp.BaseApp, []sdk.Msg{quizMsg2}, []int64{0}, []int64{2}, false, false, priv1) // result without reward
 	mock.CheckBalance(t, mapp, addr1, sdk.Coins{{"icecold", sdk.NewInt(69)}})
-	mock.SignCheckDeliver(t, mapp.BaseApp, []sdk.Msg{quizMsg1}, []int64{0}, []int64{3}, true, priv1)
+	mock.SignCheckDeliver(t, mapp.BaseApp, []sdk.Msg{quizMsg1}, []int64{0}, []int64{3}, true, true, priv1)
 	mock.CheckBalance(t, mapp, addr1, sdk.Coins{{"icecold", sdk.NewInt(138)}})
-	mock.SignCheckDeliver(t, mapp.BaseApp, []sdk.Msg{setTrendMsg2}, []int64{0}, []int64{4}, true, priv1) // reset the trend
-	mock.SignCheckDeliver(t, mapp.BaseApp, []sdk.Msg{quizMsg1}, []int64{0}, []int64{5}, false, priv1)    // the same answer will nolonger do!
+	mock.SignCheckDeliver(t, mapp.BaseApp, []sdk.Msg{setTrendMsg2}, []int64{0}, []int64{4}, true, true, priv1) // reset the trend
+	mock.SignCheckDeliver(t, mapp.BaseApp, []sdk.Msg{quizMsg1}, []int64{0}, []int64{5}, false, false, priv1)   // the same answer will nolonger do!
 	mock.CheckBalance(t, mapp, addr1, sdk.Coins{{"icecold", sdk.NewInt(138)}})
-	mock.SignCheckDeliver(t, mapp.BaseApp, []sdk.Msg{quizMsg2}, []int64{0}, []int64{6}, true, priv1) // earlier answer now relevant again
+	mock.SignCheckDeliver(t, mapp.BaseApp, []sdk.Msg{quizMsg2}, []int64{0}, []int64{6}, true, true, priv1) // earlier answer now relevant again
 	mock.CheckBalance(t, mapp, addr1, sdk.Coins{{"badvibesonly", sdk.NewInt(69)}, {"icecold", sdk.NewInt(138)}})
-	mock.SignCheckDeliver(t, mapp.BaseApp, []sdk.Msg{setTrendMsg3}, []int64{0}, []int64{7}, false, priv1) // expect to fail to set the trend to something which is not cool
+	mock.SignCheckDeliver(t, mapp.BaseApp, []sdk.Msg{setTrendMsg3}, []int64{0}, []int64{7}, false, false, priv1) // expect to fail to set the trend to something which is not cool
 }

--- a/examples/democoin/x/pow/app_test.go
+++ b/examples/democoin/x/pow/app_test.go
@@ -74,13 +74,13 @@ func TestMsgMine(t *testing.T) {
 
 	// Mine and check for reward
 	mineMsg1 := GenerateMsgMine(addr1, 1, 2)
-	mock.SignCheckDeliver(t, mapp.BaseApp, []sdk.Msg{mineMsg1}, []int64{0}, []int64{0}, true, priv1)
+	mock.SignCheckDeliver(t, mapp.BaseApp, []sdk.Msg{mineMsg1}, []int64{0}, []int64{0}, true, true, priv1)
 	mock.CheckBalance(t, mapp, addr1, sdk.Coins{{"pow", sdk.NewInt(1)}})
 	// Mine again and check for reward
 	mineMsg2 := GenerateMsgMine(addr1, 2, 3)
-	mock.SignCheckDeliver(t, mapp.BaseApp, []sdk.Msg{mineMsg2}, []int64{0}, []int64{1}, true, priv1)
+	mock.SignCheckDeliver(t, mapp.BaseApp, []sdk.Msg{mineMsg2}, []int64{0}, []int64{1}, true, true, priv1)
 	mock.CheckBalance(t, mapp, addr1, sdk.Coins{{"pow", sdk.NewInt(2)}})
 	// Mine again - should be invalid
-	mock.SignCheckDeliver(t, mapp.BaseApp, []sdk.Msg{mineMsg2}, []int64{0}, []int64{1}, false, priv1)
+	mock.SignCheckDeliver(t, mapp.BaseApp, []sdk.Msg{mineMsg2}, []int64{0}, []int64{1}, false, false, priv1)
 	mock.CheckBalance(t, mapp, addr1, sdk.Coins{{"pow", sdk.NewInt(2)}})
 }

--- a/x/auth/ante.go
+++ b/x/auth/ante.go
@@ -175,14 +175,11 @@ func processSig(
 				fmt.Sprintf("Invalid sequence. Got %d, expected %d", sig.Sequence, seq)).Result()
 		}
 	}
-	// Increment sequence number
 	err := acc.SetSequence(seq + 1)
 	if err != nil {
 		// Handle w/ #870
 		panic(err)
 	}
-	// If pubkey is not known for account,
-	// set it from the StdSignature.
 	pubKey, res := processPubKey(acc, sig, simulate)
 	if !res.IsOK() {
 		return nil, res

--- a/x/auth/ante.go
+++ b/x/auth/ante.go
@@ -68,9 +68,6 @@ func NewAnteHandler(am AccountMapper, fck FeeCollectionKeeper) sdk.AnteHandler {
 		sigs := stdTx.GetSignatures() // When simulating, this would just be a 0-length slice.
 		signerAddrs := stdTx.GetSigners()
 		msgs := tx.GetMsgs()
-		if simulate {
-			sigs = make([]StdSignature, len(signerAddrs))
-		}
 
 		// charge gas for the memo
 		newCtx.GasMeter().ConsumeGas(memoCostPerByte*sdk.Gas(len(stdTx.GetMemo())), "memo")
@@ -160,20 +157,16 @@ func processSig(
 	accnum := acc.GetAccountNumber()
 	seq := acc.GetSequence()
 
-	// Perform checks that wouldn't pass successfully in simulation, i.e. sig
-	// would be empty as simulated transactions come with no signatures whatsoever.
-	if !simulate {
-		// Check account number.
-		if accnum != sig.AccountNumber {
-			return nil, sdk.ErrInvalidSequence(
-				fmt.Sprintf("Invalid account number. Got %d, expected %d", sig.AccountNumber, accnum)).Result()
-		}
+	// Check account number.
+	if accnum != sig.AccountNumber {
+		return nil, sdk.ErrInvalidSequence(
+			fmt.Sprintf("Invalid account number. Got %d, expected %d", sig.AccountNumber, accnum)).Result()
+	}
 
-		// Check sequence number.
-		if seq != sig.Sequence {
-			return nil, sdk.ErrInvalidSequence(
-				fmt.Sprintf("Invalid sequence. Got %d, expected %d", sig.Sequence, seq)).Result()
-		}
+	// Check sequence number.
+	if seq != sig.Sequence {
+		return nil, sdk.ErrInvalidSequence(
+			fmt.Sprintf("Invalid sequence. Got %d, expected %d", sig.Sequence, seq)).Result()
 	}
 	err := acc.SetSequence(seq + 1)
 	if err != nil {

--- a/x/auth/client/rest/query.go
+++ b/x/auth/client/rest/query.go
@@ -33,13 +33,13 @@ func QueryAccountRequestHandlerFn(
 
 		addr, err := sdk.AccAddressFromBech32(bech32addr)
 		if err != nil {
-			utils.WriteErrorResponse(&w, http.StatusInternalServerError, err.Error())
+			utils.WriteErrorResponse(w, http.StatusInternalServerError, err.Error())
 			return
 		}
 
 		res, err := cliCtx.QueryStore(auth.AddressStoreKey(addr), storeName)
 		if err != nil {
-			utils.WriteErrorResponse(&w, http.StatusInternalServerError, fmt.Sprintf("couldn't query account. Error: %s", err.Error()))
+			utils.WriteErrorResponse(w, http.StatusInternalServerError, fmt.Sprintf("couldn't query account. Error: %s", err.Error()))
 			return
 		}
 
@@ -52,14 +52,14 @@ func QueryAccountRequestHandlerFn(
 		// decode the value
 		account, err := decoder(res)
 		if err != nil {
-			utils.WriteErrorResponse(&w, http.StatusInternalServerError, fmt.Sprintf("couldn't parse query result. Result: %s. Error: %s", res, err.Error()))
+			utils.WriteErrorResponse(w, http.StatusInternalServerError, fmt.Sprintf("couldn't parse query result. Result: %s. Error: %s", res, err.Error()))
 			return
 		}
 
 		// print out whole account
 		output, err := cdc.MarshalJSON(account)
 		if err != nil {
-			utils.WriteErrorResponse(&w, http.StatusInternalServerError, fmt.Sprintf("couldn't marshall query result. Error: %s", err.Error()))
+			utils.WriteErrorResponse(w, http.StatusInternalServerError, fmt.Sprintf("couldn't marshall query result. Error: %s", err.Error()))
 			return
 		}
 

--- a/x/bank/app_test.go
+++ b/x/bank/app_test.go
@@ -21,6 +21,7 @@ type (
 	}
 
 	appTestCase struct {
+		expSimPass       bool
 		expPass          bool
 		msgs             []sdk.Msg
 		accNums          []int64
@@ -107,27 +108,29 @@ func TestMsgSendWithAccounts(t *testing.T) {
 
 	testCases := []appTestCase{
 		{
-			msgs:     []sdk.Msg{sendMsg1},
-			accNums:  []int64{0},
-			accSeqs:  []int64{0},
-			expPass:  true,
-			privKeys: []crypto.PrivKey{priv1},
+			msgs:       []sdk.Msg{sendMsg1},
+			accNums:    []int64{0},
+			accSeqs:    []int64{0},
+			expSimPass: true,
+			expPass:    true,
+			privKeys:   []crypto.PrivKey{priv1},
 			expectedBalances: []expectedBalance{
 				{addr1, sdk.Coins{sdk.NewInt64Coin("foocoin", 57)}},
 				{addr2, sdk.Coins{sdk.NewInt64Coin("foocoin", 10)}},
 			},
 		},
 		{
-			msgs:     []sdk.Msg{sendMsg1, sendMsg2},
-			accNums:  []int64{0},
-			accSeqs:  []int64{0},
-			expPass:  false,
-			privKeys: []crypto.PrivKey{priv1},
+			msgs:       []sdk.Msg{sendMsg1, sendMsg2},
+			accNums:    []int64{0},
+			accSeqs:    []int64{0},
+			expSimPass: true,
+			expPass:    false,
+			privKeys:   []crypto.PrivKey{priv1},
 		},
 	}
 
 	for _, tc := range testCases {
-		mock.SignCheckDeliver(t, mapp.BaseApp, tc.msgs, tc.accNums, tc.accSeqs, tc.expPass, tc.privKeys...)
+		mock.SignCheckDeliver(t, mapp.BaseApp, tc.msgs, tc.accNums, tc.accSeqs, tc.expSimPass, tc.expPass, tc.privKeys...)
 
 		for _, eb := range tc.expectedBalances {
 			mock.CheckBalance(t, mapp, eb.addr, eb.coins)
@@ -144,7 +147,7 @@ func TestMsgSendWithAccounts(t *testing.T) {
 	require.Equal(t, sdk.ToABCICode(sdk.CodespaceRoot, sdk.CodeUnauthorized), res.Code, res.Log)
 
 	// resigning the tx with the bumped sequence should work
-	mock.SignCheckDeliver(t, mapp.BaseApp, []sdk.Msg{sendMsg1, sendMsg2}, []int64{0}, []int64{1}, true, priv1)
+	mock.SignCheckDeliver(t, mapp.BaseApp, []sdk.Msg{sendMsg1, sendMsg2}, []int64{0}, []int64{1}, true, true, priv1)
 }
 
 func TestMsgSendMultipleOut(t *testing.T) {
@@ -163,11 +166,12 @@ func TestMsgSendMultipleOut(t *testing.T) {
 
 	testCases := []appTestCase{
 		{
-			msgs:     []sdk.Msg{sendMsg2},
-			accNums:  []int64{0},
-			accSeqs:  []int64{0},
-			expPass:  true,
-			privKeys: []crypto.PrivKey{priv1},
+			msgs:       []sdk.Msg{sendMsg2},
+			accNums:    []int64{0},
+			accSeqs:    []int64{0},
+			expSimPass: true,
+			expPass:    true,
+			privKeys:   []crypto.PrivKey{priv1},
 			expectedBalances: []expectedBalance{
 				{addr1, sdk.Coins{sdk.NewInt64Coin("foocoin", 32)}},
 				{addr2, sdk.Coins{sdk.NewInt64Coin("foocoin", 47)}},
@@ -177,7 +181,7 @@ func TestMsgSendMultipleOut(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		mock.SignCheckDeliver(t, mapp.BaseApp, tc.msgs, tc.accNums, tc.accSeqs, tc.expPass, tc.privKeys...)
+		mock.SignCheckDeliver(t, mapp.BaseApp, tc.msgs, tc.accNums, tc.accSeqs, tc.expSimPass, tc.expPass, tc.privKeys...)
 
 		for _, eb := range tc.expectedBalances {
 			mock.CheckBalance(t, mapp, eb.addr, eb.coins)
@@ -205,11 +209,12 @@ func TestSengMsgMultipleInOut(t *testing.T) {
 
 	testCases := []appTestCase{
 		{
-			msgs:     []sdk.Msg{sendMsg3},
-			accNums:  []int64{0, 2},
-			accSeqs:  []int64{0, 0},
-			expPass:  true,
-			privKeys: []crypto.PrivKey{priv1, priv4},
+			msgs:       []sdk.Msg{sendMsg3},
+			accNums:    []int64{0, 2},
+			accSeqs:    []int64{0, 0},
+			expSimPass: true,
+			expPass:    true,
+			privKeys:   []crypto.PrivKey{priv1, priv4},
 			expectedBalances: []expectedBalance{
 				{addr1, sdk.Coins{sdk.NewInt64Coin("foocoin", 32)}},
 				{addr4, sdk.Coins{sdk.NewInt64Coin("foocoin", 32)}},
@@ -220,7 +225,7 @@ func TestSengMsgMultipleInOut(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		mock.SignCheckDeliver(t, mapp.BaseApp, tc.msgs, tc.accNums, tc.accSeqs, tc.expPass, tc.privKeys...)
+		mock.SignCheckDeliver(t, mapp.BaseApp, tc.msgs, tc.accNums, tc.accSeqs, tc.expSimPass, tc.expPass, tc.privKeys...)
 
 		for _, eb := range tc.expectedBalances {
 			mock.CheckBalance(t, mapp, eb.addr, eb.coins)
@@ -240,22 +245,24 @@ func TestMsgSendDependent(t *testing.T) {
 
 	testCases := []appTestCase{
 		{
-			msgs:     []sdk.Msg{sendMsg1},
-			accNums:  []int64{0},
-			accSeqs:  []int64{0},
-			expPass:  true,
-			privKeys: []crypto.PrivKey{priv1},
+			msgs:       []sdk.Msg{sendMsg1},
+			accNums:    []int64{0},
+			accSeqs:    []int64{0},
+			expSimPass: true,
+			expPass:    true,
+			privKeys:   []crypto.PrivKey{priv1},
 			expectedBalances: []expectedBalance{
 				{addr1, sdk.Coins{sdk.NewInt64Coin("foocoin", 32)}},
 				{addr2, sdk.Coins{sdk.NewInt64Coin("foocoin", 10)}},
 			},
 		},
 		{
-			msgs:     []sdk.Msg{sendMsg4},
-			accNums:  []int64{1},
-			accSeqs:  []int64{0},
-			expPass:  true,
-			privKeys: []crypto.PrivKey{priv2},
+			msgs:       []sdk.Msg{sendMsg4},
+			accNums:    []int64{1},
+			accSeqs:    []int64{0},
+			expSimPass: true,
+			expPass:    true,
+			privKeys:   []crypto.PrivKey{priv2},
 			expectedBalances: []expectedBalance{
 				{addr1, sdk.Coins{sdk.NewInt64Coin("foocoin", 42)}},
 			},
@@ -263,7 +270,7 @@ func TestMsgSendDependent(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		mock.SignCheckDeliver(t, mapp.BaseApp, tc.msgs, tc.accNums, tc.accSeqs, tc.expPass, tc.privKeys...)
+		mock.SignCheckDeliver(t, mapp.BaseApp, tc.msgs, tc.accNums, tc.accSeqs, tc.expSimPass, tc.expPass, tc.privKeys...)
 
 		for _, eb := range tc.expectedBalances {
 			mock.CheckBalance(t, mapp, eb.addr, eb.coins)

--- a/x/bank/app_test.go
+++ b/x/bank/app_test.go
@@ -123,7 +123,7 @@ func TestMsgSendWithAccounts(t *testing.T) {
 			msgs:       []sdk.Msg{sendMsg1, sendMsg2},
 			accNums:    []int64{0},
 			accSeqs:    []int64{0},
-			expSimPass: true,
+			expSimPass: false,
 			expPass:    false,
 			privKeys:   []crypto.PrivKey{priv1},
 		},

--- a/x/gov/client/rest/rest.go
+++ b/x/gov/client/rest/rest.go
@@ -81,7 +81,7 @@ func postProposalHandlerFn(cdc *wire.Codec, cliCtx context.CLIContext) http.Hand
 			return
 		}
 
-		signAndBuild(w, cliCtx, req.BaseReq, msg, cdc)
+		signAndBuild(w, r, cliCtx, req.BaseReq, msg, cdc)
 	}
 }
 
@@ -118,7 +118,7 @@ func depositHandlerFn(cdc *wire.Codec, cliCtx context.CLIContext) http.HandlerFu
 			return
 		}
 
-		signAndBuild(w, cliCtx, req.BaseReq, msg, cdc)
+		signAndBuild(w, r, cliCtx, req.BaseReq, msg, cdc)
 	}
 }
 
@@ -155,7 +155,7 @@ func voteHandlerFn(cdc *wire.Codec, cliCtx context.CLIContext) http.HandlerFunc 
 			return
 		}
 
-		signAndBuild(w, cliCtx, req.BaseReq, msg, cdc)
+		signAndBuild(w, r, cliCtx, req.BaseReq, msg, cdc)
 	}
 }
 

--- a/x/gov/client/rest/rest.go
+++ b/x/gov/client/rest/rest.go
@@ -77,7 +77,7 @@ func postProposalHandlerFn(cdc *wire.Codec, cliCtx context.CLIContext) http.Hand
 		msg := gov.NewMsgSubmitProposal(req.Title, req.Description, req.ProposalType, req.Proposer, req.InitialDeposit)
 		err = msg.ValidateBasic()
 		if err != nil {
-			utils.WriteErrorResponse(&w, http.StatusBadRequest, err.Error())
+			utils.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
 			return
 		}
 
@@ -92,7 +92,7 @@ func depositHandlerFn(cdc *wire.Codec, cliCtx context.CLIContext) http.HandlerFu
 
 		if len(strProposalID) == 0 {
 			err := errors.New("proposalId required but not specified")
-			utils.WriteErrorResponse(&w, http.StatusBadRequest, err.Error())
+			utils.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
 			return
 		}
 
@@ -114,7 +114,7 @@ func depositHandlerFn(cdc *wire.Codec, cliCtx context.CLIContext) http.HandlerFu
 		msg := gov.NewMsgDeposit(req.Depositer, proposalID, req.Amount)
 		err = msg.ValidateBasic()
 		if err != nil {
-			utils.WriteErrorResponse(&w, http.StatusBadRequest, err.Error())
+			utils.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
 			return
 		}
 
@@ -129,7 +129,7 @@ func voteHandlerFn(cdc *wire.Codec, cliCtx context.CLIContext) http.HandlerFunc 
 
 		if len(strProposalID) == 0 {
 			err := errors.New("proposalId required but not specified")
-			utils.WriteErrorResponse(&w, http.StatusBadRequest, err.Error())
+			utils.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
 			return
 		}
 
@@ -151,7 +151,7 @@ func voteHandlerFn(cdc *wire.Codec, cliCtx context.CLIContext) http.HandlerFunc 
 		msg := gov.NewMsgVote(req.Voter, proposalID, req.Option)
 		err = msg.ValidateBasic()
 		if err != nil {
-			utils.WriteErrorResponse(&w, http.StatusBadRequest, err.Error())
+			utils.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
 			return
 		}
 
@@ -166,7 +166,7 @@ func queryProposalHandlerFn(cdc *wire.Codec) http.HandlerFunc {
 
 		if len(strProposalID) == 0 {
 			err := errors.New("proposalId required but not specified")
-			utils.WriteErrorResponse(&w, http.StatusBadRequest, err.Error())
+			utils.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
 			return
 		}
 
@@ -183,13 +183,13 @@ func queryProposalHandlerFn(cdc *wire.Codec) http.HandlerFunc {
 
 		bz, err := cdc.MarshalJSON(params)
 		if err != nil {
-			utils.WriteErrorResponse(&w, http.StatusBadRequest, err.Error())
+			utils.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
 			return
 		}
 
 		res, err := cliCtx.QueryWithData("custom/gov/proposal", bz)
 		if err != nil {
-			utils.WriteErrorResponse(&w, http.StatusInternalServerError, err.Error())
+			utils.WriteErrorResponse(w, http.StatusInternalServerError, err.Error())
 			return
 		}
 
@@ -205,7 +205,7 @@ func queryDepositHandlerFn(cdc *wire.Codec) http.HandlerFunc {
 
 		if len(strProposalID) == 0 {
 			err := errors.New("proposalId required but not specified")
-			utils.WriteErrorResponse(&w, http.StatusBadRequest, err.Error())
+			utils.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
 			return
 		}
 
@@ -216,14 +216,14 @@ func queryDepositHandlerFn(cdc *wire.Codec) http.HandlerFunc {
 
 		if len(bechDepositerAddr) == 0 {
 			err := errors.New("depositer address required but not specified")
-			utils.WriteErrorResponse(&w, http.StatusBadRequest, err.Error())
+			utils.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
 			return
 		}
 
 		depositerAddr, err := sdk.AccAddressFromBech32(bechDepositerAddr)
 		if err != nil {
 			err := errors.Errorf("'%s' needs to be bech32 encoded", RestDepositer)
-			utils.WriteErrorResponse(&w, http.StatusBadRequest, err.Error())
+			utils.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
 			return
 		}
 
@@ -236,13 +236,13 @@ func queryDepositHandlerFn(cdc *wire.Codec) http.HandlerFunc {
 
 		bz, err := cdc.MarshalJSON(params)
 		if err != nil {
-			utils.WriteErrorResponse(&w, http.StatusBadRequest, err.Error())
+			utils.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
 			return
 		}
 
 		res, err := cliCtx.QueryWithData("custom/gov/deposit", bz)
 		if err != nil {
-			utils.WriteErrorResponse(&w, http.StatusInternalServerError, err.Error())
+			utils.WriteErrorResponse(w, http.StatusInternalServerError, err.Error())
 			return
 		}
 
@@ -252,11 +252,11 @@ func queryDepositHandlerFn(cdc *wire.Codec) http.HandlerFunc {
 			res, err := cliCtx.QueryWithData("custom/gov/proposal", cdc.MustMarshalBinary(gov.QueryProposalParams{params.ProposalID}))
 			if err != nil || len(res) == 0 {
 				err := errors.Errorf("proposalID [%d] does not exist", proposalID)
-				utils.WriteErrorResponse(&w, http.StatusNotFound, err.Error())
+				utils.WriteErrorResponse(w, http.StatusNotFound, err.Error())
 				return
 			}
 			err = errors.Errorf("depositer [%s] did not deposit on proposalID [%d]", bechDepositerAddr, proposalID)
-			utils.WriteErrorResponse(&w, http.StatusNotFound, err.Error())
+			utils.WriteErrorResponse(w, http.StatusNotFound, err.Error())
 			return
 		}
 
@@ -272,7 +272,7 @@ func queryVoteHandlerFn(cdc *wire.Codec) http.HandlerFunc {
 
 		if len(strProposalID) == 0 {
 			err := errors.New("proposalId required but not specified")
-			utils.WriteErrorResponse(&w, http.StatusBadRequest, err.Error())
+			utils.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
 			return
 		}
 
@@ -283,14 +283,14 @@ func queryVoteHandlerFn(cdc *wire.Codec) http.HandlerFunc {
 
 		if len(bechVoterAddr) == 0 {
 			err := errors.New("voter address required but not specified")
-			utils.WriteErrorResponse(&w, http.StatusBadRequest, err.Error())
+			utils.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
 			return
 		}
 
 		voterAddr, err := sdk.AccAddressFromBech32(bechVoterAddr)
 		if err != nil {
 			err := errors.Errorf("'%s' needs to be bech32 encoded", RestVoter)
-			utils.WriteErrorResponse(&w, http.StatusBadRequest, err.Error())
+			utils.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
 			return
 		}
 
@@ -302,13 +302,13 @@ func queryVoteHandlerFn(cdc *wire.Codec) http.HandlerFunc {
 		}
 		bz, err := cdc.MarshalJSON(params)
 		if err != nil {
-			utils.WriteErrorResponse(&w, http.StatusBadRequest, err.Error())
+			utils.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
 			return
 		}
 
 		res, err := cliCtx.QueryWithData("custom/gov/vote", bz)
 		if err != nil {
-			utils.WriteErrorResponse(&w, http.StatusInternalServerError, err.Error())
+			utils.WriteErrorResponse(w, http.StatusInternalServerError, err.Error())
 			return
 		}
 
@@ -317,17 +317,17 @@ func queryVoteHandlerFn(cdc *wire.Codec) http.HandlerFunc {
 		if vote.Empty() {
 			bz, err := cdc.MarshalJSON(gov.QueryProposalParams{params.ProposalID})
 			if err != nil {
-				utils.WriteErrorResponse(&w, http.StatusBadRequest, err.Error())
+				utils.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
 				return
 			}
 			res, err := cliCtx.QueryWithData("custom/gov/proposal", bz)
 			if err != nil || len(res) == 0 {
 				err := errors.Errorf("proposalID [%d] does not exist", proposalID)
-				utils.WriteErrorResponse(&w, http.StatusNotFound, err.Error())
+				utils.WriteErrorResponse(w, http.StatusNotFound, err.Error())
 				return
 			}
 			err = errors.Errorf("voter [%s] did not deposit on proposalID [%d]", bechVoterAddr, proposalID)
-			utils.WriteErrorResponse(&w, http.StatusNotFound, err.Error())
+			utils.WriteErrorResponse(w, http.StatusNotFound, err.Error())
 			return
 		}
 		w.Write(res)
@@ -343,7 +343,7 @@ func queryVotesOnProposalHandlerFn(cdc *wire.Codec) http.HandlerFunc {
 
 		if len(strProposalID) == 0 {
 			err := errors.New("proposalId required but not specified")
-			utils.WriteErrorResponse(&w, http.StatusBadRequest, err.Error())
+			utils.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
 			return
 		}
 
@@ -359,13 +359,13 @@ func queryVotesOnProposalHandlerFn(cdc *wire.Codec) http.HandlerFunc {
 		}
 		bz, err := cdc.MarshalJSON(params)
 		if err != nil {
-			utils.WriteErrorResponse(&w, http.StatusBadRequest, err.Error())
+			utils.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
 			return
 		}
 
 		res, err := cliCtx.QueryWithData("custom/gov/votes", bz)
 		if err != nil {
-			utils.WriteErrorResponse(&w, http.StatusInternalServerError, err.Error())
+			utils.WriteErrorResponse(w, http.StatusInternalServerError, err.Error())
 			return
 		}
 
@@ -388,7 +388,7 @@ func queryProposalsWithParameterFn(cdc *wire.Codec) http.HandlerFunc {
 			voterAddr, err := sdk.AccAddressFromBech32(bechVoterAddr)
 			if err != nil {
 				err := errors.Errorf("'%s' needs to be bech32 encoded", RestVoter)
-				utils.WriteErrorResponse(&w, http.StatusBadRequest, err.Error())
+				utils.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
 				return
 			}
 			params.Voter = voterAddr
@@ -398,7 +398,7 @@ func queryProposalsWithParameterFn(cdc *wire.Codec) http.HandlerFunc {
 			depositerAddr, err := sdk.AccAddressFromBech32(bechDepositerAddr)
 			if err != nil {
 				err := errors.Errorf("'%s' needs to be bech32 encoded", RestDepositer)
-				utils.WriteErrorResponse(&w, http.StatusBadRequest, err.Error())
+				utils.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
 				return
 			}
 			params.Depositer = depositerAddr
@@ -408,7 +408,7 @@ func queryProposalsWithParameterFn(cdc *wire.Codec) http.HandlerFunc {
 			proposalStatus, err := gov.ProposalStatusFromString(strProposalStatus)
 			if err != nil {
 				err := errors.Errorf("'%s' is not a valid Proposal Status", strProposalStatus)
-				utils.WriteErrorResponse(&w, http.StatusBadRequest, err.Error())
+				utils.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
 				return
 			}
 			params.ProposalStatus = proposalStatus
@@ -423,7 +423,7 @@ func queryProposalsWithParameterFn(cdc *wire.Codec) http.HandlerFunc {
 
 		bz, err := cdc.MarshalJSON(params)
 		if err != nil {
-			utils.WriteErrorResponse(&w, http.StatusBadRequest, err.Error())
+			utils.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
 			return
 		}
 
@@ -431,7 +431,7 @@ func queryProposalsWithParameterFn(cdc *wire.Codec) http.HandlerFunc {
 
 		res, err := cliCtx.QueryWithData("custom/gov/proposals", bz)
 		if err != nil {
-			utils.WriteErrorResponse(&w, http.StatusInternalServerError, err.Error())
+			utils.WriteErrorResponse(w, http.StatusInternalServerError, err.Error())
 			return
 		}
 

--- a/x/gov/client/rest/util.go
+++ b/x/gov/client/rest/util.go
@@ -27,12 +27,12 @@ type baseReq struct {
 func buildReq(w http.ResponseWriter, r *http.Request, cdc *wire.Codec, req interface{}) error {
 	body, err := ioutil.ReadAll(r.Body)
 	if err != nil {
-		utils.WriteErrorResponse(&w, http.StatusBadRequest, err.Error())
+		utils.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
 		return err
 	}
 	err = cdc.UnmarshalJSON(body, req)
 	if err != nil {
-		utils.WriteErrorResponse(&w, http.StatusBadRequest, err.Error())
+		utils.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
 		return err
 	}
 	return nil
@@ -40,27 +40,27 @@ func buildReq(w http.ResponseWriter, r *http.Request, cdc *wire.Codec, req inter
 
 func (req baseReq) baseReqValidate(w http.ResponseWriter) bool {
 	if len(req.Name) == 0 {
-		utils.WriteErrorResponse(&w, http.StatusUnauthorized, "Name required but not specified")
+		utils.WriteErrorResponse(w, http.StatusUnauthorized, "Name required but not specified")
 		return false
 	}
 
 	if len(req.Password) == 0 {
-		utils.WriteErrorResponse(&w, http.StatusUnauthorized, "Password required but not specified")
+		utils.WriteErrorResponse(w, http.StatusUnauthorized, "Password required but not specified")
 		return false
 	}
 
 	if len(req.ChainID) == 0 {
-		utils.WriteErrorResponse(&w, http.StatusUnauthorized, "ChainID required but not specified")
+		utils.WriteErrorResponse(w, http.StatusUnauthorized, "ChainID required but not specified")
 		return false
 	}
 
 	if req.AccountNumber < 0 {
-		utils.WriteErrorResponse(&w, http.StatusUnauthorized, "Account Number required but not specified")
+		utils.WriteErrorResponse(w, http.StatusUnauthorized, "Account Number required but not specified")
 		return false
 	}
 
 	if req.Sequence < 0 {
-		utils.WriteErrorResponse(&w, http.StatusUnauthorized, "Sequence required but not specified")
+		utils.WriteErrorResponse(w, http.StatusUnauthorized, "Sequence required but not specified")
 		return false
 	}
 	return true
@@ -78,7 +78,7 @@ func signAndBuild(w http.ResponseWriter, r *http.Request, cliCtx context.CLICont
 		Gas:           baseReq.Gas,
 	}
 
-	adjustment, ok := utils.ParseFloat64OrReturnBadRequest(&w, baseReq.GasAdjustment, client.DefaultGasAdjustment)
+	adjustment, ok := utils.ParseFloat64OrReturnBadRequest(w, baseReq.GasAdjustment, client.DefaultGasAdjustment)
 	if !ok {
 		return
 	}
@@ -87,30 +87,30 @@ func signAndBuild(w http.ResponseWriter, r *http.Request, cliCtx context.CLICont
 	if utils.HasDryRunArg(r) || baseReq.Gas == 0 {
 		newCtx, err := utils.EnrichCtxWithGas(txCtx, cliCtx, baseReq.Name, []sdk.Msg{msg})
 		if err != nil {
-			utils.WriteErrorResponse(&w, http.StatusInternalServerError, err.Error())
+			utils.WriteErrorResponse(w, http.StatusInternalServerError, err.Error())
 			return
 		}
 		if utils.HasDryRunArg(r) {
-			utils.WriteSimulationResponse(&w, txCtx.Gas)
+			utils.WriteSimulationResponse(w, txCtx.Gas)
 			return
 		}
 		txCtx = newCtx
 	}
 	txBytes, err := txCtx.BuildAndSign(baseReq.Name, baseReq.Password, []sdk.Msg{msg})
 	if err != nil {
-		utils.WriteErrorResponse(&w, http.StatusUnauthorized, err.Error())
+		utils.WriteErrorResponse(w, http.StatusUnauthorized, err.Error())
 		return
 	}
 
 	res, err := cliCtx.BroadcastTx(txBytes)
 	if err != nil {
-		utils.WriteErrorResponse(&w, http.StatusInternalServerError, err.Error())
+		utils.WriteErrorResponse(w, http.StatusInternalServerError, err.Error())
 		return
 	}
 
 	output, err := wire.MarshalJSONIndent(cdc, res)
 	if err != nil {
-		utils.WriteErrorResponse(&w, http.StatusInternalServerError, err.Error())
+		utils.WriteErrorResponse(w, http.StatusInternalServerError, err.Error())
 		return
 	}
 

--- a/x/ibc/app_test.go
+++ b/x/ibc/app_test.go
@@ -70,10 +70,10 @@ func TestIBCMsgs(t *testing.T) {
 		Sequence:  0,
 	}
 
-	mock.SignCheckDeliver(t, mapp.BaseApp, []sdk.Msg{transferMsg}, []int64{0}, []int64{0}, true, priv1)
+	mock.SignCheckDeliver(t, mapp.BaseApp, []sdk.Msg{transferMsg}, []int64{0}, []int64{0}, true, true, priv1)
 	mock.CheckBalance(t, mapp, addr1, emptyCoins)
-	mock.SignCheckDeliver(t, mapp.BaseApp, []sdk.Msg{transferMsg}, []int64{0}, []int64{1}, false, priv1)
-	mock.SignCheckDeliver(t, mapp.BaseApp, []sdk.Msg{receiveMsg}, []int64{0}, []int64{2}, true, priv1)
+	mock.SignCheckDeliver(t, mapp.BaseApp, []sdk.Msg{transferMsg}, []int64{0}, []int64{1}, false, false, priv1)
+	mock.SignCheckDeliver(t, mapp.BaseApp, []sdk.Msg{receiveMsg}, []int64{0}, []int64{2}, true, true, priv1)
 	mock.CheckBalance(t, mapp, addr1, coins)
-	mock.SignCheckDeliver(t, mapp.BaseApp, []sdk.Msg{receiveMsg}, []int64{0}, []int64{2}, false, priv1)
+	mock.SignCheckDeliver(t, mapp.BaseApp, []sdk.Msg{receiveMsg}, []int64{0}, []int64{2}, false, false, priv1)
 }

--- a/x/ibc/client/rest/transfer.go
+++ b/x/ibc/client/rest/transfer.go
@@ -4,6 +4,7 @@ import (
 	"io/ioutil"
 	"net/http"
 
+	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/context"
 	"github.com/cosmos/cosmos-sdk/client/utils"
 	"github.com/cosmos/cosmos-sdk/crypto/keys"
@@ -29,6 +30,7 @@ type transferBody struct {
 	AccountNumber    int64     `json:"account_number"`
 	Sequence         int64     `json:"sequence"`
 	Gas              int64     `json:"gas"`
+	GasAdjustment    string    `json:"gas_adjustment"`
 }
 
 // TransferRequestHandler - http request handler to transfer coins to a address
@@ -76,6 +78,12 @@ func TransferRequestHandlerFn(cdc *wire.Codec, kb keys.Keybase, cliCtx context.C
 			Sequence:      m.Sequence,
 			Gas:           m.Gas,
 		}
+
+		adjustment, ok := utils.ParseFloat64OrReturnBadRequest(&w, m.GasAdjustment, client.DefaultGasAdjustment)
+		if !ok {
+			return
+		}
+		cliCtx = cliCtx.WithGasAdjustment(adjustment)
 
 		if utils.HasDryRunArg(r) || m.Gas == 0 {
 			newCtx, err := utils.EnrichCtxWithGas(txCtx, cliCtx, m.LocalAccountName, []sdk.Msg{msg})

--- a/x/ibc/client/rest/transfer.go
+++ b/x/ibc/client/rest/transfer.go
@@ -44,26 +44,26 @@ func TransferRequestHandlerFn(cdc *wire.Codec, kb keys.Keybase, cliCtx context.C
 
 		to, err := sdk.AccAddressFromBech32(bech32addr)
 		if err != nil {
-			utils.WriteErrorResponse(&w, http.StatusBadRequest, err.Error())
+			utils.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
 			return
 		}
 
 		var m transferBody
 		body, err := ioutil.ReadAll(r.Body)
 		if err != nil {
-			utils.WriteErrorResponse(&w, http.StatusBadRequest, err.Error())
+			utils.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
 			return
 		}
 
 		err = cdc.UnmarshalJSON(body, &m)
 		if err != nil {
-			utils.WriteErrorResponse(&w, http.StatusBadRequest, err.Error())
+			utils.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
 			return
 		}
 
 		info, err := kb.Get(m.LocalAccountName)
 		if err != nil {
-			utils.WriteErrorResponse(&w, http.StatusUnauthorized, err.Error())
+			utils.WriteErrorResponse(w, http.StatusUnauthorized, err.Error())
 			return
 		}
 
@@ -79,7 +79,7 @@ func TransferRequestHandlerFn(cdc *wire.Codec, kb keys.Keybase, cliCtx context.C
 			Gas:           m.Gas,
 		}
 
-		adjustment, ok := utils.ParseFloat64OrReturnBadRequest(&w, m.GasAdjustment, client.DefaultGasAdjustment)
+		adjustment, ok := utils.ParseFloat64OrReturnBadRequest(w, m.GasAdjustment, client.DefaultGasAdjustment)
 		if !ok {
 			return
 		}
@@ -88,11 +88,11 @@ func TransferRequestHandlerFn(cdc *wire.Codec, kb keys.Keybase, cliCtx context.C
 		if utils.HasDryRunArg(r) || m.Gas == 0 {
 			newCtx, err := utils.EnrichCtxWithGas(txCtx, cliCtx, m.LocalAccountName, []sdk.Msg{msg})
 			if err != nil {
-				utils.WriteErrorResponse(&w, http.StatusInternalServerError, err.Error())
+				utils.WriteErrorResponse(w, http.StatusInternalServerError, err.Error())
 				return
 			}
 			if utils.HasDryRunArg(r) {
-				utils.WriteSimulationResponse(&w, txCtx.Gas)
+				utils.WriteSimulationResponse(w, txCtx.Gas)
 				return
 			}
 			txCtx = newCtx
@@ -100,19 +100,19 @@ func TransferRequestHandlerFn(cdc *wire.Codec, kb keys.Keybase, cliCtx context.C
 
 		txBytes, err := txCtx.BuildAndSign(m.LocalAccountName, m.Password, []sdk.Msg{msg})
 		if err != nil {
-			utils.WriteErrorResponse(&w, http.StatusUnauthorized, err.Error())
+			utils.WriteErrorResponse(w, http.StatusUnauthorized, err.Error())
 			return
 		}
 
 		res, err := cliCtx.BroadcastTx(txBytes)
 		if err != nil {
-			utils.WriteErrorResponse(&w, http.StatusInternalServerError, err.Error())
+			utils.WriteErrorResponse(w, http.StatusInternalServerError, err.Error())
 			return
 		}
 
 		output, err := cdc.MarshalJSON(res)
 		if err != nil {
-			utils.WriteErrorResponse(&w, http.StatusInternalServerError, err.Error())
+			utils.WriteErrorResponse(w, http.StatusInternalServerError, err.Error())
 			return
 		}
 

--- a/x/mock/app_test.go
+++ b/x/mock/app_test.go
@@ -61,14 +61,14 @@ func TestCheckAndDeliverGenTx(t *testing.T) {
 	SignCheckDeliver(
 		t, mApp.BaseApp, []sdk.Msg{msg},
 		[]int64{accs[0].GetAccountNumber()}, []int64{accs[0].GetSequence()},
-		true, privKeys[0],
+		true, true, privKeys[0],
 	)
 
 	// Signing a tx with the wrong privKey should result in an auth error
 	res := SignCheckDeliver(
 		t, mApp.BaseApp, []sdk.Msg{msg},
 		[]int64{accs[1].GetAccountNumber()}, []int64{accs[1].GetSequence() + 1},
-		false, privKeys[1],
+		true, false, privKeys[1],
 	)
 	require.Equal(t, sdk.ToABCICode(sdk.CodespaceRoot, sdk.CodeUnauthorized), res.Code, res.Log)
 
@@ -76,7 +76,7 @@ func TestCheckAndDeliverGenTx(t *testing.T) {
 	SignCheckDeliver(
 		t, mApp.BaseApp, []sdk.Msg{msg},
 		[]int64{accs[0].GetAccountNumber()}, []int64{accs[0].GetSequence() + 1},
-		true, privKeys[0],
+		true, true, privKeys[0],
 	)
 }
 

--- a/x/mock/test_utils.go
+++ b/x/mock/test_utils.go
@@ -71,13 +71,13 @@ func CheckGenTx(
 // returned.
 func SignCheckDeliver(
 	t *testing.T, app *baseapp.BaseApp, msgs []sdk.Msg, accNums []int64,
-	seq []int64, expPass bool, priv ...crypto.PrivKey,
+	seq []int64, expSimPass, expPass bool, priv ...crypto.PrivKey,
 ) sdk.Result {
 	tx := GenTx(msgs, accNums, seq, priv...)
 	// Must simulate now as CheckTx doesn't run Msgs anymore
 	res := app.Simulate(tx)
 
-	if expPass {
+	if expSimPass {
 		require.Equal(t, sdk.ABCICodeOK, res.Code, res.Log)
 	} else {
 		require.NotEqual(t, sdk.ABCICodeOK, res.Code, res.Log)

--- a/x/slashing/app_test.go
+++ b/x/slashing/app_test.go
@@ -102,7 +102,7 @@ func TestSlashingMsgs(t *testing.T) {
 	createValidatorMsg := stake.NewMsgCreateValidator(
 		sdk.ValAddress(addr1), priv1.PubKey(), bondCoin, description,
 	)
-	mock.SignCheckDeliver(t, mapp.BaseApp, []sdk.Msg{createValidatorMsg}, []int64{0}, []int64{0}, true, priv1)
+	mock.SignCheckDeliver(t, mapp.BaseApp, []sdk.Msg{createValidatorMsg}, []int64{0}, []int64{0}, true, true, priv1)
 	mock.CheckBalance(t, mapp, addr1, sdk.Coins{genCoin.Minus(bondCoin)})
 	mapp.BeginBlock(abci.RequestBeginBlock{})
 
@@ -116,6 +116,6 @@ func TestSlashingMsgs(t *testing.T) {
 	checkValidatorSigningInfo(t, mapp, keeper, sdk.ValAddress(addr1), false)
 
 	// unjail should fail with unknown validator
-	res := mock.SignCheckDeliver(t, mapp.BaseApp, []sdk.Msg{unjailMsg}, []int64{0}, []int64{1}, false, priv1)
+	res := mock.SignCheckDeliver(t, mapp.BaseApp, []sdk.Msg{unjailMsg}, []int64{0}, []int64{1}, false, false, priv1)
 	require.Equal(t, sdk.ToABCICode(DefaultCodespace, CodeValidatorNotJailed), res.Code)
 }

--- a/x/stake/app_test.go
+++ b/x/stake/app_test.go
@@ -131,7 +131,7 @@ func TestStakeMsgs(t *testing.T) {
 		sdk.ValAddress(addr1), priv1.PubKey(), bondCoin, description,
 	)
 
-	mock.SignCheckDeliver(t, mApp.BaseApp, []sdk.Msg{createValidatorMsg}, []int64{0}, []int64{0}, true, priv1)
+	mock.SignCheckDeliver(t, mApp.BaseApp, []sdk.Msg{createValidatorMsg}, []int64{0}, []int64{0}, true, true, priv1)
 	mock.CheckBalance(t, mApp, addr1, sdk.Coins{genCoin.Minus(bondCoin)})
 	mApp.BeginBlock(abci.RequestBeginBlock{})
 
@@ -145,7 +145,7 @@ func TestStakeMsgs(t *testing.T) {
 		addr1, sdk.ValAddress(addr2), priv2.PubKey(), bondCoin, description,
 	)
 
-	mock.SignCheckDeliver(t, mApp.BaseApp, []sdk.Msg{createValidatorMsgOnBehalfOf}, []int64{0, 1}, []int64{1, 0}, true, priv1, priv2)
+	mock.SignCheckDeliver(t, mApp.BaseApp, []sdk.Msg{createValidatorMsgOnBehalfOf}, []int64{0, 1}, []int64{1, 0}, true, true, priv1, priv2)
 	mock.CheckBalance(t, mApp, addr1, sdk.Coins{genCoin.Minus(bondCoin).Minus(bondCoin)})
 	mApp.BeginBlock(abci.RequestBeginBlock{})
 
@@ -161,7 +161,7 @@ func TestStakeMsgs(t *testing.T) {
 	description = NewDescription("bar_moniker", "", "", "")
 	editValidatorMsg := NewMsgEditValidator(sdk.ValAddress(addr1), description)
 
-	mock.SignCheckDeliver(t, mApp.BaseApp, []sdk.Msg{editValidatorMsg}, []int64{0}, []int64{2}, true, priv1)
+	mock.SignCheckDeliver(t, mApp.BaseApp, []sdk.Msg{editValidatorMsg}, []int64{0}, []int64{2}, true, true, priv1)
 	validator = checkValidator(t, mApp, keeper, sdk.ValAddress(addr1), true)
 	require.Equal(t, description, validator.Description)
 
@@ -169,13 +169,13 @@ func TestStakeMsgs(t *testing.T) {
 	mock.CheckBalance(t, mApp, addr2, sdk.Coins{genCoin})
 	delegateMsg := NewMsgDelegate(addr2, sdk.ValAddress(addr1), bondCoin)
 
-	mock.SignCheckDeliver(t, mApp.BaseApp, []sdk.Msg{delegateMsg}, []int64{1}, []int64{1}, true, priv2)
+	mock.SignCheckDeliver(t, mApp.BaseApp, []sdk.Msg{delegateMsg}, []int64{1}, []int64{1}, true, true, priv2)
 	mock.CheckBalance(t, mApp, addr2, sdk.Coins{genCoin.Minus(bondCoin)})
 	checkDelegation(t, mApp, keeper, addr2, sdk.ValAddress(addr1), true, sdk.NewDec(10))
 
 	// begin unbonding
 	beginUnbondingMsg := NewMsgBeginUnbonding(addr2, sdk.ValAddress(addr1), sdk.NewDec(10))
-	mock.SignCheckDeliver(t, mApp.BaseApp, []sdk.Msg{beginUnbondingMsg}, []int64{1}, []int64{2}, true, priv2)
+	mock.SignCheckDeliver(t, mApp.BaseApp, []sdk.Msg{beginUnbondingMsg}, []int64{1}, []int64{2}, true, true, priv2)
 
 	// delegation should exist anymore
 	checkDelegation(t, mApp, keeper, addr2, sdk.ValAddress(addr1), false, sdk.Dec{})

--- a/x/stake/client/rest/tx.go
+++ b/x/stake/client/rest/tx.go
@@ -276,10 +276,14 @@ func delegationsRequestHandlerFn(cdc *wire.Codec, kb keys.Keybase, cliCtx contex
 
 			m.Sequence++
 
-			if m.Gas == 0 {
-				newCtx, err := utils.EnrichCtxWithGas(txCtx, cliCtx, m.LocalAccountName, m.Password, []sdk.Msg{msg})
+			if utils.HasDryRunArg(r) || m.Gas == 0 {
+				newCtx, err := utils.EnrichCtxWithGas(txCtx, cliCtx, m.LocalAccountName, []sdk.Msg{msg})
 				if err != nil {
 					utils.WriteErrorResponse(&w, http.StatusInternalServerError, err.Error())
+					return
+				}
+				if utils.HasDryRunArg(r) {
+					utils.WriteSimulationResponse(&w, txCtx.Gas)
 					return
 				}
 				txCtx = newCtx

--- a/x/stake/client/rest/tx.go
+++ b/x/stake/client/rest/tx.go
@@ -108,18 +108,18 @@ func delegationsRequestHandlerFn(cdc *wire.Codec, kb keys.Keybase, cliCtx contex
 		for _, msg := range m.Delegations {
 			delAddr, err := sdk.AccAddressFromBech32(msg.DelegatorAddr)
 			if err != nil {
-				utils.WriteErrorResponse(&w, http.StatusInternalServerError, fmt.Sprintf("Couldn't decode delegator. Error: %s", err.Error()))
+				utils.WriteErrorResponse(w, http.StatusInternalServerError, fmt.Sprintf("Couldn't decode delegator. Error: %s", err.Error()))
 				return
 			}
 
 			valAddr, err := sdk.ValAddressFromBech32(msg.ValidatorAddr)
 			if err != nil {
-				utils.WriteErrorResponse(&w, http.StatusInternalServerError, fmt.Sprintf("Couldn't decode validator. Error: %s", err.Error()))
+				utils.WriteErrorResponse(w, http.StatusInternalServerError, fmt.Sprintf("Couldn't decode validator. Error: %s", err.Error()))
 				return
 			}
 
 			if !bytes.Equal(info.GetPubKey().Address(), delAddr) {
-				utils.WriteErrorResponse(&w, http.StatusUnauthorized, "Must use own delegator address")
+				utils.WriteErrorResponse(w, http.StatusUnauthorized, "Must use own delegator address")
 				return
 			}
 
@@ -135,29 +135,29 @@ func delegationsRequestHandlerFn(cdc *wire.Codec, kb keys.Keybase, cliCtx contex
 		for _, msg := range m.BeginRedelegates {
 			delAddr, err := sdk.AccAddressFromBech32(msg.DelegatorAddr)
 			if err != nil {
-				utils.WriteErrorResponse(&w, http.StatusInternalServerError, fmt.Sprintf("Couldn't decode validator. Error: %s", err.Error()))
+				utils.WriteErrorResponse(w, http.StatusInternalServerError, fmt.Sprintf("Couldn't decode validator. Error: %s", err.Error()))
 				return
 			}
 
 			if !bytes.Equal(info.GetPubKey().Address(), delAddr) {
-				utils.WriteErrorResponse(&w, http.StatusUnauthorized, "Must use own delegator address")
+				utils.WriteErrorResponse(w, http.StatusUnauthorized, "Must use own delegator address")
 				return
 			}
 
 			valSrcAddr, err := sdk.ValAddressFromBech32(msg.ValidatorSrcAddr)
 			if err != nil {
-				utils.WriteErrorResponse(&w, http.StatusInternalServerError, fmt.Sprintf("Couldn't decode validator. Error: %s", err.Error()))
+				utils.WriteErrorResponse(w, http.StatusInternalServerError, fmt.Sprintf("Couldn't decode validator. Error: %s", err.Error()))
 				return
 			}
 			valDstAddr, err := sdk.ValAddressFromBech32(msg.ValidatorDstAddr)
 			if err != nil {
-				utils.WriteErrorResponse(&w, http.StatusInternalServerError, fmt.Sprintf("Couldn't decode validator. Error: %s", err.Error()))
+				utils.WriteErrorResponse(w, http.StatusInternalServerError, fmt.Sprintf("Couldn't decode validator. Error: %s", err.Error()))
 				return
 			}
 
 			shares, err := sdk.NewDecFromStr(msg.SharesAmount)
 			if err != nil {
-				utils.WriteErrorResponse(&w, http.StatusInternalServerError, fmt.Sprintf("Couldn't decode shares amount. Error: %s", err.Error()))
+				utils.WriteErrorResponse(w, http.StatusInternalServerError, fmt.Sprintf("Couldn't decode shares amount. Error: %s", err.Error()))
 				return
 			}
 
@@ -174,24 +174,24 @@ func delegationsRequestHandlerFn(cdc *wire.Codec, kb keys.Keybase, cliCtx contex
 		for _, msg := range m.CompleteRedelegates {
 			delAddr, err := sdk.AccAddressFromBech32(msg.DelegatorAddr)
 			if err != nil {
-				utils.WriteErrorResponse(&w, http.StatusInternalServerError, fmt.Sprintf("Couldn't decode delegator. Error: %s", err.Error()))
+				utils.WriteErrorResponse(w, http.StatusInternalServerError, fmt.Sprintf("Couldn't decode delegator. Error: %s", err.Error()))
 				return
 			}
 
 			valSrcAddr, err := sdk.ValAddressFromBech32(msg.ValidatorSrcAddr)
 			if err != nil {
-				utils.WriteErrorResponse(&w, http.StatusInternalServerError, fmt.Sprintf("Couldn't decode validator. Error: %s", err.Error()))
+				utils.WriteErrorResponse(w, http.StatusInternalServerError, fmt.Sprintf("Couldn't decode validator. Error: %s", err.Error()))
 				return
 			}
 
 			valDstAddr, err := sdk.ValAddressFromBech32(msg.ValidatorDstAddr)
 			if err != nil {
-				utils.WriteErrorResponse(&w, http.StatusInternalServerError, fmt.Sprintf("Couldn't decode validator. Error: %s", err.Error()))
+				utils.WriteErrorResponse(w, http.StatusInternalServerError, fmt.Sprintf("Couldn't decode validator. Error: %s", err.Error()))
 				return
 			}
 
 			if !bytes.Equal(info.GetPubKey().Address(), delAddr) {
-				utils.WriteErrorResponse(&w, http.StatusUnauthorized, "Must use own delegator address")
+				utils.WriteErrorResponse(w, http.StatusUnauthorized, "Must use own delegator address")
 				return
 			}
 
@@ -207,24 +207,24 @@ func delegationsRequestHandlerFn(cdc *wire.Codec, kb keys.Keybase, cliCtx contex
 		for _, msg := range m.BeginUnbondings {
 			delAddr, err := sdk.AccAddressFromBech32(msg.DelegatorAddr)
 			if err != nil {
-				utils.WriteErrorResponse(&w, http.StatusInternalServerError, fmt.Sprintf("Couldn't decode delegator. Error: %s", err.Error()))
+				utils.WriteErrorResponse(w, http.StatusInternalServerError, fmt.Sprintf("Couldn't decode delegator. Error: %s", err.Error()))
 				return
 			}
 
 			if !bytes.Equal(info.GetPubKey().Address(), delAddr) {
-				utils.WriteErrorResponse(&w, http.StatusUnauthorized, "Must use own delegator address")
+				utils.WriteErrorResponse(w, http.StatusUnauthorized, "Must use own delegator address")
 				return
 			}
 
 			valAddr, err := sdk.ValAddressFromBech32(msg.ValidatorAddr)
 			if err != nil {
-				utils.WriteErrorResponse(&w, http.StatusInternalServerError, fmt.Sprintf("Couldn't decode validator. Error: %s", err.Error()))
+				utils.WriteErrorResponse(w, http.StatusInternalServerError, fmt.Sprintf("Couldn't decode validator. Error: %s", err.Error()))
 				return
 			}
 
 			shares, err := sdk.NewDecFromStr(msg.SharesAmount)
 			if err != nil {
-				utils.WriteErrorResponse(&w, http.StatusInternalServerError, fmt.Sprintf("Couldn't decode shares amount. Error: %s", err.Error()))
+				utils.WriteErrorResponse(w, http.StatusInternalServerError, fmt.Sprintf("Couldn't decode shares amount. Error: %s", err.Error()))
 				return
 			}
 
@@ -240,18 +240,18 @@ func delegationsRequestHandlerFn(cdc *wire.Codec, kb keys.Keybase, cliCtx contex
 		for _, msg := range m.CompleteUnbondings {
 			delAddr, err := sdk.AccAddressFromBech32(msg.DelegatorAddr)
 			if err != nil {
-				utils.WriteErrorResponse(&w, http.StatusInternalServerError, fmt.Sprintf("Couldn't decode delegator. Error: %s", err.Error()))
+				utils.WriteErrorResponse(w, http.StatusInternalServerError, fmt.Sprintf("Couldn't decode delegator. Error: %s", err.Error()))
 				return
 			}
 
 			valAddr, err := sdk.ValAddressFromBech32(msg.ValidatorAddr)
 			if err != nil {
-				utils.WriteErrorResponse(&w, http.StatusInternalServerError, fmt.Sprintf("Couldn't decode validator. Error: %s", err.Error()))
+				utils.WriteErrorResponse(w, http.StatusInternalServerError, fmt.Sprintf("Couldn't decode validator. Error: %s", err.Error()))
 				return
 			}
 
 			if !bytes.Equal(info.GetPubKey().Address(), delAddr) {
-				utils.WriteErrorResponse(&w, http.StatusUnauthorized, "Must use own delegator address")
+				utils.WriteErrorResponse(w, http.StatusUnauthorized, "Must use own delegator address")
 				return
 			}
 
@@ -278,7 +278,7 @@ func delegationsRequestHandlerFn(cdc *wire.Codec, kb keys.Keybase, cliCtx contex
 
 			m.Sequence++
 
-			adjustment, ok := utils.ParseFloat64OrReturnBadRequest(&w, m.GasAdjustment, client.DefaultGasAdjustment)
+			adjustment, ok := utils.ParseFloat64OrReturnBadRequest(w, m.GasAdjustment, client.DefaultGasAdjustment)
 			if !ok {
 				return
 			}
@@ -287,11 +287,11 @@ func delegationsRequestHandlerFn(cdc *wire.Codec, kb keys.Keybase, cliCtx contex
 			if utils.HasDryRunArg(r) || m.Gas == 0 {
 				newCtx, err := utils.EnrichCtxWithGas(txCtx, cliCtx, m.LocalAccountName, []sdk.Msg{msg})
 				if err != nil {
-					utils.WriteErrorResponse(&w, http.StatusInternalServerError, err.Error())
+					utils.WriteErrorResponse(w, http.StatusInternalServerError, err.Error())
 					return
 				}
 				if utils.HasDryRunArg(r) {
-					utils.WriteSimulationResponse(&w, txCtx.Gas)
+					utils.WriteSimulationResponse(w, txCtx.Gas)
 					return
 				}
 				txCtx = newCtx
@@ -299,7 +299,7 @@ func delegationsRequestHandlerFn(cdc *wire.Codec, kb keys.Keybase, cliCtx contex
 
 			txBytes, err := txCtx.BuildAndSign(m.LocalAccountName, m.Password, []sdk.Msg{msg})
 			if err != nil {
-				utils.WriteErrorResponse(&w, http.StatusUnauthorized, err.Error())
+				utils.WriteErrorResponse(w, http.StatusUnauthorized, err.Error())
 				return
 			}
 
@@ -313,7 +313,7 @@ func delegationsRequestHandlerFn(cdc *wire.Codec, kb keys.Keybase, cliCtx contex
 		for i, txBytes := range signedTxs {
 			res, err := cliCtx.BroadcastTx(txBytes)
 			if err != nil {
-				utils.WriteErrorResponse(&w, http.StatusInternalServerError, err.Error())
+				utils.WriteErrorResponse(w, http.StatusInternalServerError, err.Error())
 				return
 			}
 
@@ -322,7 +322,7 @@ func delegationsRequestHandlerFn(cdc *wire.Codec, kb keys.Keybase, cliCtx contex
 
 		output, err := wire.MarshalJSONIndent(cdc, results[:])
 		if err != nil {
-			utils.WriteErrorResponse(&w, http.StatusInternalServerError, err.Error())
+			utils.WriteErrorResponse(w, http.StatusInternalServerError, err.Error())
 			return
 		}
 


### PR DESCRIPTION
Add an extra simulate flag support to both CLI tx commands and RESTful endpoints to trigger the simulation of an unsigned transaction. Relevant changes:

* Turning `--dry-run` causes the `--gas` flag to be ignored. The simulation will return the estimate of the gas required to actually run the transaction.
* Adjustment is no longer required. It now defaults to `1.0`.
* In some test cases accounts retrieved from the state do not come with a `PubKey`. In such cases, a fake `secp256k1` key is generated and gas consumption calculated accordingly.

Closes: #2110

- [x] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [x] Wrote tests
- [x] Updated relevant documentation (`docs/`)
- [x] Added entries in `PENDING.md` with issue # 
- [x] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
