### PR TITLE
Add `keys` subcommands to sign and verify arbitrary text payloads.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,8 @@ and tx hash will be returned for specific Tendermint errors:
   * `CodeMempoolIsFull`
   * `CodeTxTooLarge`
 * [\#3872](https://github.com/cosmos/cosmos-sdk/issues/3872) Implement a RESTful endpoint and cli command to decode transactions.
+* (cli)[\#4581](https://github.com/cosmos/cosmos-sdk/issues/4581) Add `keys sign` and `keys verify` commands to respectively sign
+and verify arbitrary plain text with private keys.
 
 ### Improvements
 

--- a/client/keys/root.go
+++ b/client/keys/root.go
@@ -29,6 +29,8 @@ func Commands() *cobra.Command {
 		deleteKeyCommand(),
 		updateKeyCommand(),
 		parseKeyStringCommand(),
+		signCommand(),
+		verifyCommand(),
 	)
 	return cmd
 }

--- a/client/keys/root_test.go
+++ b/client/keys/root_test.go
@@ -11,5 +11,5 @@ func TestCommands(t *testing.T) {
 	assert.NotNil(t, rootCommands)
 
 	// Commands are registered
-	assert.Equal(t, 10, len(rootCommands.Commands()))
+	assert.Equal(t, 12, len(rootCommands.Commands()))
 }

--- a/client/keys/sign.go
+++ b/client/keys/sign.go
@@ -1,0 +1,70 @@
+package keys
+
+import (
+	"bufio"
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/cosmos/cosmos-sdk/client/input"
+)
+
+func signCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "sign <name> <filename>",
+		Short: "Sign a plain text payload with a private key and print the signed document to STDOUT",
+		Long: `Sign an arbitrary text file with a private key and produce an amino-encoded JSON output.
+The signed JSON document could eventually be verified through the 'keys verify' command and will
+have the following structure:
+{
+  "text": original text file contents,
+  "pub": public key,
+  "sig": signature
+}
+`,
+		Args: cobra.ExactArgs(2),
+		RunE: runSignCmd,
+	}
+	cmd.SetOut(os.Stdout)
+	return cmd
+}
+
+func runSignCmd(cmd *cobra.Command, args []string) error {
+	name := args[0]
+	filename := args[1]
+
+	kb, err := NewKeyBaseFromHomeFlag()
+	if err != nil {
+		return err
+	}
+
+	msg, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return err
+	}
+
+	buf := bufio.NewReader(cmd.InOrStdin())
+	passphrase, err := input.GetPassword(fmt.Sprintf("Password to sign with '%s':", name), buf)
+	if err != nil {
+		return err
+	}
+
+	sig, pub, err := kb.Sign(name, passphrase, msg)
+	if err != nil {
+		return err
+	}
+
+	out, err := MarshalJSON(signedText{
+		Text: string(msg),
+		Pub:  pub,
+		Sig:  sig,
+	})
+	if err != nil {
+		return err
+	}
+
+	cmd.Println(string(out))
+	return nil
+}

--- a/client/keys/sign_verify_test.go
+++ b/client/keys/sign_verify_test.go
@@ -1,0 +1,79 @@
+package keys
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tendermint/tendermint/libs/cli"
+
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/cosmos/cosmos-sdk/tests"
+)
+
+func Test_runSignCmd(t *testing.T) {
+	signCmd := signCommand()
+	// err := runSignCmd(signCmd, []string{"invalid", "invalid"})
+	// require.Contains(t, err.Error(), "no such file or directory")
+
+	// Prepare a plain text doc
+	tmpfile, err := ioutil.TempFile("", "")
+	require.NoError(t, err)
+	ioutil.WriteFile(tmpfile.Name(), []byte(`this is
+an example`), 0644)
+	require.NoError(t, err)
+	tmpfile.Close()
+	defer os.Remove(tmpfile.Name())
+
+	// Prepare a key base
+	// Now add a temporary keybase
+	kbHome, cleanUp := tests.NewTestCaseDir(t)
+	defer cleanUp()
+	viper.Set(flags.FlagHome, kbHome)
+	viper.Set(cli.OutputFlag, OutputFormatText)
+
+	// Initialise keybase
+	kb, err := NewKeyBaseFromHomeFlag()
+	assert.NoError(t, err)
+	_, err = kb.CreateAccount("key1", tests.TestMnemonic, "", "test1234", 0, 0)
+	assert.NoError(t, err)
+
+	// Mock standard streams
+	mockIn, mockOut, _ := tests.ApplyMockIO(signCmd)
+	mockIn.Reset("test1234\n")
+	require.NoError(t, runSignCmd(signCmd, []string{"key1", tmpfile.Name()}))
+
+	signedDocBytes := mockOut.Bytes()
+	var signedDoc signedText
+	require.NoError(t, UnmarshalJSON(signedDocBytes, &signedDoc))
+
+	// Prepare a signed doc file
+	outTmpFile, err := ioutil.TempFile("", "")
+	require.NoError(t, err)
+	ioutil.WriteFile(outTmpFile.Name(), signedDocBytes, 0644)
+	require.NoError(t, err)
+	outTmpFile.Close()
+	defer os.Remove(outTmpFile.Name())
+
+	// Verify
+	verifyCommand := verifyCommand()
+	require.NoError(t, runVerifyCmd(verifyCommand, []string{outTmpFile.Name()}))
+
+	// Prepare a file with corrupted signature
+	signedDoc.Text = "this is an example"
+	signedDocBytes, err = MarshalJSON(signedDoc)
+	require.NoError(t, err)
+
+	// Verification fails
+	outTmpFile, err = ioutil.TempFile("", "")
+	require.NoError(t, err)
+	ioutil.WriteFile(outTmpFile.Name(), signedDocBytes, 0644)
+	require.NoError(t, err)
+	outTmpFile.Close()
+	defer os.Remove(outTmpFile.Name())
+
+	require.Error(t, runVerifyCmd(verifyCommand, []string{outTmpFile.Name()}))
+}

--- a/client/keys/types.go
+++ b/client/keys/types.go
@@ -1,5 +1,9 @@
 package keys
 
+import (
+	"github.com/tendermint/tendermint/crypto"
+)
+
 // used for outputting keys.Info over REST
 
 // AddNewKey request a new key
@@ -53,3 +57,9 @@ type DeleteKeyReq struct {
 
 // NewDeleteKeyReq constructs a new DeleteKeyReq structure.
 func NewDeleteKeyReq(password string) DeleteKeyReq { return DeleteKeyReq{Password: password} }
+
+type signedText struct {
+	Text string        `json:"text"`
+	Pub  crypto.PubKey `json:"pub"`
+	Sig  []byte        `json:"sig"`
+}

--- a/client/keys/verify.go
+++ b/client/keys/verify.go
@@ -1,0 +1,42 @@
+package keys
+
+import (
+	"errors"
+	"io/ioutil"
+
+	"github.com/spf13/cobra"
+)
+
+func verifyCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "verify <filename>",
+		Short: "Verify a plain text's signature",
+		Long: `Read a document generated with the 'key sign' command and verify the signature.
+It exits with 0 if the signature verification succeed; it returns a value different than 0
+if the signature verification fails.
+`,
+		Args: cobra.ExactArgs(1),
+		RunE: runVerifyCmd,
+	}
+	return cmd
+}
+
+func runVerifyCmd(cmd *cobra.Command, args []string) error {
+	filename := args[0]
+
+	signedDoc, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return err
+	}
+
+	var doc signedText
+	if err := UnmarshalJSON(signedDoc, &doc); err != nil {
+		return err
+	}
+
+	if doc.Pub.VerifyBytes([]byte(doc.Text), doc.Sig) {
+		cmd.PrintErrln("signature verified")
+		return nil
+	}
+	return errors.New("bad signature")
+}


### PR DESCRIPTION
Closes: #4581

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
