### PR TITLE
Update revoked -> jailed in the docs, and in minor places within cmd.

### DIFF
--- a/cmd/gaia/app/genesis.go
+++ b/cmd/gaia/app/genesis.go
@@ -234,7 +234,7 @@ func genesisAccountFromGenTx(genTx GaiaGenTx) GenesisAccount {
 }
 
 // GaiaValidateGenesisState ensures that the genesis state obeys the expected invariants
-// TODO: No validators are both bonded and revoked (#2088)
+// TODO: No validators are both bonded and jailed (#2088)
 // TODO: Error if there is a duplicate validator (#1708)
 // TODO: Ensure all state machine parameters are in genesis (#1704)
 func GaiaValidateGenesisState(genesisState GenesisState) (err error) {
@@ -258,7 +258,7 @@ func validateGenesisStateValidators(validators []stakeTypes.Validator) (err erro
 			return fmt.Errorf("Duplicate validator in genesis state: moniker %v, Address %v", val.Description.Moniker, val.ConsAddress())
 		}
 		if val.Jailed && val.Status == sdk.Bonded {
-			return fmt.Errorf("Validator is bonded and revoked in genesis state: moniker %v, Address %v", val.Description.Moniker, val.ConsAddress())
+			return fmt.Errorf("Validator is bonded and jailed in genesis state: moniker %v, Address %v", val.Description.Moniker, val.ConsAddress())
 		}
 		addrMap[strKey] = true
 	}

--- a/cmd/gaia/app/genesis_test.go
+++ b/cmd/gaia/app/genesis_test.go
@@ -84,7 +84,7 @@ func TestGaiaGenesisValidation(t *testing.T) {
 	genesisState := makeGenesisState(genTxs)
 	err := GaiaValidateGenesisState(genesisState)
 	require.NotNil(t, err)
-	// Test bonded + revoked validator fails
+	// Test bonded + jailed validator fails
 	genesisState = makeGenesisState(genTxs[:1])
 	val1 := stakeTypes.NewValidator(addr1, pk1, stakeTypes.Description{Moniker: "test #2"})
 	val1.Jailed = true

--- a/cmd/gaia/cmd/gaiadebug/hack.go
+++ b/cmd/gaia/cmd/gaiadebug/hack.go
@@ -65,7 +65,7 @@ func runHackCmd(cmd *cobra.Command, args []string) error {
 	// The following powerKey was there, but the corresponding "trouble" validator did not exist.
 	// So here we do a binary search on the past states to find when the powerKey first showed up ...
 
-	// operator of the validator the bonds, gets revoked, later unbonds, and then later is still found in the bypower store
+	// operator of the validator the bonds, gets jailed, later unbonds, and then later is still found in the bypower store
 	trouble := hexToBytes("D3DC0FF59F7C3B548B7AFA365561B87FD0208AF8")
 	// this is his "bypower" key
 	powerKey := hexToBytes("05303030303030303030303033FFFFFFFFFFFF4C0C0000FFFED3DC0FF59F7C3B548B7AFA365561B87FD0208AF8")

--- a/cmd/gaia/testnets/STATUS.md
+++ b/cmd/gaia/testnets/STATUS.md
@@ -34,7 +34,7 @@ See [testnets repo](https://github.com/cosmos/testnets).
 ## *June 13, 2018, 17:00 EST* - Gaia-6002 is making blocks!
 
 - Gaia-6002 is live and making blocks
-- Absent validators have been slashed and revoked 
+- Absent validators have been slashed and jailed 
 - Currently live with 17 validators
 
 ## *June 13, 2018, 4:30 EST* - New Testnet Gaia-6002

--- a/docs/resources/whitepaper.md
+++ b/docs/resources/whitepaper.md
@@ -1003,7 +1003,7 @@ where the processes that caused the consensus to fail (ie. caused clients of
 the protocol to accept different values - a fork) can be identified and punished
 according to the rules of the protocol, or, possibly, the legal system. When
 the legal system is unreliable or excessively expensive to invoke, validators can be forced to make security
-deposits in order to participate, and those deposits can be revoked, or slashed,
+deposits in order to participate, and those deposits can be jailed, or slashed,
 when malicious behaviour is detected [\[10\]][10].
 
 Note this is unlike Bitcoin, where forking is a regular occurence due to

--- a/docs/spec/staking/transactions.md
+++ b/docs/spec/staking/transactions.md
@@ -100,7 +100,7 @@ type TxDelegate struct {
 
 delegate(tx TxDelegate):
     pool = getPool()
-    if validator.Status == Revoked return
+    if validator.Status == Jailed return
 
     delegation = getDelegatorBond(DelegatorAddr, ValidatorAddr)
     if delegation == nil then delegation = NewDelegation(DelegatorAddr, ValidatorAddr)
@@ -141,7 +141,7 @@ startUnbonding(tx TxStartUnbonding):
 	revokeCandidacy = false
 	if bond.Shares.IsZero() {
 
-		if bond.DelegatorAddr == validator.Operator && validator.Revoked == false
+		if bond.DelegatorAddr == validator.Operator && validator.Jailed == false
 			revokeCandidacy = true
 
 		removeDelegation( bond)
@@ -157,7 +157,7 @@ startUnbonding(tx TxStartUnbonding):
     setUnbondingDelegation(unbondingDelegation)
 
 	if revokeCandidacy
-		validator.Revoked = true
+		validator.Jailed = true
 
 	validator = updateValidator(validator)
 
@@ -279,9 +279,9 @@ updateBondedValidators(newValidator Validator) (updatedVal Validator)
         else
 			validator = getValidator(operatorAddr)
 
-		// if not previously a validator (and unrevoked),
+		// if not previously a validator (and unjailed),
 		// kick the cliff validator / bond this new validator
-		if validator.Status() != Bonded && !validator.Revoked {
+		if validator.Status() != Bonded && !validator.Jailed {
 			kickCliffValidator = true
 
 			validator = bondValidator(ctx, store, validator)


### PR DESCRIPTION
closes #2279. The only remaining usage of revoked not updated is the usage in the faq, but that is because "jailed" didn't grammatically make sense in those sentences, whereas revoked did still make sense.
______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
