### PR TITLE
R4R: Don't fallback to any default values for chain id

### DIFF
--- a/PENDING.md
+++ b/PENDING.md
@@ -5,6 +5,9 @@ BREAKING CHANGES
 * Gaia REST API (`gaiacli advanced rest-server`)
 
 * Gaia CLI  (`gaiacli`)
+  * [\#810](https://github.com/cosmos/cosmos-sdk/issues/810) Don't fallback to any default values for chain ID.
+    - Users need to supply chain ID either via config file or the `--chain-id` flag.
+    - Change `chain_id` and `trust_node` in `gaiacli` configuration to `chain-id` and `trust-node` respectively.
 
 * Gaia
 

--- a/client/config.go
+++ b/client/config.go
@@ -24,7 +24,7 @@ var configDefaults map[string]string
 
 func init() {
 	configDefaults = map[string]string{
-		"chain_id": "",
+		"chain-id": "",
 		"output":   "text",
 		"node":     "tcp://localhost:26657",
 	}
@@ -78,7 +78,7 @@ func runConfigCmd(cmd *cobra.Command, args []string) error {
 	// Get value action
 	if getAction {
 		switch key {
-		case "trace", "trust_node":
+		case "trace", "trust-node":
 			fmt.Println(tree.GetDefault(key, false).(bool))
 		default:
 			if defaultValue, ok := configDefaults[key]; ok {
@@ -93,9 +93,9 @@ func runConfigCmd(cmd *cobra.Command, args []string) error {
 	// Set value action
 	value := args[1]
 	switch key {
-	case "chain_id", "output", "node":
+	case "chain-id", "output", "node":
 		tree.Set(key, value)
-	case "trace", "trust_node":
+	case "trace", "trust-node":
 		boolVal, err := strconv.ParseBool(value)
 		if err != nil {
 			return err

--- a/client/flags.go
+++ b/client/flags.go
@@ -96,6 +96,8 @@ func PostCommands(cmds ...*cobra.Command) []*cobra.Command {
 		viper.BindPFlag(FlagUseLedger, c.Flags().Lookup(FlagUseLedger))
 		viper.BindPFlag(FlagChainID, c.Flags().Lookup(FlagChainID))
 		viper.BindPFlag(FlagNode, c.Flags().Lookup(FlagNode))
+
+		c.MarkFlagRequired(FlagChainID)
 	}
 	return cmds
 }

--- a/cmd/gaia/cli_test/cli_test.go
+++ b/cmd/gaia/cli_test/cli_test.go
@@ -632,16 +632,16 @@ func TestGaiaCLIConfig(t *testing.T) {
 	node := fmt.Sprintf("%s:%s", servAddr, port)
 	executeWrite(t, fmt.Sprintf(`gaiacli --home=%s config node %s`, gaiacliHome, node))
 	executeWrite(t, fmt.Sprintf(`gaiacli --home=%s config output text`, gaiacliHome))
-	executeWrite(t, fmt.Sprintf(`gaiacli --home=%s config trust_node true`, gaiacliHome))
-	executeWrite(t, fmt.Sprintf(`gaiacli --home=%s config chain_id %s`, gaiacliHome, chainID))
+	executeWrite(t, fmt.Sprintf(`gaiacli --home=%s config trust-node true`, gaiacliHome))
+	executeWrite(t, fmt.Sprintf(`gaiacli --home=%s config chain-id %s`, gaiacliHome, chainID))
 	executeWrite(t, fmt.Sprintf(`gaiacli --home=%s config trace false`, gaiacliHome))
 	config, err := ioutil.ReadFile(path.Join(gaiacliHome, "config", "config.toml"))
 	require.NoError(t, err)
-	expectedConfig := fmt.Sprintf(`chain_id = "%s"
+	expectedConfig := fmt.Sprintf(`chain-id = "%s"
 node = "%s"
 output = "text"
 trace = false
-trust_node = true
+trust-node = true
 `, chainID, node)
 	require.Equal(t, expectedConfig, string(config))
 	cleanupDirs(gaiadHome, gaiacliHome)

--- a/types/utils.go
+++ b/types/utils.go
@@ -4,9 +4,6 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"time"
-
-	tcmd "github.com/tendermint/tendermint/cmd/tendermint/commands"
-	tmtypes "github.com/tendermint/tendermint/types"
 )
 
 // SortedJSON takes any JSON and returns it sorted by keys. Also, all white-spaces
@@ -60,23 +57,4 @@ func ParseTimeBytes(bz []byte) (time.Time, error) {
 		return t, err
 	}
 	return t.UTC().Round(0), nil
-}
-
-// DefaultChainID returns the chain ID from the genesis file if present. An
-// error is returned if the file cannot be read or parsed.
-//
-// TODO: This should be removed and the chainID should always be provided by
-// the end user.
-func DefaultChainID() (string, error) {
-	cfg, err := tcmd.ParseConfig()
-	if err != nil {
-		return "", err
-	}
-
-	doc, err := tmtypes.GenesisDocFromFile(cfg.GenesisFile())
-	if err != nil {
-		return "", err
-	}
-
-	return doc.ChainID, nil
 }

--- a/x/auth/client/txbuilder/txbuilder.go
+++ b/x/auth/client/txbuilder/txbuilder.go
@@ -28,12 +28,6 @@ type TxBuilder struct {
 func NewTxBuilderFromCLI() TxBuilder {
 	// if chain ID is not specified manually, read default chain ID
 	chainID := viper.GetString(client.FlagChainID)
-	if chainID == "" {
-		defaultChainID, err := sdk.DefaultChainID()
-		if err != nil {
-			chainID = defaultChainID
-		}
-	}
 
 	return TxBuilder{
 		ChainID:       chainID,


### PR DESCRIPTION
- Remove DefaultChainID(). User needs to suplly chain ID via either config or flag.
- Mark --chain-id as required by all tx commands.
- Fix gaiacli config values containing underscores.
  Underscore '_' character is not automagically translated into hyphen '-'. Viper values wouldn't be affected.
- Refresh gaiacli config tests

Closes: #810

- [x] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [x] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [x] Added entries in `PENDING.md` with issue # 
- [x] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
