### PR TITLE
Fix Height Queries

### DIFF
--- a/.pending/breaking/_All-REST-responses-
+++ b/.pending/breaking/_All-REST-responses-
@@ -1,0 +1,2 @@
+All REST responses now wrap the original resource/result. The response
+will contain two fields: height and result.

--- a/.pending/bugfixes/_Return-height-in-re
+++ b/.pending/bugfixes/_Return-height-in-re
@@ -1,0 +1,1 @@
+Return height in responses when querying against BaseApp

--- a/client/context/query.go
+++ b/client/context/query.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/cosmos/cosmos-sdk/client/rpc"
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/crypto/merkle"
 	cmn "github.com/tendermint/tendermint/libs/common"
@@ -79,6 +80,16 @@ func (ctx CLIContext) query(path string, key cmn.HexBytes) (res []byte, height i
 	node, err := ctx.GetNode()
 	if err != nil {
 		return res, height, err
+	}
+
+	// When a client did not provide a query height, manually query for it so it can
+	// be injected downstream into responses.
+	if ctx.Height == 0 {
+		height, err := rpc.GetChainHeight(ctx)
+		if err != nil {
+			return res, height, err
+		}
+		ctx = ctx.WithHeight(height)
 	}
 
 	opts := rpcclient.ABCIQueryOptions{

--- a/client/context/query.go
+++ b/client/context/query.go
@@ -88,9 +88,6 @@ func (ctx CLIContext) query(path string, key cmn.HexBytes) (res []byte, height i
 		if err != nil {
 			return res, height, err
 		}
-		if status.SyncInfo.CatchingUp {
-			return res, height, errors.New("node catching up")
-		}
 		ctx = ctx.WithHeight(status.SyncInfo.LatestBlockHeight)
 	}
 

--- a/types/rest/rest.go
+++ b/types/rest/rest.go
@@ -31,6 +31,14 @@ type ResponseWithHeight struct {
 	Result json.RawMessage `json:"result"`
 }
 
+// NewResponseWithHeight creates a new ResponseWithHeight instance
+func NewResponseWithHeight(height int64, result json.RawMessage) ResponseWithHeight {
+	return ResponseWithHeight{
+		Height: height,
+		Result: result,
+	}
+}
+
 // GasEstimateResponse defines a response definition for tx gas estimation.
 type GasEstimateResponse struct {
 	GasEstimate uint64 `json:"gas_estimate"`
@@ -258,10 +266,7 @@ func PostProcessResponse(w http.ResponseWriter, cliCtx context.CLIContext, resp 
 		}
 	}
 
-	wrappedResp := ResponseWithHeight{
-		Height: cliCtx.Height,
-		Result: result,
-	}
+	wrappedResp := NewResponseWithHeight(cliCtx.Height, result)
 
 	var (
 		output []byte

--- a/types/rest/rest.go
+++ b/types/rest/rest.go
@@ -24,6 +24,13 @@ const (
 	DefaultLimit = 30 // should be consistent with tendermint/tendermint/rpc/core/pipe.go:19
 )
 
+// ResponseWithHeight defines a response object type that wraps an original
+// response with a height.
+type ResponseWithHeight struct {
+	Height int64           `json:"height"`
+	Result json.RawMessage `json:"result"`
+}
+
 // GasEstimateResponse defines a response definition for tx gas estimation.
 type GasEstimateResponse struct {
 	GasEstimate uint64 `json:"gas_estimate"`
@@ -222,28 +229,27 @@ func ParseQueryHeightOrReturnBadRequest(w http.ResponseWriter, cliCtx context.CL
 	return cliCtx, true
 }
 
-// PostProcessResponse performs post processing for a REST response.
-// If the height is greater than zero it will be injected into the body
-// of the response. An internal server error is written to the response
-// if the height is negative or an encoding/decoding error occurs.
-func PostProcessResponse(w http.ResponseWriter, cliCtx context.CLIContext, response interface{}) {
-	var output []byte
+// PostProcessResponse performs post processing for a REST response. The result
+// returned to clients will contain two fields, the height at which the resource
+// was queried at and the original result.
+func PostProcessResponse(w http.ResponseWriter, cliCtx context.CLIContext, resp interface{}) {
+	var result []byte
 
 	if cliCtx.Height < 0 {
 		WriteErrorResponse(w, http.StatusInternalServerError, fmt.Errorf("negative height in response").Error())
 		return
 	}
 
-	switch response.(type) {
+	switch resp.(type) {
 	case []byte:
-		output = response.([]byte)
+		result = resp.([]byte)
 
 	default:
 		var err error
 		if cliCtx.Indent {
-			output, err = cliCtx.Codec.MarshalJSONIndent(response, "", "  ")
+			result, err = cliCtx.Codec.MarshalJSONIndent(resp, "", "  ")
 		} else {
-			output, err = cliCtx.Codec.MarshalJSON(response)
+			result, err = cliCtx.Codec.MarshalJSON(resp)
 		}
 
 		if err != nil {
@@ -252,29 +258,25 @@ func PostProcessResponse(w http.ResponseWriter, cliCtx context.CLIContext, respo
 		}
 	}
 
-	// inject the height into the response by:
-	// - decoding into a map
-	// - adding the height to the map
-	// - encoding using standard JSON library
-	if cliCtx.Height > 0 {
-		m := make(map[string]interface{})
-		err := json.Unmarshal(output, &m)
-		if err != nil {
-			WriteErrorResponse(w, http.StatusInternalServerError, err.Error())
-			return
-		}
+	wrappedResp := ResponseWithHeight{
+		Height: cliCtx.Height,
+		Result: result,
+	}
 
-		m["height"] = cliCtx.Height
+	var (
+		output []byte
+		err    error
+	)
 
-		if cliCtx.Indent {
-			output, err = json.MarshalIndent(m, "", "  ")
-		} else {
-			output, err = json.Marshal(m)
-		}
-		if err != nil {
-			WriteErrorResponse(w, http.StatusInternalServerError, err.Error())
-			return
-		}
+	if cliCtx.Indent {
+		output, err = json.MarshalIndent(wrappedResp, "", "  ")
+	} else {
+		output, err = json.Marshal(wrappedResp)
+	}
+
+	if err != nil {
+		WriteErrorResponse(w, http.StatusInternalServerError, err.Error())
+		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/types/rest/rest.go
+++ b/types/rest/rest.go
@@ -269,9 +269,9 @@ func PostProcessResponse(w http.ResponseWriter, cliCtx context.CLIContext, resp 
 	)
 
 	if cliCtx.Indent {
-		output, err = json.MarshalIndent(wrappedResp, "", "  ")
+		output, err = cliCtx.Codec.MarshalJSONIndent(wrappedResp, "", "  ")
 	} else {
-		output, err = json.Marshal(wrappedResp)
+		output, err = cliCtx.Codec.MarshalJSON(wrappedResp)
 	}
 
 	if err != nil {

--- a/types/rest/rest_test.go
+++ b/types/rest/rest_test.go
@@ -177,8 +177,8 @@ func TestProcessPostResponse(t *testing.T) {
 	require.Nil(t, err)
 	jsonWithIndent, err := ctx.Codec.MarshalJSONIndent(acc, "", "  ")
 	require.Nil(t, err)
-	respNoIndent := ResponseWithHeight{height, jsonNoIndent}
-	respWithIndent := ResponseWithHeight{height, jsonWithIndent}
+	respNoIndent := NewResponseWithHeight(height, jsonNoIndent)
+	respWithIndent := NewResponseWithHeight(height, jsonWithIndent)
 	expectedNoIndent, err := ctx.Codec.MarshalJSON(respNoIndent)
 	require.Nil(t, err)
 	expectedWithIndent, err := ctx.Codec.MarshalJSONIndent(respWithIndent, "", "  ")

--- a/types/rest/rest_test.go
+++ b/types/rest/rest_test.go
@@ -3,12 +3,10 @@
 package rest
 
 import (
-	"encoding/json"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
-	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -173,23 +171,17 @@ func TestProcessPostResponse(t *testing.T) {
 	cdc.RegisterConcrete(&mockAccount{}, "cosmos-sdk/mockAccount", nil)
 	ctx = ctx.WithCodec(cdc)
 
-	// setup expected json responses with zero height
-	jsonNoHeight, err := cdc.MarshalJSON(acc)
+	// setup expected results
+	jsonNoIndent, err := ctx.Codec.MarshalJSON(acc)
 	require.Nil(t, err)
-	require.NotNil(t, jsonNoHeight)
-	jsonIndentNoHeight, err := cdc.MarshalJSONIndent(acc, "", "  ")
+	jsonWithIndent, err := ctx.Codec.MarshalJSONIndent(acc, "", "  ")
 	require.Nil(t, err)
-	require.NotNil(t, jsonIndentNoHeight)
-
-	// decode into map to order alphabetically
-	m := make(map[string]interface{})
-	err = json.Unmarshal(jsonNoHeight, &m)
+	respNoIndent := ResponseWithHeight{height, jsonNoIndent}
+	respWithIndent := ResponseWithHeight{height, jsonWithIndent}
+	expectedNoIndent, err := ctx.Codec.MarshalJSON(respNoIndent)
 	require.Nil(t, err)
-	jsonMap, err := json.Marshal(m)
+	expectedWithIndent, err := ctx.Codec.MarshalJSONIndent(respWithIndent, "", "  ")
 	require.Nil(t, err)
-	jsonWithHeight := append(append([]byte(`{"height":`), []byte(strconv.Itoa(int(height))+",")...), jsonMap[1:]...)
-	jsonIndentMap, err := json.MarshalIndent(m, "", "  ")
-	jsonIndentWithHeight := append(append([]byte(`{`+"\n "+` "height": `), []byte(strconv.Itoa(int(height))+",")...), jsonIndentMap[1:]...)
 
 	// check that negative height writes an error
 	w := httptest.NewRecorder()
@@ -197,16 +189,11 @@ func TestProcessPostResponse(t *testing.T) {
 	PostProcessResponse(w, ctx, acc)
 	require.Equal(t, http.StatusInternalServerError, w.Code)
 
-	// check that zero height returns expected response
-	ctx = ctx.WithHeight(0)
-	runPostProcessResponse(t, ctx, acc, jsonNoHeight, false)
-	// check zero height with indent
-	runPostProcessResponse(t, ctx, acc, jsonIndentNoHeight, true)
 	// check that height returns expected response
 	ctx = ctx.WithHeight(height)
-	runPostProcessResponse(t, ctx, acc, jsonWithHeight, false)
+	runPostProcessResponse(t, ctx, acc, expectedNoIndent, false)
 	// check height with indent
-	runPostProcessResponse(t, ctx, acc, jsonIndentWithHeight, true)
+	runPostProcessResponse(t, ctx, acc, expectedWithIndent, true)
 }
 
 // asserts that ResponseRecorder returns the expected code and body


### PR DESCRIPTION
Thanks for pairing with me on this @alexanderbez. The approach here is to first query for the height if it is not provided and then make queries use that height. This results in atomic queries w/ height getting properly returned.

closes: #4773