### PR TITLE
R4R: Add Account Decoder to the LCD

### DIFF
--- a/client/lcd/root.go
+++ b/client/lcd/root.go
@@ -39,7 +39,7 @@ type RestServer struct {
 // NewRestServer creates a new rest server instance
 func NewRestServer(cdc *codec.Codec) *RestServer {
 	r := mux.NewRouter()
-	cliCtx := context.NewCLIContext().WithCodec(cdc)
+	cliCtx := context.NewCLIContext().WithCodec(cdc).WithAccountDecoder(cdc)
 
 	// Register version methods on the router
 	r.HandleFunc("/version", CLIVersionRequestHandler).Methods("GET")


### PR DESCRIPTION
Currently trying to send transactions through the LCD fails because the `cliCtx` in the LCD doesn't have an `AccountDecoder`. This PR adds the one line fix necessary.

While this doesn't pop up in gaia for some reason (repro case below):
```bash
$ gaiad init --chain-id foo --moniker foo
$ gaiacli keys add jack
$ gaiacli keys add alice
$ gaiad add-genesis-account $(gaiacli keys show jack -a) 1000STAKE,1000jackToken
$ gaiad add-genesis-account $(gaiacli keys show alice -a) 1000STAKE,1000aliceToken
$ gaiad gentx --from jack
$ gaiad collect-gentxs
$ gaiad start
$ gaiacli rest-server --chain-id foo
$ curl -k -s https://localhost:1317/bank/accounts/{{ .Alice.Address }}/transfers --data-binary '{"base_req":{"name":"jack","password":"foobarbaz","chain_id":"foo","account_number":"0","sequence":"1"},"amount":[{"denom":"STAKE","amount":"50"}]}'
```

I am running into it in the SDK tutorial and would like this fixed for users.