### PR TITLE
Add an example for the size of a transaction

### DIFF
--- a/cmd/gaia/app/benchmarks/txsize_test.go
+++ b/cmd/gaia/app/benchmarks/txsize_test.go
@@ -1,0 +1,34 @@
+package app
+
+import (
+	"fmt"
+
+	"github.com/cosmos/cosmos-sdk/cmd/gaia/app"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/auth"
+	"github.com/cosmos/cosmos-sdk/x/bank"
+	"github.com/tendermint/tendermint/crypto/secp256k1"
+)
+
+// This will fail half the time with the second output being 173
+// This is due to secp256k1 signatures not being constant size.
+// This will be resolved when updating to tendermint v0.24.0
+func ExampleTxSendSize() {
+	cdc := app.MakeCodec()
+	priv1 := secp256k1.GenPrivKeySecp256k1([]byte{0})
+	addr1 := sdk.AccAddress(priv1.PubKey().Address())
+	priv2 := secp256k1.GenPrivKey()
+	addr2 := sdk.AccAddress(priv2.PubKey().Address())
+	coins := []sdk.Coin{sdk.NewCoin("denom", sdk.NewInt(10))}
+	msg1 := bank.MsgSend{
+		Inputs:  []bank.Input{bank.NewInput(addr1, coins)},
+		Outputs: []bank.Output{bank.NewOutput(addr2, coins)},
+	}
+	sig, _ := priv1.Sign(msg1.GetSignBytes())
+	sigs := []auth.StdSignature{auth.StdSignature{nil, sig, 0, 0}}
+	tx := auth.NewStdTx([]sdk.Msg{msg1}, auth.NewStdFee(0, coins...), sigs, "")
+	fmt.Println(len(cdc.MustMarshalBinaryBare([]sdk.Msg{msg1})))
+	fmt.Println(len(cdc.MustMarshalBinaryBare(tx)))
+	// output: 80
+	// 173
+}

--- a/cmd/gaia/app/benchmarks/txsize_test.go
+++ b/cmd/gaia/app/benchmarks/txsize_test.go
@@ -13,11 +13,12 @@ import (
 // This will fail half the time with the second output being 173
 // This is due to secp256k1 signatures not being constant size.
 // This will be resolved when updating to tendermint v0.24.0
+// nolint: vet
 func ExampleTxSendSize() {
 	cdc := app.MakeCodec()
 	priv1 := secp256k1.GenPrivKeySecp256k1([]byte{0})
 	addr1 := sdk.AccAddress(priv1.PubKey().Address())
-	priv2 := secp256k1.GenPrivKey()
+	priv2 := secp256k1.GenPrivKeySecp256k1([]byte{1})
 	addr2 := sdk.AccAddress(priv2.PubKey().Address())
 	coins := []sdk.Coin{sdk.NewCoin("denom", sdk.NewInt(10))}
 	msg1 := bank.MsgSend{


### PR DESCRIPTION
This shows that the size of a send tx from 1 input to 1 output is 173 bytes. (Will decrease by 6 bytes once we update tendermint versions!)
This is good information to have, though we need to find the correct place
to put it. I put this in gaia, because eventually it would probably be useful
to see an example of how to build each message type and their respective
sizes all in one place.

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
