### PR TITLE
R4R: Implement GenesisState.Sanitize()

### DIFF
--- a/PENDING.md
+++ b/PENDING.md
@@ -15,11 +15,12 @@ BREAKING CHANGES
 
 FEATURES
 
-* Gaia REST API (`gaiacli advanced rest-server`)
+* Gaia REST API
 
 * Gaia CLI  (`gaiacli`)
 
 * Gaia
+  - [\#3397](https://github.com/cosmos/cosmos-sdk/pull/3397) Implement genesis file sanitization to avoid failures at chain init.
 
 * SDK
   * \#3270 [x/staking] limit number of ongoing unbonding delegations /redelegations per pair/trio
@@ -29,7 +30,7 @@ FEATURES
 
 IMPROVEMENTS
 
-* Gaia REST API (`gaiacli advanced rest-server`)
+* Gaia REST API
 
 * Gaia CLI  (`gaiacli`)
 
@@ -42,7 +43,7 @@ IMPROVEMENTS
 
 BUG FIXES
 
-* Gaia REST API (`gaiacli advanced rest-server`)
+* Gaia REST API
 
 * Gaia CLI  (`gaiacli`)
 

--- a/cmd/gaia/app/app.go
+++ b/cmd/gaia/app/app.go
@@ -228,10 +228,7 @@ func (app *GaiaApp) EndBlocker(ctx sdk.Context, req abci.RequestEndBlock) abci.R
 
 // initialize store from a genesis state
 func (app *GaiaApp) initFromGenesisState(ctx sdk.Context, genesisState GenesisState) []abci.ValidatorUpdate {
-	// sort by account number to maintain consistency
-	sort.Slice(genesisState.Accounts, func(i, j int) bool {
-		return genesisState.Accounts[i].AccountNumber < genesisState.Accounts[j].AccountNumber
-	})
+	genesisState.Sanitize()
 
 	// load the accounts
 	for _, gacc := range genesisState.Accounts {
@@ -256,8 +253,7 @@ func (app *GaiaApp) initFromGenesisState(ctx sdk.Context, genesisState GenesisSt
 	mint.InitGenesis(ctx, app.mintKeeper, genesisState.MintData)
 
 	// validate genesis state
-	err = GaiaValidateGenesisState(genesisState)
-	if err != nil {
+	if err := GaiaValidateGenesisState(genesisState); err != nil {
 		panic(err) // TODO find a way to do this w/o panics
 	}
 

--- a/cmd/gaia/app/genesis.go
+++ b/cmd/gaia/app/genesis.go
@@ -58,6 +58,17 @@ func NewGenesisState(accounts []GenesisAccount, authData auth.GenesisState,
 	}
 }
 
+// Sanitize sorts accounts and coin sets.
+func (gs GenesisState) Sanitize() {
+	sort.Slice(gs.Accounts, func(i, j int) bool {
+		return gs.Accounts[i].AccountNumber < gs.Accounts[j].AccountNumber
+	})
+
+	for _, acc := range gs.Accounts {
+		acc.Coins = acc.Coins.Sort()
+	}
+}
+
 // GenesisAccount defines an account initialized at genesis.
 type GenesisAccount struct {
 	Address       sdk.AccAddress `json:"address"`

--- a/cmd/gaia/cli_test/cli_test.go
+++ b/cmd/gaia/cli_test/cli_test.go
@@ -909,10 +909,7 @@ func TestGaiadCollectGentxs(t *testing.T) {
 	f.UnsafeResetAll()
 
 	// Initialize keys
-	f.KeysDelete(keyFoo)
-	f.KeysDelete(keyBar)
 	f.KeysAdd(keyFoo)
-	f.KeysAdd(keyBar)
 
 	// Configure json output
 	f.CLIConfig("output", "json")
@@ -930,6 +927,42 @@ func TestGaiadCollectGentxs(t *testing.T) {
 	f.CollectGenTxs(fmt.Sprintf("--gentx-dir=%s", gentxDir))
 
 	f.Cleanup(gentxDir)
+}
+
+func TestGaiadAddGenesisAccount(t *testing.T) {
+	t.Parallel()
+	f := NewFixtures(t)
+
+	// Reset testing path
+	f.UnsafeResetAll()
+
+	// Initialize keys
+	f.KeysDelete(keyFoo)
+	f.KeysDelete(keyBar)
+	f.KeysDelete(keyBaz)
+	f.KeysAdd(keyFoo)
+	f.KeysAdd(keyBar)
+	f.KeysAdd(keyBaz)
+
+	// Configure json output
+	f.CLIConfig("output", "json")
+
+	// Run init
+	f.GDInit(keyFoo)
+
+	// Add account to genesis.json
+	bazCoins := sdk.Coins{
+		sdk.NewInt64Coin("acoin", 1000000),
+		sdk.NewInt64Coin("bcoin", 1000000),
+	}
+
+	f.AddGenesisAccount(f.KeyAddress(keyFoo), startCoins)
+	f.AddGenesisAccount(f.KeyAddress(keyBar), bazCoins)
+	genesisState := f.GenesisState()
+	require.Equal(t, genesisState.Accounts[0].Address, f.KeyAddress(keyFoo))
+	require.Equal(t, genesisState.Accounts[1].Address, f.KeyAddress(keyBar))
+	require.True(t, genesisState.Accounts[0].Coins.IsEqual(startCoins))
+	require.True(t, genesisState.Accounts[1].Coins.IsEqual(bazCoins))
 }
 
 func TestSlashingGetParams(t *testing.T) {

--- a/cmd/gaia/cli_test/test_helpers.go
+++ b/cmd/gaia/cli_test/test_helpers.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/keys"
 	"github.com/cosmos/cosmos-sdk/client/tx"
 	"github.com/cosmos/cosmos-sdk/cmd/gaia/app"
+	appInit "github.com/cosmos/cosmos-sdk/cmd/gaia/init"
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/server"
 	"github.com/cosmos/cosmos-sdk/tests"
@@ -74,6 +75,22 @@ func NewFixtures(t *testing.T) *Fixtures {
 		P2PAddr:  p2pAddr,
 		Port:     port,
 	}
+}
+
+// GenesisFile returns the path of the genesis file
+func (f Fixtures) GenesisFile() string {
+	return filepath.Join(f.GDHome, "config", "genesis.json")
+}
+
+// GenesisFile returns the application's genesis state
+func (f Fixtures) GenesisState() app.GenesisState {
+	cdc := codec.New()
+	genDoc, err := appInit.LoadGenesisDoc(cdc, f.GenesisFile())
+	require.NoError(f.T, err)
+
+	var appState app.GenesisState
+	require.NoError(f.T, cdc.UnmarshalJSON(genDoc.AppState, &appState))
+	return appState
 }
 
 // InitFixtures is called at the beginning of a test

--- a/cmd/gaia/init/collect.go
+++ b/cmd/gaia/init/collect.go
@@ -44,7 +44,7 @@ func CollectGenTxsCmd(ctx *server.Context, cdc *codec.Codec) *cobra.Command {
 				return err
 			}
 
-			genDoc, err := loadGenesisDoc(cdc, config.GenesisFile())
+			genDoc, err := LoadGenesisDoc(cdc, config.GenesisFile())
 			if err != nil {
 				return err
 			}

--- a/cmd/gaia/init/gentx.go
+++ b/cmd/gaia/init/gentx.go
@@ -66,7 +66,7 @@ following delegation and commission default parameters:
 				return err
 			}
 
-			genDoc, err := loadGenesisDoc(cdc, config.GenesisFile())
+			genDoc, err := LoadGenesisDoc(cdc, config.GenesisFile())
 			if err != nil {
 				return err
 			}

--- a/cmd/gaia/init/testnet.go
+++ b/cmd/gaia/init/testnet.go
@@ -295,7 +295,7 @@ func collectGenFiles(
 		nodeID, valPubKey := nodeIDs[i], valPubKeys[i]
 		initCfg := newInitConfig(chainID, gentxsDir, moniker, nodeID, valPubKey)
 
-		genDoc, err := loadGenesisDoc(cdc, config.GenesisFile())
+		genDoc, err := LoadGenesisDoc(cdc, config.GenesisFile())
 		if err != nil {
 			return err
 		}

--- a/cmd/gaia/init/utils.go
+++ b/cmd/gaia/init/utils.go
@@ -88,7 +88,8 @@ func InitializeNodeValidatorFiles(
 	return nodeID, valPubKey, nil
 }
 
-func loadGenesisDoc(cdc *amino.Codec, genFile string) (genDoc types.GenesisDoc, err error) {
+// LoadGenesisDoc reads and unmarshals GenesisDoc from the given file.
+func LoadGenesisDoc(cdc *amino.Codec, genFile string) (genDoc types.GenesisDoc, err error) {
 	genContents, err := ioutil.ReadFile(genFile)
 	if err != nil {
 		return genDoc, err


### PR DESCRIPTION
Implement genesis file sanitization to avoid failures at chain init.

* Add GenesisState.Sanitize(). It sorts genesis accounts and
  coin sets to ensure genesis state passes validation.
* gaia app calls GenesisState.Sanitize() on initFromGenesisState()
  before processing the genesis state.

Closes: #3390

- [x] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [x] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [x] Added entries in `PENDING.md` with issue # 
- [x] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
