### PR TITLE
Continue help with ICS 7 tests

### DIFF
--- a/x/ibc/03-connection/types/connection.go
+++ b/x/ibc/03-connection/types/connection.go
@@ -16,7 +16,7 @@ var _ exported.ConnectionI = ConnectionEnd{}
 
 // ConnectionEnd defines a stateful object on a chain connected to another separate
 // one.
-// NOTE: there must only be 2 defined ConnectionEnds to stablish a connection
+// NOTE: there must only be 2 defined ConnectionEnds to establish a connection
 // between two chains.
 type ConnectionEnd struct {
 	State    exported.State `json:"state" yaml:"state"`

--- a/x/ibc/04-channel/types/msgs_test.go
+++ b/x/ibc/04-channel/types/msgs_test.go
@@ -486,6 +486,8 @@ func (suite *MsgTestSuite) TestMsgTimeout() {
 		NewMsgTimeout(packet, 0, proof, 0, addr),
 		NewMsgTimeout(packet, 0, proof, 1, emptyAddr),
 		NewMsgTimeout(packet, 0, emptyProof, 1, addr),
+		NewMsgTimeout(invalidPacket, 0, proof, 1, addr),
+		NewMsgTimeout(packet, 0, invalidProofs1, 1, addr),
 	}
 
 	testCases := []struct {
@@ -497,6 +499,8 @@ func (suite *MsgTestSuite) TestMsgTimeout() {
 		{testMsgs[1], false, "proof height must be > 0"},
 		{testMsgs[2], false, "missing signer address"},
 		{testMsgs[3], false, "cannot submit an empty proof"},
+		{testMsgs[4], false, "invalid packet"},
+		{testMsgs[5], false, "cannot submit an invalid proof"},
 	}
 
 	for i, tc := range testCases {
@@ -516,6 +520,9 @@ func (suite *MsgTestSuite) TestMsgAcknowledgement() {
 		NewMsgAcknowledgement(packet, packet.GetData(), proof, 0, addr),
 		NewMsgAcknowledgement(packet, packet.GetData(), proof, 1, emptyAddr),
 		NewMsgAcknowledgement(packet, packet.GetData(), emptyProof, 1, addr),
+		NewMsgAcknowledgement(invalidPacket, packet.GetData(), proof, 1, addr),
+		NewMsgAcknowledgement(packet, invalidPacket.GetData(), proof, 1, addr),
+		NewMsgAcknowledgement(packet, packet.GetData(), invalidProofs1, 1, addr),
 	}
 
 	testCases := []struct {
@@ -527,6 +534,9 @@ func (suite *MsgTestSuite) TestMsgAcknowledgement() {
 		{testMsgs[1], false, "proof height must be > 0"},
 		{testMsgs[2], false, "missing signer address"},
 		{testMsgs[3], false, "cannot submit an empty proof"},
+		{testMsgs[4], false, "invalid packet"},
+		{testMsgs[5], false, "invalid acknowledgement"},
+		{testMsgs[6], false, "cannot submit an invalid proof"},
 	}
 
 	for i, tc := range testCases {

--- a/x/ibc/04-channel/types/msgs_test.go
+++ b/x/ibc/04-channel/types/msgs_test.go
@@ -78,6 +78,54 @@ func TestMsgTestSuite(t *testing.T) {
 	suite.Run(t, new(MsgTestSuite))
 }
 
+// TestMsgTimeout tests ValidateBasic for MsgTimeout
+func (suite *MsgTestSuite) TestMsgTimeout() {
+	testMsgs := []MsgTimeout{
+		NewMsgTimeout(nil, 0, proof, 0, addr),
+	}
+
+	testCases := []struct {
+		msg     MsgTimeout
+		expPass bool
+		errMsg  string
+	}{
+		{testMsgs[0], true, ""},
+	}
+
+	for i, tc := range testCases {
+		err := tc.msg.ValidateBasic()
+		if tc.expPass {
+			suite.Require().NoError(err, "Msg %d failed: %s", i, tc.errMsg)
+		} else {
+			suite.Require().Error(err, "Invalid Msg %d passed: %s", i, tc.errMsg)
+		}
+	}
+}
+
+// TestMsgAcknowledgement tests ValidateBasic for MsgAcknowledgement
+func (suite *MsgTestSuite) TestMsgAcknowledgement() {
+	testMsgs := []MsgAcknowledgement{
+		NewMsgAcknowledgement(nil, nil, proof, 0, addr),
+	}
+
+	testCases := []struct {
+		msg     MsgAcknowledgement
+		expPass bool
+		errMsg  string
+	}{
+		{testMsgs[0], true, ""},
+	}
+
+	for i, tc := range testCases {
+		err := tc.msg.ValidateBasic()
+		if tc.expPass {
+			suite.Require().NoError(err, "Msg %d failed: %s", i, tc.errMsg)
+		} else {
+			suite.Require().Error(err, "Invalid Msg %d passed: %s", i, tc.errMsg)
+		}
+	}
+}
+
 // TestMsgChannelOpenInit tests ValidateBasic for MsgChannelOpenInit
 func (suite *MsgTestSuite) TestMsgChannelOpenInit() {
 	testMsgs := []MsgChannelOpenInit{

--- a/x/ibc/04-channel/types/msgs_test.go
+++ b/x/ibc/04-channel/types/msgs_test.go
@@ -548,28 +548,3 @@ func (suite *MsgTestSuite) TestMsgAcknowledgement() {
 		}
 	}
 }
-
-func (suite *MsgTestSuite) TestPacketValidateBasic() {
-	testCases := []struct {
-		packet  Packet
-		expPass bool
-		errMsg  string
-	}{
-		{NewPacket(validPacketT{}, 1, portid, chanid, cpportid, cpchanid), true, ""},
-		{NewPacket(validPacketT{}, 0, portid, chanid, cpportid, cpchanid), false, "invalid sequence"},
-		{NewPacket(validPacketT{}, 1, invalidPort, chanid, cpportid, cpchanid), false, "invalid source port"},
-		{NewPacket(validPacketT{}, 1, portid, invalidChannel, cpportid, cpchanid), false, "invalid source channel"},
-		{NewPacket(validPacketT{}, 1, portid, chanid, invalidPort, cpchanid), false, "invalid destination port"},
-		{NewPacket(validPacketT{}, 1, portid, chanid, cpportid, invalidChannel), false, "invalid destination channel"},
-		{NewPacket(invalidPacketT{}, 1, portid, chanid, cpportid, cpchanid), false, "invalid packet data"},
-	}
-
-	for i, tc := range testCases {
-		err := tc.packet.ValidateBasic()
-		if tc.expPass {
-			suite.Require().NoError(err, "Msg %d failed: %s", i, tc.errMsg)
-		} else {
-			suite.Require().Error(err, "Invalid Msg %d passed: %s", i, tc.errMsg)
-		}
-	}
-}

--- a/x/ibc/04-channel/types/msgs_test.go
+++ b/x/ibc/04-channel/types/msgs_test.go
@@ -483,6 +483,9 @@ func TestMsgPacketGetSigners(t *testing.T) {
 func (suite *MsgTestSuite) TestMsgTimeout() {
 	testMsgs := []MsgTimeout{
 		NewMsgTimeout(packet, 0, proof, 1, addr),
+		NewMsgTimeout(packet, 0, proof, 0, addr),
+		NewMsgTimeout(packet, 0, proof, 1, emptyAddr),
+		NewMsgTimeout(packet, 0, emptyProof, 1, addr),
 	}
 
 	testCases := []struct {
@@ -491,6 +494,9 @@ func (suite *MsgTestSuite) TestMsgTimeout() {
 		errMsg  string
 	}{
 		{testMsgs[0], true, ""},
+		{testMsgs[1], false, "proof height must be > 0"},
+		{testMsgs[2], false, "missing signer address"},
+		{testMsgs[3], false, "cannot submit an empty proof"},
 	}
 
 	for i, tc := range testCases {
@@ -507,6 +513,9 @@ func (suite *MsgTestSuite) TestMsgTimeout() {
 func (suite *MsgTestSuite) TestMsgAcknowledgement() {
 	testMsgs := []MsgAcknowledgement{
 		NewMsgAcknowledgement(packet, packet.GetData(), proof, 1, addr),
+		NewMsgAcknowledgement(packet, packet.GetData(), proof, 0, addr),
+		NewMsgAcknowledgement(packet, packet.GetData(), proof, 1, emptyAddr),
+		NewMsgAcknowledgement(packet, packet.GetData(), emptyProof, 1, addr),
 	}
 
 	testCases := []struct {
@@ -515,6 +524,9 @@ func (suite *MsgTestSuite) TestMsgAcknowledgement() {
 		errMsg  string
 	}{
 		{testMsgs[0], true, ""},
+		{testMsgs[1], false, "proof height must be > 0"},
+		{testMsgs[2], false, "missing signer address"},
+		{testMsgs[3], false, "cannot submit an empty proof"},
 	}
 
 	for i, tc := range testCases {

--- a/x/ibc/04-channel/types/msgs_test.go
+++ b/x/ibc/04-channel/types/msgs_test.go
@@ -548,3 +548,28 @@ func (suite *MsgTestSuite) TestMsgAcknowledgement() {
 		}
 	}
 }
+
+func (suite *MsgTestSuite) TestPacketValidateBasic() {
+	testCases := []struct {
+		packet  Packet
+		expPass bool
+		errMsg  string
+	}{
+		{NewPacket(validPacketT{}, 1, portid, chanid, cpportid, cpchanid), true, ""},
+		{NewPacket(validPacketT{}, 0, portid, chanid, cpportid, cpchanid), false, "invalid sequence"},
+		{NewPacket(validPacketT{}, 1, invalidPort, chanid, cpportid, cpchanid), false, "invalid source port"},
+		{NewPacket(validPacketT{}, 1, portid, invalidChannel, cpportid, cpchanid), false, "invalid source channel"},
+		{NewPacket(validPacketT{}, 1, portid, chanid, invalidPort, cpchanid), false, "invalid destination port"},
+		{NewPacket(validPacketT{}, 1, portid, chanid, cpportid, invalidChannel), false, "invalid destination channel"},
+		{NewPacket(invalidPacketT{}, 1, portid, chanid, cpportid, cpchanid), false, "invalid packet data"},
+	}
+
+	for i, tc := range testCases {
+		err := tc.packet.ValidateBasic()
+		if tc.expPass {
+			suite.Require().NoError(err, "Msg %d failed: %s", i, tc.errMsg)
+		} else {
+			suite.Require().Error(err, "Invalid Msg %d passed: %s", i, tc.errMsg)
+		}
+	}
+}

--- a/x/ibc/04-channel/types/msgs_test.go
+++ b/x/ibc/04-channel/types/msgs_test.go
@@ -78,54 +78,6 @@ func TestMsgTestSuite(t *testing.T) {
 	suite.Run(t, new(MsgTestSuite))
 }
 
-// TestMsgTimeout tests ValidateBasic for MsgTimeout
-func (suite *MsgTestSuite) TestMsgTimeout() {
-	testMsgs := []MsgTimeout{
-		NewMsgTimeout(nil, 0, proof, 0, addr),
-	}
-
-	testCases := []struct {
-		msg     MsgTimeout
-		expPass bool
-		errMsg  string
-	}{
-		{testMsgs[0], true, ""},
-	}
-
-	for i, tc := range testCases {
-		err := tc.msg.ValidateBasic()
-		if tc.expPass {
-			suite.Require().NoError(err, "Msg %d failed: %s", i, tc.errMsg)
-		} else {
-			suite.Require().Error(err, "Invalid Msg %d passed: %s", i, tc.errMsg)
-		}
-	}
-}
-
-// TestMsgAcknowledgement tests ValidateBasic for MsgAcknowledgement
-func (suite *MsgTestSuite) TestMsgAcknowledgement() {
-	testMsgs := []MsgAcknowledgement{
-		NewMsgAcknowledgement(nil, nil, proof, 0, addr),
-	}
-
-	testCases := []struct {
-		msg     MsgAcknowledgement
-		expPass bool
-		errMsg  string
-	}{
-		{testMsgs[0], true, ""},
-	}
-
-	for i, tc := range testCases {
-		err := tc.msg.ValidateBasic()
-		if tc.expPass {
-			suite.Require().NoError(err, "Msg %d failed: %s", i, tc.errMsg)
-		} else {
-			suite.Require().Error(err, "Invalid Msg %d passed: %s", i, tc.errMsg)
-		}
-	}
-}
-
 // TestMsgChannelOpenInit tests ValidateBasic for MsgChannelOpenInit
 func (suite *MsgTestSuite) TestMsgChannelOpenInit() {
 	testMsgs := []MsgChannelOpenInit{
@@ -525,4 +477,52 @@ func TestMsgPacketGetSigners(t *testing.T) {
 
 	expected := "[746573746164647231]"
 	require.Equal(t, expected, fmt.Sprintf("%v", res))
+}
+
+// TestMsgTimeout tests ValidateBasic for MsgTimeout
+func (suite *MsgTestSuite) TestMsgTimeout() {
+	testMsgs := []MsgTimeout{
+		NewMsgTimeout(packet, 0, proof, 1, addr),
+	}
+
+	testCases := []struct {
+		msg     MsgTimeout
+		expPass bool
+		errMsg  string
+	}{
+		{testMsgs[0], true, ""},
+	}
+
+	for i, tc := range testCases {
+		err := tc.msg.ValidateBasic()
+		if tc.expPass {
+			suite.Require().NoError(err, "Msg %d failed: %s", i, tc.errMsg)
+		} else {
+			suite.Require().Error(err, "Invalid Msg %d passed: %s", i, tc.errMsg)
+		}
+	}
+}
+
+// TestMsgAcknowledgement tests ValidateBasic for MsgAcknowledgement
+func (suite *MsgTestSuite) TestMsgAcknowledgement() {
+	testMsgs := []MsgAcknowledgement{
+		NewMsgAcknowledgement(packet, packet.GetData(), proof, 1, addr),
+	}
+
+	testCases := []struct {
+		msg     MsgAcknowledgement
+		expPass bool
+		errMsg  string
+	}{
+		{testMsgs[0], true, ""},
+	}
+
+	for i, tc := range testCases {
+		err := tc.msg.ValidateBasic()
+		if tc.expPass {
+			suite.Require().NoError(err, "Msg %d failed: %s", i, tc.errMsg)
+		} else {
+			suite.Require().Error(err, "Invalid Msg %d passed: %s", i, tc.errMsg)
+		}
+	}
 }

--- a/x/ibc/04-channel/types/packet_test.go
+++ b/x/ibc/04-channel/types/packet_test.go
@@ -1,0 +1,32 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPacketValidateBasic(t *testing.T) {
+	testCases := []struct {
+		packet  Packet
+		expPass bool
+		errMsg  string
+	}{
+		{NewPacket(validPacketT{}, 1, portid, chanid, cpportid, cpchanid), true, ""},
+		{NewPacket(validPacketT{}, 0, portid, chanid, cpportid, cpchanid), false, "invalid sequence"},
+		{NewPacket(validPacketT{}, 1, invalidPort, chanid, cpportid, cpchanid), false, "invalid source port"},
+		{NewPacket(validPacketT{}, 1, portid, invalidChannel, cpportid, cpchanid), false, "invalid source channel"},
+		{NewPacket(validPacketT{}, 1, portid, chanid, invalidPort, cpchanid), false, "invalid destination port"},
+		{NewPacket(validPacketT{}, 1, portid, chanid, cpportid, invalidChannel), false, "invalid destination channel"},
+		{NewPacket(invalidPacketT{}, 1, portid, chanid, cpportid, cpchanid), false, "invalid packet data"},
+	}
+
+	for i, tc := range testCases {
+		err := tc.packet.ValidateBasic()
+		if tc.expPass {
+			require.NoError(t, err, "Msg %d failed: %s", i, tc.errMsg)
+		} else {
+			require.Error(t, err, "Invalid Msg %d passed: %s", i, tc.errMsg)
+		}
+	}
+}


### PR DESCRIPTION
- Add `ValidateBasic` tests for `MsgTimeout` and `MsgAcknowledgement` (ICS 4)
- Add `ValidateBasic` tests for `Packet` (ICS 4)
