### PR TITLE
Fix types/findDup()

### DIFF
--- a/.pending/bugfixes/sdk/4303-Fix-NewCoins-un
+++ b/.pending/bugfixes/sdk/4303-Fix-NewCoins-un
@@ -1,0 +1,1 @@
+#4303 Fix NewCoins() underlying function for duplicate coins detection.

--- a/types/coin.go
+++ b/types/coin.go
@@ -646,11 +646,12 @@ func findDup(coins Coins) int {
 		return -1
 	}
 
-	prevDenom := coins[0]
+	prevDenom := coins[0].Denom
 	for i := 1; i < len(coins); i++ {
-		if coins[i] == prevDenom {
+		if coins[i].Denom == prevDenom {
 			return i
 		}
+		prevDenom = coins[i].Denom
 	}
 
 	return -1

--- a/types/coin_test.go
+++ b/types/coin_test.go
@@ -593,3 +593,31 @@ func TestCoinsIsAnyGT(t *testing.T) {
 	require.False(t, Coins{twoBtc, twoAtom, threeEth}.IsAnyGT(Coins{fiveAtom, sixEth}))
 	require.False(t, Coins{twoAtom, sixEth}.IsAnyGT(Coins{twoBtc, fiveAtom}))
 }
+
+func TestFindDup(t *testing.T) {
+	abc := NewInt64Coin("abc", 10)
+	def := NewInt64Coin("def", 10)
+	ghi := NewInt64Coin("ghi", 10)
+
+	type args struct {
+		coins Coins
+	}
+	tests := []struct {
+		name string
+		args args
+		want int
+	}{
+		{"empty", args{NewCoins()}, -1},
+		{"one coin", args{NewCoins(NewInt64Coin("xyz", 10))}, -1},
+		{"no dups", args{Coins{abc, def, ghi}}, -1},
+		{"dup at first position", args{Coins{abc, abc, def}}, 1},
+		{"dup after first position", args{Coins{abc, def, def}}, 2},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := findDup(tt.args.coins); got != tt.want {
+				t.Errorf("findDup() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The function does not work as expected - denoms need
to be compared, not coins.

Add unit test.

Thanks: @zhuliting for pointing this out

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added a relevant changelog entry: `clog add [section] [stanza] [message]`
- [ ] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
