### PR TITLE
Cosmos reDecAmt allow to get integer

### DIFF
--- a/types/coin.go
+++ b/types/coin.go
@@ -592,7 +592,7 @@ var (
 	// Denominations can be 3 ~ 16 characters long.
 	reDnmString = `[a-z][a-z0-9]{2,15}`
 	reAmt       = `[[:digit:]]+`
-	reDecAmt    = `[[:digit:]]*\.[[:digit:]]+`
+	reDecAmt    = `[[:digit:]]*\.?[[:digit:]]+`
 	reSpc       = `[[:space:]]*`
 	reDnm       = regexp.MustCompile(fmt.Sprintf(`^%s$`, reDnmString))
 	reCoin      = regexp.MustCompile(fmt.Sprintf(`^(%s)%s(%s)$`, reAmt, reSpc, reDnmString))

--- a/x/staking/types/params.go
+++ b/x/staking/types/params.go
@@ -14,7 +14,7 @@ const (
 	// DefaultUnbondingTime reflects three weeks in seconds as the default
 	// unbonding time.
 	// TODO: Justify our choice of default here.
-	DefaultUnbondingTime time.Duration = time.Second * 60 * 60 * 24 * 3
+	DefaultUnbondingTime time.Duration = time.Second * 60 * 60 * 24 * 7 * 3
 
 	// Default maximum number of bonded validators
 	DefaultMaxValidators uint16 = 100


### PR DESCRIPTION
Current code can not accept non-float number as a minimum gas price.

For example, If I put "1coin" as a minimum gas price it throws an error. To prevent this error user needs to put "1.0coin" which is useless.

I suggest to allow user put non-float number(integer) as a minimum gas price.
