### PR TITLE
JSON Decode Log in REST Client

### DIFF
--- a/PENDING.md
+++ b/PENDING.md
@@ -39,8 +39,8 @@
 
 ### Gaia REST API
 
-* [\#3601] Implement a custom JSON encoder/decoder for the `TxResponse` type allowing
-for the `log` result to be JSON decoded automatically.
+* [\#3601] Update the `TxResponse` type allowing for the `Logs` result to be JSON
+decoded automatically.
 
 ### Gaia CLI
 

--- a/PENDING.md
+++ b/PENDING.md
@@ -39,6 +39,9 @@
 
 ### Gaia REST API
 
+* [\#3601] Implement a custom JSON encoder/decoder for the `TxResponse` type allowing
+for the `log` result to be JSON decoded automatically.
+
 ### Gaia CLI
 
 ### Gaia

--- a/PENDING.md
+++ b/PENDING.md
@@ -6,7 +6,7 @@
 
 ### Gaia REST API
 
-* Remove the ability to use a Keybase from the REST API client:
+* [\#3641] Remove the ability to use a Keybase from the REST API client:
   * `password` and `generate_only` have been removed from the `base_req` object
   * All txs that used to sign or use the Keybase now only generate the tx
   * `keys` routes completely removed
@@ -39,7 +39,7 @@
 
 ### Gaia REST API
 
-* [\#3601] Update the `TxResponse` type allowing for the `Logs` result to be JSON
+* Update the `TxResponse` type allowing for the `Logs` result to be JSON
 decoded automatically.
 
 ### Gaia CLI

--- a/PENDING.md
+++ b/PENDING.md
@@ -6,7 +6,7 @@
 
 ### Gaia REST API
 
-* [\#3641] Remove the ability to use a Keybase from the REST API client:
+* Remove the ability to use a Keybase from the REST API client:
   * `password` and `generate_only` have been removed from the `base_req` object
   * All txs that used to sign or use the Keybase now only generate the tx
   * `keys` routes completely removed

--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -628,15 +628,9 @@ func (app *BaseApp) getContextForTx(mode runTxMode, txBytes []byte) (ctx sdk.Con
 	return
 }
 
-type indexedABCILog struct {
-	MsgIndex int    `json:"msg_index"`
-	Success  bool   `json:"success"`
-	Log      string `json:"log"`
-}
-
 // runMsgs iterates through all the messages and executes them.
 func (app *BaseApp) runMsgs(ctx sdk.Context, msgs []sdk.Msg, mode runTxMode) (result sdk.Result) {
-	idxlogs := make([]indexedABCILog, 0, len(msgs)) // a list of JSON-encoded logs with msg index
+	idxlogs := make([]sdk.IndexedABCILog, 0, len(msgs)) // a list of JSON-encoded logs with msg index
 
 	var data []byte   // NOTE: we just append them all (?!)
 	var tags sdk.Tags // also just append them all
@@ -665,7 +659,7 @@ func (app *BaseApp) runMsgs(ctx sdk.Context, msgs []sdk.Msg, mode runTxMode) (re
 		tags = append(tags, sdk.MakeTag(sdk.TagAction, msg.Type()))
 		tags = append(tags, msgResult.Tags...)
 
-		idxLog := indexedABCILog{MsgIndex: msgIdx, Log: msgResult.Log}
+		idxLog := sdk.IndexedABCILog{MsgIndex: msgIdx, Log: msgResult.Log}
 
 		// stop execution and return on first failed message
 		if !msgResult.IsOK() {

--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -630,7 +630,7 @@ func (app *BaseApp) getContextForTx(mode runTxMode, txBytes []byte) (ctx sdk.Con
 
 // runMsgs iterates through all the messages and executes them.
 func (app *BaseApp) runMsgs(ctx sdk.Context, msgs []sdk.Msg, mode runTxMode) (result sdk.Result) {
-	idxlogs := make([]sdk.IndexedABCILog, 0, len(msgs)) // a list of JSON-encoded logs with msg index
+	idxlogs := make([]sdk.ABCIMessageLog, 0, len(msgs)) // a list of JSON-encoded logs with msg index
 
 	var data []byte   // NOTE: we just append them all (?!)
 	var tags sdk.Tags // also just append them all
@@ -659,7 +659,7 @@ func (app *BaseApp) runMsgs(ctx sdk.Context, msgs []sdk.Msg, mode runTxMode) (re
 		tags = append(tags, sdk.MakeTag(sdk.TagAction, msg.Type()))
 		tags = append(tags, msgResult.Tags...)
 
-		idxLog := sdk.IndexedABCILog{MsgIndex: msgIdx, Log: msgResult.Log}
+		idxLog := sdk.ABCIMessageLog{MsgIndex: msgIdx, Log: msgResult.Log}
 
 		// stop execution and return on first failed message
 		if !msgResult.IsOK() {

--- a/client/context/context.go
+++ b/client/context/context.go
@@ -254,6 +254,7 @@ func (ctx CLIContext) PrintOutput(toPrint fmt.Stringer) (err error) {
 	switch ctx.OutputFormat {
 	case "text":
 		out = []byte(toPrint.String())
+
 	case "json":
 		if ctx.Indent {
 			out, err = ctx.Codec.MarshalJSONIndent(toPrint, "", " ")

--- a/types/rest/rest.go
+++ b/types/rest/rest.go
@@ -192,6 +192,9 @@ func PostProcessResponse(w http.ResponseWriter, cdc *codec.Codec, response inter
 	var output []byte
 
 	switch response.(type) {
+	case []byte:
+		output = response.([]byte)
+
 	default:
 		var err error
 		if indent {
@@ -203,8 +206,6 @@ func PostProcessResponse(w http.ResponseWriter, cdc *codec.Codec, response inter
 			WriteErrorResponse(w, http.StatusInternalServerError, err.Error())
 			return
 		}
-	case []byte:
-		output = response.([]byte)
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/types/result.go
+++ b/types/result.go
@@ -39,18 +39,18 @@ func (res Result) IsOK() bool {
 	return res.Code.IsOK()
 }
 
-// IndexedABCILogs represents a slice of IndexedABCILog.
-type IndexedABCILogs []IndexedABCILog
+// ABCIMessageLogs represents a slice of ABCIMessageLog.
+type ABCIMessageLogs []ABCIMessageLog
 
-// IndexedABCILog defines a structure containing an indexed tx ABCI message log.
-type IndexedABCILog struct {
+// ABCIMessageLog defines a structure containing an indexed tx ABCI message log.
+type ABCIMessageLog struct {
 	MsgIndex int    `json:"msg_index"`
 	Success  bool   `json:"success"`
 	Log      string `json:"log"`
 }
 
-// String implements the fmt.Stringer interface for the IndexedABCILogs type.
-func (logs IndexedABCILogs) String() (str string) {
+// String implements the fmt.Stringer interface for the ABCIMessageLogs type.
+func (logs ABCIMessageLogs) String() (str string) {
 	if logs != nil {
 		raw, err := json.Marshal(logs)
 		if err == nil {
@@ -68,7 +68,7 @@ type TxResponse struct {
 	TxHash    string          `json:"txhash"`
 	Code      uint32          `json:"code,omitempty"`
 	Data      []byte          `json:"data,omitempty"`
-	Logs      IndexedABCILogs `json:"logs,omitempty"`
+	Logs      ABCIMessageLogs `json:"logs,omitempty"`
 	Info      string          `json:"info,omitempty"`
 	GasWanted int64           `json:"gas_wanted,omitempty"`
 	GasUsed   int64           `json:"gas_used,omitempty"`
@@ -196,8 +196,8 @@ func (r TxResponse) Empty() bool {
 }
 
 // ParseABCILogs attempts to parse a stringified ABCI tx log into a slice of
-// IndexedABCILog types. It returns an error upon JSON decoding failure.
-func ParseABCILogs(logs string) (res IndexedABCILogs, err error) {
+// ABCIMessageLog types. It returns an error upon JSON decoding failure.
+func ParseABCILogs(logs string) (res ABCIMessageLogs, err error) {
 	err = json.Unmarshal([]byte(logs), &res)
 	return res, err
 }

--- a/types/result.go
+++ b/types/result.go
@@ -39,6 +39,9 @@ func (res Result) IsOK() bool {
 	return res.Code.IsOK()
 }
 
+// IndexedABCILogs represents a slice of IndexedABCILog.
+type IndexedABCILogs []IndexedABCILog
+
 // IndexedABCILog defines a structure containing an indexed tx ABCI message log.
 type IndexedABCILog struct {
 	MsgIndex int    `json:"msg_index"`
@@ -46,20 +49,32 @@ type IndexedABCILog struct {
 	Log      string `json:"log"`
 }
 
+// String implements the fmt.Stringer interface for the IndexedABCILogs type.
+func (logs IndexedABCILogs) String() (str string) {
+	if logs != nil {
+		raw, err := json.Marshal(logs)
+		if err == nil {
+			str = string(raw)
+		}
+	}
+
+	return str
+}
+
 // TxResponse defines a structure containing relevant tx data and metadata. The
 // tags are stringified and the log is JSON decoded.
 type TxResponse struct {
-	Height    int64            `json:"height"`
-	TxHash    string           `json:"txhash"`
-	Code      uint32           `json:"code,omitempty"`
-	Data      []byte           `json:"data,omitempty"`
-	Logs      []IndexedABCILog `json:"logs,omitempty"`
-	Info      string           `json:"info,omitempty"`
-	GasWanted int64            `json:"gas_wanted,omitempty"`
-	GasUsed   int64            `json:"gas_used,omitempty"`
-	Tags      StringTags       `json:"tags,omitempty"`
-	Codespace string           `json:"codespace,omitempty"`
-	Tx        Tx               `json:"tx,omitempty"`
+	Height    int64           `json:"height"`
+	TxHash    string          `json:"txhash"`
+	Code      uint32          `json:"code,omitempty"`
+	Data      []byte          `json:"data,omitempty"`
+	Logs      IndexedABCILogs `json:"logs,omitempty"`
+	Info      string          `json:"info,omitempty"`
+	GasWanted int64           `json:"gas_wanted,omitempty"`
+	GasUsed   int64           `json:"gas_used,omitempty"`
+	Tags      StringTags      `json:"tags,omitempty"`
+	Codespace string          `json:"codespace,omitempty"`
+	Tx        Tx              `json:"tx,omitempty"`
 }
 
 // NewResponseResultTx returns a TxResponse given a ResultTx from tendermint
@@ -149,10 +164,7 @@ func (r TxResponse) String() string {
 	}
 
 	if r.Logs != nil {
-		logStr, err := json.Marshal(r.Logs)
-		if err == nil {
-			sb.WriteString(fmt.Sprintf("  Logs: %s\n", logStr))
-		}
+		sb.WriteString(fmt.Sprintf("  Logs: %s\n", r.Logs))
 	}
 
 	if r.Info != "" {
@@ -185,7 +197,7 @@ func (r TxResponse) Empty() bool {
 
 // ParseABCILogs attempts to parse a stringified ABCI tx log into a slice of
 // IndexedABCILog types. It returns an error upon JSON decoding failure.
-func ParseABCILogs(logs string) (res []IndexedABCILog, err error) {
+func ParseABCILogs(logs string) (res IndexedABCILogs, err error) {
 	err = json.Unmarshal([]byte(logs), &res)
 	return res, err
 }

--- a/types/result_test.go
+++ b/types/result_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/cosmos/cosmos-sdk/codec"
 )
 
 func TestResult(t *testing.T) {
@@ -15,4 +17,20 @@ func TestResult(t *testing.T) {
 
 	res.Code = CodeType(1)
 	require.False(t, res.IsOK())
+}
+
+func TestTxResponseJSON(t *testing.T) {
+	cdc := codec.New()
+	txr := TxResponse{
+		Log: `[{"log":"","msg_index":"0","success":true}]`,
+	}
+
+	bz, err := cdc.MarshalJSON(txr)
+	require.NoError(t, err)
+
+	var txr2 TxResponse
+	err = cdc.UnmarshalJSON(bz, &txr2)
+	require.NoError(t, err)
+
+	require.Equal(t, txr, txr2)
 }

--- a/types/result_test.go
+++ b/types/result_test.go
@@ -4,8 +4,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
-	"github.com/cosmos/cosmos-sdk/codec"
 )
 
 func TestResult(t *testing.T) {
@@ -19,18 +17,13 @@ func TestResult(t *testing.T) {
 	require.False(t, res.IsOK())
 }
 
-func TestTxResponseJSON(t *testing.T) {
-	cdc := codec.New()
-	txr := TxResponse{
-		Log: `[{"log":"","msg_index":"0","success":true}]`,
-	}
+func TestParseABCILog(t *testing.T) {
+	logs := `[{"log":"","msg_index":1,"success":true}]`
 
-	bz, err := cdc.MarshalJSON(txr)
+	res, err := ParseABCILogs(logs)
 	require.NoError(t, err)
-
-	var txr2 TxResponse
-	err = cdc.UnmarshalJSON(bz, &txr2)
-	require.NoError(t, err)
-
-	require.Equal(t, txr, txr2)
+	require.Len(t, res, 1)
+	require.Equal(t, res[0].Log, "")
+	require.Equal(t, res[0].MsgIndex, 1)
+	require.True(t, res[0].Success)
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Essentially this PR updates the `TxResponse#Log`  type to be directly what the BaseApp encodes as the log. In other words, client will no longer have to manually JSON decode this value.

/cc @cosmos/cosmos-ui this finally gets you what you want ⚡️ 

----

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/develop/CONTRIBUTING.md#pr-targeting))

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [x] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [x] Added entries in `PENDING.md` with issue # 
- [x] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
