### PR TITLE
R4R: bugfix in validatorset query and refactor transaction search

### DIFF
--- a/client/rpc/block.go
+++ b/client/rpc/block.go
@@ -43,7 +43,7 @@ func getBlock(cliCtx context.CLIContext, height *int64) ([]byte, error) {
 	}
 
 	if !cliCtx.TrustNode {
-		check, err := cliCtx.Certify(*height)
+		check, err := cliCtx.Certify(res.Block.Height)
 		if err != nil {
 			return nil, err
 		}

--- a/client/rpc/validators.go
+++ b/client/rpc/validators.go
@@ -73,7 +73,7 @@ func getValidators(cliCtx context.CLIContext, height *int64) ([]byte, error) {
 	}
 
 	if !cliCtx.TrustNode {
-		check, err := cliCtx.Certify(*height)
+		check, err := cliCtx.Certify(validatorsRes.BlockHeight)
 		if err != nil {
 			return nil, err
 		}

--- a/client/tx/search.go
+++ b/client/tx/search.go
@@ -102,7 +102,7 @@ func searchTxs(cliCtx context.CLIContext, cdc *codec.Codec, tags []string) ([]In
 		}
 	}
 
-	info, err := FormatTxResults(cdc, cliCtx, res.Txs)
+	info, err := FormatTxResults(cdc, res.Txs)
 	if err != nil {
 		return nil, err
 	}
@@ -111,7 +111,7 @@ func searchTxs(cliCtx context.CLIContext, cdc *codec.Codec, tags []string) ([]In
 }
 
 // parse the indexed txs into an array of Info
-func FormatTxResults(cdc *codec.Codec, cliCtx context.CLIContext, res []*ctypes.ResultTx) ([]Info, error) {
+func FormatTxResults(cdc *codec.Codec, res []*ctypes.ResultTx) ([]Info, error) {
 	var err error
 	out := make([]Info, len(res))
 	for i := range res {

--- a/x/stake/client/rest/utils.go
+++ b/x/stake/client/rest/utils.go
@@ -40,5 +40,5 @@ func queryTxs(node rpcclient.Client, cliCtx context.CLIContext, cdc *codec.Codec
 		}
 	}
 
-	return tx.FormatTxResults(cdc, cliCtx, res.Txs)
+	return tx.FormatTxResults(cdc, res.Txs)
 }


### PR DESCRIPTION
* When we query validatorset, we may not provide height. The the height pointer may be null. So here I replaced `*height` with `validatorsRes.BlockHeight`
* The same problems also exist in getBlock. I replaced `*height` with `res.Block.Height`.
* FormatTxResults has a useless parameters which was added by me. I correct it here.