### PR TITLE
Remove redundant action tag in x/gov

### DIFF
--- a/x/gov/client/utils/query.go
+++ b/x/gov/client/utils/query.go
@@ -33,7 +33,7 @@ func QueryDepositsByTxQuery(
 ) ([]byte, error) {
 
 	tags := []string{
-		fmt.Sprintf("%s='%s'", tags.Action, tags.ActionProposalDeposit),
+		fmt.Sprintf("%s='%s'", tags.Action, gov.MsgDeposit{}.Type()),
 		fmt.Sprintf("%s='%s'", tags.ProposalID, []byte(fmt.Sprintf("%d", params.ProposalID))),
 	}
 
@@ -78,7 +78,7 @@ func QueryVotesByTxQuery(
 ) ([]byte, error) {
 
 	tags := []string{
-		fmt.Sprintf("%s='%s'", tags.Action, tags.ActionProposalVote),
+		fmt.Sprintf("%s='%s'", tags.Action, gov.MsgVote{}.Type()),
 		fmt.Sprintf("%s='%s'", tags.ProposalID, []byte(fmt.Sprintf("%d", params.ProposalID))),
 	}
 
@@ -118,7 +118,7 @@ func QueryVoteByTxQuery(
 ) ([]byte, error) {
 
 	tags := []string{
-		fmt.Sprintf("%s='%s'", tags.Action, tags.ActionProposalVote),
+		fmt.Sprintf("%s='%s'", tags.Action, gov.MsgVote{}.Type()),
 		fmt.Sprintf("%s='%s'", tags.ProposalID, []byte(fmt.Sprintf("%d", params.ProposalID))),
 		fmt.Sprintf("%s='%s'", tags.Voter, []byte(params.Voter.String())),
 	}
@@ -161,7 +161,7 @@ func QueryDepositByTxQuery(
 ) ([]byte, error) {
 
 	tags := []string{
-		fmt.Sprintf("%s='%s'", tags.Action, tags.ActionProposalDeposit),
+		fmt.Sprintf("%s='%s'", tags.Action, gov.MsgDeposit{}.Type()),
 		fmt.Sprintf("%s='%s'", tags.ProposalID, []byte(fmt.Sprintf("%d", params.ProposalID))),
 		fmt.Sprintf("%s='%s'", tags.Depositor, []byte(params.Depositor.String())),
 	}
@@ -204,7 +204,7 @@ func QueryProposerByTxQuery(
 ) ([]byte, error) {
 
 	tags := []string{
-		fmt.Sprintf("%s='%s'", tags.Action, tags.ActionProposalSubmitted),
+		fmt.Sprintf("%s='%s'", tags.Action, gov.MsgSubmitProposal{}.Type()),
 		fmt.Sprintf("%s='%s'", tags.ProposalID, []byte(fmt.Sprintf("%d", proposalID))),
 	}
 

--- a/x/gov/handler.go
+++ b/x/gov/handler.go
@@ -35,7 +35,6 @@ func handleMsgSubmitProposal(ctx sdk.Context, keeper Keeper, msg MsgSubmitPropos
 	}
 
 	resTags := sdk.NewTags(
-		tags.Action, tags.ActionProposalSubmitted,
 		tags.Proposer, []byte(msg.Proposer.String()),
 		tags.ProposalID, proposalIDBytes,
 	)
@@ -58,7 +57,6 @@ func handleMsgDeposit(ctx sdk.Context, keeper Keeper, msg MsgDeposit) sdk.Result
 
 	proposalIDBytes := []byte(fmt.Sprintf("%d", msg.ProposalID))
 	resTags := sdk.NewTags(
-		tags.Action, tags.ActionProposalDeposit,
 		tags.Depositor, []byte(msg.Depositor.String()),
 		tags.ProposalID, proposalIDBytes,
 	)
@@ -80,7 +78,6 @@ func handleMsgVote(ctx sdk.Context, keeper Keeper, msg MsgVote) sdk.Result {
 
 	return sdk.Result{
 		Tags: sdk.NewTags(
-			tags.Action, tags.ActionProposalVote,
 			tags.Voter, []byte(msg.Voter.String()),
 			tags.ProposalID, []byte(fmt.Sprintf("%d", msg.ProposalID)),
 		),

--- a/x/gov/tags/tags.go
+++ b/x/gov/tags/tags.go
@@ -6,12 +6,9 @@ import (
 
 // Governance tags
 var (
-	ActionProposalDropped   = []byte("proposal-dropped")
-	ActionProposalPassed    = []byte("proposal-passed")
-	ActionProposalRejected  = []byte("proposal-rejected")
-	ActionProposalSubmitted = []byte("proposal-submitted")
-	ActionProposalVote      = []byte("proposal-vote")
-	ActionProposalDeposit   = []byte("proposal-deposit")
+	ActionProposalDropped  = []byte("proposal-dropped")
+	ActionProposalPassed   = []byte("proposal-passed")
+	ActionProposalRejected = []byte("proposal-rejected")
 
 	Action            = sdk.TagAction
 	Proposer          = "proposer"


### PR DESCRIPTION
The transaction action tag is already set in `runMsgs` of `baseapp.go`. Ref: #2943

https://github.com/cosmos/cosmos-sdk/blob/f65ae493566bd5d71a68886dd84b929d3b43ca5c/baseapp/baseapp.go#L634

Redundant tags make it hard to distinguish between results of multiple messages in a transaction.

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added entries in `PENDING.md` with issue # 
- [ ] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
