### PR TITLE
Results from profiling slashing.BeginBlocker

### DIFF
--- a/profile.md
+++ b/profile.md
@@ -1,0 +1,67 @@
+slashing profiling results
+==========================
+
+original bench
+===
+
+benchmark
+---
+
+```
+goos: linux
+goarch: amd64
+pkg: github.com/cosmos/cosmos-sdk/x/slashing
+BenchmarkBeginBlocker100-8           100          30795066 ns/op         7486165 B/op      90541 allocs/op
+PASS
+ok      github.com/cosmos/cosmos-sdk/x/slashing	5.915s
+```
+
+db size
+---
+
+```
+14M	/tmp/bench-slashing111093085/test.db
+14M	/tmp/bench-slashing111093085
+```
+
+missed array stored as a single batch
+===
+
+benchcmp to original
+---
+```
+benchmark                      old ns/op     new ns/op     delta
+BenchmarkBeginBlocker100-8     30795066      15535438      -49.55%
+
+benchmark                      old allocs     new allocs     delta
+BenchmarkBeginBlocker100-8     90541          49348          -45.50%
+
+benchmark                      old bytes     new bytes     delta
+BenchmarkBeginBlocker100-8     7486165       3915672       -47.69%
+```
+
+db size
+---
+
+```
+2,3M	/tmp/bench-slashing347257969/test.db
+2,3M	/tmp/bench-slashing347257969
+```
+
+
+reuse SignedBlocksWindow and MinSignedBlocksWindow
+===
+
+benchcmp to original
+---
+
+```
+benchmark                      old ns/op     new ns/op     delta
+BenchmarkBeginBlocker100-8     30795066      13009027      -57.76%
+
+benchmark                      old allocs     new allocs     delta
+BenchmarkBeginBlocker100-8     90541          43555          -51.89%
+
+benchmark                      old bytes     new bytes     delta
+BenchmarkBeginBlocker100-8     7486165       3654145       -51.19%
+```

--- a/slashing.0
+++ b/slashing.0
@@ -1,0 +1,6 @@
+goos: linux
+goarch: amd64
+pkg: github.com/cosmos/cosmos-sdk/x/slashing
+BenchmarkBeginBlocker100-8   	     100	  30795066 ns/op	 7486165 B/op	   90541 allocs/op
+PASS
+ok  	github.com/cosmos/cosmos-sdk/x/slashing	5.915s

--- a/slashing.1
+++ b/slashing.1
@@ -1,0 +1,6 @@
+goos: linux
+goarch: amd64
+pkg: github.com/cosmos/cosmos-sdk/x/slashing
+BenchmarkBeginBlocker100-8   	     100	  15535438 ns/op	 3915672 B/op	   49348 allocs/op
+PASS
+ok  	github.com/cosmos/cosmos-sdk/x/slashing	1.710s

--- a/slashing.2
+++ b/slashing.2
@@ -1,0 +1,6 @@
+goos: linux
+goarch: amd64
+pkg: github.com/cosmos/cosmos-sdk/x/slashing
+BenchmarkBeginBlocker100-8   	     100	  13009027 ns/op	 3654145 B/op	   43555 allocs/op
+PASS
+ok  	github.com/cosmos/cosmos-sdk/x/slashing	1.465s

--- a/weblist-last.txt
+++ b/weblist-last.txt
@@ -1,0 +1,121 @@
+File: bench.0
+Type: cpu
+Time: Dec 27, 2019 at 4:53pm (EET)
+Duration: 1.50s, Total samples = 1.59s (105.75%)
+Total: 1.59s
+github.com/cosmos/cosmos-sdk/x/slashing/internal/keeper.Keeper.HandleValidatorSignatureReuse
+/home/dd/cosmos/src/github.com/cosmos/cosmos-sdk/x/slashing/internal/keeper/infractions.go
+
+  Total:           0      460ms (flat, cum) 28.93%
+    218            .          .
+    219            .          .                 // Set the updated signing info
+    220            .          .                 k.SetValidatorSigningInfo(ctx, consAddr, signInfo)
+    221            .          .           }
+    222            .          .
+    223            .          .           func (k Keeper) HandleValidatorSignatureReuse(ctx sdk.Context, addr crypto.Address, power int64, signed bool, swin, minswin int64) {
+    224            .          .                 logger := k.Logger(ctx)
+    225            .          .                 height := ctx.BlockHeight()
+    226            .          .
+    227            .          .                 // fetch the validator public key
+    228            .          .                 consAddr := sdk.ConsAddress(addr)
+    229            .      140ms                 if _, err := k.GetPubkey(ctx, addr); err != nil {
+    230            .          .                         panic(fmt.Sprintf("Validator consensus-address %s not found", consAddr))
+    231            .          .                 }
+    232            .          .
+    233            .          .                 // fetch signing info
+    234            .       90ms                 signInfo, found := k.GetValidatorSigningInfo(ctx, consAddr)
+    235            .          .                 if !found {
+    236            .          .                         panic(fmt.Sprintf("Expected signing info for validator %s but not found", consAddr))
+    237            .          .                 }
+    238            .          .
+    239            .          .                 // this is a relative index, so it counts blocks the validator *should* have signed
+    240            .          .                 // will use the 0-value default signing info if not present, except for start height
+    241            .          .                 index := signInfo.IndexOffset % swin
+    242            .          .                 signInfo.IndexOffset++
+    243            .          .
+    244            .      100ms                 votearray := k.GetVoteArray(ctx, consAddr)
+    245            .          .                 if votearray == nil {
+    246            .          .                         votearray = types.NewVoteArray(int(swin))
+    247            .          .                 }
+    248            .          .
+    249            .          .                 // Update signed block bit array & counter
+    250            .          .                 // This counter just tracks the sum of the bit array
+    251            .          .                 vote := votearray.Get(int(index))
+    252            .          .                 previous := vote.Missed()
+    253            .          .                 missed := !signed
+    254            .          .                 switch {
+    255            .          .                 case !previous && missed:
+    256            .          .                         // Array value has changed from not missed to missed, increment counter
+    257            .          .                         vote.Miss()
+    258            .          .                         signInfo.MissedBlocksCounter++
+    259            .          .                 case previous && !missed:
+    260            .          .                         // Array value has changed from missed to not missed, decrement counter
+    261            .          .                         vote.Vote()
+    262            .          .                         signInfo.MissedBlocksCounter--
+    263            .          .                 default:
+    264            .          .                         // Array value at this index has not changed, no need to update counter
+    265            .          .                 }
+    266            .       40ms                 k.StoreVoteArray(ctx, consAddr, votearray)
+    267            .          .
+    268            .          .                 if missed {
+    269            .          .                         ctx.EventManager().EmitEvent(
+    270            .          .                                 sdk.NewEvent(
+    271            .          .                                         types.EventTypeLiveness,
+    272            .       10ms                                         sdk.NewAttribute(types.AttributeKeyAddress, consAddr.String()),
+    273            .          .                                         sdk.NewAttribute(types.AttributeKeyMissedBlocks, fmt.Sprintf("%d", signInfo.MissedBlocksCounter)),
+    274            .          .                                         sdk.NewAttribute(types.AttributeKeyHeight, fmt.Sprintf("%d", height)),
+    275            .          .                                 ),
+    276            .          .                         )
+    277            .          .
+    278            .          .                         logger.Info(
+    279            .       30ms                                 fmt.Sprintf("Absent validator %s at height %d, %d missed, threshold %d", consAddr, height, signInfo.MissedBlocksCounter, minswin))
+    280            .          .                 }
+    281            .          .
+    282            .          .                 minHeight := signInfo.StartHeight + swin
+    283            .          .                 maxMissed := swin - minswin
+    284            .          .
+    285            .          .                 // if we are past the minimum height and the validator has missed too many blocks, punish them
+    286            .          .                 if height > minHeight && signInfo.MissedBlocksCounter > maxMissed {
+    287            .          .                         validator := k.sk.ValidatorByConsAddr(ctx, consAddr)
+    288            .          .                         if validator != nil && !validator.IsJailed() {
+    289            .          .
+    290            .          .                                 // Downtime confirmed: slash and jail the validator
+    291            .          .                                 logger.Info(fmt.Sprintf("Validator %s past min height of %d and below signed blocks threshold of %d",
+    292            .          .                                         consAddr, minHeight, minswin))
+    293            .          .
+    294            .          .                                 // We need to retrieve the stake distribution which signed the block, so we subtract ValidatorUpdateDelay from the evidence height,
+    295            .          .                                 // and subtract an additional 1 since this is the LastCommit.
+    296            .          .                                 // Note that this *can* result in a negative "distributionHeight" up to -ValidatorUpdateDelay-1,
+    297            .          .                                 // i.e. at the end of the pre-genesis block (none) = at the beginning of the genesis block.
+    298            .          .                                 // That's fine since this is just used to filter unbonding delegations & redelegations.
+    299            .          .                                 distributionHeight := height - sdk.ValidatorUpdateDelay - 1
+    300            .          .
+    301            .          .                                 ctx.EventManager().EmitEvent(
+    302            .          .                                         sdk.NewEvent(
+    303            .          .                                                 types.EventTypeSlash,
+    304            .          .                                                 sdk.NewAttribute(types.AttributeKeyAddress, consAddr.String()),
+    305            .          .                                                 sdk.NewAttribute(types.AttributeKeyPower, fmt.Sprintf("%d", power)),
+    306            .          .                                                 sdk.NewAttribute(types.AttributeKeyReason, types.AttributeValueMissingSignature),
+    307            .          .                                                 sdk.NewAttribute(types.AttributeKeyJailed, consAddr.String()),
+    308            .          .                                         ),
+    309            .          .                                 )
+    310            .          .                                 k.sk.Slash(ctx, consAddr, distributionHeight, power, k.SlashFractionDowntime(ctx))
+    311            .          .                                 k.sk.Jail(ctx, consAddr)
+    312            .          .
+    313            .          .                                 signInfo.JailedUntil = ctx.BlockHeader().Time.Add(k.DowntimeJailDuration(ctx))
+    314            .          .
+    315            .          .                                 // We need to reset the counter & array so that the validator won't be immediately slashed for downtime upon rebonding.
+    316            .          .                                 signInfo.MissedBlocksCounter = 0
+    317            .          .                                 signInfo.IndexOffset = 0
+    318            .          .                                 k.ClearVoteArray(ctx, consAddr)
+    319            .          .                         } else {
+    320            .          .                                 // Validator was (a) not found or (b) already jailed, don't slash
+    321            .          .                                 logger.Info(
+    322            .          .                                         fmt.Sprintf("Validator %s would have been slashed for downtime, but was either not found in store or already jailed", consAddr),
+    323            .          .                                 )
+    324            .          .                         }
+    325            .          .                 }
+    326            .          .
+    327            .          .                 // Set the updated signing info
+    328            .       50ms                 k.SetValidatorSigningInfo(ctx, consAddr, signInfo)
+    329            .          .           }

--- a/weblist-orig.txt
+++ b/weblist-orig.txt
@@ -1,0 +1,120 @@
+File: bench.1
+Type: cpu
+Time: Dec 27, 2019 at 4:56pm (EET)
+Duration: 6.01s, Total samples = 7.65s (127.21%)
+Total: 7.65s
+github.com/cosmos/cosmos-sdk/x/slashing/internal/keeper.Keeper.HandleValidatorSignatureOrig
+/home/dd/cosmos/src/github.com/cosmos/cosmos-sdk/x/slashing/internal/keeper/infractions.go
+
+  Total:           0      1.73s (flat, cum) 22.61%
+      8            .          .                 sdk "github.com/cosmos/cosmos-sdk/types"
+      9            .          .                 "github.com/cosmos/cosmos-sdk/x/slashing/internal/types"
+     10            .          .           )
+     11            .          .
+     12            .          .           // HandleValidatorSignature handles a validator signature, must be called once per validator per block.
+     13            .          .           func (k Keeper) HandleValidatorSignatureOrig(ctx sdk.Context, addr crypto.Address, power int64, signed bool) {
+     14            .          .                 logger := k.Logger(ctx)
+     15            .          .                 height := ctx.BlockHeight()
+     16            .          .
+     17            .          .                 // fetch the validator public key
+     18            .          .                 consAddr := sdk.ConsAddress(addr)
+     19            .      310ms                 if _, err := k.GetPubkey(ctx, addr); err != nil {
+     20            .          .                         panic(fmt.Sprintf("Validator consensus-address %s not found", consAddr))
+     21            .          .                 }
+     22            .          .
+     23            .          .                 // fetch signing info
+     24            .      110ms                 signInfo, found := k.GetValidatorSigningInfo(ctx, consAddr)
+     25            .          .                 if !found {
+     26            .          .                         panic(fmt.Sprintf("Expected signing info for validator %s but not found", consAddr))
+     27            .          .                 }
+     28            .          .
+     29            .          .                 // this is a relative index, so it counts blocks the validator *should* have signed
+     30            .          .                 // will use the 0-value default signing info if not present, except for start height
+     31            .       20ms                 index := signInfo.IndexOffset % k.SignedBlocksWindow(ctx)
+     32            .          .                 signInfo.IndexOffset++
+     33            .          .
+     34            .          .                 // Update signed block bit array & counter
+     35            .          .                 // This counter just tracks the sum of the bit array
+     36            .          .                 // That way we avoid needing to read/write the whole array each time
+     37            .      950ms                 previous := k.GetValidatorMissedBlockBitArray(ctx, consAddr, index)
+     38            .          .                 missed := !signed
+     39            .          .                 switch {
+     40            .          .                 case !previous && missed:
+     41            .          .                         // Array value has changed from not missed to missed, increment counter
+     42            .          .                         k.SetValidatorMissedBlockBitArray(ctx, consAddr, index, true)
+     43            .          .                         signInfo.MissedBlocksCounter++
+     44            .          .                 case previous && !missed:
+     45            .          .                         // Array value has changed from missed to not missed, decrement counter
+     46            .       70ms                         k.SetValidatorMissedBlockBitArray(ctx, consAddr, index, false)
+     47            .          .                         signInfo.MissedBlocksCounter--
+     48            .          .                 default:
+     49            .          .                         // Array value at this index has not changed, no need to update counter
+     50            .          .                 }
+     51            .          .
+     52            .          .                 if missed {
+     53            .          .                         ctx.EventManager().EmitEvent(
+     54            .          .                                 sdk.NewEvent(
+     55            .          .                                         types.EventTypeLiveness,
+     56            .       30ms                                         sdk.NewAttribute(types.AttributeKeyAddress, consAddr.String()),
+     57            .          .                                         sdk.NewAttribute(types.AttributeKeyMissedBlocks, fmt.Sprintf("%d", signInfo.MissedBlocksCounter)),
+     58            .          .                                         sdk.NewAttribute(types.AttributeKeyHeight, fmt.Sprintf("%d", height)),
+     59            .          .                                 ),
+     60            .          .                         )
+     61            .          .
+     62            .          .                         logger.Info(
+     63            .       50ms                                 fmt.Sprintf("Absent validator %s at height %d, %d missed, threshold %d", consAddr, height, signInfo.MissedBlocksCounter, k.MinSignedPerWindow(ctx)))
+     64            .          .                 }
+     65            .          .
+     66            .       10ms                 minHeight := signInfo.StartHeight + k.SignedBlocksWindow(ctx)
+     67            .       90ms                 maxMissed := k.SignedBlocksWindow(ctx) - k.MinSignedPerWindow(ctx)
+     68            .          .
+     69            .          .                 // if we are past the minimum height and the validator has missed too many blocks, punish them
+     70            .          .                 if height > minHeight && signInfo.MissedBlocksCounter > maxMissed {
+     71            .          .                         validator := k.sk.ValidatorByConsAddr(ctx, consAddr)
+     72            .          .                         if validator != nil && !validator.IsJailed() {
+     73            .          .
+     74            .          .                                 // Downtime confirmed: slash and jail the validator
+     75            .          .                                 logger.Info(fmt.Sprintf("Validator %s past min height of %d and below signed blocks threshold of %d",
+     76            .          .                                         consAddr, minHeight, k.MinSignedPerWindow(ctx)))
+     77            .          .
+     78            .          .                                 // We need to retrieve the stake distribution which signed the block, so we subtract ValidatorUpdateDelay from the evidence height,
+     79            .          .                                 // and subtract an additional 1 since this is the LastCommit.
+     80            .          .                                 // Note that this *can* result in a negative "distributionHeight" up to -ValidatorUpdateDelay-1,
+     81            .          .                                 // i.e. at the end of the pre-genesis block (none) = at the beginning of the genesis block.
+     82            .          .                                 // That's fine since this is just used to filter unbonding delegations & redelegations.
+     83            .          .                                 distributionHeight := height - sdk.ValidatorUpdateDelay - 1
+     84            .          .
+     85            .          .                                 ctx.EventManager().EmitEvent(
+     86            .          .                                         sdk.NewEvent(
+     87            .          .                                                 types.EventTypeSlash,
+     88            .          .                                                 sdk.NewAttribute(types.AttributeKeyAddress, consAddr.String()),
+     89            .          .                                                 sdk.NewAttribute(types.AttributeKeyPower, fmt.Sprintf("%d", power)),
+     90            .          .                                                 sdk.NewAttribute(types.AttributeKeyReason, types.AttributeValueMissingSignature),
+     91            .          .                                                 sdk.NewAttribute(types.AttributeKeyJailed, consAddr.String()),
+     92            .          .                                         ),
+     93            .          .                                 )
+     94            .          .                                 k.sk.Slash(ctx, consAddr, distributionHeight, power, k.SlashFractionDowntime(ctx))
+     95            .          .                                 k.sk.Jail(ctx, consAddr)
+     96            .          .
+     97            .          .                                 signInfo.JailedUntil = ctx.BlockHeader().Time.Add(k.DowntimeJailDuration(ctx))
+     98            .          .
+     99            .          .                                 // We need to reset the counter & array so that the validator won't be immediately slashed for downtime upon rebonding.
+    100            .          .                                 signInfo.MissedBlocksCounter = 0
+    101            .          .                                 signInfo.IndexOffset = 0
+    102            .          .                                 k.clearValidatorMissedBlockBitArray(ctx, consAddr)
+    103            .          .                         } else {
+    104            .          .                                 // Validator was (a) not found or (b) already jailed, don't slash
+    105            .          .                                 logger.Info(
+    106            .          .                                         fmt.Sprintf("Validator %s would have been slashed for downtime, but was either not found in store or already jailed", consAddr),
+    107            .          .                                 )
+    108            .          .                         }
+    109            .          .                 }
+    110            .          .
+    111            .          .                 // Set the updated signing info
+    112            .       90ms                 k.SetValidatorSigningInfo(ctx, consAddr, signInfo)
+    113            .          .           }
+    114            .          .
+    115            .          .           func (k Keeper) HandleValidatorSignature(ctx sdk.Context, addr crypto.Address, power int64, signed bool) {
+    116            .          .                 logger := k.Logger(ctx)
+    117            .          .                 height := ctx.BlockHeight()
+    118            .          .

--- a/x/slashing/abci.go
+++ b/x/slashing/abci.go
@@ -12,9 +12,9 @@ func BeginBlocker(ctx sdk.Context, req abci.RequestBeginBlock, k Keeper) {
 	// Iterate over all the validators which *should* have signed this block
 	// store whether or not they have actually signed it and slash/unbond any
 	// which have missed too many blocks in a row (downtime slashing)
-	//swin := k.SignedBlocksWindow(ctx)
-	//minswin := k.MinSignedPerWindow(ctx)
+	swin := k.SignedBlocksWindow(ctx)
+	minswin := k.MinSignedPerWindow(ctx)
 	for _, voteInfo := range req.LastCommitInfo.GetVotes() {
-		k.HandleValidatorSignatureOrig(ctx, voteInfo.Validator.Address, voteInfo.Validator.Power, voteInfo.SignedLastBlock)
+		k.HandleValidatorSignatureReuse(ctx, voteInfo.Validator.Address, voteInfo.Validator.Power, voteInfo.SignedLastBlock, swin, minswin)
 	}
 }

--- a/x/slashing/abci.go
+++ b/x/slashing/abci.go
@@ -12,9 +12,9 @@ func BeginBlocker(ctx sdk.Context, req abci.RequestBeginBlock, k Keeper) {
 	// Iterate over all the validators which *should* have signed this block
 	// store whether or not they have actually signed it and slash/unbond any
 	// which have missed too many blocks in a row (downtime slashing)
-	swin := k.SignedBlocksWindow(ctx)
-	minswin := k.MinSignedPerWindow(ctx)
+	//swin := k.SignedBlocksWindow(ctx)
+	//minswin := k.MinSignedPerWindow(ctx)
 	for _, voteInfo := range req.LastCommitInfo.GetVotes() {
-		k.HandleValidatorSignatureReuse(ctx, voteInfo.Validator.Address, voteInfo.Validator.Power, voteInfo.SignedLastBlock, swin, minswin)
+		k.HandleValidatorSignatureOrig(ctx, voteInfo.Validator.Address, voteInfo.Validator.Power, voteInfo.SignedLastBlock)
 	}
 }

--- a/x/slashing/abci.go
+++ b/x/slashing/abci.go
@@ -12,7 +12,9 @@ func BeginBlocker(ctx sdk.Context, req abci.RequestBeginBlock, k Keeper) {
 	// Iterate over all the validators which *should* have signed this block
 	// store whether or not they have actually signed it and slash/unbond any
 	// which have missed too many blocks in a row (downtime slashing)
+	swin := k.SignedBlocksWindow(ctx)
+	minswin := k.MinSignedPerWindow(ctx)
 	for _, voteInfo := range req.LastCommitInfo.GetVotes() {
-		k.HandleValidatorSignature(ctx, voteInfo.Validator.Address, voteInfo.Validator.Power, voteInfo.SignedLastBlock)
+		k.HandleValidatorSignatureReuse(ctx, voteInfo.Validator.Address, voteInfo.Validator.Power, voteInfo.SignedLastBlock, swin, minswin)
 	}
 }

--- a/x/slashing/abci_test.go
+++ b/x/slashing/abci_test.go
@@ -110,13 +110,12 @@ func benchmarkBeginBlocker(b *testing.B, num int) {
 		keeper.SetValidatorSigningInfo(ctx, sdk.ConsAddress(addr), signInfo)
 		keeper.AddPubkey(ctx, edkey)
 		// uncomment if MissedBlockBitArray is used
-		/*
-			for i := 0; i < 500; i++ {
-				keeper.SetValidatorMissedBlockBitArray(ctx, sdk.ConsAddress(addr), int64(i), true)
-			}
-		*/
 
-		keeper.StoreVoteArray(ctx, sdk.ConsAddress(addr), types.NewVoteArray(int(params.SignedBlocksWindow)))
+		for i := 0; i < 500; i++ {
+			keeper.SetValidatorMissedBlockBitArray(ctx, sdk.ConsAddress(addr), int64(i), true)
+		}
+
+		//keeper.StoreVoteArray(ctx, sdk.ConsAddress(addr), types.NewVoteArray(int(params.SignedBlocksWindow)))
 
 	}
 	store.Commit()

--- a/x/slashing/abci_test.go
+++ b/x/slashing/abci_test.go
@@ -110,12 +110,12 @@ func benchmarkBeginBlocker(b *testing.B, num int) {
 		keeper.SetValidatorSigningInfo(ctx, sdk.ConsAddress(addr), signInfo)
 		keeper.AddPubkey(ctx, edkey)
 		// uncomment if MissedBlockBitArray is used
-
-		for i := 0; i < 500; i++ {
-			keeper.SetValidatorMissedBlockBitArray(ctx, sdk.ConsAddress(addr), int64(i), true)
-		}
-
-		//keeper.StoreVoteArray(ctx, sdk.ConsAddress(addr), types.NewVoteArray(int(params.SignedBlocksWindow)))
+		/*
+			for i := 0; i < 500; i++ {
+				keeper.SetValidatorMissedBlockBitArray(ctx, sdk.ConsAddress(addr), int64(i), true)
+			}
+		*/
+		keeper.StoreVoteArray(ctx, sdk.ConsAddress(addr), types.NewVoteArray(int(params.SignedBlocksWindow)))
 
 	}
 	store.Commit()

--- a/x/slashing/abci_test.go
+++ b/x/slashing/abci_test.go
@@ -1,15 +1,18 @@
 package slashing
 
 import (
+	"math/rand"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 
 	abci "github.com/tendermint/tendermint/abci/types"
+	"github.com/tendermint/tendermint/crypto/ed25519"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	slashingkeeper "github.com/cosmos/cosmos-sdk/x/slashing/internal/keeper"
+	"github.com/cosmos/cosmos-sdk/x/slashing/internal/types"
 	"github.com/cosmos/cosmos-sdk/x/staking"
 )
 
@@ -89,4 +92,69 @@ func TestBeginBlocker(t *testing.T) {
 	validator, found := sk.GetValidatorByConsAddr(ctx, sdk.GetConsAddress(pk))
 	require.True(t, found)
 	require.Equal(t, sdk.Unbonding, validator.GetStatus())
+}
+
+func benchmarkBeginBlocker(b *testing.B, num int) {
+	params := DefaultParams()
+	params.SignedBlocksWindow = 500
+	ctx, _, _, _, keeper, store, _ := slashingkeeper.CreateTestInputStore(b, params)
+
+	validators := []abci.Validator{}
+	signInfo := types.ValidatorSigningInfo{}
+	pubkey := [32]byte{}
+	for i := 0; i < num; i++ {
+		rand.Read(pubkey[:])
+		edkey := ed25519.PubKeyEd25519(pubkey)
+		addr := edkey.Address()
+		validators = append(validators, abci.Validator{Address: addr})
+		keeper.SetValidatorSigningInfo(ctx, sdk.ConsAddress(addr), signInfo)
+		keeper.AddPubkey(ctx, edkey)
+		// uncomment if MissedBlockBitArray is used
+		/*
+			for i := 0; i < 500; i++ {
+				keeper.SetValidatorMissedBlockBitArray(ctx, sdk.ConsAddress(addr), int64(i), true)
+			}
+		*/
+
+		keeper.StoreVoteArray(ctx, sdk.ConsAddress(addr), types.NewVoteArray(int(params.SignedBlocksWindow)))
+
+	}
+	store.Commit()
+	require.NoError(b, store.LoadVersion(0))
+	require.NoError(b, store.LoadVersion(1))
+	req := abci.RequestBeginBlock{
+		LastCommitInfo: abci.LastCommitInfo{
+			Votes: []abci.VoteInfo{},
+		},
+	}
+	op := abci.RequestBeginBlock{
+		LastCommitInfo: abci.LastCommitInfo{
+			Votes: []abci.VoteInfo{},
+		},
+	}
+
+	// two requests with opposite votes to trigger changes in missed block array
+	for i := range validators {
+		req.LastCommitInfo.Votes = append(req.LastCommitInfo.Votes, abci.VoteInfo{Validator: validators[i], SignedLastBlock: true})
+		op.LastCommitInfo.Votes = append(op.LastCommitInfo.Votes, abci.VoteInfo{Validator: validators[i]})
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		ctx = ctx.WithBlockHeight(int64(i))
+		if i%2 == 0 {
+			BeginBlocker(ctx, req, keeper)
+		} else {
+			BeginBlocker(ctx, op, keeper)
+		}
+		commit := store.Commit()
+		// reset iavl tree with latest version
+		require.NoError(b, store.LoadVersion(0))
+		require.NoError(b, store.LoadVersion(commit.Version))
+	}
+
+}
+
+func BenchmarkBeginBlocker100(b *testing.B) {
+	benchmarkBeginBlocker(b, 100)
 }

--- a/x/slashing/internal/keeper/infractions.go
+++ b/x/slashing/internal/keeper/infractions.go
@@ -10,7 +10,7 @@ import (
 )
 
 // HandleValidatorSignature handles a validator signature, must be called once per validator per block.
-func (k Keeper) HandleValidatorSignature(ctx sdk.Context, addr crypto.Address, power int64, signed bool) {
+func (k Keeper) HandleValidatorSignatureOrig(ctx sdk.Context, addr crypto.Address, power int64, signed bool) {
 	logger := k.Logger(ctx)
 	height := ctx.BlockHeight()
 
@@ -100,6 +100,222 @@ func (k Keeper) HandleValidatorSignature(ctx sdk.Context, addr crypto.Address, p
 			signInfo.MissedBlocksCounter = 0
 			signInfo.IndexOffset = 0
 			k.clearValidatorMissedBlockBitArray(ctx, consAddr)
+		} else {
+			// Validator was (a) not found or (b) already jailed, don't slash
+			logger.Info(
+				fmt.Sprintf("Validator %s would have been slashed for downtime, but was either not found in store or already jailed", consAddr),
+			)
+		}
+	}
+
+	// Set the updated signing info
+	k.SetValidatorSigningInfo(ctx, consAddr, signInfo)
+}
+
+func (k Keeper) HandleValidatorSignature(ctx sdk.Context, addr crypto.Address, power int64, signed bool) {
+	logger := k.Logger(ctx)
+	height := ctx.BlockHeight()
+
+	// fetch the validator public key
+	consAddr := sdk.ConsAddress(addr)
+	if _, err := k.GetPubkey(ctx, addr); err != nil {
+		panic(fmt.Sprintf("Validator consensus-address %s not found", consAddr))
+	}
+
+	// fetch signing info
+	signInfo, found := k.GetValidatorSigningInfo(ctx, consAddr)
+	if !found {
+		panic(fmt.Sprintf("Expected signing info for validator %s but not found", consAddr))
+	}
+
+	// this is a relative index, so it counts blocks the validator *should* have signed
+	// will use the 0-value default signing info if not present, except for start height
+	index := signInfo.IndexOffset % k.SignedBlocksWindow(ctx)
+	signInfo.IndexOffset++
+
+	votearray := k.GetVoteArray(ctx, consAddr)
+	if votearray == nil {
+		votearray = types.NewVoteArray(int(k.SignedBlocksWindow(ctx)))
+	}
+
+	// Update signed block bit array & counter
+	// This counter just tracks the sum of the bit array
+	vote := votearray.Get(int(index))
+	previous := vote.Missed()
+	missed := !signed
+	switch {
+	case !previous && missed:
+		// Array value has changed from not missed to missed, increment counter
+		vote.Miss()
+		signInfo.MissedBlocksCounter++
+	case previous && !missed:
+		// Array value has changed from missed to not missed, decrement counter
+		vote.Vote()
+		signInfo.MissedBlocksCounter--
+	default:
+		// Array value at this index has not changed, no need to update counter
+	}
+	k.StoreVoteArray(ctx, consAddr, votearray)
+
+	if missed {
+		ctx.EventManager().EmitEvent(
+			sdk.NewEvent(
+				types.EventTypeLiveness,
+				sdk.NewAttribute(types.AttributeKeyAddress, consAddr.String()),
+				sdk.NewAttribute(types.AttributeKeyMissedBlocks, fmt.Sprintf("%d", signInfo.MissedBlocksCounter)),
+				sdk.NewAttribute(types.AttributeKeyHeight, fmt.Sprintf("%d", height)),
+			),
+		)
+
+		logger.Info(
+			fmt.Sprintf("Absent validator %s at height %d, %d missed, threshold %d", consAddr, height, signInfo.MissedBlocksCounter, k.MinSignedPerWindow(ctx)))
+	}
+
+	minHeight := signInfo.StartHeight + k.SignedBlocksWindow(ctx)
+	maxMissed := k.SignedBlocksWindow(ctx) - k.MinSignedPerWindow(ctx)
+
+	// if we are past the minimum height and the validator has missed too many blocks, punish them
+	if height > minHeight && signInfo.MissedBlocksCounter > maxMissed {
+		validator := k.sk.ValidatorByConsAddr(ctx, consAddr)
+		if validator != nil && !validator.IsJailed() {
+
+			// Downtime confirmed: slash and jail the validator
+			logger.Info(fmt.Sprintf("Validator %s past min height of %d and below signed blocks threshold of %d",
+				consAddr, minHeight, k.MinSignedPerWindow(ctx)))
+
+			// We need to retrieve the stake distribution which signed the block, so we subtract ValidatorUpdateDelay from the evidence height,
+			// and subtract an additional 1 since this is the LastCommit.
+			// Note that this *can* result in a negative "distributionHeight" up to -ValidatorUpdateDelay-1,
+			// i.e. at the end of the pre-genesis block (none) = at the beginning of the genesis block.
+			// That's fine since this is just used to filter unbonding delegations & redelegations.
+			distributionHeight := height - sdk.ValidatorUpdateDelay - 1
+
+			ctx.EventManager().EmitEvent(
+				sdk.NewEvent(
+					types.EventTypeSlash,
+					sdk.NewAttribute(types.AttributeKeyAddress, consAddr.String()),
+					sdk.NewAttribute(types.AttributeKeyPower, fmt.Sprintf("%d", power)),
+					sdk.NewAttribute(types.AttributeKeyReason, types.AttributeValueMissingSignature),
+					sdk.NewAttribute(types.AttributeKeyJailed, consAddr.String()),
+				),
+			)
+			k.sk.Slash(ctx, consAddr, distributionHeight, power, k.SlashFractionDowntime(ctx))
+			k.sk.Jail(ctx, consAddr)
+
+			signInfo.JailedUntil = ctx.BlockHeader().Time.Add(k.DowntimeJailDuration(ctx))
+
+			// We need to reset the counter & array so that the validator won't be immediately slashed for downtime upon rebonding.
+			signInfo.MissedBlocksCounter = 0
+			signInfo.IndexOffset = 0
+			k.ClearVoteArray(ctx, consAddr)
+		} else {
+			// Validator was (a) not found or (b) already jailed, don't slash
+			logger.Info(
+				fmt.Sprintf("Validator %s would have been slashed for downtime, but was either not found in store or already jailed", consAddr),
+			)
+		}
+	}
+
+	// Set the updated signing info
+	k.SetValidatorSigningInfo(ctx, consAddr, signInfo)
+}
+
+func (k Keeper) HandleValidatorSignatureReuse(ctx sdk.Context, addr crypto.Address, power int64, signed bool, swin, minswin int64) {
+	logger := k.Logger(ctx)
+	height := ctx.BlockHeight()
+
+	// fetch the validator public key
+	consAddr := sdk.ConsAddress(addr)
+	if _, err := k.GetPubkey(ctx, addr); err != nil {
+		panic(fmt.Sprintf("Validator consensus-address %s not found", consAddr))
+	}
+
+	// fetch signing info
+	signInfo, found := k.GetValidatorSigningInfo(ctx, consAddr)
+	if !found {
+		panic(fmt.Sprintf("Expected signing info for validator %s but not found", consAddr))
+	}
+
+	// this is a relative index, so it counts blocks the validator *should* have signed
+	// will use the 0-value default signing info if not present, except for start height
+	index := signInfo.IndexOffset % swin
+	signInfo.IndexOffset++
+
+	votearray := k.GetVoteArray(ctx, consAddr)
+	if votearray == nil {
+		votearray = types.NewVoteArray(int(swin))
+	}
+
+	// Update signed block bit array & counter
+	// This counter just tracks the sum of the bit array
+	vote := votearray.Get(int(index))
+	previous := vote.Missed()
+	missed := !signed
+	switch {
+	case !previous && missed:
+		// Array value has changed from not missed to missed, increment counter
+		vote.Miss()
+		signInfo.MissedBlocksCounter++
+	case previous && !missed:
+		// Array value has changed from missed to not missed, decrement counter
+		vote.Vote()
+		signInfo.MissedBlocksCounter--
+	default:
+		// Array value at this index has not changed, no need to update counter
+	}
+	k.StoreVoteArray(ctx, consAddr, votearray)
+
+	if missed {
+		ctx.EventManager().EmitEvent(
+			sdk.NewEvent(
+				types.EventTypeLiveness,
+				sdk.NewAttribute(types.AttributeKeyAddress, consAddr.String()),
+				sdk.NewAttribute(types.AttributeKeyMissedBlocks, fmt.Sprintf("%d", signInfo.MissedBlocksCounter)),
+				sdk.NewAttribute(types.AttributeKeyHeight, fmt.Sprintf("%d", height)),
+			),
+		)
+
+		logger.Info(
+			fmt.Sprintf("Absent validator %s at height %d, %d missed, threshold %d", consAddr, height, signInfo.MissedBlocksCounter, minswin))
+	}
+
+	minHeight := signInfo.StartHeight + swin
+	maxMissed := swin - minswin
+
+	// if we are past the minimum height and the validator has missed too many blocks, punish them
+	if height > minHeight && signInfo.MissedBlocksCounter > maxMissed {
+		validator := k.sk.ValidatorByConsAddr(ctx, consAddr)
+		if validator != nil && !validator.IsJailed() {
+
+			// Downtime confirmed: slash and jail the validator
+			logger.Info(fmt.Sprintf("Validator %s past min height of %d and below signed blocks threshold of %d",
+				consAddr, minHeight, minswin))
+
+			// We need to retrieve the stake distribution which signed the block, so we subtract ValidatorUpdateDelay from the evidence height,
+			// and subtract an additional 1 since this is the LastCommit.
+			// Note that this *can* result in a negative "distributionHeight" up to -ValidatorUpdateDelay-1,
+			// i.e. at the end of the pre-genesis block (none) = at the beginning of the genesis block.
+			// That's fine since this is just used to filter unbonding delegations & redelegations.
+			distributionHeight := height - sdk.ValidatorUpdateDelay - 1
+
+			ctx.EventManager().EmitEvent(
+				sdk.NewEvent(
+					types.EventTypeSlash,
+					sdk.NewAttribute(types.AttributeKeyAddress, consAddr.String()),
+					sdk.NewAttribute(types.AttributeKeyPower, fmt.Sprintf("%d", power)),
+					sdk.NewAttribute(types.AttributeKeyReason, types.AttributeValueMissingSignature),
+					sdk.NewAttribute(types.AttributeKeyJailed, consAddr.String()),
+				),
+			)
+			k.sk.Slash(ctx, consAddr, distributionHeight, power, k.SlashFractionDowntime(ctx))
+			k.sk.Jail(ctx, consAddr)
+
+			signInfo.JailedUntil = ctx.BlockHeader().Time.Add(k.DowntimeJailDuration(ctx))
+
+			// We need to reset the counter & array so that the validator won't be immediately slashed for downtime upon rebonding.
+			signInfo.MissedBlocksCounter = 0
+			signInfo.IndexOffset = 0
+			k.ClearVoteArray(ctx, consAddr)
 		} else {
 			// Validator was (a) not found or (b) already jailed, don't slash
 			logger.Info(

--- a/x/slashing/internal/keeper/signing_info.go
+++ b/x/slashing/internal/keeper/signing_info.go
@@ -141,3 +141,31 @@ func (k Keeper) clearValidatorMissedBlockBitArray(ctx sdk.Context, address sdk.C
 		store.Delete(iter.Key())
 	}
 }
+
+func (k Keeper) GetVoteArray(ctx sdk.Context, address sdk.ConsAddress) *types.VoteArray {
+	store := ctx.KVStore(k.storeKey)
+	key := make([]byte, len(address)+1)
+	key[0] = 10
+	copy(key[1:], address)
+	value := store.Get(key)
+	if len(value) == 0 {
+		return nil
+	}
+	return types.NewVoteArrayFromBytes(value)
+}
+
+func (k Keeper) StoreVoteArray(ctx sdk.Context, address sdk.ConsAddress, votes *types.VoteArray) {
+	store := ctx.KVStore(k.storeKey)
+	key := make([]byte, len(address)+1)
+	key[0] = 10
+	copy(key[1:], address)
+	store.Set(key, votes.Bytes())
+}
+
+func (k Keeper) ClearVoteArray(ctx sdk.Context, address sdk.ConsAddress) {
+	store := ctx.KVStore(k.storeKey)
+	key := make([]byte, len(address)+1)
+	key[0] = 10
+	copy(key[1:], address)
+	store.Delete(key)
+}

--- a/x/slashing/internal/types/bitarray.go
+++ b/x/slashing/internal/types/bitarray.go
@@ -1,0 +1,49 @@
+package types
+
+func NewBitArray(hint int) BitArray {
+	quo := hint / 8
+	rem := hint % 8
+	if rem != 0 {
+		quo++
+	}
+	return make(BitArray, quo)
+}
+
+type BitArray []byte
+
+func (b BitArray) position(index int) int {
+	return index / 8
+}
+
+func (b BitArray) bit(index int) int {
+	return index % 8
+}
+
+func (b BitArray) Clear(index int) {
+	b.Set(index, 0)
+}
+
+func (b BitArray) Fill(index int) {
+	b.Set(index, 1)
+}
+
+func (b BitArray) Set(index, val int) {
+	pos := b.position(index)
+	if pos >= len(b) {
+		panic("index overflow")
+	}
+	bit := b.bit(index)
+	if val != 0 {
+		b[pos] |= 1 << bit
+	} else {
+		b[pos] &= ^(1 << bit)
+	}
+}
+
+func (b BitArray) Get(index int) bool {
+	pos := b.position(index)
+	if pos >= len(b) {
+		panic("index overlow")
+	}
+	return (b[pos] & (1 << b.bit(index))) > 0
+}

--- a/x/slashing/internal/types/bitarray_test.go
+++ b/x/slashing/internal/types/bitarray_test.go
@@ -1,0 +1,28 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBitArrayClear(t *testing.T) {
+	ba := NewBitArray(8)
+	ba.Fill(7)
+	require.True(t, ba.Get(7))
+	ba.Clear(7)
+	require.False(t, ba.Get(7))
+}
+
+func TestBitArrayFill(t *testing.T) {
+	ba := NewBitArray(16)
+	ba.Fill(8)
+	ba.Fill(9)
+	require.True(t, ba.Get(8))
+	require.True(t, ba.Get(9))
+}
+
+func TestBitArrayHintAlloc(t *testing.T) {
+	require.Len(t, NewBitArray(8), 1)
+	require.Len(t, NewBitArray(9), 2)
+}

--- a/x/slashing/internal/types/votearray.go
+++ b/x/slashing/internal/types/votearray.go
@@ -1,0 +1,51 @@
+package types
+
+func NewVoteArrayFromBytes(value []byte) *VoteArray {
+	bitarray := BitArray(value)
+	return &VoteArray{
+		bitarray: bitarray,
+	}
+}
+
+func NewVoteArray(votersSize int) *VoteArray {
+	bitarray := NewBitArray(votersSize)
+	return &VoteArray{
+		bitarray: bitarray,
+	}
+}
+
+type VoteArray struct {
+	bitarray BitArray
+}
+
+func (v VoteArray) Get(index int) Vote {
+	return Vote{
+		index:    index,
+		bitarray: v.bitarray,
+	}
+}
+
+func (v VoteArray) Bytes() []byte {
+	return v.bitarray
+}
+
+type Vote struct {
+	bitarray BitArray
+	index    int
+}
+
+func (v Vote) Voted() bool {
+	return !v.Missed()
+}
+
+func (v Vote) Missed() bool {
+	return v.bitarray.Get(v.index)
+}
+
+func (v Vote) Miss() {
+	v.bitarray.Fill(v.index)
+}
+
+func (v Vote) Vote() {
+	v.bitarray.Clear(v.index)
+}

--- a/x/slashing/internal/types/votearray_test.go
+++ b/x/slashing/internal/types/votearray_test.go
@@ -1,0 +1,23 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestVoteArray(t *testing.T) {
+	va := NewVoteArray(100)
+	for i := 0; i < 100; i++ {
+		vote := va.Get(i)
+		require.False(t, vote.Missed())
+		require.True(t, vote.Voted())
+
+		vote.Miss()
+
+		vote = va.Get(i)
+		require.True(t, vote.Missed())
+		require.False(t, vote.Voted())
+	}
+
+}


### PR DESCRIPTION
results related to https://github.com/cosmos/cosmos-sdk/issues/4977

I found right knobs and made slashing.BeginBlocker work in a similar way how it works in real scenarios, it is somewhat hacky, but profile picture resembles one reported by @alexanderbez 

As it was noted in one of the issues, majority of time is spent due to read amplifications in iavl store. I tried approach similar  to one proposed by @ValarDragon , but i kept it simple and instead of partitioning bit array i basically created one per validator. Considered that array is limited by the size of sliding window (10000 bits or even bigger?) and we need only one per validator - this is >~1 mb per 1000 validators. I also collected db sizes after benchmark, with constant number of iterations. and storing single bitarray is clearly beneficial, unless i missed something :)

Before proceeding with this pr i will try to sync mainnet with this change (tests are passing so i assume nothing is broken) and see if this change has an expected effect.
Until then this is mostly for any early feedback, as it is highly appreciated.

Pasting results from profile.md, and there are two weblists for handleValidatorSignature attached to this PR, one before changes and one after.

slashing profiling results
==========================

original bench
===

benchmark
---

```
goos: linux
goarch: amd64
pkg: github.com/cosmos/cosmos-sdk/x/slashing
BenchmarkBeginBlocker100-8           100          30795066 ns/op         7486165 B/op      90541 allocs/op
PASS
ok      github.com/cosmos/cosmos-sdk/x/slashing	5.915s
```

db size
---

```
14M	/tmp/bench-slashing111093085/test.db
14M	/tmp/bench-slashing111093085
```

missed array stored as a single batch
===

benchcmp to original
---
```
benchmark                      old ns/op     new ns/op     delta
BenchmarkBeginBlocker100-8     30795066      15535438      -49.55%

benchmark                      old allocs     new allocs     delta
BenchmarkBeginBlocker100-8     90541          49348          -45.50%

benchmark                      old bytes     new bytes     delta
BenchmarkBeginBlocker100-8     7486165       3915672       -47.69%
```

db size
---

```
2,3M	/tmp/bench-slashing347257969/test.db
2,3M	/tmp/bench-slashing347257969
```


reuse SignedBlocksWindow and MinSignedBlocksWindow
===

benchcmp to original
---

```
benchmark                      old ns/op     new ns/op     delta
BenchmarkBeginBlocker100-8     30795066      13009027      -57.76%

benchmark                      old allocs     new allocs     delta
BenchmarkBeginBlocker100-8     90541          43555          -51.89%

benchmark                      old bytes     new bytes     delta
BenchmarkBeginBlocker100-8     7486165       3654145       -51.19%
```
______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added  relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

______

For admin use:

- [ ] Added appropriate labels to PR (ex. `WIP`, `R4R`, `docs`, etc)
- [ ] Reviewers assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
