### PR TITLE
R4R: Add indent to prompt of `gaiacli tx send`.

### DIFF
--- a/client/utils/utils.go
+++ b/client/utils/utils.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"bytes"
 	"fmt"
+	"github.com/spf13/viper"
 	"io/ioutil"
 	"os"
 
@@ -69,9 +70,14 @@ func CompleteAndBroadcastTxCLI(txBldr authtxb.TxBuilder, cliCtx context.CLIConte
 			return err
 		}
 
-		json, err := cliCtx.Codec.MarshalJSONIndent(stdSignMsg, "", "  ")
-		if err != nil {
-			panic(err)
+		var json []byte
+		if viper.GetBool(client.FlagIndentResponse) {
+			json, err = cliCtx.Codec.MarshalJSONIndent(stdSignMsg, "", "  ")
+			if err != nil {
+				panic(err)
+			}
+		} else {
+			json = cliCtx.Codec.MustMarshalJSON(stdSignMsg)
 		}
 		fmt.Fprintf(os.Stderr, "%s\n\n", json)
 

--- a/client/utils/utils.go
+++ b/client/utils/utils.go
@@ -69,7 +69,11 @@ func CompleteAndBroadcastTxCLI(txBldr authtxb.TxBuilder, cliCtx context.CLIConte
 			return err
 		}
 
-		fmt.Fprintf(os.Stderr, "%s\n\n", cliCtx.Codec.MustMarshalJSON(stdSignMsg))
+		json, err := cliCtx.Codec.MarshalJSONIndent(stdSignMsg, "", "  ")
+		if err != nil {
+			panic(err)
+		}
+		fmt.Fprintf(os.Stderr, "%s\n\n", json)
 
 		buf := client.BufferStdin()
 		ok, err := client.GetConfirmation("confirm transaction before signing and broadcasting", buf)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/develop/CONTRIBUTING.md#pr-targeting))

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [x] Added entries in `PENDING.md` with issue # 
- [x] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
