### PR TITLE
fix/add-back-auth-tx-routes

### DIFF
--- a/x/auth/module.go
+++ b/x/auth/module.go
@@ -57,6 +57,7 @@ func (AppModuleBasic) ValidateGenesis(bz json.RawMessage) error {
 // RegisterRESTRoutes registers the REST routes for the auth module.
 func (AppModuleBasic) RegisterRESTRoutes(ctx context.CLIContext, rtr *mux.Router) {
 	rest.RegisterRoutes(ctx, rtr, types.StoreKey)
+	rest.RegisterTxRoutes(ctx, rtr)
 }
 
 // GetTxCmd returns the root tx command for the auth module.


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Maybe this was overlooked, or maybe we're doing something wrong, but we're unable to broadcast transactions (route `POST /txs` on the LCD server) on `v0.37`.

Haven't been able to find any discussion about this either.

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
