### PR TITLE
R4R: Introduce RESTful error responses

### DIFF
--- a/PENDING.md
+++ b/PENDING.md
@@ -5,6 +5,7 @@ BREAKING CHANGES
 * Gaia REST API (`gaiacli advanced rest-server`)
   * [\#3284](https://github.com/cosmos/cosmos-sdk/issues/3284) Rename the `name`
   field to `from` in the `base_req` body.
+  * [\#3485](https://github.com/cosmos/cosmos-sdk/pull/3485) Error responses are now JSON objects.
 
 * Gaia CLI  (`gaiacli`)
   - [#3399](https://github.com/cosmos/cosmos-sdk/pull/3399) Add `gaiad validate-genesis` command to facilitate checking of genesis files

--- a/client/utils/rest.go
+++ b/client/utils/rest.go
@@ -24,11 +24,23 @@ type GasEstimateResponse struct {
 //-----------------------------------------------------------------------------
 // Basic HTTP utilities
 
+// ErrorResponse defines the attributes of a JSON error response.
+type ErrorResponse struct {
+	Code    int    `json:"code,omitempty"`
+	Message string `json:"message"`
+}
+
+// NewErrorResponse creates a new ErrorResponse instance.
+func NewErrorResponse(code int, msg string) ErrorResponse {
+	return ErrorResponse{Code: code, Message: msg}
+}
+
 // WriteErrorResponse prepares and writes a HTTP error
 // given a status code and an error message.
 func WriteErrorResponse(w http.ResponseWriter, status int, err string) {
+	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
-	w.Write([]byte(err))
+	w.Write(codec.Cdc.MustMarshalJSON(NewErrorResponse(0, err)))
 }
 
 // WriteSimulationResponse prepares and writes an HTTP
@@ -353,6 +365,7 @@ func WriteGenerateStdTxResponse(
 		return
 	}
 
+	w.Header().Set("Content-Type", "application/json")
 	w.Write(output)
 	return
 }


### PR DESCRIPTION
Make error responses turn into JSON responses.

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [x] Added entries in `PENDING.md` with issue # 
- [x] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
