### PR TITLE
R4R: Run fewer blocks on CI multi-seed simulation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,7 +178,7 @@ jobs:
           name: Test multi-seed Gaia simulation
           command: |
             export PATH="$GOBIN:$PATH"
-            make test_sim_gaia_multi_seed
+            scripts/multisim.sh 25 TestFullGaiaSimulation
 
   test_cover:
     <<: *defaults


### PR DESCRIPTION
Tiny PR to make the CI test meaningful again - we should manually run longer simulations prior to release.

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
