### PR TITLE
R4R: Support adding offline pubkeys to gaiacli keys 

### DIFF
--- a/PENDING.md
+++ b/PENDING.md
@@ -51,6 +51,8 @@ IMPROVEMENTS
 * Gaia REST API (`gaiacli advanced rest-server`)
 
 * Gaia CLI  (`gaiacli`)
+  *[\#3203](https://github.com/cosmos/cosmos-sdk/pull/3202) Support adding offline public keys to the keystore
+
 
 * Gaia
   * [\#3158](https://github.com/cosmos/cosmos-sdk/pull/3158) Validate slashing genesis

--- a/client/keys/add.go
+++ b/client/keys/add.go
@@ -43,12 +43,12 @@ and encrypted with the given password. The only input that is required is the en
 If run with -i, it will prompt the user for BIP44 path, BIP39 mnemonic, and passphrase.
 The flag --recover allows one to recover a key from a seed passphrase.
 If run with --dry-run, a key would be generated (or recovered) but not stored to the local keystore.
-Use the --pubkey flag to add arbitrary public keys to the keystore for constructing multisignature transactions
+Use the --pubkey flag to add arbitrary public keys to the keystore for constructing multisig transactions
 `,
 		Args: cobra.ExactArgs(1),
 		RunE: runAddCmd,
 	}
-	cmd.Flags().String(FlagPublicKey, "", "Store only a public key (useful for constructing multisigs) e.g.  cosmospub1...")
+	cmd.Flags().String(FlagPublicKey, "", "Store only a public key (useful for constructing multisigs e.g.  cosmospub1...)")
 	cmd.Flags().BoolP(flagInteractive, "i", false, "Interactively prompt user for BIP39 passphrase and mnemonic")
 	cmd.Flags().Bool(client.FlagUseLedger, false, "Store a local reference to a private key on a Ledger device")
 	cmd.Flags().String(flagBIP44Path, "44'/118'/0'/0/0", "BIP44 path from which to derive a private key")

--- a/client/keys/add.go
+++ b/client/keys/add.go
@@ -117,7 +117,6 @@ func runAddCmd(cmd *cobra.Command, args []string) error {
 	}
 
 	if pubKeyFlag.Changed {
-
 		pk, err := sdk.GetAccPubKeyBech32(pubKeyFlag.Value.String())
 		if err != nil {
 			return err

--- a/client/keys/add.go
+++ b/client/keys/add.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 	"os"
 
-	bip39 "github.com/bartekn/go-bip39"
-	"github.com/gorilla/mux"
+    "github.com/cosmos/go-bip39"		
+    "github.com/gorilla/mux"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"

--- a/client/keys/add.go
+++ b/client/keys/add.go
@@ -48,7 +48,7 @@ If run with --dry-run, a key would be generated (or recovered) but not stored to
 		Args: cobra.ExactArgs(1),
 		RunE: runAddCmd,
 	}
-	cmd.Flags().String(FlagPublicKey, "cosmospub1....", "store only a public key. Useful for constructuing multisigs")
+	cmd.Flags().String(FlagPublicKey, "cosmospub1....", "Store only a public key (useful for constructing multisigs)")
 	cmd.Flags().BoolP(flagInteractive, "i", false, "Interactively prompt user for BIP39 passphrase and mnemonic")
 	cmd.Flags().Bool(client.FlagUseLedger, false, "Store a local reference to a private key on a Ledger device")
 	cmd.Flags().String(flagBIP44Path, "44'/118'/0'/0/0", "BIP44 path from which to derive a private key")


### PR DESCRIPTION
Support adding offline public keys to gaiacli.

Closes https://github.com/cosmos/cosmos-sdk/issues/3197

- [x] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [x] Added entries in `PENDING.md` with issue # 
- [ ] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
