### PR TITLE
R4R: Expose necessary ante handler auxiliary functions

### DIFF
--- a/x/auth/ante_test.go
+++ b/x/auth/ante_test.go
@@ -665,7 +665,7 @@ func TestProcessPubKey(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := processPubKey(tt.args.acc, tt.args.sig, tt.args.simulate)
+			_, err := ProcessPubKey(tt.args.acc, tt.args.sig, tt.args.simulate)
 			require.Equal(t, tt.wantErr, !err.IsOK())
 		})
 	}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

This PR achieves a middle ground @cwgoes and I discussed during an Ethermint discussion where while we wait on #2996 to be finalized and merged (as to not block Ethermint), we expose the necessary auxiliary/helper functions in the ante handler to be used by Ethermint.

This keeps the code DRY and does not block Ethermint.

----

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/develop/CONTRIBUTING.md#pr-targeting))

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added entries in `PENDING.md` with issue # 
- [x] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
