### PR TITLE
Fix #5112, make pubkey of MsgCreateValidator more readable 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,13 +130,13 @@ caching through `CommitKVStoreCacheManager`. Any application wishing to utilize 
 must set it in their app via a `BaseApp` option. The `BaseApp` docs have been drastically improved
 to detail this new feature and how state transitions occur.
 * (docs/spec) All module specs moved into their respective module dir in x/ (i.e. docs/spec/staking -->> x/staking/spec)
-* (cli) [\#5112](https://github.com/cosmos/cosmos-sdk/issues/5112) Bech32ify pubkey of MsgCreateValidator during yaml marshal, to make `gaiacli q tx` more readable when tx msg is CreateValidator.
 
 ### Bug Fixes
 
 * (cli) [\#4763](https://github.com/cosmos/cosmos-sdk/issues/4763) Fix flag `--min-self-delegation` for staking `EditValidator`
 * (keys) Fix ledger custom coin type support bug
 * (genesis) [\#5095](https://github.com/cosmos/cosmos-sdk/issues/5095) Fix genesis file migration from v0.34 to v0.36 not converting validator consensus pubkey to bech32 format
+* (cli) [\#5112](https://github.com/cosmos/cosmos-sdk/issues/5112) Bech32ify pubkey of MsgCreateValidator during yaml marshal, to make `gaiacli q tx` more readable when tx msg is CreateValidator.
 
 ## [v0.37.1] - 2019-09-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,7 @@ caching through `CommitKVStoreCacheManager`. Any application wishing to utilize 
 must set it in their app via a `BaseApp` option. The `BaseApp` docs have been drastically improved
 to detail this new feature and how state transitions occur.
 * (docs/spec) All module specs moved into their respective module dir in x/ (i.e. docs/spec/staking -->> x/staking/spec)
+* (cli) [\#5112](https://github.com/cosmos/cosmos-sdk/issues/5112) Bech32ify pubkey of MsgCreateValidator during yaml marshal, to make `gaiacli q tx` more readable when tx msg is CreateValidator.
 
 ### Bug Fixes
 

--- a/x/staking/types/msg.go
+++ b/x/staking/types/msg.go
@@ -3,9 +3,8 @@ package types
 import (
 	"bytes"
 	"encoding/json"
-	"gopkg.in/yaml.v2"
-
 	"github.com/tendermint/tendermint/crypto"
+	"gopkg.in/yaml.v2"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
@@ -79,7 +78,16 @@ func (msg MsgCreateValidator) GetSigners() []sdk.AccAddress {
 // MarshalJSON implements the json.Marshaler interface to provide custom JSON
 // serialization of the MsgCreateValidator type.
 func (msg MsgCreateValidator) MarshalJSON() ([]byte, error) {
-	return json.Marshal(msgCreateValidatorJSON{
+	return json.Marshal(msg.toMarshalObj())
+}
+
+func (msg MsgCreateValidator) MarshalYAML() (interface{}, error) {
+	bz, err := yaml.Marshal(msg.toMarshalObj())
+	return string(bz), err
+}
+
+func (msg MsgCreateValidator) toMarshalObj() msgCreateValidatorJSON {
+	return msgCreateValidatorJSON{
 		Description:       msg.Description,
 		Commission:        msg.Commission,
 		DelegatorAddress:  msg.DelegatorAddress,
@@ -87,7 +95,7 @@ func (msg MsgCreateValidator) MarshalJSON() ([]byte, error) {
 		PubKey:            sdk.MustBech32ifyConsPub(msg.PubKey),
 		Value:             msg.Value,
 		MinSelfDelegation: msg.MinSelfDelegation,
-	})
+	}
 }
 
 // UnmarshalJSON implements the json.Unmarshaler interface to provide custom
@@ -112,21 +120,6 @@ func (msg *MsgCreateValidator) UnmarshalJSON(bz []byte) error {
 
 	return nil
 }
-
-
-func (msg MsgCreateValidator) MarshalYAML() (interface{}, error) {
-	bz, err := yaml.Marshal(msgCreateValidatorJSON{
-		Description:       msg.Description,
-		Commission:        msg.Commission,
-		DelegatorAddress:  msg.DelegatorAddress,
-		ValidatorAddress:  msg.ValidatorAddress,
-		PubKey:            sdk.MustBech32ifyConsPub(msg.PubKey),
-		Value:             msg.Value,
-		MinSelfDelegation: msg.MinSelfDelegation,
-	})
-	return string(bz), err
-}
-
 
 // GetSignBytes returns the message bytes to sign over.
 func (msg MsgCreateValidator) GetSignBytes() []byte {

--- a/x/staking/types/msg.go
+++ b/x/staking/types/msg.go
@@ -3,6 +3,7 @@ package types
 import (
 	"bytes"
 	"encoding/json"
+	"gopkg.in/yaml.v2"
 
 	"github.com/tendermint/tendermint/crypto"
 
@@ -111,6 +112,21 @@ func (msg *MsgCreateValidator) UnmarshalJSON(bz []byte) error {
 
 	return nil
 }
+
+
+func (msg MsgCreateValidator) MarshalYAML() (interface{}, error) {
+	bz, err := yaml.Marshal(msgCreateValidatorJSON{
+		Description:       msg.Description,
+		Commission:        msg.Commission,
+		DelegatorAddress:  msg.DelegatorAddress,
+		ValidatorAddress:  msg.ValidatorAddress,
+		PubKey:            sdk.MustBech32ifyConsPub(msg.PubKey),
+		Value:             msg.Value,
+		MinSelfDelegation: msg.MinSelfDelegation,
+	})
+	return string(bz), err
+}
+
 
 // GetSignBytes returns the message bytes to sign over.
 func (msg MsgCreateValidator) GetSignBytes() []byte {

--- a/x/staking/types/msg_test.go
+++ b/x/staking/types/msg_test.go
@@ -2,11 +2,11 @@ package types
 
 import (
 	"fmt"
-	"gopkg.in/yaml.v2"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"github.com/tendermint/tendermint/crypto"
+	yaml "gopkg.in/yaml.v2"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )


### PR DESCRIPTION
For: https://github.com/cosmos/cosmos-sdk/issues/5112

Before fix:
```
GOROOT=/usr/local/go #gosetup
GOPATH=/Users/j/go #gosetup
/usr/local/go/bin/go test -c -o /private/var/folders/qh/zplspkbx5bl9rghk_xk_406m0000gn/T/___TestMsgCreateValidator_in_github_com_cosmos_cosmos_sdk_x_staking_types github.com/cosmos/cosmos-sdk/x/staking/types #gosetup
/usr/local/go/bin/go tool test2json -t /private/var/folders/qh/zplspkbx5bl9rghk_xk_406m0000gn/T/___TestMsgCreateValidator_in_github_com_cosmos_cosmos_sdk_x_staking_types -test.v -test.run ^TestMsgCreateValidator$ #gosetup
=== RUN   TestMsgCreateValidator
description:
  moniker: a
  identity: b
  website: c
  security_contact: d
  details: e
commission:
  rate: "0.000000000000000000"
  max_rate: "0.000000000000000000"
  max_change_rate: "0.000000000000000000"
min_self_delegation: "1"
delegator_address: cosmos13uh33h2lem3n82z7kuw83tauetwpyv8zgcy8dz
validator_address: cosmosvaloper13uh33h2lem3n82z7kuw83tauetwpyv8zdvsjp3
pubkey:
- 199
- 239
- 137
- 247
- 94
- 47
- 65
- 45
- 20
- 92
- 86
- 89
- 180
- 116
- 216
- 172
- 29
- 221
- 150
- 20
- 193
- 76
- 48
- 242
- 3
- 192
- 37
- 25
- 255
- 60
- 45
- 179
value:
  denom: stake
  amount: "1000"

--- PASS: TestMsgCreateValidator (0.00s)
PASS

Process finished with exit code 0




```

After fix:
```

GOROOT=/usr/local/go #gosetup
GOPATH=/Users/j/go #gosetup
/usr/local/go/bin/go test -c -o /private/var/folders/qh/zplspkbx5bl9rghk_xk_406m0000gn/T/___TestMsgCreateValidator_in_github_com_cosmos_cosmos_sdk_x_staking_types github.com/cosmos/cosmos-sdk/x/staking/types #gosetup
/usr/local/go/bin/go tool test2json -t /private/var/folders/qh/zplspkbx5bl9rghk_xk_406m0000gn/T/___TestMsgCreateValidator_in_github_com_cosmos_cosmos_sdk_x_staking_types -test.v -test.run ^TestMsgCreateValidator$ #gosetup
=== RUN   TestMsgCreateValidator
|
  description:
    moniker: a
    identity: b
    website: c
    security_contact: d
    details: e
  commission:
    rate: "0.000000000000000000"
    max_rate: "0.000000000000000000"
    max_change_rate: "0.000000000000000000"
  min_self_delegation: "1"
  delegator_address: cosmos1kfx8kdjdqu23vtqwf6fwxh4xr3gzvj9z2xhr6n
  validator_address: cosmosvaloper1kfx8kdjdqu23vtqwf6fwxh4xr3gzvj9z0jrkkq
  pubkey: cosmosvalconspub1zcjduepq63cy6kn5e8n2392dl2pys9azzq0jgvd4wuycet5n980d24vzm62shn6f04
  value:
    denom: stake
    amount: "1000"

--- PASS: TestMsgCreateValidator (0.00s)
PASS

Process finished with exit code 0

```



<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/develop/CONTRIBUTING.md#pr-targeting))

- [x] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [x] Wrote tests
- [x] Updated relevant documentation (`docs/`)
- [x] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
