### PR TITLE
Replace defer with testing.T.Cleanup()

### DIFF
--- a/client/keys/add_ledger_test.go
+++ b/client/keys/add_ledger_test.go
@@ -39,7 +39,7 @@ func Test_runAddCmdLedgerWithCustomCoinType(t *testing.T) {
 	// Prepare a keybase
 	kbHome, kbCleanUp := tests.NewTestCaseDir(t)
 	require.NotNil(t, kbHome)
-	defer kbCleanUp()
+	t.Cleanup(kbCleanUp)
 	viper.Set(flags.FlagHome, kbHome)
 	viper.Set(flags.FlagUseLedger, true)
 
@@ -54,9 +54,9 @@ func Test_runAddCmdLedgerWithCustomCoinType(t *testing.T) {
 	kb, err := keys.NewKeyring(sdk.KeyringServiceName(), viper.GetString(flags.FlagKeyringBackend), viper.GetString(flags.FlagHome), mockIn)
 	require.NoError(t, err)
 	require.NotNil(t, kb)
-	defer func() {
+	t.Cleanup(func() {
 		kb.Delete("keyname1", "", false)
-	}()
+	})
 	mockIn.Reset("test1234\n")
 	if runningUnattended {
 		mockIn.Reset("test1234\ntest1234\n")
@@ -87,7 +87,7 @@ func Test_runAddCmdLedger(t *testing.T) {
 	// Prepare a keybase
 	kbHome, kbCleanUp := tests.NewTestCaseDir(t)
 	require.NotNil(t, kbHome)
-	defer kbCleanUp()
+	t.Cleanup(kbCleanUp)
 	viper.Set(flags.FlagHome, kbHome)
 	viper.Set(flags.FlagUseLedger, true)
 
@@ -101,9 +101,9 @@ func Test_runAddCmdLedger(t *testing.T) {
 	kb, err := keys.NewKeyring(sdk.KeyringServiceName(), viper.GetString(flags.FlagKeyringBackend), kbHome, mockIn)
 	require.NoError(t, err)
 	require.NotNil(t, kb)
-	defer func() {
+	t.Cleanup(func() {
 		kb.Delete("keyname1", "", false)
-	}()
+	})
 	mockIn.Reset("test1234\n")
 	if runningUnattended {
 		mockIn.Reset("test1234\ntest1234\n")

--- a/client/keys/add_test.go
+++ b/client/keys/add_test.go
@@ -23,7 +23,7 @@ func Test_runAddCmdBasic(t *testing.T) {
 
 	kbHome, kbCleanUp := tests.NewTestCaseDir(t)
 	assert.NotNil(t, kbHome)
-	defer kbCleanUp()
+	t.Cleanup(kbCleanUp)
 	viper.Set(flags.FlagHome, kbHome)
 	viper.Set(cli.OutputFlag, OutputFormatText)
 
@@ -33,10 +33,10 @@ func Test_runAddCmdBasic(t *testing.T) {
 		mockIn.Reset("y\n")
 		kb, err := keys.NewKeyring(sdk.KeyringServiceName(), viper.GetString(flags.FlagKeyringBackend), kbHome, mockIn)
 		require.NoError(t, err)
-		defer func() {
+		t.Cleanup(func() {
 			kb.Delete("keyname1", "", false)
 			kb.Delete("keyname2", "", false)
-		}()
+		})
 	}
 	assert.NoError(t, runAddCmd(cmd, []string{"keyname1"}))
 

--- a/client/keys/delete_test.go
+++ b/client/keys/delete_test.go
@@ -29,15 +29,15 @@ func Test_runDeleteCmd(t *testing.T) {
 	if !runningUnattended {
 		kb, err := keys.NewKeyring(sdk.KeyringServiceName(), viper.GetString(flags.FlagKeyringBackend), viper.GetString(flags.FlagHome), mockIn)
 		require.NoError(t, err)
-		defer func() {
+		t.Cleanup(func() {
 			kb.Delete("runDeleteCmd_Key1", "", false)
 			kb.Delete("runDeleteCmd_Key2", "", false)
 
-		}()
+		})
 	}
 	// Now add a temporary keybase
 	kbHome, cleanUp := tests.NewTestCaseDir(t)
-	defer cleanUp()
+	t.Cleanup(cleanUp)
 	viper.Set(flags.FlagHome, kbHome)
 
 	// Now

--- a/client/keys/export_test.go
+++ b/client/keys/export_test.go
@@ -19,16 +19,16 @@ func Test_runExportCmd(t *testing.T) {
 
 	// Now add a temporary keybase
 	kbHome, cleanUp := tests.NewTestCaseDir(t)
-	defer cleanUp()
+	t.Cleanup(cleanUp)
 	viper.Set(flags.FlagHome, kbHome)
 
 	// create a key
 	kb, err := keys.NewKeyring(sdk.KeyringServiceName(), viper.GetString(flags.FlagKeyringBackend), viper.GetString(flags.FlagHome), mockIn)
 	require.NoError(t, err)
 	if !runningUnattended {
-		defer func() {
+		t.Cleanup(func() {
 			kb.Delete("keyname1", "", false)
-		}()
+		})
 	}
 
 	if runningUnattended {

--- a/client/keys/import_test.go
+++ b/client/keys/import_test.go
@@ -21,15 +21,15 @@ func Test_runImportCmd(t *testing.T) {
 
 	// Now add a temporary keybase
 	kbHome, cleanUp := tests.NewTestCaseDir(t)
-	defer cleanUp()
+	t.Cleanup(cleanUp)
 	viper.Set(flags.FlagHome, kbHome)
 
 	if !runningUnattended {
 		kb, err := keys.NewKeyring(sdk.KeyringServiceName(), viper.GetString(flags.FlagKeyringBackend), viper.GetString(flags.FlagHome), mockIn)
 		require.NoError(t, err)
-		defer func() {
+		t.Cleanup(func() {
 			kb.Delete("keyname1", "", false)
-		}()
+		})
 	}
 
 	keyfile := filepath.Join(kbHome, "key.asc")

--- a/client/keys/list_test.go
+++ b/client/keys/list_test.go
@@ -24,11 +24,11 @@ func Test_runListCmd(t *testing.T) {
 
 	// Prepare some keybases
 	kbHome1, cleanUp1 := tests.NewTestCaseDir(t)
-	defer cleanUp1()
+	t.Cleanup(cleanUp1)
 	// Do nothing, leave home1 empty
 
 	kbHome2, cleanUp2 := tests.NewTestCaseDir(t)
-	defer cleanUp2()
+	t.Cleanup(cleanUp2)
 	viper.Set(flags.FlagHome, kbHome2)
 
 	mockIn, _, _ := tests.ApplyMockIO(cmdBasic)
@@ -41,9 +41,9 @@ func Test_runListCmd(t *testing.T) {
 	_, err = kb.CreateAccount("something", tests.TestMnemonic, "", "", "", keys.Secp256k1)
 	require.NoError(t, err)
 
-	defer func() {
+	t.Cleanup(func() {
 		kb.Delete("something", "", false)
-	}()
+	})
 	testData := []struct {
 		name    string
 		kbDir   string

--- a/client/keys/migrate_test.go
+++ b/client/keys/migrate_test.go
@@ -19,14 +19,13 @@ func Test_runMigrateCmd(t *testing.T) {
 
 	kbHome, kbCleanUp := tests.NewTestCaseDir(t)
 	assert.NotNil(t, kbHome)
-	defer kbCleanUp()
+	t.Cleanup(kbCleanUp)
 	viper.Set(flags.FlagHome, kbHome)
 
 	viper.Set(cli.OutputFlag, OutputFormatText)
 
 	mockIn.Reset("test1234\ntest1234\n")
-	err := runAddCmd(cmd, []string{"keyname1"})
-	assert.NoError(t, err)
+	assert.NoError(t, runAddCmd(cmd, []string{"keyname1"}))
 
 	viper.Set(flags.FlagDryRun, true)
 	cmd = MigrateCommand()

--- a/client/keys/mnemonic_test.go
+++ b/client/keys/mnemonic_test.go
@@ -12,8 +12,7 @@ import (
 
 func Test_RunMnemonicCmdNormal(t *testing.T) {
 	cmdBasic := MnemonicKeyCommand()
-	err := runMnemonicCmd(cmdBasic, []string{})
-	require.NoError(t, err)
+	require.NoError(t, runMnemonicCmd(cmdBasic, []string{}))
 }
 
 func Test_RunMnemonicCmdUser(t *testing.T) {
@@ -37,18 +36,15 @@ func Test_RunMnemonicCmdUser(t *testing.T) {
 	// Now provide "good" entropy :)
 	fakeEntropy := strings.Repeat(":)", 40) + "\ny\n" // entropy + accept count
 	mockIn.Reset(fakeEntropy)
-	err = runMnemonicCmd(cmdUser, []string{})
-	require.NoError(t, err)
+	require.NoError(t, runMnemonicCmd(cmdUser, []string{}))
 
 	// Now provide "good" entropy but no answer
 	fakeEntropy = strings.Repeat(":)", 40) + "\n" // entropy + accept count
 	mockIn.Reset(fakeEntropy)
-	err = runMnemonicCmd(cmdUser, []string{})
-	require.Error(t, err)
+	require.Error(t, runMnemonicCmd(cmdUser, []string{}))
 
 	// Now provide "good" entropy but say no
 	fakeEntropy = strings.Repeat(":)", 40) + "\nn\n" // entropy + accept count
 	mockIn.Reset(fakeEntropy)
-	err = runMnemonicCmd(cmdUser, []string{})
-	require.NoError(t, err)
+	require.NoError(t, runMnemonicCmd(cmdUser, []string{}))
 }

--- a/client/keys/show_test.go
+++ b/client/keys/show_test.go
@@ -44,17 +44,17 @@ func Test_runShowCmd(t *testing.T) {
 	// Prepare a key base
 	// Now add a temporary keybase
 	kbHome, cleanUp := tests.NewTestCaseDir(t)
-	defer cleanUp()
+	t.Cleanup(cleanUp)
 	viper.Set(flags.FlagHome, kbHome)
 
 	fakeKeyName1 := "runShowCmd_Key1"
 	fakeKeyName2 := "runShowCmd_Key2"
 	kb, err := keys.NewKeyring(sdk.KeyringServiceName(), viper.GetString(flags.FlagKeyringBackend), viper.GetString(flags.FlagHome), mockIn)
 	require.NoError(t, err)
-	defer func() {
+	t.Cleanup(func() {
 		kb.Delete("runShowCmd_Key1", "", false)
 		kb.Delete("runShowCmd_Key2", "", false)
-	}()
+	})
 	if runningUnattended {
 		mockIn.Reset("testpass1\ntestpass1\n")
 	}

--- a/client/keys/types_test.go
+++ b/client/keys/types_test.go
@@ -1,0 +1,29 @@
+package keys_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cosmos/cosmos-sdk/client/keys"
+)
+
+func TestConstructors(t *testing.T) {
+	require.Equal(t, keys.AddNewKey{
+		Name:     "name",
+		Password: "password",
+		Mnemonic: "mnemonic",
+		Account:  1,
+		Index:    1,
+	}, keys.NewAddNewKey("name", "password", "mnemonic", 1, 1))
+
+	require.Equal(t, keys.RecoverKey{
+		Password: "password",
+		Mnemonic: "mnemonic",
+		Account:  1,
+		Index:    1,
+	}, keys.NewRecoverKey("password", "mnemonic", 1, 1))
+
+	require.Equal(t, keys.UpdateKeyReq{OldPassword: "old", NewPassword: "new"}, keys.NewUpdateKeyReq("old", "new"))
+	require.Equal(t, keys.DeleteKeyReq{Password: "password"}, keys.NewDeleteKeyReq("password"))
+}

--- a/client/keys/update_test.go
+++ b/client/keys/update_test.go
@@ -12,8 +12,7 @@ import (
 )
 
 func Test_updateKeyCommand(t *testing.T) {
-	cmd := UpdateKeyCommand()
-	assert.NotNil(t, cmd)
+	assert.NotNil(t, UpdateKeyCommand())
 	// No flags  or defaults to validate
 }
 
@@ -34,7 +33,7 @@ func Test_runUpdateCmd(t *testing.T) {
 	// Prepare a key base
 	// Now add a temporary keybase
 	kbHome, cleanUp1 := tests.NewTestCaseDir(t)
-	defer cleanUp1()
+	t.Cleanup(cleanUp1)
 	viper.Set(flags.FlagHome, kbHome)
 
 	kb, err := NewKeyBaseFromDir(viper.GetString(flags.FlagHome))

--- a/crypto/keys/keyring_test.go
+++ b/crypto/keys/keyring_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestLazyKeyManagementKeyRing(t *testing.T) {
 	dir, cleanup := tests.NewTestCaseDir(t)
-	defer cleanup()
+	t.Cleanup(cleanup)
 	kb, err := NewKeyring("keybasename", "test", dir, nil)
 	require.NoError(t, err)
 
@@ -100,7 +100,7 @@ func TestLazyKeyManagementKeyRing(t *testing.T) {
 
 func TestLazySignVerifyKeyRing(t *testing.T) {
 	dir, cleanup := tests.NewTestCaseDir(t)
-	defer cleanup()
+	t.Cleanup(cleanup)
 	kb, err := NewKeyring("keybasename", "test", dir, nil)
 	require.NoError(t, err)
 	algo := Secp256k1
@@ -176,7 +176,7 @@ func TestLazySignVerifyKeyRing(t *testing.T) {
 
 func TestLazyExportImportKeyRing(t *testing.T) {
 	dir, cleanup := tests.NewTestCaseDir(t)
-	defer cleanup()
+	t.Cleanup(cleanup)
 	kb, err := NewKeyring("keybasename", "test", dir, nil)
 	require.NoError(t, err)
 
@@ -205,7 +205,7 @@ func TestLazyExportImportKeyRing(t *testing.T) {
 
 func TestLazyExportImportPubKeyKeyRing(t *testing.T) {
 	dir, cleanup := tests.NewTestCaseDir(t)
-	defer cleanup()
+	t.Cleanup(cleanup)
 	kb, err := NewKeyring("keybasename", "test", dir, nil)
 	require.NoError(t, err)
 	algo := Secp256k1
@@ -246,7 +246,7 @@ func TestLazyExportImportPubKeyKeyRing(t *testing.T) {
 
 func TestLazyExportPrivateKeyObjectKeyRing(t *testing.T) {
 	dir, cleanup := tests.NewTestCaseDir(t)
-	defer cleanup()
+	t.Cleanup(cleanup)
 	kb, err := NewKeyring("keybasename", "test", dir, nil)
 	require.NoError(t, err)
 
@@ -262,7 +262,7 @@ func TestLazyExportPrivateKeyObjectKeyRing(t *testing.T) {
 
 func TestLazyAdvancedKeyManagementKeyRing(t *testing.T) {
 	dir, cleanup := tests.NewTestCaseDir(t)
-	defer cleanup()
+	t.Cleanup(cleanup)
 	kb, err := NewKeyring("keybasename", "test", dir, nil)
 	require.NoError(t, err)
 
@@ -296,7 +296,7 @@ func TestLazyAdvancedKeyManagementKeyRing(t *testing.T) {
 
 func TestLazySeedPhraseKeyRing(t *testing.T) {
 	dir, cleanup := tests.NewTestCaseDir(t)
-	defer cleanup()
+	t.Cleanup(cleanup)
 	kb, err := NewKeyring("keybasename", "test", dir, nil)
 	require.NoError(t, err)
 

--- a/crypto/keys/lazy_keybase_test.go
+++ b/crypto/keys/lazy_keybase_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestNew(t *testing.T) {
 	dir, cleanup := tests.NewTestCaseDir(t)
-	defer cleanup()
+	t.Cleanup(cleanup)
 	kb := New("keybasename", dir)
 	lazykb, ok := kb.(lazyKeybase)
 	require.True(t, ok)
@@ -28,7 +28,7 @@ func TestNew(t *testing.T) {
 
 func TestLazyKeyManagement(t *testing.T) {
 	dir, cleanup := tests.NewTestCaseDir(t)
-	defer cleanup()
+	t.Cleanup(cleanup)
 	kb := New("keybasename", dir)
 
 	algo := Secp256k1
@@ -111,7 +111,7 @@ func TestLazyKeyManagement(t *testing.T) {
 
 func TestLazySignVerify(t *testing.T) {
 	dir, cleanup := tests.NewTestCaseDir(t)
-	defer cleanup()
+	t.Cleanup(cleanup)
 	kb := New("keybasename", dir)
 	algo := Secp256k1
 
@@ -186,7 +186,7 @@ func TestLazySignVerify(t *testing.T) {
 
 func TestLazyExportImport(t *testing.T) {
 	dir, cleanup := tests.NewTestCaseDir(t)
-	defer cleanup()
+	t.Cleanup(cleanup)
 	kb := New("keybasename", dir)
 
 	info, _, err := kb.CreateMnemonic("john", English, "secretcpw", Secp256k1)
@@ -214,7 +214,7 @@ func TestLazyExportImport(t *testing.T) {
 
 func TestLazyExportImportPrivKey(t *testing.T) {
 	dir, cleanup := tests.NewTestCaseDir(t)
-	defer cleanup()
+	t.Cleanup(cleanup)
 	kb := New("keybasename", dir)
 
 	info, _, err := kb.CreateMnemonic("john", English, "secretcpw", Secp256k1)
@@ -243,7 +243,7 @@ func TestLazyExportImportPrivKey(t *testing.T) {
 
 func TestLazyExportImportPubKey(t *testing.T) {
 	dir, cleanup := tests.NewTestCaseDir(t)
-	defer cleanup()
+	t.Cleanup(cleanup)
 	kb := New("keybasename", dir)
 	algo := Secp256k1
 
@@ -283,7 +283,7 @@ func TestLazyExportImportPubKey(t *testing.T) {
 
 func TestLazyExportPrivateKeyObject(t *testing.T) {
 	dir, cleanup := tests.NewTestCaseDir(t)
-	defer cleanup()
+	t.Cleanup(cleanup)
 	kb := New("keybasename", dir)
 
 	info, _, err := kb.CreateMnemonic("john", English, "secretcpw", Secp256k1)
@@ -300,7 +300,7 @@ func TestLazyExportPrivateKeyObject(t *testing.T) {
 
 func TestLazyAdvancedKeyManagement(t *testing.T) {
 	dir, cleanup := tests.NewTestCaseDir(t)
-	defer cleanup()
+	t.Cleanup(cleanup)
 	kb := New("keybasename", dir)
 
 	algo := Secp256k1
@@ -348,7 +348,7 @@ func TestLazyAdvancedKeyManagement(t *testing.T) {
 // TestSeedPhrase verifies restoring from a seed phrase
 func TestLazySeedPhrase(t *testing.T) {
 	dir, cleanup := tests.NewTestCaseDir(t)
-	defer cleanup()
+	t.Cleanup(cleanup)
 	kb := New("keybasename", dir)
 
 	algo := Secp256k1
@@ -401,13 +401,13 @@ func (key testPub) Equals(other crypto.PubKey) bool         { return true }
 
 func TestKeygenOverride(t *testing.T) {
 	dir, cleanup := tests.NewTestCaseDir(t)
-	defer cleanup()
+	t.Cleanup(cleanup)
 
 	// Save existing codec and reset after test
 	cryptoCdc := CryptoCdc
-	defer func() {
+	t.Cleanup(func() {
 		CryptoCdc = cryptoCdc
-	}()
+	})
 
 	// Setup testCdc encoding and decoding new key type
 	testCdc = codec.New()

--- a/server/constructors_test.go
+++ b/server/constructors_test.go
@@ -12,7 +12,7 @@ import (
 func Test_openDB(t *testing.T) {
 	t.Parallel()
 	dir, cleanup := tests.NewTestCaseDir(t)
-	defer cleanup()
+	t.Cleanup(cleanup)
 	_, err := openDB(dir)
 	require.NoError(t, err)
 }
@@ -20,7 +20,7 @@ func Test_openDB(t *testing.T) {
 func Test_openTraceWriter(t *testing.T) {
 	t.Parallel()
 	dir, cleanup := tests.NewTestCaseDir(t)
-	defer cleanup()
+	t.Cleanup(cleanup)
 	fname := filepath.Join(dir, "logfile")
 	w, err := openTraceWriter(fname)
 	require.NoError(t, err)

--- a/server/init_test.go
+++ b/server/init_test.go
@@ -25,7 +25,7 @@ func TestGenerateCoinKey(t *testing.T) {
 func TestGenerateSaveCoinKey(t *testing.T) {
 	t.Parallel()
 	dir, cleanup := tests.NewTestCaseDir(t)
-	defer cleanup() // clean after itself
+	t.Cleanup(cleanup)
 
 	kb, err := crkeys.NewKeyring(t.Name(), "test", dir, nil)
 	require.NoError(t, err)
@@ -47,7 +47,7 @@ func TestGenerateSaveCoinKey(t *testing.T) {
 func TestGenerateSaveCoinKeyOverwriteFlag(t *testing.T) {
 	t.Parallel()
 	dir, cleanup := tests.NewTestCaseDir(t)
-	defer cleanup() // clean after itself
+	t.Cleanup(cleanup)
 
 	kb, err := crkeys.NewKeyring(t.Name(), "test", dir, nil)
 	require.NoError(t, err)

--- a/x/genutil/client/cli/init_test.go
+++ b/x/genutil/client/cli/init_test.go
@@ -27,10 +27,10 @@ import (
 var testMbm = module.NewBasicManager(genutil.AppModuleBasic{})
 
 func TestInitCmd(t *testing.T) {
-	defer server.SetupViper(t)()
-	defer setupClientHome(t)()
+	t.Cleanup(server.SetupViper(t))
+	t.Cleanup(server.SetupViper(t))
 	home, cleanup := tests.NewTestCaseDir(t)
-	defer cleanup()
+	t.Cleanup(cleanup)
 
 	logger := log.NewNopLogger()
 	cfg, err := tcmd.ParseConfig()
@@ -50,11 +50,11 @@ func setupClientHome(t *testing.T) func() {
 }
 
 func TestEmptyState(t *testing.T) {
-	defer server.SetupViper(t)()
-	defer setupClientHome(t)()
+	t.Cleanup(server.SetupViper(t))
+	t.Cleanup(setupClientHome(t))
 
 	home, cleanup := tests.NewTestCaseDir(t)
-	defer cleanup()
+	t.Cleanup(cleanup)
 
 	logger := log.NewNopLogger()
 	cfg, err := tcmd.ParseConfig()
@@ -94,9 +94,9 @@ func TestEmptyState(t *testing.T) {
 
 func TestStartStandAlone(t *testing.T) {
 	home, cleanup := tests.NewTestCaseDir(t)
-	defer cleanup()
+	t.Cleanup(cleanup)
 	viper.Set(cli.HomeFlag, home)
-	defer setupClientHome(t)()
+	t.Cleanup(setupClientHome(t))
 
 	logger := log.NewNopLogger()
 	cfg, err := tcmd.ParseConfig()
@@ -124,7 +124,7 @@ func TestStartStandAlone(t *testing.T) {
 
 func TestInitNodeValidatorFiles(t *testing.T) {
 	home, cleanup := tests.NewTestCaseDir(t)
-	defer cleanup()
+	t.Cleanup(cleanup)
 	viper.Set(cli.HomeFlag, home)
 	viper.Set(flags.FlagName, "moniker")
 	cfg, err := tcmd.ParseConfig()

--- a/x/genutil/client/cli/migrate_test.go
+++ b/x/genutil/client/cli/migrate_test.go
@@ -38,6 +38,7 @@ func TestGetMigrationCallback(t *testing.T) {
 
 func TestMigrateGenesis(t *testing.T) {
 	home, cleanup := tests.NewTestCaseDir(t)
+	t.Cleanup(cleanup)
 	viper.Set(cli.HomeFlag, home)
 	viper.Set(flags.FlagName, "moniker")
 	logger := log.NewNopLogger()
@@ -48,8 +49,6 @@ func TestMigrateGenesis(t *testing.T) {
 
 	genesisPath := path.Join(home, "genesis.json")
 	target := "v0.36"
-
-	defer cleanup()
 
 	// Reject if we dont' have the right parameters or genesis does not exists
 	require.Error(t, MigrateGenesisCmd(ctx, cdc).RunE(nil, []string{target, genesisPath}))

--- a/x/genutil/utils_test.go
+++ b/x/genutil/utils_test.go
@@ -14,7 +14,7 @@ import (
 func TestExportGenesisFileWithTime(t *testing.T) {
 	t.Parallel()
 	dir, cleanup := tests.NewTestCaseDir(t)
-	defer cleanup()
+	t.Cleanup(cleanup)
 
 	fname := filepath.Join(dir, "genesis.json")
 	require.NoError(t, ExportGenesisFileWithTime(fname, "test", nil, json.RawMessage(""), time.Now()))

--- a/x/upgrade/types/storeloader_test.go
+++ b/x/upgrade/types/storeloader_test.go
@@ -68,8 +68,8 @@ func checkStore(t *testing.T, db dbm.DB, ver int64, storeKey string, k, v []byte
 // Test that LoadLatestVersion actually does.
 func TestSetLoader(t *testing.T) {
 	// set a temporary home dir
-	homeDir, cleanUp := tests.NewTestCaseDir(t)
-	defer cleanUp()
+	homeDir, cleanup := tests.NewTestCaseDir(t)
+	t.Cleanup(cleanup)
 	// TODO cleanup viper
 	viper.Set(flags.FlagHome, homeDir)
 


### PR DESCRIPTION
In Go 1.14, the testing package now includes a method,
testing.(*T).Cleanup, which aims to make creating and
cleaning up dependencies of tests easier.

Drop defer function calls in favour of Cleanup() wherever
it makes sense to do so.

______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added  relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

______

For admin use:

- [ ] Added appropriate labels to PR (ex. `WIP`, `R4R`, `docs`, etc)
- [ ] Reviewers assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
