### PR TITLE
JSON output for the CLI to 2 spaces

### DIFF
--- a/client/context/context.go
+++ b/client/context/context.go
@@ -259,7 +259,7 @@ func (ctx CLIContext) PrintOutput(toPrint fmt.Stringer) (err error) {
 
 	case "json":
 		if ctx.Indent {
-			out, err = ctx.Codec.MarshalJSONIndent(toPrint, "", " ")
+			out, err = ctx.Codec.MarshalJSONIndent(toPrint, "", "  ")
 		} else {
 			out, err = ctx.Codec.MarshalJSON(toPrint)
 		}


### PR DESCRIPTION
The output is currently single spaced, which IMO looks weird visually.