### PR TITLE
Add generate-only option to withdraw-rewards

### DIFF
--- a/x/distribution/client/cli/tx.go
+++ b/x/distribution/client/cli/tx.go
@@ -3,6 +3,7 @@ package cli
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -86,6 +87,10 @@ func GetCmdWithdrawRewards(cdc *codec.Codec) *cobra.Command {
 					return err
 				}
 				msg = types.NewMsgWithdrawDelegatorRewardsAll(delAddr)
+			}
+
+			if cliCtx.GenerateOnly {
+				return utils.PrintUnsignedStdTx(os.Stdout, txBldr, cliCtx, []sdk.Msg{msg}, false)
 			}
 
 			// build and sign the transaction, then broadcast to Tendermint


### PR DESCRIPTION
- Add generate-only option to `gaiacli tx dist withdraw-rewards ` command 
- PR without Issue because it is trivial fix


before patch ( not working  `--generate-only` option )

```
gaiacli tx dist withdraw-rewards --from=node0 --is
-validator  --trust-
node  --generate-only
Committed at block 22 (tx hash: 4943F550B5F8C29BF30A0FD30BF9B0E0F78B7B9A6951A5F98C580B3003B8D52E, response: {Code:0 Data:[] Log:Msg 0:  Info: GasWanted:200000 GasUsed:4868 Tags:[{Key:[97 99 116 105 111 110] Value:[119 105 116 104 100 114 97 119 95 118 97 108 105 100 97 116 111 114 95 114 101 119 97 114 100 115 95 97 108 108] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0} {Key:[115 111 117 114 99 101 45 118 97 108 105 100 97 116 111 114] Value:[99 111 115 109 111 115 118 97 108 111 112 101 114 49 53 113 57 118 107 106 118 117 51 99 109 110 109 55 55 108 115 101 122 107 54 110 115 114 109 103 110 122 53 48 115 116 101 55 99 114 120 52] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}] Codespace: XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0})
```


after patch

```
gaiacli tx dist withdraw-rewards --from=node0 --is
-validator  --trust-
node --generate-only
{"type":"auth/StdTx","value":{"msg":[{"type":"cosmos-sdk/MsgWithdrawValidatorRewardsAll","value":{"validator_addr":"cosmosvaloper15q9vkjvu3cmnm77lsezk6nsrmgnz50ste7crx4"}}],"fee":{"amount":[{"denom":"","amount":"0"}],"gas":"200000"},"signatures":null,"memo":""}}
```

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added entries in `PENDING.md` with issue # 
- [x] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))