### PR TITLE
R4R: Block conflicting redelegations

### DIFF
--- a/PENDING.md
+++ b/PENDING.md
@@ -70,6 +70,7 @@ BREAKING CHANGES
     * [x/staking] \#2236 more distribution hooks for distribution
     * [x/stake] \#2394 Split up UpdateValidator into distinct state transitions applied only in EndBlock
     * [x/stake] \#2412 Added an unbonding validator queue to EndBlock to automatically update validator.Status when finished Unbonding
+    * [x/stake] \#2500 Block conflicting redelegations until we add an index
 
 * Tendermint
   * Update tendermint version from v0.23.0 to v0.25.0, notable changes

--- a/x/stake/keeper/delegation.go
+++ b/x/stake/keeper/delegation.go
@@ -526,6 +526,13 @@ func (k Keeper) CompleteUnbonding(ctx sdk.Context, delAddr sdk.AccAddress, valAd
 func (k Keeper) BeginRedelegation(ctx sdk.Context, delAddr sdk.AccAddress,
 	valSrcAddr, valDstAddr sdk.ValAddress, sharesAmount sdk.Dec) (types.Redelegation, sdk.Error) {
 
+	// check if there is already a redelgation in progress from src to dst
+	// TODO quick fix, instead we should use an index, see https://github.com/cosmos/cosmos-sdk/issues/1402
+	_, found := k.GetRedelegation(ctx, delAddr, valSrcAddr, valDstAddr)
+	if found {
+		return types.Redelegation{}, types.ErrConflictingRedelegation(k.Codespace())
+	}
+
 	// check if this is a transitive redelegation
 	if k.HasReceivingRedelegation(ctx, delAddr, valSrcAddr) {
 		return types.Redelegation{}, types.ErrTransitiveRedelegation(k.Codespace())

--- a/x/stake/types/errors.go
+++ b/x/stake/types/errors.go
@@ -164,6 +164,11 @@ func ErrTransitiveRedelegation(codespace sdk.CodespaceType) sdk.Error {
 		"redelegation to this validator already in progress, first redelegation to this validator must complete before next redelegation")
 }
 
+func ErrConflictingRedelegation(codespace sdk.CodespaceType) sdk.Error {
+	return sdk.NewError(codespace, CodeInvalidDelegation,
+		"conflicting redelegation from this source validator to this dest validator already exists, you must wait for it to finish")
+}
+
 func ErrBothShareMsgsGiven(codespace sdk.CodespaceType) sdk.Error {
 	return sdk.NewError(codespace, CodeInvalidInput, "both shares amount and shares percent provided")
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Quick fix to #1402 for GoS, but we should eventually add an index instead.

Simply prevents redelegation by delegator `D` from validator `A` to validator `B` if any existing redelegation by `D` from `A` to `B` already exists. Includes a testcase.

- [x] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [x] Wrote tests
- [x] Updated relevant documentation (`docs/`)
- [x] Added entries in `PENDING.md` with issue # 
- [x] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
