### PR TITLE
R4R: Fix gaia lite docs on REST server's SSL flags

### DIFF
--- a/docs/clients/lite/getting_started.md
+++ b/docs/clients/lite/getting_started.md
@@ -26,7 +26,7 @@ gaiacli advanced rest-server --chain-id=test \
     --laddr=tcp://localhost:1317 \
     --node tcp://localhost:26657 \
     --trust-node=false \
-    --certfile=mycert.pem --keyfile=mykey.key
+    --ssl-certfile=mycert.pem --ssl-keyfile=mykey.key
 ```
 
 If no certificate/keyfile pair is supplied, a self-signed certificate will be generated and its fingerprint printed out.

--- a/docs/clients/lite/getting_started.md
+++ b/docs/clients/lite/getting_started.md
@@ -13,7 +13,7 @@ To start a REST server, we need to specify the following parameters:
 For example::
 
 ```bash
-gaiacli advanced rest-server --chain-id=test \
+gaiacli rest-server --chain-id=test \
     --laddr=tcp://localhost:1317 \
     --node tcp://localhost:26657 \
     --trust-node=false
@@ -22,7 +22,7 @@ gaiacli advanced rest-server --chain-id=test \
 The server listens on HTTPS by default. You can set the SSL certificate to be used by the server with these additional flags:
 
 ```bash
-gaiacli advanced rest-server --chain-id=test \
+gaiacli rest-server --chain-id=test \
     --laddr=tcp://localhost:1317 \
     --node tcp://localhost:26657 \
     --trust-node=false \


### PR DESCRIPTION
Closes: #3086

- [x] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [x] Updated relevant documentation (`docs/`)
- [ ] Added entries in `PENDING.md` with issue # 
- [ ] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
