### PR TITLE
[wip] slashing: remove validator missed bit array from HandleValidatorSignature

### DIFF
--- a/x/slashing/types/signing_info.go
+++ b/x/slashing/types/signing_info.go
@@ -10,8 +10,7 @@ import (
 // Signing info for a validator
 type ValidatorSigningInfo struct {
 	Address             sdk.ConsAddress `json:"address"`               // validator consensus address
-	StartHeight         int64           `json:"start_height"`          // height at which validator was first a candidate OR was unjailed
-	IndexOffset         int64           `json:"index_offset"`          // index offset into signed block bit array
+	LastMissHeight      int64           `json:"last_miss_height"`      // height at which the validator last missed a block
 	JailedUntil         time.Time       `json:"jailed_until"`          // timestamp validator cannot be unjailed until
 	Tombstoned          bool            `json:"tombstoned"`            // whether or not a validator has been tombstoned (killed out of validator set)
 	MissedBlocksCounter int64           `json:"missed_blocks_counter"` // missed blocks counter (to avoid scanning the array every time)
@@ -19,14 +18,12 @@ type ValidatorSigningInfo struct {
 
 // Construct a new `ValidatorSigningInfo` struct
 func NewValidatorSigningInfo(
-	condAddr sdk.ConsAddress, startHeight, indexOffset int64,
+	condAddr sdk.ConsAddress, indexOffset int64,
 	jailedUntil time.Time, tombstoned bool, missedBlocksCounter int64,
 ) ValidatorSigningInfo {
 
 	return ValidatorSigningInfo{
 		Address:             condAddr,
-		StartHeight:         startHeight,
-		IndexOffset:         indexOffset,
 		JailedUntil:         jailedUntil,
 		Tombstoned:          tombstoned,
 		MissedBlocksCounter: missedBlocksCounter,
@@ -37,11 +34,9 @@ func NewValidatorSigningInfo(
 func (i ValidatorSigningInfo) String() string {
 	return fmt.Sprintf(`Validator Signing Info:
   Address:               %s
-  Start Height:          %d
-  Index Offset:          %d
   Jailed Until:          %v
   Tombstoned:            %t
   Missed Blocks Counter: %d`,
-		i.Address, i.StartHeight, i.IndexOffset, i.JailedUntil,
+		i.Address, i.JailedUntil,
 		i.Tombstoned, i.MissedBlocksCounter)
 }


### PR DESCRIPTION
While working on a program for block replay, I did some cpu profiling of my application. I found that one area where it was spending a lot of time was in the `HandleValidatorSignature` routine - specifically around getting the missed block bit array.

After looking at the code and how the bit array is used, I propose this alternative implementation which maintains the same slashing logic but avoids the use of a bit array, the index offset, and the start height. These are replaced by a last miss height and the existing miss block counter.

When a validator misses signing a block, their miss counter is incremented and the last miss height is recorded. If the miss counter exceeds the maximum allowed misses in a window, then the validator is slashed and jailed (as before). The miss counter is decremented when the validator successfully signs a block AND their last miss occurred outside the sign window. The latter is important to capture a missed block for the duration of the sign window.

---
I imagine this code change would fall under the "hard fork" category due to the app state changes it introduces (tho the slashing condition remains unchanged). I am not sure of the appropriate approach to land such a change.

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/develop/CONTRIBUTING.md#pr-targeting))

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added a relevant changelog entry: `clog add [section] [stanza] [message]`
- [ ] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
