### PR TITLE
Add newline to echo of `gaiacli keys ...`

### DIFF
--- a/PENDING.md
+++ b/PENDING.md
@@ -39,6 +39,8 @@
 
 ### Gaia CLI
 
+* [\#3859](https://github.com/cosmos/cosmos-sdk/pull/3859) Add newline to echo of `gaiacli keys ...`
+
 ### Gaia
 
 * #3808 `gaiad` and `gaiacli` integration tests use ./build/ binaries.

--- a/client/keys/add.go
+++ b/client/keys/add.go
@@ -146,7 +146,7 @@ func runAddCmd(_ *cobra.Command, args []string) error {
 				return err
 			}
 
-			fmt.Fprintf(os.Stderr, "Key %q saved to disk.", name)
+			fmt.Fprintf(os.Stderr, "Key %q saved to disk.\n", name)
 			return nil
 		}
 
@@ -216,7 +216,7 @@ func runAddCmd(_ *cobra.Command, args []string) error {
 	}
 
 	if !bip39.IsMnemonicValid(mnemonic) {
-		fmt.Fprintf(os.Stderr, "Error: Mnemonic is not valid")
+		fmt.Fprintf(os.Stderr, "Error: Mnemonic is not valid.\n")
 		return nil
 	}
 


### PR DESCRIPTION
`gaiacli keys add a123 --multisig a1,a2,a3 --multisig-threshold 2`
`gaiacli keys add temp --recover` with incorrect mnemonic

```bash
root@503a9ff8dd9c:/# gaiacli keys add a123 --multisig a1,a2,a3 --multisig-threshold 2
Key "a123" saved to disk.root@503a9ff8dd9c:/#
root@503a9ff8dd9c:/# gaiacli keys add temp --recover
Enter a passphrase to encrypt your key to disk:
Repeat the passphrase:
> Enter your bip39 mnemonic
1 2 3 4 5 6
Error: Mnemonic is not validroot@503a9ff8dd9c:/#
```

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/develop/CONTRIBUTING.md#pr-targeting))

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [x] Added entries in `PENDING.md` with issue # 
- [x] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
