### PR TITLE
Gaiacli should not panic when user just presses enter during Y/n confirmation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ longer panics if the store to load contains substores that we didn't explicitly 
 * (cli) [\#4763](https://github.com/cosmos/cosmos-sdk/issues/4763) Fix flag `--min-self-delegation` for staking `EditValidator`
 * (keys) Fix ledger custom coin type support bug
 * (simulation) [\#4912](https://github.com/cosmos/cosmos-sdk/issues/4912) Fix SimApp ModuleAccountAddrs to properly return black listed addresses for bank keeper initialization
+* (cli) [\#4919](https://github.com/cosmos/cosmos-sdk/pull/4919) Don't crash cli if user doesn't answer y/n confirmation request
 
 ## [v0.36.0] - 2019-08-13
 

--- a/client/input/input.go
+++ b/client/input/input.go
@@ -74,7 +74,12 @@ func GetConfirmation(prompt string, buf *bufio.Reader) (bool, error) {
 		return false, err
 	}
 
-	response = strings.ToLower(strings.TrimSpace(response))
+	response = strings.TrimSpace(response)
+	if len(response) == 0 {
+		return false, nil
+	}
+
+	response = strings.ToLower(response)
 	if response[0] == 'y' {
 		return true, nil
 	}


### PR DESCRIPTION
Addressing the issue encountered here: https://github.com/e-money/em-ledger/issues/1

If the user does not enter a character in response to the CLI query `confirm transaction before signing and broadcasting [y/N]:` gaiacli will crash with a panic.


- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the github PR explorer
