### PR TITLE
Fix another is_valid bug

### DIFF
--- a/types/coin.go
+++ b/types/coin.go
@@ -142,12 +142,13 @@ func (coins Coins) IsValid() bool {
 	case 0:
 		return true
 	case 1:
-		return coins[0].IsPositive()
-	default:
 		if strings.ToLower(coins[0].Denom) != coins[0].Denom {
 			return false
 		}
-		if !coins[0].IsPositive() {
+		return coins[0].IsPositive()
+	default:
+		// Check single coin case
+		if !(Coins{coins[0]}).IsValid() {
 			return false
 		}
 		lowDenom := coins[0].Denom

--- a/types/coin_test.go
+++ b/types/coin_test.go
@@ -255,10 +255,17 @@ func TestCoins(t *testing.T) {
 		{"mineral", NewInt(1)},
 		{"tree", NewInt(1)},
 	}
-	mixedCase := Coins{
+	mixedCase1 := Coins{
 		{"gAs", NewInt(1)},
 		{"MineraL", NewInt(1)},
 		{"TREE", NewInt(1)},
+	}
+	mixedCase2 := Coins{
+		{"gAs", NewInt(1)},
+		{"mineral", NewInt(1)},
+	}
+	mixedCase3 := Coins{
+		{"gAs", NewInt(1)},
 	}
 	empty := Coins{
 		{"gold", NewInt(0)},
@@ -292,7 +299,9 @@ func TestCoins(t *testing.T) {
 	}
 
 	assert.True(t, good.IsValid(), "Coins are valid")
-	assert.False(t, mixedCase.IsValid(), "Coins denoms contain upper case characters")
+	assert.False(t, mixedCase1.IsValid(), "Coins denoms contain upper case characters")
+	assert.False(t, mixedCase2.IsValid(), "First Coins denoms contain upper case characters")
+	assert.False(t, mixedCase3.IsValid(), "Single denom in Coins contains upper case characters")
 	assert.True(t, good.IsPositive(), "Expected coins to be positive: %v", good)
 	assert.False(t, null.IsPositive(), "Expected coins to not be positive: %v", null)
 	assert.True(t, good.IsAllGTE(empty), "Expected %v to be >= %v", good, empty)


### PR DESCRIPTION
We didn't check the casing on the single coin case within is_valid. This also changes default-case handling to re-use logic on the single coins case.

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [x] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [x] Added entries in `PENDING.md` with issue # - case checks are new to this release
- [x] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
