### PR TITLE
Update golangci-lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,8 +145,7 @@ test_sim_app_profile:
 test_cover:
 	@export VERSION=$(VERSION); bash -x tests/test_cover.sh
 
-lint: tools ci-lint
-ci-lint:
+lint: tools
 	golangci-lint run
 	find . -name '*.go' -type f -not -path "./vendor*" -not -path "*.git*" | xargs gofmt -d -s
 	go mod verify

--- a/Makefile
+++ b/Makefile
@@ -145,7 +145,7 @@ test_sim_app_profile:
 test_cover:
 	@export VERSION=$(VERSION); bash -x tests/test_cover.sh
 
-lint: tools
+lint: golangci-lint
 	golangci-lint run
 	find . -name '*.go' -type f -not -path "./vendor*" -not -path "*.git*" | xargs gofmt -d -s
 	go mod verify

--- a/contrib/devtools/Makefile
+++ b/contrib/devtools/Makefile
@@ -52,7 +52,7 @@ CLOG            = $(TOOLS_DESTDIR)/clog
 all: tools
 
 tools: tools-stamp
-tools-stamp: $(STATIK) $(GOIMPORTS) $(CLOG) $(GOLANGCI_LINT)
+tools-stamp: $(STATIK) $(GOIMPORTS) $(CLOG)
 	touch $@
 
 $(GOLANGCI_LINT): $(mkfile_dir)/install-golangci-lint.sh
@@ -66,6 +66,8 @@ $(GOIMPORTS):
 
 $(CLOG):
 	$(call go_install,alessio,clog,1)
+
+golangci-lint: $(GOLANGCI_LINT)
 
 tools-clean:
 	rm -f $(STATIK) $(GOIMPORTS) $(CLOG) $(GOLANGCI_LINT)

--- a/contrib/devtools/Makefile
+++ b/contrib/devtools/Makefile
@@ -17,8 +17,8 @@ endif
 
 GOPATH ?= $(shell $(GO) env GOPATH)
 GITHUBDIR := $(GOPATH)$(FS)src$(FS)github.com
-GOLANGCI_LINT_VERSION := v1.16.0
-GOLANGCI_LINT_HASHSUM := ac897cadc180bf0c1a4bf27776c410debad27205b22856b861d41d39d06509cf
+GOLANGCI_LINT_VERSION := v1.17.1
+GOLANGCI_LINT_HASHSUM := f5fa647a12f658924d9f7d6b9628d505ab118e8e049e43272de6526053ebe08d
 
 ###
 # Functions
@@ -62,7 +62,7 @@ $(STATIK):
 	$(call go_install,rakyll,statik,v0.1.5)
 
 $(GOIMPORTS):
-	go get golang.org/x/tools/cmd/goimports@v0.0.0-20190114222345-bf090417da8b
+	go get golang.org/x/tools/cmd/goimports@v0.0.0-20190628034336-212fb13d595e
 
 $(CLOG):
 	$(call go_install,alessio,clog,1)


### PR DESCRIPTION
Update golangci-lint to latest version.

Remove ci-lint, no longer used.

Remove golangci-lint from tools target to prevent CI builds
from downloading automatically (and unnecessarily).
Developers can still run make golangci-lint to download
it locally for development and testing purposes.

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added a relevant changelog entry: `clog add [section] [stanza] [message]`
- [ ] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
