### PR TITLE
R4R: Empty mnemonic should return error when recover key

### DIFF
--- a/.pending/bugfixes/gaiacli/4219-Empty-mnemonic-
+++ b/.pending/bugfixes/gaiacli/4219-Empty-mnemonic-
@@ -1,1 +1,1 @@
-#4219 Empty mnemonic should return error when recover key
+#4219 Return an error when an empty mnemonic is provided during key recovery.

--- a/.pending/bugfixes/gaiacli/4219-Empty-mnemonic-
+++ b/.pending/bugfixes/gaiacli/4219-Empty-mnemonic-
@@ -1,1 +1,1 @@
-4219 Empty mnemonic should return error when recover key
+#4219 Empty mnemonic should return error when recover key

--- a/.pending/bugfixes/gaiacli/4219-Empty-mnemonic-
+++ b/.pending/bugfixes/gaiacli/4219-Empty-mnemonic-
@@ -1,0 +1,1 @@
+4219 Empty mnemonic should return error when recover key

--- a/client/keys/add.go
+++ b/client/keys/add.go
@@ -197,8 +197,7 @@ func runAddCmd(_ *cobra.Command, args []string) error {
 		}
 
 		if !bip39.IsMnemonicValid(mnemonic) {
-			_, _ = fmt.Fprintf(os.Stderr, "Error: Mnemonic is not valid.\n")
-			return nil
+			return errors.New("invalid mnemonic")
 		}
 	}
 

--- a/client/keys/add.go
+++ b/client/keys/add.go
@@ -33,11 +33,6 @@ const (
 	flagNoSort      = "nosort"
 )
 
-const (
-	maxValidAccountValue = int(0x80000000 - 1)
-	maxValidIndexalue    = int(0x80000000 - 1)
-)
-
 func addKeyCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "add <name>",
@@ -200,6 +195,11 @@ func runAddCmd(_ *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
+
+		if !bip39.IsMnemonicValid(mnemonic) {
+			_, _ = fmt.Fprintf(os.Stderr, "Error: Mnemonic is not valid.\n")
+			return nil
+		}
 	}
 
 	if len(mnemonic) == 0 {
@@ -213,11 +213,6 @@ func runAddCmd(_ *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-	}
-
-	if !bip39.IsMnemonicValid(mnemonic) {
-		fmt.Fprintf(os.Stderr, "Error: Mnemonic is not valid.\n")
-		return nil
 	}
 
 	// override bip39 passphrase

--- a/cmd/gaia/cli_test/cli_test.go
+++ b/cmd/gaia/cli_test/cli_test.go
@@ -51,7 +51,14 @@ func TestGaiaCLIKeysAddRecover(t *testing.T) {
 	t.Parallel()
 	f := InitFixtures(t)
 
-	f.KeysAddRecover("test-recover", "dentist task convince chimney quality leave banana trade firm crawl eternal easily")
+	invalidPrompt := "Mnemonic is not valid"
+
+	exitSuccess, _, stderr := f.KeysAddRecover("empty-mnemonic", "")
+	require.Contains(t, stderr, invalidPrompt)
+
+	exitSuccess, _, stderr = f.KeysAddRecover("test-recover", "dentist task convince chimney quality leave banana trade firm crawl eternal easily")
+	require.True(t, exitSuccess)
+	require.NotContains(t, stderr, invalidPrompt)
 	require.Equal(t, "cosmos1qcfdf69js922qrdr4yaww3ax7gjml6pdds46f4", f.KeyAddress("test-recover").String())
 }
 

--- a/cmd/gaia/cli_test/cli_test.go
+++ b/cmd/gaia/cli_test/cli_test.go
@@ -51,14 +51,11 @@ func TestGaiaCLIKeysAddRecover(t *testing.T) {
 	t.Parallel()
 	f := InitFixtures(t)
 
-	invalidPrompt := "Mnemonic is not valid"
+	exitSuccess, _, _ := f.KeysAddRecover("empty-mnemonic", "")
+	require.False(t, exitSuccess)
 
-	exitSuccess, _, stderr := f.KeysAddRecover("empty-mnemonic", "")
-	require.Contains(t, stderr, invalidPrompt)
-
-	exitSuccess, _, stderr = f.KeysAddRecover("test-recover", "dentist task convince chimney quality leave banana trade firm crawl eternal easily")
+	exitSuccess, _, _ = f.KeysAddRecover("test-recover", "dentist task convince chimney quality leave banana trade firm crawl eternal easily")
 	require.True(t, exitSuccess)
-	require.NotContains(t, stderr, invalidPrompt)
 	require.Equal(t, "cosmos1qcfdf69js922qrdr4yaww3ax7gjml6pdds46f4", f.KeyAddress("test-recover").String())
 }
 

--- a/cmd/gaia/cli_test/test_helpers.go
+++ b/cmd/gaia/cli_test/test_helpers.go
@@ -264,9 +264,9 @@ func (f *Fixtures) KeysAdd(name string, flags ...string) {
 }
 
 // KeysAddRecover prepares gaiacli keys add --recover
-func (f *Fixtures) KeysAddRecover(name, mnemonic string, flags ...string) {
+func (f *Fixtures) KeysAddRecover(name, mnemonic string, flags ...string) (exitSuccess bool, stdout, stderr string) {
 	cmd := fmt.Sprintf("%s keys add --home=%s --recover %s", f.GaiacliBinary, f.GaiacliHome, name)
-	executeWriteCheckErr(f.T, addFlags(cmd, flags), client.DefaultKeyPass, mnemonic)
+	return executeWriteRetStdStreams(f.T, addFlags(cmd, flags), client.DefaultKeyPass, mnemonic)
 }
 
 // KeysAddRecoverHDPath prepares gaiacli keys add --recover --account --index


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

close: #4219 

The following codes can NOT fail, so I move `!bip39.IsMnemonicValid(mnemonic)`  into the range of human input.

```go
	if len(mnemonic) == 0 {
		// read entropy seed straight from crypto.Rand and convert to mnemonic
		entropySeed, err := bip39.NewEntropy(mnemonicEntropySize)
		if err != nil {
			return err
		}

		mnemonic, err = bip39.NewMnemonic(entropySeed[:])
		if err != nil {
			return err
		}
	}
```

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/develop/CONTRIBUTING.md#pr-targeting))
- [x] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [x] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [x] Added a relevant changelog entry: `sdkch add [section] [stanza] [message]`
- [x] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
