### PR TITLE
R4R - Fix channel and packet check

### DIFF
--- a/x/ibc/04-channel/keeper/handshake.go
+++ b/x/ibc/04-channel/keeper/handshake.go
@@ -182,7 +182,7 @@ func (k Keeper) ChanOpenAck(
 	// counterparty of the counterparty channel end (i.e self)
 	counterparty := types.NewCounterparty(portID, channelID)
 	expectedChannel := types.NewChannel(
-		types.INIT, channel.Ordering, counterparty,
+		types.OPENTRY, channel.Ordering, counterparty,
 		channel.CounterpartyHops(), channel.Version,
 	)
 

--- a/x/ibc/04-channel/keeper/packet.go
+++ b/x/ibc/04-channel/keeper/packet.go
@@ -195,9 +195,9 @@ func (k Keeper) RecvPacket(
 	acknowledgement []byte,
 ) (exported.PacketI, error) {
 
-	channel, found := k.GetChannel(ctx, packet.SourcePort(), packet.SourceChannel())
+	channel, found := k.GetChannel(ctx, packet.DestPort(), packet.DestChannel())
 	if !found {
-		return nil, types.ErrChannelNotFound(k.codespace, packet.SourceChannel())
+		return nil, types.ErrChannelNotFound(k.codespace, packet.DestChannel())
 	}
 
 	if channel.State != types.OPEN {
@@ -207,7 +207,7 @@ func (k Keeper) RecvPacket(
 		)
 	}
 
-	_, found = k.GetChannelCapability(ctx, packet.SourcePort(), packet.SourceChannel())
+	_, found = k.GetChannelCapability(ctx, packet.DestPort(), packet.DestChannel())
 	if !found {
 		return nil, types.ErrChannelCapabilityNotFound(k.codespace)
 	}


### PR DESCRIPTION
*  On `ChanOpenAck`, the  counterparty channel state should be `OPENTRY`.
*  On `RecvPacket`, its self channel should be related with `RecvPacket.DestPort` and `RecvPacket.DestChannel`.