### PR TITLE
R4R: Support removal of accounts in account mapper

### DIFF
--- a/PENDING.md
+++ b/PENDING.md
@@ -111,6 +111,7 @@ FEATURES
   * [x/auth] \#2376 Remove FeePayer() from StdTx
   * [x/stake] [\#1672](https://github.com/cosmos/cosmos-sdk/issues/1672) Implement
   basis for the validator commission model.
+  * [x/auth] Support account removal in the account mapper.
 
 * Tendermint
 

--- a/x/auth/mapper.go
+++ b/x/auth/mapper.go
@@ -83,6 +83,13 @@ func (am AccountMapper) SetAccount(ctx sdk.Context, acc Account) {
 	store.Set(AddressStoreKey(addr), bz)
 }
 
+// RemoveAccount removes an account for the account mapper store.
+func (am AccountMapper) RemoveAccount(ctx sdk.Context, acc Account) {
+	addr := acc.GetAddress()
+	store := ctx.KVStore(am.key)
+	store.Delete(AddressStoreKey(addr))
+}
+
 // Implements sdk.AccountMapper.
 func (am AccountMapper) IterateAccounts(ctx sdk.Context, process func(Account) (stop bool)) {
 	store := ctx.KVStore(am.key)

--- a/x/auth/mapper_test.go
+++ b/x/auth/mapper_test.go
@@ -61,6 +61,44 @@ func TestAccountMapperGetSet(t *testing.T) {
 	require.Equal(t, newSequence, acc.GetSequence())
 }
 
+func TestAccountMapperRemoveAccount(t *testing.T) {
+	ms, capKey, _ := setupMultiStore()
+	cdc := codec.New()
+	RegisterBaseAccount(cdc)
+
+	// make context and mapper
+	ctx := sdk.NewContext(ms, abci.Header{}, false, log.NewNopLogger())
+	mapper := NewAccountMapper(cdc, capKey, ProtoBaseAccount)
+
+	addr1 := sdk.AccAddress([]byte("addr1"))
+	addr2 := sdk.AccAddress([]byte("addr2"))
+
+	// create accounts
+	acc1 := mapper.NewAccountWithAddress(ctx, addr1)
+	acc2 := mapper.NewAccountWithAddress(ctx, addr2)
+
+	accSeq1 := int64(20)
+	accSeq2 := int64(40)
+
+	acc1.SetSequence(accSeq1)
+	acc2.SetSequence(accSeq2)
+	mapper.SetAccount(ctx, acc1)
+	mapper.SetAccount(ctx, acc2)
+
+	acc1 = mapper.GetAccount(ctx, addr1)
+	require.NotNil(t, acc1)
+	require.Equal(t, accSeq1, acc1.GetSequence())
+
+	// remove one account
+	mapper.RemoveAccount(ctx, acc1)
+	acc1 = mapper.GetAccount(ctx, addr1)
+	require.Nil(t, acc1)
+
+	acc2 = mapper.GetAccount(ctx, addr2)
+	require.NotNil(t, acc2)
+	require.Equal(t, accSeq2, acc2.GetSequence())
+}
+
 func BenchmarkAccountMapperGetAccountFound(b *testing.B) {
 	ms, capKey, _ := setupMultiStore()
 	cdc := codec.New()


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

In Ethermint, when an account (contract) is suicided or is empty, it'll need to be removed from state. Being that StateDB in Ethermint will utilize the account mapper for external accounts and contract accounts, we need this functionality.

If we don't feel safe this this in the SDK, the alternative is to make account mapper an interface that I can implement in Ethermint with the additional method of removal.

----

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/develop/CONTRIBUTING.md#pr-targeting))

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [x] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [x] Added entries in `PENDING.md` with issue # 
- [x] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
