### PR TITLE
R4R: Allow overriding of CLI transaction response handling

### DIFF
--- a/client/context/broadcast.go
+++ b/client/context/broadcast.go
@@ -131,11 +131,16 @@ func (ctx CLIContext) broadcastTxCommit(txBytes []byte) (*ctypes.ResultBroadcast
 		return res, err
 	}
 
-	if ctx.ResponseHandler != nil {
-		ctx.ResponseHandler(res)
-		return res, nil
+	if ctx.TxResponseHandler != nil {
+		err = ctx.TxResponseHandler(res)
+	} else {
+		err = ctx.DefaultTxResponseHandler(res)
 	}
+	return res, err
 
+}
+
+func (ctx CLIContext) DefaultTxResponseHandler(res *ctypes.ResultBroadcastTxCommit) error {
 	if ctx.OutputFormat == "json" {
 		// Since JSON is intended for automated scripts, always include response in
 		// JSON mode.
@@ -149,14 +154,14 @@ func (ctx CLIContext) broadcastTxCommit(txBytes []byte) (*ctypes.ResultBroadcast
 			resJSON := toJSON{res.Height, res.Hash.String(), res.DeliverTx}
 			bz, err := ctx.Codec.MarshalJSON(resJSON)
 			if err != nil {
-				return res, err
+				return err
 			}
 
 			ctx.Output.Write(bz)
 			io.WriteString(ctx.Output, "\n")
 		}
 
-		return res, nil
+		return nil
 	}
 
 	if ctx.Output != nil {
@@ -171,5 +176,5 @@ func (ctx CLIContext) broadcastTxCommit(txBytes []byte) (*ctypes.ResultBroadcast
 		io.WriteString(ctx.Output, resStr)
 	}
 
-	return res, nil
+	return nil
 }

--- a/client/context/broadcast.go
+++ b/client/context/broadcast.go
@@ -132,7 +132,8 @@ func (ctx CLIContext) broadcastTxCommit(txBytes []byte) (*ctypes.ResultBroadcast
 	}
 
 	if ctx.ResponseHandler != nil {
-		return ctx.ResponseHandler(res)
+		ctx.ResponseHandler(res)
+		return res, nil
 	}
 
 	if ctx.OutputFormat == "json" {

--- a/client/context/broadcast.go
+++ b/client/context/broadcast.go
@@ -131,6 +131,10 @@ func (ctx CLIContext) broadcastTxCommit(txBytes []byte) (*ctypes.ResultBroadcast
 		return res, err
 	}
 
+	if ctx.ResponseHandler != nil {
+		return ctx.ResponseHandler(res)
+	}
+
 	if ctx.OutputFormat == "json" {
 		// Since JSON is intended for automated scripts, always include response in
 		// JSON mode.
@@ -158,13 +162,9 @@ func (ctx CLIContext) broadcastTxCommit(txBytes []byte) (*ctypes.ResultBroadcast
 		resStr := fmt.Sprintf("Committed at block %d (tx hash: %s)\n", res.Height, res.Hash.String())
 
 		if ctx.PrintResponse {
-			if ctx.ResponsePrinter != nil {
-				resStr = ctx.ResponsePrinter(res)
-			} else {
-				resStr = fmt.Sprintf("Committed at block %d (tx hash: %s, response: %+v)\n",
-					res.Height, res.Hash.String(), res.DeliverTx,
-				)
-			}
+			resStr = fmt.Sprintf("Committed at block %d (tx hash: %s, response: %+v)\n",
+				res.Height, res.Hash.String(), res.DeliverTx,
+			)
 		}
 
 		io.WriteString(ctx.Output, resStr)

--- a/client/context/broadcast.go
+++ b/client/context/broadcast.go
@@ -158,13 +158,13 @@ func (ctx CLIContext) broadcastTxCommit(txBytes []byte) (*ctypes.ResultBroadcast
 		resStr := fmt.Sprintf("Committed at block %d (tx hash: %s)\n", res.Height, res.Hash.String())
 
 		if ctx.PrintResponse {
-			resStr = fmt.Sprintf("Committed at block %d (tx hash: %s, response: %+v)\n",
-				res.Height, res.Hash.String(), res.DeliverTx,
-			)
-		}
-
-		if ctx.ResponseHandler != nil {
-			ctx.ResponseHandler(res)
+			if ctx.ResponsePrinter != nil {
+				resStr = ctx.ResponsePrinter(res)
+			} else {
+				resStr = fmt.Sprintf("Committed at block %d (tx hash: %s, response: %+v)\n",
+					res.Height, res.Hash.String(), res.DeliverTx,
+				)
+			}
 		}
 
 		io.WriteString(ctx.Output, resStr)

--- a/client/context/broadcast.go
+++ b/client/context/broadcast.go
@@ -163,6 +163,10 @@ func (ctx CLIContext) broadcastTxCommit(txBytes []byte) (*ctypes.ResultBroadcast
 			)
 		}
 
+		if ctx.ResponseHandler != nil {
+			ctx.ResponseHandler(res)
+		}
+
 		io.WriteString(ctx.Output, resStr)
 	}
 

--- a/client/context/context.go
+++ b/client/context/context.go
@@ -3,6 +3,7 @@ package context
 import (
 	"bytes"
 	"fmt"
+	"github.com/tendermint/tendermint/rpc/core/types"
 	"io"
 	"os"
 	"path/filepath"
@@ -26,28 +27,31 @@ import (
 
 var verifier tmlite.Verifier
 
+type ResponseHandler = func(res *core_types.ResultBroadcastTxCommit)
+
 // CLIContext implements a typical CLI context created in SDK modules for
 // transaction handling and queries.
 type CLIContext struct {
-	Codec         *codec.Codec
-	AccDecoder    auth.AccountDecoder
-	Client        rpcclient.Client
-	Output        io.Writer
+	Codec           *codec.Codec
+	AccDecoder      auth.AccountDecoder
+	Client          rpcclient.Client
+	Output          io.Writer
 	OutputFormat  string
-	Height        int64
-	NodeURI       string
-	From          string
-	AccountStore  string
-	TrustNode     bool
-	UseLedger     bool
-	Async         bool
-	PrintResponse bool
-	Verifier      tmlite.Verifier
-	Simulate      bool
-	GenerateOnly  bool
+	Height          int64
+	NodeURI         string
+	From            string
+	AccountStore    string
+	TrustNode       bool
+	UseLedger       bool
+	Async           bool
+	PrintResponse   bool
+	ResponseHandler ResponseHandler
+	Verifier        tmlite.Verifier
+	Simulate        bool
+	GenerateOnly    bool
 	FromAddress   sdk.AccAddress
 	FromName      string
-	Indent        bool
+	Indent          bool
 }
 
 // NewCLIContext returns a new initialized CLIContext with parameters from the

--- a/client/context/context.go
+++ b/client/context/context.go
@@ -44,7 +44,7 @@ type CLIContext struct {
 	Async         bool
 	PrintResponse bool
 	// Overrides the default CLI transaction response handling with a custom handler
-	ResponseHandler func(res *ctypes.ResultBroadcastTxCommit) (*ctypes.ResultBroadcastTxCommit, error)
+	ResponseHandler func(res *ctypes.ResultBroadcastTxCommit)
 	Verifier        tmlite.Verifier
 	Simulate        bool
 	GenerateOnly    bool

--- a/client/context/context.go
+++ b/client/context/context.go
@@ -3,7 +3,6 @@ package context
 import (
 	"bytes"
 	"fmt"
-	"github.com/tendermint/tendermint/rpc/core/types"
 	"io"
 	"os"
 	"path/filepath"
@@ -21,13 +20,12 @@ import (
 	tmlite "github.com/tendermint/tendermint/lite"
 	tmliteProxy "github.com/tendermint/tendermint/lite/proxy"
 	rpcclient "github.com/tendermint/tendermint/rpc/client"
+	ctypes "github.com/tendermint/tendermint/rpc/core/types"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 var verifier tmlite.Verifier
-
-type ResponsePrinter = func(res *core_types.ResultBroadcastTxCommit) string
 
 // CLIContext implements a typical CLI context created in SDK modules for
 // transaction handling and queries.
@@ -45,7 +43,8 @@ type CLIContext struct {
 	UseLedger       bool
 	Async           bool
 	PrintResponse   bool
-	ResponsePrinter ResponsePrinter
+	// Overrides the default CLI transaction response handling
+	ResponseHandler func(res *ctypes.ResultBroadcastTxCommit) (*ctypes.ResultBroadcastTxCommit, error)
 	Verifier        tmlite.Verifier
 	Simulate        bool
 	GenerateOnly    bool

--- a/client/context/context.go
+++ b/client/context/context.go
@@ -44,13 +44,13 @@ type CLIContext struct {
 	Async         bool
 	PrintResponse bool
 	// Overrides the default CLI transaction response handling with a custom handler
-	ResponseHandler func(res *ctypes.ResultBroadcastTxCommit)
-	Verifier        tmlite.Verifier
-	Simulate        bool
-	GenerateOnly    bool
-	FromAddress     sdk.AccAddress
-	FromName        string
-	Indent          bool
+	TxResponseHandler func(res *ctypes.ResultBroadcastTxCommit) error
+	Verifier          tmlite.Verifier
+	Simulate          bool
+	GenerateOnly      bool
+	FromAddress       sdk.AccAddress
+	FromName          string
+	Indent            bool
 }
 
 // NewCLIContext returns a new initialized CLIContext with parameters from the

--- a/client/context/context.go
+++ b/client/context/context.go
@@ -27,7 +27,7 @@ import (
 
 var verifier tmlite.Verifier
 
-type ResponseHandler = func(res *core_types.ResultBroadcastTxCommit)
+type ResponsePrinter = func(res *core_types.ResultBroadcastTxCommit) string
 
 // CLIContext implements a typical CLI context created in SDK modules for
 // transaction handling and queries.
@@ -45,7 +45,7 @@ type CLIContext struct {
 	UseLedger       bool
 	Async           bool
 	PrintResponse   bool
-	ResponseHandler ResponseHandler
+	ResponsePrinter ResponsePrinter
 	Verifier        tmlite.Verifier
 	Simulate        bool
 	GenerateOnly    bool

--- a/client/context/context.go
+++ b/client/context/context.go
@@ -30,26 +30,26 @@ var verifier tmlite.Verifier
 // CLIContext implements a typical CLI context created in SDK modules for
 // transaction handling and queries.
 type CLIContext struct {
-	Codec           *codec.Codec
-	AccDecoder      auth.AccountDecoder
-	Client          rpcclient.Client
-	Output          io.Writer
+	Codec         *codec.Codec
+	AccDecoder    auth.AccountDecoder
+	Client        rpcclient.Client
+	Output        io.Writer
 	OutputFormat  string
-	Height          int64
-	NodeURI         string
-	From            string
-	AccountStore    string
-	TrustNode       bool
-	UseLedger       bool
-	Async           bool
-	PrintResponse   bool
-	// Overrides the default CLI transaction response handling
+	Height        int64
+	NodeURI       string
+	From          string
+	AccountStore  string
+	TrustNode     bool
+	UseLedger     bool
+	Async         bool
+	PrintResponse bool
+	// Overrides the default CLI transaction response handling with a custom handler
 	ResponseHandler func(res *ctypes.ResultBroadcastTxCommit) (*ctypes.ResultBroadcastTxCommit, error)
 	Verifier        tmlite.Verifier
 	Simulate        bool
 	GenerateOnly    bool
-	FromAddress   sdk.AccAddress
-	FromName      string
+	FromAddress     sdk.AccAddress
+	FromName        string
 	Indent          bool
 }
 


### PR DESCRIPTION
Currently printing of tx results in the cli is pretty basic and encodes things like `Tags` as byte arrays whereas in most cases they are actually strings. Also, in my case I would sometimes like to use `Data` to return useful information to the client.

This is just one of many approaches that could be used, but is pretty flexible in that it lets cli commands customize the output.

Open for discussion.
______

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/develop/CONTRIBUTING.md#pr-targeting))

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added entries in `PENDING.md` with issue # 
- [x] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))