### PR TITLE
Don't reject config files with create_empty_blocks=false

### DIFF
--- a/.pending/improvements/sdk/Revert-2284-https-gi
+++ b/.pending/improvements/sdk/Revert-2284-https-gi
@@ -1,0 +1,1 @@
+Revert (#2284)[https://github.com/cosmos/cosmos-sdk/pull/2284] to allow create_empty_blocks in the config

--- a/server/util.go
+++ b/server/util.go
@@ -58,10 +58,6 @@ func PersistentPreRunEFn(context *Context) func(*cobra.Command, []string) error 
 		if err != nil {
 			return err
 		}
-		err = validateConfig(config)
-		if err != nil {
-			return err
-		}
 		logger := log.NewTMLogger(log.NewSyncWriter(os.Stdout))
 		logger, err = tmflags.ParseLogLevel(config.LogLevel, logger, cfg.DefaultLogLevel())
 		if err != nil {
@@ -115,14 +111,6 @@ func interceptLoadConfig() (conf *cfg.Config, err error) {
 	err = viper.MergeInConfig()
 
 	return
-}
-
-// validate the config with the sdk's requirements.
-func validateConfig(conf *cfg.Config) error {
-	if !conf.Consensus.CreateEmptyBlocks {
-		return errors.New("config option CreateEmptyBlocks = false is currently unsupported")
-	}
-	return nil
 }
 
 // add server commands


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Only valid with #4613 - please merge that first

This reverts https://github.com/cosmos/cosmos-sdk/pull/2284 as with https://github.com/cosmos/cosmos-sdk/pull/4613 we now support the `create_empty_blocks` config option. There is no issue, but approval for this PR was given in a review comment: https://github.com/cosmos/cosmos-sdk/pull/4613#issuecomment-505512700

As there were no tests for the functionality I removed, I see no need to add a test that this is no longer prohibited.

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/develop/CONTRIBUTING.md#pr-targeting))

- [x] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [x] Added a relevant changelog entry: `clog add [section] [stanza] [message]`
- [x] rereviewed `Files changed` in the github PR explorer


______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
