### PR TITLE
validator slash event stored by period and height

### DIFF
--- a/.pending/bugfixes/sdk/4654-validator-slash
+++ b/.pending/bugfixes/sdk/4654-validator-slash
@@ -1,0 +1,1 @@
+#4654 validator slash event stored by period and height

--- a/x/distribution/genesis.go
+++ b/x/distribution/genesis.go
@@ -32,7 +32,7 @@ func InitGenesis(ctx sdk.Context, keeper Keeper, data types.GenesisState) {
 		keeper.SetDelegatorStartingInfo(ctx, del.ValidatorAddress, del.DelegatorAddress, del.StartingInfo)
 	}
 	for _, evt := range data.ValidatorSlashEvents {
-		keeper.SetValidatorSlashEvent(ctx, evt.ValidatorAddress, evt.Height, evt.Event)
+		keeper.SetValidatorSlashEvent(ctx, evt.ValidatorAddress, evt.Height, evt.Period, evt.Event)
 	}
 }
 
@@ -110,6 +110,7 @@ func ExportGenesis(ctx sdk.Context, keeper Keeper) types.GenesisState {
 			slashes = append(slashes, types.ValidatorSlashEventRecord{
 				ValidatorAddress: val,
 				Height:           height,
+				Period:           event.ValidatorPeriod,
 				Event:            event,
 			})
 			return false

--- a/x/distribution/keeper/querier_test.go
+++ b/x/distribution/keeper/querier_test.go
@@ -175,8 +175,8 @@ func TestQueries(t *testing.T) {
 	// test validator slashes query with height range
 	slashOne := types.NewValidatorSlashEvent(3, sdk.NewDecWithPrec(5, 1))
 	slashTwo := types.NewValidatorSlashEvent(7, sdk.NewDecWithPrec(6, 1))
-	keeper.SetValidatorSlashEvent(ctx, valOpAddr1, 3, slashOne)
-	keeper.SetValidatorSlashEvent(ctx, valOpAddr1, 7, slashTwo)
+	keeper.SetValidatorSlashEvent(ctx, valOpAddr1, 3, 0, slashOne)
+	keeper.SetValidatorSlashEvent(ctx, valOpAddr1, 7, 0, slashTwo)
 	slashes := getQueriedValidatorSlashes(t, ctx, cdc, querier, valOpAddr1, 0, 2)
 	require.Equal(t, 0, len(slashes))
 	slashes = getQueriedValidatorSlashes(t, ctx, cdc, querier, valOpAddr1, 0, 5)

--- a/x/distribution/keeper/store.go
+++ b/x/distribution/keeper/store.go
@@ -307,9 +307,9 @@ func (k Keeper) IterateValidatorOutstandingRewards(ctx sdk.Context, handler func
 }
 
 // get slash event for height
-func (k Keeper) GetValidatorSlashEvent(ctx sdk.Context, val sdk.ValAddress, height uint64) (event types.ValidatorSlashEvent, found bool) {
+func (k Keeper) GetValidatorSlashEvent(ctx sdk.Context, val sdk.ValAddress, height, period uint64) (event types.ValidatorSlashEvent, found bool) {
 	store := ctx.KVStore(k.storeKey)
-	b := store.Get(GetValidatorSlashEventKey(val, height))
+	b := store.Get(GetValidatorSlashEventKey(val, height, period))
 	if b == nil {
 		return types.ValidatorSlashEvent{}, false
 	}
@@ -318,10 +318,10 @@ func (k Keeper) GetValidatorSlashEvent(ctx sdk.Context, val sdk.ValAddress, heig
 }
 
 // set slash event for height
-func (k Keeper) SetValidatorSlashEvent(ctx sdk.Context, val sdk.ValAddress, height uint64, event types.ValidatorSlashEvent) {
+func (k Keeper) SetValidatorSlashEvent(ctx sdk.Context, val sdk.ValAddress, height, period uint64, event types.ValidatorSlashEvent) {
 	store := ctx.KVStore(k.storeKey)
 	b := k.cdc.MustMarshalBinaryLengthPrefixed(event)
-	store.Set(GetValidatorSlashEventKey(val, height), b)
+	store.Set(GetValidatorSlashEventKey(val, height, period), b)
 }
 
 // iterate over slash events between heights, inclusive
@@ -329,8 +329,8 @@ func (k Keeper) IterateValidatorSlashEventsBetween(ctx sdk.Context, val sdk.ValA
 	handler func(height uint64, event types.ValidatorSlashEvent) (stop bool)) {
 	store := ctx.KVStore(k.storeKey)
 	iter := store.Iterator(
-		GetValidatorSlashEventKey(val, startingHeight),
-		GetValidatorSlashEventKey(val, endingHeight+1),
+		GetValidatorSlashEventKeyPrefix(val, startingHeight),
+		GetValidatorSlashEventKeyPrefix(val, endingHeight+1),
 	)
 	defer iter.Close()
 	for ; iter.Valid(); iter.Next() {

--- a/x/distribution/keeper/validator.go
+++ b/x/distribution/keeper/validator.go
@@ -1,6 +1,8 @@
 package keeper
 
 import (
+	"fmt"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/cosmos/cosmos-sdk/x/distribution/types"
@@ -86,33 +88,20 @@ func (k Keeper) decrementReferenceCount(ctx sdk.Context, valAddr sdk.ValAddress,
 }
 
 func (k Keeper) updateValidatorSlashFraction(ctx sdk.Context, valAddr sdk.ValAddress, fraction sdk.Dec) {
-	if fraction.GT(sdk.OneDec()) {
-		panic("fraction greater than one")
+	if fraction.GT(sdk.OneDec()) || fraction.LT(sdk.ZeroDec()) {
+		panic(fmt.Sprintf("fraction must be >=0 and <=1, current fraction: %v", fraction))
 	}
+
+	val := k.stakingKeeper.Validator(ctx, valAddr)
+
+	// increment current period
+	newPeriod := k.incrementValidatorPeriod(ctx, val)
+
+	// increment reference count on period we need to track
+	k.incrementReferenceCount(ctx, valAddr, newPeriod)
+
+	slashEvent := types.NewValidatorSlashEvent(newPeriod, fraction)
 	height := uint64(ctx.BlockHeight())
-	currentFraction := sdk.ZeroDec()
-	endedPeriod := k.GetValidatorCurrentRewards(ctx, valAddr).Period - 1
-	current, found := k.GetValidatorSlashEvent(ctx, valAddr, height)
-	if found {
-		// there has already been a slash event this height,
-		// and we don't need to store more than one,
-		// so just update the current slash fraction
-		currentFraction = current.Fraction
-	} else {
-		val := k.stakingKeeper.Validator(ctx, valAddr)
-		// increment current period
-		endedPeriod = k.incrementValidatorPeriod(ctx, val)
-		// increment reference count on period we need to track
-		k.incrementReferenceCount(ctx, valAddr, endedPeriod)
-	}
-	currentMultiplicand := sdk.OneDec().Sub(currentFraction)
-	newMultiplicand := sdk.OneDec().Sub(fraction)
 
-	// using MulTruncate here conservatively increases the slashing amount
-	updatedFraction := sdk.OneDec().Sub(currentMultiplicand.MulTruncate(newMultiplicand))
-
-	if updatedFraction.LT(sdk.ZeroDec()) {
-		panic("negative slash fraction")
-	}
-	k.SetValidatorSlashEvent(ctx, valAddr, height, types.NewValidatorSlashEvent(endedPeriod, updatedFraction))
+	k.SetValidatorSlashEvent(ctx, valAddr, height, newPeriod, slashEvent)
 }

--- a/x/distribution/types/genesis.go
+++ b/x/distribution/types/genesis.go
@@ -49,6 +49,7 @@ type DelegatorStartingInfoRecord struct {
 type ValidatorSlashEventRecord struct {
 	ValidatorAddress sdk.ValAddress      `json:"validator_address"`
 	Height           uint64              `json:"height"`
+	Period           uint64              `json:"period"`
 	Event            ValidatorSlashEvent `json:"validator_slash_event"`
 }
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Followup to fuzzer bug Icarus issue:
ref https://github.com/cosmos/cosmos-sdk/issues/4653

The solution (thanks @cwgoes) is to no longer average slash events by height:

> I believe there is a bug in consolidation of slash events by height.
Consider the following sequence of slashes:
> 1. Validator `A` is slashed. A new slash event is created.
> 2. A redelegation from validator `A` to `B` is slashed. The validator's period is incremented.
> 3. Validator `A` is again slashed. The previous slash event is updated, using the period from (2).
> 4. A redelegation from validator `A` to `B` is again slashed. The second slash event is now skipped > when it ought to have been included, since the ended period of the slash event is the same as the starting period of the modified delegation (after (2)).
> Part of this was conjecture, so we should confirm in the actual simulation run.
I suggest what should be a straightforward fix of no longer consolidating slashes and instead keying by validator address, height, and period in that order. As slashes are expensive to create, the iteration overhead shouldn't be a concern.

________________

## Summary of Bug

Running `go test -race -covermode=atomic -coverprofile=769332655.1.profile.out -coverpkg=./... -mod=readonly github.com/cosmos/cosmos-sdk/simapp -run TestFullAppSimulation -SimulationEnabled=true -SimulationNumBlocks=400 -SimulationBlockSize=200 -SimulationGenesis= -SimulationVerbose=false -SimulationCommit=true -SimulationSeed=769332655 -SimulationPeriod=5 -v -timeout 6h` on current `HEAD` (commit `ac2e765607a64f9dacb475244895ba3e99ec927d`) fails with:
```
Simulating... block 29/400, operation 50/78. panic with err: calculated final stake for delegator cosmos1y7wu8egpm6w2zkzdmtdf6tgu0gnz70mdryuq3v greater than current stake
	final stake:	367984183.087167908909931651
	current stake:	325658474.336187830811153603
```
Full log: [769332655.log](https://github.com/cosmos/cosmos-sdk-icarus-private/files/3293875/769332655.log)


## Version

```
$ git log -1
commit ac2e765607a64f9dacb475244895ba3e99ec927d (HEAD, origin/master, origin/HEAD)
Author: Alexander Bezobchuk <alexanderbez@users.noreply.github.com>
Date:   Sat Jun 15 16:17:39 2019 +0200

    Merge PR #4561: Add account JSON tag to AccountWithHeight
```



- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/develop/CONTRIBUTING.md#pr-targeting))

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added a relevant changelog entry: `clog add [section] [stanza] [message]`
- [ ] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
