### PR TITLE
R4R: Add a name field to the message type

### DIFF
--- a/PENDING.md
+++ b/PENDING.md
@@ -46,6 +46,7 @@ BREAKING CHANGES
     * [baseapp] Remove `SetTxDecoder` in favor of requiring the decoder be set in baseapp initialization. [#1441](https://github.com/cosmos/cosmos-sdk/issues/1441)
     * [store] Change storeInfo within the root multistore to use tmhash instead of ripemd160 \#2308
     * [codec] \#2324 All referrences to wire have been renamed to codec. Additionally, wire.NewCodec is now codec.New().
+    * [types] \#2343 Make sdk.Msg have a names field, to facilitate automatic tagging.
 
 * Tendermint
 

--- a/baseapp/baseapp_test.go
+++ b/baseapp/baseapp_test.go
@@ -302,6 +302,7 @@ type msgCounter struct {
 
 // Implements Msg
 func (msg msgCounter) Type() string                 { return typeMsgCounter }
+func (msg msgCounter) Name() string                 { return "counter1" }
 func (msg msgCounter) GetSignBytes() []byte         { return nil }
 func (msg msgCounter) GetSigners() []sdk.AccAddress { return nil }
 func (msg msgCounter) ValidateBasic() sdk.Error {
@@ -340,6 +341,7 @@ type msgCounter2 struct {
 
 // Implements Msg
 func (msg msgCounter2) Type() string                 { return typeMsgCounter2 }
+func (msg msgCounter2) Name() string                 { return "counter2" }
 func (msg msgCounter2) GetSignBytes() []byte         { return nil }
 func (msg msgCounter2) GetSigners() []sdk.AccAddress { return nil }
 func (msg msgCounter2) ValidateBasic() sdk.Error {

--- a/docs/sdk/core/examples/app1.go
+++ b/docs/sdk/core/examples/app1.go
@@ -57,6 +57,7 @@ func NewMsgSend(from, to sdk.AccAddress, amt sdk.Coins) MsgSend {
 
 // Implements Msg.
 func (msg MsgSend) Type() string { return "send" }
+func (msg MsgSend) Name() string { return "send" }
 
 // Implements Msg. Ensure the addresses are good and the
 // amount is positive.

--- a/docs/sdk/core/examples/app2.go
+++ b/docs/sdk/core/examples/app2.go
@@ -77,6 +77,7 @@ type MsgIssue struct {
 
 // Implements Msg.
 func (msg MsgIssue) Type() string { return "issue" }
+func (msg MsgIssue) Name() string { return "issue" }
 
 // Implements Msg. Ensures addresses are valid and Coin is positive
 func (msg MsgIssue) ValidateBasic() sdk.Error {

--- a/examples/democoin/x/cool/types.go
+++ b/examples/democoin/x/cool/types.go
@@ -33,6 +33,7 @@ var _ sdk.Msg = MsgSetTrend{}
 
 // nolint
 func (msg MsgSetTrend) Type() string                 { return "cool" }
+func (msg MsgSetTrend) Name() string                 { return "set_trend" }
 func (msg MsgSetTrend) GetSigners() []sdk.AccAddress { return []sdk.AccAddress{msg.Sender} }
 func (msg MsgSetTrend) String() string {
 	return fmt.Sprintf("MsgSetTrend{Sender: %v, Cool: %v}", msg.Sender, msg.Cool)
@@ -83,6 +84,7 @@ var _ sdk.Msg = MsgQuiz{}
 
 // nolint
 func (msg MsgQuiz) Type() string                 { return "cool" }
+func (msg MsgQuiz) Name() string                 { return "quiz" }
 func (msg MsgQuiz) GetSigners() []sdk.AccAddress { return []sdk.AccAddress{msg.Sender} }
 func (msg MsgQuiz) String() string {
 	return fmt.Sprintf("MsgQuiz{Sender: %v, CoolAnswer: %v}", msg.Sender, msg.CoolAnswer)

--- a/examples/democoin/x/oracle/oracle_test.go
+++ b/examples/democoin/x/oracle/oracle_test.go
@@ -34,6 +34,9 @@ type seqOracle struct {
 func (o seqOracle) Type() string {
 	return "seq"
 }
+func (o seqOracle) Name() string {
+	return "seq"
+}
 
 func (o seqOracle) ValidateBasic() sdk.Error {
 	return nil

--- a/examples/democoin/x/oracle/types.go
+++ b/examples/democoin/x/oracle/types.go
@@ -29,5 +29,6 @@ func (msg Msg) GetSigners() []sdk.AccAddress {
 // Payload defines inner data for actual execution
 type Payload interface {
 	Type() string
+	Name() string
 	ValidateBasic() sdk.Error
 }

--- a/examples/democoin/x/pow/types.go
+++ b/examples/democoin/x/pow/types.go
@@ -32,6 +32,7 @@ func NewMsgMine(sender sdk.AccAddress, difficulty uint64, count uint64, nonce ui
 
 // nolint
 func (msg MsgMine) Type() string                 { return "pow" }
+func (msg MsgMine) Name() string                 { return "mine" }
 func (msg MsgMine) GetSigners() []sdk.AccAddress { return []sdk.AccAddress{msg.Sender} }
 func (msg MsgMine) String() string {
 	return fmt.Sprintf("MsgMine{Sender: %s, Difficulty: %d, Count: %d, Nonce: %d, Proof: %s}", msg.Sender, msg.Difficulty, msg.Count, msg.Nonce, msg.Proof)

--- a/examples/democoin/x/simplestake/msgs.go
+++ b/examples/democoin/x/simplestake/msgs.go
@@ -27,6 +27,7 @@ func NewMsgBond(addr sdk.AccAddress, stake sdk.Coin, pubKey crypto.PubKey) MsgBo
 
 //nolint
 func (msg MsgBond) Type() string                 { return moduleName } //TODO update "stake/createvalidator"
+func (msg MsgBond) Name() string                 { return "bond" }
 func (msg MsgBond) GetSigners() []sdk.AccAddress { return []sdk.AccAddress{msg.Address} }
 
 // basic validation of the bond message
@@ -66,6 +67,7 @@ func NewMsgUnbond(addr sdk.AccAddress) MsgUnbond {
 
 //nolint
 func (msg MsgUnbond) Type() string                 { return moduleName } //TODO update "stake/createvalidator"
+func (msg MsgUnbond) Name() string                 { return "unbond" }
 func (msg MsgUnbond) GetSigners() []sdk.AccAddress { return []sdk.AccAddress{msg.Address} }
 func (msg MsgUnbond) ValidateBasic() sdk.Error     { return nil }
 

--- a/examples/kvstore/tx.go
+++ b/examples/kvstore/tx.go
@@ -18,6 +18,10 @@ func (tx kvstoreTx) Type() string {
 	return "kvstore"
 }
 
+func (tx kvstoreTx) Name() string {
+	return "kvstore"
+}
+
 func (tx kvstoreTx) GetMsgs() []sdk.Msg {
 	return []sdk.Msg{tx}
 }

--- a/server/mock/tx.go
+++ b/server/mock/tx.go
@@ -31,6 +31,10 @@ func (tx kvstoreTx) Type() string {
 	return "kvstore"
 }
 
+func (tx kvstoreTx) Name() string {
+	return "kvstore_tx"
+}
+
 func (tx kvstoreTx) GetMsgs() []sdk.Msg {
 	return []sdk.Msg{tx}
 }

--- a/types/tx_msg.go
+++ b/types/tx_msg.go
@@ -11,6 +11,10 @@ type Msg interface {
 	// Must be alphanumeric or empty.
 	Type() string
 
+	// Returns a human-readable string for the message, intended for utilization
+	// within tags
+	Name() string
+
 	// ValidateBasic does a simple validation check that
 	// doesn't require access to any other information.
 	ValidateBasic() Error
@@ -55,6 +59,7 @@ func NewTestMsg(addrs ...AccAddress) *TestMsg {
 
 //nolint
 func (msg *TestMsg) Type() string { return "TestMsg" }
+func (msg *TestMsg) Name() string { return "Test message" }
 func (msg *TestMsg) GetSignBytes() []byte {
 	bz, err := json.Marshal(msg.signers)
 	if err != nil {

--- a/x/bank/msgs.go
+++ b/x/bank/msgs.go
@@ -20,7 +20,9 @@ func NewMsgSend(in []Input, out []Output) MsgSend {
 }
 
 // Implements Msg.
+// nolint
 func (msg MsgSend) Type() string { return "bank" } // TODO: "bank/send"
+func (msg MsgSend) Name() string { return "send" }
 
 // Implements Msg.
 func (msg MsgSend) ValidateBasic() sdk.Error {
@@ -101,7 +103,9 @@ func NewMsgIssue(banker sdk.AccAddress, out []Output) MsgIssue {
 }
 
 // Implements Msg.
+// nolint
 func (msg MsgIssue) Type() string { return "bank" } // TODO: "bank/issue"
+func (msg MsgIssue) Name() string { return "issue" }
 
 // Implements Msg.
 func (msg MsgIssue) ValidateBasic() sdk.Error {

--- a/x/gov/msgs.go
+++ b/x/gov/msgs.go
@@ -9,6 +9,8 @@ import (
 // name to idetify transaction types
 const MsgType = "gov"
 
+var _, _, _ sdk.Msg = MsgSubmitProposal{}, MsgDeposit{}, MsgVote{}
+
 //-----------------------------------------------------------
 // MsgSubmitProposal
 type MsgSubmitProposal struct {
@@ -31,6 +33,7 @@ func NewMsgSubmitProposal(title string, description string, proposalType Proposa
 
 // Implements Msg.
 func (msg MsgSubmitProposal) Type() string { return MsgType }
+func (msg MsgSubmitProposal) Name() string { return "submit_proposal" }
 
 // Implements Msg.
 func (msg MsgSubmitProposal) ValidateBasic() sdk.Error {
@@ -95,7 +98,9 @@ func NewMsgDeposit(depositer sdk.AccAddress, proposalID int64, amount sdk.Coins)
 }
 
 // Implements Msg.
+// nolint
 func (msg MsgDeposit) Type() string { return MsgType }
+func (msg MsgDeposit) Name() string { return "deposit" }
 
 // Implements Msg.
 func (msg MsgDeposit) ValidateBasic() sdk.Error {
@@ -154,7 +159,9 @@ func NewMsgVote(voter sdk.AccAddress, proposalID int64, option VoteOption) MsgVo
 }
 
 // Implements Msg.
+// nolint
 func (msg MsgVote) Type() string { return MsgType }
+func (msg MsgVote) Name() string { return "vote" }
 
 // Implements Msg.
 func (msg MsgVote) ValidateBasic() sdk.Error {

--- a/x/ibc/types.go
+++ b/x/ibc/types.go
@@ -72,6 +72,7 @@ type IBCTransferMsg struct {
 
 // nolint
 func (msg IBCTransferMsg) Type() string { return "ibc" }
+func (msg IBCTransferMsg) Name() string { return "transfer" }
 
 // x/bank/tx.go MsgSend.GetSigners()
 func (msg IBCTransferMsg) GetSigners() []sdk.AccAddress { return []sdk.AccAddress{msg.SrcAddr} }
@@ -100,6 +101,7 @@ type IBCReceiveMsg struct {
 
 // nolint
 func (msg IBCReceiveMsg) Type() string             { return "ibc" }
+func (msg IBCReceiveMsg) Name() string             { return "receive" }
 func (msg IBCReceiveMsg) ValidateBasic() sdk.Error { return msg.IBCPacket.ValidateBasic() }
 
 // x/bank/tx.go MsgSend.GetSigners()

--- a/x/mock/app_test.go
+++ b/x/mock/app_test.go
@@ -24,6 +24,7 @@ type testMsg struct {
 }
 
 func (tx testMsg) Type() string                       { return msgType }
+func (tx testMsg) Name() string                       { return "test" }
 func (tx testMsg) GetMsg() sdk.Msg                    { return tx }
 func (tx testMsg) GetMemo() string                    { return "" }
 func (tx testMsg) GetSignBytes() []byte               { return nil }

--- a/x/slashing/msg.go
+++ b/x/slashing/msg.go
@@ -26,6 +26,7 @@ func NewMsgUnjail(validatorAddr sdk.ValAddress) MsgUnjail {
 
 //nolint
 func (msg MsgUnjail) Type() string { return MsgType }
+func (msg MsgUnjail) Name() string { return "unjail" }
 func (msg MsgUnjail) GetSigners() []sdk.AccAddress {
 	return []sdk.AccAddress{sdk.AccAddress(msg.ValidatorAddr)}
 }

--- a/x/stake/types/msg.go
+++ b/x/stake/types/msg.go
@@ -7,7 +7,7 @@ import (
 	"github.com/tendermint/tendermint/crypto"
 )
 
-// name to idetify transaction types
+// name to identify transaction types
 const MsgType = "stake"
 
 // Verify interface at compile time
@@ -49,6 +49,7 @@ func NewMsgCreateValidatorOnBehalfOf(delAddr sdk.AccAddress, valAddr sdk.ValAddr
 
 //nolint
 func (msg MsgCreateValidator) Type() string { return MsgType }
+func (msg MsgCreateValidator) Name() string { return "create_validator" }
 
 // Return address(es) that must sign over msg.GetSignBytes()
 func (msg MsgCreateValidator) GetSigners() []sdk.AccAddress {
@@ -118,6 +119,7 @@ func NewMsgEditValidator(valAddr sdk.ValAddress, description Description) MsgEdi
 
 //nolint
 func (msg MsgEditValidator) Type() string { return MsgType }
+func (msg MsgEditValidator) Name() string { return "edit_validator" }
 func (msg MsgEditValidator) GetSigners() []sdk.AccAddress {
 	return []sdk.AccAddress{sdk.AccAddress(msg.ValidatorAddr)}
 }
@@ -168,6 +170,7 @@ func NewMsgDelegate(delAddr sdk.AccAddress, valAddr sdk.ValAddress, delegation s
 
 //nolint
 func (msg MsgDelegate) Type() string { return MsgType }
+func (msg MsgDelegate) Name() string { return "delegate" }
 func (msg MsgDelegate) GetSigners() []sdk.AccAddress {
 	return []sdk.AccAddress{msg.DelegatorAddr}
 }
@@ -218,6 +221,7 @@ func NewMsgBeginRedelegate(delAddr sdk.AccAddress, valSrcAddr,
 
 //nolint
 func (msg MsgBeginRedelegate) Type() string { return MsgType }
+func (msg MsgBeginRedelegate) Name() string { return "begin_redelegate" }
 func (msg MsgBeginRedelegate) GetSigners() []sdk.AccAddress {
 	return []sdk.AccAddress{msg.DelegatorAddr}
 }
@@ -275,6 +279,7 @@ func NewMsgCompleteRedelegate(delAddr sdk.AccAddress, valSrcAddr, valDstAddr sdk
 
 //nolint
 func (msg MsgCompleteRedelegate) Type() string { return MsgType }
+func (msg MsgCompleteRedelegate) Name() string { return "complete_redelegate" }
 func (msg MsgCompleteRedelegate) GetSigners() []sdk.AccAddress {
 	return []sdk.AccAddress{msg.DelegatorAddr}
 }
@@ -321,6 +326,7 @@ func NewMsgBeginUnbonding(delAddr sdk.AccAddress, valAddr sdk.ValAddress, shares
 
 //nolint
 func (msg MsgBeginUnbonding) Type() string                 { return MsgType }
+func (msg MsgBeginUnbonding) Name() string                 { return "begin_unbonding" }
 func (msg MsgBeginUnbonding) GetSigners() []sdk.AccAddress { return []sdk.AccAddress{msg.DelegatorAddr} }
 
 // get the bytes for the message signer to sign on
@@ -369,6 +375,7 @@ func NewMsgCompleteUnbonding(delAddr sdk.AccAddress, valAddr sdk.ValAddress) Msg
 
 //nolint
 func (msg MsgCompleteUnbonding) Type() string { return MsgType }
+func (msg MsgCompleteUnbonding) Name() string { return "complete_unbonding" }
 func (msg MsgCompleteUnbonding) GetSigners() []sdk.AccAddress {
 	return []sdk.AccAddress{msg.DelegatorAddr}
 }


### PR DESCRIPTION
This is to facillitate ease of implementing #1406. (Tags for messages
could then be added dynamically)

Ultimately once we make the router support hiearchical routing, (#770)
we can then remove the name field and just the parse info for tags from that.

Until then, we can parse the tag name as
`fmt.Sprintf("%s %s", msg.Type(), msg.Name())`

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/develop/CONTRIBUTING.md#pr-targeting))

- [x] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [x] Updated relevant documentation (`docs/`)
- [x] Added entries in `PENDING.md` with issue # 
- [x] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
