### PR TITLE
FIX: small typo in stake/client/cli/tx.go

### DIFF
--- a/x/stake/client/cli/tx.go
+++ b/x/stake/client/cli/tx.go
@@ -114,7 +114,7 @@ func GetCmdEditValidator(cdc *codec.Codec) *cobra.Command {
 func GetCmdDelegate(cdc *codec.Codec) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "delegate",
-		Short: "delegate liquid tokens to an validator",
+		Short: "delegate liquid tokens to a validator",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			txBldr := authtxb.NewTxBuilderFromCLI().WithTxEncoder(auth.DefaultTxEncoder(cdc))
 			cliCtx := context.NewCLIContext().

--- a/x/stake/client/cli/tx.go
+++ b/x/stake/client/cli/tx.go
@@ -62,7 +62,7 @@ func GetCmdCreateValidator(cdc *codec.Codec) *cobra.Command {
 func GetCmdEditValidator(cdc *codec.Codec) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "edit-validator",
-		Short: "edit and existing validator account",
+		Short: "edit an existing validator account",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			txBldr := authtxb.NewTxBuilderFromCLI().WithTxEncoder(auth.DefaultTxEncoder(cdc))
 			cliCtx := context.NewCLIContext().


### PR DESCRIPTION
Just a small typo fix.