### PR TITLE
fix types.ChainAnteDecorators() panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ resulted in a panic when the tx execution mode was `CheckTx`.
 * (client) [\#5618](https://github.com/cosmos/cosmos-sdk/pull/5618) Fix crash on the client when the verifier is not set.
 * (x/distribution) [\#5620](https://github.com/cosmos/cosmos-sdk/pull/5620) Fix nil pointer deref in distribution tax/rewward validation helpers.
 * (genesis) [\#5086](https://github.com/cosmos/cosmos-sdk/issues/5086) Ensure `gentxs` are always an empty array instead of `nil`
+* (types) [\#5741](https://github.com/cosmos/cosmos-sdk/issues/5741) Prevent ChainAnteDecorators() from panicking when empty AnteDecorator slice is supplied.
 
 ### State Machine Breaking
 

--- a/types/handler.go
+++ b/types/handler.go
@@ -31,12 +31,6 @@ func ChainAnteDecorators(chain ...AnteDecorator) AnteHandler {
 		return nil
 	}
 
-	if len(chain) == 1 {
-		return func(ctx Context, tx Tx, simulate bool) (Context, error) {
-			return chain[0].AnteHandle(ctx, tx, simulate, nil)
-		}
-	}
-
 	// handle non-terminated decorators chain
 	if (chain[len(chain)-1] != Terminator{}) {
 		chain = append(chain, Terminator{})

--- a/types/handler.go
+++ b/types/handler.go
@@ -25,15 +25,21 @@ type AnteDecorator interface {
 // MUST set GasMeter with the FIRST AnteDecorator. Failing to do so will cause
 // transactions to be processed with an infinite gasmeter and open a DOS attack vector.
 // Use `ante.SetUpContextDecorator` or a custom Decorator with similar functionality.
+// Returns nil when no AnteDecorator are supplied.
 func ChainAnteDecorators(chain ...AnteDecorator) AnteHandler {
-	if (chain[len(chain)-1] != Terminator{}) {
-		chain = append(chain, Terminator{})
+	if len(chain) == 0 {
+		return nil
 	}
 
 	if len(chain) == 1 {
 		return func(ctx Context, tx Tx, simulate bool) (Context, error) {
 			return chain[0].AnteHandle(ctx, tx, simulate, nil)
 		}
+	}
+
+	// handle non-terminated decorators chain
+	if (chain[len(chain)-1] != Terminator{}) {
+		chain = append(chain, Terminator{})
 	}
 
 	return func(ctx Context, tx Tx, simulate bool) (Context, error) {

--- a/types/handler_test.go
+++ b/types/handler_test.go
@@ -18,7 +18,7 @@ func TestChainAnteDecorators(t *testing.T) {
 	ctx, tx := sdk.Context{}, sdk.Tx(nil)
 	mockCtrl := gomock.NewController(t)
 	mockAnteDecorator1 := mocks.NewMockAnteDecorator(mockCtrl)
-	mockAnteDecorator1.EXPECT().AnteHandle(gomock.Eq(ctx), gomock.Eq(tx), true, nil).Times(1)
+	mockAnteDecorator1.EXPECT().AnteHandle(gomock.Eq(ctx), gomock.Eq(tx), true, gomock.Any()).Times(1)
 	sdk.ChainAnteDecorators(mockAnteDecorator1)(ctx, tx, true)
 
 	mockAnteDecorator2 := mocks.NewMockAnteDecorator(mockCtrl)

--- a/types/handler_test.go
+++ b/types/handler_test.go
@@ -1,0 +1,28 @@
+package types_test
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cosmos/cosmos-sdk/tests/mocks"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+func TestChainAnteDecorators(t *testing.T) {
+	t.Parallel()
+	// test panic
+	require.Nil(t, sdk.ChainAnteDecorators([]sdk.AnteDecorator{}...))
+
+	ctx, tx := sdk.Context{}, sdk.Tx(nil)
+	mockCtrl := gomock.NewController(t)
+	mockAnteDecorator1 := mocks.NewMockAnteDecorator(mockCtrl)
+	mockAnteDecorator1.EXPECT().AnteHandle(gomock.Eq(ctx), gomock.Eq(tx), true, nil).Times(1)
+	sdk.ChainAnteDecorators(mockAnteDecorator1)(ctx, tx, true)
+
+	mockAnteDecorator2 := mocks.NewMockAnteDecorator(mockCtrl)
+	mockAnteDecorator1.EXPECT().AnteHandle(gomock.Eq(ctx), gomock.Eq(tx), true, mockAnteDecorator2).Times(1)
+	mockAnteDecorator2.EXPECT().AnteHandle(gomock.Eq(ctx), gomock.Eq(tx), true, nil).Times(1)
+	sdk.ChainAnteDecorators(mockAnteDecorator1, mockAnteDecorator2)
+}


### PR DESCRIPTION
ChainAnteDecorators() panics when no arguments are supplied.
This changes its behaviour and the function now returns a nil
AnteHandler in case no AnteDecorator instances are supplied.

Closes: #5741

______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added  relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

______

For admin use:

- [ ] Added appropriate labels to PR (ex. `WIP`, `R4R`, `docs`, etc)
- [ ] Reviewers assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
