### PR TITLE
Fixes "too many arguments in call to bcrypt.GenerateFromPassword"

### DIFF
--- a/crypto/keys/mintkey/mintkey.go
+++ b/crypto/keys/mintkey/mintkey.go
@@ -105,8 +105,7 @@ func EncryptArmorPrivKey(privKey crypto.PrivKey, passphrase string) string {
 // generated salt and the xsalsa20 cipher. returns the salt and the
 // encrypted priv key.
 func encryptPrivKey(privKey crypto.PrivKey, passphrase string) (saltBytes []byte, encBytes []byte) {
-	saltBytes = crypto.CRandBytes(16)
-	key, err := bcrypt.GenerateFromPassword(saltBytes, []byte(passphrase), BcryptSecurityParameter)
+	key, err := bcrypt.GenerateFromPassword([]byte(passphrase), BcryptSecurityParameter)
 	if err != nil {
 		cmn.Exit("Error generating bcrypt key from passphrase: " + err.Error())
 	}
@@ -131,16 +130,12 @@ func UnarmorDecryptPrivKey(armorStr string, passphrase string) (crypto.PrivKey, 
 	if header["salt"] == "" {
 		return privKey, fmt.Errorf("Missing salt bytes")
 	}
-	saltBytes, err := hex.DecodeString(header["salt"])
-	if err != nil {
-		return privKey, fmt.Errorf("Error decoding salt: %v", err.Error())
-	}
-	privKey, err = decryptPrivKey(saltBytes, encBytes, passphrase)
+	privKey, err = decryptPrivKey(encBytes, passphrase)
 	return privKey, err
 }
 
-func decryptPrivKey(saltBytes []byte, encBytes []byte, passphrase string) (privKey crypto.PrivKey, err error) {
-	key, err := bcrypt.GenerateFromPassword(saltBytes, []byte(passphrase), BcryptSecurityParameter)
+func decryptPrivKey(encBytes []byte, passphrase string) (privKey crypto.PrivKey, err error) {
+	key, err := bcrypt.GenerateFromPassword([]byte(passphrase), BcryptSecurityParameter)
 	if err != nil {
 		cmn.Exit("Error generating bcrypt key from passphrase: " + err.Error())
 	}


### PR DESCRIPTION
Fixes an incorrect argument error after switching back from the forked golang.org/x/crypto library

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/develop/CONTRIBUTING.md#pr-targeting))

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added a relevant changelog entry: `clog add [section] [stanza] [message]`
- [ ] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
