### PR TITLE
Skip LCD Test TestVersion When ENV Var is Missing

### DIFF
--- a/client/lcd/lcd_test.go
+++ b/client/lcd/lcd_test.go
@@ -120,6 +120,11 @@ func TestKeys(t *testing.T) {
 }
 
 func TestVersion(t *testing.T) {
+	// skip the test if the VERSION environment variable has not been set
+	if version.Version == "" {
+		t.SkipNow()
+	}
+
 	cleanup, _, port := InitializeTestLCD(t, 1, []sdk.AccAddress{})
 	defer cleanup()
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

When `VERSION` is missing (e.g. when you run the test manually or all the LCD tests manually for that matter), the `TestVersion` test will fail. Simply skip it if the env var is not set.

Not sure if this warrants a PENDING log update.

----

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/develop/CONTRIBUTING.md#pr-targeting))

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added entries in `PENDING.md` with issue # 
- [ ] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
