### PR TITLE
R4R: Register x/gov Message Types on init

### DIFF
--- a/x/gov/codec.go
+++ b/x/gov/codec.go
@@ -4,9 +4,10 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 )
 
+var msgCdc = codec.New()
+
 // Register concrete types on codec codec
 func RegisterCodec(cdc *codec.Codec) {
-
 	cdc.RegisterConcrete(MsgSubmitProposal{}, "cosmos-sdk/MsgSubmitProposal", nil)
 	cdc.RegisterConcrete(MsgDeposit{}, "cosmos-sdk/MsgDeposit", nil)
 	cdc.RegisterConcrete(MsgVote{}, "cosmos-sdk/MsgVote", nil)
@@ -15,4 +16,6 @@ func RegisterCodec(cdc *codec.Codec) {
 	cdc.RegisterConcrete(&TextProposal{}, "gov/TextProposal", nil)
 }
 
-var msgCdc = codec.New()
+func init() {
+	RegisterCodec(msgCdc)
+}

--- a/x/gov/msgs_test.go
+++ b/x/gov/msgs_test.go
@@ -55,6 +55,15 @@ func TestMsgSubmitProposal(t *testing.T) {
 	}
 }
 
+func TestMsgDepositGetSignBytes(t *testing.T) {
+	addr := sdk.AccAddress("addr1")
+	msg := NewMsgDeposit(addr, 0, coinsPos)
+	res := msg.GetSignBytes()
+
+	expected := `{"type":"cosmos-sdk/MsgDeposit","value":{"amount":[{"amount":"1000","denom":"stake"}],"depositor":"cosmos1v9jxgu33kfsgr5","proposal_id":"0"}}`
+	require.Equal(t, expected, string(res))
+}
+
 // test ValidateBasic for MsgDeposit
 func TestMsgDeposit(t *testing.T) {
 	_, addrs, _, _ := mock.CreateGenAccounts(1, sdk.Coins{})


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Register `x/gov` message types on `init`. This will ensure message signature bytes have the canonical type and value fields.

closes: #3443

----

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/develop/CONTRIBUTING.md#pr-targeting))

- [x] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [x] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added entries in `PENDING.md` with issue # 
- [x] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
