### PR TITLE
R4R: allow generation of gentxs with empty memo field

### DIFF
--- a/PENDING.md
+++ b/PENDING.md
@@ -51,6 +51,7 @@ IMPROVEMENTS
   * [\#3418](https://github.com/cosmos/cosmos-sdk/issues/3418) Add vesting account
   genesis validation checks to `GaiaValidateGenesisState`.
   * [\#3420](https://github.com/cosmos/cosmos-sdk/issues/3420) Added maximum length to governance proposal descriptions and titles
+  * [\#3424](https://github.com/cosmos/cosmos-sdk/issues/3424) Allow generation of gentxs with empty memo field.
 
 * SDK
   * \#3435 Test that store implementations do not allow nil values

--- a/cmd/gaia/init/gentx.go
+++ b/cmd/gaia/init/gentx.go
@@ -61,9 +61,11 @@ following delegation and commission default parameters:
 			if err != nil {
 				return err
 			}
+
 			ip, err := server.ExternalIP()
 			if err != nil {
-				return err
+				fmt.Fprintf(os.Stderr, "couldn't retrieve an external IP, "+
+					"consequently the tx's memo field will be unset: %s", err)
 			}
 
 			genDoc, err := LoadGenesisDoc(cdc, config.GenesisFile())


### PR DESCRIPTION
Let gentx generation continue when gaiad is unable to retrieve
machine's external IP and print a warning message.

Closes: #3424

- [x] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [x] Added entries in `PENDING.md` with issue # 
- [x] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
