### PR TITLE
WIP: auto redelegate commission

### DIFF
--- a/x/distribution/keeper/allocation.go
+++ b/x/distribution/keeper/allocation.go
@@ -104,4 +104,14 @@ func (k Keeper) AllocateTokensToValidator(ctx sdk.Context, val exported.Validato
 	outstanding := k.GetValidatorOutstandingRewards(ctx, val.GetOperator())
 	outstanding = outstanding.Add(tokens)
 	k.SetValidatorOutstandingRewards(ctx, val.GetOperator(), outstanding)
+
+	if val.GetAutoRedelegateCommission() {
+		coins, err := WithdrawValidatorCommission(ctx, val.GetOperator())
+		// TODO(roman): What should be done with this error?
+
+		accAddr := sdk.AccAddress(valAddr)
+		withdrawAddr := k.GetDelegatorWithdrawAddr(ctx, accAddr)
+
+		k.GetStakingKeeper().Delegate(ctx, withdrawAddr, coins, val, true /* what is the purpose of this bool parameter? */)
+	}
 }

--- a/x/staking/exported/exported.go
+++ b/x/staking/exported/exported.go
@@ -29,6 +29,7 @@ type ValidatorI interface {
 	GetCommission() sdk.Dec                                     // validator commission rate
 	GetMinSelfDelegation() sdk.Int                              // validator minimum self delegation
 	GetDelegatorShares() sdk.Dec                                // total outstanding delegator shares
+	GetAutoRedelegateCommission() bool                          // validator automatic redelegation of commission
 	TokensFromShares(sdk.Dec) sdk.Dec                           // token worth of provided delegator shares
 	TokensFromSharesTruncated(sdk.Dec) sdk.Dec                  // token worth of provided delegator shares, truncated
 	TokensFromSharesRoundUp(sdk.Dec) sdk.Dec                    // token worth of provided delegator shares, rounded up


### PR DESCRIPTION
_This PR is in the early stages. Looking for feedback on both the idea then guidance with proper implementation and testing._

This changeset adds a new validator option for automatic withdraw and re-delegation of commission back to itself. I added this as a parameter on the validator so it could be publicly visible but I do not feel strongly about that - it could be done similar to SetWithdrawAddress.

This is the first step towards helping automate reward and commission re-delegation.

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added a relevant changelog entry: `clog add [section] [stanza] [message]`
- [ ] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
