### PR TITLE
R4R: Fix Fee Usage for Vesting Accounts in Simulation 

### DIFF
--- a/x/auth/simulation/fake.go
+++ b/x/auth/simulation/fake.go
@@ -20,7 +20,7 @@ func SimulateDeductFee(m auth.AccountKeeper, f auth.FeeCollectionKeeper) simulat
 
 		account := simulation.RandomAcc(r, accs)
 		stored := m.GetAccount(ctx, account.Address)
-		initCoins := stored.GetCoins()
+		initCoins := stored.SpendableCoins(ctx.BlockHeader().Time)
 
 		if len(initCoins) == 0 {
 			event(fmt.Sprintf("auth/SimulateDeductFee/false"))


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Only consider spendable coins when attempting to deduct fees in simulation.

closes: #3353

----

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/develop/CONTRIBUTING.md#pr-targeting))

- [x] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] ~~Wrote tests~~
- [ ] ~~Updated relevant documentation (`docs/`)~~
- [ ] ~~Added entries in `PENDING.md` with issue #~~
- [x] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
