### PR TITLE
Fix BroadcastTxCommit Response

### DIFF
--- a/.pending/bugfixes/rest/_4858-Do-not-return-
+++ b/.pending/bugfixes/rest/_4858-Do-not-return-
@@ -1,0 +1,3 @@
+#4858 Do not return an error in BroadcastTxCommit when the tx broadcasting
+was successful. This allows the proper REST response to be returned for a
+failed tx during `block` broadcasting mode.

--- a/client/context/broadcast.go
+++ b/client/context/broadcast.go
@@ -30,7 +30,8 @@ func (ctx CLIContext) BroadcastTx(txBytes []byte) (res sdk.TxResponse, err error
 }
 
 // BroadcastTxCommit broadcasts transaction bytes to a Tendermint node and
-// waits for a commit.
+// waits for a commit. An error is only returned if there is no RPC node
+// connection or if broadcasting fails.
 //
 // NOTE: This should ideally not be used as the request may timeout but the tx
 // may still be included in a block. Use BroadcastTxAsync or BroadcastTxSync

--- a/client/context/broadcast.go
+++ b/client/context/broadcast.go
@@ -47,11 +47,11 @@ func (ctx CLIContext) BroadcastTxCommit(txBytes []byte) (sdk.TxResponse, error) 
 	}
 
 	if !res.CheckTx.IsOK() {
-		return sdk.NewResponseFormatBroadcastTxCommit(res), fmt.Errorf(res.CheckTx.Log)
+		return sdk.NewResponseFormatBroadcastTxCommit(res), nil
 	}
 
 	if !res.DeliverTx.IsOK() {
-		return sdk.NewResponseFormatBroadcastTxCommit(res), fmt.Errorf(res.DeliverTx.Log)
+		return sdk.NewResponseFormatBroadcastTxCommit(res), nil
 	}
 
 	return sdk.NewResponseFormatBroadcastTxCommit(res), nil


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

When an invalid/failed tx is submitted with `block` mode, a proper REST response should be returned. Because we were returning an error, this wasn't happening.

closes: #4858

----

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/develop/CONTRIBUTING.md#pr-targeting))

- [x] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [x] Added a relevant changelog entry: `clog add [section] [-t <tag>] [-m <msg>]`
- [x] Re-reviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
