### PR TITLE
R4R: Fix LCD Validator Initialization

### DIFF
--- a/client/lcd/lcd_test.go
+++ b/client/lcd/lcd_test.go
@@ -518,8 +518,11 @@ func TestBonding(t *testing.T) {
 	name, password, denom := "test", "1234567890", "steak"
 	addr, seed := CreateAddr(t, name, password, GetKeyBase(t))
 
-	cleanup, _, operAddrs, port := InitializeTestLCD(t, 1, []sdk.AccAddress{addr})
+	cleanup, valPubKeys, operAddrs, port := InitializeTestLCD(t, 2, []sdk.AccAddress{addr})
 	defer cleanup()
+
+	require.Equal(t, 2, len(valPubKeys))
+	require.Equal(t, 2, len(operAddrs))
 
 	amt := sdk.NewDec(60)
 	validator := getValidator(t, port, operAddrs[0])

--- a/client/lcd/test_helpers.go
+++ b/client/lcd/test_helpers.go
@@ -146,7 +146,7 @@ func InitializeTestLCD(
 	// append initial (proposing) validator
 	genDoc.Validators[0] = tmtypes.GenesisValidator{
 		PubKey: privVal.GetPubKey(),
-		Power:  999999, // create enough power to enable 2/3 voting power
+		Power:  100, // create enough power to enable 2/3 voting power
 		Name:   "validator-1",
 	}
 

--- a/client/lcd/test_helpers.go
+++ b/client/lcd/test_helpers.go
@@ -176,7 +176,7 @@ func InitializeTestLCD(
 		appGenTxs = append(appGenTxs, appGenTx)
 	}
 
-	genesisState, err := gapp.GaiaAppGenState(cdc, appGenTxs[:])
+	genesisState, err := gapp.NewTestGaiaAppGenState(cdc, appGenTxs[:], genDoc.Validators, valOperAddrs)
 	require.NoError(t, err)
 
 	// add some tokens to init accounts

--- a/cmd/gaia/app/genesis.go
+++ b/cmd/gaia/app/genesis.go
@@ -161,7 +161,6 @@ func GaiaAppGenTxNF(cdc *codec.Codec, pk crypto.PubKey, addr sdk.AccAddress, nam
 // Create the core parameters for genesis initialization for gaia
 // note that the pubkey input is this machines pubkey
 func GaiaAppGenState(cdc *codec.Codec, appGenTxs []json.RawMessage) (genesisState GenesisState, err error) {
-
 	if len(appGenTxs) == 0 {
 		err = errors.New("must provide at least genesis transaction")
 		return
@@ -196,6 +195,7 @@ func GaiaAppGenState(cdc *codec.Codec, appGenTxs []json.RawMessage) (genesisStat
 		StakeData: stakeData,
 		GovData:   gov.DefaultGenesisState(),
 	}
+
 	return
 }
 

--- a/cmd/gaia/app/test_utils.go
+++ b/cmd/gaia/app/test_utils.go
@@ -52,7 +52,7 @@ func NewTestGaiaAppGenState(
 
 		// add the validator
 		desc := stake.NewDescription(tmVal.Name, "", "", "")
-		validator := stake.NewValidator(sdk.ValAddress(valOperAddrs[i]), tmVal.PubKey, desc)
+		validator := stake.NewValidator(valOperAddrs[i], tmVal.PubKey, desc)
 
 		validator, stakeData.Pool, issuedDelShares = validator.AddTokensFromDel(stakeData.Pool, power)
 		stakeData.Validators = append(stakeData.Validators, validator)

--- a/cmd/gaia/app/test_utils.go
+++ b/cmd/gaia/app/test_utils.go
@@ -1,0 +1,74 @@
+package app
+
+import (
+	"encoding/json"
+	"errors"
+
+	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/gov"
+	"github.com/cosmos/cosmos-sdk/x/stake"
+	tmtypes "github.com/tendermint/tendermint/types"
+)
+
+// NewTestGaiaAppGenState creates the core parameters for a test genesis
+// initialization given a set of genesis txs, TM validators and their respective
+// operating addresses.
+func NewTestGaiaAppGenState(
+	cdc *codec.Codec, appGenTxs []json.RawMessage, tmVals []tmtypes.GenesisValidator, valOperAddrs []sdk.ValAddress,
+) (GenesisState, error) {
+
+	switch {
+	case len(appGenTxs) == 0:
+		return GenesisState{}, errors.New("must provide at least genesis transaction")
+	case len(tmVals) != len(valOperAddrs):
+		return GenesisState{}, errors.New("number of TM validators does not match number of operator addresses")
+	}
+
+	// start with the default staking genesis state
+	stakeData := stake.DefaultGenesisState()
+
+	// get genesis account information
+	genAccs := make([]GenesisAccount, len(appGenTxs))
+	for i, appGenTx := range appGenTxs {
+
+		var genTx GaiaGenTx
+		if err := cdc.UnmarshalJSON(appGenTx, &genTx); err != nil {
+			return GenesisState{}, err
+		}
+
+		// create the genesis account for the given genesis tx
+		genAccs[i] = genesisAccountFromGenTx(genTx)
+	}
+
+	for i, tmVal := range tmVals {
+		var issuedDelShares sdk.Dec
+
+		// increase total supply by validator's power
+		power := sdk.NewInt(tmVal.Power)
+		stakeData.Pool.LooseTokens = stakeData.Pool.LooseTokens.Add(sdk.NewDecFromInt(power))
+
+		// add the validator
+		desc := stake.NewDescription(tmVal.Name, "", "", "")
+		validator := stake.NewValidator(sdk.ValAddress(valOperAddrs[i]), tmVal.PubKey, desc)
+
+		validator, stakeData.Pool, issuedDelShares = validator.AddTokensFromDel(stakeData.Pool, power)
+		stakeData.Validators = append(stakeData.Validators, validator)
+
+		// create the self-delegation from the issuedDelShares
+		selfDel := stake.Delegation{
+			DelegatorAddr: sdk.AccAddress(validator.OperatorAddr),
+			ValidatorAddr: validator.OperatorAddr,
+			Shares:        issuedDelShares,
+			Height:        0,
+		}
+
+		stakeData.Bonds = append(stakeData.Bonds, selfDel)
+	}
+
+	return GenesisState{
+		Accounts:  genAccs,
+		StakeData: stakeData,
+		GovData:   gov.DefaultGenesisState(),
+	}, nil
+}

--- a/cmd/gaia/app/test_utils.go
+++ b/cmd/gaia/app/test_utils.go
@@ -37,6 +37,8 @@ func NewTestGaiaAppGenState(
 			return GenesisState{}, err
 		}
 
+		stakeData.Pool.LooseTokens = stakeData.Pool.LooseTokens.Add(sdk.NewDecFromInt(freeFermionsAcc))
+
 		// create the genesis account for the given genesis tx
 		genAccs[i] = genesisAccountFromGenTx(genTx)
 	}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

- Update genesis app state initialization logic to allow for properly creating more than one validator during LCD tests.
- Updated existing `TestBonding` to create two validators instead of one to provide an example.

Throughout this process, I've realized that the existing genesis logic is a bit convoluted, confusing and would warrant some rewriting. 

closes: #2339

----

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/develop/CONTRIBUTING.md#pr-targeting))

- [x] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added entries in `PENDING.md` with issue # 
- [x] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
