### PR TITLE
Pretty/Flatten Events by Type when Stringified

### DIFF
--- a/types/events.go
+++ b/types/events.go
@@ -164,10 +164,26 @@ func (se StringEvents) String() string {
 	return strings.TrimRight(sb.String(), "\n")
 }
 
+// Flatten returns a flattened version of StringEvents by grouping all attributes
+// per unique event type.
+func (se StringEvents) Flatten() StringEvents {
+	flatEvents := make(map[string][]Attribute)
+
+	for _, e := range se {
+		flatEvents[e.Type] = append(flatEvents[e.Type], e.Attributes...)
+	}
+
+	var res StringEvents
+	for ty, attrs := range flatEvents {
+		res = append(res, StringEvent{Type: ty, Attributes: attrs})
+	}
+
+	return res
+}
+
 // StringifyEvent converts an Event object to a StringEvent object.
 func StringifyEvent(e abci.Event) StringEvent {
-	res := StringEvent{}
-	res.Type = e.Type
+	res := StringEvent{Type: e.Type}
 
 	for _, attr := range e.Attributes {
 		res.Attributes = append(
@@ -188,5 +204,5 @@ func StringifyEvents(events []abci.Event) StringEvents {
 		res = append(res, StringifyEvent(e))
 	}
 
-	return res
+	return res.Flatten()
 }

--- a/types/events_test.go
+++ b/types/events_test.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -50,4 +51,21 @@ func TestEventManager(t *testing.T) {
 
 	require.Len(t, em.Events(), 2)
 	require.Equal(t, em.Events(), events.AppendEvent(event))
+}
+
+func TestStringifyEvents(t *testing.T) {
+	e := Events{
+		NewEvent("message", NewAttribute("sender", "foo")),
+		NewEvent("message", NewAttribute("module", "bank")),
+	}
+	se := StringifyEvents(e.ToABCIEvents())
+
+	expectedTxtStr := "\t\t- message\n\t\t\t- sender: foo\n\t\t\t- module: bank"
+	require.Equal(t, expectedTxtStr, se.String())
+
+	bz, err := json.Marshal(se)
+	require.NoError(t, err)
+
+	expectedJSONStr := "[{\"type\":\"message\",\"attributes\":[{\"key\":\"sender\",\"value\":\"foo\"},{\"key\":\"module\",\"value\":\"bank\"}]}]"
+	require.Equal(t, expectedJSONStr, string(bz))
 }

--- a/types/result.go
+++ b/types/result.go
@@ -240,7 +240,7 @@ func (r TxResponse) String() string {
 	}
 
 	if len(r.Events) > 0 {
-		sb.WriteString(fmt.Sprintf("  Tags: \n%s\n", r.Events.String()))
+		sb.WriteString(fmt.Sprintf("  Events: \n%s\n", r.Events.String()))
 	}
 
 	return strings.TrimSpace(sb.String())


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

When events are stringified, they'll be easier to read if they're grouped by unique type.

----

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/develop/CONTRIBUTING.md#pr-targeting))

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [x] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added a relevant changelog entry: `clog add [section] [stanza] [message]`
- [x] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
