### PR TITLE
WIP: CLI Response Formatting

### DIFF
--- a/client/output.go
+++ b/client/output.go
@@ -1,0 +1,29 @@
+package client
+
+import (
+	"fmt"
+
+	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/spf13/viper"
+	"github.com/tendermint/tendermint/libs/cli"
+)
+
+// PrintOutput prints output while respecting output and indent flags
+// NOTE: pass in marshalled structs that have been unmarshaled
+// because this function doesn't return errors for marshaling
+func PrintOutput(cdc *codec.Codec, toPrint fmt.Stringer) {
+	switch viper.Get(cli.OutputFlag) {
+	case "text":
+		fmt.Println(toPrint.String())
+	case "json":
+		if viper.GetBool(FlagIndentResponse) {
+			out, err := codec.MarshalJSONIndent(cdc, toPrint)
+			if err != nil {
+				panic(err)
+			}
+			fmt.Println(string(out))
+		} else {
+			fmt.Println(string(cdc.MustMarshalJSON(toPrint)))
+		}
+	}
+}

--- a/client/tx/search.go
+++ b/client/tx/search.go
@@ -86,6 +86,7 @@ $ gaiacli query txs --tags '<tag1>:<value1>&<tag2>:<value2>'
 	cmd.Flags().Bool(client.FlagTrustNode, false, "Trust connected full node (don't verify proofs for responses)")
 	viper.BindPFlag(client.FlagTrustNode, cmd.Flags().Lookup(client.FlagTrustNode))
 	cmd.Flags().String(flagTags, "", "tag:value list of tags that must match")
+	cmd.MarkFlagRequired(flagTags)
 	return cmd
 }
 

--- a/cmd/gaia/cli_test/cli_test.go
+++ b/cmd/gaia/cli_test/cli_test.go
@@ -332,8 +332,9 @@ func TestGaiaCLISubmitProposal(t *testing.T) {
 	fooAcc := f.QueryAccount(fooAddr)
 	require.Equal(t, int64(50), fooAcc.GetCoins().AmountOf(stakingTypes.DefaultBondDenom).Int64())
 
+	// Ensure there are no proposals to start
 	proposalsQuery := f.QueryGovProposals()
-	require.Equal(t, "No matching proposals found", proposalsQuery)
+	require.Empty(t, proposalsQuery)
 
 	// Test submit generate only for submit proposal
 	success, stdout, stderr := f.TxGovSubmitProposal(
@@ -368,7 +369,7 @@ func TestGaiaCLISubmitProposal(t *testing.T) {
 
 	// Ensure query proposals returns properly
 	proposalsQuery = f.QueryGovProposals()
-	require.Equal(t, "  1 - Test", proposalsQuery)
+	require.Equal(t, uint64(1), proposalsQuery[0].GetProposalID())
 
 	// Query the deposits on the proposal
 	deposit := f.QueryGovDeposit(1, fooAddr)
@@ -439,11 +440,11 @@ func TestGaiaCLISubmitProposal(t *testing.T) {
 
 	// Ensure no proposals in deposit period
 	proposalsQuery = f.QueryGovProposals("--status=DepositPeriod")
-	require.Equal(t, "No matching proposals found", proposalsQuery)
+	require.Empty(t, proposalsQuery)
 
 	// Ensure the proposal returns as in the voting period
 	proposalsQuery = f.QueryGovProposals("--status=VotingPeriod")
-	require.Equal(t, "  1 - Test", proposalsQuery)
+	require.Equal(t, uint64(1), proposalsQuery[0].GetProposalID())
 
 	// submit a second test proposal
 	f.TxGovSubmitProposal(keyFoo, "Text", "Apples", "test", sdk.NewInt64Coin(denom, 5))
@@ -451,7 +452,7 @@ func TestGaiaCLISubmitProposal(t *testing.T) {
 
 	// Test limit on proposals query
 	proposalsQuery = f.QueryGovProposals("--limit=1")
-	require.Equal(t, "  2 - Apples", proposalsQuery)
+	require.Equal(t, uint64(2), proposalsQuery[0].GetProposalID())
 
 	f.Cleanup()
 }

--- a/cmd/gaia/cli_test/test_helpers.go
+++ b/cmd/gaia/cli_test/test_helpers.go
@@ -399,11 +399,18 @@ func (f *Fixtures) QueryGovParamTallying() gov.TallyParams {
 }
 
 // QueryGovProposals is gaiacli query gov proposals
-func (f *Fixtures) QueryGovProposals(flags ...string) string {
+func (f *Fixtures) QueryGovProposals(flags ...string) gov.Proposals {
 	cmd := fmt.Sprintf("gaiacli query gov proposals %v", f.Flags())
 	stdout, stderr := tests.ExecuteT(f.T, addFlags(cmd, flags), "")
+	if stderr == "ERROR: No matching proposals found" {
+		return gov.Proposals{}
+	}
 	require.Empty(f.T, stderr)
-	return stdout
+	var out gov.Proposals
+	cdc := app.MakeCodec()
+	err := cdc.UnmarshalJSON([]byte(stdout), &out)
+	require.NoError(f.T, err)
+	return out
 }
 
 // QueryGovProposal is gaiacli query gov proposal

--- a/cmd/gaia/cli_test/test_helpers.go
+++ b/cmd/gaia/cli_test/test_helpers.go
@@ -353,7 +353,7 @@ func (f *Fixtures) QueryStakingPool(flags ...string) staking.Pool {
 
 // QueryStakingParameters is gaiacli query staking parameters
 func (f *Fixtures) QueryStakingParameters(flags ...string) staking.Params {
-	cmd := fmt.Sprintf("gaiacli query staking parameters %v", f.Flags())
+	cmd := fmt.Sprintf("gaiacli query staking params %v", f.Flags())
 	out, _ := tests.ExecuteT(f.T, addFlags(cmd, flags), "")
 	var params staking.Params
 	cdc := app.MakeCodec()

--- a/x/auth/account.go
+++ b/x/auth/account.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/tendermint/tendermint/crypto"
@@ -35,6 +36,8 @@ type Account interface {
 	// Calculates the amount of coins that can be sent to other accounts given
 	// the current time.
 	SpendableCoins(blockTime time.Time) sdk.Coins
+
+	String() string
 }
 
 // VestingAccount defines an account type that vests coins via a vesting schedule.
@@ -69,6 +72,15 @@ type BaseAccount struct {
 	PubKey        crypto.PubKey  `json:"public_key"`
 	AccountNumber uint64         `json:"account_number"`
 	Sequence      uint64         `json:"sequence"`
+}
+
+func (acc BaseAccount) String() string {
+	return fmt.Sprintf(`Account %s:
+  Coins:         %s
+  PubKey:        %s
+  AccountNumber: %d
+  Sequence:      %d`, acc.Address, acc.Coins,
+		acc.PubKey.Address(), acc.AccountNumber, acc.Sequence)
 }
 
 // Prototype function for BaseAccount
@@ -159,6 +171,21 @@ type BaseVestingAccount struct {
 	DelegatedVesting sdk.Coins // coins that vesting and delegated
 
 	EndTime time.Time // when the coins become unlocked
+}
+
+func (bva BaseVestingAccount) String() string {
+	return fmt.Sprintf(`Vesting Account %s:
+  Coins:            %s
+  PubKey:           %s
+  AccountNumber:    %d
+  Sequence:         %d
+  OriginalVesting:  %s
+  DelegatedFree:    %s
+  DelegatedVesting: %s
+  EndTime:          %s `, bva.Address, bva.Coins,
+		bva.PubKey.Address(), bva.AccountNumber, bva.Sequence,
+		bva.OriginalVesting, bva.DelegatedFree,
+		bva.DelegatedVesting, bva.EndTime)
 }
 
 // spendableCoins returns all the spendable coins for a vesting account given a
@@ -321,6 +348,22 @@ type ContinuousVestingAccount struct {
 	*BaseVestingAccount
 
 	StartTime time.Time // when the coins start to vest
+}
+
+func (cva ContinuousVestingAccount) String() string {
+	return fmt.Sprintf(`Vesting Account %s:
+  Coins:            %s
+  PubKey:           %s
+  AccountNumber:    %d
+  Sequence:         %d
+  OriginalVesting:  %s
+  DelegatedFree:    %s
+  DelegatedVesting: %s
+  StartTime:        %s
+  EndTime:          %s `, cva.Address, cva.Coins,
+		cva.PubKey.Address(), cva.AccountNumber, cva.Sequence,
+		cva.OriginalVesting, cva.DelegatedFree,
+		cva.DelegatedVesting, cva.StartTime, cva.EndTime)
 }
 
 func NewContinuousVestingAccount(

--- a/x/auth/client/cli/account.go
+++ b/x/auth/client/cli/account.go
@@ -1,8 +1,6 @@
 package cli
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 
 	"github.com/cosmos/cosmos-sdk/client"
@@ -20,17 +18,14 @@ func GetAccountCmd(storeName string, cdc *codec.Codec) *cobra.Command {
 		Short: "Query account balance",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// find the key to look up the account
-			addr := args[0]
-
-			key, err := sdk.AccAddressFromBech32(addr)
-			if err != nil {
-				return err
-			}
-
 			cliCtx := context.NewCLIContext().
 				WithCodec(cdc).
 				WithAccountDecoder(cdc)
+
+			key, err := sdk.AccAddressFromBech32(args[0])
+			if err != nil {
+				return err
+			}
 
 			if err = cliCtx.EnsureAccountExistsFromAddr(key); err != nil {
 				return err
@@ -41,17 +36,7 @@ func GetAccountCmd(storeName string, cdc *codec.Codec) *cobra.Command {
 				return err
 			}
 
-			var output []byte
-			if cliCtx.Indent {
-				output, err = cdc.MarshalJSONIndent(acc, "", "  ")
-			} else {
-				output, err = cdc.MarshalJSON(acc)
-			}
-			if err != nil {
-				return err
-			}
-
-			fmt.Println(string(output))
+			client.PrintOutput(cdc, acc)
 			return nil
 		},
 	}

--- a/x/gov/client/cli/query.go
+++ b/x/gov/client/cli/query.go
@@ -434,7 +434,7 @@ func GetCmdQueryParams(queryRoute string, cdc *codec.Codec) *cobra.Command {
 			var votingParams gov.VotingParams
 			cdc.MustUnmarshalJSON(vp, &votingParams)
 
-			client.PrintOutput(cdc, gov.NewGovParams(votingParams, tallyParams, depositParams))
+			client.PrintOutput(cdc, gov.NewParams(votingParams, tallyParams, depositParams))
 			return nil
 		},
 	}
@@ -469,7 +469,7 @@ func GetCmdQueryParam(queryRoute string, cdc *codec.Codec) *cobra.Command {
 				cdc.MustUnmarshalJSON(res, &param)
 				out = param
 			default:
-				return fmt.Errorf("Arguement must be one of (voting|tallying|deposit), was %s", args[0])
+				return fmt.Errorf("Argument must be one of (voting|tallying|deposit), was %s", args[0])
 			}
 
 			client.PrintOutput(cdc, out)

--- a/x/gov/client/cli/query.go
+++ b/x/gov/client/cli/query.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
+	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/context"
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -17,7 +18,7 @@ import (
 
 // GetCmdQueryProposal implements the query proposal command.
 func GetCmdQueryProposal(queryRoute string, cdc *codec.Codec) *cobra.Command {
-	cmd := &cobra.Command{
+	return &cobra.Command{
 		Use:   "proposal [proposal-id]",
 		Args:  cobra.ExactArgs(1),
 		Short: "Query details of a single proposal",
@@ -36,33 +37,16 @@ $ gaiacli query gov proposal 1
 			}
 
 			// Query the proposal
-			res, err := queryProposal(proposalID, cliCtx, cdc, queryRoute)
+			res, err := gcutils.QueryProposalByID(proposalID, cliCtx, cdc, queryRoute)
 			if err != nil {
 				return err
 			}
-
-			fmt.Println(string(res))
+			var proposal gov.Proposal
+			cdc.MustUnmarshalJSON(res, &proposal)
+			client.PrintOutput(cdc, proposal)
 			return nil
 		},
 	}
-
-	return cmd
-}
-
-func queryProposal(proposalID uint64, cliCtx context.CLIContext, cdc *codec.Codec, queryRoute string) ([]byte, error) {
-	// Construct query
-	params := gov.NewQueryProposalParams(proposalID)
-	bz, err := cdc.MarshalJSON(params)
-	if err != nil {
-		return nil, err
-	}
-
-	// Query store
-	res, err := cliCtx.QueryWithData(fmt.Sprintf("custom/%s/proposal", queryRoute), bz)
-	if err != nil {
-		return nil, err
-	}
-	return res, err
 }
 
 // GetCmdQueryProposals implements a query proposals command.
@@ -125,21 +109,17 @@ $ gaiacli query gov proposals --status (DepositPeriod|VotingPeriod|Passed|Reject
 				return err
 			}
 
-			var matchingProposals []gov.Proposal
+			var matchingProposals gov.Proposals
 			err = cdc.UnmarshalJSON(res, &matchingProposals)
 			if err != nil {
 				return err
 			}
 
 			if len(matchingProposals) == 0 {
-				fmt.Println("No matching proposals found")
-				return nil
+				return fmt.Errorf("No matching proposals found")
 			}
 
-			for _, proposal := range matchingProposals {
-				fmt.Printf("  %d - %s\n", proposal.GetProposalID(), proposal.GetTitle())
-			}
-
+			client.PrintOutput(cdc, matchingProposals)
 			return nil
 		},
 	}
@@ -155,7 +135,7 @@ $ gaiacli query gov proposals --status (DepositPeriod|VotingPeriod|Passed|Reject
 // Command to Get a Proposal Information
 // GetCmdQueryVote implements the query proposal vote command.
 func GetCmdQueryVote(queryRoute string, cdc *codec.Codec) *cobra.Command {
-	cmd := &cobra.Command{
+	return &cobra.Command{
 		Use:   "vote [proposal-id] [voter-address]",
 		Args:  cobra.ExactArgs(2),
 		Short: "Query details of a single vote",
@@ -175,7 +155,7 @@ $ gaiacli query gov vote 1 cosmos1skjwj5whet0lpe65qaq4rpq03hjxlwd9nf39lk
 			}
 
 			// check to see if the proposal is in the store
-			_, err = queryProposal(proposalID, cliCtx, cdc, queryRoute)
+			_, err = gcutils.QueryProposalByID(proposalID, cliCtx, cdc, queryRoute)
 			if err != nil {
 				return fmt.Errorf("Failed to fetch proposal-id %d: %s", proposalID, err)
 			}
@@ -204,19 +184,17 @@ $ gaiacli query gov vote 1 cosmos1skjwj5whet0lpe65qaq4rpq03hjxlwd9nf39lk
 				if err != nil {
 					return err
 				}
+				cdc.UnmarshalJSON(res, &vote)
 			}
-
-			fmt.Println(string(res))
+			client.PrintOutput(cdc, vote)
 			return nil
 		},
 	}
-
-	return cmd
 }
 
 // GetCmdQueryVotes implements the command to query for proposal votes.
 func GetCmdQueryVotes(queryRoute string, cdc *codec.Codec) *cobra.Command {
-	cmd := &cobra.Command{
+	return &cobra.Command{
 		Use:   "votes [proposal-id]",
 		Args:  cobra.ExactArgs(1),
 		Short: "Query votes on a proposal",
@@ -242,15 +220,13 @@ $ gaiacli query gov votes 1
 			}
 
 			// check to see if the proposal is in the store
-			res, err := queryProposal(proposalID, cliCtx, cdc, queryRoute)
+			res, err := gcutils.QueryProposalByID(proposalID, cliCtx, cdc, queryRoute)
 			if err != nil {
 				return fmt.Errorf("Failed to fetch proposal-id %d: %s", proposalID, err)
 			}
 
 			var proposal gov.Proposal
-			if err := cdc.UnmarshalJSON(res, &proposal); err != nil {
-				return err
-			}
+			cdc.MustUnmarshalJSON(res, &proposal)
 
 			propStatus := proposal.GetStatus()
 			if !(propStatus == gov.StatusVotingPeriod || propStatus == gov.StatusDepositPeriod) {
@@ -263,18 +239,18 @@ $ gaiacli query gov votes 1
 				return err
 			}
 
-			fmt.Println(string(res))
+			var votes gov.Votes
+			cdc.MustUnmarshalJSON(res, &votes)
+			client.PrintOutput(cdc, votes)
 			return nil
 		},
 	}
-
-	return cmd
 }
 
 // Command to Get a specific Deposit Information
 // GetCmdQueryDeposit implements the query proposal deposit command.
 func GetCmdQueryDeposit(queryRoute string, cdc *codec.Codec) *cobra.Command {
-	cmd := &cobra.Command{
+	return &cobra.Command{
 		Use:   "deposit [proposal-id] [depositer-address]",
 		Args:  cobra.ExactArgs(2),
 		Short: "Query details of a deposit",
@@ -294,7 +270,7 @@ $ gaiacli query gov deposit 1 cosmos1skjwj5whet0lpe65qaq4rpq03hjxlwd9nf39lk
 			}
 
 			// check to see if the proposal is in the store
-			_, err = queryProposal(proposalID, cliCtx, cdc, queryRoute)
+			_, err = gcutils.QueryProposalByID(proposalID, cliCtx, cdc, queryRoute)
 			if err != nil {
 				return fmt.Errorf("Failed to fetch proposal-id %d: %s", proposalID, err)
 			}
@@ -319,23 +295,21 @@ $ gaiacli query gov deposit 1 cosmos1skjwj5whet0lpe65qaq4rpq03hjxlwd9nf39lk
 			cdc.UnmarshalJSON(res, &deposit)
 
 			if deposit.Empty() {
-				res, err = gcutils.QueryDepositByTxQuery(cdc, cliCtx, params)
+				deposit, err = gcutils.QueryDepositByTxQuery(cdc, cliCtx, params)
 				if err != nil {
 					return err
 				}
 			}
 
-			fmt.Println(string(res))
+			client.PrintOutput(cdc, deposit)
 			return nil
 		},
 	}
-
-	return cmd
 }
 
 // GetCmdQueryDeposits implements the command to query for proposal deposits.
 func GetCmdQueryDeposits(queryRoute string, cdc *codec.Codec) *cobra.Command {
-	cmd := &cobra.Command{
+	return &cobra.Command{
 		Use:   "deposits [proposal-id]",
 		Args:  cobra.ExactArgs(1),
 		Short: "Query deposits on a proposal",
@@ -350,7 +324,7 @@ $ gaiacli query gov deposits 1
 			// validate that the proposal id is a uint
 			proposalID, err := strconv.ParseUint(args[0], 10, 64)
 			if err != nil {
-				return fmt.Errorf("proposal-id %s not a valid uint, please input a valid proposal-id", args[0])
+				return fmt.Errorf("proposal-id %s not valid, please input a valid proposal-id", args[0])
 			}
 
 			params := gov.NewQueryProposalParams(proposalID)
@@ -360,15 +334,13 @@ $ gaiacli query gov deposits 1
 			}
 
 			// check to see if the proposal is in the store
-			res, err := queryProposal(proposalID, cliCtx, cdc, queryRoute)
+			res, err := gcutils.QueryProposalByID(proposalID, cliCtx, cdc, queryRoute)
 			if err != nil {
-				return fmt.Errorf("Failed to fetch proposal-id %d: %s", proposalID, err)
+				return fmt.Errorf("Failed to fetch proposal with id %d: %s", proposalID, err)
 			}
 
 			var proposal gov.Proposal
-			if err := cdc.UnmarshalJSON(res, &proposal); err != nil {
-				return err
-			}
+			cdc.MustUnmarshalJSON(res, &proposal)
 
 			propStatus := proposal.GetStatus()
 			if !(propStatus == gov.StatusVotingPeriod || propStatus == gov.StatusDepositPeriod) {
@@ -376,22 +348,21 @@ $ gaiacli query gov deposits 1
 			} else {
 				res, err = cliCtx.QueryWithData(fmt.Sprintf("custom/%s/deposits", queryRoute), bz)
 			}
-
 			if err != nil {
 				return err
 			}
 
-			fmt.Println(string(res))
+			var dep gov.Deposits
+			cdc.MustUnmarshalJSON(res, &dep)
+			client.PrintOutput(cdc, dep)
 			return nil
 		},
 	}
-
-	return cmd
 }
 
 // GetCmdQueryTally implements the command to query for proposal tally result.
 func GetCmdQueryTally(queryRoute string, cdc *codec.Codec) *cobra.Command {
-	cmd := &cobra.Command{
+	return &cobra.Command{
 		Use:   "tally [proposal-id]",
 		Args:  cobra.ExactArgs(1),
 		Short: "Get the tally of a proposal vote",
@@ -410,7 +381,7 @@ $ gaiacli query gov tally 1
 			}
 
 			// check to see if the proposal is in the store
-			_, err = queryProposal(proposalID, cliCtx, cdc, queryRoute)
+			_, err = gcutils.QueryProposalByID(proposalID, cliCtx, cdc, queryRoute)
 			if err != nil {
 				return fmt.Errorf("Failed to fetch proposal-id %d: %s", proposalID, err)
 			}
@@ -428,17 +399,50 @@ $ gaiacli query gov tally 1
 				return err
 			}
 
-			fmt.Println(string(res))
+			var tally gov.TallyResult
+			cdc.MustUnmarshalJSON(res, &tally)
+			client.PrintOutput(cdc, tally)
 			return nil
 		},
 	}
-
-	return cmd
 }
 
 // GetCmdQueryProposal implements the query proposal command.
 func GetCmdQueryParams(queryRoute string, cdc *codec.Codec) *cobra.Command {
-	cmd := &cobra.Command{
+	return &cobra.Command{
+		Use:   "params",
+		Short: "Query the parameters (voting|tallying|deposit) of the governance process",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cliCtx := context.NewCLIContext().WithCodec(cdc)
+			tp, err := cliCtx.QueryWithData(fmt.Sprintf("custom/%s/params/tallying", queryRoute), nil)
+			if err != nil {
+				return err
+			}
+			dp, err := cliCtx.QueryWithData(fmt.Sprintf("custom/%s/params/deposit", queryRoute), nil)
+			if err != nil {
+				return err
+			}
+			vp, err := cliCtx.QueryWithData(fmt.Sprintf("custom/%s/params/voting", queryRoute), nil)
+			if err != nil {
+				return err
+			}
+
+			var tallyParams gov.TallyParams
+			cdc.MustUnmarshalJSON(tp, &tallyParams)
+			var depositParams gov.DepositParams
+			cdc.MustUnmarshalJSON(dp, &depositParams)
+			var votingParams gov.VotingParams
+			cdc.MustUnmarshalJSON(vp, &votingParams)
+
+			client.PrintOutput(cdc, gov.NewGovParams(votingParams, tallyParams, depositParams))
+			return nil
+		},
+	}
+}
+
+// GetCmdQueryProposal implements the query proposal command.
+func GetCmdQueryParam(queryRoute string, cdc *codec.Codec) *cobra.Command {
+	return &cobra.Command{
 		Use:   "param [param-type]",
 		Args:  cobra.ExactArgs(1),
 		Short: "Query the parameters (voting|tallying|deposit) of the governance process",
@@ -450,18 +454,33 @@ func GetCmdQueryParams(queryRoute string, cdc *codec.Codec) *cobra.Command {
 			if err != nil {
 				return err
 			}
+			var out fmt.Stringer
+			switch args[0] {
+			case "voting":
+				var param gov.VotingParams
+				cdc.MustUnmarshalJSON(res, &param)
+				out = param
+			case "tallying":
+				var param gov.TallyParams
+				cdc.MustUnmarshalJSON(res, &param)
+				out = param
+			case "deposit":
+				var param gov.DepositParams
+				cdc.MustUnmarshalJSON(res, &param)
+				out = param
+			default:
+				return fmt.Errorf("Arguement must be one of (voting|tallying|deposit), was %s", args[0])
+			}
 
-			fmt.Println(string(res))
+			client.PrintOutput(cdc, out)
 			return nil
 		},
 	}
-
-	return cmd
 }
 
 // GetCmdQueryProposer implements the query proposer command.
 func GetCmdQueryProposer(queryRoute string, cdc *codec.Codec) *cobra.Command {
-	cmd := &cobra.Command{
+	return &cobra.Command{
 		Use:   "proposer [proposal-id]",
 		Args:  cobra.ExactArgs(1),
 		Short: "Query the proposer of a governance proposal",
@@ -474,15 +493,16 @@ func GetCmdQueryProposer(queryRoute string, cdc *codec.Codec) *cobra.Command {
 				return fmt.Errorf("proposal-id %s is not a valid uint", args[0])
 			}
 
-			res, err := gcutils.QueryProposerByTxQuery(cdc, cliCtx, proposalID)
+			prop, err := gcutils.QueryProposerByTxQuery(cdc, cliCtx, proposalID)
 			if err != nil {
 				return err
 			}
 
-			fmt.Println(string(res))
+			client.PrintOutput(cdc, prop)
 			return nil
 		},
 	}
-
-	return cmd
 }
+
+// Utils
+//----------------------------------

--- a/x/gov/client/cli/tx.go
+++ b/x/gov/client/cli/tx.go
@@ -194,7 +194,7 @@ $ gaiacli tx gov deposit 1 10stake --from mykey
 			}
 
 			// check to see if the proposal is in the store
-			_, err = queryProposal(proposalID, cliCtx, cdc, queryRoute)
+			_, err = govClientUtils.QueryProposalByID(proposalID, cliCtx, cdc, queryRoute)
 			if err != nil {
 				return fmt.Errorf("Failed to fetch proposal-id %d: %s", proposalID, err)
 			}
@@ -270,7 +270,7 @@ $ gaiacli tx gov vote 1 yes --from mykey
 			}
 
 			// check to see if the proposal is in the store
-			_, err = queryProposal(proposalID, cliCtx, cdc, queryRoute)
+			_, err = govClientUtils.QueryProposalByID(proposalID, cliCtx, cdc, queryRoute)
 			if err != nil {
 				return fmt.Errorf("Failed to fetch proposal-id %d: %s", proposalID, err)
 			}

--- a/x/gov/client/module_client.go
+++ b/x/gov/client/module_client.go
@@ -32,6 +32,7 @@ func (mc ModuleClient) GetQueryCmd() *cobra.Command {
 		govCli.GetCmdQueryVote(mc.storeKey, mc.cdc),
 		govCli.GetCmdQueryVotes(mc.storeKey, mc.cdc),
 		govCli.GetCmdQueryParams(mc.storeKey, mc.cdc),
+		govCli.GetCmdQueryParam(mc.storeKey, mc.cdc),
 		govCli.GetCmdQueryProposer(mc.storeKey, mc.cdc),
 		govCli.GetCmdQueryDeposit(mc.storeKey, mc.cdc),
 		govCli.GetCmdQueryDeposits(mc.storeKey, mc.cdc),

--- a/x/gov/client/rest/rest.go
+++ b/x/gov/client/rest/rest.go
@@ -369,11 +369,12 @@ func queryDepositHandlerFn(cdc *codec.Codec, cliCtx context.CLIContext) http.Han
 				return
 			}
 
-			res, err = gcutils.QueryDepositByTxQuery(cdc, cliCtx, params)
+			deposit, err = gcutils.QueryDepositByTxQuery(cdc, cliCtx, params)
 			if err != nil {
 				utils.WriteErrorResponse(w, http.StatusInternalServerError, err.Error())
 				return
 			}
+			res = cdc.MustMarshalJSON(deposit)
 		}
 
 		utils.PostProcessResponse(w, cdc, res, cliCtx.Indent)

--- a/x/gov/depositsvotes.go
+++ b/x/gov/depositsvotes.go
@@ -16,15 +16,29 @@ type Vote struct {
 	Option     VoteOption     `json:"option"`      //  option from OptionSet chosen by the voter
 }
 
+func (v Vote) String() string {
+	return fmt.Sprintf(`Voter %s voted with option %s on proposal %d`, v.Voter, v.Option, v.ProposalID)
+}
+
+// Votes is a collection of Vote
+type Votes []Vote
+
+func (v Votes) String() string {
+	out := fmt.Sprintf("Votes for Proposal %d:", v[0].ProposalID)
+	for _, vot := range v {
+		out += fmt.Sprintf("\n  %s: %s", vot.Voter, vot.Option)
+	}
+	return out
+}
+
 // Returns whether 2 votes are equal
-func (voteA Vote) Equals(voteB Vote) bool {
-	return voteA.Voter.Equals(voteB.Voter) && voteA.ProposalID == voteB.ProposalID && voteA.Option == voteB.Option
+func (v Vote) Equals(comp Vote) bool {
+	return v.Voter.Equals(comp.Voter) && v.ProposalID == comp.ProposalID && v.Option == comp.Option
 }
 
 // Returns whether a vote is empty
-func (voteA Vote) Empty() bool {
-	voteB := Vote{}
-	return voteA.Equals(voteB)
+func (v Vote) Empty() bool {
+	return v.Equals(Vote{})
 }
 
 // Deposit
@@ -34,15 +48,30 @@ type Deposit struct {
 	Amount     sdk.Coins      `json:"amount"`      //  Deposit amount
 }
 
+func (d Deposit) String() string {
+	return fmt.Sprintf(`Deposit by %s on Proposal %d is for the amount %s`,
+		d.Depositor, d.ProposalID, d.Amount)
+}
+
+// Deposits is a collection of depoist
+type Deposits []Deposit
+
+func (d Deposits) String() string {
+	out := fmt.Sprintf(`Deposits for Proposal %d:`, d[0].ProposalID)
+	for _, dep := range d {
+		out += fmt.Sprintf("\n  %s: %s", dep.Depositor, dep.Amount)
+	}
+	return out
+}
+
 // Returns whether 2 deposits are equal
-func (depositA Deposit) Equals(depositB Deposit) bool {
-	return depositA.Depositor.Equals(depositB.Depositor) && depositA.ProposalID == depositB.ProposalID && depositA.Amount.IsEqual(depositB.Amount)
+func (d Deposit) Equals(comp Deposit) bool {
+	return d.Depositor.Equals(comp.Depositor) && d.ProposalID == comp.ProposalID && d.Amount.IsEqual(comp.Amount)
 }
 
 // Returns whether a deposit is empty
-func (depositA Deposit) Empty() bool {
-	depositB := Deposit{}
-	return depositA.Equals(depositB)
+func (d Deposit) Empty() bool {
+	return d.Equals(Deposit{})
 }
 
 // Type that represents VoteOption as a byte

--- a/x/gov/params.go
+++ b/x/gov/params.go
@@ -1,6 +1,7 @@
 package gov
 
 import (
+	"fmt"
 	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -10,6 +11,12 @@ import (
 type DepositParams struct {
 	MinDeposit       sdk.Coins     `json:"min_deposit"`        //  Minimum deposit for a proposal to enter voting period.
 	MaxDepositPeriod time.Duration `json:"max_deposit_period"` //  Maximum period for Atom holders to deposit on a proposal. Initial value: 2 months
+}
+
+func (dp DepositParams) String() string {
+	return fmt.Sprintf(`Deposit Params:
+  Min Deposit:        %s
+  Max Deposit Period: %s`, dp.MinDeposit, dp.MaxDepositPeriod)
 }
 
 // Checks equality of DepositParams
@@ -25,7 +32,41 @@ type TallyParams struct {
 	GovernancePenalty sdk.Dec `json:"governance_penalty"` //  Penalty if validator does not vote
 }
 
+func (tp TallyParams) String() string {
+	return fmt.Sprintf(`Tally Params:
+  Quorum:             %s
+  Threshold:          %s
+  Veto:               %s
+  Governance Penalty: %s`, tp.Quorum,
+		tp.Threshold, tp.Veto, tp.GovernancePenalty)
+}
+
 // Param around Voting in governance
 type VotingParams struct {
 	VotingPeriod time.Duration `json:"voting_period"` //  Length of the voting period.
+}
+
+func (vp VotingParams) String() string {
+	return fmt.Sprintf(`Voting Params:
+  Voting Period:      %s`, vp.VotingPeriod)
+}
+
+// GovParams returns all of the governance params
+type GovParams struct {
+	VotingParams  VotingParams  `json:"voting_params"`
+	TallyParams   TallyParams   `json:"tally_params"`
+	DepositParams DepositParams `json:"deposit_params"`
+}
+
+func (gp GovParams) String() string {
+	return gp.VotingParams.String() + "\n" +
+		gp.TallyParams.String() + "\n" + gp.DepositParams.String()
+}
+
+func NewGovParams(vp VotingParams, tp TallyParams, dp DepositParams) GovParams {
+	return GovParams{
+		VotingParams:  vp,
+		DepositParams: dp,
+		TallyParams:   tp,
+	}
 }

--- a/x/gov/params.go
+++ b/x/gov/params.go
@@ -51,20 +51,20 @@ func (vp VotingParams) String() string {
   Voting Period:      %s`, vp.VotingPeriod)
 }
 
-// GovParams returns all of the governance params
-type GovParams struct {
+// Params returns all of the governance params
+type Params struct {
 	VotingParams  VotingParams  `json:"voting_params"`
 	TallyParams   TallyParams   `json:"tally_params"`
 	DepositParams DepositParams `json:"deposit_params"`
 }
 
-func (gp GovParams) String() string {
+func (gp Params) String() string {
 	return gp.VotingParams.String() + "\n" +
 		gp.TallyParams.String() + "\n" + gp.DepositParams.String()
 }
 
-func NewGovParams(vp VotingParams, tp TallyParams, dp DepositParams) GovParams {
-	return GovParams{
+func NewParams(vp VotingParams, tp TallyParams, dp DepositParams) Params {
+	return Params{
 		VotingParams:  vp,
 		DepositParams: dp,
 		TallyParams:   tp,

--- a/x/gov/proposals.go
+++ b/x/gov/proposals.go
@@ -3,6 +3,7 @@ package gov
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -45,6 +46,21 @@ type Proposal interface {
 
 	GetVotingEndTime() time.Time
 	SetVotingEndTime(time.Time)
+
+	String() string
+}
+
+// Proposals is an array of proposal
+type Proposals []Proposal
+
+func (p Proposals) String() string {
+	out := "ID - (Status) [Type] Title\n"
+	for _, prop := range p {
+		out += fmt.Sprintf("%d - (%s) [%s] %s\n",
+			prop.GetProposalID(), prop.GetStatus(),
+			prop.GetProposalType(), prop.GetTitle())
+	}
+	return strings.TrimSpace(out)
 }
 
 // checks if two proposals are equal
@@ -117,6 +133,19 @@ func (tp *TextProposal) SetVotingStartTime(votingStartTime time.Time) {
 func (tp TextProposal) GetVotingEndTime() time.Time { return tp.VotingEndTime }
 func (tp *TextProposal) SetVotingEndTime(votingEndTime time.Time) {
 	tp.VotingEndTime = votingEndTime
+}
+func (tp TextProposal) String() string {
+	return fmt.Sprintf(`Proposal %d:
+  Title:              %s
+  Type:               %s
+  Status:             %s
+  Submit Time:        %s
+  Deposit End Time:   %s
+  Total Deposit:      %s
+  Voting Start Time:  %s
+  Voting End Time:    %s`, tp.ProposalID, tp.Title, tp.ProposalType,
+		tp.Status, tp.SubmitTime, tp.DepositEndTime,
+		tp.TotalDeposit, tp.VotingStartTime, tp.VotingEndTime)
 }
 
 //-----------------------------------------------------------
@@ -343,9 +372,17 @@ func EmptyTallyResult() TallyResult {
 }
 
 // checks if two proposals are equal
-func (resultA TallyResult) Equals(resultB TallyResult) bool {
-	return (resultA.Yes.Equal(resultB.Yes) &&
-		resultA.Abstain.Equal(resultB.Abstain) &&
-		resultA.No.Equal(resultB.No) &&
-		resultA.NoWithVeto.Equal(resultB.NoWithVeto))
+func (tr TallyResult) Equals(comp TallyResult) bool {
+	return (tr.Yes.Equal(comp.Yes) &&
+		tr.Abstain.Equal(comp.Abstain) &&
+		tr.No.Equal(comp.No) &&
+		tr.NoWithVeto.Equal(comp.NoWithVeto))
+}
+
+func (tr TallyResult) String() string {
+	return fmt.Sprintf(`Tally Result:
+  Yes:        %s
+  Abstain:    %s
+  No:         %s
+  NoWithVeto: %s`, tr.Yes, tr.Abstain, tr.No, tr.NoWithVeto)
 }

--- a/x/slashing/client/cli/query.go
+++ b/x/slashing/client/cli/query.go
@@ -4,9 +4,8 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
-	"github.com/tendermint/tendermint/libs/cli"
 
+	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/context"
 	"github.com/cosmos/cosmos-sdk/codec" // XXX fix
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -15,7 +14,7 @@ import (
 
 // GetCmdQuerySigningInfo implements the command to query signing info.
 func GetCmdQuerySigningInfo(storeName string, cdc *codec.Codec) *cobra.Command {
-	cmd := &cobra.Command{
+	return &cobra.Command{
 		Use:   "signing-info [validator-pubkey]",
 		Short: "Query a validator's signing information",
 		Args:  cobra.ExactArgs(1),
@@ -33,34 +32,17 @@ func GetCmdQuerySigningInfo(storeName string, cdc *codec.Codec) *cobra.Command {
 				return err
 			}
 
-			signingInfo := new(slashing.ValidatorSigningInfo)
-			cdc.MustUnmarshalBinaryLengthPrefixed(res, signingInfo)
-
-			switch viper.Get(cli.OutputFlag) {
-
-			case "text":
-				human := signingInfo.HumanReadableString()
-				fmt.Println(human)
-
-			case "json":
-				// parse out the signing info
-				output, err := codec.MarshalJSONIndent(cdc, signingInfo)
-				if err != nil {
-					return err
-				}
-				fmt.Println(string(output))
-			}
-
+			var signingInfo slashing.ValidatorSigningInfo
+			cdc.MustUnmarshalBinaryLengthPrefixed(res, &signingInfo)
+			client.PrintOutput(cdc, signingInfo)
 			return nil
 		},
 	}
-
-	return cmd
 }
 
 // GetCmdQueryParams implements a command to fetch slashing parameters.
 func GetCmdQueryParams(cdc *codec.Codec) *cobra.Command {
-	cmd := &cobra.Command{
+	return &cobra.Command{
 		Use:   "params",
 		Short: "Query the current slashing parameters",
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -72,10 +54,10 @@ func GetCmdQueryParams(cdc *codec.Codec) *cobra.Command {
 				return err
 			}
 
-			fmt.Println(string(res))
+			var params slashing.Params
+			cdc.MustUnmarshalJSON(res, &params)
+			client.PrintOutput(cdc, params)
 			return nil
 		},
 	}
-
-	return cmd
 }

--- a/x/slashing/params.go
+++ b/x/slashing/params.go
@@ -1,6 +1,7 @@
 package slashing
 
 import (
+	"fmt"
 	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -40,6 +41,19 @@ type Params struct {
 	DowntimeJailDuration    time.Duration `json:"downtime-jail-duration"`
 	SlashFractionDoubleSign sdk.Dec       `json:"slash-fraction-double-sign"`
 	SlashFractionDowntime   sdk.Dec       `json:"slash-fraction-downtime"`
+}
+
+func (p Params) String() string {
+	return fmt.Sprintf(`Slashing Params:
+  MaxEvidenceAge:          %s
+  SignedBlocksWindow:      %d
+  MinSignedPerWindow:      %s
+  DowntimeJailDuration:    %s
+  SlashFractionDoubleSign: %d
+  SlashFractionDowntime:   %d`, p.MaxEvidenceAge,
+		p.SignedBlocksWindow, p.MinSignedPerWindow,
+		p.DowntimeJailDuration, p.SlashFractionDoubleSign,
+		p.SlashFractionDowntime)
 }
 
 // Implements params.ParamStruct

--- a/x/slashing/signing_info.go
+++ b/x/slashing/signing_info.go
@@ -106,12 +106,17 @@ type ValidatorSigningInfo struct {
 	StartHeight         int64     `json:"start_height"`          // height at which validator was first a candidate OR was unjailed
 	IndexOffset         int64     `json:"index_offset"`          // index offset into signed block bit array
 	JailedUntil         time.Time `json:"jailed_until"`          // timestamp validator cannot be unjailed until
-	Tombstoned          bool      `json:"tombstoned"`             // whether or not a validator has been tombstoned (killed out of validator set)
+	Tombstoned          bool      `json:"tombstoned"`            // whether or not a validator has been tombstoned (killed out of validator set)
 	MissedBlocksCounter int64     `json:"missed_blocks_counter"` // missed blocks counter (to avoid scanning the array every time)
 }
 
 // Return human readable signing info
-func (i ValidatorSigningInfo) HumanReadableString() string {
-	return fmt.Sprintf("Start height: %d, index offset: %d, jailed until: %v, missed blocks counter: %d",
-		i.StartHeight, i.IndexOffset, i.JailedUntil, i.MissedBlocksCounter)
+func (i ValidatorSigningInfo) String() string {
+	return fmt.Sprintf(`Start Height:          %d
+Index Offset:          %d
+Jailed Until:          %v
+Tombstoned:            %t
+Missed Blocks Counter: %d`,
+		i.StartHeight, i.IndexOffset, i.JailedUntil,
+		i.Tombstoned, i.MissedBlocksCounter)
 }

--- a/x/staking/staking.go
+++ b/x/staking/staking.go
@@ -11,11 +11,15 @@ import (
 type (
 	Keeper                  = keeper.Keeper
 	Validator               = types.Validator
+	Validators              = types.Validators
 	Description             = types.Description
 	Commission              = types.Commission
 	Delegation              = types.Delegation
+	Delegations             = types.Delegations
 	UnbondingDelegation     = types.UnbondingDelegation
+	UnbondingDelegations    = types.UnbondingDelegations
 	Redelegation            = types.Redelegation
+	Redelegations           = types.Redelegations
 	Params                  = types.Params
 	Pool                    = types.Pool
 	MsgCreateValidator      = types.MsgCreateValidator

--- a/x/staking/types/delegation.go
+++ b/x/staking/types/delegation.go
@@ -3,6 +3,7 @@ package types
 import (
 	"bytes"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -70,16 +71,23 @@ func (d Delegation) GetDelegatorAddr() sdk.AccAddress { return d.DelegatorAddr }
 func (d Delegation) GetValidatorAddr() sdk.ValAddress { return d.ValidatorAddr }
 func (d Delegation) GetShares() sdk.Dec               { return d.Shares }
 
-// HumanReadableString returns a human readable string representation of a
-// Delegation. An error is returned if the Delegation's delegator or validator
-// addresses cannot be Bech32 encoded.
-func (d Delegation) HumanReadableString() (string, error) {
-	resp := "Delegation \n"
-	resp += fmt.Sprintf("Delegator: %s\n", d.DelegatorAddr)
-	resp += fmt.Sprintf("Validator: %s\n", d.ValidatorAddr)
-	resp += fmt.Sprintf("Shares: %s\n", d.Shares.String())
+// String returns a human readable string representation of a Delegation.
+func (d Delegation) String() string {
+	return fmt.Sprintf(`Delegation:
+  Delegator: %s
+  Validator: %s
+  Shares:    %s`, d.DelegatorAddr,
+		d.ValidatorAddr, d.Shares)
+}
 
-	return resp, nil
+// Delegations is a collection of delegations
+type Delegations []Delegation
+
+func (d Delegations) String() (out string) {
+	for _, del := range d {
+		out += del.String() + "\n"
+	}
+	return strings.TrimSpace(out)
 }
 
 // UnbondingDelegation reflects a delegation's passive unbonding queue.
@@ -119,19 +127,25 @@ func (d UnbondingDelegation) Equal(d2 UnbondingDelegation) bool {
 	return bytes.Equal(bz1, bz2)
 }
 
-// HumanReadableString returns a human readable string representation of an
-// UnbondingDelegation. An error is returned if the UnbondingDelegation's
-// delegator or validator addresses cannot be Bech32 encoded.
-func (d UnbondingDelegation) HumanReadableString() (string, error) {
-	resp := "Unbonding Delegation \n"
-	resp += fmt.Sprintf("Delegator: %s\n", d.DelegatorAddr)
-	resp += fmt.Sprintf("Validator: %s\n", d.ValidatorAddr)
-	resp += fmt.Sprintf("Creation height: %v\n", d.CreationHeight)
-	resp += fmt.Sprintf("Min time to unbond (unix): %v\n", d.MinTime)
-	resp += fmt.Sprintf("Expected balance: %s", d.Balance.String())
+// String returns a human readable string representation of an UnbondingDelegation.
+func (d UnbondingDelegation) String() string {
+	return fmt.Sprintf(`Unbonding Delegation:
+  Delegator:                 %s
+  Validator:                 %s
+  Creation height:           %v
+  Min time to unbond (unix): %v
+  Expected balance:          %s`, d.Balance.String(),
+		d.DelegatorAddr, d.ValidatorAddr, d.CreationHeight, d.MinTime)
+}
 
-	return resp, nil
+// UnbondingDelegations is a collection of UnbondingDelegation
+type UnbondingDelegations []UnbondingDelegation
 
+func (ubds UnbondingDelegations) String() (out string) {
+	for _, u := range ubds {
+		out += u.String() + "\n"
+	}
+	return strings.TrimSpace(out)
 }
 
 // Redelegation reflects a delegation's passive re-delegation queue.
@@ -174,19 +188,26 @@ func (d Redelegation) Equal(d2 Redelegation) bool {
 	return bytes.Equal(bz1, bz2)
 }
 
-// HumanReadableString returns a human readable string representation of a
-// Redelegation. An error is returned if the UnbondingDelegation's delegator or
-// validator addresses cannot be Bech32 encoded.
-func (d Redelegation) HumanReadableString() (string, error) {
-	resp := "Redelegation \n"
-	resp += fmt.Sprintf("Delegator: %s\n", d.DelegatorAddr)
-	resp += fmt.Sprintf("Source Validator: %s\n", d.ValidatorSrcAddr)
-	resp += fmt.Sprintf("Destination Validator: %s\n", d.ValidatorDstAddr)
-	resp += fmt.Sprintf("Creation height: %v\n", d.CreationHeight)
-	resp += fmt.Sprintf("Min time to unbond (unix): %v\n", d.MinTime)
-	resp += fmt.Sprintf("Source shares: %s\n", d.SharesSrc.String())
-	resp += fmt.Sprintf("Destination shares: %s", d.SharesDst.String())
+// String returns a human readable string representation of a Redelegation.
+func (d Redelegation) String() string {
+	return fmt.Sprintf(`Redelegation:
+  Delegator:                 %s
+  Source Validator:          %s
+  Destination Validator:     %s
+  Creation height:           %v
+  Min time to unbond (unix): %v
+  Source shares:             %s
+  Destination shares:        %s`, d.DelegatorAddr,
+		d.ValidatorSrcAddr, d.ValidatorDstAddr, d.CreationHeight,
+		d.MinTime, d.SharesSrc, d.SharesDst)
+}
 
-	return resp, nil
+// Redelegations are a collection of Redelegation
+type Redelegations []Redelegation
 
+func (d Redelegations) String() (out string) {
+	for _, red := range d {
+		out += red.String() + "\n"
+	}
+	return strings.TrimSpace(out)
 }

--- a/x/staking/types/delegation_test.go
+++ b/x/staking/types/delegation_test.go
@@ -31,7 +31,7 @@ func TestDelegationEqual(t *testing.T) {
 	require.False(t, ok)
 }
 
-func TestDelegationHumanReadableString(t *testing.T) {
+func TestDelegationString(t *testing.T) {
 	d := Delegation{
 		DelegatorAddr: sdk.AccAddress(addr1),
 		ValidatorAddr: addr2,
@@ -40,9 +40,7 @@ func TestDelegationHumanReadableString(t *testing.T) {
 
 	// NOTE: Being that the validator's keypair is random, we cannot test the
 	// actual contents of the string.
-	valStr, err := d.HumanReadableString()
-	require.Nil(t, err)
-	require.NotEmpty(t, valStr)
+	require.NotEmpty(t, d.String())
 }
 
 func TestUnbondingDelegationEqual(t *testing.T) {
@@ -65,7 +63,7 @@ func TestUnbondingDelegationEqual(t *testing.T) {
 	require.False(t, ok)
 }
 
-func TestUnbondingDelegationHumanReadableString(t *testing.T) {
+func TestUnbondingDelegationString(t *testing.T) {
 	ud := UnbondingDelegation{
 		DelegatorAddr: sdk.AccAddress(addr1),
 		ValidatorAddr: addr2,
@@ -73,9 +71,7 @@ func TestUnbondingDelegationHumanReadableString(t *testing.T) {
 
 	// NOTE: Being that the validator's keypair is random, we cannot test the
 	// actual contents of the string.
-	valStr, err := ud.HumanReadableString()
-	require.Nil(t, err)
-	require.NotEmpty(t, valStr)
+	require.NotEmpty(t, ud.String())
 }
 
 func TestRedelegationEqual(t *testing.T) {
@@ -101,7 +97,7 @@ func TestRedelegationEqual(t *testing.T) {
 	require.False(t, ok)
 }
 
-func TestRedelegationHumanReadableString(t *testing.T) {
+func TestRedelegationString(t *testing.T) {
 	r := Redelegation{
 		DelegatorAddr:    sdk.AccAddress(addr1),
 		ValidatorSrcAddr: addr2,
@@ -112,7 +108,5 @@ func TestRedelegationHumanReadableString(t *testing.T) {
 
 	// NOTE: Being that the validator's keypair is random, we cannot test the
 	// actual contents of the string.
-	valStr, err := r.HumanReadableString()
-	require.Nil(t, err)
-	require.NotEmpty(t, valStr)
+	require.NotEmpty(t, r.String())
 }

--- a/x/staking/types/params.go
+++ b/x/staking/types/params.go
@@ -66,15 +66,13 @@ func DefaultParams() Params {
 	}
 }
 
-// HumanReadableString returns a human readable string representation of the
-// parameters.
-func (p Params) HumanReadableString() string {
-
-	resp := "Params \n"
-	resp += fmt.Sprintf("Unbonding Time: %s\n", p.UnbondingTime)
-	resp += fmt.Sprintf("Max Validators: %d\n", p.MaxValidators)
-	resp += fmt.Sprintf("Bonded Coin Denomination: %s\n", p.BondDenom)
-	return resp
+// String returns a human readable string representation of the parameters.
+func (p Params) String() string {
+	return fmt.Sprintf(`Params:
+  Unbonding Time: %s)
+  Max Validators: %d)
+  Bonded Coin Denomination: %s`, p.UnbondingTime,
+		p.MaxValidators, p.BondDenom)
 }
 
 // unmarshal the current staking params value from store key or panic

--- a/x/staking/types/pool.go
+++ b/x/staking/types/pool.go
@@ -68,16 +68,15 @@ func (p Pool) bondedTokensToLoose(bondedTokens sdk.Int) Pool {
 	return p
 }
 
-// HumanReadableString returns a human readable string representation of a
-// pool.
-func (p Pool) HumanReadableString() string {
-
-	resp := "Pool \n"
-	resp += fmt.Sprintf("Loose Tokens: %s\n", p.LooseTokens)
-	resp += fmt.Sprintf("Bonded Tokens: %s\n", p.BondedTokens)
-	resp += fmt.Sprintf("Token Supply: %s\n", p.TokenSupply())
-	resp += fmt.Sprintf("Bonded Ratio: %v\n", p.BondedRatio())
-	return resp
+// String returns a human readable string representation of a pool.
+func (p Pool) String() string {
+	return fmt.Sprintf(`Pool:
+  Loose Tokens: %s
+  Bonded Tokens: %s
+  Token Supply: %s
+  Bonded Ratio: %v`, p.LooseTokens,
+		p.BondedTokens, p.TokenSupply(),
+		p.BondedRatio())
 }
 
 // unmarshal the current pool value from store key or panics

--- a/x/staking/types/validator.go
+++ b/x/staking/types/validator.go
@@ -3,6 +3,7 @@ package types
 import (
 	"bytes"
 	"fmt"
+	"strings"
 	"time"
 
 	abci "github.com/tendermint/tendermint/abci/types"
@@ -36,6 +37,16 @@ type Validator struct {
 	UnbondingMinTime time.Time `json:"unbonding_time"`   // if unbonding, min time for the validator to complete unbonding
 
 	Commission Commission `json:"commission"` // commission parameters
+}
+
+// Validators is a collection of Validator
+type Validators []Validator
+
+func (v Validators) String() (out string) {
+	for _, val := range v {
+		out += val.String() + "\n"
+	}
+	return strings.TrimSpace(out)
 }
 
 // NewValidator - initialize a new validator
@@ -75,29 +86,27 @@ func UnmarshalValidator(cdc *codec.Codec, value []byte) (validator Validator, er
 	return validator, err
 }
 
-// HumanReadableString returns a human readable string representation of a
-// validator. An error is returned if the operator or the operator's public key
-// cannot be converted to Bech32 format.
-func (v Validator) HumanReadableString() (string, error) {
+// String returns a human readable string representation of a validator.
+func (v Validator) String() string {
 	bechConsPubKey, err := sdk.Bech32ifyConsPub(v.ConsPubKey)
 	if err != nil {
-		return "", err
+		panic(err)
 	}
-
-	resp := "Validator \n"
-	resp += fmt.Sprintf("Operator Address: %s\n", v.OperatorAddr)
-	resp += fmt.Sprintf("Validator Consensus Pubkey: %s\n", bechConsPubKey)
-	resp += fmt.Sprintf("Jailed: %v\n", v.Jailed)
-	resp += fmt.Sprintf("Status: %s\n", sdk.BondStatusToString(v.Status))
-	resp += fmt.Sprintf("Tokens: %s\n", v.Tokens)
-	resp += fmt.Sprintf("Delegator Shares: %s\n", v.DelegatorShares.String())
-	resp += fmt.Sprintf("Description: %s\n", v.Description)
-	resp += fmt.Sprintf("Bond Height: %d\n", v.BondHeight)
-	resp += fmt.Sprintf("Unbonding Height: %d\n", v.UnbondingHeight)
-	resp += fmt.Sprintf("Minimum Unbonding Time: %v\n", v.UnbondingMinTime)
-	resp += fmt.Sprintf("Commission: {%s}\n", v.Commission)
-
-	return resp, nil
+	return fmt.Sprintf(`Validator
+  Operator Address:           %s
+  Validator Consensus Pubkey: %s
+  Jailed:                     %v
+  Status:                     %s
+  Tokens:                     %s
+  Delegator Shares:           %s
+  Description:                %s
+  Bond Height:                %d
+  Unbonding Height:           %d
+  Minimum Unbonding Time:     %v
+  Commission:                 %s`, v.OperatorAddr, bechConsPubKey,
+		v.Jailed, sdk.BondStatusToString(v.Status), v.Tokens,
+		v.DelegatorShares.String(), v.Description, v.BondHeight,
+		v.UnbondingHeight, v.UnbondingMinTime, v.Commission)
 }
 
 //___________________________________________________________________

--- a/x/staking/types/validator_test.go
+++ b/x/staking/types/validator_test.go
@@ -245,14 +245,12 @@ func TestPossibleOverflow(t *testing.T) {
 		msg, newValidator.DelegatorShareExRate())
 }
 
-func TestHumanReadableString(t *testing.T) {
+func TestString(t *testing.T) {
 	validator := NewValidator(addr1, pk1, Description{})
 
 	// NOTE: Being that the validator's keypair is random, we cannot test the
 	// actual contents of the string.
-	valStr, err := validator.HumanReadableString()
-	require.Nil(t, err)
-	require.NotEmpty(t, valStr)
+	require.NotEmpty(t, validator.String())
 }
 
 func TestValidatorMarshalUnmarshalJSON(t *testing.T) {


### PR DESCRIPTION
(Replaces #3275)

Three are currently a number of issues about properly formatting CLI responses:
- https://github.com/cosmos/cosmos-sdk/issues/3268
- https://github.com/cosmos/cosmos-sdk/issues/3255
- https://github.com/cosmos/cosmos-sdk/issues/3249
- https://github.com/cosmos/cosmos-sdk/issues/3178
- https://github.com/cosmos/cosmos-sdk/issues/2953
- https://github.com/cosmos/cosmos-sdk/issues/2856
- https://github.com/cosmos/cosmos-sdk/issues/2607

There are two major issues underlying the above reports: 
1. Calls to `cliCtx.QueryWithData` return bytes, many places in the cli don't respect `--indent` or `-o json` because the code isn't there
2. Calls to `utils.CompleteAndBroadcastTxCli` don't respect the `-o json` or `--indent` flags either, and the human readable text format returned is not really readable by humans.

The first commit here unifies the `params` calls across the modules. Subsequent commits will generalize the approach for printing developed there to all other query CLI calls. Then the same will be done with the Tx calls. Testing will be added as well.

- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added entries in `PENDING.md` with issue # 
- [ ] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
