### PR TITLE
avoid clogging /tmp with test runs leftover

### DIFF
--- a/cmd/gaia/cli_test/cli_test.go
+++ b/cmd/gaia/cli_test/cli_test.go
@@ -45,6 +45,9 @@ func TestGaiaCLIKeysAddMultisig(t *testing.T) {
 		fmt.Sprintf("--multisig=%s,%s", keyBaz, keyBar),
 		"--nosort")
 	require.NotEqual(t, f.KeysShow("msig3").Address, f.KeysShow("msig4").Address)
+
+	// Cleanup testing directories
+	f.Cleanup()
 }
 
 func TestGaiaCLIKeysAddRecover(t *testing.T) {
@@ -57,6 +60,9 @@ func TestGaiaCLIKeysAddRecover(t *testing.T) {
 	exitSuccess, _, _ = f.KeysAddRecover("test-recover", "dentist task convince chimney quality leave banana trade firm crawl eternal easily")
 	require.True(t, exitSuccess)
 	require.Equal(t, "cosmos1qcfdf69js922qrdr4yaww3ax7gjml6pdds46f4", f.KeyAddress("test-recover").String())
+
+	// Cleanup testing directories
+	f.Cleanup()
 }
 
 func TestGaiaCLIKeysAddRecoverHDPath(t *testing.T) {
@@ -74,6 +80,9 @@ func TestGaiaCLIKeysAddRecoverHDPath(t *testing.T) {
 
 	f.KeysAddRecoverHDPath("test-recoverH4", "dentist task convince chimney quality leave banana trade firm crawl eternal easily", 2, 17)
 	require.Equal(t, "cosmos1v9plmhvyhgxk3th9ydacm7j4z357s3nhtwsjat", f.KeyAddress("test-recoverH4").String())
+
+	// Cleanup testing directories
+	f.Cleanup()
 }
 
 func TestGaiaCLIMinimumFees(t *testing.T) {
@@ -298,6 +307,9 @@ func TestGaiaCLIConfirmTx(t *testing.T) {
 	// ensure account balances match expected
 	barAcc = f.QueryAccount(barAddr)
 	require.Equal(t, sendTokens, barAcc.GetCoins().AmountOf(denom))
+
+	// Cleanup testing directories
+	f.Cleanup()
 }
 
 func TestGaiaCLIGasAuto(t *testing.T) {
@@ -661,6 +673,9 @@ func TestGaiaCLISubmitParamChangeProposal(t *testing.T) {
 	// ensure the correct deposit amount on the proposal
 	deposit := f.QueryGovDeposit(1, fooAddr)
 	require.Equal(t, proposalTokens, deposit.Amount.AmountOf(denom))
+
+	// Cleanup testing directories
+	f.Cleanup()
 }
 
 func TestGaiaCLIQueryTxPagination(t *testing.T) {
@@ -710,6 +725,9 @@ func TestGaiaCLIQueryTxPagination(t *testing.T) {
 
 	// limit = 0
 	f.QueryTxsInvalid(errors.New("ERROR: limit must greater than 0"), 1, 0, fmt.Sprintf("sender:%s", fooAddr))
+
+	// Cleanup testing directories
+	f.Cleanup()
 }
 
 func TestGaiaCLIValidateSignatures(t *testing.T) {
@@ -900,6 +918,9 @@ func TestGaiaCLIMultisignInsufficientCosigners(t *testing.T) {
 	// Broadcast the transaction
 	success, _, _ = f.TxBroadcast(signedTxFile.Name())
 	require.False(t, success)
+
+	// Cleanup testing directories
+	f.Cleanup()
 }
 
 func TestGaiaCLIEncode(t *testing.T) {
@@ -1000,6 +1021,9 @@ func TestGaiaCLIMultisignSortSignatures(t *testing.T) {
 	// Broadcast the transaction
 	success, _, _ = f.TxBroadcast(signedTxFile.Name())
 	require.True(t, success)
+
+	// Cleanup testing directories
+	f.Cleanup()
 }
 
 func TestGaiaCLIMultisign(t *testing.T) {
@@ -1063,6 +1087,9 @@ func TestGaiaCLIMultisign(t *testing.T) {
 	// Broadcast the transaction
 	success, _, _ = f.TxBroadcast(signedTxFile.Name())
 	require.True(t, success)
+
+	// Cleanup testing directories
+	f.Cleanup()
 }
 
 func TestGaiaCLIConfig(t *testing.T) {
@@ -1176,6 +1203,9 @@ func TestGaiadAddGenesisAccount(t *testing.T) {
 	require.Equal(t, genesisState.Accounts[1].Address, f.KeyAddress(keyBar))
 	require.True(t, genesisState.Accounts[0].Coins.IsEqual(startCoins))
 	require.True(t, genesisState.Accounts[1].Coins.IsEqual(bazCoins))
+
+	// Cleanup testing directories
+	f.Cleanup()
 }
 
 func TestSlashingGetParams(t *testing.T) {
@@ -1194,6 +1224,9 @@ func TestSlashingGetParams(t *testing.T) {
 	sinfo := f.QuerySigningInfo(f.GDTendermint("show-validator"))
 	require.Equal(t, int64(0), sinfo.StartHeight)
 	require.False(t, sinfo.Tombstoned)
+
+	// Cleanup testing directories
+	f.Cleanup()
 }
 
 func TestValidateGenesis(t *testing.T) {
@@ -1205,4 +1238,7 @@ func TestValidateGenesis(t *testing.T) {
 	defer proc.Stop(false)
 
 	f.ValidateGenesis()
+
+	// Cleanup testing directories
+	f.Cleanup()
 }

--- a/cmd/gaia/cli_test/test_helpers.go
+++ b/cmd/gaia/cli_test/test_helpers.go
@@ -62,6 +62,7 @@ var (
 // Fixtures is used to setup the testing environment
 type Fixtures struct {
 	BuildDir      string
+	RootDir       string
 	GaiadBinary   string
 	GaiacliBinary string
 	ChainID       string
@@ -93,6 +94,7 @@ func NewFixtures(t *testing.T) *Fixtures {
 	return &Fixtures{
 		T:             t,
 		BuildDir:      buildDir,
+		RootDir:       tmpDir,
 		GaiadBinary:   filepath.Join(buildDir, "gaiad"),
 		GaiacliBinary: filepath.Join(buildDir, "gaiacli"),
 		GaiadHome:     filepath.Join(tmpDir, ".gaiad"),
@@ -165,10 +167,9 @@ func InitFixtures(t *testing.T) (f *Fixtures) {
 
 // Cleanup is meant to be run at the end of a test to clean up an remaining test state
 func (f *Fixtures) Cleanup(dirs ...string) {
-	clean := append(dirs, f.GaiadHome, f.GaiacliHome)
+	clean := append(dirs, f.RootDir)
 	for _, d := range clean {
-		err := os.RemoveAll(d)
-		require.NoError(f.T, err)
+		require.NoError(f.T, os.RemoveAll(d))
 	}
 }
 

--- a/cmd/gaia/lcd_test/helpers_test.go
+++ b/cmd/gaia/lcd_test/helpers_test.go
@@ -354,6 +354,7 @@ func InitializeTestLCD(t *testing.T, nValidators int, initAddrs []sdk.AccAddress
 		node.Stop() //nolint:errcheck
 		node.Wait()
 		lcd.Close()
+		require.NoError(t, os.RemoveAll(config.RootDir))
 	}
 
 	return cleanup, valConsPubKeys, valOperAddrs, port


### PR DESCRIPTION
Some tests did not clean after themselves once they ran successfully.

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added a relevant changelog entry: `clog add [section] [stanza] [message]`
- [ ] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
