### PR TITLE
R4R: Don't lock keys database on read only ops

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -671,6 +671,7 @@
     "github.com/spf13/viper",
     "github.com/stretchr/testify/assert",
     "github.com/stretchr/testify/require",
+    "github.com/syndtr/goleveldb/leveldb/opt",
     "github.com/tendermint/go-amino",
     "github.com/tendermint/iavl",
     "github.com/tendermint/tendermint/abci/server",

--- a/PENDING.md
+++ b/PENDING.md
@@ -146,6 +146,7 @@ FEATURES
   basis for the validator commission model.
   * [x/auth] Support account removal in the account mapper.
   * [client/keys] [\#2544](https://github.com/cosmos/cosmos-sdk/issues/2544) Add `GetReadOnlyKeyBase()` to acquire read-only LevelDB databases.
+  * [crypto/keys] [\#2544](https://github.com/cosmos/cosmos-sdk/issues/2544) Add `CloseDB()` to release locks and close the storage backend.
 
 * Tendermint
 

--- a/PENDING.md
+++ b/PENDING.md
@@ -145,6 +145,7 @@ FEATURES
   * [x/stake] [\#1672](https://github.com/cosmos/cosmos-sdk/issues/1672) Implement
   basis for the validator commission model.
   * [x/auth] Support account removal in the account mapper.
+  * [client/keys] [\#2544](https://github.com/cosmos/cosmos-sdk/issues/2544) Add `GetReadOnlyKeyBase()` to acquire read-only LevelDB databases.
 
 * Tendermint
 

--- a/client/context/context.go
+++ b/client/context/context.go
@@ -138,7 +138,7 @@ func fromFields(from string) (fromAddr types.AccAddress, fromName string) {
 		return nil, ""
 	}
 
-	keybase, err := keys.GetKeyBase()
+	keybase, err := keys.GetReadOnlyKeyBase()
 	if err != nil {
 		fmt.Println("no keybase found")
 		os.Exit(1)

--- a/client/keys/list.go
+++ b/client/keys/list.go
@@ -18,7 +18,7 @@ along with their associated name and address.`,
 }
 
 func runListCmd(cmd *cobra.Command, args []string) error {
-	kb, err := GetKeyBase()
+	kb, err := GetReadOnlyKeyBase()
 	if err != nil {
 		return err
 	}
@@ -36,7 +36,7 @@ func runListCmd(cmd *cobra.Command, args []string) error {
 // query key list REST handler
 func QueryKeysRequestHandler(indent bool) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		kb, err := GetKeyBase()
+		kb, err := GetReadOnlyKeyBase()
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 			w.Write([]byte(err.Error()))

--- a/client/utils/utils.go
+++ b/client/utils/utils.go
@@ -111,7 +111,7 @@ func PrintUnsignedStdTx(txBldr authtxb.TxBuilder, cliCtx context.CLIContext, msg
 func SignStdTx(txBldr authtxb.TxBuilder, cliCtx context.CLIContext, name string, stdTx auth.StdTx, appendSig bool, offline bool) (auth.StdTx, error) {
 	var signedStdTx auth.StdTx
 
-	keybase, err := keys.GetKeyBase()
+	keybase, err := keys.GetReadOnlyKeyBase()
 	if err != nil {
 		return signedStdTx, err
 	}

--- a/crypto/keys/keybase.go
+++ b/crypto/keys/keybase.go
@@ -426,6 +426,11 @@ func (kb dbKeybase) Update(name, oldpass string, getNewpass func() (string, erro
 	}
 }
 
+// CloseDB releases the lock and closes the storage backend.
+func (kb dbKeybase) CloseDB() {
+	kb.db.Close()
+}
+
 func (kb dbKeybase) writeLocalKey(priv tmcrypto.PrivKey, name, passphrase string) Info {
 	// encrypt private key using passphrase
 	privArmor := mintkey.EncryptArmorPrivKey(priv, passphrase)

--- a/crypto/keys/types.go
+++ b/crypto/keys/types.go
@@ -47,6 +47,9 @@ type Keybase interface {
 
 	// *only* works on locally-stored keys. Temporary method until we redo the exporting API
 	ExportPrivateKeyObject(name string, passphrase string) (crypto.PrivKey, error)
+
+	// Close the database
+	CloseDB()
 }
 
 // KeyType reflects a human-readable type for key listing.

--- a/server/init.go
+++ b/server/init.go
@@ -115,7 +115,7 @@ func GenerateCoinKey() (sdk.AccAddress, string, error) {
 func GenerateSaveCoinKey(clientRoot, keyName, keyPass string, overwrite bool) (sdk.AccAddress, string, error) {
 
 	// get the keystore from the client
-	keybase, err := clkeys.GetKeyBaseFromDir(clientRoot)
+	keybase, err := clkeys.GetKeyBaseFromDir(clientRoot, false)
 	if err != nil {
 		return sdk.AccAddress([]byte{}), "", err
 	}

--- a/x/auth/client/txbuilder/txbuilder.go
+++ b/x/auth/client/txbuilder/txbuilder.go
@@ -150,7 +150,7 @@ func (bldr TxBuilder) BuildWithPubKey(name string, msgs []sdk.Msg) ([]byte, erro
 		return nil, err
 	}
 
-	keybase, err := keys.GetKeyBase()
+	keybase, err := keys.GetReadOnlyKeyBase()
 	if err != nil {
 		return nil, err
 	}
@@ -196,7 +196,7 @@ func (bldr TxBuilder) SignStdTx(name, passphrase string, stdTx auth.StdTx, appen
 
 // MakeSignature builds a StdSignature given key name, passphrase, and a StdSignMsg.
 func MakeSignature(name, passphrase string, msg StdSignMsg) (sig auth.StdSignature, err error) {
-	keybase, err := keys.GetKeyBase()
+	keybase, err := keys.GetReadOnlyKeyBase()
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
Leverage Tendermint's new `dbm.NewGoLevelDBWithOpts()` call to avoid locking a keys database on read-only operations. This allows piping `gaiacli` commands's `stdout`s and `stdin`s.

Ref. #966

- [x] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [x] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [x] Added entries in `PENDING.md` with issue # 
- [x] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
