### PR TITLE
crypto/keys: remove DecodeSignature from baseKeybase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ are now replaced by human-readable expressions. This change can potentially brea
 that parse log messages.
 * (client) [\#5799](https://github.com/cosmos/cosmos-sdk/pull/5799) The `tx encode/decode` commands, due to change on encoding break compatibility with
 older clients.
+* (x/auth) [\#5844](https://github.com/cosmos/cosmos-sdk/pull/5844) `tx sign` command now returns an error when signing is attempted with offline/multisig keys.
 
 ### API Breaking Changes
 
@@ -87,6 +88,8 @@ resulted in a panic when the tx execution mode was `CheckTx`.
 * (modules) [\#5569](https://github.com/cosmos/cosmos-sdk/issues/5569) `InitGenesis`, for the relevant modules, now ensures module accounts exist.
 * (crypto/keys/mintkey) [\#5823](https://github.com/cosmos/cosmos-sdk/pull/5823) fix errors handling in UnarmorPubKeyBytes (underlying armoring function's
 return error was not being checked).
+* (crypto/keys) [\#5844](https://github.com/cosmos/cosmos-sdk/pull/5844) Keybase/Keyring `Sign()` methods no longer decode amino signatures
+when method receivers are offline/multisig keys.
 
 ### State Machine Breaking
 

--- a/crypto/keys/keybase.go
+++ b/crypto/keys/keybase.go
@@ -215,7 +215,7 @@ func (kb dbKeybase) Sign(name, passphrase string, msg []byte) (sig []byte, pub t
 		return SignWithLedger(info, msg)
 
 	case offlineInfo, multiInfo:
-		return kb.base.DecodeSignature(info, msg)
+		return nil, info.GetPubKey(), errors.New("cannot sign with offline keys")
 	}
 
 	sig, err = priv.Sign(msg)

--- a/crypto/keys/keybase_base.go
+++ b/crypto/keys/keybase_base.go
@@ -1,10 +1,6 @@
 package keys
 
 import (
-	"bufio"
-	"fmt"
-	"os"
-
 	"github.com/cosmos/go-bip39"
 	"github.com/pkg/errors"
 	tmcrypto "github.com/tendermint/tendermint/crypto"
@@ -102,33 +98,6 @@ func SecpPrivKeyGen(bz []byte) tmcrypto.PrivKey {
 	var bzArr [32]byte
 	copy(bzArr[:], bz)
 	return secp256k1.PrivKeySecp256k1(bzArr)
-}
-
-// DecodeSignature decodes a an length-prefixed binary signature from standard input
-// and return it as a byte slice.
-func (kb baseKeybase) DecodeSignature(info Info, msg []byte) (sig []byte, pub tmcrypto.PubKey, err error) {
-	_, err = fmt.Fprintf(os.Stderr, "Message to sign:\n\n%s\n", msg)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	buf := bufio.NewReader(os.Stdin)
-	_, err = fmt.Fprintf(os.Stderr, "\nEnter Amino-encoded signature:\n")
-	if err != nil {
-		return nil, nil, err
-	}
-
-	// will block until user inputs the signature
-	signed, err := buf.ReadString('\n')
-	if err != nil {
-		return nil, nil, err
-	}
-
-	if err := CryptoCdc.UnmarshalBinaryLengthPrefixed([]byte(signed), sig); err != nil {
-		return nil, nil, errors.Wrap(err, "failed to decode signature")
-	}
-
-	return sig, info.GetPubKey(), nil
 }
 
 // CreateAccount creates an account Info object.

--- a/crypto/keys/keybase_test.go
+++ b/crypto/keys/keybase_test.go
@@ -2,9 +2,7 @@
 package keys
 
 import (
-	"errors"
 	"fmt"
-	"io"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -280,7 +278,8 @@ func TestSignVerify(t *testing.T) {
 
 	// Now try to sign data with a secret-less key
 	_, _, err = cstore.Sign(n3, p3, d3)
-	require.True(t, errors.Is(io.EOF, err))
+	require.Error(t, err)
+	require.Equal(t, "cannot sign with offline keys", err.Error())
 }
 
 func assertPassword(t *testing.T, cstore Keybase, name, pass, badpass string) {

--- a/crypto/keys/keyring.go
+++ b/crypto/keys/keyring.go
@@ -219,7 +219,7 @@ func (kb keyringKeybase) Sign(name, passphrase string, msg []byte) (sig []byte, 
 		return SignWithLedger(info, msg)
 
 	case offlineInfo, multiInfo:
-		return kb.base.DecodeSignature(info, msg)
+		return nil, info.GetPubKey(), errors.New("cannot sign with offline keys")
 	}
 
 	sig, err = priv.Sign(msg)

--- a/crypto/keys/keyring_test.go
+++ b/crypto/keys/keyring_test.go
@@ -208,7 +208,8 @@ func TestLazySignVerifyKeyRing(t *testing.T) {
 
 	// Now try to sign data with a secret-less key
 	_, _, err = kb.Sign(n3, p3, d3)
-	require.NotNil(t, err)
+	require.Error(t, err)
+	require.Equal(t, "cannot sign with offline keys", err.Error())
 }
 
 func TestLazyExportImportKeyRing(t *testing.T) {


### PR DESCRIPTION
Keybase implementations should return errors when
signature generation is attempted with offline/multisig
keys since theyr lack private keys.

This is a change in Keyring/Keybase.Sign() methods
semantics that have been broken for long time.

______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added  relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

______

For admin use:

- [ ] Added appropriate labels to PR (ex. `WIP`, `R4R`, `docs`, etc)
- [ ] Reviewers assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
