### PR TITLE
WIP: CLI Context Certifier Handling

### DIFF
--- a/client/context/context.go
+++ b/client/context/context.go
@@ -3,10 +3,11 @@ package context
 import (
 	"bytes"
 	"fmt"
+	"io"
+
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/wire"
 	"github.com/cosmos/cosmos-sdk/x/auth"
-	"io"
 
 	"github.com/spf13/viper"
 
@@ -63,16 +64,18 @@ func NewCLIContext() CLIContext {
 		Async:           viper.GetBool(client.FlagAsync),
 		JSON:            viper.GetBool(client.FlagJson),
 		PrintResponse:   viper.GetBool(client.FlagPrintResponse),
-		Certifier:       createCertifier(),
 		DryRun:          viper.GetBool(client.FlagDryRun),
 	}
 }
 
-func createCertifier() tmlite.Certifier {
+// CreateCertifier creates a Tendermint lite certifier used for proof
+// verification.
+func CreateCertifier() tmlite.Certifier {
 	trustNode := viper.GetBool(client.FlagTrustNode)
 	if trustNode {
 		return nil
 	}
+
 	chainID := viper.GetString(client.FlagChainID)
 	home := viper.GetString(cli.HomeFlag)
 	nodeURI := viper.GetString(client.FlagNode)
@@ -87,14 +90,16 @@ func createCertifier() tmlite.Certifier {
 	if nodeURI == "" {
 		errMsg.WriteString("node ")
 	}
-	// errMsg is not empty
+
 	if errMsg.Len() != 0 {
-		panic(fmt.Errorf("can't create certifier for distrust mode, empty values from these options: %s", errMsg.String()))
+		panic(fmt.Errorf("failed to create certifier for distrust mode; empty values from these options: %s", errMsg.String()))
 	}
+
 	certifier, err := tmliteProxy.GetCertifier(chainID, home, nodeURI)
 	if err != nil {
 		panic(err)
 	}
+
 	return certifier
 }
 

--- a/x/gov/client/cli/tx.go
+++ b/x/gov/client/cli/tx.go
@@ -249,7 +249,7 @@ func GetCmdQueryProposal(queryRoute string, cdc *wire.Codec) *cobra.Command {
 		Use:   "query-proposal",
 		Short: "query proposal details",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cliCtx := context.NewCLIContext().WithCodec(cdc)
+			cliCtx := context.NewCLIContext().WithCodec(cdc).WithCertifier(context.CreateCertifier())
 			proposalID := viper.GetInt64(flagProposalID)
 
 			params := gov.QueryProposalParams{
@@ -321,7 +321,7 @@ func GetCmdQueryProposals(queryRoute string, cdc *wire.Codec) *cobra.Command {
 				return err
 			}
 
-			cliCtx := context.NewCLIContext().WithCodec(cdc)
+			cliCtx := context.NewCLIContext().WithCodec(cdc).WithCertifier(context.CreateCertifier())
 
 			res, err := cliCtx.QueryWithData(fmt.Sprintf("custom/%s/proposals", queryRoute), bz)
 			if err != nil {
@@ -362,7 +362,7 @@ func GetCmdQueryVote(queryRoute string, cdc *wire.Codec) *cobra.Command {
 		Use:   "query-vote",
 		Short: "query vote",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cliCtx := context.NewCLIContext().WithCodec(cdc)
+			cliCtx := context.NewCLIContext().WithCodec(cdc).WithCertifier(context.CreateCertifier())
 			proposalID := viper.GetInt64(flagProposalID)
 
 			voterAddr, err := sdk.AccAddressFromBech32(viper.GetString(flagVoter))
@@ -401,7 +401,7 @@ func GetCmdQueryVotes(queryRoute string, cdc *wire.Codec) *cobra.Command {
 		Use:   "query-votes",
 		Short: "query votes on a proposal",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cliCtx := context.NewCLIContext().WithCodec(cdc)
+			cliCtx := context.NewCLIContext().WithCodec(cdc).WithCertifier(context.CreateCertifier())
 			proposalID := viper.GetInt64(flagProposalID)
 
 			params := gov.QueryVotesParams{
@@ -434,7 +434,7 @@ func GetCmdQueryDeposit(queryRoute string, cdc *wire.Codec) *cobra.Command {
 		Use:   "query-deposit",
 		Short: "query deposit",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cliCtx := context.NewCLIContext().WithCodec(cdc)
+			cliCtx := context.NewCLIContext().WithCodec(cdc).WithCertifier(context.CreateCertifier())
 			proposalID := viper.GetInt64(flagProposalID)
 
 			depositerAddr, err := sdk.AccAddressFromBech32(viper.GetString(flagDepositer))
@@ -473,7 +473,7 @@ func GetCmdQueryDeposits(queryRoute string, cdc *wire.Codec) *cobra.Command {
 		Use:   "query-deposits",
 		Short: "query deposits on a proposal",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cliCtx := context.NewCLIContext().WithCodec(cdc)
+			cliCtx := context.NewCLIContext().WithCodec(cdc).WithCertifier(context.CreateCertifier())
 			proposalID := viper.GetInt64(flagProposalID)
 
 			params := gov.QueryDepositsParams{
@@ -505,7 +505,7 @@ func GetCmdQueryTally(queryRoute string, cdc *wire.Codec) *cobra.Command {
 		Use:   "query-tally",
 		Short: "get the tally of a proposal vote",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cliCtx := context.NewCLIContext().WithCodec(cdc)
+			cliCtx := context.NewCLIContext().WithCodec(cdc).WithCertifier(context.CreateCertifier())
 			proposalID := viper.GetInt64(flagProposalID)
 
 			params := gov.QueryTallyParams{

--- a/x/gov/client/rest/rest.go
+++ b/x/gov/client/rest/rest.go
@@ -175,7 +175,7 @@ func queryProposalHandlerFn(cdc *wire.Codec) http.HandlerFunc {
 			return
 		}
 
-		cliCtx := context.NewCLIContext().WithCodec(cdc)
+		cliCtx := context.NewCLIContext().WithCodec(cdc).WithCertifier(context.CreateCertifier())
 
 		params := gov.QueryProposalParams{
 			ProposalID: proposalID,
@@ -227,7 +227,7 @@ func queryDepositHandlerFn(cdc *wire.Codec) http.HandlerFunc {
 			return
 		}
 
-		cliCtx := context.NewCLIContext().WithCodec(cdc)
+		cliCtx := context.NewCLIContext().WithCodec(cdc).WithCertifier(context.CreateCertifier())
 
 		params := gov.QueryDepositParams{
 			ProposalID: proposalID,
@@ -294,7 +294,7 @@ func queryVoteHandlerFn(cdc *wire.Codec) http.HandlerFunc {
 			return
 		}
 
-		cliCtx := context.NewCLIContext().WithCodec(cdc)
+		cliCtx := context.NewCLIContext().WithCodec(cdc).WithCertifier(context.CreateCertifier())
 
 		params := gov.QueryVoteParams{
 			Voter:      voterAddr,
@@ -352,7 +352,7 @@ func queryVotesOnProposalHandlerFn(cdc *wire.Codec) http.HandlerFunc {
 			return
 		}
 
-		cliCtx := context.NewCLIContext().WithCodec(cdc)
+		cliCtx := context.NewCLIContext().WithCodec(cdc).WithCertifier(context.CreateCertifier())
 
 		params := gov.QueryVotesParams{
 			ProposalID: proposalID,
@@ -427,7 +427,7 @@ func queryProposalsWithParameterFn(cdc *wire.Codec) http.HandlerFunc {
 			return
 		}
 
-		cliCtx := context.NewCLIContext().WithCodec(cdc)
+		cliCtx := context.NewCLIContext().WithCodec(cdc).WithCertifier(context.CreateCertifier())
 
 		res, err := cliCtx.QueryWithData("custom/gov/proposals", bz)
 		if err != nil {
@@ -459,7 +459,7 @@ func queryTallyOnProposalHandlerFn(cdc *wire.Codec) http.HandlerFunc {
 			return
 		}
 
-		cliCtx := context.NewCLIContext().WithCodec(cdc)
+		cliCtx := context.NewCLIContext().WithCodec(cdc).WithCertifier(context.CreateCertifier())
 
 		params := gov.QueryTallyParams{
 			ProposalID: proposalID,

--- a/x/slashing/client/cli/query.go
+++ b/x/slashing/client/cli/query.go
@@ -26,7 +26,7 @@ func GetCmdQuerySigningInfo(storeName string, cdc *wire.Codec) *cobra.Command {
 			}
 
 			key := slashing.GetValidatorSigningInfoKey(sdk.ConsAddress(pk.Address()))
-			cliCtx := context.NewCLIContext().WithCodec(cdc)
+			cliCtx := context.NewCLIContext().WithCodec(cdc).WithCertifier(context.CreateCertifier())
 
 			res, err := cliCtx.QueryStore(key, storeName)
 			if err != nil {

--- a/x/stake/client/cli/query.go
+++ b/x/stake/client/cli/query.go
@@ -27,7 +27,7 @@ func GetCmdQueryValidator(storeName string, cdc *wire.Codec) *cobra.Command {
 			}
 
 			key := stake.GetValidatorKey(addr)
-			cliCtx := context.NewCLIContext().WithCodec(cdc)
+			cliCtx := context.NewCLIContext().WithCodec(cdc).WithCertifier(context.CreateCertifier())
 
 			res, err := cliCtx.QueryStore(key, storeName)
 			if err != nil {
@@ -71,7 +71,7 @@ func GetCmdQueryValidators(storeName string, cdc *wire.Codec) *cobra.Command {
 		Short: "Query for all validators",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			key := stake.ValidatorsKey
-			cliCtx := context.NewCLIContext().WithCodec(cdc)
+			cliCtx := context.NewCLIContext().WithCodec(cdc).WithCertifier(context.CreateCertifier())
 
 			resKVs, err := cliCtx.QuerySubspace(key, storeName)
 			if err != nil {
@@ -131,7 +131,7 @@ func GetCmdQueryDelegation(storeName string, cdc *wire.Codec) *cobra.Command {
 			}
 
 			key := stake.GetDelegationKey(delAddr, valAddr)
-			cliCtx := context.NewCLIContext().WithCodec(cdc)
+			cliCtx := context.NewCLIContext().WithCodec(cdc).WithCertifier(context.CreateCertifier())
 
 			res, err := cliCtx.QueryStore(key, storeName)
 			if err != nil {
@@ -186,7 +186,7 @@ func GetCmdQueryDelegations(storeName string, cdc *wire.Codec) *cobra.Command {
 			}
 
 			key := stake.GetDelegationsKey(delegatorAddr)
-			cliCtx := context.NewCLIContext().WithCodec(cdc)
+			cliCtx := context.NewCLIContext().WithCodec(cdc).WithCertifier(context.CreateCertifier())
 
 			resKVs, err := cliCtx.QuerySubspace(key, storeName)
 			if err != nil {
@@ -233,7 +233,7 @@ func GetCmdQueryUnbondingDelegation(storeName string, cdc *wire.Codec) *cobra.Co
 			}
 
 			key := stake.GetUBDKey(delAddr, valAddr)
-			cliCtx := context.NewCLIContext().WithCodec(cdc)
+			cliCtx := context.NewCLIContext().WithCodec(cdc).WithCertifier(context.CreateCertifier())
 
 			res, err := cliCtx.QueryStore(key, storeName)
 			if err != nil {
@@ -285,7 +285,7 @@ func GetCmdQueryUnbondingDelegations(storeName string, cdc *wire.Codec) *cobra.C
 			}
 
 			key := stake.GetUBDsKey(delegatorAddr)
-			cliCtx := context.NewCLIContext().WithCodec(cdc)
+			cliCtx := context.NewCLIContext().WithCodec(cdc).WithCertifier(context.CreateCertifier())
 
 			resKVs, err := cliCtx.QuerySubspace(key, storeName)
 			if err != nil {
@@ -337,7 +337,7 @@ func GetCmdQueryRedelegation(storeName string, cdc *wire.Codec) *cobra.Command {
 			}
 
 			key := stake.GetREDKey(delAddr, valSrcAddr, valDstAddr)
-			cliCtx := context.NewCLIContext().WithCodec(cdc)
+			cliCtx := context.NewCLIContext().WithCodec(cdc).WithCertifier(context.CreateCertifier())
 
 			res, err := cliCtx.QueryStore(key, storeName)
 			if err != nil {
@@ -389,7 +389,7 @@ func GetCmdQueryRedelegations(storeName string, cdc *wire.Codec) *cobra.Command 
 			}
 
 			key := stake.GetREDsKey(delegatorAddr)
-			cliCtx := context.NewCLIContext().WithCodec(cdc)
+			cliCtx := context.NewCLIContext().WithCodec(cdc).WithCertifier(context.CreateCertifier())
 
 			resKVs, err := cliCtx.QuerySubspace(key, storeName)
 			if err != nil {
@@ -426,7 +426,7 @@ func GetCmdQueryPool(storeName string, cdc *wire.Codec) *cobra.Command {
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			key := stake.PoolKey
-			cliCtx := context.NewCLIContext().WithCodec(cdc)
+			cliCtx := context.NewCLIContext().WithCodec(cdc).WithCertifier(context.CreateCertifier())
 
 			res, err := cliCtx.QueryStore(key, storeName)
 			if err != nil {
@@ -465,7 +465,7 @@ func GetCmdQueryParams(storeName string, cdc *wire.Codec) *cobra.Command {
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			key := stake.ParamKey
-			cliCtx := context.NewCLIContext().WithCodec(cdc)
+			cliCtx := context.NewCLIContext().WithCodec(cdc).WithCertifier(context.CreateCertifier())
 
 			res, err := cliCtx.QueryStore(key, storeName)
 			if err != nil {

--- a/x/stake/client/cli/tx.go
+++ b/x/stake/client/cli/tx.go
@@ -269,7 +269,8 @@ func getShares(
 		key := stake.GetDelegationKey(delAddr, valAddr)
 		cliCtx := context.NewCLIContext().
 			WithCodec(cdc).
-			WithAccountDecoder(authcmd.GetAccountDecoder(cdc))
+			WithAccountDecoder(authcmd.GetAccountDecoder(cdc)).
+			WithCertifier(context.CreateCertifier())
 
 		resQuery, err := cliCtx.QueryStore(key, storeName)
 		if err != nil {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

PR #2192 introduced the notion of a `Certifier` that gets created by default in a `CLIContext` via `createCertifier`. This function performed a no-op if `trust-node` is enabled (which it is by default). However, not all commands have this flag or even require a certifier. This created a problem of where commands like `status` would never be able to execute.

This PR addresses by making anything that may potentially make a query, manually set the context's certifier.

__Note__: 

* This was quick n dirty. There may be a better way to do this and I may have even missed a few places needing update.

/cc @HaoyangLiu 

----

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/develop/CONTRIBUTING.md#pr-targeting))

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added entries in `PENDING.md` with issue # 
- [ ] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
