### PR TITLE
R4R: make gaiacli config handle "indent" flag

### DIFF
--- a/PENDING.md
+++ b/PENDING.md
@@ -64,6 +64,7 @@ FEATURES
   * [\#3198](https://github.com/cosmos/cosmos-sdk/issues/3198) New `multisign` command to generate multisig signatures.
   * [\#3198](https://github.com/cosmos/cosmos-sdk/issues/3198) New `sign --multisig` flag to enable multisig mode.
   * [\#2715](https://github.com/cosmos/cosmos-sdk/issues/2715) Reintroduce gaia server's insecure mode.
+  * [\#2607](https://github.com/cosmos/cosmos-sdk/issues/2607) Make `gaiacli config` handle the boolean `indent` flag to beautify commands JSON output.
 
 * Gaia
   * [\#2182] [x/staking] Added querier for querying a single redelegation

--- a/client/config.go
+++ b/client/config.go
@@ -78,7 +78,7 @@ func runConfigCmd(cmd *cobra.Command, args []string) error {
 	// Get value action
 	if getAction {
 		switch key {
-		case "trace", "trust-node":
+		case "trace", "trust-node", "indent":
 			fmt.Println(tree.GetDefault(key, false).(bool))
 		default:
 			if defaultValue, ok := configDefaults[key]; ok {
@@ -98,7 +98,7 @@ func runConfigCmd(cmd *cobra.Command, args []string) error {
 	switch key {
 	case "chain-id", "output", "node":
 		tree.Set(key, value)
-	case "trace", "trust-node":
+	case "trace", "trust-node", "indent":
 		boolVal, err := strconv.ParseBool(value)
 		if err != nil {
 			return err

--- a/cmd/gaia/cli_test/cli_test.go
+++ b/cmd/gaia/cli_test/cli_test.go
@@ -880,10 +880,12 @@ func TestGaiaCLIConfig(t *testing.T) {
 	f.CLIConfig("trust-node", "true")
 	f.CLIConfig("chain-id", f.ChainID)
 	f.CLIConfig("trace", "false")
+	f.CLIConfig("indent", "true")
 
 	config, err := ioutil.ReadFile(path.Join(f.GCLIHome, "config", "config.toml"))
 	require.NoError(t, err)
 	expectedConfig := fmt.Sprintf(`chain-id = "%s"
+indent = true
 node = "%s"
 output = "text"
 trace = false


### PR DESCRIPTION
It defaults to false, users can override it via gaiacli config
and avoid to append --indent to all commands:

    $ gaiacli config indent true

Closes: #2607

- [x] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [x] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [x] Added entries in `PENDING.md` with issue # 
- [x] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
