### PR TITLE
Add devtools-stamp to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ examples/build/*
 docs/_build
 docs/tutorial
 dist
+devtools-stamp
 
 # Data - ideally these don't exist
 examples/basecoin/app/data


### PR DESCRIPTION
Trivial change, since we don't want to add this file to the repo it should be in `.gitignore`.

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
