### PR TITLE
Quick fix to docs to not show staging website

### DIFF
--- a/docs/DOCS_README.md
+++ b/docs/DOCS_README.md
@@ -4,19 +4,16 @@ If you want to open a PR on the Cosmos SDK to update the documentation, please f
 
 ## Docs Build Workflow
 
-The documentation for the Cosmos SDK is hosted at:
-
-- https://cosmos.network/docs/ and
-- https://cosmos-staging.interblock.io/docs/
+The documentation for the Cosmos SDK is hosted at https://cosmos.network/docs/
 
 built from the files in this (`/docs`) directory for
 [master](https://github.com/cosmos/cosmos-sdk/tree/master/docs).
 
 ### How It Works
 
-There is a CircleCI job listening for changes in the `/docs` directory, on both
-the  `master` and `develop` branches. Any updates to files in this directory
-on those branches will automatically trigger a website deployment. Under the hood,
+There is a CircleCI job listening for changes in the `/docs` directory, on
+the `master` branch. Any updates to files in this directory
+on that branch will automatically trigger a website deployment. Under the hood,
 the private website repository has a `make build-docs` target consumed by a CircleCI job in that repo.
 
 ## README
@@ -111,14 +108,14 @@ much as possible with its [counterpart in the Tendermint Core repo](https://gith
 ### Update and Build the RPC docs
 
 1. Execute the following command at the root directory to install the swagger-ui generate tool.
-    ```bash
-    make tools
-    ```
+   ```bash
+   make tools
+   ```
 2. Edit API docs
-    1. Directly Edit API docs manually: `client/lcd/swagger-ui/swagger.yaml`.
-    2. Edit API docs within the [Swagger Editor](https://editor.swagger.io/). Please refer to this [document](https://swagger.io/docs/specification/2-0/basic-structure/) for the correct structure in `.yaml`.
+   1. Directly Edit API docs manually: `client/lcd/swagger-ui/swagger.yaml`.
+   2. Edit API docs within the [Swagger Editor](https://editor.swagger.io/). Please refer to this [document](https://swagger.io/docs/specification/2-0/basic-structure/) for the correct structure in `.yaml`.
 3. Download `swagger.yaml` and replace the old `swagger.yaml` under fold `client/lcd/swagger-ui`.
 4. Compile gaiacli
-    ```bash
-    make install
-    ```
+   ```bash
+   make install
+   ```


### PR DESCRIPTION
- remove mention of develop and staging env

Signed-off-by: Marko Baricevic <marbar3778@yahoo.com>

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/develop/CONTRIBUTING.md#pr-targeting))

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
