### PR TITLE
WIP: Fix initChainer regression

### DIFF
--- a/cmd/gaia/app/app.go
+++ b/cmd/gaia/app/app.go
@@ -202,6 +202,9 @@ func (app *GaiaApp) BeginBlocker(ctx sdk.Context, req abci.RequestBeginBlock) ab
 	// TODO: This should really happen at EndBlocker.
 	tags := slashing.BeginBlocker(ctx, req, app.slashingKeeper)
 
+	// assert runtime invariants
+	app.assertRuntimeInvariants()
+
 	return abci.ResponseBeginBlock{
 		Tags: tags.ToKVPairs(),
 	}
@@ -302,9 +305,6 @@ func (app *GaiaApp) initChainer(ctx sdk.Context, req abci.RequestInitChain) abci
 			}
 		}
 	}
-
-	// assert runtime invariants
-	app.assertRuntimeInvariants()
 
 	return abci.ResponseInitChain{
 		Validators: validators,


### PR DESCRIPTION
app.assertRuntimeInvariants() fails because the function hasn't yet returned.
Move the call up to BeginBlocker so that invariants run at the beginning of every block.

This fixes a regression introduced in ad121f14984c18659764629b52b15fe8fc762a5c

Closes: #2960

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added entries in `PENDING.md` with issue # 
- [ ] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
