### PR TITLE
The semantics of specifying multiple fees in configuration should be OR instead of AND

### DIFF
--- a/cmd/gaia/cli_test/cli_test.go
+++ b/cmd/gaia/cli_test/cli_test.go
@@ -59,12 +59,12 @@ func TestGaiaCLIMinimumFees(t *testing.T) {
 
 	// Ensure tx with correct fees (stake) pass
 	success = executeWrite(t, fmt.Sprintf(
-		"gaiacli tx send %v --amount=10%s --to=%s --from=foo --fees=2%s", flags, stakeTypes.DefaultBondDenom, barAddr, stakeTypes.DefaultBondDenom), app.DefaultKeyPass)
+		"gaiacli tx send %v --amount=10%s --to=%s --from=foo --fees=23%s", flags, stakeTypes.DefaultBondDenom, barAddr, stakeTypes.DefaultBondDenom), app.DefaultKeyPass)
 	require.True(t, success)
 
 	// Ensure tx with correct fees (feetoken) pass
 	success = executeWrite(t, fmt.Sprintf(
-		"gaiacli tx send %v --amount=10%s --to=%s --from=foo --fees=2feetoken", flags, stakeTypes.DefaultBondDenom, barAddr), app.DefaultKeyPass)
+		"gaiacli tx send %v --amount=10feetoken --to=%s --from=foo --fees=23feetoken", flags, barAddr), app.DefaultKeyPass)
 	require.True(t, success)
 
 	// Ensure tx with improper fees fails

--- a/cmd/gaia/cli_test/cli_test.go
+++ b/cmd/gaia/cli_test/cli_test.go
@@ -61,11 +61,13 @@ func TestGaiaCLIMinimumFees(t *testing.T) {
 	success = executeWrite(t, fmt.Sprintf(
 		"gaiacli tx send %v --amount=10%s --to=%s --from=foo --fees=23%s", flags, stakeTypes.DefaultBondDenom, barAddr, stakeTypes.DefaultBondDenom), app.DefaultKeyPass)
 	require.True(t, success)
+	tests.WaitForNextNBlocksTM(1, port)
 
 	// Ensure tx with correct fees (feetoken) pass
 	success = executeWrite(t, fmt.Sprintf(
 		"gaiacli tx send %v --amount=10feetoken --to=%s --from=foo --fees=23feetoken", flags, barAddr), app.DefaultKeyPass)
 	require.True(t, success)
+	tests.WaitForNextNBlocksTM(1, port)
 
 	// Ensure tx with improper fees fails
 	success = executeWrite(t, fmt.Sprintf(

--- a/cmd/gaia/cli_test/cli_test.go
+++ b/cmd/gaia/cli_test/cli_test.go
@@ -40,7 +40,7 @@ func TestGaiaCLIMinimumFees(t *testing.T) {
 	flags := fmt.Sprintf("--home=%s --node=%v --chain-id=%v", gaiacliHome, servAddr, chainID)
 
 	// start gaiad server with minimum fees
-	proc := tests.GoExecuteTWithStdout(t, fmt.Sprintf("gaiad start --home=%s --rpc.laddr=%v --p2p.laddr=%v --minimum_fees=2feetoken", gaiadHome, servAddr, p2pAddr))
+	proc := tests.GoExecuteTWithStdout(t, fmt.Sprintf("gaiad start --home=%s --rpc.laddr=%v --p2p.laddr=%v --minimum_fees=2%s,2feetoken", gaiadHome, servAddr, p2pAddr, stakeTypes.DefaultBondDenom))
 
 	defer proc.Stop(false)
 	tests.WaitForTMStart(port)
@@ -52,9 +52,26 @@ func TestGaiaCLIMinimumFees(t *testing.T) {
 	fooAcc := executeGetAccount(t, fmt.Sprintf("gaiacli query account %s %v", fooAddr, flags))
 	require.Equal(t, int64(50), fooAcc.GetCoins().AmountOf(stakeTypes.DefaultBondDenom).Int64())
 
+	// Ensure that a tx with no fees fails
 	success := executeWrite(t, fmt.Sprintf(
 		"gaiacli tx send %v --amount=10%s --to=%s --from=foo", flags, stakeTypes.DefaultBondDenom, barAddr), app.DefaultKeyPass)
 	require.False(t, success)
+
+	// Ensure tx with correct fees (stake) pass
+	success = executeWrite(t, fmt.Sprintf(
+		"gaiacli tx send %v --amount=10%s --to=%s --from=foo --fees=2%s", flags, stakeTypes.DefaultBondDenom, barAddr, stakeTypes.DefaultBondDenom), app.DefaultKeyPass)
+	require.True(t, success)
+
+	// Ensure tx with correct fees (feetoken) pass
+	success = executeWrite(t, fmt.Sprintf(
+		"gaiacli tx send %v --amount=10%s --to=%s --from=foo --fees=2feetoken", flags, stakeTypes.DefaultBondDenom, barAddr), app.DefaultKeyPass)
+	require.True(t, success)
+
+	// Ensure tx with improper fees fails
+	success = executeWrite(t, fmt.Sprintf(
+		"gaiacli tx send %v --amount=10%s --to=%s --from=foo --fees=2footoken", flags, stakeTypes.DefaultBondDenom, barAddr), app.DefaultKeyPass)
+	require.False(t, success)
+
 	cleanupDirs(gaiadHome, gaiacliHome)
 }
 
@@ -732,7 +749,7 @@ func initializeFixtures(t *testing.T) (chainID, servAddr, port, gaiadHome, gaiac
 	chainID = executeInit(t, fmt.Sprintf("gaiad init -o --moniker=foo --home=%s", gaiadHome))
 
 	executeWriteCheckErr(t, fmt.Sprintf(
-		"gaiad add-genesis-account %s 150%s,1000footoken --home=%s", fooAddr, stakeTypes.DefaultBondDenom, gaiadHome))
+		"gaiad add-genesis-account %s 150%s,1000footoken,1000feetoken --home=%s", fooAddr, stakeTypes.DefaultBondDenom, gaiadHome))
 	executeWrite(t, fmt.Sprintf("cat %s%sconfig%sgenesis.json", gaiadHome, string(os.PathSeparator), string(os.PathSeparator)))
 	executeWriteCheckErr(t, fmt.Sprintf(
 		"gaiad gentx --name=foo --home=%s --home-client=%s", gaiadHome, gaiacliHome), app.DefaultKeyPass)

--- a/types/coin.go
+++ b/types/coin.go
@@ -293,7 +293,7 @@ func (coins Coins) IsAllGT(coinsB Coins) bool {
 }
 
 // IsAnyGTE returns true if for any denom in coins, the denom is present at a
-//an  equal or greater amount in coinsB
+// an equal or greater amount in coinsB.
 func (coins Coins) IsAnyGTE(coinsB Coins) bool {
 	diff, _ := coins.SafeMinus(coinsB)
 	if len(diff) == 0 {

--- a/types/coin.go
+++ b/types/coin.go
@@ -302,7 +302,7 @@ func (coins Coins) IsAnyGTE(coinsB Coins) bool {
 	}
 
 	for _, coin := range coins {
-		if coin.IsPositive() {
+		if coin.IsNotNegative() {
 			return true
 		}
 	}

--- a/types/coin.go
+++ b/types/coin.go
@@ -269,7 +269,7 @@ func (coins Coins) SafeMinus(coinsB Coins) (Coins, bool) {
 // that is present at a smaller amount in coinsB; it
 // returns false otherwise.
 func (coins Coins) IsAnyGT(coinsB Coins) bool {
-	intersection := coins.denomsIntersection(coinsB)
+	intersection := coins.intersect(coinsB)
 	if intersection.Empty() {
 		return false
 	}
@@ -302,7 +302,7 @@ func (coins Coins) IsAllGT(coinsB Coins) bool {
 // that is present at a smaller or equal amount in coinsB; it
 // returns false otherwise.
 func (coins Coins) IsAnyGTE(coinsB Coins) bool {
-	intersection := coins.denomsIntersection(coinsB)
+	intersection := coins.intersect(coinsB)
 	if intersection.Empty() {
 		return false
 	}
@@ -474,7 +474,7 @@ func removeZeroCoins(coins Coins) Coins {
 	return coins[:i]
 }
 
-func (coins Coins) denomsIntersection(coinsB Coins) Coins {
+func (coins Coins) intersect(coinsB Coins) Coins {
 	intersection := Coins{}
 	for _, coin := range coins {
 		for _, bCoin := range coinsB {

--- a/types/coin.go
+++ b/types/coin.go
@@ -273,7 +273,7 @@ func (coins Coins) IsAnyGT(coinsB Coins) bool {
 		return false
 	}
 
-	for _, coin := range coins {
+	for _, coin := range diff {
 		if coin.IsPositive() {
 			return true
 		}
@@ -294,14 +294,13 @@ func (coins Coins) IsAllGT(coinsB Coins) bool {
 
 // IsAnyGTE returns true if for any denom in coins, the denom is present at a
 //an  equal or greater amount in coinsB
-
 func (coins Coins) IsAnyGTE(coinsB Coins) bool {
 	diff, _ := coins.SafeMinus(coinsB)
 	if len(diff) == 0 {
 		return false
 	}
 
-	for _, coin := range coins {
+	for _, coin := range diff {
 		if coin.IsNotNegative() {
 			return true
 		}

--- a/types/coin.go
+++ b/types/coin.go
@@ -265,7 +265,23 @@ func (coins Coins) SafeMinus(coinsB Coins) (Coins, bool) {
 	return diff, !diff.IsNotNegative()
 }
 
-// IsAllGT returns true iff for every denom in coins, the denom is present at a
+// IsAnyGT returns true if any denom in coins, the denom is present at a
+// greater amount in coinsA.
+func (coins Coins) IsAnyGT(coinsB Coins) bool {
+	diff, _ := coins.SafeMinus(coinsB)
+	if len(diff) == 0 {
+		return false
+	}
+
+	for _, coin := range coins {
+		if coin.IsPositive() {
+			return true
+		}
+	}
+	return false
+}
+
+// IsAllGT returns true if for every denom in coins, the denom is present at a
 // greater amount in coinsB.
 func (coins Coins) IsAllGT(coinsB Coins) bool {
 	diff, _ := coins.SafeMinus(coinsB)
@@ -274,6 +290,23 @@ func (coins Coins) IsAllGT(coinsB Coins) bool {
 	}
 
 	return diff.IsPositive()
+}
+
+// IsAnyGTE returns true if for any denom in coins, the denom is present at a
+//an  equal or greater amount in coinsB
+
+func (coins Coins) IsAnyGTE(coinsB Coins) bool {
+	diff, _ := coins.SafeMinus(coinsB)
+	if len(diff) == 0 {
+		return false
+	}
+
+	for _, coin := range coins {
+		if coin.IsPositive() {
+			return true
+		}
+	}
+	return false
 }
 
 // IsAllGTE returns true iff for every denom in coins, the denom is present at

--- a/types/coin_test.go
+++ b/types/coin_test.go
@@ -368,6 +368,28 @@ func TestCoinsLTE(t *testing.T) {
 	assert.True(t, Coins{}.IsAllLTE(Coins{{"a", one}}))
 }
 
+func TestCoinsIsAnyGT(t *testing.T) {
+	one := NewInt(1)
+	two := NewInt(2)
+	assert.False(t, Coins{}.IsAnyGT(Coins{}))
+	assert.False(t, Coins{{"a", one}}.IsAnyGT(Coins{}))
+	assert.False(t, Coins{}.IsAnyGT(Coins{{"a", one}}))
+	assert.False(t, Coins{{"a", one}}.IsAnyGT(Coins{{"a", one}}))
+	assert.True(t, Coins{{"a", one}, {"b", two}}.IsAnyGT(Coins{{"a", one}, {"b", one}}))
+	assert.True(t, Coins{{"a", two}, {"b", one}}.IsAnyGT(Coins{{"a", one}, {"b", two}}))
+}
+
+func TestCoinsIsAnyGTE(t *testing.T) {
+	one := NewInt(1)
+	two := NewInt(2)
+	assert.False(t, Coins{}.IsAnyGTE(Coins{}))
+	assert.False(t, Coins{{"a", one}}.IsAnyGTE(Coins{}))
+	assert.False(t, Coins{}.IsAnyGTE(Coins{{"a", one}}))
+	assert.True(t, Coins{{"a", one}}.IsAnyGTE(Coins{{"a", one}}))
+	assert.True(t, Coins{{"a", one}, {"b", two}}.IsAnyGTE(Coins{{"a", one}, {"b", one}}))
+	assert.True(t, Coins{{"a", one}, {"b", one}}.IsAnyGTE(Coins{{"a", one}, {"b", two}}))
+}
+
 func TestParse(t *testing.T) {
 	one := NewInt(1)
 

--- a/x/auth/ante.go
+++ b/x/auth/ante.go
@@ -294,7 +294,7 @@ func EnsureSufficientMempoolFees(ctx sdk.Context, stdTx StdTx) sdk.Result {
 	requiredFees := adjustFeesByGas(ctx.MinimumFees(), stdTx.Fee.Gas)
 
 	// NOTE: !A.IsAllGTE(B) is not the same as A.IsAllLT(B).
-	if !ctx.MinimumFees().IsZero() && !stdTx.Fee.Amount.IsAllGTE(requiredFees) {
+	if !ctx.MinimumFees().IsZero() && !stdTx.Fee.Amount.IsAnyGTE(requiredFees) {
 		// validators reject any tx from the mempool with less than the minimum fee per gas * gas factor
 		return sdk.ErrInsufficientFee(
 			fmt.Sprintf(


### PR DESCRIPTION
The intended behavior in the mempool is that any denom specified in the configuration parameter `--minimum` should be sufficient to pay fees. The current behavior requires all denoms to pay fees.
______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
