### PR TITLE
R4R simulator bugfix for multisim 7601778

### DIFF
--- a/.pending/bugfixes/sdk/4362-simulation-setu
+++ b/.pending/bugfixes/sdk/4362-simulation-setu
@@ -1,0 +1,1 @@
+#4362 simulation setup bugfix for multisim 7601778

--- a/cmd/gaia/contrib/runsim/main.go
+++ b/cmd/gaia/contrib/runsim/main.go
@@ -25,7 +25,7 @@ var (
 		3012, 4728, 37827, 981928, 87821, 891823782,
 		989182, 89182391, 11, 22, 44, 77, 99, 2020,
 		3232, 123123, 124124, 582582, 18931893,
-		29892989, 30123012, 47284728,
+		29892989, 30123012, 47284728, 7601778,
 	}
 
 	// goroutine-safe process map
@@ -36,7 +36,7 @@ var (
 	results chan bool
 
 	// command line arguments and options
-	jobs       int = runtime.GOMAXPROCS(0)
+	jobs       = runtime.GOMAXPROCS(0)
 	blocks     string
 	period     string
 	testname   string

--- a/x/simulation/params.go
+++ b/x/simulation/params.go
@@ -134,7 +134,7 @@ func RandomParams(r *rand.Rand) Params {
 		PastEvidenceFraction:      r.Float64(),
 		NumKeys:                   RandIntBetween(r, 2, 250),
 		EvidenceFraction:          r.Float64(),
-		InitialLivenessWeightings: []int{r.Intn(80), r.Intn(10), r.Intn(10)},
+		InitialLivenessWeightings: []int{RandIntBetween(r, 1, 80), r.Intn(10), r.Intn(10)},
 		LivenessTransitionMatrix:  defaultLivenessTransitionMatrix,
 		BlockSizeTransitionMatrix: defaultBlockSizeTransitionMatrix,
 	}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

closes #4362

For the record what was happening is all three integers set in `InitialLivenessWeightings` were set to 0 making the "total" of that equal to zero which caused an error for rand here:
https://github.com/cosmos/cosmos-sdk/blob/a23eb322c609e2be63a0ec386222c0411715ef1e/x/simulation/transition_matrix.go#L61

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [x] Added a relevant changelog entry: `clog add [section] [stanza] [message]`
- [ ] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
