### PR TITLE
localnet does not require setup_dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -381,9 +381,7 @@ workflows:
       - test_cover:
           requires:
             - setup_dependencies
-      - localnet:
-          requires:
-            - setup_dependencies
+      - localnet
       - upload_coverage:
           requires:
             - test_cover


### PR DESCRIPTION
Small improvement to circleci config file


- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added entries in `PENDING.md` with issue # 
- [ ] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
