### PR TITLE
Immediately set bond height/intratxcounter for new validators

### DIFF
--- a/PENDING.md
+++ b/PENDING.md
@@ -17,6 +17,7 @@ BREAKING CHANGES
 
 * SDK
  - [auth] \#2952 Signatures are no longer serialized on chain with the account number and sequence number
+ - [stake] Newly creator validators have bond height/intratxcounter immediately set
 
 * Tendermint
 

--- a/x/stake/handler.go
+++ b/x/stake/handler.go
@@ -112,6 +112,8 @@ func handleMsgCreateValidator(ctx sdk.Context, msg types.MsgCreateValidator, k k
 	}
 
 	validator := NewValidator(msg.ValidatorAddr, msg.PubKey, msg.Description)
+	k.BumpValidatorBondHeightAndCounter(ctx, &validator)
+
 	commission := NewCommissionWithTime(
 		msg.Commission.Rate, msg.Commission.MaxRate,
 		msg.Commission.MaxChangeRate, ctx.BlockHeader().Time,


### PR DESCRIPTION
Addresses https://github.com/cosmos/cosmos-sdk/issues/3049

NOTE: Need tests and refactors.
TODO: create issue to refactor NewValidator() to require certain arguments including bond height/intertxcounter.  Unify the two into a single struct.  Refactor all around.

Many thanks to @Slamper for identifying the issue and finding the root cause.