### PR TITLE
Speed tests execution up

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -203,7 +203,8 @@ jobs:
             export PATH="$GOBIN:$PATH"
             export VERSION="$(git describe --tags --long | sed 's/v\(.*\)/\1/')"
             make install
-            GOCACHE=off go test -race -timeout 8m -covermode=atomic -coverprofile=coverage.txt -failfast ./...
+            PKGS="$(go list github.com/cosmos/cosmos-sdk/... | grep -v github.com/cosmos/cosmos-sdk/cmd/gaia/cli_test | grep -v '/simulation')"
+            GOCACHE=off go test -race -timeout 8m -covermode=atomic -coverprofile=/tmp/workspace/coverage.txt -failfast $PKGS
       - persist_to_workspace:
           root: /tmp/workspace
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -201,12 +201,9 @@ jobs:
           name: Run tests
           command: |
             export PATH="$GOBIN:$PATH"
-            make install
             export VERSION="$(git describe --tags --long | sed 's/v\(.*\)/\1/')"
-            for pkg in $(go list github.com/cosmos/cosmos-sdk/... | grep -v github.com/cosmos/cosmos-sdk/cmd/gaia/cli_test | grep -v '/simulation' | circleci tests split --split-by=timings); do
-              id=$(basename "$pkg")
-              GOCACHE=off go test -timeout 8m -race -coverprofile=/tmp/workspace/profiles/$id.out -covermode=atomic "$pkg" | tee "/tmp/logs/$id-$RANDOM.log"
-            done
+            make install
+            GOCACHE=off go test -race -timeout 8m -covermode=atomic -coverprofile=coverage.txt -failfast ./...
       - persist_to_workspace:
           root: /tmp/workspace
           paths:
@@ -222,15 +219,6 @@ jobs:
           at: /tmp/workspace
       - checkout
       - *dependencies
-      - run:
-          name: gather
-          command: |
-            set -ex
-
-            echo "mode: atomic" > coverage.txt
-            for prof in $(ls /tmp/workspace/profiles/); do
-              tail -n +2 /tmp/workspace/profiles/"$prof" >> coverage.txt
-            done
       - run:
           name: upload
           command: bash <(curl -s https://codecov.io/bash) -f coverage.txt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -208,7 +208,7 @@ jobs:
       - persist_to_workspace:
           root: /tmp/workspace
           paths:
-            - "profiles/*"
+            - coverage.txt
       - store_artifacts:
           path: /tmp/logs
 

--- a/Makefile
+++ b/Makefile
@@ -198,7 +198,8 @@ test_sim_gaia_profile:
 		-SimulationEnabled=true -SimulationNumBlocks=$(SIM_NUM_BLOCKS) -SimulationBlockSize=$(SIM_BLOCK_SIZE) -SimulationCommit=$(SIM_COMMIT) -timeout 24h -cpuprofile cpu.out -memprofile mem.out
 
 test_cover:
-	@export VERSION=$(VERSION); GOCACHE=off go test -race -timeout 8m -covermode=atomic -coverprofile=coverage.txt -failfast ./...
+	@export VERSION=$(VERSION); GOCACHE=off go test -race -timeout 8m -covermode=atomic -coverprofile=coverage.txt -failfast \
+	$(shell go list github.com/cosmos/cosmos-sdk/... | grep -v github.com/cosmos/cosmos-sdk/cmd/gaia/cli_test | grep -v '/simulation')
 
 test_lint:
 	gometalinter --config=tools/gometalinter.json ./...

--- a/Makefile
+++ b/Makefile
@@ -198,7 +198,7 @@ test_sim_gaia_profile:
 		-SimulationEnabled=true -SimulationNumBlocks=$(SIM_NUM_BLOCKS) -SimulationBlockSize=$(SIM_BLOCK_SIZE) -SimulationCommit=$(SIM_COMMIT) -timeout 24h -cpuprofile cpu.out -memprofile mem.out
 
 test_cover:
-	@export VERSION=$(VERSION); bash -x tests/test_cover.sh
+	@export VERSION=$(VERSION); GOCACHE=off go test -race -timeout 8m -covermode=atomic -coverprofile=coverage.txt -failfast ./...
 
 test_lint:
 	gometalinter --config=tools/gometalinter.json ./...


### PR DESCRIPTION
- Use go -failfast
- Remove circleci tests split --by-timings as we are not storing
  timings data at all, i.e. we're not using store_test_results in
  our circlei configuration. For more information see:
  https://circleci.com/docs/2.0/parallelism-faster-jobs/#splitting-by-timings-data
- Revert bash -x introduced in a previous commit


- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added entries in `PENDING.md` with issue # 
- [ ] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
