### PR TITLE
Added the NewAppModuleBasic method to the staking module

### DIFF
--- a/x/staking/alias.go
+++ b/x/staking/alias.go
@@ -133,6 +133,7 @@ var (
 	ErrMissingSignature                = types.ErrMissingSignature
 	NewGenesisState                    = types.NewGenesisState
 	DefaultGenesisState                = types.DefaultGenesisState
+	DefaultGenesisStateWithParams      = types.DefaultGenesisStateWitParams
 	NewMultiStakingHooks               = types.NewMultiStakingHooks
 	GetValidatorKey                    = types.GetValidatorKey
 	GetValidatorByConsAddrKey          = types.GetValidatorByConsAddrKey

--- a/x/staking/module.go
+++ b/x/staking/module.go
@@ -31,7 +31,14 @@ var (
 )
 
 // AppModuleBasic defines the basic application module used by the staking module.
-type AppModuleBasic struct{}
+type AppModuleBasic struct {
+	params Params
+}
+
+// NewAppModuleBasic returns a new basic application module having the given set of parameters
+func NewAppModuleBasic(params Params) AppModuleBasic {
+	return AppModuleBasic{params: params}
+}
 
 var _ module.AppModuleBasic = AppModuleBasic{}
 
@@ -47,8 +54,8 @@ func (AppModuleBasic) RegisterCodec(cdc *codec.Codec) {
 
 // DefaultGenesis returns default genesis state as raw bytes for the staking
 // module.
-func (AppModuleBasic) DefaultGenesis() json.RawMessage {
-	return ModuleCdc.MustMarshalJSON(DefaultGenesisState())
+func (amb AppModuleBasic) DefaultGenesis() json.RawMessage {
+	return ModuleCdc.MustMarshalJSON(DefaultGenesisStateWithParams(amb.params))
 }
 
 // ValidateGenesis performs genesis state validation for the staking module.

--- a/x/staking/types/genesis.go
+++ b/x/staking/types/genesis.go
@@ -36,3 +36,10 @@ func DefaultGenesisState() GenesisState {
 		Params: DefaultParams(),
 	}
 }
+
+// get raw genesis raw message having the given set of parameters
+func DefaultGenesisStateWitParams(params Params) GenesisState {
+	return GenesisState{
+		Params: UseParamsOrDefault(params),
+	}
+}

--- a/x/staking/types/params.go
+++ b/x/staking/types/params.go
@@ -3,6 +3,7 @@ package types
 import (
 	"bytes"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -76,6 +77,28 @@ func (p Params) Equal(p2 Params) bool {
 // DefaultParams returns a default set of parameters.
 func DefaultParams() Params {
 	return NewParams(DefaultUnbondingTime, DefaultMaxValidators, DefaultMaxEntries, sdk.DefaultBondDenom)
+}
+
+// UseParamsOrDefault returns a set of parameters that contains the data
+// present inside the given set, or the default value if some parameter is missing
+func UseParamsOrDefault(original Params) Params {
+	if original.UnbondingTime == 0 {
+		original.UnbondingTime = DefaultUnbondingTime
+	}
+
+	if original.MaxEntries == 0 {
+		original.MaxEntries = DefaultMaxEntries
+	}
+
+	if original.MaxValidators == 0 {
+		original.MaxValidators = DefaultMaxValidators
+	}
+
+	if len(strings.TrimSpace(original.BondDenom)) == 0 {
+		original.BondDenom = sdk.DefaultBondDenom
+	}
+
+	return original
 }
 
 // String returns a human readable string representation of the parameters.


### PR DESCRIPTION
## Description
I open this PR following a recent discussion on the VIP chat. 
It introduces a new method, `staking.NewAppModuleBasic`, which allows to easily set a default parameters set into the module that will later be used during the default genesis state creation.

The main reason behind this implementation is to allow zones to customize the default staking parameters during local development without having to create a custom script that edits the genesis.json file after its creation (DRY). 

While being very small, I think this might improve a lot the UX of new zones' developers. 

## Checklist
- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/develop/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
