### PR TITLE
R4R: Fix baseapp ante handler simulation mode bug

### DIFF
--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -660,7 +660,9 @@ func (app *BaseApp) runTx(mode runTxMode, txBytes []byte, tx sdk.Tx) (result sdk
 		if !newCtx.IsZero() {
 			ctx = newCtx
 		}
-		msCache.Write()
+		if mode != runTxModeSimulate {
+			msCache.Write()
+		}
 		gasWanted = result.GasWanted
 	}
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Fixes the CI failures introduced by https://github.com/cosmos/cosmos-sdk/pull/2781#issuecomment-439513042. The failing test was correct - we were calling `msCache.Write()` after the ante handler when simulating transactions, which should not happen - instead we should not write any state when simulating.

edit: See below comments.

- [x] Wrote tests
- [x] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
