### PR TITLE
CLIContext.Logger -> .Output as it isn't a logger

### DIFF
--- a/client/context/broadcast.go
+++ b/client/context/broadcast.go
@@ -91,7 +91,7 @@ func (ctx CLIContext) broadcastTxAsync(txBytes []byte) (*ctypes.ResultBroadcastT
 		return res, err
 	}
 
-	if ctx.Logger != nil {
+	if ctx.Output != nil {
 		if ctx.JSON {
 			type toJSON struct {
 				TxHash string
@@ -103,10 +103,10 @@ func (ctx CLIContext) broadcastTxAsync(txBytes []byte) (*ctypes.ResultBroadcastT
 				return res, err
 			}
 
-			ctx.Logger.Write(bz)
-			io.WriteString(ctx.Logger, "\n")
+			ctx.Output.Write(bz)
+			io.WriteString(ctx.Output, "\n")
 		} else {
-			io.WriteString(ctx.Logger, fmt.Sprintf("async tx sent (tx hash: %s)\n", res.Hash))
+			io.WriteString(ctx.Output, fmt.Sprintf("async tx sent (tx hash: %s)\n", res.Hash))
 		}
 	}
 
@@ -128,21 +128,21 @@ func (ctx CLIContext) broadcastTxCommit(txBytes []byte) (*ctypes.ResultBroadcast
 			Response abci.ResponseDeliverTx
 		}
 
-		if ctx.Logger != nil {
+		if ctx.Output != nil {
 			resJSON := toJSON{res.Height, res.Hash.String(), res.DeliverTx}
 			bz, err := ctx.Codec.MarshalJSON(resJSON)
 			if err != nil {
 				return res, err
 			}
 
-			ctx.Logger.Write(bz)
-			io.WriteString(ctx.Logger, "\n")
+			ctx.Output.Write(bz)
+			io.WriteString(ctx.Output, "\n")
 		}
 
 		return res, nil
 	}
 
-	if ctx.Logger != nil {
+	if ctx.Output != nil {
 		resStr := fmt.Sprintf("Committed at block %d (tx hash: %s)\n", res.Height, res.Hash.String())
 
 		if ctx.PrintResponse {
@@ -151,7 +151,7 @@ func (ctx CLIContext) broadcastTxCommit(txBytes []byte) (*ctypes.ResultBroadcast
 			)
 		}
 
-		io.WriteString(ctx.Logger, resStr)
+		io.WriteString(ctx.Output, resStr)
 	}
 
 	return res, nil

--- a/client/context/context.go
+++ b/client/context/context.go
@@ -11,14 +11,14 @@ import (
 
 	"github.com/spf13/viper"
 
+	"github.com/cosmos/cosmos-sdk/client/keys"
+	cskeys "github.com/cosmos/cosmos-sdk/crypto/keys"
+	"github.com/cosmos/cosmos-sdk/types"
 	"github.com/tendermint/tendermint/libs/cli"
 	tmlite "github.com/tendermint/tendermint/lite"
 	tmliteProxy "github.com/tendermint/tendermint/lite/proxy"
 	rpcclient "github.com/tendermint/tendermint/rpc/client"
 	"os"
-	"github.com/cosmos/cosmos-sdk/types"
-	"github.com/cosmos/cosmos-sdk/client/keys"
-	cskeys "github.com/cosmos/cosmos-sdk/crypto/keys"
 )
 
 const ctxAccStoreName = "acc"
@@ -29,7 +29,7 @@ type CLIContext struct {
 	Codec         *codec.Codec
 	AccDecoder    auth.AccountDecoder
 	Client        rpcclient.Client
-	Logger        io.Writer
+	Output        io.Writer
 	Height        int64
 	NodeURI       string
 	From          string
@@ -61,6 +61,7 @@ func NewCLIContext() CLIContext {
 
 	return CLIContext{
 		Client:        rpc,
+		Output:        os.Stdout,
 		NodeURI:       nodeURI,
 		AccountStore:  ctxAccStoreName,
 		From:          viper.GetString(client.FlagFrom),
@@ -162,9 +163,9 @@ func (ctx CLIContext) WithAccountDecoder(decoder auth.AccountDecoder) CLIContext
 	return ctx
 }
 
-// WithLogger returns a copy of the context with an updated logger.
-func (ctx CLIContext) WithLogger(w io.Writer) CLIContext {
-	ctx.Logger = w
+// WithOutput returns a copy of the context with an updated output writer (e.g. stdout).
+func (ctx CLIContext) WithOutput(w io.Writer) CLIContext {
+	ctx.Output = w
 	return ctx
 }
 

--- a/client/lcd/root.go
+++ b/client/lcd/root.go
@@ -136,7 +136,7 @@ func createHandler(cdc *codec.Codec) http.Handler {
 		panic(err)
 	}
 
-	cliCtx := context.NewCLIContext().WithCodec(cdc).WithLogger(os.Stdout)
+	cliCtx := context.NewCLIContext().WithCodec(cdc)
 
 	// TODO: make more functional? aka r = keys.RegisterRoutes(r)
 	r.HandleFunc("/version", CLIVersionRequestHandler).Methods("GET")

--- a/examples/democoin/x/cool/client/cli/tx.go
+++ b/examples/democoin/x/cool/client/cli/tx.go
@@ -1,8 +1,6 @@
 package cli
 
 import (
-	"os"
-
 	"github.com/spf13/cobra"
 
 	"github.com/cosmos/cosmos-sdk/client/context"
@@ -24,7 +22,6 @@ func QuizTxCmd(cdc *codec.Codec) *cobra.Command {
 			txBldr := authtxb.NewTxBuilderFromCLI().WithCodec(cdc)
 			cliCtx := context.NewCLIContext().
 				WithCodec(cdc).
-				WithLogger(os.Stdout).
 				WithAccountDecoder(authcmd.GetAccountDecoder(cdc))
 
 			from, err := cliCtx.GetFromAddress()
@@ -49,7 +46,6 @@ func SetTrendTxCmd(cdc *codec.Codec) *cobra.Command {
 			txBldr := authtxb.NewTxBuilderFromCLI().WithCodec(cdc)
 			cliCtx := context.NewCLIContext().
 				WithCodec(cdc).
-				WithLogger(os.Stdout).
 				WithAccountDecoder(authcmd.GetAccountDecoder(cdc))
 
 			from, err := cliCtx.GetFromAddress()

--- a/examples/democoin/x/pow/client/cli/tx.go
+++ b/examples/democoin/x/pow/client/cli/tx.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"os"
 	"strconv"
 
 	"github.com/cosmos/cosmos-sdk/client/context"
@@ -25,7 +24,6 @@ func MineCmd(cdc *codec.Codec) *cobra.Command {
 			txBldr := authtxb.NewTxBuilderFromCLI().WithCodec(cdc)
 			cliCtx := context.NewCLIContext().
 				WithCodec(cdc).
-				WithLogger(os.Stdout).
 				WithAccountDecoder(authcmd.GetAccountDecoder(cdc))
 
 			from, err := cliCtx.GetFromAddress()

--- a/examples/democoin/x/simplestake/client/cli/commands.go
+++ b/examples/democoin/x/simplestake/client/cli/commands.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"encoding/hex"
 	"fmt"
-	"os"
 
 	"github.com/cosmos/cosmos-sdk/client/context"
 	"github.com/cosmos/cosmos-sdk/client/utils"
@@ -33,7 +32,6 @@ func BondTxCmd(cdc *codec.Codec) *cobra.Command {
 			txBldr := authtxb.NewTxBuilderFromCLI().WithCodec(cdc)
 			cliCtx := context.NewCLIContext().
 				WithCodec(cdc).
-				WithLogger(os.Stdout).
 				WithAccountDecoder(authcmd.GetAccountDecoder(cdc))
 
 			from, err := cliCtx.GetFromAddress()
@@ -86,8 +84,7 @@ func UnbondTxCmd(cdc *codec.Codec) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			txBldr := authtxb.NewTxBuilderFromCLI().WithCodec(cdc)
 			cliCtx := context.NewCLIContext().
-				WithCodec(cdc).
-				WithLogger(os.Stdout)
+				WithCodec(cdc)
 
 			from, err := cliCtx.GetFromAddress()
 			if err != nil {

--- a/x/bank/client/cli/broadcast.go
+++ b/x/bank/client/cli/broadcast.go
@@ -20,7 +20,7 @@ Read a transaction from <file> and broadcast it to a node. If you supply a dash 
 in place of an input filename, the command reads from standard input.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
-			cliCtx := context.NewCLIContext().WithCodec(codec).WithLogger(os.Stdout)
+			cliCtx := context.NewCLIContext().WithCodec(codec)
 			stdTx, err := readAndUnmarshalStdTx(cliCtx.Codec, args[0])
 			if err != nil {
 				return

--- a/x/bank/client/cli/sendtx.go
+++ b/x/bank/client/cli/sendtx.go
@@ -1,8 +1,6 @@
 package cli
 
 import (
-	"os"
-
 	"github.com/cosmos/cosmos-sdk/client/context"
 	"github.com/cosmos/cosmos-sdk/client/utils"
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -30,7 +28,6 @@ func SendTxCmd(cdc *codec.Codec) *cobra.Command {
 			txBldr := authtxb.NewTxBuilderFromCLI().WithCodec(cdc)
 			cliCtx := context.NewCLIContext().
 				WithCodec(cdc).
-				WithLogger(os.Stdout).
 				WithAccountDecoder(authcmd.GetAccountDecoder(cdc))
 
 			if err := cliCtx.EnsureAccountExists(); err != nil {

--- a/x/gov/client/cli/tx.go
+++ b/x/gov/client/cli/tx.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/cosmos/cosmos-sdk/client/context"
 	"github.com/cosmos/cosmos-sdk/client/utils"
@@ -80,7 +79,6 @@ $ gaiacli gov submit-proposal --title="Test Proposal" --description="My awesome 
 			txBldr := authtxb.NewTxBuilderFromCLI().WithCodec(cdc)
 			cliCtx := context.NewCLIContext().
 				WithCodec(cdc).
-				WithLogger(os.Stdout).
 				WithAccountDecoder(authcmd.GetAccountDecoder(cdc))
 
 			fromAddr, err := cliCtx.GetFromAddress()
@@ -164,7 +162,6 @@ func GetCmdDeposit(cdc *codec.Codec) *cobra.Command {
 			txBldr := authtxb.NewTxBuilderFromCLI().WithCodec(cdc)
 			cliCtx := context.NewCLIContext().
 				WithCodec(cdc).
-				WithLogger(os.Stdout).
 				WithAccountDecoder(authcmd.GetAccountDecoder(cdc))
 
 			depositerAddr, err := cliCtx.GetFromAddress()
@@ -210,7 +207,6 @@ func GetCmdVote(cdc *codec.Codec) *cobra.Command {
 			txBldr := authtxb.NewTxBuilderFromCLI().WithCodec(cdc)
 			cliCtx := context.NewCLIContext().
 				WithCodec(cdc).
-				WithLogger(os.Stdout).
 				WithAccountDecoder(authcmd.GetAccountDecoder(cdc))
 
 			voterAddr, err := cliCtx.GetFromAddress()

--- a/x/ibc/client/cli/ibctx.go
+++ b/x/ibc/client/cli/ibctx.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"encoding/hex"
-	"os"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/context"
@@ -31,7 +30,6 @@ func IBCTransferCmd(cdc *codec.Codec) *cobra.Command {
 			txBldr := authtxb.NewTxBuilderFromCLI().WithCodec(cdc)
 			cliCtx := context.NewCLIContext().
 				WithCodec(cdc).
-				WithLogger(os.Stdout).
 				WithAccountDecoder(authcmd.GetAccountDecoder(cdc))
 
 			from, err := cliCtx.GetFromAddress()

--- a/x/slashing/client/cli/tx.go
+++ b/x/slashing/client/cli/tx.go
@@ -1,8 +1,6 @@
 package cli
 
 import (
-	"os"
-
 	"github.com/cosmos/cosmos-sdk/client/context"
 	"github.com/cosmos/cosmos-sdk/client/utils"
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -24,7 +22,6 @@ func GetCmdUnjail(cdc *codec.Codec) *cobra.Command {
 			txBldr := authtxb.NewTxBuilderFromCLI().WithCodec(cdc)
 			cliCtx := context.NewCLIContext().
 				WithCodec(cdc).
-				WithLogger(os.Stdout).
 				WithAccountDecoder(authcmd.GetAccountDecoder(cdc))
 
 			valAddr, err := cliCtx.GetFromAddress()

--- a/x/stake/client/cli/tx.go
+++ b/x/stake/client/cli/tx.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/context"
@@ -26,7 +25,6 @@ func GetCmdCreateValidator(cdc *codec.Codec) *cobra.Command {
 			txBldr := authtxb.NewTxBuilderFromCLI().WithCodec(cdc)
 			cliCtx := context.NewCLIContext().
 				WithCodec(cdc).
-				WithLogger(os.Stdout).
 				WithAccountDecoder(authcmd.GetAccountDecoder(cdc))
 
 			amounstStr := viper.GetString(FlagAmount)
@@ -116,7 +114,6 @@ func GetCmdEditValidator(cdc *codec.Codec) *cobra.Command {
 			txBldr := authtxb.NewTxBuilderFromCLI().WithCodec(cdc)
 			cliCtx := context.NewCLIContext().
 				WithCodec(cdc).
-				WithLogger(os.Stdout).
 				WithAccountDecoder(authcmd.GetAccountDecoder(cdc))
 
 			valAddr, err := cliCtx.GetFromAddress()
@@ -169,7 +166,6 @@ func GetCmdDelegate(cdc *codec.Codec) *cobra.Command {
 			txBldr := authtxb.NewTxBuilderFromCLI().WithCodec(cdc)
 			cliCtx := context.NewCLIContext().
 				WithCodec(cdc).
-				WithLogger(os.Stdout).
 				WithAccountDecoder(authcmd.GetAccountDecoder(cdc))
 
 			amount, err := sdk.ParseCoin(viper.GetString(FlagAmount))
@@ -228,7 +224,6 @@ func GetCmdBeginRedelegate(storeName string, cdc *codec.Codec) *cobra.Command {
 			txBldr := authtxb.NewTxBuilderFromCLI().WithCodec(cdc)
 			cliCtx := context.NewCLIContext().
 				WithCodec(cdc).
-				WithLogger(os.Stdout).
 				WithAccountDecoder(authcmd.GetAccountDecoder(cdc))
 
 			var err error
@@ -284,7 +279,6 @@ func GetCmdCompleteRedelegate(cdc *codec.Codec) *cobra.Command {
 			txBldr := authtxb.NewTxBuilderFromCLI().WithCodec(cdc)
 			cliCtx := context.NewCLIContext().
 				WithCodec(cdc).
-				WithLogger(os.Stdout).
 				WithAccountDecoder(authcmd.GetAccountDecoder(cdc))
 
 			delAddr, err := cliCtx.GetFromAddress()
@@ -342,7 +336,6 @@ func GetCmdBeginUnbonding(storeName string, cdc *codec.Codec) *cobra.Command {
 			txBldr := authtxb.NewTxBuilderFromCLI().WithCodec(cdc)
 			cliCtx := context.NewCLIContext().
 				WithCodec(cdc).
-				WithLogger(os.Stdout).
 				WithAccountDecoder(authcmd.GetAccountDecoder(cdc))
 
 			delAddr, err := cliCtx.GetFromAddress()
@@ -391,7 +384,6 @@ func GetCmdCompleteUnbonding(cdc *codec.Codec) *cobra.Command {
 			txBldr := authtxb.NewTxBuilderFromCLI().WithCodec(cdc)
 			cliCtx := context.NewCLIContext().
 				WithCodec(cdc).
-				WithLogger(os.Stdout).
 				WithAccountDecoder(authcmd.GetAccountDecoder(cdc))
 
 			delAddr, err := cliCtx.GetFromAddress()


### PR DESCRIPTION
This changes .Logger to .Output, as it isn't used anywhere except as os.Stdout.

Merging this without review based on best judgement.