### PR TITLE
cachekvstore: Remove conditional branching in calls within sort

### DIFF
--- a/PENDING.md
+++ b/PENDING.md
@@ -103,6 +103,7 @@ IMPROVEMENTS
     * [spec] Added simple piggy bank distribution spec
     * [cli] [\#1632](https://github.com/cosmos/cosmos-sdk/issues/1632) Add integration tests to ensure `basecoind init && basecoind` start sequences run successfully for both `democoin` and `basecoin` examples.
     * [store] Speedup IAVL iteration, and consequently everything that requires IAVL iteration. [#2143](https://github.com/cosmos/cosmos-sdk/issues/2143)
+    * [store] Slightly speedup cache iteration. \#2287
     * [store] \#1952, \#2281 Update IAVL dependency to v0.11.0
     * [simulation] Make timestamps randomized [#2153](https://github.com/cosmos/cosmos-sdk/pull/2153)
     * [simulation] Make logs not just pure strings, speeding it up by a large factor at greater block heights \#2282

--- a/store/cachekvstore.go
+++ b/store/cachekvstore.go
@@ -176,15 +176,20 @@ func (ci *cacheKVStore) dirtyItems(ascending bool) []cmn.KVPair {
 		items = append(items, cmn.KVPair{Key: []byte(key), Value: cacheValue.value})
 	}
 
-	sort.Slice(items, func(i, j int) bool {
-		if ascending {
-			return bytes.Compare(items[i].Key, items[j].Key) < 0
-		}
-
-		return bytes.Compare(items[i].Key, items[j].Key) > 0
-	})
+	sort.Slice(items, bytesCmpFunc(items, ascending))
 
 	return items
+}
+
+func bytesCmpFunc(items []cmn.KVPair, ascending bool) func(i, j int) bool {
+	if ascending {
+		return func(i, j int) bool {
+			return bytes.Compare(items[i].Key, items[j].Key) < 0
+		}
+	}
+	return func(i, j int) bool {
+		return bytes.Compare(items[i].Key, items[j].Key) > 0
+	}
 }
 
 //----------------------------------------


### PR DESCRIPTION
These removes conditional branching from calls within dirtyItems sort. This changes the benchmarks in #2286 that stated dirtyItems took 31% of time over 100 blocks to it now taking 13%. I believe this is due to not having to keep ascending in a register. However in the 200 blocks case, it basically only cuts out 1 second out of the 56 seconds spent there, so not as big of a performance increase. 
 
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/develop/CONTRIBUTING.md#pr-targeting))

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [X] Added entries in `PENDING.md` with issue # 
- [X] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
