### PR TITLE
R4R Use .gitattributes to ignore JS files - this is not a js repo :)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+client/lcd/swagger-ui/* linguist-vendored


### PR DESCRIPTION
This was really bugging me so I investigated and turns out it's quite easy to fix.

Github uses https://github.com/github/linguist to get the language stats for a repo. A simple `.gitattributes` file can tell it to ignore certain files. We have about 75k lines of javascript in `client/lcd/swagger-ui`. With this commit, github will ignore files in that dir when computing language stats. Running the linguist tool locally, here's a before and after this commit:

Before:
```
cosmos-sdk$ github-linguist 
62.87%  JavaScript
34.34%  Go
1.56%   Python
0.50%   Makefile
0.42%   HCL
0.22%   Shell
0.07%   HTML
0.02%   Dockerfile
```

After:
```
cosmos-sdk$ github-linguist 
92.65%  Go
4.20%   Python
1.35%   Makefile
1.14%   HCL
0.60%   Shell
0.07%   Dockerfile
```

Much better!

Apparently it can take some time to update in Github - I tried to test it out in a fork first. 
______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
