### PR TITLE
Remove LoadGenesisDoc() in favor of GenesisDocFromFile()

### DIFF
--- a/.pending/improvements/gaia/4062-Remove-cmd-gaia
+++ b/.pending/improvements/gaia/4062-Remove-cmd-gaia
@@ -1,0 +1,2 @@
+#4062 Remove cmd/gaia/init.LoadGenesisDoc() in favor of
+tendermint types.GenesisDocFromFile().

--- a/cmd/gaia/cli_test/test_helpers.go
+++ b/cmd/gaia/cli_test/test_helpers.go
@@ -15,10 +15,10 @@ import (
 	"github.com/stretchr/testify/require"
 
 	cmn "github.com/tendermint/tendermint/libs/common"
+	tmtypes "github.com/tendermint/tendermint/types"
 
 	clientkeys "github.com/cosmos/cosmos-sdk/client/keys"
 	"github.com/cosmos/cosmos-sdk/cmd/gaia/app"
-	appInit "github.com/cosmos/cosmos-sdk/cmd/gaia/init"
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/crypto/keys"
 	"github.com/cosmos/cosmos-sdk/server"
@@ -98,7 +98,7 @@ func (f Fixtures) GenesisFile() string {
 // GenesisFile returns the application's genesis state
 func (f Fixtures) GenesisState() app.GenesisState {
 	cdc := codec.New()
-	genDoc, err := appInit.LoadGenesisDoc(cdc, f.GenesisFile())
+	genDoc, err := tmtypes.GenesisDocFromFile(f.GenesisFile())
 	require.NoError(f.T, err)
 
 	var appState app.GenesisState

--- a/cmd/gaia/init/collect.go
+++ b/cmd/gaia/init/collect.go
@@ -46,7 +46,7 @@ func CollectGenTxsCmd(ctx *server.Context, cdc *codec.Codec) *cobra.Command {
 				return err
 			}
 
-			genDoc, err := LoadGenesisDoc(cdc, config.GenesisFile())
+			genDoc, err := types.GenesisDocFromFile(config.GenesisFile())
 			if err != nil {
 				return err
 			}
@@ -59,7 +59,7 @@ func CollectGenTxsCmd(ctx *server.Context, cdc *codec.Codec) *cobra.Command {
 			toPrint := newPrintInfo(config.Moniker, genDoc.ChainID, nodeID, genTxsDir, json.RawMessage(""))
 			initCfg := newInitConfig(genDoc.ChainID, genTxsDir, name, nodeID, valPubKey)
 
-			appMessage, err := genAppStateFromConfig(cdc, config, initCfg, genDoc)
+			appMessage, err := genAppStateFromConfig(cdc, config, initCfg, *genDoc)
 			if err != nil {
 				return err
 			}

--- a/cmd/gaia/init/genesis_accts.go
+++ b/cmd/gaia/init/genesis_accts.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spf13/viper"
 	"github.com/tendermint/tendermint/libs/cli"
 	"github.com/tendermint/tendermint/libs/common"
+	tmtypes "github.com/tendermint/tendermint/types"
 
 	"github.com/cosmos/cosmos-sdk/client/keys"
 	"github.com/cosmos/cosmos-sdk/cmd/gaia/app"
@@ -58,7 +59,7 @@ func AddGenesisAccountCmd(ctx *server.Context, cdc *codec.Codec) *cobra.Command 
 				return fmt.Errorf("%s does not exist, run `gaiad init` first", genFile)
 			}
 
-			genDoc, err := LoadGenesisDoc(cdc, genFile)
+			genDoc, err := tmtypes.GenesisDocFromFile(genFile)
 			if err != nil {
 				return err
 			}

--- a/cmd/gaia/init/gentx.go
+++ b/cmd/gaia/init/gentx.go
@@ -17,6 +17,7 @@ import (
 	"github.com/tendermint/tendermint/crypto"
 	tmcli "github.com/tendermint/tendermint/libs/cli"
 	"github.com/tendermint/tendermint/libs/common"
+	tmtypes "github.com/tendermint/tendermint/types"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/context"
@@ -79,7 +80,7 @@ following delegation and commission default parameters:
 					"the tx's memo field will be unset")
 			}
 
-			genDoc, err := LoadGenesisDoc(cdc, config.GenesisFile())
+			genDoc, err := tmtypes.GenesisDocFromFile(config.GenesisFile())
 			if err != nil {
 				return err
 			}

--- a/cmd/gaia/init/testnet.go
+++ b/cmd/gaia/init/testnet.go
@@ -306,12 +306,12 @@ func collectGenFiles(
 		nodeID, valPubKey := nodeIDs[i], valPubKeys[i]
 		initCfg := newInitConfig(chainID, gentxsDir, moniker, nodeID, valPubKey)
 
-		genDoc, err := LoadGenesisDoc(cdc, config.GenesisFile())
+		genDoc, err := types.GenesisDocFromFile(config.GenesisFile())
 		if err != nil {
 			return err
 		}
 
-		nodeAppState, err := genAppStateFromConfig(cdc, config, initCfg, genDoc)
+		nodeAppState, err := genAppStateFromConfig(cdc, config, initCfg, *genDoc)
 		if err != nil {
 			return err
 		}

--- a/cmd/gaia/init/utils.go
+++ b/cmd/gaia/init/utils.go
@@ -3,11 +3,9 @@ package init
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"path/filepath"
 	"time"
 
-	amino "github.com/tendermint/go-amino"
 	cfg "github.com/tendermint/tendermint/config"
 	"github.com/tendermint/tendermint/crypto"
 	"github.com/tendermint/tendermint/libs/common"
@@ -86,20 +84,6 @@ func InitializeNodeValidatorFiles(
 	valPubKey = privval.LoadOrGenFilePV(pvKeyFile, pvStateFile).GetPubKey()
 
 	return nodeID, valPubKey, nil
-}
-
-// LoadGenesisDoc reads and unmarshals GenesisDoc from the given file.
-func LoadGenesisDoc(cdc *amino.Codec, genFile string) (genDoc types.GenesisDoc, err error) {
-	genContents, err := ioutil.ReadFile(genFile)
-	if err != nil {
-		return genDoc, err
-	}
-
-	if err := cdc.UnmarshalJSON(genContents, &genDoc); err != nil {
-		return genDoc, err
-	}
-
-	return genDoc, err
 }
 
 func initializeEmptyGenesis(

--- a/cmd/gaia/init/utils_test.go
+++ b/cmd/gaia/init/utils_test.go
@@ -2,13 +2,10 @@ package init
 
 import (
 	"encoding/json"
-	"fmt"
-	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
-	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/tests"
 
 	"github.com/stretchr/testify/require"
@@ -21,29 +18,4 @@ func TestExportGenesisFileWithTime(t *testing.T) {
 
 	fname := filepath.Join(dir, "genesis.json")
 	require.NoError(t, ExportGenesisFileWithTime(fname, "test", nil, json.RawMessage(""), time.Now()))
-}
-
-func TestLoadGenesisDoc(t *testing.T) {
-	t.Parallel()
-	dir, cleanup := tests.NewTestCaseDir(t)
-	defer cleanup()
-
-	fname := filepath.Join(dir, "genesis.json")
-	require.NoError(t, ExportGenesisFileWithTime(fname, "test", nil, json.RawMessage(""), time.Now()))
-
-	_, err := LoadGenesisDoc(codec.Cdc, fname)
-	require.NoError(t, err)
-
-	// Non-existing file
-	_, err = LoadGenesisDoc(codec.Cdc, "non-existing-file")
-	require.Error(t, err)
-
-	malformedFilename := filepath.Join(dir, "malformed")
-	malformedFile, err := os.Create(malformedFilename)
-	require.NoError(t, err)
-	fmt.Fprint(malformedFile, "invalidjson")
-	malformedFile.Close()
-	// Non-existing file
-	_, err = LoadGenesisDoc(codec.Cdc, malformedFilename)
-	require.Error(t, err)
 }

--- a/cmd/gaia/init/validate_genesis.go
+++ b/cmd/gaia/init/validate_genesis.go
@@ -31,8 +31,8 @@ func ValidateGenesisCmd(ctx *server.Context, cdc *codec.Codec) *cobra.Command {
 			//nolint
 			fmt.Fprintf(os.Stderr, "validating genesis file at %s\n", genesis)
 
-			var genDoc types.GenesisDoc
-			if genDoc, err = LoadGenesisDoc(cdc, genesis); err != nil {
+			var genDoc *types.GenesisDoc
+			if genDoc, err = types.GenesisDocFromFile(genesis); err != nil {
 				return fmt.Errorf("Error loading genesis doc from %s: %s", genesis, err.Error())
 			}
 


### PR DESCRIPTION
Duplication of effort discovered while on #3130

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added a relevant changelog entry: `sdkch add [section] [stanza] [message]`
- [ ] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
