### PR TITLE
Print out all 3 public key encoding with gaiadebug

### DIFF
--- a/cmd/gaia/cmd/gaiadebug/main.go
+++ b/cmd/gaia/cmd/gaiadebug/main.go
@@ -138,11 +138,17 @@ func runPubKeyCmd(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+
+	consenusPub, err := sdk.Bech32ifyConsPub(pubKey)
+	if err != nil {
+		return err
+	}
 	fmt.Println("Address:", pubKey.Address())
 	fmt.Printf("Hex: %X\n", pubkeyBytes)
 	fmt.Println("JSON (base64):", string(pubKeyJSONBytes))
 	fmt.Println("Bech32 Acc:", accPub)
-	fmt.Println("Bech32 Val:", valPub)
+	fmt.Println("Bech32 Validator Operator:", valPub)
+	fmt.Println("Bech32 Validator Consensus:", consenusPub)
 	return nil
 }
 


### PR DESCRIPTION
Update `gaiadebug` to print out all three `bech32` address versions