### PR TITLE
WIP: CLI Response Formatting

### DIFF
--- a/client/output.go
+++ b/client/output.go
@@ -1,0 +1,34 @@
+package client
+
+import (
+	"fmt"
+
+	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/spf13/viper"
+	"github.com/tendermint/tendermint/libs/cli"
+)
+
+// Printable defines which structs can be printed by
+// CLI output functions
+type Printable interface {
+	HumanReadableString() string
+}
+
+// PrintOutput prints output while respecting output and indent flags
+// NOTE: pass in marshalled structs that have been unmarshalled
+func PrintOutput(cdc *codec.Codec, toPrint Printable) {
+	switch viper.Get(cli.OutputFlag) {
+	case "text":
+		fmt.Println(toPrint.HumanReadableString())
+	case "json":
+		if viper.GetBool(FlagIndentResponse) {
+			out, err := codec.MarshalJSONIndent(cdc, toPrint)
+			if err != nil {
+				panic(err)
+			}
+			fmt.Println(string(out))
+		} else {
+			fmt.Println(string(cdc.MustMarshalJSON(toPrint)))
+		}
+	}
+}

--- a/client/tx/search.go
+++ b/client/tx/search.go
@@ -86,6 +86,7 @@ $ gaiacli query txs --tags '<tag1>:<value1>&<tag2>:<value2>'
 	cmd.Flags().Bool(client.FlagTrustNode, false, "Trust connected full node (don't verify proofs for responses)")
 	viper.BindPFlag(client.FlagTrustNode, cmd.Flags().Lookup(client.FlagTrustNode))
 	cmd.Flags().String(flagTags, "", "tag:value list of tags that must match")
+	cmd.MarkFlagRequired(flagTags)
 	return cmd
 }
 

--- a/x/gov/client/module_client.go
+++ b/x/gov/client/module_client.go
@@ -31,6 +31,7 @@ func (mc ModuleClient) GetQueryCmd() *cobra.Command {
 		govCli.GetCmdQueryProposals(mc.storeKey, mc.cdc),
 		govCli.GetCmdQueryVote(mc.storeKey, mc.cdc),
 		govCli.GetCmdQueryVotes(mc.storeKey, mc.cdc),
+		govCli.GetCmdQueryParam(mc.storeKey, mc.cdc),
 		govCli.GetCmdQueryParams(mc.storeKey, mc.cdc),
 		govCli.GetCmdQueryProposer(mc.storeKey, mc.cdc),
 		govCli.GetCmdQueryDeposit(mc.storeKey, mc.cdc),

--- a/x/gov/depositsvotes.go
+++ b/x/gov/depositsvotes.go
@@ -3,6 +3,7 @@ package gov
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/pkg/errors"
 
@@ -16,15 +17,34 @@ type Vote struct {
 	Option     VoteOption     `json:"option"`      //  option from OptionSet chosen by the voter
 }
 
+// HumanReadableString implements client.Printable
+func (v Vote) HumanReadableString() string {
+	return fmt.Sprintf("%s voted with option %s for proposal %d...", v.Voter, v.Option, v.ProposalID)
+}
+
+// Votes is an array of vote
+type Votes []Vote
+
+// HumanReadableString implements client.Printable
+func (v Votes) HumanReadableString() (out string) {
+	if len(v) < 1 {
+		return ""
+	}
+	out += fmt.Sprintf("Votes for Proposal %d:\n", v[0].ProposalID)
+	for _, vot := range v {
+		out += fmt.Sprintf("  %s: %s\n", vot.Voter, vot.Option)
+	}
+	return strings.TrimSpace(out)
+}
+
 // Returns whether 2 votes are equal
-func (voteA Vote) Equals(voteB Vote) bool {
-	return voteA.Voter.Equals(voteB.Voter) && voteA.ProposalID == voteB.ProposalID && voteA.Option == voteB.Option
+func (v Vote) Equals(comp Vote) bool {
+	return v.Voter.Equals(comp.Voter) && v.ProposalID == comp.ProposalID && v.Option == comp.Option
 }
 
 // Returns whether a vote is empty
-func (voteA Vote) Empty() bool {
-	voteB := Vote{}
-	return voteA.Equals(voteB)
+func (v Vote) Empty() bool {
+	return v.Equals(Vote{})
 }
 
 // Deposit
@@ -34,15 +54,34 @@ type Deposit struct {
 	Amount     sdk.Coins      `json:"amount"`      //  Deposit amount
 }
 
+// HumanReadableString implements client.Printable
+func (d Deposit) HumanReadableString() string {
+	return fmt.Sprintf("%s deposited %s on proposal %d...", d.Depositor, d.Amount, d.ProposalID)
+}
+
+// Deposits is a collection of deposit
+type Deposits []Deposit
+
+// HumanReadableString implements client.Printable
+func (d Deposits) HumanReadableString() (out string) {
+	if len(d) < 1 {
+		return ""
+	}
+	out += fmt.Sprintf("Deposits for Proposal %d:\n", d[0].ProposalID)
+	for _, dep := range d {
+		out += fmt.Sprintf("  %s: %s\n", dep.Depositor, dep.Amount)
+	}
+	return strings.TrimSpace(out)
+}
+
 // Returns whether 2 deposits are equal
-func (depositA Deposit) Equals(depositB Deposit) bool {
-	return depositA.Depositor.Equals(depositB.Depositor) && depositA.ProposalID == depositB.ProposalID && depositA.Amount.IsEqual(depositB.Amount)
+func (d Deposit) Equals(comp Deposit) bool {
+	return d.Depositor.Equals(comp.Depositor) && d.ProposalID == comp.ProposalID && d.Amount.IsEqual(comp.Amount)
 }
 
 // Returns whether a deposit is empty
-func (depositA Deposit) Empty() bool {
-	depositB := Deposit{}
-	return depositA.Equals(depositB)
+func (d Deposit) Empty() bool {
+	return d.Equals(Deposit{})
 }
 
 // Type that represents VoteOption as a byte

--- a/x/gov/params.go
+++ b/x/gov/params.go
@@ -1,15 +1,29 @@
 package gov
 
 import (
+	"fmt"
 	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
+// GovParams is a common type for the different governance params
+type GovParams interface {
+	HumanReadableString() string
+}
+
 // Param around Deposits for governance
 type DepositParams struct {
 	MinDeposit       sdk.Coins     `json:"min_deposit"`        //  Minimum deposit for a proposal to enter voting period.
 	MaxDepositPeriod time.Duration `json:"max_deposit_period"` //  Maximum period for Atom holders to deposit on a proposal. Initial value: 2 months
+}
+
+// HumanReadableString satisfies GovParams
+func (dp DepositParams) HumanReadableString() string {
+	return fmt.Sprintf(`Deposit Params:
+  Min Deposit:         %s
+  Max Deposit Period:  %s
+`, dp.MinDeposit, dp.MaxDepositPeriod)
 }
 
 // Checks equality of DepositParams
@@ -25,7 +39,38 @@ type TallyParams struct {
 	GovernancePenalty sdk.Dec `json:"governance_penalty"` //  Penalty if validator does not vote
 }
 
+// HumanReadableString satisfies GovParams
+func (tp TallyParams) HumanReadableString() string {
+	return fmt.Sprintf(`Tally Params:
+  Quorum:              %s
+  Threshold:           %s
+  Veto:                %s
+  Goverance Penalty:   %s
+`, tp.Quorum, tp.Threshold, tp.Veto, tp.GovernancePenalty)
+}
+
 // Param around Voting in governance
 type VotingParams struct {
 	VotingPeriod time.Duration `json:"voting_period"` //  Length of the voting period.
+}
+
+// HumanReadableString satisfies GovParams
+func (vp VotingParams) HumanReadableString() string {
+	return fmt.Sprintf(`Voting Params:
+  Voting Period:       %s
+`, vp.VotingPeriod)
+}
+
+// AllGovParams contains all the different params used by governance
+type AllGovParams struct {
+	DepositParams DepositParams `json:"deposit_params"`
+	TallyParams   TallyParams   `json:"tally_params"`
+	VotingParams  VotingParams  `json:"voting_params"`
+}
+
+// HumanReadableString satisfies GovParams
+func (ap AllGovParams) HumanReadableString() string {
+	return ap.DepositParams.HumanReadableString() +
+		ap.TallyParams.HumanReadableString() +
+		ap.VotingParams.HumanReadableString()
 }

--- a/x/gov/params.go
+++ b/x/gov/params.go
@@ -22,8 +22,7 @@ type DepositParams struct {
 func (dp DepositParams) HumanReadableString() string {
 	return fmt.Sprintf(`Deposit Params:
   Min Deposit:         %s
-  Max Deposit Period:  %s
-`, dp.MinDeposit, dp.MaxDepositPeriod)
+  Max Deposit Period:  %s`, dp.MinDeposit, dp.MaxDepositPeriod)
 }
 
 // Checks equality of DepositParams
@@ -45,8 +44,8 @@ func (tp TallyParams) HumanReadableString() string {
   Quorum:              %s
   Threshold:           %s
   Veto:                %s
-  Goverance Penalty:   %s
-`, tp.Quorum, tp.Threshold, tp.Veto, tp.GovernancePenalty)
+  Goverance Penalty:   %s`, tp.Quorum, tp.Threshold,
+		tp.Veto, tp.GovernancePenalty)
 }
 
 // Param around Voting in governance
@@ -57,8 +56,7 @@ type VotingParams struct {
 // HumanReadableString satisfies GovParams
 func (vp VotingParams) HumanReadableString() string {
 	return fmt.Sprintf(`Voting Params:
-  Voting Period:       %s
-`, vp.VotingPeriod)
+  Voting Period:       %s`, vp.VotingPeriod)
 }
 
 // AllGovParams contains all the different params used by governance
@@ -70,7 +68,7 @@ type AllGovParams struct {
 
 // HumanReadableString satisfies GovParams
 func (ap AllGovParams) HumanReadableString() string {
-	return ap.DepositParams.HumanReadableString() +
-		ap.TallyParams.HumanReadableString() +
+	return ap.DepositParams.HumanReadableString() + "\n" +
+		ap.TallyParams.HumanReadableString() + "\n" +
 		ap.VotingParams.HumanReadableString()
 }

--- a/x/gov/proposals.go
+++ b/x/gov/proposals.go
@@ -3,6 +3,7 @@ package gov
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -45,6 +46,21 @@ type Proposal interface {
 
 	GetVotingEndTime() time.Time
 	SetVotingEndTime(time.Time)
+
+	HumanReadableString() string
+}
+
+// Proposals is an array of proposal
+type Proposals []Proposal
+
+// HumanReadableString implements client.Printable
+func (p Proposals) HumanReadableString() string {
+	var out string
+	for _, proposal := range p {
+		out += fmt.Sprintf("%d - %s\n",
+			proposal.GetProposalID(), proposal.GetTitle())
+	}
+	return strings.TrimSpace(out)
 }
 
 // checks if two proposals are equal
@@ -86,6 +102,21 @@ type TextProposal struct {
 
 // Implements Proposal Interface
 var _ Proposal = (*TextProposal)(nil)
+
+// HumanReadableString implements client.Printable
+func (tp TextProposal) HumanReadableString() string {
+	return fmt.Sprintf(`Proposal %d:
+  Title:              %s
+  Type:               %s
+  Status:             %s
+  Submit Time:        %s
+  Deposit End Time:   %s
+  Total Deposit:      %s
+  Voting Start Time:  %s
+  Voting End Time:    %s`, tp.ProposalID, tp.Title, tp.ProposalType,
+		tp.Status, tp.SubmitTime, tp.DepositEndTime,
+		tp.TotalDeposit, tp.VotingStartTime, tp.VotingEndTime)
+}
 
 // nolint
 func (tp TextProposal) GetProposalID() uint64                      { return tp.ProposalID }
@@ -330,6 +361,15 @@ type TallyResult struct {
 	Abstain    sdk.Dec `json:"abstain"`
 	No         sdk.Dec `json:"no"`
 	NoWithVeto sdk.Dec `json:"no_with_veto"`
+}
+
+// HumanReadableString implements client.Printable
+func (tr TallyResult) HumanReadableString() string {
+	return fmt.Sprintf(`Tally Result:
+  Yes:          %d
+  Abstain:      %d
+  No:           %d
+  No With Veto: %d`, tr.Yes, tr.Abstain, tr.No, tr.NoWithVeto)
 }
 
 // checks if two proposals are equal

--- a/x/slashing/client/cli/query.go
+++ b/x/slashing/client/cli/query.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spf13/viper"
 	"github.com/tendermint/tendermint/libs/cli"
 
+	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/context"
 	"github.com/cosmos/cosmos-sdk/codec" // XXX fix
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -39,18 +40,15 @@ func GetCmdQuerySigningInfo(storeName string, cdc *codec.Codec) *cobra.Command {
 			switch viper.Get(cli.OutputFlag) {
 
 			case "text":
-				human := signingInfo.HumanReadableString()
-				fmt.Println(human)
-
+				fmt.Println(signingInfo.HumanReadableString())
 			case "json":
-				// parse out the signing info
-				output, err := codec.MarshalJSONIndent(cdc, signingInfo)
-				if err != nil {
-					return err
+				if viper.GetBool(client.FlagIndentResponse) {
+					out, _ := codec.MarshalJSONIndent(cdc, signingInfo)
+					fmt.Println(string(out))
+				} else {
+					fmt.Println(string(cdc.MustMarshalJSON(signingInfo)))
 				}
-				fmt.Println(string(output))
 			}
-
 			return nil
 		},
 	}
@@ -72,7 +70,21 @@ func GetCmdQueryParams(cdc *codec.Codec) *cobra.Command {
 				return err
 			}
 
-			fmt.Println(string(res))
+			var params slashing.Params
+			cdc.MustUnmarshalJSON(res, &params)
+
+			switch viper.Get(cli.OutputFlag) {
+			case "text":
+				fmt.Println(params.HumanReadableString())
+			case "json":
+				if viper.GetBool(client.FlagIndentResponse) {
+					out, _ := codec.MarshalJSONIndent(cdc, params)
+					fmt.Println(string(out))
+				} else {
+					fmt.Println(string(cdc.MustMarshalJSON(params)))
+				}
+			}
+
 			return nil
 		},
 	}

--- a/x/slashing/params.go
+++ b/x/slashing/params.go
@@ -1,6 +1,7 @@
 package slashing
 
 import (
+	"fmt"
 	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -37,6 +38,21 @@ type Params struct {
 	DowntimeUnbondDuration   time.Duration `json:"downtime-unbond-duration"`
 	SlashFractionDoubleSign  sdk.Dec       `json:"slash-fraction-double-sign"`
 	SlashFractionDowntime    sdk.Dec       `json:"slash-fraction-downtime"`
+}
+
+// HumanReadableString returns a string for printing to the CLI
+func (p Params) HumanReadableString() string {
+	return fmt.Sprintf(`Params:
+  Max Evidence Age:            %s
+  Signed Blocks Window:        %d
+  Min Signed Per Window:       %s
+  Double Sign Unbond Duration: %s
+  Downtime Unbond Duration:    %s
+  Slash Fraction Double Sign:  %s
+  Slash Fraction Downtime:     %s
+`, p.MaxEvidenceAge, p.SignedBlocksWindow, p.MinSignedPerWindow,
+		p.DoubleSignUnbondDuration, p.DowntimeUnbondDuration,
+		p.SlashFractionDoubleSign, p.SlashFractionDowntime)
 }
 
 // Implements params.ParamStruct

--- a/x/stake/types/params.go
+++ b/x/stake/types/params.go
@@ -69,12 +69,11 @@ func DefaultParams() Params {
 // HumanReadableString returns a human readable string representation of the
 // parameters.
 func (p Params) HumanReadableString() string {
-
-	resp := "Params \n"
-	resp += fmt.Sprintf("Unbonding Time: %s\n", p.UnbondingTime)
-	resp += fmt.Sprintf("Max Validators: %d\n", p.MaxValidators)
-	resp += fmt.Sprintf("Bonded Coin Denomination: %s\n", p.BondDenom)
-	return resp
+	return fmt.Sprintf(`Params:
+  Unbonding Time: %s
+  Max Validators: %d
+  Bonded Coin Denom: %s
+`, p.UnbondingTime, p.MaxValidators, p.BondDenom)
 }
 
 // unmarshal the current staking params value from store key or panic


### PR DESCRIPTION
Three are currently a number of issues about properly formatting CLI responses:
- https://github.com/cosmos/cosmos-sdk/issues/3268
- https://github.com/cosmos/cosmos-sdk/issues/3255
- https://github.com/cosmos/cosmos-sdk/issues/3249
- https://github.com/cosmos/cosmos-sdk/issues/3178
- https://github.com/cosmos/cosmos-sdk/issues/2953
- https://github.com/cosmos/cosmos-sdk/issues/2856
- https://github.com/cosmos/cosmos-sdk/issues/2607

There are two major issues underlying the above reports: 
1. Calls to `cliCtx.QueryWithData` return bytes, many places in the cli don't respect `--indent` or `-o json` because the code isn't there
2. Calls to `utils.CompleteAndBroadcastTxCli` don't respect the `-o json` or `--indent` flags either, and the human readable text format returned is not really readable by humans.

The first commit here unifies the `params` calls across the modules. Subsequent commits will generalize the approach for printing developed there to all other query CLI calls. Then the same will be done with the Tx calls. Testing will be added as well.

- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added entries in `PENDING.md` with issue # 
- [ ] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
