### PR TITLE
Revert "changed bench32prefixes, gaiacli keys parse command still use cosmos …"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,7 +130,6 @@ that allows for arbitrary vesting periods.
 
 ### Improvements
 
-* (keys) [\#5091](https://github.com/cosmos/cosmos-sdk/issues/5091) Changed prefixes using `SetBech32PrefixForAccount(), SetBech32PrefixForValidator(), SetBech32PrefixForConsensusNode()` methods are respected in `keys parse`.
 * (server) [\#4215](https://github.com/cosmos/cosmos-sdk/issues/4215) The `--pruning` flag
 has been moved to the configuration file, to allow easier node configuration.
 * (cli) [\#5116](https://github.com/cosmos/cosmos-sdk/issues/5116) The `CLIContext` now supports multiple verifiers
@@ -150,6 +149,7 @@ chain ID and node URI or client set. To use a `CLIContext` with a verifier for a
     context.CreateVerifier(sideCtx, context.DefaultVerifierCacheSize),
   )
   ```
+
 * (modules) [\#5017](https://github.com/cosmos/cosmos-sdk/pull/5017) The `x/auth` package now supports
 generalized genesis accounts through the `GenesisAccount` interface.
 * (modules) [\#4762](https://github.com/cosmos/cosmos-sdk/issues/4762) Deprecate remove and add permissions in ModuleAccount.

--- a/client/keys/parse.go
+++ b/client/keys/parse.go
@@ -17,17 +17,14 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
-func bech32Prefixes() []string {
-	config := sdk.GetConfig()
-
-	return []string{
-		config.GetBech32AccountAddrPrefix(),
-		config.GetBech32AccountPubPrefix(),
-		config.GetBech32ValidatorAddrPrefix(),
-		config.GetBech32ValidatorPubPrefix(),
-		config.GetBech32ConsensusAddrPrefix(),
-		config.GetBech32ConsensusPubPrefix(),
-	}
+var config = sdk.GetConfig()
+var bech32Prefixes = []string{
+	config.GetBech32AccountAddrPrefix(),
+	config.GetBech32AccountPubPrefix(),
+	config.GetBech32ValidatorAddrPrefix(),
+	config.GetBech32ValidatorPubPrefix(),
+	config.GetBech32ConsensusAddrPrefix(),
+	config.GetBech32ConsensusPubPrefix(),
 }
 
 type hexOutput struct {
@@ -48,7 +45,6 @@ type bech32Output struct {
 }
 
 func newBech32Output(bs []byte) bech32Output {
-	bech32Prefixes := bech32Prefixes()
 	out := bech32Output{Formats: make([]string, len(bech32Prefixes))}
 	for i, prefix := range bech32Prefixes {
 		bech32Addr, err := bech32.ConvertAndEncode(prefix, bs)


### PR DESCRIPTION
Reverts cosmos/cosmos-sdk#5092 due to race condition (e.g. [here](https://circleci.com/gh/cosmos/cosmos-sdk/146878#tests/containers/3))

/cc @elvin-du any chance you can look into this?