### PR TITLE
Remove ripemd160 entirely

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -679,7 +679,6 @@
     "github.com/tendermint/tmlibs/cli",
     "github.com/zondax/ledger-goclient",
     "golang.org/x/crypto/blowfish",
-    "golang.org/x/crypto/ripemd160",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/PENDING.md
+++ b/PENDING.md
@@ -43,6 +43,7 @@ BREAKING CHANGES
     * [simulation] Remove log and testing.TB from Operation and Invariants, in favor of using errors \#2282
     * [tools] Removed gocyclo [#2211](https://github.com/cosmos/cosmos-sdk/issues/2211)
     * [baseapp] Remove `SetTxDecoder` in favor of requiring the decoder be set in baseapp initialization. [#1441](https://github.com/cosmos/cosmos-sdk/issues/1441)
+    * [store] Change storeInfo within the root multistore to use tmhash instead of ripemd160 \#2308
 
 * Tendermint
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -253,7 +253,7 @@ first time.
 
 Accounts are serialized and stored in a Merkle tree under the key
 ``base/a/<address>``, where ``<address>`` is the address of the account.
-Typically, the address of the account is the 20-byte ``RIPEMD160`` hash
+Typically, the address of the account is the first 20-bytes of the ``sha256`` hash
 of the public key, but other formats are acceptable as well, as defined
 in the `Tendermint crypto
 library <https://github.com/tendermint/tendermint/tree/master/crypto>`__. The Merkle tree

--- a/store/multistoreproof.go
+++ b/store/multistoreproof.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"bytes"
+
 	"github.com/pkg/errors"
 	"github.com/tendermint/iavl"
 	cmn "github.com/tendermint/tendermint/libs/common"
@@ -47,7 +48,6 @@ func VerifyMultiStoreCommitInfo(storeName string, storeInfos []storeInfo, appHas
 		Version:    height,
 		StoreInfos: storeInfos,
 	}
-
 	if !bytes.Equal(appHash, ci.Hash()) {
 		return nil, cmn.NewError("the merkle root of multiStoreCommitInfo doesn't equal to appHash")
 	}

--- a/store/multistoreproof_test.go
+++ b/store/multistoreproof_test.go
@@ -5,13 +5,14 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/tendermint/iavl"
 	cmn "github.com/tendermint/tendermint/libs/common"
 	"github.com/tendermint/tendermint/libs/db"
 )
 
 func TestVerifyMultiStoreCommitInfo(t *testing.T) {
-	appHash, _ := hex.DecodeString("ebf3c1fb724d3458023c8fefef7b33add2fc1e84")
+	appHash, _ := hex.DecodeString("69959B1B4E68E0F7BD3551A50C8F849B81801AF2")
 
 	substoreRootHash, _ := hex.DecodeString("ea5d468431015c2cd6295e9a0bb1fc0e49033828")
 	storeName := "acc"
@@ -83,13 +84,13 @@ func TestVerifyMultiStoreCommitInfo(t *testing.T) {
 	})
 
 	commitHash, err := VerifyMultiStoreCommitInfo(storeName, storeInfos, appHash)
-	assert.Nil(t, err)
-	assert.Equal(t, commitHash, substoreRootHash)
+	require.Nil(t, err)
+	require.Equal(t, commitHash, substoreRootHash)
 
 	appHash, _ = hex.DecodeString("29de216bf5e2531c688de36caaf024cd3bb09ee3")
 
 	_, err = VerifyMultiStoreCommitInfo(storeName, storeInfos, appHash)
-	assert.Error(t, err, "appHash doesn't match to the merkle root of multiStoreCommitInfo")
+	require.Error(t, err, "appHash doesn't match to the merkle root of multiStoreCommitInfo")
 }
 
 func TestVerifyRangeProof(t *testing.T) {

--- a/store/rootmultistore.go
+++ b/store/rootmultistore.go
@@ -5,10 +5,9 @@ import (
 	"io"
 	"strings"
 
-	"golang.org/x/crypto/ripemd160"
-
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/crypto/merkle"
+	"github.com/tendermint/tendermint/crypto/tmhash"
 	dbm "github.com/tendermint/tendermint/libs/db"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -424,7 +423,7 @@ func (si storeInfo) Hash() []byte {
 	// Doesn't write Name, since merkle.SimpleHashFromMap() will
 	// include them via the keys.
 	bz, _ := cdc.MarshalBinary(si.Core) // Does not error
-	hasher := ripemd160.New()
+	hasher := tmhash.New()
 	_, err := hasher.Write(bz)
 	if err != nil {
 		// TODO: Handle with #870


### PR DESCRIPTION
We already made this decision awhile ago, and have had tendermint switched
for awhile. I was surprised to find ripemd still used within the storeinfo.
This actually leads me to think the new "byter" API change in the tendermint
PR, for RFC compliance is better, as it avoids things like this from ever happening.

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/develop/CONTRIBUTING.md#pr-targeting))

- [X] Updated relevant documentation (`docs/`)
- [X] Added entries in `PENDING.md` with issue # 
- [X] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
