### PR TITLE
Rely on rpcserver.DefaultConfig() to inherit default config values

### DIFF
--- a/client/lcd/root.go
+++ b/client/lcd/root.go
@@ -54,11 +54,10 @@ func (rs *RestServer) Start(listenAddr string, maxOpen int, readTimeout, writeTi
 		rs.log.Error("error closing listener", "err", err)
 	})
 
-	cfg := &rpcserver.Config{
-		MaxOpenConnections: maxOpen,
-		ReadTimeout:        time.Duration(readTimeout) * time.Second,
-		WriteTimeout:       time.Duration(writeTimeout) * time.Second,
-	}
+	cfg := rpcserver.DefaultConfig()
+	cfg.MaxOpenConnections = maxOpen
+	cfg.ReadTimeout = time.Duration(readTimeout) * time.Second
+	cfg.WriteTimeout = time.Duration(writeTimeout) * time.Second
 
 	rs.listener, err = rpcserver.Listen(listenAddr, cfg)
 	if err != nil {


### PR DESCRIPTION
This fixes a small regression inadvertently introduced
in 99df748dda8c8 that caused the REST server to return
"http: request body too large" on POST requests handling.

closes: #4845

----

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added a relevant changelog entry: `clog add [section] [-t <tag>] [-m <msg>]`
- [ ] Re-reviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
