### PR TITLE
R4R: make rest-server respect persistent flags

### DIFF
--- a/PENDING.md
+++ b/PENDING.md
@@ -67,6 +67,8 @@ BUG FIXES
     https://github.com/ZondaX/ledger-cosmos-go/commit/ed9aa39ce8df31bad1448c72d3d226bf2cb1a8d1 in order to fix a derivation path issue that causes `gaiacli keys add --recover`
     to malfunction.
   - [\#3419](https://github.com/cosmos/cosmos-sdk/pull/3419) Fix `q distr slashes` panic 
+  - [\#3453](https://github.com/cosmos/cosmos-sdk/pull/3453) The `rest-server` command didn't respect persistent flags such as `--chain-id` and `--trust-node` if they were
+    passed on the command line.
 
 * Gaia
 

--- a/client/flags.go
+++ b/client/flags.go
@@ -103,21 +103,15 @@ func PostCommands(cmds ...*cobra.Command) []*cobra.Command {
 
 // RegisterRestServerFlags registers the flags required for rest server
 func RegisterRestServerFlags(cmd *cobra.Command) *cobra.Command {
+	cmd = GetCommands(cmd)[0]
 	cmd.Flags().String(FlagListenAddr, "tcp://localhost:1317", "The address for the server to listen on")
 	cmd.Flags().Bool(FlagInsecure, false, "Do not set up SSL/TLS layer")
 	cmd.Flags().String(FlagSSLHosts, "", "Comma-separated hostnames and IPs to generate a certificate for")
 	cmd.Flags().String(FlagSSLCertFile, "", "Path to a SSL certificate file. If not supplied, a self-signed certificate will be generated.")
 	cmd.Flags().String(FlagSSLKeyFile, "", "Path to a key file; ignored if a certificate file is not supplied.")
 	cmd.Flags().String(FlagCORS, "", "Set the domains that can make CORS requests (* for all)")
-	cmd.Flags().String(FlagChainID, "", "Chain ID of Tendermint node")
-	cmd.Flags().String(FlagNode, "tcp://localhost:26657", "Address of the node to connect to")
 	cmd.Flags().Int(FlagMaxOpenConnections, 1000, "The number of maximum open connections")
-	cmd.Flags().Bool(FlagTrustNode, false, "Trust connected full node (don't verify proofs for responses)")
-	cmd.Flags().Bool(FlagIndentResponse, false, "Add indent to JSON response")
 
-	viper.BindPFlag(FlagTrustNode, cmd.Flags().Lookup(FlagTrustNode))
-	viper.BindPFlag(FlagChainID, cmd.Flags().Lookup(FlagChainID))
-	viper.BindPFlag(FlagNode, cmd.Flags().Lookup(FlagNode))
 	return cmd
 }
 

--- a/client/lcd/root.go
+++ b/client/lcd/root.go
@@ -84,7 +84,8 @@ func (rs *RestServer) Start(listenAddr string, sslHosts string,
 	if err != nil {
 		return
 	}
-	rs.log.Info("Starting Gaia Lite REST service...")
+	rs.log.Info(fmt.Sprintf("Starting Gaia Lite REST service (chain-id: %q)...",
+		viper.GetString(client.FlagChainID)))
 
 	// launch rest-server in insecure mode
 	if insecure {
@@ -151,9 +152,7 @@ func ServeCommand(cdc *codec.Codec, registerRoutesFn func(*RestServer)) *cobra.C
 		},
 	}
 
-	client.RegisterRestServerFlags(cmd)
-
-	return cmd
+	return client.RegisterRestServerFlags(cmd)
 }
 
 func (rs *RestServer) registerSwaggerUI() {


### PR DESCRIPTION
The `rest-server` command didn't respect persistent flags such as `--chain-id` and `--trust-node` if they were passed on the command line.

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [x] Added entries in `PENDING.md` with issue # 
- [ ] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
