### PR TITLE
Remove unnecessary account check

### DIFF
--- a/x/auth/client/cli/query.go
+++ b/x/auth/client/cli/query.go
@@ -56,10 +56,6 @@ func GetAccountCmd(cdc *codec.Codec) *cobra.Command {
 				return err
 			}
 
-			if err := accGetter.EnsureExists(key); err != nil {
-				return err
-			}
-
 			acc, err := accGetter.GetAccount(key)
 			if err != nil {
 				return err


### PR DESCRIPTION
EnsureExists just calls GetAccount, so there is no need to do this check