### PR TITLE
Hotfix: double curlies breaks vuepress - single curlies does not

### DIFF
--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -4,7 +4,7 @@
 - [ ] 2. Add commits/PRs that are desired for this release **that haven’t already been added to develop**
 - [ ] 3. Merge items in `PENDING.md` into the `CHANGELOG.md`. While doing this make sure that each entry contains links to issues/PRs for each item
 - [ ] 4. Summarize breaking API changes section under “Breaking Changes” section to the `CHANGELOG.md` to bring attention to any breaking API changes that affect RPC consumers.
-- [ ] 5. Tag the commit `{{ .Release.Name }}-rcN`
+- [ ] 5. Tag the commit `{ .Release.Name }-rcN`
 - [ ] 6. Kick off 1 day of automated fuzz testing
 - [ ] 7. Release Lead assigns 2 people to perform [buddy testing script](/docs/RELEASE_TEST_SCRIPT.md) and update the relevant documentation
 - [ ] 8. If errors are found in either #6 or #7 go back to #2 (*NOTE*: be sure to increment the `rcN`)


### PR DESCRIPTION
- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/develop/CONTRIBUTING.md#pr-targeting)) - Targeted master, cherry-picked change from develop.

- [X] Linked to github-issue with discussion and accepted design OR link to spec that describes this work. - tendermint/devops/issues/59 - fix docs auto-deployment
- [X] Wrote tests - tested on staging
- [X] Updated relevant documentation (`docs/`)
- [ ] Added entries in `PENDING.md` with issue # - not a user-facing change
- [X] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
