### PR TITLE
R4R: Fix tag usage in handlers and EndBlocker

### DIFF
--- a/PENDING.md
+++ b/PENDING.md
@@ -23,6 +23,7 @@ BREAKING CHANGES
   * [\#2019](https://github.com/cosmos/cosmos-sdk/issues/2019) Cap total number of signatures. Current per-transaction limit is 7, and if that is exceeded transaction is rejected.
   * [\#2801](https://github.com/cosmos/cosmos-sdk/pull/2801) Remove AppInit structure.
   * [\#2798](https://github.com/cosmos/cosmos-sdk/issues/2798) Governance API has miss-spelled English word in JSON response ('depositer' -> 'depositor')
+  * [\#2943](https://github.com/cosmos/cosmos-sdk/pull/2943) Transaction action tags equal the message type. Stake EndBlocker tags are included.
 
 * Tendermint
   - Update to Tendermint 0.27.0

--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -615,13 +615,13 @@ func (app *BaseApp) runMsgs(ctx sdk.Context, msgs []sdk.Msg, mode runTxMode) (re
 		if mode != runTxModeCheck {
 			msgResult = handler(ctx, msg)
 		}
-		msgResult.Tags = append(msgResult.Tags, sdk.MakeTag("action", []byte(msg.Type())))
 
 		// NOTE: GasWanted is determined by ante handler and
 		// GasUsed by the GasMeter
 
 		// Append Data and Tags
 		data = append(data, msgResult.Data...)
+		tags = append(tags, sdk.MakeTag(sdk.TagAction, []byte(msg.Type())))
 		tags = append(tags, msgResult.Tags...)
 
 		// Stop execution and return on first failed message.

--- a/client/lcd/lcd_test.go
+++ b/client/lcd/lcd_test.go
@@ -564,7 +564,7 @@ func TestBonding(t *testing.T) {
 
 	// query tx
 	txs = getTransactions(t, port,
-		fmt.Sprintf("action=begin-unbonding&delegator=%s", addr),
+		fmt.Sprintf("action=begin_unbonding&delegator=%s", addr),
 		fmt.Sprintf("source-validator=%s", operAddrs[0]),
 	)
 	require.Len(t, txs, 1)
@@ -582,7 +582,7 @@ func TestBonding(t *testing.T) {
 
 	// query tx
 	txs = getTransactions(t, port,
-		fmt.Sprintf("action=begin-redelegation&delegator=%s", addr),
+		fmt.Sprintf("action=begin_redelegate&delegator=%s", addr),
 		fmt.Sprintf("source-validator=%s", operAddrs[0]),
 		fmt.Sprintf("destination-validator=%s", operAddrs[1]),
 	)
@@ -649,7 +649,7 @@ func TestSubmitProposal(t *testing.T) {
 	require.Equal(t, "Test", proposal.GetTitle())
 
 	// query tx
-	txs := getTransactions(t, port, fmt.Sprintf("action=submit-proposal&proposer=%s", addr))
+	txs := getTransactions(t, port, fmt.Sprintf("action=submit_proposal&proposer=%s", addr))
 	require.Len(t, txs, 1)
 	require.Equal(t, resultTx.Height, txs[0].Height)
 }

--- a/cmd/gaia/app/app.go
+++ b/cmd/gaia/app/app.go
@@ -212,7 +212,8 @@ func (app *GaiaApp) BeginBlocker(ctx sdk.Context, req abci.RequestBeginBlock) ab
 func (app *GaiaApp) EndBlocker(ctx sdk.Context, req abci.RequestEndBlock) abci.ResponseEndBlock {
 
 	tags := gov.EndBlocker(ctx, app.govKeeper)
-	validatorUpdates := stake.EndBlocker(ctx, app.stakeKeeper)
+	validatorUpdates, endBlockerTags := stake.EndBlocker(ctx, app.stakeKeeper)
+	tags = append(tags, endBlockerTags...)
 
 	app.assertRuntimeInvariants()
 

--- a/cmd/gaia/cli_test/cli_test.go
+++ b/cmd/gaia/cli_test/cli_test.go
@@ -222,10 +222,7 @@ func TestGaiaCLICreateValidator(t *testing.T) {
 
 	fooAddr, _ := executeGetAddrPK(t, fmt.Sprintf("gaiacli keys show foo --output=json --home=%s", gaiacliHome))
 	barAddr, _ := executeGetAddrPK(t, fmt.Sprintf("gaiacli keys show bar --output=json --home=%s", gaiacliHome))
-	consPubKey, err := sdk.Bech32ifyConsPub(ed25519.GenPrivKey().PubKey())
-	if err != nil {
-		panic(err)
-	}
+	consPubKey := sdk.MustBech32ifyConsPub(ed25519.GenPrivKey().PubKey())
 
 	executeWrite(t, fmt.Sprintf("gaiacli tx send %v --amount=10%s --to=%s --from=foo", flags, stakeTypes.DefaultBondDenom, barAddr), app.DefaultKeyPass)
 	tests.WaitForNextNBlocksTM(2, port)

--- a/cmd/gaia/cli_test/cli_test.go
+++ b/cmd/gaia/cli_test/cli_test.go
@@ -357,7 +357,7 @@ func TestGaiaCLISubmitProposal(t *testing.T) {
 	executeWrite(t, spStr, app.DefaultKeyPass)
 	tests.WaitForNextNBlocksTM(2, port)
 
-	txs := executeGetTxs(t, fmt.Sprintf("gaiacli query txs --tags='action:submit-proposal&proposer:%s' %v", fooAddr, flags))
+	txs := executeGetTxs(t, fmt.Sprintf("gaiacli query txs --tags='action:submit_proposal&proposer:%s' %v", fooAddr, flags))
 	require.Len(t, txs, 1)
 
 	fooAcc = executeGetAccount(t, fmt.Sprintf("gaiacli query account %s %v", fooAddr, flags))

--- a/cmd/gaia/cmd/gaiadebug/hack.go
+++ b/cmd/gaia/cmd/gaiadebug/hack.go
@@ -225,10 +225,11 @@ func (app *GaiaApp) BeginBlocker(ctx sdk.Context, req abci.RequestBeginBlock) ab
 // application updates every end block
 // nolint: unparam
 func (app *GaiaApp) EndBlocker(ctx sdk.Context, req abci.RequestEndBlock) abci.ResponseEndBlock {
-	validatorUpdates := stake.EndBlocker(ctx, app.stakeKeeper)
+	validatorUpdates, tags := stake.EndBlocker(ctx, app.stakeKeeper)
 
 	return abci.ResponseEndBlock{
 		ValidatorUpdates: validatorUpdates,
+		Tags:             tags,
 	}
 }
 

--- a/docs/gaia/gaiacli.md
+++ b/docs/gaia/gaiacli.md
@@ -209,6 +209,8 @@ gaiacli query txs --tags='<tag1>:<value1>&<tag2>:<value2>'
 
 ::: tip Note
 
+The action tag always equals the message type returned by the `Type()` function of the relevant message. 
+
 You can find a list of available `tags` on each of the SDK modules:
 
 - [Common tags](https://github.com/cosmos/cosmos-sdk/blob/d1e76221d8e28824bb4791cb4ad8662d2ae9051e/types/tags.go#L57-L63)

--- a/x/distribution/alias.go
+++ b/x/distribution/alias.go
@@ -72,11 +72,6 @@ var (
 	ErrNilWithdrawAddr  = types.ErrNilWithdrawAddr
 	ErrNilValidatorAddr = types.ErrNilValidatorAddr
 
-	ActionModifyWithdrawAddress       = tags.ActionModifyWithdrawAddress
-	ActionWithdrawDelegatorRewardsAll = tags.ActionWithdrawDelegatorRewardsAll
-	ActionWithdrawDelegatorReward     = tags.ActionWithdrawDelegatorReward
-	ActionWithdrawValidatorRewardsAll = tags.ActionWithdrawValidatorRewardsAll
-
 	TagValidator = tags.Validator
 	TagDelegator = tags.Delegator
 )

--- a/x/distribution/alias.go
+++ b/x/distribution/alias.go
@@ -77,7 +77,6 @@ var (
 	ActionWithdrawDelegatorReward     = tags.ActionWithdrawDelegatorReward
 	ActionWithdrawValidatorRewardsAll = tags.ActionWithdrawValidatorRewardsAll
 
-	TagAction    = tags.Action
 	TagValidator = tags.Validator
 	TagDelegator = tags.Delegator
 )

--- a/x/distribution/handler.go
+++ b/x/distribution/handler.go
@@ -35,7 +35,6 @@ func handleMsgModifyWithdrawAddress(ctx sdk.Context, msg types.MsgSetWithdrawAdd
 	k.SetDelegatorWithdrawAddr(ctx, msg.DelegatorAddr, msg.WithdrawAddr)
 
 	tags := sdk.NewTags(
-		tags.Action, tags.ActionModifyWithdrawAddress,
 		tags.Delegator, []byte(msg.DelegatorAddr.String()),
 	)
 	return sdk.Result{
@@ -48,7 +47,6 @@ func handleMsgWithdrawDelegatorRewardsAll(ctx sdk.Context, msg types.MsgWithdraw
 	k.WithdrawDelegationRewardsAll(ctx, msg.DelegatorAddr)
 
 	tags := sdk.NewTags(
-		tags.Action, tags.ActionWithdrawDelegatorRewardsAll,
 		tags.Delegator, []byte(msg.DelegatorAddr.String()),
 	)
 	return sdk.Result{
@@ -64,7 +62,6 @@ func handleMsgWithdrawDelegatorReward(ctx sdk.Context, msg types.MsgWithdrawDele
 	}
 
 	tags := sdk.NewTags(
-		tags.Action, tags.ActionWithdrawDelegatorReward,
 		tags.Delegator, []byte(msg.DelegatorAddr.String()),
 		tags.Validator, []byte(msg.ValidatorAddr.String()),
 	)
@@ -81,7 +78,6 @@ func handleMsgWithdrawValidatorRewardsAll(ctx sdk.Context, msg types.MsgWithdraw
 	}
 
 	tags := sdk.NewTags(
-		tags.Action, tags.ActionWithdrawValidatorRewardsAll,
 		tags.Validator, []byte(msg.ValidatorAddr.String()),
 	)
 	return sdk.Result{

--- a/x/distribution/tags/tags.go
+++ b/x/distribution/tags/tags.go
@@ -11,7 +11,6 @@ var (
 	ActionWithdrawDelegatorReward     = []byte("withdraw-delegator-reward")
 	ActionWithdrawValidatorRewardsAll = []byte("withdraw-validator-rewards-all")
 
-	Action    = sdk.TagAction
 	Validator = sdk.TagSrcValidator
 	Delegator = sdk.TagDelegator
 )

--- a/x/distribution/tags/tags.go
+++ b/x/distribution/tags/tags.go
@@ -6,11 +6,6 @@ import (
 )
 
 var (
-	ActionModifyWithdrawAddress       = []byte("modify-withdraw-address")
-	ActionWithdrawDelegatorRewardsAll = []byte("withdraw-delegator-rewards-all")
-	ActionWithdrawDelegatorReward     = []byte("withdraw-delegator-reward")
-	ActionWithdrawValidatorRewardsAll = []byte("withdraw-validator-rewards-all")
-
 	Validator = sdk.TagSrcValidator
 	Delegator = sdk.TagDelegator
 )

--- a/x/gov/handler.go
+++ b/x/gov/handler.go
@@ -36,7 +36,6 @@ func handleMsgSubmitProposal(ctx sdk.Context, keeper Keeper, msg MsgSubmitPropos
 	proposalIDBytes := keeper.cdc.MustMarshalBinaryLengthPrefixed(proposal.GetProposalID())
 
 	resTags := sdk.NewTags(
-		tags.Action, tags.ActionSubmitProposal,
 		tags.Proposer, []byte(msg.Proposer.String()),
 		tags.ProposalID, proposalIDBytes,
 	)
@@ -62,7 +61,6 @@ func handleMsgDeposit(ctx sdk.Context, keeper Keeper, msg MsgDeposit) sdk.Result
 
 	// TODO: Add tag for if voting period started
 	resTags := sdk.NewTags(
-		tags.Action, tags.ActionDeposit,
 		tags.Depositor, []byte(msg.Depositor.String()),
 		tags.ProposalID, proposalIDBytes,
 	)
@@ -86,7 +84,6 @@ func handleMsgVote(ctx sdk.Context, keeper Keeper, msg MsgVote) sdk.Result {
 	proposalIDBytes := keeper.cdc.MustMarshalBinaryBare(msg.ProposalID)
 
 	resTags := sdk.NewTags(
-		tags.Action, tags.ActionVote,
 		tags.Voter, []byte(msg.Voter.String()),
 		tags.ProposalID, proposalIDBytes,
 	)

--- a/x/gov/tags/tags.go
+++ b/x/gov/tags/tags.go
@@ -6,9 +6,6 @@ import (
 )
 
 var (
-	ActionSubmitProposal   = []byte("submit-proposal")
-	ActionDeposit          = []byte("deposit")
-	ActionVote             = []byte("vote")
 	ActionProposalDropped  = []byte("proposal-dropped")
 	ActionProposalPassed   = []byte("proposal-passed")
 	ActionProposalRejected = []byte("proposal-rejected")

--- a/x/slashing/app_test.go
+++ b/x/slashing/app_test.go
@@ -52,9 +52,10 @@ func getMockApp(t *testing.T) (*mock.App, stake.Keeper, Keeper) {
 // stake endblocker
 func getEndBlocker(keeper stake.Keeper) sdk.EndBlocker {
 	return func(ctx sdk.Context, req abci.RequestEndBlock) abci.ResponseEndBlock {
-		validatorUpdates := stake.EndBlocker(ctx, keeper)
+		validatorUpdates, tags := stake.EndBlocker(ctx, keeper)
 		return abci.ResponseEndBlock{
 			ValidatorUpdates: validatorUpdates,
+			Tags:             tags,
 		}
 	}
 }

--- a/x/slashing/handler.go
+++ b/x/slashing/handler.go
@@ -49,7 +49,7 @@ func handleMsgUnjail(ctx sdk.Context, msg MsgUnjail, k Keeper) sdk.Result {
 	// unjail the validator
 	k.validatorSet.Unjail(ctx, consAddr)
 
-	tags := sdk.NewTags("action", []byte("unjail"), "validator", []byte(msg.ValidatorAddr.String()))
+	tags := sdk.NewTags("validator", []byte(msg.ValidatorAddr.String()))
 
 	return sdk.Result{
 		Tags: tags,

--- a/x/slashing/keeper_test.go
+++ b/x/slashing/keeper_test.go
@@ -409,7 +409,7 @@ func TestValidatorDippingInAndOut(t *testing.T) {
 	newAmt := int64(101)
 	got = sh(ctx, NewTestMsgCreateValidator(addrs[1], pks[1], sdk.NewInt(newAmt)))
 	require.True(t, got.IsOK())
-	validatorUpdates := stake.EndBlocker(ctx, sk)
+	validatorUpdates, _ := stake.EndBlocker(ctx, sk)
 	require.Equal(t, 2, len(validatorUpdates))
 	validator, _ := sk.GetValidator(ctx, addr)
 	require.Equal(t, sdk.Unbonding, validator.Status)
@@ -421,7 +421,7 @@ func TestValidatorDippingInAndOut(t *testing.T) {
 	// validator added back in
 	got = sh(ctx, newTestMsgDelegate(sdk.AccAddress(addrs[2]), addrs[0], sdk.NewInt(2)))
 	require.True(t, got.IsOK())
-	validatorUpdates = stake.EndBlocker(ctx, sk)
+	validatorUpdates, _ = stake.EndBlocker(ctx, sk)
 	require.Equal(t, 2, len(validatorUpdates))
 	validator, _ = sk.GetValidator(ctx, addr)
 	require.Equal(t, sdk.Bonded, validator.Status)

--- a/x/stake/app_test.go
+++ b/x/stake/app_test.go
@@ -42,10 +42,11 @@ func getMockApp(t *testing.T) (*mock.App, Keeper) {
 // getEndBlocker returns a stake endblocker.
 func getEndBlocker(keeper Keeper) sdk.EndBlocker {
 	return func(ctx sdk.Context, req abci.RequestEndBlock) abci.ResponseEndBlock {
-		validatorUpdates := EndBlocker(ctx, keeper)
+		validatorUpdates, tags := EndBlocker(ctx, keeper)
 
 		return abci.ResponseEndBlock{
 			ValidatorUpdates: validatorUpdates,
+			Tags:             tags,
 		}
 	}
 }

--- a/x/stake/client/rest/query.go
+++ b/x/stake/client/rest/query.go
@@ -1,6 +1,7 @@
 package rest
 
 import (
+	"github.com/cosmos/cosmos-sdk/x/stake"
 	"net/http"
 	"strings"
 
@@ -161,18 +162,18 @@ func delegatorTxsHandlerFn(cliCtx context.CLIContext, cdc *codec.Codec) http.Han
 
 		switch {
 		case isBondTx:
-			actions = append(actions, string(tags.ActionDelegate))
+			actions = append(actions, string(stake.MsgDelegate{}.Type()))
 		case isUnbondTx:
-			actions = append(actions, string(tags.ActionBeginUnbonding))
+			actions = append(actions, string(stake.MsgBeginUnbonding{}.Type()))
 			actions = append(actions, string(tags.ActionCompleteUnbonding))
 		case isRedTx:
-			actions = append(actions, string(tags.ActionBeginRedelegation))
+			actions = append(actions, string(stake.MsgBeginRedelegate{}.Type()))
 			actions = append(actions, string(tags.ActionCompleteRedelegation))
 		case noQuery:
-			actions = append(actions, string(tags.ActionDelegate))
-			actions = append(actions, string(tags.ActionBeginUnbonding))
+			actions = append(actions, string(stake.MsgDelegate{}.Type()))
+			actions = append(actions, string(stake.MsgBeginUnbonding{}.Type()))
 			actions = append(actions, string(tags.ActionCompleteUnbonding))
-			actions = append(actions, string(tags.ActionBeginRedelegation))
+			actions = append(actions, string(stake.MsgBeginRedelegate{}.Type()))
 			actions = append(actions, string(tags.ActionCompleteRedelegation))
 		default:
 			w.WriteHeader(http.StatusNoContent)

--- a/x/stake/client/rest/query.go
+++ b/x/stake/client/rest/query.go
@@ -162,18 +162,18 @@ func delegatorTxsHandlerFn(cliCtx context.CLIContext, cdc *codec.Codec) http.Han
 
 		switch {
 		case isBondTx:
-			actions = append(actions, string(stake.MsgDelegate{}.Type()))
+			actions = append(actions, stake.MsgDelegate{}.Type())
 		case isUnbondTx:
-			actions = append(actions, string(stake.MsgBeginUnbonding{}.Type()))
+			actions = append(actions, stake.MsgBeginUnbonding{}.Type())
 			actions = append(actions, string(tags.ActionCompleteUnbonding))
 		case isRedTx:
-			actions = append(actions, string(stake.MsgBeginRedelegate{}.Type()))
+			actions = append(actions, stake.MsgBeginRedelegate{}.Type())
 			actions = append(actions, string(tags.ActionCompleteRedelegation))
 		case noQuery:
-			actions = append(actions, string(stake.MsgDelegate{}.Type()))
-			actions = append(actions, string(stake.MsgBeginUnbonding{}.Type()))
+			actions = append(actions, stake.MsgDelegate{}.Type())
+			actions = append(actions, stake.MsgBeginUnbonding{}.Type())
 			actions = append(actions, string(tags.ActionCompleteUnbonding))
-			actions = append(actions, string(stake.MsgBeginRedelegate{}.Type()))
+			actions = append(actions, stake.MsgBeginRedelegate{}.Type())
 			actions = append(actions, string(tags.ActionCompleteRedelegation))
 		default:
 			w.WriteHeader(http.StatusNoContent)

--- a/x/stake/handler.go
+++ b/x/stake/handler.go
@@ -31,9 +31,7 @@ func NewHandler(k keeper.Keeper) sdk.Handler {
 }
 
 // Called every block, update validator set
-func EndBlocker(ctx sdk.Context, k keeper.Keeper) (validatorUpdates []abci.ValidatorUpdate) {
-	endBlockerTags := sdk.EmptyTags()
-
+func EndBlocker(ctx sdk.Context, k keeper.Keeper) (validatorUpdates []abci.ValidatorUpdate, endBlockerTags sdk.Tags) {
 	// Reset the intra-transaction counter.
 	k.SetIntraTxCounter(ctx, 0)
 
@@ -127,7 +125,6 @@ func handleMsgCreateValidator(ctx sdk.Context, msg types.MsgCreateValidator, k k
 	}
 
 	tags := sdk.NewTags(
-		tags.Action, tags.ActionCreateValidator,
 		tags.DstValidator, []byte(msg.ValidatorAddr.String()),
 		tags.Moniker, []byte(msg.Description.Moniker),
 		tags.Identity, []byte(msg.Description.Identity),
@@ -165,7 +162,6 @@ func handleMsgEditValidator(ctx sdk.Context, msg types.MsgEditValidator, k keepe
 	k.SetValidator(ctx, validator)
 
 	tags := sdk.NewTags(
-		tags.Action, tags.ActionEditValidator,
 		tags.DstValidator, []byte(msg.ValidatorAddr.String()),
 		tags.Moniker, []byte(description.Moniker),
 		tags.Identity, []byte(description.Identity),
@@ -196,7 +192,6 @@ func handleMsgDelegate(ctx sdk.Context, msg types.MsgDelegate, k keeper.Keeper) 
 	}
 
 	tags := sdk.NewTags(
-		tags.Action, tags.ActionDelegate,
 		tags.Delegator, []byte(msg.DelegatorAddr.String()),
 		tags.DstValidator, []byte(msg.ValidatorAddr.String()),
 	)
@@ -215,7 +210,6 @@ func handleMsgBeginUnbonding(ctx sdk.Context, msg types.MsgBeginUnbonding, k kee
 	finishTime := types.MsgCdc.MustMarshalBinaryLengthPrefixed(ubd.MinTime)
 
 	tags := sdk.NewTags(
-		tags.Action, tags.ActionBeginUnbonding,
 		tags.Delegator, []byte(msg.DelegatorAddr.String()),
 		tags.SrcValidator, []byte(msg.ValidatorAddr.String()),
 		tags.EndTime, finishTime,
@@ -233,7 +227,6 @@ func handleMsgBeginRedelegate(ctx sdk.Context, msg types.MsgBeginRedelegate, k k
 	finishTime := types.MsgCdc.MustMarshalBinaryLengthPrefixed(red.MinTime)
 
 	tags := sdk.NewTags(
-		tags.Action, tags.ActionBeginRedelegation,
 		tags.Delegator, []byte(msg.DelegatorAddr.String()),
 		tags.SrcValidator, []byte(msg.ValidatorSrcAddr.String()),
 		tags.DstValidator, []byte(msg.ValidatorDstAddr.String()),

--- a/x/stake/simulation/sim_test.go
+++ b/x/stake/simulation/sim_test.go
@@ -37,9 +37,10 @@ func TestStakeWithRandomMessages(t *testing.T) {
 	distrKeeper := distribution.NewKeeper(mapp.Cdc, distrKey, paramstore.Subspace(distribution.DefaultParamspace), bankKeeper, stakeKeeper, feeCollectionKeeper, distribution.DefaultCodespace)
 	mapp.Router().AddRoute("stake", stake.NewHandler(stakeKeeper))
 	mapp.SetEndBlocker(func(ctx sdk.Context, req abci.RequestEndBlock) abci.ResponseEndBlock {
-		validatorUpdates := stake.EndBlocker(ctx, stakeKeeper)
+		validatorUpdates, tags := stake.EndBlocker(ctx, stakeKeeper)
 		return abci.ResponseEndBlock{
 			ValidatorUpdates: validatorUpdates,
+			Tags:             tags,
 		}
 	})
 

--- a/x/stake/stake.go
+++ b/x/stake/stake.go
@@ -151,12 +151,7 @@ var (
 )
 
 var (
-	ActionCreateValidator      = tags.ActionCreateValidator
-	ActionEditValidator        = tags.ActionEditValidator
-	ActionDelegate             = tags.ActionDelegate
-	ActionBeginUnbonding       = tags.ActionBeginUnbonding
 	ActionCompleteUnbonding    = tags.ActionCompleteUnbonding
-	ActionBeginRedelegation    = tags.ActionBeginRedelegation
 	ActionCompleteRedelegation = tags.ActionCompleteRedelegation
 
 	TagAction       = tags.Action

--- a/x/stake/tags/tags.go
+++ b/x/stake/tags/tags.go
@@ -6,12 +6,7 @@ import (
 )
 
 var (
-	ActionCreateValidator      = []byte("create-validator")
-	ActionEditValidator        = []byte("edit-validator")
-	ActionDelegate             = []byte("delegate")
-	ActionBeginUnbonding       = []byte("begin-unbonding")
 	ActionCompleteUnbonding    = []byte("complete-unbonding")
-	ActionBeginRedelegation    = []byte("begin-redelegation")
 	ActionCompleteRedelegation = []byte("complete-redelegation")
 
 	Action       = sdk.TagAction


### PR DESCRIPTION
Closes #2941

The tags of the staking EndBlocker have been ignored by now and action tags were added twice for some transactions.

CC @cwgoes - could we get this in for v0.27.0 since this is a blocker for our block explorer?

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added entries in `PENDING.md` with issue # 
- [ ] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
