### PR TITLE
gaiacli switches back to insecure mode by default

### DIFF
--- a/PENDING.md
+++ b/PENDING.md
@@ -9,6 +9,9 @@ BREAKING CHANGES
 * Gaia CLI  (`gaiacli`)
   - [#3399](https://github.com/cosmos/cosmos-sdk/pull/3399) Add `gaiad validate-genesis` command to facilitate checking of genesis files
   - [\#1894](https://github.com/cosmos/cosmos-sdk/issues/1894) `version` prints out short info by default. Add `--long` flag. Proper handling of `--format` flag introduced.
+  - [\#3465](https://github.com/cosmos/cosmos-sdk/issues/3465) `gaiacli rest-server` switched back to insecure mode by default:
+    - `--insecure` flag is removed.
+    - `--tls` is now used to enable secure layer.
 
 * Gaia
 

--- a/client/flags.go
+++ b/client/flags.go
@@ -40,7 +40,7 @@ const (
 	FlagListenAddr         = "laddr"
 	FlagCORS               = "cors"
 	FlagMaxOpenConnections = "max-open"
-	FlagInsecure           = "insecure"
+	FlagTLS                = "tls"
 	FlagSSLHosts           = "ssl-hosts"
 	FlagSSLCertFile        = "ssl-certfile"
 	FlagSSLKeyFile         = "ssl-keyfile"
@@ -105,7 +105,7 @@ func PostCommands(cmds ...*cobra.Command) []*cobra.Command {
 func RegisterRestServerFlags(cmd *cobra.Command) *cobra.Command {
 	cmd = GetCommands(cmd)[0]
 	cmd.Flags().String(FlagListenAddr, "tcp://localhost:1317", "The address for the server to listen on")
-	cmd.Flags().Bool(FlagInsecure, false, "Do not set up SSL/TLS layer")
+	cmd.Flags().Bool(FlagTLS, true, "Enable SSL/TLS layer")
 	cmd.Flags().String(FlagSSLHosts, "", "Comma-separated hostnames and IPs to generate a certificate for")
 	cmd.Flags().String(FlagSSLCertFile, "", "Path to a SSL certificate file. If not supplied, a self-signed certificate will be generated.")
 	cmd.Flags().String(FlagSSLKeyFile, "", "Path to a key file; ignored if a certificate file is not supplied.")

--- a/client/lcd/root.go
+++ b/client/lcd/root.go
@@ -70,7 +70,7 @@ func (rs *RestServer) setKeybase(kb keybase.Keybase) {
 
 // Start starts the rest server
 func (rs *RestServer) Start(listenAddr string, sslHosts string,
-	certFile string, keyFile string, maxOpen int, insecure bool) (err error) {
+	certFile string, keyFile string, maxOpen int, secure bool) (err error) {
 
 	server.TrapSignal(func() {
 		err := rs.listener.Close()
@@ -88,7 +88,7 @@ func (rs *RestServer) Start(listenAddr string, sslHosts string,
 		viper.GetString(client.FlagChainID)))
 
 	// launch rest-server in insecure mode
-	if insecure {
+	if !secure {
 		return rpcserver.StartHTTPServer(rs.listener, rs.Mux, rs.log)
 	}
 
@@ -146,7 +146,7 @@ func ServeCommand(cdc *codec.Codec, registerRoutesFn func(*RestServer)) *cobra.C
 				viper.GetString(client.FlagSSLCertFile),
 				viper.GetString(client.FlagSSLKeyFile),
 				viper.GetInt(client.FlagMaxOpenConnections),
-				viper.GetBool(client.FlagInsecure))
+				viper.GetBool(client.FlagTLS))
 
 			return err
 		},

--- a/docs/clients/lite/getting_started.md
+++ b/docs/clients/lite/getting_started.md
@@ -19,17 +19,18 @@ gaiacli rest-server --chain-id=test \
     --trust-node=false
 ```
 
-The server listens on HTTPS by default. You can set the SSL certificate to be used by the server with these additional flags:
+The server listens on HTTP by default. You can enable the secure layer by adding the `--tls` flag.
+By default a self-signed certificate will be generated and its fingerprint printed out. You can
+configure the server to use a SSL certificate by passing the certificate and key files via the
+`--ssl-certfile` and `--ssl-keyfile` flags:
 
 ```bash
 gaiacli rest-server --chain-id=test \
     --laddr=tcp://localhost:1317 \
     --node tcp://localhost:26657 \
     --trust-node=false \
+    --tls \
     --ssl-certfile=mycert.pem --ssl-keyfile=mykey.key
 ```
-
-If no certificate/keyfile pair is supplied, a self-signed certificate will be generated and its fingerprint printed out.
-Append `--insecure` to the command line if you want to disable the secure layer and listen on an insecure HTTP port.
 
 For more information about the Gaia-Lite RPC, see the [swagger documentation](https://cosmos.network/rpc/)


### PR DESCRIPTION
- `--insecure` flag is removed.
- `--tls` is now used to enable secure layer.

Closes: #3465

- [x] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [x] Updated relevant documentation (`docs/`)
- [x] Added entries in `PENDING.md` with issue # 
- [x] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
