### PR TITLE
Add errors.Is support to the wrappedError

### DIFF
--- a/types/errors/errors.go
+++ b/types/errors/errors.go
@@ -263,6 +263,15 @@ func (e *wrappedError) Cause() error {
 	return e.parent
 }
 
+// Is implements the built-in errors.Is
+func (e *wrappedError) Is(target error) bool {
+	return target == e.parent
+}
+
+func (e *wrappedError) Unwrap() error {
+	return e.parent
+}
+
 // Recover captures a panic and stop its propagation. If panic happens it is
 // transformed into a ErrPanic instance and assigned to given error. Call this
 // function using defer in order to work as expected.

--- a/types/errors/errors.go
+++ b/types/errors/errors.go
@@ -263,9 +263,27 @@ func (e *wrappedError) Cause() error {
 	return e.parent
 }
 
-// Is implements the built-in errors.Is
+// Is reports whether any error in e's chain matches a target.
 func (e *wrappedError) Is(target error) bool {
-	return target == e.parent
+	if target == nil {
+		return e == target
+	}
+
+	w := e.Cause()
+
+	for {
+		if w == target {
+			return true
+		}
+
+		x, ok := w.(causer)
+		if ok {
+			w = x.Cause()
+		}
+		if x == nil {
+			return false
+		}
+	}
 }
 
 // Unwrap implements the built-in errors.Unwrap

--- a/types/errors/errors.go
+++ b/types/errors/errors.go
@@ -268,6 +268,7 @@ func (e *wrappedError) Is(target error) bool {
 	return target == e.parent
 }
 
+// Unwrap implements the built-in errors.Unwrap
 func (e *wrappedError) Unwrap() error {
 	return e.parent
 }

--- a/types/errors/errors_test.go
+++ b/types/errors/errors_test.go
@@ -3,6 +3,7 @@ package errors
 import (
 	stdlib "errors"
 	"fmt"
+	"github.com/stretchr/testify/require"
 	"testing"
 
 	"github.com/pkg/errors"
@@ -162,15 +163,39 @@ func TestWrapEmpty(t *testing.T) {
 func TestWrapIs(t *testing.T) {
 	var errTest = errors.New("test error")
 	err := Wrap(errTest, "some random description")
-	if !stdlib.Is(err, errTest) {
-		t.Error("should be true, because wrapped error contains the errTest")
-	}
+	require.True(t, stdlib.Is(err, errTest))
+}
+
+func TestWrapIsMultiple(t *testing.T) {
+	var errTest = errors.New("test error")
+	var errTest2 = errors.New("test error 2")
+	err := Wrap(errTest2, Wrap(errTest, "some random description").Error())
+	require.True(t, stdlib.Is(err, errTest2))
+}
+
+func TestWrapIsFail(t *testing.T) {
+	var errTest = errors.New("test error")
+	var errTest2 = errors.New("test error 2")
+	err := Wrap(errTest2, Wrap(errTest, "some random description").Error())
+	require.False(t, stdlib.Is(err, errTest))
 }
 
 func TestWrapUnwrap(t *testing.T) {
 	var errTest = errors.New("test error")
 	err := Wrap(errTest, "some random description")
-	if unwrapedErr := stdlib.Unwrap(err); unwrapedErr != errTest {
-		t.Errorf("Unwrapped error should be %v, instead of %v", errTest, unwrapedErr)
-	}
+	require.Equal(t, errTest, stdlib.Unwrap(err))
+}
+
+func TestWrapUnwrapMultiple(t *testing.T) {
+	var errTest = errors.New("test error")
+	var errTest2 = errors.New("test error 2")
+	err := Wrap(errTest2, Wrap(errTest, "some random description").Error())
+	require.Equal(t, errTest2, stdlib.Unwrap(err))
+}
+
+func TestWrapUnwrapFail(t *testing.T) {
+	var errTest = errors.New("test error")
+	var errTest2 = errors.New("test error 2")
+	err := Wrap(errTest2, Wrap(errTest, "some random description").Error())
+	require.NotEqual(t, errTest, stdlib.Unwrap(err))
 }

--- a/types/errors/errors_test.go
+++ b/types/errors/errors_test.go
@@ -160,40 +160,48 @@ func TestWrapEmpty(t *testing.T) {
 	}
 }
 
-func TestWrapIs(t *testing.T) {
-	var errTest = errors.New("test error")
-	err := Wrap(errTest, "some random description")
-	require.True(t, stdlib.Is(err, errTest))
+func TestWrappedIs(t *testing.T) {
+	err := Wrap(ErrTxTooLarge, "context")
+	require.True(t, stdlib.Is(err, ErrTxTooLarge))
+
+	err = Wrap(err, "more context")
+	require.True(t, stdlib.Is(err, ErrTxTooLarge))
+
+	err = Wrap(err, "even more context")
+	require.True(t, stdlib.Is(err, ErrTxTooLarge))
+
+	err = Wrap(ErrInsufficientFee, "...")
+	require.False(t, stdlib.Is(err, ErrTxTooLarge))
 }
 
-func TestWrapIsMultiple(t *testing.T) {
+func TestWrappedIsMultiple(t *testing.T) {
 	var errTest = errors.New("test error")
 	var errTest2 = errors.New("test error 2")
 	err := Wrap(errTest2, Wrap(errTest, "some random description").Error())
 	require.True(t, stdlib.Is(err, errTest2))
 }
 
-func TestWrapIsFail(t *testing.T) {
+func TestWrappedIsFail(t *testing.T) {
 	var errTest = errors.New("test error")
 	var errTest2 = errors.New("test error 2")
 	err := Wrap(errTest2, Wrap(errTest, "some random description").Error())
 	require.False(t, stdlib.Is(err, errTest))
 }
 
-func TestWrapUnwrap(t *testing.T) {
+func TestWrappedUnwrap(t *testing.T) {
 	var errTest = errors.New("test error")
 	err := Wrap(errTest, "some random description")
 	require.Equal(t, errTest, stdlib.Unwrap(err))
 }
 
-func TestWrapUnwrapMultiple(t *testing.T) {
+func TestWrappedUnwrapMultiple(t *testing.T) {
 	var errTest = errors.New("test error")
 	var errTest2 = errors.New("test error 2")
 	err := Wrap(errTest2, Wrap(errTest, "some random description").Error())
 	require.Equal(t, errTest2, stdlib.Unwrap(err))
 }
 
-func TestWrapUnwrapFail(t *testing.T) {
+func TestWrappedUnwrapFail(t *testing.T) {
 	var errTest = errors.New("test error")
 	var errTest2 = errors.New("test error 2")
 	err := Wrap(errTest2, Wrap(errTest, "some random description").Error())

--- a/types/errors/errors_test.go
+++ b/types/errors/errors_test.go
@@ -3,8 +3,9 @@ package errors
 import (
 	stdlib "errors"
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/pkg/errors"
 )

--- a/types/errors/errors_test.go
+++ b/types/errors/errors_test.go
@@ -158,3 +158,19 @@ func TestWrapEmpty(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestWrapIs(t *testing.T) {
+	var errTest = errors.New("test error")
+	err := Wrap(errTest, "some random description")
+	if !stdlib.Is(err, errTest) {
+		t.Error("should be true, because wrapped error contains the errTest")
+	}
+}
+
+func TestWrapUnwrap(t *testing.T) {
+	var errTest = errors.New("test error")
+	err := Wrap(errTest, "some random description")
+	if unwrapedErr := stdlib.Unwrap(err); unwrapedErr != errTest {
+		t.Errorf("Unwrapped error should be %v, instead of %v", errTest, unwrapedErr)
+	}
+}


### PR DESCRIPTION
Closes: #5481

## Description

Add built-in `errors.Is` and `errors.Unwrap` support for wrappedError of `types/errors`.
I had to skip the `errors.As` support, because each errors replaced with `withStack` type, so the parent won't match the original error type. I don't think that the errors.As is urgent to implement, but if I can add an extra field as `original error` it can keep the type of it.
______

For contributor use:

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [x] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added  relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer

______

For admin use:

- [ ] Added appropriate labels to PR (ex. `WIP`, `R4R`, `docs`, etc)
- [ ] Reviewers assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
