### PR TITLE
R4R: Fix validator power key

### DIFF
--- a/PENDING.md
+++ b/PENDING.md
@@ -73,6 +73,7 @@ BREAKING CHANGES
     * [x/stake] \#2412 Added an unbonding validator queue to EndBlock to automatically update validator.Status when finished Unbonding
     * [x/stake] \#2500 Block conflicting redelegations until we add an index
     * [x/params] Global Paramstore refactored
+    * [x/stake] \#2508 Utilize Tendermint power for validator power key
 
 * Tendermint
   * Update tendermint version from v0.23.0 to v0.25.0, notable changes

--- a/x/stake/keeper/key.go
+++ b/x/stake/keeper/key.go
@@ -71,8 +71,15 @@ func GetBondedValidatorIndexKey(operator sdk.ValAddress) []byte {
 func getValidatorPowerRank(validator types.Validator) []byte {
 
 	potentialPower := validator.Tokens
-	powerBytes := []byte(potentialPower.ToLeftPadded(maxDigitsForAccount)) // power big-endian (more powerful validators first)
+
+	// todo: deal with cases above 2**64, ref https://github.com/cosmos/cosmos-sdk/issues/2439#issuecomment-427167556
+	tendermintPower := potentialPower.RoundInt64()
+	tendermintPowerBytes := make([]byte, 8)
+	binary.BigEndian.PutUint64(tendermintPowerBytes[:], uint64(tendermintPower))
+
+	powerBytes := tendermintPowerBytes
 	powerBytesLen := len(powerBytes)
+
 	// key is of format prefix || powerbytes || heightBytes || counterBytes
 	key := make([]byte, 1+powerBytesLen+8+2)
 

--- a/x/stake/keeper/key_test.go
+++ b/x/stake/keeper/key_test.go
@@ -35,10 +35,10 @@ func TestGetValidatorPowerRank(t *testing.T) {
 		validator types.Validator
 		wantHex   string
 	}{
-		{val1, "05303030303030303030303030ffffffffffffffffffff"},
-		{val2, "05303030303030303030303031ffffffffffffffffffff"},
-		{val3, "05303030303030303030303130ffffffffffffffffffff"},
-		{val4, "0531303939353131363237373736ffffffffffffffffffff"},
+		{val1, "050000000000000000ffffffffffffffffffff"},
+		{val2, "050000000000000001ffffffffffffffffffff"},
+		{val3, "05000000000000000affffffffffffffffffff"},
+		{val4, "050000010000000000ffffffffffffffffffff"},
 	}
 	for i, tt := range tests {
 		got := hex.EncodeToString(getValidatorPowerRank(tt.validator))


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Ref #2439, although it doesn't address all of that issue (only fixing the current key, not changing the Tendermint power calculation).

- [x] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [x] Wrote tests
- [x] Updated relevant documentation (`docs/`)
- [x] Added entries in `PENDING.md` with issue # 
- [x] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
