### PR TITLE
Fix standalone execution

### DIFF
--- a/.pending/bugfixes/tendermint/_4879-Don-t-terminat
+++ b/.pending/bugfixes/tendermint/_4879-Don-t-terminat
@@ -1,0 +1,1 @@
+#4879 Don't terminate the process immediately after startup when run in standalone mode.

--- a/server/start.go
+++ b/server/start.go
@@ -89,7 +89,6 @@ func startStandAlone(ctx *Context, appCreator AppCreator) error {
 		cmn.Exit(err.Error())
 	}
 
-	// wait forever
 	cmn.TrapSignal(ctx.Logger, func() {
 		// cleanup
 		err = svr.Stop()
@@ -97,6 +96,10 @@ func startStandAlone(ctx *Context, appCreator AppCreator) error {
 			cmn.Exit(err.Error())
 		}
 	})
+
+	// run forever (the node will not be returned)
+	select {}
+
 	return nil
 }
 


### PR DESCRIPTION
Add infinite loop at the end of startStandAlone() to prevent
the server process from exiting immediately after bootstrap.

Closes: #4879

- [x] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [x] Added a relevant changelog entry: `clog add [section] [-t <tag>] [-m <msg>]`
- [x] Re-reviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
