### PR TITLE
Invariant Benchmarks

### DIFF
--- a/.pending/improvements/sdk/3914-Implement-invariant-benchmarks-and-add-target-to-makefile
+++ b/.pending/improvements/sdk/3914-Implement-invariant-benchmarks-and-add-target-to-makefile
@@ -1,0 +1,1 @@
+#3914 Implement invariant benchmarks and add target to makefile.

--- a/Makefile
+++ b/Makefile
@@ -181,6 +181,12 @@ test_sim_gaia_multi_seed:
 	@echo "Running multi-seed Gaia simulation. This may take awhile!"
 	@bash scripts/multisim.sh 400 5 TestFullGaiaSimulation
 
+test_sim_benchmark_invariants:
+	@echo "Running simulation invariant benchmarks..."
+	@go test -mod=readonly ./cmd/gaia/app -benchmem -bench=BenchmarkInvariants -run=^$ \
+	-SimulationEnabled=true -SimulationNumBlocks=1000 -SimulationBlockSize=200 \
+	-SimulationCommit=true -SimulationSeed=57 -v -timeout 24h
+
 SIM_NUM_BLOCKS ?= 500
 SIM_BLOCK_SIZE ?= 200
 SIM_COMMIT ?= true
@@ -268,5 +274,5 @@ test_cover lint benchmark devdoc_init devdoc devdoc_save devdoc_update \
 build-linux build-docker-gaiadnode localnet-start localnet-stop \
 format check-ledger test_sim_gaia_nondeterminism test_sim_modules test_sim_gaia_fast \
 test_sim_gaia_custom_genesis_fast test_sim_gaia_custom_genesis_multi_seed \
-test_sim_gaia_multi_seed test_sim_gaia_import_export \
+test_sim_gaia_multi_seed test_sim_gaia_import_export test_sim_benchmark_invariants \
 go-mod-cache

--- a/cmd/gaia/app/sim_test.go
+++ b/cmd/gaia/app/sim_test.go
@@ -359,7 +359,7 @@ func TestFullGaiaSimulation(t *testing.T) {
 	require.Equal(t, "GaiaApp", app.Name())
 
 	// Run randomized simulation
-	_, err := simulation.SimulateFromSeed(getSimulateFromSeedInput(t, os.Stdout,app))
+	_, err := simulation.SimulateFromSeed(getSimulateFromSeedInput(t, os.Stdout, app))
 	if commit {
 		// for memdb:
 		// fmt.Println("Database Size", db.Stats()["database.size"])
@@ -483,7 +483,7 @@ func TestGaiaSimulationAfterImport(t *testing.T) {
 	require.Equal(t, "GaiaApp", app.Name())
 
 	// Run randomized simulation
-	stopEarly, err := simulation.SimulateFromSeed(getSimulateFromSeedInput(t, os.Stdout,app))
+	stopEarly, err := simulation.SimulateFromSeed(getSimulateFromSeedInput(t, os.Stdout, app))
 
 	if commit {
 		// for memdb:
@@ -522,7 +522,7 @@ func TestGaiaSimulationAfterImport(t *testing.T) {
 	})
 
 	// Run randomized simulation on imported app
-	_, err = simulation.SimulateFromSeed(getSimulateFromSeedInput(t, os.Stdout,newApp))
+	_, err = simulation.SimulateFromSeed(getSimulateFromSeedInput(t, os.Stdout, newApp))
 	require.Nil(t, err)
 
 }
@@ -579,7 +579,7 @@ func BenchmarkInvariants(b *testing.B) {
 
 	// 2. Run parameterized simulation (w/o invariants)
 	_, err := simulation.SimulateFromSeed(
-		b, ioutil.Discard, app.BaseApp, appStateFn, seed, testAndRunTxs(app), 
+		b, ioutil.Discard, app.BaseApp, appStateFn, seed, testAndRunTxs(app),
 		[]sdk.Invariant{}, numBlocks, blockSize, commit, lean,
 	)
 	if err != nil {
@@ -588,17 +588,17 @@ func BenchmarkInvariants(b *testing.B) {
 	}
 
 	// 3. Benchmark each invariant separately
-	// 
+	//
 	// NOTE: We use the crisis keeper as it has all the invariants registered with
 	// their respective metadata which makes it useful for testing/benchmarking.
-  for _, cr := range app.crisisKeeper.Routes()  {
+  for _, cr := range app.crisisKeeper.Routes() {
 		ctx := app.NewContext(true, abci.Header{Height: app.LastBlockHeight() + 1})
-		
+
 		b.Run(fmt.Sprintf("%s/%s", cr.ModuleName, cr.Route), func(b *testing.B) {
 			if err := cr.Invar(ctx); err != nil {
 				fmt.Println(err)
 				b.FailNow()
 			}
-		})	
+		})
 	}
 }

--- a/cmd/gaia/app/sim_test.go
+++ b/cmd/gaia/app/sim_test.go
@@ -587,13 +587,13 @@ func BenchmarkInvariants(b *testing.B) {
 		b.FailNow()
 	}
 
+	ctx := app.NewContext(true, abci.Header{Height: app.LastBlockHeight() + 1})
+
 	// 3. Benchmark each invariant separately
 	//
 	// NOTE: We use the crisis keeper as it has all the invariants registered with
 	// their respective metadata which makes it useful for testing/benchmarking.
 	for _, cr := range app.crisisKeeper.Routes() {
-		ctx := app.NewContext(true, abci.Header{Height: app.LastBlockHeight() + 1})
-
 		b.Run(fmt.Sprintf("%s/%s", cr.ModuleName, cr.Route), func(b *testing.B) {
 			if err := cr.Invar(ctx); err != nil {
 				fmt.Println(err)

--- a/cmd/gaia/app/sim_test.go
+++ b/cmd/gaia/app/sim_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"math/rand"
 	"os"
@@ -61,11 +62,11 @@ func init() {
 }
 
 // helper function for populating input for SimulateFromSeed
-func getSimulateFromSeedInput(tb testing.TB, app *GaiaApp) (
-	testing.TB, *baseapp.BaseApp, simulation.AppStateFn, int64,
+func getSimulateFromSeedInput(tb testing.TB, w io.Writer, app *GaiaApp) (
+	testing.TB, io.Writer, *baseapp.BaseApp, simulation.AppStateFn, int64,
 	simulation.WeightedOperations, sdk.Invariants, int, int, bool, bool) {
 
-	return tb, app.BaseApp, appStateFn, seed,
+	return tb, w, app.BaseApp, appStateFn, seed,
 		testAndRunTxs(app), invariants(app), numBlocks, blockSize, commit, lean
 }
 
@@ -323,7 +324,7 @@ func BenchmarkFullGaiaSimulation(b *testing.B) {
 
 	// Run randomized simulation
 	// TODO parameterize numbers, save for a later PR
-	_, err := simulation.SimulateFromSeed(getSimulateFromSeedInput(b, app))
+	_, err := simulation.SimulateFromSeed(getSimulateFromSeedInput(b, os.Stdout, app))
 	if err != nil {
 		fmt.Println(err)
 		b.Fail()
@@ -358,7 +359,7 @@ func TestFullGaiaSimulation(t *testing.T) {
 	require.Equal(t, "GaiaApp", app.Name())
 
 	// Run randomized simulation
-	_, err := simulation.SimulateFromSeed(getSimulateFromSeedInput(t, app))
+	_, err := simulation.SimulateFromSeed(getSimulateFromSeedInput(t, os.Stdout,app))
 	if commit {
 		// for memdb:
 		// fmt.Println("Database Size", db.Stats()["database.size"])
@@ -392,7 +393,7 @@ func TestGaiaImportExport(t *testing.T) {
 	require.Equal(t, "GaiaApp", app.Name())
 
 	// Run randomized simulation
-	_, err := simulation.SimulateFromSeed(getSimulateFromSeedInput(t, app))
+	_, err := simulation.SimulateFromSeed(getSimulateFromSeedInput(t, os.Stdout, app))
 
 	if commit {
 		// for memdb:
@@ -482,7 +483,7 @@ func TestGaiaSimulationAfterImport(t *testing.T) {
 	require.Equal(t, "GaiaApp", app.Name())
 
 	// Run randomized simulation
-	stopEarly, err := simulation.SimulateFromSeed(getSimulateFromSeedInput(t, app))
+	stopEarly, err := simulation.SimulateFromSeed(getSimulateFromSeedInput(t, os.Stdout,app))
 
 	if commit {
 		// for memdb:
@@ -521,7 +522,7 @@ func TestGaiaSimulationAfterImport(t *testing.T) {
 	})
 
 	// Run randomized simulation on imported app
-	_, err = simulation.SimulateFromSeed(getSimulateFromSeedInput(t, newApp))
+	_, err = simulation.SimulateFromSeed(getSimulateFromSeedInput(t, os.Stdout,newApp))
 	require.Nil(t, err)
 
 }
@@ -546,7 +547,7 @@ func TestAppStateDeterminism(t *testing.T) {
 
 			// Run randomized simulation
 			simulation.SimulateFromSeed(
-				t, app.BaseApp, appStateFn, seed,
+				t, os.Stdout, app.BaseApp, appStateFn, seed,
 				testAndRunTxs(app),
 				[]sdk.Invariant{},
 				50,

--- a/cmd/gaia/app/sim_test.go
+++ b/cmd/gaia/app/sim_test.go
@@ -591,7 +591,7 @@ func BenchmarkInvariants(b *testing.B) {
 	//
 	// NOTE: We use the crisis keeper as it has all the invariants registered with
 	// their respective metadata which makes it useful for testing/benchmarking.
-  for _, cr := range app.crisisKeeper.Routes() {
+	for _, cr := range app.crisisKeeper.Routes() {
 		ctx := app.NewContext(true, abci.Header{Height: app.LastBlockHeight() + 1})
 
 		b.Run(fmt.Sprintf("%s/%s", cr.ModuleName, cr.Route), func(b *testing.B) {

--- a/types/invariant.go
+++ b/types/invariant.go
@@ -6,5 +6,5 @@ package types
 // The simulator will then halt and print the logs.
 type Invariant func(ctx Context) error
 
-// group of Invarient
+// Invariants defines a group of invariants
 type Invariants []Invariant

--- a/x/auth/client/txbuilder/txbuilder.go
+++ b/x/auth/client/txbuilder/txbuilder.go
@@ -250,7 +250,7 @@ func (bldr TxBuilder) SignStdTx(name, passphrase string, stdTx auth.StdTx, appen
 	if bldr.chainID == "" {
 		return auth.StdTx{}, fmt.Errorf("chain ID required but not specified")
 	}
-	
+
 	stdSignature, err := MakeSignature(bldr.keybase, name, passphrase, StdSignMsg{
 		ChainID:       bldr.chainID,
 		AccountNumber: bldr.accountNumber,

--- a/x/simulation/event_stats.go
+++ b/x/simulation/event_stats.go
@@ -2,6 +2,7 @@ package simulation
 
 import (
 	"fmt"
+	"io"
 	"sort"
 )
 
@@ -17,14 +18,16 @@ func (es eventStats) tally(eventDesc string) {
 }
 
 // Pretty-print events as a table
-func (es eventStats) Print() {
+func (es eventStats) Print(w io.Writer) {
 	var keys []string
 	for key := range es {
 		keys = append(keys, key)
 	}
+
 	sort.Strings(keys)
-	fmt.Printf("Event statistics: \n")
+	fmt.Fprintf(w, "Event statistics: \n")
+
 	for _, key := range keys {
-		fmt.Printf("  % 60s => %d\n", key, es[key])
+		fmt.Fprintf(w, "  % 60s => %d\n", key, es[key])
 	}
 }

--- a/x/simulation/simulate.go
+++ b/x/simulation/simulate.go
@@ -124,7 +124,7 @@ func SimulateFromSeed(
 		// Recover logs in case of panic
 		defer func() {
 			if r := recover(); r != nil {
-				fmt.Fprintf(w, "panic with err\n", r)
+				fmt.Fprintf(w, "panic with err: %v\n", r)
 				stackTrace := string(debug.Stack())
 				fmt.Println(stackTrace)
 				logWriter.PrintLogs()

--- a/x/simulation/simulate.go
+++ b/x/simulation/simulate.go
@@ -3,6 +3,7 @@ package simulation
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"math/rand"
 	"os"
 	"os/signal"
@@ -26,7 +27,7 @@ func Simulate(t *testing.T, app *baseapp.BaseApp,
 	invariants sdk.Invariants, numBlocks, blockSize int, commit, lean bool) (bool, error) {
 
 	time := time.Now().UnixNano()
-	return SimulateFromSeed(t, app, appStateFn, time, ops,
+	return SimulateFromSeed(t, os.Stdout, app, appStateFn, time, ops,
 		invariants, numBlocks, blockSize, commit, lean)
 }
 
@@ -51,19 +52,20 @@ func initChain(
 // SimulateFromSeed tests an application by running the provided
 // operations, testing the provided invariants, but using the provided seed.
 // TODO split this monster function up
-func SimulateFromSeed(tb testing.TB, app *baseapp.BaseApp,
+func SimulateFromSeed(
+	tb testing.TB, w io.Writer, app *baseapp.BaseApp,
 	appStateFn AppStateFn, seed int64, ops WeightedOperations,
 	invariants sdk.Invariants,
-	numBlocks, blockSize int, commit, lean bool) (stopEarly bool, simError error) {
+	numBlocks, blockSize int, commit, lean bool,
+) (stopEarly bool, simError error) {
 
 	// in case we have to end early, don't os.Exit so that we can run cleanup code.
 	testingMode, t, b := getTestingMode(tb)
-	fmt.Printf("Starting SimulateFromSeed with randomness "+
-		"created with seed %d\n", int(seed))
+	fmt.Fprintf(w, "Starting SimulateFromSeed with randomness created with seed %d\n", int(seed))
 
 	r := rand.New(rand.NewSource(seed))
 	params := RandomParams(r) // := DefaultParams()
-	fmt.Printf("Randomized simulation params: %+v\n", params)
+	fmt.Fprintf(w, "Randomized simulation params: %+v\n", params)
 
 	genesisTimestamp := RandTimestamp(r)
 	fmt.Printf("Starting the simulation from time %v, unixtime %v\n",
@@ -94,8 +96,7 @@ func SimulateFromSeed(tb testing.TB, app *baseapp.BaseApp,
 	signal.Notify(c, os.Interrupt, syscall.SIGTERM, syscall.SIGINT)
 	go func() {
 		receivedSignal := <-c
-		fmt.Printf("\nExiting early due to %s, on block %d, operation %d\n",
-			receivedSignal, header.Height, opCount)
+		fmt.Fprintf(w, "\nExiting early due to %s, on block %d, operation %d\n", receivedSignal, header.Height, opCount)
 		simError = fmt.Errorf("Exited due to %s", receivedSignal)
 		stopEarly = true
 	}()
@@ -123,13 +124,11 @@ func SimulateFromSeed(tb testing.TB, app *baseapp.BaseApp,
 		// Recover logs in case of panic
 		defer func() {
 			if r := recover(); r != nil {
-				fmt.Println("Panic with err\n", r)
+				fmt.Fprintf(w, "panic with err\n", r)
 				stackTrace := string(debug.Stack())
 				fmt.Println(stackTrace)
 				logWriter.PrintLogs()
-				simError = fmt.Errorf(
-					"Simulation halted due to panic on block %d",
-					header.Height)
+				simError = fmt.Errorf("Simulation halted due to panic on block %d", header.Height)
 			}
 		}()
 	}
@@ -188,8 +187,7 @@ func SimulateFromSeed(tb testing.TB, app *baseapp.BaseApp,
 		}
 
 		if header.ProposerAddress == nil {
-			fmt.Printf("\nSimulation stopped early as all validators " +
-				"have been unbonded, there is nobody left propose a block!\n")
+			fmt.Fprintf(w, "\nSimulation stopped early as all validators have been unbonded; nobody left to propose a block!\n")
 			stopEarly = true
 			break
 		}
@@ -210,9 +208,11 @@ func SimulateFromSeed(tb testing.TB, app *baseapp.BaseApp,
 		eventStats.Print()
 		return true, simError
 	}
-	fmt.Printf("\nSimulation complete. Final height (blocks): %d, "+
-		"final time (seconds), : %v, operations ran %d\n",
-		header.Height, header.Time, opCount)
+	fmt.Fprintf(
+		w,
+		"\nSimulation complete; Final height (blocks): %d, final time (seconds): %v, operations ran: %d\n",
+		header.Height, header.Time, opCount,
+	)
 
 	eventStats.Print()
 	return false, nil


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Implement `BenchmarkInvariants` which benchmarks each respective invariant that is registered with the crisis keeper against a simulated gaia app.

__Note__: The benchmark results for most invariants is extremely negligible with few blocks (< 1000). However, some invariants, namely `distr/can-withdraw` and `staking/delegator-shares` can take relatively significant time (>3s). The benchmark values for these two invariants can greatly differ depending on simulation parameters (e.g. seed, number of blocks and block size). 

Perhaps we should also attempt to simulate state that is more representative of what we can expect to see on mainnet (100 validators, significant amount of bonds and redelegations, many accounts, etc...)

e.g.

```
$ go test -mod=readonly -benchmem -run=^$ github.com/cosmos/cosmos-sdk/cmd/gaia/app \
  -bench ^(BenchmarkInvariants)$ -v -SimulationEnabled=true -SimulationNumBlocks=5000 \
  -SimulationBlockSize=200 -SimulationCommit=true -SimulationSeed=57 -timeout 24h

goos: darwin
goarch: amd64
pkg: github.com/cosmos/cosmos-sdk/cmd/gaia/app
BenchmarkInvariants/bank/nonnegative-outstanding-4         	2000000000	         0.00 ns/op	       0 B/op	       0 allocs/op
BenchmarkInvariants/distr/nonnegative-outstanding-4        	2000000000	         0.00 ns/op	       0 B/op	       0 allocs/op
BenchmarkInvariants/distr/can-withdraw-4                   	  300000	      3412 ns/op	     422 B/op	       9 allocs/op
BenchmarkInvariants/distr/reference-count-4                	2000000000	         0.02 ns/op	       0 B/op	       0 allocs/op
BenchmarkInvariants/staking/supply-4                       	2000000000	         0.01 ns/op	       0 B/op	       0 allocs/op
BenchmarkInvariants/staking/nonnegative-power-4            	2000000000	         0.00 ns/op	       0 B/op	       0 allocs/op
BenchmarkInvariants/staking/positive-delegation-4          	2000000000	         0.01 ns/op	       0 B/op	       0 allocs/op
BenchmarkInvariants/staking/delegator-shares-4             	       1	3277646398 ns/op	279621280 B/op	 8234694 allocs/op
PASS
ok  	github.com/cosmos/cosmos-sdk/cmd/gaia/app	80.637s
```

```
$ go test -mod=readonly -benchmem -run=^$ github.com/cosmos/cosmos-sdk/cmd/gaia/app \
  -bench ^(BenchmarkInvariants)$ -v -SimulationEnabled=true -SimulationNumBlocks=100 \
  -SimulationBlockSize=200 -SimulationCommit=true -SimulationSeed=57 -timeout 24h

goos: darwin
goarch: amd64
pkg: github.com/cosmos/cosmos-sdk/cmd/gaia/app
BenchmarkInvariants/bank/nonnegative-outstanding-4         	2000000000	         0.00 ns/op	       0 B/op	       0 allocs/op
BenchmarkInvariants/distr/nonnegative-outstanding-4        	2000000000	         0.00 ns/op	       0 B/op	       0 allocs/op
BenchmarkInvariants/distr/can-withdraw-4                   	     200	   5353214 ns/op	  634396 B/op	   14093 allocs/op
BenchmarkInvariants/distr/reference-count-4                	2000000000	         0.02 ns/op	       0 B/op	       0 allocs/op
BenchmarkInvariants/staking/supply-4                       	2000000000	         0.01 ns/op	       0 B/op	       0 allocs/op
BenchmarkInvariants/staking/nonnegative-power-4            	2000000000	         0.00 ns/op	       0 B/op	       0 allocs/op
BenchmarkInvariants/staking/positive-delegation-4          	2000000000	         0.01 ns/op	       0 B/op	       0 allocs/op
BenchmarkInvariants/staking/delegator-shares-4             	       1	3877705648 ns/op	279622432 B/op	 8234706 allocs/op
PASS
ok  	github.com/cosmos/cosmos-sdk/cmd/gaia/app	71.943s
```

closes: #3914

cc @ValarDragon @cwgoes @rigelrozanski 

----

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/develop/CONTRIBUTING.md#pr-targeting))

- [x] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [x] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added a relevant changelog entry: `sdkch add [section] [stanza] [message]`
- [x] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
