### PR TITLE
remove redundant temporary variable remDelPool when calc DelPool

### DIFF
--- a/x/distribution/types/delegator_info.go
+++ b/x/distribution/types/delegator_info.go
@@ -50,9 +50,8 @@ func (di DelegationDistInfo) WithdrawRewards(wc WithdrawContext, vi ValidatorDis
 	accum := di.GetDelAccum(wc.Height, delegatorShares)
 	di.DelPoolWithdrawalHeight = wc.Height
 	withdrawalTokens := vi.DelPool.MulDec(accum).QuoDec(vi.DelAccum.Accum)
-	remDelPool := vi.DelPool.Minus(withdrawalTokens)
 
-	vi.DelPool = remDelPool
+	vi.DelPool = vi.DelPool.Minus(withdrawalTokens)
 	vi.DelAccum.Accum = vi.DelAccum.Accum.Sub(accum)
 
 	return di, vi, fp, withdrawalTokens


### PR DESCRIPTION
remove redundant temporary variable `remDelPool` when calc `DelPool` in `WithdrawRewards` function

PR without Issue because it is trivial fix

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added entries in `PENDING.md` with issue # 
- [x] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))