### PR TITLE
Allow substore migrations upon multistore loading

### DIFF
--- a/.pending/features/store/4724-Multistore-supp
+++ b/.pending/features/store/4724-Multistore-supp
@@ -1,4 +1,4 @@
-4724 Multistore supports substore migrations upon load.
+#4724 Multistore supports substore migrations upon load.
 New `rootmulti.Store.LoadLatestVersionAndUpgrade` method
 Baseapp supports `StoreLoader` to enable various upgrade strategies
 No longer panics if the store to load contains substores that we didn't explicitly mount.

--- a/.pending/features/store/4724-Multistore-supp
+++ b/.pending/features/store/4724-Multistore-supp
@@ -1,0 +1,4 @@
+4724 Multistore supports substore migrations upon load.
+New `rootmulti.Store.LoadLatestVersionAndUpgrade` method
+Baseapp supports `StoreLoader` to enable various upgrade strategies
+No longer panics if the store to load contains substores that we didn't explicitly mount.

--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -80,7 +80,7 @@ type BaseApp struct {
 	name        string               // application name from abci.Info
 	db          dbm.DB               // common DB backend
 	cms         sdk.CommitMultiStore // Main (uncached) state
-	storeLoader StoreLoader          // function to handle store loading, may be overriden with SetStoreLoader()
+	storeLoader StoreLoader          // function to handle store loading, may be overridden with SetStoreLoader()
 	router      sdk.Router           // handle any kind of message
 	queryRouter sdk.QueryRouter      // router for redirecting query calls
 	txDecoder   sdk.TxDecoder        // unmarshal []byte into sdk.Tx

--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -44,12 +44,22 @@ const (
 	MainStoreKey = "main"
 )
 
+// StoreLoader defines a customizable function to control how we load the CommitMultiStore
+// from disk
 type StoreLoader func(ms sdk.CommitMultiStore) error
 
+// DefaultStoreLoader will be used by default and loads the latest version
 func DefaultStoreLoader(ms sdk.CommitMultiStore) error {
 	return ms.LoadLatestVersion()
 }
 
+// UpgradeableStoreLoader can be configured by SetStoreLoader() to check for the
+// existence of a given upgrade file - json encoded StoreUpgrades data.
+// If the file if present, parse it and execute those upgrades
+// (rename or delete stores), while loading the data.
+//
+// This is useful for in place migrations when a store key is renamed between
+// two versions of the software.
 func UpgradeableStoreLoader(upgradeInfoPath string) StoreLoader {
 	return func(ms sdk.CommitMultiStore) error {
 		_, err := os.Stat(upgradeInfoPath)

--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -45,7 +45,7 @@ const (
 )
 
 // StoreLoader defines a customizable function to control how we load the CommitMultiStore
-// from disk. This is useful for state migration, when loading a datastore writen with
+// from disk. This is useful for state migration, when loading a datastore written with
 // an older version of the software. In particular, if a module changed the substore key name
 // (or removed a substore) between two versions of the software.
 type StoreLoader func(ms sdk.CommitMultiStore) error

--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -232,7 +232,7 @@ func StoreLoaderWithUpgrade(upgrades *storetypes.StoreUpgrades) StoreLoader {
 // and not re-applied on next restart
 //
 // This is useful for in place migrations when a store key is renamed between
-// two versions of the software. (Note: this code will move to x/upgrades
+// two versions of the software. (TODO: this code will move to x/upgrades
 // when PR #4233 is merged, here mainly to help test the design)
 func UpgradeableStoreLoader(upgradeInfoPath string) StoreLoader {
 	return func(ms sdk.CommitMultiStore) error {
@@ -263,7 +263,7 @@ func UpgradeableStoreLoader(upgradeInfoPath string) StoreLoader {
 		// if we have a successful load, we delete the file
 		err = os.Remove(upgradeInfoPath)
 		if err != nil {
-			return fmt.Errorf("Deleting upgrade file %s: %v", upgradeInfoPath, err)
+			return fmt.Errorf("deleting upgrade file %s: %v", upgradeInfoPath, err)
 		}
 		return nil
 	}

--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -3,7 +3,6 @@ package baseapp
 import (
 	"encoding/json"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"os"
 	"reflect"
@@ -142,17 +141,6 @@ func (app *BaseApp) AppVersion() string {
 // Logger returns the logger of the BaseApp.
 func (app *BaseApp) Logger() log.Logger {
 	return app.logger
-}
-
-// SetCommitMultiStoreTracer sets the store tracer on the BaseApp's underlying
-// CommitMultiStore.
-func (app *BaseApp) SetCommitMultiStoreTracer(w io.Writer) {
-	app.cms.SetTracer(w)
-}
-
-// SetStoreLoader allows us to customize the rootMultiStore initialization.
-func (app *BaseApp) SetStoreLoader(loader StoreLoader) {
-	app.storeLoader = loader
 }
 
 // MountStores mounts all IAVL or DB stores to the provided keys in the BaseApp

--- a/baseapp/baseapp_test.go
+++ b/baseapp/baseapp_test.go
@@ -185,7 +185,7 @@ func TestSetLoader(t *testing.T) {
 	// write a renamer to a file
 	f, err := ioutil.TempFile("", "upgrade-*.json")
 	require.NoError(t, err)
-	data := []byte(`{"renamed":[{"old": "bnk", "new": "banker"}]}`)
+	data := []byte(`{"renamed":[{"old_key": "bnk", "new_key": "banker"}]}`)
 	_, err = f.Write(data)
 	require.NoError(t, err)
 	configName := f.Name()
@@ -1133,7 +1133,6 @@ func TestMaxBlockGasLimits(t *testing.T) {
 	}
 
 	for i, tc := range testCases {
-		fmt.Printf("debug i: %v\n", i)
 		tx := tc.tx
 
 		// reset the block gas

--- a/baseapp/baseapp_test.go
+++ b/baseapp/baseapp_test.go
@@ -4,10 +4,10 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"testing"
 
-	store "github.com/cosmos/cosmos-sdk/store/types"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -17,6 +17,8 @@ import (
 	dbm "github.com/tendermint/tm-db"
 
 	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/store/rootmulti"
+	store "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -129,6 +131,146 @@ func TestLoadVersion(t *testing.T) {
 	app.Commit()
 	testLoadVersionHelper(t, app, int64(2), commitID2)
 }
+
+func useDefaultLoader(app *BaseApp) {
+		app.SetStoreLoader(DefaultStoreLoader)
+}
+
+func useUpgradeLoader(upgrades *store.StoreUpgrades) func(*BaseApp) {
+	return func(app *BaseApp) {
+		app.SetStoreLoader(StoreLoaderWithUpgrade(upgrades))
+	}
+}
+
+func useFileUpgradeLoader(upgradeInfoPath string) func(*BaseApp) {
+	return func(app *BaseApp) {
+		app.SetStoreLoader(UpgradeableStoreLoader(upgradeInfoPath))
+	}
+}
+
+func initStore(t *testing.T, db dbm.DB, storeKey string, k, v []byte) {
+	rs := rootmulti.NewStore(db)
+	rs.SetPruning(store.PruneSyncable)
+	key := sdk.NewKVStoreKey(storeKey)
+	rs.MountStoreWithDB(key, store.StoreTypeIAVL, nil)
+	err := rs.LoadLatestVersion()
+	require.Nil(t, err)
+	require.Equal(t, int64(0), rs.LastCommitID().Version)
+
+	// write some data in substore
+	kv, _ := rs.GetStore(key).(store.KVStore)
+	require.NotNil(t, kv)
+	kv.Set(k, v)
+	commitID := rs.Commit()
+	require.Equal(t, int64(1), commitID.Version)	
+}
+
+func checkStore(t *testing.T, db dbm.DB, ver int64, storeKey string, k, v []byte) {
+	rs := rootmulti.NewStore(db)
+	rs.SetPruning(store.PruneSyncable)
+	key := sdk.NewKVStoreKey(storeKey)
+	rs.MountStoreWithDB(key, store.StoreTypeIAVL, nil)
+	err := rs.LoadLatestVersion()
+	require.Nil(t, err)
+	require.Equal(t, ver, rs.LastCommitID().Version)
+
+	// query data in substore
+	kv, _ := rs.GetStore(key).(store.KVStore)
+	require.NotNil(t, kv)
+	require.Equal(t, v, kv.Get(k))
+}
+
+
+// Test that we can make commits and then reload old versions.
+// Test that LoadLatestVersion actually does.
+func TestSetLoader(t *testing.T) {
+	// write a renamer to a file
+	f, err := ioutil.TempFile("", "upgrade-*.json")
+	require.NoError(t, err)
+	data := []byte(`{"renamed":[{"old": "bnk", "new": "banker"}]}`)
+	_, err = f.Write(data)
+	require.NoError(t, err)
+	configName := f.Name()
+	require.NoError(t, f.Close())
+
+	// make sure it exists before running everything
+	_, err = os.Stat(configName)
+	require.NoError(t, err)
+
+
+	cases := map[string]struct{
+		setLoader func(*BaseApp)
+		origStoreKey string
+		loadStoreKey string
+	}{
+		"don't set loader": {
+			origStoreKey: "foo",
+			loadStoreKey: "foo",
+		},
+		"default loader": {
+			setLoader: useDefaultLoader,
+			origStoreKey: "foo",
+			loadStoreKey: "foo",
+		},
+		"rename with inline opts": {
+			setLoader: useUpgradeLoader(&store.StoreUpgrades{
+				Renamed: []store.StoreRename{{
+					OldKey: "foo",
+					NewKey: "bar",
+				}},
+			}),
+			origStoreKey: "foo",
+			loadStoreKey: "bar",
+		},
+		"file loader with missing file": {
+			setLoader: useFileUpgradeLoader(configName + "randomchars"),
+			origStoreKey: "bnk",
+			loadStoreKey: "bnk",
+		},
+		"file loader with existing file": {
+			setLoader: useFileUpgradeLoader(configName),
+			origStoreKey: "bnk",
+			loadStoreKey: "banker",
+		},
+	}
+
+	k := []byte("key")
+	v := []byte("value")
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			// prepare a db with some data
+			db := dbm.NewMemDB()
+			initStore(t, db, tc.origStoreKey, k, v)
+		
+			// load the app with the existing db
+			opts := []func(*BaseApp){SetPruning(store.PruneSyncable)}
+			if tc.setLoader != nil {
+				opts = append(opts, tc.setLoader)
+			}	
+			app := NewBaseApp(t.Name(), defaultLogger(), db, nil, opts...)
+			capKey := sdk.NewKVStoreKey(MainStoreKey)
+			app.MountStores(capKey)
+			app.MountStores(sdk.NewKVStoreKey(tc.loadStoreKey))
+			err := app.LoadLatestVersion(capKey) 
+			require.Nil(t, err)
+
+			// "execute" one block
+			app.BeginBlock(abci.RequestBeginBlock{Header: abci.Header{Height: 2}})
+			res := app.Commit()
+			require.NotNil(t, res.Data)
+		
+			// check db is properly updated
+			checkStore(t, db, 2, tc.loadStoreKey, k, v)
+			checkStore(t, db, 2, tc.loadStoreKey, []byte("foo"), nil)
+		})
+	}
+
+	// ensure config file was deleted
+	_, err = os.Stat(configName)
+	require.True(t, os.IsNotExist(err))
+}
+
 
 func TestAppVersionSetterGetter(t *testing.T) {
 	logger := defaultLogger()

--- a/baseapp/baseapp_test.go
+++ b/baseapp/baseapp_test.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"testing"
 
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -133,7 +132,7 @@ func TestLoadVersion(t *testing.T) {
 }
 
 func useDefaultLoader(app *BaseApp) {
-		app.SetStoreLoader(DefaultStoreLoader)
+	app.SetStoreLoader(DefaultStoreLoader)
 }
 
 func useUpgradeLoader(upgrades *store.StoreUpgrades) func(*BaseApp) {
@@ -162,7 +161,7 @@ func initStore(t *testing.T, db dbm.DB, storeKey string, k, v []byte) {
 	require.NotNil(t, kv)
 	kv.Set(k, v)
 	commitID := rs.Commit()
-	require.Equal(t, int64(1), commitID.Version)	
+	require.Equal(t, int64(1), commitID.Version)
 }
 
 func checkStore(t *testing.T, db dbm.DB, ver int64, storeKey string, k, v []byte) {
@@ -180,7 +179,6 @@ func checkStore(t *testing.T, db dbm.DB, ver int64, storeKey string, k, v []byte
 	require.Equal(t, v, kv.Get(k))
 }
 
-
 // Test that we can make commits and then reload old versions.
 // Test that LoadLatestVersion actually does.
 func TestSetLoader(t *testing.T) {
@@ -197,9 +195,8 @@ func TestSetLoader(t *testing.T) {
 	_, err = os.Stat(configName)
 	require.NoError(t, err)
 
-
-	cases := map[string]struct{
-		setLoader func(*BaseApp)
+	cases := map[string]struct {
+		setLoader    func(*BaseApp)
 		origStoreKey string
 		loadStoreKey string
 	}{
@@ -208,7 +205,7 @@ func TestSetLoader(t *testing.T) {
 			loadStoreKey: "foo",
 		},
 		"default loader": {
-			setLoader: useDefaultLoader,
+			setLoader:    useDefaultLoader,
 			origStoreKey: "foo",
 			loadStoreKey: "foo",
 		},
@@ -223,12 +220,12 @@ func TestSetLoader(t *testing.T) {
 			loadStoreKey: "bar",
 		},
 		"file loader with missing file": {
-			setLoader: useFileUpgradeLoader(configName + "randomchars"),
+			setLoader:    useFileUpgradeLoader(configName + "randomchars"),
 			origStoreKey: "bnk",
 			loadStoreKey: "bnk",
 		},
 		"file loader with existing file": {
-			setLoader: useFileUpgradeLoader(configName),
+			setLoader:    useFileUpgradeLoader(configName),
 			origStoreKey: "bnk",
 			loadStoreKey: "banker",
 		},
@@ -242,24 +239,24 @@ func TestSetLoader(t *testing.T) {
 			// prepare a db with some data
 			db := dbm.NewMemDB()
 			initStore(t, db, tc.origStoreKey, k, v)
-		
+
 			// load the app with the existing db
 			opts := []func(*BaseApp){SetPruning(store.PruneSyncable)}
 			if tc.setLoader != nil {
 				opts = append(opts, tc.setLoader)
-			}	
+			}
 			app := NewBaseApp(t.Name(), defaultLogger(), db, nil, opts...)
 			capKey := sdk.NewKVStoreKey(MainStoreKey)
 			app.MountStores(capKey)
 			app.MountStores(sdk.NewKVStoreKey(tc.loadStoreKey))
-			err := app.LoadLatestVersion(capKey) 
+			err := app.LoadLatestVersion(capKey)
 			require.Nil(t, err)
 
 			// "execute" one block
 			app.BeginBlock(abci.RequestBeginBlock{Header: abci.Header{Height: 2}})
 			res := app.Commit()
 			require.NotNil(t, res.Data)
-		
+
 			// check db is properly updated
 			checkStore(t, db, 2, tc.loadStoreKey, k, v)
 			checkStore(t, db, 2, tc.loadStoreKey, []byte("foo"), nil)
@@ -270,7 +267,6 @@ func TestSetLoader(t *testing.T) {
 	_, err = os.Stat(configName)
 	require.True(t, os.IsNotExist(err))
 }
-
 
 func TestAppVersionSetterGetter(t *testing.T) {
 	logger := defaultLogger()

--- a/baseapp/options.go
+++ b/baseapp/options.go
@@ -3,6 +3,7 @@ package baseapp
 
 import (
 	"fmt"
+	"io"
 
 	dbm "github.com/tendermint/tm-db"
 
@@ -109,4 +110,18 @@ func (app *BaseApp) SetFauxMerkleMode() {
 		panic("SetFauxMerkleMode() on sealed BaseApp")
 	}
 	app.fauxMerkleMode = true
+}
+
+// SetCommitMultiStoreTracer sets the store tracer on the BaseApp's underlying
+// CommitMultiStore.
+func (app *BaseApp) SetCommitMultiStoreTracer(w io.Writer) {
+	app.cms.SetTracer(w)
+}
+
+// SetStoreLoader allows us to customize the rootMultiStore initialization.
+func (app *BaseApp) SetStoreLoader(loader StoreLoader) {
+	if app.sealed {
+		panic("SetStoreLoader() on sealed BaseApp")
+	}
+	app.storeLoader = loader
 }

--- a/server/mock/store.go
+++ b/server/mock/store.go
@@ -75,6 +75,10 @@ func (ms multiStore) LoadLatestVersionAndUpgrade(upgrades *store.StoreUpgrades) 
 	return nil
 }
 
+func (ms multiStore) LoadVersionAndUpgrade(ver int64, upgrades *store.StoreUpgrades) error {
+	panic("not implemented")
+}
+
 func (ms multiStore) LoadVersion(ver int64) error {
 	panic("not implemented")
 }

--- a/server/mock/store.go
+++ b/server/mock/store.go
@@ -5,6 +5,7 @@ import (
 
 	dbm "github.com/tendermint/tm-db"
 
+	store "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -67,6 +68,10 @@ func (ms multiStore) MountStoreWithDB(key sdk.StoreKey, typ sdk.StoreType, db db
 }
 
 func (ms multiStore) LoadLatestVersion() error {
+	return nil
+}
+
+func (ms multiStore) LoadLatestVersionAndUpgrade(upgrades *store.StoreUpgrades) error {
 	return nil
 }
 

--- a/store/rootmulti/store.go
+++ b/store/rootmulti/store.go
@@ -148,7 +148,9 @@ func (rs *Store) loadVersion(ver int64, upgrades *types.StoreUpgrades) error {
 
 		// If it was deleted, remove all data
 		if upgrades.IsDeleted(key.Name()) {
-			deleteKVStore(store.(types.KVStore))
+			if err := deleteKVStore(store.(types.KVStore)); err != nil {
+				return fmt.Errorf("failed to delete store %s: %v", key.Name(), err)
+			}
 		} else if oldName := upgrades.RenamedFrom(key.Name()); oldName != "" {
 			// handle renames specially
 			// make an unregistered key to satify loadCommitStore params
@@ -163,7 +165,9 @@ func (rs *Store) loadVersion(ver int64, upgrades *types.StoreUpgrades) error {
 			}
 
 			// move all data
-			moveKVStoreData(oldStore.(types.KVStore), store.(types.KVStore))
+			if err := moveKVStoreData(oldStore.(types.KVStore), store.(types.KVStore)); err != nil {
+				return fmt.Errorf("failed to move store %s -> %s: %v", oldName, key.Name(), err)
+			}
 		}
 	}
 

--- a/store/rootmulti/store.go
+++ b/store/rootmulti/store.go
@@ -100,14 +100,24 @@ func (rs *Store) GetCommitKVStore(key types.StoreKey) types.CommitKVStore {
 	return rs.stores[key].(types.CommitKVStore)
 }
 
-// Implements CommitMultiStore.
-func (rs *Store) LoadLatestVersion() error {
+// LoadLatestVersionAndUpgrade implements CommitMultiStore
+func (rs *Store) LoadLatestVersionAndUpgrade(upgrades *types.StoreUpgrades) error {
 	ver := getLatestVersion(rs.db)
-	return rs.LoadVersion(ver)
+	return rs.loadVersion(ver, upgrades)
 }
 
-// Implements CommitMultiStore.
+// LoadLatestVersion implements CommitMultiStore.
+func (rs *Store) LoadLatestVersion() error {
+	ver := getLatestVersion(rs.db)
+	return rs.loadVersion(ver, nil)
+}
+
+// LoadVersion implements CommitMultiStore.
 func (rs *Store) LoadVersion(ver int64) error {
+	return rs.loadVersion(ver, nil)
+}
+
+func (rs *Store) loadVersion(ver int64, upgrades *types.StoreUpgrades) error {
 	if ver == 0 {
 		// Special logic for version 0 where there is no need to get commit
 		// information.
@@ -127,6 +137,11 @@ func (rs *Store) LoadVersion(ver int64) error {
 	cInfo, err := getCommitInfo(rs.db, ver)
 	if err != nil {
 		return err
+	}
+
+	if upgrades != nil {
+		// TODO: run upgrades if present
+
 	}
 
 	// convert StoreInfos slice to map

--- a/store/rootmulti/store.go
+++ b/store/rootmulti/store.go
@@ -106,6 +106,11 @@ func (rs *Store) LoadLatestVersionAndUpgrade(upgrades *types.StoreUpgrades) erro
 	return rs.loadVersion(ver, upgrades)
 }
 
+// LoadVersionAndUpgrade allows us to rename substores while loading an older version
+func (rs *Store) LoadVersionAndUpgrade(ver int64, upgrades *types.StoreUpgrades) error {
+	return rs.loadVersion(ver, upgrades)
+}
+
 // LoadLatestVersion implements CommitMultiStore.
 func (rs *Store) LoadLatestVersion() error {
 	ver := getLatestVersion(rs.db)

--- a/store/rootmulti/store.go
+++ b/store/rootmulti/store.go
@@ -475,15 +475,6 @@ func (rs *Store) loadCommitStoreFromParams(key types.StoreKey, id types.CommitID
 	}
 }
 
-func (rs *Store) nameToKey(name string) types.StoreKey {
-	for key := range rs.storesParams {
-		if key.Name() == name {
-			return key
-		}
-	}
-	panic("Unknown name " + name)
-}
-
 //----------------------------------------
 // storeParams
 

--- a/store/rootmulti/store_test.go
+++ b/store/rootmulti/store_test.go
@@ -215,9 +215,9 @@ func TestMultistoreLoadWithUpgrade(t *testing.T) {
 	require.Nil(t, st2)
 
 	// restore2 has the old data
-	rs1, _ := restore.getStoreByName("restore2").(types.KVStore)
-	require.NotNil(t, rs1)
-	require.Equal(t, v1, rs1.Get(k1))
+	rs2, _ := restore.getStoreByName("restore2").(types.KVStore)
+	require.NotNil(t, rs2)
+	require.Equal(t, v2, rs2.Get(k2))
 }
 
 func TestParsePath(t *testing.T) {

--- a/store/rootmulti/store_test.go
+++ b/store/rootmulti/store_test.go
@@ -208,7 +208,7 @@ func TestMultistoreLoadWithUpgrade(t *testing.T) {
 	// store3 is mounted, but data deleted are gone
 	s3, _ = restore.getStoreByName("store3").(types.KVStore)
 	require.NotNil(t, s3)
-	require.Equal(t, nil, s3.Get(k3)) // data was deleted
+	require.Nil(t, s3.Get(k3)) // data was deleted
 
 	// store2 is no longer mounted
 	st2 := restore.getStoreByName("store2")

--- a/store/rootmulti/store_test.go
+++ b/store/rootmulti/store_test.go
@@ -249,7 +249,6 @@ func TestMultistoreLoadWithUpgrade(t *testing.T) {
 	require.Equal(t, int64(2), ci.Version)
 	require.Equal(t, 3, len(ci.StoreInfos), ci.StoreInfos)
 	checkContains(t, ci.StoreInfos, []string{"store1", "restore2", "store3"})
-	require.Equal(t, "restore2", ci.StoreInfos[1].Name)
 }
 
 func TestParsePath(t *testing.T) {

--- a/store/rootmulti/store_test.go
+++ b/store/rootmulti/store_test.go
@@ -218,6 +218,25 @@ func TestMultistoreLoadWithUpgrade(t *testing.T) {
 	rs2, _ := restore.getStoreByName("restore2").(types.KVStore)
 	require.NotNil(t, rs2)
 	require.Equal(t, v2, rs2.Get(k2))
+
+	// store this migrated data, and load it again without migrations
+	migratedID := restore.Commit()
+	require.Equal(t, migratedID.Version, int64(2))
+
+	reload, _ := newMultiStoreWithModifiedMounts(db)
+	err = reload.LoadLatestVersion()
+	require.Nil(t, err)
+	require.Equal(t, migratedID, reload.LastCommitID())
+
+	// query this new store
+	rl1, _ := reload.getStoreByName("store1").(types.KVStore)
+	require.NotNil(t, rl1)
+	require.Equal(t, v1, rl1.Get(k1))
+
+	rl2, _ := reload.getStoreByName("restore2").(types.KVStore)
+	require.NotNil(t, rl2)
+	require.Equal(t, v2, rl2.Get(k2))
+
 }
 
 func TestParsePath(t *testing.T) {

--- a/store/types/store.go
+++ b/store/types/store.go
@@ -38,15 +38,18 @@ type Queryable interface {
 //----------------------------------------
 // MultiStore
 
+// StoreUpgrades defines a series of transformations to apply the multistore db upon load
 type StoreUpgrades struct {
-	New     []string
-	Renamed []StoreRename
-	Deleted []string
+	Renamed []StoreRename `json:"renamed"`
+	Deleted []string      `json:"deleted"`
 }
 
+// StoreRename defines a name change of a sub-store.
+// All data previously under a PrefixStore with OldKey will be copied
+// to a PrefixStore with NewKey, then deleted from OldKey store.
 type StoreRename struct {
-	OldKey string
-	NewKey string
+	OldKey string `json:"old"`
+	NewKey string `json:"new"`
 }
 
 // IsDeleted returns true if the given key should be deleted

--- a/store/types/store.go
+++ b/store/types/store.go
@@ -38,6 +38,17 @@ type Queryable interface {
 //----------------------------------------
 // MultiStore
 
+type StoreUpgrades struct {
+	New     []StoreKey
+	Renamed []StoreRename
+	Deleted []StoreKey
+}
+
+type StoreRename struct {
+	OldKey StoreKey
+	NewKey StoreKey
+}
+
 type MultiStore interface { //nolint
 	Store
 
@@ -93,6 +104,11 @@ type CommitMultiStore interface {
 	// Load the latest persisted version. Called once after all calls to
 	// Mount*Store() are complete.
 	LoadLatestVersion() error
+
+	// LoadLatestVersionAndUpgrade will load the latest version, but also
+	// rename/delete/create sub-store keys, before registering all the keys
+	// in order to handle breaking formats in migrations
+	LoadLatestVersionAndUpgrade(upgrades *StoreUpgrades) error
 
 	// Load a specific persisted version. When you load an old version, or when
 	// the last commit attempt didn't complete, the next commit after loading

--- a/store/types/store.go
+++ b/store/types/store.go
@@ -39,14 +39,14 @@ type Queryable interface {
 // MultiStore
 
 type StoreUpgrades struct {
-	New     []StoreKey
+	New     []string
 	Renamed []StoreRename
-	Deleted []StoreKey
+	Deleted []string
 }
 
 type StoreRename struct {
-	OldKey StoreKey
-	NewKey StoreKey
+	OldKey string
+	NewKey string
 }
 
 type MultiStore interface { //nolint

--- a/store/types/store.go
+++ b/store/types/store.go
@@ -49,6 +49,34 @@ type StoreRename struct {
 	NewKey string
 }
 
+// IsDeleted returns true if the given key should be deleted
+func (s *StoreUpgrades) IsDeleted(key string) bool {
+	if s == nil {
+		return false
+	}
+	for _, d := range s.Deleted {
+		if d == key {
+			return true
+		}
+	}
+	return false
+}
+
+// RenamedFrom returns the oldKey if it was renamed
+// Returns "" if it was not renamed
+func (s *StoreUpgrades) RenamedFrom(key string) string {
+	if s == nil {
+		return ""
+	}
+	for _, re := range s.Renamed {
+		if re.NewKey == key {
+			return re.OldKey
+		}
+	}
+	return ""
+
+}
+
 type MultiStore interface { //nolint
 	Store
 

--- a/store/types/store.go
+++ b/store/types/store.go
@@ -141,6 +141,11 @@ type CommitMultiStore interface {
 	// in order to handle breaking formats in migrations
 	LoadLatestVersionAndUpgrade(upgrades *StoreUpgrades) error
 
+	// LoadVersionAndUpgrade will load the named version, but also
+	// rename/delete/create sub-store keys, before registering all the keys
+	// in order to handle breaking formats in migrations
+	LoadVersionAndUpgrade(ver int64, upgrades *StoreUpgrades) error
+
 	// Load a specific persisted version. When you load an old version, or when
 	// the last commit attempt didn't complete, the next commit after loading
 	// must be idempotent (return the same commit id). Otherwise the behavior is

--- a/store/types/store.go
+++ b/store/types/store.go
@@ -48,8 +48,8 @@ type StoreUpgrades struct {
 // All data previously under a PrefixStore with OldKey will be copied
 // to a PrefixStore with NewKey, then deleted from OldKey store.
 type StoreRename struct {
-	OldKey string `json:"old"`
-	NewKey string `json:"new"`
+	OldKey string `json:"old_key"`
+	NewKey string `json:"new_key"`
 }
 
 // IsDeleted returns true if the given key should be deleted

--- a/store/types/store_test.go
+++ b/store/types/store_test.go
@@ -1,0 +1,56 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStoreUpgrades(t *testing.T) {
+	type toDelete struct {
+		key    string
+		delete bool
+	}
+	type toRename struct {
+		newkey string
+		result string
+	}
+
+	cases := map[string]struct {
+		upgrades     *StoreUpgrades
+		expectDelete []toDelete
+		expectRename []toRename
+	}{
+		"empty upgrade": {
+			expectDelete: []toDelete{{"foo", false}},
+			expectRename: []toRename{{"foo", ""}},
+		},
+		"simple matches": {
+			upgrades: &StoreUpgrades{
+				Deleted: []string{"foo"},
+				Renamed: []StoreRename{{"bar", "baz"}},
+			},
+			expectDelete: []toDelete{{"foo", true}, {"bar", false}, {"baz", false}},
+			expectRename: []toRename{{"foo", ""}, {"bar", ""}, {"baz", "bar"}},
+		},
+		"many data points": {
+			upgrades: &StoreUpgrades{
+				Deleted: []string{"one", "two", "three", "four", "five"},
+				Renamed: []StoreRename{{"old", "new"}, {"white", "blue"}, {"black", "orange"}, {"fun", "boring"}},
+			},
+			expectDelete: []toDelete{{"four", true}, {"six", false}, {"baz", false}},
+			expectRename: []toRename{{"white", ""}, {"blue", "white"}, {"boring", "fun"}, {"missing", ""}},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			for _, d := range tc.expectDelete {
+				assert.Equal(t, tc.upgrades.IsDeleted(d.key), d.delete)
+			}
+			for _, r := range tc.expectRename {
+				assert.Equal(t, tc.upgrades.RenamedFrom(r.newkey), r.result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

This is needed for the regen upgrade module (#4233), as there are cases (eg. 0.34 -> 0.36) where a substore is renamed (distr -> distribution). The current master panics when trying to read the store with an unknown key. This no longer panics, and allows the user to pass in a set of rename steps to actually rename the store upon loading (so other data migration steps of individual items can function) 

Provides a few different store loaders for testing and demonstration purposes. This actual functionality probably doesn't make too much sense to an end-user until #4233 is merged, but it may be needed in cases where one does want to rename stores before doing some debugging.

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/develop/CONTRIBUTING.md#pr-targeting))

- [x] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [x] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [x] Added a relevant changelog entry: `clog add [section] [stanza] [message]`
- [x] rereviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
