### PR TITLE
R4R: fix regression in gaiacli config file handling

### DIFF
--- a/PENDING.md
+++ b/PENDING.md
@@ -107,6 +107,7 @@ BUG FIXES
 
 * Gaia CLI  (`gaiacli`)
   * \#3141 Fix the bug in GetAccount when `len(res) == 0` and `err == nil`
+  * [\#810](https://github.com/cosmos/cosmos-sdk/pull/3316) Fix regression in gaiacli config file handling
 
 * Gaia
   * \#3148 Fix `gaiad export` by adding a boolean to `NewGaiaApp` determining whether or not to load the latest version

--- a/client/config.go
+++ b/client/config.go
@@ -91,6 +91,9 @@ func runConfigCmd(cmd *cobra.Command, args []string) error {
 	}
 
 	// Set value action
+	if len(args) != 2 {
+		return fmt.Errorf("wrong number of arguments")
+	}
 	value := args[1]
 	switch key {
 	case "chain-id", "output", "node":

--- a/client/flags.go
+++ b/client/flags.go
@@ -59,13 +59,13 @@ func GetCommands(cmds ...*cobra.Command) []*cobra.Command {
 		c.Flags().Bool(FlagIndentResponse, false, "Add indent to JSON response")
 		c.Flags().Bool(FlagTrustNode, false, "Trust connected full node (don't verify proofs for responses)")
 		c.Flags().Bool(FlagUseLedger, false, "Use a connected Ledger device")
-		c.Flags().String(FlagChainID, "", "Chain ID of tendermint node")
 		c.Flags().String(FlagNode, "tcp://localhost:26657", "<host>:<port> to tendermint rpc interface for this chain")
 		c.Flags().Int64(FlagHeight, 0, "block height to query, omit to get most recent provable block")
 		viper.BindPFlag(FlagTrustNode, c.Flags().Lookup(FlagTrustNode))
 		viper.BindPFlag(FlagUseLedger, c.Flags().Lookup(FlagUseLedger))
-		viper.BindPFlag(FlagChainID, c.Flags().Lookup(FlagChainID))
 		viper.BindPFlag(FlagNode, c.Flags().Lookup(FlagNode))
+
+		c.MarkFlagRequired(FlagChainID)
 	}
 	return cmds
 }
@@ -79,7 +79,6 @@ func PostCommands(cmds ...*cobra.Command) []*cobra.Command {
 		c.Flags().Uint64(FlagSequence, 0, "Sequence number to sign the tx")
 		c.Flags().String(FlagMemo, "", "Memo to send along with transaction")
 		c.Flags().String(FlagFees, "", "Fees to pay along with transaction; eg: 10stake,1atom")
-		c.Flags().String(FlagChainID, "", "Chain ID of tendermint node")
 		c.Flags().String(FlagNode, "tcp://localhost:26657", "<host>:<port> to tendermint rpc interface for this chain")
 		c.Flags().Bool(FlagUseLedger, false, "Use a connected Ledger device")
 		c.Flags().Float64(FlagGasAdjustment, DefaultGasAdjustment, "adjustment factor to be multiplied against the estimate returned by the tx simulation; if the gas limit is set manually this flag is ignored ")
@@ -94,7 +93,6 @@ func PostCommands(cmds ...*cobra.Command) []*cobra.Command {
 			"gas limit to set per-transaction; set to %q to calculate required gas automatically (default %d)", GasFlagAuto, DefaultGasLimit))
 		viper.BindPFlag(FlagTrustNode, c.Flags().Lookup(FlagTrustNode))
 		viper.BindPFlag(FlagUseLedger, c.Flags().Lookup(FlagUseLedger))
-		viper.BindPFlag(FlagChainID, c.Flags().Lookup(FlagChainID))
 		viper.BindPFlag(FlagNode, c.Flags().Lookup(FlagNode))
 
 		c.MarkFlagRequired(FlagChainID)

--- a/client/rpc/block.go
+++ b/client/rpc/block.go
@@ -28,7 +28,6 @@ func BlockCommand() *cobra.Command {
 	viper.BindPFlag(client.FlagNode, cmd.Flags().Lookup(client.FlagNode))
 	cmd.Flags().Bool(client.FlagTrustNode, false, "Trust connected full node (don't verify proofs for responses)")
 	viper.BindPFlag(client.FlagTrustNode, cmd.Flags().Lookup(client.FlagTrustNode))
-	cmd.Flags().String(client.FlagChainID, "", "Chain ID of Tendermint node")
 	return cmd
 }
 

--- a/client/rpc/validators.go
+++ b/client/rpc/validators.go
@@ -32,8 +32,6 @@ func ValidatorCommand() *cobra.Command {
 	viper.BindPFlag(client.FlagNode, cmd.Flags().Lookup(client.FlagNode))
 	cmd.Flags().Bool(client.FlagTrustNode, false, "Trust connected full node (don't verify proofs for responses)")
 	viper.BindPFlag(client.FlagTrustNode, cmd.Flags().Lookup(client.FlagTrustNode))
-	cmd.Flags().String(client.FlagChainID, "", "Chain ID of Tendermint node")
-	viper.BindPFlag(client.FlagChainID, cmd.Flags().Lookup(client.FlagChainID))
 	return cmd
 }
 

--- a/client/tx/query.go
+++ b/client/tx/query.go
@@ -46,8 +46,6 @@ func QueryTxCmd(cdc *codec.Codec) *cobra.Command {
 
 	cmd.Flags().StringP(client.FlagNode, "n", "tcp://localhost:26657", "Node to connect to")
 	viper.BindPFlag(client.FlagNode, cmd.Flags().Lookup(client.FlagNode))
-	cmd.Flags().String(client.FlagChainID, "", "Chain ID of Tendermint node")
-	viper.BindPFlag(client.FlagChainID, cmd.Flags().Lookup(client.FlagChainID))
 	cmd.Flags().Bool(client.FlagTrustNode, false, "Trust connected full node (don't verify proofs for responses)")
 	viper.BindPFlag(client.FlagTrustNode, cmd.Flags().Lookup(client.FlagTrustNode))
 	return cmd

--- a/client/tx/search.go
+++ b/client/tx/search.go
@@ -93,8 +93,6 @@ $ gaiacli query txs --tags '<tag1>:<value1>&<tag2>:<value2>' --page 1 --limit 30
 
 	cmd.Flags().StringP(client.FlagNode, "n", "tcp://localhost:26657", "Node to connect to")
 	viper.BindPFlag(client.FlagNode, cmd.Flags().Lookup(client.FlagNode))
-	cmd.Flags().String(client.FlagChainID, "", "Chain ID of Tendermint node")
-	viper.BindPFlag(client.FlagChainID, cmd.Flags().Lookup(client.FlagChainID))
 	cmd.Flags().Bool(client.FlagTrustNode, false, "Trust connected full node (don't verify proofs for responses)")
 	viper.BindPFlag(client.FlagTrustNode, cmd.Flags().Lookup(client.FlagTrustNode))
 	cmd.Flags().String(flagTags, "", "tag:value list of tags that must match")

--- a/cmd/gaia/cli_test/test_helpers.go
+++ b/cmd/gaia/cli_test/test_helpers.go
@@ -98,6 +98,7 @@ func InitFixtures(t *testing.T) (f *Fixtures) {
 
 	// NOTE: GDInit sets the ChainID
 	f.GDInit(keyFoo)
+	f.CLIConfig("chain-id", f.ChainID)
 
 	// Start an account with tokens
 	f.AddGenesisAccount(f.KeyAddress(keyFoo), startCoins)
@@ -117,7 +118,7 @@ func (f *Fixtures) Cleanup(dirs ...string) {
 
 // Flags returns the flags necessary for making most CLI calls
 func (f *Fixtures) Flags() string {
-	return fmt.Sprintf("--home=%s --node=%s --chain-id=%s", f.GCLIHome, f.RPCAddr, f.ChainID)
+	return fmt.Sprintf("--home=%s --node=%s", f.GCLIHome, f.RPCAddr)
 }
 
 //___________________________________________________________________________________

--- a/docs/gaia/gaiacli.md
+++ b/docs/gaia/gaiacli.md
@@ -16,7 +16,7 @@ you must choose whether you wish to verify lite client proofs. If you trust the 
 Its configuration file resides in `$HOME/.gaiacli/config/config.toml` and can be edited either
 by hand or via the `gaiacli config` command:
 
-```
+```bash
 gaiacli config chain-id gaia-9004
 ```
 

--- a/docs/gaia/gaiacli.md
+++ b/docs/gaia/gaiacli.md
@@ -12,7 +12,17 @@ Must specify these options: --chain-id  when --trust-node is false
 you must choose whether you wish to verify lite client proofs. If you trust the node which you are querying, you can simply pass `--trust-node=true` - otherwise you'll need to specify `--chain-id`.
 :::
 
-`gaiacli` is the command line interface to manage accounts and transactions on Cosmos testnets. Here is a list of useful `gaiacli` commands, including usage examples.
+`gaiacli` is the command line interface to manage accounts and transactions on Cosmos testnets.
+Its configuration file resides in `$HOME/.gaiacli/config/config.toml` and can be edited either
+by hand or via the `gaiacli config` command:
+
+```
+gaiacli config chain-id gaia-9004
+```
+
+For more information on the command usage, refer to its help screen: `gaiacli config --help`.
+
+Here is a list of useful `gaiacli` commands, including usage examples.
 
 ### Keys
 


### PR DESCRIPTION
--chain-id must be a persistent flag to be successfully read from config.

Closes: #810

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added entries in `PENDING.md` with issue # 
- [ ] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
