### PR TITLE
R4R: Move all store keys into constants

### DIFF
--- a/PENDING.md
+++ b/PENDING.md
@@ -10,6 +10,7 @@ BREAKING CHANGES
 * Gaia CLI  (`gaiacli`)
 
 * Gaia
+  * https://github.com/cosmos/cosmos-sdk/issues/2838 - Move store keys to constants
 
 * SDK
 

--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -33,6 +33,9 @@ const (
 	runTxModeSimulate runTxMode = iota
 	// Deliver a transaction
 	runTxModeDeliver runTxMode = iota
+
+	// MainStoreKey is the string representation of the main store
+	MainStoreKey = "main"
 )
 
 // BaseApp reflects the ABCI application implementation.

--- a/baseapp/baseapp_test.go
+++ b/baseapp/baseapp_test.go
@@ -90,7 +90,7 @@ func TestLoadVersion(t *testing.T) {
 	app := NewBaseApp(name, logger, db, nil)
 
 	// make a cap key and mount the store
-	capKey := sdk.NewKVStoreKey("main")
+	capKey := sdk.NewKVStoreKey(MainStoreKey)
 	app.MountStores(capKey)
 	err := app.LoadLatestVersion(capKey) // needed to make stores non-nil
 	require.Nil(t, err)
@@ -160,7 +160,7 @@ func testChangeNameHelper(name string) func(*BaseApp) {
 	app := newBaseApp(t.Name())
 
 	// make a cap key and mount the store
-	capKey := sdk.NewKVStoreKey("main")
+	capKey := sdk.NewKVStoreKey(MainStoreKey)
 	app.MountStores(capKey)
 	err := app.LoadLatestVersion(capKey) // needed to make stores non-nil
 	require.Nil(t, err)
@@ -217,7 +217,7 @@ func TestInitChainer(t *testing.T) {
 	db := dbm.NewMemDB()
 	logger := defaultLogger()
 	app := NewBaseApp(name, logger, db, nil)
-	capKey := sdk.NewKVStoreKey("main")
+	capKey := sdk.NewKVStoreKey(MainStoreKey)
 	capKey2 := sdk.NewKVStoreKey("key2")
 	app.MountStores(capKey, capKey2)
 

--- a/client/context/context.go
+++ b/client/context/context.go
@@ -24,8 +24,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/types"
 )
 
-const ctxAccStoreName = "acc"
-
 var (
 	verifier tmlite.Verifier
 )
@@ -76,7 +74,7 @@ func NewCLIContext() CLIContext {
 		Client:        rpc,
 		Output:        os.Stdout,
 		NodeURI:       nodeURI,
-		AccountStore:  ctxAccStoreName,
+		AccountStore:  auth.StoreKey,
 		From:          viper.GetString(client.FlagFrom),
 		Height:        viper.GetInt64(client.FlagHeight),
 		TrustNode:     viper.GetBool(client.FlagTrustNode),

--- a/client/lcd/test_helpers.go
+++ b/client/lcd/test_helpers.go
@@ -386,7 +386,7 @@ func registerRoutes(rs *RestServer) {
 	keys.RegisterRoutes(rs.Mux, rs.CliCtx.Indent)
 	rpc.RegisterRoutes(rs.CliCtx, rs.Mux)
 	tx.RegisterRoutes(rs.CliCtx, rs.Mux, rs.Cdc)
-	authRest.RegisterRoutes(rs.CliCtx, rs.Mux, rs.Cdc, "acc")
+	authRest.RegisterRoutes(rs.CliCtx, rs.Mux, rs.Cdc, auth.StoreKey)
 	bankRest.RegisterRoutes(rs.CliCtx, rs.Mux, rs.Cdc, rs.KeyBase)
 	stakeRest.RegisterRoutes(rs.CliCtx, rs.Mux, rs.Cdc, rs.KeyBase)
 	slashingRest.RegisterRoutes(rs.CliCtx, rs.Mux, rs.Cdc, rs.KeyBase)

--- a/cmd/gaia/app/app.go
+++ b/cmd/gaia/app/app.go
@@ -154,9 +154,9 @@ func NewGaiaApp(logger log.Logger, db dbm.DB, traceStore io.Writer, baseAppOptio
 		AddRoute(gov.RouterKey, gov.NewHandler(app.govKeeper))
 
 	app.QueryRouter().
-		AddRoute(gov.QuerierKey, gov.NewQuerier(app.govKeeper)).
-    AddRoute(slashing.QuerierKey, slashing.NewQuerier(app.slashingKeeper, app.cdc)).
-		AddRoute(stake.QuerierKey, stake.NewQuerier(app.stakeKeeper, app.cdc))
+		AddRoute(gov.QuerierRoute, gov.NewQuerier(app.govKeeper)).
+    AddRoute(slashing.QuerierRoute, slashing.NewQuerier(app.slashingKeeper, app.cdc)).
+		AddRoute(stake.QuerierRoute, stake.NewQuerier(app.stakeKeeper, app.cdc))
 
 	// initialize BaseApp
 	app.MountStores(app.keyMain, app.keyAccount, app.keyStake, app.keyMint, app.keyDistr,

--- a/cmd/gaia/app/app.go
+++ b/cmd/gaia/app/app.go
@@ -77,18 +77,18 @@ func NewGaiaApp(logger log.Logger, db dbm.DB, traceStore io.Writer, baseAppOptio
 	var app = &GaiaApp{
 		BaseApp:          bApp,
 		cdc:              cdc,
-		keyMain:          sdk.NewKVStoreKey("main"),
-		keyAccount:       sdk.NewKVStoreKey("acc"),
-		keyStake:         sdk.NewKVStoreKey("stake"),
-		tkeyStake:        sdk.NewTransientStoreKey("transient_stake"),
-		keyMint:          sdk.NewKVStoreKey("mint"),
-		keyDistr:         sdk.NewKVStoreKey("distr"),
-		tkeyDistr:        sdk.NewTransientStoreKey("transient_distr"),
-		keySlashing:      sdk.NewKVStoreKey("slashing"),
-		keyGov:           sdk.NewKVStoreKey("gov"),
-		keyFeeCollection: sdk.NewKVStoreKey("fee"),
-		keyParams:        sdk.NewKVStoreKey("params"),
-		tkeyParams:       sdk.NewTransientStoreKey("transient_params"),
+		keyMain:          sdk.NewKVStoreKey(bam.MainStoreKey),
+		keyAccount:       sdk.NewKVStoreKey(auth.StoreKey),
+		keyStake:         sdk.NewKVStoreKey(stake.StoreKey),
+		tkeyStake:        sdk.NewTransientStoreKey(stake.TStoreKey),
+		keyMint:          sdk.NewKVStoreKey(mint.StoreKey),
+		keyDistr:         sdk.NewKVStoreKey(distr.StoreKey),
+		tkeyDistr:        sdk.NewTransientStoreKey(distr.TStoreKey),
+		keySlashing:      sdk.NewKVStoreKey(slashing.StoreKey),
+		keyGov:           sdk.NewKVStoreKey(gov.StoreKey),
+		keyFeeCollection: sdk.NewKVStoreKey(auth.FeeStoreKey),
+		keyParams:        sdk.NewKVStoreKey(params.StoreKey),
+		tkeyParams:       sdk.NewTransientStoreKey(params.TStoreKey),
 	}
 
 	// define the accountKeeper
@@ -147,15 +147,15 @@ func NewGaiaApp(logger log.Logger, db dbm.DB, traceStore io.Writer, baseAppOptio
 
 	// register message routes
 	app.Router().
-		AddRoute("bank", bank.NewHandler(app.bankKeeper)).
-		AddRoute("stake", stake.NewHandler(app.stakeKeeper)).
-		AddRoute("distr", distr.NewHandler(app.distrKeeper)).
-		AddRoute("slashing", slashing.NewHandler(app.slashingKeeper)).
-		AddRoute("gov", gov.NewHandler(app.govKeeper))
+		AddRoute(bank.RouterKey, bank.NewHandler(app.bankKeeper)).
+		AddRoute(stake.RouterKey, stake.NewHandler(app.stakeKeeper)).
+		AddRoute(distr.RouterKey, distr.NewHandler(app.distrKeeper)).
+		AddRoute(slashing.RouterKey, slashing.NewHandler(app.slashingKeeper)).
+		AddRoute(gov.RouterKey, gov.NewHandler(app.govKeeper))
 
 	app.QueryRouter().
-		AddRoute("gov", gov.NewQuerier(app.govKeeper)).
-		AddRoute("stake", stake.NewQuerier(app.stakeKeeper, app.cdc))
+		AddRoute(gov.QuerierKey, gov.NewQuerier(app.govKeeper)).
+		AddRoute(stake.QuerierKey, stake.NewQuerier(app.stakeKeeper, app.cdc))
 
 	// initialize BaseApp
 	app.MountStores(app.keyMain, app.keyAccount, app.keyStake, app.keyMint, app.keyDistr,

--- a/cmd/gaia/cmd/gaiacli/main.go
+++ b/cmd/gaia/cmd/gaiacli/main.go
@@ -22,10 +22,15 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/version"
 
+	at "github.com/cosmos/cosmos-sdk/x/auth"
 	auth "github.com/cosmos/cosmos-sdk/x/auth/client/rest"
 	bank "github.com/cosmos/cosmos-sdk/x/bank/client/rest"
+	dist "github.com/cosmos/cosmos-sdk/x/distribution"
+	gv "github.com/cosmos/cosmos-sdk/x/gov"
 	gov "github.com/cosmos/cosmos-sdk/x/gov/client/rest"
+	sl "github.com/cosmos/cosmos-sdk/x/slashing"
 	slashing "github.com/cosmos/cosmos-sdk/x/slashing/client/rest"
+	st "github.com/cosmos/cosmos-sdk/x/stake"
 	stake "github.com/cosmos/cosmos-sdk/x/stake/client/rest"
 
 	authcmd "github.com/cosmos/cosmos-sdk/x/auth/client/cli"
@@ -36,14 +41,6 @@ import (
 	stakeClient "github.com/cosmos/cosmos-sdk/x/stake/client"
 
 	_ "github.com/cosmos/cosmos-sdk/client/lcd/statik"
-)
-
-const (
-	storeAcc      = "acc"
-	storeGov      = "gov"
-	storeSlashing = "slashing"
-	storeStake    = "stake"
-	storeDist     = "distr"
 )
 
 func main() {
@@ -67,10 +64,10 @@ func main() {
 	// Module clients hold cli commnads (tx,query) and lcd routes
 	// TODO: Make the lcd command take a list of ModuleClient
 	mc := []sdk.ModuleClients{
-		govClient.NewModuleClient(storeGov, cdc),
-		distClient.NewModuleClient(storeDist, cdc),
-		stakeClient.NewModuleClient(storeStake, cdc),
-		slashingClient.NewModuleClient(storeSlashing, cdc),
+		govClient.NewModuleClient(gv.StoreKey, cdc),
+		distClient.NewModuleClient(dist.StoreKey, cdc),
+		stakeClient.NewModuleClient(st.StoreKey, cdc),
+		slashingClient.NewModuleClient(sl.StoreKey, cdc),
 	}
 
 	rootCmd := &cobra.Command{
@@ -120,7 +117,7 @@ func queryCmd(cdc *amino.Codec, mc []sdk.ModuleClients) *cobra.Command {
 		tx.SearchTxCmd(cdc),
 		tx.QueryTxCmd(cdc),
 		client.LineBreak,
-		authcmd.GetAccountCmd(storeAcc, cdc),
+		authcmd.GetAccountCmd(at.StoreKey, cdc),
 	)
 
 	for _, m := range mc {
@@ -159,7 +156,7 @@ func registerRoutes(rs *lcd.RestServer) {
 	keys.RegisterRoutes(rs.Mux, rs.CliCtx.Indent)
 	rpc.RegisterRoutes(rs.CliCtx, rs.Mux)
 	tx.RegisterRoutes(rs.CliCtx, rs.Mux, rs.Cdc)
-	auth.RegisterRoutes(rs.CliCtx, rs.Mux, rs.Cdc, storeAcc)
+	auth.RegisterRoutes(rs.CliCtx, rs.Mux, rs.Cdc, at.StoreKey)
 	bank.RegisterRoutes(rs.CliCtx, rs.Mux, rs.Cdc, rs.KeyBase)
 	stake.RegisterRoutes(rs.CliCtx, rs.Mux, rs.Cdc, rs.KeyBase)
 	slashing.RegisterRoutes(rs.CliCtx, rs.Mux, rs.Cdc, rs.KeyBase)

--- a/cmd/gaia/cmd/gaiadebug/hack.go
+++ b/cmd/gaia/cmd/gaiadebug/hack.go
@@ -156,13 +156,13 @@ func NewGaiaApp(logger log.Logger, db dbm.DB, baseAppOptions ...func(*bam.BaseAp
 	var app = &GaiaApp{
 		BaseApp:     bApp,
 		cdc:         cdc,
-		keyMain:     sdk.NewKVStoreKey("main"),
-		keyAccount:  sdk.NewKVStoreKey("acc"),
-		keyStake:    sdk.NewKVStoreKey("stake"),
-		tkeyStake:   sdk.NewTransientStoreKey("transient_stake"),
-		keySlashing: sdk.NewKVStoreKey("slashing"),
-		keyParams:   sdk.NewKVStoreKey("params"),
-		tkeyParams:  sdk.NewTransientStoreKey("transient_params"),
+		keyMain:     sdk.NewKVStoreKey(bam.MainStoreKey),
+		keyAccount:  sdk.NewKVStoreKey(auth.StoreKey),
+		keyStake:    sdk.NewKVStoreKey(stake.StoreKey),
+		tkeyStake:   sdk.NewTransientStoreKey(stake.TStoreKey),
+		keySlashing: sdk.NewKVStoreKey(slashing.StoreKey),
+		keyParams:   sdk.NewKVStoreKey(params.StoreKey),
+		tkeyParams:  sdk.NewTransientStoreKey(params.TStoreKey),
 	}
 
 	// define the accountKeeper
@@ -181,7 +181,7 @@ func NewGaiaApp(logger log.Logger, db dbm.DB, baseAppOptions ...func(*bam.BaseAp
 	// register message routes
 	app.Router().
 		AddRoute("bank", bank.NewHandler(app.bankKeeper)).
-		AddRoute("stake", stake.NewHandler(app.stakeKeeper))
+		AddRoute(stake.RouterKey, stake.NewHandler(app.stakeKeeper))
 
 	// initialize BaseApp
 	app.SetInitChainer(app.initChainer)

--- a/docs/_attic/sdk/core/app1.md
+++ b/docs/_attic/sdk/core/app1.md
@@ -426,7 +426,7 @@ func NewApp1(logger log.Logger, db dbm.DB) *bapp.BaseApp {
     app := bapp.NewBaseApp(app1Name, logger, db, tx1Decoder)
 
     // Create a capability key for accessing the account store.
-    keyAccount := sdk.NewKVStoreKey("acc")
+    keyAccount := sdk.NewKVStoreKey(auth.StoreKey)
 
     // Register message routes.
     // Note the handler receives the keyAccount and thus

--- a/docs/_attic/sdk/core/app2.md
+++ b/docs/_attic/sdk/core/app2.md
@@ -2,7 +2,7 @@
 
 In the previous app we built a simple bank with one message type `send` for sending
 coins and one store for storing accounts.
-Here we build `App2`, which expands on `App1` by introducing 
+Here we build `App2`, which expands on `App1` by introducing
 
 - a new message type for issuing new coins
 - a new store for coin metadata (like who can issue coins)
@@ -38,7 +38,7 @@ methods for `MsgIssue` are similar to `MsgSend`.
 ## Handler
 
 We'll need a new handler to support the new message type. It just checks if the
-sender of the `MsgIssue` is the correct issuer for the given coin type, as per the information 
+sender of the `MsgIssue` is the correct issuer for the given coin type, as per the information
 in the issuer store:
 
 ```go
@@ -107,11 +107,11 @@ but that's left as an excercise for the reader :).
 
 ## Amino
 
-Now that we have two implementations of `Msg`, we won't know before hand 
+Now that we have two implementations of `Msg`, we won't know before hand
 which type is contained in a serialized `Tx`. Ideally, we would use the
 `Msg` interface inside our `Tx` implementation, but the JSON decoder can't
-decode into interface types. In fact, there's no standard way to unmarshal 
-into interfaces in Go. This is one of the primary reasons we built 
+decode into interface types. In fact, there's no standard way to unmarshal
+into interfaces in Go. This is one of the primary reasons we built
 [Amino](https://github.com/tendermint/go-amino) :).
 
 While SDK developers can encode transactions and state objects however they
@@ -121,7 +121,7 @@ excludes the `oneof` keyword.
 
 While `oneof` provides union types, Amino aims to provide interfaces.
 The main difference being that with union types, you have to know all the types
-up front. But anyone can implement an interface type whenever and however 
+up front. But anyone can implement an interface type whenever and however
 they like.
 
 To implement interface types, Amino allows any concrete implementation of an
@@ -164,7 +164,7 @@ Now that we're using Amino, we can embed the `Msg` interface directly in our
 // Simple tx to wrap the Msg.
 type app2Tx struct {
     sdk.Msg
-    
+
     PubKey    crypto.PubKey
     Signature []byte
 }
@@ -189,7 +189,7 @@ func tx2Decoder(cdc *codec.Codec) sdk.TxDecoder {
 
 ## AnteHandler
 
-Now that we have an implementation of `Tx` that includes more than just the Msg, 
+Now that we have an implementation of `Tx` that includes more than just the Msg,
 we need to specify how that extra information is validated and processed. This
 is the role of the `AnteHandler`. The word `ante` here denotes "before", as the
 `AnteHandler` is run before a `Handler`. While an app can have many Handlers,
@@ -209,7 +209,7 @@ according to whatever capability keys it was granted. Instead of a `Msg`,
 however, it takes a `Tx`.
 
 Like Handler, AnteHandler returns a `Result` type, but it also returns a new
-`Context` and an `abort bool`. 
+`Context` and an `abort bool`.
 
 For `App2`, we simply check if the PubKey matches the Address, and the Signature validates with the PubKey:
 
@@ -259,7 +259,7 @@ func NewApp2(logger log.Logger, db dbm.DB) *bapp.BaseApp {
 	app := bapp.NewBaseApp(app2Name, logger, db, txDecoder(cdc))
 
 	// Create a key for accessing the account store.
-	keyAccount := sdk.NewKVStoreKey("acc")
+	keyAccount := sdk.NewKVStoreKey(auth.StoreKey)
 	// Create a key for accessing the issue store.
 	keyIssue := sdk.NewKVStoreKey("issue")
 

--- a/docs/_attic/sdk/core/app3.md
+++ b/docs/_attic/sdk/core/app3.md
@@ -1,8 +1,8 @@
 # Modules
 
 In the previous app, we introduced a new `Msg` type and used Amino to encode
-transactions. We also introduced additional data to the `Tx`, and used a simple 
-`AnteHandler` to validate it. 
+transactions. We also introduced additional data to the `Tx`, and used a simple
+`AnteHandler` to validate it.
 
 Here, in `App3`, we introduce two built-in SDK modules to
 replace the `Msg`, `Tx`, `Handler`, and `AnteHandler` implementations we've seen
@@ -16,11 +16,11 @@ The `x/bank` module implements `Msg` and `Handler` - it has everything we need
 to transfer coins between accounts.
 
 Here, we'll introduce the important types from `x/auth` and `x/bank`, and use
-them to build `App3`, our shortest app yet. The complete code can be found in 
+them to build `App3`, our shortest app yet. The complete code can be found in
 [app3.go](examples/app3.go), and at the end of this section.
 
 For more details, see the
-[x/auth](https://godoc.org/github.com/cosmos/cosmos-sdk/x/auth) and 
+[x/auth](https://godoc.org/github.com/cosmos/cosmos-sdk/x/auth) and
 [x/bank](https://godoc.org/github.com/cosmos/cosmos-sdk/x/bank) API documentation.
 
 ## Accounts
@@ -102,7 +102,7 @@ the `BaseAccount` to store additional data without requiring another lookup from
 the store.
 
 Creating an AccountKeeper is easy - we just need to specify a codec, a
-capability key, and a prototype of the object being encoded 
+capability key, and a prototype of the object being encoded
 
 ```go
 accountKeeper := auth.NewAccountKeeper(cdc, keyAccount, auth.ProtoBaseAccount)
@@ -145,7 +145,7 @@ type StdTx struct {
 This is the standard form for a transaction in the SDK. Besides the Msgs, it
 includes:
 
-- a fee to be paid by the first signer 
+- a fee to be paid by the first signer
 - replay protecting nonces in the signature
 - a memo of prunable additional data
 
@@ -166,8 +166,8 @@ type StdSignature struct {
 }
 ```
 
-The signature includes both an `AccountNumber` and a `Sequence`. 
-The `Sequence` must match the one in the 
+The signature includes both an `AccountNumber` and a `Sequence`.
+The `Sequence` must match the one in the
 corresponding account when the transaction is processed, and will increment by
 one with every transaction. This prevents the same
 transaction from being replayed multiple times, resolving the insecurity that
@@ -200,10 +200,10 @@ transaction fee can be paid, and reject the transaction if not.
 The `StdTx` supports multiple messages and multiple signers.
 To sign the transaction, each signer must collect the following information:
 
-- the ChainID 
+- the ChainID
 - the AccountNumber and Sequence for the given signer's account (from the
   blockchain)
-- the transaction fee 
+- the transaction fee
 - the list of transaction messages
 - an optional memo
 
@@ -244,7 +244,7 @@ Note that validating
 signatures requires checking that the correct account number and sequence was
 used by each signer, as this information is required in the `StdSignBytes`.
 
-If any of the above are not satisfied, the AnteHandelr returns an error. 
+If any of the above are not satisfied, the AnteHandelr returns an error.
 
 If all of the above verifications pass, the AnteHandler makes the following
 changes to the state:
@@ -254,7 +254,7 @@ changes to the state:
 - deduct the fee from the first signer's account
 
 Recall that incrementing the `Sequence` prevents "replay attacks" where
-the same message could be executed over and over again. 
+the same message could be executed over and over again.
 
 The PubKey is required for signature verification, but it is only required in
 the StdSignature once. From that point on, it will be stored in the account.
@@ -267,13 +267,13 @@ Now that we've seen the `auth.AccountKeeper` and how its used to build a
 complete AnteHandler, it's time to look at how to build higher-level
 abstractions for taking action on accounts.
 
-Earlier, we noted that `Mappers` are abstactions over KVStores that handle 
-marshalling and unmarshalling data types to and from underlying stores. 
-We can build another abstraction on top of `Mappers` that we call `Keepers`, 
+Earlier, we noted that `Mappers` are abstactions over KVStores that handle
+marshalling and unmarshalling data types to and from underlying stores.
+We can build another abstraction on top of `Mappers` that we call `Keepers`,
 which expose only limitted functionality on the underlying types stored by the `Mapper`.
 
 For instance, the `x/bank` module defines the canonical versions of `MsgSend`
-and `MsgIssue` for the SDK, as well as a `Handler` for processing them. However, 
+and `MsgIssue` for the SDK, as well as a `Handler` for processing them. However,
 rather than passing a `KVStore` or even an `AccountKeeper` directly to the handler,
 we introduce a `bank.Keeper`, which can only be used to transfer coins in and out of accounts.
 This allows us to determine up front that the only effect the bank module's
@@ -302,21 +302,21 @@ docs](https://godoc.org/github.com/cosmos/cosmos-sdk/x/bank#Keeper) for the full
 
 Note we can refine the `bank.Keeper` by restricting it's method set. For
 instance, the
-[bank.ViewKeeper](https://godoc.org/github.com/cosmos/cosmos-sdk/x/bank#ViewKeeper) 
+[bank.ViewKeeper](https://godoc.org/github.com/cosmos/cosmos-sdk/x/bank#ViewKeeper)
 is a read-only version, while the
-[bank.SendKeeper](https://godoc.org/github.com/cosmos/cosmos-sdk/x/bank#SendKeeper) 
+[bank.SendKeeper](https://godoc.org/github.com/cosmos/cosmos-sdk/x/bank#SendKeeper)
 only executes transfers of coins from input accounts to output
 accounts.
 
 We use this `Keeper` paradigm extensively in the SDK as the way to define what
 kind of functionality each module gets access to. In particular, we try to
 follow the *principle of least authority*.
-Rather than providing full blown access to the `KVStore` or the `AccountKeeper`, 
+Rather than providing full blown access to the `KVStore` or the `AccountKeeper`,
 we restrict access to a small number of functions that do very specific things.
 
 ## App3
 
-With the `auth.AccountKeeper` and `bank.Keeper` in hand, 
+With the `auth.AccountKeeper` and `bank.Keeper` in hand,
 we're now ready to build `App3`.
 The `x/auth` and `x/bank` modules do all the heavy lifting:
 
@@ -330,8 +330,8 @@ func NewApp3(logger log.Logger, db dbm.DB) *bapp.BaseApp {
 	app := bapp.NewBaseApp(app3Name, logger, db, auth.DefaultTxDecoder(cdc))
 
 	// Create a key for accessing the account store.
-	keyAccount := sdk.NewKVStoreKey("acc")
-	keyFees := sdk.NewKVStoreKey("fee")  // TODO
+	keyAccount := sdk.NewKVStoreKey(auth.StoreKey)
+	keyFees := sdk.NewKVStoreKey(auth.FeeStoreKey)  // TODO
 
 	// Set various mappers/keepers to interact easily with underlying stores
 	accountKeeper := auth.NewAccountKeeper(cdc, keyAccount, auth.ProtoBaseAccount)
@@ -355,8 +355,8 @@ func NewApp3(logger log.Logger, db dbm.DB) *bapp.BaseApp {
 }
 ```
 
-Note we use `bank.NewHandler`, which handles only `bank.MsgSend`, 
-and receives only the `bank.Keeper`. See the 
+Note we use `bank.NewHandler`, which handles only `bank.MsgSend`,
+and receives only the `bank.Keeper`. See the
 [x/bank API docs](https://godoc.org/github.com/cosmos/cosmos-sdk/x/bank)
 for more details.
 
@@ -366,7 +366,7 @@ We also use the default txDecoder in `x/auth`, which decodes amino-encoded
 ## Conclusion
 
 Armed with native modules for authentication and coin transfer,
-emboldened by the paradigm of mappers and keepers, 
-and ever invigorated by the desire to build secure state-machines, 
+emboldened by the paradigm of mappers and keepers,
+and ever invigorated by the desire to build secure state-machines,
 we find ourselves here with a full-blown, all-checks-in-place, multi-asset
 cryptocurrency - the beating heart of the Cosmos-SDK.

--- a/docs/_attic/sdk/core/examples/app1.go
+++ b/docs/_attic/sdk/core/examples/app1.go
@@ -9,6 +9,7 @@ import (
 
 	bapp "github.com/cosmos/cosmos-sdk/baseapp"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/auth"
 )
 
 const (
@@ -22,7 +23,7 @@ func NewApp1(logger log.Logger, db dbm.DB) *bapp.BaseApp {
 	app := bapp.NewBaseApp(app1Name, logger, db, tx1Decoder)
 
 	// Create a key for accessing the account store.
-	keyAccount := sdk.NewKVStoreKey("acc")
+	keyAccount := sdk.NewKVStoreKey(auth.StoreKey)
 
 	// Register message routes.
 	// Note the handler gets access to the account store.

--- a/docs/_attic/sdk/core/examples/app2.go
+++ b/docs/_attic/sdk/core/examples/app2.go
@@ -15,6 +15,7 @@ import (
 	bapp "github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/auth"
 )
 
 const (
@@ -42,7 +43,7 @@ func NewApp2(logger log.Logger, db dbm.DB) *bapp.BaseApp {
 	app := bapp.NewBaseApp(app2Name, logger, db, tx2Decoder(cdc))
 
 	// Create a key for accessing the account store.
-	keyAccount := sdk.NewKVStoreKey("acc")
+	keyAccount := sdk.NewKVStoreKey(auth.StoreKey)
 	// Create a key for accessing the issue store.
 	keyIssue := sdk.NewKVStoreKey("issue")
 

--- a/docs/_attic/sdk/core/examples/app3.go
+++ b/docs/_attic/sdk/core/examples/app3.go
@@ -26,8 +26,8 @@ func NewApp3(logger log.Logger, db dbm.DB) *bapp.BaseApp {
 	app := bapp.NewBaseApp(app3Name, logger, db, auth.DefaultTxDecoder(cdc))
 
 	// Create a key for accessing the account store.
-	keyAccount := sdk.NewKVStoreKey("acc")
-	keyFees := sdk.NewKVStoreKey("fee") // TODO
+	keyAccount := sdk.NewKVStoreKey(auth.StoreKey)
+	keyFees := sdk.NewKVStoreKey(auth.FeeStoreKey) // TODO
 
 	// Set various mappers/keepers to interact easily with underlying stores
 	accountKeeper := auth.NewAccountKeeper(cdc, keyAccount, auth.ProtoBaseAccount)

--- a/docs/_attic/sdk/core/examples/app4.go
+++ b/docs/_attic/sdk/core/examples/app4.go
@@ -25,14 +25,14 @@ func NewApp4(logger log.Logger, db dbm.DB) *bapp.BaseApp {
 	app := bapp.NewBaseApp(app4Name, logger, db, auth.DefaultTxDecoder(cdc))
 
 	// Create a key for accessing the account store.
-	keyAccount := sdk.NewKVStoreKey("acc")
+	keyAccount := sdk.NewKVStoreKey(auth.StoreKey)
 
 	// Set various mappers/keepers to interact easily with underlying stores
 	accountKeeper := auth.NewAccountKeeper(cdc, keyAccount, auth.ProtoBaseAccount)
 	bankKeeper := bank.NewBaseKeeper(accountKeeper)
 
 	// TODO
-	keyFees := sdk.NewKVStoreKey("fee")
+	keyFees := sdk.NewKVStoreKey(auth.FeeStoreKey)
 	feeKeeper := auth.NewFeeCollectionKeeper(cdc, keyFees)
 
 	app.SetAnteHandler(auth.NewAnteHandler(accountKeeper, feeKeeper))

--- a/docs/_attic/sdk/sdk-by-examples/simple-governance/bridging-it-all.md
+++ b/docs/_attic/sdk/sdk-by-examples/simple-governance/bridging-it-all.md
@@ -56,7 +56,7 @@ type SimpleGovApp struct {
 
 Let us do a quick reminder so that it is  clear why we need these stores and keepers. Our application is primarily based on the `simple_governance` module. However, we have established in section [Keepers for our app](module-keeper.md) that our module needs access to two other modules: the `bank` module and the `stake` module. We also need the `auth` module for basic account functionalities. Finally, we need access to the main multistore to declare the stores of each of the module we use.
 
-## CLI and Rest server 
+## CLI and Rest server
 
 We will need to add the newly created commands to our application. To do so, go to the `cmd` folder inside your root  directory:
 
@@ -66,7 +66,7 @@ cd cmd
 ```
 `simplegovd` is the folder that stores the command for running the server daemon, whereas `simplegovcli` defines the commands of your application.
 
-### Application CLI 
+### Application CLI
 
 **File: [`cmd/simplegovcli/maing.go`](https://github.com/cosmos/cosmos-sdk/blob/fedekunze/module_tutorial/examples/simpleGov/cmd/simplegovcli/main.go)**
 
@@ -191,9 +191,9 @@ var cdc = MakeCodec()
     var app = &SimpleGovApp{
         BaseApp:              bam.NewBaseApp(appName, cdc, logger, db),
         cdc:                  cdc,
-        capKeyMainStore:      sdk.NewKVStoreKey("main"),
-        capKeyAccountStore:   sdk.NewKVStoreKey("acc"),
-        capKeyStakingStore:   sdk.NewKVStoreKey("stake"),
+        capKeyMainStore:      sdk.NewKVStoreKey(bam.MainStoreKey),
+        capKeyAccountStore:   sdk.NewKVStoreKey(auth.StoreKey),
+        capKeyStakingStore:   sdk.NewKVStoreKey(stake.StoreKey),
         capKeySimpleGovStore: sdk.NewKVStoreKey("simpleGov"),
     }
 ```

--- a/docs/concepts/baseapp.md
+++ b/docs/concepts/baseapp.md
@@ -13,7 +13,7 @@ commitment, only the `DeliverTx` is persisted.
 The BaseApp requires stores to be mounted via capabilities keys - handlers can
 only access stores they're given the key to. The `baseApp` ensures all stores are
 properly loaded, cached, and committed. One mounted store is considered the
-"main" - it holds the latest block header, from which we can find and load the
+"main" (`baseApp.MainStoreKey`) - it holds the latest block header, from which we can find and load the
 most recent state.
 
 The BaseApp distinguishes between two handler types - the `AnteHandler` and the
@@ -116,9 +116,9 @@ otherwise a gas meter with `ConsensusParam.BlockSize.MaxGas` is initialized.
 
 Before the transaction logic is run, the `BlockGasMeter` is first checked to
 see if any gas remains. If no gas remains, then `DeliverTx` immediately returns
-an error. 
+an error.
 
 After the transaction has been processed, the used gas (up to the transaction
 gas limit) is deducted from the BlockGasMeter. If the remaining gas exceeds the
 meter's limits, then DeliverTx returns an error and the transaction is not
-committed. 
+committed.

--- a/docs/examples/basecoin/app/app.go
+++ b/docs/examples/basecoin/app/app.go
@@ -62,8 +62,8 @@ func NewBasecoinApp(logger log.Logger, db dbm.DB, baseAppOptions ...func(*bam.Ba
 	var app = &BasecoinApp{
 		cdc:        cdc,
 		BaseApp:    bam.NewBaseApp(appName, logger, db, auth.DefaultTxDecoder(cdc), baseAppOptions...),
-		keyMain:    sdk.NewKVStoreKey("main"),
-		keyAccount: sdk.NewKVStoreKey("acc"),
+		keyMain:    sdk.NewKVStoreKey(bam.MainStoreKey),
+		keyAccount: sdk.NewKVStoreKey(auth.StoreKey),
 		keyIBC:     sdk.NewKVStoreKey("ibc"),
 	}
 

--- a/docs/examples/basecoin/cmd/basecli/main.go
+++ b/docs/examples/basecoin/cmd/basecli/main.go
@@ -14,21 +14,18 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/version"
+	at "github.com/cosmos/cosmos-sdk/x/auth"
 	authcmd "github.com/cosmos/cosmos-sdk/x/auth/client/cli"
 	auth "github.com/cosmos/cosmos-sdk/x/auth/client/rest"
 	bankcmd "github.com/cosmos/cosmos-sdk/x/bank/client/cli"
 	bank "github.com/cosmos/cosmos-sdk/x/bank/client/rest"
 	ibccmd "github.com/cosmos/cosmos-sdk/x/ibc/client/cli"
+	sl "github.com/cosmos/cosmos-sdk/x/slashing"
 	slashingcmd "github.com/cosmos/cosmos-sdk/x/slashing/client/cli"
 	slashing "github.com/cosmos/cosmos-sdk/x/slashing/client/rest"
+	st "github.com/cosmos/cosmos-sdk/x/stake"
 	stakecmd "github.com/cosmos/cosmos-sdk/x/stake/client/cli"
 	stake "github.com/cosmos/cosmos-sdk/x/stake/client/rest"
-)
-
-const (
-	storeAcc      = "acc"
-	storeSlashing = "slashing"
-	storeStake    = "stake"
 )
 
 // rootCmd is the entry point for this binary
@@ -69,21 +66,21 @@ func main() {
 
 	// add query/post commands (custom to binary)
 	rootCmd.AddCommand(
-		stakecmd.GetCmdQueryValidator(storeStake, cdc),
-		stakecmd.GetCmdQueryValidators(storeStake, cdc),
-		stakecmd.GetCmdQueryValidatorUnbondingDelegations(storeStake, cdc),
-		stakecmd.GetCmdQueryValidatorRedelegations(storeStake, cdc),
-		stakecmd.GetCmdQueryDelegation(storeStake, cdc),
-		stakecmd.GetCmdQueryDelegations(storeStake, cdc),
-		stakecmd.GetCmdQueryPool(storeStake, cdc),
-		stakecmd.GetCmdQueryParams(storeStake, cdc),
-		stakecmd.GetCmdQueryUnbondingDelegation(storeStake, cdc),
-		stakecmd.GetCmdQueryUnbondingDelegations(storeStake, cdc),
-		stakecmd.GetCmdQueryRedelegation(storeStake, cdc),
-		stakecmd.GetCmdQueryRedelegations(storeStake, cdc),
-		slashingcmd.GetCmdQuerySigningInfo(storeSlashing, cdc),
-		stakecmd.GetCmdQueryValidatorDelegations(storeStake, cdc),
-		authcmd.GetAccountCmd(storeAcc, cdc),
+		stakecmd.GetCmdQueryValidator(st.StoreKey, cdc),
+		stakecmd.GetCmdQueryValidators(st.StoreKey, cdc),
+		stakecmd.GetCmdQueryValidatorUnbondingDelegations(st.StoreKey, cdc),
+		stakecmd.GetCmdQueryValidatorRedelegations(st.StoreKey, cdc),
+		stakecmd.GetCmdQueryDelegation(st.StoreKey, cdc),
+		stakecmd.GetCmdQueryDelegations(st.StoreKey, cdc),
+		stakecmd.GetCmdQueryPool(st.StoreKey, cdc),
+		stakecmd.GetCmdQueryParams(st.StoreKey, cdc),
+		stakecmd.GetCmdQueryUnbondingDelegation(st.StoreKey, cdc),
+		stakecmd.GetCmdQueryUnbondingDelegations(st.StoreKey, cdc),
+		stakecmd.GetCmdQueryRedelegation(st.StoreKey, cdc),
+		stakecmd.GetCmdQueryRedelegations(st.StoreKey, cdc),
+		slashingcmd.GetCmdQuerySigningInfo(sl.StoreKey, cdc),
+		stakecmd.GetCmdQueryValidatorDelegations(st.StoreKey, cdc),
+		authcmd.GetAccountCmd(at.StoreKey, cdc),
 	)
 
 	rootCmd.AddCommand(
@@ -93,8 +90,8 @@ func main() {
 		stakecmd.GetCmdCreateValidator(cdc),
 		stakecmd.GetCmdEditValidator(cdc),
 		stakecmd.GetCmdDelegate(cdc),
-		stakecmd.GetCmdUnbond(storeStake, cdc),
-		stakecmd.GetCmdRedelegate(storeStake, cdc),
+		stakecmd.GetCmdUnbond(st.StoreKey, cdc),
+		stakecmd.GetCmdRedelegate(st.StoreKey, cdc),
 		slashingcmd.GetCmdUnjail(cdc),
 	)
 
@@ -120,7 +117,7 @@ func registerRoutes(rs *lcd.RestServer) {
 	keys.RegisterRoutes(rs.Mux, rs.CliCtx.Indent)
 	rpc.RegisterRoutes(rs.CliCtx, rs.Mux)
 	tx.RegisterRoutes(rs.CliCtx, rs.Mux, rs.Cdc)
-	auth.RegisterRoutes(rs.CliCtx, rs.Mux, rs.Cdc, storeAcc)
+	auth.RegisterRoutes(rs.CliCtx, rs.Mux, rs.Cdc, at.StoreKey)
 	bank.RegisterRoutes(rs.CliCtx, rs.Mux, rs.Cdc, rs.KeyBase)
 	stake.RegisterRoutes(rs.CliCtx, rs.Mux, rs.Cdc, rs.KeyBase)
 	slashing.RegisterRoutes(rs.CliCtx, rs.Mux, rs.Cdc, rs.KeyBase)

--- a/docs/examples/democoin/app/app.go
+++ b/docs/examples/democoin/app/app.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/auth"
 	"github.com/cosmos/cosmos-sdk/x/bank"
 	"github.com/cosmos/cosmos-sdk/x/ibc"
+	"github.com/cosmos/cosmos-sdk/x/stake"
 
 	"github.com/cosmos/cosmos-sdk/docs/examples/democoin/types"
 	"github.com/cosmos/cosmos-sdk/docs/examples/democoin/x/cool"
@@ -67,11 +68,11 @@ func NewDemocoinApp(logger log.Logger, db dbm.DB) *DemocoinApp {
 	var app = &DemocoinApp{
 		BaseApp:            bam.NewBaseApp(appName, logger, db, auth.DefaultTxDecoder(cdc)),
 		cdc:                cdc,
-		capKeyMainStore:    sdk.NewKVStoreKey("main"),
-		capKeyAccountStore: sdk.NewKVStoreKey("acc"),
+		capKeyMainStore:    sdk.NewKVStoreKey(bam.MainStoreKey),
+		capKeyAccountStore: sdk.NewKVStoreKey(auth.StoreKey),
 		capKeyPowStore:     sdk.NewKVStoreKey("pow"),
 		capKeyIBCStore:     sdk.NewKVStoreKey("ibc"),
-		capKeyStakingStore: sdk.NewKVStoreKey("stake"),
+		capKeyStakingStore: sdk.NewKVStoreKey(stake.StoreKey),
 	}
 
 	// Define the accountKeeper.

--- a/docs/examples/democoin/cmd/democli/main.go
+++ b/docs/examples/democoin/cmd/democli/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/tx"
 
 	"github.com/cosmos/cosmos-sdk/version"
+	at "github.com/cosmos/cosmos-sdk/x/auth"
 	authcmd "github.com/cosmos/cosmos-sdk/x/auth/client/cli"
 	auth "github.com/cosmos/cosmos-sdk/x/auth/client/rest"
 	bankcmd "github.com/cosmos/cosmos-sdk/x/bank/client/cli"
@@ -31,7 +32,6 @@ var (
 		Use:   "democli",
 		Short: "Democoin light-client",
 	}
-	storeAcc = "acc"
 )
 
 func main() {
@@ -66,7 +66,7 @@ func main() {
 	// add query/post commands (custom to binary)
 	// start with commands common to basecoin
 	rootCmd.AddCommand(
-		authcmd.GetAccountCmd(storeAcc, cdc),
+		authcmd.GetAccountCmd(at.StoreKey, cdc),
 	)
 	rootCmd.AddCommand(
 		bankcmd.SendTxCmd(cdc),
@@ -109,6 +109,6 @@ func registerRoutes(rs *lcd.RestServer) {
 	keys.RegisterRoutes(rs.Mux, rs.CliCtx.Indent)
 	rpc.RegisterRoutes(rs.CliCtx, rs.Mux)
 	tx.RegisterRoutes(rs.CliCtx, rs.Mux, rs.Cdc)
-	auth.RegisterRoutes(rs.CliCtx, rs.Mux, rs.Cdc, storeAcc)
+	auth.RegisterRoutes(rs.CliCtx, rs.Mux, rs.Cdc, at.StoreKey)
 	bank.RegisterRoutes(rs.CliCtx, rs.Mux, rs.Cdc, rs.KeyBase)
 }

--- a/docs/examples/democoin/x/simplestake/keeper.go
+++ b/docs/examples/democoin/x/simplestake/keeper.go
@@ -6,9 +6,8 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/bank"
+	stakeTypes "github.com/cosmos/cosmos-sdk/x/stake/types"
 )
-
-const stakingToken = "stake"
 
 const moduleName = "simplestake"
 
@@ -62,7 +61,7 @@ func (k Keeper) deleteBondInfo(ctx sdk.Context, addr sdk.AccAddress) {
 
 // register a bond with the keeper
 func (k Keeper) Bond(ctx sdk.Context, addr sdk.AccAddress, pubKey crypto.PubKey, stake sdk.Coin) (int64, sdk.Error) {
-	if stake.Denom != stakingToken {
+	if stake.Denom != stakeTypes.DefaultBondDenom {
 		return 0, ErrIncorrectStakingToken(k.codespace)
 	}
 
@@ -93,7 +92,7 @@ func (k Keeper) Unbond(ctx sdk.Context, addr sdk.AccAddress) (crypto.PubKey, int
 	}
 	k.deleteBondInfo(ctx, addr)
 
-	returnedBond := sdk.NewInt64Coin(stakingToken, bi.Power)
+	returnedBond := sdk.NewInt64Coin(stakeTypes.DefaultBondDenom, bi.Power)
 
 	_, _, err := k.ck.AddCoins(ctx, addr, []sdk.Coin{returnedBond})
 	if err != nil {
@@ -106,7 +105,7 @@ func (k Keeper) Unbond(ctx sdk.Context, addr sdk.AccAddress) (crypto.PubKey, int
 // FOR TESTING PURPOSES -------------------------------------------------
 
 func (k Keeper) bondWithoutCoins(ctx sdk.Context, addr sdk.AccAddress, pubKey crypto.PubKey, stake sdk.Coin) (int64, sdk.Error) {
-	if stake.Denom != stakingToken {
+	if stake.Denom != stakeTypes.DefaultBondDenom {
 		return 0, ErrIncorrectStakingToken(k.codespace)
 	}
 

--- a/docs/examples/democoin/x/simplestake/keeper_test.go
+++ b/docs/examples/democoin/x/simplestake/keeper_test.go
@@ -17,6 +17,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/auth"
 	"github.com/cosmos/cosmos-sdk/x/bank"
+	stakeTypes "github.com/cosmos/cosmos-sdk/x/stake/types"
 )
 
 func setupMultiStore() (sdk.MultiStore, *sdk.KVStoreKey, *sdk.KVStoreKey) {
@@ -75,10 +76,10 @@ func TestBonding(t *testing.T) {
 	_, _, err := stakeKeeper.unbondWithoutCoins(ctx, addr)
 	require.Equal(t, err, ErrInvalidUnbond(DefaultCodespace))
 
-	_, err = stakeKeeper.bondWithoutCoins(ctx, addr, pubKey, sdk.NewInt64Coin("stake", 10))
+	_, err = stakeKeeper.bondWithoutCoins(ctx, addr, pubKey, sdk.NewInt64Coin(stakeTypes.DefaultBondDenom, 10))
 	require.Nil(t, err)
 
-	power, err := stakeKeeper.bondWithoutCoins(ctx, addr, pubKey, sdk.NewInt64Coin("stake", 10))
+	power, err := stakeKeeper.bondWithoutCoins(ctx, addr, pubKey, sdk.NewInt64Coin(stakeTypes.DefaultBondDenom, 10))
 	require.Nil(t, err)
 	require.Equal(t, int64(20), power)
 

--- a/docs/examples/kvstore/main.go
+++ b/docs/examples/kvstore/main.go
@@ -19,7 +19,7 @@ import (
 
 func main() {
 
-	logger := log.NewTMLogger(log.NewSyncWriter(os.Stdout)).With("module", "main")
+	logger := log.NewTMLogger(log.NewSyncWriter(os.Stdout)).With("module", bam.MainStoreKey)
 
 	rootDir := viper.GetString(cli.HomeFlag)
 	db, err := dbm.NewGoLevelDB("basecoind", filepath.Join(rootDir, "data"))
@@ -29,7 +29,7 @@ func main() {
 	}
 
 	// Capabilities key to access the main KVStore.
-	var capKeyMainStore = sdk.NewKVStoreKey("main")
+	var capKeyMainStore = sdk.NewKVStoreKey(bam.MainStoreKey)
 
 	// Create BaseApp.
 	var baseApp = bam.NewBaseApp("kvstore", logger, db, decodeTx)

--- a/server/mock/app.go
+++ b/server/mock/app.go
@@ -26,7 +26,7 @@ func NewApp(rootDir string, logger log.Logger) (abci.Application, error) {
 	}
 
 	// Capabilities key to access the main KVStore.
-	capKeyMainStore := sdk.NewKVStoreKey("main")
+	capKeyMainStore := sdk.NewKVStoreKey(bam.MainStoreKey)
 
 	// Create BaseApp.
 	baseApp := bam.NewBaseApp("kvstore", logger, db, decodeTx)

--- a/x/auth/keeper.go
+++ b/x/auth/keeper.go
@@ -12,6 +12,11 @@ var (
 	AddressStoreKeyPrefix = []byte{0x01}
 
 	globalAccountNumberKey = []byte("globalAccountNumber")
+
+	// StoreKey is string representation of the store key for auth
+	StoreKey = "acc"
+
+	FeeStoreKey = "fee"
 )
 
 // This AccountKeeper encodes/decodes accounts using the

--- a/x/auth/keeper.go
+++ b/x/auth/keeper.go
@@ -16,6 +16,7 @@ var (
 	// StoreKey is string representation of the store key for auth
 	StoreKey = "acc"
 
+	// FeeStoreKey is a string representation of the store key for fees
 	FeeStoreKey = "fee"
 )
 

--- a/x/bank/msgs.go
+++ b/x/bank/msgs.go
@@ -7,7 +7,7 @@ import (
 )
 
 // name to identify transaction routes
-const MsgRoute = "bank"
+const RouterKey = "bank"
 
 // MsgSend - high level transaction of the coin module
 type MsgSend struct {
@@ -24,7 +24,7 @@ func NewMsgSend(in []Input, out []Output) MsgSend {
 
 // Implements Msg.
 // nolint
-func (msg MsgSend) Route() string { return MsgRoute }
+func (msg MsgSend) Route() string { return RouterKey }
 func (msg MsgSend) Type() string  { return "send" }
 
 // Implements Msg.

--- a/x/distribution/alias.go
+++ b/x/distribution/alias.go
@@ -71,7 +71,7 @@ const (
 	StoreKey         = types.StoreKey
 	TStoreKey        = types.TStoreKey
 	RouterKey        = types.RouterKey
-	QuerierKey       = types.QuerierKey
+	QuerierRoute       = types.QuerierRoute
 )
 
 var (

--- a/x/distribution/alias.go
+++ b/x/distribution/alias.go
@@ -68,6 +68,10 @@ var (
 const (
 	DefaultCodespace = types.DefaultCodespace
 	CodeInvalidInput = types.CodeInvalidInput
+	StoreKey         = types.StoreKey
+	TStoreKey        = types.TStoreKey
+	RouterKey        = types.RouterKey
+	QuerierKey       = types.QuerierKey
 )
 
 var (

--- a/x/distribution/keeper/test_common.go
+++ b/x/distribution/keeper/test_common.go
@@ -83,13 +83,13 @@ func CreateTestInputAdvanced(t *testing.T, isCheckTx bool, initCoins int64,
 	communityTax sdk.Dec) (
 	sdk.Context, auth.AccountKeeper, Keeper, stake.Keeper, DummyFeeCollectionKeeper) {
 
-	keyDistr := sdk.NewKVStoreKey("distr")
-	keyStake := sdk.NewKVStoreKey("stake")
-	tkeyStake := sdk.NewTransientStoreKey("transient_stake")
-	keyAcc := sdk.NewKVStoreKey("acc")
-	keyFeeCollection := sdk.NewKVStoreKey("fee")
-	keyParams := sdk.NewKVStoreKey("params")
-	tkeyParams := sdk.NewTransientStoreKey("transient_params")
+	keyDistr := sdk.NewKVStoreKey(types.StoreKey)
+	keyStake := sdk.NewKVStoreKey(stake.StoreKey)
+	tkeyStake := sdk.NewTransientStoreKey(stake.TStoreKey)
+	keyAcc := sdk.NewKVStoreKey(auth.StoreKey)
+	keyFeeCollection := sdk.NewKVStoreKey(auth.FeeStoreKey)
+	keyParams := sdk.NewKVStoreKey(params.StoreKey)
+	tkeyParams := sdk.NewTransientStoreKey(params.TStoreKey)
 
 	db := dbm.NewMemDB()
 	ms := store.NewCommitMultiStore(db)

--- a/x/distribution/types/delegation_info_test.go
+++ b/x/distribution/types/delegation_info_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	stakeTypes "github.com/cosmos/cosmos-sdk/x/stake/types"
 )
 
 func TestWithdrawRewards(t *testing.T) {
@@ -27,7 +28,7 @@ func TestWithdrawRewards(t *testing.T) {
 
 	// simulate adding some stake for inflation
 	height = 10
-	fp.ValPool = DecCoins{NewDecCoin("stake", 1000)}
+	fp.ValPool = DecCoins{NewDecCoin(stakeTypes.DefaultBondDenom, 1000)}
 
 	// withdraw rewards
 	wc := NewWithdrawContext(fp, height,

--- a/x/distribution/types/keys.go
+++ b/x/distribution/types/keys.go
@@ -10,6 +10,6 @@ const (
 	// RouterKey is the message route for distribution
 	RouterKey = "distr"
 
-	// QuerierKey is the querier route for distribution
-	QuerierKey = "distr"
+	// QuerierRoute is the querier route for distribution
+	QuerierRoute = "distr"
 )

--- a/x/distribution/types/keys.go
+++ b/x/distribution/types/keys.go
@@ -1,0 +1,15 @@
+package types
+
+const (
+	// StoreKey is the store key string for distribution
+	StoreKey = "distr"
+
+	// TStoreKey is the transient store key for distribution
+	TStoreKey = "transient_distr"
+
+	// RouterKey is the message route for distribution
+	RouterKey = "distr"
+
+	// QuerierKey is the querier route for distribution
+	QuerierKey = "distr"
+)

--- a/x/distribution/types/msg.go
+++ b/x/distribution/types/msg.go
@@ -5,9 +5,6 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
-// name to identify transaction types
-const MsgRoute = "distr"
-
 // Verify interface at compile time
 var _, _ sdk.Msg = &MsgSetWithdrawAddress{}, &MsgWithdrawDelegatorRewardsAll{}
 var _, _ sdk.Msg = &MsgWithdrawDelegatorReward{}, &MsgWithdrawValidatorRewardsAll{}
@@ -27,7 +24,7 @@ func NewMsgSetWithdrawAddress(delAddr, withdrawAddr sdk.AccAddress) MsgSetWithdr
 	}
 }
 
-func (msg MsgSetWithdrawAddress) Route() string { return MsgRoute }
+func (msg MsgSetWithdrawAddress) Route() string { return RouterKey }
 func (msg MsgSetWithdrawAddress) Type() string  { return "set_withdraw_address" }
 
 // Return address that must sign over msg.GetSignBytes()
@@ -68,7 +65,7 @@ func NewMsgWithdrawDelegatorRewardsAll(delAddr sdk.AccAddress) MsgWithdrawDelega
 	}
 }
 
-func (msg MsgWithdrawDelegatorRewardsAll) Route() string { return MsgRoute }
+func (msg MsgWithdrawDelegatorRewardsAll) Route() string { return RouterKey }
 func (msg MsgWithdrawDelegatorRewardsAll) Type() string  { return "withdraw_delegation_rewards_all" }
 
 // Return address that must sign over msg.GetSignBytes()
@@ -108,7 +105,7 @@ func NewMsgWithdrawDelegatorReward(delAddr sdk.AccAddress, valAddr sdk.ValAddres
 	}
 }
 
-func (msg MsgWithdrawDelegatorReward) Route() string { return MsgRoute }
+func (msg MsgWithdrawDelegatorReward) Route() string { return RouterKey }
 func (msg MsgWithdrawDelegatorReward) Type() string  { return "withdraw_delegation_reward" }
 
 // Return address that must sign over msg.GetSignBytes()
@@ -149,7 +146,7 @@ func NewMsgWithdrawValidatorRewardsAll(valAddr sdk.ValAddress) MsgWithdrawValida
 	}
 }
 
-func (msg MsgWithdrawValidatorRewardsAll) Route() string { return MsgRoute }
+func (msg MsgWithdrawValidatorRewardsAll) Route() string { return RouterKey }
 func (msg MsgWithdrawValidatorRewardsAll) Type() string  { return "withdraw_validator_rewards_all" }
 
 // Return address that must sign over msg.GetSignBytes()

--- a/x/distribution/types/validator_info_test.go
+++ b/x/distribution/types/validator_info_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	stakeTypes "github.com/cosmos/cosmos-sdk/x/stake/types"
 )
 
 func TestTakeFeePoolRewards(t *testing.T) {
@@ -27,7 +28,7 @@ func TestTakeFeePoolRewards(t *testing.T) {
 
 	// simulate adding some stake for inflation
 	height = 10
-	fp.ValPool = DecCoins{NewDecCoin("stake", 1000)}
+	fp.ValPool = DecCoins{NewDecCoin(stakeTypes.DefaultBondDenom, 1000)}
 
 	vi1, fp = vi1.TakeFeePoolRewards(NewWithdrawContext(
 		fp, height, totalBondedTokens, validatorTokens1, commissionRate1))
@@ -67,7 +68,7 @@ func TestWithdrawCommission(t *testing.T) {
 
 	// simulate adding some stake for inflation
 	height = 10
-	fp.ValPool = DecCoins{NewDecCoin("stake", 1000)}
+	fp.ValPool = DecCoins{NewDecCoin(stakeTypes.DefaultBondDenom, 1000)}
 
 	// for a more fun staring condition, have an non-withdraw update
 	vi, fp = vi.TakeFeePoolRewards(NewWithdrawContext(

--- a/x/gov/client/rest/rest.go
+++ b/x/gov/client/rest/rest.go
@@ -25,7 +25,6 @@ const (
 	RestVoter          = "voter"
 	RestProposalStatus = "status"
 	RestNumLimit       = "limit"
-	storeName          = "gov"
 )
 
 // RegisterRoutes - Central function to define routes that get registered by the main application

--- a/x/gov/keeper.go
+++ b/x/gov/keeper.go
@@ -18,8 +18,8 @@ const (
 	// RouterKey is the message route for gov
 	RouterKey = "gov"
 
-	// QuerierKey is the querier route for gov
-	QuerierKey = "gov"
+	// QuerierRoute is the querier route for gov
+	QuerierRoute = "gov"
 
 	// Parameter store default namestore
 	DefaultParamspace = "gov"

--- a/x/gov/keeper.go
+++ b/x/gov/keeper.go
@@ -11,8 +11,17 @@ import (
 	"github.com/tendermint/tendermint/crypto"
 )
 
-// Parameter store default namestore
 const (
+	// StoreKey is the store key string for gov
+	StoreKey = "gov"
+
+	// RouterKey is the message route for gov
+	RouterKey = "gov"
+
+	// QuerierKey is the querier route for gov
+	QuerierKey = "gov"
+
+	// Parameter store default namestore
 	DefaultParamspace = "gov"
 )
 

--- a/x/gov/msgs.go
+++ b/x/gov/msgs.go
@@ -6,9 +6,6 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
-// name to idetify transaction types
-const MsgRoute = "gov"
-
 var _, _, _ sdk.Msg = MsgSubmitProposal{}, MsgDeposit{}, MsgVote{}
 
 //-----------------------------------------------------------
@@ -32,7 +29,7 @@ func NewMsgSubmitProposal(title string, description string, proposalType Proposa
 }
 
 //nolint
-func (msg MsgSubmitProposal) Route() string { return MsgRoute }
+func (msg MsgSubmitProposal) Route() string { return RouterKey }
 func (msg MsgSubmitProposal) Type() string  { return "submit_proposal" }
 
 // Implements Msg.
@@ -99,7 +96,7 @@ func NewMsgDeposit(depositor sdk.AccAddress, proposalID uint64, amount sdk.Coins
 
 // Implements Msg.
 // nolint
-func (msg MsgDeposit) Route() string { return MsgRoute }
+func (msg MsgDeposit) Route() string { return RouterKey }
 func (msg MsgDeposit) Type() string  { return "deposit" }
 
 // Implements Msg.
@@ -160,7 +157,7 @@ func NewMsgVote(voter sdk.AccAddress, proposalID uint64, option VoteOption) MsgV
 
 // Implements Msg.
 // nolint
-func (msg MsgVote) Route() string { return MsgRoute }
+func (msg MsgVote) Route() string { return RouterKey }
 func (msg MsgVote) Type() string  { return "vote" }
 
 // Implements Msg.

--- a/x/gov/querier_test.go
+++ b/x/gov/querier_test.go
@@ -11,9 +11,11 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
+const custom = "custom"
+
 func getQueriedParams(t *testing.T, ctx sdk.Context, cdc *codec.Codec, querier sdk.Querier) (DepositParams, VotingParams, TallyParams) {
 	query := abci.RequestQuery{
-		Path: strings.Join([]string{"custom", "gov", QueryParams, ParamDeposit}, "/"),
+		Path: strings.Join([]string{custom, QuerierKey, QueryParams, ParamDeposit}, "/"),
 		Data: []byte{},
 	}
 
@@ -26,7 +28,7 @@ func getQueriedParams(t *testing.T, ctx sdk.Context, cdc *codec.Codec, querier s
 	require.Nil(t, err2)
 
 	query = abci.RequestQuery{
-		Path: strings.Join([]string{"custom", "gov", QueryParams, ParamVoting}, "/"),
+		Path: strings.Join([]string{custom, QuerierKey, QueryParams, ParamVoting}, "/"),
 		Data: []byte{},
 	}
 
@@ -39,7 +41,7 @@ func getQueriedParams(t *testing.T, ctx sdk.Context, cdc *codec.Codec, querier s
 	require.Nil(t, err2)
 
 	query = abci.RequestQuery{
-		Path: strings.Join([]string{"custom", "gov", QueryParams, ParamTallying}, "/"),
+		Path: strings.Join([]string{custom, QuerierKey, QueryParams, ParamTallying}, "/"),
 		Data: []byte{},
 	}
 
@@ -56,7 +58,7 @@ func getQueriedParams(t *testing.T, ctx sdk.Context, cdc *codec.Codec, querier s
 
 func getQueriedProposal(t *testing.T, ctx sdk.Context, cdc *codec.Codec, querier sdk.Querier, proposalID uint64) Proposal {
 	query := abci.RequestQuery{
-		Path: strings.Join([]string{"custom", "gov", QueryProposal}, "/"),
+		Path: strings.Join([]string{custom, QuerierKey, QueryProposal}, "/"),
 		Data: cdc.MustMarshalJSON(NewQueryProposalParams(proposalID)),
 	}
 
@@ -72,7 +74,7 @@ func getQueriedProposal(t *testing.T, ctx sdk.Context, cdc *codec.Codec, querier
 
 func getQueriedProposals(t *testing.T, ctx sdk.Context, cdc *codec.Codec, querier sdk.Querier, depositor, voter sdk.AccAddress, status ProposalStatus, limit uint64) []Proposal {
 	query := abci.RequestQuery{
-		Path: strings.Join([]string{"custom", "gov", QueryProposals}, "/"),
+		Path: strings.Join([]string{custom, QuerierKey, QueryProposals}, "/"),
 		Data: cdc.MustMarshalJSON(NewQueryProposalsParams(status, limit, voter, depositor)),
 	}
 
@@ -88,7 +90,7 @@ func getQueriedProposals(t *testing.T, ctx sdk.Context, cdc *codec.Codec, querie
 
 func getQueriedDeposit(t *testing.T, ctx sdk.Context, cdc *codec.Codec, querier sdk.Querier, proposalID uint64, depositor sdk.AccAddress) Deposit {
 	query := abci.RequestQuery{
-		Path: strings.Join([]string{"custom", "gov", QueryDeposit}, "/"),
+		Path: strings.Join([]string{custom, QuerierKey, QueryDeposit}, "/"),
 		Data: cdc.MustMarshalJSON(NewQueryDepositParams(proposalID, depositor)),
 	}
 
@@ -104,7 +106,7 @@ func getQueriedDeposit(t *testing.T, ctx sdk.Context, cdc *codec.Codec, querier 
 
 func getQueriedDeposits(t *testing.T, ctx sdk.Context, cdc *codec.Codec, querier sdk.Querier, proposalID uint64) []Deposit {
 	query := abci.RequestQuery{
-		Path: strings.Join([]string{"custom", "gov", QueryDeposits}, "/"),
+		Path: strings.Join([]string{custom, QuerierKey, QueryDeposits}, "/"),
 		Data: cdc.MustMarshalJSON(NewQueryProposalParams(proposalID)),
 	}
 
@@ -120,7 +122,7 @@ func getQueriedDeposits(t *testing.T, ctx sdk.Context, cdc *codec.Codec, querier
 
 func getQueriedVote(t *testing.T, ctx sdk.Context, cdc *codec.Codec, querier sdk.Querier, proposalID uint64, voter sdk.AccAddress) Vote {
 	query := abci.RequestQuery{
-		Path: strings.Join([]string{"custom", "gov", QueryVote}, "/"),
+		Path: strings.Join([]string{custom, QuerierKey, QueryVote}, "/"),
 		Data: cdc.MustMarshalJSON(NewQueryVoteParams(proposalID, voter)),
 	}
 
@@ -136,7 +138,7 @@ func getQueriedVote(t *testing.T, ctx sdk.Context, cdc *codec.Codec, querier sdk
 
 func getQueriedVotes(t *testing.T, ctx sdk.Context, cdc *codec.Codec, querier sdk.Querier, proposalID uint64) []Vote {
 	query := abci.RequestQuery{
-		Path: strings.Join([]string{"custom", "gov", QueryVote}, "/"),
+		Path: strings.Join([]string{custom, QuerierKey, QueryVote}, "/"),
 		Data: cdc.MustMarshalJSON(NewQueryProposalParams(proposalID)),
 	}
 
@@ -152,7 +154,7 @@ func getQueriedVotes(t *testing.T, ctx sdk.Context, cdc *codec.Codec, querier sd
 
 func getQueriedTally(t *testing.T, ctx sdk.Context, cdc *codec.Codec, querier sdk.Querier, proposalID uint64) TallyResult {
 	query := abci.RequestQuery{
-		Path: strings.Join([]string{"custom", "gov", QueryTally}, "/"),
+		Path: strings.Join([]string{custom, QuerierKey, QueryTally}, "/"),
 		Data: cdc.MustMarshalJSON(NewQueryProposalParams(proposalID)),
 	}
 

--- a/x/gov/querier_test.go
+++ b/x/gov/querier_test.go
@@ -15,7 +15,7 @@ const custom = "custom"
 
 func getQueriedParams(t *testing.T, ctx sdk.Context, cdc *codec.Codec, querier sdk.Querier) (DepositParams, VotingParams, TallyParams) {
 	query := abci.RequestQuery{
-		Path: strings.Join([]string{custom, QuerierKey, QueryParams, ParamDeposit}, "/"),
+		Path: strings.Join([]string{custom, QuerierRoute, QueryParams, ParamDeposit}, "/"),
 		Data: []byte{},
 	}
 
@@ -28,7 +28,7 @@ func getQueriedParams(t *testing.T, ctx sdk.Context, cdc *codec.Codec, querier s
 	require.Nil(t, err2)
 
 	query = abci.RequestQuery{
-		Path: strings.Join([]string{custom, QuerierKey, QueryParams, ParamVoting}, "/"),
+		Path: strings.Join([]string{custom, QuerierRoute, QueryParams, ParamVoting}, "/"),
 		Data: []byte{},
 	}
 
@@ -41,7 +41,7 @@ func getQueriedParams(t *testing.T, ctx sdk.Context, cdc *codec.Codec, querier s
 	require.Nil(t, err2)
 
 	query = abci.RequestQuery{
-		Path: strings.Join([]string{custom, QuerierKey, QueryParams, ParamTallying}, "/"),
+		Path: strings.Join([]string{custom, QuerierRoute, QueryParams, ParamTallying}, "/"),
 		Data: []byte{},
 	}
 
@@ -58,7 +58,7 @@ func getQueriedParams(t *testing.T, ctx sdk.Context, cdc *codec.Codec, querier s
 
 func getQueriedProposal(t *testing.T, ctx sdk.Context, cdc *codec.Codec, querier sdk.Querier, proposalID uint64) Proposal {
 	query := abci.RequestQuery{
-		Path: strings.Join([]string{custom, QuerierKey, QueryProposal}, "/"),
+		Path: strings.Join([]string{custom, QuerierRoute, QueryProposal}, "/"),
 		Data: cdc.MustMarshalJSON(NewQueryProposalParams(proposalID)),
 	}
 
@@ -74,7 +74,7 @@ func getQueriedProposal(t *testing.T, ctx sdk.Context, cdc *codec.Codec, querier
 
 func getQueriedProposals(t *testing.T, ctx sdk.Context, cdc *codec.Codec, querier sdk.Querier, depositor, voter sdk.AccAddress, status ProposalStatus, limit uint64) []Proposal {
 	query := abci.RequestQuery{
-		Path: strings.Join([]string{custom, QuerierKey, QueryProposals}, "/"),
+		Path: strings.Join([]string{custom, QuerierRoute, QueryProposals}, "/"),
 		Data: cdc.MustMarshalJSON(NewQueryProposalsParams(status, limit, voter, depositor)),
 	}
 
@@ -90,7 +90,7 @@ func getQueriedProposals(t *testing.T, ctx sdk.Context, cdc *codec.Codec, querie
 
 func getQueriedDeposit(t *testing.T, ctx sdk.Context, cdc *codec.Codec, querier sdk.Querier, proposalID uint64, depositor sdk.AccAddress) Deposit {
 	query := abci.RequestQuery{
-		Path: strings.Join([]string{custom, QuerierKey, QueryDeposit}, "/"),
+		Path: strings.Join([]string{custom, QuerierRoute, QueryDeposit}, "/"),
 		Data: cdc.MustMarshalJSON(NewQueryDepositParams(proposalID, depositor)),
 	}
 
@@ -106,7 +106,7 @@ func getQueriedDeposit(t *testing.T, ctx sdk.Context, cdc *codec.Codec, querier 
 
 func getQueriedDeposits(t *testing.T, ctx sdk.Context, cdc *codec.Codec, querier sdk.Querier, proposalID uint64) []Deposit {
 	query := abci.RequestQuery{
-		Path: strings.Join([]string{custom, QuerierKey, QueryDeposits}, "/"),
+		Path: strings.Join([]string{custom, QuerierRoute, QueryDeposits}, "/"),
 		Data: cdc.MustMarshalJSON(NewQueryProposalParams(proposalID)),
 	}
 
@@ -122,7 +122,7 @@ func getQueriedDeposits(t *testing.T, ctx sdk.Context, cdc *codec.Codec, querier
 
 func getQueriedVote(t *testing.T, ctx sdk.Context, cdc *codec.Codec, querier sdk.Querier, proposalID uint64, voter sdk.AccAddress) Vote {
 	query := abci.RequestQuery{
-		Path: strings.Join([]string{custom, QuerierKey, QueryVote}, "/"),
+		Path: strings.Join([]string{custom, QuerierRoute, QueryVote}, "/"),
 		Data: cdc.MustMarshalJSON(NewQueryVoteParams(proposalID, voter)),
 	}
 
@@ -138,7 +138,7 @@ func getQueriedVote(t *testing.T, ctx sdk.Context, cdc *codec.Codec, querier sdk
 
 func getQueriedVotes(t *testing.T, ctx sdk.Context, cdc *codec.Codec, querier sdk.Querier, proposalID uint64) []Vote {
 	query := abci.RequestQuery{
-		Path: strings.Join([]string{custom, QuerierKey, QueryVote}, "/"),
+		Path: strings.Join([]string{custom, QuerierRoute, QueryVote}, "/"),
 		Data: cdc.MustMarshalJSON(NewQueryProposalParams(proposalID)),
 	}
 
@@ -154,7 +154,7 @@ func getQueriedVotes(t *testing.T, ctx sdk.Context, cdc *codec.Codec, querier sd
 
 func getQueriedTally(t *testing.T, ctx sdk.Context, cdc *codec.Codec, querier sdk.Querier, proposalID uint64) TallyResult {
 	query := abci.RequestQuery{
-		Path: strings.Join([]string{custom, QuerierKey, QueryTally}, "/"),
+		Path: strings.Join([]string{custom, QuerierRoute, QueryTally}, "/"),
 		Data: cdc.MustMarshalJSON(NewQueryProposalParams(proposalID)),
 	}
 

--- a/x/gov/test_common.go
+++ b/x/gov/test_common.go
@@ -39,7 +39,7 @@ func getMockApp(t *testing.T, numGenAccs int) (*mock.App, Keeper, stake.Keeper, 
 	keeper := NewKeeper(mapp.Cdc, keyGov, pk, pk.Subspace("testgov"), ck, sk, DefaultCodespace)
 
 	mapp.Router().AddRoute(RouterKey, NewHandler(keeper))
-	mapp.QueryRouter().AddRoute(QuerierKey, NewQuerier(keeper))
+	mapp.QueryRouter().AddRoute(QuerierRoute, NewQuerier(keeper))
 
 	mapp.SetEndBlocker(getEndBlocker(keeper))
 	mapp.SetInitChainer(getInitChainer(mapp, keeper, sk))

--- a/x/gov/test_common.go
+++ b/x/gov/test_common.go
@@ -27,19 +27,19 @@ func getMockApp(t *testing.T, numGenAccs int) (*mock.App, Keeper, stake.Keeper, 
 	stake.RegisterCodec(mapp.Cdc)
 	RegisterCodec(mapp.Cdc)
 
-	keyGlobalParams := sdk.NewKVStoreKey("params")
-	tkeyGlobalParams := sdk.NewTransientStoreKey("transient_params")
-	keyStake := sdk.NewKVStoreKey("stake")
-	tkeyStake := sdk.NewTransientStoreKey("transient_stake")
-	keyGov := sdk.NewKVStoreKey("gov")
+	keyGlobalParams := sdk.NewKVStoreKey(params.StoreKey)
+	tkeyGlobalParams := sdk.NewTransientStoreKey(params.TStoreKey)
+	keyStake := sdk.NewKVStoreKey(stake.StoreKey)
+	tkeyStake := sdk.NewTransientStoreKey(stake.TStoreKey)
+	keyGov := sdk.NewKVStoreKey(StoreKey)
 
 	pk := params.NewKeeper(mapp.Cdc, keyGlobalParams, tkeyGlobalParams)
 	ck := bank.NewBaseKeeper(mapp.AccountKeeper)
 	sk := stake.NewKeeper(mapp.Cdc, keyStake, tkeyStake, ck, pk.Subspace(stake.DefaultParamspace), stake.DefaultCodespace)
 	keeper := NewKeeper(mapp.Cdc, keyGov, pk, pk.Subspace("testgov"), ck, sk, DefaultCodespace)
 
-	mapp.Router().AddRoute("gov", NewHandler(keeper))
-	mapp.QueryRouter().AddRoute("gov", NewQuerier(keeper))
+	mapp.Router().AddRoute(RouterKey, NewHandler(keeper))
+	mapp.QueryRouter().AddRoute(QuerierKey, NewQuerier(keeper))
 
 	mapp.SetEndBlocker(getEndBlocker(keeper))
 	mapp.SetInitChainer(getInitChainer(mapp, keeper, sk))

--- a/x/ibc/client/cli/relay.go
+++ b/x/ibc/client/cli/relay.go
@@ -1,10 +1,12 @@
 package cli
 
 import (
-	"github.com/cosmos/cosmos-sdk/client/utils"
 	"os"
 	"time"
 
+	"github.com/cosmos/cosmos-sdk/client/utils"
+
+	bam "github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/client/context"
 	"github.com/cosmos/cosmos-sdk/client/keys"
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -44,8 +46,8 @@ func IBCRelayCmd(cdc *codec.Codec) *cobra.Command {
 		cdc:       cdc,
 		decoder:   context.GetAccountDecoder(cdc),
 		ibcStore:  "ibc",
-		mainStore: "main",
-		accStore:  "acc",
+		mainStore: bam.MainStoreKey,
+		accStore:  auth.StoreKey,
 
 		logger: log.NewTMLogger(log.NewSyncWriter(os.Stdout)),
 	}

--- a/x/mint/keeper.go
+++ b/x/mint/keeper.go
@@ -48,6 +48,9 @@ func ParamTypeTable() params.TypeTable {
 const (
 	// default paramspace for params keeper
 	DefaultParamspace = "mint"
+
+	// StoreKey is the default store key for mint
+	StoreKey = "mint"
 )
 
 //______________________________________________________________________

--- a/x/mock/app.go
+++ b/x/mock/app.go
@@ -55,8 +55,8 @@ func NewApp() *App {
 	app := &App{
 		BaseApp:          bam.NewBaseApp("mock", logger, db, auth.DefaultTxDecoder(cdc)),
 		Cdc:              cdc,
-		KeyMain:          sdk.NewKVStoreKey("main"),
-		KeyAccount:       sdk.NewKVStoreKey("acc"),
+		KeyMain:          sdk.NewKVStoreKey(bam.MainStoreKey),
+		KeyAccount:       sdk.NewKVStoreKey(auth.StoreKey),
 		TotalCoinsSupply: sdk.Coins{},
 	}
 

--- a/x/params/keeper.go
+++ b/x/params/keeper.go
@@ -7,6 +7,14 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/params/subspace"
 )
 
+const (
+	// StoreKey is the string key for the params store
+	StoreKey = subspace.StoreKey
+
+	// TStoreKey is the string key for the params transient store
+	TStoreKey = subspace.TStoreKey
+)
+
 // Keeper of the global paramstore
 type Keeper struct {
 	cdc  *codec.Codec

--- a/x/params/subspace/subspace.go
+++ b/x/params/subspace/subspace.go
@@ -7,6 +7,14 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
+const (
+	// StoreKey is the string store key for the param store
+	StoreKey = "params"
+
+	// TStoreKey is the string store key for the param transient store
+	TStoreKey = "transient_params"
+)
+
 // Individual parameter store for each keeper
 // Transient store persists for a block, so we use it for
 // recording whether the parameter has been changed or not

--- a/x/params/subspace/test_common.go
+++ b/x/params/subspace/test_common.go
@@ -23,8 +23,8 @@ const (
 // Returns components for testing
 func DefaultTestComponents(t *testing.T, table TypeTable) (sdk.Context, Subspace, func() sdk.CommitID) {
 	cdc := codec.New()
-	key := sdk.NewKVStoreKey("params")
-	tkey := sdk.NewTransientStoreKey("tparams")
+	key := sdk.NewKVStoreKey(StoreKey)
+	tkey := sdk.NewTransientStoreKey(TStoreKey)
 	db := dbm.NewMemDB()
 	ms := store.NewCommitMultiStore(db)
 	ms.WithTracer(os.Stdout)

--- a/x/slashing/app_test.go
+++ b/x/slashing/app_test.go
@@ -27,19 +27,19 @@ func getMockApp(t *testing.T) (*mock.App, stake.Keeper, Keeper) {
 	mapp := mock.NewApp()
 
 	RegisterCodec(mapp.Cdc)
-	keyStake := sdk.NewKVStoreKey("stake")
-	tkeyStake := sdk.NewTransientStoreKey("transient_stake")
-	keySlashing := sdk.NewKVStoreKey("slashing")
+	keyStake := sdk.NewKVStoreKey(stake.StoreKey)
+	tkeyStake := sdk.NewTransientStoreKey(stake.TStoreKey)
+	keySlashing := sdk.NewKVStoreKey(StoreKey)
 
-	keyParams := sdk.NewKVStoreKey("params")
-	tkeyParams := sdk.NewTransientStoreKey("transient_params")
+	keyParams := sdk.NewKVStoreKey(params.StoreKey)
+	tkeyParams := sdk.NewTransientStoreKey(params.TStoreKey)
 	bankKeeper := bank.NewBaseKeeper(mapp.AccountKeeper)
 
 	paramsKeeper := params.NewKeeper(mapp.Cdc, keyParams, tkeyParams)
 	stakeKeeper := stake.NewKeeper(mapp.Cdc, keyStake, tkeyStake, bankKeeper, paramsKeeper.Subspace(stake.DefaultParamspace), stake.DefaultCodespace)
 	keeper := NewKeeper(mapp.Cdc, keySlashing, stakeKeeper, paramsKeeper.Subspace(DefaultParamspace), DefaultCodespace)
-	mapp.Router().AddRoute("stake", stake.NewHandler(stakeKeeper))
-	mapp.Router().AddRoute("slashing", NewHandler(keeper))
+	mapp.Router().AddRoute(stake.RouterKey, stake.NewHandler(stakeKeeper))
+	mapp.Router().AddRoute(RouterKey, NewHandler(keeper))
 
 	mapp.SetEndBlocker(getEndBlocker(stakeKeeper))
 	mapp.SetInitChainer(getInitChainer(mapp, stakeKeeper))

--- a/x/slashing/client/rest/query.go
+++ b/x/slashing/client/rest/query.go
@@ -15,7 +15,7 @@ import (
 func registerQueryRoutes(cliCtx context.CLIContext, r *mux.Router, cdc *codec.Codec) {
 	r.HandleFunc(
 		"/slashing/validators/{validatorPubKey}/signing_info",
-		signingInfoHandlerFn(cliCtx, "slashing", cdc),
+		signingInfoHandlerFn(cliCtx, slashing.StoreKey, cdc),
 	).Methods("GET")
 }
 

--- a/x/slashing/keys.go
+++ b/x/slashing/keys.go
@@ -14,8 +14,8 @@ const (
 	// RouterKey is the message route for slashing
 	RouterKey = "slashing"
 
-	// QuerierKey is the querier route for slashing
-	QuerierKey = "slashing"
+	// QuerierRoute is the querier route for slashing
+	QuerierRoute = "slashing"
 )
 
 // key prefix bytes

--- a/x/slashing/keys.go
+++ b/x/slashing/keys.go
@@ -7,6 +7,17 @@ import (
 	stake "github.com/cosmos/cosmos-sdk/x/stake/types"
 )
 
+const (
+	// StoreKey is the store key string for slashing
+	StoreKey = "slashing"
+
+	// RouterKey is the message route for slashing
+	RouterKey = "slashing"
+
+	// QuerierKey is the querier route for slashing
+	QuerierKey = "slashing"
+)
+
 // key prefix bytes
 var (
 	ValidatorSigningInfoKey         = []byte{0x01} // Prefix for signing info

--- a/x/slashing/msg.go
+++ b/x/slashing/msg.go
@@ -7,9 +7,6 @@ import (
 
 var cdc = codec.New()
 
-// name to identify transaction types
-const MsgRoute = "slashing"
-
 // verify interface at compile time
 var _ sdk.Msg = &MsgUnjail{}
 
@@ -25,7 +22,7 @@ func NewMsgUnjail(validatorAddr sdk.ValAddress) MsgUnjail {
 }
 
 //nolint
-func (msg MsgUnjail) Route() string { return MsgRoute }
+func (msg MsgUnjail) Route() string { return RouterKey }
 func (msg MsgUnjail) Type() string  { return "unjail" }
 func (msg MsgUnjail) GetSigners() []sdk.AccAddress {
 	return []sdk.AccAddress{sdk.AccAddress(msg.ValidatorAddr)}

--- a/x/slashing/querier.go
+++ b/x/slashing/querier.go
@@ -9,8 +9,6 @@ import (
 
 // Query endpoints supported by the slashing querier
 const (
-	QuerierRoute = "slashing"
-
 	QueryParameters = "parameters"
 )
 

--- a/x/slashing/test_common.go
+++ b/x/slashing/test_common.go
@@ -51,12 +51,12 @@ func createTestCodec() *codec.Codec {
 }
 
 func createTestInput(t *testing.T, defaults Params) (sdk.Context, bank.Keeper, stake.Keeper, params.Subspace, Keeper) {
-	keyAcc := sdk.NewKVStoreKey("acc")
-	keyStake := sdk.NewKVStoreKey("stake")
-	tkeyStake := sdk.NewTransientStoreKey("transient_stake")
-	keySlashing := sdk.NewKVStoreKey("slashing")
-	keyParams := sdk.NewKVStoreKey("params")
-	tkeyParams := sdk.NewTransientStoreKey("transient_params")
+	keyAcc := sdk.NewKVStoreKey(auth.StoreKey)
+	keyStake := sdk.NewKVStoreKey(stake.StoreKey)
+	tkeyStake := sdk.NewTransientStoreKey(stake.TStoreKey)
+	keySlashing := sdk.NewKVStoreKey(StoreKey)
+	keyParams := sdk.NewKVStoreKey(params.StoreKey)
+	tkeyParams := sdk.NewTransientStoreKey(params.TStoreKey)
 	db := dbm.NewMemDB()
 	ms := store.NewCommitMultiStore(db)
 	ms.MountStoreWithDB(keyAcc, sdk.StoreTypeIAVL, db)

--- a/x/stake/app_test.go
+++ b/x/stake/app_test.go
@@ -20,18 +20,18 @@ func getMockApp(t *testing.T) (*mock.App, Keeper) {
 
 	RegisterCodec(mApp.Cdc)
 
-	keyStake := sdk.NewKVStoreKey("stake")
+	keyStake := sdk.NewKVStoreKey(StoreKey)
 
-	tkeyStake := sdk.NewTransientStoreKey("transient_stake")
-	keyParams := sdk.NewKVStoreKey("params")
-	tkeyParams := sdk.NewTransientStoreKey("transient_params")
+	tkeyStake := sdk.NewTransientStoreKey(TStoreKey)
+	keyParams := sdk.NewKVStoreKey(params.StoreKey)
+	tkeyParams := sdk.NewTransientStoreKey(params.TStoreKey)
 
 	bankKeeper := bank.NewBaseKeeper(mApp.AccountKeeper)
 	pk := params.NewKeeper(mApp.Cdc, keyParams, tkeyParams)
 
 	keeper := NewKeeper(mApp.Cdc, keyStake, tkeyStake, bankKeeper, pk.Subspace(DefaultParamspace), DefaultCodespace)
 
-	mApp.Router().AddRoute("stake", NewHandler(keeper))
+	mApp.Router().AddRoute(RouterKey, NewHandler(keeper))
 	mApp.SetEndBlocker(getEndBlocker(keeper))
 	mApp.SetInitChainer(getInitChainer(mApp, keeper))
 

--- a/x/stake/client/rest/query.go
+++ b/x/stake/client/rest/query.go
@@ -16,8 +16,6 @@ import (
 	"github.com/gorilla/mux"
 )
 
-const storeName = "stake"
-
 func registerQueryRoutes(cliCtx context.CLIContext, r *mux.Router, cdc *codec.Codec) {
 
 	// Get all delegations from a delegator

--- a/x/stake/keeper/test_common.go
+++ b/x/stake/keeper/test_common.go
@@ -77,11 +77,11 @@ func MakeTestCodec() *codec.Codec {
 // hogpodge of all sorts of input required for testing
 func CreateTestInput(t *testing.T, isCheckTx bool, initCoins int64) (sdk.Context, auth.AccountKeeper, Keeper) {
 
-	keyStake := sdk.NewKVStoreKey("stake")
-	tkeyStake := sdk.NewTransientStoreKey("transient_stake")
-	keyAcc := sdk.NewKVStoreKey("acc")
-	keyParams := sdk.NewKVStoreKey("params")
-	tkeyParams := sdk.NewTransientStoreKey("transient_params")
+	keyStake := sdk.NewKVStoreKey(types.StoreKey)
+	tkeyStake := sdk.NewTransientStoreKey(types.TStoreKey)
+	keyAcc := sdk.NewKVStoreKey(auth.StoreKey)
+	keyParams := sdk.NewKVStoreKey(params.StoreKey)
+	tkeyParams := sdk.NewTransientStoreKey(params.TStoreKey)
 
 	db := dbm.NewMemDB()
 	ms := store.NewCommitMultiStore(db)

--- a/x/stake/stake.go
+++ b/x/stake/stake.go
@@ -108,7 +108,7 @@ const (
 const (
 	StoreKey              = types.StoreKey
 	TStoreKey             = types.TStoreKey
-	QuerierKey            = types.QuerierKey
+	QuerierRoute            = types.QuerierRoute
 	RouterKey             = types.RouterKey
 	DefaultCodespace      = types.DefaultCodespace
 	CodeInvalidValidator  = types.CodeInvalidValidator

--- a/x/stake/stake.go
+++ b/x/stake/stake.go
@@ -106,6 +106,10 @@ const (
 )
 
 const (
+	StoreKey              = types.StoreKey
+	TStoreKey             = types.TStoreKey
+	QuerierKey            = types.QuerierKey
+	RouterKey             = types.RouterKey
 	DefaultCodespace      = types.DefaultCodespace
 	CodeInvalidValidator  = types.CodeInvalidValidator
 	CodeInvalidDelegation = types.CodeInvalidDelegation

--- a/x/stake/types/keys.go
+++ b/x/stake/types/keys.go
@@ -1,0 +1,15 @@
+package types
+
+const (
+	// StoreKey is the string store representation
+	StoreKey = "stake"
+
+	// TStoreKey is the string transient store representation
+	TStoreKey = "transient_stake"
+
+	// QuerierKey is the querier route for the stake module
+	QuerierKey = "stake"
+
+	// RouterKey is the msg router key for the stake module
+	RouterKey = "stake"
+)

--- a/x/stake/types/keys.go
+++ b/x/stake/types/keys.go
@@ -7,8 +7,8 @@ const (
 	// TStoreKey is the string transient store representation
 	TStoreKey = "transient_stake"
 
-	// QuerierKey is the querier route for the stake module
-	QuerierKey = "stake"
+	// QuerierRoute is the querier route for the stake module
+	QuerierRoute = "stake"
 
 	// RouterKey is the msg router key for the stake module
 	RouterKey = "stake"

--- a/x/stake/types/msg.go
+++ b/x/stake/types/msg.go
@@ -8,9 +8,6 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
-// name to identify transaction routes
-const MsgRoute = "stake"
-
 // Verify interface at compile time
 var _, _, _ sdk.Msg = &MsgCreateValidator{}, &MsgEditValidator{}, &MsgDelegate{}
 
@@ -49,7 +46,7 @@ func NewMsgCreateValidatorOnBehalfOf(delAddr sdk.AccAddress, valAddr sdk.ValAddr
 }
 
 //nolint
-func (msg MsgCreateValidator) Route() string { return MsgRoute }
+func (msg MsgCreateValidator) Route() string { return RouterKey }
 func (msg MsgCreateValidator) Type() string  { return "create_validator" }
 
 // Return address(es) that must sign over msg.GetSignBytes()
@@ -131,7 +128,7 @@ func NewMsgEditValidator(valAddr sdk.ValAddress, description Description, newRat
 }
 
 //nolint
-func (msg MsgEditValidator) Route() string { return MsgRoute }
+func (msg MsgEditValidator) Route() string { return RouterKey }
 func (msg MsgEditValidator) Type() string  { return "edit_validator" }
 func (msg MsgEditValidator) GetSigners() []sdk.AccAddress {
 	return []sdk.AccAddress{sdk.AccAddress(msg.ValidatorAddr)}
@@ -183,7 +180,7 @@ func NewMsgDelegate(delAddr sdk.AccAddress, valAddr sdk.ValAddress, delegation s
 }
 
 //nolint
-func (msg MsgDelegate) Route() string { return MsgRoute }
+func (msg MsgDelegate) Route() string { return RouterKey }
 func (msg MsgDelegate) Type() string  { return "delegate" }
 func (msg MsgDelegate) GetSigners() []sdk.AccAddress {
 	return []sdk.AccAddress{msg.DelegatorAddr}
@@ -234,7 +231,7 @@ func NewMsgBeginRedelegate(delAddr sdk.AccAddress, valSrcAddr,
 }
 
 //nolint
-func (msg MsgBeginRedelegate) Route() string { return MsgRoute }
+func (msg MsgBeginRedelegate) Route() string { return RouterKey }
 func (msg MsgBeginRedelegate) Type() string  { return "begin_redelegate" }
 func (msg MsgBeginRedelegate) GetSigners() []sdk.AccAddress {
 	return []sdk.AccAddress{msg.DelegatorAddr}
@@ -294,7 +291,7 @@ func NewMsgBeginUnbonding(delAddr sdk.AccAddress, valAddr sdk.ValAddress, shares
 }
 
 //nolint
-func (msg MsgBeginUnbonding) Route() string                { return MsgRoute }
+func (msg MsgBeginUnbonding) Route() string                { return RouterKey }
 func (msg MsgBeginUnbonding) Type() string                 { return "begin_unbonding" }
 func (msg MsgBeginUnbonding) GetSigners() []sdk.AccAddress { return []sdk.AccAddress{msg.DelegatorAddr} }
 


### PR DESCRIPTION
- [X] Issue: https://github.com/cosmos/cosmos-sdk/issues/2838
- [ ] Added entries in `PENDING.md` with issue # 
- [X] rereviewed `Files changed` in the github PR explorer

This PR cleans up storekeys, query routes and message routes that were previously defined as string (e.g. "gov" and "acc") and used in many places in the SDK by placing them in their module.

cc @alexanderbez @cwgoes 