### PR TITLE
Remove baseapp dependency on the version package

### DIFF
--- a/.pending/breaking/sdk/4250-BaseApp-Query-r
+++ b/.pending/breaking/sdk/4250-BaseApp-Query-r
@@ -1,0 +1,3 @@
+#4250 BaseApp.Query() returns app's version string set via BaseApp.SetAppVersion()
+when handling /app/version queries instead of the version string passed as build
+flag at compile time.

--- a/.pending/features/sdk/4250-New-BaseApp-Set
+++ b/.pending/features/sdk/4250-New-BaseApp-Set
@@ -1,0 +1,1 @@
+#4250 New BaseApp.{,Set}AppVersion() methods to get/set app's version string.

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,8 @@ build_tags := $(strip $(build_tags))
 
 # process linker flags
 
-ldflags = -X github.com/cosmos/cosmos-sdk/version.Version=$(VERSION) \
+ldflags = -X github.com/cosmos/cosmos-sdk/version.Name=gaia \
+	-X github.com/cosmos/cosmos-sdk/version.Version=$(VERSION) \
 	-X github.com/cosmos/cosmos-sdk/version.Commit=$(COMMIT) \
   -X "github.com/cosmos/cosmos-sdk/version.BuildTags=$(build_tags)"
 

--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -20,7 +20,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/store"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/cosmos/cosmos-sdk/version"
 )
 
 // Key to store the consensus params in the main store.
@@ -85,6 +84,9 @@ type BaseApp struct {
 
 	// height at which to halt the chain and gracefully shutdown
 	haltHeight uint64
+
+	// application's version string
+	appVersion string
 }
 
 var _ abci.Application = (*BaseApp)(nil)
@@ -130,6 +132,12 @@ func (app *BaseApp) Logger() log.Logger {
 func (app *BaseApp) SetCommitMultiStoreTracer(w io.Writer) {
 	app.cms.SetTracer(w)
 }
+
+// AppVersion returns the application's version string.
+func (app *BaseApp) AppVersion() string { return app.appVersion }
+
+// SetAppVersion sets the application's version string.
+func (app *BaseApp) SetAppVersion(v string) { app.appVersion = v }
 
 // MountStores mounts all IAVL or DB stores to the provided keys in the BaseApp
 // multistore.
@@ -439,7 +447,7 @@ func handleQueryApp(app *BaseApp, path []string, req abci.RequestQuery) (res abc
 			return abci.ResponseQuery{
 				Code:      uint32(sdk.CodeOK),
 				Codespace: string(sdk.CodespaceRoot),
-				Value:     []byte(version.Version),
+				Value:     []byte(app.appVersion),
 			}
 
 		default:

--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -122,6 +122,11 @@ func (app *BaseApp) Name() string {
 	return app.name
 }
 
+// AppVersion returns the application's version string.
+func (app *BaseApp) AppVersion() string {
+	return app.appVersion
+}
+
 // Logger returns the logger of the BaseApp.
 func (app *BaseApp) Logger() log.Logger {
 	return app.logger
@@ -132,12 +137,6 @@ func (app *BaseApp) Logger() log.Logger {
 func (app *BaseApp) SetCommitMultiStoreTracer(w io.Writer) {
 	app.cms.SetTracer(w)
 }
-
-// AppVersion returns the application's version string.
-func (app *BaseApp) AppVersion() string { return app.appVersion }
-
-// SetAppVersion sets the application's version string.
-func (app *BaseApp) SetAppVersion(v string) { app.appVersion = v }
 
 // MountStores mounts all IAVL or DB stores to the provided keys in the BaseApp
 // multistore.

--- a/baseapp/baseapp_test.go
+++ b/baseapp/baseapp_test.go
@@ -130,6 +130,26 @@ func TestLoadVersion(t *testing.T) {
 	testLoadVersionHelper(t, app, int64(2), commitID2)
 }
 
+func TestAppVersionSetterGetter(t *testing.T) {
+	logger := defaultLogger()
+	pruningOpt := SetPruning(store.PruneSyncable)
+	db := dbm.NewMemDB()
+	name := t.Name()
+	app := NewBaseApp(name, logger, db, nil, pruningOpt)
+
+	require.Equal(t, "", app.AppVersion())
+	res := app.Query(abci.RequestQuery{Path: "app/version"})
+	require.True(t, res.IsOK())
+	require.Equal(t, "", string(res.Value))
+
+	versionString := "1.0.0"
+	app.SetAppVersion(versionString)
+	require.Equal(t, versionString, app.AppVersion())
+	res = app.Query(abci.RequestQuery{Path: "app/version"})
+	require.True(t, res.IsOK())
+	require.Equal(t, versionString, string(res.Value))
+}
+
 func TestLoadVersionInvalid(t *testing.T) {
 	logger := log.NewNopLogger()
 	pruningOpt := SetPruning(store.PruneSyncable)

--- a/baseapp/baseapp_test.go
+++ b/baseapp/baseapp_test.go
@@ -247,6 +247,9 @@ func TestBaseAppOptionSeal(t *testing.T) {
 		app.SetName("")
 	})
 	require.Panics(t, func() {
+		app.SetAppVersion("")
+	})
+	require.Panics(t, func() {
 		app.SetDB(nil)
 	})
 	require.Panics(t, func() {

--- a/baseapp/options.go
+++ b/baseapp/options.go
@@ -40,6 +40,14 @@ func (app *BaseApp) SetName(name string) {
 	app.name = name
 }
 
+// SetAppVersion sets the application's version string.
+func (app *BaseApp) SetAppVersion(v string) {
+	if app.sealed {
+		panic("SetAppVersion() on sealed BaseApp")
+	}
+	app.appVersion = v
+}
+
 func (app *BaseApp) SetDB(db dbm.DB) {
 	if app.sealed {
 		panic("SetDB() on sealed BaseApp")

--- a/cmd/gaia/Makefile
+++ b/cmd/gaia/Makefile
@@ -43,7 +43,8 @@ build_tags := $(strip $(build_tags))
 
 # process linker flags
 
-ldflags = -X github.com/cosmos/cosmos-sdk/version.Version=$(VERSION) \
+ldflags = -X github.com/cosmos/cosmos-sdk/version.Name=gaia \
+	-X github.com/cosmos/cosmos-sdk/version.Version=$(VERSION) \
 	-X github.com/cosmos/cosmos-sdk/version.Commit=$(COMMIT) \
   -X "github.com/cosmos/cosmos-sdk/version.BuildTags=$(build_tags)"
 

--- a/cmd/gaia/app/app.go
+++ b/cmd/gaia/app/app.go
@@ -9,6 +9,7 @@ import (
 	bam "github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/version"
 	"github.com/cosmos/cosmos-sdk/x/auth"
 	"github.com/cosmos/cosmos-sdk/x/bank"
 	"github.com/cosmos/cosmos-sdk/x/crisis"
@@ -78,6 +79,7 @@ func NewGaiaApp(logger log.Logger, db dbm.DB, traceStore io.Writer, loadLatest b
 
 	bApp := bam.NewBaseApp(appName, logger, db, auth.DefaultTxDecoder(cdc), baseAppOptions...)
 	bApp.SetCommitMultiStoreTracer(traceStore)
+	bApp.SetAppVersion(version.Version)
 
 	var app = &GaiaApp{
 		BaseApp:          bApp,

--- a/version/command.go
+++ b/version/command.go
@@ -16,7 +16,8 @@ const (
 
 var (
 
-	// VersionCmd prints out the current sdk version
+	// VersionCmd prints out the application's version
+	// information passed via build flags.
 	VersionCmd = &cobra.Command{
 		Use:   "version",
 		Short: "Print the app version",
@@ -24,7 +25,7 @@ var (
 			verInfo := newVersionInfo()
 
 			if !viper.GetBool(flagLong) {
-				fmt.Println(verInfo.CosmosSDK)
+				fmt.Println(verInfo.Version)
 				return nil
 			}
 

--- a/version/command.go
+++ b/version/command.go
@@ -30,7 +30,7 @@ var (
 			}
 
 			if viper.GetString(cli.OutputFlag) != "json" {
-				fmt.Print(verInfo)
+				fmt.Println(verInfo)
 				return nil
 			}
 

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,19 @@
-//nolint
+// This package is a convenience utility that provides SDK
+// consumers with a ready-to-use version command that
+// produces apps versioning information based on flags
+// passed at compile time.
+//
+// Configure the version command
+//
+// The version command can be just added to your cobra root command.
+// At build time, the variables Name, Version, Commit, GoSumHash, and
+// BuildTags can be passed as build flags as shown in the following
+// example:
+//
+//  go build -X github.com/cosmos/cosmos-sdk/version.Name=dapp \
+//   -X github.com/cosmos/cosmos-sdk/version.Version=1.0 \
+//   -X github.com/cosmos/cosmos-sdk/version.Commit=f0f7b7dab7e36c20b757cebce0e8f4fc5b95de60 \
+//   -X "github.com/cosmos/cosmos-sdk/version.BuildTags=linux darwin amd64"
 package version
 
 import (
@@ -6,8 +21,6 @@ import (
 	"runtime"
 )
 
-// Variables representin application's versioning
-// information set at build time.
 var (
 	// Application's name
 	Name = ""

--- a/version/version.go
+++ b/version/version.go
@@ -6,16 +6,24 @@ import (
 	"runtime"
 )
 
-// Variables set by build flags
+// Variables representin application's versioning
+// information set at build time.
 var (
-	Commit    = ""
-	Version   = ""
+	// Application's name
+	Name = ""
+	// Application's version string
+	Version = ""
+	// Commit
+	Commit = ""
+	// Hash of the go.sum file
 	GoSumHash = ""
+	// Build tags
 	BuildTags = ""
 )
 
 type versionInfo struct {
-	CosmosSDK string `json:"cosmos_sdk"`
+	Name      string `json:"name"`
+	Version   string `json:"version"`
 	GitCommit string `json:"commit"`
 	GoSumHash string `json:"gosum_hash"`
 	BuildTags string `json:"build_tags"`
@@ -23,15 +31,16 @@ type versionInfo struct {
 }
 
 func (v versionInfo) String() string {
-	return fmt.Sprintf(`cosmos-sdk: %s
+	return fmt.Sprintf(`%s: %s
 git commit: %s
 go.sum hash: %s
 build tags: %s
-%s`, v.CosmosSDK, v.GitCommit, v.GoSumHash, v.BuildTags, v.GoVersion)
+%s`, v.Name, v.Version, v.GitCommit, v.GoSumHash, v.BuildTags, v.GoVersion)
 }
 
 func newVersionInfo() versionInfo {
 	return versionInfo{
+		Name,
 		Version,
 		Commit,
 		GoSumHash,

--- a/version/version.go
+++ b/version/version.go
@@ -45,5 +45,5 @@ func newVersionInfo() versionInfo {
 		Commit,
 		GoSumHash,
 		BuildTags,
-		fmt.Sprintf("go version %s %s/%s\n", runtime.Version(), runtime.GOOS, runtime.GOARCH)}
+		fmt.Sprintf("go version %s %s/%s", runtime.Version(), runtime.GOOS, runtime.GOARCH)}
 }


### PR DESCRIPTION
The version package is meant to be a convenience utility
that provides SDK consumers with a ready-to-use version
command that produces app's versioning information from
flags passed at compile time.
It will not make sense anymore for the baseapp package
to depend on the version package once gaia will have been
migrated away from the SDK main repository as we neither
want to make assumptions nor set expectations on downstream
apps buildsystems. Thus BaseApp now provides SetAppVersion()
and AppVersion() to to allow SDK consumers to set BaseApp's
version information string once the struct is initialised.

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added a relevant changelog entry: `clog add [section] [stanza] [message]`
- [ ] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
