### PR TITLE
Do not allow nil values to be set in CacheKVStore

### DIFF
--- a/PENDING.md
+++ b/PENDING.md
@@ -52,7 +52,8 @@ IMPROVEMENTS
  - \#2660 [x/mock/simulation] Staking transactions get tested far more frequently
  - \#2610 [x/stake] Block redelegation to and from the same validator
  - \#2652 [x/auth] Add benchmark for get and set account
- - \#2685 [x/store] Add general merkle absence proof (also for empty substores)
+ - \#2685 [store] Add general merkle absence proof (also for empty substores)
+ - \#2708 [store] Disallow setting nil values
 
 * Tendermint
 

--- a/store/cachekvstore.go
+++ b/store/cachekvstore.go
@@ -61,6 +61,7 @@ func (ci *cacheKVStore) Set(key []byte, value []byte) {
 	ci.mtx.Lock()
 	defer ci.mtx.Unlock()
 	ci.assertValidKey(key)
+	ci.assertValidValue(value)
 
 	ci.setCacheValue(key, value, false, true)
 }
@@ -193,6 +194,12 @@ func (ci *cacheKVStore) dirtyItems(ascending bool) []cmn.KVPair {
 func (ci *cacheKVStore) assertValidKey(key []byte) {
 	if key == nil {
 		panic("key is nil")
+	}
+}
+
+func (ci *cacheKVStore) assertValidValue(value []byte) {
+	if value == nil {
+		panic("value is nil")
 	}
 }
 

--- a/types/store.go
+++ b/types/store.go
@@ -127,7 +127,7 @@ type KVStore interface {
 	// Has checks if a key exists. Panics on nil key.
 	Has(key []byte) bool
 
-	// Set sets the key. Panics on nil key.
+	// Set sets the key. Panics on nil key or value.
 	Set(key, value []byte)
 
 	// Delete deletes the key. Panics on nil key.


### PR DESCRIPTION
Haven't written tests, but merging for 0.26.0 before I forget.
Also added an issue for testing: https://github.com/cosmos/cosmos-sdk/issues/2707