### PR TITLE
R4R: Fix #3899, Using `gaiacli config node` breaks ~/config/config.toml

### DIFF
--- a/.pending/bugfixes/gaiacli/3899-Using-gaiacli-c
+++ b/.pending/bugfixes/gaiacli/3899-Using-gaiacli-c
@@ -1,0 +1,1 @@
+#3899 Using 'gaiacli config node' breaks ~/config/config.toml

--- a/client/config.go
+++ b/client/config.go
@@ -144,7 +144,7 @@ func loadConfigFile(cfgFile string) (*toml.Tree, error) {
 }
 
 func saveConfigFile(cfgFile string, tree *toml.Tree) error {
-	fp, err := os.OpenFile(cfgFile, os.O_WRONLY|os.O_CREATE, 0644)
+	fp, err := os.OpenFile(cfgFile, os.O_WRONLY|os.O_TRUNC|os.O_CREATE, 0644)
 	if err != nil {
 		return err
 	}

--- a/client/config_test.go
+++ b/client/config_test.go
@@ -1,0 +1,44 @@
+package client
+
+import (
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tendermint/tendermint/libs/cli"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// For https://github.com/cosmos/cosmos-sdk/issues/3899
+func Test_runConfigCmdTwiceWithShorterNodeValue(t *testing.T) {
+	// Prepare environment
+	t.Parallel()
+	configHome, cleanup := tmpDir(t)
+	defer cleanup()
+	_ = os.RemoveAll(filepath.Join(configHome, "config"))
+	viper.Set(cli.HomeFlag, configHome)
+
+	// Init command config
+	cmd := ConfigCmd(configHome)
+	assert.NotNil(t, cmd)
+
+	err := cmd.RunE(cmd, []string{"node", "tcp://localhost:26657"})
+	assert.Nil(t, err)
+
+	err = cmd.RunE(cmd, []string{"node", "--get"})
+	assert.Nil(t, err)
+
+	err = cmd.RunE(cmd, []string{"node", "tcp://local:26657"})
+	assert.Nil(t, err)
+
+	err = cmd.RunE(cmd, []string{"node", "--get"})
+	assert.Nil(t, err)
+}
+
+func tmpDir(t *testing.T) (string, func()) {
+	dir, err := ioutil.TempDir("", t.Name()+"_")
+	require.NoError(t, err)
+	return dir, func() { _ = os.RemoveAll(dir) }
+}


### PR DESCRIPTION
Config file need to be truncated while rewriting.

close: #3899

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/develop/CONTRIBUTING.md#pr-targeting))

- [x] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [x] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [x] Added a relevant changelog entry: `sdkch add [section] [stanza] [message]`
- [x] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
