### PR TITLE
R4R: Inflation bug fixes

### DIFF
--- a/PENDING.md
+++ b/PENDING.md
@@ -52,5 +52,6 @@ BUG FIXES
 * Gaia
 
 * SDK
+  * \#2967 Change ordering of `mint.BeginBlocker` and `distr.BeginBlocker`, recalculate inflation each block
 
 * Tendermint

--- a/cmd/gaia/app/app.go
+++ b/cmd/gaia/app/app.go
@@ -189,11 +189,11 @@ func MakeCodec() *codec.Codec {
 // application updates every end block
 func (app *GaiaApp) BeginBlocker(ctx sdk.Context, req abci.RequestBeginBlock) abci.ResponseBeginBlock {
 
-	// distribute rewards from previous block
-	distr.BeginBlocker(ctx, req, app.distrKeeper)
-
 	// mint new tokens for this new block
 	mint.BeginBlocker(ctx, app.mintKeeper)
+
+	// distribute rewards for this block
+	distr.BeginBlocker(ctx, req, app.distrKeeper)
 
 	// slash anyone who double signed.
 	// NOTE: This should happen after distr.BeginBlocker so that

--- a/cmd/gaia/app/app.go
+++ b/cmd/gaia/app/app.go
@@ -189,10 +189,10 @@ func MakeCodec() *codec.Codec {
 // application updates every end block
 func (app *GaiaApp) BeginBlocker(ctx sdk.Context, req abci.RequestBeginBlock) abci.ResponseBeginBlock {
 
-	// mint new tokens for this new block
+	// mint new tokens for the previous block
 	mint.BeginBlocker(ctx, app.mintKeeper)
 
-	// distribute rewards for this block
+	// distribute rewards for the previous block
 	distr.BeginBlocker(ctx, req, app.distrKeeper)
 
 	// slash anyone who double signed.

--- a/cmd/gaia/app/export.go
+++ b/cmd/gaia/app/export.go
@@ -57,7 +57,7 @@ func (app *GaiaApp) ExportAppStateAndValidators(forZeroHeight bool) (
 func (app *GaiaApp) prepForZeroHeightGenesis(ctx sdk.Context) {
 
 	/* Just to be safe, assert the invariants on current state. */
-	app.assertRuntimeInvariantsWith(ctx)
+	app.assertRuntimeInvariantsOnContext(ctx)
 
 	/* Handle fee distribution state. */
 
@@ -81,7 +81,7 @@ func (app *GaiaApp) prepForZeroHeightGenesis(ctx sdk.Context) {
 	}
 	app.distrKeeper.IterateDelegationDistInfos(ctx, ddiIter)
 
-	app.assertRuntimeInvariantsWith(ctx)
+	app.assertRuntimeInvariantsOnContext(ctx)
 
 	// set distribution info withdrawal heights to 0
 	app.distrKeeper.IterateDelegationDistInfos(ctx, func(_ int64, delInfo distr.DelegationDistInfo) (stop bool) {
@@ -107,7 +107,7 @@ func (app *GaiaApp) prepForZeroHeightGenesis(ctx sdk.Context) {
 	}
 
 	// reset fee pool height, save fee pool
-	feePool.TotalValAccum = distr.TotalAccum{0, sdk.ZeroDec()}
+	feePool.TotalValAccum = distr.NewTotalAccum(0)
 	app.distrKeeper.SetFeePool(ctx, feePool)
 
 	/* Handle stake state. */

--- a/cmd/gaia/app/export.go
+++ b/cmd/gaia/app/export.go
@@ -113,7 +113,6 @@ func (app *GaiaApp) prepForZeroHeightGenesis(ctx sdk.Context) {
 	/* Handle stake state. */
 
 	// iterate through validators by power descending, reset bond height, update bond intra-tx counter
-	pool := app.stakeKeeper.GetPool(ctx)
 	store := ctx.KVStore(app.keyStake)
 	iter := sdk.KVStoreReversePrefixIterator(store, stake.ValidatorsByPowerIndexKey)
 	counter := int16(0)
@@ -127,7 +126,6 @@ func (app *GaiaApp) prepForZeroHeightGenesis(ctx sdk.Context) {
 		validator.BondIntraTxCounter = counter
 		validator.UnbondingHeight = 0
 		app.stakeKeeper.SetValidator(ctx, validator)
-		app.stakeKeeper.SetValidatorByPowerIndex(ctx, validator, pool)
 		counter++
 	}
 	iter.Close()
@@ -143,8 +141,4 @@ func (app *GaiaApp) prepForZeroHeightGenesis(ctx sdk.Context) {
 		app.slashingKeeper.SetValidatorSigningInfo(ctx, addr, info)
 		return false
 	})
-
-	/* assert runtime invariants */
-	ctx = ctx.WithBlockHeight(0)
-	app.assertRuntimeInvariantsWith(ctx)
 }

--- a/cmd/gaia/app/export.go
+++ b/cmd/gaia/app/export.go
@@ -81,12 +81,18 @@ func (app *GaiaApp) prepForZeroHeightGenesis(ctx sdk.Context) {
 	}
 	app.distrKeeper.IterateDelegationDistInfos(ctx, ddiIter)
 
-	app.assertRuntimeInvariantsWith(ctx)
-	fmt.Printf("pre-deletion\n")
+	app.distrKeeper.IterateValidatorDistInfos(ctx, func(_ int64, valInfo distr.ValidatorDistInfo) (stop bool) {
+		if !valInfo.DelPool.IsZero() || !valInfo.ValCommission.IsZero() {
+			panic(fmt.Sprintf("valInfo: %+v", valInfo))
+		}
+		return false
+	})
 
 	// delete all distribution infos
 	// these will be recreated in InitGenesis
 	app.distrKeeper.RemoveValidatorDistInfos(ctx)
+	app.assertRuntimeInvariantsWith(ctx)
+	fmt.Printf("pre-deletion\n")
 	app.distrKeeper.RemoveDelegationDistInfos(ctx)
 
 	// assert again

--- a/cmd/gaia/app/invariants.go
+++ b/cmd/gaia/app/invariants.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	banksim "github.com/cosmos/cosmos-sdk/x/bank/simulation"
 	distrsim "github.com/cosmos/cosmos-sdk/x/distribution/simulation"
 	"github.com/cosmos/cosmos-sdk/x/mock/simulation"
@@ -22,9 +23,13 @@ func (app *GaiaApp) runtimeInvariants() []simulation.Invariant {
 }
 
 func (app *GaiaApp) assertRuntimeInvariants() {
-	invariants := app.runtimeInvariants()
-	start := time.Now()
 	ctx := app.NewContext(false, abci.Header{Height: app.LastBlockHeight() + 1})
+	app.assertRuntimeInvariantsWith(ctx)
+}
+
+func (app *GaiaApp) assertRuntimeInvariantsWith(ctx sdk.Context) {
+	start := time.Now()
+	invariants := app.runtimeInvariants()
 	for _, inv := range invariants {
 		if err := inv(ctx); err != nil {
 			panic(fmt.Errorf("invariant broken: %s", err))

--- a/cmd/gaia/app/invariants.go
+++ b/cmd/gaia/app/invariants.go
@@ -24,10 +24,10 @@ func (app *GaiaApp) runtimeInvariants() []simulation.Invariant {
 
 func (app *GaiaApp) assertRuntimeInvariants() {
 	ctx := app.NewContext(false, abci.Header{Height: app.LastBlockHeight() + 1})
-	app.assertRuntimeInvariantsWith(ctx)
+	app.assertRuntimeInvariantsOnContext(ctx)
 }
 
-func (app *GaiaApp) assertRuntimeInvariantsWith(ctx sdk.Context) {
+func (app *GaiaApp) assertRuntimeInvariantsOnContext(ctx sdk.Context) {
 	start := time.Now()
 	invariants := app.runtimeInvariants()
 	for _, inv := range invariants {

--- a/docs/spec/mint/begin_block.md
+++ b/docs/spec/mint/begin_block.md
@@ -1,12 +1,12 @@
 # Begin-Block
 
-Inflation occurs at the beginning of each block, however minting parameters
-are only calculated once per hour.
+Minting parameters are recalculated and inflation
+paid at the beginning of each block.
 
 ## NextInflationRate
 
-The target annual inflation rate is recalculated at the first block of each new
-hour. The inflation is also subject to a rate change (positive or negative)
+The target annual inflation rate is recalculated each block.
+The inflation is also subject to a rate change (positive or negative)
 depending on the distance from the desired ratio (67%). The maximum rate change
 possible is defined to be 13% per year, however the annual inflation is capped
 as between 7% and 20%.
@@ -14,7 +14,7 @@ as between 7% and 20%.
 ```
 NextInflationRate(params Params, bondedRatio sdk.Dec) (inflation sdk.Dec) {
 	inflationRateChangePerYear = (1 - bondedRatio/params.GoalBonded) * params.InflationRateChange
-	inflationRateChange = inflationRateChangePerYear/hrsPerYr
+	inflationRateChange = inflationRateChangePerYear/blocksPerYr
 
 	// increase the new annual inflation for this next cycle
 	inflation += inflationRateChange

--- a/docs/spec/mint/state.md
+++ b/docs/spec/mint/state.md
@@ -8,7 +8,6 @@ The minter is a space for holding current inflation information.
 
 ```golang
 type Minter struct {
-	LastUpdate       time.Time // time which the last update was made to the minter
 	Inflation        sdk.Dec   // current annual inflation rate
 	AnnualProvisions sdk.Dec   // current annual exptected provisions
 }
@@ -30,4 +29,3 @@ type Params struct {
 	BlocksPerYear       uint64   // expected blocks per year
 }
 ```
-

--- a/x/distribution/alias.go
+++ b/x/distribution/alias.go
@@ -60,6 +60,8 @@ var (
 	NewMsgWithdrawValidatorRewardsAll = types.NewMsgWithdrawValidatorRewardsAll
 
 	NewDecCoins = types.NewDecCoins
+
+	NewTotalAccum = types.NewTotalAccum
 )
 
 const (

--- a/x/distribution/types/dec_coin.go
+++ b/x/distribution/types/dec_coin.go
@@ -194,6 +194,7 @@ func (coins DecCoins) HasNegative() bool {
 	return false
 }
 
+// return whether all coins are zero
 func (coins DecCoins) IsZero() bool {
 	for _, coin := range coins {
 		if !coin.Amount.IsZero() {

--- a/x/distribution/types/dec_coin.go
+++ b/x/distribution/types/dec_coin.go
@@ -193,3 +193,12 @@ func (coins DecCoins) HasNegative() bool {
 	}
 	return false
 }
+
+func (coins DecCoins) IsZero() bool {
+	for _, coin := range coins {
+		if !coin.Amount.IsZero() {
+			return false
+		}
+	}
+	return true
+}

--- a/x/mint/abci_app.go
+++ b/x/mint/abci_app.go
@@ -1,31 +1,26 @@
 package mint
 
 import (
-	"time"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 // Inflate every block, update inflation parameters once per hour
 func BeginBlocker(ctx sdk.Context, k Keeper) {
 
-	blockTime := ctx.BlockHeader().Time
+	// fetch stored minter & params
 	minter := k.GetMinter(ctx)
 	params := k.GetParams(ctx)
 
-	mintedCoin := minter.BlockProvision(params)
-	k.fck.AddCollectedFees(ctx, sdk.Coins{mintedCoin})
-	k.sk.InflateSupply(ctx, sdk.NewDecFromInt(mintedCoin.Amount))
-
-	if blockTime.Sub(minter.LastUpdate) < time.Hour {
-		return
-	}
-
-	// adjust the inflation, hourly-provision rate every hour
+	// recalculate inflation rate
 	totalSupply := k.sk.TotalPower(ctx)
 	bondedRatio := k.sk.BondedRatio(ctx)
 	minter.Inflation = minter.NextInflationRate(params, bondedRatio)
 	minter.AnnualProvisions = minter.NextAnnualProvisions(params, totalSupply)
-	minter.LastUpdate = blockTime
 	k.SetMinter(ctx, minter)
+
+	// mint coins, add to collected fees, update supply
+	mintedCoin := minter.BlockProvision(params)
+	k.fck.AddCollectedFees(ctx, sdk.Coins{mintedCoin})
+	k.sk.InflateSupply(ctx, sdk.NewDecFromInt(mintedCoin.Amount))
+
 }

--- a/x/mint/minter.go
+++ b/x/mint/minter.go
@@ -2,24 +2,20 @@ package mint
 
 import (
 	"fmt"
-	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 // Minter represents the minting state
 type Minter struct {
-	LastUpdate       time.Time `json:"last_update"`       // time which the last update was made to the minter
-	Inflation        sdk.Dec   `json:"inflation"`         // current annual inflation rate
-	AnnualProvisions sdk.Dec   `json:"annual_provisions"` // current annual expected provisions
+	Inflation        sdk.Dec `json:"inflation"`         // current annual inflation rate
+	AnnualProvisions sdk.Dec `json:"annual_provisions"` // current annual expected provisions
 }
 
 // Create a new minter object
-func NewMinter(lastUpdate time.Time, inflation,
-	annualProvisions sdk.Dec) Minter {
+func NewMinter(inflation, annualProvisions sdk.Dec) Minter {
 
 	return Minter{
-		LastUpdate:       lastUpdate,
 		Inflation:        inflation,
 		AnnualProvisions: annualProvisions,
 	}
@@ -28,7 +24,6 @@ func NewMinter(lastUpdate time.Time, inflation,
 // minter object for a new chain
 func InitialMinter(inflation sdk.Dec) Minter {
 	return NewMinter(
-		time.Unix(0, 0),
 		inflation,
 		sdk.NewDec(0),
 	)
@@ -50,8 +45,6 @@ func validateMinter(minter Minter) error {
 	return nil
 }
 
-var hrsPerYr = sdk.NewDec(8766) // as defined by a julian year of 365.25 days
-
 // get the new inflation rate for the next hour
 func (m Minter) NextInflationRate(params Params, bondedRatio sdk.Dec) (
 	inflation sdk.Dec) {
@@ -66,7 +59,7 @@ func (m Minter) NextInflationRate(params Params, bondedRatio sdk.Dec) (
 	inflationRateChangePerYear := sdk.OneDec().
 		Sub(bondedRatio.Quo(params.GoalBonded)).
 		Mul(params.InflationRateChange)
-	inflationRateChange := inflationRateChangePerYear.Quo(hrsPerYr)
+	inflationRateChange := inflationRateChangePerYear.Quo(sdk.NewDec(int64(params.BlocksPerYear)))
 
 	// increase the new annual inflation for this next cycle
 	inflation = m.Inflation.Add(inflationRateChange)

--- a/x/mint/minter_test.go
+++ b/x/mint/minter_test.go
@@ -117,7 +117,7 @@ func BenchmarkNextInflation(b *testing.B) {
 }
 
 // Next annual provisions benchmarking
-// BenchmarkNextAnnualProvisions-4 5000000251 ns/op
+// BenchmarkNextAnnualProvisions-4 5000000 251 ns/op
 func BenchmarkNextAnnualProvisions(b *testing.B) {
 	minter := InitialMinter(sdk.NewDecWithPrec(1, 1))
 	params := DefaultParams()

--- a/x/mint/minter_test.go
+++ b/x/mint/minter_test.go
@@ -96,8 +96,36 @@ func BenchmarkBlockProvision(b *testing.B) {
 	r1 := rand.New(s1)
 	minter.AnnualProvisions = sdk.NewDec(r1.Int63n(1000000))
 
-	// run the Fib function b.N times
+	// run the BlockProvision function b.N times
 	for n := 0; n < b.N; n++ {
 		minter.BlockProvision(params)
 	}
+}
+
+// Next inflation benchmarking
+// BenchmarkNextInflation-4 1000000 1828 ns/op
+func BenchmarkNextInflation(b *testing.B) {
+	minter := InitialMinter(sdk.NewDecWithPrec(1, 1))
+	params := DefaultParams()
+	bondedRatio := sdk.NewDecWithPrec(1, 1)
+
+	// run the NextInflationRate function b.N times
+	for n := 0; n < b.N; n++ {
+		minter.NextInflationRate(params, bondedRatio)
+	}
+
+}
+
+// Next annual provisions benchmarking
+// BenchmarkNextAnnualProvisions-4 5000000251 ns/op
+func BenchmarkNextAnnualProvisions(b *testing.B) {
+	minter := InitialMinter(sdk.NewDecWithPrec(1, 1))
+	params := DefaultParams()
+	totalSupply := sdk.NewDec(100000000000000)
+
+	// run the NextAnnualProvisions function b.N times
+	for n := 0; n < b.N; n++ {
+		minter.NextAnnualProvisions(params, totalSupply)
+	}
+
 }

--- a/x/mint/minter_test.go
+++ b/x/mint/minter_test.go
@@ -12,6 +12,7 @@ import (
 func TestNextInflation(t *testing.T) {
 	minter := DefaultInitialMinter()
 	params := DefaultParams()
+	blocksPerYr := sdk.NewDec(int64(params.BlocksPerYear))
 
 	// Governing Mechanism:
 	//    inflationRateChangePerYear = (1- BondedRatio/ GoalBonded) * MaxInflationRateChange
@@ -20,24 +21,24 @@ func TestNextInflation(t *testing.T) {
 		bondedRatio, setInflation, expChange sdk.Dec
 	}{
 		// with 0% bonded atom supply the inflation should increase by InflationRateChange
-		{sdk.ZeroDec(), sdk.NewDecWithPrec(7, 2), params.InflationRateChange.Quo(hrsPerYr)},
+		{sdk.ZeroDec(), sdk.NewDecWithPrec(7, 2), params.InflationRateChange.Quo(blocksPerYr)},
 
 		// 100% bonded, starting at 20% inflation and being reduced
 		// (1 - (1/0.67))*(0.13/8667)
 		{sdk.OneDec(), sdk.NewDecWithPrec(20, 2),
-			sdk.OneDec().Sub(sdk.OneDec().Quo(params.GoalBonded)).Mul(params.InflationRateChange).Quo(hrsPerYr)},
+			sdk.OneDec().Sub(sdk.OneDec().Quo(params.GoalBonded)).Mul(params.InflationRateChange).Quo(blocksPerYr)},
 
 		// 50% bonded, starting at 10% inflation and being increased
 		{sdk.NewDecWithPrec(5, 1), sdk.NewDecWithPrec(10, 2),
-			sdk.OneDec().Sub(sdk.NewDecWithPrec(5, 1).Quo(params.GoalBonded)).Mul(params.InflationRateChange).Quo(hrsPerYr)},
+			sdk.OneDec().Sub(sdk.NewDecWithPrec(5, 1).Quo(params.GoalBonded)).Mul(params.InflationRateChange).Quo(blocksPerYr)},
 
 		// test 7% minimum stop (testing with 100% bonded)
 		{sdk.OneDec(), sdk.NewDecWithPrec(7, 2), sdk.ZeroDec()},
-		{sdk.OneDec(), sdk.NewDecWithPrec(70001, 6), sdk.NewDecWithPrec(-1, 6)},
+		{sdk.OneDec(), sdk.NewDecWithPrec(700000001, 10), sdk.NewDecWithPrec(-1, 10)},
 
 		// test 20% maximum stop (testing with 0% bonded)
 		{sdk.ZeroDec(), sdk.NewDecWithPrec(20, 2), sdk.ZeroDec()},
-		{sdk.ZeroDec(), sdk.NewDecWithPrec(199999, 6), sdk.NewDecWithPrec(1, 6)},
+		{sdk.ZeroDec(), sdk.NewDecWithPrec(1999999999, 10), sdk.NewDecWithPrec(1, 10)},
 
 		// perfect balance shouldn't change inflation
 		{sdk.NewDecWithPrec(67, 2), sdk.NewDecWithPrec(15, 2), sdk.ZeroDec()},


### PR DESCRIPTION
Closes https://github.com/cosmos/cosmos-sdk/issues/2967

Changes:

- Tokens are minted for the previous block before distributing rewards
- Inflation rate is now recalculated each block instead of each hour
- For zero-height export, delegation withdrawal infos / validator withdrawal infos are not deleted but instead reset to height 0

Standard checklist:

- [x] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [x] Wrote tests
- [x] Updated relevant documentation (`docs/`)
- [x] Added entries in `PENDING.md` with issue # 
- [x] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
