### PR TITLE
Make the slashing logger print a string representation of slashFactor

### DIFF
--- a/x/stake/keeper/slash.go
+++ b/x/stake/keeper/slash.go
@@ -108,8 +108,8 @@ func (k Keeper) Slash(ctx sdk.Context, pubkey crypto.PubKey, infractionHeight in
 
 	// Log that a slash occurred!
 	logger.Info(fmt.Sprintf(
-		"Validator %s slashed by slashFactor %v, burned %v tokens",
-		pubkey.Address(), slashFactor, tokensToBurn))
+		"Validator %s slashed by slashFactor %s, burned %v tokens",
+		pubkey.Address(), slashFactor.String(), tokensToBurn))
 
 	// TODO Return event(s), blocked on https://github.com/tendermint/tendermint/pull/1803
 	return


### PR DESCRIPTION
It used to print the decimal number, which has an extra factor of 10**10,
and is thus confusing.

Before:
```
I[09-01|20:48:46.742] Validator 0C42E48313EF7B6E45985050F608000190EDEF5F slashed by slashFactor 100000000, burned 6500000000 tokens module=x/stake 
```
After:
```
I[09-01|20:53:29.445] Validator 67C75D900A905BC804600A1AE16CA29470510BCD slashed by slashFactor .0500000000, burned 48000000000 tokens module=x/stake 
```
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

A changelog entry feels unnecessary here, as decimals are new to this release.

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
