### PR TITLE
Only change rootmultistore hash when substore hashes change

### DIFF
--- a/.pending/bugfixes/sdk/1351-https-github-co
+++ b/.pending/bugfixes/sdk/1351-https-github-co
@@ -1,0 +1,1 @@
+[\#1351](https://github.com/cosmos/cosmos-sdk/issues/1351) Stable AppHash allows no_empty_blocks

--- a/store/rootmulti/store.go
+++ b/store/rootmulti/store.go
@@ -477,7 +477,7 @@ type storeCore struct {
 func (si storeInfo) Hash() []byte {
 	// Doesn't write Name, since merkle.SimpleHashFromMap() will
 	// include them via the keys.
-	bz, _ := cdc.MarshalBinaryLengthPrefixed(si.Core)
+	bz := si.Core.CommitID.Hash
 	hasher := tmhash.New()
 
 	_, err := hasher.Write(bz)

--- a/store/rootmulti/store_test.go
+++ b/store/rootmulti/store_test.go
@@ -77,6 +77,33 @@ func TestCacheMultiStoreWithVersion(t *testing.T) {
 	})
 }
 
+func TestHashStableWithEmptyCommit(t *testing.T) {
+	var db dbm.DB = dbm.NewMemDB()
+	if useDebugDB {
+		db = dbm.NewDebugDB("CMS", db)
+	}
+	ms := newMultiStoreWithMounts(db)
+	err := ms.LoadLatestVersion()
+	require.Nil(t, err)
+
+	commitID := types.CommitID{}
+	checkStore(t, ms, commitID, commitID)
+
+	k, v := []byte("wind"), []byte("blows")
+
+	store1 := ms.getStoreByName("store1").(types.KVStore)
+	store1.Set(k, v)
+
+	cID := ms.Commit()
+	require.Equal(t, int64(1), cID.Version)
+	hash := cID.Hash
+
+	// make an empty commit, it should update version, but not affect hash
+	cID = ms.Commit()
+	require.Equal(t, int64(2), cID.Version)
+	require.Equal(t, hash, cID.Hash)
+}
+
 func TestMultistoreCommitLoad(t *testing.T) {
 	var db dbm.DB = dbm.NewMemDB()
 	if useDebugDB {

--- a/types/abci.go
+++ b/types/abci.go
@@ -2,14 +2,20 @@ package types
 
 import abci "github.com/tendermint/tendermint/abci/types"
 
-// initialize application state at genesis
+// InitChainer initializes application state at genesis
 type InitChainer func(ctx Context, req abci.RequestInitChain) abci.ResponseInitChain
 
-// run code before the transactions in a block
+// BeginBlocker runs code before the transactions in a block
+//
+// Note: applications which set create_empty_blocks=false will not have regular block timing and should use
+// e.g. BFT timestamps rather than block height for any periodic BeginBlock logic
 type BeginBlocker func(ctx Context, req abci.RequestBeginBlock) abci.ResponseBeginBlock
 
-// run code after the transactions in a block and return updates to the validator set
+// EndBlocker runs code after the transactions in a block and return updates to the validator set
+//
+// Note: applications which set create_empty_blocks=false will not have regular block timing and should use
+// e.g. BFT timestamps rather than block height for any periodic EndBlock logic
 type EndBlocker func(ctx Context, req abci.RequestEndBlock) abci.ResponseEndBlock
 
-// respond to p2p filtering queries from Tendermint
+// PeerFilter responds to p2p filtering queries from Tendermint
 type PeerFilter func(info string) abci.ResponseQuery


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes #1351 

The fix was proposed one year ago, and was recently moved to "proposal accepted". This enables no-empty-block to be enabled with cosmos-sdk code without any other breaking changes.

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/develop/CONTRIBUTING.md#pr-targeting))

- [x] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [x] Wrote tests
- [x] Updated relevant documentation (`docs/`)
- [x] Added a relevant changelog entry: `clog add [section] [stanza] [message]`
- [x] rereviewed `Files changed` in the github PR explorer

Note: I don't know of any relevant documentation as this is a bugfix. Please point me to any points I need to update if any.
______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
