### PR TITLE
Change User Supplied Param Change Value to json.RawMessage

### DIFF
--- a/client/lcd/swagger-ui/swagger.yaml
+++ b/client/lcd/swagger-ui/swagger.yaml
@@ -2408,5 +2408,5 @@ definitions:
         type: string
         example: ""
       value:
-        type: string
-        example: "105"
+        type: object
+        example: 105

--- a/client/lcd/swagger-ui/swagger.yaml
+++ b/client/lcd/swagger-ui/swagger.yaml
@@ -2409,4 +2409,3 @@ definitions:
         example: ""
       value:
         type: object
-        example: 105

--- a/cmd/gaia/cli_test/cli_test.go
+++ b/cmd/gaia/cli_test/cli_test.go
@@ -623,7 +623,7 @@ func TestGaiaCLISubmitParamChangeProposal(t *testing.T) {
     {
       "subspace": "staking",
       "key": "MaxValidators",
-      "value": "105"
+      "value": 105
     }
   ],
   "deposit": [

--- a/cmd/gaia/lcd_test/helpers_test.go
+++ b/cmd/gaia/lcd_test/helpers_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/lcd"
 	"github.com/cosmos/cosmos-sdk/client/utils"
 	"github.com/cosmos/cosmos-sdk/crypto/keys"
-	"github.com/cosmos/cosmos-sdk/x/params"
 
 	"github.com/cosmos/cosmos-sdk/client/rpc"
 	"github.com/cosmos/cosmos-sdk/client/tx"
@@ -1179,8 +1178,8 @@ func doSubmitParamChangeProposal(
 		Description: "test",
 		Proposer:    proposerAddr,
 		Deposit:     sdk.Coins{sdk.NewCoin(sdk.DefaultBondDenom, amount)},
-		Changes: []params.ParamChange{
-			params.NewParamChange("staking", "MaxValidators", "", "105"),
+		Changes: paramscutils.ParamChangesJSON{
+			paramscutils.ParamChangeJSON{"staking", "MaxValidators", "", []byte(`105`)},
 		},
 	}
 

--- a/cmd/gaia/lcd_test/helpers_test.go
+++ b/cmd/gaia/lcd_test/helpers_test.go
@@ -1187,7 +1187,6 @@ func doSubmitParamChangeProposal(
 	require.NoError(t, err)
 
 	resp, body := Request(t, port, "POST", "/gov/proposals/param_change", req)
-	fmt.Println(resp)
 	require.Equal(t, http.StatusOK, resp.StatusCode, body)
 
 	resp, body = signAndBroadcastGenTx(t, port, name, pwd, body, acc, client.DefaultGasAdjustment, false)

--- a/cmd/gaia/lcd_test/helpers_test.go
+++ b/cmd/gaia/lcd_test/helpers_test.go
@@ -1179,7 +1179,7 @@ func doSubmitParamChangeProposal(
 		Proposer:    proposerAddr,
 		Deposit:     sdk.Coins{sdk.NewCoin(sdk.DefaultBondDenom, amount)},
 		Changes: paramscutils.ParamChangesJSON{
-			paramscutils.ParamChangeJSON{"staking", "MaxValidators", "", []byte(`105`)},
+			paramscutils.NewParamChangeJSON("staking", "MaxValidators", "", []byte(`105`)),
 		},
 	}
 

--- a/docs/cosmos-hub/gaiacli.md
+++ b/docs/cosmos-hub/gaiacli.md
@@ -599,7 +599,7 @@ Where `proposal.json` contains the following:
     {
       "subspace": "staking",
       "key": "MaxValidators",
-      "value": "105"
+      "value": 105
     }
   ],
   "deposit": [

--- a/x/params/client/cli/tx.go
+++ b/x/params/client/cli/tx.go
@@ -44,7 +44,7 @@ where proposal.json contains:
     {
       "subspace": "staking",
       "key": "MaxValidators",
-      "value": "105"
+      "value": 105
     }
   ],
   "deposit": [
@@ -67,7 +67,7 @@ where proposal.json contains:
 			}
 
 			from := cliCtx.GetFromAddress()
-			content := params.NewParameterChangeProposal(proposal.Title, proposal.Description, proposal.Changes)
+			content := params.NewParameterChangeProposal(proposal.Title, proposal.Description, proposal.Changes.ToParamChanges())
 
 			msg := gov.NewMsgSubmitProposal(content, proposal.Deposit, from)
 			if err := msg.ValidateBasic(); err != nil {

--- a/x/params/client/rest/rest.go
+++ b/x/params/client/rest/rest.go
@@ -35,7 +35,7 @@ func postProposalHandlerFn(cdc *codec.Codec, cliCtx context.CLIContext) http.Han
 			return
 		}
 
-		content := params.NewParameterChangeProposal(req.Title, req.Description, req.Changes)
+		content := params.NewParameterChangeProposal(req.Title, req.Description, req.Changes.ToParamChanges())
 
 		msg := gov.NewMsgSubmitProposal(content, req.Deposit, req.Proposer)
 		if err := msg.ValidateBasic(); err != nil {

--- a/x/params/client/utils/utils.go
+++ b/x/params/client/utils/utils.go
@@ -45,6 +45,10 @@ type (
 	}
 )
 
+func NewParamChangeJSON(subspace, key, subkey string, value json.RawMessage) ParamChangeJSON {
+	return ParamChangeJSON{subspace, key, subkey, value}
+}
+
 // ToParamChange converts a ParamChangeJSON object to ParamChange.
 func (pcj ParamChangeJSON) ToParamChange() params.ParamChange {
 	return params.NewParamChange(pcj.Subspace, pcj.Key, pcj.Subkey, string(pcj.Value))

--- a/x/params/client/utils/utils.go
+++ b/x/params/client/utils/utils.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"encoding/json"
 	"io/ioutil"
 
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -9,24 +10,54 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/params"
 )
 
-// ParamChangeProposalJSON defines a ParameterChangeProposal with a deposit used
-// to parse  parameter change proposals from a JSON file.
-type ParamChangeProposalJSON struct {
-	Title       string               `json:"title"`
-	Description string               `json:"description"`
-	Changes     []params.ParamChange `json:"changes"`
-	Deposit     sdk.Coins            `json:"deposit"`
+type (
+	// ParamChangesJSON defines a slice of ParamChangeJSON objects which can be
+	// converted to a slice of ParamChange objects.
+	ParamChangesJSON []ParamChangeJSON
+
+	// ParamChangeJSON defines a parameter change used in JSON input. This
+	// allows values to be specified in raw JSON instead of being string encoded.
+	ParamChangeJSON struct {
+		Subspace string          `json:"subspace"`
+		Key      string          `json:"key"`
+		Subkey   string          `json:"subkey,omitempty"`
+		Value    json.RawMessage `json:"value"`
+	}
+
+	// ParamChangeProposalJSON defines a ParameterChangeProposal with a deposit used
+	// to parse parameter change proposals from a JSON file.
+	ParamChangeProposalJSON struct {
+		Title       string           `json:"title"`
+		Description string           `json:"description"`
+		Changes     ParamChangesJSON `json:"changes"`
+		Deposit     sdk.Coins        `json:"deposit"`
+	}
+
+	// ParamChangeProposalReq defines a parameter change proposal request body.
+	ParamChangeProposalReq struct {
+		BaseReq rest.BaseReq `json:"base_req"`
+
+		Title       string           `json:"title"`
+		Description string           `json:"description"`
+		Changes     ParamChangesJSON `json:"changes"`
+		Proposer    sdk.AccAddress   `json:"proposer"`
+		Deposit     sdk.Coins        `json:"deposit"`
+	}
+)
+
+// ToParamChange converts a ParamChangeJSON object to ParamChange.
+func (pcj ParamChangeJSON) ToParamChange() params.ParamChange {
+	return params.NewParamChange(pcj.Subspace, pcj.Key, pcj.Subkey, string(pcj.Value))
 }
 
-// ParamChangeProposalReq defines a parameter change proposal request body.
-type ParamChangeProposalReq struct {
-	BaseReq rest.BaseReq `json:"base_req"`
-
-	Title       string               `json:"title"`
-	Description string               `json:"description"`
-	Changes     []params.ParamChange `json:"changes"`
-	Proposer    sdk.AccAddress       `json:"proposer"`
-	Deposit     sdk.Coins            `json:"deposit"`
+// ToParamChanges converts a slice of ParamChangeJSON objects to a slice of
+// ParamChange.
+func (pcj ParamChangesJSON) ToParamChanges() []params.ParamChange {
+	res := make([]params.ParamChange, len(pcj))
+	for i, pc := range pcj {
+		res[i] = pc.ToParamChange()
+	}
+	return res
 }
 
 // ParseParamChangeProposalJSON reads and parses a ParamChangeProposalJSON from

--- a/x/params/client/utils/utils_test.go
+++ b/x/params/client/utils/utils_test.go
@@ -1,0 +1,35 @@
+package utils
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewParamChangeJSON(t *testing.T) {
+	pcj := NewParamChangeJSON("subspace", "key", "subkey", json.RawMessage(`{}`))
+	require.Equal(t, "subspace", pcj.Subspace)
+	require.Equal(t, "key", pcj.Key)
+	require.Equal(t, "subkey", pcj.Subkey)
+	require.Equal(t, json.RawMessage(`{}`), pcj.Value)
+}
+
+func TestToParamChanges(t *testing.T) {
+	pcj1 := NewParamChangeJSON("subspace", "key1", "", json.RawMessage(`{}`))
+	pcj2 := NewParamChangeJSON("subspace", "key2", "", json.RawMessage(`{}`))
+	pcjs := ParamChangesJSON{pcj1, pcj2}
+
+	paramChanges := pcjs.ToParamChanges()
+	require.Len(t, paramChanges, 2)
+
+	require.Equal(t, paramChanges[0].Subspace, pcj1.Subspace)
+	require.Equal(t, paramChanges[0].Key, pcj1.Key)
+	require.Equal(t, paramChanges[0].Subkey, pcj1.Subkey)
+	require.Equal(t, paramChanges[0].Value, string(pcj1.Value))
+
+	require.Equal(t, paramChanges[1].Subspace, pcj2.Subspace)
+	require.Equal(t, paramChanges[1].Key, pcj2.Key)
+	require.Equal(t, paramChanges[1].Subkey, pcj2.Subkey)
+	require.Equal(t, paramChanges[1].Value, string(pcj2.Value))
+}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

The values in `changes` in Parameter change proposals are now of type `json.RawMessage` so users no longer have to string-encode them leading to a better UX.

closes #4237

----

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/develop/CONTRIBUTING.md#pr-targeting))

- [x] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [x] Updated relevant documentation (`docs/`)
- [ ] Added a relevant changelog entry: `clog add [section] [stanza] [message]`
- [x] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
