### PR TITLE
R4R: Fix CLI commands JSON output

### DIFF
--- a/PENDING.md
+++ b/PENDING.md
@@ -105,6 +105,7 @@ BUG FIXES
 
 * Gaia CLI  (`gaiacli`)
     * [cli] [\#1997](https://github.com/cosmos/cosmos-sdk/issues/1997) Handle panics gracefully when `gaiacli stake {delegation,unbond}` fail to unmarshal delegation.
+    * [cli] [\#2265](https://github.com/cosmos/cosmos-sdk/issues/2265) Fix JSON formatting of the `gaiacli send` command.
 
 * Gaia
 

--- a/client/context/query.go
+++ b/client/context/query.go
@@ -255,11 +255,11 @@ func (ctx CLIContext) ensureBroadcastTx(txBytes []byte) error {
 		type toJSON struct {
 			Height   int64
 			TxHash   string
-			Response string
+			Response abci.ResponseDeliverTx
 		}
 
 		if ctx.Logger != nil {
-			resJSON := toJSON{res.Height, res.Hash.String(), fmt.Sprintf("%+v", res.DeliverTx)}
+			resJSON := toJSON{res.Height, res.Hash.String(), res.DeliverTx}
 			bz, err := ctx.Codec.MarshalJSON(resJSON)
 			if err != nil {
 				return err


### PR DESCRIPTION
When running with --json, commands should produce
correctly JSON-encoded output.

Closes: #2265

- [x] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [x] Wrote tests
- [ ] ~Updated relevant documentation (`docs/`)~
- [x] Added entries in `PENDING.md` with issue # 
- [x] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
