### PR TITLE
R4R: improve denom validation

### DIFF
--- a/PENDING.md
+++ b/PENDING.md
@@ -23,6 +23,7 @@
 
 * [\#3669] Ensure consistency in message naming, codec registration, and JSON
 tags.
+* [\#3666] Improve coins denom validation.
 
 ### Tendermint
 

--- a/types/coin.go
+++ b/types/coin.go
@@ -477,20 +477,18 @@ func (coins Coins) Sort() Coins {
 
 var (
 	// Denominations can be 3 ~ 16 characters long.
-	reDnm     = `[[:alpha:]][[:alnum:]]{2,15}`
-	reAmt     = `[[:digit:]]+`
-	reDecAmt  = `[[:digit:]]*\.[[:digit:]]+`
-	reSpc     = `[[:space:]]*`
-	reCoin    = regexp.MustCompile(fmt.Sprintf(`^(%s)%s(%s)$`, reAmt, reSpc, reDnm))
-	reDecCoin = regexp.MustCompile(fmt.Sprintf(`^(%s)%s(%s)$`, reDecAmt, reSpc, reDnm))
+	reDnmString = `[[:lower:]][[:alnum:]]{2,15}`
+	reAmt       = `[[:digit:]]+`
+	reDecAmt    = `[[:digit:]]*\.[[:digit:]]+`
+	reSpc       = `[[:space:]]*`
+	reDnm       = regexp.MustCompile(fmt.Sprintf(`^%s$`, reDnmString))
+	reCoin      = regexp.MustCompile(fmt.Sprintf(`^(%s)%s(%s)$`, reAmt, reSpc, reDnmString))
+	reDecCoin   = regexp.MustCompile(fmt.Sprintf(`^(%s)%s(%s)$`, reDecAmt, reSpc, reDnmString))
 )
 
 func validateDenom(denom string) {
-	if len(denom) < 3 || len(denom) > 16 {
-		panic(fmt.Sprintf("invalid denom length: %s", denom))
-	}
-	if strings.ToLower(denom) != denom {
-		panic(fmt.Sprintf("denom cannot contain upper case characters: %s", denom))
+	if !reDnm.MatchString(denom) {
+		panic("illegal characters")
 	}
 }
 

--- a/types/coin.go
+++ b/types/coin.go
@@ -478,7 +478,7 @@ func (coins Coins) Sort() Coins {
 
 var (
 	// Denominations can be 3 ~ 16 characters long.
-	reDnmString = `[[:lower:]][[:alnum:]]{2,15}`
+	reDnmString = `[a-z][a-z0-9]{2,15}`
 	reAmt       = `[[:digit:]]+`
 	reDecAmt    = `[[:digit:]]*\.[[:digit:]]+`
 	reSpc       = `[[:space:]]*`

--- a/types/dec_coin.go
+++ b/types/dec_coin.go
@@ -32,7 +32,7 @@ func NewDecCoin(denom string, amount Int) DecCoin {
 }
 
 func NewDecCoinFromDec(denom string, amount Dec) DecCoin {
-	validateDenom(denom)
+	mustValidateDenom(denom)
 
 	if amount.LT(ZeroDec()) {
 		panic(fmt.Sprintf("negative decimal coin amount: %v\n", amount))

--- a/types/dec_coin.go
+++ b/types/dec_coin.go
@@ -19,7 +19,7 @@ type DecCoin struct {
 }
 
 func NewDecCoin(denom string, amount Int) DecCoin {
-	validateDenom(denom)
+	mustValidateDenom(denom)
 
 	if amount.LT(ZeroInt()) {
 		panic(fmt.Sprintf("negative coin amount: %v\n", amount))
@@ -366,7 +366,7 @@ func (coins DecCoins) Empty() bool {
 
 // returns the amount of a denom from deccoins
 func (coins DecCoins) AmountOf(denom string) Dec {
-	validateDenom(denom)
+	mustValidateDenom(denom)
 
 	switch len(coins) {
 	case 0:
@@ -429,7 +429,7 @@ func (coins DecCoins) IsValid() bool {
 		return true
 
 	case 1:
-		if strings.ToLower(coins[0].Denom) != coins[0].Denom {
+		if err := validateDenom(coins[0].Denom); err != nil {
 			return false
 		}
 		return coins[0].IsPositive()
@@ -529,8 +529,8 @@ func ParseDecCoin(coinStr string) (coin DecCoin, err error) {
 		return DecCoin{}, errors.Wrap(err, fmt.Sprintf("failed to parse decimal coin amount: %s", amountStr))
 	}
 
-	if denomStr != strings.ToLower(denomStr) {
-		return DecCoin{}, fmt.Errorf("denom cannot contain upper case characters: %s", denomStr)
+	if err := validateDenom(denomStr); err != nil {
+		return DecCoin{}, fmt.Errorf("invalid denom cannot contain upper case characters or spaces: %s", err)
 	}
 
 	return NewDecCoinFromDec(denomStr, amount), nil


### PR DESCRIPTION
* Use a more precise regular expression to match denom strings (e.g. [[:lower:]] instead of [[:alpha:]]) and avoid trimming spaces.
* validateDenom() -> validateDenom() error, use mustValidateDenom() in constructors to forcibly panic when validation fails.

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [x] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [x] Added entries in `PENDING.md` with issue # 
- [x] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
