### PR TITLE
Create sdk.Result from any error type

### DIFF
--- a/types/errors.go
+++ b/types/errors.go
@@ -250,10 +250,14 @@ func (err *sdkError) Code() CodeType {
 // Implements ABCIError.
 func (err *sdkError) ABCILog() string {
 	errMsg := err.cmnError.Error()
+	return encodeErrorLog(err.codespace, err.code, errMsg)
+}
+
+func encodeErrorLog(codespace CodespaceType, code CodeType, msg string) string {
 	jsonErr := humanReadableError{
-		Codespace: err.codespace,
-		Code:      err.code,
-		Message:   errMsg,
+		Codespace: codespace,
+		Code:      code,
+		Message:   msg,
 	}
 
 	var buff bytes.Buffer
@@ -298,7 +302,7 @@ func ResultFromError(err error) Result {
 	return Result{
 		Codespace: CodespaceType(space),
 		Code:      CodeType(code),
-		Log:       log,
+		Log:       encodeErrorLog(CodespaceType(space), CodeType(code), log),
 	}
 }
 

--- a/types/errors_test.go
+++ b/types/errors_test.go
@@ -114,7 +114,7 @@ func TestResultFromError(t *testing.T) {
 			expect: Result{
 				Codespace: CodespaceRoot,
 				Code:      CodeUnauthorized,
-				Log:       "not owner: unauthorized",
+				Log:       `{"codespace":"sdk","code":4,"message":"not owner: unauthorized"}`,
 			},
 		},
 		"stdlib errors": {
@@ -123,7 +123,7 @@ func TestResultFromError(t *testing.T) {
 				Codespace: CodespaceType("undefined"),
 				Code:      CodeInternal,
 				// note that we redact the internal errors in the new package to not leak eg. panics
-				Log: "internal error",
+				Log: `{"codespace":"undefined","code":1,"message":"internal error"}`,
 			},
 		},
 	}

--- a/types/errors_test.go
+++ b/types/errors_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
 
 var codeTypes = []CodeType{
@@ -91,5 +93,45 @@ func TestAppendMsgToErr(t *testing.T) {
 			),
 			msg,
 			fmt.Sprintf("Should have formatted the error message of ABCI Log. tc #%d", i))
+	}
+}
+
+func TestResultFromError(t *testing.T) {
+	cases := map[string]struct {
+		err    error
+		expect Result
+	}{
+		"sdk.Error": {
+			err: ErrUnauthorized("not owner"),
+			expect: Result{
+				Codespace: CodespaceRoot,
+				Code:      CodeUnauthorized,
+				Log:       `{"codespace":"sdk","code":4,"message":"not owner"}`,
+			},
+		},
+		"types/errors": {
+			err: sdkerrors.Wrap(sdkerrors.ErrUnauthorized, "not owner"),
+			expect: Result{
+				Codespace: CodespaceRoot,
+				Code:      CodeUnauthorized,
+				Log:       "not owner: unauthorized",
+			},
+		},
+		"stdlib errors": {
+			err: fmt.Errorf("not owner"),
+			expect: Result{
+				Codespace: CodespaceType("undefined"),
+				Code:      CodeInternal,
+				// note that we redact the internal errors in the new package to not leak eg. panics
+				Log: "internal error",
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			res := ResultFromError(tc.err)
+			require.Equal(t, tc.expect, res)
+		})
 	}
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Implements the first part of #4844 (the non-breaking enhancement to transform any error into a Result). Maintain the current log format (json) and types/errors behaves almost identical to sdk error (just a bit more info in log, via Wrap). 

I can add a clog entry if needed, but this is really just internal code to support later refactoring. Just wanted to do it while I still had the types/errors package in my head.

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/develop/CONTRIBUTING.md#pr-targeting))

- [x] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [x] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added a relevant changelog entry: `clog add [section] [-t <tag>] [-m <msg>]`
- [x] Re-reviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
