### PR TITLE
[R4R] #1255 make keybase opened with readonly option for query-purpose cli commands 

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -671,6 +671,7 @@
     "github.com/spf13/viper",
     "github.com/stretchr/testify/assert",
     "github.com/stretchr/testify/require",
+    "github.com/syndtr/goleveldb/leveldb/opt",
     "github.com/tendermint/go-amino",
     "github.com/tendermint/iavl",
     "github.com/tendermint/tendermint/abci/server",

--- a/PENDING.md
+++ b/PENDING.md
@@ -159,6 +159,7 @@ IMPROVEMENTS
 * Gaia CLI  (`gaiacli`)
     * [cli] #2060 removed `--select` from `block` command
     * [cli] #2128 fixed segfault when exporting directly after `gaiad init`
+    * [cli] [\#1255](https://github.com/cosmos/cosmos-sdk/issues/1255) make keybase opened with readonly option for query-purpose cli commands
 
 * Gaia
     * [x/stake] [#2023](https://github.com/cosmos/cosmos-sdk/pull/2023) Terminate iteration loop in `UpdateBondedValidators` and `UpdateBondedValidatorsFull` when the first revoked validator is encountered and perform a sanity check.

--- a/client/keys/add.go
+++ b/client/keys/add.go
@@ -63,7 +63,7 @@ func runAddCmd(cmd *cobra.Command, args []string) error {
 			return errMissingName()
 		}
 		name = args[0]
-		kb, err = GetKeyBase()
+		kb, err = GetKeyBaseWithWritePerm()
 		if err != nil {
 			return err
 		}
@@ -174,7 +174,7 @@ func AddNewKeyRequestHandler(indent bool) http.HandlerFunc {
 		var kb keys.Keybase
 		var m NewKeyBody
 
-		kb, err := GetKeyBase()
+		kb, err := GetKeyBaseWithWritePerm()
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 			w.Write([]byte(err.Error()))
@@ -311,7 +311,7 @@ func RecoverRequestHandler(indent bool) http.HandlerFunc {
 			return
 		}
 
-		kb, err := GetKeyBase()
+		kb, err := GetKeyBaseWithWritePerm()
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 			w.Write([]byte(err.Error()))

--- a/client/keys/delete.go
+++ b/client/keys/delete.go
@@ -25,7 +25,7 @@ func deleteKeyCommand() *cobra.Command {
 func runDeleteCmd(cmd *cobra.Command, args []string) error {
 	name := args[0]
 
-	kb, err := GetKeyBase()
+	kb, err := GetKeyBaseWithWritePerm()
 	if err != nil {
 		return err
 	}
@@ -73,7 +73,7 @@ func DeleteKeyRequestHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	kb, err = GetKeyBase()
+	kb, err = GetKeyBaseWithWritePerm()
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))

--- a/client/keys/update.go
+++ b/client/keys/update.go
@@ -26,7 +26,7 @@ func runUpdateCmd(cmd *cobra.Command, args []string) error {
 	name := args[0]
 
 	buf := client.BufferStdin()
-	kb, err := GetKeyBase()
+	kb, err := GetKeyBaseWithWritePerm()
 	if err != nil {
 		return err
 	}
@@ -74,7 +74,7 @@ func UpdateKeyRequestHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	kb, err = GetKeyBase()
+	kb, err = GetKeyBaseWithWritePerm()
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))

--- a/client/keys/utils.go
+++ b/client/keys/utils.go
@@ -2,6 +2,7 @@ package keys
 
 import (
 	"fmt"
+	"github.com/syndtr/goleveldb/leveldb/opt"
 	"path/filepath"
 
 	"github.com/spf13/viper"
@@ -24,14 +25,6 @@ const KeyDBName = "keys"
 var keybase keys.Keybase
 
 type bechKeyOutFn func(keyInfo keys.Info) (KeyOutput, error)
-
-// TODO make keybase take a database not load from the directory
-
-// initialize a keybase based on the configuration
-func GetKeyBase() (keys.Keybase, error) {
-	rootDir := viper.GetString(cli.HomeFlag)
-	return GetKeyBaseFromDir(rootDir)
-}
 
 // GetKeyInfo returns key info for a given name. An error is returned if the
 // keybase cannot be retrieved or getting the info fails.
@@ -82,10 +75,28 @@ func ReadPassphraseFromStdin(name string) (string, error) {
 	return passphrase, nil
 }
 
+// TODO make keybase take a database not load from the directory
+
 // initialize a keybase based on the configuration
-func GetKeyBaseFromDir(rootDir string) (keys.Keybase, error) {
+func GetKeyBase() (keys.Keybase, error) {
+	rootDir := viper.GetString(cli.HomeFlag)
+	return getKeyBaseFromDirWithOpts(rootDir, &opt.Options{ReadOnly: true})
+}
+
+// initialize a keybase based on the configuration with write permission
+func GetKeyBaseWithWritePerm() (keys.Keybase, error) {
+	rootDir := viper.GetString(cli.HomeFlag)
+	return GetKeyBaseFromDirWithWritePerm(rootDir)
+}
+
+// initialize a keybase at particular dir with write permission
+func GetKeyBaseFromDirWithWritePerm(rootDir string) (keys.Keybase, error) {
+	return getKeyBaseFromDirWithOpts(rootDir, &opt.Options{ReadOnly: false})
+}
+
+func getKeyBaseFromDirWithOpts(rootDir string, o *opt.Options) (keys.Keybase, error) {
 	if keybase == nil {
-		db, err := dbm.NewGoLevelDB(KeyDBName, filepath.Join(rootDir, "keys"))
+		db, err := dbm.NewGoLevelDBWithOpts(KeyDBName, filepath.Join(rootDir, "keys"), o)
 		if err != nil {
 			return nil, err
 		}

--- a/client/lcd/test_helpers.go
+++ b/client/lcd/test_helpers.go
@@ -94,7 +94,7 @@ func GetKeyBase(t *testing.T) crkeys.Keybase {
 
 	viper.Set(cli.HomeFlag, dir)
 
-	keybase, err := keys.GetKeyBase()
+	keybase, err := keys.GetKeyBaseWithWritePerm()
 	require.NoError(t, err)
 
 	return keybase

--- a/server/init.go
+++ b/server/init.go
@@ -115,7 +115,7 @@ func GenerateCoinKey() (sdk.AccAddress, string, error) {
 func GenerateSaveCoinKey(clientRoot, keyName, keyPass string, overwrite bool) (sdk.AccAddress, string, error) {
 
 	// get the keystore from the client
-	keybase, err := clkeys.GetKeyBaseFromDir(clientRoot)
+	keybase, err := clkeys.GetKeyBaseFromDirWithWritePerm(clientRoot)
 	if err != nil {
 		return sdk.AccAddress([]byte{}), "", err
 	}


### PR DESCRIPTION
This is a PR for #1255 

make keybase opened with readonly option for query-purpose to support better parallelization between gaiacli

This change enabled parallelization between read and write of keys db via gaiacli, so most of operations can be parallelized except multiple add/update keys to keys db at the same time (but sending transactions and serve rest-server can be parallelized!) **in trust mode**

There are more work to do to supprt non-trust mode, which have to made change to tendermint code. The remainning work mostly reside on make open and close dbprovider in verifier fine grained. 
```
func NewVerifier(chainID, rootDir string, client lclient.SignStatusClient, logger log.Logger) (*lite.DynamicVerifier, error) {

	logger = logger.With("module", "lite/proxy")
	logger.Info("lite/proxy/NewVerifier()...", "chainID", chainID, "rootDir", rootDir, "client", client)

	memProvider := lite.NewDBProvider("trusted.mem", dbm.NewMemDB()).SetLimit(10)
	lvlProvider := lite.NewDBProvider("trusted.lvl", dbm.NewDB("trust-base", dbm.LevelDBBackend, rootDir))
```

just like golevel db, the cleveldb interface in tendermint should also expose readonly option to up-level caller:

```
func NewCLevelDB(name string, dir string) (*CLevelDB, error) {
	dbPath := filepath.Join(dir, name+".db")

	opts := levigo.NewOptions()
	opts.SetCache(levigo.NewLRUCache(1 << 30))
	opts.SetCreateIfMissing(true)
	db, err := levigo.Open(dbPath, opts)
	if err != nil {
		return nil, err
	}
	ro := levigo.NewReadOptions()
	wo := levigo.NewWriteOptions()
	woSync := levigo.NewWriteOptions()
	woSync.SetSync(true)
	database := &CLevelDB{
		db:     db,
		ro:     ro,
		wo:     wo,
		woSync: woSync,
	}
	return database, nil
}
```

This was manually tested:
1. start a single-node chain by `gaiad start`
2. start a rest-server by `gaiacli rest-server --chain-id test-chain-2UzoT6 --insecure true --trust-node`
3. query account balance while keep the rest-server running: `gaiacli query account cosmos1uw7nvnfccr3fnumtjs82qvvn3z8uzw7fdznn3t --chain-id test-chain-2UzoT6`

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/develop/CONTRIBUTING.md#pr-targeting))

- [x] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [x] Wrote tests - investigating the failed test case
- [x] Updated relevant documentation (`docs/`) - no need update docs
- [x] Added entries in `PENDING.md` with issue # 
- [x] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
