### PR TITLE
Increase server package's coverage by adding DONTCOVER

### DIFF
--- a/server/start.go
+++ b/server/start.go
@@ -151,3 +151,5 @@ func startInProcess(ctx *Context, appCreator AppCreator) (*node.Node, error) {
 	// run forever (the node will not be returned)
 	select {}
 }
+
+// DONTCOVER

--- a/server/test_helpers.go
+++ b/server/test_helpers.go
@@ -52,3 +52,5 @@ func SetupViper(t *testing.T) func() {
 		}
 	}
 }
+
+// DONTCOVER

--- a/server/util.go
+++ b/server/util.go
@@ -256,3 +256,5 @@ func addrToIP(addr net.Addr) net.IP {
 	}
 	return ip
 }
+
+// DONTCOVER


### PR DESCRIPTION
Although ideally we really should find a way to test the server package
functionalities in isolation, we are in fact testing it by running the binaries.
This PR aims to increase the SDK's horrible coverage stats by largely
ignoring server.

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added a relevant changelog entry: `clog add [section] [stanza] [message]`
- [ ] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
