### PR TITLE
x/auth/client/cli: tx sign should support downloading files from HTTP(s)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -179,6 +179,7 @@ be executed without an internet connection. Previously, `--generate-only` served
 txs to be generated. Now, `--generate-only` solely allows txs to be generated without being broadcasted and disallows
 Keybase use and `--offline` allows the use of Keybase but does not allow any functionality that requires an online connection.
 * (types/module) [\#5724](https://github.com/cosmos/cosmos-sdk/issues/5724) The `types/module` package does no longer depend on `x/simulation`.
+* (x/auth) [\#5863](https://github.com/cosmos/cosmos-sdk/pull/5863) `tx sign` supports downloading unsigned Tx files via HTTP(s).
 
 ## [v0.38.1] - 2020-02-11
 

--- a/x/auth/client/cli/tx_sign.go
+++ b/x/auth/client/cli/tx_sign.go
@@ -29,7 +29,7 @@ const (
 // GetSignCommand returns the transaction sign command.
 func GetSignCommand(codec *codec.Codec) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "sign [file]",
+		Use:   "sign [file_or_URL]",
 		Short: "Sign transactions generated offline",
 		Long: `Sign transactions created with the --generate-only flag.
 It will read a transaction from [file], sign it, and print its JSON encoding.
@@ -88,7 +88,7 @@ func preSignCmd(cmd *cobra.Command, _ []string) {
 
 func makeSignCmd(cdc *codec.Codec) func(cmd *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, args []string) error {
-		stdTx, err := client.ReadStdTxFromFile(cdc, args[0])
+		stdTx, err := client.ReadStdTxFromURI(cdc, args[0])
 		if err != nil {
 			return err
 		}

--- a/x/auth/client/tx.go
+++ b/x/auth/client/tx.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
@@ -236,7 +237,10 @@ func ReadStdTxFromURI(cdc *codec.Codec, uri string) (authtypes.StdTx, error) {
 		return ReadStdTxFromFile(cdc, uri)
 	}
 
-	resp, err := http.Get(uri)
+	httpclient := http.Client{
+		Timeout: time.Second * 10, // should be reasonable
+	}
+	resp, err := httpclient.Get(uri)
 	if err != nil {
 		return authtypes.StdTx{}, err
 	}


### PR DESCRIPTION
Make tx sign download unsigned Txs via HTTP(s).

Ref: #5661 

______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added  relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

______

For admin use:

- [ ] Added appropriate labels to PR (ex. `WIP`, `R4R`, `docs`, etc)
- [ ] Reviewers assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
