### PR TITLE
allow splitting withdrawal txs

### DIFF
--- a/.pending/improvements/sdk/4384-WithdrawalTxSplitting
+++ b/.pending/improvements/sdk/4384-WithdrawalTxSplitting
@@ -1,0 +1,1 @@
+#4384- Allow splitting withdrawal transaction in several chunks

--- a/x/distribution/client/cli/tx.go
+++ b/x/distribution/client/cli/tx.go
@@ -58,7 +58,9 @@ func splitGenerateOrBroadcast(cliCtx context.CLIContext, txBldr authtxb.TxBuilde
 			sliceEnd = totalMessages
 		}
 		msgChunk := msgs[i:sliceEnd]
-		err := utils.GenerateOrBroadcastMsgs(cliCtx, txBldr, msgChunk)
+		if err := utils.GenerateOrBroadcastMsgs(cliCtx, txBldr, msgChunk); err != nil {
+			return err
+		}
 		if err != nil {
 			return err
 		}

--- a/x/distribution/client/cli/tx.go
+++ b/x/distribution/client/cli/tx.go
@@ -100,7 +100,7 @@ $ <appcli> tx distr withdraw-rewards cosmosvaloper1gghjut3ccd8ay0zduzj64hwre2fxs
 			return splitGenerateOrBroadcast(cliCtx, txBldr, msgs)
 		},
 	}
-	cmd.Flags().Int(flagMaxMessagesPerTx, MaxMessagesPerTxDefault, "limit the number of messages per tx")
+	cmd.Flags().Int(flagMaxMessagesPerTx, MaxMessagesPerTxDefault, "limit the number of messages per tx. Zero for unlimited")
 	cmd.Flags().Bool(flagComission, false, "also withdraw validator's commission")
 	return cmd
 }
@@ -131,7 +131,7 @@ $ <appcli> tx distr withdraw-all-rewards --from mykey
 			return splitGenerateOrBroadcast(cliCtx, txBldr, msgs)
 		},
 	}
-	cmd.Flags().Int(flagMaxMessagesPerTx, MaxMessagesPerTxDefault, "limit the number of messages per tx [zero=unlimited]")
+	cmd.Flags().Int(flagMaxMessagesPerTx, MaxMessagesPerTxDefault, "limit the number of messages per tx. Zero for unlimited")
 	return cmd
 }
 
@@ -162,6 +162,6 @@ $ <appcli> tx set-withdraw-addr cosmos1gghjut3ccd8ay0zduzj64hwre2fxs9ld75ru9p --
 			return splitGenerateOrBroadcast(cliCtx, txBldr, []sdk.Msg{msg})
 		},
 	}
-	cmd.Flags().Int(flagMaxMessagesPerTx, MaxMessagesPerTxDefault, "limit the number of messages per tx")
+	cmd.Flags().Int(flagMaxMessagesPerTx, MaxMessagesPerTxDefault, "limit the number of messages per tx. Zero for unlimited")
 	return cmd
 }

--- a/x/distribution/client/cli/tx.go
+++ b/x/distribution/client/cli/tx.go
@@ -46,8 +46,6 @@ func GetTxCmd(storeKey string, cdc *amino.Codec) *cobra.Command {
 }
 
 func splitGenerateOrBroadcast(cliCtx context.CLIContext, txBldr authtxb.TxBuilder, msgs []sdk.Msg) error {
-	var lastErr error = nil
-
 	chunkSize := viper.GetInt(flagMaxMessagesPerTx)
 	totalMessages := len(msgs)
 	if chunkSize == 0 {
@@ -60,9 +58,9 @@ func splitGenerateOrBroadcast(cliCtx context.CLIContext, txBldr authtxb.TxBuilde
 			sliceEnd = totalMessages
 		}
 		msgChunk := msgs[i:sliceEnd]
-		lastErr = utils.GenerateOrBroadcastMsgs(cliCtx, txBldr, msgChunk)
-		if lastErr != nil {
-			return lastErr
+		err = utils.GenerateOrBroadcastMsgs(cliCtx, txBldr, msgChunk)
+		if err != nil {
+			return err
 		}
 	}
 

--- a/x/distribution/client/cli/tx.go
+++ b/x/distribution/client/cli/tx.go
@@ -58,7 +58,7 @@ func splitGenerateOrBroadcast(cliCtx context.CLIContext, txBldr authtxb.TxBuilde
 			sliceEnd = totalMessages
 		}
 		msgChunk := msgs[i:sliceEnd]
-		err = utils.GenerateOrBroadcastMsgs(cliCtx, txBldr, msgChunk)
+		err := utils.GenerateOrBroadcastMsgs(cliCtx, txBldr, msgChunk)
 		if err != nil {
 			return err
 		}

--- a/x/distribution/client/cli/tx.go
+++ b/x/distribution/client/cli/tx.go
@@ -61,9 +61,6 @@ func splitGenerateOrBroadcast(cliCtx context.CLIContext, txBldr authtxb.TxBuilde
 		if err := utils.GenerateOrBroadcastMsgs(cliCtx, txBldr, msgChunk); err != nil {
 			return err
 		}
-		if err != nil {
-			return err
-		}
 	}
 
 	return nil

--- a/x/distribution/client/cli/tx.go
+++ b/x/distribution/client/cli/tx.go
@@ -54,21 +54,26 @@ func splitAndApply(
 	msgs []sdk.Msg,
 	chunkSize int,
 ) error {
-	totalMessages := len(msgs)
+
 	if chunkSize == 0 {
-		chunkSize = totalMessages
+		return generateOrBroadcast(cliCtx, txBldr, msgs)
 	}
 
+	// split messages into slices of length chunkSize
+	totalMessages := len(msgs)
 	for i := 0; i < len(msgs); i += chunkSize {
+
 		sliceEnd := i + chunkSize
 		if sliceEnd > totalMessages {
 			sliceEnd = totalMessages
 		}
+
 		msgChunk := msgs[i:sliceEnd]
 		if err := generateOrBroadcast(cliCtx, txBldr, msgChunk); err != nil {
 			return err
 		}
 	}
+
 	return nil
 }
 

--- a/x/distribution/client/cli/tx.go
+++ b/x/distribution/client/cli/tx.go
@@ -134,7 +134,7 @@ $ <appcli> tx distr withdraw-all-rewards --from mykey
 			return splitAndApply(utils.GenerateOrBroadcastMsgs, cliCtx, txBldr, msgs, chunkSize)
 		},
 	}
-	cmd.Flags().Int(flagMaxMessagesPerTx, MaxMessagesPerTxDefault, "limit the number of messages per tx. Zero for unlimited")
+	cmd.Flags().Int(flagMaxMessagesPerTx, MaxMessagesPerTxDefault, "Limit the number of messages per tx (0 for unlimited)")
 	return cmd
 }
 

--- a/x/distribution/client/cli/tx_test.go
+++ b/x/distribution/client/cli/tx_test.go
@@ -1,0 +1,77 @@
+package cli
+
+import (
+	"github.com/cosmos/cosmos-sdk/client/context"
+	"github.com/cosmos/cosmos-sdk/client/utils"
+	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	authtxb "github.com/cosmos/cosmos-sdk/x/auth/client/txbuilder"
+	"github.com/stretchr/testify/assert"
+	"github.com/tendermint/tendermint/crypto/secp256k1"
+	"testing"
+)
+
+func createFakeTxBuilder() authtxb.TxBuilder {
+	cdc := codec.New()
+	return authtxb.NewTxBuilder(
+		utils.GetTxEncoder(cdc),
+		123,
+		9876,
+		0,
+		1.2,
+		false,
+		"test_chain",
+		"hello",
+		sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(1))),
+		sdk.DecCoins{sdk.NewDecCoinFromDec(sdk.DefaultBondDenom, sdk.NewDecWithPrec(10000, sdk.Precision))},
+	)
+}
+
+func Test_splitAndCall_NoMessages(t *testing.T) {
+	ctx := context.CLIContext{}
+	txBldr := createFakeTxBuilder()
+
+	err := splitAndApply(nil, ctx, txBldr, nil, 10)
+	assert.NoError(t, err, "")
+}
+
+func Test_splitAndCall_Splitting(t *testing.T) {
+	ctx := context.CLIContext{}
+	txBldr := createFakeTxBuilder()
+
+	addr := sdk.AccAddress(secp256k1.GenPrivKey().PubKey().Address())
+
+	// Add five messages
+	msgs := []sdk.Msg{
+		sdk.NewTestMsg(addr),
+		sdk.NewTestMsg(addr),
+		sdk.NewTestMsg(addr),
+		sdk.NewTestMsg(addr),
+		sdk.NewTestMsg(addr),
+	}
+
+	// Keep track of number of calls
+	const chunkSize = 2
+
+	callCount := 0
+	err := splitAndApply(
+		func(ctx context.CLIContext, txBldr authtxb.TxBuilder, msgs []sdk.Msg) error {
+			callCount += 1
+
+			assert.NotNil(t, ctx)
+			assert.NotNil(t, txBldr)
+			assert.NotNil(t, msgs)
+
+			if callCount < 3 {
+				assert.Equal(t, len(msgs), 2)
+			} else {
+				assert.Equal(t, len(msgs), 1)
+			}
+
+			return nil
+		},
+		ctx, txBldr, msgs, chunkSize)
+
+	assert.NoError(t, err, "")
+	assert.Equal(t, 3, callCount)
+}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Due to HSM limitations (Ledger Nano S), big transactions such as withdrawing rewards from a large number of validators, may be rejected to due memory constraints.

This PR introduces an additional flag that allows splitting the withdrawal messages and generates several transactions. Users can then define the maximum number of messages that they want to use.

This is related to: https://github.com/cosmos/ledger-cosmos/issues/143
While we have extended limits to Nano X in the next release, it is important to provide an alternative to users of Nano S.

- [x] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [x] Wrote tests
- [x] Updated relevant documentation (`docs/`)
- [x] Added a relevant changelog entry: `clog add [section] [stanza] [message]`
- [x] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
