### PR TITLE
WIP: pass home flag as argument to Cmds underlying functions

### DIFF
--- a/client/keys/add.go
+++ b/client/keys/add.go
@@ -65,7 +65,9 @@ required through --multisig-threshold. The keys are sorted by address, unless
 the flag --nosort is set.
 `,
 		Args: cobra.ExactArgs(1),
-		RunE: runAddCmd,
+		RunE: func(_ *cobra.Command, args []string) error {
+			return runAddCmd(viper.GetString(cli.HomeFlag), args)
+		},
 	}
 	cmd.Flags().StringSlice(flagMultisig, nil, "Construct and store a multisig public key (implies --pubkey)")
 	cmd.Flags().Uint(flagMultiSigThreshold, 1, "K out of N required signatures. For use in conjunction with --multisig")
@@ -90,7 +92,7 @@ input
 output
 	- armor encrypted private key (saved to file)
 */
-func runAddCmd(_ *cobra.Command, args []string) error {
+func runAddCmd(home string, args []string) error {
 	var kb keys.Keybase
 	var err error
 	var encryptPassword string
@@ -107,7 +109,7 @@ func runAddCmd(_ *cobra.Command, args []string) error {
 		kb = client.MockKeyBase()
 		encryptPassword = app.DefaultKeyPass
 	} else {
-		kb, err = NewKeyBaseFromHomeFlag()
+		kb, err = NewKeyBaseFromDir(home)
 		if err != nil {
 			return err
 		}

--- a/client/keys/add_test.go
+++ b/client/keys/add_test.go
@@ -20,50 +20,41 @@ import (
 )
 
 func Test_runAddCmdBasic(t *testing.T) {
-	cmd := addKeyCommand()
-	assert.NotNil(t, cmd)
-
-	// Missing input (enter password)
-	err := runAddCmd(cmd, []string{"keyname"})
-	assert.EqualError(t, err, "EOF")
-
 	// Prepare a keybase
 	kbHome, kbCleanUp := tests.NewTestCaseDir(t)
 	assert.NotNil(t, kbHome)
 	defer kbCleanUp()
-	viper.Set(cli.HomeFlag, kbHome)
+
+	// Missing input (enter password)
+	assert.EqualError(t, runAddCmd(kbHome, []string{"keyname"}), "EOF")
 
 	/// Test Text
 	viper.Set(cli.OutputFlag, OutputFormatText)
 	// Now enter password
 	cleanUp1 := client.OverrideStdin(bufio.NewReader(strings.NewReader("test1234\ntest1234\n")))
 	defer cleanUp1()
-	err = runAddCmd(cmd, []string{"keyname1"})
-	assert.NoError(t, err)
+	assert.NoError(t, runAddCmd(kbHome, []string{"keyname1"}))
 
 	/// Test Text - Replace? >> FAIL
 	viper.Set(cli.OutputFlag, OutputFormatText)
 	// Now enter password
 	cleanUp2 := client.OverrideStdin(bufio.NewReader(strings.NewReader("test1234\ntest1234\n")))
 	defer cleanUp2()
-	err = runAddCmd(cmd, []string{"keyname1"})
-	assert.Error(t, err)
+	assert.Error(t, runAddCmd(kbHome, []string{"keyname1"}))
 
 	/// Test Text - Replace? Answer >> PASS
 	viper.Set(cli.OutputFlag, OutputFormatText)
 	// Now enter password
 	cleanUp3 := client.OverrideStdin(bufio.NewReader(strings.NewReader("y\ntest1234\ntest1234\n")))
 	defer cleanUp3()
-	err = runAddCmd(cmd, []string{"keyname1"})
-	assert.NoError(t, err)
+	assert.NoError(t, runAddCmd(kbHome, []string{"keyname1"}))
 
 	// Check JSON
 	viper.Set(cli.OutputFlag, OutputFormatJSON)
 	// Now enter password
 	cleanUp4 := client.OverrideStdin(bufio.NewReader(strings.NewReader("test1234\ntest1234\n")))
 	defer cleanUp4()
-	err = runAddCmd(cmd, []string{"keyname2"})
-	assert.NoError(t, err)
+	assert.NoError(t, runAddCmd(kbHome, []string{"keyname2"}))
 }
 
 type MockResponseWriter struct {


### PR DESCRIPTION
This also removes the cruft leftover in client/keys/keys/


- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added entries in `PENDING.md` with issue # 
- [ ] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
