### PR TITLE
Improve GetValidator speed

### DIFF
--- a/PENDING.md
+++ b/PENDING.md
@@ -78,7 +78,7 @@ IMPROVEMENTS
     * [x/stake] [#2023](https://github.com/cosmos/cosmos-sdk/pull/2023) Terminate iteration loop in `UpdateBondedValidators` and `UpdateBondedValidatorsFull` when the first revoked validator is encountered and perform a sanity check.
     * [x/auth] Signature verification's gas cost now accounts for pubkey type. [#2046](https://github.com/tendermint/tendermint/pull/2046)
     * [x/stake] [x/slashing] Ensure delegation invariants to jailed validators [#1883](https://github.com/cosmos/cosmos-sdk/issues/1883).
-
+    * [x/stake] Improve speed of GetValidator, which was shown to be a performance bottleneck. [#2046](https://github.com/tendermint/tendermint/pull/2200)
 * SDK
     * [tools] Make get_vendor_deps deletes `.vendor-new` directories, in case scratch files are present.
     * [cli] \#1632 Add integration tests to ensure `basecoind init && basecoind` start sequences run successfully for both `democoin` and `basecoin` examples.

--- a/x/stake/keeper/validator.go
+++ b/x/stake/keeper/validator.go
@@ -34,16 +34,17 @@ func (k Keeper) GetValidator(ctx sdk.Context, addr sdk.ValAddress) (validator ty
 		// Doesn't mutate the cache's value
 		valToReturn.Operator = addr
 		return valToReturn, true
-	} else { // get validator from cache
-		validator = types.MustUnmarshalValidator(k.cdc, addr, value)
-		cachedVal := cachedValidator{validator, strValue}
-		validatorCache[strValue] = cachedValidator{validator, strValue}
-		validatorCacheList.PushBack(cachedVal)
-		if validatorCacheList.Len() > 500 {
-			valToRemove := validatorCacheList.Remove(validatorCacheList.Front()).(cachedValidator)
-			delete(validatorCache, valToRemove.marshalled)
-		}
 	}
+	// get validator from cache
+	validator = types.MustUnmarshalValidator(k.cdc, addr, value)
+	cachedVal := cachedValidator{validator, strValue}
+	validatorCache[strValue] = cachedValidator{validator, strValue}
+	validatorCacheList.PushBack(cachedVal)
+	if validatorCacheList.Len() > 500 {
+		valToRemove := validatorCacheList.Remove(validatorCacheList.Front()).(cachedValidator)
+		delete(validatorCache, valToRemove.marshalled)
+	}
+
 	validator = types.MustUnmarshalValidator(k.cdc, addr, value)
 	return validator, true
 }

--- a/x/stake/keeper/validator.go
+++ b/x/stake/keeper/validator.go
@@ -12,12 +12,16 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/stake/types"
 )
 
+// Cache the amino decoding of validators, as it can be the case that repeated slashing calls
+// cause many calls to GetValidator, which were shown to throttle the state machine in our
+// simulation. Note this is quite biased though, as the simulator does more slashes than a
+// live chain should, however we require the slashing to be fast as noone pays gas for it.
 type cachedValidator struct {
 	val        types.Validator
 	marshalled string
 }
 
-var validatorCache = make(map[string]cachedValidator, 1000)
+var validatorCache = make(map[string]cachedValidator, 500)
 var validatorCacheList = list.New()
 
 // get a single validator
@@ -27,7 +31,7 @@ func (k Keeper) GetValidator(ctx sdk.Context, addr sdk.ValAddress) (validator ty
 	if value == nil {
 		return validator, false
 	}
-	// return cached validator
+	// If these amino encoded bytes are in the cache, return the cached validator
 	strValue := string(value)
 	if val, ok := validatorCache[strValue]; ok {
 		valToReturn := val.val
@@ -35,11 +39,12 @@ func (k Keeper) GetValidator(ctx sdk.Context, addr sdk.ValAddress) (validator ty
 		valToReturn.Operator = addr
 		return valToReturn, true
 	}
-	// get validator from cache
+	// amino bytes weren't found in cache, so amino unmarshal and add it to the cache
 	validator = types.MustUnmarshalValidator(k.cdc, addr, value)
 	cachedVal := cachedValidator{validator, strValue}
 	validatorCache[strValue] = cachedValidator{validator, strValue}
 	validatorCacheList.PushBack(cachedVal)
+	// if the cache is too big, pop off the last element from it
 	if validatorCacheList.Len() > 500 {
 		valToRemove := validatorCacheList.Remove(validatorCacheList.Front()).(cachedValidator)
 		delete(validatorCache, valToRemove.marshalled)


### PR DESCRIPTION
In simulation, this was shown to cause a 4x speedup for the entire system (with IAVL commits + GoLevelDB). There are no safety concerns here, as amino encoding is deterministic. This 4x speedup scales to even bigger block / operation sizes.

I think it is very reasonable to have a cache just for these get validator calls. Its like an L1 CPU cache, we have caching for something that is getting used often and we know is a bottleneck.

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/develop/CONTRIBUTING.md#pr-targeting))

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added entries in `PENDING.md` with issue # 
- [ ] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
