### PR TITLE
Fix dangling link in docs/spec/

### DIFF
--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -15,7 +15,7 @@ block.
 
 - [Auth](../../x/auth/spec) - The structure and authentication of accounts and transactions.
 - [Bank](../../x/bank/spec) - Sending tokens.
-- [Governance](../../x/governance/spec) - Proposals and voting.
+- [Governance](../../x/gov/spec) - Proposals and voting.
 - [Staking](../../x/staking/spec) - Proof-of-stake bonding, delegation, etc.
 - [Slashing](../../x/slashing/spec) - Validator punishment mechanisms.
 - [Distribution](../../x/distribution/spec) - Fee distribution, and staking token provision distribution.


### PR DESCRIPTION

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
