### PR TITLE
R4R: Fix validator address encoding in tm validator set command

### DIFF
--- a/PENDING.md
+++ b/PENDING.md
@@ -15,6 +15,8 @@ BREAKING CHANGES
     - `--insecure` flag is removed.
     - `--tls` is now used to enable secure layer.
   - [\#3451](https://github.com/cosmos/cosmos-sdk/pull/3451) `gaiacli` now returns transactions in plain text including tags.
+  * [\#3501](https://github.com/cosmos/cosmos-sdk/issues/3501) Change validator
+  address Bech32 encoding to consensus address in `tendermint-validator-set`.
 
 * Gaia
   *  [\#3457](https://github.com/cosmos/cosmos-sdk/issues/3457) Changed governance tally validatorGovInfo to use sdk.Int power instead of sdk.Dec

--- a/client/lcd/lcd_test.go
+++ b/client/lcd/lcd_test.go
@@ -198,7 +198,7 @@ func TestValidators(t *testing.T) {
 	cleanup, _, _, port := InitializeTestLCD(t, 1, []sdk.AccAddress{})
 	defer cleanup()
 	resultVals := getValidatorSets(t, port, -1, false)
-	require.Contains(t, resultVals.Validators[0].Address.String(), "cosmosvaloper")
+	require.Contains(t, resultVals.Validators[0].Address.String(), "cosmosvalcons")
 	require.Contains(t, resultVals.Validators[0].PubKey, "cosmosvalconspub")
 	getValidatorSets(t, port, 2, false)
 	getValidatorSets(t, port, 10000000, true)

--- a/client/rpc/validators.go
+++ b/client/rpc/validators.go
@@ -5,6 +5,9 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
+
+	"github.com/cosmos/cosmos-sdk/codec"
 
 	"github.com/cosmos/cosmos-sdk/client/rest"
 
@@ -22,32 +25,80 @@ import (
 // TODO these next two functions feel kinda hacky based on their placement
 
 //ValidatorCommand returns the validator set for a given height
-func ValidatorCommand() *cobra.Command {
+func ValidatorCommand(cdc *codec.Codec) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "tendermint-validator-set [height]",
 		Short: "Get the full tendermint validator set at given height",
 		Args:  cobra.MaximumNArgs(1),
-		RunE:  printValidators,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var height *int64
+
+			// optional height
+			if len(args) > 0 {
+				h, err := strconv.Atoi(args[0])
+				if err != nil {
+					return err
+				}
+				if h > 0 {
+					tmp := int64(h)
+					height = &tmp
+				}
+			}
+
+			cliCtx := context.NewCLIContext().WithCodec(cdc)
+
+			result, err := getValidators(cliCtx, height)
+			if err != nil {
+				return err
+			}
+
+			return cliCtx.PrintOutput(result)
+		},
 	}
+
 	cmd.Flags().StringP(client.FlagNode, "n", "tcp://localhost:26657", "Node to connect to")
 	viper.BindPFlag(client.FlagNode, cmd.Flags().Lookup(client.FlagNode))
 	cmd.Flags().Bool(client.FlagTrustNode, false, "Trust connected full node (don't verify proofs for responses)")
 	viper.BindPFlag(client.FlagTrustNode, cmd.Flags().Lookup(client.FlagTrustNode))
+	cmd.Flags().Bool(client.FlagIndentResponse, false, "indent JSON response")
+	viper.BindPFlag(client.FlagIndentResponse, cmd.Flags().Lookup(client.FlagIndentResponse))
+
 	return cmd
 }
 
 // Validator output in bech32 format
 type ValidatorOutput struct {
-	Address          sdk.ValAddress `json:"address"` // in bech32
-	PubKey           string         `json:"pub_key"` // in bech32
-	ProposerPriority int64          `json:"proposer_priority"`
-	VotingPower      int64          `json:"voting_power"`
+	Address          sdk.ConsAddress `json:"address"`
+	PubKey           string          `json:"pub_key"`
+	ProposerPriority int64           `json:"proposer_priority"`
+	VotingPower      int64           `json:"voting_power"`
 }
 
 // Validators at a certain height output in bech32 format
 type ResultValidatorsOutput struct {
 	BlockHeight int64             `json:"block_height"`
 	Validators  []ValidatorOutput `json:"validators"`
+}
+
+func (rvo ResultValidatorsOutput) String() string {
+	var b strings.Builder
+
+	b.WriteString(fmt.Sprintf("block height: %d\n", rvo.BlockHeight))
+
+	for _, val := range rvo.Validators {
+		b.WriteString(
+			fmt.Sprintf(`
+  Address:          %s
+  Pubkey:           %s
+  ProposerPriority: %d
+  VotingPower:      %d
+		`,
+				val.Address, val.PubKey, val.ProposerPriority, val.VotingPower,
+			),
+		)
+	}
+
+	return b.String()
 }
 
 func bech32ValidatorOutput(validator *tmtypes.Validator) (ValidatorOutput, error) {
@@ -57,33 +108,33 @@ func bech32ValidatorOutput(validator *tmtypes.Validator) (ValidatorOutput, error
 	}
 
 	return ValidatorOutput{
-		Address:          sdk.ValAddress(validator.Address),
+		Address:          sdk.ConsAddress(validator.Address),
 		PubKey:           bechValPubkey,
 		ProposerPriority: validator.ProposerPriority,
 		VotingPower:      validator.VotingPower,
 	}, nil
 }
 
-func getValidators(cliCtx context.CLIContext, height *int64) ([]byte, error) {
+func getValidators(cliCtx context.CLIContext, height *int64) (ResultValidatorsOutput, error) {
 	// get the node
 	node, err := cliCtx.GetNode()
 	if err != nil {
-		return nil, err
+		return ResultValidatorsOutput{}, err
 	}
 
 	validatorsRes, err := node.Validators(height)
 	if err != nil {
-		return nil, err
+		return ResultValidatorsOutput{}, err
 	}
 
 	if !cliCtx.TrustNode {
 		check, err := cliCtx.Verify(validatorsRes.BlockHeight)
 		if err != nil {
-			return nil, err
+			return ResultValidatorsOutput{}, err
 		}
 
 		if !bytes.Equal(check.ValidatorsHash, tmtypes.NewValidatorSet(validatorsRes.Validators).Hash()) {
-			return nil, fmt.Errorf("got invalid validatorset")
+			return ResultValidatorsOutput{}, fmt.Errorf("received invalid validatorset")
 		}
 	}
 
@@ -95,40 +146,11 @@ func getValidators(cliCtx context.CLIContext, height *int64) ([]byte, error) {
 	for i := 0; i < len(validatorsRes.Validators); i++ {
 		outputValidatorsRes.Validators[i], err = bech32ValidatorOutput(validatorsRes.Validators[i])
 		if err != nil {
-			return nil, err
+			return ResultValidatorsOutput{}, err
 		}
 	}
 
-	if cliCtx.Indent {
-		return cdc.MarshalJSONIndent(outputValidatorsRes, "", "  ")
-	}
-	return cdc.MarshalJSON(outputValidatorsRes)
-
-}
-
-// CMD
-
-func printValidators(cmd *cobra.Command, args []string) error {
-	var height *int64
-	// optional height
-	if len(args) > 0 {
-		h, err := strconv.Atoi(args[0])
-		if err != nil {
-			return err
-		}
-		if h > 0 {
-			tmp := int64(h)
-			height = &tmp
-		}
-	}
-
-	output, err := getValidators(context.NewCLIContext(), height)
-	if err != nil {
-		return err
-	}
-
-	fmt.Println(string(output))
-	return nil
+	return outputValidatorsRes, nil
 }
 
 // REST

--- a/cmd/gaia/cmd/gaiacli/main.go
+++ b/cmd/gaia/cmd/gaiacli/main.go
@@ -115,7 +115,7 @@ func queryCmd(cdc *amino.Codec, mc []sdk.ModuleClients) *cobra.Command {
 	}
 
 	queryCmd.AddCommand(
-		rpc.ValidatorCommand(),
+		rpc.ValidatorCommand(cdc),
 		rpc.BlockCommand(),
 		tx.SearchTxCmd(cdc),
 		tx.QueryTxCmd(cdc),


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

- Use consensus address bech32 prefixing
- Use `CLIContext#PrintOutput`

closes: #3501

---

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/develop/CONTRIBUTING.md#pr-targeting))

- [x] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added entries in `PENDING.md` with issue # 
- [x] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
