### PR TITLE
Implement MarshalJSON for Coins Type

### DIFF
--- a/types/coin.go
+++ b/types/coin.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"encoding/json"
 	"fmt"
 	"regexp"
 	"sort"
@@ -149,6 +150,16 @@ func NewCoins(coins ...Coin) Coins {
 	}
 
 	return newCoins
+}
+
+type coinsJSON Coins
+
+func (coins Coins) MarshalJSON() ([]byte, error) {
+	if coins == nil {
+		return json.Marshal(coinsJSON(Coins{}))
+	}
+
+	return json.Marshal(coinsJSON(coins))
 }
 
 func (coins Coins) String() string {

--- a/types/coin_test.go
+++ b/types/coin_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -620,4 +621,28 @@ func TestFindDup(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestMarshalJSONCoins(t *testing.T) {
+	cdc := codec.New()
+	RegisterCodec(cdc)
+
+	var coins Coins
+
+	bz, err := cdc.MarshalJSON(coins)
+	require.NoError(t, err)
+	require.Equal(t, `[]`, string(bz))
+
+	var newCoins Coins
+
+	require.NoError(t, cdc.UnmarshalJSON(bz, &newCoins))
+	require.Nil(t, newCoins)
+
+	coins = NewCoins(NewInt64Coin("foo", 50))
+	bz, err = cdc.MarshalJSON(coins)
+	require.NoError(t, err)
+	require.Equal(t, `[{"denom":"foo","amount":"50"}]`, string(bz))
+
+	require.NoError(t, cdc.UnmarshalJSON(bz, &newCoins))
+	require.Equal(t, coins, newCoins)
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

When coins are `nil`, they are JSON encoded as `null` in responses which is a bad UX for API and client consumers. This PR implements a custom JSON marshaler that encodes `nil` coins as `[]`.

closes: #4259

/cc @vikmeup

----

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/develop/CONTRIBUTING.md#pr-targeting))

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added a relevant changelog entry: `clog add [section] [stanza] [message]`
- [ ] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
