### PR TITLE
types/errors: rename Wrap{,f} -> Extend{,f}

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ that parse log messages.
 * (client) [\#5799](https://github.com/cosmos/cosmos-sdk/pull/5799) The `tx encode/decode` commands, due to change on encoding break compatibility with
 older clients.
 * (x/auth) [\#5844](https://github.com/cosmos/cosmos-sdk/pull/5844) `tx sign` command now returns an error when signing is attempted with offline/multisig keys.
+* (types/errors) [\#5876](https://github.com/cosmos/cosmos-sdk/pull/5876) rename Wrap{,f} to Extend{,f}.
 
 ### API Breaking Changes
 

--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -389,7 +389,7 @@ func (app *BaseApp) validateHeight(req abci.RequestBeginBlock) error {
 // validateBasicTxMsgs executes basic validator calls for messages.
 func validateBasicTxMsgs(msgs []sdk.Msg) error {
 	if len(msgs) == 0 {
-		return sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "must contain at least one message")
+		return sdkerrors.Extend(sdkerrors.ErrInvalidRequest, "must contain at least one message")
 	}
 
 	for _, msg := range msgs {
@@ -467,7 +467,7 @@ func (app *BaseApp) runTx(mode runTxMode, txBytes []byte, tx sdk.Tx) (gInfo sdk.
 	// only run the tx if there is block gas remaining
 	if mode == runTxModeDeliver && ctx.BlockGasMeter().IsOutOfGas() {
 		gInfo = sdk.GasInfo{GasUsed: ctx.BlockGasMeter().GasConsumed()}
-		return gInfo, nil, sdkerrors.Wrap(sdkerrors.ErrOutOfGas, "no block gas left to run tx")
+		return gInfo, nil, sdkerrors.Extend(sdkerrors.ErrOutOfGas, "no block gas left to run tx")
 	}
 
 	var startingGas uint64
@@ -481,7 +481,7 @@ func (app *BaseApp) runTx(mode runTxMode, txBytes []byte, tx sdk.Tx) (gInfo sdk.
 			// TODO: Use ErrOutOfGas instead of ErrorOutOfGas which would allow us
 			// to keep the stracktrace.
 			case sdk.ErrorOutOfGas:
-				err = sdkerrors.Wrap(
+				err = sdkerrors.Extend(
 					sdkerrors.ErrOutOfGas, fmt.Sprintf(
 						"out of gas in location: %v; gasWanted: %d, gasUsed: %d",
 						rType.Descriptor, gasWanted, ctx.GasMeter().GasConsumed(),
@@ -489,7 +489,7 @@ func (app *BaseApp) runTx(mode runTxMode, txBytes []byte, tx sdk.Tx) (gInfo sdk.
 				)
 
 			default:
-				err = sdkerrors.Wrap(
+				err = sdkerrors.Extend(
 					sdkerrors.ErrPanic, fmt.Sprintf(
 						"recovered: %v\nstack:\n%v", r, string(debug.Stack()),
 					),
@@ -595,12 +595,12 @@ func (app *BaseApp) runMsgs(ctx sdk.Context, msgs []sdk.Msg, mode runTxMode) (*s
 		msgRoute := msg.Route()
 		handler := app.router.Route(ctx, msgRoute)
 		if handler == nil {
-			return nil, sdkerrors.Wrapf(sdkerrors.ErrUnknownRequest, "unrecognized message route: %s; message index: %d", msgRoute, i)
+			return nil, sdkerrors.Extendf(sdkerrors.ErrUnknownRequest, "unrecognized message route: %s; message index: %d", msgRoute, i)
 		}
 
 		msgResult, err := handler(ctx, msg)
 		if err != nil {
-			return nil, sdkerrors.Wrapf(err, "failed to execute message; message index: %d", i)
+			return nil, sdkerrors.Extendf(err, "failed to execute message; message index: %d", i)
 		}
 
 		msgEvents := sdk.Events{

--- a/baseapp/baseapp_test.go
+++ b/baseapp/baseapp_test.go
@@ -576,7 +576,7 @@ func (msg msgCounter) ValidateBasic() error {
 	if msg.Counter >= 0 {
 		return nil
 	}
-	return sdkerrors.Wrap(sdkerrors.ErrInvalidSequence, "counter should be a non-negative integer")
+	return sdkerrors.Extend(sdkerrors.ErrInvalidSequence, "counter should be a non-negative integer")
 }
 
 func newTxCounter(counter int64, msgCounters ...int64) *txTest {
@@ -616,7 +616,7 @@ func (msg msgCounter2) ValidateBasic() error {
 	if msg.Counter >= 0 {
 		return nil
 	}
-	return sdkerrors.Wrap(sdkerrors.ErrInvalidSequence, "counter should be a non-negative integer")
+	return sdkerrors.Extend(sdkerrors.ErrInvalidSequence, "counter should be a non-negative integer")
 }
 
 // amino decode
@@ -624,7 +624,7 @@ func testTxDecoder(cdc *codec.Codec) sdk.TxDecoder {
 	return func(txBytes []byte) (sdk.Tx, error) {
 		var tx txTest
 		if len(txBytes) == 0 {
-			return nil, sdkerrors.Wrap(sdkerrors.ErrTxDecode, "tx bytes are empty")
+			return nil, sdkerrors.Extend(sdkerrors.ErrTxDecode, "tx bytes are empty")
 		}
 
 		err := cdc.UnmarshalBinaryBare(txBytes, &tx)
@@ -642,7 +642,7 @@ func anteHandlerTxTest(t *testing.T, capKey sdk.StoreKey, storeKey []byte) sdk.A
 		txTest := tx.(txTest)
 
 		if txTest.FailOnAnte {
-			return newCtx, sdkerrors.Wrap(sdkerrors.ErrUnauthorized, "ante handler failure")
+			return newCtx, sdkerrors.Extend(sdkerrors.ErrUnauthorized, "ante handler failure")
 		}
 
 		_, err = incrementingCounter(t, store, storeKey, txTest.Counter)
@@ -662,7 +662,7 @@ func handlerMsgCounter(t *testing.T, capKey sdk.StoreKey, deliverKey []byte) sdk
 		switch m := msg.(type) {
 		case *msgCounter:
 			if m.FailOnHandler {
-				return nil, sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "message handler failure")
+				return nil, sdkerrors.Extend(sdkerrors.ErrInvalidRequest, "message handler failure")
 			}
 
 			msgCount = m.Counter
@@ -1066,7 +1066,7 @@ func TestTxGasLimits(t *testing.T) {
 				if r := recover(); r != nil {
 					switch rType := r.(type) {
 					case sdk.ErrorOutOfGas:
-						err = sdkerrors.Wrapf(sdkerrors.ErrOutOfGas, "out of gas in location: %v", rType.Descriptor)
+						err = sdkerrors.Extendf(sdkerrors.ErrOutOfGas, "out of gas in location: %v", rType.Descriptor)
 					default:
 						panic(r)
 					}
@@ -1150,7 +1150,7 @@ func TestMaxBlockGasLimits(t *testing.T) {
 				if r := recover(); r != nil {
 					switch rType := r.(type) {
 					case sdk.ErrorOutOfGas:
-						err = sdkerrors.Wrapf(sdkerrors.ErrOutOfGas, "out of gas in location: %v", rType.Descriptor)
+						err = sdkerrors.Extendf(sdkerrors.ErrOutOfGas, "out of gas in location: %v", rType.Descriptor)
 					default:
 						panic(r)
 					}
@@ -1321,7 +1321,7 @@ func TestGasConsumptionBadTx(t *testing.T) {
 					switch rType := r.(type) {
 					case sdk.ErrorOutOfGas:
 						log := fmt.Sprintf("out of gas in location: %v", rType.Descriptor)
-						err = sdkerrors.Wrap(sdkerrors.ErrOutOfGas, log)
+						err = sdkerrors.Extend(sdkerrors.ErrOutOfGas, log)
 					default:
 						panic(r)
 					}
@@ -1331,7 +1331,7 @@ func TestGasConsumptionBadTx(t *testing.T) {
 			txTest := tx.(txTest)
 			newCtx.GasMeter().ConsumeGas(uint64(txTest.Counter), "counter-ante")
 			if txTest.FailOnAnte {
-				return newCtx, sdkerrors.Wrap(sdkerrors.ErrUnauthorized, "ante handler failure")
+				return newCtx, sdkerrors.Extend(sdkerrors.ErrUnauthorized, "ante handler failure")
 			}
 
 			return

--- a/codec/std/msgs.go
+++ b/codec/std/msgs.go
@@ -33,7 +33,7 @@ func (msg MsgSubmitEvidence) ValidateBasic() error {
 		return nil
 	}
 	if msg.Evidence == nil {
-		return sdkerrors.Wrap(evidence.ErrInvalidEvidence, "missing evidence")
+		return sdkerrors.Extend(evidence.ErrInvalidEvidence, "missing evidence")
 	}
 	if err := msg.Evidence.GetEvidence().ValidateBasic(); err != nil {
 		return err
@@ -66,10 +66,10 @@ func (msg MsgSubmitProposal) ValidateBasic() error {
 		return nil
 	}
 	if msg.Content == nil {
-		return sdkerrors.Wrap(gov.ErrInvalidProposalContent, "missing content")
+		return sdkerrors.Extend(gov.ErrInvalidProposalContent, "missing content")
 	}
 	if !gov.IsValidProposalType(msg.Content.GetContent().ProposalType()) {
-		return sdkerrors.Wrap(gov.ErrInvalidProposalType, msg.Content.GetContent().ProposalType())
+		return sdkerrors.Extend(gov.ErrInvalidProposalType, msg.Content.GetContent().ProposalType())
 	}
 	if err := msg.Content.GetContent().ValidateBasic(); err != nil {
 		return err

--- a/codec/std/tx.go
+++ b/codec/std/tx.go
@@ -71,12 +71,12 @@ func (tx Transaction) ValidateBasic() error {
 	stdSigs := tx.GetSignatures()
 
 	if tx.Fee.Gas > auth.MaxGasWanted {
-		return sdkerrors.Wrapf(
+		return sdkerrors.Extendf(
 			sdkerrors.ErrInvalidRequest, "invalid gas supplied; %d > %d", tx.Fee.Gas, auth.MaxGasWanted,
 		)
 	}
 	if tx.Fee.Amount.IsAnyNegative() {
-		return sdkerrors.Wrapf(
+		return sdkerrors.Extendf(
 			sdkerrors.ErrInsufficientFee, "invalid fee provided: %s", tx.Fee.Amount,
 		)
 	}
@@ -84,7 +84,7 @@ func (tx Transaction) ValidateBasic() error {
 		return sdkerrors.ErrNoSignatures
 	}
 	if len(stdSigs) != len(tx.GetSigners()) {
-		return sdkerrors.Wrapf(
+		return sdkerrors.Extendf(
 			sdkerrors.ErrUnauthorized, "wrong number of signers; expected %d, got %d", tx.GetSigners(), len(stdSigs),
 		)
 	}

--- a/crypto/armor.go
+++ b/crypto/armor.go
@@ -138,7 +138,7 @@ func encryptPrivKey(privKey crypto.PrivKey, passphrase string) (saltBytes []byte
 	saltBytes = crypto.CRandBytes(16)
 	key, err := bcrypt.GenerateFromPassword(saltBytes, []byte(passphrase), BcryptSecurityParameter)
 	if err != nil {
-		panic(sdkerrors.Wrap(err, "error generating bcrypt key from passphrase"))
+		panic(sdkerrors.Extend(err, "error generating bcrypt key from passphrase"))
 	}
 	key = crypto.Sha256(key) // get 32 bytes
 	privKeyBytes := privKey.Bytes()
@@ -175,7 +175,7 @@ func UnarmorDecryptPrivKey(armorStr string, passphrase string) (privKey crypto.P
 func decryptPrivKey(saltBytes []byte, encBytes []byte, passphrase string) (privKey crypto.PrivKey, err error) {
 	key, err := bcrypt.GenerateFromPassword(saltBytes, []byte(passphrase), BcryptSecurityParameter)
 	if err != nil {
-		return privKey, sdkerrors.Wrap(err, "error generating bcrypt key from passphrase")
+		return privKey, sdkerrors.Extend(err, "error generating bcrypt key from passphrase")
 	}
 	key = crypto.Sha256(key) // Get 32 bytes
 	privKeyBytes, err := xsalsa20symmetric.DecryptSymmetric(encBytes, key)

--- a/crypto/keyring/db_keybase.go
+++ b/crypto/keyring/db_keybase.go
@@ -117,7 +117,7 @@ func (kb dbKeybase) Get(name string) (Info, error) {
 	}
 
 	if len(bs) == 0 {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrKeyNotFound, name)
+		return nil, sdkerrors.Extend(sdkerrors.ErrKeyNotFound, name)
 	}
 
 	return unmarshalInfo(bs)

--- a/crypto/keyring/keyring.go
+++ b/crypto/keyring/keyring.go
@@ -145,7 +145,7 @@ func (kb keyringKeybase) List() ([]Info, error) {
 			}
 
 			if len(rawInfo.Data) == 0 {
-				return nil, sdkerrors.Wrap(sdkerrors.ErrKeyNotFound, key)
+				return nil, sdkerrors.Extend(sdkerrors.ErrKeyNotFound, key)
 			}
 
 			info, err := unmarshalInfo(rawInfo.Data)
@@ -170,7 +170,7 @@ func (kb keyringKeybase) Get(name string) (Info, error) {
 	}
 
 	if len(bs.Data) == 0 {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrKeyNotFound, name)
+		return nil, sdkerrors.Extend(sdkerrors.ErrKeyNotFound, name)
 	}
 
 	return unmarshalInfo(bs.Data)

--- a/docs/building-modules/errors.md
+++ b/docs/building-modules/errors.md
@@ -8,7 +8,7 @@ This document outlines the recommended usage and APIs for error handling in Cosm
 
 Modules are encouraged to define and register their own errors to provide better
 context on failed message or handler execution. Typically, these errors should be
-common or general errors which can be further wrapped to provide additional specific
+common or general errors which can be further extended to provide additional specific
 execution context.
 
 ## Registration
@@ -30,17 +30,17 @@ necessarily have to be. The only restrictions on error codes are the following:
 
 Note, the SDK provides a core set of *common* errors. These errors are defined in `types/errors/errors.go`.
 
-## Wrapping
+## Extending
 
 The custom module errors can be returned as their concrete type as they already fulfill the `error`
-interface. However, module errors can be wrapped to provide further context and meaning to failed
+interface. However, module errors can be extended to provide further context and meaning to failed
 execution.
 
 Example:
 
 +++ https://github.com/cosmos/cosmos-sdk/blob/v0.38.1/x/distribution/keeper/querier.go#L62-L80
 
-Regardless if an error is wrapped or not, the SDK's `errors` package provides an API to determine if
+Regardless if an error is extended or not, the SDK's `errors` package provides an API to determine if
 an error is of a particular kind via `Is`.
 
 ## ABCI

--- a/server/mock/tx.go
+++ b/server/mock/tx.go
@@ -69,7 +69,7 @@ func decodeTx(txBytes []byte) (sdk.Tx, error) {
 		k, v := split[0], split[1]
 		tx = kvstoreTx{k, v, txBytes}
 	} else {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrTxDecode, "too many '='")
+		return nil, sdkerrors.Extend(sdkerrors.ErrTxDecode, "too many '='")
 	}
 
 	return tx, nil

--- a/store/iavl/store.go
+++ b/store/iavl/store.go
@@ -256,7 +256,7 @@ func getHeight(tree Tree, req abci.RequestQuery) int64 {
 // explicitly set the height you want to see
 func (st *Store) Query(req abci.RequestQuery) (res abci.ResponseQuery) {
 	if len(req.Data) == 0 {
-		return sdkerrors.QueryResult(sdkerrors.Wrap(sdkerrors.ErrTxDecode, "query cannot be zero length"))
+		return sdkerrors.QueryResult(sdkerrors.Extend(sdkerrors.ErrTxDecode, "query cannot be zero length"))
 	}
 
 	tree := st.tree
@@ -315,7 +315,7 @@ func (st *Store) Query(req abci.RequestQuery) (res abci.ResponseQuery) {
 		res.Value = cdc.MustMarshalBinaryBare(KVs)
 
 	default:
-		return sdkerrors.QueryResult(sdkerrors.Wrapf(sdkerrors.ErrUnknownRequest, "unexpected query path: %v", req.Path))
+		return sdkerrors.QueryResult(sdkerrors.Extendf(sdkerrors.ErrUnknownRequest, "unexpected query path: %v", req.Path))
 	}
 
 	return res

--- a/store/rootmulti/store.go
+++ b/store/rootmulti/store.go
@@ -422,12 +422,12 @@ func (rs *Store) Query(req abci.RequestQuery) abci.ResponseQuery {
 
 	store := rs.getStoreByName(storeName)
 	if store == nil {
-		return sdkerrors.QueryResult(sdkerrors.Wrapf(sdkerrors.ErrUnknownRequest, "no such store: %s", storeName))
+		return sdkerrors.QueryResult(sdkerrors.Extendf(sdkerrors.ErrUnknownRequest, "no such store: %s", storeName))
 	}
 
 	queryable, ok := store.(types.Queryable)
 	if !ok {
-		return sdkerrors.QueryResult(sdkerrors.Wrapf(sdkerrors.ErrUnknownRequest, "store %s (type %T) doesn't support queries", storeName, store))
+		return sdkerrors.QueryResult(sdkerrors.Extendf(sdkerrors.ErrUnknownRequest, "store %s (type %T) doesn't support queries", storeName, store))
 	}
 
 	// trim the path and make the query
@@ -439,7 +439,7 @@ func (rs *Store) Query(req abci.RequestQuery) abci.ResponseQuery {
 	}
 
 	if res.Proof == nil || len(res.Proof.Ops) == 0 {
-		return sdkerrors.QueryResult(sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "proof is unexpectedly empty; ensure height has not been pruned"))
+		return sdkerrors.QueryResult(sdkerrors.Extend(sdkerrors.ErrInvalidRequest, "proof is unexpectedly empty; ensure height has not been pruned"))
 	}
 
 	// If the request's height is the latest height we've committed, then utilize
@@ -472,7 +472,7 @@ func (rs *Store) Query(req abci.RequestQuery) abci.ResponseQuery {
 // Returns error if it doesn't start with /
 func parsePath(path string) (storeName string, subpath string, err error) {
 	if !strings.HasPrefix(path, "/") {
-		return storeName, subpath, sdkerrors.Wrapf(sdkerrors.ErrUnknownRequest, "invalid path: %s", path)
+		return storeName, subpath, sdkerrors.Extendf(sdkerrors.ErrUnknownRequest, "invalid path: %s", path)
 	}
 
 	paths := strings.SplitN(path[1:], "/", 2)
@@ -508,7 +508,7 @@ func (rs *Store) loadCommitStoreFromParams(key types.StoreKey, id types.CommitID
 		}
 
 		if rs.interBlockCache != nil {
-			// Wrap and get a CommitKVStore with inter-block caching. Note, this should
+			// Extend and get a CommitKVStore with inter-block caching. Note, this should
 			// only wrap the primary CommitKVStore, not any store that is already
 			// cache-wrapped as that will create unexpected behavior.
 			store = rs.interBlockCache.GetStoreCache(key, store)

--- a/store/tracekv/store.go
+++ b/store/tracekv/store.go
@@ -187,11 +187,11 @@ func writeOperation(w io.Writer, op operation, tc types.TraceContext, key, value
 
 	raw, err := json.Marshal(traceOp)
 	if err != nil {
-		panic(errors.Wrap(err, "failed to serialize trace operation"))
+		panic(errors.Extend(err, "failed to serialize trace operation"))
 	}
 
 	if _, err := w.Write(raw); err != nil {
-		panic(errors.Wrap(err, "failed to write trace operation"))
+		panic(errors.Extend(err, "failed to write trace operation"))
 	}
 
 	io.WriteString(w, "\n")

--- a/types/errors/abci_test.go
+++ b/types/errors/abci_test.go
@@ -26,7 +26,7 @@ func TestABCInfo(t *testing.T) {
 			wantSpace: RootCodespace,
 		},
 		"wrapped SDK error": {
-			err:       Wrap(Wrap(ErrUnauthorized, "foo"), "bar"),
+			err:       Extend(Extend(ErrUnauthorized, "foo"), "bar"),
 			debug:     false,
 			wantLog:   "unauthorized: foo: bar",
 			wantCode:  ErrUnauthorized.code,
@@ -61,7 +61,7 @@ func TestABCInfo(t *testing.T) {
 			wantSpace: UndefinedCodespace,
 		},
 		"wrapped stdlib is only a generic message": {
-			err:       Wrap(io.EOF, "cannot read file"),
+			err:       Extend(io.EOF, "cannot read file"),
 			debug:     false,
 			wantLog:   "internal error",
 			wantCode:  1,
@@ -70,7 +70,7 @@ func TestABCInfo(t *testing.T) {
 		// This is hard to test because of attached stacktrace. This
 		// case is tested in an another test.
 		//"wrapped stdlib is a full message in debug mode": {
-		//	err:      Wrap(io.EOF, "cannot read file"),
+		//	err:      Extend(io.EOF, "cannot read file"),
 		//	debug:    true,
 		//	wantLog:  "cannot read file: EOF",
 		//	wantCode: 1,
@@ -116,25 +116,25 @@ func TestABCIInfoStacktrace(t *testing.T) {
 		wantErrMsg     string
 	}{
 		"wrapped SDK error in debug mode provides stacktrace": {
-			err:            Wrap(ErrUnauthorized, "wrapped"),
+			err:            Extend(ErrUnauthorized, "wrapped"),
 			debug:          true,
 			wantStacktrace: true,
 			wantErrMsg:     "unauthorized: wrapped",
 		},
 		"wrapped SDK error in non-debug mode does not have stacktrace": {
-			err:            Wrap(ErrUnauthorized, "wrapped"),
+			err:            Extend(ErrUnauthorized, "wrapped"),
 			debug:          false,
 			wantStacktrace: false,
 			wantErrMsg:     "unauthorized: wrapped",
 		},
 		"wrapped stdlib error in debug mode provides stacktrace": {
-			err:            Wrap(fmt.Errorf("stdlib"), "wrapped"),
+			err:            Extend(fmt.Errorf("stdlib"), "wrapped"),
 			debug:          true,
 			wantStacktrace: true,
 			wantErrMsg:     "stdlib: wrapped",
 		},
 		"wrapped stdlib error in non-debug mode does not have stacktrace": {
-			err:            Wrap(fmt.Errorf("stdlib"), "wrapped"),
+			err:            Extend(fmt.Errorf("stdlib"), "wrapped"),
 			debug:          false,
 			wantStacktrace: false,
 			wantErrMsg:     "internal error",
@@ -163,7 +163,7 @@ func TestABCIInfoStacktrace(t *testing.T) {
 }
 
 func TestABCIInfoHidesStacktrace(t *testing.T) {
-	err := Wrap(ErrUnauthorized, "wrapped")
+	err := Extend(ErrUnauthorized, "wrapped")
 	_, _, log := ABCIInfo(err, false)
 
 	if log != "unauthorized: wrapped" {
@@ -195,8 +195,8 @@ func TestRedact(t *testing.T) {
 func TestABCIInfoSerializeErr(t *testing.T) {
 	var (
 		// Create errors with stacktrace for equal comparison.
-		myErrDecode = Wrap(ErrTxDecode, "test")
-		myErrAddr   = Wrap(ErrInvalidAddress, "tester")
+		myErrDecode = Extend(ErrTxDecode, "test")
+		myErrAddr   = Extend(ErrInvalidAddress, "tester")
 		myPanic     = ErrPanic
 	)
 
@@ -251,7 +251,7 @@ func TestABCIInfoSerializeErr(t *testing.T) {
 		// `,
 		// 		},
 		// 		"wrapped multi error with redact": {
-		// 			src:   Wrap(Append(myPanic, myErrMsg), "wrap"),
+		// 			src:   Extend(Append(myPanic, myErrMsg), "wrap"),
 		// 			debug: false,
 		// 			exp:   "internal error",
 		// 		},

--- a/types/errors/doc.go
+++ b/types/errors/doc.go
@@ -14,11 +14,11 @@ function. You must provide a unique, non zero error code and a short description
   var ErrZeroDivision = errors.Register(9241, "zero division")
 
 When returning an error, you can attach to it an additional context
-information by using Wrap function, for example:
+information by using Extend function, for example:
 
    func safeDiv(val, div int) (int, err) {
 	   if div == 0 {
-		   return 0, errors.Wrapf(ErrZeroDivision, "cannot divide %d", val)
+		   return 0, errors.Extendf(ErrZeroDivision, "cannot divide %d", val)
 	   }
 	   return val / div, nil
    }

--- a/types/errors/errors.go
+++ b/types/errors/errors.go
@@ -138,11 +138,11 @@ func setUsed(err *Error) {
 // The server (abci app / blockchain) should only refer to registered errors
 func ABCIError(codespace string, code uint32, log string) error {
 	if e := getUsed(codespace, code); e != nil {
-		return Wrap(e, log)
+		return Extend(e, log)
 	}
 	// This is a unique error, will never match on .Is()
-	// Use Wrap here to get a stack trace
-	return Wrap(New(codespace, code, "unknown"), log)
+	// Use Extend here to get a stack trace
+	return Extend(New(codespace, code, "unknown"), log)
 }
 
 // Error represents a root error.
@@ -220,14 +220,14 @@ func isNilErr(err error) bool {
 	return reflect.ValueOf(err).IsNil()
 }
 
-// Wrap extends given error with an additional information.
+// Extend an error with additional information.
 //
-// If the wrapped error does not provide ABCICode method (ie. stdlib errors),
+// If the original error does not provide ABCICode method (ie. stdlib errors),
 // it will be labeled as internal error.
 //
 // If err is nil, this returns nil, avoiding the need for an if statement when
 // wrapping a error returned at the end of a function
-func Wrap(err error, description string) error {
+func Extend(err error, description string) error {
 	if err == nil {
 		return nil
 	}
@@ -245,13 +245,13 @@ func Wrap(err error, description string) error {
 	}
 }
 
-// Wrapf extends given error with an additional information.
+// Extendf extends an error with additional information.
 //
-// This function works like Wrap function with additional functionality of
+// This function works like Extend with additional functionality of
 // formatting the input as specified.
-func Wrapf(err error, format string, args ...interface{}) error {
+func Extendf(err error, format string, args ...interface{}) error {
 	desc := fmt.Sprintf(format, args...)
-	return Wrap(err, desc)
+	return Extend(err, desc)
 }
 
 type wrappedError struct {
@@ -302,13 +302,13 @@ func (e *wrappedError) Unwrap() error {
 // function using defer in order to work as expected.
 func Recover(err *error) {
 	if r := recover(); r != nil {
-		*err = Wrapf(ErrPanic, "%v", r)
+		*err = Extendf(ErrPanic, "%v", r)
 	}
 }
 
 // WithType is a helper to augment an error with a corresponding type message
 func WithType(err error, obj interface{}) error {
-	return Wrap(err, fmt.Sprintf("%T", obj))
+	return Extend(err, fmt.Sprintf("%T", obj))
 }
 
 // causer is an interface implemented by an error that supports wrapping. Use

--- a/types/errors/stacktrace.go
+++ b/types/errors/stacktrace.go
@@ -48,8 +48,8 @@ func trimInternal(st errors.StackTrace) errors.StackTrace {
 	// manual error creation, or runtime for caught panics
 	for matchesFunc(st[0],
 		// where we create errors
-		"github.com/cosmos/cosmos-sdk/types/errors.Wrap",
-		"github.com/cosmos/cosmos-sdk/types/errors.Wrapf",
+		"github.com/cosmos/cosmos-sdk/types/errors.Extend",
+		"github.com/cosmos/cosmos-sdk/types/errors.Extendf",
 		"github.com/cosmos/cosmos-sdk/types/errors.WithType",
 		// runtime are added on panics
 		"runtime.",

--- a/types/errors/stacktrace_test.go
+++ b/types/errors/stacktrace_test.go
@@ -14,27 +14,27 @@ func TestStackTrace(t *testing.T) {
 		wantError string
 	}{
 		"New gives us a stacktrace": {
-			err:       Wrap(ErrNoSignatures, "name"),
+			err:       Extend(ErrNoSignatures, "name"),
 			wantError: "no signatures supplied: name",
 		},
 		"Wrapping stderr gives us a stacktrace": {
-			err:       Wrap(fmt.Errorf("foo"), "standard"),
+			err:       Extend(fmt.Errorf("foo"), "standard"),
 			wantError: "foo: standard",
 		},
 		"Wrapping pkg/errors gives us clean stacktrace": {
-			err:       Wrap(errors.New("bar"), "pkg"),
+			err:       Extend(errors.New("bar"), "pkg"),
 			wantError: "bar: pkg",
 		},
 		"Wrapping inside another function is still clean": {
-			err:       Wrap(fmt.Errorf("indirect"), "do the do"),
+			err:       Extend(fmt.Errorf("indirect"), "do the do"),
 			wantError: "indirect: do the do",
 		},
 	}
 
 	// Wrapping code is unwanted in the errors stack trace.
 	unwantedSrc := []string{
-		"github.com/cosmos/cosmos-sdk/types/errors.Wrap\n",
-		"github.com/cosmos/cosmos-sdk/types/errors.Wrapf\n",
+		"github.com/cosmos/cosmos-sdk/types/errors.Extend\n",
+		"github.com/cosmos/cosmos-sdk/types/errors.Extendf\n",
 		"runtime.goexit\n",
 	}
 	const thisTestSrc = "types/errors/stacktrace_test.go"
@@ -74,7 +74,7 @@ func TestStackTrace(t *testing.T) {
 				t.Fatal("only one stack line is expected")
 			}
 			// contains a link to where it was created, which must
-			// be here, not the Wrap() function
+			// be here, not the Extend() function
 			if !strings.Contains(tinyStack, thisTestSrc) {
 				t.Fatalf("this file missing in stack info:\n %s", tinyStack)
 			}

--- a/x/auth/ante/ante_test.go
+++ b/x/auth/ante/ante_test.go
@@ -709,7 +709,7 @@ func TestCustomSignatureVerificationGasConsumer(t *testing.T) {
 			meter.ConsumeGas(params.SigVerifyCostED25519, "ante verify: ed25519")
 			return nil
 		default:
-			return sdkerrors.Wrapf(sdkerrors.ErrInvalidPubKey, "unrecognized public key type: %T", pubkey)
+			return sdkerrors.Extendf(sdkerrors.ErrInvalidPubKey, "unrecognized public key type: %T", pubkey)
 		}
 	})
 

--- a/x/auth/ante/basic.go
+++ b/x/auth/ante/basic.go
@@ -60,14 +60,14 @@ func NewValidateMemoDecorator(ak keeper.AccountKeeper) ValidateMemoDecorator {
 func (vmd ValidateMemoDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (sdk.Context, error) {
 	memoTx, ok := tx.(TxWithMemo)
 	if !ok {
-		return ctx, sdkerrors.Wrap(sdkerrors.ErrTxDecode, "invalid transaction type")
+		return ctx, sdkerrors.Extend(sdkerrors.ErrTxDecode, "invalid transaction type")
 	}
 
 	params := vmd.ak.GetParams(ctx)
 
 	memoLength := len(memoTx.GetMemo())
 	if uint64(memoLength) > params.MaxMemoCharacters {
-		return ctx, sdkerrors.Wrapf(sdkerrors.ErrMemoTooLarge,
+		return ctx, sdkerrors.Extendf(sdkerrors.ErrMemoTooLarge,
 			"maximum number of characters is %d but received %d characters",
 			params.MaxMemoCharacters, memoLength,
 		)
@@ -98,7 +98,7 @@ func NewConsumeGasForTxSizeDecorator(ak keeper.AccountKeeper) ConsumeTxSizeGasDe
 func (cgts ConsumeTxSizeGasDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (sdk.Context, error) {
 	sigTx, ok := tx.(SigVerifiableTx)
 	if !ok {
-		return ctx, sdkerrors.Wrap(sdkerrors.ErrTxDecode, "invalid tx type")
+		return ctx, sdkerrors.Extend(sdkerrors.ErrTxDecode, "invalid tx type")
 	}
 	params := cgts.ak.GetParams(ctx)
 	ctx.GasMeter().ConsumeGas(params.TxSizeCostPerByte*sdk.Gas(len(ctx.TxBytes())), "txSize")

--- a/x/auth/ante/setup.go
+++ b/x/auth/ante/setup.go
@@ -36,7 +36,7 @@ func (sud SetUpContextDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate
 		// Set a gas meter with limit 0 as to prevent an infinite gas meter attack
 		// during runTx.
 		newCtx = SetGasMeter(simulate, ctx, 0)
-		return newCtx, sdkerrors.Wrap(sdkerrors.ErrTxDecode, "Tx must be GasTx")
+		return newCtx, sdkerrors.Extend(sdkerrors.ErrTxDecode, "Tx must be GasTx")
 	}
 
 	newCtx = SetGasMeter(simulate, ctx, gasTx.GetGas())
@@ -54,7 +54,7 @@ func (sud SetUpContextDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate
 					"out of gas in location: %v; gasWanted: %d, gasUsed: %d",
 					rType.Descriptor, gasTx.GetGas(), newCtx.GasMeter().GasConsumed())
 
-				err = sdkerrors.Wrap(sdkerrors.ErrOutOfGas, log)
+				err = sdkerrors.Extend(sdkerrors.ErrOutOfGas, log)
 			default:
 				panic(r)
 			}

--- a/x/auth/keeper/keeper.go
+++ b/x/auth/keeper/keeper.go
@@ -48,7 +48,7 @@ func (ak AccountKeeper) Logger(ctx sdk.Context) log.Logger {
 func (ak AccountKeeper) GetPubKey(ctx sdk.Context, addr sdk.AccAddress) (crypto.PubKey, error) {
 	acc := ak.GetAccount(ctx, addr)
 	if acc == nil {
-		return nil, sdkerrors.Wrapf(sdkerrors.ErrUnknownAddress, "account %s does not exist", addr)
+		return nil, sdkerrors.Extendf(sdkerrors.ErrUnknownAddress, "account %s does not exist", addr)
 	}
 
 	return acc.GetPubKey(), nil
@@ -58,7 +58,7 @@ func (ak AccountKeeper) GetPubKey(ctx sdk.Context, addr sdk.AccAddress) (crypto.
 func (ak AccountKeeper) GetSequence(ctx sdk.Context, addr sdk.AccAddress) (uint64, error) {
 	acc := ak.GetAccount(ctx, addr)
 	if acc == nil {
-		return 0, sdkerrors.Wrapf(sdkerrors.ErrUnknownAddress, "account %s does not exist", addr)
+		return 0, sdkerrors.Extendf(sdkerrors.ErrUnknownAddress, "account %s does not exist", addr)
 	}
 
 	return acc.GetSequence(), nil

--- a/x/auth/keeper/querier.go
+++ b/x/auth/keeper/querier.go
@@ -20,7 +20,7 @@ func NewQuerier(k AccountKeeper) sdk.Querier {
 			return queryParams(ctx, k)
 
 		default:
-			return nil, sdkerrors.Wrapf(sdkerrors.ErrUnknownRequest, "unknown query path: %s", path[0])
+			return nil, sdkerrors.Extendf(sdkerrors.ErrUnknownRequest, "unknown query path: %s", path[0])
 		}
 	}
 }
@@ -28,17 +28,17 @@ func NewQuerier(k AccountKeeper) sdk.Querier {
 func queryAccount(ctx sdk.Context, req abci.RequestQuery, k AccountKeeper) ([]byte, error) {
 	var params types.QueryAccountParams
 	if err := k.cdc.UnmarshalJSON(req.Data, &params); err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONUnmarshal, err.Error())
+		return nil, sdkerrors.Extend(sdkerrors.ErrJSONUnmarshal, err.Error())
 	}
 
 	account := k.GetAccount(ctx, params.Address)
 	if account == nil {
-		return nil, sdkerrors.Wrapf(sdkerrors.ErrUnknownAddress, "account %s does not exist", params.Address)
+		return nil, sdkerrors.Extendf(sdkerrors.ErrUnknownAddress, "account %s does not exist", params.Address)
 	}
 
 	bz, err := codec.MarshalJSONIndent(k.cdc, account)
 	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
+		return nil, sdkerrors.Extend(sdkerrors.ErrJSONMarshal, err.Error())
 	}
 
 	return bz, nil
@@ -49,7 +49,7 @@ func queryParams(ctx sdk.Context, k AccountKeeper) ([]byte, error) {
 
 	res, err := codec.MarshalJSONIndent(k.cdc, params)
 	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
+		return nil, sdkerrors.Extend(sdkerrors.ErrJSONMarshal, err.Error())
 	}
 
 	return res, nil

--- a/x/auth/types/stdtx.go
+++ b/x/auth/types/stdtx.go
@@ -178,13 +178,13 @@ func (tx StdTx) ValidateBasic() error {
 	stdSigs := tx.GetSignatures()
 
 	if tx.Fee.Gas > MaxGasWanted {
-		return sdkerrors.Wrapf(
+		return sdkerrors.Extendf(
 			sdkerrors.ErrInvalidRequest,
 			"invalid gas supplied; %d > %d", tx.Fee.Gas, MaxGasWanted,
 		)
 	}
 	if tx.Fee.Amount.IsAnyNegative() {
-		return sdkerrors.Wrapf(
+		return sdkerrors.Extendf(
 			sdkerrors.ErrInsufficientFee,
 			"invalid fee provided: %s", tx.Fee.Amount,
 		)
@@ -193,7 +193,7 @@ func (tx StdTx) ValidateBasic() error {
 		return sdkerrors.ErrNoSignatures
 	}
 	if len(stdSigs) != len(tx.GetSigners()) {
-		return sdkerrors.Wrapf(
+		return sdkerrors.Extendf(
 			sdkerrors.ErrUnauthorized,
 			"wrong number of signers; expected %d, got %d", tx.GetSigners(), len(stdSigs),
 		)
@@ -326,14 +326,14 @@ func DefaultTxDecoder(cdc *codec.Codec) sdk.TxDecoder {
 		var tx = StdTx{}
 
 		if len(txBytes) == 0 {
-			return nil, sdkerrors.Wrap(sdkerrors.ErrTxDecode, "tx bytes are empty")
+			return nil, sdkerrors.Extend(sdkerrors.ErrTxDecode, "tx bytes are empty")
 		}
 
 		// StdTx.Msg is an interface. The concrete types
 		// are registered by MakeTxCodec
 		err := cdc.UnmarshalBinaryBare(txBytes, &tx)
 		if err != nil {
-			return nil, sdkerrors.Wrap(sdkerrors.ErrTxDecode, err.Error())
+			return nil, sdkerrors.Extend(sdkerrors.ErrTxDecode, err.Error())
 		}
 
 		return tx, nil

--- a/x/bank/handler.go
+++ b/x/bank/handler.go
@@ -20,7 +20,7 @@ func NewHandler(k keeper.Keeper) sdk.Handler {
 			return handleMsgMultiSend(ctx, k, msg)
 
 		default:
-			return nil, sdkerrors.Wrapf(sdkerrors.ErrUnknownRequest, "unrecognized bank message type: %T", msg)
+			return nil, sdkerrors.Extendf(sdkerrors.ErrUnknownRequest, "unrecognized bank message type: %T", msg)
 		}
 	}
 }
@@ -32,7 +32,7 @@ func handleMsgSend(ctx sdk.Context, k keeper.Keeper, msg types.MsgSend) (*sdk.Re
 	}
 
 	if k.BlacklistedAddr(msg.ToAddress) {
-		return nil, sdkerrors.Wrapf(sdkerrors.ErrUnauthorized, "%s is not allowed to receive transactions", msg.ToAddress)
+		return nil, sdkerrors.Extendf(sdkerrors.ErrUnauthorized, "%s is not allowed to receive transactions", msg.ToAddress)
 	}
 
 	err := k.SendCoins(ctx, msg.FromAddress, msg.ToAddress, msg.Amount)
@@ -59,7 +59,7 @@ func handleMsgMultiSend(ctx sdk.Context, k keeper.Keeper, msg types.MsgMultiSend
 
 	for _, out := range msg.Outputs {
 		if k.BlacklistedAddr(out.Address) {
-			return nil, sdkerrors.Wrapf(sdkerrors.ErrUnauthorized, "%s is not allowed to receive transactions", out.Address)
+			return nil, sdkerrors.Extendf(sdkerrors.ErrUnauthorized, "%s is not allowed to receive transactions", out.Address)
 		}
 	}
 

--- a/x/bank/keeper/keeper.go
+++ b/x/bank/keeper/keeper.go
@@ -54,11 +54,11 @@ func NewBaseKeeper(
 func (k BaseKeeper) DelegateCoins(ctx sdk.Context, delegatorAddr, moduleAccAddr sdk.AccAddress, amt sdk.Coins) error {
 	moduleAcc := k.ak.GetAccount(ctx, moduleAccAddr)
 	if moduleAcc == nil {
-		return sdkerrors.Wrapf(sdkerrors.ErrUnknownAddress, "module account %s does not exist", moduleAccAddr)
+		return sdkerrors.Extendf(sdkerrors.ErrUnknownAddress, "module account %s does not exist", moduleAccAddr)
 	}
 
 	if !amt.IsValid() {
-		return sdkerrors.Wrap(sdkerrors.ErrInvalidCoins, amt.String())
+		return sdkerrors.Extend(sdkerrors.ErrInvalidCoins, amt.String())
 	}
 
 	balances := sdk.NewCoins()
@@ -66,7 +66,7 @@ func (k BaseKeeper) DelegateCoins(ctx sdk.Context, delegatorAddr, moduleAccAddr 
 	for _, coin := range amt {
 		balance := k.GetBalance(ctx, delegatorAddr, coin.Denom)
 		if balance.IsLT(coin) {
-			return sdkerrors.Wrapf(
+			return sdkerrors.Extendf(
 				sdkerrors.ErrInsufficientFunds, "failed to delegate; %s is smaller than %s", balance, amt,
 			)
 		}
@@ -79,7 +79,7 @@ func (k BaseKeeper) DelegateCoins(ctx sdk.Context, delegatorAddr, moduleAccAddr 
 	}
 
 	if err := k.trackDelegation(ctx, delegatorAddr, ctx.BlockHeader().Time, balances, amt); err != nil {
-		return sdkerrors.Wrap(err, "failed to track delegation")
+		return sdkerrors.Extend(err, "failed to track delegation")
 	}
 
 	_, err := k.AddCoins(ctx, moduleAccAddr, amt)
@@ -98,11 +98,11 @@ func (k BaseKeeper) DelegateCoins(ctx sdk.Context, delegatorAddr, moduleAccAddr 
 func (k BaseKeeper) UndelegateCoins(ctx sdk.Context, moduleAccAddr, delegatorAddr sdk.AccAddress, amt sdk.Coins) error {
 	moduleAcc := k.ak.GetAccount(ctx, moduleAccAddr)
 	if moduleAcc == nil {
-		return sdkerrors.Wrapf(sdkerrors.ErrUnknownAddress, "module account %s does not exist", moduleAccAddr)
+		return sdkerrors.Extendf(sdkerrors.ErrUnknownAddress, "module account %s does not exist", moduleAccAddr)
 	}
 
 	if !amt.IsValid() {
-		return sdkerrors.Wrap(sdkerrors.ErrInvalidCoins, amt.String())
+		return sdkerrors.Extend(sdkerrors.ErrInvalidCoins, amt.String())
 	}
 
 	_, err := k.SubtractCoins(ctx, moduleAccAddr, amt)
@@ -111,7 +111,7 @@ func (k BaseKeeper) UndelegateCoins(ctx sdk.Context, moduleAccAddr, delegatorAdd
 	}
 
 	if err := k.trackUndelegation(ctx, delegatorAddr, amt); err != nil {
-		return sdkerrors.Wrap(err, "failed to track undelegation")
+		return sdkerrors.Extend(err, "failed to track undelegation")
 	}
 
 	_, err = k.AddCoins(ctx, delegatorAddr, amt)
@@ -255,7 +255,7 @@ func (k BaseSendKeeper) SendCoins(ctx sdk.Context, fromAddr sdk.AccAddress, toAd
 // returned if the resulting balance is negative or the initial amount is invalid.
 func (k BaseSendKeeper) SubtractCoins(ctx sdk.Context, addr sdk.AccAddress, amt sdk.Coins) (sdk.Coins, error) {
 	if !amt.IsValid() {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrInvalidCoins, amt.String())
+		return nil, sdkerrors.Extend(sdkerrors.ErrInvalidCoins, amt.String())
 	}
 
 	resultCoins := sdk.NewCoins()
@@ -268,7 +268,7 @@ func (k BaseSendKeeper) SubtractCoins(ctx sdk.Context, addr sdk.AccAddress, amt 
 
 		_, hasNeg := sdk.Coins{spendable}.SafeSub(sdk.Coins{coin})
 		if hasNeg {
-			return nil, sdkerrors.Wrapf(sdkerrors.ErrInsufficientFunds, "%s is smaller than %s", spendable, coin)
+			return nil, sdkerrors.Extendf(sdkerrors.ErrInsufficientFunds, "%s is smaller than %s", spendable, coin)
 		}
 
 		newBalance := balance.Sub(coin)
@@ -288,7 +288,7 @@ func (k BaseSendKeeper) SubtractCoins(ctx sdk.Context, addr sdk.AccAddress, amt 
 // balance is negative.
 func (k BaseSendKeeper) AddCoins(ctx sdk.Context, addr sdk.AccAddress, amt sdk.Coins) (sdk.Coins, error) {
 	if !amt.IsValid() {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrInvalidCoins, amt.String())
+		return nil, sdkerrors.Extend(sdkerrors.ErrInvalidCoins, amt.String())
 	}
 
 	var resultCoins sdk.Coins
@@ -343,7 +343,7 @@ func (k BaseSendKeeper) SetBalances(ctx sdk.Context, addr sdk.AccAddress, balanc
 // SetBalance sets the coin balance for an account by address.
 func (k BaseSendKeeper) SetBalance(ctx sdk.Context, addr sdk.AccAddress, balance sdk.Coin) error {
 	if !balance.IsValid() {
-		return sdkerrors.Wrap(sdkerrors.ErrInvalidCoins, balance.String())
+		return sdkerrors.Extend(sdkerrors.ErrInvalidCoins, balance.String())
 	}
 
 	store := ctx.KVStore(k.storeKey)
@@ -531,7 +531,7 @@ func (k BaseViewKeeper) SpendableCoins(ctx sdk.Context, addr sdk.AccAddress) sdk
 func (k BaseViewKeeper) ValidateBalance(ctx sdk.Context, addr sdk.AccAddress) error {
 	acc := k.ak.GetAccount(ctx, addr)
 	if acc == nil {
-		return sdkerrors.Wrapf(sdkerrors.ErrUnknownAddress, "account %s does not exist", addr)
+		return sdkerrors.Extendf(sdkerrors.ErrUnknownAddress, "account %s does not exist", addr)
 	}
 
 	balances := k.GetAllBalances(ctx, addr)
@@ -553,7 +553,7 @@ func (k BaseViewKeeper) ValidateBalance(ctx sdk.Context, addr sdk.AccAddress) er
 func (k BaseKeeper) trackDelegation(ctx sdk.Context, addr sdk.AccAddress, blockTime time.Time, balance, amt sdk.Coins) error {
 	acc := k.ak.GetAccount(ctx, addr)
 	if acc == nil {
-		return sdkerrors.Wrapf(sdkerrors.ErrUnknownAddress, "account %s does not exist", addr)
+		return sdkerrors.Extendf(sdkerrors.ErrUnknownAddress, "account %s does not exist", addr)
 	}
 
 	vacc, ok := acc.(vestexported.VestingAccount)
@@ -568,7 +568,7 @@ func (k BaseKeeper) trackDelegation(ctx sdk.Context, addr sdk.AccAddress, blockT
 func (k BaseKeeper) trackUndelegation(ctx sdk.Context, addr sdk.AccAddress, amt sdk.Coins) error {
 	acc := k.ak.GetAccount(ctx, addr)
 	if acc == nil {
-		return sdkerrors.Wrapf(sdkerrors.ErrUnknownAddress, "account %s does not exist", addr)
+		return sdkerrors.Extendf(sdkerrors.ErrUnknownAddress, "account %s does not exist", addr)
 	}
 
 	vacc, ok := acc.(vestexported.VestingAccount)

--- a/x/bank/keeper/querier.go
+++ b/x/bank/keeper/querier.go
@@ -20,7 +20,7 @@ func NewQuerier(k Keeper) sdk.Querier {
 			return queryAllBalance(ctx, req, k)
 
 		default:
-			return nil, sdkerrors.Wrapf(sdkerrors.ErrUnknownRequest, "unknown %s query endpoint: %s", types.ModuleName, path[0])
+			return nil, sdkerrors.Extendf(sdkerrors.ErrUnknownRequest, "unknown %s query endpoint: %s", types.ModuleName, path[0])
 		}
 	}
 }
@@ -29,14 +29,14 @@ func queryBalance(ctx sdk.Context, req abci.RequestQuery, k Keeper) ([]byte, err
 	var params types.QueryBalanceParams
 
 	if err := types.ModuleCdc.UnmarshalJSON(req.Data, &params); err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONUnmarshal, err.Error())
+		return nil, sdkerrors.Extend(sdkerrors.ErrJSONUnmarshal, err.Error())
 	}
 
 	balance := k.GetBalance(ctx, params.Address, params.Denom)
 
 	bz, err := codec.MarshalJSONIndent(types.ModuleCdc, balance)
 	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
+		return nil, sdkerrors.Extend(sdkerrors.ErrJSONMarshal, err.Error())
 	}
 
 	return bz, nil
@@ -46,14 +46,14 @@ func queryAllBalance(ctx sdk.Context, req abci.RequestQuery, k Keeper) ([]byte, 
 	var params types.QueryAllBalancesParams
 
 	if err := types.ModuleCdc.UnmarshalJSON(req.Data, &params); err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONUnmarshal, err.Error())
+		return nil, sdkerrors.Extend(sdkerrors.ErrJSONUnmarshal, err.Error())
 	}
 
 	balances := k.GetAllBalances(ctx, params.Address)
 
 	bz, err := codec.MarshalJSONIndent(types.ModuleCdc, balances)
 	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
+		return nil, sdkerrors.Extend(sdkerrors.ErrJSONMarshal, err.Error())
 	}
 
 	return bz, nil

--- a/x/bank/types/msgs.go
+++ b/x/bank/types/msgs.go
@@ -21,16 +21,16 @@ func (msg MsgSend) Type() string { return "send" }
 // ValidateBasic Implements Msg.
 func (msg MsgSend) ValidateBasic() error {
 	if msg.FromAddress.Empty() {
-		return sdkerrors.Wrap(sdkerrors.ErrInvalidAddress, "missing sender address")
+		return sdkerrors.Extend(sdkerrors.ErrInvalidAddress, "missing sender address")
 	}
 	if msg.ToAddress.Empty() {
-		return sdkerrors.Wrap(sdkerrors.ErrInvalidAddress, "missing recipient address")
+		return sdkerrors.Extend(sdkerrors.ErrInvalidAddress, "missing recipient address")
 	}
 	if !msg.Amount.IsValid() {
-		return sdkerrors.Wrap(sdkerrors.ErrInvalidCoins, msg.Amount.String())
+		return sdkerrors.Extend(sdkerrors.ErrInvalidCoins, msg.Amount.String())
 	}
 	if !msg.Amount.IsAllPositive() {
-		return sdkerrors.Wrap(sdkerrors.ErrInvalidCoins, msg.Amount.String())
+		return sdkerrors.Extend(sdkerrors.ErrInvalidCoins, msg.Amount.String())
 	}
 	return nil
 }
@@ -89,13 +89,13 @@ func (msg MsgMultiSend) GetSigners() []sdk.AccAddress {
 // ValidateBasic - validate transaction input
 func (in Input) ValidateBasic() error {
 	if len(in.Address) == 0 {
-		return sdkerrors.Wrap(sdkerrors.ErrInvalidAddress, "input address missing")
+		return sdkerrors.Extend(sdkerrors.ErrInvalidAddress, "input address missing")
 	}
 	if !in.Coins.IsValid() {
-		return sdkerrors.Wrap(sdkerrors.ErrInvalidCoins, in.Coins.String())
+		return sdkerrors.Extend(sdkerrors.ErrInvalidCoins, in.Coins.String())
 	}
 	if !in.Coins.IsAllPositive() {
-		return sdkerrors.Wrap(sdkerrors.ErrInvalidCoins, in.Coins.String())
+		return sdkerrors.Extend(sdkerrors.ErrInvalidCoins, in.Coins.String())
 	}
 	return nil
 }
@@ -111,13 +111,13 @@ func NewInput(addr sdk.AccAddress, coins sdk.Coins) Input {
 // ValidateBasic - validate transaction output
 func (out Output) ValidateBasic() error {
 	if len(out.Address) == 0 {
-		return sdkerrors.Wrap(sdkerrors.ErrInvalidAddress, "output address missing")
+		return sdkerrors.Extend(sdkerrors.ErrInvalidAddress, "output address missing")
 	}
 	if !out.Coins.IsValid() {
-		return sdkerrors.Wrap(sdkerrors.ErrInvalidCoins, out.Coins.String())
+		return sdkerrors.Extend(sdkerrors.ErrInvalidCoins, out.Coins.String())
 	}
 	if !out.Coins.IsAllPositive() {
-		return sdkerrors.Wrap(sdkerrors.ErrInvalidCoins, out.Coins.String())
+		return sdkerrors.Extend(sdkerrors.ErrInvalidCoins, out.Coins.String())
 	}
 	return nil
 }

--- a/x/crisis/handler.go
+++ b/x/crisis/handler.go
@@ -19,7 +19,7 @@ func NewHandler(k keeper.Keeper) sdk.Handler {
 			return handleMsgVerifyInvariant(ctx, msg, k)
 
 		default:
-			return nil, sdkerrors.Wrapf(sdkerrors.ErrUnknownRequest, "unrecognized crisis message type: %T", msg)
+			return nil, sdkerrors.Extendf(sdkerrors.ErrUnknownRequest, "unrecognized crisis message type: %T", msg)
 		}
 	}
 }

--- a/x/distribution/handler.go
+++ b/x/distribution/handler.go
@@ -26,7 +26,7 @@ func NewHandler(k keeper.Keeper) sdk.Handler {
 			return handleMsgFundCommunityPool(ctx, msg, k)
 
 		default:
-			return nil, sdkerrors.Wrapf(sdkerrors.ErrUnknownRequest, "unrecognized distribution message type: %T", msg)
+			return nil, sdkerrors.Extendf(sdkerrors.ErrUnknownRequest, "unrecognized distribution message type: %T", msg)
 		}
 	}
 }
@@ -107,7 +107,7 @@ func NewCommunityPoolSpendProposalHandler(k Keeper) govtypes.Handler {
 			return keeper.HandleCommunityPoolSpendProposal(ctx, k, c)
 
 		default:
-			return sdkerrors.Wrapf(sdkerrors.ErrUnknownRequest, "unrecognized distr proposal content type: %T", c)
+			return sdkerrors.Extendf(sdkerrors.ErrUnknownRequest, "unrecognized distr proposal content type: %T", c)
 		}
 	}
 }

--- a/x/distribution/keeper/keeper.go
+++ b/x/distribution/keeper/keeper.go
@@ -63,7 +63,7 @@ func (k Keeper) Logger(ctx sdk.Context) log.Logger {
 // SetWithdrawAddr sets a new address that will receive the rewards upon withdrawal
 func (k Keeper) SetWithdrawAddr(ctx sdk.Context, delegatorAddr sdk.AccAddress, withdrawAddr sdk.AccAddress) error {
 	if k.blacklistedAddrs[withdrawAddr.String()] {
-		return sdkerrors.Wrapf(sdkerrors.ErrUnauthorized, "%s is blacklisted from receiving external funds", withdrawAddr)
+		return sdkerrors.Extendf(sdkerrors.ErrUnauthorized, "%s is blacklisted from receiving external funds", withdrawAddr)
 	}
 
 	if !k.GetWithdrawAddrEnabled(ctx) {

--- a/x/distribution/keeper/proposal_handler.go
+++ b/x/distribution/keeper/proposal_handler.go
@@ -11,7 +11,7 @@ import (
 // HandleCommunityPoolSpendProposal is a handler for executing a passed community spend proposal
 func HandleCommunityPoolSpendProposal(ctx sdk.Context, k Keeper, p types.CommunityPoolSpendProposal) error {
 	if k.blacklistedAddrs[p.Recipient.String()] {
-		return sdkerrors.Wrapf(sdkerrors.ErrUnauthorized, "%s is blacklisted from receiving external funds", p.Recipient)
+		return sdkerrors.Extendf(sdkerrors.ErrUnauthorized, "%s is blacklisted from receiving external funds", p.Recipient)
 	}
 
 	err := k.DistributeFromFeePool(ctx, p.Amount, p.Recipient)

--- a/x/distribution/keeper/querier.go
+++ b/x/distribution/keeper/querier.go
@@ -43,7 +43,7 @@ func NewQuerier(k Keeper) sdk.Querier {
 			return queryCommunityPool(ctx, path[1:], req, k)
 
 		default:
-			return nil, sdkerrors.Wrapf(sdkerrors.ErrUnknownRequest, "unknown query path: %s", path[0])
+			return nil, sdkerrors.Extendf(sdkerrors.ErrUnknownRequest, "unknown query path: %s", path[0])
 		}
 	}
 }
@@ -53,7 +53,7 @@ func queryParams(ctx sdk.Context, path []string, req abci.RequestQuery, k Keeper
 
 	res, err := codec.MarshalJSONIndent(k.cdc, params)
 	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
+		return nil, sdkerrors.Extend(sdkerrors.ErrJSONMarshal, err.Error())
 	}
 
 	return res, nil
@@ -63,7 +63,7 @@ func queryValidatorOutstandingRewards(ctx sdk.Context, path []string, req abci.R
 	var params types.QueryValidatorOutstandingRewardsParams
 	err := k.cdc.UnmarshalJSON(req.Data, &params)
 	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONUnmarshal, err.Error())
+		return nil, sdkerrors.Extend(sdkerrors.ErrJSONUnmarshal, err.Error())
 	}
 
 	rewards := k.GetValidatorOutstandingRewards(ctx, params.ValidatorAddress)
@@ -73,7 +73,7 @@ func queryValidatorOutstandingRewards(ctx sdk.Context, path []string, req abci.R
 
 	bz, err := codec.MarshalJSONIndent(k.cdc, rewards)
 	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
+		return nil, sdkerrors.Extend(sdkerrors.ErrJSONMarshal, err.Error())
 	}
 
 	return bz, nil
@@ -83,7 +83,7 @@ func queryValidatorCommission(ctx sdk.Context, path []string, req abci.RequestQu
 	var params types.QueryValidatorCommissionParams
 	err := k.cdc.UnmarshalJSON(req.Data, &params)
 	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONUnmarshal, err.Error())
+		return nil, sdkerrors.Extend(sdkerrors.ErrJSONUnmarshal, err.Error())
 	}
 
 	commission := k.GetValidatorAccumulatedCommission(ctx, params.ValidatorAddress)
@@ -93,7 +93,7 @@ func queryValidatorCommission(ctx sdk.Context, path []string, req abci.RequestQu
 
 	bz, err := codec.MarshalJSONIndent(k.cdc, commission)
 	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
+		return nil, sdkerrors.Extend(sdkerrors.ErrJSONMarshal, err.Error())
 	}
 
 	return bz, nil
@@ -103,7 +103,7 @@ func queryValidatorSlashes(ctx sdk.Context, path []string, req abci.RequestQuery
 	var params types.QueryValidatorSlashesParams
 	err := k.cdc.UnmarshalJSON(req.Data, &params)
 	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONUnmarshal, err.Error())
+		return nil, sdkerrors.Extend(sdkerrors.ErrJSONUnmarshal, err.Error())
 	}
 
 	events := make([]types.ValidatorSlashEvent, 0)
@@ -116,7 +116,7 @@ func queryValidatorSlashes(ctx sdk.Context, path []string, req abci.RequestQuery
 
 	bz, err := codec.MarshalJSONIndent(k.cdc, events)
 	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
+		return nil, sdkerrors.Extend(sdkerrors.ErrJSONMarshal, err.Error())
 	}
 
 	return bz, nil
@@ -126,7 +126,7 @@ func queryDelegationRewards(ctx sdk.Context, _ []string, req abci.RequestQuery, 
 	var params types.QueryDelegationRewardsParams
 	err := k.cdc.UnmarshalJSON(req.Data, &params)
 	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONUnmarshal, err.Error())
+		return nil, sdkerrors.Extend(sdkerrors.ErrJSONUnmarshal, err.Error())
 	}
 
 	// cache-wrap context as to not persist state changes during querying
@@ -134,7 +134,7 @@ func queryDelegationRewards(ctx sdk.Context, _ []string, req abci.RequestQuery, 
 
 	val := k.stakingKeeper.Validator(ctx, params.ValidatorAddress)
 	if val == nil {
-		return nil, sdkerrors.Wrap(types.ErrNoValidatorExists, params.ValidatorAddress.String())
+		return nil, sdkerrors.Extend(types.ErrNoValidatorExists, params.ValidatorAddress.String())
 	}
 
 	del := k.stakingKeeper.Delegation(ctx, params.DelegatorAddress, params.ValidatorAddress)
@@ -150,7 +150,7 @@ func queryDelegationRewards(ctx sdk.Context, _ []string, req abci.RequestQuery, 
 
 	bz, err := codec.MarshalJSONIndent(k.cdc, rewards)
 	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
+		return nil, sdkerrors.Extend(sdkerrors.ErrJSONMarshal, err.Error())
 	}
 
 	return bz, nil
@@ -160,7 +160,7 @@ func queryDelegatorTotalRewards(ctx sdk.Context, _ []string, req abci.RequestQue
 	var params types.QueryDelegatorParams
 	err := k.cdc.UnmarshalJSON(req.Data, &params)
 	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONUnmarshal, err.Error())
+		return nil, sdkerrors.Extend(sdkerrors.ErrJSONUnmarshal, err.Error())
 	}
 
 	// cache-wrap context as to not persist state changes during querying
@@ -187,7 +187,7 @@ func queryDelegatorTotalRewards(ctx sdk.Context, _ []string, req abci.RequestQue
 
 	bz, err := json.Marshal(totalRewards)
 	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
+		return nil, sdkerrors.Extend(sdkerrors.ErrJSONMarshal, err.Error())
 	}
 
 	return bz, nil
@@ -197,7 +197,7 @@ func queryDelegatorValidators(ctx sdk.Context, _ []string, req abci.RequestQuery
 	var params types.QueryDelegatorParams
 	err := k.cdc.UnmarshalJSON(req.Data, &params)
 	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONUnmarshal, err.Error())
+		return nil, sdkerrors.Extend(sdkerrors.ErrJSONUnmarshal, err.Error())
 	}
 
 	// cache-wrap context as to not persist state changes during querying
@@ -215,7 +215,7 @@ func queryDelegatorValidators(ctx sdk.Context, _ []string, req abci.RequestQuery
 
 	bz, err := codec.MarshalJSONIndent(k.cdc, validators)
 	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
+		return nil, sdkerrors.Extend(sdkerrors.ErrJSONMarshal, err.Error())
 	}
 
 	return bz, nil
@@ -225,7 +225,7 @@ func queryDelegatorWithdrawAddress(ctx sdk.Context, _ []string, req abci.Request
 	var params types.QueryDelegatorWithdrawAddrParams
 	err := k.cdc.UnmarshalJSON(req.Data, &params)
 	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONUnmarshal, err.Error())
+		return nil, sdkerrors.Extend(sdkerrors.ErrJSONUnmarshal, err.Error())
 	}
 
 	// cache-wrap context as to not persist state changes during querying
@@ -234,7 +234,7 @@ func queryDelegatorWithdrawAddress(ctx sdk.Context, _ []string, req abci.Request
 
 	bz, err := codec.MarshalJSONIndent(k.cdc, withdrawAddr)
 	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
+		return nil, sdkerrors.Extend(sdkerrors.ErrJSONMarshal, err.Error())
 	}
 
 	return bz, nil
@@ -248,7 +248,7 @@ func queryCommunityPool(ctx sdk.Context, _ []string, req abci.RequestQuery, k Ke
 
 	bz, err := k.cdc.MarshalJSON(pool)
 	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
+		return nil, sdkerrors.Extend(sdkerrors.ErrJSONMarshal, err.Error())
 	}
 
 	return bz, nil

--- a/x/distribution/types/msg.go
+++ b/x/distribution/types/msg.go
@@ -135,10 +135,10 @@ func (msg MsgFundCommunityPool) GetSignBytes() []byte {
 // ValidateBasic performs basic MsgFundCommunityPool message validation.
 func (msg MsgFundCommunityPool) ValidateBasic() error {
 	if !msg.Amount.IsValid() {
-		return sdkerrors.Wrap(sdkerrors.ErrInvalidCoins, msg.Amount.String())
+		return sdkerrors.Extend(sdkerrors.ErrInvalidCoins, msg.Amount.String())
 	}
 	if msg.Depositor.Empty() {
-		return sdkerrors.Wrap(sdkerrors.ErrInvalidAddress, msg.Depositor.String())
+		return sdkerrors.Extend(sdkerrors.ErrInvalidAddress, msg.Depositor.String())
 	}
 
 	return nil

--- a/x/evidence/handler.go
+++ b/x/evidence/handler.go
@@ -12,7 +12,7 @@ func NewHandler(k Keeper) sdk.Handler {
 
 		switch msg := msg.(type) {
 		case MsgSubmitEvidenceBase:
-			return nil, sdkerrors.Wrapf(sdkerrors.ErrInvalidRequest, "%T must be extended to support evidence", msg)
+			return nil, sdkerrors.Extendf(sdkerrors.ErrInvalidRequest, "%T must be extended to support evidence", msg)
 
 		default:
 			msgSubEv, ok := msg.(exported.MsgSubmitEvidence)
@@ -20,7 +20,7 @@ func NewHandler(k Keeper) sdk.Handler {
 				return handleMsgSubmitEvidence(ctx, k, msgSubEv)
 			}
 
-			return nil, sdkerrors.Wrapf(sdkerrors.ErrUnknownRequest, "unrecognized %s message type: %T", ModuleName, msg)
+			return nil, sdkerrors.Extendf(sdkerrors.ErrUnknownRequest, "unrecognized %s message type: %T", ModuleName, msg)
 		}
 	}
 }

--- a/x/evidence/keeper/keeper.go
+++ b/x/evidence/keeper/keeper.go
@@ -72,7 +72,7 @@ func (k *Keeper) SetRouter(rtr types.Router) {
 // no handler exists, an error is returned.
 func (k Keeper) GetEvidenceHandler(evidenceRoute string) (types.Handler, error) {
 	if !k.router.HasRoute(evidenceRoute) {
-		return nil, sdkerrors.Wrap(types.ErrNoEvidenceHandlerExists, evidenceRoute)
+		return nil, sdkerrors.Extend(types.ErrNoEvidenceHandlerExists, evidenceRoute)
 	}
 
 	return k.router.GetRoute(evidenceRoute), nil
@@ -84,15 +84,15 @@ func (k Keeper) GetEvidenceHandler(evidenceRoute string) (types.Handler, error) 
 // persisted.
 func (k Keeper) SubmitEvidence(ctx sdk.Context, evidence exported.Evidence) error {
 	if _, ok := k.GetEvidence(ctx, evidence.Hash()); ok {
-		return sdkerrors.Wrap(types.ErrEvidenceExists, evidence.Hash().String())
+		return sdkerrors.Extend(types.ErrEvidenceExists, evidence.Hash().String())
 	}
 	if !k.router.HasRoute(evidence.Route()) {
-		return sdkerrors.Wrap(types.ErrNoEvidenceHandlerExists, evidence.Route())
+		return sdkerrors.Extend(types.ErrNoEvidenceHandlerExists, evidence.Route())
 	}
 
 	handler := k.router.GetRoute(evidence.Route())
 	if err := handler(ctx, evidence); err != nil {
-		return sdkerrors.Wrap(types.ErrInvalidEvidence, err.Error())
+		return sdkerrors.Extend(types.ErrInvalidEvidence, err.Error())
 	}
 
 	ctx.EventManager().EmitEvent(

--- a/x/evidence/keeper/querier.go
+++ b/x/evidence/keeper/querier.go
@@ -31,7 +31,7 @@ func NewQuerier(k Keeper) sdk.Querier {
 			res, err = queryAllEvidence(ctx, req, k)
 
 		default:
-			err = sdkerrors.Wrapf(sdkerrors.ErrUnknownRequest, "unknown %s query endpoint: %s", types.ModuleName, path[0])
+			err = sdkerrors.Extendf(sdkerrors.ErrUnknownRequest, "unknown %s query endpoint: %s", types.ModuleName, path[0])
 		}
 
 		return res, err
@@ -43,7 +43,7 @@ func queryParams(ctx sdk.Context, k Keeper) ([]byte, error) {
 
 	res, err := codec.MarshalJSONIndent(k.cdc, params)
 	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
+		return nil, sdkerrors.Extend(sdkerrors.ErrJSONMarshal, err.Error())
 	}
 
 	return res, nil
@@ -54,22 +54,22 @@ func queryEvidence(ctx sdk.Context, req abci.RequestQuery, k Keeper) ([]byte, er
 
 	err := k.cdc.UnmarshalJSON(req.Data, &params)
 	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONUnmarshal, err.Error())
+		return nil, sdkerrors.Extend(sdkerrors.ErrJSONUnmarshal, err.Error())
 	}
 
 	hash, err := hex.DecodeString(params.EvidenceHash)
 	if err != nil {
-		return nil, sdkerrors.Wrap(err, "failed to decode evidence hash string query")
+		return nil, sdkerrors.Extend(err, "failed to decode evidence hash string query")
 	}
 
 	evidence, ok := k.GetEvidence(ctx, hash)
 	if !ok {
-		return nil, sdkerrors.Wrap(types.ErrNoEvidenceExists, params.EvidenceHash)
+		return nil, sdkerrors.Extend(types.ErrNoEvidenceExists, params.EvidenceHash)
 	}
 
 	res, err := codec.MarshalJSONIndent(k.cdc, evidence)
 	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
+		return nil, sdkerrors.Extend(sdkerrors.ErrJSONMarshal, err.Error())
 	}
 
 	return res, nil
@@ -80,7 +80,7 @@ func queryAllEvidence(ctx sdk.Context, req abci.RequestQuery, k Keeper) ([]byte,
 
 	err := k.cdc.UnmarshalJSON(req.Data, &params)
 	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONUnmarshal, err.Error())
+		return nil, sdkerrors.Extend(sdkerrors.ErrJSONUnmarshal, err.Error())
 	}
 
 	evidence := k.GetAllEvidence(ctx)
@@ -94,7 +94,7 @@ func queryAllEvidence(ctx sdk.Context, req abci.RequestQuery, k Keeper) ([]byte,
 
 	res, err := codec.MarshalJSONIndent(k.cdc, evidence)
 	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
+		return nil, sdkerrors.Extend(sdkerrors.ErrJSONMarshal, err.Error())
 	}
 
 	return res, nil

--- a/x/evidence/types/msgs.go
+++ b/x/evidence/types/msgs.go
@@ -30,7 +30,7 @@ func (m MsgSubmitEvidenceBase) Type() string { return TypeMsgSubmitEvidence }
 // ValidateBasic performs basic (non-state-dependant) validation on a MsgSubmitEvidenceBase.
 func (m MsgSubmitEvidenceBase) ValidateBasic() error {
 	if m.Submitter.Empty() {
-		return sdkerrors.Wrap(sdkerrors.ErrInvalidAddress, m.Submitter.String())
+		return sdkerrors.Extend(sdkerrors.ErrInvalidAddress, m.Submitter.String())
 	}
 
 	return nil

--- a/x/gov/handler.go
+++ b/x/gov/handler.go
@@ -24,7 +24,7 @@ func NewHandler(keeper Keeper) sdk.Handler {
 			return handleMsgVote(ctx, keeper, msg)
 
 		default:
-			return nil, sdkerrors.Wrapf(sdkerrors.ErrUnknownRequest, "unrecognized %s message type: %T", ModuleName, msg)
+			return nil, sdkerrors.Extendf(sdkerrors.ErrUnknownRequest, "unrecognized %s message type: %T", ModuleName, msg)
 		}
 	}
 }

--- a/x/gov/keeper/deposit.go
+++ b/x/gov/keeper/deposit.go
@@ -98,12 +98,12 @@ func (keeper Keeper) AddDeposit(ctx sdk.Context, proposalID uint64, depositorAdd
 	// Checks to see if proposal exists
 	proposal, ok := keeper.GetProposal(ctx, proposalID)
 	if !ok {
-		return false, sdkerrors.Wrapf(types.ErrUnknownProposal, "%d", proposalID)
+		return false, sdkerrors.Extendf(types.ErrUnknownProposal, "%d", proposalID)
 	}
 
 	// Check if proposal is still depositable
 	if (proposal.Status != types.StatusDepositPeriod) && (proposal.Status != types.StatusVotingPeriod) {
-		return false, sdkerrors.Wrapf(types.ErrInactiveProposal, "%d", proposalID)
+		return false, sdkerrors.Extendf(types.ErrInactiveProposal, "%d", proposalID)
 	}
 
 	// update the governance module's account coins pool

--- a/x/gov/keeper/proposal.go
+++ b/x/gov/keeper/proposal.go
@@ -12,7 +12,7 @@ import (
 // SubmitProposal create new proposal given a content
 func (keeper Keeper) SubmitProposal(ctx sdk.Context, content types.Content) (types.Proposal, error) {
 	if !keeper.router.HasRoute(content.ProposalRoute()) {
-		return types.Proposal{}, sdkerrors.Wrap(types.ErrNoProposalHandlerExists, content.ProposalRoute())
+		return types.Proposal{}, sdkerrors.Extend(types.ErrNoProposalHandlerExists, content.ProposalRoute())
 	}
 
 	// Execute the proposal content in a cache-wrapped context to validate the
@@ -21,7 +21,7 @@ func (keeper Keeper) SubmitProposal(ctx sdk.Context, content types.Content) (typ
 	cacheCtx, _ := ctx.CacheContext()
 	handler := keeper.router.GetRoute(content.ProposalRoute())
 	if err := handler(cacheCtx, content); err != nil {
-		return types.Proposal{}, sdkerrors.Wrap(types.ErrInvalidProposalContent, err.Error())
+		return types.Proposal{}, sdkerrors.Extend(types.ErrInvalidProposalContent, err.Error())
 	}
 
 	proposalID, err := keeper.GetProposalID(ctx)
@@ -168,7 +168,7 @@ func (keeper Keeper) GetProposalID(ctx sdk.Context) (proposalID uint64, err erro
 	store := ctx.KVStore(keeper.storeKey)
 	bz := store.Get(types.ProposalIDKey)
 	if bz == nil {
-		return 0, sdkerrors.Wrap(types.ErrInvalidGenesis, "initial proposal ID hasn't been set")
+		return 0, sdkerrors.Extend(types.ErrInvalidGenesis, "initial proposal ID hasn't been set")
 	}
 
 	proposalID = types.GetProposalIDFromBytes(bz)

--- a/x/gov/keeper/querier.go
+++ b/x/gov/keeper/querier.go
@@ -39,7 +39,7 @@ func NewQuerier(keeper Keeper) sdk.Querier {
 			return queryTally(ctx, path[1:], req, keeper)
 
 		default:
-			return nil, sdkerrors.Wrapf(sdkerrors.ErrUnknownRequest, "unknown query path: %s", path[0])
+			return nil, sdkerrors.Extendf(sdkerrors.ErrUnknownRequest, "unknown query path: %s", path[0])
 		}
 	}
 }
@@ -49,26 +49,26 @@ func queryParams(ctx sdk.Context, path []string, req abci.RequestQuery, keeper K
 	case types.ParamDeposit:
 		bz, err := codec.MarshalJSONIndent(keeper.cdc, keeper.GetDepositParams(ctx))
 		if err != nil {
-			return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
+			return nil, sdkerrors.Extend(sdkerrors.ErrJSONMarshal, err.Error())
 		}
 		return bz, nil
 
 	case types.ParamVoting:
 		bz, err := codec.MarshalJSONIndent(keeper.cdc, keeper.GetVotingParams(ctx))
 		if err != nil {
-			return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
+			return nil, sdkerrors.Extend(sdkerrors.ErrJSONMarshal, err.Error())
 		}
 		return bz, nil
 
 	case types.ParamTallying:
 		bz, err := codec.MarshalJSONIndent(keeper.cdc, keeper.GetTallyParams(ctx))
 		if err != nil {
-			return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
+			return nil, sdkerrors.Extend(sdkerrors.ErrJSONMarshal, err.Error())
 		}
 		return bz, nil
 
 	default:
-		return nil, sdkerrors.Wrapf(sdkerrors.ErrUnknownRequest, "%s is not a valid query request path", req.Path)
+		return nil, sdkerrors.Extendf(sdkerrors.ErrUnknownRequest, "%s is not a valid query request path", req.Path)
 	}
 }
 
@@ -77,17 +77,17 @@ func queryProposal(ctx sdk.Context, path []string, req abci.RequestQuery, keeper
 	var params types.QueryProposalParams
 	err := keeper.cdc.UnmarshalJSON(req.Data, &params)
 	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONUnmarshal, err.Error())
+		return nil, sdkerrors.Extend(sdkerrors.ErrJSONUnmarshal, err.Error())
 	}
 
 	proposal, ok := keeper.GetProposal(ctx, params.ProposalID)
 	if !ok {
-		return nil, sdkerrors.Wrapf(types.ErrUnknownProposal, "%d", params.ProposalID)
+		return nil, sdkerrors.Extendf(types.ErrUnknownProposal, "%d", params.ProposalID)
 	}
 
 	bz, err := codec.MarshalJSONIndent(keeper.cdc, proposal)
 	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
+		return nil, sdkerrors.Extend(sdkerrors.ErrJSONMarshal, err.Error())
 	}
 
 	return bz, nil
@@ -98,13 +98,13 @@ func queryDeposit(ctx sdk.Context, path []string, req abci.RequestQuery, keeper 
 	var params types.QueryDepositParams
 	err := keeper.cdc.UnmarshalJSON(req.Data, &params)
 	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONUnmarshal, err.Error())
+		return nil, sdkerrors.Extend(sdkerrors.ErrJSONUnmarshal, err.Error())
 	}
 
 	deposit, _ := keeper.GetDeposit(ctx, params.ProposalID, params.Depositor)
 	bz, err := codec.MarshalJSONIndent(keeper.cdc, deposit)
 	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
+		return nil, sdkerrors.Extend(sdkerrors.ErrJSONMarshal, err.Error())
 	}
 
 	return bz, nil
@@ -115,13 +115,13 @@ func queryVote(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Kee
 	var params types.QueryVoteParams
 	err := keeper.cdc.UnmarshalJSON(req.Data, &params)
 	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONUnmarshal, err.Error())
+		return nil, sdkerrors.Extend(sdkerrors.ErrJSONUnmarshal, err.Error())
 	}
 
 	vote, _ := keeper.GetVote(ctx, params.ProposalID, params.Voter)
 	bz, err := codec.MarshalJSONIndent(keeper.cdc, vote)
 	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
+		return nil, sdkerrors.Extend(sdkerrors.ErrJSONMarshal, err.Error())
 	}
 
 	return bz, nil
@@ -132,7 +132,7 @@ func queryDeposits(ctx sdk.Context, path []string, req abci.RequestQuery, keeper
 	var params types.QueryProposalParams
 	err := keeper.cdc.UnmarshalJSON(req.Data, &params)
 	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONUnmarshal, err.Error())
+		return nil, sdkerrors.Extend(sdkerrors.ErrJSONUnmarshal, err.Error())
 	}
 
 	deposits := keeper.GetDeposits(ctx, params.ProposalID)
@@ -142,7 +142,7 @@ func queryDeposits(ctx sdk.Context, path []string, req abci.RequestQuery, keeper
 
 	bz, err := codec.MarshalJSONIndent(keeper.cdc, deposits)
 	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
+		return nil, sdkerrors.Extend(sdkerrors.ErrJSONMarshal, err.Error())
 	}
 
 	return bz, nil
@@ -153,14 +153,14 @@ func queryTally(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Ke
 	var params types.QueryProposalParams
 	err := keeper.cdc.UnmarshalJSON(req.Data, &params)
 	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONUnmarshal, err.Error())
+		return nil, sdkerrors.Extend(sdkerrors.ErrJSONUnmarshal, err.Error())
 	}
 
 	proposalID := params.ProposalID
 
 	proposal, ok := keeper.GetProposal(ctx, proposalID)
 	if !ok {
-		return nil, sdkerrors.Wrapf(types.ErrUnknownProposal, "%d", proposalID)
+		return nil, sdkerrors.Extendf(types.ErrUnknownProposal, "%d", proposalID)
 	}
 
 	var tallyResult types.TallyResult
@@ -179,7 +179,7 @@ func queryTally(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Ke
 
 	bz, err := codec.MarshalJSONIndent(keeper.cdc, tallyResult)
 	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
+		return nil, sdkerrors.Extend(sdkerrors.ErrJSONMarshal, err.Error())
 	}
 
 	return bz, nil
@@ -190,7 +190,7 @@ func queryVotes(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Ke
 	var params types.QueryProposalVotesParams
 	err := keeper.cdc.UnmarshalJSON(req.Data, &params)
 	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONUnmarshal, err.Error())
+		return nil, sdkerrors.Extend(sdkerrors.ErrJSONUnmarshal, err.Error())
 	}
 
 	votes := keeper.GetVotes(ctx, params.ProposalID)
@@ -207,7 +207,7 @@ func queryVotes(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Ke
 
 	bz, err := codec.MarshalJSONIndent(keeper.cdc, votes)
 	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
+		return nil, sdkerrors.Extend(sdkerrors.ErrJSONMarshal, err.Error())
 	}
 
 	return bz, nil
@@ -217,7 +217,7 @@ func queryProposals(ctx sdk.Context, _ []string, req abci.RequestQuery, keeper K
 	var params types.QueryProposalsParams
 	err := keeper.cdc.UnmarshalJSON(req.Data, &params)
 	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONUnmarshal, err.Error())
+		return nil, sdkerrors.Extend(sdkerrors.ErrJSONUnmarshal, err.Error())
 	}
 
 	proposals := keeper.GetProposalsFiltered(ctx, params)
@@ -227,7 +227,7 @@ func queryProposals(ctx sdk.Context, _ []string, req abci.RequestQuery, keeper K
 
 	bz, err := codec.MarshalJSONIndent(keeper.cdc, proposals)
 	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
+		return nil, sdkerrors.Extend(sdkerrors.ErrJSONMarshal, err.Error())
 	}
 
 	return bz, nil

--- a/x/gov/keeper/vote.go
+++ b/x/gov/keeper/vote.go
@@ -12,14 +12,14 @@ import (
 func (keeper Keeper) AddVote(ctx sdk.Context, proposalID uint64, voterAddr sdk.AccAddress, option types.VoteOption) error {
 	proposal, ok := keeper.GetProposal(ctx, proposalID)
 	if !ok {
-		return sdkerrors.Wrapf(types.ErrUnknownProposal, "%d", proposalID)
+		return sdkerrors.Extendf(types.ErrUnknownProposal, "%d", proposalID)
 	}
 	if proposal.Status != types.StatusVotingPeriod {
-		return sdkerrors.Wrapf(types.ErrInactiveProposal, "%d", proposalID)
+		return sdkerrors.Extendf(types.ErrInactiveProposal, "%d", proposalID)
 	}
 
 	if !types.ValidVoteOption(option) {
-		return sdkerrors.Wrap(types.ErrInvalidVote, option.String())
+		return sdkerrors.Extend(types.ErrInvalidVote, option.String())
 	}
 
 	vote := types.NewVote(proposalID, voterAddr, option)

--- a/x/gov/types/content.go
+++ b/x/gov/types/content.go
@@ -37,18 +37,18 @@ type Handler func(ctx sdk.Context, content Content) error
 func ValidateAbstract(c Content) error {
 	title := c.GetTitle()
 	if len(strings.TrimSpace(title)) == 0 {
-		return sdkerrors.Wrap(ErrInvalidProposalContent, "proposal title cannot be blank")
+		return sdkerrors.Extend(ErrInvalidProposalContent, "proposal title cannot be blank")
 	}
 	if len(title) > MaxTitleLength {
-		return sdkerrors.Wrapf(ErrInvalidProposalContent, "proposal title is longer than max length of %d", MaxTitleLength)
+		return sdkerrors.Extendf(ErrInvalidProposalContent, "proposal title is longer than max length of %d", MaxTitleLength)
 	}
 
 	description := c.GetDescription()
 	if len(description) == 0 {
-		return sdkerrors.Wrap(ErrInvalidProposalContent, "proposal description cannot be blank")
+		return sdkerrors.Extend(ErrInvalidProposalContent, "proposal description cannot be blank")
 	}
 	if len(description) > MaxDescriptionLength {
-		return sdkerrors.Wrapf(ErrInvalidProposalContent, "proposal description is longer than max length of %d", MaxDescriptionLength)
+		return sdkerrors.Extendf(ErrInvalidProposalContent, "proposal description is longer than max length of %d", MaxDescriptionLength)
 	}
 
 	return nil

--- a/x/gov/types/msgs.go
+++ b/x/gov/types/msgs.go
@@ -44,13 +44,13 @@ func (msg MsgSubmitProposalBase) Type() string { return TypeMsgSubmitProposal }
 // ValidateBasic implements Msg
 func (msg MsgSubmitProposalBase) ValidateBasic() error {
 	if msg.Proposer.Empty() {
-		return sdkerrors.Wrap(sdkerrors.ErrInvalidAddress, msg.Proposer.String())
+		return sdkerrors.Extend(sdkerrors.ErrInvalidAddress, msg.Proposer.String())
 	}
 	if !msg.InitialDeposit.IsValid() {
-		return sdkerrors.Wrap(sdkerrors.ErrInvalidCoins, msg.InitialDeposit.String())
+		return sdkerrors.Extend(sdkerrors.ErrInvalidCoins, msg.InitialDeposit.String())
 	}
 	if msg.InitialDeposit.IsAnyNegative() {
-		return sdkerrors.Wrap(sdkerrors.ErrInvalidCoins, msg.InitialDeposit.String())
+		return sdkerrors.Extend(sdkerrors.ErrInvalidCoins, msg.InitialDeposit.String())
 	}
 
 	return nil
@@ -87,13 +87,13 @@ func (msg MsgDeposit) Type() string { return TypeMsgDeposit }
 // ValidateBasic implements Msg
 func (msg MsgDeposit) ValidateBasic() error {
 	if msg.Depositor.Empty() {
-		return sdkerrors.Wrap(sdkerrors.ErrInvalidAddress, msg.Depositor.String())
+		return sdkerrors.Extend(sdkerrors.ErrInvalidAddress, msg.Depositor.String())
 	}
 	if !msg.Amount.IsValid() {
-		return sdkerrors.Wrap(sdkerrors.ErrInvalidCoins, msg.Amount.String())
+		return sdkerrors.Extend(sdkerrors.ErrInvalidCoins, msg.Amount.String())
 	}
 	if msg.Amount.IsAnyNegative() {
-		return sdkerrors.Wrap(sdkerrors.ErrInvalidCoins, msg.Amount.String())
+		return sdkerrors.Extend(sdkerrors.ErrInvalidCoins, msg.Amount.String())
 	}
 
 	return nil
@@ -130,10 +130,10 @@ func (msg MsgVote) Type() string { return TypeMsgVote }
 // ValidateBasic implements Msg
 func (msg MsgVote) ValidateBasic() error {
 	if msg.Voter.Empty() {
-		return sdkerrors.Wrap(sdkerrors.ErrInvalidAddress, msg.Voter.String())
+		return sdkerrors.Extend(sdkerrors.ErrInvalidAddress, msg.Voter.String())
 	}
 	if !ValidVoteOption(msg.Option) {
-		return sdkerrors.Wrap(ErrInvalidVote, msg.Option.String())
+		return sdkerrors.Extend(ErrInvalidVote, msg.Option.String())
 	}
 
 	return nil
@@ -182,19 +182,19 @@ func NewMsgSubmitProposal(content Content, initialDeposit sdk.Coins, proposer sd
 // ValidateBasic implements Msg
 func (msg MsgSubmitProposal) ValidateBasic() error {
 	if msg.Content == nil {
-		return sdkerrors.Wrap(ErrInvalidProposalContent, "missing content")
+		return sdkerrors.Extend(ErrInvalidProposalContent, "missing content")
 	}
 	if msg.Proposer.Empty() {
-		return sdkerrors.Wrap(sdkerrors.ErrInvalidAddress, msg.Proposer.String())
+		return sdkerrors.Extend(sdkerrors.ErrInvalidAddress, msg.Proposer.String())
 	}
 	if !msg.InitialDeposit.IsValid() {
-		return sdkerrors.Wrap(sdkerrors.ErrInvalidCoins, msg.InitialDeposit.String())
+		return sdkerrors.Extend(sdkerrors.ErrInvalidCoins, msg.InitialDeposit.String())
 	}
 	if msg.InitialDeposit.IsAnyNegative() {
-		return sdkerrors.Wrap(sdkerrors.ErrInvalidCoins, msg.InitialDeposit.String())
+		return sdkerrors.Extend(sdkerrors.ErrInvalidCoins, msg.InitialDeposit.String())
 	}
 	if !IsValidProposalType(msg.Content.ProposalType()) {
-		return sdkerrors.Wrap(ErrInvalidProposalType, msg.Content.ProposalType())
+		return sdkerrors.Extend(ErrInvalidProposalType, msg.Content.ProposalType())
 	}
 
 	return msg.Content.ValidateBasic()

--- a/x/gov/types/proposal.go
+++ b/x/gov/types/proposal.go
@@ -268,6 +268,6 @@ func ProposalHandler(_ sdk.Context, c Content) error {
 		return nil
 
 	default:
-		return sdkerrors.Wrapf(sdkerrors.ErrUnknownRequest, "unrecognized gov proposal type: %s", c.ProposalType())
+		return sdkerrors.Extendf(sdkerrors.ErrUnknownRequest, "unrecognized gov proposal type: %s", c.ProposalType())
 	}
 }

--- a/x/ibc/24-host/validate.go
+++ b/x/ibc/24-host/validate.go
@@ -19,15 +19,15 @@ type ValidateFn func(string) error
 func defaultIdentifierValidator(id string, min, max int) error {
 	// valid id MUST NOT contain "/" separator
 	if strings.Contains(id, "/") {
-		return sdkerrors.Wrapf(ErrInvalidID, "identifier %s cannot contain separator '/'", id)
+		return sdkerrors.Extendf(ErrInvalidID, "identifier %s cannot contain separator '/'", id)
 	}
 	// valid id must be between 10 and 20 characters
 	if len(id) < min || len(id) > max {
-		return sdkerrors.Wrapf(ErrInvalidID, "identifier %s has invalid length: %d, must be between %d-%d characters", id, len(id), min, max)
+		return sdkerrors.Extendf(ErrInvalidID, "identifier %s has invalid length: %d, must be between %d-%d characters", id, len(id), min, max)
 	}
 	// valid id must contain only lower alphabetic characters
 	if !sdk.IsAlphaLower(id) {
-		return sdkerrors.Wrapf(ErrInvalidID, "identifier %s must contain only lowercase alphabetic characters", id)
+		return sdkerrors.Extendf(ErrInvalidID, "identifier %s must contain only lowercase alphabetic characters", id)
 	}
 	return nil
 }
@@ -70,7 +70,7 @@ func NewPathValidator(idValidator ValidateFn) ValidateFn {
 			// Each path element must either be valid identifier or alphanumeric
 			err := idValidator(p)
 			if err != nil && !sdk.IsAlphaNumeric(p) {
-				return sdkerrors.Wrapf(ErrInvalidPath, "path %s contains invalid identifier or non-alphanumeric path element: %s", path, p)
+				return sdkerrors.Extendf(ErrInvalidPath, "path %s contains invalid identifier or non-alphanumeric path element: %s", path, p)
 			}
 		}
 		return nil
@@ -83,13 +83,13 @@ func NewPathValidator(idValidator ValidateFn) ValidateFn {
 func DefaultPathValidator(path string) error {
 	pathArr := strings.Split(path, "/")
 	if pathArr[0] == path {
-		return sdkerrors.Wrapf(ErrInvalidPath, "path %s doesn't contain any separator '/'", path)
+		return sdkerrors.Extendf(ErrInvalidPath, "path %s doesn't contain any separator '/'", path)
 	}
 
 	for _, p := range pathArr {
 		// Each path element must be alphanumeric and non-blank
 		if strings.TrimSpace(p) == "" || !sdk.IsAlphaNumeric(p) {
-			return sdkerrors.Wrapf(ErrInvalidPath, "path %s contains an invalid non-alphanumeric character: '%s'", path, p)
+			return sdkerrors.Extendf(ErrInvalidPath, "path %s contains an invalid non-alphanumeric character: '%s'", path, p)
 		}
 	}
 	return nil

--- a/x/mint/keeper/querier.go
+++ b/x/mint/keeper/querier.go
@@ -23,7 +23,7 @@ func NewQuerier(k Keeper) sdk.Querier {
 			return queryAnnualProvisions(ctx, k)
 
 		default:
-			return nil, sdkerrors.Wrapf(sdkerrors.ErrUnknownRequest, "unknown query path: %s", path[0])
+			return nil, sdkerrors.Extendf(sdkerrors.ErrUnknownRequest, "unknown query path: %s", path[0])
 		}
 	}
 }
@@ -33,7 +33,7 @@ func queryParams(ctx sdk.Context, k Keeper) ([]byte, error) {
 
 	res, err := codec.MarshalJSONIndent(k.cdc, params)
 	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
+		return nil, sdkerrors.Extend(sdkerrors.ErrJSONMarshal, err.Error())
 	}
 
 	return res, nil
@@ -44,7 +44,7 @@ func queryInflation(ctx sdk.Context, k Keeper) ([]byte, error) {
 
 	res, err := codec.MarshalJSONIndent(k.cdc, minter.Inflation)
 	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
+		return nil, sdkerrors.Extend(sdkerrors.ErrJSONMarshal, err.Error())
 	}
 
 	return res, nil
@@ -55,7 +55,7 @@ func queryAnnualProvisions(ctx sdk.Context, k Keeper) ([]byte, error) {
 
 	res, err := codec.MarshalJSONIndent(k.cdc, minter.AnnualProvisions)
 	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
+		return nil, sdkerrors.Extend(sdkerrors.ErrJSONMarshal, err.Error())
 	}
 
 	return res, nil

--- a/x/params/proposal_handler.go
+++ b/x/params/proposal_handler.go
@@ -18,7 +18,7 @@ func NewParamChangeProposalHandler(k keeper.Keeper) govtypes.Handler {
 			return handleParameterChangeProposal(ctx, k, c)
 
 		default:
-			return sdkerrors.Wrapf(sdkerrors.ErrUnknownRequest, "unrecognized param proposal content type: %T", c)
+			return sdkerrors.Extendf(sdkerrors.ErrUnknownRequest, "unrecognized param proposal content type: %T", c)
 		}
 	}
 }
@@ -27,7 +27,7 @@ func handleParameterChangeProposal(ctx sdk.Context, k keeper.Keeper, p proposal.
 	for _, c := range p.Changes {
 		ss, ok := k.GetSubspace(c.Subspace)
 		if !ok {
-			return sdkerrors.Wrap(proposal.ErrUnknownSubspace, c.Subspace)
+			return sdkerrors.Extend(proposal.ErrUnknownSubspace, c.Subspace)
 		}
 
 		k.Logger(ctx).Info(
@@ -35,7 +35,7 @@ func handleParameterChangeProposal(ctx sdk.Context, k keeper.Keeper, p proposal.
 		)
 
 		if err := ss.Update(ctx, []byte(c.Key), []byte(c.Value)); err != nil {
-			return sdkerrors.Wrapf(proposal.ErrSettingParameter, "key: %s, value: %s, err: %s", c.Key, c.Value, err.Error())
+			return sdkerrors.Extendf(proposal.ErrSettingParameter, "key: %s, value: %s, err: %s", c.Key, c.Value, err.Error())
 		}
 	}
 

--- a/x/slashing/handler.go
+++ b/x/slashing/handler.go
@@ -16,7 +16,7 @@ func NewHandler(k Keeper) sdk.Handler {
 			return handleMsgUnjail(ctx, msg, k)
 
 		default:
-			return nil, sdkerrors.Wrapf(sdkerrors.ErrUnknownRequest, "unrecognized %s message type: %T", ModuleName, msg)
+			return nil, sdkerrors.Extendf(sdkerrors.ErrUnknownRequest, "unrecognized %s message type: %T", ModuleName, msg)
 		}
 	}
 }

--- a/x/slashing/keeper/querier.go
+++ b/x/slashing/keeper/querier.go
@@ -24,7 +24,7 @@ func NewQuerier(k Keeper) sdk.Querier {
 			return querySigningInfos(ctx, req, k)
 
 		default:
-			return nil, sdkerrors.Wrapf(sdkerrors.ErrUnknownRequest, "unknown %s query endpoint: %s", types.ModuleName, path[0])
+			return nil, sdkerrors.Extendf(sdkerrors.ErrUnknownRequest, "unknown %s query endpoint: %s", types.ModuleName, path[0])
 		}
 	}
 }
@@ -34,7 +34,7 @@ func queryParams(ctx sdk.Context, k Keeper) ([]byte, error) {
 
 	res, err := codec.MarshalJSONIndent(types.ModuleCdc, params)
 	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
+		return nil, sdkerrors.Extend(sdkerrors.ErrJSONMarshal, err.Error())
 	}
 
 	return res, nil
@@ -45,17 +45,17 @@ func querySigningInfo(ctx sdk.Context, req abci.RequestQuery, k Keeper) ([]byte,
 
 	err := types.ModuleCdc.UnmarshalJSON(req.Data, &params)
 	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONUnmarshal, err.Error())
+		return nil, sdkerrors.Extend(sdkerrors.ErrJSONUnmarshal, err.Error())
 	}
 
 	signingInfo, found := k.GetValidatorSigningInfo(ctx, params.ConsAddress)
 	if !found {
-		return nil, sdkerrors.Wrap(types.ErrNoSigningInfoFound, params.ConsAddress.String())
+		return nil, sdkerrors.Extend(types.ErrNoSigningInfoFound, params.ConsAddress.String())
 	}
 
 	res, err := codec.MarshalJSONIndent(types.ModuleCdc, signingInfo)
 	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
+		return nil, sdkerrors.Extend(sdkerrors.ErrJSONMarshal, err.Error())
 	}
 
 	return res, nil
@@ -66,7 +66,7 @@ func querySigningInfos(ctx sdk.Context, req abci.RequestQuery, k Keeper) ([]byte
 
 	err := types.ModuleCdc.UnmarshalJSON(req.Data, &params)
 	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONUnmarshal, err.Error())
+		return nil, sdkerrors.Extend(sdkerrors.ErrJSONUnmarshal, err.Error())
 	}
 
 	var signingInfos []types.ValidatorSigningInfo
@@ -85,7 +85,7 @@ func querySigningInfos(ctx sdk.Context, req abci.RequestQuery, k Keeper) ([]byte
 
 	res, err := codec.MarshalJSONIndent(types.ModuleCdc, signingInfos)
 	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
+		return nil, sdkerrors.Extend(sdkerrors.ErrJSONMarshal, err.Error())
 	}
 
 	return res, nil

--- a/x/staking/handler.go
+++ b/x/staking/handler.go
@@ -34,7 +34,7 @@ func NewHandler(k keeper.Keeper) sdk.Handler {
 			return handleMsgUndelegate(ctx, msg, k)
 
 		default:
-			return nil, sdkerrors.Wrapf(sdkerrors.ErrUnknownRequest, "unrecognized %s message type: %T", ModuleName, msg)
+			return nil, sdkerrors.Extendf(sdkerrors.ErrUnknownRequest, "unrecognized %s message type: %T", ModuleName, msg)
 		}
 	}
 }
@@ -68,7 +68,7 @@ func handleMsgCreateValidator(ctx sdk.Context, msg types.MsgCreateValidator, k k
 	if ctx.ConsensusParams() != nil {
 		tmPubKey := tmtypes.TM2PB.PubKey(pk)
 		if !tmstrings.StringInSlice(tmPubKey.Type, ctx.ConsensusParams().Validator.PubKeyTypes) {
-			return nil, sdkerrors.Wrapf(
+			return nil, sdkerrors.Extendf(
 				ErrValidatorPubKeyTypeNotSupported,
 				"got: %s, expected: %s", tmPubKey.Type, ctx.ConsensusParams().Validator.PubKeyTypes,
 			)

--- a/x/staking/keeper/delegation.go
+++ b/x/staking/keeper/delegation.go
@@ -563,7 +563,7 @@ func (k Keeper) Unbond(
 
 	// ensure that we have enough shares to remove
 	if delegation.Shares.LT(shares) {
-		return amount, sdkerrors.Wrap(types.ErrNotEnoughDelegationShares, delegation.Shares.String())
+		return amount, sdkerrors.Extend(types.ErrNotEnoughDelegationShares, delegation.Shares.String())
 	}
 
 	// get validator

--- a/x/staking/keeper/querier.go
+++ b/x/staking/keeper/querier.go
@@ -60,7 +60,7 @@ func NewQuerier(k Keeper) sdk.Querier {
 			return queryParameters(ctx, k)
 
 		default:
-			return nil, sdkerrors.Wrapf(sdkerrors.ErrUnknownRequest, "unknown %s query endpoint: %s", types.ModuleName, path[0])
+			return nil, sdkerrors.Extendf(sdkerrors.ErrUnknownRequest, "unknown %s query endpoint: %s", types.ModuleName, path[0])
 		}
 	}
 }
@@ -70,7 +70,7 @@ func queryValidators(ctx sdk.Context, req abci.RequestQuery, k Keeper) ([]byte, 
 
 	err := types.ModuleCdc.UnmarshalJSON(req.Data, &params)
 	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONUnmarshal, err.Error())
+		return nil, sdkerrors.Extend(sdkerrors.ErrJSONUnmarshal, err.Error())
 	}
 
 	validators := k.GetAllValidators(ctx)
@@ -91,7 +91,7 @@ func queryValidators(ctx sdk.Context, req abci.RequestQuery, k Keeper) ([]byte, 
 
 	res, err := codec.MarshalJSONIndent(types.ModuleCdc, filteredVals)
 	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
+		return nil, sdkerrors.Extend(sdkerrors.ErrJSONMarshal, err.Error())
 	}
 
 	return res, nil
@@ -102,7 +102,7 @@ func queryValidator(ctx sdk.Context, req abci.RequestQuery, k Keeper) ([]byte, e
 
 	err := types.ModuleCdc.UnmarshalJSON(req.Data, &params)
 	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONUnmarshal, err.Error())
+		return nil, sdkerrors.Extend(sdkerrors.ErrJSONUnmarshal, err.Error())
 	}
 
 	validator, found := k.GetValidator(ctx, params.ValidatorAddr)
@@ -112,7 +112,7 @@ func queryValidator(ctx sdk.Context, req abci.RequestQuery, k Keeper) ([]byte, e
 
 	res, err := codec.MarshalJSONIndent(types.ModuleCdc, validator)
 	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
+		return nil, sdkerrors.Extend(sdkerrors.ErrJSONMarshal, err.Error())
 	}
 
 	return res, nil
@@ -123,7 +123,7 @@ func queryValidatorDelegations(ctx sdk.Context, req abci.RequestQuery, k Keeper)
 
 	err := types.ModuleCdc.UnmarshalJSON(req.Data, &params)
 	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONUnmarshal, err.Error())
+		return nil, sdkerrors.Extend(sdkerrors.ErrJSONUnmarshal, err.Error())
 	}
 
 	delegations := k.GetValidatorDelegations(ctx, params.ValidatorAddr)
@@ -138,7 +138,7 @@ func queryValidatorDelegations(ctx sdk.Context, req abci.RequestQuery, k Keeper)
 
 	res, err := codec.MarshalJSONIndent(types.ModuleCdc, delegationResps)
 	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
+		return nil, sdkerrors.Extend(sdkerrors.ErrJSONMarshal, err.Error())
 	}
 
 	return res, nil
@@ -149,7 +149,7 @@ func queryValidatorUnbondingDelegations(ctx sdk.Context, req abci.RequestQuery, 
 
 	err := types.ModuleCdc.UnmarshalJSON(req.Data, &params)
 	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONUnmarshal, err.Error())
+		return nil, sdkerrors.Extend(sdkerrors.ErrJSONUnmarshal, err.Error())
 	}
 
 	unbonds := k.GetUnbondingDelegationsFromValidator(ctx, params.ValidatorAddr)
@@ -159,7 +159,7 @@ func queryValidatorUnbondingDelegations(ctx sdk.Context, req abci.RequestQuery, 
 
 	res, err := codec.MarshalJSONIndent(types.ModuleCdc, unbonds)
 	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
+		return nil, sdkerrors.Extend(sdkerrors.ErrJSONMarshal, err.Error())
 	}
 
 	return res, nil
@@ -170,7 +170,7 @@ func queryDelegatorDelegations(ctx sdk.Context, req abci.RequestQuery, k Keeper)
 
 	err := types.ModuleCdc.UnmarshalJSON(req.Data, &params)
 	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONUnmarshal, err.Error())
+		return nil, sdkerrors.Extend(sdkerrors.ErrJSONUnmarshal, err.Error())
 	}
 
 	delegations := k.GetAllDelegatorDelegations(ctx, params.DelegatorAddr)
@@ -185,7 +185,7 @@ func queryDelegatorDelegations(ctx sdk.Context, req abci.RequestQuery, k Keeper)
 
 	res, err := codec.MarshalJSONIndent(types.ModuleCdc, delegationResps)
 	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
+		return nil, sdkerrors.Extend(sdkerrors.ErrJSONMarshal, err.Error())
 	}
 
 	return res, nil
@@ -196,7 +196,7 @@ func queryDelegatorUnbondingDelegations(ctx sdk.Context, req abci.RequestQuery, 
 
 	err := types.ModuleCdc.UnmarshalJSON(req.Data, &params)
 	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONUnmarshal, err.Error())
+		return nil, sdkerrors.Extend(sdkerrors.ErrJSONUnmarshal, err.Error())
 	}
 
 	unbondingDelegations := k.GetAllUnbondingDelegations(ctx, params.DelegatorAddr)
@@ -206,7 +206,7 @@ func queryDelegatorUnbondingDelegations(ctx sdk.Context, req abci.RequestQuery, 
 
 	res, err := codec.MarshalJSONIndent(types.ModuleCdc, unbondingDelegations)
 	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
+		return nil, sdkerrors.Extend(sdkerrors.ErrJSONMarshal, err.Error())
 	}
 
 	return res, nil
@@ -219,7 +219,7 @@ func queryDelegatorValidators(ctx sdk.Context, req abci.RequestQuery, k Keeper) 
 
 	err := types.ModuleCdc.UnmarshalJSON(req.Data, &params)
 	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONUnmarshal, err.Error())
+		return nil, sdkerrors.Extend(sdkerrors.ErrJSONUnmarshal, err.Error())
 	}
 
 	validators := k.GetDelegatorValidators(ctx, params.DelegatorAddr, stakingParams.MaxValidators)
@@ -229,7 +229,7 @@ func queryDelegatorValidators(ctx sdk.Context, req abci.RequestQuery, k Keeper) 
 
 	res, err := codec.MarshalJSONIndent(types.ModuleCdc, validators)
 	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
+		return nil, sdkerrors.Extend(sdkerrors.ErrJSONMarshal, err.Error())
 	}
 
 	return res, nil
@@ -240,7 +240,7 @@ func queryDelegatorValidator(ctx sdk.Context, req abci.RequestQuery, k Keeper) (
 
 	err := types.ModuleCdc.UnmarshalJSON(req.Data, &params)
 	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONUnmarshal, err.Error())
+		return nil, sdkerrors.Extend(sdkerrors.ErrJSONUnmarshal, err.Error())
 	}
 
 	validator, err := k.GetDelegatorValidator(ctx, params.DelegatorAddr, params.ValidatorAddr)
@@ -250,7 +250,7 @@ func queryDelegatorValidator(ctx sdk.Context, req abci.RequestQuery, k Keeper) (
 
 	res, err := codec.MarshalJSONIndent(types.ModuleCdc, validator)
 	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
+		return nil, sdkerrors.Extend(sdkerrors.ErrJSONMarshal, err.Error())
 	}
 
 	return res, nil
@@ -261,7 +261,7 @@ func queryDelegation(ctx sdk.Context, req abci.RequestQuery, k Keeper) ([]byte, 
 
 	err := types.ModuleCdc.UnmarshalJSON(req.Data, &params)
 	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONUnmarshal, err.Error())
+		return nil, sdkerrors.Extend(sdkerrors.ErrJSONUnmarshal, err.Error())
 	}
 
 	delegation, found := k.GetDelegation(ctx, params.DelegatorAddr, params.ValidatorAddr)
@@ -276,7 +276,7 @@ func queryDelegation(ctx sdk.Context, req abci.RequestQuery, k Keeper) ([]byte, 
 
 	res, err := codec.MarshalJSONIndent(types.ModuleCdc, delegationResp)
 	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
+		return nil, sdkerrors.Extend(sdkerrors.ErrJSONMarshal, err.Error())
 	}
 
 	return res, nil
@@ -287,7 +287,7 @@ func queryUnbondingDelegation(ctx sdk.Context, req abci.RequestQuery, k Keeper) 
 
 	err := types.ModuleCdc.UnmarshalJSON(req.Data, &params)
 	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONUnmarshal, err.Error())
+		return nil, sdkerrors.Extend(sdkerrors.ErrJSONUnmarshal, err.Error())
 	}
 
 	unbond, found := k.GetUnbondingDelegation(ctx, params.DelegatorAddr, params.ValidatorAddr)
@@ -297,7 +297,7 @@ func queryUnbondingDelegation(ctx sdk.Context, req abci.RequestQuery, k Keeper) 
 
 	res, err := codec.MarshalJSONIndent(types.ModuleCdc, unbond)
 	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
+		return nil, sdkerrors.Extend(sdkerrors.ErrJSONMarshal, err.Error())
 	}
 
 	return res, nil
@@ -308,7 +308,7 @@ func queryRedelegations(ctx sdk.Context, req abci.RequestQuery, k Keeper) ([]byt
 
 	err := types.ModuleCdc.UnmarshalJSON(req.Data, &params)
 	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONUnmarshal, err.Error())
+		return nil, sdkerrors.Extend(sdkerrors.ErrJSONUnmarshal, err.Error())
 	}
 
 	var redels []types.Redelegation
@@ -338,7 +338,7 @@ func queryRedelegations(ctx sdk.Context, req abci.RequestQuery, k Keeper) ([]byt
 
 	res, err := codec.MarshalJSONIndent(types.ModuleCdc, redelResponses)
 	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
+		return nil, sdkerrors.Extend(sdkerrors.ErrJSONMarshal, err.Error())
 	}
 
 	return res, nil
@@ -349,7 +349,7 @@ func queryHistoricalInfo(ctx sdk.Context, req abci.RequestQuery, k Keeper) ([]by
 
 	err := types.ModuleCdc.UnmarshalJSON(req.Data, &params)
 	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONUnmarshal, err.Error())
+		return nil, sdkerrors.Extend(sdkerrors.ErrJSONUnmarshal, err.Error())
 	}
 
 	hi, found := k.GetHistoricalInfo(ctx, params.Height)
@@ -359,7 +359,7 @@ func queryHistoricalInfo(ctx sdk.Context, req abci.RequestQuery, k Keeper) ([]by
 
 	res, err := codec.MarshalJSONIndent(types.ModuleCdc, hi)
 	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
+		return nil, sdkerrors.Extend(sdkerrors.ErrJSONMarshal, err.Error())
 	}
 
 	return res, nil
@@ -381,7 +381,7 @@ func queryPool(ctx sdk.Context, k Keeper) ([]byte, error) {
 
 	res, err := codec.MarshalJSONIndent(types.ModuleCdc, pool)
 	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
+		return nil, sdkerrors.Extend(sdkerrors.ErrJSONMarshal, err.Error())
 	}
 
 	return res, nil
@@ -392,7 +392,7 @@ func queryParameters(ctx sdk.Context, k Keeper) ([]byte, error) {
 
 	res, err := codec.MarshalJSONIndent(types.ModuleCdc, params)
 	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
+		return nil, sdkerrors.Extend(sdkerrors.ErrJSONMarshal, err.Error())
 	}
 
 	return res, nil

--- a/x/staking/types/historical_info.go
+++ b/x/staking/types/historical_info.go
@@ -42,10 +42,10 @@ func UnmarshalHistoricalInfo(cdc codec.Marshaler, value []byte) (hi HistoricalIn
 // ValidateBasic will ensure HistoricalInfo is not nil and sorted
 func ValidateBasic(hi HistoricalInfo) error {
 	if len(hi.Valset) == 0 {
-		return sdkerrors.Wrap(ErrInvalidHistoricalInfo, "validator set is empty")
+		return sdkerrors.Extend(ErrInvalidHistoricalInfo, "validator set is empty")
 	}
 	if !sort.IsSorted(Validators(hi.Valset)) {
-		return sdkerrors.Wrap(ErrInvalidHistoricalInfo, "validator set is not sorted by address")
+		return sdkerrors.Extend(ErrInvalidHistoricalInfo, "validator set is not sorted by address")
 	}
 
 	return nil

--- a/x/staking/types/msg.go
+++ b/x/staking/types/msg.go
@@ -85,10 +85,10 @@ func (msg MsgCreateValidator) ValidateBasic() error {
 		return ErrBadDelegationAmount
 	}
 	if msg.Description == (Description{}) {
-		return sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "empty description")
+		return sdkerrors.Extend(sdkerrors.ErrInvalidRequest, "empty description")
 	}
 	if msg.Commission == (CommissionRates{}) {
-		return sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "empty commission")
+		return sdkerrors.Extend(sdkerrors.ErrInvalidRequest, "empty commission")
 	}
 	if err := msg.Commission.Validate(); err != nil {
 		return err
@@ -136,14 +136,14 @@ func (msg MsgEditValidator) ValidateBasic() error {
 		return ErrEmptyValidatorAddr
 	}
 	if msg.Description == (Description{}) {
-		return sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "empty description")
+		return sdkerrors.Extend(sdkerrors.ErrInvalidRequest, "empty description")
 	}
 	if msg.MinSelfDelegation != nil && !msg.MinSelfDelegation.IsPositive() {
 		return ErrMinSelfDelegationInvalid
 	}
 	if msg.CommissionRate != nil {
 		if msg.CommissionRate.GT(sdk.OneDec()) || msg.CommissionRate.IsNegative() {
-			return sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "commission rate must be between 0 and 1 (inclusive)")
+			return sdkerrors.Extend(sdkerrors.ErrInvalidRequest, "commission rate must be between 0 and 1 (inclusive)")
 		}
 	}
 

--- a/x/staking/types/validator.go
+++ b/x/staking/types/validator.go
@@ -191,19 +191,19 @@ func (d Description) UpdateDescription(d2 Description) (Description, error) {
 // EnsureLength ensures the length of a validator's description.
 func (d Description) EnsureLength() (Description, error) {
 	if len(d.Moniker) > MaxMonikerLength {
-		return d, sdkerrors.Wrapf(sdkerrors.ErrInvalidRequest, "invalid moniker length; got: %d, max: %d", len(d.Moniker), MaxMonikerLength)
+		return d, sdkerrors.Extendf(sdkerrors.ErrInvalidRequest, "invalid moniker length; got: %d, max: %d", len(d.Moniker), MaxMonikerLength)
 	}
 	if len(d.Identity) > MaxIdentityLength {
-		return d, sdkerrors.Wrapf(sdkerrors.ErrInvalidRequest, "invalid identity length; got: %d, max: %d", len(d.Identity), MaxIdentityLength)
+		return d, sdkerrors.Extendf(sdkerrors.ErrInvalidRequest, "invalid identity length; got: %d, max: %d", len(d.Identity), MaxIdentityLength)
 	}
 	if len(d.Website) > MaxWebsiteLength {
-		return d, sdkerrors.Wrapf(sdkerrors.ErrInvalidRequest, "invalid website length; got: %d, max: %d", len(d.Website), MaxWebsiteLength)
+		return d, sdkerrors.Extendf(sdkerrors.ErrInvalidRequest, "invalid website length; got: %d, max: %d", len(d.Website), MaxWebsiteLength)
 	}
 	if len(d.SecurityContact) > MaxSecurityContactLength {
-		return d, sdkerrors.Wrapf(sdkerrors.ErrInvalidRequest, "invalid security contact length; got: %d, max: %d", len(d.SecurityContact), MaxSecurityContactLength)
+		return d, sdkerrors.Extendf(sdkerrors.ErrInvalidRequest, "invalid security contact length; got: %d, max: %d", len(d.SecurityContact), MaxSecurityContactLength)
 	}
 	if len(d.Details) > MaxDetailsLength {
-		return d, sdkerrors.Wrapf(sdkerrors.ErrInvalidRequest, "invalid details length; got: %d, max: %d", len(d.Details), MaxDetailsLength)
+		return d, sdkerrors.Extendf(sdkerrors.ErrInvalidRequest, "invalid details length; got: %d, max: %d", len(d.Details), MaxDetailsLength)
 	}
 
 	return d, nil

--- a/x/supply/keeper/bank.go
+++ b/x/supply/keeper/bank.go
@@ -16,7 +16,7 @@ func (k Keeper) SendCoinsFromModuleToAccount(
 
 	senderAddr := k.GetModuleAddress(senderModule)
 	if senderAddr == nil {
-		panic(sdkerrors.Wrapf(sdkerrors.ErrUnknownAddress, "module account %s does not exist", senderModule))
+		panic(sdkerrors.Extendf(sdkerrors.ErrUnknownAddress, "module account %s does not exist", senderModule))
 	}
 
 	return k.bk.SendCoins(ctx, senderAddr, recipientAddr, amt)
@@ -30,12 +30,12 @@ func (k Keeper) SendCoinsFromModuleToModule(
 
 	senderAddr := k.GetModuleAddress(senderModule)
 	if senderAddr == nil {
-		panic(sdkerrors.Wrapf(sdkerrors.ErrUnknownAddress, "module account %s does not exist", senderModule))
+		panic(sdkerrors.Extendf(sdkerrors.ErrUnknownAddress, "module account %s does not exist", senderModule))
 	}
 
 	recipientAcc := k.GetModuleAccount(ctx, recipientModule)
 	if recipientAcc == nil {
-		panic(sdkerrors.Wrapf(sdkerrors.ErrUnknownAddress, "module account %s does not exist", recipientModule))
+		panic(sdkerrors.Extendf(sdkerrors.ErrUnknownAddress, "module account %s does not exist", recipientModule))
 	}
 
 	return k.bk.SendCoins(ctx, senderAddr, recipientAcc.GetAddress(), amt)
@@ -49,7 +49,7 @@ func (k Keeper) SendCoinsFromAccountToModule(
 
 	recipientAcc := k.GetModuleAccount(ctx, recipientModule)
 	if recipientAcc == nil {
-		panic(sdkerrors.Wrapf(sdkerrors.ErrUnknownAddress, "module account %s does not exist", recipientModule))
+		panic(sdkerrors.Extendf(sdkerrors.ErrUnknownAddress, "module account %s does not exist", recipientModule))
 	}
 
 	return k.bk.SendCoins(ctx, senderAddr, recipientAcc.GetAddress(), amt)
@@ -64,11 +64,11 @@ func (k Keeper) DelegateCoinsFromAccountToModule(
 
 	recipientAcc := k.GetModuleAccount(ctx, recipientModule)
 	if recipientAcc == nil {
-		panic(sdkerrors.Wrapf(sdkerrors.ErrUnknownAddress, "module account %s does not exist", recipientModule))
+		panic(sdkerrors.Extendf(sdkerrors.ErrUnknownAddress, "module account %s does not exist", recipientModule))
 	}
 
 	if !recipientAcc.HasPermission(types.Staking) {
-		panic(sdkerrors.Wrapf(sdkerrors.ErrUnauthorized, "module account %s does not have permissions to receive delegated coins", recipientModule))
+		panic(sdkerrors.Extendf(sdkerrors.ErrUnauthorized, "module account %s does not have permissions to receive delegated coins", recipientModule))
 	}
 
 	return k.bk.DelegateCoins(ctx, senderAddr, recipientAcc.GetAddress(), amt)
@@ -83,11 +83,11 @@ func (k Keeper) UndelegateCoinsFromModuleToAccount(
 
 	acc := k.GetModuleAccount(ctx, senderModule)
 	if acc == nil {
-		panic(sdkerrors.Wrapf(sdkerrors.ErrUnknownAddress, "module account %s does not exist", senderModule))
+		panic(sdkerrors.Extendf(sdkerrors.ErrUnknownAddress, "module account %s does not exist", senderModule))
 	}
 
 	if !acc.HasPermission(types.Staking) {
-		panic(sdkerrors.Wrapf(sdkerrors.ErrUnauthorized, "module account %s does not have permissions to undelegate coins", senderModule))
+		panic(sdkerrors.Extendf(sdkerrors.ErrUnauthorized, "module account %s does not have permissions to undelegate coins", senderModule))
 	}
 
 	return k.bk.UndelegateCoins(ctx, acc.GetAddress(), recipientAddr, amt)
@@ -98,11 +98,11 @@ func (k Keeper) UndelegateCoinsFromModuleToAccount(
 func (k Keeper) MintCoins(ctx sdk.Context, moduleName string, amt sdk.Coins) error {
 	acc := k.GetModuleAccount(ctx, moduleName)
 	if acc == nil {
-		panic(sdkerrors.Wrapf(sdkerrors.ErrUnknownAddress, "module account %s does not exist", moduleName))
+		panic(sdkerrors.Extendf(sdkerrors.ErrUnknownAddress, "module account %s does not exist", moduleName))
 	}
 
 	if !acc.HasPermission(types.Minter) {
-		panic(sdkerrors.Wrapf(sdkerrors.ErrUnauthorized, "module account %s does not have permissions to mint tokens", moduleName))
+		panic(sdkerrors.Extendf(sdkerrors.ErrUnauthorized, "module account %s does not have permissions to mint tokens", moduleName))
 	}
 
 	_, err := k.bk.AddCoins(ctx, acc.GetAddress(), amt)
@@ -127,11 +127,11 @@ func (k Keeper) MintCoins(ctx sdk.Context, moduleName string, amt sdk.Coins) err
 func (k Keeper) BurnCoins(ctx sdk.Context, moduleName string, amt sdk.Coins) error {
 	acc := k.GetModuleAccount(ctx, moduleName)
 	if acc == nil {
-		panic(sdkerrors.Wrapf(sdkerrors.ErrUnknownAddress, "module account %s does not exist", moduleName))
+		panic(sdkerrors.Extendf(sdkerrors.ErrUnknownAddress, "module account %s does not exist", moduleName))
 	}
 
 	if !acc.HasPermission(types.Burner) {
-		panic(sdkerrors.Wrapf(sdkerrors.ErrUnauthorized, "module account %s does not have permissions to burn tokens", moduleName))
+		panic(sdkerrors.Extendf(sdkerrors.ErrUnauthorized, "module account %s does not have permissions to burn tokens", moduleName))
 	}
 
 	_, err := k.bk.SubtractCoins(ctx, acc.GetAddress(), amt)

--- a/x/supply/keeper/querier.go
+++ b/x/supply/keeper/querier.go
@@ -21,7 +21,7 @@ func NewQuerier(k Keeper) sdk.Querier {
 			return querySupplyOf(ctx, req, k)
 
 		default:
-			return nil, sdkerrors.Wrapf(sdkerrors.ErrUnknownRequest, "unknown %s query endpoint: %s", types.ModuleName, path[0])
+			return nil, sdkerrors.Extendf(sdkerrors.ErrUnknownRequest, "unknown %s query endpoint: %s", types.ModuleName, path[0])
 		}
 	}
 }
@@ -31,7 +31,7 @@ func queryTotalSupply(ctx sdk.Context, req abci.RequestQuery, k Keeper) ([]byte,
 
 	err := types.ModuleCdc.UnmarshalJSON(req.Data, &params)
 	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONUnmarshal, err.Error())
+		return nil, sdkerrors.Extend(sdkerrors.ErrJSONUnmarshal, err.Error())
 	}
 
 	totalSupply := k.GetSupply(ctx).GetTotal()
@@ -45,7 +45,7 @@ func queryTotalSupply(ctx sdk.Context, req abci.RequestQuery, k Keeper) ([]byte,
 
 	res, err := totalSupply.MarshalJSON()
 	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
+		return nil, sdkerrors.Extend(sdkerrors.ErrJSONMarshal, err.Error())
 	}
 
 	return res, nil
@@ -56,14 +56,14 @@ func querySupplyOf(ctx sdk.Context, req abci.RequestQuery, k Keeper) ([]byte, er
 
 	err := types.ModuleCdc.UnmarshalJSON(req.Data, &params)
 	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONUnmarshal, err.Error())
+		return nil, sdkerrors.Extend(sdkerrors.ErrJSONUnmarshal, err.Error())
 	}
 
 	supply := k.GetSupply(ctx).GetTotal().AmountOf(params.Denom)
 
 	res, err := supply.MarshalJSON()
 	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
+		return nil, sdkerrors.Extend(sdkerrors.ErrJSONMarshal, err.Error())
 	}
 
 	return res, nil

--- a/x/upgrade/handler.go
+++ b/x/upgrade/handler.go
@@ -19,7 +19,7 @@ func NewSoftwareUpgradeProposalHandler(k Keeper) govtypes.Handler {
 			return handleCancelSoftwareUpgradeProposal(ctx, k, c)
 
 		default:
-			return sdkerrors.Wrapf(sdkerrors.ErrUnknownRequest, "unrecognized software upgrade proposal content type: %T", c)
+			return sdkerrors.Extendf(sdkerrors.ErrUnknownRequest, "unrecognized software upgrade proposal content type: %T", c)
 		}
 	}
 }

--- a/x/upgrade/keeper/keeper.go
+++ b/x/upgrade/keeper/keeper.go
@@ -60,14 +60,14 @@ func (k Keeper) ScheduleUpgrade(ctx sdk.Context, plan types.Plan) error {
 
 	if !plan.Time.IsZero() {
 		if !plan.Time.After(ctx.BlockHeader().Time) {
-			return sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "upgrade cannot be scheduled in the past")
+			return sdkerrors.Extend(sdkerrors.ErrInvalidRequest, "upgrade cannot be scheduled in the past")
 		}
 	} else if plan.Height <= ctx.BlockHeight() {
-		return sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "upgrade cannot be scheduled in the past")
+		return sdkerrors.Extend(sdkerrors.ErrInvalidRequest, "upgrade cannot be scheduled in the past")
 	}
 
 	if k.GetDoneHeight(ctx, plan.Name) != 0 {
-		return sdkerrors.Wrapf(sdkerrors.ErrInvalidRequest, "upgrade with name %s has already been completed", plan.Name)
+		return sdkerrors.Extendf(sdkerrors.ErrInvalidRequest, "upgrade with name %s has already been completed", plan.Name)
 	}
 
 	bz := k.cdc.MustMarshalBinaryBare(&plan)

--- a/x/upgrade/keeper/querier.go
+++ b/x/upgrade/keeper/querier.go
@@ -23,7 +23,7 @@ func NewQuerier(k Keeper) sdk.Querier {
 			return queryApplied(ctx, req, k)
 
 		default:
-			return nil, sdkerrors.Wrapf(sdkerrors.ErrUnknownRequest, "unknown %s query endpoint: %s", types.ModuleName, path[0])
+			return nil, sdkerrors.Extendf(sdkerrors.ErrUnknownRequest, "unknown %s query endpoint: %s", types.ModuleName, path[0])
 		}
 	}
 }
@@ -36,7 +36,7 @@ func queryCurrent(ctx sdk.Context, req abci.RequestQuery, k Keeper) ([]byte, err
 
 	res, err := k.cdc.MarshalJSON(&plan)
 	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
+		return nil, sdkerrors.Extend(sdkerrors.ErrJSONMarshal, err.Error())
 	}
 
 	return res, nil
@@ -47,7 +47,7 @@ func queryApplied(ctx sdk.Context, req abci.RequestQuery, k Keeper) ([]byte, err
 
 	err := k.cdc.UnmarshalJSON(req.Data, &params)
 	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONUnmarshal, err.Error())
+		return nil, sdkerrors.Extend(sdkerrors.ErrJSONUnmarshal, err.Error())
 	}
 
 	applied := k.GetDoneHeight(ctx, params.Name)

--- a/x/upgrade/types/plan.go
+++ b/x/upgrade/types/plan.go
@@ -21,16 +21,16 @@ func (p Plan) String() string {
 // ValidateBasic does basic validation of a Plan
 func (p Plan) ValidateBasic() error {
 	if len(p.Name) == 0 {
-		return sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "name cannot be empty")
+		return sdkerrors.Extend(sdkerrors.ErrInvalidRequest, "name cannot be empty")
 	}
 	if p.Height < 0 {
-		return sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "height cannot be negative")
+		return sdkerrors.Extend(sdkerrors.ErrInvalidRequest, "height cannot be negative")
 	}
 	if p.Time.IsZero() && p.Height == 0 {
-		return sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "must set either time or height")
+		return sdkerrors.Extend(sdkerrors.ErrInvalidRequest, "must set either time or height")
 	}
 	if !p.Time.IsZero() && p.Height != 0 {
-		return sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "cannot set both time and height")
+		return sdkerrors.Extend(sdkerrors.ErrInvalidRequest, "cannot set both time and height")
 	}
 
 	return nil


### PR DESCRIPTION
Wrap(ErrInsufficientFunds, "40 < 500") returns strings like
"insufficient funds: 40 < 50". Although he function syntax
fits perfectly SDK app developers use case and as such it
should not be changed, the name is still counter-intuitive,
as most Golang developers may reasonably expect a different
result similar to what other popular libraries' (see [1])
would produce (e.g. "40 < 500: insufficient funds").

[1] https://godoc.org/github.com/pkg/errors#Wrapf

______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added  relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

______

For admin use:

- [ ] Added appropriate labels to PR (ex. `WIP`, `R4R`, `docs`, etc)
- [ ] Reviewers assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
