### PR TITLE
WIP: [x/auth] Add lru cache for account

### DIFF
--- a/client/context/context.go
+++ b/client/context/context.go
@@ -7,21 +7,19 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/cosmos/cosmos-sdk/client"
-	"github.com/cosmos/cosmos-sdk/codec"
-	"github.com/cosmos/cosmos-sdk/x/auth"
-
 	"github.com/spf13/viper"
-
 	"github.com/tendermint/tendermint/libs/cli"
 	"github.com/tendermint/tendermint/libs/log"
 	tmlite "github.com/tendermint/tendermint/lite"
 	tmliteProxy "github.com/tendermint/tendermint/lite/proxy"
 	rpcclient "github.com/tendermint/tendermint/rpc/client"
 
+	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/keys"
+	"github.com/cosmos/cosmos-sdk/codec"
 	cskeys "github.com/cosmos/cosmos-sdk/crypto/keys"
 	"github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/auth"
 )
 
 const ctxAccStoreName = "acc"
@@ -178,7 +176,7 @@ func (ctx CLIContext) WithCodec(cdc *codec.Codec) CLIContext {
 
 // GetAccountDecoder gets the account decoder for auth.DefaultAccount.
 func GetAccountDecoder(cdc *codec.Codec) auth.AccountDecoder {
-	return func(accBytes []byte) (acct auth.Account, err error) {
+	return func(accBytes []byte) (acct types.Account, err error) {
 		err = cdc.UnmarshalBinaryBare(accBytes, &acct)
 		if err != nil {
 			panic(err)

--- a/client/context/query.go
+++ b/client/context/query.go
@@ -2,14 +2,9 @@ package context
 
 import (
 	"fmt"
-
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/cosmos/cosmos-sdk/x/auth"
-
-	"github.com/pkg/errors"
-
 	"strings"
 
+	"github.com/pkg/errors"
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/crypto/merkle"
 	cmn "github.com/tendermint/tendermint/libs/common"
@@ -19,6 +14,8 @@ import (
 	tmtypes "github.com/tendermint/tendermint/types"
 
 	"github.com/cosmos/cosmos-sdk/store"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/auth"
 )
 
 // GetNode returns an RPC client. If the context's client is not defined, an
@@ -61,7 +58,7 @@ func (ctx CLIContext) QuerySubspace(subspace []byte, storeName string) (res []sd
 
 // GetAccount queries for an account given an address and a block height. An
 // error is returned if the query or decoding fails.
-func (ctx CLIContext) GetAccount(address []byte) (auth.Account, error) {
+func (ctx CLIContext) GetAccount(address []byte) (sdk.Account, error) {
 	if ctx.AccDecoder == nil {
 		return nil, errors.New("account decoder required but not provided")
 	}

--- a/client/lcd/lcd_test.go
+++ b/client/lcd/lcd_test.go
@@ -13,20 +13,19 @@ import (
 
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
-
-	p2p "github.com/tendermint/tendermint/p2p"
+	"github.com/tendermint/tendermint/p2p"
 	ctypes "github.com/tendermint/tendermint/rpc/core/types"
 
-	client "github.com/cosmos/cosmos-sdk/client"
-	keys "github.com/cosmos/cosmos-sdk/client/keys"
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/keys"
 	"github.com/cosmos/cosmos-sdk/client/rpc"
 	"github.com/cosmos/cosmos-sdk/client/tx"
 	"github.com/cosmos/cosmos-sdk/codec"
 	cryptoKeys "github.com/cosmos/cosmos-sdk/crypto/keys"
 	"github.com/cosmos/cosmos-sdk/crypto/keys/mintkey"
-	tests "github.com/cosmos/cosmos-sdk/tests"
+	"github.com/cosmos/cosmos-sdk/tests"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	version "github.com/cosmos/cosmos-sdk/version"
+	"github.com/cosmos/cosmos-sdk/version"
 	"github.com/cosmos/cosmos-sdk/x/auth"
 	authrest "github.com/cosmos/cosmos-sdk/x/auth/client/rest"
 	"github.com/cosmos/cosmos-sdk/x/gov"
@@ -888,10 +887,10 @@ func TestProposalsQuery(t *testing.T) {
 
 //_____________________________________________________________________________
 // get the account to get the sequence
-func getAccount(t *testing.T, port string, addr sdk.AccAddress) auth.Account {
+func getAccount(t *testing.T, port string, addr sdk.AccAddress) sdk.Account {
 	res, body := Request(t, port, "GET", fmt.Sprintf("/auth/accounts/%s", addr.String()), nil)
 	require.Equal(t, http.StatusOK, res.StatusCode, body)
-	var acc auth.Account
+	var acc sdk.Account
 	err := cdc.UnmarshalJSON([]byte(body), &acc)
 	require.Nil(t, err)
 	return acc

--- a/cmd/gaia/app/export.go
+++ b/cmd/gaia/app/export.go
@@ -14,7 +14,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/gov"
 	"github.com/cosmos/cosmos-sdk/x/mint"
 	"github.com/cosmos/cosmos-sdk/x/slashing"
-	stake "github.com/cosmos/cosmos-sdk/x/stake"
+	"github.com/cosmos/cosmos-sdk/x/stake"
 )
 
 // export the state of gaia for a genesis file
@@ -30,7 +30,7 @@ func (app *GaiaApp) ExportAppStateAndValidators(forZeroHeight bool) (
 
 	// iterate to get the accounts
 	accounts := []GenesisAccount{}
-	appendAccount := func(acc auth.Account) (stop bool) {
+	appendAccount := func(acc sdk.Account) (stop bool) {
 		account := NewGenesisAccountI(acc)
 		accounts = append(accounts, account)
 		return false

--- a/cmd/gaia/app/genesis.go
+++ b/cmd/gaia/app/genesis.go
@@ -75,7 +75,7 @@ func NewGenesisAccount(acc *auth.BaseAccount) GenesisAccount {
 	}
 }
 
-func NewGenesisAccountI(acc auth.Account) GenesisAccount {
+func NewGenesisAccountI(acc sdk.Account) GenesisAccount {
 	return GenesisAccount{
 		Address:       acc.GetAddress(),
 		Coins:         acc.GetCoins(),

--- a/docs/examples/basecoin/app/app.go
+++ b/docs/examples/basecoin/app/app.go
@@ -71,7 +71,7 @@ func NewBasecoinApp(logger log.Logger, db dbm.DB, baseAppOptions ...func(*bam.Ba
 	app.accountKeeper = auth.NewAccountKeeper(
 		cdc,
 		app.keyAccount, // target store
-		func() auth.Account {
+		func() sdk.Account {
 			return &types.AppAccount{}
 		},
 	)
@@ -168,7 +168,7 @@ func (app *BasecoinApp) ExportAppStateAndValidators() (appState json.RawMessage,
 	ctx := app.NewContext(true, abci.Header{})
 	accounts := []*types.GenesisAccount{}
 
-	appendAccountsFn := func(acc auth.Account) bool {
+	appendAccountsFn := func(acc sdk.Account) bool {
 		account := &types.GenesisAccount{
 			Address: acc.GetAddress(),
 			Coins:   acc.GetCoins(),

--- a/docs/examples/basecoin/types/account.go
+++ b/docs/examples/basecoin/types/account.go
@@ -6,7 +6,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/auth"
 )
 
-var _ auth.Account = (*AppAccount)(nil)
+var _ sdk.Account = (*AppAccount)(nil)
 
 // AppAccount is a custom extension for this application. It is an example of
 // extending auth.BaseAccount with custom fields. It is compatible with the
@@ -31,7 +31,7 @@ func NewAppAccount(name string, baseAcct auth.BaseAccount) *AppAccount {
 // GetAccountDecoder returns the AccountDecoder function for the custom
 // AppAccount.
 func GetAccountDecoder(cdc *codec.Codec) auth.AccountDecoder {
-	return func(accBytes []byte) (auth.Account, error) {
+	return func(accBytes []byte) (sdk.Account, error) {
 		if len(accBytes) == 0 {
 			return nil, sdk.ErrTxDecode("accBytes are empty")
 		}

--- a/docs/examples/democoin/app/app.go
+++ b/docs/examples/democoin/app/app.go
@@ -12,16 +12,15 @@ import (
 
 	bam "github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/codec"
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/cosmos/cosmos-sdk/x/auth"
-	"github.com/cosmos/cosmos-sdk/x/bank"
-	"github.com/cosmos/cosmos-sdk/x/ibc"
-
 	"github.com/cosmos/cosmos-sdk/docs/examples/democoin/types"
 	"github.com/cosmos/cosmos-sdk/docs/examples/democoin/x/cool"
 	"github.com/cosmos/cosmos-sdk/docs/examples/democoin/x/pow"
 	"github.com/cosmos/cosmos-sdk/docs/examples/democoin/x/simplestake"
 	"github.com/cosmos/cosmos-sdk/docs/examples/democoin/x/sketchy"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/auth"
+	"github.com/cosmos/cosmos-sdk/x/bank"
+	"github.com/cosmos/cosmos-sdk/x/ibc"
 )
 
 const (
@@ -121,7 +120,7 @@ func MakeCodec() *codec.Codec {
 	simplestake.RegisterCodec(cdc)
 
 	// Register AppAccount
-	cdc.RegisterInterface((*auth.Account)(nil), nil)
+	cdc.RegisterInterface((*sdk.Account)(nil), nil)
 	cdc.RegisterConcrete(&types.AppAccount{}, "democoin/Account", nil)
 
 	cdc.Seal()
@@ -174,7 +173,7 @@ func (app *DemocoinApp) ExportAppStateAndValidators() (appState json.RawMessage,
 
 	// iterate to get the accounts
 	accounts := []*types.GenesisAccount{}
-	appendAccount := func(acc auth.Account) (stop bool) {
+	appendAccount := func(acc sdk.Account) (stop bool) {
 		account := &types.GenesisAccount{
 			Address: acc.GetAddress(),
 			Coins:   acc.GetCoins(),

--- a/docs/examples/democoin/types/account.go
+++ b/docs/examples/democoin/types/account.go
@@ -2,14 +2,13 @@ package types
 
 import (
 	"github.com/cosmos/cosmos-sdk/codec"
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/cosmos/cosmos-sdk/x/auth"
-
 	"github.com/cosmos/cosmos-sdk/docs/examples/democoin/x/cool"
 	"github.com/cosmos/cosmos-sdk/docs/examples/democoin/x/pow"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/auth"
 )
 
-var _ auth.Account = (*AppAccount)(nil)
+var _ sdk.Account = (*AppAccount)(nil)
 
 // Custom extensions for this application.  This is just an example of
 // extending auth.BaseAccount with custom fields.
@@ -22,7 +21,7 @@ type AppAccount struct {
 }
 
 // Constructor for AppAccount
-func ProtoAppAccount() auth.Account {
+func ProtoAppAccount() sdk.Account {
 	return &AppAccount{}
 }
 
@@ -32,7 +31,7 @@ func (acc *AppAccount) SetName(name string) { acc.Name = name }
 
 // Get the AccountDecoder function for the custom AppAccount
 func GetAccountDecoder(cdc *codec.Codec) auth.AccountDecoder {
-	return func(accBytes []byte) (res auth.Account, err error) {
+	return func(accBytes []byte) (res sdk.Account, err error) {
 		if len(accBytes) == 0 {
 			return nil, sdk.ErrTxDecode("accBytes are empty")
 		}

--- a/docs/examples/democoin/x/cool/app_test.go
+++ b/docs/examples/democoin/x/cool/app_test.go
@@ -9,7 +9,7 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/auth"
-	bank "github.com/cosmos/cosmos-sdk/x/bank"
+	"github.com/cosmos/cosmos-sdk/x/bank"
 	"github.com/cosmos/cosmos-sdk/x/mock"
 )
 
@@ -78,7 +78,7 @@ func TestMsgQuiz(t *testing.T) {
 		Address: addr1,
 		Coins:   nil,
 	}
-	accs := []auth.Account{acc1}
+	accs := []sdk.Account{acc1}
 
 	// Initialize the chain (nil)
 	mock.SetGenesis(mapp, accs)

--- a/docs/examples/democoin/x/pow/app_test.go
+++ b/docs/examples/democoin/x/pow/app_test.go
@@ -4,14 +4,13 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	abci "github.com/tendermint/tendermint/abci/types"
+	"github.com/tendermint/tendermint/crypto/ed25519"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/auth"
 	"github.com/cosmos/cosmos-sdk/x/bank"
 	"github.com/cosmos/cosmos-sdk/x/mock"
-
-	abci "github.com/tendermint/tendermint/abci/types"
-	"github.com/tendermint/tendermint/crypto/ed25519"
 )
 
 var (
@@ -62,7 +61,7 @@ func TestMsgMine(t *testing.T) {
 		Address: addr1,
 		Coins:   nil,
 	}
-	accs := []auth.Account{acc1}
+	accs := []sdk.Account{acc1}
 
 	// Initialize the chain (nil)
 	mock.SetGenesis(mapp, accs)

--- a/types/account.go
+++ b/types/account.go
@@ -1,0 +1,28 @@
+package types
+
+import "github.com/tendermint/tendermint/crypto"
+
+// Account is an interface used to store coins at a given address within state.
+// It presumes a notion of sequence numbers for replay protection,
+// a notion of account numbers for replay protection for previously pruned accounts,
+// and a pubkey for authentication purposes.
+//
+// Many complex conditions can be used in the concrete struct which implements Account.
+type Account interface {
+	GetAddress() AccAddress
+	SetAddress(AccAddress) error // errors if already set.
+
+	GetPubKey() crypto.PubKey // can return nil.
+	SetPubKey(crypto.PubKey) error
+
+	GetAccountNumber() uint64
+	SetAccountNumber(uint64) error
+
+	GetSequence() uint64
+	SetSequence(uint64) error
+
+	GetCoins() Coins
+	SetCoins(Coins) error
+
+	Clone() Account
+}

--- a/types/account_cache.go
+++ b/types/account_cache.go
@@ -1,0 +1,14 @@
+package types
+
+type AccountStoreCache interface {
+	GetAccount(addr AccAddress) Account
+	SetAccount(addr AccAddress, acc Account)
+	Delete(addr AccAddress)
+}
+
+type AccountCache interface {
+	AccountStoreCache
+
+	Cache() AccountCache
+	Write()
+}

--- a/types/context.go
+++ b/types/context.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/golang/protobuf/proto"
-
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/libs/log"
 )
@@ -143,6 +142,7 @@ const (
 	contextKeyBlockGasMeter
 	contextKeyMinimumFees
 	contextKeyConsensusParams
+	contextKeyAccountCache
 )
 
 func (c Context) MultiStore() MultiStore {
@@ -173,6 +173,10 @@ func (c Context) MinimumFees() Coins { return c.Value(contextKeyMinimumFees).(Co
 
 func (c Context) ConsensusParams() *abci.ConsensusParams {
 	return c.Value(contextKeyConsensusParams).(*abci.ConsensusParams)
+}
+
+func (c Context) AccountCache() AccountCache {
+	return c.Value(contextKeyAccountCache).(AccountCache)
 }
 
 func (c Context) WithMultiStore(ms MultiStore) Context {
@@ -228,6 +232,10 @@ func (c Context) WithMinimumFees(minFees Coins) Context {
 
 func (c Context) WithConsensusParams(params *abci.ConsensusParams) Context {
 	return c.withValue(contextKeyConsensusParams, params)
+}
+
+func (c Context) WithAccountCache(cache AccountCache) Context {
+	return c.withValue(contextKeyAccountCache, cache)
 }
 
 // Cache the multistore and return a new cached context. The cached context is

--- a/x/auth/ante.go
+++ b/x/auth/ante.go
@@ -116,8 +116,8 @@ func NewAnteHandler(am AccountKeeper, fck FeeCollectionKeeper) sdk.AnteHandler {
 	}
 }
 
-func getSignerAccs(ctx sdk.Context, am AccountKeeper, addrs []sdk.AccAddress) (accs []Account, res sdk.Result) {
-	accs = make([]Account, len(addrs))
+func getSignerAccs(ctx sdk.Context, am AccountKeeper, addrs []sdk.AccAddress) (accs []sdk.Account, res sdk.Result) {
+	accs = make([]sdk.Account, len(addrs))
 	for i := 0; i < len(accs); i++ {
 		accs[i] = am.GetAccount(ctx, addrs[i])
 		if accs[i] == nil {
@@ -131,8 +131,8 @@ func getSignerAccs(ctx sdk.Context, am AccountKeeper, addrs []sdk.AccAddress) (a
 // verify the signature and increment the sequence. If the account doesn't have
 // a pubkey, set it.
 func processSig(
-	ctx sdk.Context, acc Account, sig StdSignature, signBytes []byte, simulate bool,
-) (updatedAcc Account, res sdk.Result) {
+	ctx sdk.Context, acc sdk.Account, sig StdSignature, signBytes []byte, simulate bool,
+) (updatedAcc sdk.Account, res sdk.Result) {
 
 	pubKey, res := processPubKey(acc, sig, simulate)
 	if !res.IsOK() {
@@ -165,7 +165,7 @@ func init() {
 	copy(dummySecp256k1Pubkey[:], bz)
 }
 
-func processPubKey(acc Account, sig StdSignature, simulate bool) (crypto.PubKey, sdk.Result) {
+func processPubKey(acc sdk.Account, sig StdSignature, simulate bool) (crypto.PubKey, sdk.Result) {
 	// If pubkey is not known for account, set it from the StdSignature.
 	pubKey := acc.GetPubKey()
 	if simulate {
@@ -222,7 +222,7 @@ func adjustFeesByGas(fees sdk.Coins, gas uint64) sdk.Coins {
 // Deduct the fee from the account.
 // We could use the CoinKeeper (in addition to the AccountKeeper,
 // because the CoinKeeper doesn't give us accounts), but it seems easier to do this.
-func deductFees(acc Account, fee StdFee) (Account, sdk.Result) {
+func deductFees(acc sdk.Account, fee StdFee) (sdk.Account, sdk.Result) {
 	coins := acc.GetCoins()
 	feeAmount := fee.Amount
 
@@ -280,7 +280,7 @@ func setGasMeter(simulate bool, ctx sdk.Context, stdTx StdTx) sdk.Context {
 	return ctx.WithGasMeter(sdk.NewGasMeter(stdTx.Fee.Gas))
 }
 
-func getSignBytesList(chainID string, stdTx StdTx, accs []Account, genesis bool) (signatureBytesList [][]byte) {
+func getSignBytesList(chainID string, stdTx StdTx, accs []sdk.Account, genesis bool) (signatureBytesList [][]byte) {
 	signatureBytesList = make([][]byte, len(accs))
 	for i := 0; i < len(accs); i++ {
 		accNum := accs[i].GetAccountNumber()

--- a/x/auth/ante_test.go
+++ b/x/auth/ante_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/tendermint/tendermint/crypto/secp256k1"
 	"github.com/tendermint/tendermint/libs/log"
 
-	codec "github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -649,7 +649,7 @@ func TestProcessPubKey(t *testing.T) {
 	priv2, _ := privAndAddr()
 	acc1 := mapper.NewAccountWithAddress(ctx, addr1)
 	type args struct {
-		acc      Account
+		acc      sdk.Account
 		sig      StdSignature
 		simulate bool
 	}

--- a/x/auth/codec.go
+++ b/x/auth/codec.go
@@ -2,11 +2,12 @@ package auth
 
 import (
 	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/types"
 )
 
 // Register concrete types on codec codec for default AppAccount
 func RegisterCodec(cdc *codec.Codec) {
-	cdc.RegisterInterface((*Account)(nil), nil)
+	cdc.RegisterInterface((*types.Account)(nil), nil)
 	cdc.RegisterConcrete(&BaseAccount{}, "auth/Account", nil)
 	cdc.RegisterConcrete(StdTx{}, "auth/StdTx", nil)
 }

--- a/x/auth/context.go
+++ b/x/auth/context.go
@@ -34,15 +34,15 @@ const (
 )
 
 // add the signers to the context
-func WithSigners(ctx types.Context, accounts []Account) types.Context {
+func WithSigners(ctx types.Context, accounts []types.Account) types.Context {
 	return ctx.WithValue(contextKeySigners, accounts)
 }
 
 // get the signers from the context
-func GetSigners(ctx types.Context) []Account {
+func GetSigners(ctx types.Context) []types.Account {
 	v := ctx.Value(contextKeySigners)
 	if v == nil {
-		return []Account{}
+		return []types.Account{}
 	}
-	return v.([]Account)
+	return v.([]types.Account)
 }

--- a/x/auth/context_test.go
+++ b/x/auth/context_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/libs/log"
 
@@ -26,7 +25,7 @@ func TestContextWithSigners(t *testing.T) {
 	signers := GetSigners(ctx)
 	require.Equal(t, 0, len(signers))
 
-	ctx2 := WithSigners(ctx, []Account{&acc1, &acc2})
+	ctx2 := WithSigners(ctx, []sdk.Account{&acc1, &acc2})
 
 	// original context is unchanged
 	signers = GetSigners(ctx)

--- a/x/bank/app_test.go
+++ b/x/bank/app_test.go
@@ -3,15 +3,14 @@ package bank
 import (
 	"testing"
 
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/cosmos/cosmos-sdk/x/auth"
-	"github.com/cosmos/cosmos-sdk/x/mock"
-
 	"github.com/stretchr/testify/require"
-
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/crypto"
 	"github.com/tendermint/tendermint/crypto/ed25519"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/auth"
+	"github.com/cosmos/cosmos-sdk/x/mock"
 )
 
 type (
@@ -98,7 +97,7 @@ func TestMsgSendWithAccounts(t *testing.T) {
 		Coins:   sdk.Coins{sdk.NewInt64Coin("foocoin", 67)},
 	}
 
-	mock.SetGenesis(mapp, []auth.Account{acc})
+	mock.SetGenesis(mapp, []sdk.Account{acc})
 
 	ctxCheck := mapp.BaseApp.NewContext(true, abci.Header{})
 
@@ -150,7 +149,7 @@ func TestMsgSendMultipleOut(t *testing.T) {
 		Coins:   sdk.Coins{sdk.NewInt64Coin("foocoin", 42)},
 	}
 
-	mock.SetGenesis(mapp, []auth.Account{acc1, acc2})
+	mock.SetGenesis(mapp, []sdk.Account{acc1, acc2})
 
 	testCases := []appTestCase{
 		{
@@ -193,7 +192,7 @@ func TestSengMsgMultipleInOut(t *testing.T) {
 		Coins:   sdk.Coins{sdk.NewInt64Coin("foocoin", 42)},
 	}
 
-	mock.SetGenesis(mapp, []auth.Account{acc1, acc2, acc4})
+	mock.SetGenesis(mapp, []sdk.Account{acc1, acc2, acc4})
 
 	testCases := []appTestCase{
 		{
@@ -229,7 +228,7 @@ func TestMsgSendDependent(t *testing.T) {
 		Coins:   sdk.Coins{sdk.NewInt64Coin("foocoin", 42)},
 	}
 
-	mock.SetGenesis(mapp, []auth.Account{acc1})
+	mock.SetGenesis(mapp, []sdk.Account{acc1})
 
 	testCases := []appTestCase{
 		{

--- a/x/bank/bench_test.go
+++ b/x/bank/bench_test.go
@@ -3,11 +3,11 @@ package bank
 import (
 	"testing"
 
+	abci "github.com/tendermint/tendermint/abci/types"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/auth"
 	"github.com/cosmos/cosmos-sdk/x/mock"
-
-	abci "github.com/tendermint/tendermint/abci/types"
 )
 
 // getBenchmarkMockApp initializes a mock application for this module, for purposes of benchmarking
@@ -32,7 +32,7 @@ func BenchmarkOneBankSendTxPerBlock(b *testing.B) {
 		// Some value conceivably higher than the benchmarks would ever go
 		Coins: sdk.Coins{sdk.NewInt64Coin("foocoin", 100000000000)},
 	}
-	accs := []auth.Account{acc}
+	accs := []sdk.Account{acc}
 
 	// Construct genesis state
 	mock.SetGenesis(benchmarkApp, accs)

--- a/x/bank/simulation/invariants.go
+++ b/x/bank/simulation/invariants.go
@@ -32,7 +32,7 @@ func TotalCoinsInvariant(mapper auth.AccountKeeper, totalSupplyFn func() sdk.Coi
 	return func(ctx sdk.Context) error {
 		totalCoins := sdk.Coins{}
 
-		chkAccount := func(acc auth.Account) bool {
+		chkAccount := func(acc sdk.Account) bool {
 			coins := acc.GetCoins()
 			totalCoins = totalCoins.Plus(coins)
 			return false

--- a/x/ibc/app_test.go
+++ b/x/ibc/app_test.go
@@ -4,14 +4,13 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	abci "github.com/tendermint/tendermint/abci/types"
+	"github.com/tendermint/tendermint/crypto/ed25519"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/auth"
 	"github.com/cosmos/cosmos-sdk/x/bank"
 	"github.com/cosmos/cosmos-sdk/x/mock"
-
-	abci "github.com/tendermint/tendermint/abci/types"
-	"github.com/tendermint/tendermint/crypto/ed25519"
 )
 
 // initialize the mock application for this module
@@ -43,7 +42,7 @@ func TestIBCMsgs(t *testing.T) {
 		Address: addr1,
 		Coins:   coins,
 	}
-	accs := []auth.Account{acc}
+	accs := []sdk.Account{acc}
 
 	mock.SetGenesis(mapp, accs)
 

--- a/x/ibc/ibc_test.go
+++ b/x/ibc/ibc_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/crypto/ed25519"
 	dbm "github.com/tendermint/tendermint/libs/db"
@@ -48,7 +47,7 @@ func makeCodec() *codec.Codec {
 	cdc.RegisterConcrete(IBCReceiveMsg{}, "test/ibc/IBCReceiveMsg", nil)
 
 	// Register AppAccount
-	cdc.RegisterInterface((*auth.Account)(nil), nil)
+	cdc.RegisterInterface((*sdk.Account)(nil), nil)
 	cdc.RegisterConcrete(&auth.BaseAccount{}, "test/ibc/Account", nil)
 	codec.RegisterCrypto(cdc)
 

--- a/x/mock/app.go
+++ b/x/mock/app.go
@@ -35,7 +35,7 @@ type App struct {
 	AccountKeeper       auth.AccountKeeper
 	FeeCollectionKeeper auth.FeeCollectionKeeper
 
-	GenesisAccounts  []auth.Account
+	GenesisAccounts  []sdk.Account
 	TotalCoinsSupply sdk.Coins
 }
 
@@ -145,7 +145,7 @@ func (b AddrKeysSlice) Swap(i, j int) {
 
 // CreateGenAccounts generates genesis accounts loaded with coins, and returns
 // their addresses, pubkeys, and privkeys.
-func CreateGenAccounts(numAccs int, genCoins sdk.Coins) (genAccs []auth.Account, addrs []sdk.AccAddress, pubKeys []crypto.PubKey, privKeys []crypto.PrivKey) {
+func CreateGenAccounts(numAccs int, genCoins sdk.Coins) (genAccs []sdk.Account, addrs []sdk.AccAddress, pubKeys []crypto.PubKey, privKeys []crypto.PrivKey) {
 	addrKeysSlice := AddrKeysSlice{}
 
 	for i := 0; i < numAccs; i++ {
@@ -176,7 +176,7 @@ func CreateGenAccounts(numAccs int, genCoins sdk.Coins) (genAccs []auth.Account,
 }
 
 // SetGenesis sets the mock app genesis accounts.
-func SetGenesis(app *App, accs []auth.Account) {
+func SetGenesis(app *App, accs []sdk.Account) {
 	// Pass the accounts in via the application (lazy) instead of through
 	// RequestInitChain.
 	app.GenesisAccounts = accs
@@ -263,7 +263,7 @@ func GeneratePrivKeyAddressPairsFromRand(rand *rand.Rand, n int) (keys []crypto.
 // provided addresses and coin denominations.
 // nolint: errcheck
 func RandomSetGenesis(r *rand.Rand, app *App, addrs []sdk.AccAddress, denoms []string) {
-	accts := make([]auth.Account, len(addrs), len(addrs))
+	accts := make([]sdk.Account, len(addrs), len(addrs))
 	randCoinIntervals := []BigInterval{
 		{sdk.NewIntWithDecimal(1, 0), sdk.NewIntWithDecimal(1, 1)},
 		{sdk.NewIntWithDecimal(1, 2), sdk.NewIntWithDecimal(1, 3)},
@@ -290,9 +290,9 @@ func RandomSetGenesis(r *rand.Rand, app *App, addrs []sdk.AccAddress, denoms []s
 }
 
 // GetAllAccounts returns all accounts in the accountKeeper.
-func GetAllAccounts(mapper auth.AccountKeeper, ctx sdk.Context) []auth.Account {
-	accounts := []auth.Account{}
-	appendAccount := func(acc auth.Account) (stop bool) {
+func GetAllAccounts(mapper auth.AccountKeeper, ctx sdk.Context) []sdk.Account {
+	accounts := []sdk.Account{}
+	appendAccount := func(acc sdk.Account) (stop bool) {
 		accounts = append(accounts, acc)
 		return false
 	}

--- a/x/slashing/app_test.go
+++ b/x/slashing/app_test.go
@@ -103,7 +103,7 @@ func TestSlashingMsgs(t *testing.T) {
 		Address: addr1,
 		Coins:   sdk.Coins{genCoin},
 	}
-	accs := []auth.Account{acc1}
+	accs := []sdk.Account{acc1}
 	mock.SetGenesis(mapp, accs)
 
 	description := stake.NewDescription("foo_moniker", "", "", "")

--- a/x/stake/app_test.go
+++ b/x/stake/app_test.go
@@ -114,7 +114,7 @@ func TestStakeMsgs(t *testing.T) {
 		Address: addr2,
 		Coins:   sdk.Coins{genCoin},
 	}
-	accs := []auth.Account{acc1, acc2}
+	accs := []sdk.Account{acc1, acc2}
 
 	mock.SetGenesis(mApp, accs)
 	mock.CheckBalance(t, mApp, addr1, sdk.Coins{genCoin})

--- a/x/stake/keeper/test_common.go
+++ b/x/stake/keeper/test_common.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/crypto"
 	"github.com/tendermint/tendermint/crypto/ed25519"
@@ -67,7 +66,7 @@ func MakeTestCodec() *codec.Codec {
 	cdc.RegisterConcrete(types.MsgBeginRedelegate{}, "test/stake/BeginRedelegate", nil)
 
 	// Register AppAccount
-	cdc.RegisterInterface((*auth.Account)(nil), nil)
+	cdc.RegisterInterface((*sdk.Account)(nil), nil)
 	cdc.RegisterConcrete(&auth.BaseAccount{}, "test/stake/Account", nil)
 	codec.RegisterCrypto(cdc)
 

--- a/x/stake/simulation/invariants.go
+++ b/x/stake/simulation/invariants.go
@@ -54,7 +54,7 @@ func SupplyInvariants(ck bank.Keeper, k stake.Keeper,
 
 		loose := sdk.ZeroDec()
 		bonded := sdk.ZeroDec()
-		am.IterateAccounts(ctx, func(acc auth.Account) bool {
+		am.IterateAccounts(ctx, func(acc sdk.Account) bool {
 			loose = loose.Add(sdk.NewDecFromInt(acc.GetCoins().AmountOf(stakeTypes.DefaultBondDenom)))
 			return false
 		})


### PR DESCRIPTION
Ref: #2652

Add a lru cache for Account because getting and setting accounts happened frequently(CheckTx and DeliverTx) and decoding is time-consuming.