### PR TITLE
Fix v0.33.x export script to port gov data correctly

### DIFF
--- a/contrib/export/v0.33.x-to-v0.34.0.py
+++ b/contrib/export/v0.33.x-to-v0.34.0.py
@@ -48,6 +48,7 @@ def migrate_gov_data(gov_data):
         del p['type']
         del p['value']
 
+        assert t == 'gov/TextProposal', 'invalid proposal type: {t}'
         assert p == {}, 'expected proposal to be empty after deleting contents'
 
         p['proposal_content'] = {
@@ -55,15 +56,16 @@ def migrate_gov_data(gov_data):
             'value': {
                 'title': v['title'],
                 'description': v['description']
-            },
-            'proposal_id': v['proposal_id'],
-            'final_tally_result': v['final_tally_result'],
-            'submit_time': v['submit_time'],
-            'deposit_end_time': v['deposit_end_time'],
-            'total_deposit': v['total_deposit'],
-            'voting_start_time': v['voting_start_time'],
-            'voting_end_time': v['voting_end_time']
+            }
         }
+
+        p['proposal_id'] = v['proposal_id']
+        p['final_tally_result'] = v['final_tally_result']
+        p['submit_time'] = v['submit_time']
+        p['deposit_end_time'] = v['deposit_end_time']
+        p['total_deposit'] = v['total_deposit']
+        p['voting_start_time'] = v['voting_start_time']
+        p['voting_end_time'] = v['voting_end_time']
 
 
 if __name__ == '__main__':

--- a/contrib/export/v0.33.x-to-v0.34.0.py
+++ b/contrib/export/v0.33.x-to-v0.34.0.py
@@ -16,7 +16,7 @@ def process_raw_genesis(genesis, parsed_args):
     }
 
     # migrate governance state as the internal structure of proposals has changed
-    migrate_gov_data(genesis['gov'])
+    migrate_gov_data(genesis['app_state']['gov'])
 
     # default Tendermint block time (ms)
     genesis['consensus_params']['block']['time_iota_ms'] = '1000'
@@ -60,6 +60,7 @@ def migrate_gov_data(gov_data):
         }
 
         p['proposal_id'] = v['proposal_id']
+        p['proposal_status'] = v['proposal_status']
         p['final_tally_result'] = v['final_tally_result']
         p['submit_time'] = v['submit_time']
         p['deposit_end_time'] = v['deposit_end_time']

--- a/contrib/export/v0.33.x-to-v0.34.0.py
+++ b/contrib/export/v0.33.x-to-v0.34.0.py
@@ -15,7 +15,10 @@ def process_raw_genesis(genesis, parsed_args):
         },
     }
 
-    # default tm value
+    # migrate governance state as the internal structure of proposals has changed
+    migrate_gov_data(genesis['gov'])
+
+    # default Tendermint block time (ms)
     genesis['consensus_params']['block']['time_iota_ms'] = '1000'
 
     # proposal #1 updates
@@ -34,6 +37,33 @@ def process_raw_genesis(genesis, parsed_args):
     genesis['genesis_time'] = parsed_args.start_time
 
     return genesis
+
+
+def migrate_gov_data(gov_data):
+    for p in gov_data['proposals']:
+        # get Amino type and value
+        t = p['type']
+        v = p['value']
+
+        del p['type']
+        del p['value']
+
+        assert p == {}, 'expected proposal to be empty after deleting contents'
+
+        p['proposal_content'] = {
+            'type': t,
+            'value': {
+                'title': v['title'],
+                'description': v['description']
+            },
+            'proposal_id': v['proposal_id'],
+            'final_tally_result': v['final_tally_result'],
+            'submit_time': v['submit_time'],
+            'deposit_end_time': v['deposit_end_time'],
+            'total_deposit': v['total_deposit'],
+            'voting_start_time': v['voting_start_time'],
+            'voting_end_time': v['voting_end_time']
+        }
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Update the python export script to properly migrate governance state. This state machine breaking [change](https://github.com/cosmos/cosmos-sdk/pull/3779) was included in the 0.34 release but was not documented and as a result was not included in the original script.

__Note__: A node will _not_ panic if this fix is not included, however, querying for past proposals will fail.

----

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/develop/CONTRIBUTING.md#pr-targeting))

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added a relevant changelog entry: `sdkch add [section] [stanza] [message]`
- [ ] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
