### PR TITLE
Fix negative stake & invariance bug

### DIFF
--- a/cmd/gaia/app/invariants.go
+++ b/cmd/gaia/app/invariants.go
@@ -18,7 +18,7 @@ func (app *GaiaApp) runtimeInvariants() []simulation.Invariant {
 		distrsim.ValAccumInvariants(app.distrKeeper, app.stakeKeeper),
 		stakesim.SupplyInvariants(app.bankKeeper, app.stakeKeeper,
 			app.feeCollectionKeeper, app.distrKeeper, app.accountKeeper),
-		stakesim.PositivePowerInvariant(app.stakeKeeper),
+		stakesim.NonNegativePowerInvariant(app.stakeKeeper),
 	}
 }
 

--- a/cmd/gaia/cmd/gaiareplay/main.go
+++ b/cmd/gaia/cmd/gaiareplay/main.go
@@ -127,7 +127,9 @@ func run(rootDir string) {
 	if err != nil {
 		panic(err)
 	}
-	defer proxyApp.Stop()
+	defer func() {
+		_ = proxyApp.Stop()
+	}()
 
 	var state tmsm.State = tmsm.LoadState(tmDB)
 	if state.LastBlockHeight == 0 {

--- a/types/decimal.go
+++ b/types/decimal.go
@@ -272,6 +272,10 @@ func (d Dec) Format(s fmt.State, verb rune) {
 }
 
 func (d Dec) String() string {
+	isNeg := d.IsNegative()
+	if d.IsNegative() {
+		d = d.Neg()
+	}
 	bz, err := d.Int.MarshalText()
 	if err != nil {
 		return ""
@@ -298,7 +302,11 @@ func (d Dec) String() string {
 		bzWDec[inputSize-10] = byte('.')
 		copy(bzWDec[inputSize-9:], bz[inputSize-10:])
 	}
-	return string(bzWDec)
+	if isNeg {
+		return "-" + string(bzWDec)
+	} else {
+		return string(bzWDec)
+	}
 }
 
 //     ____

--- a/types/decimal.go
+++ b/types/decimal.go
@@ -304,9 +304,8 @@ func (d Dec) String() string {
 	}
 	if isNeg {
 		return "-" + string(bzWDec)
-	} else {
-		return string(bzWDec)
 	}
+	return string(bzWDec)
 }
 
 //     ____

--- a/x/stake/genesis.go
+++ b/x/stake/genesis.go
@@ -38,7 +38,7 @@ func InitGenesis(ctx sdk.Context, keeper Keeper, data types.GenesisState) (res [
 
 		// Manually set indices for the first time
 		keeper.SetValidatorByConsAddr(ctx, validator)
-		keeper.SetValidatorByPowerIndex(ctx, validator, data.Pool)
+		keeper.SetValidatorByPowerIndex(ctx, validator)
 		keeper.OnValidatorCreated(ctx, validator.OperatorAddr)
 
 		// Set timeslice if necessary

--- a/x/stake/handler_test.go
+++ b/x/stake/handler_test.go
@@ -55,8 +55,7 @@ func TestValidatorByPowerIndex(t *testing.T) {
 	// verify that the by power index exists
 	validator, found := keeper.GetValidator(ctx, validatorAddr)
 	require.True(t, found)
-	pool := keeper.GetPool(ctx)
-	power := keep.GetValidatorsByPowerIndexKey(validator, pool)
+	power := keep.GetValidatorsByPowerIndexKey(validator)
 	require.True(t, keep.ValidatorByPowerIndexExists(ctx, keeper, power))
 
 	// create a second validator keep it bonded
@@ -85,12 +84,11 @@ func TestValidatorByPowerIndex(t *testing.T) {
 	// but the new power record should have been created
 	validator, found = keeper.GetValidator(ctx, validatorAddr)
 	require.True(t, found)
-	pool = keeper.GetPool(ctx)
-	power2 := GetValidatorsByPowerIndexKey(validator, pool)
+	power2 := GetValidatorsByPowerIndexKey(validator)
 	require.True(t, keep.ValidatorByPowerIndexExists(ctx, keeper, power2))
 
 	// now the new record power index should be the same as the original record
-	power3 := GetValidatorsByPowerIndexKey(validator, pool)
+	power3 := GetValidatorsByPowerIndexKey(validator)
 	require.Equal(t, power2, power3)
 
 	// unbond self-delegation

--- a/x/stake/keeper/delegation_test.go
+++ b/x/stake/keeper/delegation_test.go
@@ -240,7 +240,7 @@ func TestUndelegateSelfDelegation(t *testing.T) {
 	keeper.SetDelegation(ctx, selfDelegation)
 
 	// create a second delegation to this validator
-	keeper.DeleteValidatorByPowerIndex(ctx, validator, pool)
+	keeper.DeleteValidatorByPowerIndex(ctx, validator)
 	validator, pool, issuedShares = validator.AddTokensFromDel(pool, sdk.NewInt(10))
 	require.Equal(t, int64(10), issuedShares.RoundInt64())
 	keeper.SetPool(ctx, pool)
@@ -288,7 +288,7 @@ func TestUndelegateFromUnbondingValidator(t *testing.T) {
 	keeper.SetDelegation(ctx, selfDelegation)
 
 	// create a second delegation to this validator
-	keeper.DeleteValidatorByPowerIndex(ctx, validator, pool)
+	keeper.DeleteValidatorByPowerIndex(ctx, validator)
 	validator, pool, issuedShares = validator.AddTokensFromDel(pool, sdk.NewInt(10))
 	require.Equal(t, int64(10), issuedShares.RoundInt64())
 	keeper.SetPool(ctx, pool)
@@ -365,7 +365,7 @@ func TestUndelegateFromUnbondedValidator(t *testing.T) {
 	keeper.SetDelegation(ctx, selfDelegation)
 
 	// create a second delegation to this validator
-	keeper.DeleteValidatorByPowerIndex(ctx, validator, pool)
+	keeper.DeleteValidatorByPowerIndex(ctx, validator)
 	validator, pool, issuedShares = validator.AddTokensFromDel(pool, sdk.NewInt(10))
 	require.Equal(t, int64(10), issuedShares.RoundInt64())
 	keeper.SetPool(ctx, pool)
@@ -444,7 +444,7 @@ func TestUnbondingAllDelegationFromValidator(t *testing.T) {
 	keeper.SetDelegation(ctx, selfDelegation)
 
 	// create a second delegation to this validator
-	keeper.DeleteValidatorByPowerIndex(ctx, validator, pool)
+	keeper.DeleteValidatorByPowerIndex(ctx, validator)
 	validator, pool, issuedShares = validator.AddTokensFromDel(pool, sdk.NewInt(10))
 	require.Equal(t, int64(10), issuedShares.RoundInt64())
 	keeper.SetPool(ctx, pool)
@@ -689,7 +689,7 @@ func TestRedelegateFromUnbondingValidator(t *testing.T) {
 	keeper.SetDelegation(ctx, selfDelegation)
 
 	// create a second delegation to this validator
-	keeper.DeleteValidatorByPowerIndex(ctx, validator, pool)
+	keeper.DeleteValidatorByPowerIndex(ctx, validator)
 	validator, pool, issuedShares = validator.AddTokensFromDel(pool, sdk.NewInt(10))
 	require.Equal(t, int64(10), issuedShares.RoundInt64())
 	keeper.SetPool(ctx, pool)
@@ -773,7 +773,7 @@ func TestRedelegateFromUnbondedValidator(t *testing.T) {
 	keeper.SetDelegation(ctx, selfDelegation)
 
 	// create a second delegation to this validator
-	keeper.DeleteValidatorByPowerIndex(ctx, validator, pool)
+	keeper.DeleteValidatorByPowerIndex(ctx, validator)
 	validator, pool, issuedShares = validator.AddTokensFromDel(pool, sdk.NewInt(10))
 	validator.BondIntraTxCounter = 1
 	require.Equal(t, int64(10), issuedShares.RoundInt64())

--- a/x/stake/keeper/key.go
+++ b/x/stake/keeper/key.go
@@ -61,7 +61,7 @@ func AddressFromLastValidatorPowerKey(key []byte) []byte {
 // Power index is the key used in the power-store, and represents the relative
 // power ranking of the validator.
 // VALUE: validator operator address ([]byte)
-func GetValidatorsByPowerIndexKey(validator types.Validator, pool types.Pool) []byte {
+func GetValidatorsByPowerIndexKey(validator types.Validator) []byte {
 	// NOTE the address doesn't need to be stored because counter bytes must always be different
 	return getValidatorPowerRank(validator)
 }

--- a/x/stake/keeper/test_common.go
+++ b/x/stake/keeper/test_common.go
@@ -202,9 +202,8 @@ func ValidatorByPowerIndexExists(ctx sdk.Context, keeper Keeper, power []byte) b
 
 // update validator for testing
 func TestingUpdateValidator(keeper Keeper, ctx sdk.Context, validator types.Validator) types.Validator {
-	pool := keeper.GetPool(ctx)
 	keeper.SetValidator(ctx, validator)
-	keeper.SetValidatorByPowerIndex(ctx, validator, pool)
+	keeper.SetValidatorByPowerIndex(ctx, validator)
 	keeper.ApplyAndReturnValidatorSetUpdates(ctx)
 	validator, found := keeper.GetValidator(ctx, validator.OperatorAddr)
 	if !found {

--- a/x/stake/keeper/validator.go
+++ b/x/stake/keeper/validator.go
@@ -99,26 +99,25 @@ func (k Keeper) SetValidatorByConsAddr(ctx sdk.Context, validator types.Validato
 }
 
 // validator index
-func (k Keeper) SetValidatorByPowerIndex(ctx sdk.Context, validator types.Validator, pool types.Pool) {
+func (k Keeper) SetValidatorByPowerIndex(ctx sdk.Context, validator types.Validator) {
 	// jailed validators are not kept in the power index
 	if validator.Jailed {
 		return
 	}
 	store := ctx.KVStore(k.storeKey)
-	store.Set(GetValidatorsByPowerIndexKey(validator, pool), validator.OperatorAddr)
+	store.Set(GetValidatorsByPowerIndexKey(validator), validator.OperatorAddr)
 }
 
 // validator index
-func (k Keeper) DeleteValidatorByPowerIndex(ctx sdk.Context, validator types.Validator, pool types.Pool) {
+func (k Keeper) DeleteValidatorByPowerIndex(ctx sdk.Context, validator types.Validator) {
 	store := ctx.KVStore(k.storeKey)
-	store.Delete(GetValidatorsByPowerIndexKey(validator, pool))
+	store.Delete(GetValidatorsByPowerIndexKey(validator))
 }
 
 // validator index
 func (k Keeper) SetNewValidatorByPowerIndex(ctx sdk.Context, validator types.Validator) {
 	store := ctx.KVStore(k.storeKey)
-	pool := k.GetPool(ctx)
-	store.Set(GetValidatorsByPowerIndexKey(validator, pool), validator.OperatorAddr)
+	store.Set(GetValidatorsByPowerIndexKey(validator), validator.OperatorAddr)
 }
 
 //___________________________________________________________________________
@@ -127,8 +126,8 @@ func (k Keeper) SetNewValidatorByPowerIndex(ctx sdk.Context, validator types.Val
 func (k Keeper) AddValidatorTokensAndShares(ctx sdk.Context, validator types.Validator,
 	tokensToAdd sdk.Int) (valOut types.Validator, addedShares sdk.Dec) {
 
+	k.DeleteValidatorByPowerIndex(ctx, validator)
 	pool := k.GetPool(ctx)
-	k.DeleteValidatorByPowerIndex(ctx, validator, pool)
 	validator, pool, addedShares = validator.AddTokensFromDel(pool, tokensToAdd)
 	// increment the intra-tx counter
 	// in case of a conflict, the validator which least recently changed power takes precedence
@@ -137,7 +136,7 @@ func (k Keeper) AddValidatorTokensAndShares(ctx sdk.Context, validator types.Val
 	k.SetIntraTxCounter(ctx, counter+1)
 	k.SetValidator(ctx, validator)
 	k.SetPool(ctx, pool)
-	k.SetValidatorByPowerIndex(ctx, validator, pool)
+	k.SetValidatorByPowerIndex(ctx, validator)
 	return validator, addedShares
 }
 
@@ -145,24 +144,24 @@ func (k Keeper) AddValidatorTokensAndShares(ctx sdk.Context, validator types.Val
 func (k Keeper) RemoveValidatorTokensAndShares(ctx sdk.Context, validator types.Validator,
 	sharesToRemove sdk.Dec) (valOut types.Validator, removedTokens sdk.Dec) {
 
+	k.DeleteValidatorByPowerIndex(ctx, validator)
 	pool := k.GetPool(ctx)
-	k.DeleteValidatorByPowerIndex(ctx, validator, pool)
 	validator, pool, removedTokens = validator.RemoveDelShares(pool, sharesToRemove)
 	k.SetValidator(ctx, validator)
 	k.SetPool(ctx, pool)
-	k.SetValidatorByPowerIndex(ctx, validator, pool)
+	k.SetValidatorByPowerIndex(ctx, validator)
 	return validator, removedTokens
 }
 
 // Update the tokens of an existing validator, update the validators power index key
 func (k Keeper) RemoveValidatorTokens(ctx sdk.Context, validator types.Validator, tokensToRemove sdk.Dec) types.Validator {
 
+	k.DeleteValidatorByPowerIndex(ctx, validator)
 	pool := k.GetPool(ctx)
-	k.DeleteValidatorByPowerIndex(ctx, validator, pool)
 	validator, pool = validator.RemoveTokens(pool, tokensToRemove)
 	k.SetValidator(ctx, validator)
 	k.SetPool(ctx, pool)
-	k.SetValidatorByPowerIndex(ctx, validator, pool)
+	k.SetValidatorByPowerIndex(ctx, validator)
 	return validator
 }
 
@@ -195,12 +194,17 @@ func (k Keeper) RemoveValidator(ctx sdk.Context, address sdk.ValAddress) {
 		panic("Cannot call RemoveValidator on bonded or unbonding validators")
 	}
 
+	// if any tokens remain, remove from pool.
+	// this happens if shares are zero but tokens are not.
+	pool := k.GetPool(ctx)
+	pool.LooseTokens = pool.LooseTokens.Sub(validator.Tokens)
+	k.SetPool(ctx, pool)
+
 	// delete the old validator record
 	store := ctx.KVStore(k.storeKey)
-	pool := k.GetPool(ctx)
 	store.Delete(GetValidatorKey(address))
 	store.Delete(GetValidatorByConsAddrKey(sdk.ConsAddress(validator.ConsPubKey.Address())))
-	store.Delete(GetValidatorsByPowerIndexKey(validator, pool))
+	store.Delete(GetValidatorsByPowerIndexKey(validator))
 
 	// call hook if present
 	if k.hooks != nil {

--- a/x/stake/keeper/validator.go
+++ b/x/stake/keeper/validator.go
@@ -194,8 +194,9 @@ func (k Keeper) RemoveValidator(ctx sdk.Context, address sdk.ValAddress) {
 		panic("Cannot call RemoveValidator on bonded or unbonding validators")
 	}
 
-	// if any tokens remain, remove from pool.
+	// if any tokens remain, remove from pool (burning the tokens).
 	// this happens if shares are zero but tokens are not.
+	// TODO: Remove once https://github.com/cosmos/cosmos-sdk/pull/2958 is merged
 	pool := k.GetPool(ctx)
 	pool.LooseTokens = pool.LooseTokens.Sub(validator.Tokens)
 	k.SetPool(ctx, pool)

--- a/x/stake/querier/querier_test.go
+++ b/x/stake/querier/querier_test.go
@@ -29,7 +29,7 @@ func TestNewQuerier(t *testing.T) {
 		validators[i], pool, _ = validators[i].AddTokensFromDel(pool, amt)
 		validators[i].BondIntraTxCounter = int16(i)
 		keeper.SetValidator(ctx, validators[i])
-		keeper.SetValidatorByPowerIndex(ctx, validators[i], pool)
+		keeper.SetValidatorByPowerIndex(ctx, validators[i])
 	}
 	keeper.SetPool(ctx, pool)
 
@@ -170,13 +170,11 @@ func TestQueryDelegation(t *testing.T) {
 	// Create Validators and Delegation
 	val1 := types.NewValidator(addrVal1, pk1, types.Description{})
 	keeper.SetValidator(ctx, val1)
-	pool := keeper.GetPool(ctx)
-	keeper.SetValidatorByPowerIndex(ctx, val1, pool)
+	keeper.SetValidatorByPowerIndex(ctx, val1)
 
 	val2 := types.NewValidator(addrVal2, pk2, types.Description{})
 	keeper.SetValidator(ctx, val2)
-	pool = keeper.GetPool(ctx)
-	keeper.SetValidatorByPowerIndex(ctx, val2, pool)
+	keeper.SetValidatorByPowerIndex(ctx, val2)
 
 	keeper.Delegate(ctx, addrAcc2, sdk.NewCoin(types.DefaultBondDenom, sdk.NewInt(20)), val1, true)
 

--- a/x/stake/simulation/invariants.go
+++ b/x/stake/simulation/invariants.go
@@ -26,7 +26,7 @@ func AllInvariants(ck bank.Keeper, k stake.Keeper,
 			return err
 		}
 
-		err = PositivePowerInvariant(k)(ctx)
+		err = NonNegativePowerInvariant(k)(ctx)
 		if err != nil {
 			return err
 		}
@@ -111,8 +111,8 @@ func SupplyInvariants(ck bank.Keeper, k stake.Keeper,
 	}
 }
 
-// PositivePowerInvariant checks that all stored validators have > 0 power.
-func PositivePowerInvariant(k stake.Keeper) simulation.Invariant {
+// NonNegativePowerInvariant checks that all stored validators have >= 0 power.
+func NonNegativePowerInvariant(k stake.Keeper) simulation.Invariant {
 	return func(ctx sdk.Context) error {
 		iterator := k.ValidatorsPowerStoreIterator(ctx)
 
@@ -127,6 +127,10 @@ func PositivePowerInvariant(k stake.Keeper) simulation.Invariant {
 			if !bytes.Equal(iterator.Key(), powerKey) {
 				return fmt.Errorf("power store invariance:\n\tvalidator.Power: %v"+
 					"\n\tkey should be: %v\n\tkey in store: %v", validator.GetPower(), powerKey, iterator.Key())
+			}
+
+			if validator.Tokens.LT(sdk.ZeroDec()) {
+				return fmt.Errorf("negative tokens for validator: %v", validator)
 			}
 		}
 		iterator.Close()

--- a/x/stake/simulation/invariants.go
+++ b/x/stake/simulation/invariants.go
@@ -115,7 +115,6 @@ func SupplyInvariants(ck bank.Keeper, k stake.Keeper,
 func PositivePowerInvariant(k stake.Keeper) simulation.Invariant {
 	return func(ctx sdk.Context) error {
 		iterator := k.ValidatorsPowerStoreIterator(ctx)
-		pool := k.GetPool(ctx)
 
 		for ; iterator.Valid(); iterator.Next() {
 			validator, found := k.GetValidator(ctx, iterator.Value())
@@ -123,7 +122,7 @@ func PositivePowerInvariant(k stake.Keeper) simulation.Invariant {
 				panic(fmt.Sprintf("validator record not found for address: %X\n", iterator.Value()))
 			}
 
-			powerKey := keeper.GetValidatorsByPowerIndexKey(validator, pool)
+			powerKey := keeper.GetValidatorsByPowerIndexKey(validator)
 
 			if !bytes.Equal(iterator.Key(), powerKey) {
 				return fmt.Errorf("power store invariance:\n\tvalidator.Power: %v"+


### PR DESCRIPTION
Upon debugging https://github.com/cosmos/cosmos-sdk/issues/3019, I discovered, in order,:

(1) the transactions of the offending block aren't relevant.
(2) stake.EndBlocker is the offender.
(3) UnbondAllMatureValidatorQueue is the offender.
(4) that RemoveValidator was being called.
(5) the pool is being passed around in places where it is unnecessary.
(6) that this validator had 0 shares and *negative* staking tokens.
(7) RemoveTokens is not being re-used, and it lacks sanity checks.

There are 2 bugs here that are addressed here:
* negative staking token can happen because RemoveDelShares isn't clipping properly.
* RemoveValidator is not removing the tokens properly from the pool.

Also, the pool is removed where unnecessary, and RemoveTokens is reused.

I've verified that these changes would have made 9002 pass at least that offending block, though I'm not certain that I've found all the places where negative staked validators can occur.

TODO: Run simulations. --- Simulation is still failing.
TODO: Create PositiveValidatorStakeInvariant