### PR TITLE
R4R - Store consensus state correctly

### DIFF
--- a/x/ibc/02-client/client/cli/tx.go
+++ b/x/ibc/02-client/client/cli/tx.go
@@ -91,7 +91,7 @@ func GetCmdUpdateClient(cdc *codec.Codec) *cobra.Command {
 		Long: strings.TrimSpace(fmt.Sprintf(`update existing client with a header:
 
 Example:
-$ %s tx ibc client create [client-id] [path/to/header.json] --from node0 --home ../node0/<app>cli --chain-id $CID
+$ %s tx ibc client update [client-id] [path/to/header.json] --from node0 --home ../node0/<app>cli --chain-id $CID
 		`, version.ClientName),
 		),
 		Args: cobra.ExactArgs(2),

--- a/x/ibc/02-client/keeper/keeper.go
+++ b/x/ibc/02-client/keeper/keeper.go
@@ -79,7 +79,7 @@ func (k Keeper) SetClientType(ctx sdk.Context, clientID string, clientType expor
 // GetConsensusState creates a new client state and populates it with a given consensus state
 func (k Keeper) GetConsensusState(ctx sdk.Context, clientID string) (exported.ConsensusState, bool) {
 	store := prefix.NewStore(ctx.KVStore(k.storeKey), k.prefix)
-	bz := store.Get(types.KeyClientState(clientID))
+	bz := store.Get(types.KeyConsensusState(clientID))
 	if bz == nil {
 		return nil, false
 	}
@@ -93,7 +93,7 @@ func (k Keeper) GetConsensusState(ctx sdk.Context, clientID string) (exported.Co
 func (k Keeper) SetConsensusState(ctx sdk.Context, clientID string, consensusState exported.ConsensusState) {
 	store := prefix.NewStore(ctx.KVStore(k.storeKey), k.prefix)
 	bz := k.cdc.MustMarshalBinaryLengthPrefixed(consensusState)
-	store.Set(types.KeyClientState(clientID), bz)
+	store.Set(types.KeyConsensusState(clientID), bz)
 }
 
 // GetVerifiedRoot gets a verified commitment Root from a particular height to


### PR DESCRIPTION
Store consensus by `KeyConsensusState` instead of `KeyClientState`.