### PR TITLE
R4R: reintroduce gaia server's insecure mode

### DIFF
--- a/PENDING.md
+++ b/PENDING.md
@@ -51,6 +51,7 @@ FEATURES
   * [\#3198](https://github.com/cosmos/cosmos-sdk/issues/3198) New `keys add --multisig` flag to store multisig keys locally.
   * [\#3198](https://github.com/cosmos/cosmos-sdk/issues/3198) New `multisign` command to generate multisig signatures.
   * [\#3198](https://github.com/cosmos/cosmos-sdk/issues/3198) New `sign --multisig` flag to enable multisig mode.
+  * [\#2715](https://github.com/cosmos/cosmos-sdk/issues/2715) Reintroduce gaia server's insecure mode.
 
 * Gaia
   * [\#2182] [x/staking] Added querier for querying a single redelegation

--- a/client/lcd/root.go
+++ b/client/lcd/root.go
@@ -77,68 +77,52 @@ func (rs *RestServer) Start(listenAddr string, sslHosts string,
 		rs.log.Error("error closing listener", "err", err)
 	})
 
-	// TODO: re-enable insecure mode once #2715 has been addressed
+	rs.listener, err = rpcserver.Listen(
+		listenAddr,
+		rpcserver.Config{MaxOpenConnections: maxOpen},
+	)
+	if err != nil {
+		return
+	}
+	rs.log.Info("Starting Gaia Lite REST service...")
+
+	// launch rest-server in insecure mode
 	if insecure {
-		fmt.Println(
-			"Insecure mode is temporarily disabled, please locally generate an " +
-				"SSL certificate to test. Support will be re-enabled soon!",
-		)
-		// listener, err = rpcserver.StartHTTPServer(
-		// 	listenAddr, handler, logger,
-		// 	rpcserver.Config{MaxOpenConnections: maxOpen},
-		// )
-		// if err != nil {
-		// 	return
-		// }
-	} else {
-		if certFile != "" {
-			// validateCertKeyFiles() is needed to work around tendermint/tendermint#2460
-			err = validateCertKeyFiles(certFile, keyFile)
-			if err != nil {
-				return err
-			}
+		return rpcserver.StartHTTPServer(rs.listener, rs.Mux, rs.log)
+	}
 
-			//  cert/key pair is provided, read the fingerprint
-			rs.fingerprint, err = fingerprintFromFile(certFile)
-			if err != nil {
-				return err
-			}
-		} else {
-			// if certificate is not supplied, generate a self-signed one
-			certFile, keyFile, rs.fingerprint, err = genCertKeyFilesAndReturnFingerprint(sslHosts)
-			if err != nil {
-				return err
-			}
-
-			defer func() {
-				os.Remove(certFile)
-				os.Remove(keyFile)
-			}()
+	// handle certificates
+	if certFile != "" {
+		// validateCertKeyFiles() is needed to work around tendermint/tendermint#2460
+		if err := validateCertKeyFiles(certFile, keyFile); err != nil {
+			return err
 		}
 
-		rs.listener, err = rpcserver.Listen(
-			listenAddr,
-			rpcserver.Config{MaxOpenConnections: maxOpen},
-		)
-		if err != nil {
-			return
-		}
-
-		rs.log.Info("Starting Gaia Lite REST service...")
-		rs.log.Info(rs.fingerprint)
-
-		err := rpcserver.StartHTTPAndTLSServer(
-			rs.listener,
-			rs.Mux,
-			certFile, keyFile,
-			rs.log,
-		)
+		//  cert/key pair is provided, read the fingerprint
+		rs.fingerprint, err = fingerprintFromFile(certFile)
 		if err != nil {
 			return err
 		}
+	} else {
+		// if certificate is not supplied, generate a self-signed one
+		certFile, keyFile, rs.fingerprint, err = genCertKeyFilesAndReturnFingerprint(sslHosts)
+		if err != nil {
+			return err
+		}
+
+		defer func() {
+			os.Remove(certFile)
+			os.Remove(keyFile)
+		}()
 	}
 
-	return nil
+	rs.log.Info(rs.fingerprint)
+	return rpcserver.StartHTTPAndTLSServer(
+		rs.listener,
+		rs.Mux,
+		certFile, keyFile,
+		rs.log,
+	)
 }
 
 // ServeCommand will start a Gaia Lite REST service as a blocking process. It


### PR DESCRIPTION
Closes: #2715

- [x] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [x] Added entries in `PENDING.md` with issue # 
- [x] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
