### PR TITLE
switch version to master

### DIFF
--- a/docs/versions
+++ b/docs/versions
@@ -1,1 +1,1 @@
-updated-docs
+master


### PR DESCRIPTION
For docs deployment purposes `versions` file now contains `master`, so that when docs are deployed the script checks out `master` branch and builds all required files for the website.