### PR TITLE
R4R: Improve SDK Error Messages & Allow Unicode

### DIFF
--- a/PENDING.md
+++ b/PENDING.md
@@ -34,6 +34,8 @@ IMPROVEMENTS
 * Gaia
 
 * SDK
+  * [\#3601] Improve SDK funds related error messages and allow for unicode in
+  JSON ABCI log.
 
 * Tendermint
 

--- a/PENDING.md
+++ b/PENDING.md
@@ -34,7 +34,7 @@ IMPROVEMENTS
 * Gaia
 
 * SDK
-  * [\#3601] Improve SDK funds related error messages and allow for unicode in
+  * [\#3604] Improve SDK funds related error messages and allow for unicode in
   JSON ABCI log.
 
 * Tendermint

--- a/types/errors.go
+++ b/types/errors.go
@@ -262,7 +262,7 @@ func (err *sdkError) ABCILog() string {
 		panic(errors.Wrap(err, "failed to encode ABCI error log"))
 	}
 
-	return buff.String()
+	return strings.TrimSpace(buff.String())
 }
 
 func (err *sdkError) Result() Result {

--- a/types/errors.go
+++ b/types/errors.go
@@ -1,12 +1,13 @@
 package types
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"strings"
 
+	"github.com/pkg/errors"
 	cmn "github.com/tendermint/tendermint/libs/common"
-
-	"github.com/cosmos/cosmos-sdk/codec"
 
 	abci "github.com/tendermint/tendermint/abci/types"
 )
@@ -246,19 +247,22 @@ func (err *sdkError) Code() CodeType {
 
 // Implements ABCIError.
 func (err *sdkError) ABCILog() string {
-	cdc := codec.New()
 	errMsg := err.cmnError.Error()
 	jsonErr := humanReadableError{
 		Codespace: err.codespace,
 		Code:      err.code,
 		Message:   errMsg,
 	}
-	bz, er := cdc.MarshalJSON(jsonErr)
-	if er != nil {
-		panic(er)
+
+	var buff bytes.Buffer
+	enc := json.NewEncoder(&buff)
+	enc.SetEscapeHTML(false)
+
+	if err := enc.Encode(jsonErr); err != nil {
+		panic(errors.Wrap(err, "failed to encode error for ABCI log"))
 	}
-	stringifiedJSON := string(bz)
-	return stringifiedJSON
+
+	return buff.String()
 }
 
 func (err *sdkError) Result() Result {

--- a/types/errors.go
+++ b/types/errors.go
@@ -259,7 +259,7 @@ func (err *sdkError) ABCILog() string {
 	enc.SetEscapeHTML(false)
 
 	if err := enc.Encode(jsonErr); err != nil {
-		panic(errors.Wrap(err, "failed to encode error for ABCI log"))
+		panic(errors.Wrap(err, "failed to encode ABCI error log"))
 	}
 
 	return buff.String()

--- a/types/errors_test.go
+++ b/types/errors_test.go
@@ -72,18 +72,23 @@ func TestAppendMsgToErr(t *testing.T) {
 
 		// plain msg error
 		msg := AppendMsgToErr("something unexpected happened", errMsg)
-		require.Equal(t, fmt.Sprintf("something unexpected happened; %s",
-			errMsg),
+		require.Equal(
+			t,
+			fmt.Sprintf("something unexpected happened; %s", errMsg),
 			msg,
-			fmt.Sprintf("Should have formatted the error message of ABCI Log. tc #%d", i))
+			fmt.Sprintf("Should have formatted the error message of ABCI Log. tc #%d", i),
+		)
 
 		// ABCI Log msg error
 		msg = AppendMsgToErr("something unexpected happened", abciLog)
 		msgIdx := mustGetMsgIndex(abciLog)
-		require.Equal(t, fmt.Sprintf("%s%s; %s}",
-			abciLog[:msgIdx],
-			"something unexpected happened",
-			abciLog[msgIdx:len(abciLog)-1]),
+		require.Equal(
+			t,
+			fmt.Sprintf("%s%s; %s}",
+				abciLog[:msgIdx],
+				"something unexpected happened",
+				abciLog[msgIdx:len(abciLog)-1],
+			),
 			msg,
 			fmt.Sprintf("Should have formatted the error message of ABCI Log. tc #%d", i))
 	}

--- a/x/bank/keeper.go
+++ b/x/bank/keeper.go
@@ -230,7 +230,9 @@ func subtractCoins(ctx sdk.Context, ak auth.AccountKeeper, addr sdk.AccAddress, 
 	// So the check here is sufficient instead of subtracting from oldCoins.
 	_, hasNeg := spendableCoins.SafeMinus(amt)
 	if hasNeg {
-		return amt, nil, sdk.ErrInsufficientCoins(fmt.Sprintf("%s < %s", spendableCoins, amt))
+		return amt, nil, sdk.ErrInsufficientCoins(
+			fmt.Sprintf("insufficient account funds; %s < %s", spendableCoins, amt),
+		)
 	}
 
 	newCoins := oldCoins.Minus(amt) // should not panic as spendable coins was already checked
@@ -246,7 +248,9 @@ func addCoins(ctx sdk.Context, am auth.AccountKeeper, addr sdk.AccAddress, amt s
 	newCoins := oldCoins.Plus(amt)
 
 	if newCoins.IsAnyNegative() {
-		return amt, nil, sdk.ErrInsufficientCoins(fmt.Sprintf("%s < %s", oldCoins, amt))
+		return amt, nil, sdk.ErrInsufficientCoins(
+			fmt.Sprintf("insufficient account funds; %s < %s", oldCoins, amt),
+		)
 	}
 
 	err := setCoins(ctx, am, addr, newCoins)
@@ -319,7 +323,9 @@ func delegateCoins(
 
 	_, hasNeg := oldCoins.SafeMinus(amt)
 	if hasNeg {
-		return nil, sdk.ErrInsufficientCoins(fmt.Sprintf("%s < %s", oldCoins, amt))
+		return nil, sdk.ErrInsufficientCoins(
+			fmt.Sprintf("insufficient account funds; %s < %s", oldCoins, amt),
+		)
 	}
 
 	if err := trackDelegation(acc, ctx.BlockHeader().Time, amt); err != nil {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

* Improve funds-based SDK error messages
* Allow unicode to not be escaped in JSON (e.g. so error messages will actually display `<`)

----

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/develop/CONTRIBUTING.md#pr-targeting))

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [x] Added entries in `PENDING.md` with issue # 
- [x] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
