### PR TITLE
Fix lcd-testing 303030 bug continued

### DIFF
--- a/client/lcd/lcd_test.go
+++ b/client/lcd/lcd_test.go
@@ -522,12 +522,17 @@ func TestBonding(t *testing.T) {
 	resultTx = doBeginRedelegation(t, port, name1, pw, addr, operAddrs[0], operAddrs[1], rdTokens, fees)
 	require.Equal(t, uint32(0), resultTx.Code)
 	tests.WaitForHeight(resultTx.Height+1, port)
+	validator2 := getValidator(t, port, operAddrs[1])
+
+	// query delegations, unbondings and redelegations from validator and delegator
+	delegatorDels = getDelegatorDelegations(t, port, addr)
+	require.Len(t, delegatorDels, 1)
+	require.Equal(t, operAddrs[1], delegatorDels[0].ValidatorAddress)
 
 	// because the second validator never signs during these tests, if this
 	// this test takes a long time to run,  eventually this second validator
 	// will get slashed, meaning that it's exchange rate is no-longer 1-to-1,
 	// hence we utilize the exchange rate in the following test
-	validator2 := getValidator(t, port, operAddrs[1])
 	delTokensAfterRedelegation := validator2.ShareTokens(delegatorDels[0].GetShares())
 	require.Equal(t, rdTokens.ToDec(), delTokensAfterRedelegation)
 
@@ -548,11 +553,6 @@ func TestBonding(t *testing.T) {
 	)
 	require.Len(t, txs, 1)
 	require.Equal(t, resultTx.Height, txs[0].Height)
-
-	// query delegations, unbondings and redelegations from validator and delegator
-	delegatorDels = getDelegatorDelegations(t, port, addr)
-	require.Len(t, delegatorDels, 1)
-	require.Equal(t, operAddrs[1], delegatorDels[0].ValidatorAddress)
 
 	redelegation := getRedelegations(t, port, addr, operAddrs[0], operAddrs[1])
 	require.Len(t, redelegation, 1)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

closes https://github.com/cosmos/cosmos-sdk/issues/3739

This simple code movement should do the trick, basically, this provides only two blocks for the slash to take place if this bug is to come up again. So this bug *may* still come up once in a blue blue moon - highly unlikely though. The actual solution is to restructure the lcd so that all the validators are signing..... 

CC @alexanderbez 

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/develop/CONTRIBUTING.md#pr-targeting))

- [x] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added a relevant changelog entry: `sdkch add [section] [stanza] [message]`
- [ ] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
