### PR TITLE
x/slashing: Use single bit array to store all non-signed validator blocks

### DIFF
--- a/x/slashing/alias.go
+++ b/x/slashing/alias.go
@@ -44,32 +44,31 @@ const (
 
 var (
 	// functions aliases
-	NewKeeper                                = keeper.NewKeeper
-	NewQuerier                               = keeper.NewQuerier
-	RegisterCodec                            = types.RegisterCodec
-	ErrNoValidatorForAddress                 = types.ErrNoValidatorForAddress
-	ErrBadValidatorAddr                      = types.ErrBadValidatorAddr
-	ErrValidatorJailed                       = types.ErrValidatorJailed
-	ErrValidatorNotJailed                    = types.ErrValidatorNotJailed
-	ErrMissingSelfDelegation                 = types.ErrMissingSelfDelegation
-	ErrSelfDelegationTooLowToUnjail          = types.ErrSelfDelegationTooLowToUnjail
-	ErrNoSigningInfoFound                    = types.ErrNoSigningInfoFound
-	NewGenesisState                          = types.NewGenesisState
-	NewMissedBlock                           = types.NewMissedBlock
-	DefaultGenesisState                      = types.DefaultGenesisState
-	ValidateGenesis                          = types.ValidateGenesis
-	GetValidatorSigningInfoKey               = types.GetValidatorSigningInfoKey
-	GetValidatorSigningInfoAddress           = types.GetValidatorSigningInfoAddress
-	GetValidatorMissedBlockBitArrayPrefixKey = types.GetValidatorMissedBlockBitArrayPrefixKey
-	GetValidatorMissedBlockBitArrayKey       = types.GetValidatorMissedBlockBitArrayKey
-	GetAddrPubkeyRelationKey                 = types.GetAddrPubkeyRelationKey
-	NewMsgUnjail                             = types.NewMsgUnjail
-	ParamKeyTable                            = types.ParamKeyTable
-	NewParams                                = types.NewParams
-	DefaultParams                            = types.DefaultParams
-	NewQuerySigningInfoParams                = types.NewQuerySigningInfoParams
-	NewQuerySigningInfosParams               = types.NewQuerySigningInfosParams
-	NewValidatorSigningInfo                  = types.NewValidatorSigningInfo
+	NewKeeper                          = keeper.NewKeeper
+	NewQuerier                         = keeper.NewQuerier
+	RegisterCodec                      = types.RegisterCodec
+	ErrNoValidatorForAddress           = types.ErrNoValidatorForAddress
+	ErrBadValidatorAddr                = types.ErrBadValidatorAddr
+	ErrValidatorJailed                 = types.ErrValidatorJailed
+	ErrValidatorNotJailed              = types.ErrValidatorNotJailed
+	ErrMissingSelfDelegation           = types.ErrMissingSelfDelegation
+	ErrSelfDelegationTooLowToUnjail    = types.ErrSelfDelegationTooLowToUnjail
+	ErrNoSigningInfoFound              = types.ErrNoSigningInfoFound
+	NewGenesisState                    = types.NewGenesisState
+	NewMissedBlock                     = types.NewMissedBlock
+	DefaultGenesisState                = types.DefaultGenesisState
+	ValidateGenesis                    = types.ValidateGenesis
+	GetValidatorSigningInfoKey         = types.GetValidatorSigningInfoKey
+	GetValidatorSigningInfoAddress     = types.GetValidatorSigningInfoAddress
+	GetValidatorMissedBlockBitArrayKey = types.GetValidatorMissedBlockBitArrayKey
+	GetAddrPubkeyRelationKey           = types.GetAddrPubkeyRelationKey
+	NewMsgUnjail                       = types.NewMsgUnjail
+	ParamKeyTable                      = types.ParamKeyTable
+	NewParams                          = types.NewParams
+	DefaultParams                      = types.DefaultParams
+	NewQuerySigningInfoParams          = types.NewQuerySigningInfoParams
+	NewQuerySigningInfosParams         = types.NewQuerySigningInfosParams
+	NewValidatorSigningInfo            = types.NewValidatorSigningInfo
 
 	// variable aliases
 	ModuleCdc                       = types.ModuleCdc

--- a/x/slashing/genesis.go
+++ b/x/slashing/genesis.go
@@ -70,7 +70,7 @@ func ExportGenesis(ctx sdk.Context, keeper Keeper) (data types.GenesisState) {
 		}
 		for i := int64(0); i < params.SignedBlocksWindow; i++ {
 			vote := voteArray.Get(i)
-			// not missed blocks are skipped in ImportGenesis
+			// not missed blocks are skipped in InitGenesis, so we skip them here as well
 			if vote.Missed() {
 				localMissedBlocks = append(localMissedBlocks, types.MissedBlock{Index: i, Missed: true})
 			}

--- a/x/slashing/internal/keeper/infractions.go
+++ b/x/slashing/internal/keeper/infractions.go
@@ -33,6 +33,8 @@ func (k Keeper) HandleValidatorSignature(ctx sdk.Context, addr crypto.Address, p
 	votearray := k.GetVoteArray(ctx, consAddr)
 	if votearray == nil {
 		votearray = types.NewVoteArray(k.SignedBlocksWindow(ctx))
+	} else if votearray.Size() != k.SignedBlocksWindow(ctx) {
+		votearray.ChangeSize(k.SignedBlocksWindow(ctx))
 	}
 
 	// Update signed block bit array & counter

--- a/x/slashing/internal/keeper/keeper_test.go
+++ b/x/slashing/internal/keeper/keeper_test.go
@@ -179,10 +179,7 @@ func TestValidatorDippingInAndOut(t *testing.T) {
 	require.Equal(t, int64(0), signInfo.MissedBlocksCounter)
 	require.Equal(t, int64(0), signInfo.IndexOffset)
 	// array should be cleared
-	for offset := int64(0); offset < keeper.SignedBlocksWindow(ctx); offset++ {
-		missed := keeper.GetValidatorMissedBlockBitArray(ctx, consAddr, offset)
-		require.False(t, missed)
-	}
+	require.Nil(t, keeper.GetVoteArray(ctx, consAddr))
 
 	// some blocks pass
 	height = int64(5000)

--- a/x/slashing/internal/types/bitarray.go
+++ b/x/slashing/internal/types/bitarray.go
@@ -1,0 +1,55 @@
+package types
+
+// NewBitArray create new BitArray instance for elements not lower then hinted.
+func NewBitArray(hint int64) BitArray {
+	quo := hint / 8
+	rem := hint % 8
+	if rem != 0 {
+		quo++
+	}
+	return make(BitArray, quo)
+}
+
+// BitArray can be used to check for existence of an element in an efficient way.
+type BitArray []byte
+
+func (b BitArray) position(index int64) int64 {
+	return index / 8
+}
+
+func (b BitArray) bit(index int64) int64 {
+	return index % 8
+}
+
+// Clear sets bit at a given position to zero. Panics if bit is out of bounds.
+func (b BitArray) Clear(index int64) {
+	b.Set(index, 0)
+}
+
+// Fill sets bit at a given position to one. Panics if bit is out of bounds.
+func (b BitArray) Fill(index int64) {
+	b.Set(index, 1)
+}
+
+// Set sets bit to either one or zero. Panics if bit is out of bounds.
+func (b BitArray) Set(index, val int64) {
+	pos := b.position(index)
+	if pos >= int64(len(b)) {
+		panic("index overflow")
+	}
+	bit := b.bit(index)
+	if val != 0 {
+		b[pos] |= 1 << bit
+	} else {
+		b[pos] &= ^(1 << bit)
+	}
+}
+
+// Get returns true if bit at a given position is set. Panics if bit is out of bounds.
+func (b BitArray) Get(index int64) bool {
+	pos := b.position(index)
+	if pos >= int64(len(b)) {
+		panic("index overlow")
+	}
+	return (b[pos] & (1 << b.bit(index))) > 0
+}

--- a/x/slashing/internal/types/bitarray.go
+++ b/x/slashing/internal/types/bitarray.go
@@ -31,6 +31,11 @@ func (b BitArray) Fill(index int64) {
 	b.Set(index, 1)
 }
 
+// Size returns amount of bits that can fit in the bit array instance.
+func (b BitArray) Size() int64 {
+	return int64(len(b) * 8)
+}
+
 // Set sets bit to either one or zero. Panics if bit is out of bounds.
 func (b BitArray) Set(index, val int64) {
 	pos := b.position(index)

--- a/x/slashing/internal/types/bitarray_test.go
+++ b/x/slashing/internal/types/bitarray_test.go
@@ -1,0 +1,35 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBitArrayClear(t *testing.T) {
+	ba := NewBitArray(8)
+	ba.Fill(7)
+	require.True(t, ba.Get(7))
+	ba.Clear(7)
+	require.False(t, ba.Get(7))
+}
+
+func TestBitArrayFill(t *testing.T) {
+	ba := NewBitArray(16)
+	ba.Fill(8)
+	ba.Fill(9)
+	require.True(t, ba.Get(8))
+	require.True(t, ba.Get(9))
+}
+
+func TestBitArrayHintAlloc(t *testing.T) {
+	require.Len(t, NewBitArray(8), 1)
+	require.Len(t, NewBitArray(9), 2)
+}
+
+func TestBitArrayGetSetOutOfIndexPanic(t *testing.T) {
+	ba := NewBitArray(8)
+
+	require.Panics(t, func() { ba.Get(45) })
+	require.Panics(t, func() { ba.Set(33, 1) })
+}

--- a/x/slashing/internal/types/keys.go
+++ b/x/slashing/internal/types/keys.go
@@ -1,8 +1,6 @@
 package types
 
 import (
-	"encoding/binary"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -48,16 +46,9 @@ func GetValidatorSigningInfoAddress(key []byte) (v sdk.ConsAddress) {
 	return sdk.ConsAddress(addr)
 }
 
-// GetValidatorMissedBlockBitArrayPrefixKey - stored by *Consensus* address (not operator address)
-func GetValidatorMissedBlockBitArrayPrefixKey(v sdk.ConsAddress) []byte {
-	return append(ValidatorMissedBlockBitArrayKey, v.Bytes()...)
-}
-
 // GetValidatorMissedBlockBitArrayKey - stored by *Consensus* address (not operator address)
-func GetValidatorMissedBlockBitArrayKey(v sdk.ConsAddress, i int64) []byte {
-	b := make([]byte, 8)
-	binary.LittleEndian.PutUint64(b, uint64(i))
-	return append(GetValidatorMissedBlockBitArrayPrefixKey(v), b...)
+func GetValidatorMissedBlockBitArrayKey(v sdk.ConsAddress) []byte {
+	return append(ValidatorMissedBlockBitArrayKey, v.Bytes()...)
 }
 
 // GetAddrPubkeyRelationKey gets pubkey relation key used to get the pubkey from the address

--- a/x/slashing/internal/types/votearray.go
+++ b/x/slashing/internal/types/votearray.go
@@ -1,0 +1,61 @@
+package types
+
+// NewVoteArrayFromBytes creates VoteArray from stored bytes.
+func NewVoteArrayFromBytes(value []byte) *VoteArray {
+	bitarray := BitArray(value)
+	return &VoteArray{
+		bitarray: bitarray,
+	}
+}
+
+// NewVoteArray creates VoteArray instance for number of elements not lower then size.
+func NewVoteArray(size int64) *VoteArray {
+	bitarray := NewBitArray(size)
+	return &VoteArray{
+		bitarray: bitarray,
+	}
+}
+
+// VoteArray can be used to check if vote was missed in an efficient way.
+type VoteArray struct {
+	bitarray BitArray
+}
+
+// Get returns vote stored at index.
+func (v VoteArray) Get(index int64) Vote {
+	return Vote{
+		index:    index,
+		bitarray: v.bitarray,
+	}
+}
+
+// Bytes returns byte slice that can be saved on disk.
+func (v VoteArray) Bytes() []byte {
+	return v.bitarray
+}
+
+// Vote can be used to check current state of the vote at a given index or update it.
+type Vote struct {
+	bitarray BitArray
+	index    int64
+}
+
+// Voted is true if validator voted on an expected height.
+func (v Vote) Voted() bool {
+	return !v.Missed()
+}
+
+// Missed is true if validator didn't vote on an expected height.
+func (v Vote) Missed() bool {
+	return v.bitarray.Get(v.index)
+}
+
+// Miss updates vote.
+func (v Vote) Miss() {
+	v.bitarray.Fill(v.index)
+}
+
+// Vote updates vote.
+func (v Vote) Vote() {
+	v.bitarray.Clear(v.index)
+}

--- a/x/slashing/internal/types/votearray.go
+++ b/x/slashing/internal/types/votearray.go
@@ -1,6 +1,11 @@
 package types
 
-// NewVoteArrayFromBytes creates VoteArray from stored bytes.
+import (
+	"bytes"
+	"fmt"
+)
+
+// NewVoteArrayiFromBytes creates VoteArray from stored bytes.
 func NewVoteArrayFromBytes(value []byte) *VoteArray {
 	bitarray := BitArray(value)
 	return &VoteArray{
@@ -29,9 +34,40 @@ func (v VoteArray) Get(index int64) Vote {
 	}
 }
 
+// Size returns size of the vote array.
+func (v VoteArray) Size() int64 {
+	return v.bitarray.Size()
+}
+
 // Bytes returns byte slice that can be saved on disk.
 func (v VoteArray) Bytes() []byte {
 	return v.bitarray
+}
+
+// String returns string reprentation for VoteArray.
+func (v VoteArray) String() string {
+	b := bytes.NewBuffer(nil)
+	_, _ = b.WriteString("Votes<")
+	first := true
+	for i := int64(0); i < v.Size(); i++ {
+		if !first {
+			first = true
+			b.WriteString(",")
+		}
+		if v.Get(i).Missed() {
+			b.WriteString(v.Get(i).String())
+		}
+	}
+	b.WriteString(">")
+	return b.String()
+}
+
+// ChangeSize changes size to a requested size.
+// If new size is lower then the previous one out of bound indexes will be discarded.
+func (v VoteArray) ChangeSize(size int64) {
+	bitarray := NewBitArray(size)
+	copy(bitarray, v.bitarray)
+	v.bitarray = bitarray
 }
 
 // Vote can be used to check current state of the vote at a given index or update it.
@@ -58,4 +94,9 @@ func (v Vote) Miss() {
 // Vote updates vote.
 func (v Vote) Vote() {
 	v.bitarray.Clear(v.index)
+}
+
+// String returns string representation for a Vote.
+func (v Vote) String() string {
+	return fmt.Sprintf("%d:%v", v.index, v.Missed())
 }

--- a/x/slashing/internal/types/votearray_test.go
+++ b/x/slashing/internal/types/votearray_test.go
@@ -1,0 +1,23 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestVoteArray(t *testing.T) {
+	va := NewVoteArray(100)
+	for i := int64(0); i < 100; i++ {
+		vote := va.Get(i)
+		require.False(t, vote.Missed())
+		require.True(t, vote.Voted())
+
+		vote.Miss()
+
+		vote = va.Get(i)
+		require.True(t, vote.Missed())
+		require.False(t, vote.Voted())
+	}
+
+}

--- a/x/slashing/simulation/decoder.go
+++ b/x/slashing/simulation/decoder.go
@@ -22,10 +22,9 @@ func DecodeStore(cdc *codec.Codec, kvA, kvB cmn.KVPair) string {
 		return fmt.Sprintf("%v\n%v", infoA, infoB)
 
 	case bytes.Equal(kvA.Key[:1], types.ValidatorMissedBlockBitArrayKey):
-		var missedA, missedB bool
-		cdc.MustUnmarshalBinaryLengthPrefixed(kvA.Value, &missedA)
-		cdc.MustUnmarshalBinaryLengthPrefixed(kvB.Value, &missedB)
-		return fmt.Sprintf("missedA: %v\nmissedB: %v", missedA, missedB)
+		votearrayA := types.NewVoteArrayFromBytes(kvA.Value)
+		votearrayB := types.NewVoteArrayFromBytes(kvB.Value)
+		return fmt.Sprintf("%v\n%v", votearrayA, votearrayB)
 
 	case bytes.Equal(kvA.Key[:1], types.AddrPubkeyRelationKey):
 		var pubKeyA, pubKeyB crypto.PubKey

--- a/x/slashing/simulation/decoder_test.go
+++ b/x/slashing/simulation/decoder_test.go
@@ -36,11 +36,12 @@ func TestDecodeStore(t *testing.T) {
 
 	info := types.NewValidatorSigningInfo(consAddr1, 0, 1, time.Now().UTC(), false, 0)
 	bechPK := sdk.MustBech32ifyAccPub(delPk1)
-	missed := true
+	array := types.NewVoteArray(2)
+	array.Get(1).Miss()
 
 	kvPairs := cmn.KVPairs{
 		cmn.KVPair{Key: types.GetValidatorSigningInfoKey(consAddr1), Value: cdc.MustMarshalBinaryLengthPrefixed(info)},
-		cmn.KVPair{Key: types.GetValidatorMissedBlockBitArrayKey(consAddr1, 6), Value: cdc.MustMarshalBinaryLengthPrefixed(missed)},
+		cmn.KVPair{Key: types.GetValidatorMissedBlockBitArrayKey(consAddr1), Value: array.Bytes()},
 		cmn.KVPair{Key: types.GetAddrPubkeyRelationKey(delAddr1), Value: cdc.MustMarshalBinaryLengthPrefixed(delPk1)},
 		cmn.KVPair{Key: []byte{0x99}, Value: []byte{0x99}},
 	}
@@ -50,7 +51,7 @@ func TestDecodeStore(t *testing.T) {
 		expectedLog string
 	}{
 		{"ValidatorSigningInfo", fmt.Sprintf("%v\n%v", info, info)},
-		{"ValidatorMissedBlockBitArray", fmt.Sprintf("missedA: %v\nmissedB: %v", missed, missed)},
+		{"ValidatorMissedBlockBitArray", fmt.Sprintf("%v\n%v", array, array)},
 		{"AddrPubkeyRelation", fmt.Sprintf("PubKeyA: %s\nPubKeyB: %s", bechPK, bechPK)},
 		{"other", ""},
 	}


### PR DESCRIPTION
Instead of storing each index of the bit array as a separate key in iavl tree, this change stores single bit array for each validator. This makes iavl tree smaller, and greatly reduces time spent in a queries to leveldb.

To profile this change i cherry-picked it on current version used in gaia, and compared cpu profile with and without this change. You can find gaia branch with cherry-picked change at https://github.com/dshulyak/gaia/tree/bitarray-v2.0.3. It comes with two changes:
- cosmos-sdk cherry-pick https://github.com/dshulyak/cosmos-sdk/commit/7b7669474383dba19648fed16fb647cab8be9b9d
- tendermint change to disable app hash verification, due to the incompatible changes with current gaia application state. https://github.com/dshulyak/tendermint/commit/2bda8149f1eea8bd720f8d46bccf2d6f02298fdd . basically a hack that allowed to get a profile from running app, won't be needed.

I am attachiing web view for cosmos-sdk.BeginBlock so that you can see difference with and without these changes:
[without](https://github.com/cosmos/cosmos-sdk/files/4015483/profile001.pdf) , [with](https://github.com/cosmos/cosmos-sdk/files/4015487/profile002.pdf)

If someone will need full profile i can attach it, but it is also possible to reproduce same results using gaiad branch i linked before.

changes
---
- two new data types in x/lashing, bit array and vote array. bit array is simple implementation of this data structure that basically supports only set and get. vote array provides a proxy to bit array, as well as handles some other function, e.g it can change size of underlying bit array if request, or pretty print contents of the bit array
- changes to keeper, methods to update/get/delete bit array for the validator
- in HandleValidatorSignature bit array size can be changed, and based on new size some indexes might get discarded
- export genesis  includes only missed blocks now
- some changes in simulation due to the keeper changes

todo
---
- update spec once changes are finalized
- fetch signed block window and min block window once per slashing.BeginBlock (will submit a different pr for that)

______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added  relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

______

For admin use:

- [x] Added appropriate labels to PR (ex. `WIP`, `R4R`, `docs`, etc)
- [x] Reviewers assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
