### PR TITLE
Remove auth's AccountDecoder type

### DIFF
--- a/.pending/breaking/sdk/4588-Context-does-no
+++ b/.pending/breaking/sdk/4588-Context-does-no
@@ -1,0 +1,6 @@
+#4588 Context does not depend on x/auth anymore. client/context is stripped out of the following features:
+- GetAccountDecoder()
+- CLIContext.WithAccountDecoder()
+- CLIContext.WithAccountStore()
+
+x/auth.AccountDecoder is unnecessary and consequently removed.

--- a/client/alias.go
+++ b/client/alias.go
@@ -67,7 +67,6 @@ var (
 	// functions aliases
 	NewCLIContextWithFrom              = context.NewCLIContextWithFrom
 	NewCLIContext                      = context.NewCLIContext
-	GetAccountDecoder                  = context.GetAccountDecoder
 	GetFromFields                      = context.GetFromFields
 	ErrInvalidAccount                  = context.ErrInvalidAccount
 	ErrVerifyCommit                    = context.ErrVerifyCommit

--- a/client/context/context.go
+++ b/client/context/context.go
@@ -22,7 +22,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	cryptokeys "github.com/cosmos/cosmos-sdk/crypto/keys"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 )
 
 var (
@@ -34,7 +33,6 @@ var (
 // transaction handling and queries.
 type CLIContext struct {
 	Codec         *codec.Codec
-	AccDecoder    authtypes.AccountDecoder
 	Client        rpcclient.Client
 	Keybase       cryptokeys.Keybase
 	Output        io.Writer
@@ -42,7 +40,6 @@ type CLIContext struct {
 	Height        int64
 	NodeURI       string
 	From          string
-	AccountStore  string
 	TrustNode     bool
 	UseLedger     bool
 	BroadcastMode string
@@ -88,7 +85,6 @@ func NewCLIContextWithFrom(from string) CLIContext {
 		Client:        rpc,
 		Output:        os.Stdout,
 		NodeURI:       nodeURI,
-		AccountStore:  authtypes.StoreKey,
 		From:          viper.GetString(flags.FlagFrom),
 		OutputFormat:  viper.GetString(cli.OutputFlag),
 		Height:        viper.GetInt64(flags.FlagHeight),
@@ -162,34 +158,9 @@ func (ctx CLIContext) WithCodec(cdc *codec.Codec) CLIContext {
 	return ctx
 }
 
-// GetAccountDecoder gets the account decoder for auth.DefaultAccount.
-func GetAccountDecoder(cdc *codec.Codec) authtypes.AccountDecoder {
-	return func(accBytes []byte) (acct authtypes.Account, err error) {
-		err = cdc.UnmarshalBinaryBare(accBytes, &acct)
-		if err != nil {
-			panic(err)
-		}
-
-		return acct, err
-	}
-}
-
-// WithAccountDecoder returns a copy of the context with an updated account
-// decoder.
-func (ctx CLIContext) WithAccountDecoder(cdc *codec.Codec) CLIContext {
-	ctx.AccDecoder = GetAccountDecoder(cdc)
-	return ctx
-}
-
 // WithOutput returns a copy of the context with an updated output writer (e.g. stdout).
 func (ctx CLIContext) WithOutput(w io.Writer) CLIContext {
 	ctx.Output = w
-	return ctx
-}
-
-// WithAccountStore returns a copy of the context with an updated AccountStore.
-func (ctx CLIContext) WithAccountStore(accountStore string) CLIContext {
-	ctx.AccountStore = accountStore
 	return ctx
 }
 

--- a/client/lcd/root.go
+++ b/client/lcd/root.go
@@ -38,7 +38,7 @@ type RestServer struct {
 // NewRestServer creates a new rest server instance
 func NewRestServer(cdc *codec.Codec) *RestServer {
 	r := mux.NewRouter()
-	cliCtx := context.NewCLIContext().WithCodec(cdc).WithAccountDecoder(cdc)
+	cliCtx := context.NewCLIContext().WithCodec(cdc)
 	logger := log.NewTMLogger(log.NewSyncWriter(os.Stdout)).With("module", "rest-server")
 
 	return &RestServer{

--- a/x/auth/alias.go
+++ b/x/auth/alias.go
@@ -67,7 +67,6 @@ var (
 type (
 	Account                  = types.Account
 	VestingAccount           = types.VestingAccount
-	AccountDecoder           = types.AccountDecoder
 	BaseAccount              = types.BaseAccount
 	BaseVestingAccount       = types.BaseVestingAccount
 	ContinuousVestingAccount = types.ContinuousVestingAccount

--- a/x/auth/client/cli/query.go
+++ b/x/auth/client/cli/query.go
@@ -48,8 +48,7 @@ func GetAccountCmd(cdc *codec.Codec) *cobra.Command {
 		Short: "Query account balance",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cliCtx := context.NewCLIContext().
-				WithCodec(cdc).WithAccountDecoder(cdc)
+			cliCtx := context.NewCLIContext().WithCodec(cdc)
 			accGetter := types.NewAccountRetriever(cliCtx)
 
 			key, err := sdk.AccAddressFromBech32(args[0])

--- a/x/auth/client/cli/tx_multisign.go
+++ b/x/auth/client/cli/tx_multisign.go
@@ -80,7 +80,7 @@ func makeMultiSignCmd(cdc *codec.Codec) func(cmd *cobra.Command, args []string) 
 
 		multisigPub := multisigInfo.GetPubKey().(multisig.PubKeyMultisigThreshold)
 		multisigSig := multisig.NewMultisig(len(multisigPub.PubKeys))
-		cliCtx := context.NewCLIContext().WithCodec(cdc).WithAccountDecoder(cdc)
+		cliCtx := context.NewCLIContext().WithCodec(cdc)
 		txBldr := types.NewTxBuilderFromCLI()
 
 		if !viper.GetBool(flagOffline) {

--- a/x/auth/client/cli/tx_sign.go
+++ b/x/auth/client/cli/tx_sign.go
@@ -99,7 +99,7 @@ func makeSignCmd(cdc *codec.Codec) func(cmd *cobra.Command, args []string) error
 		}
 
 		offline := viper.GetBool(flagOffline)
-		cliCtx := context.NewCLIContext().WithCodec(cdc).WithAccountDecoder(cdc)
+		cliCtx := context.NewCLIContext().WithCodec(cdc)
 		txBldr := types.NewTxBuilderFromCLI()
 
 		if viper.GetBool(flagValidateSigs) {

--- a/x/auth/client/rest/query.go
+++ b/x/auth/client/rest/query.go
@@ -22,9 +22,7 @@ type AccountWithHeight struct {
 }
 
 // query accountREST Handler
-func QueryAccountRequestHandlerFn(
-	storeName string, decoder types.AccountDecoder, cliCtx context.CLIContext,
-) http.HandlerFunc {
+func QueryAccountRequestHandlerFn(storeName string, cliCtx context.CLIContext) http.HandlerFunc {
 
 	return func(w http.ResponseWriter, r *http.Request) {
 		vars := mux.Vars(r)
@@ -41,26 +39,20 @@ func QueryAccountRequestHandlerFn(
 			return
 		}
 
-		res, height, err := cliCtx.QueryStore(types.AddressStoreKey(addr), storeName)
-		if err != nil {
-			rest.WriteErrorResponse(w, http.StatusInternalServerError, err.Error())
-			return
-		}
-
+		accGetter := types.NewAccountRetriever(cliCtx)
 		// the query will return empty account if there is no data
-		if len(res) == 0 {
+		if err := accGetter.EnsureExists(addr); err != nil {
 			rest.PostProcessResponse(w, cliCtx, types.BaseAccount{})
 			return
 		}
 
-		// decode the value
-		account, err := decoder(res)
+		account, err := accGetter.GetAccount(addr)
 		if err != nil {
 			rest.WriteErrorResponse(w, http.StatusInternalServerError, err.Error())
 			return
 		}
 
-		rest.PostProcessResponse(w, cliCtx, AccountWithHeight{account, height})
+		rest.PostProcessResponse(w, cliCtx, AccountWithHeight{account, cliCtx.Height})
 	}
 }
 

--- a/x/auth/client/rest/rest.go
+++ b/x/auth/client/rest/rest.go
@@ -9,8 +9,7 @@ import (
 // RegisterRoutes registers the auth module REST routes.
 func RegisterRoutes(cliCtx context.CLIContext, r *mux.Router, storeName string) {
 	r.HandleFunc(
-		"/auth/accounts/{address}",
-		QueryAccountRequestHandlerFn(storeName, context.GetAccountDecoder(cliCtx.Codec), cliCtx),
+		"/auth/accounts/{address}", QueryAccountRequestHandlerFn(storeName, cliCtx),
 	).Methods("GET")
 }
 

--- a/x/auth/types/account.go
+++ b/x/auth/types/account.go
@@ -61,10 +61,6 @@ type VestingAccount interface {
 	GetDelegatedVesting() sdk.Coins
 }
 
-// AccountDecoder unmarshals account bytes
-// TODO: Think about removing
-type AccountDecoder func(accountBytes []byte) (Account, error)
-
 //-----------------------------------------------------------------------------
 // BaseAccount
 

--- a/x/bank/client/cli/tx.go
+++ b/x/bank/client/cli/tx.go
@@ -35,9 +35,7 @@ func SendTxCmd(cdc *codec.Codec) *cobra.Command {
 		Args:  cobra.ExactArgs(3),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			txBldr := auth.NewTxBuilderFromCLI().WithTxEncoder(utils.GetTxEncoder(cdc))
-			cliCtx := context.NewCLIContextWithFrom(args[0]).
-				WithCodec(cdc).
-				WithAccountDecoder(cdc)
+			cliCtx := context.NewCLIContextWithFrom(args[0]).WithCodec(cdc)
 
 			to, err := sdk.AccAddressFromBech32(args[1])
 			if err != nil {

--- a/x/crisis/client/cli/tx.go
+++ b/x/crisis/client/cli/tx.go
@@ -22,7 +22,7 @@ func GetCmdInvariantBroken(cdc *codec.Codec) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			txBldr := auth.NewTxBuilderFromCLI().WithTxEncoder(utils.GetTxEncoder(cdc))
-			cliCtx := context.NewCLIContext().WithCodec(cdc).WithAccountDecoder(cdc)
+			cliCtx := context.NewCLIContext().WithCodec(cdc)
 
 			senderAddr := cliCtx.GetFromAddress()
 			moduleName, route := args[0], args[1]

--- a/x/distribution/client/cli/tx.go
+++ b/x/distribution/client/cli/tx.go
@@ -102,9 +102,7 @@ $ %s tx distr withdraw-rewards cosmosvaloper1gghjut3ccd8ay0zduzj64hwre2fxs9ldmqh
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			txBldr := auth.NewTxBuilderFromCLI().WithTxEncoder(utils.GetTxEncoder(cdc))
-			cliCtx := context.NewCLIContext().
-				WithCodec(cdc).
-				WithAccountDecoder(cdc)
+			cliCtx := context.NewCLIContext().WithCodec(cdc)
 
 			delAddr := cliCtx.GetFromAddress()
 			valAddr, err := sdk.ValAddressFromBech32(args[0])
@@ -142,9 +140,7 @@ $ %s tx distr withdraw-all-rewards --from mykey
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			txBldr := auth.NewTxBuilderFromCLI().WithTxEncoder(utils.GetTxEncoder(cdc))
-			cliCtx := context.NewCLIContext().
-				WithCodec(cdc).
-				WithAccountDecoder(cdc)
+			cliCtx := context.NewCLIContext().WithCodec(cdc)
 
 			delAddr := cliCtx.GetFromAddress()
 			msgs, err := common.WithdrawAllDelegatorRewards(cliCtx, queryRoute, delAddr)
@@ -178,9 +174,7 @@ $ %s tx set-withdraw-addr cosmos1gghjut3ccd8ay0zduzj64hwre2fxs9ld75ru9p --from m
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			txBldr := auth.NewTxBuilderFromCLI().WithTxEncoder(utils.GetTxEncoder(cdc))
-			cliCtx := context.NewCLIContext().
-				WithCodec(cdc).
-				WithAccountDecoder(cdc)
+			cliCtx := context.NewCLIContext().WithCodec(cdc)
 
 			delAddr := cliCtx.GetFromAddress()
 			withdrawAddr, err := sdk.AccAddressFromBech32(args[0])
@@ -232,9 +226,7 @@ Where proposal.json contains:
 		),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			txBldr := auth.NewTxBuilderFromCLI().WithTxEncoder(utils.GetTxEncoder(cdc))
-			cliCtx := context.NewCLIContext().
-				WithCodec(cdc).
-				WithAccountDecoder(cdc)
+			cliCtx := context.NewCLIContext().WithCodec(cdc)
 
 			proposal, err := ParseCommunityPoolSpendProposalJSON(cdc, args[0])
 			if err != nil {

--- a/x/gov/client/cli/tx.go
+++ b/x/gov/client/cli/tx.go
@@ -106,9 +106,7 @@ $ %s tx gov submit-proposal --title="Test Proposal" --description="My awesome pr
 		),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			txBldr := auth.NewTxBuilderFromCLI().WithTxEncoder(utils.GetTxEncoder(cdc))
-			cliCtx := context.NewCLIContext().
-				WithCodec(cdc).
-				WithAccountDecoder(cdc)
+			cliCtx := context.NewCLIContext().WithCodec(cdc)
 
 			proposal, err := parseSubmitProposalFlags()
 			if err != nil {
@@ -158,9 +156,7 @@ $ %s tx gov deposit 1 10stake --from mykey
 		),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			txBldr := auth.NewTxBuilderFromCLI().WithTxEncoder(utils.GetTxEncoder(cdc))
-			cliCtx := context.NewCLIContext().
-				WithCodec(cdc).
-				WithAccountDecoder(cdc)
+			cliCtx := context.NewCLIContext().WithCodec(cdc)
 
 			// validate that the proposal id is a uint
 			proposalID, err := strconv.ParseUint(args[0], 10, 64)
@@ -207,9 +203,7 @@ $ %s tx gov vote 1 yes --from mykey
 		),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			txBldr := auth.NewTxBuilderFromCLI().WithTxEncoder(utils.GetTxEncoder(cdc))
-			cliCtx := context.NewCLIContext().
-				WithCodec(cdc).
-				WithAccountDecoder(cdc)
+			cliCtx := context.NewCLIContext().WithCodec(cdc)
 
 			// Get voting address
 			from := cliCtx.GetFromAddress()

--- a/x/ibc/client/cli/ibctx.go
+++ b/x/ibc/client/cli/ibctx.go
@@ -27,9 +27,7 @@ func IBCTransferCmd(cdc *codec.Codec) *cobra.Command {
 		Use: "transfer",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			txBldr := auth.NewTxBuilderFromCLI().WithTxEncoder(utils.GetTxEncoder(cdc))
-			cliCtx := context.NewCLIContext().
-				WithCodec(cdc).
-				WithAccountDecoder(cdc)
+			cliCtx := context.NewCLIContext().WithCodec(cdc)
 
 			from := cliCtx.GetFromAddress()
 			msg, err := buildMsg(from)

--- a/x/params/client/cli/tx.go
+++ b/x/params/client/cli/tx.go
@@ -65,9 +65,7 @@ Where proposal.json contains:
 		),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			txBldr := auth.NewTxBuilderFromCLI().WithTxEncoder(utils.GetTxEncoder(cdc))
-			cliCtx := context.NewCLIContext().
-				WithCodec(cdc).
-				WithAccountDecoder(cdc)
+			cliCtx := context.NewCLIContext().WithCodec(cdc)
 
 			proposal, err := paramscutils.ParseParamChangeProposalJSON(cdc, args[0])
 			if err != nil {

--- a/x/slashing/client/cli/tx.go
+++ b/x/slashing/client/cli/tx.go
@@ -41,9 +41,7 @@ $ <appcli> tx slashing unjail --from mykey
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			txBldr := auth.NewTxBuilderFromCLI().WithTxEncoder(utils.GetTxEncoder(cdc))
-			cliCtx := context.NewCLIContext().
-				WithCodec(cdc).
-				WithAccountDecoder(cdc)
+			cliCtx := context.NewCLIContext().WithCodec(cdc)
 
 			valAddr := cliCtx.GetFromAddress()
 

--- a/x/staking/client/cli/tx.go
+++ b/x/staking/client/cli/tx.go
@@ -50,9 +50,7 @@ func GetCmdCreateValidator(cdc *codec.Codec) *cobra.Command {
 		Short: "create new validator initialized with a self-delegation to it",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			txBldr := auth.NewTxBuilderFromCLI().WithTxEncoder(utils.GetTxEncoder(cdc))
-			cliCtx := context.NewCLIContext().
-				WithCodec(cdc).
-				WithAccountDecoder(cdc)
+			cliCtx := context.NewCLIContext().WithCodec(cdc)
 
 			txBldr, msg, err := BuildCreateValidatorMsg(cliCtx, txBldr)
 			if err != nil {
@@ -88,9 +86,7 @@ func GetCmdEditValidator(cdc *codec.Codec) *cobra.Command {
 		Short: "edit an existing validator account",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			txBldr := auth.NewTxBuilderFromCLI().WithTxEncoder(auth.DefaultTxEncoder(cdc))
-			cliCtx := context.NewCLIContext().
-				WithCodec(cdc).
-				WithAccountDecoder(cdc)
+			cliCtx := context.NewCLIContext().WithCodec(cdc)
 
 			valAddr := cliCtx.GetFromAddress()
 			description := types.Description{
@@ -153,9 +149,7 @@ $ %s tx staking delegate cosmosvaloper1l2rsakp388kuv9k8qzq6lrm9taddae7fpx59wm 10
 		),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			txBldr := auth.NewTxBuilderFromCLI().WithTxEncoder(auth.DefaultTxEncoder(cdc))
-			cliCtx := context.NewCLIContext().
-				WithCodec(cdc).
-				WithAccountDecoder(cdc)
+			cliCtx := context.NewCLIContext().WithCodec(cdc)
 
 			amount, err := sdk.ParseCoin(args[1])
 			if err != nil {
@@ -191,9 +185,7 @@ $ %s tx staking redelegate cosmosvaloper1gghjut3ccd8ay0zduzj64hwre2fxs9ldmqhffj 
 		),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			txBldr := auth.NewTxBuilderFromCLI().WithTxEncoder(auth.DefaultTxEncoder(cdc))
-			cliCtx := context.NewCLIContext().
-				WithCodec(cdc).
-				WithAccountDecoder(cdc)
+			cliCtx := context.NewCLIContext().WithCodec(cdc)
 
 			delAddr := cliCtx.GetFromAddress()
 			valSrcAddr, err := sdk.ValAddressFromBech32(args[0])
@@ -234,9 +226,7 @@ $ %s tx staking unbond cosmosvaloper1gghjut3ccd8ay0zduzj64hwre2fxs9ldmqhffj 100s
 		),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			txBldr := auth.NewTxBuilderFromCLI().WithTxEncoder(auth.DefaultTxEncoder(cdc))
-			cliCtx := context.NewCLIContext().
-				WithCodec(cdc).
-				WithAccountDecoder(cdc)
+			cliCtx := context.NewCLIContext().WithCodec(cdc)
 
 			delAddr := cliCtx.GetFromAddress()
 			valAddr, err := sdk.ValAddressFromBech32(args[0])


### PR DESCRIPTION
AccountDecoder is now entirely redundant.
client package now does no longer depend on x/auth.

Context: #4488

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added a relevant changelog entry: `clog add [section] [stanza] [message]`
- [ ] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
