### PR TITLE
Allow custom key types and address formats

### DIFF
--- a/.pending/breaking/sdk/The-default-signatur
+++ b/.pending/breaking/sdk/The-default-signatur
@@ -1,0 +1,2 @@
+The default signature verification gas logic (`DefaultSigVerificationGasConsumer`) now specifies explicit key types rather than string pattern matching. This means that zones that depended on string matching to allow other keys will need to write a custom `SignatureVerificationGasConsumer` function.
+

--- a/.pending/breaking/sdk/The-default-signatur
+++ b/.pending/breaking/sdk/The-default-signatur
@@ -1,2 +1,2 @@
-The default signature verification gas logic (`DefaultSigVerificationGasConsumer`) now specifies explicit key types rather than string pattern matching. This means that zones that depended on string matching to allow other keys will need to write a custom `SignatureVerificationGasConsumer` function.
+#3685 The default signature verification gas logic (`DefaultSigVerificationGasConsumer`) now specifies explicit key types rather than string pattern matching. This means that zones that depended on string matching to allow other keys will need to write a custom `SignatureVerificationGasConsumer` function.
 

--- a/.pending/breaking/sdk/The-default-signatur
+++ b/.pending/breaking/sdk/The-default-signatur
@@ -1,2 +1,1 @@
 #3685 The default signature verification gas logic (`DefaultSigVerificationGasConsumer`) now specifies explicit key types rather than string pattern matching. This means that zones that depended on string matching to allow other keys will need to write a custom `SignatureVerificationGasConsumer` function.
-

--- a/.pending/improvements/sdk/Add-SetAddressVerifi
+++ b/.pending/improvements/sdk/Add-SetAddressVerifi
@@ -1,1 +1,1 @@
-Add `SetAddressVerifier` and `GetAddressVerifier` to `sdk.Config` to allow SDK users to configure custom address format verification logic (to override the default limitation of 20-byte addresses).
+#3685  Add `SetAddressVerifier` and `GetAddressVerifier` to `sdk.Config` to allow SDK users to configure custom address format verification logic (to override the default limitation of 20-byte addresses).

--- a/.pending/improvements/sdk/Add-SetAddressVerifi
+++ b/.pending/improvements/sdk/Add-SetAddressVerifi
@@ -1,0 +1,1 @@
+Add `SetAddressVerifier` and `GetAddressVerifier` to `sdk.Config` to allow SDK users to configure custom address format verification logic (to override the default limitation of 20-byte addresses).

--- a/.pending/improvements/sdk/Add-an-additional-pa
+++ b/.pending/improvements/sdk/Add-an-additional-pa
@@ -1,1 +1,1 @@
-Add an additional parameter to NewAnteHandler for a custom `SignatureVerificationGasConsumer` (the default logic is now in `DefaultSigVerificationGasConsumer). This allows SDK users to configure their own logic for which key types are accepted and how those key types consume gas.
+#3685  Add an additional parameter to NewAnteHandler for a custom `SignatureVerificationGasConsumer` (the default logic is now in `DefaultSigVerificationGasConsumer). This allows SDK users to configure their own logic for which key types are accepted and how those key types consume gas.

--- a/.pending/improvements/sdk/Add-an-additional-pa
+++ b/.pending/improvements/sdk/Add-an-additional-pa
@@ -1,0 +1,1 @@
+Add an additional parameter to NewAnteHandler for a custom `SignatureVerificationGasConsumer` (the default logic is now in `DefaultSigVerificationGasConsumer). This allows SDK users to configure their own logic for which key types are accepted and how those key types consume gas.

--- a/cmd/gaia/app/app.go
+++ b/cmd/gaia/app/app.go
@@ -189,7 +189,7 @@ func NewGaiaApp(logger log.Logger, db dbm.DB, traceStore io.Writer, loadLatest b
 	)
 	app.SetInitChainer(app.initChainer)
 	app.SetBeginBlocker(app.BeginBlocker)
-	app.SetAnteHandler(auth.NewAnteHandler(app.accountKeeper, app.feeCollectionKeeper))
+	app.SetAnteHandler(auth.NewAnteHandler(app.accountKeeper, app.feeCollectionKeeper, auth.DefaultSigVerificationGasConsumer))
 	app.SetEndBlocker(app.EndBlocker)
 
 	if loadLatest {

--- a/cmd/gaia/cmd/gaiadebug/hack.go
+++ b/cmd/gaia/cmd/gaiadebug/hack.go
@@ -191,7 +191,7 @@ func NewGaiaApp(logger log.Logger, db dbm.DB, baseAppOptions ...func(*bam.BaseAp
 	app.SetInitChainer(app.initChainer)
 	app.SetBeginBlocker(app.BeginBlocker)
 	app.SetEndBlocker(app.EndBlocker)
-	app.SetAnteHandler(auth.NewAnteHandler(app.accountKeeper, app.feeCollectionKeeper))
+	app.SetAnteHandler(auth.NewAnteHandler(app.accountKeeper, app.feeCollectionKeeper, auth.DefaultSigVerificationGasConsumer))
 	app.MountStores(app.keyMain, app.keyAccount, app.keyStaking, app.keySlashing, app.keyParams)
 	app.MountStore(app.tkeyParams, sdk.StoreTypeTransient)
 	err := app.LoadLatestVersion(app.keyMain)

--- a/types/address.go
+++ b/types/address.go
@@ -99,8 +99,16 @@ func AccAddressFromBech32(address string) (addr AccAddress, err error) {
 		return nil, err
 	}
 
-	if len(bz) != AddrLen {
-		return nil, errors.New("Incorrect address length")
+	validator := GetConfig().GetAddressValidator()
+	if validator != nil {
+		err = validator(bz)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		if len(bz) != AddrLen {
+			return nil, errors.New("Incorrect address length")
+		}
 	}
 
 	return AccAddress(bz), nil

--- a/types/address.go
+++ b/types/address.go
@@ -86,6 +86,9 @@ func AccAddressFromHex(address string) (addr AccAddress, err error) {
 	return AccAddress(bz), nil
 }
 
+// VerifyAddressFormat verifies that the provided bytes form a valid address
+// according to the default address rules or a custom address verifier set by
+// GetConfig().SetAddressVerifier()
 func VerifyAddressFormat(bz []byte) error {
 	verifier := GetConfig().GetAddressVerifier()
 	if verifier != nil {

--- a/types/address.go
+++ b/types/address.go
@@ -86,6 +86,18 @@ func AccAddressFromHex(address string) (addr AccAddress, err error) {
 	return AccAddress(bz), nil
 }
 
+func VerifyAddressFormat(bz []byte) error {
+	verifier := GetConfig().GetAddressVerifier()
+	if verifier != nil {
+		return verifier(bz)
+	} else {
+		if len(bz) != AddrLen {
+			return errors.New("Incorrect address length")
+		}
+	}
+	return nil
+}
+
 // AccAddressFromBech32 creates an AccAddress from a Bech32 string.
 func AccAddressFromBech32(address string) (addr AccAddress, err error) {
 	if len(strings.TrimSpace(address)) == 0 {
@@ -99,16 +111,9 @@ func AccAddressFromBech32(address string) (addr AccAddress, err error) {
 		return nil, err
 	}
 
-	validator := GetConfig().GetAddressValidator()
-	if validator != nil {
-		err = validator(bz)
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		if len(bz) != AddrLen {
-			return nil, errors.New("Incorrect address length")
-		}
+	err = VerifyAddressFormat(bz)
+	if err != nil {
+		return nil, err
 	}
 
 	return AccAddress(bz), nil
@@ -237,8 +242,9 @@ func ValAddressFromBech32(address string) (addr ValAddress, err error) {
 		return nil, err
 	}
 
-	if len(bz) != AddrLen {
-		return nil, errors.New("Incorrect address length")
+	err = VerifyAddressFormat(bz)
+	if err != nil {
+		return nil, err
 	}
 
 	return ValAddress(bz), nil
@@ -368,8 +374,9 @@ func ConsAddressFromBech32(address string) (addr ConsAddress, err error) {
 		return nil, err
 	}
 
-	if len(bz) != AddrLen {
-		return nil, errors.New("Incorrect address length")
+	err = VerifyAddressFormat(bz)
+	if err != nil {
+		return nil, err
 	}
 
 	return ConsAddress(bz), nil

--- a/types/address_test.go
+++ b/types/address_test.go
@@ -1,7 +1,6 @@
 package types_test
 
 import (
-	"bytes"
 	"encoding/hex"
 	"fmt"
 	"math/rand"
@@ -295,10 +294,18 @@ func TestAddressInterface(t *testing.T) {
 
 func TestCustomAddressVerifier(t *testing.T) {
 	// Create a 10 byte address
-	addr := types.AccAddress([]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9})
-	bech := addr.String()
+	addr := []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
+	accBech := types.AccAddress(addr).String()
+	valBech := types.ValAddress(addr).String()
+	consBech := types.ConsAddress(addr).String()
 	// Verifiy that the default logic rejects this 10 byte address
-	_, err := types.AccAddressFromBech32(bech)
+	err := types.VerifyAddressFormat(addr)
+	require.NotNil(t, err)
+	_, err = types.AccAddressFromBech32(accBech)
+	require.NotNil(t, err)
+	_, err = types.ValAddressFromBech32(valBech)
+	require.NotNil(t, err)
+	_, err = types.ConsAddressFromBech32(consBech)
 	require.NotNil(t, err)
 
 	// Set a custom address verifier that accepts 10 or 20 byte addresses
@@ -311,7 +318,12 @@ func TestCustomAddressVerifier(t *testing.T) {
 	})
 
 	// Verifiy that the custom logic accepts this 10 byte address
-	addr2, err := types.AccAddressFromBech32(bech)
+	err = types.VerifyAddressFormat(addr)
 	require.Nil(t, err)
-	require.True(t, bytes.Equal(addr, addr2), "addresses not equal")
+	_, err = types.AccAddressFromBech32(accBech)
+	require.Nil(t, err)
+	_, err = types.ValAddressFromBech32(valBech)
+	require.Nil(t, err)
+	_, err = types.ConsAddressFromBech32(consBech)
+	require.Nil(t, err)
 }

--- a/types/config.go
+++ b/types/config.go
@@ -11,7 +11,7 @@ type Config struct {
 	sealed              bool
 	bech32AddressPrefix map[string]string
 	txEncoder           TxEncoder
-	addressValidator    func([]byte) error
+	addressVerifier     func([]byte) error
 }
 
 var (
@@ -74,10 +74,11 @@ func (config *Config) SetTxEncoder(encoder TxEncoder) {
 	config.txEncoder = encoder
 }
 
-// SetAddressValidator build the Config with the address validator used to validate account addresses
-func (config *Config) SetAddressValidator(addressValidator func([]byte) error) {
+// SetAddressVerifier builds the Config with the provided function for verifying that addresses
+// have the correct format
+func (config *Config) SetAddressVerifier(addressVerifier func([]byte) error) {
 	config.assertNotSealed()
-	config.addressValidator = addressValidator
+	config.addressVerifier = addressVerifier
 }
 
 // Seal seals the config such that the config state could not be modified further
@@ -124,7 +125,7 @@ func (config *Config) GetTxEncoder() TxEncoder {
 	return config.txEncoder
 }
 
-// GetAddressValidator returns function to validate account addresses
-func (config *Config) GetAddressValidator() func([]byte) error {
-	return config.addressValidator
+// GetAddressVerifier returns the function to verify that addresses have the correct format
+func (config *Config) GetAddressVerifier() func([]byte) error {
+	return config.addressVerifier
 }

--- a/types/config.go
+++ b/types/config.go
@@ -11,6 +11,7 @@ type Config struct {
 	sealed              bool
 	bech32AddressPrefix map[string]string
 	txEncoder           TxEncoder
+	addressValidator    func([]byte) error
 }
 
 var (
@@ -73,6 +74,12 @@ func (config *Config) SetTxEncoder(encoder TxEncoder) {
 	config.txEncoder = encoder
 }
 
+// SetAddressValidator build the Config with the address validator used to validate account addresses
+func (config *Config) SetAddressValidator(addressValidator func([]byte) error) {
+	config.assertNotSealed()
+	config.addressValidator = addressValidator
+}
+
 // Seal seals the config such that the config state could not be modified further
 func (config *Config) Seal() *Config {
 	config.mtx.Lock()
@@ -115,4 +122,9 @@ func (config *Config) GetBech32ConsensusPubPrefix() string {
 // GetTxEncoder return function to encode transactions
 func (config *Config) GetTxEncoder() TxEncoder {
 	return config.txEncoder
+}
+
+// GetAddressValidator returns function to validate account addresses
+func (config *Config) GetAddressValidator() func([]byte) error {
+	return config.addressValidator
 }

--- a/x/auth/ante.go
+++ b/x/auth/ante.go
@@ -27,8 +27,9 @@ func init() {
 	copy(simSecp256k1Pubkey[:], bz)
 }
 
-type SignatureVerificationGasConsumer =
-	func (meter sdk.GasMeter, sig []byte, pubkey crypto.PubKey, params Params) sdk.Result
+// SignatureVerificationGasConsumer is the type of function that is used to both consume gas when verifying signatures
+// and also to accept or reject different types of PubKey's. This is where apps can define their own PubKey types.
+type SignatureVerificationGasConsumer = func(meter sdk.GasMeter, sig []byte, pubkey crypto.PubKey, params Params) sdk.Result
 
 // NewAnteHandler returns an AnteHandler that checks and increments sequence
 // numbers, checks signatures & account numbers, and deducts fees from the first
@@ -258,11 +259,9 @@ func ProcessPubKey(acc Account, sig StdSignature, simulate bool) (crypto.PubKey,
 	return pubKey, sdk.Result{}
 }
 
-// consumeSigVerificationGas consumes gas for signature verification based upon
-// the public key type. The cost is fetched from the given params and is matched
+// DefaultSigVerificationGasConsumer is the default implementation of SignatureVerificationGasConsumer. It consumes gas
+// for signature verification based upon the public key type. The cost is fetched from the given params and is matched
 // by the concrete type.
-//
-// TODO: Design a cleaner and flexible way to match concrete public key types.
 func DefaultSigVerificationGasConsumer(
 	meter sdk.GasMeter, sig []byte, pubkey crypto.PubKey, params Params,
 ) sdk.Result {

--- a/x/auth/ante.go
+++ b/x/auth/ante.go
@@ -5,7 +5,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"github.com/tendermint/tendermint/crypto/ed25519"
-	"strings"
 	"time"
 
 	"github.com/tendermint/tendermint/crypto"
@@ -266,9 +265,6 @@ func ProcessPubKey(acc Account, sig StdSignature, simulate bool) (crypto.PubKey,
 func DefaultSigVerificationGasConsumer(
 	meter sdk.GasMeter, sig []byte, pubkey crypto.PubKey, params Params,
 ) sdk.Result {
-
-	pubkeyType := strings.ToLower(fmt.Sprintf("%T", pubkey))
-
 	switch pubkey := pubkey.(type) {
 	case ed25519.PubKeyEd25519:
 		meter.ConsumeGas(params.SigVerifyCostED25519, "ante verify: ed25519")
@@ -286,7 +282,7 @@ func DefaultSigVerificationGasConsumer(
 		return sdk.Result{}
 
 	default:
-		return sdk.ErrInvalidPubKey(fmt.Sprintf("unrecognized public key type: %s", pubkeyType)).Result()
+		return sdk.ErrInvalidPubKey(fmt.Sprintf("unrecognized public key type: %T", pubkey)).Result()
 	}
 }
 

--- a/x/auth/ante_test.go
+++ b/x/auth/ante_test.go
@@ -756,3 +756,57 @@ func TestEnsureSufficientMempoolFees(t *testing.T) {
 		)
 	}
 }
+
+// Test custom SignatureVerificationGasConsumer
+func TestCustomSignatureVerificationGasConsumer(t *testing.T) {
+	// setup
+	input := setupTestInput()
+	// setup an ante handler that only accepts PubKeyEd25519
+	anteHandler := NewAnteHandler(input.ak, input.fck, func(meter sdk.GasMeter, sig []byte, pubkey crypto.PubKey, params Params) sdk.Result {
+		switch pubkey := pubkey.(type) {
+		case ed25519.PubKeyEd25519:
+			meter.ConsumeGas(params.SigVerifyCostED25519, "ante verify: ed25519")
+			return sdk.Result{}
+		default:
+			return sdk.ErrInvalidPubKey(fmt.Sprintf("unrecognized public key type: %T", pubkey)).Result()
+		}
+	})
+	ctx := input.ctx.WithBlockHeight(1)
+
+	// verify that an secp256k1 account gets rejected
+	priv1, _, addr1 := keyPubAddr()
+	acc1 := input.ak.NewAccountWithAddress(ctx, addr1)
+	_ = acc1.SetCoins(sdk.NewCoins(sdk.NewInt64Coin("atom", 150)))
+	input.ak.SetAccount(ctx, acc1)
+	var tx sdk.Tx
+	msg := newTestMsg(addr1)
+	privs, accnums, seqs := []crypto.PrivKey{priv1}, []uint64{0}, []uint64{0}
+	fee := newStdFee()
+	msgs := []sdk.Msg{msg}
+	tx = newTestTx(ctx, msgs, privs, accnums, seqs, fee)
+	checkInvalidTx(t, anteHandler, ctx, tx, false, sdk.CodeInvalidPubKey)
+
+	// verify that an ed25519 account gets accepted
+	priv2 := ed25519.GenPrivKey()
+	pub2 := priv2.PubKey()
+	addr2 := sdk.AccAddress(pub2.Address())
+	acc2 := input.ak.NewAccountWithAddress(ctx, addr2)
+	_ = acc2.SetCoins(sdk.NewCoins(sdk.NewInt64Coin("atom", 150)))
+	input.ak.SetAccount(ctx, acc2)
+	msg = newTestMsg(addr2)
+	privs, accnums, seqs = []crypto.PrivKey{priv2}, []uint64{1}, []uint64{0}
+	fee = newStdFee()
+	msgs = []sdk.Msg{msg}
+	tx = newTestTx(ctx, msgs, privs, accnums, seqs, fee)
+	checkValidTx(t, anteHandler, ctx, tx, false)
+
+	//require.True(t, input.fck.GetCollectedFees(ctx).IsEqual(sdk.NewCoins(sdk.NewInt64Coin("atom", 150))))
+	//require.True(t, input.ak.GetAccount(ctx, addr1).GetCoins().AmountOf("atom").Equal(sdk.NewInt(0)))
+	//
+	//acc1.SetCoins(sdk.NewCoins(sdk.NewInt64Coin("atom", 150)))
+	//input.ak.SetAccount(ctx, acc1)
+	//checkValidTx(t, anteHandler, ctx, tx, false)
+	//
+	//require.True(t, input.fck.GetCollectedFees(ctx).IsEqual(sdk.NewCoins(sdk.NewInt64Coin("atom", 150))))
+	//require.True(t, input.ak.GetAccount(ctx, addr1).GetCoins().AmountOf("atom").Equal(sdk.NewInt(0)))
+}

--- a/x/auth/ante_test.go
+++ b/x/auth/ante_test.go
@@ -47,7 +47,7 @@ func TestAnteHandlerSigErrors(t *testing.T) {
 	// setup
 	input := setupTestInput()
 	ctx := input.ctx
-	anteHandler := NewAnteHandler(input.ak, input.fck)
+	anteHandler := NewAnteHandler(input.ak, input.fck, DefaultSigVerificationGasConsumer)
 
 	// keys and addresses
 	priv1, _, addr1 := keyPubAddr()
@@ -95,7 +95,7 @@ func TestAnteHandlerSigErrors(t *testing.T) {
 func TestAnteHandlerAccountNumbers(t *testing.T) {
 	// setup
 	input := setupTestInput()
-	anteHandler := NewAnteHandler(input.ak, input.fck)
+	anteHandler := NewAnteHandler(input.ak, input.fck, DefaultSigVerificationGasConsumer)
 	ctx := input.ctx.WithBlockHeight(1)
 
 	// keys and addresses
@@ -150,7 +150,7 @@ func TestAnteHandlerAccountNumbers(t *testing.T) {
 func TestAnteHandlerAccountNumbersAtBlockHeightZero(t *testing.T) {
 	// setup
 	input := setupTestInput()
-	anteHandler := NewAnteHandler(input.ak, input.fck)
+	anteHandler := NewAnteHandler(input.ak, input.fck, DefaultSigVerificationGasConsumer)
 	ctx := input.ctx.WithBlockHeight(0)
 
 	// keys and addresses
@@ -205,7 +205,7 @@ func TestAnteHandlerAccountNumbersAtBlockHeightZero(t *testing.T) {
 func TestAnteHandlerSequences(t *testing.T) {
 	// setup
 	input := setupTestInput()
-	anteHandler := NewAnteHandler(input.ak, input.fck)
+	anteHandler := NewAnteHandler(input.ak, input.fck, DefaultSigVerificationGasConsumer)
 	ctx := input.ctx.WithBlockHeight(1)
 
 	// keys and addresses
@@ -280,7 +280,7 @@ func TestAnteHandlerFees(t *testing.T) {
 	// setup
 	input := setupTestInput()
 	ctx := input.ctx
-	anteHandler := NewAnteHandler(input.ak, input.fck)
+	anteHandler := NewAnteHandler(input.ak, input.fck, DefaultSigVerificationGasConsumer)
 
 	// keys and addresses
 	priv1, _, addr1 := keyPubAddr()
@@ -319,7 +319,7 @@ func TestAnteHandlerFees(t *testing.T) {
 func TestAnteHandlerMemoGas(t *testing.T) {
 	// setup
 	input := setupTestInput()
-	anteHandler := NewAnteHandler(input.ak, input.fck)
+	anteHandler := NewAnteHandler(input.ak, input.fck, DefaultSigVerificationGasConsumer)
 	ctx := input.ctx.WithBlockHeight(1)
 
 	// keys and addresses
@@ -358,7 +358,7 @@ func TestAnteHandlerMemoGas(t *testing.T) {
 func TestAnteHandlerMultiSigner(t *testing.T) {
 	// setup
 	input := setupTestInput()
-	anteHandler := NewAnteHandler(input.ak, input.fck)
+	anteHandler := NewAnteHandler(input.ak, input.fck, DefaultSigVerificationGasConsumer)
 	ctx := input.ctx.WithBlockHeight(1)
 
 	// keys and addresses
@@ -405,7 +405,7 @@ func TestAnteHandlerMultiSigner(t *testing.T) {
 func TestAnteHandlerBadSignBytes(t *testing.T) {
 	// setup
 	input := setupTestInput()
-	anteHandler := NewAnteHandler(input.ak, input.fck)
+	anteHandler := NewAnteHandler(input.ak, input.fck, DefaultSigVerificationGasConsumer)
 	ctx := input.ctx.WithBlockHeight(1)
 
 	// keys and addresses
@@ -480,7 +480,7 @@ func TestAnteHandlerBadSignBytes(t *testing.T) {
 func TestAnteHandlerSetPubKey(t *testing.T) {
 	// setup
 	input := setupTestInput()
-	anteHandler := NewAnteHandler(input.ak, input.fck)
+	anteHandler := NewAnteHandler(input.ak, input.fck, DefaultSigVerificationGasConsumer)
 	ctx := input.ctx.WithBlockHeight(1)
 
 	// keys and addresses
@@ -594,7 +594,7 @@ func TestConsumeSignatureVerificationGas(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			res := consumeSigVerificationGas(tt.args.meter, tt.args.sig, tt.args.pubkey, tt.args.params)
+			res := DefaultSigVerificationGasConsumer(tt.args.meter, tt.args.sig, tt.args.pubkey, tt.args.params)
 
 			if tt.shouldErr {
 				require.False(t, res.IsOK())
@@ -674,7 +674,7 @@ func TestCountSubkeys(t *testing.T) {
 func TestAnteHandlerSigLimitExceeded(t *testing.T) {
 	// setup
 	input := setupTestInput()
-	anteHandler := NewAnteHandler(input.ak, input.fck)
+	anteHandler := NewAnteHandler(input.ak, input.fck, DefaultSigVerificationGasConsumer)
 	ctx := input.ctx.WithBlockHeight(1)
 
 	// keys and addresses

--- a/x/auth/ante_test.go
+++ b/x/auth/ante_test.go
@@ -799,14 +799,4 @@ func TestCustomSignatureVerificationGasConsumer(t *testing.T) {
 	msgs = []sdk.Msg{msg}
 	tx = newTestTx(ctx, msgs, privs, accnums, seqs, fee)
 	checkValidTx(t, anteHandler, ctx, tx, false)
-
-	//require.True(t, input.fck.GetCollectedFees(ctx).IsEqual(sdk.NewCoins(sdk.NewInt64Coin("atom", 150))))
-	//require.True(t, input.ak.GetAccount(ctx, addr1).GetCoins().AmountOf("atom").Equal(sdk.NewInt(0)))
-	//
-	//acc1.SetCoins(sdk.NewCoins(sdk.NewInt64Coin("atom", 150)))
-	//input.ak.SetAccount(ctx, acc1)
-	//checkValidTx(t, anteHandler, ctx, tx, false)
-	//
-	//require.True(t, input.fck.GetCollectedFees(ctx).IsEqual(sdk.NewCoins(sdk.NewInt64Coin("atom", 150))))
-	//require.True(t, input.ak.GetAccount(ctx, addr1).GetCoins().AmountOf("atom").Equal(sdk.NewInt(0)))
 }

--- a/x/mock/app.go
+++ b/x/mock/app.go
@@ -82,7 +82,7 @@ func NewApp() *App {
 	// Initialize the app. The chainers and blockers can be overwritten before
 	// calling complete setup.
 	app.SetInitChainer(app.InitChainer)
-	app.SetAnteHandler(auth.NewAnteHandler(app.AccountKeeper, app.FeeCollectionKeeper))
+	app.SetAnteHandler(auth.NewAnteHandler(app.AccountKeeper, app.FeeCollectionKeeper, auth.DefaultSigVerificationGasConsumer))
 
 	// Not sealing for custom extension
 


### PR DESCRIPTION
Resolves #3685. (Was PR #4166 before the develop branch was removed.)

Adds:
* an additional parameter to `NewAnteHandler` for a custom `SignatureVerificationGasConsumer` (the existing one is now called `DefaultSigVerificationGasConsumer)
* add an `addressVerifier` field to `sdk.Config` which allows for custom address verification (to override the current fixed 20 byte address format)

Changes:
* the `DefaultSigVerificationGasConsumer` now uses type switching as opposed to string comparison. Other zones like Ethermint can now concretely specify which key types they accept.
---
- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/develop/CONTRIBUTING.md#pr-targeting))

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [x] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [x] Added a relevant changelog entry: `sdkch add [section] [stanza] [message]`
- [x] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))