### PR TITLE
Don't overwrite coverage files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -201,10 +201,9 @@ jobs:
           name: Run tests
           command: |
             export PATH="$GOBIN:$PATH"
-            make install
             export VERSION="$(git describe --tags --long | sed 's/v\(.*\)/\1/')"
-            for pkg in $(go list github.com/cosmos/cosmos-sdk/... | grep -v github.com/cosmos/cosmos-sdk/cmd/gaia/cli_test | grep -v '/simulation' | circleci tests split --split-by=timings); do
-              id=$(basename "$pkg")
+            for pkg in $(go list ./... | grep -v github.com/cosmos/cosmos-sdk/cmd/gaia/cli_test | grep -v '/simulation' | circleci tests split --split-by=timings); do
+              id=$(echo "$pkg" | sed 's|[/.]|_|g')
               GOCACHE=off go test -timeout 8m -race -coverprofile=/tmp/workspace/profiles/$id.out -covermode=atomic "$pkg" | tee "/tmp/logs/$id-$RANDOM.log"
             done
       - persist_to_workspace:
@@ -227,6 +226,8 @@ jobs:
           command: |
             set -ex
 
+            echo "--> Concatenating profiles:"
+            ls /tmp/workspace/profiles/
             echo "mode: atomic" > coverage.txt
             for prof in $(ls /tmp/workspace/profiles/); do
               tail -n +2 /tmp/workspace/profiles/"$prof" >> coverage.txt


### PR DESCRIPTION
Some packages aren't showing up in codecov.io due to the use of `basename` to generate unique per-package coverage files.

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added entries in `PENDING.md` with issue # 
- [ ] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
