### PR TITLE
Revert bcrypto.GenerateFromPassword() to mainline go x/crypto

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -530,7 +530,7 @@
   version = "v0.8.0"
 
 [[projects]]
-  digest = "1:6f6dc6060c4e9ba73cf28aa88f12a69a030d3d19d518ef8e931879eaa099628d"
+  digest = "1:ad88c93829c6bade3400420bc1b72ec21248b008cac700cb65ba63abe8d528da"
   name = "golang.org/x/crypto"
   packages = [
     "bcrypt",
@@ -552,8 +552,7 @@
     "salsa20/salsa",
   ]
   pruneopts = "UT"
-  revision = "3764759f34a542a3aef74d6b02e35be7ab893bba"
-  source = "https://github.com/tendermint/crypto"
+  revision = "505ab145d0a99da450461ae2c1a9f6cd10d1f447"
 
 [[projects]]
   digest = "1:d36f55a999540d29b6ea3c2ea29d71c76b1d9853fdcd3e5c5cb4836f2ba118f1"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -52,11 +52,6 @@
   name = "github.com/btcsuite/btcd"
   revision = "ed77733ec07dfc8a513741138419b8d9d3de9d2d"
 
-[[override]]
-  name = "golang.org/x/crypto"
-  source = "https://github.com/tendermint/crypto"
-  revision = "3764759f34a542a3aef74d6b02e35be7ab893bba"
-
 [[constraint]]
   name = "github.com/cosmos/go-bip39"
   revision = "52158e4697b87de16ed390e1bdaf813e581008fa"
@@ -76,6 +71,10 @@
 [[override]]
   name = "github.com/syndtr/goleveldb"
   revision = "c4c61651e9e37fa117f53c5a906d3b63090d8445"
+
+[[override]]
+  name = "github.com/x/crypto"
+  revision = "505ab145d0a99da450461ae2c1a9f6cd10d1f447"
 
 [[override]]
   name = "golang.org/x/sys"

--- a/cmd/gaia/app/benchmarks/txsize_test.go
+++ b/cmd/gaia/app/benchmarks/txsize_test.go
@@ -1,4 +1,4 @@
-package app
+package benchmarks_test
 
 import (
 	"fmt"

--- a/crypto/keys/mintkey/mintkey.go
+++ b/crypto/keys/mintkey/mintkey.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/tendermint/tendermint/crypto"
 	"github.com/tendermint/tendermint/crypto/armor"
-	"github.com/tendermint/tendermint/crypto/encoding/amino"
+	cryptoAmino "github.com/tendermint/tendermint/crypto/encoding/amino"
 	"github.com/tendermint/tendermint/crypto/xsalsa20symmetric"
 
 	cmn "github.com/tendermint/tendermint/libs/common"
@@ -106,7 +106,7 @@ func EncryptArmorPrivKey(privKey crypto.PrivKey, passphrase string) string {
 // encrypted priv key.
 func encryptPrivKey(privKey crypto.PrivKey, passphrase string) (saltBytes []byte, encBytes []byte) {
 	saltBytes = crypto.CRandBytes(16)
-	key, err := bcrypt.GenerateFromPassword(saltBytes, []byte(passphrase), BcryptSecurityParameter)
+	key, err := bcrypt.GenerateFromPassword([]byte(passphrase), BcryptSecurityParameter)
 	if err != nil {
 		cmn.Exit("Error generating bcrypt key from passphrase: " + err.Error())
 	}
@@ -140,7 +140,7 @@ func UnarmorDecryptPrivKey(armorStr string, passphrase string) (crypto.PrivKey, 
 }
 
 func decryptPrivKey(saltBytes []byte, encBytes []byte, passphrase string) (privKey crypto.PrivKey, err error) {
-	key, err := bcrypt.GenerateFromPassword(saltBytes, []byte(passphrase), BcryptSecurityParameter)
+	key, err := bcrypt.GenerateFromPassword([]byte(passphrase), BcryptSecurityParameter)
 	if err != nil {
 		cmn.Exit("Error generating bcrypt key from passphrase: " + err.Error())
 	}

--- a/crypto/keys/mintkey/mintkey.go
+++ b/crypto/keys/mintkey/mintkey.go
@@ -1,7 +1,6 @@
 package mintkey
 
 import (
-	"encoding/hex"
 	"fmt"
 
 	"golang.org/x/crypto/bcrypt"
@@ -126,18 +125,11 @@ func UnarmorDecryptPrivKey(armorStr string, passphrase string) (crypto.PrivKey, 
 	if header["kdf"] != "bcrypt" {
 		return privKey, fmt.Errorf("Unrecognized KDF type: %v", header["KDF"])
 	}
-	if header["salt"] == "" {
-		return privKey, fmt.Errorf("Missing salt bytes")
-	}
-	saltBytes, err := hex.DecodeString(header["salt"])
-	if err != nil {
-		return privKey, fmt.Errorf("Error decoding salt: %v", err.Error())
-	}
-	privKey, err = decryptPrivKey(saltBytes, encBytes, passphrase)
+	privKey, err = decryptPrivKey(encBytes, passphrase)
 	return privKey, err
 }
 
-func decryptPrivKey(saltBytes []byte, encBytes []byte, passphrase string) (privKey crypto.PrivKey, err error) {
+func decryptPrivKey(encBytes []byte, passphrase string) (privKey crypto.PrivKey, err error) {
 	key, err := bcrypt.GenerateFromPassword([]byte(passphrase), BcryptSecurityParameter)
 	if err != nil {
 		cmn.Exit("Error generating bcrypt key from passphrase: " + err.Error())

--- a/crypto/keys/mintkey/mintkey.go
+++ b/crypto/keys/mintkey/mintkey.go
@@ -92,10 +92,9 @@ func unarmorBytes(armorStr, blockType string) (bz []byte, err error) {
 
 // Encrypt and armor the private key.
 func EncryptArmorPrivKey(privKey crypto.PrivKey, passphrase string) string {
-	saltBytes, encBytes := encryptPrivKey(privKey, passphrase)
+	encBytes := encryptPrivKey(privKey, passphrase)
 	header := map[string]string{
-		"kdf":  "bcrypt",
-		"salt": fmt.Sprintf("%X", saltBytes),
+		"kdf": "bcrypt",
 	}
 	armorStr := armor.EncodeArmor(blockTypePrivKey, header, encBytes)
 	return armorStr
@@ -104,15 +103,14 @@ func EncryptArmorPrivKey(privKey crypto.PrivKey, passphrase string) string {
 // encrypt the given privKey with the passphrase using a randomly
 // generated salt and the xsalsa20 cipher. returns the salt and the
 // encrypted priv key.
-func encryptPrivKey(privKey crypto.PrivKey, passphrase string) (saltBytes []byte, encBytes []byte) {
-	saltBytes = crypto.CRandBytes(16)
+func encryptPrivKey(privKey crypto.PrivKey, passphrase string) (encBytes []byte) {
 	key, err := bcrypt.GenerateFromPassword([]byte(passphrase), BcryptSecurityParameter)
 	if err != nil {
 		cmn.Exit("Error generating bcrypt key from passphrase: " + err.Error())
 	}
 	key = crypto.Sha256(key) // get 32 bytes
 	privKeyBytes := privKey.Bytes()
-	return saltBytes, xsalsa20symmetric.EncryptSymmetric(privKeyBytes, key)
+	return xsalsa20symmetric.EncryptSymmetric(privKeyBytes, key)
 }
 
 // Unarmor and decrypt the private key.

--- a/crypto/keys/mintkey/mintkey_bench_test.go
+++ b/crypto/keys/mintkey/mintkey_bench_test.go
@@ -6,8 +6,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/bcrypt"
-
-	"github.com/tendermint/tendermint/crypto"
 )
 
 func BenchmarkBcryptGenerateFromPassword(b *testing.B) {
@@ -15,7 +13,6 @@ func BenchmarkBcryptGenerateFromPassword(b *testing.B) {
 	for securityParam := 9; securityParam < 16; securityParam++ {
 		param := securityParam
 		b.Run(fmt.Sprintf("benchmark-security-param-%d", param), func(b *testing.B) {
-			saltBytes := crypto.CRandBytes(16)
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				_, err := bcrypt.GenerateFromPassword(passphrase, param)

--- a/crypto/keys/mintkey/mintkey_bench_test.go
+++ b/crypto/keys/mintkey/mintkey_bench_test.go
@@ -18,7 +18,7 @@ func BenchmarkBcryptGenerateFromPassword(b *testing.B) {
 			saltBytes := crypto.CRandBytes(16)
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				_, err := bcrypt.GenerateFromPassword(saltBytes, passphrase, param)
+				_, err := bcrypt.GenerateFromPassword(passphrase, param)
 				require.Nil(b, err)
 			}
 		})


### PR DESCRIPTION
As per tendermint#3027.
This change is required for go dep -> go mod migration.

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added a relevant changelog entry: `sdkch add [section] [stanza] [message]`
- [ ] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
