### PR TITLE
R4R: Prompt user for confirmation when deleting ledger and offline keys

### DIFF
--- a/PENDING.md
+++ b/PENDING.md
@@ -97,6 +97,7 @@ BUG FIXES
   * #2907 Refactor and fix the way Gaia Lite is started.
 
 * Gaia CLI  (`gaiacli`)
+  * [\#2921](https://github.com/cosmos/cosmos-sdk/issues/2921) Fix `keys delete` inability to delete offline and ledger keys.
 
 * Gaia
   * [\#2723] Use `cosmosvalcons` Bech32 prefix in `tendermint show-address`

--- a/client/keys/delete.go
+++ b/client/keys/delete.go
@@ -18,8 +18,15 @@ func deleteKeyCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "delete <name>",
 		Short: "Delete the given key",
-		RunE:  runDeleteCmd,
-		Args:  cobra.ExactArgs(1),
+		Long: `Delete a key from the store.
+
+Note that removing offline or ledger keys will remove
+only the public key references stored locally, i.e.
+private keys stored in a ledger device cannot be deleted with
+gaiacli.
+`,
+		RunE: runDeleteCmd,
+		Args: cobra.ExactArgs(1),
 	}
 	return cmd
 }
@@ -41,7 +48,7 @@ func runDeleteCmd(cmd *cobra.Command, args []string) error {
 		if err := kb.Delete(name, "yes"); err != nil {
 			return err
 		}
-		fmt.Fprintln(os.Stderr, "Deleted")
+		fmt.Fprintln(os.Stderr, "Public key deleted")
 	}
 
 	buf := client.BufferStdin()

--- a/client/keys/delete.go
+++ b/client/keys/delete.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	keys "github.com/cosmos/cosmos-sdk/crypto/keys"
@@ -31,9 +32,16 @@ func runDeleteCmd(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	_, err = kb.Get(name)
+	info, err := kb.Get(name)
 	if err != nil {
 		return err
+	}
+
+	if info.GetType() == keys.TypeLedger || info.GetType() == keys.TypeOffline {
+		if err := kb.Delete(name, "yes"); err != nil {
+			return err
+		}
+		fmt.Fprintln(os.Stderr, "Deleted")
 	}
 
 	buf := client.BufferStdin()
@@ -47,7 +55,7 @@ func runDeleteCmd(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	fmt.Println("Password deleted forever (uh oh!)")
+	fmt.Fprintln(os.Stderr, "Password deleted forever (uh oh!)")
 	return nil
 }
 

--- a/client/keys/delete.go
+++ b/client/keys/delete.go
@@ -48,7 +48,7 @@ func runDeleteCmd(cmd *cobra.Command, args []string) error {
 		if err := kb.Delete(name, "yes"); err != nil {
 			return err
 		}
-		fmt.Fprintln(os.Stderr, "Public key deleted")
+		fmt.Fprintln(os.Stderr, "Public key reference deleted")
 	}
 
 	buf := client.BufferStdin()
@@ -62,7 +62,7 @@ func runDeleteCmd(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	fmt.Fprintln(os.Stderr, "Password deleted forever (uh oh!)")
+	fmt.Fprintln(os.Stderr, "Key deleted forever (uh oh!)")
 	return nil
 }
 

--- a/crypto/keys/keybase.go
+++ b/crypto/keys/keybase.go
@@ -386,13 +386,9 @@ func (kb dbKeybase) Delete(name, passphrase string) error {
 		kb.db.DeleteSync(infoKey(name))
 		return nil
 	case ledgerInfo:
+		return kb.deleteOfflineLedgerKey(info, passphrase)
 	case offlineInfo:
-		if passphrase != "yes" {
-			return fmt.Errorf("enter 'yes' exactly to delete the key - this cannot be undone")
-		}
-		kb.db.DeleteSync(addrKey(info.GetAddress()))
-		kb.db.DeleteSync(infoKey(name))
-		return nil
+		return kb.deleteOfflineLedgerKey(info, passphrase)
 	}
 
 	return nil
@@ -468,4 +464,13 @@ func addrKey(address types.AccAddress) []byte {
 
 func infoKey(name string) []byte {
 	return []byte(fmt.Sprintf("%s.%s", name, infoSuffix))
+}
+
+func (kb dbKeybase) deleteOfflineLedgerKey(info Info, yesPassphrase string) error {
+	if yesPassphrase != "yes" {
+		return fmt.Errorf("enter 'yes' exactly to delete the key - this cannot be undone")
+	}
+	kb.db.DeleteSync(addrKey(info.GetAddress()))
+	kb.db.DeleteSync(infoKey(info.GetName()))
+	return nil
 }

--- a/crypto/keys/keybase.go
+++ b/crypto/keys/keybase.go
@@ -367,8 +367,10 @@ func (kb dbKeybase) ImportPubKey(name string, armor string) (err error) {
 
 // Delete removes key forever, but we must present the
 // proper passphrase before deleting it (for security).
-// A passphrase of 'yes' is used to delete stored
-// references to offline and Ledger / HW wallet keys
+// It returns an error if the key doesn't exist or
+// passphrases don't match.
+// Passphrase is ignored when deleting references to
+// offline and Ledger / HW wallet keys.
 func (kb dbKeybase) Delete(name, passphrase string) error {
 	// verify we have the proper password before deleting
 	info, err := kb.Get(name)

--- a/crypto/keys/keybase_test.go
+++ b/crypto/keys/keybase_test.go
@@ -96,9 +96,7 @@ func TestKeyManagement(t *testing.T) {
 	require.Equal(t, 2, len(keyS))
 
 	// delete the offline key
-	err = cstore.Delete(o1, "no")
-	require.NotNil(t, err)
-	err = cstore.Delete(o1, "yes")
+	err = cstore.Delete(o1, "")
 	require.NoError(t, err)
 	keyS, err = cstore.List()
 	require.NoError(t, err)


### PR DESCRIPTION
- Add --yes flag to skip confirmation.
- Keybase.Delete() does not check passphrase == "yes" anymore. It's command line tool responsibility to prompt user for confirmation when deleting ledger/offline keys.

Closes: #2921

- [x] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [x] Added entries in `PENDING.md` with issue # 
- [x] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
