### PR TITLE
Random Fuzzer fix: avoids VotingPeriod=0

### DIFF
--- a/x/simulation/params.go
+++ b/x/simulation/params.go
@@ -59,7 +59,7 @@ var (
 			return sdk.Coins{sdk.NewInt64Coin(sdk.DefaultBondDenom, int64(RandIntBetween(r, 1, 1e3)))}
 		},
 		"VotingParams/VotingPeriod": func(r *rand.Rand) interface{} {
-			return time.Duration(r.Intn(2*172800)) * time.Second
+			return time.Duration(RandIntBetween(r, 1, 2*60*60*24*2)) * time.Second
 		},
 		"TallyParams/Quorum": func(r *rand.Rand) interface{} {
 			return sdk.NewDecWithPrec(334, 3)


### PR DESCRIPTION
This fixes the bug when the Random Fuzzer samples a `VotingParams/VotingPeriod` integer equals to `0`.

First apply the following patch to force `VotingPeriod=0`:
```
$ git diff
diff --git a/x/simulation/params.go b/x/simulation/params.go
index 12eb8e59..7cbf3783 100644
--- a/x/simulation/params.go
+++ b/x/simulation/params.go
@@ -59,7 +59,7 @@ var (
                        return sdk.Coins{sdk.NewInt64Coin(sdk.DefaultBondDenom, int64(RandIntBetween(r, 1, 1e3)))}
                },
                "VotingParams/VotingPeriod": func(r *rand.Rand) interface{} {
-                       return time.Duration(r.Intn(2*172800)) * time.Second
+                       return time.Duration(0) * time.Second
                },
                "TallyParams/Quorum": func(r *rand.Rand) interface{} {
                        return sdk.NewDecWithPrec(334, 3)
```
Then run:
`go test ./cmd/gaia/app -run TestFullGaiaSimulation -SimulationEnabled=true -SimulationNumBlocks=500 -SimulationGenesis= -SimulationVerbose=true -SimulationCommit=true -SimulationSeed=7601778 -SimulationPeriod=50 -v -timeout 24h`

This will produce the following error:
```
I[2019-05-18|00:50:26.347] Absent validator 42FFEF72B501BAF304E91BF238EAA814CF086DEE (PubKeySecp256k1{03D6D8727A963EAE1BF5A73584776E248D49AA773E8A22E1D25539BC861FF1465E}) at height 1, 1 missed, threshold 79 module=x/slashing
Simulating... block 1/500, operation 100/661. I[2019-05-18|00:50:26.720] setting new parameter; key: InflationRateChange, value: "0.940000000000000000" module=x/params
I[2019-05-18|00:50:26.720] setting new parameter; key: MinSignedPerWindow, value: "0.900000000000000000" module=x/params
I[2019-05-18|00:50:26.720] setting new parameter; key: MaxValidators, value: 182 module=x/params
panic with err: invalid argument to Int63n
goroutine 6 [running]:
runtime/debug.Stack(0x12acd00, 0xc0000c2008, 0xff040c)
        /snap/go/3739/src/runtime/debug/stack.go:24 +0x9d
github.com/cosmos/cosmos-sdk/x/simulation.SimulateFromSeed.func2(0x12acd00, 0xc0000c2008, 0x12b8a00, 0xc0012ad660, 0xc00000c3c0, 0xc0004a5450)
        /home/cosmos/go/src/github.com/cosmos/cosmos-sdk/x/simulation/simulate.go:128 +0xd1
panic(0xe5c820, 0x1295c10)
        /snap/go/3739/src/runtime/panic.go:522 +0x1b5
math/rand.(*Rand).Int63n(0xc0011d63f0, 0x0, 0xc000046a80)
        /snap/go/3739/src/math/rand/rand.go:111 +0x11e
github.com/cosmos/cosmos-sdk/x/gov/simulation.SimulateSubmittingVotingAndSlashingForProposal.func1(0xc0011d63f0, 0xc0000ee6c0, 0x12c6a60, 0xc0012cfda0, 0xc000046a80, 0xc, 0xc0009c5000, 0xc4, 0xc4, 0xfe1e2f, ...)
        /home/cosmos/go/src/github.com/cosmos/cosmos-sdk/x/gov/simulation/msgs.go:83 +0x8f0
github.com/cosmos/cosmos-sdk/x/simulation.createBlockSimulator.func1(0xc0004b9c20, 0xc0000ee6c0, 0x12c6a60, 0xc0012cfda0, 0xc000046a80, 0xc, 0xc0009c5000, 0xc4, 0xc4, 0x0, ...)
        /home/cosmos/go/src/github.com/cosmos/cosmos-sdk/x/simulation/simulate.go:263 +0x5a6
github.com/cosmos/cosmos-sdk/x/simulation.SimulateFromSeed(0x12dacc0, 0xc00051cd00, 0x12acd00, 0xc0000c2008, 0xc0000ee6c0, 0x1153ba8, 0x73fe72, 0xc000017c20, 0xf, 0xf, ...)
        /home/cosmos/go/src/github.com/cosmos/cosmos-sdk/x/simulation/simulate.go:167 +0x14cf
github.com/cosmos/cosmos-sdk/cmd/gaia/app.TestFullGaiaSimulation(0xc00051cd00)
        /home/cosmos/go/src/github.com/cosmos/cosmos-sdk/cmd/gaia/app/sim_test.go:376 +0x375
testing.tRunner(0xc00051cd00, 0x1153b68)
        /snap/go/3739/src/testing/testing.go:865 +0xc0
created by testing.(*T).Run
        /snap/go/3739/src/testing/testing.go:916 +0x35a

Logs to writing to /home/cosmos/.gaiad/simulations/2019-05-18_00:50:26.log
GoLevelDB Stats
Compactions
 Level |   Tables   |    Size(MB)   |    Time(sec)  |    Read(MB)   |   Write(MB)
-------+------------+---------------+---------------+---------------+---------------

GoLevelDB cached block size 0
--- FAIL: TestFullGaiaSimulation (0.50s)
    require.go:765:
                Error Trace:    sim_test.go:384
                Error:          Expected nil, but got: &errors.errorString{s:"Simulation halted due to panic on block 1"}
                Test:           TestFullGaiaSimulation
FAIL
FAIL    github.com/cosmos/cosmos-sdk/cmd/gaia/app       0.660s
```

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
