### PR TITLE
Fix DefaultUnbondingTime parameter to 3 weeks

### DIFF
--- a/x/staking/types/params.go
+++ b/x/staking/types/params.go
@@ -14,7 +14,7 @@ const (
 	// DefaultUnbondingTime reflects three weeks in seconds as the default
 	// unbonding time.
 	// TODO: Justify our choice of default here.
-	DefaultUnbondingTime time.Duration = time.Second * 60 * 60 * 24 * 3
+	DefaultUnbondingTime time.Duration = time.Second * 60 * 60 * 24 * 7 * 3
 
 	// Default maximum number of bonded validators
 	DefaultMaxValidators uint16 = 100


### PR DESCRIPTION
cosmos-sdk's default unbonding time is 3 weeks as used right now.
But the code is written as 3 days.
DefaultUnbondingTime time.Duration = time.Second * 60 * 60 * 24 * 3

It would be better to fix this line to 3weeks
DefaultUnbondingTime time.Duration = time.Second * 60 * 60 * 24 * 7 * 3