### PR TITLE
R4R: Multisig support

### DIFF
--- a/PENDING.md
+++ b/PENDING.md
@@ -46,9 +46,14 @@ FEATURES
   * [\#2730](https://github.com/cosmos/cosmos-sdk/issues/2730) Add tx search pagination parameter
   * [\#3027](https://github.com/cosmos/cosmos-sdk/issues/3027) Implement
   `query gov proposer [proposal-id]` to query for a proposal's proposer.
+  * [\#3198](https://github.com/cosmos/cosmos-sdk/issues/3198) New `keys add --multisig` flag to store multisig keys locally.
+  * [\#3198](https://github.com/cosmos/cosmos-sdk/issues/3198) New `multisign` command to generate multisig signatures.
+  * [\#3198](https://github.com/cosmos/cosmos-sdk/issues/3198) New `sign --multisig` flag to enable multisig mode.
 
 * Gaia
-    * [\#2182] [x/staking] Added querier for querying a single redelegation
+  * [\#2182] [x/staking] Added querier for querying a single redelegation
+  * [\#3198](https://github.com/cosmos/cosmos-sdk/issues/3198) [x/auth] Add multisig transactions support
+  * [\#3198](https://github.com/cosmos/cosmos-sdk/issues/3198) `add-genesis-account` can take both account addresses and key names
 
 * SDK
   * \#2694 Vesting account implementation.

--- a/baseapp/baseapp_test.go
+++ b/baseapp/baseapp_test.go
@@ -4,9 +4,10 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
-	"github.com/cosmos/cosmos-sdk/store"
 	"os"
 	"testing"
+
+	"github.com/cosmos/cosmos-sdk/store"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/client/keys/add.go
+++ b/client/keys/add.go
@@ -1,17 +1,22 @@
 package keys
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"os"
+	"sort"
+
+	"github.com/tendermint/tendermint/crypto/multisig"
 
 	"github.com/cosmos/go-bip39"
 	"github.com/gorilla/mux"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"github.com/tendermint/tendermint/crypto"
 	"github.com/tendermint/tendermint/libs/cli"
 
 	"github.com/cosmos/cosmos-sdk/client"
@@ -22,7 +27,6 @@ import (
 )
 
 const (
-	flagPublicKey   = "pubkey"
 	flagInteractive = "interactive"
 	flagBIP44Path   = "bip44-path"
 	flagRecover     = "recover"
@@ -30,6 +34,8 @@ const (
 	flagDryRun      = "dry-run"
 	flagAccount     = "account"
 	flagIndex       = "index"
+	flagMultisig    = "multisig"
+	flagNoSort      = "nosort"
 )
 
 func addKeyCommand() *cobra.Command {
@@ -43,13 +49,23 @@ and encrypted with the given password. The only input that is required is the en
 
 If run with -i, it will prompt the user for BIP44 path, BIP39 mnemonic, and passphrase.
 The flag --recover allows one to recover a key from a seed passphrase.
-If run with --dry-run, a key would be generated (or recovered) but not stored to the local keystore.
-Use the --pubkey flag to add arbitrary public keys to the keystore for constructing multisig transactions.
+If run with --dry-run, a key would be generated (or recovered) but not stored to the
+local keystore.
+Use the --pubkey flag to add arbitrary public keys to the keystore for constructing
+multisig transactions.
+
+You can add a multisig key by passing the list of key names you want the public
+key to be composed of to the --multisig flag and the minimum number of signatures
+required through --multisig-threshold. The keys are sorted by address, unless
+the flag --nosort is set.
 `,
 		Args: cobra.ExactArgs(1),
 		RunE: runAddCmd,
 	}
-	cmd.Flags().String(FlagPublicKey, "", "Store only a public key (useful for constructing multisigs e.g. cosmospub1...)")
+	cmd.Flags().StringSlice(flagMultisig, nil, "Construct and store a multisig public key (implies --pubkey)")
+	cmd.Flags().Uint(flagMultiSigThreshold, 1, "K out of N required signatures. For use in conjunction with --multisig")
+	cmd.Flags().Bool(flagNoSort, false, "Keys passed to --multisig are taken in the order they're supplied")
+	cmd.Flags().String(FlagPublicKey, "", "Parse a public key in bech32 format and save it to disk")
 	cmd.Flags().BoolP(flagInteractive, "i", false, "Interactively prompt user for BIP39 passphrase and mnemonic")
 	cmd.Flags().Bool(client.FlagUseLedger, false, "Store a local reference to a private key on a Ledger device")
 	cmd.Flags().String(flagBIP44Path, "44'/118'/0'/0/0", "BIP44 path from which to derive a private key")
@@ -100,8 +116,40 @@ func runAddCmd(cmd *cobra.Command, args []string) error {
 			}
 		}
 
+		multisigKeys := viper.GetStringSlice(flagMultisig)
+		if len(multisigKeys) != 0 {
+			var pks []crypto.PubKey
+
+			multisigThreshold := viper.GetInt(flagMultiSigThreshold)
+			if err := validateMultisigThreshold(multisigThreshold, len(multisigKeys)); err != nil {
+				return err
+			}
+
+			for _, keyname := range multisigKeys {
+				k, err := kb.Get(keyname)
+				if err != nil {
+					return err
+				}
+				pks = append(pks, k.GetPubKey())
+			}
+
+			// Handle --nosort
+			if !viper.GetBool(flagNoSort) {
+				sort.Slice(pks, func(i, j int) bool {
+					return bytes.Compare(pks[i].Address(), pks[j].Address()) < 0
+				})
+			}
+
+			pk := multisig.NewPubKeyMultisigThreshold(multisigThreshold, pks)
+			if _, err := kb.CreateOffline(name, pk); err != nil {
+				return err
+			}
+			fmt.Fprintf(os.Stderr, "Key %q saved to disk.", name)
+			return nil
+		}
+
 		// ask for a password when generating a local key
-		if viper.GetString(flagPublicKey) == "" && !viper.GetBool(client.FlagUseLedger) {
+		if viper.GetString(FlagPublicKey) == "" && !viper.GetBool(client.FlagUseLedger) {
 			encryptPassword, err = client.GetCheckPassword(
 				"Enter a passphrase to encrypt your key to disk:",
 				"Repeat the passphrase:", buf)
@@ -111,8 +159,8 @@ func runAddCmd(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	if viper.GetString(flagPublicKey) != "" {
-		pk, err := sdk.GetAccPubKeyBech32(viper.GetString(flagPublicKey))
+	if viper.GetString(FlagPublicKey) != "" {
+		pk, err := sdk.GetAccPubKeyBech32(viper.GetString(FlagPublicKey))
 		if err != nil {
 			return err
 		}

--- a/cmd/gaia/cli_test/cli_test.go
+++ b/cmd/gaia/cli_test/cli_test.go
@@ -25,6 +25,26 @@ import (
 	stakingTypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 )
 
+func TestGaiaCLIKeysAddMultisig(t *testing.T) {
+	t.Parallel()
+	f := InitFixtures(t)
+
+	// key names order does not matter
+	f.KeysAdd("msig1", "--multisig-threshold=2",
+		fmt.Sprintf("--multisig=%s,%s", keyBar, keyBaz))
+	f.KeysAdd("msig2", "--multisig-threshold=2",
+		fmt.Sprintf("--multisig=%s,%s", keyBaz, keyBar))
+	require.Equal(t, f.KeysShow("msig1").Address, f.KeysShow("msig2").Address)
+
+	f.KeysAdd("msig3", "--multisig-threshold=2",
+		fmt.Sprintf("--multisig=%s,%s", keyBar, keyBaz),
+		"--nosort")
+	f.KeysAdd("msig4", "--multisig-threshold=2",
+		fmt.Sprintf("--multisig=%s,%s", keyBaz, keyBar),
+		"--nosort")
+	require.NotEqual(t, f.KeysShow("msig3").Address, f.KeysShow("msig4").Address)
+}
+
 func TestGaiaCLIMinimumFees(t *testing.T) {
 	t.Parallel()
 	f := InitFixtures(t)
@@ -644,6 +664,180 @@ func TestGaiaCLISendGenerateSignAndBroadcast(t *testing.T) {
 	require.Equal(t, int64(40), fooAcc.GetCoins().AmountOf(denom).Int64())
 
 	f.Cleanup()
+}
+
+func TestGaiaCLIMultisignInsufficientCosigners(t *testing.T) {
+	t.Parallel()
+	f := InitFixtures(t)
+
+	// start gaiad server with minimum fees
+	proc := f.GDStart()
+	defer proc.Stop(false)
+
+	fooBarBazAddr := f.KeyAddress(keyFooBarBaz)
+	barAddr := f.KeyAddress(keyBar)
+
+	// Send some tokens from one account to the other
+	success, _, _ := f.TxSend(keyFoo, fooBarBazAddr, sdk.NewInt64Coin(denom, 10))
+	require.True(t, success)
+	tests.WaitForNextNBlocksTM(1, f.Port)
+
+	// Test generate sendTx with multisig
+	success, stdout, _ := f.TxSend(keyFooBarBaz, barAddr, sdk.NewInt64Coin(denom, 5), "--generate-only")
+	require.True(t, success)
+
+	// Write the output to disk
+	unsignedTxFile := writeToNewTempFile(t, stdout)
+	defer os.Remove(unsignedTxFile.Name())
+
+	// Sign with foo's key
+	success, stdout, _ = f.TxSign(keyFoo, unsignedTxFile.Name(), "--multisig", fooBarBazAddr.String())
+	require.True(t, success)
+
+	// Write the output to disk
+	fooSignatureFile := writeToNewTempFile(t, stdout)
+	defer os.Remove(fooSignatureFile.Name())
+
+	// Multisign, not enough signatures
+	success, stdout, _ = f.TxMultisign(unsignedTxFile.Name(), keyFooBarBaz, []string{fooSignatureFile.Name()})
+	require.True(t, success)
+
+	// Write the output to disk
+	signedTxFile := writeToNewTempFile(t, stdout)
+	defer os.Remove(signedTxFile.Name())
+
+	// Validate the multisignature
+	success, _, _ = f.TxSign(keyFooBarBaz, signedTxFile.Name(), "--validate-signatures", "--json")
+	require.False(t, success)
+
+	// Broadcast the transaction
+	success, _, _ = f.TxBroadcast(signedTxFile.Name())
+	require.False(t, success)
+}
+
+func TestGaiaCLIMultisignSortSignatures(t *testing.T) {
+	t.Parallel()
+	f := InitFixtures(t)
+
+	// start gaiad server with minimum fees
+	proc := f.GDStart()
+	defer proc.Stop(false)
+
+	fooBarBazAddr := f.KeyAddress(keyFooBarBaz)
+	barAddr := f.KeyAddress(keyBar)
+
+	// Send some tokens from one account to the other
+	success, _, _ := f.TxSend(keyFoo, fooBarBazAddr, sdk.NewInt64Coin(denom, 10))
+	require.True(t, success)
+	tests.WaitForNextNBlocksTM(1, f.Port)
+
+	// Ensure account balances match expected
+	fooBarBazAcc := f.QueryAccount(fooBarBazAddr)
+	require.Equal(t, int64(10), fooBarBazAcc.GetCoins().AmountOf(denom).Int64())
+
+	// Test generate sendTx with multisig
+	success, stdout, _ := f.TxSend(keyFooBarBaz, barAddr, sdk.NewInt64Coin(denom, 5), "--generate-only")
+	require.True(t, success)
+
+	// Write the output to disk
+	unsignedTxFile := writeToNewTempFile(t, stdout)
+	defer os.Remove(unsignedTxFile.Name())
+
+	// Sign with foo's key
+	success, stdout, _ = f.TxSign(keyFoo, unsignedTxFile.Name(), "--multisig", fooBarBazAddr.String())
+	require.True(t, success)
+
+	// Write the output to disk
+	fooSignatureFile := writeToNewTempFile(t, stdout)
+	defer os.Remove(fooSignatureFile.Name())
+
+	// Sign with baz's key
+	success, stdout, _ = f.TxSign(keyBaz, unsignedTxFile.Name(), "--multisig", fooBarBazAddr.String())
+	require.True(t, success)
+
+	// Write the output to disk
+	bazSignatureFile := writeToNewTempFile(t, stdout)
+	defer os.Remove(bazSignatureFile.Name())
+
+	// Multisign, keys in different order
+	success, stdout, _ = f.TxMultisign(unsignedTxFile.Name(), keyFooBarBaz, []string{
+		bazSignatureFile.Name(), fooSignatureFile.Name()})
+	require.True(t, success)
+
+	// Write the output to disk
+	signedTxFile := writeToNewTempFile(t, stdout)
+	defer os.Remove(signedTxFile.Name())
+
+	// Validate the multisignature
+	success, _, _ = f.TxSign(keyFooBarBaz, signedTxFile.Name(), "--validate-signatures", "--json")
+	require.True(t, success)
+
+	// Broadcast the transaction
+	success, _, _ = f.TxBroadcast(signedTxFile.Name())
+	require.True(t, success)
+}
+
+func TestGaiaCLIMultisign(t *testing.T) {
+	t.Parallel()
+	f := InitFixtures(t)
+
+	// start gaiad server with minimum fees
+	proc := f.GDStart()
+	defer proc.Stop(false)
+
+	fooBarBazAddr := f.KeyAddress(keyFooBarBaz)
+	bazAddr := f.KeyAddress(keyBaz)
+
+	// Send some tokens from one account to the other
+	success, _, _ := f.TxSend(keyFoo, fooBarBazAddr, sdk.NewInt64Coin(denom, 10))
+	require.True(t, success)
+	tests.WaitForNextNBlocksTM(1, f.Port)
+
+	// Ensure account balances match expected
+	fooBarBazAcc := f.QueryAccount(fooBarBazAddr)
+	require.Equal(t, int64(10), fooBarBazAcc.GetCoins().AmountOf(denom).Int64())
+
+	// Test generate sendTx with multisig
+	success, stdout, stderr := f.TxSend(keyFooBarBaz, bazAddr, sdk.NewInt64Coin(denom, 10), "--generate-only")
+	require.True(t, success)
+	require.Empty(t, stderr)
+
+	// Write the output to disk
+	unsignedTxFile := writeToNewTempFile(t, stdout)
+	defer os.Remove(unsignedTxFile.Name())
+
+	// Sign with foo's key
+	success, stdout, _ = f.TxSign(keyFoo, unsignedTxFile.Name(), "--multisig", fooBarBazAddr.String())
+	require.True(t, success)
+
+	// Write the output to disk
+	fooSignatureFile := writeToNewTempFile(t, stdout)
+	defer os.Remove(fooSignatureFile.Name())
+
+	// Sign with bar's key
+	success, stdout, _ = f.TxSign(keyBar, unsignedTxFile.Name(), "--multisig", fooBarBazAddr.String())
+	require.True(t, success)
+
+	// Write the output to disk
+	barSignatureFile := writeToNewTempFile(t, stdout)
+	defer os.Remove(barSignatureFile.Name())
+
+	// Multisign
+	success, stdout, _ = f.TxMultisign(unsignedTxFile.Name(), keyFooBarBaz, []string{
+		fooSignatureFile.Name(), barSignatureFile.Name()})
+	require.True(t, success)
+
+	// Write the output to disk
+	signedTxFile := writeToNewTempFile(t, stdout)
+	defer os.Remove(signedTxFile.Name())
+
+	// Validate the multisignature
+	success, _, _ = f.TxSign(keyFooBarBaz, signedTxFile.Name(), "--validate-signatures", "--json")
+	require.True(t, success)
+
+	// Broadcast the transaction
+	success, _, _ = f.TxBroadcast(signedTxFile.Name())
+	require.True(t, success)
 }
 
 func TestGaiaCLIConfig(t *testing.T) {

--- a/cmd/gaia/cli_test/test_helpers.go
+++ b/cmd/gaia/cli_test/test_helpers.go
@@ -27,11 +27,13 @@ import (
 )
 
 const (
-	denom    = "stake"
-	keyFoo   = "foo"
-	keyBar   = "bar"
-	fooDenom = "footoken"
-	feeDenom = "feetoken"
+	denom        = "stake"
+	keyFoo       = "foo"
+	keyBar       = "bar"
+	keyBaz       = "baz"
+	keyFooBarBaz = "foobarbaz"
+	fooDenom     = "footoken"
+	feeDenom     = "feetoken"
 )
 
 var startCoins = sdk.Coins{
@@ -83,8 +85,13 @@ func InitFixtures(t *testing.T) (f *Fixtures) {
 	// Ensure keystore has foo and bar keys
 	f.KeysDelete(keyFoo)
 	f.KeysDelete(keyBar)
+	f.KeysDelete(keyBar)
+	f.KeysDelete(keyFooBarBaz)
 	f.KeysAdd(keyFoo)
 	f.KeysAdd(keyBar)
+	f.KeysAdd(keyBaz)
+	f.KeysAdd(keyFooBarBaz, "--multisig-threshold=2", fmt.Sprintf(
+		"--multisig=%s,%s,%s", keyFoo, keyBar, keyBaz))
 
 	// Ensure that CLI output is in JSON format
 	f.CLIConfig("output", "json")
@@ -175,7 +182,7 @@ func (f *Fixtures) GDStart(flags ...string) *tests.Process {
 // KeysDelete is gaiacli keys delete
 func (f *Fixtures) KeysDelete(name string, flags ...string) {
 	cmd := fmt.Sprintf("gaiacli keys delete --home=%s %s", f.GCLIHome, name)
-	executeWrite(f.T, addFlags(cmd, flags), app.DefaultKeyPass)
+	executeWrite(f.T, addFlags(cmd, append(append(flags, "-y"), "-f")))
 }
 
 // KeysAdd is gaiacli keys add
@@ -230,6 +237,16 @@ func (f *Fixtures) TxSign(signer, fileName string, flags ...string) (bool, strin
 func (f *Fixtures) TxBroadcast(fileName string, flags ...string) (bool, string, string) {
 	cmd := fmt.Sprintf("gaiacli tx broadcast %v --json %v", f.Flags(), fileName)
 	return executeWriteRetStdStreams(f.T, addFlags(cmd, flags), app.DefaultKeyPass)
+}
+
+// TxMultisign is gaiacli tx multisign
+func (f *Fixtures) TxMultisign(fileName, name string, signaturesFiles []string,
+	flags ...string) (bool, string, string) {
+
+	cmd := fmt.Sprintf("gaiacli tx multisign %v %s %s %s", f.Flags(),
+		fileName, name, strings.Join(signaturesFiles, " "),
+	)
+	return executeWriteRetStdStreams(f.T, cmd)
 }
 
 //___________________________________________________________________________________

--- a/cmd/gaia/cmd/gaiacli/main.go
+++ b/cmd/gaia/cmd/gaiacli/main.go
@@ -136,6 +136,7 @@ func txCmd(cdc *amino.Codec, mc []sdk.ModuleClients) *cobra.Command {
 		bankcmd.SendTxCmd(cdc),
 		client.LineBreak,
 		authcmd.GetSignCommand(cdc),
+		authcmd.GetMultiSignCommand(cdc),
 		bankcmd.GetBroadcastCommand(cdc),
 		client.LineBreak,
 	)

--- a/cmd/gaia/cmd/gaiad/main.go
+++ b/cmd/gaia/cmd/gaiad/main.go
@@ -2,10 +2,10 @@ package main
 
 import (
 	"encoding/json"
-	"github.com/cosmos/cosmos-sdk/store"
 	"io"
 
 	"github.com/cosmos/cosmos-sdk/baseapp"
+	"github.com/cosmos/cosmos-sdk/store"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"

--- a/cmd/gaia/cmd/gaiareplay/main.go
+++ b/cmd/gaia/cmd/gaiareplay/main.go
@@ -2,11 +2,12 @@ package main
 
 import (
 	"fmt"
-	"github.com/cosmos/cosmos-sdk/store"
 	"io"
 	"os"
 	"path/filepath"
 	"time"
+
+	"github.com/cosmos/cosmos-sdk/store"
 
 	cpm "github.com/otiai10/copy"
 	"github.com/spf13/cobra"

--- a/docs/examples/democoin/x/simplestaking/client/cli/commands.go
+++ b/docs/examples/democoin/x/simplestaking/client/cli/commands.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"encoding/hex"
 	"fmt"
+
 	"github.com/cosmos/cosmos-sdk/client/context"
 	"github.com/cosmos/cosmos-sdk/client/utils"
 	"github.com/cosmos/cosmos-sdk/codec"

--- a/x/auth/client/cli/multisign.go
+++ b/x/auth/client/cli/multisign.go
@@ -1,0 +1,159 @@
+package cli
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	amino "github.com/tendermint/go-amino"
+	"github.com/tendermint/tendermint/crypto/multisig"
+	"github.com/tendermint/tendermint/libs/cli"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/context"
+	"github.com/cosmos/cosmos-sdk/client/keys"
+	crkeys "github.com/cosmos/cosmos-sdk/crypto/keys"
+	"github.com/cosmos/cosmos-sdk/x/auth"
+	authtxb "github.com/cosmos/cosmos-sdk/x/auth/client/txbuilder"
+)
+
+// GetSignCommand returns the sign command
+func GetMultiSignCommand(codec *amino.Codec) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "multisign <file> <name> <<signature>...>",
+		Short: "Generate multisig signatures for transactions generated offline",
+		Long: `Sign transactions created with the --generate-only flag that require multisig signatures.
+
+Read signature(s) from <signature> file(s), generate a multisig signature compliant to the
+multisig key <name>, and attach it to the transaction read from <file>. Example:
+
+   gaiacli multisign transaction.json k1k2k3 k1sig.json k2sig.json k3sig.json
+
+If the flag --signature-only flag is on, it outputs a JSON representation
+of the generated signature only.
+
+The --offline flag makes sure that the client will not reach out to an external node.
+Thus account number or sequence number lookups will not be performed and it is
+recommended to set such parameters manually.
+`,
+		RunE: makeMultiSignCmd(codec),
+		Args: cobra.MinimumNArgs(3),
+	}
+	cmd.Flags().Bool(flagSigOnly, false, "Print only the generated signature, then exit")
+	cmd.Flags().Bool(flagOffline, false, "Offline mode. Do not query a full node")
+	cmd.Flags().String(flagOutfile, "",
+		"The document will be written to the given file instead of STDOUT")
+
+	// Add the flags here and return the command
+	return client.PostCommands(cmd)[0]
+}
+
+func makeMultiSignCmd(cdc *amino.Codec) func(cmd *cobra.Command, args []string) error {
+	return func(cmd *cobra.Command, args []string) (err error) {
+		stdTx, err := readAndUnmarshalStdTx(cdc, args[0])
+		if err != nil {
+			return
+		}
+
+		keybase, err := keys.GetKeyBaseFromDir(viper.GetString(cli.HomeFlag))
+		if err != nil {
+			return
+		}
+
+		multisigInfo, err := keybase.Get(args[1])
+		if err != nil {
+			return
+		}
+		if multisigInfo.GetType() != crkeys.TypeOffline {
+			return fmt.Errorf("%q must be of type offline: %s",
+				args[1], multisigInfo.GetType())
+		}
+
+		multisigPub := multisigInfo.GetPubKey().(multisig.PubKeyMultisigThreshold)
+		multisigSig := multisig.NewMultisig(len(multisigPub.PubKeys))
+		cliCtx := context.NewCLIContext().WithCodec(cdc).WithAccountDecoder(cdc)
+		txBldr := authtxb.NewTxBuilderFromCLI()
+
+		if !viper.GetBool(flagOffline) {
+			addr := multisigInfo.GetAddress()
+			accnum, err := cliCtx.GetAccountNumber(addr)
+			if err != nil {
+				return err
+			}
+
+			seq, err := cliCtx.GetAccountSequence(addr)
+			if err != nil {
+				return err
+			}
+
+			txBldr = txBldr.WithAccountNumber(accnum).WithSequence(seq)
+		}
+
+		// read each signature and add it to the multisig if valid
+		for i := 2; i < len(args); i++ {
+			stdSig, err := readAndUnmarshalStdSignature(cdc, args[i])
+			if err != nil {
+				return err
+			}
+
+			// Validate each signature
+			sigBytes := auth.StdSignBytes(
+				txBldr.GetChainID(), txBldr.GetAccountNumber(), txBldr.GetSequence(),
+				stdTx.Fee, stdTx.GetMsgs(), stdTx.GetMemo(),
+			)
+			if ok := stdSig.PubKey.VerifyBytes(sigBytes, stdSig.Signature); !ok {
+				return fmt.Errorf("couldn't verify signature")
+			}
+			multisigSig.AddSignatureFromPubKey(stdSig.Signature, stdSig.PubKey, multisigPub.PubKeys)
+		}
+
+		newStdSig := auth.StdSignature{Signature: cdc.MustMarshalBinaryBare(multisigSig), PubKey: multisigPub}
+		newTx := auth.NewStdTx(stdTx.GetMsgs(), stdTx.Fee, []auth.StdSignature{newStdSig}, stdTx.GetMemo())
+
+		sigOnly := viper.GetBool(flagSigOnly)
+		var json []byte
+		switch {
+		case sigOnly && cliCtx.Indent:
+			json, err = cdc.MarshalJSONIndent(newTx.Signatures[0], "", "  ")
+		case sigOnly && !cliCtx.Indent:
+			json, err = cdc.MarshalJSON(newTx.Signatures[0])
+		case !sigOnly && cliCtx.Indent:
+			json, err = cdc.MarshalJSONIndent(newTx, "", "  ")
+		default:
+			json, err = cdc.MarshalJSON(newTx)
+		}
+		if err != nil {
+			return err
+		}
+
+		if viper.GetString(flagOutfile) == "" {
+			fmt.Printf("%s\n", json)
+			return
+		}
+
+		fp, err := os.OpenFile(
+			viper.GetString(flagOutfile), os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644,
+		)
+		if err != nil {
+			return err
+		}
+		defer fp.Close()
+
+		fmt.Fprintf(fp, "%s\n", json)
+
+		return
+	}
+}
+
+func readAndUnmarshalStdSignature(cdc *amino.Codec, filename string) (stdSig auth.StdSignature, err error) {
+	var bytes []byte
+	if bytes, err = ioutil.ReadFile(filename); err != nil {
+		return
+	}
+	if err = cdc.UnmarshalJSON(bytes, &stdSig); err != nil {
+		return
+	}
+	return
+}

--- a/x/auth/client/cli/sign.go
+++ b/x/auth/client/cli/sign.go
@@ -19,6 +19,7 @@ import (
 )
 
 const (
+	flagMultisig     = "multisig"
 	flagAppend       = "append"
 	flagValidateSigs = "validate-signatures"
 	flagOffline      = "offline"
@@ -45,17 +46,26 @@ performed as that will require communication with a full node.
 
 The --offline flag makes sure that the client will not reach out to an external node.
 Thus account number or sequence number lookups will not be performed and it is
-recommended to set such parameters manually.`,
+recommended to set such parameters manually.
+
+The --multisig=<multisig_key> flag generates a signature on behalf of a multisig account
+key. It implies --signature-only. Full multisig signed transactions may eventually
+be generated via the 'multisign' command.
+`,
 		RunE: makeSignCmd(codec),
 		Args: cobra.ExactArgs(1),
 	}
 	cmd.Flags().String(client.FlagName, "", "Name of private key with which to sign")
+	cmd.Flags().String(flagMultisig, "",
+		"Address of the multisig account on behalf of which the "+
+			"transaction shall be signed")
 	cmd.Flags().Bool(flagAppend, true,
-		"Append the signature to the existing ones. If disabled, old signatures would be overwritten")
-	cmd.Flags().Bool(flagSigOnly, false, "Print only the generated signature, then exit.")
+		"Append the signature to the existing ones. "+
+			"If disabled, old signatures would be overwritten. Ignored if --multisig is on")
+	cmd.Flags().Bool(flagSigOnly, false, "Print only the generated signature, then exit")
 	cmd.Flags().Bool(flagValidateSigs, false, "Print the addresses that must sign the transaction, "+
-		"those who have already signed it, and make sure that signatures are in the correct order.")
-	cmd.Flags().Bool(flagOffline, false, "Offline mode. Do not query a full node.")
+		"those who have already signed it, and make sure that signatures are in the correct order")
+	cmd.Flags().Bool(flagOffline, false, "Offline mode. Do not query a full node")
 	cmd.Flags().String(flagOutfile, "",
 		"The document will be written to the given file instead of STDOUT")
 
@@ -88,9 +98,25 @@ func makeSignCmd(cdc *amino.Codec) func(cmd *cobra.Command, args []string) error
 		}
 
 		// if --signature-only is on, then override --append
+		var newTx auth.StdTx
 		generateSignatureOnly := viper.GetBool(flagSigOnly)
-		appendSig := viper.GetBool(flagAppend) && !generateSignatureOnly
-		newTx, err := utils.SignStdTx(txBldr, cliCtx, name, stdTx, appendSig, offline)
+		multisigAddrStr := viper.GetString(flagMultisig)
+
+		if multisigAddrStr != "" {
+			var multisigAddr sdk.AccAddress
+			multisigAddr, err = sdk.AccAddressFromBech32(multisigAddrStr)
+			if err != nil {
+				return err
+			}
+
+			newTx, err = utils.SignStdTxWithSignerAddress(
+				txBldr, cliCtx, multisigAddr, name, stdTx, offline)
+			generateSignatureOnly = true
+		} else {
+			appendSig := viper.GetBool(flagAppend) && !generateSignatureOnly
+			newTx, err = utils.SignStdTx(
+				txBldr, cliCtx, name, stdTx, appendSig, offline)
+		}
 		if err != nil {
 			return err
 		}

--- a/x/auth/client/rest/sign.go
+++ b/x/auth/client/rest/sign.go
@@ -36,7 +36,7 @@ func SignTxRequestHandlerFn(cdc *codec.Codec, cliCtx context.CLIContext) http.Ha
 		}
 
 		// validate tx
- 		// discard error if it's CodeNoSignatures as the tx comes with no signatures
+		// discard error if it's CodeNoSignatures as the tx comes with no signatures
 		if err := m.Tx.ValidateBasic(); err != nil && err.Code() != sdk.CodeNoSignatures {
 			utils.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
 			return

--- a/x/gov/genesis_test.go
+++ b/x/gov/genesis_test.go
@@ -3,8 +3,9 @@ package gov
 import (
 	"testing"
 
-	"github.com/cosmos/cosmos-sdk/x/mock"
 	"github.com/stretchr/testify/require"
+
+	"github.com/cosmos/cosmos-sdk/x/mock"
 
 	abci "github.com/tendermint/tendermint/abci/types"
 )


### PR DESCRIPTION
Habemus multisig:

* New `keys add --multisig` flag to store multisig keys locally.
* New `multisign` command to generate multisig signatures.
* New `sign --multisig` flag to enable multisig mode.
* Add multisig transactions support in ante handler
* `gaiad add-genesis-account` can now take both account addresses and key names

Closes: #3198

- [x] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [x] Wrote tests
- [x] Updated relevant documentation (`docs/`)
- [x] Added entries in `PENDING.md` with issue # 
- [x] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
