### PR TITLE
Added generated statik file, otherwise LCD is unusable for apps importing the SDK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,6 @@ docs/_build
 examples/basecoin/app/data
 baseapp/data/*
 client/lcd/keys/*
-client/lcd/statik/statik.go
 mytestnet
 
 # Testing


### PR DESCRIPTION
I have an app that uses the Cosmos-SDK. I need to add support for LCD, it fails to compile because the generated file statik.go file does not exist in my vendor directory. It's currently generated from the SDK Makefile, which means that all apps vendoring the SDK will miss the file.

I suggest simply adding the statik.go file in the SDK repos so any Cosmos app can enable the LCD support.