### PR TITLE
Simulation: Fix from Genesis File

### DIFF
--- a/types/module.go
+++ b/types/module.go
@@ -216,6 +216,7 @@ func (mm *ModuleManager) InitGenesis(ctx Context, genesisData map[string]json.Ra
 		if genesisData[moduleName] == nil {
 			continue
 		}
+
 		moduleValUpdates := mm.Modules[moduleName].InitGenesis(ctx, genesisData[moduleName])
 
 		// use these validator updates if provided, the module manager assumes

--- a/x/auth/genaccounts/genesis_state.go
+++ b/x/auth/genaccounts/genesis_state.go
@@ -25,8 +25,9 @@ func NewGenesisState(accounts GenesisAccounts) GenesisState {
 func GetGenesisStateFromAppState(cdc *codec.Codec, appState map[string]json.RawMessage) GenesisState {
 	var genesisState GenesisState
 	if appState[ModuleName] != nil {
-		cdc.MustUnmarshalJSON(appState[ModuleName], &genesisState)
+		cdc.MustUnmarshalJSON(appState[ModuleName], &genesisState.Accounts)
 	}
+
 	return genesisState
 }
 

--- a/x/auth/genaccounts/module.go
+++ b/x/auth/genaccounts/module.go
@@ -77,7 +77,7 @@ func NewAppModule(accountKeeper AccountKeeper) sdk.AppModule {
 // module init-genesis
 func (am AppModule) InitGenesis(ctx sdk.Context, data json.RawMessage) []abci.ValidatorUpdate {
 	var genesisState GenesisState
-	moduleCdc.MustUnmarshalJSON(data, &genesisState)
+	moduleCdc.MustUnmarshalJSON(data, &genesisState.Accounts)
 	InitGenesis(ctx, moduleCdc, am.accountKeeper, genesisState)
 	return []abci.ValidatorUpdate{}
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

The genesis state is now represented as a `map[string]json.RawMessage`. So logic that handles genesis state in each respective module needs to treat this carefully when serializing/deserializing.

## Example

### Incorrect

```go
func (am AppModule) InitGenesis(ctx sdk.Context, data json.RawMessage) []abci.ValidatorUpdate {
	var genesisState GenesisState
	moduleCdc.MustUnmarshalJSON(data, &genesisState) // <----
	InitGenesis(ctx, moduleCdc, am.accountKeeper, genesisState)
	return []abci.ValidatorUpdate{}
}
```

### Correct

```go
func (am AppModule) InitGenesis(ctx sdk.Context, data json.RawMessage) []abci.ValidatorUpdate {
	var genesisState GenesisState
	moduleCdc.MustUnmarshalJSON(data, &genesisState.Accounts)  // <----
	InitGenesis(ctx, moduleCdc, am.accountKeeper, genesisState)
	return []abci.ValidatorUpdate{}
}
```

In other words, you can't just decode the data (`json.RawMessage`) into the module's `GenesisState` type.

For auth `GenesisState`, this is simple because you just have one field: `Accounts`. For other modules where there may be more fields, you'll have to either:

1. Decode into each field OR
2. Create a temporary struct, encode that struct with the data, and then decode that into the genesis state.

Example of (2):

```go
type RawGenesisState struct {
	Accounts json.RawMessage `json:"accounts"`
}

// module init-genesis
func (am AppModule) InitGenesis(ctx sdk.Context, data json.RawMessage) []abci.ValidatorUpdate {
	var genesisState GenesisState

	// first encode the raw version
	rgs := RawGenesisState{Accounts: data}
	bz := moduleCdc.MustMarshalJSON(rgs)

	// decode into primary genesis state
	moduleCdc.MustUnmarshalJSON(bz, &genesisState)

	InitGenesis(ctx, moduleCdc, am.accountKeeper, genesisState)
	return []abci.ValidatorUpdate{}
}
```


I guess option (2) is easier and not error-prone. Once we agree upon an option (1) or (2), I'll update the rest of the modules.

EDIT: Alternatively, we can just simply have a script that does the conversion from old to new.

/cc @rigelrozanski @npinto 

----

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/develop/CONTRIBUTING.md#pr-targeting))

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added a relevant changelog entry: `clog add [section] [stanza] [message]`
- [ ] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
