### PR TITLE
gaiad: ExportGenesisFile() incorrectly overwrites genesis

### DIFF
--- a/.pending/improvements/gaia/4062-Remove-cmd-gaia
+++ b/.pending/improvements/gaia/4062-Remove-cmd-gaia
@@ -1,0 +1,1 @@
+#4066 Fix 'ExportGenesisFile() incorrectly overwrites genesis'

--- a/cmd/gaia/cli_test/cli_test.go
+++ b/cmd/gaia/cli_test/cli_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/tendermint/tendermint/crypto/ed25519"
+	tmtypes "github.com/tendermint/tendermint/types"
 
 	"github.com/stretchr/testify/require"
 
@@ -992,6 +993,7 @@ trust-node = true
 
 func TestGaiadCollectGentxs(t *testing.T) {
 	t.Parallel()
+	var customMaxBytes, customMaxGas int64 = 99999999, 1234567
 	f := NewFixtures(t)
 
 	// Initialise temporary directories
@@ -1011,6 +1013,15 @@ func TestGaiadCollectGentxs(t *testing.T) {
 	// Run init
 	f.GDInit(keyFoo)
 
+	// Customise genesis.json
+
+	genFile := f.GenesisFile()
+	genDoc, err := tmtypes.GenesisDocFromFile(genFile)
+	require.NoError(t, err)
+	genDoc.ConsensusParams.Block.MaxBytes = customMaxBytes
+	genDoc.ConsensusParams.Block.MaxGas = customMaxGas
+	genDoc.SaveAs(genFile)
+
 	// Add account to genesis.json
 	f.AddGenesisAccount(f.KeyAddress(keyFoo), startCoins)
 
@@ -1019,6 +1030,11 @@ func TestGaiadCollectGentxs(t *testing.T) {
 
 	// Collect gentxs from a custom directory
 	f.CollectGenTxs(fmt.Sprintf("--gentx-dir=%s", gentxDir))
+
+	genDoc, err = tmtypes.GenesisDocFromFile(genFile)
+	require.NoError(t, err)
+	require.Equal(t, genDoc.ConsensusParams.Block.MaxBytes, customMaxBytes)
+	require.Equal(t, genDoc.ConsensusParams.Block.MaxGas, customMaxGas)
 
 	f.Cleanup(gentxDir)
 }

--- a/cmd/gaia/cli_test/test_helpers.go
+++ b/cmd/gaia/cli_test/test_helpers.go
@@ -15,10 +15,10 @@ import (
 	"github.com/stretchr/testify/require"
 
 	cmn "github.com/tendermint/tendermint/libs/common"
+	tmtypes "github.com/tendermint/tendermint/types"
 
 	clientkeys "github.com/cosmos/cosmos-sdk/client/keys"
 	"github.com/cosmos/cosmos-sdk/cmd/gaia/app"
-	appInit "github.com/cosmos/cosmos-sdk/cmd/gaia/init"
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/crypto/keys"
 	"github.com/cosmos/cosmos-sdk/server"
@@ -98,7 +98,7 @@ func (f Fixtures) GenesisFile() string {
 // GenesisFile returns the application's genesis state
 func (f Fixtures) GenesisState() app.GenesisState {
 	cdc := codec.New()
-	genDoc, err := appInit.LoadGenesisDoc(cdc, f.GenesisFile())
+	genDoc, err := tmtypes.GenesisDocFromFile(f.GenesisFile())
 	require.NoError(f.T, err)
 
 	var appState app.GenesisState

--- a/cmd/gaia/init/collect.go
+++ b/cmd/gaia/init/collect.go
@@ -46,7 +46,7 @@ func CollectGenTxsCmd(ctx *server.Context, cdc *codec.Codec) *cobra.Command {
 				return err
 			}
 
-			genDoc, err := LoadGenesisDoc(cdc, config.GenesisFile())
+			genDoc, err := types.GenesisDocFromFile(config.GenesisFile())
 			if err != nil {
 				return err
 			}
@@ -59,7 +59,7 @@ func CollectGenTxsCmd(ctx *server.Context, cdc *codec.Codec) *cobra.Command {
 			toPrint := newPrintInfo(config.Moniker, genDoc.ChainID, nodeID, genTxsDir, json.RawMessage(""))
 			initCfg := newInitConfig(genDoc.ChainID, genTxsDir, name, nodeID, valPubKey)
 
-			appMessage, err := genAppStateFromConfig(cdc, config, initCfg, genDoc)
+			appMessage, err := genAppStateFromConfig(cdc, config, initCfg, *genDoc)
 			if err != nil {
 				return err
 			}

--- a/cmd/gaia/init/collect.go
+++ b/cmd/gaia/init/collect.go
@@ -82,7 +82,6 @@ func genAppStateFromConfig(
 	cdc *codec.Codec, config *cfg.Config, initCfg initConfig, genDoc types.GenesisDoc,
 ) (appState json.RawMessage, err error) {
 
-	genFile := config.GenesisFile()
 	var (
 		appGenTxs       []auth.StdTx
 		persistentPeers string
@@ -116,7 +115,8 @@ func genAppStateFromConfig(
 		return
 	}
 
-	err = ExportGenesisFile(&genDoc, genFile, initCfg.ChainID, genDoc.Validators, appState)
+	genDoc.AppState = appState
+	err = ExportGenesisFile(&genDoc, config.GenesisFile())
 	return
 }
 

--- a/cmd/gaia/init/collect.go
+++ b/cmd/gaia/init/collect.go
@@ -116,7 +116,7 @@ func genAppStateFromConfig(
 		return
 	}
 
-	err = ExportGenesisFile(genFile, initCfg.ChainID, nil, appState)
+	err = ExportGenesisFile(&genDoc, genFile, initCfg.ChainID, genDoc.Validators, appState)
 	return
 }
 

--- a/cmd/gaia/init/genesis_accts.go
+++ b/cmd/gaia/init/genesis_accts.go
@@ -78,7 +78,7 @@ func AddGenesisAccountCmd(ctx *server.Context, cdc *codec.Codec) *cobra.Command 
 				return err
 			}
 
-			return ExportGenesisFile(genFile, genDoc.ChainID, nil, appStateJSON)
+			return ExportGenesisFile(&genDoc, genFile, genDoc.ChainID, genDoc.Validators, appStateJSON)
 		},
 	}
 

--- a/cmd/gaia/init/genesis_accts.go
+++ b/cmd/gaia/init/genesis_accts.go
@@ -79,7 +79,8 @@ func AddGenesisAccountCmd(ctx *server.Context, cdc *codec.Codec) *cobra.Command 
 				return err
 			}
 
-			return ExportGenesisFile(genDoc, genFile, genDoc.ChainID, genDoc.Validators, appStateJSON)
+			genDoc.AppState = appStateJSON
+			return ExportGenesisFile(genDoc, genFile)
 		},
 	}
 

--- a/cmd/gaia/init/genesis_accts.go
+++ b/cmd/gaia/init/genesis_accts.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spf13/viper"
 	"github.com/tendermint/tendermint/libs/cli"
 	"github.com/tendermint/tendermint/libs/common"
+	tmtypes "github.com/tendermint/tendermint/types"
 
 	"github.com/cosmos/cosmos-sdk/client/keys"
 	"github.com/cosmos/cosmos-sdk/cmd/gaia/app"
@@ -58,7 +59,7 @@ func AddGenesisAccountCmd(ctx *server.Context, cdc *codec.Codec) *cobra.Command 
 				return fmt.Errorf("%s does not exist, run `gaiad init` first", genFile)
 			}
 
-			genDoc, err := LoadGenesisDoc(cdc, genFile)
+			genDoc, err := tmtypes.GenesisDocFromFile(genFile)
 			if err != nil {
 				return err
 			}
@@ -78,7 +79,7 @@ func AddGenesisAccountCmd(ctx *server.Context, cdc *codec.Codec) *cobra.Command 
 				return err
 			}
 
-			return ExportGenesisFile(&genDoc, genFile, genDoc.ChainID, genDoc.Validators, appStateJSON)
+			return ExportGenesisFile(genDoc, genFile, genDoc.ChainID, genDoc.Validators, appStateJSON)
 		},
 	}
 

--- a/cmd/gaia/init/gentx.go
+++ b/cmd/gaia/init/gentx.go
@@ -17,6 +17,7 @@ import (
 	"github.com/tendermint/tendermint/crypto"
 	tmcli "github.com/tendermint/tendermint/libs/cli"
 	"github.com/tendermint/tendermint/libs/common"
+	tmtypes "github.com/tendermint/tendermint/types"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/context"
@@ -79,7 +80,7 @@ following delegation and commission default parameters:
 					"the tx's memo field will be unset")
 			}
 
-			genDoc, err := LoadGenesisDoc(cdc, config.GenesisFile())
+			genDoc, err := tmtypes.GenesisDocFromFile(config.GenesisFile())
 			if err != nil {
 				return err
 			}

--- a/cmd/gaia/init/init.go
+++ b/cmd/gaia/init/init.go
@@ -89,7 +89,10 @@ func InitCmd(ctx *server.Context, cdc *codec.Codec) *cobra.Command { // nolint: 
 				}
 			}
 
-			if err = ExportGenesisFile(genDoc, genFile, chainID, nil, appState); err != nil {
+			genDoc.ChainID = chainID
+			genDoc.Validators = nil
+			genDoc.AppState = appState
+			if err = ExportGenesisFile(genDoc, genFile); err != nil {
 				return err
 			}
 

--- a/cmd/gaia/init/init.go
+++ b/cmd/gaia/init/init.go
@@ -11,6 +11,7 @@ import (
 	cfg "github.com/tendermint/tendermint/config"
 	"github.com/tendermint/tendermint/libs/cli"
 	"github.com/tendermint/tendermint/libs/common"
+	"github.com/tendermint/tendermint/types"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/cmd/gaia/app"
@@ -76,7 +77,19 @@ func InitCmd(ctx *server.Context, cdc *codec.Codec) *cobra.Command { // nolint: 
 				return err
 			}
 
-			if err = ExportGenesisFile(genFile, chainID, nil, appState); err != nil {
+			genDoc := &types.GenesisDoc{}
+			if _, err := os.Stat(genFile); err != nil {
+				if !os.IsNotExist(err) {
+					return err
+				}
+			} else {
+				genDoc, err = types.GenesisDocFromFile(genFile)
+				if err != nil {
+					return err
+				}
+			}
+
+			if err = ExportGenesisFile(genDoc, genFile, chainID, nil, appState); err != nil {
 				return err
 			}
 

--- a/cmd/gaia/init/testnet.go
+++ b/cmd/gaia/init/testnet.go
@@ -306,12 +306,12 @@ func collectGenFiles(
 		nodeID, valPubKey := nodeIDs[i], valPubKeys[i]
 		initCfg := newInitConfig(chainID, gentxsDir, moniker, nodeID, valPubKey)
 
-		genDoc, err := LoadGenesisDoc(cdc, config.GenesisFile())
+		genDoc, err := types.GenesisDocFromFile(config.GenesisFile())
 		if err != nil {
 			return err
 		}
 
-		nodeAppState, err := genAppStateFromConfig(cdc, config, initCfg, genDoc)
+		nodeAppState, err := genAppStateFromConfig(cdc, config, initCfg, *genDoc)
 		if err != nil {
 			return err
 		}

--- a/cmd/gaia/init/utils.go
+++ b/cmd/gaia/init/utils.go
@@ -20,13 +20,7 @@ import (
 
 // ExportGenesisFile creates and writes the genesis configuration to disk. An
 // error is returned if building or writing the configuration to file fails.
-func ExportGenesisFile(genDoc *types.GenesisDoc,
-	genFile, chainID string, validators []types.GenesisValidator, appState json.RawMessage,
-) error {
-
-	genDoc.ChainID = chainID
-	genDoc.Validators = validators
-	genDoc.AppState = appState
+func ExportGenesisFile(genDoc *types.GenesisDoc, genFile string) error {
 	if err := genDoc.ValidateAndComplete(); err != nil {
 		return err
 	}

--- a/cmd/gaia/init/utils.go
+++ b/cmd/gaia/init/utils.go
@@ -22,16 +22,13 @@ import (
 
 // ExportGenesisFile creates and writes the genesis configuration to disk. An
 // error is returned if building or writing the configuration to file fails.
-func ExportGenesisFile(
+func ExportGenesisFile(genDoc *types.GenesisDoc,
 	genFile, chainID string, validators []types.GenesisValidator, appState json.RawMessage,
 ) error {
 
-	genDoc := types.GenesisDoc{
-		ChainID:    chainID,
-		Validators: validators,
-		AppState:   appState,
-	}
-
+	genDoc.ChainID = chainID
+	genDoc.Validators = validators
+	genDoc.AppState = appState
 	if err := genDoc.ValidateAndComplete(); err != nil {
 		return err
 	}

--- a/cmd/gaia/init/utils.go
+++ b/cmd/gaia/init/utils.go
@@ -3,11 +3,9 @@ package init
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"path/filepath"
 	"time"
 
-	amino "github.com/tendermint/go-amino"
 	cfg "github.com/tendermint/tendermint/config"
 	"github.com/tendermint/tendermint/crypto"
 	"github.com/tendermint/tendermint/libs/common"
@@ -83,20 +81,6 @@ func InitializeNodeValidatorFiles(
 	valPubKey = privval.LoadOrGenFilePV(pvKeyFile, pvStateFile).GetPubKey()
 
 	return nodeID, valPubKey, nil
-}
-
-// LoadGenesisDoc reads and unmarshals GenesisDoc from the given file.
-func LoadGenesisDoc(cdc *amino.Codec, genFile string) (genDoc types.GenesisDoc, err error) {
-	genContents, err := ioutil.ReadFile(genFile)
-	if err != nil {
-		return genDoc, err
-	}
-
-	if err := cdc.UnmarshalJSON(genContents, &genDoc); err != nil {
-		return genDoc, err
-	}
-
-	return genDoc, err
 }
 
 func initializeEmptyGenesis(

--- a/cmd/gaia/init/utils_test.go
+++ b/cmd/gaia/init/utils_test.go
@@ -2,13 +2,10 @@ package init
 
 import (
 	"encoding/json"
-	"fmt"
-	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
-	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/tests"
 
 	"github.com/stretchr/testify/require"
@@ -21,29 +18,4 @@ func TestExportGenesisFileWithTime(t *testing.T) {
 
 	fname := filepath.Join(dir, "genesis.json")
 	require.NoError(t, ExportGenesisFileWithTime(fname, "test", nil, json.RawMessage(""), time.Now()))
-}
-
-func TestLoadGenesisDoc(t *testing.T) {
-	t.Parallel()
-	dir, cleanup := tests.NewTestCaseDir(t)
-	defer cleanup()
-
-	fname := filepath.Join(dir, "genesis.json")
-	require.NoError(t, ExportGenesisFileWithTime(fname, "test", nil, json.RawMessage(""), time.Now()))
-
-	_, err := LoadGenesisDoc(codec.Cdc, fname)
-	require.NoError(t, err)
-
-	// Non-existing file
-	_, err = LoadGenesisDoc(codec.Cdc, "non-existing-file")
-	require.Error(t, err)
-
-	malformedFilename := filepath.Join(dir, "malformed")
-	malformedFile, err := os.Create(malformedFilename)
-	require.NoError(t, err)
-	fmt.Fprint(malformedFile, "invalidjson")
-	malformedFile.Close()
-	// Non-existing file
-	_, err = LoadGenesisDoc(codec.Cdc, malformedFilename)
-	require.Error(t, err)
 }

--- a/cmd/gaia/init/validate_genesis.go
+++ b/cmd/gaia/init/validate_genesis.go
@@ -31,8 +31,8 @@ func ValidateGenesisCmd(ctx *server.Context, cdc *codec.Codec) *cobra.Command {
 			//nolint
 			fmt.Fprintf(os.Stderr, "validating genesis file at %s\n", genesis)
 
-			var genDoc types.GenesisDoc
-			if genDoc, err = LoadGenesisDoc(cdc, genesis); err != nil {
+			var genDoc *types.GenesisDoc
+			if genDoc, err = types.GenesisDocFromFile(genesis); err != nil {
 				return fmt.Errorf("Error loading genesis doc from %s: %s", genesis, err.Error())
 			}
 


### PR DESCRIPTION
ExportGenesisFile() overwrites all non-gaia related
sections of the genesis.json file as it always
creates a new one from scratch.

Remove cmd/gaia/init.LoadGenesisDoc() in favor of
tendermint's types.GenesisDocFromFile().

Closes: #4066 

- [x] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [x] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [x] Added a relevant changelog entry: `sdkch add [section] [stanza] [message]`
- [x] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
