### PR TITLE
switch GetConfirmation()'s default to no

### DIFF
--- a/.pending/improvements/sdk/4564-Allow-empty-ans
+++ b/.pending/improvements/sdk/4564-Allow-empty-ans
@@ -1,1 +1,1 @@
-#4564 Allow empty answer to evaluate as 'Y' on tx submission prompt.
+#4564 client/input.GetConfirmation()'s default is changed to No.

--- a/client/input/input.go
+++ b/client/input/input.go
@@ -85,11 +85,11 @@ func GetCheckPassword(prompt, prompt2 string, buf *bufio.Reader) (string, error)
 
 // GetConfirmation will request user give the confirmation from stdin.
 // "y", "Y", "yes", "YES", and "Yes" all count as confirmations.
-// If the input is not recognized, it will ask again.
+// If the input is not recognized, it returns false and a nil error.
 func GetConfirmation(prompt string, buf *bufio.Reader) (bool, error) {
 	for {
 		if inputIsTty() {
-			fmt.Print(fmt.Sprintf("%s [Y/n]: ", prompt))
+			fmt.Print(fmt.Sprintf("%s [y/N]: ", prompt))
 		}
 
 		response, err := readLineFromBuf(buf)
@@ -98,11 +98,11 @@ func GetConfirmation(prompt string, buf *bufio.Reader) (bool, error) {
 		}
 
 		response = strings.ToLower(strings.TrimSpace(response))
-		if response == "y" || response == "yes" || response == "" {
+		if response[0] == 'y' {
 			return true, nil
-		} else if response == "n" || response == "no" {
-			return false, nil
 		}
+
+		return false, nil
 	}
 }
 

--- a/client/keys/add.go
+++ b/client/keys/add.go
@@ -110,9 +110,12 @@ func runAddCmd(_ *cobra.Command, args []string) error {
 		_, err = kb.Get(name)
 		if err == nil {
 			// account exists, ask for user confirmation
-			if response, err2 := input.GetConfirmation(
-				fmt.Sprintf("override the existing name %s", name), buf); err2 != nil || !response {
+			response, err2 := input.GetConfirmation(fmt.Sprintf("override the existing name %s", name), buf)
+			if err2 != nil {
 				return err2
+			}
+			if !response {
+				return errors.New("aborted")
 			}
 		}
 


### PR DESCRIPTION
GetConfirmation() returns true if and only if the user's
input is confirmative.

The function is used in places where fat-fingering may cause
financial loss, e.g. gaiacli tx send command. Thus it seems
wiser to provide a conservative default in order to protect
users from accidental mistyping.

Closes: #4564

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added a relevant changelog entry: `clog add [section] [stanza] [message]`
- [ ] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
