### PR TITLE
Allow custom key types and address formats

### DIFF
--- a/cmd/gaia/app/app.go
+++ b/cmd/gaia/app/app.go
@@ -189,7 +189,7 @@ func NewGaiaApp(logger log.Logger, db dbm.DB, traceStore io.Writer, loadLatest b
 	)
 	app.SetInitChainer(app.initChainer)
 	app.SetBeginBlocker(app.BeginBlocker)
-	app.SetAnteHandler(auth.NewAnteHandler(app.accountKeeper, app.feeCollectionKeeper))
+	app.SetAnteHandler(auth.NewAnteHandler(app.accountKeeper, app.feeCollectionKeeper, auth.DefaultSigVerificationGasConsumer))
 	app.SetEndBlocker(app.EndBlocker)
 
 	if loadLatest {

--- a/cmd/gaia/cmd/gaiadebug/hack.go
+++ b/cmd/gaia/cmd/gaiadebug/hack.go
@@ -191,7 +191,7 @@ func NewGaiaApp(logger log.Logger, db dbm.DB, baseAppOptions ...func(*bam.BaseAp
 	app.SetInitChainer(app.initChainer)
 	app.SetBeginBlocker(app.BeginBlocker)
 	app.SetEndBlocker(app.EndBlocker)
-	app.SetAnteHandler(auth.NewAnteHandler(app.accountKeeper, app.feeCollectionKeeper))
+	app.SetAnteHandler(auth.NewAnteHandler(app.accountKeeper, app.feeCollectionKeeper, auth.DefaultSigVerificationGasConsumer))
 	app.MountStores(app.keyMain, app.keyAccount, app.keyStaking, app.keySlashing, app.keyParams)
 	app.MountStore(app.tkeyParams, sdk.StoreTypeTransient)
 	err := app.LoadLatestVersion(app.keyMain)

--- a/types/address.go
+++ b/types/address.go
@@ -99,8 +99,16 @@ func AccAddressFromBech32(address string) (addr AccAddress, err error) {
 		return nil, err
 	}
 
-	if len(bz) != AddrLen {
-		return nil, errors.New("Incorrect address length")
+	validator := GetConfig().GetAddressValidator()
+	if validator != nil {
+		err = validator(bz)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		if len(bz) != AddrLen {
+			return nil, errors.New("Incorrect address length")
+		}
 	}
 
 	return AccAddress(bz), nil

--- a/types/config.go
+++ b/types/config.go
@@ -11,6 +11,7 @@ type Config struct {
 	sealed              bool
 	bech32AddressPrefix map[string]string
 	txEncoder           TxEncoder
+	addressValidator    func([]byte) error
 }
 
 var (
@@ -73,6 +74,12 @@ func (config *Config) SetTxEncoder(encoder TxEncoder) {
 	config.txEncoder = encoder
 }
 
+// SetAddressValidator build the Config with the address validator used to validate account addresses
+func (config *Config) SetAddressValidator(addressValidator func([]byte) error) {
+	config.assertNotSealed()
+	config.addressValidator = addressValidator
+}
+
 // Seal seals the config such that the config state could not be modified further
 func (config *Config) Seal() *Config {
 	config.mtx.Lock()
@@ -115,4 +122,9 @@ func (config *Config) GetBech32ConsensusPubPrefix() string {
 // GetTxEncoder return function to encode transactions
 func (config *Config) GetTxEncoder() TxEncoder {
 	return config.txEncoder
+}
+
+// GetAddressValidator returns function to validate account addresses
+func (config *Config) GetAddressValidator() func([]byte) error {
+	return config.addressValidator
 }

--- a/x/auth/ante.go
+++ b/x/auth/ante.go
@@ -27,8 +27,9 @@ func init() {
 	copy(simSecp256k1Pubkey[:], bz)
 }
 
-type SignatureVerificationGasConsumer =
-	func (meter sdk.GasMeter, sig []byte, pubkey crypto.PubKey, params Params) sdk.Result
+// SignatureVerificationGasConsumer is the type of function that is used to both consume gas when verifying signatures
+// and also to accept or reject different types of PubKey's. This is where apps can define their own PubKey types.
+type SignatureVerificationGasConsumer = func(meter sdk.GasMeter, sig []byte, pubkey crypto.PubKey, params Params) sdk.Result
 
 // NewAnteHandler returns an AnteHandler that checks and increments sequence
 // numbers, checks signatures & account numbers, and deducts fees from the first
@@ -258,11 +259,9 @@ func ProcessPubKey(acc Account, sig StdSignature, simulate bool) (crypto.PubKey,
 	return pubKey, sdk.Result{}
 }
 
-// consumeSigVerificationGas consumes gas for signature verification based upon
-// the public key type. The cost is fetched from the given params and is matched
+// DefaultSigVerificationGasConsumer is the default implementation of SignatureVerificationGasConsumer. It consumes gas
+// for signature verification based upon the public key type. The cost is fetched from the given params and is matched
 // by the concrete type.
-//
-// TODO: Design a cleaner and flexible way to match concrete public key types.
 func DefaultSigVerificationGasConsumer(
 	meter sdk.GasMeter, sig []byte, pubkey crypto.PubKey, params Params,
 ) sdk.Result {

--- a/x/auth/ante_test.go
+++ b/x/auth/ante_test.go
@@ -47,7 +47,7 @@ func TestAnteHandlerSigErrors(t *testing.T) {
 	// setup
 	input := setupTestInput()
 	ctx := input.ctx
-	anteHandler := NewAnteHandler(input.ak, input.fck)
+	anteHandler := NewAnteHandler(input.ak, input.fck, DefaultSigVerificationGasConsumer)
 
 	// keys and addresses
 	priv1, _, addr1 := keyPubAddr()
@@ -95,7 +95,7 @@ func TestAnteHandlerSigErrors(t *testing.T) {
 func TestAnteHandlerAccountNumbers(t *testing.T) {
 	// setup
 	input := setupTestInput()
-	anteHandler := NewAnteHandler(input.ak, input.fck)
+	anteHandler := NewAnteHandler(input.ak, input.fck, DefaultSigVerificationGasConsumer)
 	ctx := input.ctx.WithBlockHeight(1)
 
 	// keys and addresses
@@ -150,7 +150,7 @@ func TestAnteHandlerAccountNumbers(t *testing.T) {
 func TestAnteHandlerAccountNumbersAtBlockHeightZero(t *testing.T) {
 	// setup
 	input := setupTestInput()
-	anteHandler := NewAnteHandler(input.ak, input.fck)
+	anteHandler := NewAnteHandler(input.ak, input.fck, DefaultSigVerificationGasConsumer)
 	ctx := input.ctx.WithBlockHeight(0)
 
 	// keys and addresses
@@ -205,7 +205,7 @@ func TestAnteHandlerAccountNumbersAtBlockHeightZero(t *testing.T) {
 func TestAnteHandlerSequences(t *testing.T) {
 	// setup
 	input := setupTestInput()
-	anteHandler := NewAnteHandler(input.ak, input.fck)
+	anteHandler := NewAnteHandler(input.ak, input.fck, DefaultSigVerificationGasConsumer)
 	ctx := input.ctx.WithBlockHeight(1)
 
 	// keys and addresses
@@ -280,7 +280,7 @@ func TestAnteHandlerFees(t *testing.T) {
 	// setup
 	input := setupTestInput()
 	ctx := input.ctx
-	anteHandler := NewAnteHandler(input.ak, input.fck)
+	anteHandler := NewAnteHandler(input.ak, input.fck, DefaultSigVerificationGasConsumer)
 
 	// keys and addresses
 	priv1, _, addr1 := keyPubAddr()
@@ -319,7 +319,7 @@ func TestAnteHandlerFees(t *testing.T) {
 func TestAnteHandlerMemoGas(t *testing.T) {
 	// setup
 	input := setupTestInput()
-	anteHandler := NewAnteHandler(input.ak, input.fck)
+	anteHandler := NewAnteHandler(input.ak, input.fck, DefaultSigVerificationGasConsumer)
 	ctx := input.ctx.WithBlockHeight(1)
 
 	// keys and addresses
@@ -358,7 +358,7 @@ func TestAnteHandlerMemoGas(t *testing.T) {
 func TestAnteHandlerMultiSigner(t *testing.T) {
 	// setup
 	input := setupTestInput()
-	anteHandler := NewAnteHandler(input.ak, input.fck)
+	anteHandler := NewAnteHandler(input.ak, input.fck, DefaultSigVerificationGasConsumer)
 	ctx := input.ctx.WithBlockHeight(1)
 
 	// keys and addresses
@@ -405,7 +405,7 @@ func TestAnteHandlerMultiSigner(t *testing.T) {
 func TestAnteHandlerBadSignBytes(t *testing.T) {
 	// setup
 	input := setupTestInput()
-	anteHandler := NewAnteHandler(input.ak, input.fck)
+	anteHandler := NewAnteHandler(input.ak, input.fck, DefaultSigVerificationGasConsumer)
 	ctx := input.ctx.WithBlockHeight(1)
 
 	// keys and addresses
@@ -480,7 +480,7 @@ func TestAnteHandlerBadSignBytes(t *testing.T) {
 func TestAnteHandlerSetPubKey(t *testing.T) {
 	// setup
 	input := setupTestInput()
-	anteHandler := NewAnteHandler(input.ak, input.fck)
+	anteHandler := NewAnteHandler(input.ak, input.fck, DefaultSigVerificationGasConsumer)
 	ctx := input.ctx.WithBlockHeight(1)
 
 	// keys and addresses
@@ -594,7 +594,7 @@ func TestConsumeSignatureVerificationGas(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			res := consumeSigVerificationGas(tt.args.meter, tt.args.sig, tt.args.pubkey, tt.args.params)
+			res := DefaultSigVerificationGasConsumer(tt.args.meter, tt.args.sig, tt.args.pubkey, tt.args.params)
 
 			if tt.shouldErr {
 				require.False(t, res.IsOK())
@@ -674,7 +674,7 @@ func TestCountSubkeys(t *testing.T) {
 func TestAnteHandlerSigLimitExceeded(t *testing.T) {
 	// setup
 	input := setupTestInput()
-	anteHandler := NewAnteHandler(input.ak, input.fck)
+	anteHandler := NewAnteHandler(input.ak, input.fck, DefaultSigVerificationGasConsumer)
 	ctx := input.ctx.WithBlockHeight(1)
 
 	// keys and addresses

--- a/x/mock/app.go
+++ b/x/mock/app.go
@@ -82,7 +82,7 @@ func NewApp() *App {
 	// Initialize the app. The chainers and blockers can be overwritten before
 	// calling complete setup.
 	app.SetInitChainer(app.InitChainer)
-	app.SetAnteHandler(auth.NewAnteHandler(app.AccountKeeper, app.FeeCollectionKeeper))
+	app.SetAnteHandler(auth.NewAnteHandler(app.AccountKeeper, app.FeeCollectionKeeper, auth.DefaultSigVerificationGasConsumer))
 
 	// Not sealing for custom extension
 


### PR DESCRIPTION
Resolves #3685 

Adds:
* an additional parameter to `NewAnteHandler` for a custom `SignatureVerificationGasConsumer` (the existing one is now called `DefaultSigVerificationGasConsumer)
* add an `addressValidator` field to `sdk.Config` which allows for custom address verification (to override the current fixed 20 byte address format)

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/develop/CONTRIBUTING.md#pr-targeting))

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added a relevant changelog entry: `sdkch add [section] [stanza] [message]`
- [ ] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))