### PR TITLE
Fix BaseAccount's YAML serialization

### DIFF
--- a/types/decimal.go
+++ b/types/decimal.go
@@ -596,6 +596,9 @@ func (d *Dec) UnmarshalJSON(bz []byte) error {
 	return nil
 }
 
+// MarshalYAML returns Ythe AML representation.
+func (d Dec) MarshalYAML() (interface{}, error) { return d.String(), nil }
+
 //___________________________________________________________________________________
 // helpers
 

--- a/types/int.go
+++ b/types/int.go
@@ -355,6 +355,9 @@ func (i *Int) UnmarshalJSON(bz []byte) error {
 	return unmarshalJSON(i.i, bz)
 }
 
+// MarshalYAML returns Ythe AML representation.
+func (i Int) MarshalYAML() (interface{}, error) { return i.String(), nil }
+
 // intended to be used with require/assert:  require.True(IntEq(...))
 func IntEq(t *testing.T, exp, got Int) (*testing.T, bool, string, string, string) {
 	return t, exp.Equal(got), "expected:\t%v\ngot:\t\t%v", exp.String(), got.String()

--- a/x/auth/types/account.go
+++ b/x/auth/types/account.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/tendermint/tendermint/crypto"
+	yaml "gopkg.in/yaml.v2"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
@@ -186,6 +187,33 @@ func (acc *BaseAccount) SetSequence(seq uint64) error {
 // this is simply the base coins.
 func (acc *BaseAccount) SpendableCoins(_ time.Time) sdk.Coins {
 	return acc.GetCoins()
+}
+
+// MarshalYAML returns the YAML representation of an account.
+func (acc BaseAccount) MarshalYAML() (interface{}, error) {
+	var pubkey string
+	if acc.PubKey != nil {
+		pubkey = sdk.MustBech32ifyAccPub(acc.PubKey)
+
+	}
+	bs, err := yaml.Marshal(struct {
+		Address       sdk.AccAddress
+		Coins         sdk.Coins
+		PubKey        string
+		AccountNumber uint64
+		Sequence      uint64
+	}{
+		Address:       acc.Address,
+		Coins:         acc.Coins,
+		PubKey:        pubkey,
+		AccountNumber: acc.AccountNumber,
+		Sequence:      acc.Sequence,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return string(bs), err
 }
 
 //-----------------------------------------------------------------------------

--- a/x/auth/types/account.go
+++ b/x/auth/types/account.go
@@ -191,12 +191,18 @@ func (acc *BaseAccount) SpendableCoins(_ time.Time) sdk.Coins {
 
 // MarshalYAML returns the YAML representation of an account.
 func (acc BaseAccount) MarshalYAML() (interface{}, error) {
+	var bs []byte
+	var err error
 	var pubkey string
-	if acc.PubKey != nil {
-		pubkey = sdk.MustBech32ifyAccPub(acc.PubKey)
 
+	if acc.PubKey != nil {
+		pubkey, err = sdk.Bech32ifyAccPub(acc.PubKey)
+		if err != nil {
+			return nil, err
+		}
 	}
-	bs, err := yaml.Marshal(struct {
+
+	bs, err = yaml.Marshal(struct {
 		Address       sdk.AccAddress
 		Coins         sdk.Coins
 		PubKey        string

--- a/x/auth/types/account_test.go
+++ b/x/auth/types/account_test.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-
 	tmtime "github.com/tendermint/tendermint/types/time"
 
 	"github.com/cosmos/cosmos-sdk/codec"

--- a/x/staking/types/validator_test.go
+++ b/x/staking/types/validator_test.go
@@ -331,8 +331,8 @@ func TestValidatorMarshalYAML(t *testing.T) {
   conspubkey: %s
   jailed: false
   status: 0
-  tokens: {}
-  delegatorshares: "0"
+  tokens: "0"
+  delegatorshares: "0.000000000000000000"
   description:
     moniker: ""
     identity: ""
@@ -342,11 +342,11 @@ func TestValidatorMarshalYAML(t *testing.T) {
   unbondingcompletiontime: 1970-01-01T00:00:00Z
   commission:
     commissionrates:
-      rate: "0"
-      maxrate: "0"
-      maxchangerate: "0"
+      rate: "0.000000000000000000"
+      maxrate: "0.000000000000000000"
+      maxchangerate: "0.000000000000000000"
     updatetime: 1970-01-01T00:00:00Z
-  minselfdelegation: {}
+  minselfdelegation: "1"
 `, validator.OperatorAddress.String(), bechifiedPub)
 	require.Equal(t, want, string(bs))
 }


### PR DESCRIPTION
This fixes the `gaiacli query account` cranky YAML output.

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added a relevant changelog entry: `clog add [section] [stanza] [message]`
- [ ] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
