### PR TITLE
WIP: custom Bech32 prefixes break tutorial code

### DIFF
--- a/docs/examples/basecoin/cmd/basecoind/main.go
+++ b/docs/examples/basecoin/cmd/basecoind/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/docs/examples/basecoin/app"
 	"github.com/cosmos/cosmos-sdk/server"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 const (
@@ -48,11 +49,22 @@ func main() {
 	rootDir := os.ExpandEnv("$HOME/.basecoind")
 	executor := cli.PrepareBaseCmd(rootCmd, "BC", rootDir)
 
+	// initialise the Bech32 prefixes
+	initSDKConfig()
+
 	err := executor.Execute()
 	if err != nil {
 		// Note: Handle with #870
 		panic(err)
 	}
+}
+
+func initSDKConfig() {
+	config := sdk.GetConfig()
+	config.SetBech32PrefixForAccount("baseacc", "basepub")
+	config.SetBech32PrefixForValidator("baseval", "basevalpub")
+	config.SetBech32PrefixForConsensusNode("basecons", "baseconspub")
+	config.Seal()
 }
 
 // get cmd to initialize all files for tendermint and application


### PR DESCRIPTION
Adds a function to fix #3142 to initialise the Cosmos SDK to use the same Bech32
prefixes as those which basecli uses.

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/develop/CONTRIBUTING.md#pr-targeting))

- [x] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests - *Will require refactoring of testing approach for `basecoin`*.
- [ ] Updated relevant documentation (`docs/`) - *Not necessary, fixes code to work with documentation*.
- [ ] Added entries in `PENDING.md` with issue # - *Not necessary, small issue.*
- [x] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
