### PR TITLE
Make simulation use a transition matrix for block size

### DIFF
--- a/PENDING.md
+++ b/PENDING.md
@@ -37,6 +37,7 @@ IMPROVEMENTS
 
 * SDK
  - #2573 [x/distribution] add accum invariance
+ - \#1924 [simulation] Use a transition matrix for block size
 
 * Tendermint
 

--- a/client/lcd/certificates.go
+++ b/client/lcd/certificates.go
@@ -43,7 +43,7 @@ func generateSelfSignedCert(host string) (certBytes []byte, priv *ecdsa.PrivateK
 		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 		BasicConstraintsValid: true,
-		IsCA:                  true,
+		IsCA: true,
 	}
 	hosts := strings.Split(host, ",")
 	for _, h := range hosts {

--- a/x/mock/simulation/constants.go
+++ b/x/mock/simulation/constants.go
@@ -28,4 +28,10 @@ var (
 		{10, 50, 5},
 		{0, 10, 1000},
 	})
+	// 3 states: rand in range [0, 4*provided blocksize], rand in range [0, 2 * provided blocksize], 0
+	blockSizeTransitionMatrix, _ = CreateTransitionMatrix([][]int{
+		{85, 5, 0},
+		{15, 92, 1},
+		{0, 3, 99},
+	})
 )

--- a/x/mock/simulation/random_simulate_blocks.go
+++ b/x/mock/simulation/random_simulate_blocks.go
@@ -22,12 +22,6 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
-type blockSimFn func(
-	r *rand.Rand,
-	app *baseapp.BaseApp, ctx sdk.Context,
-	accounts []Account, header abci.Header, logWriter func(string),
-) (opCount int)
-
 // Simulate tests application by sending random messages.
 func Simulate(t *testing.T, app *baseapp.BaseApp,
 	appStateFn func(r *rand.Rand, accs []Account) json.RawMessage,
@@ -201,6 +195,11 @@ func SimulateFromSeed(tb testing.TB, app *baseapp.BaseApp,
 	DisplayEvents(events)
 	return nil
 }
+
+type blockSimFn func(
+	r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context,
+	accounts []Account, header abci.Header, logWriter func(string),
+) (opCount int)
 
 // Returns a function to simulate blocks. Written like this to avoid constant parameters being passed everytime, to minimize
 // memory overhead

--- a/x/mock/simulation/random_simulate_blocks.go
+++ b/x/mock/simulation/random_simulate_blocks.go
@@ -198,8 +198,13 @@ func SimulateFromSeed(tb testing.TB, app *baseapp.BaseApp,
 
 // Returns a function to simulate blocks. Written like this to avoid constant parameters being passed everytime, to minimize
 // memory overhead
-func createBlockSimulator(testingMode bool, tb testing.TB, t *testing.T, event func(string), invariants []Invariant, ops []WeightedOperation, operationQueue map[int][]Operation, timeOperationQueue []FutureOperation, totalNumBlocks int, avgBlockSize int, displayLogs func()) func(
-	r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, accounts []Account, header abci.Header, logWriter func(string)) (opCount int) {
+func createBlockSimulator(testingMode bool, tb testing.TB, t *testing.T,
+	event func(string), invariants []Invariant,
+	ops []WeightedOperation, operationQueue map[int][]Operation, timeOperationQueue []FutureOperation,
+	totalNumBlocks int, avgBlockSize int, displayLogs func()) func(
+	r *rand.Rand,
+	app *baseapp.BaseApp, ctx sdk.Context,
+	accounts []Account, header abci.Header, logWriter func(string)) (opCount int) {
 	var (
 		lastBlocksizeState = 0 // state for [4 * uniform distribution]
 		totalOpWeight      = 0
@@ -258,6 +263,12 @@ func getTestingMode(tb testing.TB) (testingMode bool, t *testing.T, b *testing.B
 	return
 }
 
+/** getBlockSize returns a block size as determined from the transition matrix.
+It targets making average block size the provided parameter.
+The three states it moves between are:
+* "over stuffed" blocks with average size of 2 * avgblocksize,
+* normal sized blocks, hitting avgBlocksize on average,
+* and empty blocks, with no txs / only txs scheduled from the past. */
 func getBlockSize(r *rand.Rand, lastBlockSizeState, avgBlockSize int) (state, blocksize int) {
 	// TODO: Make blockSizeTransitionMatrix non-global
 	// TODO: Make default blocksize transitition matrix actually make the average blocksize equal to avgBlockSize


### PR DESCRIPTION
This enables simulating periods of high load, and periods of low to no load.
(low load because future ops will still terminate in that time frame)

Once this is merged, I think we should just delete #1924, and make a new issue tagged postlaunch for those remaining items. 

The LCD change is from make format. 

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/develop/CONTRIBUTING.md#pr-targeting))

- [x] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [x] Added entries in `PENDING.md` with issue # 
- [x] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
