### PR TITLE
[keyring] support for kwallet, pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,7 +152,7 @@ correct version via: `pkgutil --pkg-info=com.apple.pkg.CLTools_Executables`.
 by the new key store:
   - `os`: use OS default credentials storage (default).
   - `file`: use encrypted file-based store.
-  - `kwallet`: use KDE Wallet service.
+  - `kwallet`: use [KDE Wallet](https://utils.kde.org/projects/kwalletmanager/) service.
   - `pass`: use the [pass](https://www.passwordstore.org/) command line password manager.
   - `test`: use password-less key store. *For testing purposes only. Use it at your own risk.*
 * (keys) [\#5097](https://github.com/cosmos/cosmos-sdk/pull/5097) New `keys migrate` command to assist users migrate their keys

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,6 +152,8 @@ correct version via: `pkgutil --pkg-info=com.apple.pkg.CLTools_Executables`.
 by the new key store:
   - `os`: use OS default credentials storage (default).
   - `file`: use encrypted file-based store.
+  - `kwallet`: use KDE Wallet service.
+  - `pass`: use the [pass](https://www.passwordstore.org/) command line password manager.
   - `test`: use password-less key store. *For testing purposes only. Use it at your own risk.*
 * (keys) [\#5097](https://github.com/cosmos/cosmos-sdk/pull/5097) New `keys migrate` command to assist users migrate their keys
 to the new keyring.

--- a/crypto/keys/keyring.go
+++ b/crypto/keys/keyring.go
@@ -26,9 +26,11 @@ import (
 )
 
 const (
-	BackendFile = "file"
-	BackendOS   = "os"
-	BackendTest = "test"
+	BackendFile    = "file"
+	BackendOS      = "os"
+	BackendKWallet = "kwallet"
+	BackendPass    = "pass"
+	BackendTest    = "test"
 )
 
 const (
@@ -71,6 +73,10 @@ func NewKeyring(
 		db, err = keyring.Open(newFileBackendKeyringConfig(svcName, rootDir, userInput))
 	case BackendOS:
 		db, err = keyring.Open(lkbToKeyringConfig(svcName, rootDir, userInput, false))
+	case BackendKWallet:
+		db, err = keyring.Open(newKWalletBackendKeyringConfig(svcName, rootDir, userInput))
+	case BackendPass:
+		db, err = keyring.Open(newPassBackendKeyringConfig(svcName, rootDir, userInput))
 	default:
 		return nil, fmt.Errorf("unknown keyring backend %v", backend)
 	}
@@ -498,6 +504,24 @@ func lkbToKeyringConfig(name, dir string, buf io.Reader, test bool) keyring.Conf
 		ServiceName:      name,
 		FileDir:          dir,
 		FilePasswordFunc: newRealPrompt(dir, buf),
+	}
+}
+
+func newKWalletBackendKeyringConfig(name, _ string, _ io.Reader) keyring.Config {
+	return keyring.Config{
+		AllowedBackends: []keyring.BackendType{"kwallet"},
+		ServiceName:     "kdewallet",
+		KWalletAppID:    name,
+		KWalletFolder:   "",
+	}
+}
+
+func newPassBackendKeyringConfig(name, dir string, _ io.Reader) keyring.Config {
+	prefix := filepath.Join(dir, fmt.Sprintf(keyringDirNameFmt, name))
+	return keyring.Config{
+		AllowedBackends: []keyring.BackendType{"pass"},
+		ServiceName:     name,
+		PassPrefix:      prefix,
 	}
 }
 

--- a/crypto/keys/keyring.go
+++ b/crypto/keys/keyring.go
@@ -491,7 +491,7 @@ func (kb keyringKeybase) writeInfo(name string, info Info) {
 func lkbToKeyringConfig(name, dir string, buf io.Reader, test bool) keyring.Config {
 	if test {
 		return keyring.Config{
-			AllowedBackends: []keyring.BackendType{"file"},
+			AllowedBackends: []keyring.BackendType{keyring.FileBackend},
 			ServiceName:     name,
 			FileDir:         filepath.Join(dir, fmt.Sprintf(testKeyringDirNameFmt, name)),
 			FilePasswordFunc: func(_ string) (string, error) {
@@ -509,7 +509,7 @@ func lkbToKeyringConfig(name, dir string, buf io.Reader, test bool) keyring.Conf
 
 func newKWalletBackendKeyringConfig(name, _ string, _ io.Reader) keyring.Config {
 	return keyring.Config{
-		AllowedBackends: []keyring.BackendType{"kwallet"},
+		AllowedBackends: []keyring.BackendType{keyring.KWalletBackend},
 		ServiceName:     "kdewallet",
 		KWalletAppID:    name,
 		KWalletFolder:   "",
@@ -519,7 +519,7 @@ func newKWalletBackendKeyringConfig(name, _ string, _ io.Reader) keyring.Config 
 func newPassBackendKeyringConfig(name, dir string, _ io.Reader) keyring.Config {
 	prefix := filepath.Join(dir, fmt.Sprintf(keyringDirNameFmt, name))
 	return keyring.Config{
-		AllowedBackends: []keyring.BackendType{"pass"},
+		AllowedBackends: []keyring.BackendType{keyring.PassBackend},
 		ServiceName:     name,
 		PassPrefix:      prefix,
 	}
@@ -528,7 +528,7 @@ func newPassBackendKeyringConfig(name, dir string, _ io.Reader) keyring.Config {
 func newFileBackendKeyringConfig(name, dir string, buf io.Reader) keyring.Config {
 	fileDir := filepath.Join(dir, fmt.Sprintf(keyringDirNameFmt, name))
 	return keyring.Config{
-		AllowedBackends:  []keyring.BackendType{"file"},
+		AllowedBackends:  []keyring.BackendType{keyring.FileBackend},
 		ServiceName:      name,
 		FileDir:          fileDir,
 		FilePasswordFunc: newRealPrompt(fileDir, buf),


### PR DESCRIPTION
Add support for KDE Wallet service and the pass command line tool.

______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added  relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

______

For admin use:

- [ ] Added appropriate labels to PR (ex. `WIP`, `R4R`, `docs`, etc)
- [ ] Reviewers assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
