### PR TITLE
R4R: Indicate build flags in version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,6 @@ VERSION := $(shell echo $(shell git describe --tags) | sed 's/^v//')
 COMMIT := $(shell git log -1 --format='%H')
 BUILD_TAGS = netgo
 CAT := $(if $(filter $(OS),Windows_NT),type,cat)
-BUILD_FLAGS = -tags "${BUILD_TAGS}" -ldflags \
-	"-X github.com/cosmos/cosmos-sdk/version.Version=${VERSION} \
-	-X github.com/cosmos/cosmos-sdk/version.Commit=${COMMIT} \
-	-X github.com/cosmos/cosmos-sdk/version.VendorDirHash=$(shell $(CAT) vendor-deps)"
 LEDGER_ENABLED ?= true
 GOTOOLS = \
 	github.com/golang/dep/cmd/dep \
@@ -50,6 +46,14 @@ ifeq ($(LEDGER_ENABLED),true)
     endif
   endif
 endif
+
+### Update Build flags
+BUILD_FLAGS = -tags "${BUILD_TAGS}" -ldflags \
+	'-X github.com/cosmos/cosmos-sdk/version.Version=${VERSION} \
+	-X github.com/cosmos/cosmos-sdk/version.Commit=${COMMIT} \
+	-X github.com/cosmos/cosmos-sdk/version.VendorDirHash=$(shell $(CAT) vendor-deps) \
+    -X "github.com/cosmos/cosmos-sdk/version.BuildTags=${BUILD_TAGS}"'
+
 
 build:
 ifeq ($(OS),Windows_NT)

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,11 @@ VERSION := $(shell echo $(shell git describe --tags) | sed 's/^v//')
 COMMIT := $(shell git log -1 --format='%H')
 BUILD_TAGS = netgo
 CAT := $(if $(filter $(OS),Windows_NT),type,cat)
+BUILD_FLAGS = -tags "$(BUILD_TAGS)" -ldflags \
+    '-X github.com/cosmos/cosmos-sdk/version.Version=$(VERSION) \
+    -X github.com/cosmos/cosmos-sdk/version.Commit=$(COMMIT) \
+    -X github.com/cosmos/cosmos-sdk/version.VendorDirHash=$(shell $(CAT) vendor-deps) \
+    -X "github.com/cosmos/cosmos-sdk/version.BuildTags=$(BUILD_TAGS)"'
 LEDGER_ENABLED ?= true
 GOTOOLS = \
 	github.com/golang/dep/cmd/dep \
@@ -46,14 +51,6 @@ ifeq ($(LEDGER_ENABLED),true)
     endif
   endif
 endif
-
-### Update Build flags
-BUILD_FLAGS = -tags "${BUILD_TAGS}" -ldflags \
-    '-X github.com/cosmos/cosmos-sdk/version.Version=${VERSION} \
-    -X github.com/cosmos/cosmos-sdk/version.Commit=${COMMIT} \
-    -X github.com/cosmos/cosmos-sdk/version.VendorDirHash=$(shell $(CAT) vendor-deps) \
-    -X "github.com/cosmos/cosmos-sdk/version.BuildTags=${BUILD_TAGS}"'
-
 
 build:
 ifeq ($(OS),Windows_NT)

--- a/Makefile
+++ b/Makefile
@@ -49,9 +49,9 @@ endif
 
 ### Update Build flags
 BUILD_FLAGS = -tags "${BUILD_TAGS}" -ldflags \
-	'-X github.com/cosmos/cosmos-sdk/version.Version=${VERSION} \
-	-X github.com/cosmos/cosmos-sdk/version.Commit=${COMMIT} \
-	-X github.com/cosmos/cosmos-sdk/version.VendorDirHash=$(shell $(CAT) vendor-deps) \
+    '-X github.com/cosmos/cosmos-sdk/version.Version=${VERSION} \
+    -X github.com/cosmos/cosmos-sdk/version.Commit=${COMMIT} \
+    -X github.com/cosmos/cosmos-sdk/version.VendorDirHash=$(shell $(CAT) vendor-deps) \
     -X "github.com/cosmos/cosmos-sdk/version.BuildTags=${BUILD_TAGS}"'
 
 

--- a/PENDING.md
+++ b/PENDING.md
@@ -34,6 +34,9 @@ IMPROVEMENTS
 * Gaia
 
 * SDK
+  * [\#3604] Improve SDK funds related error messages and allow for unicode in
+  JSON ABCI log.
+  * [\#3620](https://github.com/cosmos/cosmos-sdk/pull/3620) Version command shows build tags
 
 * Tendermint
   * [\#3618] Upgrade to Tendermint 0.30.03

--- a/docs/gaia/installation.md
+++ b/docs/gaia/installation.md
@@ -36,9 +36,28 @@ make tools install
 That will install the `gaiad` and `gaiacli` binaries. Verify that everything is OK:
 
 ```bash
-$ gaiad version
-$ gaiacli version
+$ gaiad version --long
+$ gaiacli version --long
 ```
+
+`gaiacli` for instance should output something similar to:
+
+```
+cosmos-sdk: 0.31.2-10-g1fba7308
+git commit: 1fba7308fa226e971964cd6baad9527d4b51d9fc
+vendor hash: 1aec7edfad9888a967b3e9063e42f66b28f447e6
+build tags: netgo ledger
+go version go1.11.5 linux/amd64
+```
+
+##### Build Tags
+
+Build tags indicate special features that have been enabled in the binary.
+
+| Build Tag | Description                                     |
+| --------- | ----------------------------------------------- |
+| netgo     | Name resolution will use pure Go code           |
+| ledger    | Ledger devices are supported (hardware wallets) |
 
 ### Next
 

--- a/version/version.go
+++ b/version/version.go
@@ -18,7 +18,7 @@ type versionInfo struct {
 	CosmosSDK     string `json:"cosmos_sdk"`
 	GitCommit     string `json:"commit"`
 	VendorDirHash string `json:"vendor_hash"`
-	BuildTags     string `json:"tags"`
+	BuildTags     string `json:"build_tags"`
 	GoVersion     string `json:"go"`
 }
 

--- a/version/version.go
+++ b/version/version.go
@@ -11,12 +11,14 @@ var (
 	Commit        = ""
 	Version       = ""
 	VendorDirHash = ""
+	BuildTags     = ""
 )
 
 type versionInfo struct {
 	CosmosSDK     string `json:"cosmos_sdk"`
 	GitCommit     string `json:"commit"`
 	VendorDirHash string `json:"vendor_hash"`
+	BuildTags     string `json:"tags"`
 	GoVersion     string `json:"go"`
 }
 
@@ -24,11 +26,15 @@ func (v versionInfo) String() string {
 	return fmt.Sprintf(`cosmos-sdk: %s
 git commit: %s
 vendor hash: %s
-%s`, v.CosmosSDK, v.GitCommit, v.VendorDirHash, v.GoVersion)
+build tags: %s
+%s`, v.CosmosSDK, v.GitCommit, v.VendorDirHash, v.BuildTags, v.GoVersion)
 }
 
 func newVersionInfo() versionInfo {
 	return versionInfo{
-		Version, Commit, VendorDirHash, fmt.Sprintf("go version %s %s/%s\n",
-			runtime.Version(), runtime.GOOS, runtime.GOARCH)}
+		Version,
+		Commit,
+		VendorDirHash,
+		BuildTags,
+		fmt.Sprintf("go version %s %s/%s\n", runtime.Version(), runtime.GOOS, runtime.GOARCH)}
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

This PR adds build tags to the version command:

cosmos-sdk: 0.31.1-10-gfe548c08
git commit: fe548c0829a4f232028329ec2b93d9e4dcdb4447
vendor hash: 1aec7edfad9888a967b3e9063e42f66b28f447e6
**build tags: netgo ledger**
go version go1.11.5 linux/amd64

This is useful to understand which features were enabled when building the binary.
The issue is related to https://github.com/cosmos/cosmos-sdk/issues/3528

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/develop/CONTRIBUTING.md#pr-targeting))

- [x] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [x] Updated relevant documentation (`docs/`)
- [x] Added entries in `PENDING.md` with issue # 
- [x] rereviewed `Files changed` in the github PR explorer
- [ ] Wrote tests

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
