### PR TITLE
Add FeeAccount to StdTx and add fee-delegation module

### DIFF
--- a/client/flags/flags.go
+++ b/client/flags/flags.go
@@ -54,6 +54,7 @@ const (
 	FlagRPCWriteTimeout    = "write-timeout"
 	FlagOutputDocument     = "output-document" // inspired by wget -O
 	FlagSkipConfirmation   = "yes"
+	FlagFeeAccount         = "fee-account"
 )
 
 // LineBreak can be included in a command list to provide a blank line
@@ -99,6 +100,7 @@ func PostCommands(cmds ...*cobra.Command) []*cobra.Command {
 		c.Flags().Bool(FlagDryRun, false, "ignore the --gas flag and perform a simulation of a transaction, but don't broadcast it")
 		c.Flags().Bool(FlagGenerateOnly, false, "Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase is not accessible and the node operates offline)")
 		c.Flags().BoolP(FlagSkipConfirmation, "y", false, "Skip tx broadcasting prompt confirmation")
+		c.Flags().String(FlagFeeAccount, "", "Set a fee account to pay fess with if they have been delegated by this account")
 
 		// --gas can accept integers and "simulate"
 		c.Flags().Var(&GasFlagVar, "gas", fmt.Sprintf(

--- a/simapp/app.go
+++ b/simapp/app.go
@@ -205,7 +205,7 @@ func NewSimApp(logger log.Logger, db dbm.DB, traceStore io.Writer, loadLatest bo
 	// initialize BaseApp
 	app.SetInitChainer(app.InitChainer)
 	app.SetBeginBlocker(app.BeginBlocker)
-	app.SetAnteHandler(auth.NewAnteHandler(app.accountKeeper, app.feeCollectionKeeper, auth.DefaultSigVerificationGasConsumer))
+	app.SetAnteHandler(auth.NewAnteHandler(app.accountKeeper, app.feeCollectionKeeper, nil, auth.DefaultSigVerificationGasConsumer))
 	app.SetEndBlocker(app.EndBlocker)
 
 	if loadLatest {

--- a/x/auth/ante.go
+++ b/x/auth/ante.go
@@ -32,10 +32,16 @@ func init() {
 // and also to accept or reject different types of PubKey's. This is where apps can define their own PubKey
 type SignatureVerificationGasConsumer = func(meter sdk.GasMeter, sig []byte, pubkey crypto.PubKey, params Params) sdk.Result
 
+type FeeDelegationHandler interface {
+	// AllowDelegatedFees checks if the grantee can use the granter's account to spend the specified fees, updating
+	// any fee allowance in accordance with the provided fees
+	AllowDelegatedFees(ctx sdk.Context, grantee sdk.AccAddress, granter sdk.AccAddress, fee sdk.Coins) bool
+}
+
 // NewAnteHandler returns an AnteHandler that checks and increments sequence
 // numbers, checks signatures & account numbers, and deducts fees from the first
 // signer.
-func NewAnteHandler(ak AccountKeeper, fck FeeCollectionKeeper, sigGasConsumer SignatureVerificationGasConsumer) sdk.AnteHandler {
+func NewAnteHandler(ak AccountKeeper, fck FeeCollectionKeeper, feeDelegationHandler FeeDelegationHandler, sigGasConsumer SignatureVerificationGasConsumer) sdk.AnteHandler {
 	return func(
 		ctx sdk.Context, tx sdk.Tx, simulate bool,
 	) (newCtx sdk.Context, res sdk.Result, abort bool) {
@@ -106,14 +112,28 @@ func NewAnteHandler(ak AccountKeeper, fck FeeCollectionKeeper, sigGasConsumer Si
 		signerAccs := make([]Account, len(signerAddrs))
 		isGenesis := ctx.BlockHeight() == 0
 
-		// fetch first signer, who's going to pay the fees
-		signerAccs[0], res = GetSignerAcc(newCtx, ak, signerAddrs[0])
+		feeAddr := stdTx.FeeAccount
+		if len(feeAddr) != 0 {
+			// check if fees can be delegated
+			if feeDelegationHandler == nil {
+                return newCtx, sdk.ErrUnknownRequest("delegated fees aren't supported").Result(), true
+			}
+			if !feeDelegationHandler.AllowDelegatedFees(ctx, signerAddrs[0], feeAddr, stdTx.Fee.Amount) {
+				return newCtx, res, true
+			}
+		} else {
+			// use first signer, who's going to pay the fees
+			feeAddr = signerAddrs[0]
+		}
+
+		// pay fees with the fee account
+		feeAccount, res := GetSignerAcc(newCtx, ak, feeAddr)
 		if !res.IsOK() {
 			return newCtx, res, true
 		}
 
 		if !stdTx.Fee.Amount.IsZero() {
-			signerAccs[0], res = DeductFees(ctx.BlockHeader().Time, signerAccs[0], stdTx.Fee)
+			res = DeductFees(ctx.BlockHeader().Time, feeAccount, stdTx.Fee)
 			if !res.IsOK() {
 				return newCtx, res, true
 			}
@@ -121,13 +141,21 @@ func NewAnteHandler(ak AccountKeeper, fck FeeCollectionKeeper, sigGasConsumer Si
 			fck.AddCollectedFees(newCtx, stdTx.Fee.Amount)
 		}
 
+		if len(stdTx.FeeAccount) != 0 {
+			if err := feeAccount.SetSequence(feeAccount.GetSequence() + 1); err != nil {
+				panic(err)
+			}
+		}
+
 		// stdSigs contains the sequence number, account number, and signatures.
 		// When simulating, this would just be a 0-length slice.
 		stdSigs := stdTx.GetSignatures()
 
 		for i := 0; i < len(stdSigs); i++ {
-			// skip the fee payer, account is cached and fees were deducted already
-			if i != 0 {
+			// use cached fee account if not using a delegated fee account
+			if i == 0 && len(stdTx.FeeAccount) == 0 {
+				signerAccs[0] = feeAccount
+			} else {
 				signerAccs[i], res = GetSignerAcc(newCtx, ak, signerAddrs[i])
 				if !res.IsOK() {
 					return newCtx, res, true
@@ -327,18 +355,18 @@ func consumeMultisignatureVerificationGas(meter sdk.GasMeter,
 //
 // NOTE: We could use the CoinKeeper (in addition to the AccountKeeper, because
 // the CoinKeeper doesn't give us accounts), but it seems easier to do this.
-func DeductFees(blockTime time.Time, acc Account, fee StdFee) (Account, sdk.Result) {
+func DeductFees(blockTime time.Time, acc Account, fee StdFee) sdk.Result {
 	coins := acc.GetCoins()
 	feeAmount := fee.Amount
 
 	if !feeAmount.IsValid() {
-		return nil, sdk.ErrInsufficientFee(fmt.Sprintf("invalid fee amount: %s", feeAmount)).Result()
+		return sdk.ErrInsufficientFee(fmt.Sprintf("invalid fee amount: %s", feeAmount)).Result()
 	}
 
 	// get the resulting coins deducting the fees
 	newCoins, ok := coins.SafeSub(feeAmount)
 	if ok {
-		return nil, sdk.ErrInsufficientFunds(
+		return sdk.ErrInsufficientFunds(
 			fmt.Sprintf("insufficient funds to pay for fees; %s < %s", coins, feeAmount),
 		).Result()
 	}
@@ -347,16 +375,16 @@ func DeductFees(blockTime time.Time, acc Account, fee StdFee) (Account, sdk.Resu
 	// such as vesting accounts.
 	spendableCoins := acc.SpendableCoins(blockTime)
 	if _, hasNeg := spendableCoins.SafeSub(feeAmount); hasNeg {
-		return nil, sdk.ErrInsufficientFunds(
+		return sdk.ErrInsufficientFunds(
 			fmt.Sprintf("insufficient funds to pay for fees; %s < %s", spendableCoins, feeAmount),
 		).Result()
 	}
 
 	if err := acc.SetCoins(newCoins); err != nil {
-		return nil, sdk.ErrInternal(err.Error()).Result()
+		return sdk.ErrInternal(err.Error()).Result()
 	}
 
-	return acc, sdk.Result{}
+	return sdk.Result{}
 }
 
 // EnsureSufficientMempoolFees verifies that the given transaction has supplied
@@ -410,6 +438,6 @@ func GetSignBytes(chainID string, stdTx StdTx, acc Account, genesis bool) []byte
 	}
 
 	return StdSignBytes(
-		chainID, accNum, acc.GetSequence(), stdTx.Fee, stdTx.Msgs, stdTx.Memo,
+		chainID, accNum, acc.GetSequence(), stdTx.Fee, stdTx.Msgs, stdTx.Memo, stdTx.FeeAccount,
 	)
 }

--- a/x/auth/ante_test.go
+++ b/x/auth/ante_test.go
@@ -48,7 +48,7 @@ func TestAnteHandlerSigErrors(t *testing.T) {
 	// setup
 	input := setupTestInput()
 	ctx := input.ctx
-	anteHandler := NewAnteHandler(input.ak, input.fck, DefaultSigVerificationGasConsumer)
+	anteHandler := NewAnteHandler(input.ak, input.fck, nil, DefaultSigVerificationGasConsumer)
 
 	// keys and addresses
 	priv1, _, addr1 := types.KeyTestPubAddr()
@@ -96,7 +96,7 @@ func TestAnteHandlerSigErrors(t *testing.T) {
 func TestAnteHandlerAccountNumbers(t *testing.T) {
 	// setup
 	input := setupTestInput()
-	anteHandler := NewAnteHandler(input.ak, input.fck, DefaultSigVerificationGasConsumer)
+	anteHandler := NewAnteHandler(input.ak, input.fck, nil, DefaultSigVerificationGasConsumer)
 	ctx := input.ctx.WithBlockHeight(1)
 
 	// keys and addresses
@@ -151,7 +151,7 @@ func TestAnteHandlerAccountNumbers(t *testing.T) {
 func TestAnteHandlerAccountNumbersAtBlockHeightZero(t *testing.T) {
 	// setup
 	input := setupTestInput()
-	anteHandler := NewAnteHandler(input.ak, input.fck, DefaultSigVerificationGasConsumer)
+	anteHandler := NewAnteHandler(input.ak, input.fck, nil, DefaultSigVerificationGasConsumer)
 	ctx := input.ctx.WithBlockHeight(0)
 
 	// keys and addresses
@@ -206,7 +206,7 @@ func TestAnteHandlerAccountNumbersAtBlockHeightZero(t *testing.T) {
 func TestAnteHandlerSequences(t *testing.T) {
 	// setup
 	input := setupTestInput()
-	anteHandler := NewAnteHandler(input.ak, input.fck, DefaultSigVerificationGasConsumer)
+	anteHandler := NewAnteHandler(input.ak, input.fck, nil, DefaultSigVerificationGasConsumer)
 	ctx := input.ctx.WithBlockHeight(1)
 
 	// keys and addresses
@@ -281,7 +281,7 @@ func TestAnteHandlerFees(t *testing.T) {
 	// setup
 	input := setupTestInput()
 	ctx := input.ctx
-	anteHandler := NewAnteHandler(input.ak, input.fck, DefaultSigVerificationGasConsumer)
+	anteHandler := NewAnteHandler(input.ak, input.fck, nil, DefaultSigVerificationGasConsumer)
 
 	// keys and addresses
 	priv1, _, addr1 := types.KeyTestPubAddr()
@@ -321,7 +321,7 @@ func TestAnteHandlerFees(t *testing.T) {
 func TestAnteHandlerMemoGas(t *testing.T) {
 	// setup
 	input := setupTestInput()
-	anteHandler := NewAnteHandler(input.ak, input.fck, DefaultSigVerificationGasConsumer)
+	anteHandler := NewAnteHandler(input.ak, input.fck, nil, DefaultSigVerificationGasConsumer)
 	ctx := input.ctx.WithBlockHeight(1)
 
 	// keys and addresses
@@ -360,7 +360,7 @@ func TestAnteHandlerMemoGas(t *testing.T) {
 func TestAnteHandlerMultiSigner(t *testing.T) {
 	// setup
 	input := setupTestInput()
-	anteHandler := NewAnteHandler(input.ak, input.fck, DefaultSigVerificationGasConsumer)
+	anteHandler := NewAnteHandler(input.ak, input.fck, nil, DefaultSigVerificationGasConsumer)
 	ctx := input.ctx.WithBlockHeight(1)
 
 	// keys and addresses
@@ -407,7 +407,7 @@ func TestAnteHandlerMultiSigner(t *testing.T) {
 func TestAnteHandlerBadSignBytes(t *testing.T) {
 	// setup
 	input := setupTestInput()
-	anteHandler := NewAnteHandler(input.ak, input.fck, DefaultSigVerificationGasConsumer)
+	anteHandler := NewAnteHandler(input.ak, input.fck, nil, DefaultSigVerificationGasConsumer)
 	ctx := input.ctx.WithBlockHeight(1)
 
 	// keys and addresses
@@ -460,7 +460,7 @@ func TestAnteHandlerBadSignBytes(t *testing.T) {
 	for _, cs := range cases {
 		tx := types.NewTestTxWithSignBytes(
 			msgs, privs, accnums, seqs, fee,
-			StdSignBytes(cs.chainID, cs.accnum, cs.seq, cs.fee, cs.msgs, ""),
+			StdSignBytes(cs.chainID, cs.accnum, cs.seq, cs.fee, cs.msgs, "", nil),
 			"",
 		)
 		checkInvalidTx(t, anteHandler, ctx, tx, false, cs.code)
@@ -482,7 +482,7 @@ func TestAnteHandlerBadSignBytes(t *testing.T) {
 func TestAnteHandlerSetPubKey(t *testing.T) {
 	// setup
 	input := setupTestInput()
-	anteHandler := NewAnteHandler(input.ak, input.fck, DefaultSigVerificationGasConsumer)
+	anteHandler := NewAnteHandler(input.ak, input.fck, nil, DefaultSigVerificationGasConsumer)
 	ctx := input.ctx.WithBlockHeight(1)
 
 	// keys and addresses
@@ -676,7 +676,7 @@ func TestCountSubkeys(t *testing.T) {
 func TestAnteHandlerSigLimitExceeded(t *testing.T) {
 	// setup
 	input := setupTestInput()
-	anteHandler := NewAnteHandler(input.ak, input.fck, DefaultSigVerificationGasConsumer)
+	anteHandler := NewAnteHandler(input.ak, input.fck, nil, DefaultSigVerificationGasConsumer)
 	ctx := input.ctx.WithBlockHeight(1)
 
 	// keys and addresses
@@ -765,7 +765,7 @@ func TestCustomSignatureVerificationGasConsumer(t *testing.T) {
 	// setup
 	input := setupTestInput()
 	// setup an ante handler that only accepts PubKeyEd25519
-	anteHandler := NewAnteHandler(input.ak, input.fck, func(meter sdk.GasMeter, sig []byte, pubkey crypto.PubKey, params Params) sdk.Result {
+	anteHandler := NewAnteHandler(input.ak, input.fck, nil, func(meter sdk.GasMeter, sig []byte, pubkey crypto.PubKey, params Params) sdk.Result {
 		switch pubkey := pubkey.(type) {
 		case ed25519.PubKeyEd25519:
 			meter.ConsumeGas(params.SigVerifyCostED25519, "ante verify: ed25519")

--- a/x/auth/client/cli/tx_multisign.go
+++ b/x/auth/client/cli/tx_multisign.go
@@ -102,7 +102,7 @@ func makeMultiSignCmd(cdc *codec.Codec) func(cmd *cobra.Command, args []string) 
 			// Validate each signature
 			sigBytes := types.StdSignBytes(
 				txBldr.ChainID(), txBldr.AccountNumber(), txBldr.Sequence(),
-				stdTx.Fee, stdTx.GetMsgs(), stdTx.GetMemo(),
+				stdTx.Fee, stdTx.GetMsgs(), stdTx.GetMemo(), nil,
 			)
 			if ok := stdSig.PubKey.VerifyBytes(sigBytes, stdSig.Signature); !ok {
 				return fmt.Errorf("couldn't verify signature")
@@ -113,7 +113,7 @@ func makeMultiSignCmd(cdc *codec.Codec) func(cmd *cobra.Command, args []string) 
 		}
 
 		newStdSig := types.StdSignature{Signature: cdc.MustMarshalBinaryBare(multisigSig), PubKey: multisigPub}
-		newTx := types.NewStdTx(stdTx.GetMsgs(), stdTx.Fee, []types.StdSignature{newStdSig}, stdTx.GetMemo())
+		newTx := types.NewStdTx(stdTx.GetMsgs(), stdTx.Fee, []types.StdSignature{newStdSig}, stdTx.GetMemo(), nil)
 
 		sigOnly := viper.GetBool(flagSigOnly)
 		var json []byte

--- a/x/auth/client/cli/tx_sign.go
+++ b/x/auth/client/cli/tx_sign.go
@@ -230,7 +230,7 @@ func printAndValidateSigs(
 
 			sigBytes := types.StdSignBytes(
 				chainID, acc.GetAccountNumber(), acc.GetSequence(),
-				stdTx.Fee, stdTx.GetMsgs(), stdTx.GetMemo(),
+				stdTx.Fee, stdTx.GetMsgs(), stdTx.GetMemo(), stdTx.FeeAccount,
 			)
 
 			if ok := sig.VerifyBytes(sigBytes, sig.Signature); !ok {

--- a/x/auth/client/utils/rest.go
+++ b/x/auth/client/utils/rest.go
@@ -53,7 +53,7 @@ func WriteGenerateStdTxResponse(w http.ResponseWriter, cliCtx context.CLIContext
 		return
 	}
 
-	output, err := cliCtx.Codec.MarshalJSON(types.NewStdTx(stdMsg.Msgs, stdMsg.Fee, nil, stdMsg.Memo))
+	output, err := cliCtx.Codec.MarshalJSON(types.NewStdTx(stdMsg.Msgs, stdMsg.Fee, nil, stdMsg.Memo, stdMsg.FeeAccount))
 	if err != nil {
 		rest.WriteErrorResponse(w, http.StatusInternalServerError, err.Error())
 		return

--- a/x/auth/client/utils/tx.go
+++ b/x/auth/client/utils/tx.go
@@ -67,6 +67,17 @@ func CompleteAndBroadcastTxCLI(txBldr authtypes.TxBuilder, cliCtx context.CLICon
 		return nil
 	}
 
+	// support delegated fee payments
+	feeAccount := viper.GetString(flags.FlagFeeAccount)
+	if len(feeAccount) != 0 {
+		feeAcccountAddr, err := sdk.AccAddressFromBech32(feeAccount)
+		if err != nil {
+			return err
+		}
+        txBldr.WithFeeAccount(feeAcccountAddr)
+	}
+
+
 	if !cliCtx.SkipConfirm {
 		stdSignMsg, err := txBldr.BuildSignMsg(msgs)
 		if err != nil {
@@ -344,7 +355,7 @@ func buildUnsignedStdTxOffline(txBldr authtypes.TxBuilder, cliCtx context.CLICon
 		return stdTx, nil
 	}
 
-	return authtypes.NewStdTx(stdSignMsg.Msgs, stdSignMsg.Fee, nil, stdSignMsg.Memo), nil
+	return authtypes.NewStdTx(stdSignMsg.Msgs, stdSignMsg.Fee, nil, stdSignMsg.Memo, stdSignMsg.FeeAccount), nil
 }
 
 func isTxSigner(user sdk.AccAddress, signers []sdk.AccAddress) bool {

--- a/x/auth/client/utils/tx_test.go
+++ b/x/auth/client/utils/tx_test.go
@@ -98,7 +98,7 @@ func TestReadStdTxFromFile(t *testing.T) {
 
 	// Build a test transaction
 	fee := authtypes.NewStdFee(50000, sdk.Coins{sdk.NewInt64Coin("atom", 150)})
-	stdTx := authtypes.NewStdTx([]sdk.Msg{}, fee, []authtypes.StdSignature{}, "foomemo")
+	stdTx := authtypes.NewStdTx([]sdk.Msg{}, fee, []authtypes.StdSignature{}, "foomemo", nil)
 
 	// Write it to the file
 	encodedTx, _ := cdc.MarshalJSON(stdTx)
@@ -113,7 +113,7 @@ func TestReadStdTxFromFile(t *testing.T) {
 
 func compareEncoders(t *testing.T, expected sdk.TxEncoder, actual sdk.TxEncoder) {
 	msgs := []sdk.Msg{sdk.NewTestMsg(addr)}
-	tx := authtypes.NewStdTx(msgs, authtypes.StdFee{}, []authtypes.StdSignature{}, "")
+	tx := authtypes.NewStdTx(msgs, authtypes.StdFee{}, []authtypes.StdSignature{}, "", nil)
 
 	defaultEncoderBytes, err := expected(tx)
 	require.NoError(t, err)

--- a/x/auth/types/stdsignmsg.go
+++ b/x/auth/types/stdsignmsg.go
@@ -8,15 +8,16 @@ import (
 // a Msg with the other requirements for a StdSignDoc before
 // it is signed. For use in the CLI.
 type StdSignMsg struct {
-	ChainID       string    `json:"chain_id"`
-	AccountNumber uint64    `json:"account_number"`
-	Sequence      uint64    `json:"sequence"`
-	Fee           StdFee    `json:"fee"`
-	Msgs          []sdk.Msg `json:"msgs"`
-	Memo          string    `json:"memo"`
+	ChainID       string         `json:"chain_id"`
+	AccountNumber uint64         `json:"account_number"`
+	Sequence      uint64         `json:"sequence"`
+	Fee           StdFee         `json:"fee"`
+	Msgs          []sdk.Msg      `json:"msgs"`
+	Memo          string         `json:"memo"`
+	FeeAccount    sdk.AccAddress `json:"fee_account"`
 }
 
 // get message bytes
 func (msg StdSignMsg) Bytes() []byte {
-	return StdSignBytes(msg.ChainID, msg.AccountNumber, msg.Sequence, msg.Fee, msg.Msgs, msg.Memo)
+	return StdSignBytes(msg.ChainID, msg.AccountNumber, msg.Sequence, msg.Fee, msg.Msgs, msg.Memo, msg.FeeAccount)
 }

--- a/x/auth/types/stdtx.go
+++ b/x/auth/types/stdtx.go
@@ -24,14 +24,18 @@ type StdTx struct {
 	Fee        StdFee         `json:"fee"`
 	Signatures []StdSignature `json:"signatures"`
 	Memo       string         `json:"memo"`
+	// FeeAccount is an optional account that fees can be spent from if such
+	// delegation is enabled
+	FeeAccount sdk.AccAddress `json:"fee_account"`
 }
 
-func NewStdTx(msgs []sdk.Msg, fee StdFee, sigs []StdSignature, memo string) StdTx {
+func NewStdTx(msgs []sdk.Msg, fee StdFee, sigs []StdSignature, memo string, feeAccount sdk.AccAddress) StdTx {
 	return StdTx{
 		Msgs:       msgs,
 		Fee:        fee,
 		Signatures: sigs,
 		Memo:       memo,
+		FeeAccount: feeAccount,
 	}
 }
 
@@ -163,10 +167,11 @@ type StdSignDoc struct {
 	Memo          string            `json:"memo"`
 	Msgs          []json.RawMessage `json:"msgs"`
 	Sequence      uint64            `json:"sequence"`
+	FeeAccount    []byte            `json:"fee_account"`
 }
 
 // StdSignBytes returns the bytes to sign for a transaction.
-func StdSignBytes(chainID string, accnum uint64, sequence uint64, fee StdFee, msgs []sdk.Msg, memo string) []byte {
+func StdSignBytes(chainID string, accnum uint64, sequence uint64, fee StdFee, msgs []sdk.Msg, memo string, feeAccount sdk.AccAddress) []byte {
 	var msgsBytes []json.RawMessage
 	for _, msg := range msgs {
 		msgsBytes = append(msgsBytes, json.RawMessage(msg.GetSignBytes()))
@@ -178,6 +183,7 @@ func StdSignBytes(chainID string, accnum uint64, sequence uint64, fee StdFee, ms
 		Memo:          memo,
 		Msgs:          msgsBytes,
 		Sequence:      sequence,
+		FeeAccount:    feeAccount,
 	})
 	if err != nil {
 		panic(err)
@@ -188,7 +194,7 @@ func StdSignBytes(chainID string, accnum uint64, sequence uint64, fee StdFee, ms
 // StdSignature represents a sig
 type StdSignature struct {
 	crypto.PubKey `json:"pub_key"` // optional
-	Signature     []byte           `json:"signature"`
+	Signature     []byte `json:"signature"`
 }
 
 // DefaultTxDecoder logic for standard transaction decoding

--- a/x/auth/types/stdtx_test.go
+++ b/x/auth/types/stdtx_test.go
@@ -24,7 +24,7 @@ func TestStdTx(t *testing.T) {
 	fee := NewTestStdFee()
 	sigs := []StdSignature{}
 
-	tx := NewStdTx(msgs, fee, sigs, "")
+	tx := NewStdTx(msgs, fee, sigs, "", nil)
 	require.Equal(t, msgs, tx.GetMsgs())
 	require.Equal(t, sigs, tx.GetSignatures())
 
@@ -48,11 +48,11 @@ func TestStdSignBytes(t *testing.T) {
 	}{
 		{
 			args{"1234", 3, 6, defaultFee, []sdk.Msg{sdk.NewTestMsg(addr)}, "memo"},
-			fmt.Sprintf("{\"account_number\":\"3\",\"chain_id\":\"1234\",\"fee\":{\"amount\":[{\"amount\":\"150\",\"denom\":\"atom\"}],\"gas\":\"50000\"},\"memo\":\"memo\",\"msgs\":[[\"%s\"]],\"sequence\":\"6\"}", addr),
+			fmt.Sprintf("{\"account_number\":\"3\",\"chain_id\":\"1234\",\"fee\":{\"amount\":[{\"amount\":\"150\",\"denom\":\"atom\"}],\"gas\":\"50000\"},\"fee_account\":null,\"memo\":\"memo\",\"msgs\":[[\"%s\"]],\"sequence\":\"6\"}", addr),
 		},
 	}
 	for i, tc := range tests {
-		got := string(StdSignBytes(tc.args.chainID, tc.args.accnum, tc.args.sequence, tc.args.fee, tc.args.msgs, tc.args.memo))
+		got := string(StdSignBytes(tc.args.chainID, tc.args.accnum, tc.args.sequence, tc.args.fee, tc.args.msgs, tc.args.memo, nil))
 		require.Equal(t, tc.want, got, "Got unexpected result on test case i: %d", i)
 	}
 }
@@ -123,7 +123,7 @@ func TestDefaultTxEncoder(t *testing.T) {
 	fee := NewTestStdFee()
 	sigs := []StdSignature{}
 
-	tx := NewStdTx(msgs, fee, sigs, "")
+	tx := NewStdTx(msgs, fee, sigs, "", nil)
 
 	cdcBytes, err := cdc.MarshalBinaryLengthPrefixed(tx)
 

--- a/x/auth/types/test_common.go
+++ b/x/auth/types/test_common.go
@@ -72,7 +72,7 @@ func KeyTestPubAddr() (crypto.PrivKey, crypto.PubKey, sdk.AccAddress) {
 func NewTestTx(ctx sdk.Context, msgs []sdk.Msg, privs []crypto.PrivKey, accNums []uint64, seqs []uint64, fee StdFee) sdk.Tx {
 	sigs := make([]StdSignature, len(privs))
 	for i, priv := range privs {
-		signBytes := StdSignBytes(ctx.ChainID(), accNums[i], seqs[i], fee, msgs, "")
+		signBytes := StdSignBytes(ctx.ChainID(), accNums[i], seqs[i], fee, msgs, "", nil)
 
 		sig, err := priv.Sign(signBytes)
 		if err != nil {
@@ -82,14 +82,14 @@ func NewTestTx(ctx sdk.Context, msgs []sdk.Msg, privs []crypto.PrivKey, accNums 
 		sigs[i] = StdSignature{PubKey: priv.PubKey(), Signature: sig}
 	}
 
-	tx := NewStdTx(msgs, fee, sigs, "")
+	tx := NewStdTx(msgs, fee, sigs, "", nil)
 	return tx
 }
 
 func NewTestTxWithMemo(ctx sdk.Context, msgs []sdk.Msg, privs []crypto.PrivKey, accNums []uint64, seqs []uint64, fee StdFee, memo string) sdk.Tx {
 	sigs := make([]StdSignature, len(privs))
 	for i, priv := range privs {
-		signBytes := StdSignBytes(ctx.ChainID(), accNums[i], seqs[i], fee, msgs, memo)
+		signBytes := StdSignBytes(ctx.ChainID(), accNums[i], seqs[i], fee, msgs, memo, nil)
 
 		sig, err := priv.Sign(signBytes)
 		if err != nil {
@@ -99,7 +99,7 @@ func NewTestTxWithMemo(ctx sdk.Context, msgs []sdk.Msg, privs []crypto.PrivKey, 
 		sigs[i] = StdSignature{PubKey: priv.PubKey(), Signature: sig}
 	}
 
-	tx := NewStdTx(msgs, fee, sigs, memo)
+	tx := NewStdTx(msgs, fee, sigs, memo, nil)
 	return tx
 }
 
@@ -114,6 +114,6 @@ func NewTestTxWithSignBytes(msgs []sdk.Msg, privs []crypto.PrivKey, accNums []ui
 		sigs[i] = StdSignature{PubKey: priv.PubKey(), Signature: sig}
 	}
 
-	tx := NewStdTx(msgs, fee, sigs, memo)
+	tx := NewStdTx(msgs, fee, sigs, memo, nil)
 	return tx
 }

--- a/x/auth/types/txbuilder.go
+++ b/x/auth/types/txbuilder.go
@@ -26,6 +26,7 @@ type TxBuilder struct {
 	memo               string
 	fees               sdk.Coins
 	gasPrices          sdk.DecCoins
+	feeAccount         sdk.AccAddress
 }
 
 // NewTxBuilder returns a new initialized TxBuilder.
@@ -104,6 +105,8 @@ func (bldr TxBuilder) Memo() string { return bldr.memo }
 // Fees returns the fees for the transaction
 func (bldr TxBuilder) Fees() sdk.Coins { return bldr.fees }
 
+func (bldr *TxBuilder) FeeAccount() sdk.AccAddress { return bldr.feeAccount; }
+
 // GasPrices returns the gas prices set for the transaction, if any.
 func (bldr TxBuilder) GasPrices() sdk.DecCoins { return bldr.gasPrices }
 
@@ -135,6 +138,11 @@ func (bldr TxBuilder) WithFees(fees string) TxBuilder {
 	bldr.fees = parsedFees
 	return bldr
 }
+
+func (bldr *TxBuilder) WithFeeAccount(addr sdk.AccAddress) {
+	bldr.feeAccount = addr
+}
+
 
 // WithGasPrices returns a copy of the context with updated gas prices.
 func (bldr TxBuilder) WithGasPrices(gasPrices string) TxBuilder {
@@ -203,6 +211,7 @@ func (bldr TxBuilder) BuildSignMsg(msgs []sdk.Msg) (StdSignMsg, error) {
 		Memo:          bldr.memo,
 		Msgs:          msgs,
 		Fee:           NewStdFee(bldr.gas, fees),
+		FeeAccount:    bldr.feeAccount,
 	}, nil
 }
 
@@ -214,7 +223,7 @@ func (bldr TxBuilder) Sign(name, passphrase string, msg StdSignMsg) ([]byte, err
 		return nil, err
 	}
 
-	return bldr.txEncoder(NewStdTx(msg.Msgs, msg.Fee, []StdSignature{sig}, msg.Memo))
+	return bldr.txEncoder(NewStdTx(msg.Msgs, msg.Fee, []StdSignature{sig}, msg.Memo, bldr.feeAccount))
 }
 
 // BuildAndSign builds a single message to be signed, and signs a transaction
@@ -238,7 +247,7 @@ func (bldr TxBuilder) BuildTxForSim(msgs []sdk.Msg) ([]byte, error) {
 
 	// the ante handler will populate with a sentinel pubkey
 	sigs := []StdSignature{{}}
-	return bldr.txEncoder(NewStdTx(signMsg.Msgs, signMsg.Fee, sigs, signMsg.Memo))
+	return bldr.txEncoder(NewStdTx(signMsg.Msgs, signMsg.Fee, sigs, signMsg.Memo, bldr.feeAccount))
 }
 
 // SignStdTx appends a signature to a StdTx and returns a copy of it. If append
@@ -255,6 +264,7 @@ func (bldr TxBuilder) SignStdTx(name, passphrase string, stdTx StdTx, appendSig 
 		Fee:           stdTx.Fee,
 		Msgs:          stdTx.GetMsgs(),
 		Memo:          stdTx.GetMemo(),
+		FeeAccount:    bldr.feeAccount,
 	})
 	if err != nil {
 		return
@@ -266,7 +276,7 @@ func (bldr TxBuilder) SignStdTx(name, passphrase string, stdTx StdTx, appendSig 
 	} else {
 		sigs = append(sigs, stdSignature)
 	}
-	signedStdTx = NewStdTx(stdTx.GetMsgs(), stdTx.Fee, sigs, stdTx.GetMemo())
+	signedStdTx = NewStdTx(stdTx.GetMsgs(), stdTx.Fee, sigs, stdTx.GetMemo(), bldr.feeAccount)
 	return
 }
 

--- a/x/fee-delegation/allowances.go
+++ b/x/fee-delegation/allowances.go
@@ -1,0 +1,27 @@
+package fee_delegation
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	abci "github.com/tendermint/tendermint/abci/types"
+)
+
+type BasicFeeAllowance struct {
+	// SpendLimit specifies the maximum amount of tokens that can be spent
+	// by this capability and will be updated as tokens are spent. If it is
+	// empty, there is no spend limit and any amount of coins can be spent.
+	SpendLimit sdk.Coins
+}
+
+var _ FeeAllowance = BasicFeeAllowance{}
+
+func (cap BasicFeeAllowance) Accept(fee sdk.Coins, block abci.Header) (allow bool, updated FeeAllowance, delete bool) {
+	left, invalid := cap.SpendLimit.SafeSub(fee)
+	if invalid {
+		return false, nil, false
+	}
+	if left.IsZero() {
+		return true, nil, true
+	}
+	return true, BasicFeeAllowance{SpendLimit: left}, false
+}
+

--- a/x/fee-delegation/cli_query.go
+++ b/x/fee-delegation/cli_query.go
@@ -1,0 +1,46 @@
+package fee_delegation
+
+import (
+	"fmt"
+	"github.com/cosmos/cosmos-sdk/client"
+
+	"github.com/cosmos/cosmos-sdk/client/context"
+	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/spf13/cobra"
+)
+
+// GetQueryCmd returns the cli query commands for this module
+func GetQueryCmd(queryRoute string, cdc *codec.Codec) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "fee-delegation",
+		Short: "Querying commands for the delegation module",
+	}
+
+	cmd.AddCommand(client.GetCommands(
+		GetCmdGetFeeAllowances(queryRoute, cdc),
+	)...)
+
+	return cmd
+}
+
+func GetCmdGetFeeAllowances(queryRoute string, cdc *codec.Codec) *cobra.Command {
+	return &cobra.Command{
+		Use:   "allowances [address]",
+		Short: "get fee allowances granted to this address",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cliCtx := context.NewCLIContext().WithCodec(cdc)
+			id := args[0]
+
+			route := fmt.Sprintf("custom/delegation/%s/%s", QueryGetFeeAllowances, id)
+			res, err := cliCtx.QueryWithData(route, nil)
+			if err != nil {
+				return err
+			}
+
+			fmt.Println(string(res))
+
+			return nil
+		},
+	}
+}

--- a/x/fee-delegation/cli_tx.go
+++ b/x/fee-delegation/cli_tx.go
@@ -1,0 +1,76 @@
+package fee_delegation
+
+import (
+	"github.com/cosmos/cosmos-sdk/client/context"
+	"github.com/cosmos/cosmos-sdk/client/utils"
+	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/auth"
+	"github.com/spf13/cobra"
+)
+
+func GetCmdDelegateFees(cdc *codec.Codec) *cobra.Command {
+	return &cobra.Command{
+		Use:   "delegate [grantee] [fee-allowance]",
+		Short: "delegate",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cliCtx := context.NewCLIContext().WithCodec(cdc).WithAccountDecoder(cdc)
+
+			txBldr := auth.NewTxBuilderFromCLI().WithTxEncoder(utils.GetTxEncoder(cdc))
+
+			if err := cliCtx.EnsureAccountExists(); err != nil {
+				return err
+			}
+
+			account := cliCtx.GetFromAddress()
+
+			grantee, err := sdk.AccAddressFromBech32(args[0])
+			if err != nil {
+				return err
+			}
+
+			var allowance FeeAllowance
+			err = cdc.UnmarshalJSON([]byte(args[1]), &allowance)
+			if err != nil {
+				return err
+			}
+
+			msg := NewMsgDelegateFeeAllowance(account, grantee, allowance)
+
+			cliCtx.PrintResponse = true
+
+			return utils.CompleteAndBroadcastTxCLI(txBldr, cliCtx, []sdk.Msg{msg})
+		},
+	}
+}
+
+func GetCmdRevokeDelegatedFees(cdc *codec.Codec) *cobra.Command {
+	return &cobra.Command{
+		Use:   "revoke [grantee]",
+		Short: "revoke",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cliCtx := context.NewCLIContext().WithCodec(cdc).WithAccountDecoder(cdc)
+
+			txBldr := auth.NewTxBuilderFromCLI().WithTxEncoder(utils.GetTxEncoder(cdc))
+
+			if err := cliCtx.EnsureAccountExists(); err != nil {
+				return err
+			}
+
+			account := cliCtx.GetFromAddress()
+
+			grantee, err := sdk.AccAddressFromBech32(args[0])
+			if err != nil {
+				return err
+			}
+
+			msg := NewMsgRevokeFeeAllowance(account, grantee)
+
+			cliCtx.PrintResponse = true
+
+			return utils.CompleteAndBroadcastTxCLI(txBldr, cliCtx, []sdk.Msg{msg})
+		},
+	}
+}

--- a/x/fee-delegation/codec.go
+++ b/x/fee-delegation/codec.go
@@ -1,0 +1,13 @@
+package fee_delegation
+
+import "github.com/cosmos/cosmos-sdk/codec"
+
+var moduleCodec = codec.New()
+
+// RegisterCodec registers all the necessary types and interfaces for the module
+func RegisterCodec(cdc *codec.Codec) {
+	cdc.RegisterConcrete(MsgDelegateFeeAllowance{}, "delegation/MsgDelegateFeeAllowance", nil)
+	cdc.RegisterConcrete(MsgRevokeFeeAllowance{}, "delegation/MsgRevokeFeeAllowance", nil)
+	cdc.RegisterConcrete(BasicFeeAllowance{}, "delegation/BasicFeeAllowance", nil)
+	cdc.RegisterInterface((*FeeAllowance)(nil), nil)
+}

--- a/x/fee-delegation/genesis.go
+++ b/x/fee-delegation/genesis.go
@@ -1,0 +1,35 @@
+package fee_delegation
+
+import sdk "github.com/cosmos/cosmos-sdk/types"
+
+// GenesisState defines genesis data for the module
+type GenesisState struct {
+	// Delegations []Delegation `json:"delegations"`
+}
+
+// NewGenesisState creates a new genesis state.
+func NewGenesisState() GenesisState {
+	return GenesisState{
+		// Delegations: nil,
+	}
+}
+
+// DefaultGenesisState returns a default genesis state
+func DefaultGenesisState() GenesisState { return NewGenesisState() }
+
+// InitGenesis initializes story state from genesis file
+func InitGenesis(ctx sdk.Context, keeper Keeper, data GenesisState) {
+}
+
+// ExportGenesis exports the genesis state
+func ExportGenesis(ctx sdk.Context, keeper Keeper) GenesisState {
+	return GenesisState{
+		//		Delegations: keeper.Delegations(ctx),
+	}
+}
+
+// ValidateGenesis validates the genesis state data
+func ValidateGenesis(data GenesisState) error {
+
+	return nil
+}

--- a/x/fee-delegation/handler.go
+++ b/x/fee-delegation/handler.go
@@ -1,0 +1,22 @@
+package fee_delegation
+
+import (
+	"fmt"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+func NewHandler(k Keeper) sdk.Handler {
+	return func(ctx sdk.Context, msg sdk.Msg) sdk.Result {
+		switch msg := msg.(type) {
+		case MsgDelegateFeeAllowance:
+			k.DelegateFeeAllowance(ctx, msg.Grantee, msg.Granter, msg.Allowance)
+			return sdk.Result{}
+		case MsgRevokeFeeAllowance:
+			k.RevokeFeeAllowance(ctx, msg.Grantee, msg.Granter)
+			return sdk.Result{}
+		default:
+			errMsg := fmt.Sprintf("Unrecognized data Msg type: %v", msg.Type())
+			return sdk.ErrUnknownRequest(errMsg).Result()
+		}
+	}
+}

--- a/x/fee-delegation/keeper.go
+++ b/x/fee-delegation/keeper.go
@@ -1,0 +1,81 @@
+package fee_delegation
+
+import (
+	"fmt"
+	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+type Keeper struct {
+	storeKey sdk.StoreKey
+	cdc      *codec.Codec
+}
+
+func NewKeeper(storeKey sdk.StoreKey, cdc *codec.Codec) Keeper {
+	return Keeper{storeKey, cdc}
+}
+
+func FeeAllowanceKey(grantee sdk.AccAddress, granter sdk.AccAddress) []byte {
+	return []byte(fmt.Sprintf("f/%x/%x", grantee, granter))
+}
+
+func (k Keeper) DelegateFeeAllowance(ctx sdk.Context, grantee sdk.AccAddress, granter sdk.AccAddress, allowance FeeAllowance) {
+	store := ctx.KVStore(k.storeKey)
+	bz := k.cdc.MustMarshalBinaryBare(allowance)
+	store.Set(FeeAllowanceKey(grantee, granter), bz)
+}
+
+func (k Keeper) RevokeFeeAllowance(ctx sdk.Context, grantee sdk.AccAddress, granter sdk.AccAddress) {
+	store := ctx.KVStore(k.storeKey)
+	store.Delete(FeeAllowanceKey(grantee, granter))
+}
+
+type FeeAllowanceGrant struct {
+	Allowance FeeAllowance   `json:"allowance"`
+	Grantee   sdk.AccAddress `json:"grantee"`
+	Granter   sdk.AccAddress `json:"granter"`
+}
+
+func (k Keeper) GetFeeAllowances(ctx sdk.Context, grantee sdk.AccAddress) []FeeAllowanceGrant {
+	prefix := fmt.Sprintf("g/%x/", grantee)
+	prefixBytes := []byte(prefix)
+	store := ctx.KVStore(k.storeKey)
+	var grants []FeeAllowanceGrant
+	iter := sdk.KVStorePrefixIterator(store, prefixBytes)
+	defer iter.Close()
+	for ; iter.Valid(); iter.Next() {
+		granter, _ := sdk.AccAddressFromHex(string(iter.Key()[len(prefix):]))
+		bz := iter.Value()
+		var allowance FeeAllowance
+		k.cdc.MustUnmarshalBinaryBare(bz, &allowance)
+		grants = append(grants, FeeAllowanceGrant{
+			Allowance: allowance,
+			Grantee:   grantee,
+			Granter:   granter,
+		})
+	}
+	return grants
+}
+
+func (k Keeper) AllowDelegatedFees(ctx sdk.Context, grantee sdk.AccAddress, granter sdk.AccAddress, fee sdk.Coins) bool {
+	store := ctx.KVStore(k.storeKey)
+	bz := store.Get(FeeAllowanceKey(grantee, granter))
+	if len(bz) == 0 {
+		return false
+	}
+	var allowance FeeAllowance
+	k.cdc.MustUnmarshalBinaryBare(bz, &allowance)
+	if allowance == nil {
+		return false
+	}
+	allow, updated, delete := allowance.Accept(fee, ctx.BlockHeader())
+	if allow == false {
+		return false
+	}
+	if delete {
+		k.RevokeFeeAllowance(ctx, grantee, granter)
+	} else if updated != nil {
+		k.DelegateFeeAllowance(ctx, grantee, granter, updated)
+	}
+	return true
+}

--- a/x/fee-delegation/keeper_test.go
+++ b/x/fee-delegation/keeper_test.go
@@ -1,0 +1,114 @@
+package fee_delegation_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	abci "github.com/tendermint/tendermint/abci/types"
+	dbm "github.com/tendermint/tendermint/libs/db"
+	"github.com/tendermint/tendermint/libs/log"
+
+	codec "github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/store"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/auth"
+	"github.com/cosmos/cosmos-sdk/x/bank"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	"github.com/cosmos/cosmos-sdk/x/fee-delegation"
+	"github.com/cosmos/cosmos-sdk/x/params"
+)
+
+type testInput struct {
+	cdc    *codec.Codec
+	ctx    sdk.Context
+	ak     auth.AccountKeeper
+	pk     params.Keeper
+	bk     bank.Keeper
+	dk     fee_delegation.Keeper
+}
+
+func setupTestInput() testInput {
+	db := dbm.NewMemDB()
+
+	cdc := codec.New()
+	auth.RegisterCodec(cdc)
+	bank.RegisterCodec(cdc)
+	fee_delegation.RegisterCodec(cdc)
+	sdk.RegisterCodec(cdc)
+	codec.RegisterCrypto(cdc)
+
+	authCapKey := sdk.NewKVStoreKey("authCapKey")
+	delCapKey := sdk.NewKVStoreKey("delKey")
+	fckCapKey := sdk.NewKVStoreKey("fckCapKey")
+	keyParams := sdk.NewKVStoreKey("params")
+	tkeyParams := sdk.NewTransientStoreKey("transient_params")
+
+	ms := store.NewCommitMultiStore(db)
+	ms.MountStoreWithDB(authCapKey, sdk.StoreTypeIAVL, db)
+	ms.MountStoreWithDB(delCapKey, sdk.StoreTypeIAVL, db)
+	ms.MountStoreWithDB(fckCapKey, sdk.StoreTypeIAVL, db)
+	ms.MountStoreWithDB(keyParams, sdk.StoreTypeIAVL, db)
+	ms.MountStoreWithDB(tkeyParams, sdk.StoreTypeTransient, db)
+	ms.LoadLatestVersion()
+
+	pk := params.NewKeeper(cdc, keyParams, tkeyParams, params.DefaultCodespace)
+	ak := auth.NewAccountKeeper(
+		cdc, authCapKey, pk.Subspace(auth.DefaultParamspace), auth.ProtoBaseAccount,
+	)
+	ctx := sdk.NewContext(ms, abci.Header{ChainID: "test-chain-id", Time: time.Now().UTC()}, false, log.NewNopLogger())
+
+	bk := bank.NewBaseKeeper(ak, pk.Subspace(banktypes.DefaultParamspace), banktypes.DefaultCodespace)
+	bk.SetSendEnabled(ctx, true)
+
+	dk := fee_delegation.NewKeeper(delCapKey, cdc)
+
+	ak.SetParams(ctx, auth.DefaultParams())
+
+	return testInput{cdc: cdc, ctx: ctx, ak: ak, pk: pk, bk: bk, dk: dk}
+}
+
+const (
+	// some valid cosmos keys....
+	sender    = "cosmos157ez5zlaq0scm9aycwphhqhmg3kws4qusmekll"
+	recipient = "cosmos1rjxwm0rwyuldsg00qf5lt26wxzzppjzxs2efdw"
+)
+
+func TestKeeperFees(t *testing.T) {
+	input := setupTestInput()
+	ctx := input.ctx
+
+	addr, err := sdk.AccAddressFromBech32(sender)
+	require.NoError(t, err)
+	addr2, err := sdk.AccAddressFromBech32(recipient)
+	require.NoError(t, err)
+	input.bk.SetCoins(ctx, addr, sdk.NewCoins(sdk.NewInt64Coin("tree", 10000)))
+
+	require.True(t, input.bk.GetCoins(ctx, addr).IsEqual(sdk.NewCoins(sdk.NewInt64Coin("tree", 10000))))
+
+	now := ctx.BlockHeader().Time
+	require.NotNil(t, now)
+	smallCoin := sdk.NewCoins(sdk.NewInt64Coin("tree", 2))
+	someCoin := sdk.NewCoins(sdk.NewInt64Coin("tree", 123))
+	lotCoin := sdk.NewCoins(sdk.NewInt64Coin("tree", 4567))
+
+	// not allows
+	ok := input.dk.AllowDelegatedFees(ctx, addr2, addr, smallCoin)
+	require.False(t, ok)
+
+	// allow it
+	input.dk.DelegateFeeAllowance(ctx, addr2, addr, fee_delegation.BasicFeeAllowance{someCoin})
+
+	// okay under threshold
+	ok = input.dk.AllowDelegatedFees(ctx, addr2, addr, smallCoin)
+	require.True(t, ok)
+
+	// too high
+	ok = input.dk.AllowDelegatedFees(ctx, addr2, addr, lotCoin)
+	require.False(t, ok)
+
+	// wrong grantee
+	ok = input.dk.AllowDelegatedFees(ctx, addr2, addr2, smallCoin)
+	require.False(t, ok)
+}

--- a/x/fee-delegation/module.go
+++ b/x/fee-delegation/module.go
@@ -1,0 +1,142 @@
+package fee_delegation
+
+import (
+	"encoding/json"
+	"github.com/cosmos/cosmos-sdk/client"
+
+	"github.com/gorilla/mux"
+	"github.com/spf13/cobra"
+
+	"github.com/cosmos/cosmos-sdk/client/context"
+	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	abci "github.com/tendermint/tendermint/abci/types"
+)
+
+var (
+	_ module.AppModule      = AppModule{}
+	_ module.AppModuleBasic = AppModuleBasic{}
+)
+
+// ModuleName is the name of this module
+const ModuleName = "fee-delegation"
+const StoreKey = ModuleName
+
+// AppModuleBasic defines the internal data for the module
+// ----------------------------------------------------------------------------
+type AppModuleBasic struct{}
+
+var _ module.AppModuleBasic = AppModuleBasic{}
+
+// Name define the name of the module
+func (AppModuleBasic) Name() string {
+	return ModuleName
+}
+
+// RegisterCodec registers the types needed for amino encoding/decoding
+func (AppModuleBasic) RegisterCodec(cdc *codec.Codec) {
+	RegisterCodec(cdc)
+}
+
+// DefaultGenesis creates the default genesis state for testing
+func (AppModuleBasic) DefaultGenesis() json.RawMessage {
+	return moduleCodec.MustMarshalJSON(DefaultGenesisState())
+}
+
+// ValidateGenesis validates the genesis state
+func (AppModuleBasic) ValidateGenesis(bz json.RawMessage) error {
+	var data GenesisState
+	err := moduleCodec.UnmarshalJSON(bz, &data)
+	if err != nil {
+		return err
+	}
+	return ValidateGenesis(data)
+}
+
+// register rest routes
+func (AppModuleBasic) RegisterRESTRoutes(ctx context.CLIContext, rtr *mux.Router) {
+	// rest.RegisterRoutes(ctx, rtr, StoreKey)
+}
+
+// get the root tx command of this module
+func (AppModuleBasic) GetTxCmd(cdc *codec.Codec) *cobra.Command {
+	txCmd := &cobra.Command{
+		Use:   ModuleName,
+		Short: "Fee delegation transaction subcommands",
+	}
+
+	txCmd.AddCommand(client.PostCommands(
+		GetCmdDelegateFees(cdc),
+		GetCmdRevokeDelegatedFees(cdc),
+	)...)
+
+	return txCmd
+}
+
+// get the root query command of this module
+func (AppModuleBasic) GetQueryCmd(cdc *codec.Codec) *cobra.Command {
+	return GetQueryCmd(ModuleName, cdc)
+}
+
+// AppModule defines external data for the module
+// ----------------------------------------------------------------------------
+type AppModule struct {
+	AppModuleBasic
+	keeper Keeper
+}
+
+// NewAppModule creates a new app module
+func NewAppModule(keeper Keeper) AppModule {
+	return AppModule{
+		AppModuleBasic: AppModuleBasic{},
+		keeper:         keeper,
+	}
+}
+
+// RegisterInvariants enforces registering of invariants
+func (AppModule) RegisterInvariants(_ sdk.InvariantRegistry) {}
+
+// Route defines the key for the route
+func (AppModule) Route() string {
+	return RouterKey
+}
+
+// NewHandler creates the handler for the delegation module
+func (am AppModule) NewHandler() sdk.Handler {
+	return NewHandler(am.keeper)
+}
+
+// QuerierRoute defines the querier route
+func (AppModule) QuerierRoute() string {
+	return QuerierRoute
+}
+
+// NewQuerierHandler creates a new querier handler
+func (am AppModule) NewQuerierHandler() sdk.Querier {
+	return NewQuerier(am.keeper)
+}
+
+// InitGenesis enforces the creation of the genesis state for the delegation module
+func (am AppModule) InitGenesis(ctx sdk.Context, data json.RawMessage) []abci.ValidatorUpdate {
+	var genesisState GenesisState
+	moduleCodec.MustUnmarshalJSON(data, &genesisState)
+	InitGenesis(ctx, am.keeper, genesisState)
+	return []abci.ValidatorUpdate{}
+}
+
+// ExportGenesis enforces exporting this module's data to a genesis file
+func (am AppModule) ExportGenesis(ctx sdk.Context) json.RawMessage {
+	gs := ExportGenesis(ctx, am.keeper)
+	return moduleCodec.MustMarshalJSON(gs)
+}
+
+// BeginBlock runs before a block is processed
+func (AppModule) BeginBlock(_ sdk.Context, _ abci.RequestBeginBlock) sdk.Tags {
+	return sdk.EmptyTags()
+}
+
+// EndBlock runs at the end of each block
+func (AppModule) EndBlock(_ sdk.Context, _ abci.RequestEndBlock) ([]abci.ValidatorUpdate, sdk.Tags) {
+	return []abci.ValidatorUpdate{}, sdk.EmptyTags()
+}

--- a/x/fee-delegation/msgs.go
+++ b/x/fee-delegation/msgs.go
@@ -1,0 +1,73 @@
+package fee_delegation
+
+import (
+	"encoding/json"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+type MsgDelegateFeeAllowance struct {
+	Granter   sdk.AccAddress `json:"granter"`
+	Grantee   sdk.AccAddress `json:"grantee"`
+	Allowance FeeAllowance   `json:"allowance"`
+}
+
+func NewMsgDelegateFeeAllowance(granter sdk.AccAddress, grantee sdk.AccAddress, allowance FeeAllowance) MsgDelegateFeeAllowance {
+	return MsgDelegateFeeAllowance{Granter: granter, Grantee: grantee, Allowance: allowance}
+}
+
+func (msg MsgDelegateFeeAllowance) Route() string {
+	return "delegation"
+}
+
+func (msg MsgDelegateFeeAllowance) Type() string {
+	return "delegate-fee-allowance"
+}
+
+func (msg MsgDelegateFeeAllowance) ValidateBasic() sdk.Error {
+	return nil
+}
+
+func (msg MsgDelegateFeeAllowance) GetSignBytes() []byte {
+	b, err := json.Marshal(msg)
+	if err != nil {
+		panic(err)
+	}
+	return sdk.MustSortJSON(b)
+}
+
+func (msg MsgDelegateFeeAllowance) GetSigners() []sdk.AccAddress {
+	return []sdk.AccAddress{msg.Granter}
+}
+
+type MsgRevokeFeeAllowance struct {
+	Granter sdk.AccAddress `json:"granter"`
+	Grantee sdk.AccAddress `json:"grantee"`
+}
+
+func NewMsgRevokeFeeAllowance(granter sdk.AccAddress, grantee sdk.AccAddress) MsgRevokeFeeAllowance {
+	return MsgRevokeFeeAllowance{Granter: granter, Grantee: grantee}
+}
+
+func (msg MsgRevokeFeeAllowance) Route() string {
+	return "delegation"
+}
+
+func (msg MsgRevokeFeeAllowance) Type() string {
+	return "revoke-fee-allowance"
+}
+
+func (msg MsgRevokeFeeAllowance) ValidateBasic() sdk.Error {
+	return nil
+}
+
+func (msg MsgRevokeFeeAllowance) GetSignBytes() []byte {
+	b, err := json.Marshal(msg)
+	if err != nil {
+		panic(err)
+	}
+	return sdk.MustSortJSON(b)
+}
+
+func (msg MsgRevokeFeeAllowance) GetSigners() []sdk.AccAddress {
+	return []sdk.AccAddress{msg.Granter}
+}

--- a/x/fee-delegation/querier.go
+++ b/x/fee-delegation/querier.go
@@ -1,0 +1,40 @@
+package fee_delegation
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	abci "github.com/tendermint/tendermint/abci/types"
+)
+
+const (
+	QueryGetFeeAllowances = "fees"
+)
+
+// NewQuerier creates a new querier
+func NewQuerier(keeper Keeper) sdk.Querier {
+	return func(ctx sdk.Context, path []string, req abci.RequestQuery) ([]byte, sdk.Error) {
+		switch path[0] {
+		case QueryGetFeeAllowances:
+			return queryGetFeeAllowances(ctx, path[1:], keeper)
+		default:
+			return nil, sdk.ErrUnknownRequest("Unknown package delegation query endpoint")
+		}
+	}
+}
+
+func queryGetFeeAllowances(ctx sdk.Context, args []string, keeper Keeper) ([]byte, sdk.Error) {
+	grantee := args[0]
+	granteeAddr, err := sdk.AccAddressFromBech32(grantee)
+	if err != nil {
+		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("invalid address", err.Error()))
+	}
+
+	fees := keeper.GetFeeAllowances(ctx, granteeAddr)
+	if fees == nil {
+		fees = []FeeAllowanceGrant{}
+	}
+	bz, jErr := keeper.cdc.MarshalJSON(fees)
+	if jErr != nil {
+		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", jErr.Error()))
+	}
+	return bz, nil
+}

--- a/x/fee-delegation/rest.go
+++ b/x/fee-delegation/rest.go
@@ -1,0 +1,47 @@
+package fee_delegation
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/gorilla/mux"
+
+	"github.com/cosmos/cosmos-sdk/client/context"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/rest"
+)
+
+// RegisterRoutes registers staking-related REST handlers to a router
+func RegisterRoutes(cliCtx context.CLIContext, r *mux.Router) {
+	registerQueryRoutes(cliCtx, r)
+}
+
+func registerQueryRoutes(cliCtx context.CLIContext, r *mux.Router) {
+	r.HandleFunc(
+		"/fee-delegation/allowances/{granteeAddr}",
+		getAllowFeesHandlerFn(cliCtx),
+	).Methods("GET")
+}
+
+type QueryCapabilityParams struct {
+	Grantee sdk.AccAddress
+	Granter sdk.AccAddress
+	Route   string
+	Typ     string
+}
+
+func getAllowFeesHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		vars := mux.Vars(r)
+		grantee := vars["granteeAddr"]
+		route := fmt.Sprintf("custom/fee-delegation/%s/%s", QueryGetFeeAllowances, grantee)
+
+		res, err := cliCtx.QueryWithData(route, []byte{})
+		if err != nil {
+			rest.WriteErrorResponse(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+
+		rest.PostProcessResponse(w, cliCtx, res)
+	}
+}

--- a/x/fee-delegation/types.go
+++ b/x/fee-delegation/types.go
@@ -1,0 +1,20 @@
+package fee_delegation
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	abci "github.com/tendermint/tendermint/abci/types"
+)
+
+// Defines delegation module constants
+const (
+	RouterKey    = ModuleName
+	QuerierRoute = ModuleName
+)
+
+// FeeAllowance defines a permission for one account to use another account's balance
+// to pay fees
+type FeeAllowance interface {
+	// Accept checks whether this allowance allows the provided fees to be spent,
+	// and optionally updates the allowance or deletes it entirely
+	Accept(fee sdk.Coins, block abci.Header) (allow bool, updated FeeAllowance, delete bool)
+}

--- a/x/genutil/genesis_state_test.go
+++ b/x/genutil/genesis_state_test.go
@@ -26,7 +26,7 @@ func TestValidateGenesisMultipleMessages(t *testing.T) {
 	msg2 := staking.NewMsgCreateValidator(sdk.ValAddress(pk2.Address()), pk2,
 		sdk.NewInt64Coin(sdk.DefaultBondDenom, 50), desc, comm, sdk.OneInt())
 
-	genTxs := auth.NewStdTx([]sdk.Msg{msg1, msg2}, auth.StdFee{}, nil, "")
+	genTxs := auth.NewStdTx([]sdk.Msg{msg1, msg2}, auth.StdFee{}, nil, "", nil)
 	genesisState := NewGenesisStateFromStdTx([]auth.StdTx{genTxs})
 
 	err := ValidateGenesis(genesisState)
@@ -38,7 +38,7 @@ func TestValidateGenesisBadMessage(t *testing.T) {
 
 	msg1 := staking.NewMsgEditValidator(sdk.ValAddress(pk1.Address()), desc, nil, nil)
 
-	genTxs := auth.NewStdTx([]sdk.Msg{msg1}, auth.StdFee{}, nil, "")
+	genTxs := auth.NewStdTx([]sdk.Msg{msg1}, auth.StdFee{}, nil, "", nil)
 	genesisState := NewGenesisStateFromStdTx([]auth.StdTx{genTxs})
 
 	err := ValidateGenesis(genesisState)

--- a/x/mock/app.go
+++ b/x/mock/app.go
@@ -82,7 +82,7 @@ func NewApp() *App {
 	// Initialize the app. The chainers and blockers can be overwritten before
 	// calling complete setup.
 	app.SetInitChainer(app.InitChainer)
-	app.SetAnteHandler(auth.NewAnteHandler(app.AccountKeeper, app.FeeCollectionKeeper, auth.DefaultSigVerificationGasConsumer))
+	app.SetAnteHandler(auth.NewAnteHandler(app.AccountKeeper, app.FeeCollectionKeeper, nil, auth.DefaultSigVerificationGasConsumer))
 
 	// Not sealing for custom extension
 
@@ -221,7 +221,7 @@ func GenTx(msgs []sdk.Msg, accnums []uint64, seq []uint64, priv ...crypto.PrivKe
 	memo := "testmemotestmemo"
 
 	for i, p := range priv {
-		sig, err := p.Sign(auth.StdSignBytes(chainID, accnums[i], seq[i], fee, msgs, memo))
+		sig, err := p.Sign(auth.StdSignBytes(chainID, accnums[i], seq[i], fee, msgs, memo, nil))
 		if err != nil {
 			panic(err)
 		}
@@ -232,7 +232,7 @@ func GenTx(msgs []sdk.Msg, accnums []uint64, seq []uint64, priv ...crypto.PrivKe
 		}
 	}
 
-	return auth.NewStdTx(msgs, fee, sigs, memo)
+	return auth.NewStdTx(msgs, fee, sigs, memo, nil)
 }
 
 // GeneratePrivKeys generates a total n secp256k1 private keys.


### PR DESCRIPTION
Adds:
* The `FeeAccount sdk.AccAddress` field to `StdTx`
* The required logic in `AnteHandler` to deduct fees from the `FeeAccount` if one is provided and that account has indeed delegated fees to the account signing the transaction
* A `fee-delegation` module to manage granting of fee allowances. `FeeAllowance` is an interface which allows for different types of fee allowance policies such as daily or hourly limits
* CLI support for a `--fee-account` flag

Use cases:
- an organization can delegate fees to employees from the master organizational account so that employees can sign certain transactions onto the blockchain without needing to worry about wallets
- a user could keep a less trusted key on their phone and delegate fees to this key for purposes such as voting on proposals (this would also use generic action delegation which was worked on in the hackathon and will be submitted as a separate PR)
- a third party service could delegate fees to users who pay off-chain via fiat or other crypto so that those users can use Dapps without needing to fill their wallets

This PR is squashes many commits from the Gaian's team at Hackatom Berlin. It is now being worked on in the context of the Community Group on Key Management (https://github.com/cosmos-cg-key-management) and Regen Network intends to test it in on its live testnet in the coming weeks. Once the testing is complete and the community has had a time to discuss the design more thoroughly, we intend to move this PR out of draft status. In the meantime, this thread can be a forum for discussion and review of the proposed changes.

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added a relevant changelog entry: `clog add [section] [stanza] [message]`
- [ ] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))