### PR TITLE
[R4R] Update to tendermint v0.26.1

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -434,7 +434,7 @@
   version = "v0.11.1"
 
 [[projects]]
-  digest = "1:5b1373b03f39e6f6061cd91f3829100527ebb5f94240c092bf9e5d314b153501"
+  digest = "1:ba2ba7d6a0853472bdb7a64c4f9c1d5f9cba0eb7aac0b024654104387bf5eb57"
   name = "github.com/tendermint/tendermint"
   packages = [
     "abci/client",
@@ -500,8 +500,8 @@
     "version",
   ]
   pruneopts = "UT"
-  revision = "48ab899923c564bbf2fa2f1244c11cb930e28132"
-  version = "v0.26.1-rc3"
+  revision = "80d0a362500fea2dd089258319075a54e5d40a2d"
+  version = "v0.26.1"
 
 [[projects]]
   digest = "1:7886f86064faff6f8d08a3eb0e8c773648ff5a2e27730831e2bfbf07467f6666"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -36,7 +36,7 @@
 
 [[override]]
   name = "github.com/tendermint/tendermint"
-  version = "v0.26.1-rc3" # TODO replace w/ 0.26.1
+  version = "v0.26.1"
 
 ## deps without releases:
 


### PR DESCRIPTION
Simple upgrade to actual released version instead of rc (released this morning).