### PR TITLE
R4R: Fix Fee Comparison

### DIFF
--- a/PENDING.md
+++ b/PENDING.md
@@ -57,5 +57,7 @@ BUG FIXES
 
 * SDK
   * [\#3582](https://github.com/cosmos/cosmos-sdk/pull/3582) Running `make test_unit was failing due to a missing tag
+  * [\#3617] Fix fee comparison when the required fees does not contain any denom
+  present in the tx fees.
 
 * Tendermint

--- a/types/coin.go
+++ b/types/coin.go
@@ -311,7 +311,7 @@ func (coins Coins) IsAnyGTE(coinsB Coins) bool {
 
 	for _, coin := range coins {
 		amt := coinsB.AmountOf(coin.Denom)
-		if coin.Amount.GTE(amt) {
+		if coin.Amount.GTE(amt) && !amt.IsZero() {
 			return true
 		}
 	}

--- a/types/coin_test.go
+++ b/types/coin_test.go
@@ -517,6 +517,7 @@ func TestCoinsIsAnyGTE(t *testing.T) {
 	assert.False(t, Coins{{"a", one}}.IsAnyGTE(Coins{}))
 	assert.False(t, Coins{}.IsAnyGTE(Coins{{"a", one}}))
 	assert.False(t, Coins{{"a", one}}.IsAnyGTE(Coins{{"a", two}}))
+	assert.False(t, Coins{{"a", one}}.IsAnyGTE(Coins{{"b", one}}))
 	assert.True(t, Coins{{"a", one}, {"b", two}}.IsAnyGTE(Coins{{"a", two}, {"b", one}}))
 	assert.True(t, Coins{{"a", one}}.IsAnyGTE(Coins{{"a", one}}))
 	assert.True(t, Coins{{"a", two}}.IsAnyGTE(Coins{{"a", one}}))


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

We weren't checking for the case where the denom is not present in required fees.

closes: #3617

/cc @zmanian 

----

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/develop/CONTRIBUTING.md#pr-targeting))

- [x] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [x] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [x] Added entries in `PENDING.md` with issue # 
- [x] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
