### PR TITLE
Fixed backwards amino compatibility for KeyInfo types

### DIFF
--- a/crypto/keys/types.go
+++ b/crypto/keys/types.go
@@ -118,10 +118,10 @@ type Info interface {
 	GetPubKey() crypto.PubKey
 	// Address
 	GetAddress() types.AccAddress
-	// Algo
-	GetAlgo() SigningAlgo
 	// Bip44 Path
 	GetPath() (*hd.BIP44Params, error)
+	// Algo
+	GetAlgo() SigningAlgo
 }
 
 var (
@@ -132,11 +132,12 @@ var (
 )
 
 // localInfo is the public information about a locally stored key
+// Note: Algo must be last field in struct for backwards amino compatibility
 type localInfo struct {
 	Name         string        `json:"name"`
-	Algo         SigningAlgo   `json:"algo"`
 	PubKey       crypto.PubKey `json:"pubkey"`
 	PrivKeyArmor string        `json:"privkey.armor"`
+	Algo         SigningAlgo   `json:"algo"`
 }
 
 func newLocalInfo(name string, pub crypto.PubKey, privArmor string, algo SigningAlgo) Info {
@@ -179,6 +180,7 @@ func (i localInfo) GetPath() (*hd.BIP44Params, error) {
 }
 
 // ledgerInfo is the public information about a Ledger key
+// Note: Algo must be last field in struct for backwards amino compatibility
 type ledgerInfo struct {
 	Name   string         `json:"name"`
 	PubKey crypto.PubKey  `json:"pubkey"`
@@ -227,10 +229,11 @@ func (i ledgerInfo) GetPath() (*hd.BIP44Params, error) {
 }
 
 // offlineInfo is the public information about an offline key
+// Note: Algo must be last field in struct for backwards amino compatibility
 type offlineInfo struct {
 	Name   string        `json:"name"`
-	Algo   SigningAlgo   `json:"algo"`
 	PubKey crypto.PubKey `json:"pubkey"`
+	Algo   SigningAlgo   `json:"algo"`
 }
 
 func newOfflineInfo(name string, pub crypto.PubKey, algo SigningAlgo) Info {


### PR DESCRIPTION
Need to move `Algo` to be the last field in the `KeyInfo` structs so that they they can unmarshal old KeyInfo amino encodings in a backwards compatible way.

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added  relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

______

For admin use:

- [ ] Added appropriate labels to PR (ex. `WIP`, `R4R`, `docs`, etc)
- [ ] Reviewers assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
