### PR TITLE
R4R: Using `QueryWithData` to query unbonding delegations.

### DIFF
--- a/.pending/bugfixes/sdk/4455-Print-null-whil
+++ b/.pending/bugfixes/sdk/4455-Print-null-whil
@@ -1,0 +1,1 @@
+#4455 Use `QueryWithData()` to query unbonding delegations.

--- a/x/staking/client/cli/query.go
+++ b/x/staking/client/cli/query.go
@@ -311,7 +311,7 @@ $ %s query staking delegations-to cosmosvaloper1gghjut3ccd8ay0zduzj64hwre2fxs9ld
 
 // GetCmdQueryUnbondingDelegation implements the command to query a single
 // unbonding-delegation record.
-func GetCmdQueryUnbondingDelegation(storeName string, cdc *codec.Codec) *cobra.Command {
+func GetCmdQueryUnbondingDelegation(storeKey string, cdc *codec.Codec) *cobra.Command {
 	return &cobra.Command{
 		Use:   "unbonding-delegation [delegator-addr] [validator-addr]",
 		Short: "Query an unbonding-delegation record based on delegator and validator address",
@@ -338,20 +338,25 @@ $ %s query staking unbonding-delegation cosmos1gghjut3ccd8ay0zduzj64hwre2fxs9ld7
 				return err
 			}
 
-			res, err := cliCtx.QueryStore(types.GetUBDKey(delAddr, valAddr), storeName)
+			bz, err := cdc.MarshalJSON(querier.NewQueryBondsParams(delAddr, valAddr))
+			if err != nil {
+				return err
+			}
+
+			route := fmt.Sprintf("custom/%s/%s", storeKey, querier.QueryUnbondingDelegation)
+			res, err := cliCtx.QueryWithData(route, bz)
 			if err != nil {
 				return err
 			}
 
 			return cliCtx.PrintOutput(types.MustUnmarshalUBD(cdc, res))
-
 		},
 	}
 }
 
 // GetCmdQueryUnbondingDelegations implements the command to query all the
 // unbonding-delegation records for a delegator.
-func GetCmdQueryUnbondingDelegations(storeName string, cdc *codec.Codec) *cobra.Command {
+func GetCmdQueryUnbondingDelegations(storeKey string, cdc *codec.Codec) *cobra.Command {
 	return &cobra.Command{
 		Use:   "unbonding-delegations [delegator-addr]",
 		Short: "Query all unbonding-delegations records for one delegator",
@@ -373,14 +378,20 @@ $ %s query staking unbonding-delegation cosmos1gghjut3ccd8ay0zduzj64hwre2fxs9ld7
 				return err
 			}
 
-			resKVs, err := cliCtx.QuerySubspace(types.GetUBDsKey(delegatorAddr), storeName)
+			bz, err := cdc.MarshalJSON(querier.NewQueryDelegatorParams(delegatorAddr))
+			if err != nil {
+				return err
+			}
+
+			route := fmt.Sprintf("custom/%s/%s", storeKey, querier.QueryDelegatorUnbondingDelegations)
+			res, err := cliCtx.QueryWithData(route, bz)
 			if err != nil {
 				return err
 			}
 
 			var ubds types.UnbondingDelegations
-			for _, kv := range resKVs {
-				ubds = append(ubds, types.MustUnmarshalUBD(cdc, kv.Value))
+			if err = cdc.UnmarshalJSON(res, &ubds); err != nil {
+				return err
 			}
 
 			return cliCtx.PrintOutput(ubds)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/develop/CONTRIBUTING.md#pr-targeting))

close: #4455 

- [x] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [x] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [x] Added a relevant changelog entry: `clog add [section] [stanza] [message]`
- [x] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
