### PR TITLE
Update Invariant Printing

### DIFF
--- a/types/invariant.go
+++ b/types/invariant.go
@@ -3,8 +3,8 @@ package types
 import "fmt"
 
 // An Invariant is a function which tests a particular invariant.
-// If the invariant has been broken, it should return an error
-// containing a descriptive message about what happened.
+// The invariant returns a descriptive message about what happened
+// and a boolean indicating whether the invariant has been broken.
 // The simulator will then halt and print the logs.
 type Invariant func(ctx Context) (string, bool)
 
@@ -17,8 +17,8 @@ type InvariantRegistry interface {
 }
 
 // FormatInvariant returns a standardized invariant message along with
-// broken boolean.
+// a boolean indicating whether the invariant has been broken.
 func FormatInvariant(module, name, msg string, broken bool) (string, bool) {
-	return fmt.Sprintf("%s: %s invariant\n%s\nInvariant Broken: %v\n",
+	return fmt.Sprintf("%s: %s invariant\n%sinvariant broken: %v\n",
 		module, name, msg, broken), broken
 }

--- a/x/bank/internal/keeper/invariants.go
+++ b/x/bank/internal/keeper/invariants.go
@@ -17,21 +17,21 @@ func RegisterInvariants(ir sdk.InvariantRegistry, ak types.AccountKeeper) {
 func NonnegativeBalanceInvariant(ak types.AccountKeeper) sdk.Invariant {
 	return func(ctx sdk.Context) (string, bool) {
 		var msg string
-		var amt int
+		var count int
 
 		accts := ak.GetAllAccounts(ctx)
 		for _, acc := range accts {
 			coins := acc.GetCoins()
 			if coins.IsAnyNegative() {
-				amt++
-				msg += fmt.Sprintf("\t%s has a negative denomination of %s\n",
+				count++
+				msg += fmt.Sprintf("\n\t%s has a negative denomination of %s",
 					acc.GetAddress().String(),
 					coins.String())
 			}
 		}
-		broken := amt != 0
+		broken := count != 0
 
 		return sdk.FormatInvariant(types.ModuleName, "nonnegative-outstanding",
-			fmt.Sprintf("amount of negative accounts found %d\n%s", amt, msg), broken)
+			fmt.Sprintf("amount of negative accounts found %d%s", count, msg), broken)
 	}
 }

--- a/x/bank/internal/keeper/invariants.go
+++ b/x/bank/internal/keeper/invariants.go
@@ -24,7 +24,7 @@ func NonnegativeBalanceInvariant(ak types.AccountKeeper) sdk.Invariant {
 			coins := acc.GetCoins()
 			if coins.IsAnyNegative() {
 				count++
-				msg += fmt.Sprintf("\n\t%s has a negative denomination of %s",
+				msg += fmt.Sprintf("\t%s has a negative denomination of %s\n",
 					acc.GetAddress().String(),
 					coins.String())
 			}
@@ -32,6 +32,6 @@ func NonnegativeBalanceInvariant(ak types.AccountKeeper) sdk.Invariant {
 		broken := count != 0
 
 		return sdk.FormatInvariant(types.ModuleName, "nonnegative-outstanding",
-			fmt.Sprintf("amount of negative accounts found %d%s", count, msg), broken)
+			fmt.Sprintf("amount of negative accounts found %d\n%s", count, msg), broken)
 	}
 }

--- a/x/distribution/keeper/invariants.go
+++ b/x/distribution/keeper/invariants.go
@@ -128,7 +128,7 @@ func ReferenceCountInvariant(k Keeper) sdk.Invariant {
 
 		return sdk.FormatInvariant(types.ModuleName, "reference count",
 			fmt.Sprintf("expected historical reference count: %d = %v validators + %v delegations + %v slashes\n"+
-				"total validator historical refernce count: %d\n",
+				"total validator historical reference count: %d\n",
 				expected, valCount, len(dels), slashCount, count), broken)
 	}
 }

--- a/x/distribution/keeper/invariants.go
+++ b/x/distribution/keeper/invariants.go
@@ -126,9 +126,10 @@ func ReferenceCountInvariant(k Keeper) sdk.Invariant {
 		count := k.GetValidatorHistoricalReferenceCount(ctx)
 		broken := count != expected
 
-		return sdk.FormatInvariant(types.ModuleName, "reference count", fmt.Sprintf("unexpected number of historical rewards records: "+
-			"expected %v (%v vals + %v dels + %v slashes), got %v\n",
-			expected, valCount, len(dels), slashCount, count), broken)
+		return sdk.FormatInvariant(types.ModuleName, "reference count",
+			fmt.Sprintf("expected historical reference count: %d = %v validators + %v delegations + %v slashes\n"+
+				"total validator historical refernce count: %d\n",
+				expected, valCount, len(dels), slashCount, count), broken)
 	}
 }
 
@@ -150,8 +151,8 @@ func ModuleAccountInvariant(k Keeper) sdk.Invariant {
 
 		broken := !macc.GetCoins().IsEqual(expectedInt)
 		return sdk.FormatInvariant(types.ModuleName, "ModuleAccount coins",
-			fmt.Sprintf("\texpected ModuleAccount coins:      %s\n"+
-				"\tdistribution ModuleAccount coins : %s\n",
+			fmt.Sprintf("\texpected ModuleAccount coins:     %s\n"+
+				"\tdistribution ModuleAccount coins: %s\n",
 				expectedInt, macc.GetCoins()), broken)
 	}
 }

--- a/x/distribution/keeper/invariants.go
+++ b/x/distribution/keeper/invariants.go
@@ -149,7 +149,7 @@ func ModuleAccountInvariant(k Keeper) sdk.Invariant {
 		macc := k.GetDistributionAccount(ctx)
 
 		broken := !macc.GetCoins().IsEqual(expectedInt)
-		return sdk.FormatInvariant(types.ModuleName, "ModuleAccount coins", fmt.Sprintf("expected ModuleAccount coins: %s\n"+
+		return sdk.FormatInvariant(types.ModuleName, "ModuleAccount coins", fmt.Sprintf("\texpected ModuleAccount coins: %s\n"+
 			"\tdistribution ModuleAccount coins : %s\n", expectedInt, macc.GetCoins()), broken)
 	}
 }

--- a/x/distribution/keeper/invariants.go
+++ b/x/distribution/keeper/invariants.go
@@ -43,21 +43,21 @@ func AllInvariants(k Keeper) sdk.Invariant {
 func NonNegativeOutstandingInvariant(k Keeper) sdk.Invariant {
 	return func(ctx sdk.Context) (string, bool) {
 		var msg string
-		var amt int
+		var count int
 		var outstanding sdk.DecCoins
 
 		k.IterateValidatorOutstandingRewards(ctx, func(addr sdk.ValAddress, rewards types.ValidatorOutstandingRewards) (stop bool) {
 			outstanding = rewards
 			if outstanding.IsAnyNegative() {
-				amt++
+				count++
 				msg += fmt.Sprintf("\t%v has negative outstanding coins: %v\n", addr, outstanding)
 			}
 			return false
 		})
-		broken := amt != 0
+		broken := count != 0
 
 		return sdk.FormatInvariant(types.ModuleName, "nonnegative outstanding",
-			fmt.Sprintf("found %d validators with negative outstanding rewards\n%s", amt, msg), broken)
+			fmt.Sprintf("found %d validators with negative outstanding rewards\n%s", count, msg), broken)
 	}
 }
 
@@ -99,7 +99,7 @@ func CanWithdrawInvariant(k Keeper) sdk.Invariant {
 
 		broken := len(remaining) > 0 && remaining[0].Amount.LT(sdk.ZeroDec())
 		return sdk.FormatInvariant(types.ModuleName, "can withdraw",
-			fmt.Sprintf("remaining coins: %v", remaining), broken)
+			fmt.Sprintf("remaining coins: %v\n", remaining), broken)
 	}
 }
 
@@ -127,7 +127,7 @@ func ReferenceCountInvariant(k Keeper) sdk.Invariant {
 		broken := count != expected
 
 		return sdk.FormatInvariant(types.ModuleName, "reference count", fmt.Sprintf("unexpected number of historical rewards records: "+
-			"expected %v (%v vals + %v dels + %v slashes), got %v",
+			"expected %v (%v vals + %v dels + %v slashes), got %v\n",
 			expected, valCount, len(dels), slashCount, count), broken)
 	}
 }
@@ -150,6 +150,6 @@ func ModuleAccountInvariant(k Keeper) sdk.Invariant {
 
 		broken := !macc.GetCoins().IsEqual(expectedInt)
 		return sdk.FormatInvariant(types.ModuleName, "ModuleAccount coins", fmt.Sprintf("expected ModuleAccount coins: %s\n"+
-			"\tdistribution ModuleAccount coins : %s", expectedInt, macc.GetCoins()), broken)
+			"\tdistribution ModuleAccount coins : %s\n", expectedInt, macc.GetCoins()), broken)
 	}
 }

--- a/x/distribution/keeper/invariants.go
+++ b/x/distribution/keeper/invariants.go
@@ -149,7 +149,9 @@ func ModuleAccountInvariant(k Keeper) sdk.Invariant {
 		macc := k.GetDistributionAccount(ctx)
 
 		broken := !macc.GetCoins().IsEqual(expectedInt)
-		return sdk.FormatInvariant(types.ModuleName, "ModuleAccount coins", fmt.Sprintf("\texpected ModuleAccount coins: %s\n"+
-			"\tdistribution ModuleAccount coins : %s\n", expectedInt, macc.GetCoins()), broken)
+		return sdk.FormatInvariant(types.ModuleName, "ModuleAccount coins",
+			fmt.Sprintf("\texpected ModuleAccount coins:      %s\n"+
+				"\tdistribution ModuleAccount coins : %s\n",
+				expectedInt, macc.GetCoins()), broken)
 	}
 }

--- a/x/gov/invariants.go
+++ b/x/gov/invariants.go
@@ -34,7 +34,7 @@ func ModuleAccountInvariant(keeper Keeper) sdk.Invariant {
 		broken := !macc.GetCoins().IsEqual(expectedDeposits)
 
 		return sdk.FormatInvariant(types.ModuleName, "deposits",
-			fmt.Sprintf("\tgov ModuleAccount coins: %s\n\tsum of deposit amounts: %s\n",
+			fmt.Sprintf("\tgov ModuleAccount coins: %s\n\tsum of deposit amounts:  %s\n",
 				macc.GetCoins(), expectedDeposits), broken)
 	}
 }

--- a/x/gov/invariants.go
+++ b/x/gov/invariants.go
@@ -34,7 +34,7 @@ func ModuleAccountInvariant(keeper Keeper) sdk.Invariant {
 		broken := !macc.GetCoins().IsEqual(expectedDeposits)
 
 		return sdk.FormatInvariant(types.ModuleName, "deposits",
-			fmt.Sprintf("\tgov ModuleAccount coins: %s\n\tsum of deposit amounts: %s",
+			fmt.Sprintf("\tgov ModuleAccount coins: %s\n\tsum of deposit amounts: %s\n",
 				macc.GetCoins(), expectedDeposits), broken)
 	}
 }

--- a/x/staking/keeper/invariants.go
+++ b/x/staking/keeper/invariants.go
@@ -112,17 +112,17 @@ func NonNegativePowerInvariant(k Keeper) sdk.Invariant {
 			if !bytes.Equal(iterator.Key(), powerKey) {
 				broken = true
 				msg += fmt.Sprintf("power store invariance:\n\tvalidator.Power: %v"+
-					"\n\tkey should be: %v\n\tkey in store: %v",
+					"\n\tkey should be: %v\n\tkey in store: %v\n",
 					validator.GetConsensusPower(), powerKey, iterator.Key())
 			}
 
 			if validator.Tokens.IsNegative() {
 				broken = true
-				msg += fmt.Sprintf("negative tokens for validator: %v", validator)
+				msg += fmt.Sprintf("\tnegative tokens for validator: %v\n", validator)
 			}
 		}
 		iterator.Close()
-		return sdk.FormatInvariant(types.ModuleName, "nonnegative power", msg, broken)
+		return sdk.FormatInvariant(types.ModuleName, "nonnegative power", fmt.Sprintf("found invalid validator powers\n%s", msg), broken)
 	}
 }
 
@@ -130,23 +130,23 @@ func NonNegativePowerInvariant(k Keeper) sdk.Invariant {
 func PositiveDelegationInvariant(k Keeper) sdk.Invariant {
 	return func(ctx sdk.Context) (string, bool) {
 		var msg string
-		var amt int
+		var count int
 
 		delegations := k.GetAllDelegations(ctx)
 		for _, delegation := range delegations {
 			if delegation.Shares.IsNegative() {
-				amt++
+				count++
 				msg += fmt.Sprintf("\tdelegation with negative shares: %+v\n", delegation)
 			}
 			if delegation.Shares.IsZero() {
-				amt++
+				count++
 				msg += fmt.Sprintf("\tdelegation with zero shares: %+v\n", delegation)
 			}
 		}
-		broken := amt != 0
+		broken := count != 0
 
 		return sdk.FormatInvariant(types.ModuleName, "positive delegations", fmt.Sprintf(
-			"%d invalid delegations found\n%s", amt, msg), broken)
+			"%d invalid delegations found\n%s", count, msg), broken)
 	}
 }
 
@@ -173,7 +173,7 @@ func DelegatorSharesInvariant(k Keeper) sdk.Invariant {
 				broken = true
 				msg += fmt.Sprintf("broken delegator shares invariance:\n"+
 					"\tvalidator.DelegatorShares: %v\n"+
-					"\tsum of Delegator.Shares: %v", valTotalDelShares, totalDelShares)
+					"\tsum of Delegator.Shares: %v\n", valTotalDelShares, totalDelShares)
 			}
 		}
 		return sdk.FormatInvariant(types.ModuleName, "delegator shares", msg, broken)

--- a/x/supply/internal/keeper/invariants.go
+++ b/x/supply/internal/keeper/invariants.go
@@ -36,7 +36,7 @@ func TotalSupply(k Keeper) sdk.Invariant {
 		return sdk.FormatInvariant(types.ModuleName, "total supply",
 			fmt.Sprintf(
 				"\tsum of accounts coins: %v\n"+
-					"\tsupply.Total:          %v",
+					"\tsupply.Total:          %v\n",
 				expectedTotal, supply.Total), broken)
 	}
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->
Addresses comments from [here](https://github.com/cosmos/cosmos-sdk/pull/4707#pullrequestreview-260607459)
Example Output:
```
Starting the simulation from time Fri Dec  2 23:09:18 UTC 6783, unixtime 151912624158
Invariants broken after BeginBlock

staking: bonded and not bonded module account coins invariant
	Pool's bonded tokens: 169651462950839
	sum of bonded tokens: 169651462950839
not bonded token invariance:
	Pool's not bonded tokens: 4457903820927
	sum of not bonded tokens: 4457903820927
module accounts total (bonded + not bonded):
	Module Accounts' tokens: 174109366771766
	sum tokens:              174109366771766
invariant broken: false

staking: nonnegative power invariant
found invalid validator powers
invariant broken: false

staking: positive delegations invariant
0 invalid delegations found
invariant broken: false

staking: delegator shares invariant
invariant broken: false

bank: nonnegative-outstanding invariant
amount of negative accounts found 0
invariant broken: false

supply: total supply invariant
	sum of accounts coins: 415285460410817uatom
	supply.Total:          241176093639051uatom
invariant broken: true

distribution: nonnegative outstanding invariant
found 0 validators with negative outstanding rewards
invariant broken: false

distribution: can withdraw invariant
remaining coins: 
invariant broken: false

distribution: reference count invariant
unexpected number of historical rewards records: expected 10372 (176 vals + 10196 dels + 0 slashes), got 10372
invariant broken: false

distribution: ModuleAccount coins invariant
	expected ModuleAccount coins:      100486106210uatom
	distribution ModuleAccount coins : 100486106210uatom
invariant broken: false

gov: deposits invariant
	gov ModuleAccount coins: 686500001uatom
	sum of deposit amounts:  686500001uatom
invariant broken: false

Logs to writing to /home/colinaxner/.simapp/simulations/2019-07-11_12:50:38.log

```
- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/develop/CONTRIBUTING.md#pr-targeting))

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added a relevant changelog entry: `clog add [section] [stanza] [message]`
- [x] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
