### PR TITLE
R4R: Add tx/encode endpoint and CLI command

### DIFF
--- a/PENDING.md
+++ b/PENDING.md
@@ -25,7 +25,7 @@ BREAKING CHANGES
   *  Reintroduce OR semantics for tx fees
 
 * SDK
-  * \#2513 Tendermint updates are adjusted by 10^-6 relative to staking tokens, 
+  * \#2513 Tendermint updates are adjusted by 10^-6 relative to staking tokens,
   * [\#3487](https://github.com/cosmos/cosmos-sdk/pull/3487) Move HTTP/REST utilities out of client/utils into a new dedicated client/rest package.
   * [\#3490](https://github.com/cosmos/cosmos-sdk/issues/3490) ReadRESTReq() returns bool to avoid callers to write error responses twice.
   * [\#3502](https://github.com/cosmos/cosmos-sdk/pull/3502) Fixes issue when comparing genesis states
@@ -71,6 +71,7 @@ IMPROVEMENTS
   * [\#3423](https://github.com/cosmos/cosmos-sdk/issues/3423) Allow simulation
   (auto gas) to work with generate only.
   * [\#3514](https://github.com/cosmos/cosmos-sdk/pull/3514) REST server calls to keybase does not lock the underlying storage anymore.
+  * [\#3523](https://github.com/cosmos/cosmos-sdk/pull/3523) Added `/tx/encode` endpoint to serialize a JSON tx to base64-encoded Amino.
 
 * Gaia CLI  (`gaiacli`)
   * [\#3476](https://github.com/cosmos/cosmos-sdk/issues/3476) New `withdraw-all-rewards` command to withdraw all delegations rewards for delegators.
@@ -78,6 +79,7 @@ IMPROVEMENTS
   * [\#3518](https://github.com/cosmos/cosmos-sdk/issues/3518) Fix flow in
   `keys add` to show the mnemonic by default.
   * [\#3517](https://github.com/cosmos/cosmos-sdk/pull/3517) Increased test coverage
+  * [\#3523](https://github.com/cosmos/cosmos-sdk/pull/3523) Added `tx encode` command to serialize a JSON tx to base64-encoded Amino.
 
 * Gaia
   * [\#3418](https://github.com/cosmos/cosmos-sdk/issues/3418) Add vesting account

--- a/client/lcd/swagger-ui/swagger.yaml
+++ b/client/lcd/swagger-ui/swagger.yaml
@@ -334,6 +334,39 @@ paths:
           description: The Tx was malformated
         500:
           description: Server internal error
+  /tx/encode:
+    post:
+      tags:
+        - ICS20
+      summary: Encode a transaction to wire format
+      description: Encode a transaction (signed or not) from JSON to base64-encoded Amino serialized bytes
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - in: body
+          name: tx
+          description: The transaction to encode
+          required: true
+          schema:
+            type: object
+            properties:
+              tx:
+                $ref: "#/definitions/StdTx"
+      responses:
+        200:
+          description: Transaction was successfully decoded and re-encoded
+          schema:
+            type: object
+            properties:
+              tx:
+                type: string
+                example: The base64-encoded Amino-serialized bytes for the transaction
+        400:
+          description: The Tx was malformated
+        500:
+          description: Server internal error
   /bank/balances/{address}:
     get:
       summary: Get the account balances

--- a/cmd/gaia/cli_test/test_helpers.go
+++ b/cmd/gaia/cli_test/test_helpers.go
@@ -279,9 +279,15 @@ func (f *Fixtures) TxSign(signer, fileName string, flags ...string) (bool, strin
 	return executeWriteRetStdStreams(f.T, addFlags(cmd, flags), app.DefaultKeyPass)
 }
 
-// TxBroadcast is gaiacli tx sign
+// TxBroadcast is gaiacli tx broadcast
 func (f *Fixtures) TxBroadcast(fileName string, flags ...string) (bool, string, string) {
 	cmd := fmt.Sprintf("gaiacli tx broadcast %v %v", f.Flags(), fileName)
+	return executeWriteRetStdStreams(f.T, addFlags(cmd, flags), app.DefaultKeyPass)
+}
+
+// TxEncode is gaiacli tx encode
+func (f *Fixtures) TxEncode(fileName string, flags ...string) (bool, string, string) {
+	cmd := fmt.Sprintf("gaiacli tx encode %v %v", f.Flags(), fileName)
 	return executeWriteRetStdStreams(f.T, addFlags(cmd, flags), app.DefaultKeyPass)
 }
 
@@ -625,7 +631,8 @@ func queryTags(tags []string) (out string) {
 	return strings.TrimSuffix(out, "&")
 }
 
-func writeToNewTempFile(t *testing.T, s string) *os.File {
+// Write the given string to a new temporary file
+func WriteToNewTempFile(t *testing.T, s string) *os.File {
 	fp, err := ioutil.TempFile(os.TempDir(), "cosmos_cli_test_")
 	require.Nil(t, err)
 	_, err = fp.WriteString(s)

--- a/cmd/gaia/cmd/gaiacli/main.go
+++ b/cmd/gaia/cmd/gaiacli/main.go
@@ -141,7 +141,8 @@ func txCmd(cdc *amino.Codec, mc []sdk.ModuleClients) *cobra.Command {
 		client.LineBreak,
 		authcmd.GetSignCommand(cdc),
 		authcmd.GetMultiSignCommand(cdc),
-		bankcmd.GetBroadcastCommand(cdc),
+		authcmd.GetBroadcastCommand(cdc),
+		authcmd.GetEncodeCommand(cdc),
 		client.LineBreak,
 	)
 

--- a/x/auth/client/cli/broadcast.go
+++ b/x/auth/client/cli/broadcast.go
@@ -1,8 +1,6 @@
 package cli
 
 import (
-	"io/ioutil"
-	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -10,7 +8,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/context"
-	"github.com/cosmos/cosmos-sdk/x/auth"
+	authclient "github.com/cosmos/cosmos-sdk/x/auth/client"
 )
 
 // GetSignCommand returns the sign command
@@ -27,7 +25,7 @@ $ gaiacli tx broadcast ./mytxn.json
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			cliCtx := context.NewCLIContext().WithCodec(codec)
-			stdTx, err := readAndUnmarshalStdTx(cliCtx.Codec, args[0])
+			stdTx, err := authclient.ReadStdTxFromFile(cliCtx.Codec, args[0])
 			if err != nil {
 				return
 			}
@@ -44,20 +42,4 @@ $ gaiacli tx broadcast ./mytxn.json
 	}
 
 	return client.PostCommands(cmd)[0]
-}
-
-func readAndUnmarshalStdTx(cdc *amino.Codec, filename string) (stdTx auth.StdTx, err error) {
-	var bytes []byte
-	if filename == "-" {
-		bytes, err = ioutil.ReadAll(os.Stdin)
-	} else {
-		bytes, err = ioutil.ReadFile(filename)
-	}
-	if err != nil {
-		return
-	}
-	if err = cdc.UnmarshalJSON(bytes, &stdTx); err != nil {
-		return
-	}
-	return
 }

--- a/x/auth/client/cli/encode.go
+++ b/x/auth/client/cli/encode.go
@@ -1,0 +1,55 @@
+package cli
+
+import (
+	"encoding/base64"
+
+	"github.com/spf13/cobra"
+	amino "github.com/tendermint/go-amino"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/context"
+	authclient "github.com/cosmos/cosmos-sdk/x/auth/client"
+)
+
+// PrintOutput requires a Stringer, so we wrap string
+type encodeResp string
+
+func (e encodeResp) String() string {
+	return string(e)
+}
+
+// GetEncodeCommand returns the encode command to take a JSONified transaction and turn it into
+// Amino-serialized bytes
+func GetEncodeCommand(codec *amino.Codec) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "encode [file]",
+		Short: "encode transactions generated offline",
+		Long: `Encode transactions created with the --generate-only flag and signed with the sign command.
+Read a transaction from <file>, serialize it to the Amino wire protocol, and output it as base64.
+If you supply a dash (-) argument in place of an input filename, the command reads from standard input.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
+			cliCtx := context.NewCLIContext().WithCodec(codec)
+
+			stdTx, err := authclient.ReadStdTxFromFile(cliCtx.Codec, args[0])
+			if err != nil {
+				return
+			}
+
+			txBytes, err := cliCtx.Codec.MarshalBinaryLengthPrefixed(stdTx)
+			if err != nil {
+				return err
+			}
+
+			// Encode the bytes to base64
+			txBytesBase64 := base64.StdEncoding.EncodeToString(txBytes)
+
+			// Write it back
+			response := encodeResp(txBytesBase64)
+			cliCtx.PrintOutput(response)
+			return nil
+		},
+	}
+
+	return client.PostCommands(cmd)[0]
+}

--- a/x/auth/client/cli/multisign.go
+++ b/x/auth/client/cli/multisign.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/keys"
 	crkeys "github.com/cosmos/cosmos-sdk/crypto/keys"
 	"github.com/cosmos/cosmos-sdk/x/auth"
+	authclient "github.com/cosmos/cosmos-sdk/x/auth/client"
 	authtxb "github.com/cosmos/cosmos-sdk/x/auth/client/txbuilder"
 )
 
@@ -51,7 +52,7 @@ recommended to set such parameters manually.
 
 func makeMultiSignCmd(cdc *amino.Codec) func(cmd *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, args []string) (err error) {
-		stdTx, err := readAndUnmarshalStdTx(cdc, args[0])
+		stdTx, err := authclient.ReadStdTxFromFile(cdc, args[0])
 		if err != nil {
 			return
 		}

--- a/x/auth/client/cli/sign.go
+++ b/x/auth/client/cli/sign.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -15,6 +14,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/utils"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/auth"
+	authclient "github.com/cosmos/cosmos-sdk/x/auth/client"
 	authtxb "github.com/cosmos/cosmos-sdk/x/auth/client/txbuilder"
 )
 
@@ -75,7 +75,7 @@ be generated via the 'multisign' command.
 
 func makeSignCmd(cdc *amino.Codec) func(cmd *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, args []string) (err error) {
-		stdTx, err := readAndUnmarshalStdTx(cdc, args[0])
+		stdTx, err := authclient.ReadStdTxFromFile(cdc, args[0])
 		if err != nil {
 			return
 		}
@@ -221,15 +221,4 @@ func printAndValidateSigs(
 
 	fmt.Println("")
 	return success
-}
-
-func readAndUnmarshalStdTx(cdc *amino.Codec, filename string) (stdTx auth.StdTx, err error) {
-	var bytes []byte
-	if bytes, err = ioutil.ReadFile(filename); err != nil {
-		return
-	}
-	if err = cdc.UnmarshalJSON(bytes, &stdTx); err != nil {
-		return
-	}
-	return
 }

--- a/x/auth/client/rest/broadcast.go
+++ b/x/auth/client/rest/broadcast.go
@@ -38,7 +38,7 @@ func BroadcastTxRequestHandlerFn(cdc *codec.Codec, cliCtx context.CLIContext) ht
 	}
 }
 
-func unmarshalBodyOrReturnBadRequest(cliCtx context.CLIContext, w http.ResponseWriter, r *http.Request, m *broadcastBody) bool {
+func unmarshalBodyOrReturnBadRequest(cliCtx context.CLIContext, w http.ResponseWriter, r *http.Request, m interface{}) bool {
 	body, err := ioutil.ReadAll(r.Body)
 	if err != nil {
 		rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())

--- a/x/auth/client/rest/encode.go
+++ b/x/auth/client/rest/encode.go
@@ -1,0 +1,46 @@
+package rest
+
+import (
+	"encoding/base64"
+	"net/http"
+
+	"github.com/cosmos/cosmos-sdk/client/context"
+	"github.com/cosmos/cosmos-sdk/client/rest"
+	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/x/auth"
+)
+
+type encodeReq struct {
+	Tx auth.StdTx `json:"tx"`
+}
+
+type encodeResp struct {
+	Tx string `json:"tx"`
+}
+
+// EncodeTxRequestHandlerFn returns the encode tx REST handler.  In particular, it takes a
+// json-formatted transaction, encodes it to the Amino wire protocol, and responds with
+// base64-encoded bytes
+func EncodeTxRequestHandlerFn(cdc *codec.Codec, cliCtx context.CLIContext) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var m encodeReq
+		// Decode the transaction from JSON
+		if ok := unmarshalBodyOrReturnBadRequest(cliCtx, w, r, &m); !ok {
+			return
+		}
+
+		// Re-encode it to the wire protocol
+		txBytes, err := cliCtx.Codec.MarshalBinaryLengthPrefixed(m.Tx)
+		if err != nil {
+			rest.WriteErrorResponse(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+
+		// Encode the bytes to base64
+		txBytesBase64 := base64.StdEncoding.EncodeToString(txBytes)
+
+		// Write it back
+		response := encodeResp{Tx: txBytesBase64}
+		rest.PostProcessResponse(w, cdc, response, cliCtx.Indent)
+	}
+}

--- a/x/auth/client/rest/query.go
+++ b/x/auth/client/rest/query.go
@@ -23,6 +23,14 @@ func RegisterRoutes(cliCtx context.CLIContext, r *mux.Router, cdc *codec.Codec, 
 		QueryBalancesRequestHandlerFn(storeName, cdc, context.GetAccountDecoder(cdc), cliCtx),
 	).Methods("GET")
 	r.HandleFunc(
+		"/tx/broadcast",
+		BroadcastTxRequestHandlerFn(cdc, cliCtx),
+	).Methods("POST")
+	r.HandleFunc(
+		"/tx/encode",
+		EncodeTxRequestHandlerFn(cdc, cliCtx),
+	).Methods("POST")
+	r.HandleFunc(
 		"/tx/sign",
 		SignTxRequestHandlerFn(cdc, cliCtx),
 	).Methods("POST")

--- a/x/auth/client/util.go
+++ b/x/auth/client/util.go
@@ -1,0 +1,27 @@
+package client
+
+import (
+	"io/ioutil"
+	"os"
+
+	"github.com/tendermint/go-amino"
+
+	"github.com/cosmos/cosmos-sdk/x/auth"
+)
+
+// Read and decode a StdTx from the given filename.  Can pass "-" to read from stdin.
+func ReadStdTxFromFile(cdc *amino.Codec, filename string) (stdTx auth.StdTx, err error) {
+	var bytes []byte
+	if filename == "-" {
+		bytes, err = ioutil.ReadAll(os.Stdin)
+	} else {
+		bytes, err = ioutil.ReadFile(filename)
+	}
+	if err != nil {
+		return
+	}
+	if err = cdc.UnmarshalJSON(bytes, &stdTx); err != nil {
+		return
+	}
+	return
+}

--- a/x/auth/client/util_test.go
+++ b/x/auth/client/util_test.go
@@ -1,0 +1,32 @@
+package client
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cosmos/cosmos-sdk/cmd/gaia/cli_test"
+	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/auth"
+)
+
+func TestReadStdTxFromFile(t *testing.T) {
+	cdc := codec.New()
+	sdk.RegisterCodec(cdc)
+
+	// Build a test transaction
+	fee := auth.NewStdFee(50000, sdk.Coins{sdk.NewInt64Coin("atom", 150)})
+	stdTx := auth.NewStdTx([]sdk.Msg{}, fee, []auth.StdSignature{}, "foomemo")
+
+	// Write it to the file
+	encodedTx, _ := cdc.MarshalJSON(stdTx)
+	jsonTxFile := clitest.WriteToNewTempFile(t, string(encodedTx))
+	defer os.Remove(jsonTxFile.Name())
+
+	// Read it back
+	decodedTx, err := ReadStdTxFromFile(cdc, jsonTxFile.Name())
+	require.Nil(t, err)
+	require.Equal(t, decodedTx.Memo, "foomemo")
+}

--- a/x/bank/client/rest/sendtx.go
+++ b/x/bank/client/rest/sendtx.go
@@ -17,7 +17,6 @@ import (
 // RegisterRoutes - Central function to define routes that get registered by the main application
 func RegisterRoutes(cliCtx context.CLIContext, r *mux.Router, cdc *codec.Codec, kb keys.Keybase) {
 	r.HandleFunc("/bank/accounts/{address}/transfers", SendRequestHandlerFn(cdc, kb, cliCtx)).Methods("POST")
-	r.HandleFunc("/tx/broadcast", BroadcastTxRequestHandlerFn(cdc, cliCtx)).Methods("POST")
 }
 
 type sendReq struct {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

This PR adds a `/tx/encode` endpoint to Gaia to take a JSON-ified transaction, serialize it using the Amino wire format, and return the serialized bytes encoded to a base64 string.  The wire format is necessary to determine a transaction's hash, so it's useful for client applications that want to build their own transactions without being dependent on wire serialization changes.  I've also included an equivalent `gaiacli tx encode` command.

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/develop/CONTRIBUTING.md#pr-targeting))

- [x] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
    - N/A: Discussed the feature with the Cosmos devs in Slack
- [x] Wrote tests
- [x] Updated relevant documentation (`docs/`)
- [x] Added entries in `PENDING.md` with issue # 
- [x] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
