### PR TITLE
R4R: Simulator: write changes to store in x/gov/simulation/msgs.go

### DIFF
--- a/x/gov/simulation/msgs.go
+++ b/x/gov/simulation/msgs.go
@@ -89,9 +89,12 @@ func SimulateMsgSubmitProposal(k gov.Keeper) simulation.Operation {
 }
 
 func simulateHandleMsgSubmitProposal(msg gov.MsgSubmitProposal, handler sdk.Handler, ctx sdk.Context, event func(string)) (action string, ok bool) {
-	ctx, _ = ctx.CacheContext()
+	ctx, write := ctx.CacheContext()
 	result := handler(ctx, msg)
 	ok = result.IsOK()
+	if ok {
+		write()
+	}
 	event(fmt.Sprintf("gov/MsgSubmitProposal/%v", ok))
 	action = fmt.Sprintf("TestMsgSubmitProposal: ok %v, msg %s", ok, msg.GetSignBytes())
 	return
@@ -125,8 +128,11 @@ func SimulateMsgDeposit(k gov.Keeper) simulation.Operation {
 		if msg.ValidateBasic() != nil {
 			return "", nil, fmt.Errorf("expected msg to pass ValidateBasic: %s", msg.GetSignBytes())
 		}
-		ctx, _ = ctx.CacheContext()
+		ctx, write := ctx.CacheContext()
 		result := gov.NewHandler(k)(ctx, msg)
+		if result.IsOK() {
+			write()
+		}
 		event(fmt.Sprintf("gov/MsgDeposit/%v", result.IsOK()))
 		action = fmt.Sprintf("TestMsgDeposit: ok %v, msg %s", result.IsOK(), msg.GetSignBytes())
 		return action, nil, nil


### PR DESCRIPTION
In two places in x/gov/simulation/msgs.go, a new CacheContext is created, but its corresponding
write function is never called.  Hence, the changes to that context never make it to the underlying
store.  This commit addresses that issue.
______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
