### PR TITLE
Remove 'import "C"' from client/utils package

### DIFF
--- a/client/utils/rest.go
+++ b/client/utils/rest.go
@@ -1,6 +1,5 @@
 package utils
 
-import "C"
 import (
 	"fmt"
 	"io/ioutil"


### PR DESCRIPTION
It was introduced in #2215, it's presently unnecessary and
it is clearly breaking cross compilation.

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added entries in `PENDING.md` with issue # 
- [ ] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
