### PR TITLE
R4R: Fix token printing bug

### DIFF
--- a/PENDING.md
+++ b/PENDING.md
@@ -19,7 +19,7 @@ BREAKING CHANGES
 
 * SDK
   * [\#3064](https://github.com/cosmos/cosmos-sdk/issues/3064) Sanitize `sdk.Coin` denom. Coins denoms are now case insensitive, i.e. 100fooToken equals to 100FOOTOKEN.
-  * \# - Fix token printing bug
+  * \#3207 - Fix token printing bug
 
 * Tendermint
 

--- a/PENDING.md
+++ b/PENDING.md
@@ -19,6 +19,7 @@ BREAKING CHANGES
 
 * SDK
   * [\#3064](https://github.com/cosmos/cosmos-sdk/issues/3064) Sanitize `sdk.Coin` denom. Coins denoms are now case insensitive, i.e. 100fooToken equals to 100FOOTOKEN.
+  * \# - Fix token printing bug
 
 * Tendermint
 

--- a/types/coin.go
+++ b/types/coin.go
@@ -144,8 +144,13 @@ func (coins Coins) IsValid() bool {
 	case 1:
 		return coins[0].IsPositive()
 	default:
+		if strings.ToLower(coins[0].Denom) != coins[0].Denom {
+			return false
+		}
+		if !coins[0].IsPositive() {
+			return false
+		}
 		lowDenom := coins[0].Denom
-
 		for _, coin := range coins[1:] {
 			if strings.ToLower(coin.Denom) != coin.Denom {
 				return false

--- a/types/coin_test.go
+++ b/types/coin_test.go
@@ -286,6 +286,10 @@ func TestCoins(t *testing.T) {
 		{"gas", NewInt(1)},
 		{"mineral", NewInt(1)},
 	}
+	neg := Coins{
+		{"gas", NewInt(-1)},
+		{"mineral", NewInt(1)},
+	}
 
 	assert.True(t, good.IsValid(), "Coins are valid")
 	assert.False(t, mixedCase.IsValid(), "Coins denoms contain upper case characters")
@@ -298,6 +302,7 @@ func TestCoins(t *testing.T) {
 	assert.False(t, badSort2.IsValid(), "Coins are not sorted")
 	assert.False(t, badAmt.IsValid(), "Coins cannot include 0 amounts")
 	assert.False(t, dup.IsValid(), "Duplicate coin")
+	assert.False(t, neg.IsValid(), "Negative first-denom coin")
 }
 
 func TestCoinsGT(t *testing.T) {


### PR DESCRIPTION
Quoth @ValarDragon:

> This stems from a buggy coins.IsValid function. In the IsValid function, https://github.com/cosmos/cosmos-sdk/blob/develop/types/coin.go#L140, it just checks if the coins object is sorted and only has coins with postive value. However when there are multiple tokens, (the default case in the switch statement), the first denom doesn't get its coins value checked for being positive. This means the first denom can be negative or zero. (Recall that its a signed big int >_>, I really wish the uint war would end with everyone being convinced of uints)

This PR adds in desired checks in `coins.IsValid()` and adds a testcase for a negative first-denom coin.

- [x] Wrote tests
- [x] Updated relevant documentation (`docs/`)
- [x] Added entries in `PENDING.md` with issue # 
- [x] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
