### PR TITLE
Disable "withdraw-all-rewards" command when "--generate-only" is supplied

### DIFF
--- a/.pending/bugfixes/cli/_4870-Disable-the-wi
+++ b/.pending/bugfixes/cli/_4870-Disable-the-wi
@@ -1,0 +1,1 @@
+#4870 Disable the `withdraw-all-rewards` command when `--generate-only` is supplied

--- a/x/distribution/client/cli/tx.go
+++ b/x/distribution/client/cli/tx.go
@@ -143,6 +143,8 @@ $ %s tx distr withdraw-all-rewards --from mykey
 
 			delAddr := cliCtx.GetFromAddress()
 
+			// The transaction cannot be generated offline since it requires a query
+			// to get all the validators.
 			if cliCtx.GenerateOnly {
 				return fmt.Errorf("command disabled with the provided flag: %s", client.FlagGenerateOnly)
 			}

--- a/x/distribution/client/cli/tx.go
+++ b/x/distribution/client/cli/tx.go
@@ -138,11 +138,15 @@ $ %s tx distr withdraw-all-rewards --from mykey
 		),
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-
 			txBldr := auth.NewTxBuilderFromCLI().WithTxEncoder(utils.GetTxEncoder(cdc))
 			cliCtx := context.NewCLIContext().WithCodec(cdc)
 
 			delAddr := cliCtx.GetFromAddress()
+
+			if cliCtx.GenerateOnly {
+				return fmt.Errorf("command disabled with the provided flag: %s", client.FlagGenerateOnly)
+			}
+
 			msgs, err := common.WithdrawAllDelegatorRewards(cliCtx, queryRoute, delAddr)
 			if err != nil {
 				return err
@@ -152,6 +156,7 @@ $ %s tx distr withdraw-all-rewards --from mykey
 			return splitAndApply(utils.GenerateOrBroadcastMsgs, cliCtx, txBldr, msgs, chunkSize)
 		},
 	}
+
 	cmd.Flags().Int(flagMaxMessagesPerTx, MaxMessagesPerTxDefault, "Limit the number of messages per tx (0 for unlimited)")
 	return cmd
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

closes: #4870

----

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/develop/CONTRIBUTING.md#pr-targeting))

- [x] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [x] Added a relevant changelog entry: `clog add [section] [-t <tag>] [-m <msg>]`
- [x] Re-reviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
