### PR TITLE
HOTFIX: add temporary file to sync build with website (RPC)

### DIFF
--- a/client/lcd/swagger-ui/index.html
+++ b/client/lcd/swagger-ui/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>RPC</title>
+</head>
+
+<body>
+The Cosmos RPC using Swagger is coming soon! </br>
+
+See https://cosmos-staging.interblock.io/rpc/ for the RPC description
+on the `develop` branch of the SDK.
+</body>
+</html>
+


### PR DESCRIPTION
this file will be over-ridden on the next release. It is required to prevent the website build from failing (after implementing swagger on `develop` & the staging site)