### PR TITLE
R4R: Create separate directories for cli tests

### DIFF
--- a/cmd/gaia/cli_test/test_helpers.go
+++ b/cmd/gaia/cli_test/test_helpers.go
@@ -56,17 +56,16 @@ type Fixtures struct {
 
 // NewFixtures creates a new instance of Fixtures with many vars set
 func NewFixtures(t *testing.T) *Fixtures {
-	tmpDir := os.TempDir()
-	gaiadHome := fmt.Sprintf("%s%s%s%s.test_gaiad", tmpDir, string(os.PathSeparator), t.Name(), string(os.PathSeparator))
-	gaiacliHome := fmt.Sprintf("%s%s%s%s.test_gaiacli", tmpDir, string(os.PathSeparator), t.Name(), string(os.PathSeparator))
+	tmpDir, err := ioutil.TempDir("", "gaia_integration_"+t.Name()+"_")
+	require.NoError(t, err)
 	servAddr, port, err := server.FreeTCPAddr()
 	require.NoError(t, err)
 	p2pAddr, _, err := server.FreeTCPAddr()
 	require.NoError(t, err)
 	return &Fixtures{
 		T:        t,
-		GDHome:   gaiadHome,
-		GCLIHome: gaiacliHome,
+		GDHome:   filepath.Join(tmpDir, ".gaiad"),
+		GCLIHome: filepath.Join(tmpDir, ".gaiacli"),
 		RPCAddr:  servAddr,
 		P2PAddr:  p2pAddr,
 		Port:     port,


### PR DESCRIPTION
Rely on `ioutil.TempDir()` for safe randomized generation of cli tests home directories.

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added entries in `PENDING.md` with issue # 
- [ ] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
