### PR TITLE
R4R: Improve error handler in certifier creation

### DIFF
--- a/client/context/context.go
+++ b/client/context/context.go
@@ -94,13 +94,15 @@ func createCertifier() tmlite.Certifier {
 		errMsg.WriteString("--node ")
 	}
 	if errMsg.Len() != 0 {
-		fmt.Printf("must specify these options: %s when --trust-node is false\n", errMsg.String())
+		fmt.Printf("Must specify these options: %s when --trust-node is false\n", errMsg.String())
 		os.Exit(1)
 	}
 
 	certifier, err := tmliteProxy.GetCertifier(chainID, home, nodeURI)
 	if err != nil {
-		panic(err)
+		fmt.Printf("Create certifier failed: %s\n", err.Error())
+		fmt.Printf("Please check network connection and verify the address of the node to connect to\n")
+		os.Exit(1)
 	}
 
 	return certifier

--- a/client/rpc/validators.go
+++ b/client/rpc/validators.go
@@ -12,7 +12,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/context"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	tmTypes "github.com/tendermint/tendermint/types"
 	tmtypes "github.com/tendermint/tendermint/types"
 )
 
@@ -78,7 +77,7 @@ func getValidators(cliCtx context.CLIContext, height *int64) ([]byte, error) {
 			return nil, err
 		}
 
-		if !bytes.Equal(check.ValidatorsHash(), tmTypes.NewValidatorSet(validatorsRes.Validators).Hash()) {
+		if !bytes.Equal(check.ValidatorsHash(), tmtypes.NewValidatorSet(validatorsRes.Validators).Hash()) {
 			return nil, fmt.Errorf("got invalid validatorset")
 		}
 	}


### PR DESCRIPTION
If network connection has problems or full node url is not valid, then the certifier creation will fail and return error. Previous error handler is just panic, I think it is not elegant and will confuse users. So here I improved the error handler:
* Print error message
* Imform user how to solve the problems.

Besides, I remove duplicate import:
`tmTypes "github.com/tendermint/tendermint/types"`