### PR TITLE
Replace Redundant Bech32 PubKey Functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,9 @@ logic has been implemented for v0.38 target version. Applications can migrate vi
 
 ### API Breaking Changes
 
+* (types) [\#5495](https://github.com/cosmos/cosmos-sdk/pull/5495) Remove redundant `(Must)Bech32ify*` and `(Must)Get*KeyBech32`
+  functions in favor of `(Must)Bech32ifyPubKey` and `(Must)GetPubKeyFromBech32` respectively, both of
+  which take a `Bech32PubKeyType` (string).
 * (types) [\#5430](https://github.com/cosmos/cosmos-sdk/pull/5430) `DecCoins#Add` parameter changed from `DecCoins` 
   to `...DecCoin`, `Coins#Add` parameter changed from `Coins` to `...Coin`
 * (baseapp/types) [\#5421](https://github.com/cosmos/cosmos-sdk/pull/5421) The `Error` interface (`types/errors.go`)

--- a/client/debug/main.go
+++ b/client/debug/main.go
@@ -86,16 +86,16 @@ $ %s debug pubkey cosmos1e0jnq2sun3dzjh8p2xq95kk0expwmd7shwjpfg
 			if err != nil {
 				return err
 			}
-			accPub, err := sdk.Bech32ifyAccPub(pubKey)
+			accPub, err := sdk.Bech32ifyPubKey(sdk.Bech32PubKeyTypeAccPub, pubKey)
 			if err != nil {
 				return err
 			}
-			valPub, err := sdk.Bech32ifyValPub(pubKey)
+			valPub, err := sdk.GetPubKeyFromBech32(sdk.Bech32PubKeyTypeValPub, pubKey)
 			if err != nil {
 				return err
 			}
 
-			consenusPub, err := sdk.Bech32ifyConsPub(pubKey)
+			consenusPub, err := sdk.GetPubKeyFromBech32(sdk.Bech32PubKeyTypeConsPub, pubKey)
 			if err != nil {
 				return err
 			}

--- a/client/debug/main.go
+++ b/client/debug/main.go
@@ -32,10 +32,46 @@ func Cmd(cdc *codec.Codec) *cobra.Command {
 	return cmd
 }
 
+// getPubKeyFromString returns a Tendermint PubKey (PubKeyEd25519) by attempting
+// to decode the pubkey string from hex, base64, and finally bech32. If all
+// encodings fail, an error is returned.
+func getPubKeyFromString(pkstr string) (crypto.PubKey, error) {
+	var pubKey ed25519.PubKeyEd25519
+
+	bz, err := hex.DecodeString(pkstr)
+	if err == nil {
+		copy(pubKey[:], bz)
+		return pubKey, nil
+	}
+
+	bz, err = base64.StdEncoding.DecodeString(pkstr)
+	if err == nil {
+		copy(pubKey[:], bz)
+		return pubKey, nil
+	}
+
+	pk, err := sdk.GetPubKeyFromBech32(sdk.Bech32PubKeyTypeAccPub, pkstr)
+	if err == nil {
+		return pk, nil
+	}
+
+	pk, err = sdk.GetPubKeyFromBech32(sdk.Bech32PubKeyTypeValPub, pkstr)
+	if err == nil {
+		return pk, nil
+	}
+
+	pk, err = sdk.GetPubKeyFromBech32(sdk.Bech32PubKeyTypeConsPub, pkstr)
+	if err == nil {
+		return pk, nil
+	}
+
+	return nil, fmt.Errorf("pubkey '%s' invalid; expected hex, base64, or bech32", pubKey)
+}
+
 func PubkeyCmd(cdc *codec.Codec) *cobra.Command {
 	return &cobra.Command{
 		Use:   "pubkey [pubkey]",
-		Short: "Decode a pubkey from hex, base64, or bech32",
+		Short: "Decode a ED25519 pubkey from hex, base64, or bech32",
 		Long: fmt.Sprintf(`Decode a pubkey from hex, base64, or bech32.
 
 Example:
@@ -44,68 +80,40 @@ $ %s debug pubkey cosmos1e0jnq2sun3dzjh8p2xq95kk0expwmd7shwjpfg
 			`, version.ClientName, version.ClientName),
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-
-			pubkeyString := args[0]
-			var pubKeyI crypto.PubKey
-
-			// try hex, then base64, then bech32
-			pubkeyBytes, err := hex.DecodeString(pubkeyString)
-			if err != nil {
-				var err2 error
-				pubkeyBytes, err2 = base64.StdEncoding.DecodeString(pubkeyString)
-				if err2 != nil {
-					var err3 error
-					pubKeyI, err3 = sdk.GetPubKeyFromBech32(sdk.Bech32PubKeyTypeAccPub, pubkeyString)
-					if err3 != nil {
-						var err4 error
-						pubKeyI, err4 = sdk.GetPubKeyFromBech32(sdk.Bech32PubKeyTypeValPub, pubkeyString)
-
-						if err4 != nil {
-							var err5 error
-							pubKeyI, err5 = sdk.GetPubKeyFromBech32(sdk.Bech32PubKeyTypeConsPub, pubkeyString)
-							if err5 != nil {
-								return fmt.Errorf("expected hex, base64, or bech32. Got errors: hex: %v, base64: %v, bech32 Acc: %v, bech32 Val: %v, bech32 Cons: %v",
-									err, err2, err3, err4, err5)
-							}
-
-						}
-					}
-
-				}
-			}
-
-			var pubKey ed25519.PubKeyEd25519
-			if pubKeyI == nil {
-				copy(pubKey[:], pubkeyBytes)
-			} else {
-				pubKey = pubKeyI.(ed25519.PubKeyEd25519)
-				pubkeyBytes = pubKey[:]
-			}
-
-			pubKeyJSONBytes, err := cdc.MarshalJSON(pubKey)
-			if err != nil {
-				return err
-			}
-			accPub, err := sdk.Bech32ifyPubKey(sdk.Bech32PubKeyTypeAccPub, pubKey)
-			if err != nil {
-				return err
-			}
-			valPub, err := sdk.Bech32ifyPubKey(sdk.Bech32PubKeyTypeValPub, pubKey)
+			pk, err := getPubKeyFromString(args[0])
 			if err != nil {
 				return err
 			}
 
-			consenusPub, err := sdk.Bech32ifyPubKey(sdk.Bech32PubKeyTypeConsPub, pubKey)
+			edPK, ok := pk.(ed25519.PubKeyEd25519)
+			if !ok {
+				return fmt.Errorf("invalid pubkey type; expected ED25519")
+			}
+
+			pubKeyJSONBytes, err := cdc.MarshalJSON(edPK)
+			if err != nil {
+				return err
+			}
+			accPub, err := sdk.Bech32ifyPubKey(sdk.Bech32PubKeyTypeAccPub, edPK)
+			if err != nil {
+				return err
+			}
+			valPub, err := sdk.Bech32ifyPubKey(sdk.Bech32PubKeyTypeValPub, edPK)
+			if err != nil {
+				return err
+			}
+			consenusPub, err := sdk.Bech32ifyPubKey(sdk.Bech32PubKeyTypeConsPub, edPK)
 			if err != nil {
 				return err
 			}
 
-			cmd.Println("Address:", pubKey.Address())
-			cmd.Printf("Hex: %X\n", pubkeyBytes)
+			cmd.Println("Address:", edPK.Address())
+			cmd.Printf("Hex: %X\n", edPK[:])
 			cmd.Println("JSON (base64):", string(pubKeyJSONBytes))
 			cmd.Println("Bech32 Acc:", accPub)
 			cmd.Println("Bech32 Validator Operator:", valPub)
 			cmd.Println("Bech32 Validator Consensus:", consenusPub)
+
 			return nil
 		},
 	}

--- a/client/debug/main.go
+++ b/client/debug/main.go
@@ -55,14 +55,14 @@ $ %s debug pubkey cosmos1e0jnq2sun3dzjh8p2xq95kk0expwmd7shwjpfg
 				pubkeyBytes, err2 = base64.StdEncoding.DecodeString(pubkeyString)
 				if err2 != nil {
 					var err3 error
-					pubKeyI, err3 = sdk.GetAccPubKeyBech32(pubkeyString)
+					pubKeyI, err3 = sdk.GetPubKeyFromBech32(sdk.Bech32PubKeyTypeAccPub, pubkeyString)
 					if err3 != nil {
 						var err4 error
-						pubKeyI, err4 = sdk.GetValPubKeyBech32(pubkeyString)
+						pubKeyI, err4 = sdk.GetPubKeyFromBech32(sdk.Bech32PubKeyTypeValPub, pubkeyString)
 
 						if err4 != nil {
 							var err5 error
-							pubKeyI, err5 = sdk.GetConsPubKeyBech32(pubkeyString)
+							pubKeyI, err5 = sdk.GetPubKeyFromBech32(sdk.Bech32PubKeyTypeConsPub, pubkeyString)
 							if err5 != nil {
 								return fmt.Errorf("expected hex, base64, or bech32. Got errors: hex: %v, base64: %v, bech32 Acc: %v, bech32 Val: %v, bech32 Cons: %v",
 									err, err2, err3, err4, err5)
@@ -90,15 +90,16 @@ $ %s debug pubkey cosmos1e0jnq2sun3dzjh8p2xq95kk0expwmd7shwjpfg
 			if err != nil {
 				return err
 			}
-			valPub, err := sdk.GetPubKeyFromBech32(sdk.Bech32PubKeyTypeValPub, pubKey)
+			valPub, err := sdk.Bech32ifyPubKey(sdk.Bech32PubKeyTypeValPub, pubKey)
 			if err != nil {
 				return err
 			}
 
-			consenusPub, err := sdk.GetPubKeyFromBech32(sdk.Bech32PubKeyTypeConsPub, pubKey)
+			consenusPub, err := sdk.Bech32ifyPubKey(sdk.Bech32PubKeyTypeConsPub, pubKey)
 			if err != nil {
 				return err
 			}
+
 			cmd.Println("Address:", pubKey.Address())
 			cmd.Printf("Hex: %X\n", pubkeyBytes)
 			cmd.Println("JSON (base64):", string(pubKeyJSONBytes))

--- a/client/keys/add.go
+++ b/client/keys/add.go
@@ -160,7 +160,7 @@ func RunAddCmd(cmd *cobra.Command, args []string, kb keys.Keybase, inBuf *bufio.
 	}
 
 	if viper.GetString(FlagPublicKey) != "" {
-		pk, err := sdk.GetAccPubKeyBech32(viper.GetString(FlagPublicKey))
+		pk, err := sdk.GetPubKeyFromBech32(sdk.Bech32PubKeyTypeAccPub, viper.GetString(FlagPublicKey))
 		if err != nil {
 			return err
 		}

--- a/client/keys/add_ledger_test.go
+++ b/client/keys/add_ledger_test.go
@@ -69,7 +69,7 @@ func Test_runAddCmdLedgerWithCustomCoinType(t *testing.T) {
 	require.Equal(t, keys.TypeLedger, key1.GetType())
 	require.Equal(t,
 		"terrapub1addwnpepqvpg7r26nl2pvqqern00m6s9uaax3hauu2rzg8qpjzq9hy6xve7sw0d84m6",
-		sdk.MustBech32ifyAccPub(key1.GetPubKey()))
+		sdk.MustBech32ifyPubKey(sdk.Bech32PubKeyTypeAccPub, key1.GetPubKey()))
 
 	config.SetCoinType(118)
 	config.SetFullFundraiserPath("44'/118'/0'/0/0")
@@ -116,5 +116,5 @@ func Test_runAddCmdLedger(t *testing.T) {
 	require.Equal(t, keys.TypeLedger, key1.GetType())
 	require.Equal(t,
 		"cosmospub1addwnpepqd87l8xhcnrrtzxnkql7k55ph8fr9jarf4hn6udwukfprlalu8lgw0urza0",
-		sdk.MustBech32ifyAccPub(key1.GetPubKey()))
+		sdk.MustBech32ifyPubKey(sdk.Bech32PubKeyTypeAccPub, key1.GetPubKey()))
 }

--- a/client/rpc/validators.go
+++ b/client/rpc/validators.go
@@ -100,7 +100,7 @@ func (rvo ResultValidatorsOutput) String() string {
 }
 
 func bech32ValidatorOutput(validator *tmtypes.Validator) (ValidatorOutput, error) {
-	bechValPubkey, err := sdk.Bech32ifyConsPub(validator.PubKey)
+	bechValPubkey, err := sdk.GetPubKeyFromBech32(sdk.Bech32PubKeyTypeConsPub, validator.PubKey)
 	if err != nil {
 		return ValidatorOutput{}, err
 	}

--- a/client/rpc/validators.go
+++ b/client/rpc/validators.go
@@ -100,7 +100,7 @@ func (rvo ResultValidatorsOutput) String() string {
 }
 
 func bech32ValidatorOutput(validator *tmtypes.Validator) (ValidatorOutput, error) {
-	bechValPubkey, err := sdk.GetPubKeyFromBech32(sdk.Bech32PubKeyTypeConsPub, validator.PubKey)
+	bechValPubkey, err := sdk.Bech32ifyPubKey(sdk.Bech32PubKeyTypeConsPub, validator.PubKey)
 	if err != nil {
 		return ValidatorOutput{}, err
 	}

--- a/crypto/keys/keybase_test.go
+++ b/crypto/keys/keybase_test.go
@@ -69,7 +69,7 @@ func TestCreateLedger(t *testing.T) {
 
 	// The mock is available, check that the address is correct
 	pubKey := ledger.GetPubKey()
-	pk, err := sdk.Bech32ifyAccPub(pubKey)
+	pk, err := sdk.Bech32ifyPubKey(sdk.Bech32PubKeyTypeAccPub, pubKey)
 	assert.NoError(t, err)
 	assert.Equal(t, "cosmospub1addwnpepqdszcr95mrqqs8lw099aa9h8h906zmet22pmwe9vquzcgvnm93eqygufdlv", pk)
 
@@ -80,7 +80,7 @@ func TestCreateLedger(t *testing.T) {
 	assert.Equal(t, "some_account", restoredKey.GetName())
 	assert.Equal(t, TypeLedger, restoredKey.GetType())
 	pubKey = restoredKey.GetPubKey()
-	pk, err = sdk.Bech32ifyAccPub(pubKey)
+	pk, err = sdk.Bech32ifyPubKey(sdk.Bech32PubKeyTypeAccPub, pubKey)
 	assert.NoError(t, err)
 	assert.Equal(t, "cosmospub1addwnpepqdszcr95mrqqs8lw099aa9h8h906zmet22pmwe9vquzcgvnm93eqygufdlv", pk)
 

--- a/crypto/keys/output.go
+++ b/crypto/keys/output.go
@@ -52,7 +52,7 @@ func Bech32KeysOutput(infos []Info) ([]KeyOutput, error) {
 func Bech32ConsKeyOutput(keyInfo Info) (KeyOutput, error) {
 	consAddr := sdk.ConsAddress(keyInfo.GetPubKey().Address().Bytes())
 
-	bechPubKey, err := sdk.GetPubKeyFromBech32(sdk.Bech32PubKeyTypeConsPub, keyInfo.GetPubKey())
+	bechPubKey, err := sdk.Bech32ifyPubKey(sdk.Bech32PubKeyTypeConsPub, keyInfo.GetPubKey())
 	if err != nil {
 		return KeyOutput{}, err
 	}
@@ -64,7 +64,7 @@ func Bech32ConsKeyOutput(keyInfo Info) (KeyOutput, error) {
 func Bech32ValKeyOutput(keyInfo Info) (KeyOutput, error) {
 	valAddr := sdk.ValAddress(keyInfo.GetPubKey().Address().Bytes())
 
-	bechPubKey, err := sdk.GetPubKeyFromBech32(sdk.Bech32PubKeyTypeValPub, keyInfo.GetPubKey())
+	bechPubKey, err := sdk.Bech32ifyPubKey(sdk.Bech32PubKeyTypeValPub, keyInfo.GetPubKey())
 	if err != nil {
 		return KeyOutput{}, err
 	}

--- a/crypto/keys/output.go
+++ b/crypto/keys/output.go
@@ -52,7 +52,7 @@ func Bech32KeysOutput(infos []Info) ([]KeyOutput, error) {
 func Bech32ConsKeyOutput(keyInfo Info) (KeyOutput, error) {
 	consAddr := sdk.ConsAddress(keyInfo.GetPubKey().Address().Bytes())
 
-	bechPubKey, err := sdk.Bech32ifyConsPub(keyInfo.GetPubKey())
+	bechPubKey, err := sdk.GetPubKeyFromBech32(sdk.Bech32PubKeyTypeConsPub, keyInfo.GetPubKey())
 	if err != nil {
 		return KeyOutput{}, err
 	}
@@ -64,7 +64,7 @@ func Bech32ConsKeyOutput(keyInfo Info) (KeyOutput, error) {
 func Bech32ValKeyOutput(keyInfo Info) (KeyOutput, error) {
 	valAddr := sdk.ValAddress(keyInfo.GetPubKey().Address().Bytes())
 
-	bechPubKey, err := sdk.Bech32ifyValPub(keyInfo.GetPubKey())
+	bechPubKey, err := sdk.GetPubKeyFromBech32(sdk.Bech32PubKeyTypeValPub, keyInfo.GetPubKey())
 	if err != nil {
 		return KeyOutput{}, err
 	}
@@ -77,7 +77,7 @@ func Bech32ValKeyOutput(keyInfo Info) (KeyOutput, error) {
 // public keys will be added.
 func Bech32KeyOutput(keyInfo Info) (KeyOutput, error) {
 	accAddr := sdk.AccAddress(keyInfo.GetPubKey().Address().Bytes())
-	bechPubKey, err := sdk.Bech32ifyAccPub(keyInfo.GetPubKey())
+	bechPubKey, err := sdk.Bech32ifyPubKey(sdk.Bech32PubKeyTypeAccPub, keyInfo.GetPubKey())
 	if err != nil {
 		return KeyOutput{}, err
 	}
@@ -90,7 +90,7 @@ func Bech32KeyOutput(keyInfo Info) (KeyOutput, error) {
 		for i, pk := range mInfo.PubKeys {
 			accAddr := sdk.AccAddress(pk.PubKey.Address().Bytes())
 
-			bechPubKey, err := sdk.Bech32ifyAccPub(pk.PubKey)
+			bechPubKey, err := sdk.Bech32ifyPubKey(sdk.Bech32PubKeyTypeAccPub, pk.PubKey)
 			if err != nil {
 				return KeyOutput{}, err
 			}

--- a/crypto/keys/output_test.go
+++ b/crypto/keys/output_test.go
@@ -13,13 +13,13 @@ import (
 
 func TestBech32KeysOutput(t *testing.T) {
 	tmpKey := secp256k1.GenPrivKey().PubKey()
-	bechTmpKey := sdk.MustBech32ifyAccPub(tmpKey)
+	bechTmpKey := sdk.MustBech32ifyPubKey(sdk.Bech32PubKeyTypeAccPub, tmpKey)
 	tmpAddr := sdk.AccAddress(tmpKey.Address().Bytes())
 
 	multisigPks := multisig.NewPubKeyMultisigThreshold(1, []crypto.PubKey{tmpKey})
 	multiInfo := NewMultiInfo("multisig", multisigPks)
 	accAddr := sdk.AccAddress(multiInfo.GetPubKey().Address().Bytes())
-	bechPubKey := sdk.MustBech32ifyAccPub(multiInfo.GetPubKey())
+	bechPubKey := sdk.MustBech32ifyPubKey(sdk.Bech32PubKeyTypeAccPub, multiInfo.GetPubKey())
 
 	expectedOutput := NewKeyOutput(multiInfo.GetName(), multiInfo.GetType().String(), accAddr.String(), bechPubKey)
 	expectedOutput.Threshold = 1

--- a/crypto/keys/types_test.go
+++ b/crypto/keys/types_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/crypto/keys/hd"
 	"github.com/cosmos/cosmos-sdk/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 func Test_writeReadLedgerInfo(t *testing.T) {
@@ -24,7 +25,7 @@ func Test_writeReadLedgerInfo(t *testing.T) {
 	assert.Equal(t, "44'/118'/5'/0/1", path.String())
 	assert.Equal(t,
 		"cosmospub1addwnpepqddddqg2glc8x4fl7vxjlnr7p5a3czm5kcdp4239sg6yqdc4rc2r5wmxv8p",
-		types.MustBech32ifyAccPub(lInfo.GetPubKey()))
+		types.MustBech32ifyPubKey(sdk.Bech32PubKeyTypeAccPub, lInfo.GetPubKey()))
 
 	// Serialize and restore
 	serialized := marshalInfo(lInfo)

--- a/crypto/ledger_test.go
+++ b/crypto/ledger_test.go
@@ -32,7 +32,7 @@ func TestPublicKeyUnsafe(t *testing.T) {
 		fmt.Sprintf("%x", priv.PubKey().Bytes()),
 		"Is your device using test mnemonic: %s ?", tests.TestMnemonic)
 
-	pubKeyAddr, err := sdk.Bech32ifyAccPub(priv.PubKey())
+	pubKeyAddr, err := sdk.Bech32ifyPubKey(sdk.Bech32PubKeyTypeAccPub, priv.PubKey())
 	require.NoError(t, err)
 	require.Equal(t, "cosmospub1addwnpepqd87l8xhcnrrtzxnkql7k55ph8fr9jarf4hn6udwukfprlalu8lgw0urza0",
 		pubKeyAddr, "Is your device using test mnemonic: %s ?", tests.TestMnemonic)
@@ -74,7 +74,7 @@ func TestPublicKeyUnsafeHDPath(t *testing.T) {
 		tmp := priv.(PrivKeyLedgerSecp256k1)
 		(&tmp).AssertIsPrivKeyInner()
 
-		pubKeyAddr, err := sdk.Bech32ifyAccPub(priv.PubKey())
+		pubKeyAddr, err := sdk.Bech32ifyPubKey(sdk.Bech32PubKeyTypeAccPub, priv.PubKey())
 		require.NoError(t, err)
 		require.Equal(t,
 			expectedAnswers[i], pubKeyAddr,
@@ -108,7 +108,7 @@ func TestPublicKeySafe(t *testing.T) {
 		fmt.Sprintf("%x", priv.PubKey().Bytes()),
 		"Is your device using test mnemonic: %s ?", tests.TestMnemonic)
 
-	pubKeyAddr, err := sdk.Bech32ifyAccPub(priv.PubKey())
+	pubKeyAddr, err := sdk.Bech32ifyPubKey(sdk.Bech32PubKeyTypeAccPub, priv.PubKey())
 	require.NoError(t, err)
 	require.Equal(t, "cosmospub1addwnpepqd87l8xhcnrrtzxnkql7k55ph8fr9jarf4hn6udwukfprlalu8lgw0urza0",
 		pubKeyAddr, "Is your device using test mnemonic: %s ?", tests.TestMnemonic)
@@ -172,7 +172,7 @@ func TestPublicKeyHDPath(t *testing.T) {
 		tmp := priv.(PrivKeyLedgerSecp256k1)
 		(&tmp).AssertIsPrivKeyInner()
 
-		pubKeyAddr, err := sdk.Bech32ifyAccPub(priv.PubKey())
+		pubKeyAddr, err := sdk.Bech32ifyPubKey(sdk.Bech32PubKeyTypeAccPub, priv.PubKey())
 		require.NoError(t, err)
 		require.Equal(t,
 			expectedPubKeys[i], pubKeyAddr,

--- a/server/tm_cmds.go
+++ b/server/tm_cmds.go
@@ -53,7 +53,7 @@ func ShowValidatorCmd(ctx *Context) *cobra.Command {
 				return printlnJSON(valPubKey)
 			}
 
-			pubkey, err := sdk.Bech32ifyConsPub(valPubKey)
+			pubkey, err := sdk.GetPubKeyFromBech32(sdk.Bech32PubKeyTypeConsPub, valPubKey)
 			if err != nil {
 				return err
 			}

--- a/server/tm_cmds.go
+++ b/server/tm_cmds.go
@@ -53,7 +53,7 @@ func ShowValidatorCmd(ctx *Context) *cobra.Command {
 				return printlnJSON(valPubKey)
 			}
 
-			pubkey, err := sdk.GetPubKeyFromBech32(sdk.Bech32PubKeyTypeConsPub, valPubKey)
+			pubkey, err := sdk.Bech32ifyPubKey(sdk.Bech32PubKeyTypeConsPub, valPubKey)
 			if err != nil {
 				return err
 			}

--- a/types/address_test.go
+++ b/types/address_test.go
@@ -60,33 +60,33 @@ func TestRandBech32PubkeyConsistency(t *testing.T) {
 	for i := 0; i < 1000; i++ {
 		rand.Read(pub[:])
 
-		mustBech32AccPub := types.MustBech32ifyAccPub(pub)
-		bech32AccPub, err := types.Bech32ifyAccPub(pub)
+		mustBech32AccPub := types.MustBech32ifyPubKey(types.Bech32PubKeyTypeAccPub, pub)
+		bech32AccPub, err := types.Bech32ifyPubKey(types.Bech32PubKeyTypeAccPub, pub)
 		require.Nil(t, err)
 		require.Equal(t, bech32AccPub, mustBech32AccPub)
 
-		mustBech32ValPub := types.MustBech32ifyValPub(pub)
-		bech32ValPub, err := types.Bech32ifyValPub(pub)
+		mustBech32ValPub := types.MustBech32ifyPubKey(types.Bech32PubKeyTypeValPub, pub)
+		bech32ValPub, err := types.Bech32ifyPubKey(types.Bech32PubKeyTypeValPub, pub)
 		require.Nil(t, err)
 		require.Equal(t, bech32ValPub, mustBech32ValPub)
 
-		mustBech32ConsPub := types.MustBech32ifyConsPub(pub)
-		bech32ConsPub, err := types.Bech32ifyConsPub(pub)
+		mustBech32ConsPub := types.MustBech32ifyPubKey(types.Bech32PubKeyTypeConsPub, pub)
+		bech32ConsPub, err := types.Bech32ifyPubKey(types.Bech32PubKeyTypeConsPub, pub)
 		require.Nil(t, err)
 		require.Equal(t, bech32ConsPub, mustBech32ConsPub)
 
-		mustAccPub := types.MustGetAccPubKeyBech32(bech32AccPub)
-		accPub, err := types.GetAccPubKeyBech32(bech32AccPub)
+		mustAccPub := types.MustGetPubKeyFromBech32(types.Bech32PubKeyTypeAccPub, bech32AccPub)
+		accPub, err := types.GetPubKeyFromBech32(types.Bech32PubKeyTypeAccPub, bech32AccPub)
 		require.Nil(t, err)
 		require.Equal(t, accPub, mustAccPub)
 
-		mustValPub := types.MustGetValPubKeyBech32(bech32ValPub)
-		valPub, err := types.GetValPubKeyBech32(bech32ValPub)
+		mustValPub := types.MustGetPubKeyFromBech32(types.Bech32PubKeyTypeValPub, bech32ValPub)
+		valPub, err := types.GetPubKeyFromBech32(types.Bech32PubKeyTypeValPub, bech32ValPub)
 		require.Nil(t, err)
 		require.Equal(t, valPub, mustValPub)
 
-		mustConsPub := types.MustGetConsPubKeyBech32(bech32ConsPub)
-		consPub, err := types.GetConsPubKeyBech32(bech32ConsPub)
+		mustConsPub := types.MustGetPubKeyFromBech32(types.Bech32PubKeyTypeConsPub, bech32ConsPub)
+		consPub, err := types.GetPubKeyFromBech32(types.Bech32PubKeyTypeConsPub, bech32ConsPub)
 		require.Nil(t, err)
 		require.Equal(t, consPub, mustConsPub)
 
@@ -246,7 +246,7 @@ func TestConfiguredPrefix(t *testing.T) {
 				acc.String(),
 				prefix+types.PrefixAccount), acc.String())
 
-			bech32Pub := types.MustBech32ifyAccPub(pub)
+			bech32Pub := types.MustBech32ifyPubKey(types.Bech32PubKeyTypeAccPub, pub)
 			require.True(t, strings.HasPrefix(
 				bech32Pub,
 				prefix+types.PrefixPublic))
@@ -260,7 +260,7 @@ func TestConfiguredPrefix(t *testing.T) {
 				val.String(),
 				prefix+types.PrefixValidator+types.PrefixAddress))
 
-			bech32ValPub := types.MustBech32ifyValPub(pub)
+			bech32ValPub := types.MustBech32ifyPubKey(types.Bech32PubKeyTypeValPub, pub)
 			require.True(t, strings.HasPrefix(
 				bech32ValPub,
 				prefix+types.PrefixValidator+types.PrefixPublic))
@@ -274,12 +274,11 @@ func TestConfiguredPrefix(t *testing.T) {
 				cons.String(),
 				prefix+types.PrefixConsensus+types.PrefixAddress))
 
-			bech32ConsPub := types.MustBech32ifyConsPub(pub)
+			bech32ConsPub := types.MustBech32ifyPubKey(types.Bech32PubKeyTypeConsPub, pub)
 			require.True(t, strings.HasPrefix(
 				bech32ConsPub,
 				prefix+types.PrefixConsensus+types.PrefixPublic))
 		}
-
 	}
 }
 

--- a/x/auth/types/account.go
+++ b/x/auth/types/account.go
@@ -198,7 +198,7 @@ func (acc *BaseAccount) UnmarshalJSON(bz []byte) error {
 	}
 
 	if alias.PubKey != "" {
-		pk, err := sdk.GetAccPubKeyBech32(alias.PubKey)
+		pk, err := sdk.GetPubKeyFromBech32(sdk.Bech32PubKeyTypeAccPub, alias.PubKey)
 		if err != nil {
 			return err
 		}

--- a/x/auth/types/account.go
+++ b/x/auth/types/account.go
@@ -153,7 +153,7 @@ func (acc BaseAccount) MarshalYAML() (interface{}, error) {
 	}
 
 	if acc.PubKey != nil {
-		pks, err := sdk.Bech32ifyAccPub(acc.PubKey)
+		pks, err := sdk.Bech32ifyPubKey(sdk.Bech32PubKeyTypeAccPub, acc.PubKey)
 		if err != nil {
 			return nil, err
 		}
@@ -179,7 +179,7 @@ func (acc BaseAccount) MarshalJSON() ([]byte, error) {
 	}
 
 	if acc.PubKey != nil {
-		pks, err := sdk.Bech32ifyAccPub(acc.PubKey)
+		pks, err := sdk.Bech32ifyPubKey(sdk.Bech32PubKeyTypeAccPub, acc.PubKey)
 		if err != nil {
 			return nil, err
 		}

--- a/x/auth/types/stdtx.go
+++ b/x/auth/types/stdtx.go
@@ -284,7 +284,7 @@ func (ss StdSignature) MarshalYAML() (interface{}, error) {
 	)
 
 	if ss.PubKey != nil {
-		pubkey, err = sdk.Bech32ifyAccPub(ss.PubKey)
+		pubkey, err = sdk.Bech32ifyPubKey(sdk.Bech32PubKeyTypeAccPub, ss.PubKey)
 		if err != nil {
 			return nil, err
 		}

--- a/x/auth/types/stdtx_test.go
+++ b/x/auth/types/stdtx_test.go
@@ -153,11 +153,11 @@ func TestStdSignatureMarshalYAML(t *testing.T) {
 		},
 		{
 			StdSignature{PubKey: pubKey, Signature: []byte("dummySig")},
-			fmt.Sprintf("|\n  pubkey: %s\n  signature: dummySig\n", sdk.MustBech32ifyAccPub(pubKey)),
+			fmt.Sprintf("|\n  pubkey: %s\n  signature: dummySig\n", sdk.MustBech32ifyPubKey(sdk.Bech32PubKeyTypeAccPub, pubKey)),
 		},
 		{
 			StdSignature{PubKey: pubKey, Signature: nil},
-			fmt.Sprintf("|\n  pubkey: %s\n  signature: \"\"\n", sdk.MustBech32ifyAccPub(pubKey)),
+			fmt.Sprintf("|\n  pubkey: %s\n  signature: \"\"\n", sdk.MustBech32ifyPubKey(sdk.Bech32PubKeyTypeAccPub, pubKey)),
 		},
 	}
 

--- a/x/auth/vesting/types/vesting_account.go
+++ b/x/auth/vesting/types/vesting_account.go
@@ -274,7 +274,7 @@ func (bva *BaseVestingAccount) UnmarshalJSON(bz []byte) error {
 	)
 
 	if alias.PubKey != "" {
-		pk, err = sdk.GetAccPubKeyBech32(alias.PubKey)
+		pk, err = sdk.GetPubKeyFromBech32(sdk.Bech32PubKeyTypeAccPub, alias.PubKey)
 		if err != nil {
 			return err
 		}
@@ -461,7 +461,7 @@ func (cva *ContinuousVestingAccount) UnmarshalJSON(bz []byte) error {
 	)
 
 	if alias.PubKey != "" {
-		pk, err = sdk.GetAccPubKeyBech32(alias.PubKey)
+		pk, err = sdk.GetPubKeyFromBech32(sdk.Bech32PubKeyTypeAccPub, alias.PubKey)
 		if err != nil {
 			return err
 		}
@@ -678,7 +678,7 @@ func (pva *PeriodicVestingAccount) UnmarshalJSON(bz []byte) error {
 	)
 
 	if alias.PubKey != "" {
-		pk, err = sdk.GetAccPubKeyBech32(alias.PubKey)
+		pk, err = sdk.GetPubKeyFromBech32(sdk.Bech32PubKeyTypeAccPub, alias.PubKey)
 		if err != nil {
 			return err
 		}
@@ -805,7 +805,7 @@ func (dva *DelayedVestingAccount) UnmarshalJSON(bz []byte) error {
 	)
 
 	if alias.PubKey != "" {
-		pk, err = sdk.GetAccPubKeyBech32(alias.PubKey)
+		pk, err = sdk.GetPubKeyFromBech32(sdk.Bech32PubKeyTypeAccPub, alias.PubKey)
 		if err != nil {
 			return err
 		}

--- a/x/auth/vesting/types/vesting_account.go
+++ b/x/auth/vesting/types/vesting_account.go
@@ -220,7 +220,7 @@ func (bva BaseVestingAccount) MarshalYAML() (interface{}, error) {
 	}
 
 	if bva.PubKey != nil {
-		pks, err := sdk.Bech32ifyAccPub(bva.PubKey)
+		pks, err := sdk.Bech32ifyPubKey(sdk.Bech32PubKeyTypeAccPub, bva.PubKey)
 		if err != nil {
 			return nil, err
 		}
@@ -250,7 +250,7 @@ func (bva BaseVestingAccount) MarshalJSON() ([]byte, error) {
 	}
 
 	if bva.PubKey != nil {
-		pks, err := sdk.Bech32ifyAccPub(bva.PubKey)
+		pks, err := sdk.Bech32ifyPubKey(sdk.Bech32PubKeyTypeAccPub, bva.PubKey)
 		if err != nil {
 			return nil, err
 		}
@@ -406,7 +406,7 @@ func (cva ContinuousVestingAccount) MarshalYAML() (interface{}, error) {
 	}
 
 	if cva.PubKey != nil {
-		pks, err := sdk.Bech32ifyAccPub(cva.PubKey)
+		pks, err := sdk.Bech32ifyPubKey(sdk.Bech32PubKeyTypeAccPub, cva.PubKey)
 		if err != nil {
 			return nil, err
 		}
@@ -437,7 +437,7 @@ func (cva ContinuousVestingAccount) MarshalJSON() ([]byte, error) {
 	}
 
 	if cva.PubKey != nil {
-		pks, err := sdk.Bech32ifyAccPub(cva.PubKey)
+		pks, err := sdk.Bech32ifyPubKey(sdk.Bech32PubKeyTypeAccPub, cva.PubKey)
 		if err != nil {
 			return nil, err
 		}
@@ -622,7 +622,7 @@ func (pva PeriodicVestingAccount) MarshalYAML() (interface{}, error) {
 	}
 
 	if pva.PubKey != nil {
-		pks, err := sdk.Bech32ifyAccPub(pva.PubKey)
+		pks, err := sdk.Bech32ifyPubKey(sdk.Bech32PubKeyTypeAccPub, pva.PubKey)
 		if err != nil {
 			return nil, err
 		}
@@ -654,7 +654,7 @@ func (pva PeriodicVestingAccount) MarshalJSON() ([]byte, error) {
 	}
 
 	if pva.PubKey != nil {
-		pks, err := sdk.Bech32ifyAccPub(pva.PubKey)
+		pks, err := sdk.Bech32ifyPubKey(sdk.Bech32PubKeyTypeAccPub, pva.PubKey)
 		if err != nil {
 			return nil, err
 		}
@@ -781,7 +781,7 @@ func (dva DelayedVestingAccount) MarshalJSON() ([]byte, error) {
 	}
 
 	if dva.PubKey != nil {
-		pks, err := sdk.Bech32ifyAccPub(dva.PubKey)
+		pks, err := sdk.Bech32ifyPubKey(sdk.Bech32PubKeyTypeAccPub, dva.PubKey)
 		if err != nil {
 			return nil, err
 		}

--- a/x/genutil/client/cli/gentx.go
+++ b/x/genutil/client/cli/gentx.go
@@ -76,7 +76,7 @@ func GenTxCmd(ctx *server.Context, cdc *codec.Codec, mbm module.BasicManager, sm
 			}
 			// Read --pubkey, if empty take it from priv_validator.json
 			if valPubKeyString := viper.GetString(flagPubKey); valPubKeyString != "" {
-				valPubKey, err = sdk.GetConsPubKeyBech32(valPubKeyString)
+				valPubKey, err = sdk.GetPubKeyFromBech32(sdk.Bech32PubKeyTypeConsPub, valPubKeyString)
 				if err != nil {
 					return errors.Wrap(err, "failed to get consensus node public key")
 				}

--- a/x/slashing/client/cli/query.go
+++ b/x/slashing/client/cli/query.go
@@ -50,7 +50,7 @@ $ <appcli> query slashing signing-info cosmosvalconspub1zcjduepqfhvwcmt7p06fvdge
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cliCtx := context.NewCLIContext().WithCodec(cdc)
 
-			pk, err := sdk.GetConsPubKeyBech32(args[0])
+			pk, err := sdk.GetPubKeyFromBech32(sdk.Bech32PubKeyTypeConsPub, args[0])
 			if err != nil {
 				return err
 			}

--- a/x/slashing/client/rest/query.go
+++ b/x/slashing/client/rest/query.go
@@ -33,7 +33,7 @@ func registerQueryRoutes(cliCtx context.CLIContext, r *mux.Router) {
 func signingInfoHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		vars := mux.Vars(r)
-		pk, err := sdk.GetConsPubKeyBech32(vars["validatorPubKey"])
+		pk, err := sdk.GetPubKeyFromBech32(sdk.Bech32PubKeyTypeConsPub, vars["validatorPubKey"])
 		if err != nil {
 			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
 			return

--- a/x/slashing/simulation/decoder.go
+++ b/x/slashing/simulation/decoder.go
@@ -31,8 +31,8 @@ func DecodeStore(cdc *codec.Codec, kvA, kvB cmn.KVPair) string {
 		var pubKeyA, pubKeyB crypto.PubKey
 		cdc.MustUnmarshalBinaryLengthPrefixed(kvA.Value, &pubKeyA)
 		cdc.MustUnmarshalBinaryLengthPrefixed(kvB.Value, &pubKeyB)
-		bechPKA := sdk.MustBech32ifyAccPub(pubKeyA)
-		bechPKB := sdk.MustBech32ifyAccPub(pubKeyB)
+		bechPKA := sdk.MustBech32ifyPubKey(sdk.Bech32PubKeyTypeAccPub, pubKeyA)
+		bechPKB := sdk.MustBech32ifyPubKey(sdk.Bech32PubKeyTypeAccPub, pubKeyB)
 		return fmt.Sprintf("PubKeyA: %s\nPubKeyB: %s", bechPKA, bechPKB)
 
 	default:

--- a/x/slashing/simulation/decoder_test.go
+++ b/x/slashing/simulation/decoder_test.go
@@ -35,7 +35,7 @@ func TestDecodeStore(t *testing.T) {
 	cdc := makeTestCodec()
 
 	info := types.NewValidatorSigningInfo(consAddr1, 0, 1, time.Now().UTC(), false, 0)
-	bechPK := sdk.MustBech32ifyAccPub(delPk1)
+	bechPK := sdk.MustBech32ifyPubKey(sdk.Bech32PubKeyTypeAccPub, delPk1)
 	missed := true
 
 	kvPairs := cmn.KVPairs{

--- a/x/staking/client/cli/tx.go
+++ b/x/staking/client/cli/tx.go
@@ -315,7 +315,7 @@ func PrepareFlagsForTxCreateValidator(
 	viper.Set(flags.FlagFrom, viper.GetString(flags.FlagName))
 	viper.Set(FlagNodeID, nodeID)
 	viper.Set(FlagIP, ip)
-	viper.Set(FlagPubKey, sdk.MustBech32ifyConsPub(valPubKey))
+	viper.Set(FlagPubKey, sdk.MustGetPubKeyFromBech32(sdk.Bech32PubKeyTypeConsPub, valPubKey))
 	viper.Set(FlagMoniker, config.Moniker)
 	viper.Set(FlagWebsite, website)
 	viper.Set(FlagSecurityContact, securityContact)

--- a/x/staking/client/cli/tx.go
+++ b/x/staking/client/cli/tx.go
@@ -315,7 +315,7 @@ func PrepareFlagsForTxCreateValidator(
 	viper.Set(flags.FlagFrom, viper.GetString(flags.FlagName))
 	viper.Set(FlagNodeID, nodeID)
 	viper.Set(FlagIP, ip)
-	viper.Set(FlagPubKey, sdk.MustGetPubKeyFromBech32(sdk.Bech32PubKeyTypeConsPub, valPubKey))
+	viper.Set(FlagPubKey, sdk.MustBech32ifyPubKey(sdk.Bech32PubKeyTypeConsPub, valPubKey))
 	viper.Set(FlagMoniker, config.Moniker)
 	viper.Set(FlagWebsite, website)
 	viper.Set(FlagSecurityContact, securityContact)
@@ -353,7 +353,7 @@ func BuildCreateValidatorMsg(cliCtx context.CLIContext, txBldr auth.TxBuilder) (
 	valAddr := cliCtx.GetFromAddress()
 	pkStr := viper.GetString(FlagPubKey)
 
-	pk, err := sdk.GetConsPubKeyBech32(pkStr)
+	pk, err := sdk.GetPubKeyFromBech32(sdk.Bech32PubKeyTypeConsPub, pkStr)
 	if err != nil {
 		return txBldr, nil, err
 	}

--- a/x/staking/client/cli/tx_test.go
+++ b/x/staking/client/cli/tx_test.go
@@ -21,7 +21,7 @@ func TestPrepareFlagsForTxCreateValidator(t *testing.T) {
 	logger := log.NewNopLogger()
 	ctx := server.NewContext(config, logger)
 
-	valPubKey, _ := sdk.GetConsPubKeyBech32("cosmosvalconspub1zcjduepq7jsrkl9fgqk0wj3ahmfr8pgxj6vakj2wzn656s8pehh0zhv2w5as5gd80a")
+	valPubKey, _ := sdk.GetPubKeyFromBech32(sdk.Bech32PubKeyTypeConsPub, "cosmosvalconspub1zcjduepq7jsrkl9fgqk0wj3ahmfr8pgxj6vakj2wzn656s8pehh0zhv2w5as5gd80a")
 
 	type args struct {
 		config    *cfg.Config

--- a/x/staking/legacy/v0_34/types.go
+++ b/x/staking/legacy/v0_34/types.go
@@ -126,7 +126,7 @@ type (
 )
 
 func (v Validator) MarshalJSON() ([]byte, error) {
-	bechConsPubKey, err := sdk.Bech32ifyConsPub(v.ConsPubKey)
+	bechConsPubKey, err := sdk.GetPubKeyFromBech32(sdk.Bech32PubKeyTypeConsPub, v.ConsPubKey)
 	if err != nil {
 		return nil, err
 	}

--- a/x/staking/legacy/v0_34/types.go
+++ b/x/staking/legacy/v0_34/types.go
@@ -126,7 +126,7 @@ type (
 )
 
 func (v Validator) MarshalJSON() ([]byte, error) {
-	bechConsPubKey, err := sdk.GetPubKeyFromBech32(sdk.Bech32PubKeyTypeConsPub, v.ConsPubKey)
+	bechConsPubKey, err := sdk.Bech32ifyPubKey(sdk.Bech32PubKeyTypeConsPub, v.ConsPubKey)
 	if err != nil {
 		return nil, err
 	}
@@ -152,7 +152,7 @@ func (v *Validator) UnmarshalJSON(data []byte) error {
 	if err := codec.Cdc.UnmarshalJSON(data, bv); err != nil {
 		return err
 	}
-	consPubKey, err := sdk.GetConsPubKeyBech32(bv.ConsPubKey)
+	consPubKey, err := sdk.GetPubKeyFromBech32(sdk.Bech32PubKeyTypeConsPub, bv.ConsPubKey)
 	if err != nil {
 		return err
 	}

--- a/x/staking/legacy/v0_36/types.go
+++ b/x/staking/legacy/v0_36/types.go
@@ -89,7 +89,7 @@ func NewGenesisState(
 }
 
 func (v Validator) MarshalJSON() ([]byte, error) {
-	bechConsPubKey, err := sdk.Bech32ifyConsPub(v.ConsPubKey)
+	bechConsPubKey, err := sdk.GetPubKeyFromBech32(sdk.Bech32PubKeyTypeConsPub, v.ConsPubKey)
 	if err != nil {
 		return nil, err
 	}

--- a/x/staking/legacy/v0_36/types.go
+++ b/x/staking/legacy/v0_36/types.go
@@ -89,7 +89,7 @@ func NewGenesisState(
 }
 
 func (v Validator) MarshalJSON() ([]byte, error) {
-	bechConsPubKey, err := sdk.GetPubKeyFromBech32(sdk.Bech32PubKeyTypeConsPub, v.ConsPubKey)
+	bechConsPubKey, err := sdk.Bech32ifyPubKey(sdk.Bech32PubKeyTypeConsPub, v.ConsPubKey)
 	if err != nil {
 		return nil, err
 	}
@@ -114,7 +114,7 @@ func (v *Validator) UnmarshalJSON(data []byte) error {
 	if err := codec.Cdc.UnmarshalJSON(data, bv); err != nil {
 		return err
 	}
-	consPubKey, err := sdk.GetConsPubKeyBech32(bv.ConsPubKey)
+	consPubKey, err := sdk.GetPubKeyFromBech32(sdk.Bech32PubKeyTypeConsPub, bv.ConsPubKey)
 	if err != nil {
 		return err
 	}

--- a/x/staking/legacy/v0_38/types.go
+++ b/x/staking/legacy/v0_38/types.go
@@ -100,7 +100,7 @@ func NewGenesisState(
 
 // MarshalJSON marshals the validator to JSON using Bech32
 func (v Validator) MarshalJSON() ([]byte, error) {
-	bechConsPubKey, err := sdk.Bech32ifyConsPub(v.ConsPubKey)
+	bechConsPubKey, err := sdk.GetPubKeyFromBech32(sdk.Bech32PubKeyTypeConsPub, v.ConsPubKey)
 	if err != nil {
 		return nil, err
 	}

--- a/x/staking/legacy/v0_38/types.go
+++ b/x/staking/legacy/v0_38/types.go
@@ -100,7 +100,7 @@ func NewGenesisState(
 
 // MarshalJSON marshals the validator to JSON using Bech32
 func (v Validator) MarshalJSON() ([]byte, error) {
-	bechConsPubKey, err := sdk.GetPubKeyFromBech32(sdk.Bech32PubKeyTypeConsPub, v.ConsPubKey)
+	bechConsPubKey, err := sdk.Bech32ifyPubKey(sdk.Bech32PubKeyTypeConsPub, v.ConsPubKey)
 	if err != nil {
 		return nil, err
 	}
@@ -126,7 +126,7 @@ func (v *Validator) UnmarshalJSON(data []byte) error {
 	if err := codec.Cdc.UnmarshalJSON(data, bv); err != nil {
 		return err
 	}
-	consPubKey, err := sdk.GetConsPubKeyBech32(bv.ConsPubKey)
+	consPubKey, err := sdk.GetPubKeyFromBech32(sdk.Bech32PubKeyTypeConsPub, bv.ConsPubKey)
 	if err != nil {
 		return err
 	}

--- a/x/staking/types/msg.go
+++ b/x/staking/types/msg.go
@@ -89,7 +89,7 @@ func (msg MsgCreateValidator) MarshalJSON() ([]byte, error) {
 		Commission:        msg.Commission,
 		DelegatorAddress:  msg.DelegatorAddress,
 		ValidatorAddress:  msg.ValidatorAddress,
-		PubKey:            sdk.MustBech32ifyConsPub(msg.PubKey),
+		PubKey:            sdk.MustGetPubKeyFromBech32(sdk.Bech32PubKeyTypeConsPub, msg.PubKey),
 		Value:             msg.Value,
 		MinSelfDelegation: msg.MinSelfDelegation,
 	})
@@ -134,7 +134,7 @@ func (msg MsgCreateValidator) MarshalYAML() (interface{}, error) {
 		MinSelfDelegation: msg.MinSelfDelegation,
 		DelegatorAddress:  msg.DelegatorAddress,
 		ValidatorAddress:  msg.ValidatorAddress,
-		PubKey:            sdk.MustBech32ifyConsPub(msg.PubKey),
+		PubKey:            sdk.MustGetPubKeyFromBech32(sdk.Bech32PubKeyTypeConsPub, msg.PubKey),
 		Value:             msg.Value,
 	})
 

--- a/x/staking/types/msg.go
+++ b/x/staking/types/msg.go
@@ -89,7 +89,7 @@ func (msg MsgCreateValidator) MarshalJSON() ([]byte, error) {
 		Commission:        msg.Commission,
 		DelegatorAddress:  msg.DelegatorAddress,
 		ValidatorAddress:  msg.ValidatorAddress,
-		PubKey:            sdk.MustGetPubKeyFromBech32(sdk.Bech32PubKeyTypeConsPub, msg.PubKey),
+		PubKey:            sdk.MustBech32ifyPubKey(sdk.Bech32PubKeyTypeConsPub, msg.PubKey),
 		Value:             msg.Value,
 		MinSelfDelegation: msg.MinSelfDelegation,
 	})
@@ -108,7 +108,7 @@ func (msg *MsgCreateValidator) UnmarshalJSON(bz []byte) error {
 	msg.DelegatorAddress = msgCreateValJSON.DelegatorAddress
 	msg.ValidatorAddress = msgCreateValJSON.ValidatorAddress
 	var err error
-	msg.PubKey, err = sdk.GetConsPubKeyBech32(msgCreateValJSON.PubKey)
+	msg.PubKey, err = sdk.GetPubKeyFromBech32(sdk.Bech32PubKeyTypeConsPub, msgCreateValJSON.PubKey)
 	if err != nil {
 		return err
 	}
@@ -134,7 +134,7 @@ func (msg MsgCreateValidator) MarshalYAML() (interface{}, error) {
 		MinSelfDelegation: msg.MinSelfDelegation,
 		DelegatorAddress:  msg.DelegatorAddress,
 		ValidatorAddress:  msg.ValidatorAddress,
-		PubKey:            sdk.MustGetPubKeyFromBech32(sdk.Bech32PubKeyTypeConsPub, msg.PubKey),
+		PubKey:            sdk.MustBech32ifyPubKey(sdk.Bech32PubKeyTypeConsPub, msg.PubKey),
 		Value:             msg.Value,
 	})
 

--- a/x/staking/types/msg_test.go
+++ b/x/staking/types/msg_test.go
@@ -175,7 +175,7 @@ func TestMsgMarshalYAML(t *testing.T) {
 	msg := NewMsgCreateValidator(tc.validatorAddr, tc.pubkey, tc.bond, description, tc.CommissionRates, tc.minSelfDelegation)
 	bs, err := yaml.Marshal(msg)
 	require.NoError(t, err)
-	bechifiedPub, err := sdk.Bech32ifyConsPub(msg.PubKey)
+	bechifiedPub, err := sdk.GetPubKeyFromBech32(sdk.Bech32PubKeyTypeConsPub, msg.PubKey)
 	require.NoError(t, err)
 
 	want := fmt.Sprintf(`|

--- a/x/staking/types/msg_test.go
+++ b/x/staking/types/msg_test.go
@@ -175,7 +175,7 @@ func TestMsgMarshalYAML(t *testing.T) {
 	msg := NewMsgCreateValidator(tc.validatorAddr, tc.pubkey, tc.bond, description, tc.CommissionRates, tc.minSelfDelegation)
 	bs, err := yaml.Marshal(msg)
 	require.NoError(t, err)
-	bechifiedPub, err := sdk.GetPubKeyFromBech32(sdk.Bech32PubKeyTypeConsPub, msg.PubKey)
+	bechifiedPub, err := sdk.Bech32ifyPubKey(sdk.Bech32PubKeyTypeConsPub, msg.PubKey)
 	require.NoError(t, err)
 
 	want := fmt.Sprintf(`|

--- a/x/staking/types/validator.go
+++ b/x/staking/types/validator.go
@@ -68,7 +68,7 @@ func (v Validator) MarshalYAML() (interface{}, error) {
 		MinSelfDelegation       sdk.Int
 	}{
 		OperatorAddress:         v.OperatorAddress,
-		ConsPubKey:              sdk.MustBech32ifyConsPub(v.ConsPubKey),
+		ConsPubKey:              sdk.MustGetPubKeyFromBech32(sdk.Bech32PubKeyTypeConsPub, v.ConsPubKey),
 		Jailed:                  v.Jailed,
 		Status:                  v.Status,
 		Tokens:                  v.Tokens,
@@ -165,7 +165,7 @@ func UnmarshalValidator(cdc *codec.Codec, value []byte) (validator Validator, er
 
 // String returns a human readable string representation of a validator.
 func (v Validator) String() string {
-	bechConsPubKey, err := sdk.Bech32ifyConsPub(v.ConsPubKey)
+	bechConsPubKey, err := sdk.GetPubKeyFromBech32(sdk.Bech32PubKeyTypeConsPub, v.ConsPubKey)
 	if err != nil {
 		panic(err)
 	}
@@ -203,7 +203,7 @@ type bechValidator struct {
 
 // MarshalJSON marshals the validator to JSON using Bech32
 func (v Validator) MarshalJSON() ([]byte, error) {
-	bechConsPubKey, err := sdk.Bech32ifyConsPub(v.ConsPubKey)
+	bechConsPubKey, err := sdk.GetPubKeyFromBech32(sdk.Bech32PubKeyTypeConsPub, v.ConsPubKey)
 	if err != nil {
 		return nil, err
 	}

--- a/x/staking/types/validator.go
+++ b/x/staking/types/validator.go
@@ -68,7 +68,7 @@ func (v Validator) MarshalYAML() (interface{}, error) {
 		MinSelfDelegation       sdk.Int
 	}{
 		OperatorAddress:         v.OperatorAddress,
-		ConsPubKey:              sdk.MustGetPubKeyFromBech32(sdk.Bech32PubKeyTypeConsPub, v.ConsPubKey),
+		ConsPubKey:              sdk.MustBech32ifyPubKey(sdk.Bech32PubKeyTypeConsPub, v.ConsPubKey),
 		Jailed:                  v.Jailed,
 		Status:                  v.Status,
 		Tokens:                  v.Tokens,
@@ -165,7 +165,7 @@ func UnmarshalValidator(cdc *codec.Codec, value []byte) (validator Validator, er
 
 // String returns a human readable string representation of a validator.
 func (v Validator) String() string {
-	bechConsPubKey, err := sdk.GetPubKeyFromBech32(sdk.Bech32PubKeyTypeConsPub, v.ConsPubKey)
+	bechConsPubKey, err := sdk.Bech32ifyPubKey(sdk.Bech32PubKeyTypeConsPub, v.ConsPubKey)
 	if err != nil {
 		panic(err)
 	}
@@ -203,7 +203,7 @@ type bechValidator struct {
 
 // MarshalJSON marshals the validator to JSON using Bech32
 func (v Validator) MarshalJSON() ([]byte, error) {
-	bechConsPubKey, err := sdk.GetPubKeyFromBech32(sdk.Bech32PubKeyTypeConsPub, v.ConsPubKey)
+	bechConsPubKey, err := sdk.Bech32ifyPubKey(sdk.Bech32PubKeyTypeConsPub, v.ConsPubKey)
 	if err != nil {
 		return nil, err
 	}
@@ -229,7 +229,7 @@ func (v *Validator) UnmarshalJSON(data []byte) error {
 	if err := codec.Cdc.UnmarshalJSON(data, bv); err != nil {
 		return err
 	}
-	consPubKey, err := sdk.GetConsPubKeyBech32(bv.ConsPubKey)
+	consPubKey, err := sdk.GetPubKeyFromBech32(sdk.Bech32PubKeyTypeConsPub, bv.ConsPubKey)
 	if err != nil {
 		return err
 	}

--- a/x/staking/types/validator_test.go
+++ b/x/staking/types/validator_test.go
@@ -278,7 +278,7 @@ func TestValidatorSetInitialCommission(t *testing.T) {
 
 func TestValidatorMarshalYAML(t *testing.T) {
 	validator := NewValidator(valAddr1, pk1, Description{})
-	bechifiedPub, err := sdk.GetPubKeyFromBech32(sdk.Bech32PubKeyTypeConsPub, validator.ConsPubKey)
+	bechifiedPub, err := sdk.Bech32ifyPubKey(sdk.Bech32PubKeyTypeConsPub, validator.ConsPubKey)
 	require.NoError(t, err)
 	bs, err := yaml.Marshal(validator)
 	require.NoError(t, err)

--- a/x/staking/types/validator_test.go
+++ b/x/staking/types/validator_test.go
@@ -278,7 +278,7 @@ func TestValidatorSetInitialCommission(t *testing.T) {
 
 func TestValidatorMarshalYAML(t *testing.T) {
 	validator := NewValidator(valAddr1, pk1, Description{})
-	bechifiedPub, err := sdk.Bech32ifyConsPub(validator.ConsPubKey)
+	bechifiedPub, err := sdk.GetPubKeyFromBech32(sdk.Bech32PubKeyTypeConsPub, validator.ConsPubKey)
 	require.NoError(t, err)
 	bs, err := yaml.Marshal(validator)
 	require.NoError(t, err)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

There is no need for a `(Must)Bech32ify*` and `(Must)Get*KeyBech32` set of functions for **each** Bech32 prefix/type. Replace them with a single pair of flexible functions that accept a `Bech32PubKeyType`. To support new Bech32 prefixes, just add/use a new `Bech32PubKeyType` variable/const.

______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [x] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Added  relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [x] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer

______

For admin use:

- [x] Added appropriate labels to PR (ex. `WIP`, `R4R`, `docs`, etc)
- [x] Reviewers assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
