### PR TITLE
R4R: Checking Vesting Coins with AmountOf

### DIFF
--- a/PENDING.md
+++ b/PENDING.md
@@ -80,8 +80,10 @@ BUG FIXES
   - [\#3419](https://github.com/cosmos/cosmos-sdk/pull/3419) Fix `q distr slashes` panic 
   - [\#3453](https://github.com/cosmos/cosmos-sdk/pull/3453) The `rest-server` command didn't respect persistent flags such as `--chain-id` and `--trust-node` if they were
     passed on the command line.
-    
+
 * Gaia
+  * [\#3486](https://github.com/cosmos/cosmos-sdk/pull/3486) Use AmountOf in
+    vesting accounts instead of zipping/aligning denominations.
 
 * SDK
 


### PR DESCRIPTION
Removes the performance optimization when querying to see if vesting coins are in the correct state and just use AmountOf.

This bug was discovered on Game of Stakes 5.

Fixes #3483 and #3482 

Would be benefit from multicoin unit tests.
_____

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
