### PR TITLE
R4R: F1 storage simulation debugging

### DIFF
--- a/x/auth/simulation/fake.go
+++ b/x/auth/simulation/fake.go
@@ -34,18 +34,25 @@ func SimulateDeductFee(m auth.AccountKeeper, f auth.FeeCollectionKeeper) simulat
 			return action, nil, nil
 		}
 
-		coins := sdk.Coins{sdk.NewCoin(initCoins[denomIndex].Denom, amt)}
-		err = stored.SetCoins(initCoins.Minus(coins))
+		fees := sdk.Coins{sdk.NewCoin(initCoins[denomIndex].Denom, amt)}
+		newCoins, ok := initCoins.SafeMinus(fees)
+		if ok {
+			event(fmt.Sprintf("auth/SimulateDeductFee/false"))
+			return action, nil, nil
+		}
+
+		if _, hasNeg := initCoins.SafeMinus(fees); hasNeg {
+			event(fmt.Sprintf("auth/SimulateDeductFee/false"))
+			return action, nil, nil
+		}
+
+		err = stored.SetCoins(newCoins)
 		if err != nil {
 			panic(err)
 		}
+
 		m.SetAccount(ctx, stored)
-		if !coins.IsNotNegative() {
-			panic("setting negative fees")
-		}
-
-		f.AddCollectedFees(ctx, coins)
-
+		f.AddCollectedFees(ctx, fees)
 		event(fmt.Sprintf("auth/SimulateDeductFee/true"))
 
 		action = "TestDeductFee"

--- a/x/distribution/keeper/delegation.go
+++ b/x/distribution/keeper/delegation.go
@@ -11,6 +11,9 @@ func (k Keeper) initializeDelegation(ctx sdk.Context, val sdk.ValAddress, del sd
 	// period has already been incremented - we want to store the period ended by this delegation action
 	previousPeriod := k.GetValidatorCurrentRewards(ctx, val).Period - 1
 
+	// increment reference count for the period we're going to track
+	k.incrementReferenceCount(ctx, val, previousPeriod)
+
 	validator := k.stakingKeeper.Validator(ctx, val)
 	delegation := k.stakingKeeper.Delegation(ctx, del, val)
 

--- a/x/distribution/keeper/delegation_test.go
+++ b/x/distribution/keeper/delegation_test.go
@@ -30,13 +30,13 @@ func TestCalculateRewardsBasic(t *testing.T) {
 	del := sk.Delegation(ctx, sdk.AccAddress(valOpAddr1), valOpAddr1)
 
 	// historical count should be 2 (once for validator init, once for delegation init)
-	require.Equal(t, uint64(2), k.GetValidatorHistoricalRewardCount(ctx))
+	require.Equal(t, uint64(2), k.GetValidatorHistoricalReferenceCount(ctx))
 
 	// end period
 	endingPeriod := k.incrementValidatorPeriod(ctx, val)
 
-	// historical count should be 3 (since we ended the period, and haven't yet decremented a reference)
-	require.Equal(t, uint64(3), k.GetValidatorHistoricalRewardCount(ctx))
+	// historical count should be 2 still
+	require.Equal(t, uint64(2), k.GetValidatorHistoricalReferenceCount(ctx))
 
 	// calculate delegation rewards
 	rewards := k.calculateDelegationRewards(ctx, val, del, endingPeriod)
@@ -283,13 +283,13 @@ func TestWithdrawDelegationRewardsBasic(t *testing.T) {
 	k.AllocateTokensToValidator(ctx, val, tokens)
 
 	// historical count should be 2 (initial + latest for delegation)
-	require.Equal(t, uint64(2), k.GetValidatorHistoricalRewardCount(ctx))
+	require.Equal(t, uint64(2), k.GetValidatorHistoricalReferenceCount(ctx))
 
 	// withdraw rewards
 	require.Nil(t, k.WithdrawDelegationRewards(ctx, sdk.AccAddress(valOpAddr1), valOpAddr1))
 
 	// historical count should still be 2 (added one record, cleared one)
-	require.Equal(t, uint64(2), k.GetValidatorHistoricalRewardCount(ctx))
+	require.Equal(t, uint64(2), k.GetValidatorHistoricalReferenceCount(ctx))
 
 	// assert correct balance
 	require.Equal(t, sdk.Coins{{staking.DefaultBondDenom, sdk.NewInt(balance - bond + (initial / 2))}}, ak.GetAccount(ctx, sdk.AccAddress(valOpAddr1)).GetCoins())
@@ -460,14 +460,14 @@ func TestCalculateRewardsMultiDelegatorMultWithdraw(t *testing.T) {
 	k.AllocateTokensToValidator(ctx, val, tokens)
 
 	// historical count should be 2 (validator init, delegation init)
-	require.Equal(t, uint64(2), k.GetValidatorHistoricalRewardCount(ctx))
+	require.Equal(t, uint64(2), k.GetValidatorHistoricalReferenceCount(ctx))
 
 	// second delegation
 	msg2 := staking.NewMsgDelegate(sdk.AccAddress(valOpAddr2), valOpAddr1, sdk.NewCoin(staking.DefaultBondDenom, sdk.NewInt(100)))
 	require.True(t, sh(ctx, msg2).IsOK())
 
 	// historical count should be 3 (second delegation init)
-	require.Equal(t, uint64(3), k.GetValidatorHistoricalRewardCount(ctx))
+	require.Equal(t, uint64(3), k.GetValidatorHistoricalReferenceCount(ctx))
 
 	// fetch updated validator
 	val = sk.Validator(ctx, valOpAddr1)
@@ -486,7 +486,7 @@ func TestCalculateRewardsMultiDelegatorMultWithdraw(t *testing.T) {
 	k.WithdrawDelegationRewards(ctx, sdk.AccAddress(valOpAddr2), valOpAddr1)
 
 	// historical count should be 3 (validator init + two delegations)
-	require.Equal(t, uint64(3), k.GetValidatorHistoricalRewardCount(ctx))
+	require.Equal(t, uint64(3), k.GetValidatorHistoricalReferenceCount(ctx))
 
 	// validator withdraws commission
 	k.WithdrawValidatorCommission(ctx, valOpAddr1)

--- a/x/distribution/keeper/hooks.go
+++ b/x/distribution/keeper/hooks.go
@@ -1,6 +1,8 @@
 package keeper
 
 import (
+	"fmt"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -57,12 +59,14 @@ func (h Hooks) AfterValidatorRemoved(ctx sdk.Context, _ sdk.ConsAddress, valAddr
 	h.k.DeleteValidatorCurrentRewards(ctx, valAddr)
 }
 func (h Hooks) BeforeDelegationCreated(ctx sdk.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress) {
+	fmt.Printf("before delegation created\n")
 	val := h.k.stakingKeeper.Validator(ctx, valAddr)
 
 	// increment period
 	h.k.incrementValidatorPeriod(ctx, val)
 }
 func (h Hooks) BeforeDelegationSharesModified(ctx sdk.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress) {
+	fmt.Printf("before delegation shares modified\n")
 	val := h.k.stakingKeeper.Validator(ctx, valAddr)
 	del := h.k.stakingKeeper.Delegation(ctx, delAddr, valAddr)
 
@@ -72,9 +76,11 @@ func (h Hooks) BeforeDelegationSharesModified(ctx sdk.Context, delAddr sdk.AccAd
 	}
 }
 func (h Hooks) BeforeDelegationRemoved(ctx sdk.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress) {
+	fmt.Printf("before delegation removed\n")
 	// nothing needed here since BeforeDelegationSharesModified will always also be called
 }
 func (h Hooks) AfterDelegationModified(ctx sdk.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress) {
+	fmt.Printf("after delegation modified\n")
 	// create new delegation period record
 	h.k.initializeDelegation(ctx, valAddr, delAddr)
 }
@@ -85,6 +91,7 @@ func (h Hooks) AfterValidatorBonded(ctx sdk.Context, _ sdk.ConsAddress, valAddr 
 func (h Hooks) AfterValidatorPowerDidChange(ctx sdk.Context, _ sdk.ConsAddress, valAddr sdk.ValAddress) {
 }
 func (h Hooks) BeforeValidatorSlashed(ctx sdk.Context, valAddr sdk.ValAddress, fraction sdk.Dec) {
+	fmt.Printf("before validator slashed\n")
 	// record the slash event
 	h.k.updateValidatorSlashFraction(ctx, valAddr, fraction)
 }

--- a/x/distribution/keeper/hooks.go
+++ b/x/distribution/keeper/hooks.go
@@ -1,8 +1,6 @@
 package keeper
 
 import (
-	"fmt"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -59,14 +57,12 @@ func (h Hooks) AfterValidatorRemoved(ctx sdk.Context, _ sdk.ConsAddress, valAddr
 	h.k.DeleteValidatorCurrentRewards(ctx, valAddr)
 }
 func (h Hooks) BeforeDelegationCreated(ctx sdk.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress) {
-	fmt.Printf("before delegation created\n")
 	val := h.k.stakingKeeper.Validator(ctx, valAddr)
 
 	// increment period
 	h.k.incrementValidatorPeriod(ctx, val)
 }
 func (h Hooks) BeforeDelegationSharesModified(ctx sdk.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress) {
-	fmt.Printf("before delegation shares modified\n")
 	val := h.k.stakingKeeper.Validator(ctx, valAddr)
 	del := h.k.stakingKeeper.Delegation(ctx, delAddr, valAddr)
 
@@ -76,11 +72,9 @@ func (h Hooks) BeforeDelegationSharesModified(ctx sdk.Context, delAddr sdk.AccAd
 	}
 }
 func (h Hooks) BeforeDelegationRemoved(ctx sdk.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress) {
-	fmt.Printf("before delegation removed\n")
 	// nothing needed here since BeforeDelegationSharesModified will always also be called
 }
 func (h Hooks) AfterDelegationModified(ctx sdk.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress) {
-	fmt.Printf("after delegation modified\n")
 	// create new delegation period record
 	h.k.initializeDelegation(ctx, valAddr, delAddr)
 }
@@ -91,7 +85,6 @@ func (h Hooks) AfterValidatorBonded(ctx sdk.Context, _ sdk.ConsAddress, valAddr 
 func (h Hooks) AfterValidatorPowerDidChange(ctx sdk.Context, _ sdk.ConsAddress, valAddr sdk.ValAddress) {
 }
 func (h Hooks) BeforeValidatorSlashed(ctx sdk.Context, valAddr sdk.ValAddress, fraction sdk.Dec) {
-	fmt.Printf("before validator slashed\n")
 	// record the slash event
 	h.k.updateValidatorSlashFraction(ctx, valAddr, fraction)
 }

--- a/x/distribution/keeper/store.go
+++ b/x/distribution/keeper/store.go
@@ -175,13 +175,15 @@ func (k Keeper) DeleteAllValidatorHistoricalRewards(ctx sdk.Context) {
 	}
 }
 
-// historical record count (used for testcases)
-func (k Keeper) GetValidatorHistoricalRewardCount(ctx sdk.Context) (count uint64) {
+// historical reference count (used for testcases)
+func (k Keeper) GetValidatorHistoricalReferenceCount(ctx sdk.Context) (count uint64) {
 	store := ctx.KVStore(k.storeKey)
 	iter := sdk.KVStorePrefixIterator(store, ValidatorHistoricalRewardsPrefix)
 	defer iter.Close()
 	for ; iter.Valid(); iter.Next() {
-		count++
+		var rewards types.ValidatorHistoricalRewards
+		k.cdc.MustUnmarshalBinaryLengthPrefixed(iter.Value(), &rewards)
+		count += uint64(rewards.ReferenceCount)
 	}
 	return
 }

--- a/x/distribution/keeper/validator.go
+++ b/x/distribution/keeper/validator.go
@@ -1,6 +1,7 @@
 package keeper
 
 import (
+	"fmt"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/cosmos/cosmos-sdk/x/distribution/types"
@@ -84,11 +85,13 @@ func (k Keeper) updateValidatorSlashFraction(ctx sdk.Context, valAddr sdk.ValAdd
 	endedPeriod := k.GetValidatorCurrentRewards(ctx, valAddr).Period - 1
 	current, found := k.GetValidatorSlashEvent(ctx, valAddr, height)
 	if found {
+		fmt.Printf("had a prior slash event\n")
 		// there has already been a slash event this height,
 		// and we don't need to store more than one,
 		// so just update the current slash fraction
 		currentFraction = current.Fraction
 	} else {
+		fmt.Printf("did not have a prior slash event\n")
 		val := k.stakingKeeper.Validator(ctx, valAddr)
 		// increment current period
 		endedPeriod = k.incrementValidatorPeriod(ctx, val)

--- a/x/distribution/keeper/validator.go
+++ b/x/distribution/keeper/validator.go
@@ -46,6 +46,9 @@ func (k Keeper) incrementValidatorPeriod(ctx sdk.Context, val sdk.Validator) uin
 	// fetch historical rewards for last period
 	historical := k.GetValidatorHistoricalRewards(ctx, val.GetOperator(), rewards.Period-1).CumulativeRewardRatio
 
+	// decrement reference count
+	k.decrementReferenceCount(ctx, val.GetOperator(), rewards.Period-1)
+
 	// set new historical rewards with reference count of 1
 	k.SetValidatorHistoricalRewards(ctx, val.GetOperator(), rewards.Period, types.NewValidatorHistoricalRewards(historical.Plus(current), 1))
 
@@ -58,8 +61,8 @@ func (k Keeper) incrementValidatorPeriod(ctx sdk.Context, val sdk.Validator) uin
 // increment the reference count for a historical rewards value
 func (k Keeper) incrementReferenceCount(ctx sdk.Context, valAddr sdk.ValAddress, period uint64) {
 	historical := k.GetValidatorHistoricalRewards(ctx, valAddr, period)
-	if historical.ReferenceCount > 1 {
-		panic("reference count should never exceed 1")
+	if historical.ReferenceCount > 2 {
+		panic("reference count should never exceed 2")
 	}
 	historical.ReferenceCount++
 	k.SetValidatorHistoricalRewards(ctx, valAddr, period, historical)
@@ -85,16 +88,16 @@ func (k Keeper) updateValidatorSlashFraction(ctx sdk.Context, valAddr sdk.ValAdd
 	endedPeriod := k.GetValidatorCurrentRewards(ctx, valAddr).Period - 1
 	current, found := k.GetValidatorSlashEvent(ctx, valAddr, height)
 	if found {
-		fmt.Printf("had a prior slash event\n")
 		// there has already been a slash event this height,
 		// and we don't need to store more than one,
 		// so just update the current slash fraction
 		currentFraction = current.Fraction
 	} else {
-		fmt.Printf("did not have a prior slash event\n")
 		val := k.stakingKeeper.Validator(ctx, valAddr)
 		// increment current period
 		endedPeriod = k.incrementValidatorPeriod(ctx, val)
+		// increment reference count on period we need to track
+		k.incrementReferenceCount(ctx, valAddr, endedPeriod)
 	}
 	currentMultiplicand := sdk.OneDec().Sub(currentFraction)
 	newMultiplicand := sdk.OneDec().Sub(fraction)

--- a/x/distribution/keeper/validator.go
+++ b/x/distribution/keeper/validator.go
@@ -1,7 +1,6 @@
 package keeper
 
 import (
-	"fmt"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/cosmos/cosmos-sdk/x/distribution/types"

--- a/x/distribution/simulation/invariants.go
+++ b/x/distribution/simulation/invariants.go
@@ -1,8 +1,6 @@
 package simulation
 
 import (
-	"fmt"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	distr "github.com/cosmos/cosmos-sdk/x/distribution"
 	"github.com/cosmos/cosmos-sdk/x/distribution/types"
@@ -85,15 +83,13 @@ func ReferenceCountInvariant(k distr.Keeper, sk staking.Keeper) simulation.Invar
 			return false
 		})
 
-		// one record per validator (zeroeth period), one record per delegation (previous period), one record per slash (previous period)
+		// one record per validator (last tracked period), one record per delegation (previous period), one record per slash (previous period)
 		expected := valCount + uint64(len(dels)) + slashCount
+		count := k.GetValidatorHistoricalReferenceCount(ctx)
 
-		count := k.GetValidatorHistoricalRewardCount(ctx)
 		if count != expected {
 			return fmt.Errorf("unexpected number of historical rewards records: expected %v (%v vals + %v dels + %v slashes), got %v", expected, valCount, len(dels), slashCount, count)
 		}
-
-		fmt.Printf("expected number of historical rewards records: expected %v (%v vals + %v dels + %v slashes), got %v\n", expected, valCount, len(dels), slashCount, count)
 
 		return nil
 	}

--- a/x/distribution/simulation/invariants.go
+++ b/x/distribution/simulation/invariants.go
@@ -1,6 +1,8 @@
 package simulation
 
 import (
+	"fmt"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	distr "github.com/cosmos/cosmos-sdk/x/distribution"
 	"github.com/cosmos/cosmos-sdk/x/distribution/types"

--- a/x/distribution/simulation/invariants.go
+++ b/x/distribution/simulation/invariants.go
@@ -90,8 +90,10 @@ func ReferenceCountInvariant(k distr.Keeper, sk staking.Keeper) simulation.Invar
 
 		count := k.GetValidatorHistoricalRewardCount(ctx)
 		if count != expected {
-			return fmt.Errorf("unexpected number of historical rewards records: expected %v, got %v", expected, count)
+			return fmt.Errorf("unexpected number of historical rewards records: expected %v (%v vals + %v dels + %v slashes), got %v", expected, valCount, len(dels), slashCount, count)
 		}
+
+		fmt.Printf("expected number of historical rewards records: expected %v (%v vals + %v dels + %v slashes), got %v\n", expected, valCount, len(dels), slashCount, count)
 
 		return nil
 	}

--- a/x/staking/genesis.go
+++ b/x/staking/genesis.go
@@ -45,7 +45,6 @@ func InitGenesis(ctx sdk.Context, keeper Keeper, data types.GenesisState) (res [
 	for _, delegation := range data.Bonds {
 		keeper.BeforeDelegationCreated(ctx, delegation.DelegatorAddr, delegation.ValidatorAddr)
 		keeper.SetDelegation(ctx, delegation)
-		keeper.AfterDelegationModified(ctx, delegation.DelegatorAddr, delegation.ValidatorAddr)
 	}
 
 	for _, ubd := range data.UnbondingDelegations {


### PR DESCRIPTION
Closes https://github.com/cosmos/cosmos-sdk/issues/3366

`AfterDelegationModified` was called twice, and the distribution module wasn't quite correctly tracking references - it now correctly tracks the reference for the latest period, which we need to know regardless of whether or not a delegation started it.

Still fails due to other simulation issues.

- [x] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [x] Wrote tests
- [x] Updated relevant documentation (`docs/`)
- [x] Added entries in `PENDING.md` with issue # 
- [x] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
