### PR TITLE
Fix nil returned in Unmarshal functions

### DIFF
--- a/PENDING.md
+++ b/PENDING.md
@@ -101,6 +101,7 @@ CLI flag.
 ### Gaia
 
 * [\#3777](https://github.com/cosmso/cosmos-sdk/pull/3777) `gaiad export` no longer panics when the database is empty
+* [\#3806](https://github.com/cosmos/cosmos-sdk/pull/3806) Properly return errors from a couple of struct Unmarshal functions
 
 ### SDK
 

--- a/types/address.go
+++ b/types/address.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/tendermint/tendermint/crypto"
-	"github.com/tendermint/tendermint/crypto/encoding/amino"
 
 	"github.com/tendermint/tendermint/libs/bech32"
 )
@@ -279,7 +278,7 @@ func (va *ValAddress) UnmarshalJSON(data []byte) error {
 
 	err := json.Unmarshal(data, &s)
 	if err != nil {
-		return nil
+		return err
 	}
 
 	va2, err := ValAddressFromBech32(s)
@@ -415,7 +414,7 @@ func (ca *ConsAddress) UnmarshalJSON(data []byte) error {
 
 	err := json.Unmarshal(data, &s)
 	if err != nil {
-		return nil
+		return err
 	}
 
 	ca2, err := ConsAddressFromBech32(s)

--- a/types/address.go
+++ b/types/address.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/tendermint/tendermint/crypto"
+	"github.com/tendermint/tendermint/crypto/encoding/amino"
 
 	"github.com/tendermint/tendermint/libs/bech32"
 )

--- a/x/gov/depositsvotes.go
+++ b/x/gov/depositsvotes.go
@@ -135,7 +135,7 @@ func (vo *VoteOption) UnmarshalJSON(data []byte) error {
 	var s string
 	err := json.Unmarshal(data, &s)
 	if err != nil {
-		return nil
+		return err
 	}
 
 	bz2, err := VoteOptionFromString(s)

--- a/x/gov/proposals.go
+++ b/x/gov/proposals.go
@@ -206,7 +206,7 @@ func (pt *ProposalKind) UnmarshalJSON(data []byte) error {
 	var s string
 	err := json.Unmarshal(data, &s)
 	if err != nil {
-		return nil
+		return err
 	}
 
 	bz2, err := ProposalTypeFromString(s)
@@ -307,7 +307,7 @@ func (status *ProposalStatus) UnmarshalJSON(data []byte) error {
 	var s string
 	err := json.Unmarshal(data, &s)
 	if err != nil {
-		return nil
+		return err
 	}
 
 	bz2, err := ProposalStatusFromString(s)


### PR DESCRIPTION
Fixes: https://github.com/cosmos/cosmos-sdk/issues/3810

There are some `Unmarshal` functions for specific structs where errors are not being returned properly. This PR fixes that.