### PR TITLE
Override GOPROXY's default value

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,11 @@ LEDGER_ENABLED ?= true
 BINDIR ?= $(GOPATH)/bin
 SIMAPP = ./simapp
 MOCKS_DIR = $(CURDIR)/tests/mocks
+GOPROXY ?= direct
+goproxy := $(GOPROXY)
 
 export GO111MODULE = on
+export GOPROXY = $(goproxy)
 
 all: tools build lint test
 


### PR DESCRIPTION
Go 1.13 uses http://proxy.golang.org as GOPROXY's default
value if the environment variable is unset or blank. This
patch makes cosmos-sdk's buildsystem override Go env's
default and fallback to 'direct' if and only if GOPROXY is
unset in the user's environment.

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
