### PR TITLE
Temporarily revert x/slashing/params json field names to use dashes, …

### DIFF
--- a/x/slashing/params.go
+++ b/x/slashing/params.go
@@ -30,13 +30,13 @@ func ParamTypeTable() params.TypeTable {
 
 // Params - used for initializing default parameter for slashing at genesis
 type Params struct {
-	MaxEvidenceAge           time.Duration `json:"max_evidence_age"`
-	SignedBlocksWindow       int64         `json:"signed_blocks_window"`
-	MinSignedPerWindow       sdk.Dec       `json:"min_signed_per_window"`
-	DoubleSignUnbondDuration time.Duration `json:"double_sign_unbond_duration"`
-	DowntimeUnbondDuration   time.Duration `json:"downtime_unbond_duration"`
-	SlashFractionDoubleSign  sdk.Dec       `json:"slash_fraction_double_sign"`
-	SlashFractionDowntime    sdk.Dec       `json:"slash_fraction_downtime"`
+	MaxEvidenceAge           time.Duration `json:"max-evidence-age"`
+	SignedBlocksWindow       int64         `json:"signed-blocks-window"`
+	MinSignedPerWindow       sdk.Dec       `json:"min-signed-per-window"`
+	DoubleSignUnbondDuration time.Duration `json:"double-sign-unbond-duration"`
+	DowntimeUnbondDuration   time.Duration `json:"downtime-unbond-duration"`
+	SlashFractionDoubleSign  sdk.Dec       `json:"slash-fraction-double-sign"`
+	SlashFractionDowntime    sdk.Dec       `json:"slash-fraction-downtime"`
 }
 
 // Implements params.ParamStruct


### PR DESCRIPTION
…for GoS compat
