### PR TITLE
Add check before minting empty coins

### DIFF
--- a/.pending/bugfixes/sdk/4681-mint-check
+++ b/.pending/bugfixes/sdk/4681-mint-check
@@ -1,0 +1,2 @@
+#4681 panic on invalid amount on `MintCoins` and `BurnCoins`
+  - skip minting if inflation is set to zero

--- a/x/mint/internal/keeper/keeper.go
+++ b/x/mint/internal/keeper/keeper.go
@@ -98,6 +98,7 @@ func (k Keeper) BondedRatio(ctx sdk.Context) sdk.Dec {
 // MintCoins to be used in BeginBlocker.
 func (k Keeper) MintCoins(ctx sdk.Context, newCoins sdk.Coins) sdk.Error {
 	if newCoins.Empty() {
+		// skip as no coins need to be minted
 		return nil
 	}
 	return k.supplyKeeper.MintCoins(ctx, types.ModuleName, newCoins)

--- a/x/mint/internal/keeper/keeper.go
+++ b/x/mint/internal/keeper/keeper.go
@@ -97,6 +97,9 @@ func (k Keeper) BondedRatio(ctx sdk.Context) sdk.Dec {
 // MintCoins implements an alias call to the underlying supply keeper's
 // MintCoins to be used in BeginBlocker.
 func (k Keeper) MintCoins(ctx sdk.Context, newCoins sdk.Coins) sdk.Error {
+	if newCoins.Empty() {
+		return nil
+	}
 	return k.supplyKeeper.MintCoins(ctx, types.ModuleName, newCoins)
 }
 

--- a/x/staking/keeper/pool.go
+++ b/x/staking/keeper/pool.go
@@ -37,6 +37,7 @@ func (k Keeper) notBondedTokensToBonded(ctx sdk.Context, tokens sdk.Int) {
 // burnBondedTokens removes coins from the bonded pool module account
 func (k Keeper) burnBondedTokens(ctx sdk.Context, amt sdk.Int) sdk.Error {
 	if !amt.IsPositive() {
+		// skip as no coins need to be burned
 		return nil
 	}
 	coins := sdk.NewCoins(sdk.NewCoin(k.BondDenom(ctx), amt))
@@ -46,6 +47,7 @@ func (k Keeper) burnBondedTokens(ctx sdk.Context, amt sdk.Int) sdk.Error {
 // burnNotBondedTokens removes coins from the not bonded pool module account
 func (k Keeper) burnNotBondedTokens(ctx sdk.Context, amt sdk.Int) sdk.Error {
 	if !amt.IsPositive() {
+		// skip as no coins need to be burned
 		return nil
 	}
 	coins := sdk.NewCoins(sdk.NewCoin(k.BondDenom(ctx), amt))

--- a/x/supply/internal/keeper/account.go
+++ b/x/supply/internal/keeper/account.go
@@ -6,7 +6,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/supply/internal/types"
 )
 
-// GetModuleAddress returns a an address  based on the name
+// GetModuleAddress returns a an address based on the module name
 func (k Keeper) GetModuleAddress(moduleName string) sdk.AccAddress {
 	permAddr, ok := k.permAddrs[moduleName]
 	if !ok {
@@ -15,7 +15,7 @@ func (k Keeper) GetModuleAddress(moduleName string) sdk.AccAddress {
 	return permAddr.address
 }
 
-// GetModuleAddressAndPermission returns an address and permission  based on the name
+// GetModuleAddressAndPermission returns an address and permission based on the module name
 func (k Keeper) GetModuleAddressAndPermission(moduleName string) (addr sdk.AccAddress, permission string) {
 	permAddr, ok := k.permAddrs[moduleName]
 	if !ok {
@@ -24,7 +24,8 @@ func (k Keeper) GetModuleAddressAndPermission(moduleName string) (addr sdk.AccAd
 	return permAddr.address, permAddr.permission
 }
 
-// GetModuleAccount gets the module account to the auth account store
+// GetModuleAccountAndPermission gets the module account from the auth account store and its
+// registered permission
 func (k Keeper) GetModuleAccountAndPermission(ctx sdk.Context, moduleName string) (exported.ModuleAccountI, string) {
 	addr, perm := k.GetModuleAddressAndPermission(moduleName)
 	if addr == nil {
@@ -48,7 +49,7 @@ func (k Keeper) GetModuleAccountAndPermission(ctx sdk.Context, moduleName string
 	return maccI, perm
 }
 
-// GetModuleAccount gets the module account to the auth account store
+// GetModuleAccount gets the module account from the auth account store
 func (k Keeper) GetModuleAccount(ctx sdk.Context, moduleName string) exported.ModuleAccountI {
 	acc, _ := k.GetModuleAccountAndPermission(ctx, moduleName)
 	return acc

--- a/x/supply/internal/keeper/bank.go
+++ b/x/supply/internal/keeper/bank.go
@@ -28,12 +28,12 @@ func (k Keeper) SendCoinsFromModuleToModule(ctx sdk.Context, senderModule, recip
 	}
 
 	// create the account if it doesn't yet exist
-	recipientAddr := k.GetModuleAccount(ctx, recipientModule).GetAddress()
-	if recipientAddr == nil {
+	recipientAcc := k.GetModuleAccount(ctx, recipientModule)
+	if recipientAcc == nil {
 		panic(fmt.Sprintf("module account %s isn't able to be created", recipientModule))
 	}
 
-	return k.bk.SendCoins(ctx, senderAddr, recipientAddr, amt)
+	return k.bk.SendCoins(ctx, senderAddr, recipientAcc.GetAddress(), amt)
 }
 
 // SendCoinsFromAccountToModule transfers coins from an AccAddress to a ModuleAccount
@@ -41,12 +41,12 @@ func (k Keeper) SendCoinsFromAccountToModule(ctx sdk.Context, senderAddr sdk.Acc
 	recipientModule string, amt sdk.Coins) sdk.Error {
 
 	// create the account if it doesn't yet exist
-	recipientAddr := k.GetModuleAccount(ctx, recipientModule).GetAddress()
-	if recipientAddr == nil {
+	recipientAcc := k.GetModuleAccount(ctx, recipientModule)
+	if recipientAcc == nil {
 		panic(fmt.Sprintf("module account %s isn't able to be created", recipientModule))
 	}
 
-	return k.bk.SendCoins(ctx, senderAddr, recipientAddr, amt)
+	return k.bk.SendCoins(ctx, senderAddr, recipientAcc.GetAddress(), amt)
 }
 
 // DelegateCoinsFromAccountToModule delegates coins and transfers
@@ -55,12 +55,12 @@ func (k Keeper) DelegateCoinsFromAccountToModule(ctx sdk.Context, senderAddr sdk
 	recipientModule string, amt sdk.Coins) sdk.Error {
 
 	// create the account if it doesn't yet exist
-	recipientAddr := k.GetModuleAccount(ctx, recipientModule).GetAddress()
-	if recipientAddr == nil {
+	recipientAcc := k.GetModuleAccount(ctx, recipientModule)
+	if recipientAcc == nil {
 		panic(fmt.Sprintf("module account %s isn't able to be created", recipientModule))
 	}
 
-	return k.bk.DelegateCoins(ctx, senderAddr, recipientAddr, amt)
+	return k.bk.DelegateCoins(ctx, senderAddr, recipientAcc.GetAddress(), amt)
 }
 
 // UndelegateCoinsFromModuleToAccount undelegates the unbonding coins and transfers
@@ -76,27 +76,25 @@ func (k Keeper) UndelegateCoinsFromModuleToAccount(ctx sdk.Context, senderModule
 	return k.bk.UndelegateCoins(ctx, senderAddr, recipientAddr, amt)
 }
 
-// MintCoins creates new coins from thin air and adds it to the MinterAccount.
-// Panics if the name maps to a non-minter module account.
+// MintCoins creates new coins from thin air and adds it to the module account.
+// Panics if the name maps to a non-minter module account or if the amount is invalid.
 func (k Keeper) MintCoins(ctx sdk.Context, moduleName string, amt sdk.Coins) sdk.Error {
-	if !amt.IsValid() {
-		panic(fmt.Sprintf("invalid coins %s", amt.String()))
-	}
 
 	// create the account if it doesn't yet exist
 	acc, perm := k.GetModuleAccountAndPermission(ctx, moduleName)
-	addr := acc.GetAddress()
-	if addr == nil {
+	if acc == nil {
 		return sdk.ErrUnknownAddress(fmt.Sprintf("module account %s does not exist", moduleName))
 	}
 
+	addr := acc.GetAddress()
+
 	if perm != types.Minter {
-		panic(fmt.Sprintf("Account %s does not have permissions to mint tokens", moduleName))
+		panic(fmt.Sprintf("module account %s does not have permissions to mint tokens", moduleName))
 	}
 
 	_, err := k.bk.AddCoins(ctx, addr, amt)
 	if err != nil {
-		return err
+		panic(err)
 	}
 
 	// update total supply
@@ -110,11 +108,9 @@ func (k Keeper) MintCoins(ctx sdk.Context, moduleName string, amt sdk.Coins) sdk
 	return nil
 }
 
-// BurnCoins burns coins deletes coins from the balance of the module account
+// BurnCoins burns coins deletes coins from the balance of the module account.
+// Panics if the name maps to a non-burner module account or if the amount is invalid.
 func (k Keeper) BurnCoins(ctx sdk.Context, moduleName string, amt sdk.Coins) sdk.Error {
-	if !amt.IsValid() {
-		panic(fmt.Sprintf("invalid coins %s", amt.String()))
-	}
 
 	addr, perm := k.GetModuleAddressAndPermission(moduleName)
 	if addr == nil {
@@ -122,12 +118,12 @@ func (k Keeper) BurnCoins(ctx sdk.Context, moduleName string, amt sdk.Coins) sdk
 	}
 
 	if perm != types.Burner {
-		panic(fmt.Sprintf("Account %s does not have permissions to burn tokens", moduleName))
+		panic(fmt.Sprintf("module account %s does not have permissions to burn tokens", moduleName))
 	}
 
 	_, err := k.bk.SubtractCoins(ctx, addr, amt)
 	if err != nil {
-		return err
+		panic(err)
 	}
 
 	// update total supply

--- a/x/supply/internal/keeper/bank.go
+++ b/x/supply/internal/keeper/bank.go
@@ -79,8 +79,8 @@ func (k Keeper) UndelegateCoinsFromModuleToAccount(ctx sdk.Context, senderModule
 // MintCoins creates new coins from thin air and adds it to the MinterAccount.
 // Panics if the name maps to a non-minter module account.
 func (k Keeper) MintCoins(ctx sdk.Context, moduleName string, amt sdk.Coins) sdk.Error {
-	if amt.Empty() {
-		panic("cannot mint empty coins")
+	if !amt.IsValid() {
+		panic(fmt.Sprintf("invalid coins %s", amt.String()))
 	}
 
 	// create the account if it doesn't yet exist
@@ -112,8 +112,8 @@ func (k Keeper) MintCoins(ctx sdk.Context, moduleName string, amt sdk.Coins) sdk
 
 // BurnCoins burns coins deletes coins from the balance of the module account
 func (k Keeper) BurnCoins(ctx sdk.Context, moduleName string, amt sdk.Coins) sdk.Error {
-	if amt.Empty() {
-		panic("cannot burn empty coins")
+	if !amt.IsValid() {
+		panic(fmt.Sprintf("invalid coins %s", amt.String()))
 	}
 
 	addr, perm := k.GetModuleAddressAndPermission(moduleName)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

The previous function for inflating the supply on the mint module, `InflateSupply` wasn't checking for neg amounts, nor 0 amounts. The first is already checked on `mint` due to the fact that we use `NewCoin` to initialize the coins from the `BlockProvision`. This PR fixes the second one where a consensus failure was caused if the minted coins where empty. 

Note that this check also exists for the two `burn` functions in `staking/keeper/pool.go`.

Fix on Gaia: cosmos/gaia#56

cc: @rigelrozanski @alexanderbez 


here's the prev `InflateSupply`:
```go
// when minting new tokens    
func (k Keeper) InflateSupply(ctx sdk.Context, newTokens sdk.Int) {    
    pool := k.GetPool(ctx)    
    pool.NotBondedTokens = pool.NotBondedTokens.Add(newTokens)    
    k.SetPool(ctx, pool)    
}
```


- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/develop/CONTRIBUTING.md#pr-targeting))

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added a relevant changelog entry: `clog add [section] [stanza] [message]`
- [ ] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
