### PR TITLE
simulation: Print last block when there is an error

### DIFF
--- a/x/mock/simulation/random_simulate_blocks.go
+++ b/x/mock/simulation/random_simulate_blocks.go
@@ -221,11 +221,11 @@ func createBlockSimulator(testingMode bool, tb testing.TB, t *testing.T, event f
 		accounts []Account, header abci.Header, logWriter func(string)) (opCount int) {
 		for j := 0; j < blocksize; j++ {
 			logUpdate, futureOps, err := selectOp(r)(r, app, ctx, accounts, event)
+			logWriter(logUpdate)
 			if err != nil {
 				displayLogs()
 				tb.Fatalf("error on operation %d within block %d, %v", header.Height, opCount, err)
 			}
-			logWriter(logUpdate)
 
 			queueOperations(operationQueue, timeOperationQueue, futureOps)
 			if testingMode {

--- a/x/mock/simulation/util.go
+++ b/x/mock/simulation/util.go
@@ -134,7 +134,7 @@ func logPrinter(testingmode bool, logs []*strings.Builder) func() {
 			for i := 0; i < len(logs); i++ {
 				// We're passed the last created block
 				if logs[i] == nil {
-					numLoggers = i - 1
+					numLoggers = i
 					break
 				}
 			}


### PR DESCRIPTION
There was an off by one error in the log printing function previously

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
