### PR TITLE
R4R: Fix starting Gaia Lite

### DIFF
--- a/client/lcd/root.go
+++ b/client/lcd/root.go
@@ -131,12 +131,13 @@ func (rs *RestServer) Start(listenAddr string, sslHosts string,
 		rs.log.Info("Starting Gaia Lite REST service...")
 		rs.log.Info(rs.fingerprint)
 
-		if err := rpcserver.StartHTTPAndTLSServer(
+		err := rpcserver.StartHTTPAndTLSServer(
 			rs.listener,
 			rs.Mux,
 			certFile, keyFile,
 			rs.log,
-		); err != nil {
+		)
+		if err != nil {
 			return err
 		}
 	}

--- a/client/lcd/root.go
+++ b/client/lcd/root.go
@@ -127,17 +127,19 @@ func (rs *RestServer) Start(listenAddr string, sslHosts string,
 		if err != nil {
 			return
 		}
-		go rpcserver.StartHTTPAndTLSServer(
+
+		rs.log.Info("Starting Gaia Lite REST service...")
+		rs.log.Info(rs.fingerprint)
+
+		if err := rpcserver.StartHTTPAndTLSServer(
 			rs.listener,
 			rs.Mux,
 			certFile, keyFile,
 			rs.log,
-		)
-		rs.log.Info(rs.fingerprint)
-		rs.log.Info("REST server started")
+		); err != nil {
+			return err
+		}
 	}
-
-	// logger.Info("REST server started")
 
 	return nil
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

PR #2900 introduced a change where the Gaia Lite service was started in a goroutine (not sure if intentional?) and thus the parent process exited. The parent process must not exist but rather be controlled by another service/process (e.g. systemd) manager.

Being that this was introduced in a non-release, I don't think we need a PENDING log entry here.

Also, I don't think this addresses #2907 (which I cannot reproduce).

----

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/develop/CONTRIBUTING.md#pr-targeting))

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added entries in `PENDING.md` with issue # 
- [x] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
