### PR TITLE
make tx simulation no longer generate new privkeys

### DIFF
--- a/x/auth/ante.go
+++ b/x/auth/ante.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"bytes"
+	"encoding/hex"
 	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -190,6 +191,13 @@ func processSig(
 	return
 }
 
+var dummySecp256k1Pubkey secp256k1.PubKeySecp256k1
+
+func init() {
+	bz, _ := hex.DecodeString("035AD6810A47F073553FF30D2FCC7E0D3B1C0B74B61A1AAA2582344037151E143A")
+	copy(dummySecp256k1Pubkey[:], bz)
+}
+
 func processPubKey(acc Account, sig StdSignature, simulate bool) (crypto.PubKey, sdk.Result) {
 	// If pubkey is not known for account,
 	// set it from the StdSignature.
@@ -200,7 +208,7 @@ func processPubKey(acc Account, sig StdSignature, simulate bool) (crypto.PubKey,
 		// and gasKVStore.Set() shall consume the largest amount, i.e.
 		// it takes more gas to verifiy secp256k1 keys than ed25519 ones.
 		if pubKey == nil {
-			return secp256k1.GenPrivKey().PubKey(), sdk.Result{}
+			return dummySecp256k1Pubkey, sdk.Result{}
 		}
 		return pubKey, sdk.Result{}
 	}


### PR DESCRIPTION
Currently we generate a new private key for every tx simulation run. Not only is this unnecessary from a speed point of view, it is accessing the cryptographic RNG which doesn't really feel right. We had plans for making a minimum amount of entropy for privkey generation, so this could even cause delays in this operation once thats implemented. 

This just replaces that pubkey derivation with a static "dummy" pubkey. I don't see any safety concerns with this.

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/develop/CONTRIBUTING.md#pr-targeting))

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work. - clear from context imo
- [x] Added entries in `PENDING.md` with issue #  - new to this release
- [x] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
