### PR TITLE
Removed missing images that prevented docs from being built

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,5 @@ dependency-graph.png
 *.aux
 *.out
 *.synctex.gz
+
+docs/node_modules

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -34,6 +34,7 @@ module.exports = {
           "/intro/sdk-design"
         ]
       },
+      // UNCOMMENT THIS IF YOU WANT TO BUILD DOCS : START
       {
         title: "Tutorial",
         collapsable: true,
@@ -73,6 +74,7 @@ module.exports = {
           "/interfaces/lite/specification"
         ]
       }
+      // UNCOMMENT THIS IF YOU WANT TO BUILD DOCS : END
     ]
   }
 };

--- a/docs/interfaces/lite/readme.md
+++ b/docs/interfaces/lite/readme.md
@@ -33,7 +33,7 @@ combination of module APIs, depending on which modules the state machine uses. T
 initially support [ICS0](https://cosmos.network/rpc/#/ICS0) (TendermintAPI), [ICS1](https://cosmos.network/rpc/#/ICS1) (KeyAPI), [ICS20](https://cosmos.network/rpc/#/ICS20) (TokenAPI), [ICS21](https://cosmos.network/rpc/#/ICS21) (StakingAPI),
 [ICS22](https://cosmos.network/rpc/#/ICS22) (GovernanceAPI) and [ICS23](https://cosmos.network/rpc/#/ICS23) (SlashingAPI).
 
-![high-level](./pics/high-level.png)
+<!-- ![high-level](./pics/high-level.png) -->
 
 All applications are expected to run only against Gaia-lite. Gaia-lite is the only piece of software
 that offers stability guarantees around the zone API.
@@ -69,7 +69,7 @@ The original trusted validator set should be prepositioned into its trust store.
 validator set comes from a genesis file. During runtime, if Gaia-lite detects a different validator set,
 it will verify it and save the new validated validator set to the trust store.
 
-![validator-set-change](./pics/validatorSetChange.png)
+<!-- ![validator-set-change](./pics/validatorSetChange.png) -->
 
 ### Trust Propagation
 

--- a/docs/interfaces/lite/specification.md
+++ b/docs/interfaces/lite/specification.md
@@ -12,7 +12,7 @@ we need to extract name, height and store root hash from these substores to buil
 Merkle leaf nodes, then calculate hash from leaf nodes to root. The root hash of the simple Merkle
 tree is the AppHash which will be included in block header.
 
-![Simple Merkle Tree](./pics/simpleMerkleTree.png)
+<!-- ![Simple Merkle Tree](./pics/simpleMerkleTree.png) -->
 
 As we have discussed in [LCD trust-propagation](https://github.com/irisnet/cosmos-sdk/tree/bianjie/lcd_spec/docs/spec/lcd#trust-propagation),
 the AppHash can be verified by checking voting power against a trusted validator set. Here we just
@@ -65,7 +65,7 @@ type KeyExistsProof struct {
 The data structure of exist proof is shown as above. The process to build and verify existence proof
 is shown as follows:
 
-![Exist Proof](./pics/existProof.png)
+<!-- ![Exist Proof](./pics/existProof.png) -->
 
 Steps to build proof:
 
@@ -92,12 +92,12 @@ the position of the target key in the whole key set of this IAVL tree. As shown 
 out the left key and the right key. If we can demonstrate that both left key and right key
 definitely exist, and they are adjacent nodes. Thus the target key definitely doesn't exist.
 
-![Absence Proof1](./pics/absence1.png)
+<!-- ![Absence Proof1](./pics/absence1.png) -->
 
 If the target key is larger than the right most leaf node or less than the left most key, then the
 target key definitely doesn't exist.
 
-![Absence Proof2](./pics/absence2.png)![Absence Proof3](./pics/absence3.png)
+<!-- ![Absence Proof2](./pics/absence2.png)![Absence Proof3](./pics/absence3.png) -->
 
 ```go
 type proofLeafNode struct {
@@ -147,7 +147,7 @@ in commitID equals to proof RootHash. If not, the proof is invalid. Then sort th
 commitInfo array by the hash of substore name. Finally, build the simple Merkle tree with all
 substore commitInfo array and verify if the Merkle root hash equal to appHash.
 
-![substore proof](./pics/substoreProof.png)
+<!-- ![substore proof](./pics/substoreProof.png) -->
 
 ```go
 func SimpleHashFromTwoHashes(left []byte, right []byte) []byte {
@@ -187,7 +187,7 @@ Above sections refer appHash frequently. But where does the trusted appHash come
 the appHash exist in block header, next we need to verify blocks header at specific height against
 LCD trusted validator set. The validation flow is shown as follows:
 
-![commit verification](./pics/commitValidation.png)
+<!-- ![commit verification](./pics/commitValidation.png) -->
 
 When the trusted validator set doesn't match the block header, we need to try to update our
 validator set to the height of this block. LCD has a rule that each validator set change should not
@@ -198,7 +198,7 @@ validator set update be accomplished.
 
 For instance:
 
-![Update validator set to height](./pics/updateValidatorToHeight.png)
+<!-- ![Update validator set to height](./pics/updateValidatorToHeight.png) -->
 
 * Update to 10000, tooMuchChangeErr
 * Update to 5050,  tooMuchChangeErr

--- a/docs/translations/cn/clients/lite/README.md
+++ b/docs/translations/cn/clients/lite/README.md
@@ -16,7 +16,7 @@ Cosmos SDK 轻节点（Gaia-lite）分为两个独立的组件。 第一个组�
 
 想要为 Cosmos Hub（或任何其他 zone）构建第三方客户端应用程序的应用程序开发人员，应根据其规范 API 构建。 该API 是多个部分的组合。 所有 zone 都必须暴露ICS0（TendermintAPI）。 除此之外，任何 zone 都可以自由选择模块 API的任意组合，具体取决于状态机使用的模块。 Cosmos Hub最初将支持[ICS0](https://cosmos.network/rpc/#/ICS0) (TendermintAPI)、 [ICS1](https://cosmos.network/rpc/#/ICS1) (KeyAPI)、 [ICS20](https://cosmos.network/rpc/#/ICS20) (TokenAPI)、 [ICS21](https://cosmos.network/rpc/#/ICS21) (StakingAPI)、 [ICS22](https://cosmos.network/rpc/#/ICS22) (GovernanceAPI) 和 [ICS23](https://cosmos.network/rpc/#/ICS23) (SlashingAPI)。
 
-![high-level](../../../../clients/lite/pics/high-level.png)
+<!-- ![high-level](../../../../clients/lite/pics/high-level.png) -->
 
 预计所有应用程序仅依赖于 Gaia-lite 运行。 Gaia-lite 是唯一一款围绕 zone API 提供稳定性保证的软件。
 
@@ -49,12 +49,12 @@ Gaia-lite的基本设计理念遵循两个规则：
 
 原始的可信验证人集应该预先放置到其信任库中，通常这个验证人集来自 genesis 文件。 在运行时期间，如果 Gaia-lite 检测到不同的验证人集，它将验证它并将可信的验证人集保存到信任库中。
 
-![validator-set-change](../../../../clients/lite/pics/validatorSetChange.png)
+<!-- ![validator-set-change](../../../../clients/lite/pics/validatorSetChange.png) -->
 
 ### 信任传播
 
 从上面的小节中，我们了解了如何获得可信验证器集以及 LCD 如何跟踪验证人集演化。 验证人集是信任的基础，信任可以传播到其他区块链数据，例如块和交易。 传播架构如下所示：
 
-![change-process](../../../../clients/lite/pics/trustPropagate.png)
+<!-- ![change-process](../../../../clients/lite/pics/trustPropagate.png) -->
 
 通常，通过可信验证人集，轻客户端可以验证包含所有预提交数据和块头数据的每个提交块。 此时块哈希、数据哈希和应用哈希是可信的。 基于此和默克尔证明，所有交易数据和 ABCI 状态也可以被验证。

--- a/docs/translations/cn/clients/lite/specification.md
+++ b/docs/translations/cn/clients/lite/specification.md
@@ -6,7 +6,7 @@
 
 众所周知，基于 cosmos-sdk 的应用程序的存储包含多个子库。 每个子目录由 IAVL 存储实现。 这些子组件由简单的 Merkle 树组成。 创建树时，我们需要从这些子库中提取名字、高度和存储根哈希以构建一组简单的 Merkle 叶节点，然后计算从叶节点到根的哈希。 简单 Merkle 树的根哈希是 AppHash，它将包含在块头中。
 
-![Simple Merkle Tree](../../../../clients/lite/pics/simpleMerkleTree.png)
+<!-- ![Simple Merkle Tree](../../../../clients/lite/pics/simpleMerkleTree.png) -->
 
 正如我们在[LCD信任传播](https://github.com/irisnet/cosmos-sdk/tree/bianjie/lcd_spec/docs/spec/lcd#trust-propagation)中所讨论的那样，可以通过检查针对可信验证人集的投票权来验证 AppHash。 这里我们只需要建立从 ABCI 状态到 AppHash 的证明。 证据包含两部分：
 
@@ -54,7 +54,7 @@ type KeyExistsProof struct {
 
 存在证据的数据结构如上所示。 构建和验证存在证明的过程如下所示：
 
-![Exist Proof](../../../../clients/lite/pics/existProof.png)
+<!-- ![Exist Proof](../../../../clients/lite/pics/existProof.png) -->
 
 构建证明的步骤：
 
@@ -78,11 +78,11 @@ type KeyExistsProof struct {
 
 众所周知，所有 IAVL 叶节点都按每个叶节点的密钥排序。 因此，我们可以在 IAVL 树的整个密钥集中计算出目标密钥的位置。 如下图所示，我们可以找到左键和右键。 如果我们可以证明左键和右键肯定存在，并且它们是相邻的节点，那么目标密钥肯定不存在。
 
-![Absence Proof1](../../../../clients/lite/pics/absence1.png)
+<!-- ![Absence Proof1](../../../../clients/lite/pics/absence1.png) -->
 
 如果目标密钥大于最右边的叶节点或小于最左边的叶子节点，则目标密钥肯定不存在。
 
-![Absence Proof2](../../../../clients/lite/pics/absence2.png)![Absence Proof3](../../../../clients/lite/pics/absence3.png)
+<!-- ![Absence Proof2](../../../../clients/lite/pics/absence2.png)![Absence Proof3](../../../../clients/lite/pics/absence3.png) -->
 
 ```go
 type proofLeafNode struct {
@@ -128,7 +128,7 @@ type KeyAbsentProof struct {
 
 在验证了 IAVL 证明之后，我们就可以开始验证针对 AppHash 的 substore 证明。 首先，迭代 MultiStoreCommitInfo 并通过证明 StoreName 找到 substore commitID。 验证 commitID 中的哈希是否等于证明根哈希，如果不相等则证明无效。 然后通过 substore name 的哈希对 substore commitInfo 数组进行排序。 最后，使用所有 substore commitInfo 数组构建简单的 Merkle 树，并验证 Merkle 根哈希值是否等于appHash。
 
-![substore proof](../../../../clients/lite/pics/substoreProof.png)
+<!-- ![substore proof](../../../../clients/lite/pics/substoreProof.png) -->
 
 ```go
 func SimpleHashFromTwoHashes(left []byte, right []byte) []byte {
@@ -166,13 +166,13 @@ func SimpleHashFromHashes(hashes [][]byte) []byte {
 
 上面的小节中经常提到 appHash，但可信的appHash来自哪里？ 实际上，appHash 存在于区块头中，因此接下来我们需要针对 LCD 可信验证人集验证特定高度的区块头。 验证流程如下所示：
 
-![commit verification](../../../../clients/lite/pics/commitValidation.png)
+<!-- ![commit verification](../../../../clients/lite/pics/commitValidation.png) -->
 
 当可信验证人集与区块头不匹配时，我们需要尝试将验证人集更新为此块的高度。 LCD 有一条规则，即每个验证人集的变化不应超过1/3投票权。 如果目标验证人集的投票权变化超过1/3，则与可信验证人集进行比较。 我们必须验证，在目标验证人集之前是否存在隐含的验证人集变更。 只有当所有验证人集变更都遵循这条规则时，才能完成验证人集的更新。
 
 例如：
 
-![Update validator set to height](../../../../clients/lite/pics/updateValidatorToHeight.png)
+<!-- ![Update validator set to height](../../../../clients/lite/pics/updateValidatorToHeight.png) -->
 
 * 更新到 10000，失败，变更太大
 * 更新到 5050，失败，变更太大

--- a/docs/translations/kr/clients/lite/README.md
+++ b/docs/translations/kr/clients/lite/README.md
@@ -19,7 +19,7 @@
 기본적으로 코스모스 허브는 [ICS0](https://cosmos.network/rpc/#/ICS0) (텐더민트API), [ICS1](https://cosmos.network/rpc/#/ICS1) (키API), [ICS20](https://cosmos.network/rpc/#/ICS20) (토큰API), [ICS21](https://cosmos.network/rpc/#/ICS21) (스테이킹API),
 [ICS22](https://cosmos.network/rpc/#/ICS22) (거버넌스API) and [ICS23](https://cosmos.network/rpc/#/ICS23) (슬래싱API)를 도입하고 있습니다.
 
-![high-level](./pics/high-level.png)
+<!-- ![high-level](./pics/high-level.png) -->
 
 모든 애플리케이션은 Gaia-lite 클라이언트를 기반으로 운영되는 것을 원칙으로 삼습니다. Gaia-lite 외의 소프트웨어는 특정 존 API에 대한 안정성을 보장하지 않습니다.
 

--- a/docs/translations/kr/clients/lite/specification.md
+++ b/docs/translations/kr/clients/lite/specification.md
@@ -6,7 +6,7 @@
 
 코스모스 SDK 기반 애플리케이션은 멀티-서브스토어(multi-substore)를 이용해 저장을 합니다. 각 서브스토어는 IAVL 스토어를 응용합니다. 서브스토어는 단순한 머클 트리(Merkle tree) 형태로 정렬됩니다. 머클 트리를 만들기 위해서는 각 서브스토어의 이름, 블록 높이 그리고 스토어 루트 해시(store root hash) 필요하며, 이를 기반으로 간단한 머클 가지 노드(Merkle leaf node)를 만들 수 있습니다. 이후 가지 노드를 이용해 해시값을 머클 뿌리(Merkle root)까지 연산하게 됩니다. 단순 머클 트리(simple Merkle tree)의 루트 해시(Root hash)는 블록 헤더에 포함되는 앱 해시(AppHash)입니다.
 
-![Simple Merkle Tree](./pics/simpleMerkleTree.png)
+<!-- ![Simple Merkle Tree](./pics/simpleMerkleTree.png) -->
 
 [LCD 신뢰 전파](https://github.com/irisnet/cosmos-sdk/tree/bianjie/lcd_spec/docs/spec/lcd#trust-propagation)에서 설명했던바와 같이, 앱해시는 신뢰할 수 있는 검증인 세트의 보팅파워(총 스테이킹 수량)를 검증하는 방식으로 확인할 수 있습니다. 이 절차에는 ABCI 상태에서부터 앱해시 증거를 찾으면 됩니다. 증거에는 다음과 같은 정보가 포함되어있습니다:
 
@@ -55,7 +55,7 @@ type KeyExistsProof struct {
 존재 증거의 데이터 형식은 위와 같이 나열되어 있습니다. 존재 증거를 생성하고 검증하는 방식은 다음과 같습니다:
 
 
-![Exist Proof](./pics/existProof.png)
+<!-- ![Exist Proof](./pics/existProof.png) -->
 
 증거 생성 절차:
 
@@ -79,11 +79,11 @@ type KeyExistsProof struct {
 
 모든 IAVL 리프 노드는 각 리프노드의 키로 정렬되어있습니다. 그렇기 때문에 IAVL 트리의 전체 키 내의 목표 키 위치를 찾을 수 있습니다. 아래와 같이, 키가 좌측 키 또는 우측 키인지 확인이 가능합니다. 만약 우측 키와 좌측 키의 존재를 증명할 수 있을 경우, 인접 노드(adjecent node) 여부를 증명할 수 있는 것이며 타겟 키가 존재하지 않는다는 것을 증명하게 됩니다.
 
-![Absence Proof1](./pics/absence1.png)
+<!-- ![Absence Proof1](./pics/absence1.png) -->
 
 만약 타겟 키가 최우측 리프 노드(right most leaf node) 보다 크거나 또는 최좌측 키(left most key) 보다 작은 경우 타겟 키는 존재하지 않음을 증명합니다.
 
-![Absence Proof2](./pics/absence2.png)![Absence Proof3](./pics/absence3.png)
+<!-- ![Absence Proof2](./pics/absence2.png)![Absence Proof3](./pics/absence3.png) -->
 
 ```go
 type proofLeafNode struct {
@@ -130,7 +130,7 @@ type KeyAbsentProof struct {
 IAVL 증거를 검증했다면 substore 증거와 AppHash를 비교하여 검증할 수 있습니다. 우선 MultiStoreCommitInfo를 반복(iterate)하여 proof StoreName을 이용해 서브스토어의 commitID를 찾을 수 있습니다. 여기에서 commitID의 해시가 RootHash의 proof와 동일하다는 것을 검증합니다. 만약 동일하지 않을 경우, 증거는 유효하지 않습니다. 이후 서브스토어 commitInfo 어레이를 서브스토어 이름의 해시 값으로 정렬합니다. 마지막으로, 모든 서브스토어 commitInfo 어레이를 기반으로 단순 머클 트리(simple Merkle tree)를 빌드하여 머클 루트 해시가 앱 해시와 동일한지 검증합니다.
 
 
-![substore proof](./pics/substoreProof.png)
+<!-- ![substore proof](./pics/substoreProof.png) -->
 
 ```go
 func SimpleHashFromTwoHashes(left []byte, right []byte) []byte {
@@ -168,13 +168,13 @@ func SimpleHashFromHashes(hashes [][]byte) []byte {
 
 위 항목에서는 appHash를 자주 언급합니다. 그렇다면 appHash는 어디에서 존재하는 것일까요? appHash는 블록 헤더에 존재합니다. 그렇기 때문에 특정 블록 높이의 블록헤더를 LCD가 신뢰하는 검증인 세트에 검증해야 합니다. 검증 절차는 다음과 같습니다:
 
-![commit verification](./pics/commitValidation.png)
+<!-- ![commit verification](./pics/commitValidation.png) -->
 
 만약 신뢰 검증인 세트가 블록 헤더와 일치하지 않는 경우, 해당 블록 높이의 검증인 세트로 업데이트를 해야합니다. LCD는 검증인 세트의 변경이 보팅 파워의 1/3을 초과할 수 없다는 규칙을 따릅니다. 만약 타겟 검증인 세트가 현재 신뢰되는 검증인 세트에서 1/3 보팅파워를 초과하는 변화가 있는 경우, 타겟 검증인 세트 전에 숨겨진 검증인 세트 변경이 있었는지 확인해야 합니다. 모든 검증인 세트 변경이 이 규칙을 따를때 검증인 세트 업데이트가 이루어질 수 있습니다.
 
 예를 들어:
 
-![Update validator set to height](./pics/updateValidatorToHeight.png)
+<!-- ![Update validator set to height](./pics/updateValidatorToHeight.png) -->
 
 * Update to 10000, tooMuchChangeErr
 * Update to 5050,  tooMuchChangeErr


### PR DESCRIPTION
Commented out links to non-existent images in Chinese translation directory. Added package.json.

If you comment out Tutorial and Interfaces sections in `docs/.vuepress/config.js` it should be possible to build docs by running `cd docs && npm install && vuepress build`.