### PR TITLE
R4R: Various sign command improvements

### DIFF
--- a/PENDING.md
+++ b/PENDING.md
@@ -18,7 +18,8 @@ FEATURES
 * Gaia REST API (`gaiacli advanced rest-server`)
 
 * Gaia CLI  (`gaiacli`)
-    * [cli] [\#2569](https://github.com/cosmos/cosmos-sdk/pull/2569) Add commands to query validator unbondings and redelegations
+  * [cli] [\#2524](https://github.com/cosmos/cosmos-sdk/issues/2524) Add support offline mode to `gaiacli tx sign`. Lookups are not performed if the flag `--offline` is on.
+  * [cli] [\#2558](https://github.com/cosmos/cosmos-sdk/issues/2558) Improve --print-sigs mode. It now performs a complete set of sanity checks and reports to the user. Also added --raw-signature to print the signature only, not the whole transaction.
 
 * Gaia
 

--- a/PENDING.md
+++ b/PENDING.md
@@ -19,7 +19,8 @@ FEATURES
 
 * Gaia CLI  (`gaiacli`)
   * [cli] [\#2524](https://github.com/cosmos/cosmos-sdk/issues/2524) Add support offline mode to `gaiacli tx sign`. Lookups are not performed if the flag `--offline` is on.
-  * [cli] [\#2558](https://github.com/cosmos/cosmos-sdk/issues/2558) Improve --print-sigs mode. It now performs a complete set of sanity checks and reports to the user. Also added --raw-signature to print the signature only, not the whole transaction.
+  * [cli] [\#2558](https://github.com/cosmos/cosmos-sdk/issues/2558) Rename --print-sigs to --validate-signatures. It now performs a complete set of sanity checks and reports to the user. Also added --print-signature-only to print the signature only, not the whole transaction.
+  * [cli] [\#2554](https://github.com/cosmos/cosmos-sdk/issues/2554) Make `gaiacli keys show` multisig ready.
 
 * Gaia
 

--- a/PENDING.md
+++ b/PENDING.md
@@ -18,9 +18,10 @@ FEATURES
 * Gaia REST API (`gaiacli advanced rest-server`)
 
 * Gaia CLI  (`gaiacli`)
-  * [cli] [\#2524](https://github.com/cosmos/cosmos-sdk/issues/2524) Add support offline mode to `gaiacli tx sign`. Lookups are not performed if the flag `--offline` is on.
-  * [cli] [\#2558](https://github.com/cosmos/cosmos-sdk/issues/2558) Rename --print-sigs to --validate-signatures. It now performs a complete set of sanity checks and reports to the user. Also added --print-signature-only to print the signature only, not the whole transaction.
-  * [cli] [\#2554](https://github.com/cosmos/cosmos-sdk/issues/2554) Make `gaiacli keys show` multisig ready.
+    * [cli] [\#2569](https://github.com/cosmos/cosmos-sdk/pull/2569) Add commands to query validator unbondings and redelegations
+    * [cli] [\#2569](https://github.com/cosmos/cosmos-sdk/pull/2569) Add commands to query validator unbondings and redelegations
+    * [cli] [\#2524](https://github.com/cosmos/cosmos-sdk/issues/2524) Add support offline mode to `gaiacli tx sign`. Lookups are not performed if the flag `--offline` is on.
+    * [cli] [\#2558](https://github.com/cosmos/cosmos-sdk/issues/2558) Rename --print-sigs to --validate-signatures. It now performs a complete set of sanity checks and reports to the user. Also added --print-signature-only to print the signature only, not the whole transaction.
 
 * Gaia
 

--- a/client/utils/utils.go
+++ b/client/utils/utils.go
@@ -123,7 +123,8 @@ func SignStdTx(txBldr authtxb.TxBuilder, cliCtx context.CLIContext, name string,
 
 	// Check whether the address is a signer
 	if !isTxSigner(sdk.AccAddress(addr), stdTx.GetSigners()) {
-		fmt.Fprintf(os.Stderr, "WARNING: The generated transaction's intended signer does not match the given signer: '%v'\n", name)
+		return signedStdTx, fmt.Errorf(
+			"The generated transaction's intended signer does not match the given signer: %q", name)
 	}
 
 	if !offline && txBldr.AccountNumber == 0 {

--- a/cmd/gaia/cli_test/cli_test.go
+++ b/cmd/gaia/cli_test/cli_test.go
@@ -445,7 +445,8 @@ func TestGaiaCLISendGenerateSignAndBroadcast(t *testing.T) {
 	flags := fmt.Sprintf("--home=%s --node=%v --chain-id=%v", gaiacliHome, servAddr, chainID)
 
 	// start gaiad server
-	proc := tests.GoExecuteTWithStdout(t, fmt.Sprintf("gaiad start --home=%s --rpc.laddr=%v", gaiadHome, servAddr))
+	proc := tests.GoExecuteTWithStdout(t, fmt.Sprintf(
+		"gaiad start --home=%s --rpc.laddr=%v", gaiadHome, servAddr))
 
 	defer proc.Stop(false)
 	tests.WaitForTMStart(port)
@@ -490,9 +491,9 @@ func TestGaiaCLISendGenerateSignAndBroadcast(t *testing.T) {
 	unsignedTxFile := writeToNewTempFile(t, stdout)
 	defer os.Remove(unsignedTxFile.Name())
 
-	// Test sign --print-sigs
+	// Test sign --validate-signatures
 	success, stdout, _ = executeWriteRetStdStreams(t, fmt.Sprintf(
-		"gaiacli tx sign %v --print-sigs %v", flags, unsignedTxFile.Name()))
+		"gaiacli tx sign %v --validate-signatures %v", flags, unsignedTxFile.Name()))
 	require.False(t, success)
 	require.Equal(t, fmt.Sprintf("Signers:\n 0: %v\n\nSignatures:\n\n", fooAddr.String()), stdout)
 
@@ -511,7 +512,7 @@ func TestGaiaCLISendGenerateSignAndBroadcast(t *testing.T) {
 
 	// Test sign --print-signatures
 	success, stdout, _ = executeWriteRetStdStreams(t, fmt.Sprintf(
-		"gaiacli tx sign %v --print-sigs %v", flags, signedTxFile.Name()))
+		"gaiacli tx sign %v --validate-signatures %v", flags, signedTxFile.Name()))
 	require.True(t, success)
 	require.Equal(t, fmt.Sprintf("Signers:\n 0: %v\n\nSignatures:\n 0: %v\t[OK]\n\n", fooAddr.String(),
 		fooAddr.String()), stdout)
@@ -520,7 +521,8 @@ func TestGaiaCLISendGenerateSignAndBroadcast(t *testing.T) {
 	fooAcc := executeGetAccount(t, fmt.Sprintf("gaiacli query account %s %v", fooAddr, flags))
 	require.Equal(t, int64(50), fooAcc.GetCoins().AmountOf("steak").Int64())
 
-	success, stdout, _ = executeWriteRetStdStreams(t, fmt.Sprintf("gaiacli tx broadcast %v --json %v", flags, signedTxFile.Name()))
+	success, stdout, _ = executeWriteRetStdStreams(t, fmt.Sprintf(
+		"gaiacli tx broadcast %v --json %v", flags, signedTxFile.Name()))
 	require.True(t, success)
 	var result struct {
 		Response abci.ResponseDeliverTx

--- a/cmd/gaia/cli_test/cli_test.go
+++ b/cmd/gaia/cli_test/cli_test.go
@@ -494,7 +494,7 @@ func TestGaiaCLISendGenerateSignAndBroadcast(t *testing.T) {
 	success, stdout, _ = executeWriteRetStdStreams(t, fmt.Sprintf(
 		"gaiacli tx sign %v --print-sigs %v", flags, unsignedTxFile.Name()))
 	require.False(t, success)
-	require.Equal(t, fmt.Sprintf("Signers:\n 0: %v\n\nSignatures:\n", fooAddr.String()), stdout)
+	require.Equal(t, fmt.Sprintf("Signers:\n 0: %v\n\nSignatures:\n\n", fooAddr.String()), stdout)
 
 	// Test sign
 	success, stdout, _ = executeWriteRetStdStreams(t, fmt.Sprintf(
@@ -513,7 +513,8 @@ func TestGaiaCLISendGenerateSignAndBroadcast(t *testing.T) {
 	success, stdout, _ = executeWriteRetStdStreams(t, fmt.Sprintf(
 		"gaiacli tx sign %v --print-sigs %v", flags, signedTxFile.Name()))
 	require.True(t, success)
-	require.Equal(t, fmt.Sprintf("Signers:\n 0: %v\n\nSignatures:\n 0: %v\n", fooAddr.String(), fooAddr.String()), stdout)
+	require.Equal(t, fmt.Sprintf("Signers:\n 0: %v\n\nSignatures:\n 0: %v\t[OK]\n\n", fooAddr.String(),
+		fooAddr.String()), stdout)
 
 	// Test broadcast
 	fooAcc := executeGetAccount(t, fmt.Sprintf("gaiacli query account %s %v", fooAddr, flags))

--- a/cmd/gaia/cli_test/cli_test.go
+++ b/cmd/gaia/cli_test/cli_test.go
@@ -493,7 +493,7 @@ func TestGaiaCLISendGenerateSignAndBroadcast(t *testing.T) {
 	// Test sign --print-sigs
 	success, stdout, _ = executeWriteRetStdStreams(t, fmt.Sprintf(
 		"gaiacli tx sign %v --print-sigs %v", flags, unsignedTxFile.Name()))
-	require.True(t, success)
+	require.False(t, success)
 	require.Equal(t, fmt.Sprintf("Signers:\n 0: %v\n\nSignatures:\n", fooAddr.String()), stdout)
 
 	// Test sign

--- a/docs/sdk/clients.md
+++ b/docs/sdk/clients.md
@@ -181,6 +181,12 @@ gaiacli tx sign \
   unsignedSendTx.json > signedSendTx.json
 ```
 
+You can validate the transaction's signagures by typing the following:
+
+```bash
+gaiacli tx sign --validate-signatures signedSendTx.json
+```
+
 You can broadcast the signed transaction to a node by providing the JSON file to the following command:
 
 ```

--- a/x/auth/client/cli/sign.go
+++ b/x/auth/client/cli/sign.go
@@ -30,6 +30,9 @@ func GetSignCommand(codec *amino.Codec, decoder auth.AccountDecoder) *cobra.Comm
 		Long: `Sign transactions created with the --generate-only flag.
 Read a transaction from <file>, sign it, and print its JSON encoding.
 
+If the flag --print-signature-only flag is on, it outputs a JSON representation
+of the generated signature only.
+
 The --offline flag makes sure that the client will not reach out to the local cache.
 Thus account number or sequence number lookups will not be performed and it is
 recommended to set such parameters manually.`,

--- a/x/auth/client/cli/sign.go
+++ b/x/auth/client/cli/sign.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"github.com/pkg/errors"
 	"github.com/spf13/viper"
 	"io/ioutil"
 
@@ -62,6 +63,9 @@ func makeSignCmd(cdc *amino.Codec, decoder auth.AccountDecoder) func(cmd *cobra.
 		}
 
 		name := viper.GetString(client.FlagName)
+		if name == "" {
+			return errors.New("required flag \"name\" has not been set")
+		}
 		cliCtx := context.NewCLIContext().WithCodec(cdc).WithAccountDecoder(decoder)
 		txBldr := authtxb.NewTxBuilderFromCLI()
 

--- a/x/auth/client/cli/sign.go
+++ b/x/auth/client/cli/sign.go
@@ -73,8 +73,8 @@ func makeSignCmd(cdc *amino.Codec, decoder auth.AccountDecoder) func(cmd *cobra.
 
 		// if --signature-only is on, then override --append
 		generateSignatureOnly := viper.GetBool(flagRawSignature)
-		append := viper.GetBool(flagAppend) && !generateSignatureOnly
-		newTx, err := utils.SignStdTx(txBldr, cliCtx, name, stdTx, append, viper.GetBool(flagOffline))
+		appendSig := viper.GetBool(flagAppend) && !generateSignatureOnly
+		newTx, err := utils.SignStdTx(txBldr, cliCtx, name, stdTx, appendSig, viper.GetBool(flagOffline))
 		if err != nil {
 			return err
 		}

--- a/x/auth/client/cli/sign.go
+++ b/x/auth/client/cli/sign.go
@@ -91,13 +91,19 @@ func makeSignCmd(cdc *amino.Codec, decoder auth.AccountDecoder) func(cmd *cobra.
 
 func printSignatures(stdTx auth.StdTx) {
 	fmt.Println("Signers:")
-	for i, signer := range stdTx.GetSigners() {
+	signers := stdTx.GetSigners()
+	for i, signer := range signers {
 		fmt.Printf(" %v: %v\n", i, signer.String())
 	}
 	fmt.Println("")
 	fmt.Println("Signatures:")
 	for i, sig := range stdTx.GetSignatures() {
-		fmt.Printf(" %v: %v\n", i, sdk.AccAddress(sig.Address()).String())
+		sigAddr := sdk.AccAddress(sig.Address())
+		sigSanity := "OK"
+		if i >= len(signers) || !sigAddr.Equals(signers[i]) {
+			sigSanity = "ERROR"
+		}
+		fmt.Printf(" %v: %v\t[%s]\n", i, sigAddr.String(), sigSanity)
 	}
 	return
 }

--- a/x/auth/client/cli/sign.go
+++ b/x/auth/client/cli/sign.go
@@ -18,9 +18,9 @@ import (
 
 const (
 	flagAppend       = "append"
-	flagPrintSigs    = "print-sigs"
+	flagPrintSigs    = "validate-signatures"
 	flagOffline      = "offline"
-	flagRawSignature = "raw-signature"
+	flagRawSignature = "sig-only"
 )
 
 // GetSignCommand returns the sign command
@@ -31,7 +31,7 @@ func GetSignCommand(codec *amino.Codec, decoder auth.AccountDecoder) *cobra.Comm
 		Long: `Sign transactions created with the --generate-only flag.
 Read a transaction from <file>, sign it, and print its JSON encoding.
 
-If the flag --raw-signature flag is on, it outputs a JSON representation
+If the flag --sig-only flag is on, it outputs a JSON representation
 of the generated signature only.
 
 The --offline flag makes sure that the client will not reach out to the local cache.
@@ -41,9 +41,11 @@ recommended to set such parameters manually.`,
 		Args: cobra.ExactArgs(1),
 	}
 	cmd.Flags().String(client.FlagName, "", "Name of private key with which to sign")
-	cmd.Flags().Bool(flagAppend, true, "Append the signature to the existing ones. If disabled, old signatures would be overwritten")
+	cmd.Flags().Bool(flagAppend, true,
+		"Append the signature to the existing ones. If disabled, old signatures would be overwritten")
 	cmd.Flags().Bool(flagRawSignature, false, "Print only the generated signature, then exit.")
-	cmd.Flags().Bool(flagPrintSigs, false, "Print the addresses that must sign the transaction and those who have already signed it, then exit")
+	cmd.Flags().Bool(flagPrintSigs, false, "Print the addresses that must sign the transaction, "+
+		"those who have already signed it, and make sure that signatures are in the correct order.")
 	cmd.Flags().Bool(flagOffline, false, "Offline mode. Do not query local cache.")
 	return cmd
 }
@@ -69,7 +71,7 @@ func makeSignCmd(cdc *amino.Codec, decoder auth.AccountDecoder) func(cmd *cobra.
 		cliCtx := context.NewCLIContext().WithCodec(cdc).WithAccountDecoder(decoder)
 		txBldr := authtxb.NewTxBuilderFromCLI()
 
-		// if --print-signature-only is on, then override --append
+		// if --sig-only is on, then override --append
 		generateSignatureOnly := viper.GetBool(flagRawSignature)
 		append := viper.GetBool(flagAppend) && !generateSignatureOnly
 		newTx, err := utils.SignStdTx(txBldr, cliCtx, name, stdTx, append, viper.GetBool(flagOffline))

--- a/x/auth/client/cli/sign.go
+++ b/x/auth/client/cli/sign.go
@@ -34,6 +34,10 @@ Read a transaction from <file>, sign it, and print its JSON encoding.
 If the flag --signature-only flag is on, it outputs a JSON representation
 of the generated signature only.
 
+If the flag --validate-signatures is on, then the command would check whether all required
+signers have signed the transactions and whether the signatures were collected in the right
+order.
+
 The --offline flag makes sure that the client will not reach out to the local cache.
 Thus account number or sequence number lookups will not be performed and it is
 recommended to set such parameters manually.`,

--- a/x/auth/client/cli/sign.go
+++ b/x/auth/client/cli/sign.go
@@ -118,9 +118,7 @@ func printSignatures(stdTx auth.StdTx) bool {
 		sigSanity := "OK"
 		if i >= len(signers) || !sigAddr.Equals(signers[i]) {
 			sigSanity = fmt.Sprintf("ERROR: signature %d does not match its respective signer", i)
-			if success {
-				success = false
-			}
+			success = false
 		}
 		fmt.Printf(" %v: %v\t[%s]\n", i, sigAddr.String(), sigSanity)
 	}

--- a/x/auth/client/cli/sign.go
+++ b/x/auth/client/cli/sign.go
@@ -81,15 +81,21 @@ func makeSignCmd(cdc *amino.Codec, decoder auth.AccountDecoder) func(cmd *cobra.
 
 		var json []byte
 
-		switch {
-		case generateSignatureOnly && cliCtx.Indent:
-			json, err = cdc.MarshalJSONIndent(newTx.Signatures[0], "", "  ")
-		case generateSignatureOnly && !cliCtx.Indent:
-			json, err = cdc.MarshalJSON(newTx.Signatures[0])
-		case !generateSignatureOnly && cliCtx.Indent:
-			json, err = cdc.MarshalJSONIndent(newTx, "", "  ")
-		case !generateSignatureOnly && !cliCtx.Indent:
-			json, err = cdc.MarshalJSON(newTx)
+		switch generateSignatureOnly {
+		case true:
+			switch cliCtx.Indent {
+			case true:
+				json, err = cdc.MarshalJSONIndent(newTx.Signatures[0], "", "  ")
+			default:
+				json, err = cdc.MarshalJSON(newTx.Signatures[0])
+			}
+		default:
+			switch cliCtx.Indent {
+			case true:
+				json, err = cdc.MarshalJSONIndent(newTx, "", "  ")
+			default:
+				json, err = cdc.MarshalJSON(newTx)
+			}
 		}
 		if err != nil {
 			return err

--- a/x/auth/client/cli/sign.go
+++ b/x/auth/client/cli/sign.go
@@ -18,9 +18,9 @@ import (
 
 const (
 	flagAppend       = "append"
-	flagPrintSigs    = "validate-signatures"
+	flagValidateSigs = "validate-signatures"
 	flagOffline      = "offline"
-	flagRawSignature = "signature-only"
+	flagSigOnly      = "signature-only"
 )
 
 // GetSignCommand returns the sign command
@@ -43,8 +43,8 @@ recommended to set such parameters manually.`,
 	cmd.Flags().String(client.FlagName, "", "Name of private key with which to sign")
 	cmd.Flags().Bool(flagAppend, true,
 		"Append the signature to the existing ones. If disabled, old signatures would be overwritten")
-	cmd.Flags().Bool(flagRawSignature, false, "Print only the generated signature, then exit.")
-	cmd.Flags().Bool(flagPrintSigs, false, "Print the addresses that must sign the transaction, "+
+	cmd.Flags().Bool(flagSigOnly, false, "Print only the generated signature, then exit.")
+	cmd.Flags().Bool(flagValidateSigs, false, "Print the addresses that must sign the transaction, "+
 		"those who have already signed it, and make sure that signatures are in the correct order.")
 	cmd.Flags().Bool(flagOffline, false, "Offline mode. Do not query local cache.")
 	return cmd
@@ -57,7 +57,7 @@ func makeSignCmd(cdc *amino.Codec, decoder auth.AccountDecoder) func(cmd *cobra.
 			return
 		}
 
-		if viper.GetBool(flagPrintSigs) {
+		if viper.GetBool(flagValidateSigs) {
 			if !printSignatures(stdTx) {
 				return fmt.Errorf("signatures validation failed")
 			}
@@ -72,7 +72,7 @@ func makeSignCmd(cdc *amino.Codec, decoder auth.AccountDecoder) func(cmd *cobra.
 		txBldr := authtxb.NewTxBuilderFromCLI()
 
 		// if --signature-only is on, then override --append
-		generateSignatureOnly := viper.GetBool(flagRawSignature)
+		generateSignatureOnly := viper.GetBool(flagSigOnly)
 		appendSig := viper.GetBool(flagAppend) && !generateSignatureOnly
 		newTx, err := utils.SignStdTx(txBldr, cliCtx, name, stdTx, appendSig, viper.GetBool(flagOffline))
 		if err != nil {

--- a/x/auth/client/cli/sign.go
+++ b/x/auth/client/cli/sign.go
@@ -20,7 +20,7 @@ const (
 	flagAppend       = "append"
 	flagPrintSigs    = "validate-signatures"
 	flagOffline      = "offline"
-	flagRawSignature = "sig-only"
+	flagRawSignature = "signature-only"
 )
 
 // GetSignCommand returns the sign command
@@ -31,7 +31,7 @@ func GetSignCommand(codec *amino.Codec, decoder auth.AccountDecoder) *cobra.Comm
 		Long: `Sign transactions created with the --generate-only flag.
 Read a transaction from <file>, sign it, and print its JSON encoding.
 
-If the flag --sig-only flag is on, it outputs a JSON representation
+If the flag --signature-only flag is on, it outputs a JSON representation
 of the generated signature only.
 
 The --offline flag makes sure that the client will not reach out to the local cache.
@@ -71,7 +71,7 @@ func makeSignCmd(cdc *amino.Codec, decoder auth.AccountDecoder) func(cmd *cobra.
 		cliCtx := context.NewCLIContext().WithCodec(cdc).WithAccountDecoder(decoder)
 		txBldr := authtxb.NewTxBuilderFromCLI()
 
-		// if --sig-only is on, then override --append
+		// if --signature-only is on, then override --append
 		generateSignatureOnly := viper.GetBool(flagRawSignature)
 		append := viper.GetBool(flagAppend) && !generateSignatureOnly
 		newTx, err := utils.SignStdTx(txBldr, cliCtx, name, stdTx, append, viper.GetBool(flagOffline))


### PR DESCRIPTION
- Exit with error if the user is attempting to sign with a key whose address is not among those who are expected to sign the transaction.
- Add --print-signature-only to output only the generated signature.
- When --print-sigs is on, validate signatures order and report errors if there's any.

______

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [x] Wrote tests
- [x] Updated relevant documentation (`docs/`)
- [x] Added entries in `PENDING.md` with issue # 
- [x] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
