### PR TITLE
R4R: simulation: reduce number of failed governance msgs

### DIFF
--- a/x/gov/simulation/msgs.go
+++ b/x/gov/simulation/msgs.go
@@ -51,7 +51,11 @@ func SimulateSubmittingVotingAndSlashingForProposal(k gov.Keeper, sk stake.Keepe
 		if err != nil {
 			return "", nil, err
 		}
-		action = simulateHandleMsgSubmitProposal(msg, sk, handler, ctx, event)
+		action, ok := simulateHandleMsgSubmitProposal(msg, sk, handler, ctx, event)
+		// don't schedule votes if proposal failed
+		if !ok {
+			return action, nil, nil
+		}
 		proposalID := k.GetLastProposalID(ctx)
 		// 2) Schedule operations for votes
 		// 2.1) first pick a number of people to vote.
@@ -85,24 +89,25 @@ func SimulateMsgSubmitProposal(k gov.Keeper, sk stake.Keeper) simulation.Operati
 		if err != nil {
 			return "", nil, err
 		}
-		action = simulateHandleMsgSubmitProposal(msg, sk, handler, ctx, event)
+		action, _ = simulateHandleMsgSubmitProposal(msg, sk, handler, ctx, event)
 		return action, nil, nil
 	}
 }
 
-func simulateHandleMsgSubmitProposal(msg gov.MsgSubmitProposal, sk stake.Keeper, handler sdk.Handler, ctx sdk.Context, event func(string)) (action string) {
+func simulateHandleMsgSubmitProposal(msg gov.MsgSubmitProposal, sk stake.Keeper, handler sdk.Handler, ctx sdk.Context, event func(string)) (action string, ok bool) {
 	ctx, write := ctx.CacheContext()
 	result := handler(ctx, msg)
-	if result.IsOK() {
+	ok = result.IsOK()
+	if ok {
 		// Update pool to keep invariants
 		pool := sk.GetPool(ctx)
 		pool.LooseTokens = pool.LooseTokens.Sub(sdk.NewDecFromInt(msg.InitialDeposit.AmountOf(denom)))
 		sk.SetPool(ctx, pool)
 		write()
 	}
-	event(fmt.Sprintf("gov/MsgSubmitProposal/%v", result.IsOK()))
-	action = fmt.Sprintf("TestMsgSubmitProposal: ok %v, msg %s", result.IsOK(), msg.GetSignBytes())
-	return action
+	event(fmt.Sprintf("gov/MsgSubmitProposal/%v", ok))
+	action = fmt.Sprintf("TestMsgSubmitProposal: ok %v, msg %s", ok, msg.GetSignBytes())
+	return
 }
 
 func simulationCreateMsgSubmitProposal(r *rand.Rand, sender crypto.PrivKey) (msg gov.MsgSubmitProposal, err error) {


### PR DESCRIPTION
This PR basically makes the simulator not schedule a ton of votes for proposals that fail (due to the validator not having enough money left).

On `make test_sim_gaia_fast`
Before: 
```
gov/MsgVote/false => 23335
```
after
```
gov/MsgVote/false => 15110
```
Fixing the remaining failing votes seems a bit more complicated, as we have to ensure the proposal has enough money before those votes. We could perhaps schedule deposits as well, but I'll save that for a future PR.

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/develop/CONTRIBUTING.md#pr-targeting))

No changelog entry needed.
______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
