### PR TITLE
Add dev docs for COSMOS_SDK_TEST_KEYRING

### DIFF
--- a/client/keys/utils.go
+++ b/client/keys/utils.go
@@ -46,7 +46,9 @@ func NewKeyringFromHomeFlag(input io.Reader) (keys.Keybase, error) {
 	return NewKeyringFromDir(viper.GetString(flags.FlagHome), input)
 }
 
-// NewKeyBaseFromDir initializes a keybase at a particular dir.
+// NewKeyBaseFromDir initializes a keyring at a particular dir.
+// If the COSMOS_SDK_TEST_KEYRING environment variable is set and not empty it will
+// return an on-disk, password-less keyring that could be used for testing purposes.
 func NewKeyringFromDir(rootDir string, input io.Reader) (keys.Keybase, error) {
 	if os.Getenv("COSMOS_SDK_TEST_KEYRING") != "" {
 		return keys.NewTestKeyring(sdk.GetConfig().GetKeyringServiceName(), rootDir)

--- a/crypto/keys/keyring.go
+++ b/crypto/keys/keyring.go
@@ -47,8 +47,8 @@ func NewKeyring(name string, dir string, userInput io.Reader) (Keybase, error) {
 	return newKeyringKeybase(db), nil
 }
 
-// NewTestKeyring creates a new instance of a keyring for
-// testing purposes that  does not prompt users for password.
+// NewTestKeyring creates a new instance of an on-disk keyring for
+// testing purposes that does not prompt users for password.
 func NewTestKeyring(name string, dir string) (Keybase, error) {
 	db, err := keyring.Open(lkbToKeyringConfig(name, dir, nil, true))
 	if err != nil {


### PR DESCRIPTION
Document the usage of the COSMOS_SDK_TEST_KEYRING
environment variable for testing purposes.

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
