### PR TITLE
use DBBackend set at compile time

### DIFF
--- a/PENDING.md
+++ b/PENDING.md
@@ -40,6 +40,9 @@ tags.
 
 ### SDK
 
+* [\#3719](https://github.com/cosmos/cosmos-sdk/issues/3719) DBBackend can now be set at compile time.
+  Defaults: goleveldb. Supported: cleveldb.
+
 ### Tendermint
 
 <!------------------------------- IMPROVEMENTS ------------------------------->

--- a/cmd/gaia/app/sim_test.go
+++ b/cmd/gaia/app/sim_test.go
@@ -304,7 +304,7 @@ func BenchmarkFullGaiaSimulation(b *testing.B) {
 
 	var db dbm.DB
 	dir, _ := ioutil.TempDir("", "goleveldb-gaia-sim")
-	db, _ = dbm.NewGoLevelDB("Simulation", dir)
+	db, _ = sdk.NewLevelDB("Simulation", dir)
 	defer func() {
 		db.Close()
 		os.RemoveAll(dir)
@@ -346,7 +346,7 @@ func TestFullGaiaSimulation(t *testing.T) {
 	}
 	var db dbm.DB
 	dir, _ := ioutil.TempDir("", "goleveldb-gaia-sim")
-	db, _ = dbm.NewGoLevelDB("Simulation", dir)
+	db, _ = sdk.NewLevelDB("Simulation", dir)
 	defer func() {
 		db.Close()
 		os.RemoveAll(dir)
@@ -387,7 +387,7 @@ func TestGaiaImportExport(t *testing.T) {
 	}
 	var db dbm.DB
 	dir, _ := ioutil.TempDir("", "goleveldb-gaia-sim")
-	db, _ = dbm.NewGoLevelDB("Simulation", dir)
+	db, _ = sdk.NewLevelDB("Simulation", dir)
 	defer func() {
 		db.Close()
 		os.RemoveAll(dir)
@@ -420,7 +420,7 @@ func TestGaiaImportExport(t *testing.T) {
 	fmt.Printf("Importing genesis...\n")
 
 	newDir, _ := ioutil.TempDir("", "goleveldb-gaia-sim-2")
-	newDB, _ := dbm.NewGoLevelDB("Simulation-2", dir)
+	newDB, _ := sdk.NewLevelDB("Simulation-2", dir)
 	defer func() {
 		newDB.Close()
 		os.RemoveAll(newDir)
@@ -482,7 +482,7 @@ func TestGaiaSimulationAfterImport(t *testing.T) {
 		logger = log.NewNopLogger()
 	}
 	dir, _ := ioutil.TempDir("", "goleveldb-gaia-sim")
-	db, _ := dbm.NewGoLevelDB("Simulation", dir)
+	db, _ := sdk.NewLevelDB("Simulation", dir)
 	defer func() {
 		db.Close()
 		os.RemoveAll(dir)
@@ -524,7 +524,7 @@ func TestGaiaSimulationAfterImport(t *testing.T) {
 	fmt.Printf("Importing genesis...\n")
 
 	newDir, _ := ioutil.TempDir("", "goleveldb-gaia-sim-2")
-	newDB, _ := dbm.NewGoLevelDB("Simulation-2", dir)
+	newDB, _ := sdk.NewLevelDB("Simulation-2", dir)
 	defer func() {
 		newDB.Close()
 		os.RemoveAll(newDir)

--- a/cmd/gaia/cmd/gaiadebug/hack.go
+++ b/cmd/gaia/cmd/gaiadebug/hack.go
@@ -45,7 +45,7 @@ func runHackCmd(cmd *cobra.Command, args []string) error {
 
 	// load the app
 	logger := log.NewTMLogger(log.NewSyncWriter(os.Stdout))
-	db, err := dbm.NewGoLevelDB("gaia", dataDir)
+	db, err := sdk.NewLevelDB("gaia", dataDir)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)

--- a/cmd/gaia/cmd/gaiareplay/main.go
+++ b/cmd/gaia/cmd/gaiareplay/main.go
@@ -15,7 +15,6 @@ import (
 	abci "github.com/tendermint/tendermint/abci/types"
 	bcm "github.com/tendermint/tendermint/blockchain"
 	cmn "github.com/tendermint/tendermint/libs/common"
-	dbm "github.com/tendermint/tendermint/libs/db"
 	"github.com/tendermint/tendermint/proxy"
 	tmsm "github.com/tendermint/tendermint/state"
 	tm "github.com/tendermint/tendermint/types"
@@ -23,6 +22,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/cmd/gaia/app"
 	"github.com/cosmos/cosmos-sdk/server"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 var (
@@ -72,7 +72,7 @@ func run(rootDir string) {
 	// App DB
 	// appDB := dbm.NewMemDB()
 	fmt.Println("Opening app database")
-	appDB, err := dbm.NewGoLevelDB("application", dataDir)
+	appDB, err := sdk.NewLevelDB("application", dataDir)
 	if err != nil {
 		panic(err)
 	}
@@ -80,14 +80,14 @@ func run(rootDir string) {
 	// TM DB
 	// tmDB := dbm.NewMemDB()
 	fmt.Println("Opening tendermint state database")
-	tmDB, err := dbm.NewGoLevelDB("state", dataDir)
+	tmDB, err := sdk.NewLevelDB("state", dataDir)
 	if err != nil {
 		panic(err)
 	}
 
 	// Blockchain DB
 	fmt.Println("Opening blockstore database")
-	bcDB, err := dbm.NewGoLevelDB("blockstore", dataDir)
+	bcDB, err := sdk.NewLevelDB("blockstore", dataDir)
 	if err != nil {
 		panic(err)
 	}

--- a/crypto/keys/lazy_keybase.go
+++ b/crypto/keys/lazy_keybase.go
@@ -5,10 +5,9 @@ import (
 
 	"github.com/tendermint/tendermint/crypto"
 	cmn "github.com/tendermint/tendermint/libs/common"
-	dbm "github.com/tendermint/tendermint/libs/db"
 
 	"github.com/cosmos/cosmos-sdk/crypto/keys/hd"
-	"github.com/cosmos/cosmos-sdk/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 var _ Keybase = lazyKeybase{}
@@ -28,7 +27,7 @@ func New(name, dir string) Keybase {
 }
 
 func (lkb lazyKeybase) List() ([]Info, error) {
-	db, err := dbm.NewGoLevelDB(lkb.name, lkb.dir)
+	db, err := sdk.NewLevelDB(lkb.name, lkb.dir)
 	if err != nil {
 		return nil, err
 	}
@@ -38,7 +37,7 @@ func (lkb lazyKeybase) List() ([]Info, error) {
 }
 
 func (lkb lazyKeybase) Get(name string) (Info, error) {
-	db, err := dbm.NewGoLevelDB(lkb.name, lkb.dir)
+	db, err := sdk.NewLevelDB(lkb.name, lkb.dir)
 	if err != nil {
 		return nil, err
 	}
@@ -47,8 +46,8 @@ func (lkb lazyKeybase) Get(name string) (Info, error) {
 	return newDbKeybase(db).Get(name)
 }
 
-func (lkb lazyKeybase) GetByAddress(address types.AccAddress) (Info, error) {
-	db, err := dbm.NewGoLevelDB(lkb.name, lkb.dir)
+func (lkb lazyKeybase) GetByAddress(address sdk.AccAddress) (Info, error) {
+	db, err := sdk.NewLevelDB(lkb.name, lkb.dir)
 	if err != nil {
 		return nil, err
 	}
@@ -58,7 +57,7 @@ func (lkb lazyKeybase) GetByAddress(address types.AccAddress) (Info, error) {
 }
 
 func (lkb lazyKeybase) Delete(name, passphrase string, skipPass bool) error {
-	db, err := dbm.NewGoLevelDB(lkb.name, lkb.dir)
+	db, err := sdk.NewLevelDB(lkb.name, lkb.dir)
 	if err != nil {
 		return err
 	}
@@ -68,7 +67,7 @@ func (lkb lazyKeybase) Delete(name, passphrase string, skipPass bool) error {
 }
 
 func (lkb lazyKeybase) Sign(name, passphrase string, msg []byte) ([]byte, crypto.PubKey, error) {
-	db, err := dbm.NewGoLevelDB(lkb.name, lkb.dir)
+	db, err := sdk.NewLevelDB(lkb.name, lkb.dir)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -78,7 +77,7 @@ func (lkb lazyKeybase) Sign(name, passphrase string, msg []byte) ([]byte, crypto
 }
 
 func (lkb lazyKeybase) CreateMnemonic(name string, language Language, passwd string, algo SigningAlgo) (info Info, seed string, err error) {
-	db, err := dbm.NewGoLevelDB(lkb.name, lkb.dir)
+	db, err := sdk.NewLevelDB(lkb.name, lkb.dir)
 	if err != nil {
 		return nil, "", err
 	}
@@ -88,7 +87,7 @@ func (lkb lazyKeybase) CreateMnemonic(name string, language Language, passwd str
 }
 
 func (lkb lazyKeybase) CreateAccount(name, mnemonic, bip39Passwd, encryptPasswd string, account uint32, index uint32) (Info, error) {
-	db, err := dbm.NewGoLevelDB(lkb.name, lkb.dir)
+	db, err := sdk.NewLevelDB(lkb.name, lkb.dir)
 	if err != nil {
 		return nil, err
 	}
@@ -98,7 +97,7 @@ func (lkb lazyKeybase) CreateAccount(name, mnemonic, bip39Passwd, encryptPasswd 
 }
 
 func (lkb lazyKeybase) Derive(name, mnemonic, bip39Passwd, encryptPasswd string, params hd.BIP44Params) (Info, error) {
-	db, err := dbm.NewGoLevelDB(lkb.name, lkb.dir)
+	db, err := sdk.NewLevelDB(lkb.name, lkb.dir)
 	if err != nil {
 		return nil, err
 	}
@@ -108,7 +107,7 @@ func (lkb lazyKeybase) Derive(name, mnemonic, bip39Passwd, encryptPasswd string,
 }
 
 func (lkb lazyKeybase) CreateLedger(name string, algo SigningAlgo, account uint32, index uint32) (info Info, err error) {
-	db, err := dbm.NewGoLevelDB(lkb.name, lkb.dir)
+	db, err := sdk.NewLevelDB(lkb.name, lkb.dir)
 	if err != nil {
 		return nil, err
 	}
@@ -118,7 +117,7 @@ func (lkb lazyKeybase) CreateLedger(name string, algo SigningAlgo, account uint3
 }
 
 func (lkb lazyKeybase) CreateOffline(name string, pubkey crypto.PubKey) (info Info, err error) {
-	db, err := dbm.NewGoLevelDB(lkb.name, lkb.dir)
+	db, err := sdk.NewLevelDB(lkb.name, lkb.dir)
 	if err != nil {
 		return nil, err
 	}
@@ -128,7 +127,7 @@ func (lkb lazyKeybase) CreateOffline(name string, pubkey crypto.PubKey) (info In
 }
 
 func (lkb lazyKeybase) CreateMulti(name string, pubkey crypto.PubKey) (info Info, err error) {
-	db, err := dbm.NewGoLevelDB(lkb.name, lkb.dir)
+	db, err := sdk.NewLevelDB(lkb.name, lkb.dir)
 	if err != nil {
 		return nil, err
 	}
@@ -138,7 +137,7 @@ func (lkb lazyKeybase) CreateMulti(name string, pubkey crypto.PubKey) (info Info
 }
 
 func (lkb lazyKeybase) Update(name, oldpass string, getNewpass func() (string, error)) error {
-	db, err := dbm.NewGoLevelDB(lkb.name, lkb.dir)
+	db, err := sdk.NewLevelDB(lkb.name, lkb.dir)
 	if err != nil {
 		return err
 	}
@@ -148,7 +147,7 @@ func (lkb lazyKeybase) Update(name, oldpass string, getNewpass func() (string, e
 }
 
 func (lkb lazyKeybase) Import(name string, armor string) (err error) {
-	db, err := dbm.NewGoLevelDB(lkb.name, lkb.dir)
+	db, err := sdk.NewLevelDB(lkb.name, lkb.dir)
 	if err != nil {
 		return err
 	}
@@ -158,7 +157,7 @@ func (lkb lazyKeybase) Import(name string, armor string) (err error) {
 }
 
 func (lkb lazyKeybase) ImportPubKey(name string, armor string) (err error) {
-	db, err := dbm.NewGoLevelDB(lkb.name, lkb.dir)
+	db, err := sdk.NewLevelDB(lkb.name, lkb.dir)
 	if err != nil {
 		return err
 	}
@@ -168,7 +167,7 @@ func (lkb lazyKeybase) ImportPubKey(name string, armor string) (err error) {
 }
 
 func (lkb lazyKeybase) Export(name string) (armor string, err error) {
-	db, err := dbm.NewGoLevelDB(lkb.name, lkb.dir)
+	db, err := sdk.NewLevelDB(lkb.name, lkb.dir)
 	if err != nil {
 		return "", err
 	}
@@ -178,7 +177,7 @@ func (lkb lazyKeybase) Export(name string) (armor string, err error) {
 }
 
 func (lkb lazyKeybase) ExportPubKey(name string) (armor string, err error) {
-	db, err := dbm.NewGoLevelDB(lkb.name, lkb.dir)
+	db, err := sdk.NewLevelDB(lkb.name, lkb.dir)
 	if err != nil {
 		return "", err
 	}
@@ -188,7 +187,7 @@ func (lkb lazyKeybase) ExportPubKey(name string) (armor string, err error) {
 }
 
 func (lkb lazyKeybase) ExportPrivateKeyObject(name string, passphrase string) (crypto.PrivKey, error) {
-	db, err := dbm.NewGoLevelDB(lkb.name, lkb.dir)
+	db, err := sdk.NewLevelDB(lkb.name, lkb.dir)
 	if err != nil {
 		return nil, err
 	}

--- a/server/constructors.go
+++ b/server/constructors.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	abci "github.com/tendermint/tendermint/abci/types"
 	dbm "github.com/tendermint/tendermint/libs/db"
 	"github.com/tendermint/tendermint/libs/log"
@@ -24,7 +25,7 @@ type (
 
 func openDB(rootDir string) (dbm.DB, error) {
 	dataDir := filepath.Join(rootDir, "data")
-	db, err := dbm.NewGoLevelDB("application", dataDir)
+	db, err := sdk.NewLevelDB("application", dataDir)
 	return db, err
 }
 

--- a/server/mock/app.go
+++ b/server/mock/app.go
@@ -8,7 +8,6 @@ import (
 	"github.com/tendermint/tendermint/types"
 
 	abci "github.com/tendermint/tendermint/abci/types"
-	dbm "github.com/tendermint/tendermint/libs/db"
 	"github.com/tendermint/tendermint/libs/log"
 
 	bam "github.com/cosmos/cosmos-sdk/baseapp"
@@ -20,7 +19,7 @@ import (
 // similar to a real app. Make sure rootDir is empty before running the test,
 // in order to guarantee consistent results
 func NewApp(rootDir string, logger log.Logger) (abci.Application, error) {
-	db, err := dbm.NewGoLevelDB("mock", filepath.Join(rootDir, "data"))
+	db, err := sdk.NewLevelDB("mock", filepath.Join(rootDir, "data"))
 	if err != nil {
 		return nil, err
 	}

--- a/types/utils.go
+++ b/types/utils.go
@@ -3,7 +3,15 @@ package types
 import (
 	"encoding/binary"
 	"encoding/json"
+	"fmt"
 	"time"
+
+	dbm "github.com/tendermint/tendermint/libs/db"
+)
+
+var (
+	// This is set at compile time. Could be cleveldb, defaults is goleveldb.
+	DBBackend = ""
 )
 
 // SortedJSON takes any JSON and returns it sorted by keys. Also, all white-spaces
@@ -57,4 +65,18 @@ func ParseTimeBytes(bz []byte) (time.Time, error) {
 		return t, err
 	}
 	return t.UTC().Round(0), nil
+}
+
+// NewLevelDB instantiate a new LevelDB instance according to DBBackend.
+func NewLevelDB(name, dir string) (db dbm.DB, err error) {
+	backend := dbm.GoLevelDBBackend
+	if DBBackend == string(dbm.CLevelDBBackend) {
+		backend = dbm.CLevelDBBackend
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("couldn't create db: %v", r)
+		}
+	}()
+	return dbm.NewDB(name, backend, dir), err
 }


### PR DESCRIPTION
Replace NewGoLevelDB() with generic NewLevelDB() calls.
DB backend is picked according to build time configuration.

Makefile:
- DB backend can be switched at compile time by
  adding WITH_CLEVELDB=yes to make install.
-  Add support for user supplied ldflags and build tags.

Closes: #3719

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added entries in `PENDING.md` with issue # 
- [ ] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
