### PR TITLE
R4R: Multiply initial simulation token amounts by 1e6

### DIFF
--- a/cmd/gaia/app/sim_test.go
+++ b/cmd/gaia/app/sim_test.go
@@ -85,7 +85,7 @@ func appStateRandomizedFn(r *rand.Rand, accs []simulation.Account, genesisTimest
 
 	var genesisAccounts []GenesisAccount
 
-	amount := int64(r.Intn(1e6))
+	amount := int64(r.Intn(1e12))
 	numInitiallyBonded := int64(r.Intn(250))
 	numAccs := int64(len(accs))
 	if numInitiallyBonded > numAccs {


### PR DESCRIPTION
Just a fix after the Tendermint power reduction PR; I don't think this merits `PENDING.md`.

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
