### PR TITLE
R4R: LCD proof verification

### DIFF
--- a/PENDING.md
+++ b/PENDING.md
@@ -24,6 +24,7 @@ FEATURES
 * Gaia CLI  (`gaiacli`)
   * [\#3429](https://github.com/cosmos/cosmos-sdk/issues/3429) Support querying
   for all delegator distribution rewards.
+  * \#3449 Proof verification now works with absence proofs
 
 * Gaia
   - [\#3397](https://github.com/cosmos/cosmos-sdk/pull/3397) Implement genesis file sanitization to avoid failures at chain init.

--- a/client/context/context.go
+++ b/client/context/context.go
@@ -24,7 +24,10 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
-var verifier tmlite.Verifier
+var (
+	verifier     tmlite.Verifier
+	verifierHome string
+)
 
 // CLIContext implements a typical CLI context created in SDK modules for
 // transaction handling and queries.
@@ -43,6 +46,7 @@ type CLIContext struct {
 	Async         bool
 	PrintResponse bool
 	Verifier      tmlite.Verifier
+	VerifierHome  string
 	Simulate      bool
 	GenerateOnly  bool
 	FromAddress   sdk.AccAddress
@@ -68,8 +72,9 @@ func NewCLIContext() CLIContext {
 	}
 
 	// We need to use a single verifier for all contexts
-	if verifier == nil {
+	if verifier == nil || verifierHome != viper.GetString(cli.HomeFlag) {
 		verifier = createVerifier()
+		verifierHome = viper.GetString(cli.HomeFlag)
 	}
 
 	return CLIContext{

--- a/client/lcd/test_helpers.go
+++ b/client/lcd/test_helpers.go
@@ -10,7 +10,6 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"path/filepath"
 	"sort"
 	"strings"
 	"testing"
@@ -72,9 +71,11 @@ func makePathname() string {
 	if err != nil {
 		panic(err)
 	}
-
-	sep := string(filepath.Separator)
-	return strings.Replace(p, sep, "_", -1)
+	name, err := ioutil.TempDir(p, "lcd_test")
+	if err != nil {
+		panic(err)
+	}
+	return name
 }
 
 // GetConfig returns a Tendermint config for the test cases.

--- a/client/lcd/test_helpers.go
+++ b/client/lcd/test_helpers.go
@@ -67,15 +67,12 @@ import (
 // makePathname creates a unique pathname for each test. It will panic if it
 // cannot get the current working directory.
 func makePathname() string {
-	p, err := os.Getwd()
+	dir, err := ioutil.TempDir("", "lcd_test")
 	if err != nil {
 		panic(err)
 	}
-	name, err := ioutil.TempDir(p, "lcd_test")
-	if err != nil {
-		panic(err)
-	}
-	return name
+	viper.Set(cli.HomeFlag, dir)
+	return dir
 }
 
 // GetConfig returns a Tendermint config for the test cases.

--- a/client/lcd/test_helpers.go
+++ b/client/lcd/test_helpers.go
@@ -71,13 +71,13 @@ func makePathname() string {
 	if err != nil {
 		panic(err)
 	}
-	viper.Set(cli.HomeFlag, dir)
 	return dir
 }
 
 // GetConfig returns a Tendermint config for the test cases.
 func GetConfig() *tmcfg.Config {
 	pathname := makePathname()
+	viper.Set(cli.HomeFlag, pathname)
 	config := tmcfg.ResetTestRoot(pathname)
 
 	tmAddr, _, err := server.FreeTCPAddr()
@@ -108,14 +108,8 @@ func GetConfig() *tmcfg.Config {
 // NOTE: memDB cannot be used because the request is expecting to interact with
 // the default location.
 func GetKeyBase(t *testing.T) crkeys.Keybase {
-	dir, err := ioutil.TempDir("", "lcd_test")
-	require.NoError(t, err)
-
-	viper.Set(cli.HomeFlag, dir)
-
 	keybase, err := keys.GetKeyBaseWithWritePerm()
 	require.NoError(t, err)
-
 	return keybase
 }
 
@@ -303,9 +297,6 @@ func InitializeTestLCD(
 	viper.Set(client.FlagNode, config.RPC.ListenAddress)
 	viper.Set(client.FlagChainID, genDoc.ChainID)
 	viper.Set(client.FlagTrustNode, false)
-	dir, err := ioutil.TempDir("", "lcd_test")
-	require.NoError(t, err)
-	viper.Set(cli.HomeFlag, dir)
 
 	node, err := startTM(config, logger, genDoc, privVal, app)
 	require.NoError(t, err)


### PR DESCRIPTION
Replaces https://github.com/cosmos/cosmos-sdk/pull/3191

Closes: https://github.com/cosmos/cosmos-sdk/issues/2432

Recreate the singleton verifier if the home directory has changed.

This means that LCD proofs now test lite client verification.

- [x] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [x] Wrote tests
- [x] Updated relevant documentation (`docs/`)
- [x] Added entries in `PENDING.md` with issue # 
- [x] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
