### PR TITLE
Rename hooks from Before -> Pre and On -> Post

### DIFF
--- a/cmd/gaia/app/app.go
+++ b/cmd/gaia/app/app.go
@@ -333,39 +333,39 @@ func NewStakingHooks(dh distr.Hooks, sh slashing.Hooks) StakingHooks {
 }
 
 // nolint
-func (h StakingHooks) OnValidatorCreated(ctx sdk.Context, valAddr sdk.ValAddress) {
-	h.dh.OnValidatorCreated(ctx, valAddr)
-	h.sh.OnValidatorCreated(ctx, valAddr)
+func (h StakingHooks) PostValidatorCreated(ctx sdk.Context, valAddr sdk.ValAddress) {
+	h.dh.PostValidatorCreated(ctx, valAddr)
+	h.sh.PostValidatorCreated(ctx, valAddr)
 }
-func (h StakingHooks) OnValidatorModified(ctx sdk.Context, valAddr sdk.ValAddress) {
-	h.dh.OnValidatorModified(ctx, valAddr)
-	h.sh.OnValidatorModified(ctx, valAddr)
+func (h StakingHooks) PostValidatorModified(ctx sdk.Context, valAddr sdk.ValAddress) {
+	h.dh.PostValidatorModified(ctx, valAddr)
+	h.sh.PostValidatorModified(ctx, valAddr)
 }
-func (h StakingHooks) OnValidatorRemoved(ctx sdk.Context, consAddr sdk.ConsAddress, valAddr sdk.ValAddress) {
-	h.dh.OnValidatorRemoved(ctx, consAddr, valAddr)
-	h.sh.OnValidatorRemoved(ctx, consAddr, valAddr)
+func (h StakingHooks) PostValidatorRemoved(ctx sdk.Context, consAddr sdk.ConsAddress, valAddr sdk.ValAddress) {
+	h.dh.PostValidatorRemoved(ctx, consAddr, valAddr)
+	h.sh.PostValidatorRemoved(ctx, consAddr, valAddr)
 }
-func (h StakingHooks) OnValidatorBonded(ctx sdk.Context, consAddr sdk.ConsAddress, valAddr sdk.ValAddress) {
-	h.dh.OnValidatorBonded(ctx, consAddr, valAddr)
-	h.sh.OnValidatorBonded(ctx, consAddr, valAddr)
+func (h StakingHooks) PostValidatorBonded(ctx sdk.Context, consAddr sdk.ConsAddress, valAddr sdk.ValAddress) {
+	h.dh.PostValidatorBonded(ctx, consAddr, valAddr)
+	h.sh.PostValidatorBonded(ctx, consAddr, valAddr)
 }
-func (h StakingHooks) OnValidatorPowerDidChange(ctx sdk.Context, consAddr sdk.ConsAddress, valAddr sdk.ValAddress) {
-	h.dh.OnValidatorPowerDidChange(ctx, consAddr, valAddr)
-	h.sh.OnValidatorPowerDidChange(ctx, consAddr, valAddr)
+func (h StakingHooks) PostValidatorPowerDidChange(ctx sdk.Context, consAddr sdk.ConsAddress, valAddr sdk.ValAddress) {
+	h.dh.PostValidatorPowerDidChange(ctx, consAddr, valAddr)
+	h.sh.PostValidatorPowerDidChange(ctx, consAddr, valAddr)
 }
-func (h StakingHooks) OnValidatorBeginUnbonding(ctx sdk.Context, consAddr sdk.ConsAddress, valAddr sdk.ValAddress) {
-	h.dh.OnValidatorBeginUnbonding(ctx, consAddr, valAddr)
-	h.sh.OnValidatorBeginUnbonding(ctx, consAddr, valAddr)
+func (h StakingHooks) PostValidatorBeginUnbonding(ctx sdk.Context, consAddr sdk.ConsAddress, valAddr sdk.ValAddress) {
+	h.dh.PostValidatorBeginUnbonding(ctx, consAddr, valAddr)
+	h.sh.PostValidatorBeginUnbonding(ctx, consAddr, valAddr)
 }
-func (h StakingHooks) OnDelegationCreated(ctx sdk.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress) {
-	h.dh.OnDelegationCreated(ctx, delAddr, valAddr)
-	h.sh.OnDelegationCreated(ctx, delAddr, valAddr)
+func (h StakingHooks) PostDelegationCreated(ctx sdk.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress) {
+	h.dh.PostDelegationCreated(ctx, delAddr, valAddr)
+	h.sh.PostDelegationCreated(ctx, delAddr, valAddr)
 }
-func (h StakingHooks) OnDelegationSharesModified(ctx sdk.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress) {
-	h.dh.OnDelegationSharesModified(ctx, delAddr, valAddr)
-	h.sh.OnDelegationSharesModified(ctx, delAddr, valAddr)
+func (h StakingHooks) PostDelegationSharesModified(ctx sdk.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress) {
+	h.dh.PostDelegationSharesModified(ctx, delAddr, valAddr)
+	h.sh.PostDelegationSharesModified(ctx, delAddr, valAddr)
 }
-func (h StakingHooks) OnDelegationRemoved(ctx sdk.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress) {
-	h.dh.OnDelegationRemoved(ctx, delAddr, valAddr)
-	h.sh.OnDelegationRemoved(ctx, delAddr, valAddr)
+func (h StakingHooks) PostDelegationRemoved(ctx sdk.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress) {
+	h.dh.PostDelegationRemoved(ctx, delAddr, valAddr)
+	h.sh.PostDelegationRemoved(ctx, delAddr, valAddr)
 }

--- a/types/stake.go
+++ b/types/stake.go
@@ -115,15 +115,15 @@ type DelegationSet interface {
 
 // event hooks for staking validator object
 type StakingHooks interface {
-	OnValidatorCreated(ctx Context, valAddr ValAddress)                       // Must be called when a validator is created
-	OnValidatorModified(ctx Context, valAddr ValAddress)                      // Must be called when a validator's state changes
-	OnValidatorRemoved(ctx Context, consAddr ConsAddress, valAddr ValAddress) // Must be called when a validator is deleted
+	PostValidatorCreated(ctx Context, valAddr ValAddress)                       // Must be called when a validator is created
+	PostValidatorModified(ctx Context, valAddr ValAddress)                      // Must be called when a validator's state changes
+	PostValidatorRemoved(ctx Context, consAddr ConsAddress, valAddr ValAddress) // Must be called when a validator is deleted
 
-	OnValidatorBonded(ctx Context, consAddr ConsAddress, valAddr ValAddress)         // Must be called when a validator is bonded
-	OnValidatorBeginUnbonding(ctx Context, consAddr ConsAddress, valAddr ValAddress) // Must be called when a validator begins unbonding
-	OnValidatorPowerDidChange(ctx Context, consAddr ConsAddress, valAddr ValAddress) // Called at EndBlock when a validator's power did change
+	PostValidatorBonded(ctx Context, consAddr ConsAddress, valAddr ValAddress)         // Must be called when a validator is bonded
+	PostValidatorBeginUnbonding(ctx Context, consAddr ConsAddress, valAddr ValAddress) // Must be called when a validator begins unbonding
+	PostValidatorPowerDidChange(ctx Context, consAddr ConsAddress, valAddr ValAddress) // Called at EndBlock when a validator's power did change
 
-	OnDelegationCreated(ctx Context, delAddr AccAddress, valAddr ValAddress)        // Must be called when a delegation is created
-	OnDelegationSharesModified(ctx Context, delAddr AccAddress, valAddr ValAddress) // Must be called when a delegation's shares are modified
-	OnDelegationRemoved(ctx Context, delAddr AccAddress, valAddr ValAddress)        // Must be called when a delegation is removed
+	PostDelegationCreated(ctx Context, delAddr AccAddress, valAddr ValAddress)        // Must be called when a delegation is created
+	PostDelegationSharesModified(ctx Context, delAddr AccAddress, valAddr ValAddress) // Must be called when a delegation's shares are modified
+	PostDelegationRemoved(ctx Context, delAddr AccAddress, valAddr ValAddress)        // Must be called when a delegation is removed
 }

--- a/x/slashing/hooks.go
+++ b/x/slashing/hooks.go
@@ -8,7 +8,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
-func (k Keeper) onValidatorBonded(ctx sdk.Context, address sdk.ConsAddress, _ sdk.ValAddress) {
+func (k Keeper) postValidatorBonded(ctx sdk.Context, address sdk.ConsAddress, _ sdk.ValAddress) {
 	// Update the signing info start height or create a new signing info
 	_, found := k.getValidatorSigningInfo(ctx, address)
 	if !found {
@@ -32,20 +32,20 @@ func (k Keeper) onValidatorBonded(ctx sdk.Context, address sdk.ConsAddress, _ sd
 }
 
 // Mark the slashing period as having ended when a validator begins unbonding
-func (k Keeper) onValidatorBeginUnbonding(ctx sdk.Context, address sdk.ConsAddress, _ sdk.ValAddress) {
+func (k Keeper) postValidatorBeginUnbonding(ctx sdk.Context, address sdk.ConsAddress, _ sdk.ValAddress) {
 	slashingPeriod := k.getValidatorSlashingPeriodForHeight(ctx, address, ctx.BlockHeight())
 	slashingPeriod.EndHeight = ctx.BlockHeight()
 	k.addOrUpdateValidatorSlashingPeriod(ctx, slashingPeriod)
 }
 
 // When a validator is created, add the address-pubkey relation.
-func (k Keeper) onValidatorCreated(ctx sdk.Context, valAddr sdk.ValAddress) {
+func (k Keeper) postValidatorCreated(ctx sdk.Context, valAddr sdk.ValAddress) {
 	validator := k.validatorSet.Validator(ctx, valAddr)
 	k.addPubkey(ctx, validator.GetConsPubKey())
 }
 
 // When a validator is removed, delete the address-pubkey relation.
-func (k Keeper) onValidatorRemoved(ctx sdk.Context, address sdk.ConsAddress) {
+func (k Keeper) postValidatorRemoved(ctx sdk.Context, address sdk.ConsAddress) {
 	k.deleteAddrPubkeyRelation(ctx, crypto.Address(address))
 }
 
@@ -64,29 +64,29 @@ func (k Keeper) Hooks() Hooks {
 }
 
 // Implements sdk.ValidatorHooks
-func (h Hooks) OnValidatorBonded(ctx sdk.Context, consAddr sdk.ConsAddress, valAddr sdk.ValAddress) {
-	h.k.onValidatorBonded(ctx, consAddr, valAddr)
+func (h Hooks) PostValidatorBonded(ctx sdk.Context, consAddr sdk.ConsAddress, valAddr sdk.ValAddress) {
+	h.k.postValidatorBonded(ctx, consAddr, valAddr)
 }
 
 // Implements sdk.ValidatorHooks
-func (h Hooks) OnValidatorBeginUnbonding(ctx sdk.Context, consAddr sdk.ConsAddress, valAddr sdk.ValAddress) {
-	h.k.onValidatorBeginUnbonding(ctx, consAddr, valAddr)
+func (h Hooks) PostValidatorBeginUnbonding(ctx sdk.Context, consAddr sdk.ConsAddress, valAddr sdk.ValAddress) {
+	h.k.postValidatorBeginUnbonding(ctx, consAddr, valAddr)
 }
 
 // Implements sdk.ValidatorHooks
-func (h Hooks) OnValidatorRemoved(ctx sdk.Context, consAddr sdk.ConsAddress, _ sdk.ValAddress) {
-	h.k.onValidatorRemoved(ctx, consAddr)
+func (h Hooks) PostValidatorRemoved(ctx sdk.Context, consAddr sdk.ConsAddress, _ sdk.ValAddress) {
+	h.k.postValidatorRemoved(ctx, consAddr)
 }
 
 // Implements sdk.ValidatorHooks
-func (h Hooks) OnValidatorCreated(ctx sdk.Context, valAddr sdk.ValAddress) {
-	h.k.onValidatorCreated(ctx, valAddr)
+func (h Hooks) PostValidatorCreated(ctx sdk.Context, valAddr sdk.ValAddress) {
+	h.k.postValidatorCreated(ctx, valAddr)
 }
 
 // nolint - unused hooks
-func (h Hooks) OnValidatorPowerDidChange(ctx sdk.Context, consAddr sdk.ConsAddress, valAddr sdk.ValAddress) {
+func (h Hooks) PostValidatorPowerDidChange(ctx sdk.Context, consAddr sdk.ConsAddress, valAddr sdk.ValAddress) {
 }
-func (h Hooks) OnValidatorModified(_ sdk.Context, _ sdk.ValAddress)                          {}
-func (h Hooks) OnDelegationCreated(_ sdk.Context, _ sdk.AccAddress, _ sdk.ValAddress)        {}
-func (h Hooks) OnDelegationSharesModified(_ sdk.Context, _ sdk.AccAddress, _ sdk.ValAddress) {}
-func (h Hooks) OnDelegationRemoved(_ sdk.Context, _ sdk.AccAddress, _ sdk.ValAddress)        {}
+func (h Hooks) PostValidatorModified(_ sdk.Context, _ sdk.ValAddress)                          {}
+func (h Hooks) PostDelegationCreated(_ sdk.Context, _ sdk.AccAddress, _ sdk.ValAddress)        {}
+func (h Hooks) PostDelegationSharesModified(_ sdk.Context, _ sdk.AccAddress, _ sdk.ValAddress) {}
+func (h Hooks) PostDelegationRemoved(_ sdk.Context, _ sdk.AccAddress, _ sdk.ValAddress)        {}

--- a/x/slashing/hooks_test.go
+++ b/x/slashing/hooks_test.go
@@ -11,7 +11,7 @@ import (
 func TestHookOnValidatorBonded(t *testing.T) {
 	ctx, _, _, _, keeper := createTestInput(t, DefaultParams())
 	addr := sdk.ConsAddress(addrs[0])
-	keeper.onValidatorBonded(ctx, addr, nil)
+	keeper.postValidatorBonded(ctx, addr, nil)
 	period := keeper.getValidatorSlashingPeriodForHeight(ctx, addr, ctx.BlockHeight())
 	require.Equal(t, ValidatorSlashingPeriod{addr, ctx.BlockHeight(), 0, sdk.ZeroDec()}, period)
 }
@@ -19,8 +19,8 @@ func TestHookOnValidatorBonded(t *testing.T) {
 func TestHookOnValidatorBeginUnbonding(t *testing.T) {
 	ctx, _, _, _, keeper := createTestInput(t, DefaultParams())
 	addr := sdk.ConsAddress(addrs[0])
-	keeper.onValidatorBonded(ctx, addr, nil)
-	keeper.onValidatorBeginUnbonding(ctx, addr, addrs[0])
+	keeper.postValidatorBonded(ctx, addr, nil)
+	keeper.postValidatorBeginUnbonding(ctx, addr, addrs[0])
 	period := keeper.getValidatorSlashingPeriodForHeight(ctx, addr, ctx.BlockHeight())
 	require.Equal(t, ValidatorSlashingPeriod{addr, ctx.BlockHeight(), ctx.BlockHeight(), sdk.ZeroDec()}, period)
 }

--- a/x/stake/genesis.go
+++ b/x/stake/genesis.go
@@ -33,7 +33,7 @@ func InitGenesis(ctx sdk.Context, keeper Keeper, data types.GenesisState) (res [
 		// Manually set indices for the first time
 		keeper.SetValidatorByConsAddr(ctx, validator)
 		keeper.SetValidatorByPowerIndex(ctx, validator)
-		keeper.OnValidatorCreated(ctx, validator.OperatorAddr)
+		keeper.PostValidatorCreated(ctx, validator.OperatorAddr)
 
 		// Set timeslice if necessary
 		if validator.Status == sdk.Unbonding {
@@ -43,7 +43,7 @@ func InitGenesis(ctx sdk.Context, keeper Keeper, data types.GenesisState) (res [
 
 	for _, delegation := range data.Bonds {
 		keeper.SetDelegation(ctx, delegation)
-		keeper.OnDelegationCreated(ctx, delegation.DelegatorAddr, delegation.ValidatorAddr)
+		keeper.PostDelegationCreated(ctx, delegation.DelegatorAddr, delegation.ValidatorAddr)
 	}
 
 	sort.SliceStable(data.UnbondingDelegations[:], func(i, j int) bool {

--- a/x/stake/handler.go
+++ b/x/stake/handler.go
@@ -122,7 +122,7 @@ func handleMsgCreateValidator(ctx sdk.Context, msg types.MsgCreateValidator, k k
 	k.SetValidatorByConsAddr(ctx, validator)
 	k.SetNewValidatorByPowerIndex(ctx, validator)
 
-	k.OnValidatorCreated(ctx, validator.OperatorAddr)
+	k.PostValidatorCreated(ctx, validator.OperatorAddr)
 
 	// move coins from the msg.Address account to a (self-delegation) delegator account
 	// the validator account and global shares are updated within here
@@ -163,7 +163,7 @@ func handleMsgEditValidator(ctx sdk.Context, msg types.MsgEditValidator, k keepe
 			return err.Result()
 		}
 		validator.Commission = commission
-		k.OnValidatorModified(ctx, msg.ValidatorAddr)
+		k.PostValidatorModified(ctx, msg.ValidatorAddr)
 	}
 
 	k.SetValidator(ctx, validator)

--- a/x/stake/keeper/delegation.go
+++ b/x/stake/keeper/delegation.go
@@ -81,7 +81,7 @@ func (k Keeper) SetDelegation(ctx sdk.Context, delegation types.Delegation) {
 
 // remove a delegation from store
 func (k Keeper) RemoveDelegation(ctx sdk.Context, delegation types.Delegation) {
-	k.OnDelegationRemoved(ctx, delegation.DelegatorAddr, delegation.ValidatorAddr)
+	k.PostDelegationRemoved(ctx, delegation.DelegatorAddr, delegation.ValidatorAddr)
 	store := ctx.KVStore(k.storeKey)
 	store.Delete(GetDelegationKey(delegation.DelegatorAddr, delegation.ValidatorAddr))
 }
@@ -398,9 +398,9 @@ func (k Keeper) Delegate(ctx sdk.Context, delAddr sdk.AccAddress, bondAmt sdk.Co
 
 	// call the appropriate hook if present
 	if found {
-		k.OnDelegationSharesModified(ctx, delAddr, validator.OperatorAddr)
+		k.PostDelegationSharesModified(ctx, delAddr, validator.OperatorAddr)
 	} else {
-		k.OnDelegationCreated(ctx, delAddr, validator.OperatorAddr)
+		k.PostDelegationCreated(ctx, delAddr, validator.OperatorAddr)
 	}
 
 	if subtractAccount {
@@ -431,7 +431,7 @@ func (k Keeper) unbond(ctx sdk.Context, delAddr sdk.AccAddress, valAddr sdk.ValA
 		return
 	}
 
-	k.OnDelegationSharesModified(ctx, delAddr, valAddr)
+	k.PostDelegationSharesModified(ctx, delAddr, valAddr)
 
 	// retrieve the amount to remove
 	if delegation.Shares.LT(shares) {

--- a/x/stake/keeper/hooks.go
+++ b/x/stake/keeper/hooks.go
@@ -6,56 +6,56 @@ import (
 )
 
 // Expose the hooks if present
-func (k Keeper) OnValidatorCreated(ctx sdk.Context, valAddr sdk.ValAddress) {
+func (k Keeper) PostValidatorCreated(ctx sdk.Context, valAddr sdk.ValAddress) {
 	if k.hooks != nil {
-		k.hooks.OnValidatorCreated(ctx, valAddr)
+		k.hooks.PostValidatorCreated(ctx, valAddr)
 	}
 }
 
-func (k Keeper) OnValidatorModified(ctx sdk.Context, valAddr sdk.ValAddress) {
+func (k Keeper) PostValidatorModified(ctx sdk.Context, valAddr sdk.ValAddress) {
 	if k.hooks != nil {
-		k.hooks.OnValidatorModified(ctx, valAddr)
+		k.hooks.PostValidatorModified(ctx, valAddr)
 	}
 }
 
-func (k Keeper) OnValidatorRemoved(ctx sdk.Context, consAddr sdk.ConsAddress, valAddr sdk.ValAddress) {
+func (k Keeper) PostValidatorRemoved(ctx sdk.Context, consAddr sdk.ConsAddress, valAddr sdk.ValAddress) {
 	if k.hooks != nil {
-		k.hooks.OnValidatorRemoved(ctx, consAddr, valAddr)
+		k.hooks.PostValidatorRemoved(ctx, consAddr, valAddr)
 	}
 }
 
-func (k Keeper) OnValidatorBonded(ctx sdk.Context, consAddr sdk.ConsAddress, valAddr sdk.ValAddress) {
+func (k Keeper) PostValidatorBonded(ctx sdk.Context, consAddr sdk.ConsAddress, valAddr sdk.ValAddress) {
 	if k.hooks != nil {
-		k.hooks.OnValidatorBonded(ctx, consAddr, valAddr)
+		k.hooks.PostValidatorBonded(ctx, consAddr, valAddr)
 	}
 }
 
-func (k Keeper) OnValidatorPowerDidChange(ctx sdk.Context, consAddr sdk.ConsAddress, valAddr sdk.ValAddress) {
+func (k Keeper) PostValidatorPowerDidChange(ctx sdk.Context, consAddr sdk.ConsAddress, valAddr sdk.ValAddress) {
 	if k.hooks != nil {
-		k.hooks.OnValidatorPowerDidChange(ctx, consAddr, valAddr)
+		k.hooks.PostValidatorPowerDidChange(ctx, consAddr, valAddr)
 	}
 }
 
-func (k Keeper) OnValidatorBeginUnbonding(ctx sdk.Context, consAddr sdk.ConsAddress, valAddr sdk.ValAddress) {
+func (k Keeper) PostValidatorBeginUnbonding(ctx sdk.Context, consAddr sdk.ConsAddress, valAddr sdk.ValAddress) {
 	if k.hooks != nil {
-		k.hooks.OnValidatorBeginUnbonding(ctx, consAddr, valAddr)
+		k.hooks.PostValidatorBeginUnbonding(ctx, consAddr, valAddr)
 	}
 }
 
-func (k Keeper) OnDelegationCreated(ctx sdk.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress) {
+func (k Keeper) PostDelegationCreated(ctx sdk.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress) {
 	if k.hooks != nil {
-		k.hooks.OnDelegationCreated(ctx, delAddr, valAddr)
+		k.hooks.PostDelegationCreated(ctx, delAddr, valAddr)
 	}
 }
 
-func (k Keeper) OnDelegationSharesModified(ctx sdk.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress) {
+func (k Keeper) PostDelegationSharesModified(ctx sdk.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress) {
 	if k.hooks != nil {
-		k.hooks.OnDelegationSharesModified(ctx, delAddr, valAddr)
+		k.hooks.PostDelegationSharesModified(ctx, delAddr, valAddr)
 	}
 }
 
-func (k Keeper) OnDelegationRemoved(ctx sdk.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress) {
+func (k Keeper) PostDelegationRemoved(ctx sdk.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress) {
 	if k.hooks != nil {
-		k.hooks.OnDelegationRemoved(ctx, delAddr, valAddr)
+		k.hooks.PostDelegationRemoved(ctx, delAddr, valAddr)
 	}
 }

--- a/x/stake/keeper/slash.go
+++ b/x/stake/keeper/slash.go
@@ -51,7 +51,7 @@ func (k Keeper) Slash(ctx sdk.Context, consAddr sdk.ConsAddress, infractionHeigh
 	}
 
 	operatorAddress := validator.GetOperator()
-	k.OnValidatorModified(ctx, operatorAddress)
+	k.PostValidatorModified(ctx, operatorAddress)
 
 	// Track remaining slash amount for the validator
 	// This will decrease when we slash unbondings and

--- a/x/stake/keeper/val_state_change.go
+++ b/x/stake/keeper/val_state_change.go
@@ -81,7 +81,7 @@ func (k Keeper) ApplyAndReturnValidatorSetUpdates(ctx sdk.Context) (updates []ab
 			// Assert that the validator had updated its ValidatorDistInfo.FeePoolWithdrawalHeight.
 			// This hook is extremely useful, otherwise lazy accum bugs will be difficult to solve.
 			if k.hooks != nil {
-				k.hooks.OnValidatorPowerDidChange(ctx, validator.ConsAddress(), valAddr)
+				k.hooks.PostValidatorPowerDidChange(ctx, validator.ConsAddress(), valAddr)
 			}
 
 			// set validator power on lookup index.
@@ -197,7 +197,7 @@ func (k Keeper) bondValidator(ctx sdk.Context, validator types.Validator) types.
 
 	// call the bond hook if present
 	if k.hooks != nil {
-		k.hooks.OnValidatorBonded(ctx, validator.ConsAddress(), validator.OperatorAddr)
+		k.hooks.PostValidatorBonded(ctx, validator.ConsAddress(), validator.OperatorAddr)
 	}
 
 	return validator
@@ -232,7 +232,7 @@ func (k Keeper) beginUnbondingValidator(ctx sdk.Context, validator types.Validat
 
 	// call the unbond hook if present
 	if k.hooks != nil {
-		k.hooks.OnValidatorBeginUnbonding(ctx, validator.ConsAddress(), validator.OperatorAddr)
+		k.hooks.PostValidatorBeginUnbonding(ctx, validator.ConsAddress(), validator.OperatorAddr)
 	}
 
 	return validator

--- a/x/stake/keeper/validator.go
+++ b/x/stake/keeper/validator.go
@@ -204,7 +204,7 @@ func (k Keeper) RemoveValidator(ctx sdk.Context, address sdk.ValAddress) {
 
 	// call hook if present
 	if k.hooks != nil {
-		k.hooks.OnValidatorRemoved(ctx, validator.ConsAddress(), validator.OperatorAddr)
+		k.hooks.PostValidatorRemoved(ctx, validator.ConsAddress(), validator.OperatorAddr)
 	}
 
 }


### PR DESCRIPTION
Fixes https://github.com/cosmos/cosmos-sdk/issues/2538

This PR renames the hooks in the SDK to match the agreed upon format in the linked issue. 

cc @rigelrozanski @cwgoes 