### PR TITLE
Fix dependency of devtools Makefile and clean code.

### DIFF
--- a/contrib/devtools/Makefile
+++ b/contrib/devtools/Makefile
@@ -41,29 +41,36 @@ mkfile_dir := $(shell cd $(shell dirname $(mkfile_path)); pwd)
 ###
 # tools
 ###
+
+GOLANGCI_LINT   = $(GOBIN)/golangci-lint
+STATIK          = $(GOBIN)/statik
+GOIMPORTS       = $(GOBIN)/goimports
+GOSUM           = $(GOBIN)/gosum
+CLOG            = $(GOBIN)/clog
+
 all: tools
 
 tools: tools-stamp
-tools-stamp: $(GOBIN)/golangci-lint $(GOBIN)/statik $(GOBIN)/goimports $(GOBIN)/gosum $(GOBIN)/clog
+tools-stamp: $(GOLANGCI_LINT) $(STATIK) $(GOIMPORTS) $(GOSUM) $(CLOG)
 	touch $@
 
-$(GOBIN)/golangci-lint: $(mkfile_dir)/install-golangci-lint.sh $(GOBIN)/gosum
+$(GOLANGCI_LINT): $(mkfile_dir)/install-golangci-lint.sh $(GOSUM)
 	bash $(mkfile_dir)/install-golangci-lint.sh $(GOBIN) $(GOLANGCI_LINT_VERSION) $(GOLANGCI_LINT_HASHSUM)
 
-$(GOBIN)/statik:
+$(STATIK):
 	$(call go_install,rakyll,statik,v0.1.5)
 
-$(GOBIN)/goimports:
+$(GOIMPORTS):
 	go get golang.org/x/tools/cmd/goimports@v0.0.0-20190114222345-bf090417da8b
 
-$(GOBIN)/gosum:
-	go install -mod=readonly github.com/cosmos/cosmos-sdk/contrib/devtools/gosum/
+$(GOSUM): ./contrib/devtools/gosum/main.go
+	go install -mod=readonly ./$(<D)/
 
-$(GOBIN)/clog:
-	go install -mod=readonly github.com/cosmos/cosmos-sdk/contrib/devtools/clog/
+$(CLOG): ./contrib/devtools/clog/main.go
+	go install -mod=readonly ./$(<D)/
 
 tools-clean:
-	cd $(GOBIN) && rm -f golangci-lint statik goimports gosum clog
+	rm -f $(GOLANGCI_LINT) $(STATIK) $(GOIMPORTS) $(GOSUM) $(CLOG)
 	rm -f tools-stamp
 
 .PHONY: all tools tools-clean


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/develop/CONTRIBUTING.md#pr-targeting))

### Purpose

1. `make tools` will not updated `clog` when `clog/main.go` was changed,
   except `${GOBIN}/clog` or `tools-stamp` was deleted. `gosum` has the
   same problem.
2. $(GOBIN)/gosum was just like magic number.

______

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added a relevant changelog entry: `sdkch add [section] [stanza] [message]`
- [x] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
