### PR TITLE
WIP: Generalize Genesis Accounts

### DIFF
--- a/docs/architecture/adr-000-generalize-genesis-accounts.md
+++ b/docs/architecture/adr-000-generalize-genesis-accounts.md
@@ -1,0 +1,43 @@
+# ADR 000: Generalize Genesis Accounts
+
+## Changelog
+
+- 2019-08-30: initial draft
+
+## Context
+
+Summary: The `auth` module allows custom account types, but the `genaccounts` module does not.
+
+Currently the SDK allows for custom account types; the `auth` keeper stores any type fulfilling its Account interface. However `auth` does not handle exporting or loading accounts to/from a genesis file, this is done by `genaccounts`, which only handles one of 4 concrete account types.
+
+Projects wanting to use custom vesting accounts need to fork and modify `genaccounts`.
+
+
+## Decision
+
+We will
+ - marshal/unmarshal accounts (interface types) directly using amino
+ - remove `genaccounts`'s custom genesis account type
+ - and since the above removes the majority of `genaccounts`’s code, move all logic into auth and remove the `genaccounts` module.
+
+## Status
+
+Proposed
+
+## Consequences
+
+### Positive
+
+ - custom accounts can be used without needing to fork `genaccounts`
+ - reduced LoC
+
+### Negative
+
+
+### Neutral
+
+- genaccounts module no longer exists
+- accounts in genesis files are stored under `auth.accounts` rather than `accounts`
+- the `add-genesis-account` cli command is now in auth
+
+## References

--- a/x/auth/client/cli/add_account.go
+++ b/x/auth/client/cli/add_account.go
@@ -1,0 +1,130 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"github.com/tendermint/tendermint/libs/cli"
+
+	"github.com/cosmos/cosmos-sdk/client/keys"
+	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/server"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/auth/exported"
+	"github.com/cosmos/cosmos-sdk/x/auth/types"
+	"github.com/cosmos/cosmos-sdk/x/genutil"
+)
+
+const (
+	flagClientHome   = "home-client"
+	flagVestingStart = "vesting-start-time"
+	flagVestingEnd   = "vesting-end-time"
+	flagVestingAmt   = "vesting-amount"
+)
+
+// AddGenesisAccountCmd returns add-genesis-account cobra Command.
+func AddGenesisAccountCmd(ctx *server.Context, cdc *codec.Codec,
+	defaultNodeHome, defaultClientHome string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "add-genesis-account [address_or_key_name] [coin][,[coin]]",
+		Short: "Add an account to genesis.json",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(_ *cobra.Command, args []string) error {
+			config := ctx.Config
+			config.SetRoot(viper.GetString(cli.HomeFlag))
+
+			// ---------- Parse args ----------
+			addr, err := sdk.AccAddressFromBech32(args[0])
+			if err != nil {
+				kb, err := keys.NewKeyBaseFromDir(viper.GetString(flagClientHome))
+				if err != nil {
+					return err
+				}
+
+				info, err := kb.Get(args[0])
+				if err != nil {
+					return err
+				}
+
+				addr = info.GetAddress()
+			}
+
+			coins, err := sdk.ParseCoins(args[1])
+			if err != nil {
+				return err
+			}
+
+			vestingStart := viper.GetInt64(flagVestingStart)
+			vestingEnd := viper.GetInt64(flagVestingEnd)
+			vestingAmt, err := sdk.ParseCoins(viper.GetString(flagVestingAmt))
+			if err != nil {
+				return err
+			}
+
+			// ---------- Create Account ----------
+			baseAccount := types.NewBaseAccount(addr, coins, nil, 0, 0) // account number ignored on init genesis
+			account := exported.Account(baseAccount)
+
+			if !vestingAmt.IsZero() {
+				baseVestingAcc := types.NewBaseVestingAccount(
+					baseAccount,
+					vestingAmt,
+					sdk.NewCoins(),
+					sdk.NewCoins(),
+					vestingEnd,
+				)
+
+				switch {
+				case vestingStart != 0 && vestingEnd != 0:
+					account = types.NewContinuousVestingAccountRaw(baseVestingAcc, vestingStart)
+				case vestingEnd != 0:
+					account = types.NewDelayedVestingAccountRaw(baseVestingAcc)
+				default:
+					return errors.New("invalid vesting account specification")
+				}
+			}
+			if err := account.Validate(); err != nil {
+				return err
+			}
+
+			// ---------- Add to Genesis File ----------
+			// retrieve the app state
+			genFile := config.GenesisFile()
+			appState, genDoc, err := genutil.GenesisStateFromGenFile(cdc, genFile)
+			if err != nil {
+				return err
+			}
+
+			// add genesis account to the app state
+			var genesisState types.GenesisState
+			cdc.MustUnmarshalJSON(appState[types.ModuleName], &genesisState)
+
+			for _, acc := range genesisState.Accounts {
+				if acc.GetAddress().Equals(account.GetAddress()) {
+					return fmt.Errorf("cannot add account at existing address %v", acc.GetAddress())
+				}
+			}
+			genesisState.Accounts = append(genesisState.Accounts, account)
+
+			genesisStateBz := cdc.MustMarshalJSON(genesisState)
+			appState[types.ModuleName] = genesisStateBz
+			appStateJSON, err := cdc.MarshalJSON(appState)
+			if err != nil {
+				return err
+			}
+
+			// export app state
+			genDoc.AppState = appStateJSON
+			return genutil.ExportGenesisFile(genDoc, genFile)
+		},
+	}
+
+	cmd.Flags().String(cli.HomeFlag, defaultNodeHome, "node's home directory")
+	cmd.Flags().String(flagClientHome, defaultClientHome, "client's home directory")
+	cmd.Flags().String(flagVestingAmt, "", "amount of coins for vesting accounts")
+	cmd.Flags().Uint64(flagVestingStart, 0, "schedule start time (unix epoch) for vesting accounts")
+	cmd.Flags().Uint64(flagVestingEnd, 0, "schedule end time (unix epoch) for vesting accounts")
+	return cmd
+}

--- a/x/auth/exported/exported.go
+++ b/x/auth/exported/exported.go
@@ -36,6 +36,9 @@ type Account interface {
 
 	// Ensure that account implements stringer
 	String() string
+
+	// Basic validation for loading accounts from genesis.
+	Validate() error
 }
 
 // VestingAccount defines an account type that vests coins via a vesting schedule.

--- a/x/auth/module.go
+++ b/x/auth/module.go
@@ -41,12 +41,14 @@ func (AppModuleBasic) RegisterCodec(cdc *codec.Codec) {
 // DefaultGenesis returns default genesis state as raw bytes for the auth
 // module.
 func (AppModuleBasic) DefaultGenesis() json.RawMessage {
+	// Does not need any custom account types registered on ModuleCdc
 	return types.ModuleCdc.MustMarshalJSON(types.DefaultGenesisState())
 }
 
 // ValidateGenesis performs genesis state validation for the auth module.
 func (AppModuleBasic) ValidateGenesis(bz json.RawMessage) error {
 	var data types.GenesisState
+	// TODO This will need any custom accounts registered on ModuleCdc
 	err := types.ModuleCdc.UnmarshalJSON(bz, &data)
 	if err != nil {
 		return err
@@ -136,6 +138,7 @@ func (am AppModule) NewQuerierHandler() sdk.Querier {
 // no validator updates.
 func (am AppModule) InitGenesis(ctx sdk.Context, data json.RawMessage) []abci.ValidatorUpdate {
 	var genesisState GenesisState
+	// TODO this could use am.keeper.cdc to access codec with custom accounts
 	types.ModuleCdc.MustUnmarshalJSON(data, &genesisState)
 	InitGenesis(ctx, am.accountKeeper, genesisState)
 	return []abci.ValidatorUpdate{}
@@ -145,6 +148,7 @@ func (am AppModule) InitGenesis(ctx sdk.Context, data json.RawMessage) []abci.Va
 // module.
 func (am AppModule) ExportGenesis(ctx sdk.Context) json.RawMessage {
 	gs := ExportGenesis(ctx, am.accountKeeper)
+	// TODO this could use am.keeper.cdc to access codec with custom accounts
 	return types.ModuleCdc.MustMarshalJSON(gs)
 }
 

--- a/x/auth/types/account.go
+++ b/x/auth/types/account.go
@@ -473,10 +473,10 @@ func (cva *ContinuousVestingAccount) GetEndTime() int64 {
 	return cva.EndTime
 }
 
-// Validate - Implements ValidatableAccount. This is called on accounts after loading from a genesis file.
+// Validate is called on accounts after loading from a genesis file.
 func (cva ContinuousVestingAccount) Validate() error {
 	if cva.EndTime == 0 {
-		return fmt.Errorf("missing end time for vesting account")
+		return errors.New("missing end time for vesting account")
 	}
 	if cva.StartTime >= cva.EndTime {
 		return fmt.Errorf(
@@ -560,7 +560,7 @@ func (dva *DelayedVestingAccount) GetEndTime() int64 {
 // Validate is called on accounts after loading from a genesis file.
 func (dva DelayedVestingAccount) Validate() error {
 	if dva.EndTime == 0 {
-		return fmt.Errorf("missing end time for vesting account")
+		return errors.New("missing end time for vesting account")
 	}
 	return nil
 }

--- a/x/auth/types/account.go
+++ b/x/auth/types/account.go
@@ -136,7 +136,7 @@ func (acc *BaseAccount) SpendableCoins(_ time.Time) sdk.Coins {
 	return acc.GetCoins()
 }
 
-// Validate - Implements ValidatableAccount. This is called on accounts after loading from a genesis file.
+// Validate is called on accounts after loading from a genesis file.
 func (acc BaseAccount) Validate() error {
 	// TODO add more validation?
 	return nil
@@ -557,7 +557,7 @@ func (dva *DelayedVestingAccount) GetEndTime() int64 {
 	return dva.EndTime
 }
 
-// Validate - Implements ValidatableAccount. This is called on accounts after loading from a genesis file.
+// Validate is called on accounts after loading from a genesis file.
 func (dva DelayedVestingAccount) Validate() error {
 	if dva.EndTime == 0 {
 		return fmt.Errorf("missing end time for vesting account")

--- a/x/auth/types/account.go
+++ b/x/auth/types/account.go
@@ -119,7 +119,7 @@ func (acc *BaseAccount) SetAccountNumber(accNumber uint64) error {
 	return nil
 }
 
-// GetSequence - Implements sdk.Account.
+// GetSequence - Implements sdk.Account. // TODO update comments
 func (acc *BaseAccount) GetSequence() uint64 {
 	return acc.Sequence
 }
@@ -134,6 +134,12 @@ func (acc *BaseAccount) SetSequence(seq uint64) error {
 // this is simply the base coins.
 func (acc *BaseAccount) SpendableCoins(_ time.Time) sdk.Coins {
 	return acc.GetCoins()
+}
+
+// Validate - Implements ValidatableAccount. This is called on accounts after loading from a genesis file.
+func (acc BaseAccount) Validate() error {
+	// TODO add more validation?
+	return nil
 }
 
 // MarshalYAML returns the YAML representation of an account.
@@ -467,6 +473,21 @@ func (cva *ContinuousVestingAccount) GetEndTime() int64 {
 	return cva.EndTime
 }
 
+// Validate - Implements ValidatableAccount. This is called on accounts after loading from a genesis file.
+func (cva ContinuousVestingAccount) Validate() error {
+	if cva.EndTime == 0 {
+		return fmt.Errorf("missing end time for vesting account")
+	}
+	if cva.StartTime >= cva.EndTime {
+		return fmt.Errorf(
+			"vesting start time must before end time; start: %s, end: %s",
+			time.Unix(cva.StartTime, 0).UTC().Format(time.RFC3339),
+			time.Unix(cva.EndTime, 0).UTC().Format(time.RFC3339),
+		)
+	}
+	return nil
+}
+
 //-----------------------------------------------------------------------------
 // Delayed Vesting Account
 
@@ -534,4 +555,12 @@ func (dva *DelayedVestingAccount) GetStartTime() int64 {
 // GetEndTime returns the time when vesting ends for a delayed vesting account.
 func (dva *DelayedVestingAccount) GetEndTime() int64 {
 	return dva.EndTime
+}
+
+// Validate - Implements ValidatableAccount. This is called on accounts after loading from a genesis file.
+func (dva DelayedVestingAccount) Validate() error {
+	if dva.EndTime == 0 {
+		return fmt.Errorf("missing end time for vesting account")
+	}
+	return nil
 }

--- a/x/auth/types/codec.go
+++ b/x/auth/types/codec.go
@@ -9,6 +9,7 @@ import (
 func RegisterCodec(cdc *codec.Codec) {
 	cdc.RegisterInterface((*exported.Account)(nil), nil)
 	cdc.RegisterConcrete(&BaseAccount{}, "cosmos-sdk/Account", nil)
+	cdc.RegisterInterface((*ValidatableAccount)(nil), nil) // TODO does this work correctly
 	cdc.RegisterInterface((*exported.VestingAccount)(nil), nil)
 	cdc.RegisterConcrete(&BaseVestingAccount{}, "cosmos-sdk/BaseVestingAccount", nil)
 	cdc.RegisterConcrete(&ContinuousVestingAccount{}, "cosmos-sdk/ContinuousVestingAccount", nil)

--- a/x/auth/types/codec.go
+++ b/x/auth/types/codec.go
@@ -23,5 +23,12 @@ func init() {
 	ModuleCdc = codec.New()
 	RegisterCodec(ModuleCdc)
 	codec.RegisterCrypto(ModuleCdc)
-	ModuleCdc.Seal()
+	// leave the codec unsealed to allow custom account types to be registered
+}
+
+// RegisterAccountTypeCodec registers an external account type defined
+// in another module for the internal ModuleCdc. This allows account types to be
+// read to/from the genesis file.
+func RegisterAccountTypeCodec(o interface{}, name string) {
+	ModuleCdc.RegisterConcrete(o, name, nil)
 }

--- a/x/auth/types/genesis.go
+++ b/x/auth/types/genesis.go
@@ -8,26 +8,19 @@ import (
 
 // GenesisState - all auth state that must be provided at genesis
 type GenesisState struct {
-	Params   Params               `json:"params" yaml:"params"`
-	Accounts []ValidatableAccount `json:"accounts" yaml:"accounts"`
+	Params   Params             `json:"params" yaml:"params"`
+	Accounts []exported.Account `json:"accounts" yaml:"accounts"`
 }
 
 // NewGenesisState - Create a new genesis state
-func NewGenesisState(params Params, accounts []ValidatableAccount) GenesisState {
+func NewGenesisState(params Params, accounts []exported.Account) GenesisState {
 	return GenesisState{params, accounts}
 }
 
 // DefaultGenesisState - Return a default genesis state
 func DefaultGenesisState() GenesisState {
-	return NewGenesisState(DefaultParams(), []ValidatableAccount{}) // TODO could just create the struct and not initialize the account field.
+	return NewGenesisState(DefaultParams(), []exported.Account{})
 
-}
-
-// ValidatableAccount is an interface that accounts are unmarshalled into when the genesis file is read for the purpose of validating.
-// It exists to avoid having to add a Validate method to the Account interface.
-type ValidatableAccount interface {
-	exported.Account // TODO Is this even needed? Could almost create a generic Validatable interface
-	Validate() error
 }
 
 // ValidateGenesis performs basic validation of auth genesis data returning an
@@ -55,7 +48,7 @@ func ValidateGenesis(data GenesisState) error {
 	for _, acc := range data.Accounts {
 
 		// check for duplicated accounts
-		addrStr := acc.GetAddress().String() // TODO why string?
+		addrStr := acc.GetAddress().String()
 		if _, ok := addrMap[addrStr]; ok {
 			return fmt.Errorf("duplicate account found in genesis state; address: %s", addrStr)
 		}

--- a/x/auth/types/genesis.go
+++ b/x/auth/types/genesis.go
@@ -2,26 +2,38 @@ package types
 
 import (
 	"fmt"
+
+	"github.com/cosmos/cosmos-sdk/x/auth/exported"
 )
 
 // GenesisState - all auth state that must be provided at genesis
 type GenesisState struct {
-	Params Params `json:"params" yaml:"params"`
+	Params   Params               `json:"params" yaml:"params"`
+	Accounts []ValidatableAccount `json:"accounts" yaml:"accounts"`
 }
 
 // NewGenesisState - Create a new genesis state
-func NewGenesisState(params Params) GenesisState {
-	return GenesisState{params}
+func NewGenesisState(params Params, accounts []ValidatableAccount) GenesisState {
+	return GenesisState{params, accounts}
 }
 
 // DefaultGenesisState - Return a default genesis state
 func DefaultGenesisState() GenesisState {
-	return NewGenesisState(DefaultParams())
+	return NewGenesisState(DefaultParams(), []ValidatableAccount{}) // TODO could just create the struct and not initialize the account field.
+
+}
+
+// ValidatableAccount is an interface that accounts are unmarshalled into when the genesis file is read for the purpose of validating.
+// It exists to avoid having to add a Validate method to the Account interface.
+type ValidatableAccount interface {
+	exported.Account // TODO Is this even needed? Could almost create a generic Validatable interface
+	Validate() error
 }
 
 // ValidateGenesis performs basic validation of auth genesis data returning an
 // error for any failed validation criteria.
 func ValidateGenesis(data GenesisState) error {
+	// Validate params
 	if data.Params.TxSigLimit == 0 {
 		return fmt.Errorf("invalid tx signature limit: %d", data.Params.TxSigLimit)
 	}
@@ -37,5 +49,24 @@ func ValidateGenesis(data GenesisState) error {
 	if data.Params.TxSizeCostPerByte == 0 {
 		return fmt.Errorf("invalid tx size cost per byte: %d", data.Params.TxSizeCostPerByte)
 	}
+
+	// Validate accounts
+	addrMap := make(map[string]bool, len(data.Accounts))
+	for _, acc := range data.Accounts {
+
+		// check for duplicated accounts
+		addrStr := acc.GetAddress().String() // TODO why string?
+		if _, ok := addrMap[addrStr]; ok {
+			return fmt.Errorf("duplicate account found in genesis state; address: %s", addrStr)
+		}
+		addrMap[addrStr] = true
+
+		// check account specific validation
+		if err := acc.Validate(); err != nil {
+			return fmt.Errorf("invalid account found in genesis state; address: %s, error: %s", addrStr, err.Error())
+		}
+
+	}
+
 	return nil
 }

--- a/x/supply/internal/types/account.go
+++ b/x/supply/internal/types/account.go
@@ -91,6 +91,12 @@ func (ma ModuleAccount) SetSequence(seq uint64) error {
 	return fmt.Errorf("not supported for module accounts")
 }
 
+// Validate - Implements auth.ValidatableAccount. This is called on accounts after loading from a genesis file.
+func (ma ModuleAccount) Validate() error {
+	// TODO add more validation?
+	return nil
+}
+
 // String follows stringer interface
 func (ma ModuleAccount) String() string {
 	b, err := yaml.Marshal(ma)

--- a/x/supply/internal/types/account.go
+++ b/x/supply/internal/types/account.go
@@ -14,6 +14,11 @@ import (
 
 var _ exported.ModuleAccountI = (*ModuleAccount)(nil)
 
+// Register the module account type with the auth module codec so it can decode module accounts stored in a genesis file
+func init() {
+	authtypes.RegisterAccountTypeCodec(ModuleAccount{}, "cosmos-sdk/ModuleAccount")
+}
+
 // ModuleAccount defines an account for modules that holds coins on a pool
 type ModuleAccount struct {
 	*authtypes.BaseAccount

--- a/x/supply/internal/types/account.go
+++ b/x/supply/internal/types/account.go
@@ -91,7 +91,7 @@ func (ma ModuleAccount) SetSequence(seq uint64) error {
 	return fmt.Errorf("not supported for module accounts")
 }
 
-// Validate - Implements auth.ValidatableAccount. This is called on accounts after loading from a genesis file.
+// Validate is called on accounts after loading from a genesis file.
 func (ma ModuleAccount) Validate() error {
 	// TODO add more validation?
 	return nil


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

**Problem:** The `auth` module allows custom account types, but the `genaccounts` module does not.

**Problem Details:** The `auth` keeper can store any type fulfilling its Account interface. However auth does not handle exporting or loading accounts to/from a genesis file, this is done by `genaccounts`, which only handles one of 4 concrete account types.

This is causing a problem for our chain as we want to define custom vesting account types.

**Proposed Solution:** Marshal/Unmarshal accounts (interface types) directly using amino, rather than converting to genaccount’s GenesisAccount type. And since doing this removes the majority of genaccount’s code, move all logic into auth and remove the genaccounts module.

**Benefits:**
 - custom account types can be used in genesis
 - simplification of code

Let me know if this is a change that is desired, or I'm missing anything.

**Solution Discussion:**
Moving genesis export/load into auth is fairly straightforwards. However complexities arise from:
 - registering custom account types on the auth codec
 - genesis validation for custom account types

Proposed solution for codec registration:

Follow the pattern `gov` uses for proposals. Define an init function alongside the custom account type that imports auth/types, and registers the custom type on `auth. ModuleCdc`.

Proposed Solution for genesis validation:

Add a `Validate` method to the auth.Account interface. Then `authModuleBasic.ValidateGenesis` can call `Validate` on each account it loads.

This was the simplest solution I thought of. An alternative would be to not expand Account but instead extend it into something like:

    type ValidatableAccount interface {
        exported.Account
        Validate() error
    }

Then accounts can be unmarshalled into this type, which Validate() can be called on. This avoids adding to the account interface and `account.Validate` being available to the rest of the sdk. But could lead to some confusing errors if a custom account did not have Validate defined.

TODO
 - genesis migration
 - move tests over from genaccounts
 - delete genaccounts
 - fix simulation stuff

---
- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/develop/CONTRIBUTING.md#pr-targeting))

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))