### PR TITLE
R4R: Change /staking/validators endpoint to return all validators candidates

### DIFF
--- a/x/staking/querier/querier.go
+++ b/x/staking/querier/querier.go
@@ -129,11 +129,10 @@ func NewQueryRedelegationParams(delegatorAddr sdk.AccAddress, srcValidatorAddr s
 }
 
 func queryValidators(ctx sdk.Context, cdc *codec.Codec, k keep.Keeper) (res []byte, err sdk.Error) {
-	stakingParams := k.GetParams(ctx)
-	validators := k.GetValidators(ctx, stakingParams.MaxValidators)
+	validators := k.GetAllValidators(ctx)
 
 	res, errRes := codec.MarshalJSONIndent(cdc, validators)
-	if err != nil {
+	if errRes != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", errRes.Error()))
 	}
 	return res, nil


### PR DESCRIPTION
API documentation states "Get all validator candidates".
It was returning up to `maxValidators` validator candidates, not all of them.

Also, error below never got returned, because of typo: condition was checking err instead of errRes.

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/develop/CONTRIBUTING.md#pr-targeting))

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work. - I searched through issues, but couldn't find any related to this.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`) - API documentation already states that all validator candidates should be returned.
- [ ] Added a relevant changelog entry: `sdkch add [section] [stanza] [message]`
- [x] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))