### PR TITLE
R4R: Simulator: Set Quorum field in appStateRandomizedFn

### DIFF
--- a/cmd/gaia/app/sim_test.go
+++ b/cmd/gaia/app/sim_test.go
@@ -161,6 +161,7 @@ func appStateRandomizedFn(r *rand.Rand, accs []simulation.Account, genesisTimest
 			VotingPeriod: vp,
 		},
 		TallyParams: gov.TallyParams{
+			Quorum:    sdk.NewDecWithPrec(334, 3),
 			Threshold: sdk.NewDecWithPrec(5, 1),
 			Veto:      sdk.NewDecWithPrec(334, 3),
 		},


### PR DESCRIPTION
This avoids a nil pointer dereference, e.g., when the simulator displays log messages.  This change
is intended to be consistent with:
https://github.com/cosmos/cosmos-sdk/blob/5d05b7ff0f1fb7953b581837fd4ddd8c9fde92e6/x/gov/genesis.go#L60-L63
______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
