### PR TITLE
crypto/keys/mintkey: fix errors handling in UnarmorPubKeyBytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,8 @@ resulted in a panic when the tx execution mode was `CheckTx`.
 * (x/distribution) [\#5620](https://github.com/cosmos/cosmos-sdk/pull/5620) Fix nil pointer deref in distribution tax/rewward validation helpers.
 * (types) [\#5741](https://github.com/cosmos/cosmos-sdk/issues/5741) Prevent ChainAnteDecorators() from panicking when empty AnteDecorator slice is supplied.
 * (modules) [\#5569](https://github.com/cosmos/cosmos-sdk/issues/5569) `InitGenesis`, for the relevant modules, now ensures module accounts exist.
+* (crypto/keys/mintkey) [\#5823](https://github.com/cosmos/cosmos-sdk/pull/5823) fix errors handling in UnarmorPubKeyBytes (underlying armoring function's
+return error was not being checked).
 
 ### State Machine Breaking
 

--- a/crypto/keys/mintkey/mintkey.go
+++ b/crypto/keys/mintkey/mintkey.go
@@ -83,6 +83,10 @@ func UnarmorInfoBytes(armorStr string) ([]byte, error) {
 // UnarmorPubKeyBytes returns the pubkey byte slice, a string of the algo type, and an error
 func UnarmorPubKeyBytes(armorStr string) (bz []byte, algo string, err error) {
 	bz, header, err := unarmorBytes(armorStr, blockTypePubKey)
+	if err != nil {
+		return nil, "", fmt.Errorf("couldn't unarmor bytes: %v", err)
+	}
+
 	switch header[headerVersion] {
 	case "0.0.0":
 		return bz, defaultAlgo, err
@@ -91,6 +95,8 @@ func UnarmorPubKeyBytes(armorStr string) (bz []byte, algo string, err error) {
 			header[headerType] = defaultAlgo
 		}
 		return bz, header[headerType], err
+	case "":
+		return nil, "", fmt.Errorf("header's version field is empty")
 	default:
 		err = fmt.Errorf("unrecognized version: %v", header[headerVersion])
 		return nil, "", err

--- a/crypto/keys/mintkey/mintkey_test.go
+++ b/crypto/keys/mintkey/mintkey_test.go
@@ -88,6 +88,11 @@ func TestArmorUnarmorPubKey(t *testing.T) {
 	require.Equal(t, "unknown", algo)
 	require.True(t, pub.Equals(info.GetPubKey()))
 
+	armored, err = cstore.ExportPrivKey("Bob", "passphrase", "alessio")
+	require.NoError(t, err)
+	_, _, err = mintkey.UnarmorPubKeyBytes(armored)
+	require.Equal(t, `couldn't unarmor bytes: unrecognized armor type "TENDERMINT PRIVATE KEY", expected: "TENDERMINT PUBLIC KEY"`, err.Error())
+
 	// armor pubkey manually
 	header := map[string]string{
 		"version": "0.0.0",
@@ -108,7 +113,19 @@ func TestArmorUnarmorPubKey(t *testing.T) {
 	require.Nil(t, bz)
 	require.Empty(t, algo)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "unrecognized version")
+	require.Equal(t, "header's version field is empty", err.Error())
+
+	// unknown version header
+	header = map[string]string{
+		"type":    "unknown",
+		"version": "unknown",
+	}
+	armored = armor.EncodeArmor("TENDERMINT PUBLIC KEY", header, pubBytes)
+	bz, algo, err = mintkey.UnarmorPubKeyBytes(armored)
+	require.Nil(t, bz)
+	require.Empty(t, algo)
+	require.Error(t, err)
+	require.Equal(t, "unrecognized version: unknown", err.Error())
 }
 
 func TestArmorInfoBytes(t *testing.T) {


### PR DESCRIPTION
Check error returned by internal call to unarmorBytes()
and handle accordingly.

Handle empty version field adequately.

______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added  relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

______

For admin use:

- [ ] Added appropriate labels to PR (ex. `WIP`, `R4R`, `docs`, etc)
- [ ] Reviewers assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
