### PR TITLE
Fix 'Using --password via the CLI is insecure' when building the docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -379,7 +379,7 @@ jobs:
             docker build .
           else
             docker build -t tendermint/gaia:$GAIAD_VERSION .
-            docker login -u $DOCKER_USER -p $DOCKER_PASS
+            docker login --password-stdin -u $DOCKER_USER <<<$DOCKER_PASS
             docker push tendermint/gaia:$GAIAD_VERSION
           fi
 


### PR DESCRIPTION

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added a relevant changelog entry: `clog add [section] [stanza] [message]`
- [ ] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
