### PR TITLE
Staking store keys bug fix + memory improvement

### DIFF
--- a/PENDING.md
+++ b/PENDING.md
@@ -129,6 +129,7 @@ IMPROVEMENTS
     * [x/auth] Signature verification's gas cost now accounts for pubkey type. [#2046](https://github.com/tendermint/tendermint/pull/2046)
     * [x/stake] [x/slashing] Ensure delegation invariants to jailed validators [#1883](https://github.com/cosmos/cosmos-sdk/issues/1883).
     * [x/stake] Improve speed of GetValidator, which was shown to be a performance bottleneck. [#2046](https://github.com/tendermint/tendermint/pull/2200)
+    * [x/stake] Improve memory efficiency of getting the various store keys
     * [genesis] \#2229 Ensure that there are no duplicate accounts or validators in the genesis state.
     * Add SDK validation to `config.toml` (namely disabling `create_empty_blocks`) \#1571
     * \#1941(https://github.com/cosmos/cosmos-sdk/issues/1941) Version is now inferred via `git describe --tags`.

--- a/PENDING.md
+++ b/PENDING.md
@@ -37,6 +37,7 @@ BREAKING CHANGES
       * `cosmosaccaddr` / `cosmosaccpub` => `cosmos` / `cosmospub`
       * `cosmosvaladdr` / `cosmosvalpub` => `cosmosvaloper` / `cosmosvaloperpub`
     * [x/stake] [#1013] TendermintUpdates now uses transient store
+    * [x/stake] \#2435 Remove empty bytes from the ValidatorPowerRank store key
     * [x/gov] [#2195] Governance uses BFT Time
     * [x/gov] \#2256 Removed slashing for governance non-voting validators
     * [simulation] \#2162 Added back correct supply invariants
@@ -129,7 +130,7 @@ IMPROVEMENTS
     * [x/auth] Signature verification's gas cost now accounts for pubkey type. [#2046](https://github.com/tendermint/tendermint/pull/2046)
     * [x/stake] [x/slashing] Ensure delegation invariants to jailed validators [#1883](https://github.com/cosmos/cosmos-sdk/issues/1883).
     * [x/stake] Improve speed of GetValidator, which was shown to be a performance bottleneck. [#2046](https://github.com/tendermint/tendermint/pull/2200)
-    * [x/stake] Improve memory efficiency of getting the various store keys
+    * [x/stake] \#2435 Improve memory efficiency of getting the various store keys
     * [genesis] \#2229 Ensure that there are no duplicate accounts or validators in the genesis state.
     * Add SDK validation to `config.toml` (namely disabling `create_empty_blocks`) \#1571
     * \#1941(https://github.com/cosmos/cosmos-sdk/issues/1941) Version is now inferred via `git describe --tags`.

--- a/x/stake/keeper/key_test.go
+++ b/x/stake/keeper/key_test.go
@@ -25,7 +25,7 @@ func TestGetValidatorPowerRank(t *testing.T) {
 		validator types.Validator
 		wantHex   string
 	}{
-		{val1, "05303030303030303030303132ffffffffffffffff0000ffff"},
+		{val1, "05303030303030303030303132ffffffffffffffffffff"},
 	}
 	for i, tt := range tests {
 		got := hex.EncodeToString(getValidatorPowerRank(tt.validator))

--- a/x/stake/keeper/key_test.go
+++ b/x/stake/keeper/key_test.go
@@ -1,0 +1,35 @@
+package keeper
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/stake/types"
+	"github.com/tendermint/tendermint/crypto/ed25519"
+)
+
+var (
+	pk1 = ed25519.GenPrivKey().PubKey()
+)
+
+func TestGetValidatorPowerRank(t *testing.T) {
+	valAddr1 := sdk.ValAddress(pk1.Bytes())
+	emptyDesc := types.Description{}
+	val1 := types.NewValidator(valAddr1, pk1, emptyDesc)
+	val1.Tokens = sdk.NewDec(12)
+
+	tests := []struct {
+		validator types.Validator
+		wantHex   string
+	}{
+		{val1, "05303030303030303030303132ffffffffffffffff0000ffff"},
+	}
+	for i, tt := range tests {
+		got := hex.EncodeToString(getValidatorPowerRank(tt.validator))
+
+		assert.Equal(t, tt.wantHex, got, "Keys did not match on test case %d", i)
+	}
+}


### PR DESCRIPTION
Improves memory efficiency of getting store keys

This is done by removing repeated appends, which will create a new
slice if theres insufficient capacity, and instead creating a key
of the correct size, and then copying the data into it.

This PR also Removes empty bytes from ValidatorPowerRank store key

Closes #2433

Please do not squash, and review commit by commit.

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

- [x] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [x] Wrote tests
- [ ] Updated relevant documentation (`docs/`) - n/a?
- [x] Added entries in `PENDING.md` with issue # 
- [x] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
