### PR TITLE
R4R: Update gas costs to more reasonable numbers for GoS

### DIFF
--- a/PENDING.md
+++ b/PENDING.md
@@ -14,6 +14,7 @@ BREAKING CHANGES
  - [#128](https://github.com/tendermint/devops/issues/128) Updated CircleCI job to trigger website build on every push to master/develop.
  - [\#2994](https://github.com/cosmos/cosmos-sdk/pull/2994) Change wrong-password error message.
  - \#3009 Added missing Gaia genesis verification
+ - [gas] \#3052 Updated gas costs to more reasonable numbers
 
 * SDK
  - [auth] \#2952 Signatures are no longer serialized on chain with the account number and sequence number

--- a/scripts/multisim.sh
+++ b/scripts/multisim.sh
@@ -22,7 +22,7 @@ sim() {
   file="$tmpdir/gaia-simulation-seed-$seed-date-$(date -u +"%Y-%m-%dT%H:%M:%S+00:00").stdout"
   echo "Writing stdout to $file..."
 	go test ./cmd/gaia/app -run $testname -SimulationEnabled=true -SimulationNumBlocks=$blocks \
-    -SimulationVerbose=true -SimulationCommit=true -SimulationSeed=$seed -v -timeout 24h > $file
+    -SimulationVerbose=true -SimulationCommit=true -SimulationSeed=$seed -SimulationPeriod=5 -v -timeout 24h > $file
 }
 
 i=0

--- a/store/gaskvstore.go
+++ b/store/gaskvstore.go
@@ -179,6 +179,6 @@ func (gi *gasIterator) Close() {
 func (gi *gasIterator) consumeSeekGas() {
 	value := gi.Value()
 
-	gi.gasMeter.ConsumeGas(gi.gasConfig.ValueCostPerByte*sdk.Gas(len(value)), sdk.GasValuePerByteDesc)
+	gi.gasMeter.ConsumeGas(gi.gasConfig.ReadCostPerByte*sdk.Gas(len(value)), sdk.GasValuePerByteDesc)
 	gi.gasMeter.ConsumeGas(gi.gasConfig.IterNextCostFlat, sdk.GasIterNextCostFlatDesc)
 }

--- a/store/gaskvstore_test.go
+++ b/store/gaskvstore_test.go
@@ -12,26 +12,26 @@ import (
 )
 
 func newGasKVStore() KVStore {
-	meter := sdk.NewGasMeter(1000)
+	meter := sdk.NewGasMeter(10000)
 	mem := dbStoreAdapter{dbm.NewMemDB()}
 	return NewGasKVStore(meter, sdk.KVGasConfig(), mem)
 }
 
 func TestGasKVStoreBasic(t *testing.T) {
 	mem := dbStoreAdapter{dbm.NewMemDB()}
-	meter := sdk.NewGasMeter(1000)
+	meter := sdk.NewGasMeter(10000)
 	st := NewGasKVStore(meter, sdk.KVGasConfig(), mem)
 	require.Empty(t, st.Get(keyFmt(1)), "Expected `key1` to be empty")
 	st.Set(keyFmt(1), valFmt(1))
 	require.Equal(t, valFmt(1), st.Get(keyFmt(1)))
 	st.Delete(keyFmt(1))
 	require.Empty(t, st.Get(keyFmt(1)), "Expected `key1` to be empty")
-	require.Equal(t, meter.GasConsumed(), sdk.Gas(193))
+	require.Equal(t, meter.GasConsumed(), sdk.Gas(6429))
 }
 
 func TestGasKVStoreIterator(t *testing.T) {
 	mem := dbStoreAdapter{dbm.NewMemDB()}
-	meter := sdk.NewGasMeter(1000)
+	meter := sdk.NewGasMeter(10000)
 	st := NewGasKVStore(meter, sdk.KVGasConfig(), mem)
 	require.Empty(t, st.Get(keyFmt(1)), "Expected `key1` to be empty")
 	require.Empty(t, st.Get(keyFmt(2)), "Expected `key2` to be empty")
@@ -62,7 +62,7 @@ func TestGasKVStoreOutOfGasSet(t *testing.T) {
 
 func TestGasKVStoreOutOfGasIterator(t *testing.T) {
 	mem := dbStoreAdapter{dbm.NewMemDB()}
-	meter := sdk.NewGasMeter(200)
+	meter := sdk.NewGasMeter(2000)
 	st := NewGasKVStore(meter, sdk.KVGasConfig(), mem)
 	st.Set(keyFmt(1), valFmt(1))
 	iterator := st.Iterator(nil, nil)
@@ -71,7 +71,7 @@ func TestGasKVStoreOutOfGasIterator(t *testing.T) {
 }
 
 func testGasKVStoreWrap(t *testing.T, store KVStore) {
-	meter := sdk.NewGasMeter(10000)
+	meter := sdk.NewGasMeter(100000)
 
 	store = store.Gas(meter, sdk.GasConfig{HasCost: 10})
 	require.Equal(t, uint64(0), meter.GasConsumed())

--- a/store/gaskvstore_test.go
+++ b/store/gaskvstore_test.go
@@ -50,7 +50,7 @@ func TestGasKVStoreIterator(t *testing.T) {
 	iterator.Next()
 	require.False(t, iterator.Valid())
 	require.Panics(t, iterator.Next)
-	require.Equal(t, meter.GasConsumed(), sdk.Gas(384))
+	require.Equal(t, meter.GasConsumed(), sdk.Gas(6987))
 }
 
 func TestGasKVStoreOutOfGasSet(t *testing.T) {
@@ -62,7 +62,7 @@ func TestGasKVStoreOutOfGasSet(t *testing.T) {
 
 func TestGasKVStoreOutOfGasIterator(t *testing.T) {
 	mem := dbStoreAdapter{dbm.NewMemDB()}
-	meter := sdk.NewGasMeter(2000)
+	meter := sdk.NewGasMeter(20000)
 	st := NewGasKVStore(meter, sdk.KVGasConfig(), mem)
 	st.Set(keyFmt(1), valFmt(1))
 	iterator := st.Iterator(nil, nil)

--- a/types/gas.go
+++ b/types/gas.go
@@ -140,21 +140,19 @@ type GasConfig struct {
 	ReadCostPerByte  Gas
 	WriteCostFlat    Gas
 	WriteCostPerByte Gas
-	ValueCostPerByte Gas
 	IterNextCostFlat Gas
 }
 
 // KVGasConfig returns a default gas config for KVStores.
 func KVGasConfig() GasConfig {
 	return GasConfig{
-		HasCost:          10,
-		DeleteCost:       10,
-		ReadCostFlat:     10,
-		ReadCostPerByte:  1,
-		WriteCostFlat:    10,
-		WriteCostPerByte: 10,
-		ValueCostPerByte: 1,
-		IterNextCostFlat: 15,
+		HasCost:          1000,
+		DeleteCost:       1000,
+		ReadCostFlat:     1000,
+		ReadCostPerByte:  3,
+		WriteCostFlat:    2000,
+		WriteCostPerByte: 30,
+		IterNextCostFlat: 30,
 	}
 }
 

--- a/x/auth/ante.go
+++ b/x/auth/ante.go
@@ -12,13 +12,13 @@ import (
 )
 
 const (
-	memoCostPerByte     sdk.Gas = 1
-	ed25519VerifyCost           = 59
-	secp256k1VerifyCost         = 100
-	maxMemoCharacters           = 100
+	memoCostPerByte     sdk.Gas = 3
+	ed25519VerifyCost           = 590
+	secp256k1VerifyCost         = 1000
+	maxMemoCharacters           = 256
 
 	// how much gas = 1 atom
-	gasPerUnitCost = 1000
+	gasPerUnitCost = 10000
 
 	// max total number of sigs per tx
 	txSigLimit = 7

--- a/x/auth/ante_test.go
+++ b/x/auth/ante_test.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	codec "github.com/cosmos/cosmos-sdk/codec"
@@ -20,7 +21,7 @@ func newTestMsg(addrs ...sdk.AccAddress) *sdk.TestMsg {
 }
 
 func newStdFee() StdFee {
-	return NewStdFee(5000,
+	return NewStdFee(50000,
 		sdk.NewInt64Coin("atom", 150),
 	)
 }
@@ -437,13 +438,13 @@ func TestAnteHandlerMemoGas(t *testing.T) {
 	checkInvalidTx(t, anteHandler, ctx, tx, false, sdk.CodeOutOfGas)
 
 	// memo too large
-	fee = NewStdFee(2001, sdk.NewInt64Coin("atom", 0))
-	tx = newTestTxWithMemo(ctx, []sdk.Msg{msg}, privs, accnums, seqs, fee, "abcininasidniandsinasindiansdiansdinaisndiasndiadninsdabcininasidniandsinasindiansdiansdinaisndiasndiadninsdabcininasidniandsinasindiansdiansdinaisndiasndiadninsd")
+	fee = NewStdFee(9000, sdk.NewInt64Coin("atom", 0))
+	tx = newTestTxWithMemo(ctx, []sdk.Msg{msg}, privs, accnums, seqs, fee, strings.Repeat("01234567890", 500))
 	checkInvalidTx(t, anteHandler, ctx, tx, false, sdk.CodeMemoTooLarge)
 
 	// tx with memo has enough gas
-	fee = NewStdFee(1100, sdk.NewInt64Coin("atom", 0))
-	tx = newTestTxWithMemo(ctx, []sdk.Msg{msg}, privs, accnums, seqs, fee, "abcininasidniandsinasindiansdiansdinaisndiasndiadninsd")
+	fee = NewStdFee(9000, sdk.NewInt64Coin("atom", 0))
+	tx = newTestTxWithMemo(ctx, []sdk.Msg{msg}, privs, accnums, seqs, fee, strings.Repeat("0123456789", 10))
 	checkValidTx(t, anteHandler, ctx, tx, false)
 }
 
@@ -706,8 +707,8 @@ func TestAdjustFeesByGas(t *testing.T) {
 		args args
 		want sdk.Coins
 	}{
-		{"nil coins", args{sdk.Coins{}, 10000}, sdk.Coins{}},
-		{"nil coins", args{sdk.Coins{sdk.NewInt64Coin("A", 10), sdk.NewInt64Coin("B", 0)}, 10000}, sdk.Coins{sdk.NewInt64Coin("A", 20), sdk.NewInt64Coin("B", 10)}},
+		{"nil coins", args{sdk.Coins{}, 100000}, sdk.Coins{}},
+		{"nil coins", args{sdk.Coins{sdk.NewInt64Coin("A", 10), sdk.NewInt64Coin("B", 0)}, 100000}, sdk.Coins{sdk.NewInt64Coin("A", 20), sdk.NewInt64Coin("B", 10)}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/x/auth/stdtx_test.go
+++ b/x/auth/stdtx_test.go
@@ -47,7 +47,7 @@ func TestStdSignBytes(t *testing.T) {
 	}{
 		{
 			args{"1234", 3, 6, defaultFee, []sdk.Msg{sdk.NewTestMsg(addr)}, "memo"},
-			fmt.Sprintf("{\"account_number\":\"3\",\"chain_id\":\"1234\",\"fee\":{\"amount\":[{\"amount\":\"150\",\"denom\":\"atom\"}],\"gas\":\"5000\"},\"memo\":\"memo\",\"msgs\":[[\"%s\"]],\"sequence\":\"6\"}", addr),
+			fmt.Sprintf("{\"account_number\":\"3\",\"chain_id\":\"1234\",\"fee\":{\"amount\":[{\"amount\":\"150\",\"denom\":\"atom\"}],\"gas\":\"50000\"},\"memo\":\"memo\",\"msgs\":[[\"%s\"]],\"sequence\":\"6\"}", addr),
 		},
 	}
 	for i, tc := range tests {

--- a/x/bank/keeper.go
+++ b/x/bank/keeper.go
@@ -7,14 +7,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/auth"
 )
 
-const (
-	costGetCoins      sdk.Gas = 10
-	costHasCoins      sdk.Gas = 10
-	costSetCoins      sdk.Gas = 100
-	costSubtractCoins sdk.Gas = 10
-	costAddCoins      sdk.Gas = 10
-)
-
 //-----------------------------------------------------------------------------
 // Keeper
 
@@ -150,7 +142,6 @@ func (keeper BaseViewKeeper) HasCoins(ctx sdk.Context, addr sdk.AccAddress, amt 
 //-----------------------------------------------------------------------------
 
 func getCoins(ctx sdk.Context, am auth.AccountKeeper, addr sdk.AccAddress) sdk.Coins {
-	ctx.GasMeter().ConsumeGas(costGetCoins, "getCoins")
 	acc := am.GetAccount(ctx, addr)
 	if acc == nil {
 		return sdk.Coins{}
@@ -159,7 +150,6 @@ func getCoins(ctx sdk.Context, am auth.AccountKeeper, addr sdk.AccAddress) sdk.C
 }
 
 func setCoins(ctx sdk.Context, am auth.AccountKeeper, addr sdk.AccAddress, amt sdk.Coins) sdk.Error {
-	ctx.GasMeter().ConsumeGas(costSetCoins, "setCoins")
 	acc := am.GetAccount(ctx, addr)
 	if acc == nil {
 		acc = am.NewAccountWithAddress(ctx, addr)
@@ -175,14 +165,11 @@ func setCoins(ctx sdk.Context, am auth.AccountKeeper, addr sdk.AccAddress, amt s
 
 // HasCoins returns whether or not an account has at least amt coins.
 func hasCoins(ctx sdk.Context, am auth.AccountKeeper, addr sdk.AccAddress, amt sdk.Coins) bool {
-	ctx.GasMeter().ConsumeGas(costHasCoins, "hasCoins")
 	return getCoins(ctx, am, addr).IsAllGTE(amt)
 }
 
 // SubtractCoins subtracts amt from the coins at the addr.
 func subtractCoins(ctx sdk.Context, am auth.AccountKeeper, addr sdk.AccAddress, amt sdk.Coins) (sdk.Coins, sdk.Tags, sdk.Error) {
-	ctx.GasMeter().ConsumeGas(costSubtractCoins, "subtractCoins")
-
 	oldCoins := getCoins(ctx, am, addr)
 	newCoins, hasNeg := oldCoins.SafeMinus(amt)
 	if hasNeg {
@@ -196,7 +183,6 @@ func subtractCoins(ctx sdk.Context, am auth.AccountKeeper, addr sdk.AccAddress, 
 
 // AddCoins adds amt to the coins at the addr.
 func addCoins(ctx sdk.Context, am auth.AccountKeeper, addr sdk.AccAddress, amt sdk.Coins) (sdk.Coins, sdk.Tags, sdk.Error) {
-	ctx.GasMeter().ConsumeGas(costAddCoins, "addCoins")
 	oldCoins := getCoins(ctx, am, addr)
 	newCoins := oldCoins.Plus(amt)
 	if !newCoins.IsNotNegative() {


### PR DESCRIPTION
TODO: Create a new issue to unify gas constants in one place, and improve tests.

Recommended best-guess estimates for gas for GoS:

```
50,000 bytes per block.
1,500,000 gas per block.

50,000 bytes being written x 30 gas/byte-written ~= 1,500,000 gas
750 writes to store x 2000 gas/store-set ~= 1,500,000 gas
```

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/develop/CONTRIBUTING.md#pr-targeting))

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added entries in `PENDING.md` with issue # 
- [ ] rereviewed `Files changed` in the github PR explorer
