### PR TITLE
R4R: Revert read-only leveldb database

### DIFF
--- a/client/keys/utils.go
+++ b/client/keys/utils.go
@@ -96,7 +96,10 @@ func GetKeyBaseFromDirWithWritePerm(rootDir string) (keys.Keybase, error) {
 
 // GetKeyBaseFromDir initializes a read-only keybase at a particular dir.
 func GetKeyBaseFromDir(rootDir string) (keys.Keybase, error) {
-	// Disabled because of syndtr/goleveldb#240
+	// Disabled because of the inability to create a new keys database directory
+	// in the instance of when ReadOnly is set to true.
+	//
+	// ref: syndtr/goleveldb#240
 	// return getKeyBaseFromDirWithOpts(rootDir, &opt.Options{ReadOnly: true})
 	return getKeyBaseFromDirWithOpts(rootDir, nil)
 }

--- a/client/keys/utils.go
+++ b/client/keys/utils.go
@@ -96,7 +96,9 @@ func GetKeyBaseFromDirWithWritePerm(rootDir string) (keys.Keybase, error) {
 
 // GetKeyBaseFromDir initializes a read-only keybase at a particular dir.
 func GetKeyBaseFromDir(rootDir string) (keys.Keybase, error) {
-	return getKeyBaseFromDirWithOpts(rootDir, &opt.Options{ReadOnly: true})
+	// Disabled because of syndtr/goleveldb#240
+	// return getKeyBaseFromDirWithOpts(rootDir, &opt.Options{ReadOnly: true})
+	return getKeyBaseFromDirWithOpts(rootDir, nil)
 }
 
 func getKeyBaseFromDirWithOpts(rootDir string, o *opt.Options) (keys.Keybase, error) {


### PR DESCRIPTION
Waiting on a fix for syndtr/goleveldb#240.

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added entries in `PENDING.md` with issue # 
- [ ] rereviewed `Files changed` in the github PR explorer

closes: #2630

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
