### PR TITLE
Welcome back, logjack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,11 +49,13 @@ build:
 ifeq ($(OS),Windows_NT)
 	go build $(BUILD_FLAGS) -o build/gaiad.exe ./cmd/gaia/cmd/gaiad
 	go build $(BUILD_FLAGS) -o build/gaiacli.exe ./cmd/gaia/cmd/gaiacli
+	go build $(BUILD_FLAGS) -o build/logjack ./cmd/logjack
 else
 	go build $(BUILD_FLAGS) -o build/gaiad ./cmd/gaia/cmd/gaiad
 	go build $(BUILD_FLAGS) -o build/gaiacli ./cmd/gaia/cmd/gaiacli
 	go build $(BUILD_FLAGS) -o build/gaiareplay ./cmd/gaia/cmd/gaiareplay
 	go build $(BUILD_FLAGS) -o build/gaiakeyutil ./cmd/gaia/cmd/gaiakeyutil
+	go build $(BUILD_FLAGS) -o build/logjack ./cmd/logjack
 endif
 
 build-linux:
@@ -87,6 +89,7 @@ install: check-ledger update_gaia_lite_docs
 	go install $(BUILD_FLAGS) ./cmd/gaia/cmd/gaiacli
 	go install $(BUILD_FLAGS) ./cmd/gaia/cmd/gaiareplay
 	go install $(BUILD_FLAGS) ./cmd/gaia/cmd/gaiakeyutil
+	go install $(BUILD_FLAGS) ./cmd/logjack
 
 install_examples:
 	go install $(BUILD_FLAGS) ./docs/examples/basecoin/cmd/basecoind

--- a/cmd/logjack/main.go
+++ b/cmd/logjack/main.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+
+	auto "github.com/tendermint/tendermint/libs/autofile"
+	cmn "github.com/tendermint/tendermint/libs/common"
+)
+
+const Version = "0.0.2"
+const sleepSeconds = 1      // Every second
+const readBufferSize = 1024 // 1KB at a time
+
+// Parse command-line options
+func parseFlags() (headPath string, chopSize int64, limitSize int64, version bool) {
+	var flagSet = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	var chopSizeStr, limitSizeStr string
+	flagSet.StringVar(&headPath, "head", "logjack.out", "Destination (head) file.")
+	flagSet.StringVar(&chopSizeStr, "chop", "100M", "Move file if greater than this")
+	flagSet.StringVar(&limitSizeStr, "limit", "10G", "Only keep this much (for each specified file). Remove old files.")
+	flagSet.BoolVar(&version, "version", false, "Version")
+	flagSet.Parse(os.Args[1:])
+	chopSize = parseBytesize(chopSizeStr)
+	limitSize = parseBytesize(limitSizeStr)
+	return
+}
+
+func main() {
+
+	// Read options
+	headPath, chopSize, limitSize, version := parseFlags()
+	if version {
+		fmt.Printf("logjack version %v\n", Version)
+		return
+	}
+
+	// Open Group
+	group, err := auto.OpenGroup(headPath, auto.GroupHeadSizeLimit(chopSize), auto.GroupTotalSizeLimit(limitSize))
+	if err != nil {
+		fmt.Printf("logjack couldn't create output file %v\n", headPath)
+		os.Exit(1)
+	}
+	// TODO: Maybe fix Group to re-allow these mutations.
+	// group.SetHeadSizeLimit(chopSize)
+	// group.SetTotalSizeLimit(limitSize)
+	err = group.Start()
+	if err != nil {
+		fmt.Printf("logjack couldn't start with file %v\n", headPath)
+		os.Exit(1)
+	}
+
+	go func() {
+		// Forever, read from stdin and write to AutoFile.
+		buf := make([]byte, readBufferSize)
+		for {
+			n, err := os.Stdin.Read(buf)
+			group.Write(buf[:n])
+			group.Flush()
+			if err != nil {
+				group.Stop()
+				if err == io.EOF {
+					os.Exit(0)
+				} else {
+					fmt.Println("logjack errored")
+					os.Exit(1)
+				}
+			}
+		}
+	}()
+
+	// Trap signal
+	cmn.TrapSignal(func() {
+		fmt.Println("logjack shutting down")
+	})
+}
+
+func parseBytesize(chopSize string) int64 {
+	// Handle suffix multiplier
+	var multiplier int64 = 1
+	if strings.HasSuffix(chopSize, "T") {
+		multiplier = 1042 * 1024 * 1024 * 1024
+		chopSize = chopSize[:len(chopSize)-1]
+	}
+	if strings.HasSuffix(chopSize, "G") {
+		multiplier = 1042 * 1024 * 1024
+		chopSize = chopSize[:len(chopSize)-1]
+	}
+	if strings.HasSuffix(chopSize, "M") {
+		multiplier = 1042 * 1024
+		chopSize = chopSize[:len(chopSize)-1]
+	}
+	if strings.HasSuffix(chopSize, "K") {
+		multiplier = 1042
+		chopSize = chopSize[:len(chopSize)-1]
+	}
+
+	// Parse the numeric part
+	chopSizeInt, err := strconv.Atoi(chopSize)
+	if err != nil {
+		panic(err)
+	}
+
+	return int64(chopSizeInt) * multiplier
+}


### PR DESCRIPTION
This re-introduces a utility that is deep in the tendermint github history, called logjack.
It uses tendermint/libs/autofile Groups to allow piping stdin into a file that gets auto-rotated.
There surely exist other tools that do the same, but this tool works and requires nothing but existing tendermint dependencies to build, thus is quite portable.  logrotate and cron are a pain to use.

Usage:

./build/gaiad <options> | ./build/logjack -head logs/gaiad.log