### PR TITLE
Fix docker_image ci job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -367,14 +367,19 @@ jobs:
       - setup_remote_docker:
           docker_layer_caching: true
       - run: |
-          if [ "${CIRCLE_BRANCH}" == "master" ]; then
+          GAIAD_VERSION=''
+          if [ "${CIRCLE_BRANCH}" = "master" ]; then
             GAIAD_VERSION="stable"
-          elif [ "${CIRCLE_BRANCH}" == "develop" ]; then
+          elif [ "${CIRCLE_BRANCH}" = "develop" ]; then
             GAIAD_VERSION="develop"
           fi
-          docker build -t tendermint/gaia:$GAIAD_VERSION .
-          docker login -u $DOCKER_USER -p $DOCKER_PASS
-          docker push tendermint/gaia:$GAIAD_VERSION
+          if [ -z "${GAIAD_VERSION}" ]; then
+            docker build .
+          else
+            docker build -t tendermint/gaia:$GAIAD_VERSION .
+            docker login -u $DOCKER_USER -p $DOCKER_PASS
+            docker push tendermint/gaia:$GAIAD_VERSION
+          fi
 
   docker_tagged:
     <<: *linux_defaults
@@ -394,11 +399,6 @@ workflows:
   test-suite:
     jobs:
       - docker_image:
-          filters:
-            branches:
-              only:
-                - master
-                - develop
           requires:
             - setup_dependencies
       - docker_tagged:

--- a/.pending/bugfixes/sdk/3977-Fix-docker-imag
+++ b/.pending/bugfixes/sdk/3977-Fix-docker-imag
@@ -1,0 +1,1 @@
+#3977 Fix docker image build

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 FROM golang:alpine AS build-env
 
 # Set up dependencies
-ENV PACKAGES make git libc-dev bash gcc linux-headers eudev-dev
+ENV PACKAGES curl make git libc-dev bash gcc linux-headers eudev-dev
 
 # Set working directory for the build
 WORKDIR /go/src/github.com/cosmos/cosmos-sdk


### PR DESCRIPTION
- Always build regardless of the branch;
  push only from develop and master.
- Add curl to packages dependencies in Dockerfile
  to allow golangci-lint to be downloaded.

Closes: #3977

- [x] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added a relevant changelog entry: `sdkch add [section] [stanza] [message]`
- [x] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
