### PR TITLE
R4R: Block redelegations to the same validator

### DIFF
--- a/PENDING.md
+++ b/PENDING.md
@@ -37,6 +37,7 @@ IMPROVEMENTS
 
 * SDK
  - #2573 [x/distribution] add accum invariance
+ - #2610 [x/stake] Block redelegation to and from the same validator
 
 * Tendermint
 

--- a/x/stake/keeper/delegation.go
+++ b/x/stake/keeper/delegation.go
@@ -541,6 +541,10 @@ func (k Keeper) CompleteUnbonding(ctx sdk.Context, delAddr sdk.AccAddress, valAd
 func (k Keeper) BeginRedelegation(ctx sdk.Context, delAddr sdk.AccAddress,
 	valSrcAddr, valDstAddr sdk.ValAddress, sharesAmount sdk.Dec) (types.Redelegation, sdk.Error) {
 
+	if bytes.Equal(valSrcAddr, valDstAddr) {
+		return types.Redelegation{}, types.ErrSelfRedelegation(k.Codespace())
+	}
+
 	// check if there is already a redelgation in progress from src to dst
 	// TODO quick fix, instead we should use an index, see https://github.com/cosmos/cosmos-sdk/issues/1402
 	_, found := k.GetRedelegation(ctx, delAddr, valSrcAddr, valDstAddr)

--- a/x/stake/types/errors.go
+++ b/x/stake/types/errors.go
@@ -155,6 +155,10 @@ func ErrNoRedelegation(codespace sdk.CodespaceType) sdk.Error {
 	return sdk.NewError(codespace, CodeInvalidDelegation, "no redelegation found")
 }
 
+func ErrSelfRedelegation(codespace sdk.CodespaceType) sdk.Error {
+	return sdk.NewError(codespace, CodeInvalidDelegation, "cannot redelegate to the same validator")
+}
+
 func ErrBadRedelegationDst(codespace sdk.CodespaceType) sdk.Error {
 	return sdk.NewError(codespace, CodeInvalidDelegation, "redelegation validator not found")
 }


### PR DESCRIPTION
Closes https://github.com/cosmos/cosmos-sdk/issues/2610

- [x] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [x] Wrote tests
- [x] Updated relevant documentation (`docs/`)
- [x] Added entries in `PENDING.md` with issue # 
- [x] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
