### PR TITLE
Fix links to ocap

### DIFF
--- a/docs/intro/sdk-design.md
+++ b/docs/intro/sdk-design.md
@@ -80,7 +80,7 @@ Here is a simplified view of how a transaction is processed by the application o
                                        v
 ```
 
-Each module can be seen as a little state-machine. Developers need to define the subset of the state handled by the module, as well as custom message types that modify the state (*Note:* `messages` are extracted from `transactions` using `baseapp`). In general, each module declares its own `KVStore` in the multistore to persist the subset of the state it defines. Most developers will need to access other 3rd party modules when building their own modules. Given that the Cosmos-SDK is an open framework, some of the modules may be malicious, which means there is a need for security principles to reason about inter-module interactions. These principles are based on [object-capabilities](../coore/ocap.md). In practice, this means that instead of having each module keep an access control list for other modules, each module implements special objects called `keepers` that can be passed to other modules to grant a pre-defined set of capabilities. 
+Each module can be seen as a little state-machine. Developers need to define the subset of the state handled by the module, as well as custom message types that modify the state (*Note:* `messages` are extracted from `transactions` using `baseapp`). In general, each module declares its own `KVStore` in the multistore to persist the subset of the state it defines. Most developers will need to access other 3rd party modules when building their own modules. Given that the Cosmos-SDK is an open framework, some of the modules may be malicious, which means there is a need for security principles to reason about inter-module interactions. These principles are based on [object-capabilities](../core/ocap.md). In practice, this means that instead of having each module keep an access control list for other modules, each module implements special objects called `keepers` that can be passed to other modules to grant a pre-defined set of capabilities. 
 
 SDK modules are defined in the `x/` folder of the SDK. Some core modules include:
 
@@ -91,4 +91,4 @@ SDK modules are defined in the `x/` folder of the SDK. Some core modules include
 In addition to the already existing modules in `x/`, that anyone can use in their app, the SDK lets you build your own custom modules. You can check an [example of that in the tutorial](https://cosmos.network/docs/tutorial/keeper.html). 
 
 
-### Next, learn more about the security model of the Cosmos SDK, [ocap](./ocap.md)
+### Next, learn more about the security model of the Cosmos SDK, [ocap](../core/ocap.md)


### PR DESCRIPTION
Just walking through the intro docs to familiarize myself I noticed links to `ocap.md` were incorrect. There was a typo in the link on line 83, and an incorrect link on line 94. I believe I updated it to the correct location.
