### PR TITLE
R4R: InvariantRouter -> InvariantRegistry

### DIFF
--- a/types/invariant.go
+++ b/types/invariant.go
@@ -9,7 +9,7 @@ type Invariant func(ctx Context) error
 // Invariants defines a group of invariants
 type Invariants []Invariant
 
-// expected interface for routing invariants
-type InvariantRouter interface {
+// expected interface for registering invariants
+type InvariantRegistry interface {
 	RegisterRoute(moduleName, route string, invar Invariant)
 }

--- a/types/module/module.go
+++ b/types/module/module.go
@@ -131,7 +131,7 @@ type AppModule interface {
 	AppModuleGenesis
 
 	// registers
-	RegisterInvariants(sdk.InvariantRouter)
+	RegisterInvariants(sdk.InvariantRegistry)
 
 	// routes
 	Route() string
@@ -157,7 +157,7 @@ func NewGenesisOnlyAppModule(amg AppModuleGenesis) AppModule {
 }
 
 // register invariants
-func (GenesisOnlyAppModule) RegisterInvariants(_ sdk.InvariantRouter) {}
+func (GenesisOnlyAppModule) RegisterInvariants(_ sdk.InvariantRegistry) {}
 
 // module message route ngame
 func (GenesisOnlyAppModule) Route() string { return "" }
@@ -232,7 +232,7 @@ func (m *Manager) SetOrderEndBlockers(moduleNames ...string) {
 }
 
 // register all module routes and module querier routes
-func (m *Manager) RegisterInvariants(invarRouter sdk.InvariantRouter) {
+func (m *Manager) RegisterInvariants(invarRouter sdk.InvariantRegistry) {
 	for _, module := range m.Modules {
 		module.RegisterInvariants(invarRouter)
 	}

--- a/types/module/module.go
+++ b/types/module/module.go
@@ -232,9 +232,9 @@ func (m *Manager) SetOrderEndBlockers(moduleNames ...string) {
 }
 
 // register all module routes and module querier routes
-func (m *Manager) RegisterInvariants(invarRouter sdk.InvariantRegistry) {
+func (m *Manager) RegisterInvariants(ir sdk.InvariantRegistry) {
 	for _, module := range m.Modules {
-		module.RegisterInvariants(invarRouter)
+		module.RegisterInvariants(ir)
 	}
 }
 

--- a/x/auth/module.go
+++ b/x/auth/module.go
@@ -88,7 +88,7 @@ func (AppModule) Name() string {
 }
 
 // register invariants
-func (AppModule) RegisterInvariants(_ sdk.InvariantRouter) {}
+func (AppModule) RegisterInvariants(_ sdk.InvariantRegistry) {}
 
 // module message route name
 func (AppModule) Route() string { return "" }

--- a/x/bank/invariants.go
+++ b/x/bank/invariants.go
@@ -10,7 +10,7 @@ import (
 )
 
 // register bank invariants
-func RegisterInvariants(ir sdk.InvariantRouter, ak auth.AccountKeeper) {
+func RegisterInvariants(ir sdk.InvariantRegistry, ak auth.AccountKeeper) {
 	ir.RegisterRoute(types.ModuleName, "nonnegative-outstanding",
 		NonnegativeBalanceInvariant(ak))
 }

--- a/x/bank/module.go
+++ b/x/bank/module.go
@@ -89,7 +89,7 @@ func (AppModule) Name() string {
 }
 
 // register invariants
-func (am AppModule) RegisterInvariants(ir sdk.InvariantRouter) {
+func (am AppModule) RegisterInvariants(ir sdk.InvariantRegistry) {
 	RegisterInvariants(ir, am.accountKeeper)
 }
 

--- a/x/crisis/module.go
+++ b/x/crisis/module.go
@@ -81,7 +81,7 @@ func (AppModule) Name() string {
 }
 
 // register invariants
-func (AppModule) RegisterInvariants(_ sdk.InvariantRouter) {}
+func (AppModule) RegisterInvariants(_ sdk.InvariantRegistry) {}
 
 // module querier route name
 func (AppModule) Route() string {

--- a/x/distribution/keeper/invariants.go
+++ b/x/distribution/keeper/invariants.go
@@ -9,7 +9,7 @@ import (
 )
 
 // register all distribution invariants
-func RegisterInvariants(ir sdk.InvariantRouter, k Keeper) {
+func RegisterInvariants(ir sdk.InvariantRegistry, k Keeper) {
 	ir.RegisterRoute(types.ModuleName, "nonnegative-outstanding",
 		NonNegativeOutstandingInvariant(k))
 	ir.RegisterRoute(types.ModuleName, "can-withdraw",

--- a/x/distribution/module.go
+++ b/x/distribution/module.go
@@ -84,7 +84,7 @@ func (AppModule) Name() string {
 }
 
 // register invariants
-func (am AppModule) RegisterInvariants(ir sdk.InvariantRouter) {
+func (am AppModule) RegisterInvariants(ir sdk.InvariantRegistry) {
 	RegisterInvariants(ir, am.keeper)
 }
 

--- a/x/gov/module.go
+++ b/x/gov/module.go
@@ -109,7 +109,7 @@ func (AppModule) Name() string {
 }
 
 // register invariants
-func (AppModule) RegisterInvariants(_ sdk.InvariantRouter) {}
+func (AppModule) RegisterInvariants(_ sdk.InvariantRegistry) {}
 
 // module message route name
 func (AppModule) Route() string {

--- a/x/mint/module.go
+++ b/x/mint/module.go
@@ -83,7 +83,7 @@ func (AppModule) Name() string {
 }
 
 // register invariants
-func (am AppModule) RegisterInvariants(_ sdk.InvariantRouter) {}
+func (am AppModule) RegisterInvariants(_ sdk.InvariantRegistry) {}
 
 // module message route name
 func (AppModule) Route() string { return "" }

--- a/x/slashing/module.go
+++ b/x/slashing/module.go
@@ -90,7 +90,7 @@ func (AppModule) Name() string {
 }
 
 // register invariants
-func (am AppModule) RegisterInvariants(_ sdk.InvariantRouter) {}
+func (am AppModule) RegisterInvariants(_ sdk.InvariantRegistry) {}
 
 // module message route name
 func (AppModule) Route() string {

--- a/x/staking/keeper/invariants.go
+++ b/x/staking/keeper/invariants.go
@@ -11,7 +11,7 @@ import (
 )
 
 // register all staking invariants
-func RegisterInvariants(ir sdk.InvariantRouter, k Keeper, f types.FeeCollectionKeeper,
+func RegisterInvariants(ir sdk.InvariantRegistry, k Keeper, f types.FeeCollectionKeeper,
 	d types.DistributionKeeper, am types.AccountKeeper) {
 
 	ir.RegisterRoute(types.ModuleName, "supply",

--- a/x/staking/module.go
+++ b/x/staking/module.go
@@ -120,7 +120,7 @@ func (AppModule) Name() string {
 }
 
 // register invariants
-func (am AppModule) RegisterInvariants(ir sdk.InvariantRouter) {
+func (am AppModule) RegisterInvariants(ir sdk.InvariantRegistry) {
 	RegisterInvariants(ir, am.keeper, am.fcKeeper, am.distrKeeper, am.accKeeper)
 }
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->
as per slack discussions: 

Gautier [12:53 PM]
I feel the terminology of `sdk.InvariantRouter` is a bit confusing https://github.com/cosmos/cosmos-sdk/blob/master/types/module/module.go#L237-L241. When the `RegisterInvariants` function is called, it's actually the `keeper` of the `crisis` module that is passed https://github.com/cosmos/gaia/blob/master/app/app.go#L201. Why put the routes inside the keeper itself (https://github.com/cosmos/cosmos-sdk/blob/master/x/crisis/keeper.go#L15-L23) instead of defining a new router type in the `crisis` module, and have this type implement the `sdk.invariantRouter` interface?

fp4k   [1 hour ago]
@Gautier so the crisis keeper fundamentally requires the routes to perform it’s checks, because it implements `RegisterInvariants` is makes it an InvariantRouter, however, in light of you comments I would maybe opt to rename: `InvariantRouter`-> `InvariantRegistry` … I don’t like the idea of adding an additional abstract for the InvariateRegistry, I don’t think it actually adds any clarity, because now crisis keeper would need to have an “InvariantRegisteryRegistry” to accept the array of invariant-routes and it would need to be passed in all the same that way to the module manager anyways. Capisce? I can quickly PR for this rename

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/develop/CONTRIBUTING.md#pr-targeting))

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added a relevant changelog entry: `clog add [section] [stanza] [message]`
- [ ] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
