### PR TITLE
Gaia-9000: Update to TM 0.26.1-rc2

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -165,12 +165,13 @@
   version = "v1.2.0"
 
 [[projects]]
-  digest = "1:ea40c24cdbacd054a6ae9de03e62c5f252479b96c716375aace5c120d68647c8"
+  digest = "1:c0d19ab64b32ce9fe5cf4ddceba78d5bc9807f0016db6b1183599da3dcc24d10"
   name = "github.com/hashicorp/hcl"
   packages = [
     ".",
     "hcl/ast",
     "hcl/parser",
+    "hcl/printer",
     "hcl/scanner",
     "hcl/strconv",
     "hcl/token",
@@ -434,7 +435,7 @@
   version = "v0.11.1"
 
 [[projects]]
-  digest = "1:0ca6fdbc80b4082637066772fce683f8f8913b44aa5a91114d1dc1b48b3b2dad"
+  digest = "1:fc6b632a318f32a77b2bd4c60c6c9276ce82256a4bb0b67b4c8bebac4d367622"
   name = "github.com/tendermint/tendermint"
   packages = [
     "abci/client",
@@ -500,8 +501,8 @@
     "version",
   ]
   pruneopts = "UT"
-  revision = "6e9aee546061423864fef3f9fa332ef37c3dca96"
-  version = "v0.26.1-rc1"
+  revision = "58574b7372cc9dd224ef04aaa438578f72e69a77"
+  version = "v0.26.1-rc2"
 
 [[projects]]
   digest = "1:7886f86064faff6f8d08a3eb0e8c773648ff5a2e27730831e2bfbf07467f6666"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -298,7 +298,7 @@
     "model",
   ]
   pruneopts = "UT"
-  revision = "7e9e6cabbd393fc208072eedef99188d0ce788b6"
+  revision = "0b1957f9d949dfa3084171a6ec5642b38055276a"
 
 [[projects]]
   branch = "master"
@@ -434,7 +434,7 @@
   version = "v0.11.1"
 
 [[projects]]
-  digest = "1:395820b381043b9d2204e181ddf0f9147397c4a7b8f5dc3162de4cfcddf4589a"
+  digest = "1:0ca6fdbc80b4082637066772fce683f8f8913b44aa5a91114d1dc1b48b3b2dad"
   name = "github.com/tendermint/tendermint"
   packages = [
     "abci/client",
@@ -500,8 +500,8 @@
     "version",
   ]
   pruneopts = "UT"
-  revision = "03e42d2e3866f01a00625f608e3bbfaeb30690de"
-  version = "v0.26.1-rc0"
+  revision = "6e9aee546061423864fef3f9fa332ef37c3dca96"
+  version = "v0.26.1-rc1"
 
 [[projects]]
   digest = "1:7886f86064faff6f8d08a3eb0e8c773648ff5a2e27730831e2bfbf07467f6666"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -36,7 +36,7 @@
 
 [[override]]
   name = "github.com/tendermint/tendermint"
-  version = "v0.26.1-rc1" # TODO replace w/ 0.26.1
+  version = "v0.26.1-rc2" # TODO replace w/ 0.26.1
 
 ## deps without releases:
 

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -36,7 +36,7 @@
 
 [[override]]
   name = "github.com/tendermint/tendermint"
-  version = "v0.26.1-rc0" # TODO replace w/ 0.26.1
+  version = "v0.26.1-rc1" # TODO replace w/ 0.26.1
 
 ## deps without releases:
 


### PR DESCRIPTION
This PR is to fix the tendermint related issues we are running into with the current testnet. There are two:

- Prometheus is broken. This PR currently fixes that issue
- Seed nodes don't sync for some reason. Fix is currently being worked on here.