### PR TITLE
R4R: remove --json flag from all commands

### DIFF
--- a/PENDING.md
+++ b/PENDING.md
@@ -28,6 +28,7 @@ BREAKING CHANGES
     in order to trigger a simulation of the tx before the actual execution.
   * [\#3285](https://github.com/cosmos/cosmos-sdk/pull/3285) New `gaiad tendermint version` to print libs versions
   * [\#1894](https://github.com/cosmos/cosmos-sdk/pull/1894) `version` command now shows latest commit, vendor dir hash, and build machine info.
+  * [\#3249\(https://github.com/cosmos/cosmos-sdk/issues/3249) `tendermint`'s `show-validator` and `show-address` `--json` flags removed in favor of `--machine-parseable`.
 
 * SDK
   * [staking] \#2513 Validator power type from Dec -> Int
@@ -99,6 +100,7 @@ IMPROVEMENTS
 
 * Gaia CLI  (`gaiacli`)
   * [\#3224](https://github.com/cosmos/cosmos-sdk/pull/3224) Support adding offline public keys to the keystore
+  * [\#3249\(https://github.com/cosmos/cosmos-sdk/issues/3249) `--json` flag removed, users should use `--output=json` instead.
 
 * Gaia
   * [\#2186](https://github.com/cosmos/cosmos-sdk/issues/2186) Add Address Interface

--- a/PENDING.md
+++ b/PENDING.md
@@ -28,7 +28,7 @@ BREAKING CHANGES
     in order to trigger a simulation of the tx before the actual execution.
   * [\#3285](https://github.com/cosmos/cosmos-sdk/pull/3285) New `gaiad tendermint version` to print libs versions
   * [\#1894](https://github.com/cosmos/cosmos-sdk/pull/1894) `version` command now shows latest commit, vendor dir hash, and build machine info.
-  * [\#3249\(https://github.com/cosmos/cosmos-sdk/issues/3249) `tendermint`'s `show-validator` and `show-address` `--json` flags removed in favor of `--machine-parseable`.
+  * [\#3249\(https://github.com/cosmos/cosmos-sdk/issues/3249) `tendermint`'s `show-validator` and `show-address` `--json` flags removed in favor of `--output-format=json`.
 
 * SDK
   * [staking] \#2513 Validator power type from Dec -> Int

--- a/client/context/broadcast.go
+++ b/client/context/broadcast.go
@@ -104,7 +104,7 @@ func (ctx CLIContext) broadcastTxAsync(txBytes []byte) (*ctypes.ResultBroadcastT
 	}
 
 	if ctx.Output != nil {
-		if ctx.JSON {
+		if ctx.OutputFormat == "json" {
 			type toJSON struct {
 				TxHash string
 			}
@@ -131,7 +131,7 @@ func (ctx CLIContext) broadcastTxCommit(txBytes []byte) (*ctypes.ResultBroadcast
 		return res, err
 	}
 
-	if ctx.JSON {
+	if ctx.OutputFormat == "json" {
 		// Since JSON is intended for automated scripts, always include response in
 		// JSON mode.
 		type toJSON struct {

--- a/client/context/context.go
+++ b/client/context/context.go
@@ -43,7 +43,6 @@ type CLIContext struct {
 	TrustNode     bool
 	UseLedger     bool
 	Async         bool
-	JSON          bool
 	PrintResponse bool
 	Verifier      tmlite.Verifier
 	Simulate      bool
@@ -82,7 +81,6 @@ func NewCLIContext() CLIContext {
 		TrustNode:     viper.GetBool(client.FlagTrustNode),
 		UseLedger:     viper.GetBool(client.FlagUseLedger),
 		Async:         viper.GetBool(client.FlagAsync),
-		JSON:          viper.GetBool(client.FlagJson),
 		PrintResponse: viper.GetBool(client.FlagPrintResponse),
 		Verifier:      verifier,
 		Simulate:      viper.GetBool(client.FlagDryRun),

--- a/client/flags.go
+++ b/client/flags.go
@@ -33,7 +33,6 @@ const (
 	FlagFees               = "fees"
 	FlagGasPrices          = "gas-prices"
 	FlagAsync              = "async"
-	FlagJson               = "json"
 	FlagPrintResponse      = "print-response"
 	FlagDryRun             = "dry-run"
 	FlagGenerateOnly       = "generate-only"
@@ -86,7 +85,6 @@ func PostCommands(cmds ...*cobra.Command) []*cobra.Command {
 		c.Flags().Bool(FlagUseLedger, false, "Use a connected Ledger device")
 		c.Flags().Float64(FlagGasAdjustment, DefaultGasAdjustment, "adjustment factor to be multiplied against the estimate returned by the tx simulation; if the gas limit is set manually this flag is ignored ")
 		c.Flags().Bool(FlagAsync, false, "broadcast transactions asynchronously")
-		c.Flags().Bool(FlagJson, false, "return output in json format")
 		c.Flags().Bool(FlagPrintResponse, true, "return tx response (only works with async = false)")
 		c.Flags().Bool(FlagTrustNode, true, "Trust connected full node (don't verify proofs for responses)")
 		c.Flags().Bool(FlagDryRun, false, "ignore the --gas flag and perform a simulation of a transaction, but don't broadcast it")

--- a/cmd/gaia/cli_test/cli_test.go
+++ b/cmd/gaia/cli_test/cli_test.go
@@ -260,7 +260,7 @@ func TestGaiaCLIGasAuto(t *testing.T) {
 	require.Equal(t, int64(50), fooAcc.GetCoins().AmountOf(denom).Int64())
 
 	// Enable auto gas
-	success, stdout, stderr := f.TxSend(keyFoo, barAddr, sdk.NewInt64Coin(denom, 10), "--gas=auto", "--json")
+	success, stdout, stderr := f.TxSend(keyFoo, barAddr, sdk.NewInt64Coin(denom, 10), "--gas=auto")
 	require.NotEmpty(t, stderr)
 	require.True(t, success)
 	cdc := app.MakeCodec()
@@ -646,7 +646,7 @@ func TestGaiaCLISendGenerateSignAndBroadcast(t *testing.T) {
 	defer os.Remove(unsignedTxFile.Name())
 
 	// Test sign --validate-signatures
-	success, stdout, _ = f.TxSign(keyFoo, unsignedTxFile.Name(), "--validate-signatures", "--json")
+	success, stdout, _ = f.TxSign(keyFoo, unsignedTxFile.Name(), "--validate-signatures")
 	require.False(t, success)
 	require.Equal(t, fmt.Sprintf("Signers:\n 0: %v\n\nSignatures:\n\n", fooAddr.String()), stdout)
 
@@ -663,7 +663,7 @@ func TestGaiaCLISendGenerateSignAndBroadcast(t *testing.T) {
 	defer os.Remove(signedTxFile.Name())
 
 	// Test sign --validate-signatures
-	success, stdout, _ = f.TxSign(keyFoo, signedTxFile.Name(), "--validate-signatures", "--json")
+	success, stdout, _ = f.TxSign(keyFoo, signedTxFile.Name(), "--validate-signatures")
 	require.True(t, success)
 	require.Equal(t, fmt.Sprintf("Signers:\n 0: %v\n\nSignatures:\n 0: %v\t[OK]\n\n", fooAddr.String(),
 		fooAddr.String()), stdout)
@@ -736,7 +736,7 @@ func TestGaiaCLIMultisignInsufficientCosigners(t *testing.T) {
 	defer os.Remove(signedTxFile.Name())
 
 	// Validate the multisignature
-	success, _, _ = f.TxSign(keyFooBarBaz, signedTxFile.Name(), "--validate-signatures", "--json")
+	success, _, _ = f.TxSign(keyFooBarBaz, signedTxFile.Name(), "--validate-signatures")
 	require.False(t, success)
 
 	// Broadcast the transaction
@@ -798,7 +798,7 @@ func TestGaiaCLIMultisignSortSignatures(t *testing.T) {
 	defer os.Remove(signedTxFile.Name())
 
 	// Validate the multisignature
-	success, _, _ = f.TxSign(keyFooBarBaz, signedTxFile.Name(), "--validate-signatures", "--json")
+	success, _, _ = f.TxSign(keyFooBarBaz, signedTxFile.Name(), "--validate-signatures")
 	require.True(t, success)
 
 	// Broadcast the transaction
@@ -861,7 +861,7 @@ func TestGaiaCLIMultisign(t *testing.T) {
 	defer os.Remove(signedTxFile.Name())
 
 	// Validate the multisignature
-	success, _, _ = f.TxSign(keyFooBarBaz, signedTxFile.Name(), "--validate-signatures", "--json")
+	success, _, _ = f.TxSign(keyFooBarBaz, signedTxFile.Name(), "--validate-signatures")
 	require.True(t, success)
 
 	// Broadcast the transaction

--- a/cmd/gaia/cli_test/test_helpers.go
+++ b/cmd/gaia/cli_test/test_helpers.go
@@ -238,7 +238,7 @@ func (f *Fixtures) TxSign(signer, fileName string, flags ...string) (bool, strin
 
 // TxBroadcast is gaiacli tx sign
 func (f *Fixtures) TxBroadcast(fileName string, flags ...string) (bool, string, string) {
-	cmd := fmt.Sprintf("gaiacli tx broadcast %v --json %v", f.Flags(), fileName)
+	cmd := fmt.Sprintf("gaiacli tx broadcast %v %v", f.Flags(), fileName)
 	return executeWriteRetStdStreams(f.T, addFlags(cmd, flags), app.DefaultKeyPass)
 }
 

--- a/server/tm_cmds.go
+++ b/server/tm_cmds.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spf13/viper"
 
 	tcmd "github.com/tendermint/tendermint/cmd/tendermint/commands"
+	"github.com/tendermint/tendermint/libs/cli"
 	"github.com/tendermint/tendermint/p2p"
 	pvm "github.com/tendermint/tendermint/privval"
 	tversion "github.com/tendermint/tendermint/version"
@@ -16,8 +17,7 @@ import (
 )
 
 const (
-	flagMachineReadable = "machine-readable"
-	versionString       = `Tendermint: %s
+	versionString = `Tendermint: %s
 ABCI: %s
 BlockProtocol: %d
 P2PProtocol: %d
@@ -54,7 +54,7 @@ func ShowValidatorCmd(ctx *Context) *cobra.Command {
 				cfg.PrivValidatorKeyFile(), cfg.PrivValidatorStateFile())
 			valPubKey := privValidator.GetPubKey()
 
-			if viper.GetBool(flagMachineReadable) {
+			if viper.GetString(cli.OutputFlag) == "json" {
 				return printlnJSON(valPubKey)
 			}
 
@@ -67,7 +67,8 @@ func ShowValidatorCmd(ctx *Context) *cobra.Command {
 			return nil
 		},
 	}
-	cmd.Flags().BoolP(flagMachineReadable, "m", false, "get machine parseable output")
+
+	cmd.Flags().StringP(cli.OutputFlag, "o", "text", "Output format (text|json)")
 	return &cmd
 }
 
@@ -84,7 +85,7 @@ func ShowAddressCmd(ctx *Context) *cobra.Command {
 				cfg.PrivValidatorKeyFile(), cfg.PrivValidatorStateFile())
 			valConsAddr := (sdk.ConsAddress)(privValidator.GetAddress())
 
-			if viper.GetBool(flagMachineReadable) {
+			if viper.GetString(cli.OutputFlag) == "json" {
 				return printlnJSON(valConsAddr)
 			}
 
@@ -93,7 +94,7 @@ func ShowAddressCmd(ctx *Context) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().BoolP(flagMachineReadable, "m", false, "get machine parseable output")
+	cmd.Flags().StringP(cli.OutputFlag, "o", "text", "Output format (text|json)")
 	return cmd
 }
 

--- a/server/tm_cmds.go
+++ b/server/tm_cmds.go
@@ -6,19 +6,18 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	"github.com/cosmos/cosmos-sdk/codec"
-
 	tcmd "github.com/tendermint/tendermint/cmd/tendermint/commands"
 	"github.com/tendermint/tendermint/p2p"
 	pvm "github.com/tendermint/tendermint/privval"
 	tversion "github.com/tendermint/tendermint/version"
 
-	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 const (
-	versionString = `Tendermint: %s
+	flagMachineReadable = "machine-readable"
+	versionString       = `Tendermint: %s
 ABCI: %s
 BlockProtocol: %d
 P2PProtocol: %d
@@ -55,7 +54,7 @@ func ShowValidatorCmd(ctx *Context) *cobra.Command {
 				cfg.PrivValidatorKeyFile(), cfg.PrivValidatorStateFile())
 			valPubKey := privValidator.GetPubKey()
 
-			if viper.GetBool(client.FlagJson) {
+			if viper.GetBool(flagMachineReadable) {
 				return printlnJSON(valPubKey)
 			}
 
@@ -68,7 +67,7 @@ func ShowValidatorCmd(ctx *Context) *cobra.Command {
 			return nil
 		},
 	}
-	cmd.Flags().Bool(client.FlagJson, false, "get machine parseable output")
+	cmd.Flags().BoolP(flagMachineReadable, "m", false, "get machine parseable output")
 	return &cmd
 }
 
@@ -85,7 +84,7 @@ func ShowAddressCmd(ctx *Context) *cobra.Command {
 				cfg.PrivValidatorKeyFile(), cfg.PrivValidatorStateFile())
 			valConsAddr := (sdk.ConsAddress)(privValidator.GetAddress())
 
-			if viper.GetBool(client.FlagJson) {
+			if viper.GetBool(flagMachineReadable) {
 				return printlnJSON(valConsAddr)
 			}
 
@@ -94,7 +93,7 @@ func ShowAddressCmd(ctx *Context) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().Bool(client.FlagJson, false, "get machine parseable output")
+	cmd.Flags().BoolP(flagMachineReadable, "m", false, "get machine parseable output")
 	return cmd
 }
 


### PR DESCRIPTION
gaiad tendermint show-{address,validator} now take --machine-parseable/-m
for machine parseable output.

Closes: #3249

- [x] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [x] Added entries in `PENDING.md` with issue # 
- [ ] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
