### PR TITLE
fix undelegate losing tokens issue

### DIFF
--- a/.pending/improvements/sdk/4553-undelegate-max-entries-check-first
+++ b/.pending/improvements/sdk/4553-undelegate-max-entries-check-first
@@ -1,0 +1,1 @@
+#4553 undelegate max entries check first

--- a/x/staking/keeper/delegation.go
+++ b/x/staking/keeper/delegation.go
@@ -583,13 +583,13 @@ func (k Keeper) Undelegate(
 	ctx sdk.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress, sharesAmount sdk.Dec,
 ) (time.Time, sdk.Error) {
 
+	if k.HasMaxUnbondingDelegationEntries(ctx, delAddr, valAddr) {
+		return time.Time{}, types.ErrMaxUnbondingDelegationEntries(k.Codespace())
+	}
+
 	returnAmount, err := k.unbond(ctx, delAddr, valAddr, sharesAmount)
 	if err != nil {
 		return time.Time{}, err
-	}
-
-	if k.HasMaxUnbondingDelegationEntries(ctx, delAddr, valAddr) {
-		return time.Time{}, types.ErrMaxUnbondingDelegationEntries(k.Codespace())
 	}
 
 	completionTime := ctx.BlockHeader().Time.Add(k.UnbondingTime(ctx))


### PR DESCRIPTION
fix the issue
Undelegate may lose the delegator’s tokens when exceed the MaxEntries of unbonding delegations #4551
