### PR TITLE
R4R: Don't get command through client.{Get,Post}Commands()

### DIFF
--- a/PENDING.md
+++ b/PENDING.md
@@ -91,6 +91,7 @@ BUG FIXES
 
   - \#2733 [x/gov, x/mock/simulation] Fix governance simulation, update x/gov import/export
   - \#2854 [x/bank] Remove unused bank.MsgIssue, prevent possible panic
+  - \#2884 [docs/examples] Fix `basecli version` panic
 
 * Tendermint
   * [\#2797](https://github.com/tendermint/tendermint/pull/2797) AddressBook requires addresses to have IDs; Do not crap out immediately after sending pex addrs in seed mode

--- a/docs/examples/basecoin/cmd/basecli/main.go
+++ b/docs/examples/basecoin/cmd/basecli/main.go
@@ -85,6 +85,7 @@ func main() {
 		stakecmd.GetCmdQueryRedelegation(storeStake, cdc),
 		stakecmd.GetCmdQueryRedelegations(storeStake, cdc),
 		slashingcmd.GetCmdQuerySigningInfo(storeSlashing, cdc),
+		stakecmd.GetCmdQueryValidatorDelegations(storeStake, cdc),
 		authcmd.GetAccountCmd(storeAcc, cdc),
 	)
 

--- a/docs/examples/basecoin/cmd/basecli/main.go
+++ b/docs/examples/basecoin/cmd/basecli/main.go
@@ -72,35 +72,33 @@ func main() {
 
 	// add query/post commands (custom to binary)
 	rootCmd.AddCommand(
-		client.GetCommands(
-			stakecmd.GetCmdQueryValidator(storeStake, cdc),
-			stakecmd.GetCmdQueryValidators(storeStake, cdc),
-			stakecmd.GetCmdQueryValidatorUnbondingDelegations(storeStake, cdc),
-			stakecmd.GetCmdQueryValidatorRedelegations(storeStake, cdc),
-			stakecmd.GetCmdQueryDelegation(storeStake, cdc),
-			stakecmd.GetCmdQueryDelegations(storeStake, cdc),
-			stakecmd.GetCmdQueryPool(storeStake, cdc),
-			stakecmd.GetCmdQueryParams(storeStake, cdc),
-			stakecmd.GetCmdQueryUnbondingDelegation(storeStake, cdc),
-			stakecmd.GetCmdQueryUnbondingDelegations(storeStake, cdc),
-			stakecmd.GetCmdQueryRedelegation(storeStake, cdc),
-			stakecmd.GetCmdQueryRedelegations(storeStake, cdc),
-			slashingcmd.GetCmdQuerySigningInfo(storeSlashing, cdc),
-			authcmd.GetAccountCmd(storeAcc, cdc),
-		)...)
+		stakecmd.GetCmdQueryValidator(storeStake, cdc),
+		stakecmd.GetCmdQueryValidators(storeStake, cdc),
+		stakecmd.GetCmdQueryValidatorUnbondingDelegations(storeStake, cdc),
+		stakecmd.GetCmdQueryValidatorRedelegations(storeStake, cdc),
+		stakecmd.GetCmdQueryDelegation(storeStake, cdc),
+		stakecmd.GetCmdQueryDelegations(storeStake, cdc),
+		stakecmd.GetCmdQueryPool(storeStake, cdc),
+		stakecmd.GetCmdQueryParams(storeStake, cdc),
+		stakecmd.GetCmdQueryUnbondingDelegation(storeStake, cdc),
+		stakecmd.GetCmdQueryUnbondingDelegations(storeStake, cdc),
+		stakecmd.GetCmdQueryRedelegation(storeStake, cdc),
+		stakecmd.GetCmdQueryRedelegations(storeStake, cdc),
+		slashingcmd.GetCmdQuerySigningInfo(storeSlashing, cdc),
+		authcmd.GetAccountCmd(storeAcc, cdc),
+	)
 
 	rootCmd.AddCommand(
-		client.PostCommands(
-			bankcmd.SendTxCmd(cdc),
-			ibccmd.IBCTransferCmd(cdc),
-			ibccmd.IBCRelayCmd(cdc),
-			stakecmd.GetCmdCreateValidator(cdc),
-			stakecmd.GetCmdEditValidator(cdc),
-			stakecmd.GetCmdDelegate(cdc),
-			stakecmd.GetCmdUnbond(storeStake, cdc),
-			stakecmd.GetCmdRedelegate(storeStake, cdc),
-			slashingcmd.GetCmdUnjail(cdc),
-		)...)
+		bankcmd.SendTxCmd(cdc),
+		ibccmd.IBCTransferCmd(cdc),
+		ibccmd.IBCRelayCmd(cdc),
+		stakecmd.GetCmdCreateValidator(cdc),
+		stakecmd.GetCmdEditValidator(cdc),
+		stakecmd.GetCmdDelegate(cdc),
+		stakecmd.GetCmdUnbond(storeStake, cdc),
+		stakecmd.GetCmdRedelegate(storeStake, cdc),
+		slashingcmd.GetCmdUnjail(cdc),
+	)
 
 	// add proxy, version and key info
 	rootCmd.AddCommand(

--- a/docs/examples/democoin/cmd/democli/main.go
+++ b/docs/examples/democoin/cmd/democli/main.go
@@ -70,13 +70,11 @@ func main() {
 	// add query/post commands (custom to binary)
 	// start with commands common to basecoin
 	rootCmd.AddCommand(
-		client.GetCommands(
-			authcmd.GetAccountCmd(storeAcc, cdc),
-		)...)
+		authcmd.GetAccountCmd(storeAcc, cdc),
+	)
 	rootCmd.AddCommand(
-		client.PostCommands(
-			bankcmd.SendTxCmd(cdc),
-		)...)
+		bankcmd.SendTxCmd(cdc),
+	)
 	rootCmd.AddCommand(
 		client.PostCommands(
 			simplestakingcmd.BondTxCmd(cdc),


### PR DESCRIPTION
Logic has changed recently and commands are now enriched with flags by default.

Closes: #2884

- [x] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [x] Added entries in `PENDING.md` with issue # 
- [ ] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
