### PR TITLE
simulation: Minor changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,7 +157,7 @@ test_sim_gaia_nondeterminism:
 
 test_sim_gaia_fast:
 	@echo "Running quick Gaia simulation. This may take several minutes..."
-	@go test ./cmd/gaia/app -run TestFullGaiaSimulation -SimulationEnabled=true -SimulationNumBlocks=50 -v -timeout 24h
+	@go test ./cmd/gaia/app -run TestFullGaiaSimulation -SimulationEnabled=true -SimulationNumBlocks=150 -v -timeout 24h
 
 test_sim_gaia_slow:
 	@echo "Running full Gaia simulation. This may take awhile!"

--- a/cmd/gaia/app/sim_test.go
+++ b/cmd/gaia/app/sim_test.go
@@ -189,7 +189,7 @@ func TestAppStateDeterminism(t *testing.T) {
 		t.Skip("Skipping Gaia simulation")
 	}
 
-	numSeeds := 5
+	numSeeds := 3
 	numTimesToRunPerSeed := 5
 	appHashList := make([]json.RawMessage, numTimesToRunPerSeed)
 
@@ -206,10 +206,11 @@ func TestAppStateDeterminism(t *testing.T) {
 				testAndRunTxs(app),
 				[]simulation.RandSetup{},
 				[]simulation.Invariant{},
-				20,
-				20,
-				true,
+				50,
+				100,
+				false,
 			)
+			app.Commit()
 			appHash := app.LastCommitID().Hash
 			appHashList[j] = appHash
 		}

--- a/x/mock/simulation/random_simulate_blocks.go
+++ b/x/mock/simulation/random_simulate_blocks.go
@@ -155,7 +155,7 @@ func createBlockSimulator(testingMode bool, tb testing.TB, t *testing.T, event f
 					AssertAllInvariants(t, app, invariants, log)
 				}
 				if opCount%50 == 0 {
-					fmt.Printf("\rSimulating... block %d/%d, operation %d/%d.", header.Height, totalNumBlocks, opCount, blocksize)
+					fmt.Printf("\rSimulating... block %d/%d, operation %d/%d.  ", header.Height, totalNumBlocks, opCount, blocksize)
 				}
 			}
 			opCount++


### PR DESCRIPTION
Now that we properly initialize governance, a ton of governance slashing
doesn't happen in the first few blocks. Because of this, we can run through
blocks in the range (0,200) quite rapidly. This PR acknowledges that and
increases many of the default block heights.

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/develop/CONTRIBUTING.md#pr-targeting))

- [x] Added entries in `PENDING.md` with issue #  - not needed imo

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
