### PR TITLE
R4R: Round down when calculating rewards (fixes F1 sim bug)

### DIFF
--- a/PENDING.md
+++ b/PENDING.md
@@ -30,6 +30,7 @@ BREAKING CHANGES
   * [\#1894](https://github.com/cosmos/cosmos-sdk/pull/1894) `version` command now shows latest commit, vendor dir hash, and build machine info.
 
 * SDK
+  * [distribution] \#3359 Always round down when calculating rewards-to-be-withdrawn in F1 fee distribution
   * [staking] \#2513 Validator power type from Dec -> Int
   * [staking] \#3233 key and value now contain duplicate fields to simplify code
   * [\#3064](https://github.com/cosmos/cosmos-sdk/issues/3064) Sanitize `sdk.Coin` denom. Coins denoms are now case insensitive, i.e. 100fooToken equals to 100FOOTOKEN.

--- a/types/dec_coin.go
+++ b/types/dec_coin.go
@@ -201,6 +201,19 @@ func (coins DecCoins) MulDec(d Dec) DecCoins {
 	return res
 }
 
+// multiply all the coins by a decimal, truncating
+func (coins DecCoins) MulDecTruncate(d Dec) DecCoins {
+	res := make([]DecCoin, len(coins))
+	for i, coin := range coins {
+		product := DecCoin{
+			Denom:  coin.Denom,
+			Amount: coin.Amount.MulTruncate(d),
+		}
+		res[i] = product
+	}
+	return res
+}
+
 // divide all the coins by a decimal
 func (coins DecCoins) QuoDec(d Dec) DecCoins {
 	res := make([]DecCoin, len(coins))
@@ -208,6 +221,19 @@ func (coins DecCoins) QuoDec(d Dec) DecCoins {
 		quotient := DecCoin{
 			Denom:  coin.Denom,
 			Amount: coin.Amount.Quo(d),
+		}
+		res[i] = quotient
+	}
+	return res
+}
+
+// divide all the coins by a decimal, truncating
+func (coins DecCoins) QuoDecTruncate(d Dec) DecCoins {
+	res := make([]DecCoin, len(coins))
+	for i, coin := range coins {
+		quotient := DecCoin{
+			Denom:  coin.Denom,
+			Amount: coin.Amount.QuoTruncate(d),
 		}
 		res[i] = quotient
 	}

--- a/types/decimal.go
+++ b/types/decimal.go
@@ -351,6 +351,9 @@ func chopPrecisionAndRound(d *big.Int) *big.Int {
 	quo, rem := d, big.NewInt(0)
 	quo, rem = quo.QuoRem(d, precisionReuse, rem)
 
+	// TODO testing
+	return quo
+
 	if rem.Sign() == 0 { // remainder is zero
 		return quo
 	}

--- a/x/distribution/keeper/delegation.go
+++ b/x/distribution/keeper/delegation.go
@@ -16,13 +16,13 @@ func (k Keeper) initializeDelegation(ctx sdk.Context, val sdk.ValAddress, del sd
 
 	// calculate delegation stake in tokens
 	// we don't store directly, so multiply delegation shares * (tokens per share)
-	stake := delegation.GetShares().Mul(validator.GetDelegatorShareExRate())
+	stake := delegation.GetShares().MulTruncate(validator.GetDelegatorShareExRate())
 	k.SetDelegatorStartingInfo(ctx, val, del, types.NewDelegatorStartingInfo(previousPeriod, stake, uint64(ctx.BlockHeight())))
 }
 
 // calculate the rewards accrued by a delegation between two periods
 func (k Keeper) calculateDelegationRewardsBetween(ctx sdk.Context, val sdk.Validator,
-	startingPeriod, endingPeriod uint64, staking sdk.Dec) (rewards sdk.DecCoins) {
+	startingPeriod, endingPeriod uint64, stake sdk.Dec) (rewards sdk.DecCoins) {
 	// sanity check
 	if startingPeriod > endingPeriod {
 		panic("startingPeriod cannot be greater than endingPeriod")
@@ -32,7 +32,7 @@ func (k Keeper) calculateDelegationRewardsBetween(ctx sdk.Context, val sdk.Valid
 	starting := k.GetValidatorHistoricalRewards(ctx, val.GetOperator(), startingPeriod)
 	ending := k.GetValidatorHistoricalRewards(ctx, val.GetOperator(), endingPeriod)
 	difference := ending.CumulativeRewardRatio.Minus(starting.CumulativeRewardRatio)
-	rewards = difference.MulDec(staking)
+	rewards = difference.MulDecTruncate(stake)
 	return
 }
 
@@ -54,7 +54,7 @@ func (k Keeper) calculateDelegationRewards(ctx sdk.Context, val sdk.Validator, d
 			func(height uint64, event types.ValidatorSlashEvent) (stop bool) {
 				endingPeriod := event.ValidatorPeriod
 				rewards = rewards.Plus(k.calculateDelegationRewardsBetween(ctx, val, startingPeriod, endingPeriod, stake))
-				stake = stake.Mul(sdk.OneDec().Sub(event.Fraction))
+				stake = stake.MulTruncate(sdk.OneDec().Sub(event.Fraction))
 				startingPeriod = endingPeriod
 				return false
 			},

--- a/x/distribution/keeper/validator.go
+++ b/x/distribution/keeper/validator.go
@@ -38,7 +38,7 @@ func (k Keeper) incrementValidatorPeriod(ctx sdk.Context, val sdk.Validator) uin
 
 		current = sdk.DecCoins{}
 	} else {
-		current = rewards.Rewards.QuoDec(sdk.NewDecFromInt(val.GetTokens()))
+		current = rewards.Rewards.QuoDecTruncate(sdk.NewDecFromInt(val.GetTokens()))
 	}
 
 	// fetch historical rewards for last period

--- a/x/distribution/keeper/validator.go
+++ b/x/distribution/keeper/validator.go
@@ -38,6 +38,7 @@ func (k Keeper) incrementValidatorPeriod(ctx sdk.Context, val sdk.Validator) uin
 
 		current = sdk.DecCoins{}
 	} else {
+		// note: necessary to truncate so we don't allow withdrawing more rewards than owed
 		current = rewards.Rewards.QuoDecTruncate(sdk.NewDecFromInt(val.GetTokens()))
 	}
 


### PR DESCRIPTION
Closes https://github.com/cosmos/cosmos-sdk/issues/3354

Always round down when calculating rewards in F1 fee distribution. As far as I can tell, this fixes all the F1-related simulation issues, but I haven't yet run a long multi-seed test.

- [x] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] ~Wrote tests~
- [ ] ~Updated relevant documentation (`docs/`)~
- [x] Added entries in `PENDING.md` with issue # 
- [x] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
