### PR TITLE
R4R: Return on zero-length byte array input

### DIFF
--- a/PENDING.md
+++ b/PENDING.md
@@ -86,6 +86,7 @@ CLI flag.
 
 ### SDK
 
+* \#3727 Return on zero-length (including []byte{}) PrefixEndBytes() calls
 * \#3559 fix occasional failing due to non-determinism in lcd test TestBonding
   where validator is unexpectedly slashed throwing off test calculations
 * [\#3411] Include the `RequestInitChain.Time` in the block header init during

--- a/store/types/utils.go
+++ b/store/types/utils.go
@@ -58,7 +58,7 @@ func DiffKVStores(a KVStore, b KVStore, prefixesToSkip [][]byte) (kvA cmn.KVPair
 // range query for all []byte with a certain prefix
 // Deals with last byte of prefix being FF without overflowing
 func PrefixEndBytes(prefix []byte) []byte {
-	if prefix == nil {
+	if len(prefix) == 0 {
 		return nil
 	}
 


### PR DESCRIPTION
Closes https://github.com/cosmos/cosmos-sdk/issues/3727

cc @mossid 

- [x] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [x] Wrote tests
- [x] Updated relevant documentation (`docs/`)
- [x] Added entries in `PENDING.md` with issue # 
- [x] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
