### PR TITLE
[R4R] simulation: Make validator choice use validator set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -169,7 +169,7 @@ test_sim_gaia_nondeterminism:
 
 test_sim_gaia_fast:
 	@echo "Running quick Gaia simulation. This may take several minutes..."
-	@go test ./cmd/gaia/app -run TestFullGaiaSimulation -SimulationEnabled=true -SimulationNumBlocks=500 -SimulationBlockSize=200 -SimulationCommit=true -SimulationSeed=9 -v -timeout 24h
+	@go test ./cmd/gaia/app -run TestFullGaiaSimulation -SimulationEnabled=true -SimulationNumBlocks=500 -SimulationBlockSize=200 -SimulationCommit=true -SimulationSeed=10 -v -timeout 24h
 
 test_sim_gaia_multi_seed:
 	@echo "Running multi-seed Gaia simulation. This may take awhile!"

--- a/PENDING.md
+++ b/PENDING.md
@@ -41,7 +41,8 @@ IMPROVEMENTS
 
 * SDK
  - #2573 [x/distribution] add accum invariance
- - \#1924 [simulation] Use a transition matrix for block size
+ - \#1924 [x/mock/simulation] Use a transition matrix for block size
+ - \#2660 [x/mock/simulation] Staking transactions get tested far more frequently
  - #2610 [x/stake] Block redelegation to and from the same validator
 
 

--- a/x/mock/simulation/util.go
+++ b/x/mock/simulation/util.go
@@ -2,6 +2,7 @@ package simulation
 
 import (
 	"fmt"
+	"math/big"
 	"math/rand"
 	"os"
 	"sort"
@@ -69,6 +70,12 @@ func RandomAcc(r *rand.Rand, accs []Account) Account {
 // Generate a random amount
 func RandomAmount(r *rand.Rand, max sdk.Int) sdk.Int {
 	return sdk.NewInt(int64(r.Intn(int(max.Int64()))))
+}
+
+// RandomDecAmount generates a random decimal amount
+func RandomDecAmount(r *rand.Rand, max sdk.Dec) sdk.Dec {
+	randInt := big.NewInt(0).Rand(r, max.Int)
+	return sdk.NewDecFromBigIntWithPrec(randInt, sdk.Precision)
 }
 
 // RandomAccounts generates n random accounts

--- a/x/stake/keeper/test_common.go
+++ b/x/stake/keeper/test_common.go
@@ -3,6 +3,7 @@ package keeper
 import (
 	"bytes"
 	"encoding/hex"
+	"math/rand"
 	"strconv"
 	"testing"
 
@@ -214,4 +215,18 @@ func TestingUpdateValidator(keeper Keeper, ctx sdk.Context, validator types.Vali
 func validatorByPowerIndexExists(k Keeper, ctx sdk.Context, power []byte) bool {
 	store := ctx.KVStore(k.storeKey)
 	return store.Has(power)
+}
+
+// RandomValidator returns a random validator given access to the keeper and ctx
+func RandomValidator(r *rand.Rand, keeper Keeper, ctx sdk.Context) types.Validator {
+	vals := keeper.GetAllValidators(ctx)
+	i := r.Intn(len(vals))
+	return vals[i]
+}
+
+// RandomBondedValidator returns a random bonded validator given access to the keeper and ctx
+func RandomBondedValidator(r *rand.Rand, keeper Keeper, ctx sdk.Context) types.Validator {
+	vals := keeper.GetBondedValidatorsByPower(ctx)
+	i := r.Intn(len(vals))
+	return vals[i]
 }

--- a/x/stake/simulation/msgs.go
+++ b/x/stake/simulation/msgs.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/mock"
 	"github.com/cosmos/cosmos-sdk/x/mock/simulation"
 	"github.com/cosmos/cosmos-sdk/x/stake"
+	"github.com/cosmos/cosmos-sdk/x/stake/keeper"
 	abci "github.com/tendermint/tendermint/abci/types"
 )
 
@@ -87,8 +88,8 @@ func SimulateMsgEditValidator(k stake.Keeper) simulation.Operation {
 		maxCommission := sdk.NewInt(10)
 		newCommissionRate := sdk.NewDecWithPrec(simulation.RandomAmount(r, maxCommission).Int64(), 1)
 
-		acc := simulation.RandomAcc(r, accs)
-		address := sdk.ValAddress(acc.Address)
+		val := keeper.RandomValidator(r, k, ctx)
+		address := val.GetOperator()
 		msg := stake.MsgEditValidator{
 			Description:    description,
 			ValidatorAddr:  address,
@@ -118,8 +119,8 @@ func SimulateMsgDelegate(m auth.AccountKeeper, k stake.Keeper) simulation.Operat
 		action string, fOp []simulation.FutureOperation, err error) {
 
 		denom := k.GetParams(ctx).BondDenom
-		validatorAcc := simulation.RandomAcc(r, accs)
-		validatorAddress := sdk.ValAddress(validatorAcc.Address)
+		val := keeper.RandomValidator(r, k, ctx)
+		validatorAddress := val.GetOperator()
 		delegatorAcc := simulation.RandomAcc(r, accs)
 		delegatorAddress := delegatorAcc.Address
 		amount := m.GetAccount(ctx, delegatorAddress).GetCoins().AmountOf(denom)
@@ -155,25 +156,26 @@ func SimulateMsgBeginUnbonding(m auth.AccountKeeper, k stake.Keeper) simulation.
 		accs []simulation.Account, event func(string)) (
 		action string, fOp []simulation.FutureOperation, err error) {
 
-		denom := k.GetParams(ctx).BondDenom
-		validatorAcc := simulation.RandomAcc(r, accs)
-		validatorAddress := sdk.ValAddress(validatorAcc.Address)
 		delegatorAcc := simulation.RandomAcc(r, accs)
 		delegatorAddress := delegatorAcc.Address
-		amount := m.GetAccount(ctx, delegatorAddress).GetCoins().AmountOf(denom)
-		if amount.GT(sdk.ZeroInt()) {
-			amount = simulation.RandomAmount(r, amount)
+		delegations := k.GetAllDelegatorDelegations(ctx, delegatorAddress)
+		if len(delegations) == 0 {
+			return "no-operation", nil, nil
 		}
-		if amount.Equal(sdk.ZeroInt()) {
+		delegation := delegations[r.Intn(len(delegations))]
+
+		numShares := simulation.RandomDecAmount(r, delegation.Shares)
+		if numShares.Equal(sdk.ZeroDec()) {
 			return "no-operation", nil, nil
 		}
 		msg := stake.MsgBeginUnbonding{
 			DelegatorAddr: delegatorAddress,
-			ValidatorAddr: validatorAddress,
-			SharesAmount:  sdk.NewDecFromInt(amount),
+			ValidatorAddr: delegation.ValidatorAddr,
+			SharesAmount:  numShares,
 		}
 		if msg.ValidateBasic() != nil {
-			return "", nil, fmt.Errorf("expected msg to pass ValidateBasic: %s", msg.GetSignBytes())
+			return "", nil, fmt.Errorf("expected msg to pass ValidateBasic: %s, got error %v",
+				msg.GetSignBytes(), msg.ValidateBasic())
 		}
 		ctx, write := ctx.CacheContext()
 		result := handler(ctx, msg)
@@ -194,10 +196,10 @@ func SimulateMsgBeginRedelegate(m auth.AccountKeeper, k stake.Keeper) simulation
 		action string, fOp []simulation.FutureOperation, err error) {
 
 		denom := k.GetParams(ctx).BondDenom
-		sourceValidatorAcc := simulation.RandomAcc(r, accs)
-		sourceValidatorAddress := sdk.ValAddress(sourceValidatorAcc.Address)
-		destValidatorAcc := simulation.RandomAcc(r, accs)
-		destValidatorAddress := sdk.ValAddress(destValidatorAcc.Address)
+		srcVal := keeper.RandomValidator(r, k, ctx)
+		srcValidatorAddress := srcVal.GetOperator()
+		destVal := keeper.RandomValidator(r, k, ctx)
+		destValidatorAddress := destVal.GetOperator()
 		delegatorAcc := simulation.RandomAcc(r, accs)
 		delegatorAddress := delegatorAcc.Address
 		// TODO
@@ -210,7 +212,7 @@ func SimulateMsgBeginRedelegate(m auth.AccountKeeper, k stake.Keeper) simulation
 		}
 		msg := stake.MsgBeginRedelegate{
 			DelegatorAddr:    delegatorAddress,
-			ValidatorSrcAddr: sourceValidatorAddress,
+			ValidatorSrcAddr: srcValidatorAddress,
 			ValidatorDstAddr: destValidatorAddress,
 			SharesAmount:     sdk.NewDecFromInt(amount),
 		}


### PR DESCRIPTION
This also had to change the default seed, since with the previous one it
actually got into a state where there were no validators left bonded, lol.

This also changes Unbond msgs from failing with almost 100% probability to now
only failing with 33% probability.
Thus more of the state machine is getting tested!

This does slow it down a fair amount (went from 500 blocks in ~55 seconds, to now 500 blocks in 100 seconds) but I think this is a fair trade-off since now its actually testing these, whereas before it wasn't. 

Before:
```
stake/MsgDelegate/false => 650
stake/MsgDelegate/true => 2896
stake/MsgBeginUnbonding/false => 3481
stake/MsgBeginUnbonding/true => 70
```

After:
```
stake/MsgDelegate/false => 291
stake/MsgDelegate/true => 2864
stake/MsgBeginUnbonding/false => 1156
stake/MsgBeginUnbonding/true => 2181
```
Closes #2621 
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/develop/CONTRIBUTING.md#pr-targeting))

- [x] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [x] Wrote tests - sim is the test
- [x] Updated relevant documentation (`docs/`)
- [x] Added entries in `PENDING.md` with issue # 
- [x] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
