### PR TITLE
R4R: Fix staking hooks on import exported state

### DIFF
--- a/x/staking/genesis.go
+++ b/x/staking/genesis.go
@@ -47,6 +47,9 @@ func InitGenesis(ctx sdk.Context, keeper Keeper, data types.GenesisState) (res [
 			keeper.BeforeDelegationCreated(ctx, delegation.DelegatorAddr, delegation.ValidatorAddr)
 		}
 		keeper.SetDelegation(ctx, delegation)
+		if !data.Exported {
+			keeper.AfterDelegationModified(ctx, delegation.DelegatorAddr, delegation.ValidatorAddr)
+		}
 	}
 
 	for _, ubd := range data.UnbondingDelegations {

--- a/x/staking/genesis.go
+++ b/x/staking/genesis.go
@@ -43,7 +43,9 @@ func InitGenesis(ctx sdk.Context, keeper Keeper, data types.GenesisState) (res [
 	}
 
 	for _, delegation := range data.Bonds {
-		keeper.BeforeDelegationCreated(ctx, delegation.DelegatorAddr, delegation.ValidatorAddr)
+		if !data.Exported {
+			keeper.BeforeDelegationCreated(ctx, delegation.DelegatorAddr, delegation.ValidatorAddr)
+		}
 		keeper.SetDelegation(ctx, delegation)
 	}
 

--- a/x/staking/genesis.go
+++ b/x/staking/genesis.go
@@ -34,7 +34,9 @@ func InitGenesis(ctx sdk.Context, keeper Keeper, data types.GenesisState) (res [
 		// Manually set indices for the first time
 		keeper.SetValidatorByConsAddr(ctx, validator)
 		keeper.SetValidatorByPowerIndex(ctx, validator)
-		keeper.AfterValidatorCreated(ctx, validator.OperatorAddr)
+		if !data.Exported {
+			keeper.AfterValidatorCreated(ctx, validator.OperatorAddr)
+		}
 
 		// Set timeslice if necessary
 		if validator.Status == sdk.Unbonding {

--- a/x/staking/keeper/delegation.go
+++ b/x/staking/keeper/delegation.go
@@ -77,7 +77,6 @@ func (k Keeper) SetDelegation(ctx sdk.Context, delegation types.Delegation) {
 	store := ctx.KVStore(k.storeKey)
 	b := types.MustMarshalDelegation(k.cdc, delegation)
 	store.Set(GetDelegationKey(delegation.DelegatorAddr, delegation.ValidatorAddr), b)
-	k.AfterDelegationModified(ctx, delegation.DelegatorAddr, delegation.ValidatorAddr)
 }
 
 // remove a delegation from store
@@ -468,6 +467,7 @@ func (k Keeper) Delegate(ctx sdk.Context, delAddr sdk.AccAddress, bondAmt sdk.Co
 	// Update delegation
 	delegation.Shares = delegation.Shares.Add(newShares)
 	k.SetDelegation(ctx, delegation)
+	k.AfterDelegationModified(ctx, delegation.DelegatorAddr, delegation.ValidatorAddr)
 
 	return newShares, nil
 }
@@ -512,6 +512,7 @@ func (k Keeper) unbond(ctx sdk.Context, delAddr sdk.AccAddress, valAddr sdk.ValA
 	} else {
 		// update the delegation
 		k.SetDelegation(ctx, delegation)
+		k.AfterDelegationModified(ctx, delegation.DelegatorAddr, delegation.ValidatorAddr)
 	}
 
 	// remove the coins from the validator


### PR DESCRIPTION
Hooks should only be called in genesis when we're importing from *non*-exported state.

- [ ] ~Linked to github-issue with discussion and accepted design OR link to spec that describes this work.~
- [x] Wrote tests
- [ ] ~Updated relevant documentation (`docs/`)~
- [ ] ~Added entries in `PENDING.md` with issue #~
- [x] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
