### PR TITLE
Remove @cwgoes from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 # CODEOWNERS: https://help.github.com/articles/about-codeowners/
 
 # Primary repo maintainers
-*       @ebuchman @rigelrozanski @cwgoes
+*       @ebuchman @rigelrozanski
 
 # Precious documentation
 /docs/README.md  @zramsay


### PR DESCRIPTION
I'm still quite glad to review SDK PRs, but at the moment I get notified for every one, which isn't particularly helpful. This doesn't have anything to do with write permissions.

(probably we should add @alexanderbez or @jackzampolin?)

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
