### PR TITLE
R4R: Reintroduce collect-gentxs's --gentx-dir flag

### DIFF
--- a/PENDING.md
+++ b/PENDING.md
@@ -34,6 +34,7 @@ IMPROVEMENTS
 * Gaia CLI  (`gaiacli`)
 
 * Gaia
+  * [\#3021](https://github.com/cosmos/cosmos-sdk/pull/3021) Add `--gentx-dir` to `gaiad collect-gentxs` to specify a directory from which collect and load gentxs.
 
 * SDK
 

--- a/PENDING.md
+++ b/PENDING.md
@@ -35,6 +35,7 @@ IMPROVEMENTS
 
 * Gaia
   * [\#3021](https://github.com/cosmos/cosmos-sdk/pull/3021) Add `--gentx-dir` to `gaiad collect-gentxs` to specify a directory from which collect and load gentxs.
+    Add `--output-document` to `gaiad init` to allow one to redirect output to file.
 
 * SDK
 

--- a/client/flags.go
+++ b/client/flags.go
@@ -43,6 +43,7 @@ const (
 	FlagSSLHosts           = "ssl-hosts"
 	FlagSSLCertFile        = "ssl-certfile"
 	FlagSSLKeyFile         = "ssl-keyfile"
+	FlagOutputDocument     = "output-document" // inspired by wget -O
 )
 
 // LineBreak can be included in a command list to provide a blank line

--- a/cmd/gaia/cli_test/cli_test.go
+++ b/cmd/gaia/cli_test/cli_test.go
@@ -645,6 +645,37 @@ trust_node = true
 	cleanupDirs(gaiadHome, gaiacliHome)
 }
 
+func TestGaiadCollectGentxs(t *testing.T) {
+	t.Parallel()
+	// Initialise temporary directories
+	gaiadHome, gaiacliHome := getTestingHomeDirs(t.Name())
+	gentxDir, err := ioutil.TempDir("", "")
+	gentxDoc := filepath.Join(gentxDir, "gentx.json")
+	require.NoError(t, err)
+
+	tests.ExecuteT(t, fmt.Sprintf("gaiad --home=%s unsafe-reset-all", gaiadHome), "")
+	os.RemoveAll(filepath.Join(gaiadHome, "config", "gentx"))
+	executeWrite(t, fmt.Sprintf("gaiacli keys delete --home=%s foo", gaiacliHome), app.DefaultKeyPass)
+	executeWrite(t, fmt.Sprintf("gaiacli keys delete --home=%s bar", gaiacliHome), app.DefaultKeyPass)
+	executeWriteCheckErr(t, fmt.Sprintf("gaiacli keys add --home=%s foo", gaiacliHome), app.DefaultKeyPass)
+	executeWriteCheckErr(t, fmt.Sprintf("gaiacli keys add --home=%s bar", gaiacliHome), app.DefaultKeyPass)
+	executeWriteCheckErr(t, fmt.Sprintf("gaiacli config --home=%s output json", gaiacliHome))
+	fooAddr, _ := executeGetAddrPK(t, fmt.Sprintf("gaiacli keys show foo --home=%s", gaiacliHome))
+
+	// Run init
+	_ = executeInit(t, fmt.Sprintf("gaiad init -o --moniker=foo --home=%s", gaiadHome))
+	// Add account to genesis.json
+	executeWriteCheckErr(t, fmt.Sprintf(
+		"gaiad add-genesis-account %s 150%s,1000fooToken --home=%s", fooAddr, stakeTypes.DefaultBondDenom, gaiadHome))
+	executeWrite(t, fmt.Sprintf("cat %s%sconfig%sgenesis.json", gaiadHome, string(os.PathSeparator), string(os.PathSeparator)))
+	// Write gentx file
+	executeWriteCheckErr(t, fmt.Sprintf(
+		"gaiad gentx --name=foo --home=%s --home-client=%s --output-document=%s", gaiadHome, gaiacliHome, gentxDoc), app.DefaultKeyPass)
+	// Collect gentxs from a custom directory
+	executeWriteCheckErr(t, fmt.Sprintf("gaiad collect-gentxs --home=%s --gentx-dir=%s", gaiadHome, gentxDir), app.DefaultKeyPass)
+	cleanupDirs(gaiadHome, gaiacliHome, gentxDir)
+}
+
 //___________________________________________________________________________________
 // helper methods
 

--- a/cmd/gaia/init/collect.go
+++ b/cmd/gaia/init/collect.go
@@ -18,6 +18,10 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/auth"
 )
 
+const (
+	flagGenTxDir = "gentx-dir"
+)
+
 type initConfig struct {
 	ChainID   string
 	GenTxsDir string
@@ -35,7 +39,6 @@ func CollectGenTxsCmd(ctx *server.Context, cdc *codec.Codec) *cobra.Command {
 			config := ctx.Config
 			config.SetRoot(viper.GetString(cli.HomeFlag))
 			name := viper.GetString(client.FlagName)
-
 			nodeID, valPubKey, err := InitializeNodeValidatorFiles(config)
 			if err != nil {
 				return err
@@ -46,19 +49,13 @@ func CollectGenTxsCmd(ctx *server.Context, cdc *codec.Codec) *cobra.Command {
 				return err
 			}
 
-			toPrint := printInfo{
-				Moniker: config.Moniker,
-				ChainID: genDoc.ChainID,
-				NodeID:  nodeID,
+			genTxsDir := viper.GetString(flagGenTxDir)
+			if genTxsDir == "" {
+				genTxsDir = filepath.Join(config.RootDir, "config", "gentx")
 			}
 
-			initCfg := initConfig{
-				ChainID:   genDoc.ChainID,
-				GenTxsDir: filepath.Join(config.RootDir, "config", "gentx"),
-				Name:      name,
-				NodeID:    nodeID,
-				ValPubKey: valPubKey,
-			}
+			toPrint := newPrintInfo(config.Moniker, genDoc.ChainID, nodeID, genTxsDir, json.RawMessage(""))
+			initCfg := newInitConfig(genDoc.ChainID, genTxsDir, name, nodeID, valPubKey)
 
 			appMessage, err := genAppStateFromConfig(cdc, config, initCfg, genDoc)
 			if err != nil {
@@ -73,6 +70,9 @@ func CollectGenTxsCmd(ctx *server.Context, cdc *codec.Codec) *cobra.Command {
 	}
 
 	cmd.Flags().String(cli.HomeFlag, app.DefaultNodeHome, "node's home directory")
+	cmd.Flags().String(flagGenTxDir, "",
+		"override default \"gentx\" directory from which collect and execute "+
+			"genesis transactions; default [--home]/config/gentx/")
 	return cmd
 }
 
@@ -116,4 +116,28 @@ func genAppStateFromConfig(
 
 	err = ExportGenesisFile(genFile, initCfg.ChainID, nil, appState)
 	return
+}
+
+func newInitConfig(chainID, genTxsDir, name, nodeID string,
+	valPubKey crypto.PubKey) initConfig {
+
+	return initConfig{
+		ChainID:   chainID,
+		GenTxsDir: genTxsDir,
+		Name:      name,
+		NodeID:    nodeID,
+		ValPubKey: valPubKey,
+	}
+}
+
+func newPrintInfo(moniker, chainID, nodeID, genTxsDir string,
+	appMessage json.RawMessage) printInfo {
+
+	return printInfo{
+		Moniker:    moniker,
+		ChainID:    chainID,
+		NodeID:     nodeID,
+		GenTxsDir:  genTxsDir,
+		AppMessage: appMessage,
+	}
 }

--- a/cmd/gaia/init/gentx.go
+++ b/cmd/gaia/init/gentx.go
@@ -137,9 +137,12 @@ following delegation and commission default parameters:
 			}
 
 			// Fetch output file name
-			outputDocument, err := makeOutputFilepath(config.RootDir, nodeID)
-			if err != nil {
-				return err
+			outputDocument := viper.GetString(client.FlagOutputDocument)
+			if outputDocument == "" {
+				outputDocument, err = makeOutputFilepath(config.RootDir, nodeID)
+				if err != nil {
+					return err
+				}
 			}
 
 			if err := writeSignedGenTx(cdc, outputDocument, signedTx); err != nil {
@@ -154,6 +157,8 @@ following delegation and commission default parameters:
 	cmd.Flags().String(tmcli.HomeFlag, app.DefaultNodeHome, "node's home directory")
 	cmd.Flags().String(flagClientHome, app.DefaultCLIHome, "client's home directory")
 	cmd.Flags().String(client.FlagName, "", "name of private key with which to sign the gentx")
+	cmd.Flags().String(client.FlagOutputDocument, "",
+		"write the genesis transaction JSON document to the given file instead of the default location")
 	cmd.Flags().AddFlagSet(cli.FsCommissionCreate)
 	cmd.Flags().AddFlagSet(cli.FsAmount)
 	cmd.Flags().AddFlagSet(cli.FsPk)

--- a/cmd/gaia/init/init.go
+++ b/cmd/gaia/init/init.go
@@ -28,6 +28,7 @@ type printInfo struct {
 	Moniker    string          `json:"moniker"`
 	ChainID    string          `json:"chain_id"`
 	NodeID     string          `json:"node_id"`
+	GenTxsDir  string          `json:"gentxs_dir"`
 	AppMessage json.RawMessage `json:"app_message"`
 }
 
@@ -77,12 +78,7 @@ func InitCmd(ctx *server.Context, cdc *codec.Codec) *cobra.Command {
 				return err
 			}
 
-			toPrint := printInfo{
-				ChainID:    chainID,
-				Moniker:    config.Moniker,
-				NodeID:     nodeID,
-				AppMessage: appState,
-			}
+			toPrint := newPrintInfo(config.Moniker, chainID, nodeID, "", appState)
 
 			cfg.WriteConfigFile(filepath.Join(config.RootDir, "config", "config.toml"), config)
 

--- a/cmd/gaia/init/testnet.go
+++ b/cmd/gaia/init/testnet.go
@@ -279,13 +279,7 @@ func collectGenFiles(
 		config.SetRoot(nodeDir)
 
 		nodeID, valPubKey := nodeIDs[i], valPubKeys[i]
-		initCfg := initConfig{
-			ChainID:   chainID,
-			GenTxsDir: gentxsDir,
-			Name:      moniker,
-			NodeID:    nodeID,
-			ValPubKey: valPubKey,
-		}
+		initCfg := newInitConfig(chainID, gentxsDir, moniker, nodeID, valPubKey)
 
 		genDoc, err := loadGenesisDoc(cdc, config.GenesisFile())
 		if err != nil {

--- a/x/stake/client/cli/flags.go
+++ b/x/stake/client/cli/flags.go
@@ -29,8 +29,6 @@ const (
 	FlagGenesisFormat = "genesis-format"
 	FlagNodeID        = "node-id"
 	FlagIP            = "ip"
-
-	FlagOutputDocument = "output-document" // inspired by wget -O
 )
 
 // common flagsets to add to various functions


### PR DESCRIPTION
It was lost in the last genesis workflow refactoring.

Also address structs initializations as per #2835.

- [x] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added entries in `PENDING.md` with issue # 
- [ ] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
