### PR TITLE
Negative height paramter's value leads to undefined behaviour

### DIFF
--- a/types/rest/rest.go
+++ b/types/rest/rest.go
@@ -208,6 +208,11 @@ func ParseQueryHeightOrReturnBadRequest(w http.ResponseWriter, cliCtx context.CL
 			return cliCtx, false
 		}
 
+		if height < 0 {
+			WriteErrorResponse(w, http.StatusBadRequest, "height must be equal or greater than zero")
+			return cliCtx, false
+		}
+
 		if height > 0 {
 			cliCtx = cliCtx.WithHeight(height)
 		}

--- a/types/rest/rest_test.go
+++ b/types/rest/rest_test.go
@@ -122,7 +122,7 @@ func TestParseQueryHeight(t *testing.T) {
 		{"no height", req0, httptest.NewRecorder(), context.CLIContext{}, emptyHeight, true},
 		{"height", req1, httptest.NewRecorder(), context.CLIContext{}, height, true},
 		{"invalid height", req2, httptest.NewRecorder(), context.CLIContext{}, emptyHeight, false},
-		{"negative height", req3, httptest.NewRecorder(), context.CLIContext{}, emptyHeight, true},
+		{"negative height", req3, httptest.NewRecorder(), context.CLIContext{}, emptyHeight, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Follow-up of #4505
Issue: #4501

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added a relevant changelog entry: `clog add [section] [stanza] [message]`
- [ ] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
