### PR TITLE
Remove KeyringServiceName from the sdk.Config struct

### DIFF
--- a/client/context/context.go
+++ b/client/context/context.go
@@ -274,7 +274,7 @@ func GetFromFields(input io.Reader, from string, genOnly bool) (sdk.AccAddress, 
 		return addr, "", nil
 	}
 
-	keybase, err := keys.NewKeyring(sdk.GetConfig().GetKeyringServiceName(),
+	keybase, err := keys.NewKeyring(sdk.KeyringServiceName(),
 		viper.GetString(flags.FlagKeyringBackend), viper.GetString(flags.FlagHome), input)
 	if err != nil {
 		return nil, "", err

--- a/client/keys/add.go
+++ b/client/keys/add.go
@@ -86,7 +86,7 @@ func getKeybase(transient bool, buf io.Reader) (keys.Keybase, error) {
 		return keys.NewInMemory(), nil
 	}
 
-	return keys.NewKeyring(sdk.GetConfig().GetKeyringServiceName(), viper.GetString(flags.FlagKeyringBackend), viper.GetString(flags.FlagHome), buf)
+	return keys.NewKeyring(sdk.KeyringServiceName(), viper.GetString(flags.FlagKeyringBackend), viper.GetString(flags.FlagHome), buf)
 }
 
 func runAddCmd(cmd *cobra.Command, args []string) error {

--- a/client/keys/add_ledger_test.go
+++ b/client/keys/add_ledger_test.go
@@ -51,7 +51,7 @@ func Test_runAddCmdLedgerWithCustomCoinType(t *testing.T) {
 	require.NoError(t, runAddCmd(cmd, []string{"keyname1"}))
 
 	// Now check that it has been stored properly
-	kb, err := keys.NewKeyring(sdk.GetConfig().GetKeyringServiceName(), viper.GetString(flags.FlagKeyringBackend), viper.GetString(flags.FlagHome), mockIn)
+	kb, err := keys.NewKeyring(sdk.KeyringServiceName(), viper.GetString(flags.FlagKeyringBackend), viper.GetString(flags.FlagHome), mockIn)
 	require.NoError(t, err)
 	require.NotNil(t, kb)
 	defer func() {
@@ -98,7 +98,7 @@ func Test_runAddCmdLedger(t *testing.T) {
 	require.NoError(t, runAddCmd(cmd, []string{"keyname1"}))
 
 	// Now check that it has been stored properly
-	kb, err := keys.NewKeyring(sdk.GetConfig().GetKeyringServiceName(), viper.GetString(flags.FlagKeyringBackend), kbHome, mockIn)
+	kb, err := keys.NewKeyring(sdk.KeyringServiceName(), viper.GetString(flags.FlagKeyringBackend), kbHome, mockIn)
 	require.NoError(t, err)
 	require.NotNil(t, kb)
 	defer func() {

--- a/client/keys/add_test.go
+++ b/client/keys/add_test.go
@@ -31,7 +31,7 @@ func Test_runAddCmdBasic(t *testing.T) {
 		mockIn.Reset("testpass1\ntestpass1\n")
 	} else {
 		mockIn.Reset("y\n")
-		kb, err := keys.NewKeyring(sdk.GetConfig().GetKeyringServiceName(), viper.GetString(flags.FlagKeyringBackend), kbHome, mockIn)
+		kb, err := keys.NewKeyring(sdk.KeyringServiceName(), viper.GetString(flags.FlagKeyringBackend), kbHome, mockIn)
 		require.NoError(t, err)
 		defer func() {
 			kb.Delete("keyname1", "", false)

--- a/client/keys/delete.go
+++ b/client/keys/delete.go
@@ -43,7 +43,7 @@ private keys stored in a ledger device cannot be deleted with the CLI.
 func runDeleteCmd(cmd *cobra.Command, args []string) error {
 	buf := bufio.NewReader(cmd.InOrStdin())
 
-	kb, err := keys.NewKeyring(sdk.GetConfig().GetKeyringServiceName(), viper.GetString(flags.FlagKeyringBackend), viper.GetString(flags.FlagHome), buf)
+	kb, err := keys.NewKeyring(sdk.KeyringServiceName(), viper.GetString(flags.FlagKeyringBackend), viper.GetString(flags.FlagHome), buf)
 	if err != nil {
 		return err
 	}

--- a/client/keys/delete_test.go
+++ b/client/keys/delete_test.go
@@ -27,7 +27,7 @@ func Test_runDeleteCmd(t *testing.T) {
 	fakeKeyName1 := "runDeleteCmd_Key1"
 	fakeKeyName2 := "runDeleteCmd_Key2"
 	if !runningUnattended {
-		kb, err := keys.NewKeyring(sdk.GetConfig().GetKeyringServiceName(), viper.GetString(flags.FlagKeyringBackend), viper.GetString(flags.FlagHome), mockIn)
+		kb, err := keys.NewKeyring(sdk.KeyringServiceName(), viper.GetString(flags.FlagKeyringBackend), viper.GetString(flags.FlagHome), mockIn)
 		require.NoError(t, err)
 		defer func() {
 			kb.Delete("runDeleteCmd_Key1", "", false)
@@ -41,7 +41,7 @@ func Test_runDeleteCmd(t *testing.T) {
 	viper.Set(flags.FlagHome, kbHome)
 
 	// Now
-	kb, err := keys.NewKeyring(sdk.GetConfig().GetKeyringServiceName(), viper.GetString(flags.FlagKeyringBackend), kbHome, mockIn)
+	kb, err := keys.NewKeyring(sdk.KeyringServiceName(), viper.GetString(flags.FlagKeyringBackend), kbHome, mockIn)
 	require.NoError(t, err)
 	if runningUnattended {
 		mockIn.Reset("testpass1\ntestpass1\n")

--- a/client/keys/export.go
+++ b/client/keys/export.go
@@ -25,7 +25,7 @@ func ExportKeyCommand() *cobra.Command {
 
 func runExportCmd(cmd *cobra.Command, args []string) error {
 	buf := bufio.NewReader(cmd.InOrStdin())
-	kb, err := keys.NewKeyring(sdk.GetConfig().GetKeyringServiceName(), viper.GetString(flags.FlagKeyringBackend), viper.GetString(flags.FlagHome), buf)
+	kb, err := keys.NewKeyring(sdk.KeyringServiceName(), viper.GetString(flags.FlagKeyringBackend), viper.GetString(flags.FlagHome), buf)
 	if err != nil {
 		return err
 	}

--- a/client/keys/export_test.go
+++ b/client/keys/export_test.go
@@ -23,7 +23,7 @@ func Test_runExportCmd(t *testing.T) {
 	viper.Set(flags.FlagHome, kbHome)
 
 	// create a key
-	kb, err := keys.NewKeyring(sdk.GetConfig().GetKeyringServiceName(), viper.GetString(flags.FlagKeyringBackend), viper.GetString(flags.FlagHome), mockIn)
+	kb, err := keys.NewKeyring(sdk.KeyringServiceName(), viper.GetString(flags.FlagKeyringBackend), viper.GetString(flags.FlagHome), mockIn)
 	require.NoError(t, err)
 	if !runningUnattended {
 		defer func() {

--- a/client/keys/import.go
+++ b/client/keys/import.go
@@ -26,7 +26,7 @@ func ImportKeyCommand() *cobra.Command {
 
 func runImportCmd(cmd *cobra.Command, args []string) error {
 	buf := bufio.NewReader(cmd.InOrStdin())
-	kb, err := keys.NewKeyring(sdk.GetConfig().GetKeyringServiceName(), viper.GetString(flags.FlagKeyringBackend), viper.GetString(flags.FlagHome), buf)
+	kb, err := keys.NewKeyring(sdk.KeyringServiceName(), viper.GetString(flags.FlagKeyringBackend), viper.GetString(flags.FlagHome), buf)
 	if err != nil {
 		return err
 	}

--- a/client/keys/import_test.go
+++ b/client/keys/import_test.go
@@ -25,7 +25,7 @@ func Test_runImportCmd(t *testing.T) {
 	viper.Set(flags.FlagHome, kbHome)
 
 	if !runningUnattended {
-		kb, err := keys.NewKeyring(sdk.GetConfig().GetKeyringServiceName(), viper.GetString(flags.FlagKeyringBackend), viper.GetString(flags.FlagHome), mockIn)
+		kb, err := keys.NewKeyring(sdk.KeyringServiceName(), viper.GetString(flags.FlagKeyringBackend), viper.GetString(flags.FlagHome), mockIn)
 		require.NoError(t, err)
 		defer func() {
 			kb.Delete("keyname1", "", false)

--- a/client/keys/list.go
+++ b/client/keys/list.go
@@ -26,7 +26,7 @@ along with their associated name and address.`,
 }
 
 func runListCmd(cmd *cobra.Command, _ []string) error {
-	kb, err := keys.NewKeyring(sdk.GetConfig().GetKeyringServiceName(), viper.GetString(flags.FlagKeyringBackend), viper.GetString(flags.FlagHome), cmd.InOrStdin())
+	kb, err := keys.NewKeyring(sdk.KeyringServiceName(), viper.GetString(flags.FlagKeyringBackend), viper.GetString(flags.FlagHome), cmd.InOrStdin())
 	if err != nil {
 		return err
 	}

--- a/client/keys/list_test.go
+++ b/client/keys/list_test.go
@@ -32,7 +32,7 @@ func Test_runListCmd(t *testing.T) {
 	viper.Set(flags.FlagHome, kbHome2)
 
 	mockIn, _, _ := tests.ApplyMockIO(cmdBasic)
-	kb, err := keys.NewKeyring(sdk.GetConfig().GetKeyringServiceName(), viper.GetString(flags.FlagKeyringBackend), viper.GetString(flags.FlagHome), mockIn)
+	kb, err := keys.NewKeyring(sdk.KeyringServiceName(), viper.GetString(flags.FlagKeyringBackend), viper.GetString(flags.FlagHome), mockIn)
 	require.NoError(t, err)
 	if runningUnattended {
 		mockIn.Reset("testpass1\ntestpass1\n")

--- a/client/keys/migrate.go
+++ b/client/keys/migrate.go
@@ -9,7 +9,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/input"
 	"github.com/cosmos/cosmos-sdk/crypto/keys"
-	"github.com/cosmos/cosmos-sdk/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -55,7 +55,7 @@ func runMigrateCmd(cmd *cobra.Command, args []string) error {
 	}
 
 	buf := bufio.NewReader(cmd.InOrStdin())
-	keyringServiceName := types.GetConfig().GetKeyringServiceName()
+	keyringServiceName := sdk.KeyringServiceName()
 
 	var (
 		tmpDir  string

--- a/client/keys/show.go
+++ b/client/keys/show.go
@@ -57,7 +57,7 @@ consisting of all the keys provided by name and multisig threshold.`,
 func runShowCmd(cmd *cobra.Command, args []string) (err error) {
 	var info keys.Info
 
-	kb, err := keys.NewKeyring(sdk.GetConfig().GetKeyringServiceName(), viper.GetString(flags.FlagKeyringBackend), viper.GetString(flags.FlagHome), cmd.InOrStdin())
+	kb, err := keys.NewKeyring(sdk.KeyringServiceName(), viper.GetString(flags.FlagKeyringBackend), viper.GetString(flags.FlagHome), cmd.InOrStdin())
 	if err != nil {
 		return err
 	}

--- a/client/keys/show_test.go
+++ b/client/keys/show_test.go
@@ -49,7 +49,7 @@ func Test_runShowCmd(t *testing.T) {
 
 	fakeKeyName1 := "runShowCmd_Key1"
 	fakeKeyName2 := "runShowCmd_Key2"
-	kb, err := keys.NewKeyring(sdk.GetConfig().GetKeyringServiceName(), viper.GetString(flags.FlagKeyringBackend), viper.GetString(flags.FlagHome), mockIn)
+	kb, err := keys.NewKeyring(sdk.KeyringServiceName(), viper.GetString(flags.FlagKeyringBackend), viper.GetString(flags.FlagHome), mockIn)
 	require.NoError(t, err)
 	defer func() {
 		kb.Delete("runShowCmd_Key1", "", false)

--- a/crypto/keys/keyring.go
+++ b/crypto/keys/keyring.go
@@ -60,7 +60,7 @@ func newKeyringKeybase(db keyring.Keyring, opts ...KeybaseOption) Keybase {
 // options can be applied when generating this new Keybase.
 // Available backends are "os", "file", "test".
 func NewKeyring(
-	svcName, backend, rootDir string, userInput io.Reader, opts ...KeybaseOption,
+	appName, backend, rootDir string, userInput io.Reader, opts ...KeybaseOption,
 ) (Keybase, error) {
 
 	var db keyring.Keyring
@@ -68,15 +68,15 @@ func NewKeyring(
 
 	switch backend {
 	case BackendTest:
-		db, err = keyring.Open(lkbToKeyringConfig(svcName, rootDir, nil, true))
+		db, err = keyring.Open(lkbToKeyringConfig(appName, rootDir, nil, true))
 	case BackendFile:
-		db, err = keyring.Open(newFileBackendKeyringConfig(svcName, rootDir, userInput))
+		db, err = keyring.Open(newFileBackendKeyringConfig(appName, rootDir, userInput))
 	case BackendOS:
-		db, err = keyring.Open(lkbToKeyringConfig(svcName, rootDir, userInput, false))
+		db, err = keyring.Open(lkbToKeyringConfig(appName, rootDir, userInput, false))
 	case BackendKWallet:
-		db, err = keyring.Open(newKWalletBackendKeyringConfig(svcName, rootDir, userInput))
+		db, err = keyring.Open(newKWalletBackendKeyringConfig(appName, rootDir, userInput))
 	case BackendPass:
-		db, err = keyring.Open(newPassBackendKeyringConfig(svcName, rootDir, userInput))
+		db, err = keyring.Open(newPassBackendKeyringConfig(appName, rootDir, userInput))
 	default:
 		return nil, fmt.Errorf("unknown keyring backend %v", backend)
 	}
@@ -488,12 +488,12 @@ func (kb keyringKeybase) writeInfo(name string, info Info) {
 	}
 }
 
-func lkbToKeyringConfig(name, dir string, buf io.Reader, test bool) keyring.Config {
+func lkbToKeyringConfig(appName, dir string, buf io.Reader, test bool) keyring.Config {
 	if test {
 		return keyring.Config{
 			AllowedBackends: []keyring.BackendType{keyring.FileBackend},
-			ServiceName:     name,
-			FileDir:         filepath.Join(dir, fmt.Sprintf(testKeyringDirNameFmt, name)),
+			ServiceName:     appName,
+			FileDir:         filepath.Join(dir, fmt.Sprintf(testKeyringDirNameFmt, appName)),
 			FilePasswordFunc: func(_ string) (string, error) {
 				return "test", nil
 			},
@@ -501,26 +501,26 @@ func lkbToKeyringConfig(name, dir string, buf io.Reader, test bool) keyring.Conf
 	}
 
 	return keyring.Config{
-		ServiceName:      name,
+		ServiceName:      appName,
 		FileDir:          dir,
 		FilePasswordFunc: newRealPrompt(dir, buf),
 	}
 }
 
-func newKWalletBackendKeyringConfig(name, _ string, _ io.Reader) keyring.Config {
+func newKWalletBackendKeyringConfig(appName, _ string, _ io.Reader) keyring.Config {
 	return keyring.Config{
 		AllowedBackends: []keyring.BackendType{keyring.KWalletBackend},
 		ServiceName:     "kdewallet",
-		KWalletAppID:    name,
+		KWalletAppID:    appName,
 		KWalletFolder:   "",
 	}
 }
 
-func newPassBackendKeyringConfig(name, dir string, _ io.Reader) keyring.Config {
-	prefix := filepath.Join(dir, fmt.Sprintf(keyringDirNameFmt, name))
+func newPassBackendKeyringConfig(appName, dir string, _ io.Reader) keyring.Config {
+	prefix := filepath.Join(dir, fmt.Sprintf(keyringDirNameFmt, appName))
 	return keyring.Config{
 		AllowedBackends: []keyring.BackendType{keyring.PassBackend},
-		ServiceName:     name,
+		ServiceName:     appName,
 		PassPrefix:      prefix,
 	}
 }

--- a/types/config.go
+++ b/types/config.go
@@ -2,6 +2,8 @@ package types
 
 import (
 	"sync"
+
+	"github.com/cosmos/cosmos-sdk/version"
 )
 
 // DefaultKeyringServiceName defines a default service name for the keyring.
@@ -11,7 +13,6 @@ const DefaultKeyringServiceName = "cosmos"
 // This could be used to initialize certain configuration parameters for the SDK.
 type Config struct {
 	fullFundraiserPath  string
-	keyringServiceName  string
 	bech32AddressPrefix map[string]string
 	txEncoder           TxEncoder
 	addressVerifier     func([]byte) error
@@ -28,6 +29,7 @@ func GetConfig() *Config {
 	if sdkConfig != nil {
 		return sdkConfig
 	}
+
 	sdkConfig = &Config{
 		sealed: false,
 		bech32AddressPrefix: map[string]string{
@@ -41,7 +43,6 @@ func GetConfig() *Config {
 		coinType:           CoinType,
 		fullFundraiserPath: FullFundraiserPath,
 		txEncoder:          nil,
-		keyringServiceName: DefaultKeyringServiceName,
 	}
 	return sdkConfig
 }
@@ -104,12 +105,6 @@ func (config *Config) SetFullFundraiserPath(fullFundraiserPath string) {
 	config.fullFundraiserPath = fullFundraiserPath
 }
 
-// Set the keyringServiceName (BIP44Prefix) on the config
-func (config *Config) SetKeyringServiceName(keyringServiceName string) {
-	config.assertNotSealed()
-	config.keyringServiceName = keyringServiceName
-}
-
 // Seal seals the config such that the config state could not be modified further
 func (config *Config) Seal() *Config {
 	config.mtx.Lock()
@@ -169,7 +164,9 @@ func (config *Config) GetFullFundraiserPath() string {
 	return config.fullFundraiserPath
 }
 
-// GetKeyringServiceName returns the keyring service name from the config.
-func (config *Config) GetKeyringServiceName() string {
-	return config.keyringServiceName
+func KeyringServiceName() string {
+	if len(version.Name) == 0 {
+		return DefaultKeyringServiceName
+	}
+	return version.Name
 }

--- a/x/auth/client/cli/tx_multisign.go
+++ b/x/auth/client/cli/tx_multisign.go
@@ -66,7 +66,7 @@ func makeMultiSignCmd(cdc *codec.Codec) func(cmd *cobra.Command, args []string) 
 		}
 
 		inBuf := bufio.NewReader(cmd.InOrStdin())
-		kb, err := keys.NewKeyring(sdk.GetConfig().GetKeyringServiceName(),
+		kb, err := keys.NewKeyring(sdk.KeyringServiceName(),
 			viper.GetString(flags.FlagKeyringBackend), viper.GetString(flags.FlagHome), inBuf)
 		if err != nil {
 			return

--- a/x/auth/types/txbuilder.go
+++ b/x/auth/types/txbuilder.go
@@ -53,7 +53,7 @@ func NewTxBuilder(
 // NewTxBuilderFromCLI returns a new initialized TxBuilder with parameters from
 // the command line using Viper.
 func NewTxBuilderFromCLI(input io.Reader) TxBuilder {
-	kb, err := keys.NewKeyring(sdk.GetConfig().GetKeyringServiceName(), viper.GetString(flags.FlagKeyringBackend), viper.GetString(flags.FlagHome), input)
+	kb, err := keys.NewKeyring(sdk.KeyringServiceName(), viper.GetString(flags.FlagKeyringBackend), viper.GetString(flags.FlagHome), input)
 	if err != nil {
 		panic(err)
 	}
@@ -276,7 +276,7 @@ func MakeSignature(keybase keys.Keybase, name, passphrase string,
 	msg StdSignMsg) (sig StdSignature, err error) {
 
 	if keybase == nil {
-		keybase, err = keys.NewKeyring(sdk.GetConfig().GetKeyringServiceName(), viper.GetString(flags.FlagKeyringBackend), viper.GetString(flags.FlagHome), os.Stdin)
+		keybase, err = keys.NewKeyring(sdk.KeyringServiceName(), viper.GetString(flags.FlagKeyringBackend), viper.GetString(flags.FlagHome), os.Stdin)
 		if err != nil {
 			return
 		}

--- a/x/genutil/client/cli/gentx.go
+++ b/x/genutil/client/cli/gentx.go
@@ -93,7 +93,7 @@ func GenTxCmd(ctx *server.Context, cdc *codec.Codec, mbm module.BasicManager, sm
 			}
 
 			inBuf := bufio.NewReader(cmd.InOrStdin())
-			kb, err := keys.NewKeyring(sdk.GetConfig().GetKeyringServiceName(),
+			kb, err := keys.NewKeyring(sdk.KeyringServiceName(),
 				viper.GetString(flags.FlagKeyringBackend), viper.GetString(flagClientHome), inBuf)
 			if err != nil {
 				return errors.Wrap(err, "failed to initialize keybase")


### PR DESCRIPTION
Remove KeyringServiceName from sdk Config structure.
Clients can pass the app name as parameter to the constructor, whilst SDK commands
will inherit it from the build flag `-x github.com/cosmos-sdk/version.Name`.

Plus, NewKeyring()'s serviceName parameter is now renamed to appName.

______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added  relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

______

For admin use:

- [ ] Added appropriate labels to PR (ex. `WIP`, `R4R`, `docs`, etc)
- [ ] Reviewers assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
