### PR TITLE
R4R: gaiad gentx subcommands refactoring

### DIFF
--- a/PENDING.md
+++ b/PENDING.md
@@ -10,7 +10,7 @@ BREAKING CHANGES
   * [cli] [\#2786](https://github.com/cosmos/cosmos-sdk/pull/2786) Fix redelegation command flow
   * [cli] [\#2829](https://github.com/cosmos/cosmos-sdk/pull/2829) add-genesis-account command now validates state when adding accounts
   * [cli] [\#2804](https://github.com/cosmos/cosmos-sdk/issues/2804) Check whether key exists before passing it on to `tx create-validator`.
-  * [cli] [\#2874](https://github.com/cosmos/cosmos-sdk/pull/2874) `gaiacli tx sign` takes an optional `--output-document/-O` flag to support output redirection.
+  * [cli] [\#2874](https://github.com/cosmos/cosmos-sdk/pull/2874) `gaiacli tx sign` takes an optional `--output-document` flag to support output redirection.
 
 * Gaia
 

--- a/PENDING.md
+++ b/PENDING.md
@@ -10,6 +10,7 @@ BREAKING CHANGES
   * [cli] [\#2786](https://github.com/cosmos/cosmos-sdk/pull/2786) Fix redelegation command flow
   * [cli] [\#2829](https://github.com/cosmos/cosmos-sdk/pull/2829) add-genesis-account command now validates state when adding accounts
   * [cli] [\#2804](https://github.com/cosmos/cosmos-sdk/issues/2804) Check whether key exists before passing it on to `tx create-validator`.
+  * [cli] [\#2874](https://github.com/cosmos/cosmos-sdk/pull/2874) `gaiacli tx sign` takes an optional `--output-document/-O` flag to support output redirection.
 
 * Gaia
 

--- a/client/utils/utils.go
+++ b/client/utils/utils.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/cosmos/cosmos-sdk/client/context"
@@ -88,7 +89,7 @@ func CalculateGas(queryFunc func(string, common.HexBytes) ([]byte, error), cdc *
 
 // PrintUnsignedStdTx builds an unsigned StdTx and prints it to os.Stdout.
 // Don't perform online validation or lookups if offline is true.
-func PrintUnsignedStdTx(txBldr authtxb.TxBuilder, cliCtx context.CLIContext, msgs []sdk.Msg, offline bool) (err error) {
+func PrintUnsignedStdTx(w io.Writer, txBldr authtxb.TxBuilder, cliCtx context.CLIContext, msgs []sdk.Msg, offline bool) (err error) {
 	var stdTx auth.StdTx
 	if offline {
 		stdTx, err = buildUnsignedStdTxOffline(txBldr, cliCtx, msgs)
@@ -100,7 +101,7 @@ func PrintUnsignedStdTx(txBldr authtxb.TxBuilder, cliCtx context.CLIContext, msg
 	}
 	json, err := txBldr.Codec.MarshalJSON(stdTx)
 	if err == nil {
-		fmt.Printf("%s\n", json)
+		fmt.Fprintf(w, "%s\n", json)
 	}
 	return
 }

--- a/x/bank/client/cli/sendtx.go
+++ b/x/bank/client/cli/sendtx.go
@@ -8,6 +8,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtxb "github.com/cosmos/cosmos-sdk/x/auth/client/txbuilder"
 	bankClient "github.com/cosmos/cosmos-sdk/x/bank/client"
+	"os"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -66,7 +67,7 @@ func SendTxCmd(cdc *codec.Codec) *cobra.Command {
 			// build and sign the transaction, then broadcast to Tendermint
 			msg := bankClient.CreateMsg(from, to, coins)
 			if cliCtx.GenerateOnly {
-				return utils.PrintUnsignedStdTx(txBldr, cliCtx, []sdk.Msg{msg}, false)
+				return utils.PrintUnsignedStdTx(os.Stdout, txBldr, cliCtx, []sdk.Msg{msg}, false)
 			}
 
 			return utils.CompleteAndBroadcastTxCli(txBldr, cliCtx, []sdk.Msg{msg})

--- a/x/gov/client/cli/tx.go
+++ b/x/gov/client/cli/tx.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/cosmos/cosmos-sdk/client/context"
 	"github.com/cosmos/cosmos-sdk/client/utils"
@@ -103,7 +104,7 @@ $ gaiacli gov submit-proposal --title="Test Proposal" --description="My awesome 
 			}
 
 			if cliCtx.GenerateOnly {
-				return utils.PrintUnsignedStdTx(txBldr, cliCtx, []sdk.Msg{msg}, false)
+				return utils.PrintUnsignedStdTx(os.Stdout, txBldr, cliCtx, []sdk.Msg{msg}, false)
 			}
 
 			// Build and sign the transaction, then broadcast to Tendermint
@@ -183,7 +184,7 @@ func GetCmdDeposit(cdc *codec.Codec) *cobra.Command {
 			}
 
 			if cliCtx.GenerateOnly {
-				return utils.PrintUnsignedStdTx(txBldr, cliCtx, []sdk.Msg{msg}, false)
+				return utils.PrintUnsignedStdTx(os.Stdout, txBldr, cliCtx, []sdk.Msg{msg}, false)
 			}
 
 			// Build and sign the transaction, then broadcast to a Tendermint
@@ -229,7 +230,7 @@ func GetCmdVote(cdc *codec.Codec) *cobra.Command {
 			}
 
 			if cliCtx.GenerateOnly {
-				return utils.PrintUnsignedStdTx(txBldr, cliCtx, []sdk.Msg{msg}, false)
+				return utils.PrintUnsignedStdTx(os.Stdout, txBldr, cliCtx, []sdk.Msg{msg}, false)
 			}
 
 			fmt.Printf("Vote[Voter:%s,ProposalID:%d,Option:%s]",

--- a/x/ibc/client/cli/ibctx.go
+++ b/x/ibc/client/cli/ibctx.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"encoding/hex"
+	"os"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/context"
@@ -41,7 +42,7 @@ func IBCTransferCmd(cdc *codec.Codec) *cobra.Command {
 				return err
 			}
 			if cliCtx.GenerateOnly {
-				return utils.PrintUnsignedStdTx(txBldr, cliCtx, []sdk.Msg{msg}, false)
+				return utils.PrintUnsignedStdTx(os.Stdout, txBldr, cliCtx, []sdk.Msg{msg}, false)
 			}
 
 			return utils.CompleteAndBroadcastTxCli(txBldr, cliCtx, []sdk.Msg{msg})

--- a/x/slashing/client/cli/tx.go
+++ b/x/slashing/client/cli/tx.go
@@ -7,6 +7,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtxb "github.com/cosmos/cosmos-sdk/x/auth/client/txbuilder"
 	"github.com/cosmos/cosmos-sdk/x/slashing"
+	"os"
 
 	"github.com/spf13/cobra"
 )
@@ -30,7 +31,7 @@ func GetCmdUnjail(cdc *codec.Codec) *cobra.Command {
 
 			msg := slashing.NewMsgUnjail(sdk.ValAddress(valAddr))
 			if cliCtx.GenerateOnly {
-				return utils.PrintUnsignedStdTx(txBldr, cliCtx, []sdk.Msg{msg}, false)
+				return utils.PrintUnsignedStdTx(os.Stdout, txBldr, cliCtx, []sdk.Msg{msg}, false)
 			}
 			return utils.CompleteAndBroadcastTxCli(txBldr, cliCtx, []sdk.Msg{msg})
 		},

--- a/x/stake/client/cli/tx.go
+++ b/x/stake/client/cli/tx.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/context"
@@ -26,76 +27,13 @@ func GetCmdCreateValidator(cdc *codec.Codec) *cobra.Command {
 				WithCodec(cdc).
 				WithAccountDecoder(cdc)
 
-			amounstStr := viper.GetString(FlagAmount)
-			if amounstStr == "" {
-				return fmt.Errorf("Must specify amount to stake using --amount")
-			}
-			amount, err := sdk.ParseCoin(amounstStr)
+			cliCtx, txBldr, msg, err := BuildCreateValidatorMsg(cliCtx, txBldr)
 			if err != nil {
 				return err
-			}
-
-			valAddr, err := cliCtx.GetFromAddress()
-			if err != nil {
-				return err
-			}
-
-			pkStr := viper.GetString(FlagPubKey)
-			if len(pkStr) == 0 {
-				return fmt.Errorf("must use --pubkey flag")
-			}
-
-			pk, err := sdk.GetConsPubKeyBech32(pkStr)
-			if err != nil {
-				return err
-			}
-
-			if viper.GetString(FlagMoniker) == "" {
-				return fmt.Errorf("please enter a moniker for the validator using --moniker")
-			}
-
-			description := stake.Description{
-				Moniker:  viper.GetString(FlagMoniker),
-				Identity: viper.GetString(FlagIdentity),
-				Website:  viper.GetString(FlagWebsite),
-				Details:  viper.GetString(FlagDetails),
-			}
-
-			// get the initial validator commission parameters
-			rateStr := viper.GetString(FlagCommissionRate)
-			maxRateStr := viper.GetString(FlagCommissionMaxRate)
-			maxChangeRateStr := viper.GetString(FlagCommissionMaxChangeRate)
-			commissionMsg, err := buildCommissionMsg(rateStr, maxRateStr, maxChangeRateStr)
-			if err != nil {
-				return err
-			}
-
-			var msg sdk.Msg
-			if viper.GetString(FlagAddressDelegator) != "" {
-				delAddr, err := sdk.AccAddressFromBech32(viper.GetString(FlagAddressDelegator))
-				if err != nil {
-					return err
-				}
-
-				msg = stake.NewMsgCreateValidatorOnBehalfOf(
-					delAddr, sdk.ValAddress(valAddr), pk, amount, description, commissionMsg,
-				)
-			} else {
-				msg = stake.NewMsgCreateValidator(
-					sdk.ValAddress(valAddr), pk, amount, description, commissionMsg,
-				)
-			}
-
-			if viper.GetBool(FlagGenesisFormat) {
-				ip := viper.GetString(FlagIP)
-				nodeID := viper.GetString(FlagNodeID)
-				if nodeID != "" && ip != "" {
-					txBldr = txBldr.WithMemo(fmt.Sprintf("%s@%s:26656", nodeID, ip))
-				}
 			}
 
 			if viper.GetBool(FlagGenesisFormat) || cliCtx.GenerateOnly {
-				return utils.PrintUnsignedStdTx(txBldr, cliCtx, []sdk.Msg{msg}, true)
+				return utils.PrintUnsignedStdTx(os.Stdout, txBldr, cliCtx, []sdk.Msg{msg}, true)
 			}
 
 			// build and sign the transaction, then broadcast to Tendermint
@@ -112,6 +50,9 @@ func GetCmdCreateValidator(cdc *codec.Codec) *cobra.Command {
 	cmd.Flags().String(FlagIP, "", fmt.Sprintf("Node's public IP. It takes effect only when used in combination with --%s", FlagGenesisFormat))
 	cmd.Flags().String(FlagNodeID, "", "Node's ID")
 	cmd.MarkFlagRequired(client.FlagFrom)
+	cmd.MarkFlagRequired(FlagAmount)
+	cmd.MarkFlagRequired(FlagPubKey)
+	cmd.MarkFlagRequired(FlagMoniker)
 
 	return cmd
 }
@@ -154,7 +95,7 @@ func GetCmdEditValidator(cdc *codec.Codec) *cobra.Command {
 			msg := stake.NewMsgEditValidator(sdk.ValAddress(valAddr), description, newRate)
 
 			if cliCtx.GenerateOnly {
-				return utils.PrintUnsignedStdTx(txBldr, cliCtx, []sdk.Msg{msg}, false)
+				return utils.PrintUnsignedStdTx(os.Stdout, txBldr, cliCtx, []sdk.Msg{msg}, false)
 			}
 
 			// build and sign the transaction, then broadcast to Tendermint
@@ -197,7 +138,7 @@ func GetCmdDelegate(cdc *codec.Codec) *cobra.Command {
 			msg := stake.NewMsgDelegate(delAddr, valAddr, amount)
 
 			if cliCtx.GenerateOnly {
-				return utils.PrintUnsignedStdTx(txBldr, cliCtx, []sdk.Msg{msg}, false)
+				return utils.PrintUnsignedStdTx(os.Stdout, txBldr, cliCtx, []sdk.Msg{msg}, false)
 			}
 			// build and sign the transaction, then broadcast to Tendermint
 			return utils.CompleteAndBroadcastTxCli(txBldr, cliCtx, []sdk.Msg{msg})
@@ -252,7 +193,7 @@ func GetCmdRedelegate(storeName string, cdc *codec.Codec) *cobra.Command {
 			msg := stake.NewMsgBeginRedelegate(delAddr, valSrcAddr, valDstAddr, sharesAmount)
 
 			if cliCtx.GenerateOnly {
-				return utils.PrintUnsignedStdTx(txBldr, cliCtx, []sdk.Msg{msg}, false)
+				return utils.PrintUnsignedStdTx(os.Stdout, txBldr, cliCtx, []sdk.Msg{msg}, false)
 			}
 			// build and sign the transaction, then broadcast to Tendermint
 			return utils.CompleteAndBroadcastTxCli(txBldr, cliCtx, []sdk.Msg{msg})
@@ -300,7 +241,7 @@ func GetCmdUnbond(storeName string, cdc *codec.Codec) *cobra.Command {
 			msg := stake.NewMsgBeginUnbonding(delAddr, valAddr, sharesAmount)
 
 			if cliCtx.GenerateOnly {
-				return utils.PrintUnsignedStdTx(txBldr, cliCtx, []sdk.Msg{msg}, false)
+				return utils.PrintUnsignedStdTx(os.Stdout, txBldr, cliCtx, []sdk.Msg{msg}, false)
 			}
 			// build and sign the transaction, then broadcast to Tendermint
 			return utils.CompleteAndBroadcastTxCli(txBldr, cliCtx, []sdk.Msg{msg})
@@ -311,4 +252,65 @@ func GetCmdUnbond(storeName string, cdc *codec.Codec) *cobra.Command {
 	cmd.Flags().AddFlagSet(fsValidator)
 
 	return cmd
+}
+
+// BuildCreateValidatorMsg makes a new MsgCreateValidator.
+func BuildCreateValidatorMsg(cliCtx context.CLIContext, txBldr authtxb.TxBuilder) (context.CLIContext, authtxb.TxBuilder, sdk.Msg, error) {
+	amounstStr := viper.GetString(FlagAmount)
+	amount, err := sdk.ParseCoin(amounstStr)
+	if err != nil {
+		return cliCtx, txBldr, nil, err
+	}
+
+	valAddr, err := cliCtx.GetFromAddress()
+	if err != nil {
+		return cliCtx, txBldr, nil, err
+	}
+
+	pkStr := viper.GetString(FlagPubKey)
+	pk, err := sdk.GetConsPubKeyBech32(pkStr)
+	if err != nil {
+		return cliCtx, txBldr, nil, err
+	}
+
+	description := stake.NewDescription(
+		viper.GetString(FlagMoniker),
+		viper.GetString(FlagIdentity),
+		viper.GetString(FlagWebsite),
+		viper.GetString(FlagDetails),
+	)
+
+	// get the initial validator commission parameters
+	rateStr := viper.GetString(FlagCommissionRate)
+	maxRateStr := viper.GetString(FlagCommissionMaxRate)
+	maxChangeRateStr := viper.GetString(FlagCommissionMaxChangeRate)
+	commissionMsg, err := buildCommissionMsg(rateStr, maxRateStr, maxChangeRateStr)
+	if err != nil {
+		return cliCtx, txBldr, nil, err
+	}
+
+	var msg sdk.Msg
+	if viper.GetString(FlagAddressDelegator) != "" {
+		delAddr, err := sdk.AccAddressFromBech32(viper.GetString(FlagAddressDelegator))
+		if err != nil {
+			return cliCtx, txBldr, nil, err
+		}
+
+		msg = stake.NewMsgCreateValidatorOnBehalfOf(
+			delAddr, sdk.ValAddress(valAddr), pk, amount, description, commissionMsg,
+		)
+	} else {
+		msg = stake.NewMsgCreateValidator(
+			sdk.ValAddress(valAddr), pk, amount, description, commissionMsg,
+		)
+	}
+
+	if viper.GetBool(FlagGenesisFormat) {
+		ip := viper.GetString(FlagIP)
+		nodeID := viper.GetString(FlagNodeID)
+		if nodeID != "" && ip != "" {
+			txBldr = txBldr.WithMemo(fmt.Sprintf("%s@%s:26656", nodeID, ip))
+		}
+	}
+	return cliCtx, txBldr, msg, nil
 }


### PR DESCRIPTION
- Replace STDIN/STDOUT redirection in `gaiad gentx` with subcommands command line options to redirect streams to file since viper does not handle redirection well.
- Use `BuildCreateValidatorMsg` to build a `MsgCreateValidator` rather than redirecting to `gaiacli tx stake create-validator`.
 - `PrintUnsignedStdTx` now takes an `io.Writer` object.
- Mark `--pubkey`, `--amount` and `--moniker` as required flags instead of validating them manually.

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [x] Added entries in `PENDING.md` with issue # 
- [x] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
