### PR TITLE
R4R F1 mechanism rounding fix 

### DIFF
--- a/PENDING.md
+++ b/PENDING.md
@@ -24,6 +24,7 @@
 * [\#3669] Ensure consistency in message naming, codec registration, and JSON
 tags.
 * #3788 change order of operations for greater accuracy when calculation delegation share token value
+* #3788 DecCoins.Cap -> DecCoins.Intersect
 
 ### Tendermint
 

--- a/PENDING.md
+++ b/PENDING.md
@@ -23,6 +23,7 @@
 
 * [\#3669] Ensure consistency in message naming, codec registration, and JSON
 tags.
+* #3788 change order of operations for greater accuracy when calculation delegation share token value
 
 ### Tendermint
 

--- a/client/lcd/lcd_test.go
+++ b/client/lcd/lcd_test.go
@@ -553,7 +553,7 @@ func TestBonding(t *testing.T) {
 	// hence we utilize the exchange rate in the following test
 
 	validator2 := getValidator(t, port, operAddrs[1])
-	delTokensAfterRedelegation := delegatorDels[0].GetShares().Mul(validator2.DelegatorShareExRate())
+	delTokensAfterRedelegation := validator2.ShareTokens(delegatorDels[0].GetShares())
 	require.Equal(t, rdTokens.ToDec(), delTokensAfterRedelegation)
 
 	redelegation := getRedelegations(t, port, addr, operAddrs[0], operAddrs[1])

--- a/cmd/gaia/app/export.go
+++ b/cmd/gaia/app/export.go
@@ -104,6 +104,13 @@ func (app *GaiaApp) prepForZeroHeightGenesis(ctx sdk.Context, jailWhiteList []st
 
 	// reinitialize all validators
 	app.stakingKeeper.IterateValidators(ctx, func(_ int64, val sdk.Validator) (stop bool) {
+
+		// donate any unwithdrawn outstanding reward fraction tokens to the community pool
+		scraps := app.distrKeeper.GetValidatorOutstandingRewards(ctx, val.GetOperator())
+		feePool := app.distrKeeper.GetFeePool(ctx)
+		feePool.CommunityPool = feePool.CommunityPool.Add(scraps)
+		app.distrKeeper.SetFeePool(ctx, feePool)
+
 		app.distrKeeper.Hooks().AfterValidatorCreated(ctx, val.GetOperator())
 		return false
 	})

--- a/types/dec_coin.go
+++ b/types/dec_coin.go
@@ -278,9 +278,12 @@ func (coins DecCoins) SafeSub(coinsB DecCoins) (DecCoins, bool) {
 	return diff, diff.IsAnyNegative()
 }
 
-// Trims any denom amount from coin which exceeds that of coinB,
-// such that (coin.Cap(coinB)).IsLTE(coinB).
-func (coins DecCoins) Cap(coinsB DecCoins) DecCoins {
+// Intersect will return a new set of coins which contains the minimum DecCoin
+// for common denoms found in both `coins` and `coinsB`. For denoms not common
+// to both `coins` and `coinsB` the minimum is considered to be 0, thus they
+// are not added to the final set.In other words, trim any denom amount from
+// coin which exceeds that of coinB, such that (coin.Intersect(coinB)).IsLTE(coinB).
+func (coins DecCoins) Intersect(coinsB DecCoins) DecCoins {
 	res := make([]DecCoin, len(coins))
 	for i, coin := range coins {
 		minCoin := DecCoin{
@@ -476,27 +479,6 @@ func (coins DecCoins) IsAllPositive() bool {
 	}
 
 	return true
-}
-
-// MinSet will return a new set of coins which contains the minimum decCoin
-// for common denoms found in both `coins` and `coinsB`. For denoms not common
-// to both `coins` and `coinsB` the minimum is considered to be 0, thus they are
-// not added to the final set.
-func MinSet(coinsA, coinsB DecCoins) DecCoins {
-	minSet := ([]DecCoin)(nil)
-
-	for _, coinA := range coinsA {
-		denom := coinA.Denom
-		amountA := coinA.Amount
-		amountB := coinsB.AmountOf(coinA.Denom)
-
-		if amountA.LT(amountB) {
-			minSet = append(minSet, coinA)
-		} else {
-			minSet = append(minSet, NewDecCoinFromDec(denom, amountB))
-		}
-	}
-	return minSet
 }
 
 func removeZeroDecCoins(coins DecCoins) DecCoins {

--- a/types/dec_coin.go
+++ b/types/dec_coin.go
@@ -478,6 +478,27 @@ func (coins DecCoins) IsAllPositive() bool {
 	return true
 }
 
+// MinSet will return a new set of coins which containts the minimum decCoin
+// for common denoms found in both `coins` and `coinsB`.  for denoms not common
+// to both `coins` and `coinsB` the minimum is considered to be 0, thus they are
+// not added to the final set.
+func MinSet(coinsA, coinsB DecCoins) DecCoins {
+	minSet := ([]DecCoin)(nil)
+
+	for _, coinA := range coinsA {
+		denom := coinA.Denom
+		amountA := coinA.Amount
+		amountB := coinsB.AmountOf(coinA.Denom)
+
+		if amountA.LT(amountB) {
+			minSet = append(minSet, coinA)
+		} else {
+			minSet = append(minSet, NewDecCoinFromDec(denom, amountB))
+		}
+	}
+	return minSet
+}
+
 func removeZeroDecCoins(coins DecCoins) DecCoins {
 	i, l := 0, len(coins)
 	for i < l {

--- a/types/dec_coin.go
+++ b/types/dec_coin.go
@@ -478,8 +478,8 @@ func (coins DecCoins) IsAllPositive() bool {
 	return true
 }
 
-// MinSet will return a new set of coins which containts the minimum decCoin
-// for common denoms found in both `coins` and `coinsB`.  for denoms not common
+// MinSet will return a new set of coins which contains the minimum decCoin
+// for common denoms found in both `coins` and `coinsB`. For denoms not common
 // to both `coins` and `coinsB` the minimum is considered to be 0, thus they are
 // not added to the final set.
 func MinSet(coinsA, coinsB DecCoins) DecCoins {

--- a/types/dec_coin_test.go
+++ b/types/dec_coin_test.go
@@ -225,7 +225,7 @@ func TestDecCoinsString(t *testing.T) {
 	}
 }
 
-func TestDecCoinsCap(t *testing.T) {
+func TestDecCoinsIntersect(t *testing.T) {
 	testCases := []struct {
 		input1         string
 		input2         string
@@ -252,7 +252,7 @@ func TestDecCoinsCap(t *testing.T) {
 		exr, err := ParseDecCoins(tc.expectedResult)
 		require.NoError(t, err, "unexpected parse error in %v", i)
 
-		require.True(t, in1.Cap(in2).IsEqual(exr), "in1.cap(in2) != exr in %v", i)
-		// require.Equal(t, tc.expectedResult, in1.Cap(in2).String(), "in1.cap(in2) != exr in %v", i)
+		require.True(t, in1.Intersect(in2).IsEqual(exr), "in1.cap(in2) != exr in %v", i)
+		// require.Equal(t, tc.expectedResult, in1.Intersect(in2).String(), "in1.cap(in2) != exr in %v", i)
 	}
 }

--- a/types/staking.go
+++ b/types/staking.go
@@ -61,20 +61,20 @@ func (b BondStatus) Equal(b2 BondStatus) bool {
 
 // validator for a delegated proof of stake system
 type Validator interface {
-	GetJailed() bool                       // whether the validator is jailed
-	GetMoniker() string                    // moniker of the validator
-	GetStatus() BondStatus                 // status of the validator
-	GetOperator() ValAddress               // operator address to receive/return validators coins
-	GetConsPubKey() crypto.PubKey          // validation consensus pubkey
-	GetConsAddr() ConsAddress              // validation consensus address
-	GetTokens() Int                        // validation tokens
-	GetBondedTokens() Int                  // validator bonded tokens
-	GetTendermintPower() int64             // validation power in tendermint
-	GetCommission() Dec                    // validator commission rate
-	GetMinSelfDelegation() Int             // validator minimum self delegation
-	GetDelegatorShares() Dec               // total outstanding delegator shares
-	GetDelegatorShareExRate() Dec          // tokens per delegator share exchange rate
-	GetDelegatorShareExRateTruncated() Dec // tokens per delegator share exchange rate
+	GetJailed() bool              // whether the validator is jailed
+	GetMoniker() string           // moniker of the validator
+	GetStatus() BondStatus        // status of the validator
+	GetOperator() ValAddress      // operator address to receive/return validators coins
+	GetConsPubKey() crypto.PubKey // validation consensus pubkey
+	GetConsAddr() ConsAddress     // validation consensus address
+	GetTokens() Int               // validation tokens
+	GetBondedTokens() Int         // validator bonded tokens
+	GetTendermintPower() int64    // validation power in tendermint
+	GetCommission() Dec           // validator commission rate
+	GetMinSelfDelegation() Int    // validator minimum self delegation
+	GetDelegatorShares() Dec      // total outstanding delegator shares
+	ShareTokens(Dec) Dec          // token worth of provided delegator shares
+	ShareTokensTruncated(Dec) Dec // token worth of provided delegator shares, truncated
 }
 
 // validator which fulfills abci validator interface for use in Tendermint

--- a/x/distribution/keeper/allocation.go
+++ b/x/distribution/keeper/allocation.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	"fmt"
+
 	abci "github.com/tendermint/tendermint/abci/types"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -48,7 +49,10 @@ func (k Keeper) AllocateTokens(ctx sdk.Context, sumPrecommitPower, totalPower in
 		// block X+1's endblock, then X+2 we need to refer to the previous
 		// proposer for X+1, but we've forgotten about them.
 		logger.Error(fmt.Sprintf(
-			"WARNING: Attempt to allocate proposer rewards to unknown proposer %s. This should happen only if the proposer unbonded completely within a single block, which generally should not happen except in exceptional circumstances (or fuzz testing). We recommend you investigate immediately.",
+			"WARNING: Attempt to allocate proposer rewards to unknown proposer %s. "+
+				"This should happen only if the proposer unbonded completely within a single block, "+
+				"which generally should not happen except in exceptional circumstances (or fuzz testing). "+
+				"We recommend you investigate immediately.",
 			proposer.String()))
 	}
 
@@ -65,7 +69,7 @@ func (k Keeper) AllocateTokens(ctx sdk.Context, sumPrecommitPower, totalPower in
 		// ref https://github.com/cosmos/cosmos-sdk/issues/2525#issuecomment-430838701
 		powerFraction := sdk.NewDec(vote.Validator.Power).QuoTruncate(sdk.NewDec(totalPower))
 		reward := feesCollected.MulDecTruncate(voteMultiplier).MulDecTruncate(powerFraction)
-		reward = reward.Cap(remaining)
+		reward = reward.Intersect(remaining)
 		k.AllocateTokensToValidator(ctx, validator, reward)
 		remaining = remaining.Sub(reward)
 	}

--- a/x/distribution/keeper/delegation.go
+++ b/x/distribution/keeper/delegation.go
@@ -116,7 +116,6 @@ func (k Keeper) withdrawDelegationRewards(ctx sdk.Context, val sdk.Validator, de
 
 	// defensive edge case may happen on the very final digits
 	// of the decCoins due to operation order of the distribution mechanism.
-	// TODO log if rewards is reduced in this step
 	rewards := rewardsRaw.Intersect(outstanding)
 	if !rewards.IsEqual(rewardsRaw) {
 		logger := ctx.Logger().With("module", "x/distr")

--- a/x/distribution/keeper/delegation.go
+++ b/x/distribution/keeper/delegation.go
@@ -117,8 +117,8 @@ func (k Keeper) withdrawDelegationRewards(ctx sdk.Context, val sdk.Validator, de
 	// defensive edge case may happen on the very final digits
 	// of the decCoins due to operation order of the distribution mechanism.
 	// TODO log if rewards is reduced in this step
-	rewards = sdk.MinSet(rewardsRaw, outstanding)
-	if !rewards.Equals(rewardsRaw) {
+	rewards := sdk.MinSet(rewardsRaw, outstanding)
+	if !rewards.IsEqual(rewardsRaw) {
 		logger := ctx.Logger().With("module", "x/distr")
 		logger.Info(fmt.Sprintf("missing rewards rounding error, delegator %v"+
 			"withdrawing rewards from validator %v, should have received %v, got %v",

--- a/x/distribution/keeper/delegation.go
+++ b/x/distribution/keeper/delegation.go
@@ -22,8 +22,7 @@ func (k Keeper) initializeDelegation(ctx sdk.Context, val sdk.ValAddress, del sd
 	// calculate delegation stake in tokens
 	// we don't store directly, so multiply delegation shares * (tokens per share)
 	// note: necessary to truncate so we don't allow withdrawing more rewards than owed
-	stake := delegation.GetShares().MulTruncate(validator.GetDelegatorShareExRateTruncated()) // XXX XXX XXX XXX XXX XXX XXX XXX XXX
-	//stake := validator.GetTokens().ToDec().MulTruncate(delegation.GetShares()).QuoTruncate(validator.GetDelegatorShares())
+	stake := delegation.GetShares().MulTruncate(validator.GetDelegatorShareExRateTruncated())
 	k.SetDelegatorStartingInfo(ctx, val, del, types.NewDelegatorStartingInfo(previousPeriod, stake, uint64(ctx.BlockHeight())))
 }
 

--- a/x/distribution/keeper/delegation.go
+++ b/x/distribution/keeper/delegation.go
@@ -117,7 +117,7 @@ func (k Keeper) withdrawDelegationRewards(ctx sdk.Context, val sdk.Validator, de
 	// defensive edge case may happen on the very final digits
 	// of the decCoins due to operation order of the distribution mechanism.
 	// TODO log if rewards is reduced in this step
-	rewards := sdk.MinSet(rewardsRaw, outstanding)
+	rewards := rewardsRaw.Intersect(outstanding)
 	if !rewards.IsEqual(rewardsRaw) {
 		logger := ctx.Logger().With("module", "x/distr")
 		logger.Info(fmt.Sprintf("missing rewards rounding error, delegator %v"+

--- a/x/mock/simulation/util.go
+++ b/x/mock/simulation/util.go
@@ -71,13 +71,13 @@ func logPrinter(testingmode bool, logs []*strings.Builder) func() {
 		}
 
 		var f *os.File
-		if numLoggers > 10 {
-			fileName := fmt.Sprintf("simulation_log_%s.txt",
-				time.Now().Format("2006-01-02 15:04:05"))
-			fmt.Printf("Too many logs to display, instead writing to %s\n",
-				fileName)
-			f, _ = os.Create(fileName)
-		}
+		//if numLoggers > 10 {
+		fileName := fmt.Sprintf("simulation_log_%s.txt",
+			time.Now().Format("2006-01-02 15:04:05"))
+		fmt.Printf("Too many logs to display, instead writing to %s\n",
+			fileName)
+		f, _ = os.Create(fileName)
+		//}
 
 		for i := 0; i < numLoggers; i++ {
 			if f == nil {

--- a/x/mock/simulation/util.go
+++ b/x/mock/simulation/util.go
@@ -71,13 +71,13 @@ func logPrinter(testingmode bool, logs []*strings.Builder) func() {
 		}
 
 		var f *os.File
-		//if numLoggers > 10 {
-		fileName := fmt.Sprintf("simulation_log_%s.txt",
-			time.Now().Format("2006-01-02 15:04:05"))
-		fmt.Printf("Too many logs to display, instead writing to %s\n",
-			fileName)
-		f, _ = os.Create(fileName)
-		//}
+		if numLoggers > 10 {
+			fileName := fmt.Sprintf("simulation_log_%s.txt",
+				time.Now().Format("2006-01-02 15:04:05"))
+			fmt.Printf("Too many logs to display, instead writing to %s\n",
+				fileName)
+			f, _ = os.Create(fileName)
+		}
 
 		for i := 0; i < numLoggers; i++ {
 			if f == nil {

--- a/x/slashing/handler.go
+++ b/x/slashing/handler.go
@@ -31,7 +31,7 @@ func handleMsgUnjail(ctx sdk.Context, msg MsgUnjail, k Keeper) sdk.Result {
 		return ErrMissingSelfDelegation(k.codespace).Result()
 	}
 
-	if validator.GetDelegatorShareExRate().Mul(selfDel.GetShares()).TruncateInt().LT(validator.GetMinSelfDelegation()) {
+	if validator.ShareTokens(selfDel.GetShares()).TruncateInt().LT(validator.GetMinSelfDelegation()) {
 		return ErrSelfDelegationTooLowToUnjail(k.codespace).Result()
 	}
 

--- a/x/staking/handler_test.go
+++ b/x/staking/handler_test.go
@@ -333,8 +333,6 @@ func TestIncrementsMsgDelegate(t *testing.T) {
 	require.Equal(t, bondAmount, bond.Shares.RoundInt())
 
 	pool := keeper.GetPool(ctx)
-	exRate := validator.DelegatorShareExRate()
-	require.True(t, exRate.Equal(sdk.OneDec()), "expected exRate 1 got %v", exRate)
 	require.Equal(t, bondAmount, pool.BondedTokens)
 
 	// just send the same msgbond multiple times
@@ -351,9 +349,6 @@ func TestIncrementsMsgDelegate(t *testing.T) {
 		require.True(t, found)
 		bond, found := keeper.GetDelegation(ctx, delegatorAddr, validatorAddr)
 		require.True(t, found)
-
-		exRate := validator.DelegatorShareExRate()
-		require.True(t, exRate.Equal(sdk.OneDec()), "expected exRate 1 got %v, i = %v", exRate, i)
 
 		expBond := bondAmount.MulRaw(i + 1)
 		expDelegatorShares := bondAmount.MulRaw(i + 2) // (1 self delegation)

--- a/x/staking/types/validator.go
+++ b/x/staking/types/validator.go
@@ -349,7 +349,7 @@ func (v Validator) SetInitialCommission(commission Commission) (Validator, sdk.E
 func (v Validator) AddTokensFromDel(pool Pool, amount sdk.Int) (Validator, Pool, sdk.Dec) {
 
 	// calculate the shares to issue
-	issuedShares := sdk.Dec{}
+	var issuedShares sdk.Dec
 	if v.DelegatorShares.IsZero() {
 		// the first delegation to a validator sets the exchange rate to one
 		issuedShares = amount.ToDec()

--- a/x/staking/types/validator.go
+++ b/x/staking/types/validator.go
@@ -354,7 +354,7 @@ func (v Validator) AddTokensFromDel(pool Pool, amount sdk.Int) (Validator, Pool,
 		// the first delegation to a validator sets the exchange rate to one
 		issuedShares = amount.ToDec()
 	} else {
-		issuedShares = v.DelegatorShares.MulInt(v.Tokens).QuoInt(amount)
+		issuedShares = v.DelegatorShares.MulInt(amount).QuoInt(v.Tokens)
 	}
 
 	if v.Status == sdk.Bonded {

--- a/x/staking/types/validator.go
+++ b/x/staking/types/validator.go
@@ -348,10 +348,13 @@ func (v Validator) SetInitialCommission(commission Commission) (Validator, sdk.E
 // CONTRACT: Tokens are assumed to have come from not-bonded pool.
 func (v Validator) AddTokensFromDel(pool Pool, amount sdk.Int) (Validator, Pool, sdk.Dec) {
 
-	// bondedShare/delegatedShare
-	exRate := v.DelegatorShareExRate()
-	if exRate.IsZero() {
-		panic("zero exRate should not happen")
+	// calculate the shares to issue
+	issuedShares := sdk.Dec{}
+	if v.DelegatorShares.IsZero() {
+		// the first delegation to a validator sets the exchange rate to one
+		issuedShares = amount.ToDec()
+	} else {
+		issuedShares = v.DelegatorShares.MulInt(v.Tokens).QuoInt(amount)
 	}
 
 	if v.Status == sdk.Bonded {
@@ -359,7 +362,6 @@ func (v Validator) AddTokensFromDel(pool Pool, amount sdk.Int) (Validator, Pool,
 	}
 
 	v.Tokens = v.Tokens.Add(amount)
-	issuedShares := amount.ToDec().Quo(exRate)
 	v.DelegatorShares = v.DelegatorShares.Add(issuedShares)
 
 	return v, pool, issuedShares
@@ -382,7 +384,7 @@ func (v Validator) RemoveDelShares(pool Pool, delShares sdk.Dec) (Validator, Poo
 
 		// leave excess tokens in the validator
 		// however fully use all the delegator shares
-		issuedTokens = v.DelegatorShareExRate().Mul(delShares).TruncateInt()
+		issuedTokens = v.ShareTokens(delShares).TruncateInt()
 		v.Tokens = v.Tokens.Sub(issuedTokens)
 		if v.Tokens.IsNegative() {
 			panic("attempting to remove more tokens than available in validator")
@@ -397,24 +399,21 @@ func (v Validator) RemoveDelShares(pool Pool, delShares sdk.Dec) (Validator, Poo
 	return v, pool, issuedTokens
 }
 
-// DelegatorShareExRate gets the exchange rate of tokens over delegator shares.
-// UNITS: tokens/delegator-shares
-func (v Validator) DelegatorShareExRate() sdk.Dec {
-	if v.DelegatorShares.IsZero() {
-		// the first delegation to a validator sets the exchange rate to one
-		return sdk.OneDec()
-	}
-	return v.Tokens.ToDec().Quo(v.DelegatorShares)
+// In some situations, the exchange rate becomes invalid, e.g. if
+// Validator loses all tokens due to slashing. In this case,
+// make all future delegations invalid.
+func (v Validator) InvalidExRate() bool {
+	return v.Tokens.IsZero() && v.DelegatorShares.IsPositive()
 }
 
-// DelegatorShareExRateTruncated gets the exchange rate of tokens over delegator shares, truncated.
-// UNITS: tokens/delegator-shares
-func (v Validator) DelegatorShareExRateTruncated() sdk.Dec {
-	if v.DelegatorShares.IsZero() {
-		// the first delegation to a validator sets the exchange rate to one
-		return sdk.OneDec()
-	}
-	return v.Tokens.ToDec().QuoTruncate(v.DelegatorShares)
+// calculate the token worth of provided shares
+func (v Validator) ShareTokens(shares sdk.Dec) sdk.Dec {
+	return (shares.MulInt(v.Tokens)).Quo(v.DelegatorShares)
+}
+
+// calculate the token worth of provided shares, truncated
+func (v Validator) ShareTokensTruncated(shares sdk.Dec) sdk.Dec {
+	return (shares.MulInt(v.Tokens)).QuoTruncate(v.DelegatorShares)
 }
 
 // get the bonded tokens which the validator holds
@@ -443,19 +442,15 @@ func (v Validator) PotentialTendermintPower() int64 {
 var _ sdk.Validator = Validator{}
 
 // nolint - for sdk.Validator
-func (v Validator) GetJailed() bool                  { return v.Jailed }
-func (v Validator) GetMoniker() string               { return v.Description.Moniker }
-func (v Validator) GetStatus() sdk.BondStatus        { return v.Status }
-func (v Validator) GetOperator() sdk.ValAddress      { return v.OperatorAddress }
-func (v Validator) GetConsPubKey() crypto.PubKey     { return v.ConsPubKey }
-func (v Validator) GetConsAddr() sdk.ConsAddress     { return sdk.ConsAddress(v.ConsPubKey.Address()) }
-func (v Validator) GetTokens() sdk.Int               { return v.Tokens }
-func (v Validator) GetBondedTokens() sdk.Int         { return v.BondedTokens() }
-func (v Validator) GetTendermintPower() int64        { return v.TendermintPower() }
-func (v Validator) GetCommission() sdk.Dec           { return v.Commission.Rate }
-func (v Validator) GetMinSelfDelegation() sdk.Int    { return v.MinSelfDelegation }
-func (v Validator) GetDelegatorShares() sdk.Dec      { return v.DelegatorShares }
-func (v Validator) GetDelegatorShareExRate() sdk.Dec { return v.DelegatorShareExRate() }
-func (v Validator) GetDelegatorShareExRateTruncated() sdk.Dec {
-	return v.DelegatorShareExRateTruncated()
-}
+func (v Validator) GetJailed() bool               { return v.Jailed }
+func (v Validator) GetMoniker() string            { return v.Description.Moniker }
+func (v Validator) GetStatus() sdk.BondStatus     { return v.Status }
+func (v Validator) GetOperator() sdk.ValAddress   { return v.OperatorAddress }
+func (v Validator) GetConsPubKey() crypto.PubKey  { return v.ConsPubKey }
+func (v Validator) GetConsAddr() sdk.ConsAddress  { return sdk.ConsAddress(v.ConsPubKey.Address()) }
+func (v Validator) GetTokens() sdk.Int            { return v.Tokens }
+func (v Validator) GetBondedTokens() sdk.Int      { return v.BondedTokens() }
+func (v Validator) GetTendermintPower() int64     { return v.TendermintPower() }
+func (v Validator) GetCommission() sdk.Dec        { return v.Commission.Rate }
+func (v Validator) GetMinSelfDelegation() sdk.Int { return v.MinSelfDelegation }
+func (v Validator) GetDelegatorShares() sdk.Dec   { return v.DelegatorShares }

--- a/x/staking/types/validator_test.go
+++ b/x/staking/types/validator_test.go
@@ -1,7 +1,6 @@
 package types
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -267,10 +266,8 @@ func TestPossibleOverflow(t *testing.T) {
 		BondedTokens:    poolTokens,
 	}
 	tokens := int64(71)
-	msg := fmt.Sprintf("validator %#v", validator)
 	newValidator, _, _ := validator.AddTokensFromDel(pool, sdk.NewInt(tokens))
 
-	msg = fmt.Sprintf("Added %d tokens to %s", tokens, msg)
 	require.False(t, newValidator.DelegatorShares.IsNegative())
 	require.False(t, newValidator.Tokens.IsNegative())
 }

--- a/x/staking/types/validator_test.go
+++ b/x/staking/types/validator_test.go
@@ -208,6 +208,26 @@ func TestRemoveDelShares(t *testing.T) {
 		pool.NotBondedTokens.Add(pool.BondedTokens)))
 }
 
+func TestAddTokensFromDel(t *testing.T) {
+	val := NewValidator(addr1, pk1, Description{})
+	pool := InitialPool()
+	pool.NotBondedTokens = sdk.NewInt(10)
+
+	val, pool, shares := val.AddTokensFromDel(pool, sdk.NewInt(6))
+	require.True(sdk.DecEq(t, sdk.NewDec(6), shares))
+	require.True(sdk.DecEq(t, sdk.NewDec(6), val.DelegatorShares))
+	require.True(sdk.IntEq(t, sdk.NewInt(6), val.Tokens))
+	require.True(sdk.IntEq(t, sdk.NewInt(0), pool.BondedTokens))
+	require.True(sdk.IntEq(t, sdk.NewInt(10), pool.NotBondedTokens))
+
+	val, pool, shares = val.AddTokensFromDel(pool, sdk.NewInt(3))
+	require.True(sdk.DecEq(t, sdk.NewDec(3), shares))
+	require.True(sdk.DecEq(t, sdk.NewDec(9), val.DelegatorShares))
+	require.True(sdk.IntEq(t, sdk.NewInt(9), val.Tokens))
+	require.True(sdk.IntEq(t, sdk.NewInt(0), pool.BondedTokens))
+	require.True(sdk.IntEq(t, sdk.NewInt(10), pool.NotBondedTokens))
+}
+
 func TestUpdateStatus(t *testing.T) {
 	pool := InitialPool()
 	pool.NotBondedTokens = sdk.NewInt(100)

--- a/x/staking/types/validator_test.go
+++ b/x/staking/types/validator_test.go
@@ -70,6 +70,21 @@ func TestABCIValidatorUpdateZero(t *testing.T) {
 	require.Equal(t, int64(0), abciVal.Power)
 }
 
+func TestShareTokens(t *testing.T) {
+	validator := Validator{
+		OperatorAddress: addr1,
+		ConsPubKey:      pk1,
+		Status:          sdk.Bonded,
+		Tokens:          sdk.NewInt(100),
+		DelegatorShares: sdk.NewDec(100),
+	}
+	assert.True(sdk.DecEq(t, sdk.NewDec(50), validator.ShareTokens(sdk.NewDec(50))))
+
+	validator.Tokens = sdk.NewInt(50)
+	assert.True(sdk.DecEq(t, sdk.NewDec(25), validator.ShareTokens(sdk.NewDec(50))))
+	assert.True(sdk.DecEq(t, sdk.NewDec(5), validator.ShareTokens(sdk.NewDec(10))))
+}
+
 func TestRemoveTokens(t *testing.T) {
 
 	validator := Validator{
@@ -112,10 +127,9 @@ func TestAddTokensValidatorBonded(t *testing.T) {
 	validator, pool = validator.UpdateStatus(pool, sdk.Bonded)
 	validator, pool, delShares := validator.AddTokensFromDel(pool, sdk.NewInt(10))
 
-	require.Equal(t, sdk.OneDec(), validator.DelegatorShareExRate())
-
 	assert.True(sdk.DecEq(t, sdk.NewDec(10), delShares))
 	assert.True(sdk.IntEq(t, sdk.NewInt(10), validator.BondedTokens()))
+	assert.True(sdk.DecEq(t, sdk.NewDec(10), validator.DelegatorShares))
 }
 
 func TestAddTokensValidatorUnbonding(t *testing.T) {
@@ -125,11 +139,10 @@ func TestAddTokensValidatorUnbonding(t *testing.T) {
 	validator, pool = validator.UpdateStatus(pool, sdk.Unbonding)
 	validator, pool, delShares := validator.AddTokensFromDel(pool, sdk.NewInt(10))
 
-	require.Equal(t, sdk.OneDec(), validator.DelegatorShareExRate())
-
 	assert.True(sdk.DecEq(t, sdk.NewDec(10), delShares))
 	assert.Equal(t, sdk.Unbonding, validator.Status)
 	assert.True(sdk.IntEq(t, sdk.NewInt(10), validator.Tokens))
+	assert.True(sdk.DecEq(t, sdk.NewDec(10), validator.DelegatorShares))
 }
 
 func TestAddTokensValidatorUnbonded(t *testing.T) {
@@ -139,11 +152,10 @@ func TestAddTokensValidatorUnbonded(t *testing.T) {
 	validator, pool = validator.UpdateStatus(pool, sdk.Unbonded)
 	validator, pool, delShares := validator.AddTokensFromDel(pool, sdk.NewInt(10))
 
-	require.Equal(t, sdk.OneDec(), validator.DelegatorShareExRate())
-
 	assert.True(sdk.DecEq(t, sdk.NewDec(10), delShares))
 	assert.Equal(t, sdk.Unbonded, validator.Status)
 	assert.True(sdk.IntEq(t, sdk.NewInt(10), validator.Tokens))
+	assert.True(sdk.DecEq(t, sdk.NewDec(10), validator.DelegatorShares))
 }
 
 // TODO refactor to make simpler like the AddToken tests above
@@ -158,7 +170,6 @@ func TestRemoveDelShares(t *testing.T) {
 	poolA := InitialPool()
 	poolA.NotBondedTokens = sdk.NewInt(10)
 	poolA.BondedTokens = valA.BondedTokens()
-	require.Equal(t, valA.DelegatorShareExRate(), sdk.OneDec())
 
 	// Remove delegator shares
 	valB, poolB, coinsB := valA.RemoveDelShares(poolA, sdk.NewDec(10))
@@ -240,9 +251,8 @@ func TestPossibleOverflow(t *testing.T) {
 	newValidator, _, _ := validator.AddTokensFromDel(pool, sdk.NewInt(tokens))
 
 	msg = fmt.Sprintf("Added %d tokens to %s", tokens, msg)
-	require.False(t, newValidator.DelegatorShareExRate().LT(sdk.ZeroDec()),
-		"Applying operation \"%s\" resulted in negative DelegatorShareExRate(): %v",
-		msg, newValidator.DelegatorShareExRate())
+	require.False(t, newValidator.DelegatorShares.IsNegative())
+	require.False(t, newValidator.Tokens.IsNegative())
 }
 
 func TestValidatorMarshalUnmarshalJSON(t *testing.T) {


### PR DESCRIPTION
REF https://github.com/cosmos/cosmos-sdk/pull/3750

due to order of operations F1 was actually calculating stake slightly differently than staking... see the diff in the code comments for more explanation

fixes problem found here:
https://github.com/cosmos/cosmos-sdk/pull/3750#issuecomment-468477401

Also added a defensive minimum if rewards > outstanding (which could occur in the old code if everyone withdrew in the same block)

(feel free to push to this branch)