### PR TITLE
Temporarily remove snap from installation instructions

### DIFF
--- a/docs/gaia/installation.md
+++ b/docs/gaia/installation.md
@@ -61,34 +61,7 @@ Build tags indicate special features that have been enabled in the binary.
 
 ### Install binary distribution via snap (Linux only)
 
-Gaia can be installed on various GNU/Linux distributions from the [Snapcraft.io](https://snapcraft.io/gaia) store:
-
-```bash
-$ sudo snap install gaia
-```
-
-Development builds are available through the `edge` channel:
-
-```bash
-$ sudo snap install --edge gaia
-```
-
-::: tip
-At the time of writing, only the following [architectures are supported](https://build.snapcraft.io/user/cosmos/cosmos-sdk): `amd64` `i386` `arm64` `armhf` `ppc64el` `s390x`.
-:::
-
-`snap` installs Gaia binaries as `gaia.gaiad` and `gaia.gaiacli`. It is recommended to create commands aliases for the user's convenience once the package is installed:
-
-```
-$ sudo snap alias gaia.gaiad gaiad
-$ sudo snap alias gaia.gaiacli gaiacli
-```
-
-::: warning
-Note that the binaries provided by the snap package save their data into **$HOME/snap/gaia/** instead of **$HOME**.
-:::
-
-Please refer to [Snap documentation](https://docs.snapcraft.io/installing-snapd/6735) for specific information on how to install `snap` on your distribution.
+**Do not use snap at this time to install the binaries for production until we have a reproduceable binary system.**
 
 
 ### Next


### PR DESCRIPTION
Temporarily remove snap from installation instructions until it's been more thoroughly audited.