### PR TITLE
R4R: Don't acquire lock on read-only keybase

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -671,6 +671,7 @@
     "github.com/spf13/viper",
     "github.com/stretchr/testify/assert",
     "github.com/stretchr/testify/require",
+    "github.com/syndtr/goleveldb/leveldb/opt",
     "github.com/tendermint/go-amino",
     "github.com/tendermint/iavl",
     "github.com/tendermint/tendermint/abci/server",

--- a/PENDING.md
+++ b/PENDING.md
@@ -159,6 +159,7 @@ IMPROVEMENTS
 * Gaia CLI  (`gaiacli`)
     * [cli] #2060 removed `--select` from `block` command
     * [cli] #2128 fixed segfault when exporting directly after `gaiad init`
+    * [cli] [\#1255](https://github.com/cosmos/cosmos-sdk/issues/1255) make keybase opened with readonly option for query-purpose cli commands
 
 * Gaia
     * [x/stake] [#2023](https://github.com/cosmos/cosmos-sdk/pull/2023) Terminate iteration loop in `UpdateBondedValidators` and `UpdateBondedValidatorsFull` when the first revoked validator is encountered and perform a sanity check.

--- a/PENDING.md
+++ b/PENDING.md
@@ -159,7 +159,8 @@ IMPROVEMENTS
 * Gaia CLI  (`gaiacli`)
     * [cli] #2060 removed `--select` from `block` command
     * [cli] #2128 fixed segfault when exporting directly after `gaiad init`
-    * [cli] [\#1255](https://github.com/cosmos/cosmos-sdk/issues/1255) make keybase opened with readonly option for query-purpose cli commands
+    * [cli] [\#1255](https://github.com/cosmos/cosmos-sdk/issues/1255) open KeyBase in read-only mode
+     for query-purpose CLI commands
 
 * Gaia
     * [x/stake] [#2023](https://github.com/cosmos/cosmos-sdk/pull/2023) Terminate iteration loop in `UpdateBondedValidators` and `UpdateBondedValidatorsFull` when the first revoked validator is encountered and perform a sanity check.

--- a/client/keys/add.go
+++ b/client/keys/add.go
@@ -63,7 +63,7 @@ func runAddCmd(cmd *cobra.Command, args []string) error {
 			return errMissingName()
 		}
 		name = args[0]
-		kb, err = GetKeyBase()
+		kb, err = GetKeyBaseWithWritePerm()
 		if err != nil {
 			return err
 		}
@@ -174,7 +174,7 @@ func AddNewKeyRequestHandler(indent bool) http.HandlerFunc {
 		var kb keys.Keybase
 		var m NewKeyBody
 
-		kb, err := GetKeyBase()
+		kb, err := GetKeyBaseWithWritePerm()
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 			w.Write([]byte(err.Error()))
@@ -311,7 +311,7 @@ func RecoverRequestHandler(indent bool) http.HandlerFunc {
 			return
 		}
 
-		kb, err := GetKeyBase()
+		kb, err := GetKeyBaseWithWritePerm()
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 			w.Write([]byte(err.Error()))

--- a/client/keys/delete.go
+++ b/client/keys/delete.go
@@ -25,7 +25,7 @@ func deleteKeyCommand() *cobra.Command {
 func runDeleteCmd(cmd *cobra.Command, args []string) error {
 	name := args[0]
 
-	kb, err := GetKeyBase()
+	kb, err := GetKeyBaseWithWritePerm()
 	if err != nil {
 		return err
 	}
@@ -73,7 +73,7 @@ func DeleteKeyRequestHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	kb, err = GetKeyBase()
+	kb, err = GetKeyBaseWithWritePerm()
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))

--- a/client/keys/update.go
+++ b/client/keys/update.go
@@ -26,7 +26,7 @@ func runUpdateCmd(cmd *cobra.Command, args []string) error {
 	name := args[0]
 
 	buf := client.BufferStdin()
-	kb, err := GetKeyBase()
+	kb, err := GetKeyBaseWithWritePerm()
 	if err != nil {
 		return err
 	}
@@ -74,7 +74,7 @@ func UpdateKeyRequestHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	kb, err = GetKeyBase()
+	kb, err = GetKeyBaseWithWritePerm()
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))

--- a/client/keys/utils.go
+++ b/client/keys/utils.go
@@ -77,7 +77,7 @@ func ReadPassphraseFromStdin(name string) (string, error) {
 
 // TODO make keybase take a database not load from the directory
 
-// GetKeyBase initializes a keybase based on the configuration.
+// GetKeyBase initializes a read-only KeyBase based on the configuration. 
 func GetKeyBase() (keys.Keybase, error) {
 	rootDir := viper.GetString(cli.HomeFlag)
 	return GetKeyBaseFromDir(rootDir)

--- a/client/keys/utils.go
+++ b/client/keys/utils.go
@@ -77,21 +77,26 @@ func ReadPassphraseFromStdin(name string) (string, error) {
 
 // TODO make keybase take a database not load from the directory
 
-// initialize a keybase based on the configuration
+// GetKeyBase initializes a keybase based on the configuration.
 func GetKeyBase() (keys.Keybase, error) {
 	rootDir := viper.GetString(cli.HomeFlag)
-	return getKeyBaseFromDirWithOpts(rootDir, &opt.Options{ReadOnly: true})
+	return GetKeyBaseFromDir(rootDir)
 }
 
-// initialize a keybase based on the configuration with write permission
+// GetKeyBaseWithWritePerm initialize a keybase based on the configuration with write permissions.
 func GetKeyBaseWithWritePerm() (keys.Keybase, error) {
 	rootDir := viper.GetString(cli.HomeFlag)
 	return GetKeyBaseFromDirWithWritePerm(rootDir)
 }
 
-// initialize a keybase at particular dir with write permission
+// GetKeyBaseFromDirWithWritePerm initializes a keybase at a particular dir with write permissions.
 func GetKeyBaseFromDirWithWritePerm(rootDir string) (keys.Keybase, error) {
-	return getKeyBaseFromDirWithOpts(rootDir, &opt.Options{ReadOnly: false})
+	return getKeyBaseFromDirWithOpts(rootDir, nil)
+}
+
+// GetKeyBaseFromDir initializes a read-only keybase at a particular dir.
+func GetKeyBaseFromDir(rootDir string) (keys.Keybase, error) {
+	return getKeyBaseFromDirWithOpts(rootDir, &opt.Options{ReadOnly: true})
 }
 
 func getKeyBaseFromDirWithOpts(rootDir string, o *opt.Options) (keys.Keybase, error) {

--- a/client/keys/utils.go
+++ b/client/keys/utils.go
@@ -2,6 +2,7 @@ package keys
 
 import (
 	"fmt"
+	"github.com/syndtr/goleveldb/leveldb/opt"
 	"path/filepath"
 
 	"github.com/spf13/viper"
@@ -24,14 +25,6 @@ const KeyDBName = "keys"
 var keybase keys.Keybase
 
 type bechKeyOutFn func(keyInfo keys.Info) (KeyOutput, error)
-
-// TODO make keybase take a database not load from the directory
-
-// initialize a keybase based on the configuration
-func GetKeyBase() (keys.Keybase, error) {
-	rootDir := viper.GetString(cli.HomeFlag)
-	return GetKeyBaseFromDir(rootDir)
-}
 
 // GetKeyInfo returns key info for a given name. An error is returned if the
 // keybase cannot be retrieved or getting the info fails.
@@ -82,10 +75,28 @@ func ReadPassphraseFromStdin(name string) (string, error) {
 	return passphrase, nil
 }
 
+// TODO make keybase take a database not load from the directory
+
 // initialize a keybase based on the configuration
-func GetKeyBaseFromDir(rootDir string) (keys.Keybase, error) {
+func GetKeyBase() (keys.Keybase, error) {
+	rootDir := viper.GetString(cli.HomeFlag)
+	return getKeyBaseFromDirWithOpts(rootDir, &opt.Options{ReadOnly: true})
+}
+
+// initialize a keybase based on the configuration with write permission
+func GetKeyBaseWithWritePerm() (keys.Keybase, error) {
+	rootDir := viper.GetString(cli.HomeFlag)
+	return GetKeyBaseFromDirWithWritePerm(rootDir)
+}
+
+// initialize a keybase at particular dir with write permission
+func GetKeyBaseFromDirWithWritePerm(rootDir string) (keys.Keybase, error) {
+	return getKeyBaseFromDirWithOpts(rootDir, &opt.Options{ReadOnly: false})
+}
+
+func getKeyBaseFromDirWithOpts(rootDir string, o *opt.Options) (keys.Keybase, error) {
 	if keybase == nil {
-		db, err := dbm.NewGoLevelDB(KeyDBName, filepath.Join(rootDir, "keys"))
+		db, err := dbm.NewGoLevelDBWithOpts(KeyDBName, filepath.Join(rootDir, "keys"), o)
 		if err != nil {
 			return nil, err
 		}

--- a/client/keys/utils_test.go
+++ b/client/keys/utils_test.go
@@ -1,0 +1,39 @@
+package keys
+
+import (
+	"github.com/cosmos/cosmos-sdk/crypto/keys"
+	"github.com/stretchr/testify/require"
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+func TestGetKeyBaseLocks(t *testing.T) {
+	dir, err := ioutil.TempDir("", "cosmos-sdk-keys")
+	require.Nil(t, err)
+	defer os.RemoveAll(dir)
+
+	// Acquire db
+	kb, err := GetKeyBaseFromDirWithWritePerm(dir)
+	require.Nil(t, err)
+	_, _,  err = kb.CreateMnemonic("foo", keys.English, "12345678", keys.Secp256k1)
+	require.Nil(t, err)
+	// Reset global variable
+	keybase = nil
+	// Try to acquire another keybase from the same storage
+	_, err = GetKeyBaseFromDirWithWritePerm(dir)
+	require.NotNil(t, err)
+	_, err = GetKeyBaseFromDirWithWritePerm(dir)
+	require.NotNil(t, err)
+
+	// Close the db and try to acquire the lock
+	kb.CloseDB()
+	kb, err = GetKeyBaseFromDirWithWritePerm(dir)
+	require.Nil(t, err)
+
+	// Try to acquire another read-only keybase from the same storage
+	_, err = GetKeyBaseFromDir(dir)
+	require.Nil(t, err)
+
+	kb.CloseDB()
+}

--- a/client/lcd/test_helpers.go
+++ b/client/lcd/test_helpers.go
@@ -94,7 +94,7 @@ func GetKeyBase(t *testing.T) crkeys.Keybase {
 
 	viper.Set(cli.HomeFlag, dir)
 
-	keybase, err := keys.GetKeyBase()
+	keybase, err := keys.GetKeyBaseWithWritePerm()
 	require.NoError(t, err)
 
 	return keybase

--- a/crypto/keys/keybase.go
+++ b/crypto/keys/keybase.go
@@ -426,6 +426,11 @@ func (kb dbKeybase) Update(name, oldpass string, getNewpass func() (string, erro
 	}
 }
 
+// CloseDB releases the lock and closes the storage backend.
+func (kb dbKeybase) CloseDB() {
+	kb.db.Close()
+}
+
 func (kb dbKeybase) writeLocalKey(priv tmcrypto.PrivKey, name, passphrase string) Info {
 	// encrypt private key using passphrase
 	privArmor := mintkey.EncryptArmorPrivKey(priv, passphrase)

--- a/crypto/keys/types.go
+++ b/crypto/keys/types.go
@@ -47,6 +47,9 @@ type Keybase interface {
 
 	// *only* works on locally-stored keys. Temporary method until we redo the exporting API
 	ExportPrivateKeyObject(name string, passphrase string) (crypto.PrivKey, error)
+
+	// Close closes the database.
+	CloseDB()
 }
 
 // KeyType reflects a human-readable type for key listing.

--- a/server/init.go
+++ b/server/init.go
@@ -115,7 +115,7 @@ func GenerateCoinKey() (sdk.AccAddress, string, error) {
 func GenerateSaveCoinKey(clientRoot, keyName, keyPass string, overwrite bool) (sdk.AccAddress, string, error) {
 
 	// get the keystore from the client
-	keybase, err := clkeys.GetKeyBaseFromDir(clientRoot)
+	keybase, err := clkeys.GetKeyBaseFromDirWithWritePerm(clientRoot)
 	if err != nil {
 		return sdk.AccAddress([]byte{}), "", err
 	}


### PR DESCRIPTION
Expose calls to acquire non-blocking read lock on LevelDB stores.
Change `GetKeyBase()` so that it opens stores in read-only mode by default.
Add `GetKeyBaseWithWritePerm()` to acquire write locks on stores.

Closes: #1255

- [x] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [x] Wrote tests
- [x] Updated relevant documentation (`docs/`)
- [x] Added entries in `PENDING.md` with issue # 
- [x] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
