### PR TITLE
Fix directory listing in intro

### DIFF
--- a/docs/intro/README.md
+++ b/docs/intro/README.md
@@ -29,7 +29,7 @@ The SDK is laid out in the following directories:
 
 - `baseapp`: Defines the template for a basic [ABCI](https://github.com/tendermint/tendermint/tree/master/abci) application so that your Cosmos-SDK application can communicate with the underlying Tendermint node.
 - `client`: CLI and REST server tooling for interacting with SDK application.
-- `examples`: Examples of how to build working standalone applications.
+- `docs/examples`: Examples of how to build working standalone applications.
 - `server`: The full node server for running an SDK application on top of
   Tendermint.
 - `store`: The database of the SDK - a Merkle multistore supporting multiple types of underling Merkle key-value stores.


### PR DESCRIPTION
Fix directory listing in SDK intro so that it gets the path to the examples right (docs/examples/ as opposed to examples/).

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/develop/CONTRIBUTING.md#pr-targeting))

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [x] Updated relevant documentation (`docs/`)
- [ ] Added entries in `PENDING.md` with issue # 
- [x] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
