### PR TITLE
R4R: Return an empty TxResponse

### DIFF
--- a/PENDING.md
+++ b/PENDING.md
@@ -54,6 +54,8 @@ BUG FIXES
 
 * Gaia
   * [\#3585] Fix setting the tx hash in `NewResponseFormatBroadcastTxCommit`.
+  * [\#3585] Return an empty `TxResponse` when Tendermint returns an empty
+  `ResultBroadcastTx`.
 
 * SDK
   * [\#3582](https://github.com/cosmos/cosmos-sdk/pull/3582) Running `make test_unit was failing due to a missing tag

--- a/types/result.go
+++ b/types/result.go
@@ -55,6 +55,10 @@ type TxResponse struct {
 }
 
 func NewResponseResultTx(res *ctypes.ResultTx, tx Tx) TxResponse {
+	if res == nil {
+		return TxResponse{}
+	}
+
 	return TxResponse{
 		TxHash:    res.Hash.String(),
 		Height:    res.Height,
@@ -70,6 +74,10 @@ func NewResponseResultTx(res *ctypes.ResultTx, tx Tx) TxResponse {
 }
 
 func NewResponseFormatBroadcastTxCommit(res *ctypes.ResultBroadcastTxCommit) TxResponse {
+	if res == nil {
+		return TxResponse{}
+	}
+
 	var txHash string
 	if res.Hash != nil {
 		txHash = res.Hash.String()
@@ -90,6 +98,10 @@ func NewResponseFormatBroadcastTxCommit(res *ctypes.ResultBroadcastTxCommit) TxR
 }
 
 func NewResponseFormatBroadcastTx(res *ctypes.ResultBroadcastTx) TxResponse {
+	if res == nil {
+		return TxResponse{}
+	}
+
 	return TxResponse{
 		Code:   res.Code,
 		Data:   res.Data.Bytes(),


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

closes: #3585

----

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/develop/CONTRIBUTING.md#pr-targeting))

- [x] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [x] Added entries in `PENDING.md` with issue # 
- [x] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
