### PR TITLE
sim fixes

### DIFF
--- a/cmd/gaia/app/sim_test.go
+++ b/cmd/gaia/app/sim_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/tendermint/tendermint/libs/log"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	// authsim "github.com/cosmos/cosmos-sdk/x/auth/simulation"
+	authsim "github.com/cosmos/cosmos-sdk/x/auth/simulation"
 	banksim "github.com/cosmos/cosmos-sdk/x/bank/simulation"
 	distr "github.com/cosmos/cosmos-sdk/x/distribution"
 	distributionsim "github.com/cosmos/cosmos-sdk/x/distribution/simulation"
@@ -104,19 +104,19 @@ func appStateFn(r *rand.Rand, accs []simulation.Account) json.RawMessage {
 
 func testAndRunTxs(app *GaiaApp) []simulation.WeightedOperation {
 	return []simulation.WeightedOperation{
-		//{5, authsim.SimulateDeductFee(app.accountMapper, app.feeCollectionKeeper)},
+		{5, authsim.SimulateDeductFee(app.accountMapper, app.feeCollectionKeeper)},
 		{100, banksim.SingleInputSendMsg(app.accountMapper, app.bankKeeper)},
-		// {50, distributionsim.SimulateMsgSetWithdrawAddress(app.accountMapper, app.distrKeeper)},
+		{50, distributionsim.SimulateMsgSetWithdrawAddress(app.accountMapper, app.distrKeeper)},
 		{50, distributionsim.SimulateMsgWithdrawDelegatorRewardsAll(app.accountMapper, app.distrKeeper)},
 		{50, distributionsim.SimulateMsgWithdrawDelegatorReward(app.accountMapper, app.distrKeeper)},
-		// {50, distributionsim.SimulateMsgWithdrawValidatorRewardsAll(app.accountMapper, app.distrKeeper)},
-		//{5, govsim.SimulateSubmittingVotingAndSlashingForProposal(app.govKeeper, app.stakeKeeper)},
-		//{100, govsim.SimulateMsgDeposit(app.govKeeper, app.stakeKeeper)},
-		//{100, stakesim.SimulateMsgCreateValidator(app.accountMapper, app.stakeKeeper)},
-		//{5, stakesim.SimulateMsgEditValidator(app.stakeKeeper)},
+		{50, distributionsim.SimulateMsgWithdrawValidatorRewardsAll(app.accountMapper, app.distrKeeper)},
+		{5, govsim.SimulateSubmittingVotingAndSlashingForProposal(app.govKeeper, app.stakeKeeper)},
+		{100, govsim.SimulateMsgDeposit(app.govKeeper, app.stakeKeeper)},
+		{100, stakesim.SimulateMsgCreateValidator(app.accountMapper, app.stakeKeeper)},
+		{5, stakesim.SimulateMsgEditValidator(app.stakeKeeper)},
 		{100, stakesim.SimulateMsgDelegate(app.accountMapper, app.stakeKeeper)},
-		//{100, stakesim.SimulateMsgBeginUnbonding(app.accountMapper, app.stakeKeeper)},
-		//{100, stakesim.SimulateMsgBeginRedelegate(app.accountMapper, app.stakeKeeper)},
+		{100, stakesim.SimulateMsgBeginUnbonding(app.accountMapper, app.stakeKeeper)},
+		{100, stakesim.SimulateMsgBeginRedelegate(app.accountMapper, app.stakeKeeper)},
 		{100, slashingsim.SimulateMsgUnjail(app.slashingKeeper)},
 	}
 }

--- a/x/distribution/keeper/allocation.go
+++ b/x/distribution/keeper/allocation.go
@@ -13,6 +13,7 @@ func (k Keeper) AllocateTokens(ctx sdk.Context, percentVotes sdk.Dec, proposer s
 
 	// get the proposer of this block
 	proposerValidator := k.stakeKeeper.ValidatorByConsAddr(ctx, proposer)
+
 	proposerDist := k.GetValidatorDistInfo(ctx, proposerValidator.GetOperator())
 
 	// get the fees which have been getting collected through all the

--- a/x/distribution/keeper/hooks.go
+++ b/x/distribution/keeper/hooks.go
@@ -104,7 +104,6 @@ func (h Hooks) OnDelegationRemoved(ctx sdk.Context, delAddr sdk.AccAddress, valA
 func (h Hooks) OnValidatorBeginUnbonding(ctx sdk.Context, _ sdk.ConsAddress, addr sdk.ValAddress) {
 	h.k.onValidatorModified(ctx, addr)
 }
-
 func (h Hooks) OnValidatorBonded(ctx sdk.Context, _ sdk.ConsAddress, addr sdk.ValAddress) {
 	h.k.onValidatorModified(ctx, addr)
 }

--- a/x/mock/simulation/random_simulate_blocks.go
+++ b/x/mock/simulation/random_simulate_blocks.go
@@ -233,7 +233,7 @@ func createBlockSimulator(testingMode bool, tb testing.TB, t *testing.T, event f
 					assertAllInvariants(t, app, invariants, fmt.Sprintf("operation: %v", logUpdate), displayLogs)
 				}
 				if opCount%50 == 0 {
-					fmt.Printf("\rSimulating... block %d/%d, operation %d/%d.  ", header.Height, totalNumBlocks, opCount, blocksize)
+					fmt.Printf("\rSimulating... block %d/%d, operation %d/%d. ", header.Height, totalNumBlocks, opCount, blocksize)
 				}
 			}
 			opCount++

--- a/x/mock/simulation/random_simulate_blocks.go
+++ b/x/mock/simulation/random_simulate_blocks.go
@@ -176,6 +176,12 @@ func SimulateFromSeed(tb testing.TB, app *baseapp.BaseApp,
 			app.Commit()
 		}
 
+		if header.ProposerAddress == nil {
+			fmt.Printf("\nSimulation stopped early as all validators have been unbonded, there is nobody left propose a block!\n")
+			stopEarly = true
+			break
+		}
+
 		// Generate a random RequestBeginBlock with the current validator set for the next block
 		request = RandomRequestBeginBlock(r, validators, livenessTransitionMatrix, evidenceFraction, pastTimes, pastVoteInfos, event, header)
 


### PR DESCRIPTION
rige [12:05 AM]
so I figured out the bug - it was in the simulation logic - basically all the validators have been unbonded and the simulation assumed it was okay to keep running with a nil proposer! - added a check which stop and exits the simulation if all the validators have been unbonded.

rige [12:05 AM]
however I’m really really confused as to why validators are unbonding given that the unbond delegation transaction has been disabled…

rige [12:21 AM]
OH it’s because they are getting jailed once in a while
phew - I thought this was something super messy

rige [12:27 AM]
still on your branch - just turned up the %weight of unjail msgs by 10x…… already at block 100 (promising)….. ah still stops at 113 due to not enough validators again, going to enable other messages just to se