### PR TITLE
Generalize auth/type.StdFee

### DIFF
--- a/.pending/breaking/sdk/4509-New-Fee-generic
+++ b/.pending/breaking/sdk/4509-New-Fee-generic
@@ -1,0 +1,3 @@
+#4509 New `Fee` generic interface available in the top level types package.
+`auth.StdFee` implements such interface. User defined auth module can now
+define their own custom fee types.

--- a/client/utils/utils_test.go
+++ b/client/utils/utils_test.go
@@ -95,15 +95,15 @@ func TestConfiguredTxEncoder(t *testing.T) {
 }
 
 func TestReadStdTxFromFile(t *testing.T) {
-	cdc := codec.New()
-	sdk.RegisterCodec(cdc)
+	cdc := makeCodec()
 
 	// Build a test transaction
 	fee := authtypes.NewStdFee(50000, sdk.Coins{sdk.NewInt64Coin("atom", 150)})
 	stdTx := authtypes.NewStdTx([]sdk.Msg{}, fee, nil, "foomemo")
 
 	// Write it to the file
-	encodedTx, _ := cdc.MarshalJSON(stdTx)
+	encodedTx, err := cdc.MarshalJSON(stdTx)
+	require.NoError(t, err)
 	jsonTxFile := writeToNewTempFile(t, string(encodedTx))
 	defer os.Remove(jsonTxFile.Name())
 
@@ -158,7 +158,7 @@ func TestValidateCmd(t *testing.T) {
 
 func compareEncoders(t *testing.T, expected sdk.TxEncoder, actual sdk.TxEncoder) {
 	msgs := []sdk.Msg{sdk.NewTestMsg(addr)}
-	tx := authtypes.NewStdTx(msgs, authtypes.StdFee{}, []sdk.Signature{}, "")
+	tx := authtypes.NewStdTx(msgs, sdk.Fee(nil), []sdk.Signature{}, "")
 
 	defaultEncoderBytes, err := expected(tx)
 	require.NoError(t, err)

--- a/docs/spec/auth/03_types.md
+++ b/docs/spec/auth/03_types.md
@@ -8,8 +8,9 @@ a struct which implements the `sdk.Tx` interface using `StdFee` and `StdSignatur
 
 ## StdFee
 
-A `StdFee` is simply the combination of a fee amount, in any number of denominations,
-and a gas limit (where dividing the amount by the gas limit gives a "gas price").
+`StdFee` implements the `sdk.Fee` interface and consists of a combination of a fee
+amount, in any number of denominations, and a gas limit (where dividing the amount
+by the gas limit gives a "gas price").
 
 ```golang
 type StdFee struct {

--- a/types/codec.go
+++ b/types/codec.go
@@ -7,4 +7,5 @@ func RegisterCodec(cdc *codec.Codec) {
 	cdc.RegisterInterface((*Msg)(nil), nil)
 	cdc.RegisterInterface((*Tx)(nil), nil)
 	cdc.RegisterInterface((*Signature)(nil), nil)
+	cdc.RegisterInterface((*Fee)(nil), nil)
 }

--- a/types/tx_msg.go
+++ b/types/tx_msg.go
@@ -50,6 +50,16 @@ type Signature interface {
 	GetSignature() []byte
 }
 
+//__________________________________________________________
+
+// Fee defines the properties of a fee concrete type.
+type Fee interface {
+	GasLimit() uint64
+	Cost() Coins
+	Bytes() []byte
+	GasPrices() DecCoins
+}
+
 // TxDecoder unmarshals transaction bytes
 type TxDecoder func(txBytes []byte) (Tx, Error)
 

--- a/x/auth/ante_test.go
+++ b/x/auth/ante_test.go
@@ -36,7 +36,7 @@ func checkInvalidTx(t *testing.T, anteHandler sdk.AnteHandler, ctx sdk.Context, 
 		stdTx, ok := tx.(types.StdTx)
 		require.True(t, ok, "tx must be in form auth.types.StdTx")
 		// GasWanted set correctly
-		require.Equal(t, stdTx.Fee.Gas, result.GasWanted, "Gas wanted not set correctly")
+		require.Equal(t, stdTx.Fee.GasLimit(), result.GasWanted, "Gas wanted not set correctly")
 		require.True(t, result.GasUsed > result.GasWanted, "GasUsed not greated than GasWanted")
 		// Check that context is set correctly
 		require.Equal(t, result.GasUsed, newCtx.GasMeter().GasConsumed(), "Context not updated correctly")
@@ -87,7 +87,7 @@ func TestAnteHandlerSigErrors(t *testing.T) {
 
 	// save the first account, but second is still unrecognized
 	acc1 := input.ak.NewAccountWithAddress(ctx, addr1)
-	acc1.SetCoins(fee.Amount)
+	acc1.SetCoins(fee.Cost())
 	input.ak.SetAccount(ctx, acc1)
 	checkInvalidTx(t, anteHandler, ctx, tx, false, sdk.CodeUnknownAddress)
 }

--- a/x/auth/types/codec.go
+++ b/x/auth/types/codec.go
@@ -14,6 +14,7 @@ func RegisterCodec(cdc *codec.Codec) {
 	cdc.RegisterConcrete(&DelayedVestingAccount{}, "auth/DelayedVestingAccount", nil)
 	cdc.RegisterConcrete(StdTx{}, "auth/StdTx", nil)
 	cdc.RegisterConcrete(StdSignature{}, "auth/StdSignature", nil)
+	cdc.RegisterConcrete(StdFee{}, "auth/StdFee", nil)
 }
 
 // RegisterBaseAccount most users shouldn't use this, but this comes in handy for tests.

--- a/x/auth/types/stdsignmsg.go
+++ b/x/auth/types/stdsignmsg.go
@@ -11,7 +11,7 @@ type StdSignMsg struct {
 	ChainID       string    `json:"chain_id"`
 	AccountNumber uint64    `json:"account_number"`
 	Sequence      uint64    `json:"sequence"`
-	Fee           StdFee    `json:"fee"`
+	Fee           sdk.Fee   `json:"fee"`
 	Msgs          []sdk.Msg `json:"msgs"`
 	Memo          string    `json:"memo"`
 }

--- a/x/auth/types/test_common.go
+++ b/x/auth/types/test_common.go
@@ -69,7 +69,7 @@ func KeyTestPubAddr() (crypto.PrivKey, crypto.PubKey, sdk.AccAddress) {
 	return key, pub, addr
 }
 
-func NewTestTx(ctx sdk.Context, msgs []sdk.Msg, privs []crypto.PrivKey, accNums []uint64, seqs []uint64, fee StdFee) sdk.Tx {
+func NewTestTx(ctx sdk.Context, msgs []sdk.Msg, privs []crypto.PrivKey, accNums []uint64, seqs []uint64, fee sdk.Fee) sdk.Tx {
 	sigs := make([]sdk.Signature, len(privs))
 	for i, priv := range privs {
 		signBytes := StdSignBytes(ctx.ChainID(), accNums[i], seqs[i], fee, msgs, "")
@@ -86,7 +86,7 @@ func NewTestTx(ctx sdk.Context, msgs []sdk.Msg, privs []crypto.PrivKey, accNums 
 	return tx
 }
 
-func NewTestTxWithMemo(ctx sdk.Context, msgs []sdk.Msg, privs []crypto.PrivKey, accNums []uint64, seqs []uint64, fee StdFee, memo string) sdk.Tx {
+func NewTestTxWithMemo(ctx sdk.Context, msgs []sdk.Msg, privs []crypto.PrivKey, accNums []uint64, seqs []uint64, fee sdk.Fee, memo string) sdk.Tx {
 	sigs := make([]sdk.Signature, len(privs))
 	for i, priv := range privs {
 		signBytes := StdSignBytes(ctx.ChainID(), accNums[i], seqs[i], fee, msgs, memo)
@@ -103,7 +103,7 @@ func NewTestTxWithMemo(ctx sdk.Context, msgs []sdk.Msg, privs []crypto.PrivKey, 
 	return tx
 }
 
-func NewTestTxWithSignBytes(msgs []sdk.Msg, privs []crypto.PrivKey, accNums []uint64, seqs []uint64, fee StdFee, signBytes []byte, memo string) sdk.Tx {
+func NewTestTxWithSignBytes(msgs []sdk.Msg, privs []crypto.PrivKey, accNums []uint64, seqs []uint64, fee sdk.Fee, signBytes []byte, memo string) sdk.Tx {
 	sigs := make([]sdk.Signature, len(privs))
 	for i, priv := range privs {
 		sig, err := priv.Sign(signBytes)

--- a/x/genutil/genesis_state_test.go
+++ b/x/genutil/genesis_state_test.go
@@ -27,7 +27,7 @@ func TestValidateGenesisMultipleMessages(t *testing.T) {
 	msg2 := staking.NewMsgCreateValidator(sdk.ValAddress(pk2.Address()), pk2,
 		sdk.NewInt64Coin(sdk.DefaultBondDenom, 50), desc, comm, sdk.OneInt())
 
-	genTxs := auth.NewStdTx([]sdk.Msg{msg1, msg2}, auth.StdFee{}, nil, "")
+	genTxs := auth.NewStdTx([]sdk.Msg{msg1, msg2}, sdk.Fee(nil), nil, "")
 	genesisState := NewGenesisStateFromStdTx([]auth.StdTx{genTxs})
 
 	err := ValidateGenesis(genesisState)
@@ -39,7 +39,7 @@ func TestValidateGenesisBadMessage(t *testing.T) {
 
 	msg1 := staking.NewMsgEditValidator(sdk.ValAddress(pk1.Address()), desc, nil, nil)
 
-	genTxs := auth.NewStdTx([]sdk.Msg{msg1}, auth.StdFee{}, nil, "")
+	genTxs := auth.NewStdTx([]sdk.Msg{msg1}, sdk.Fee(nil), nil, "")
 	genesisState := NewGenesisStateFromStdTx([]auth.StdTx{genTxs})
 
 	err := ValidateGenesis(genesisState)

--- a/x/mock/app.go
+++ b/x/mock/app.go
@@ -212,11 +212,7 @@ func SetGenesis(app *App, accs []auth.Account) {
 // GenTx generates a signed mock transaction.
 func GenTx(msgs []sdk.Msg, accnums []uint64, seq []uint64, priv ...crypto.PrivKey) auth.StdTx {
 	// Make the transaction free
-	fee := auth.StdFee{
-		Amount: sdk.NewCoins(sdk.NewInt64Coin("foocoin", 0)),
-		Gas:    100000,
-	}
-
+	fee := auth.NewStdFee(100000, sdk.NewCoins(sdk.NewInt64Coin("foocoin", 0)))
 	sigs := make([]sdk.Signature, len(priv))
 	memo := "testmemotestmemo"
 


### PR DESCRIPTION
A new Fee interface is made available in the top level types package.
auth.StdFee implements such interface. User defined auth module can
now define their own custom fee types.

Work carried out in the context of the following issues:
- #4488
- #4487

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added a relevant changelog entry: `clog add [section] [stanza] [message]`
- [ ] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
