### PR TITLE
exclude generated code from code coverage statistics

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,6 +165,8 @@ jobs:
           name: filter out DONTCOVER
           command: |
             excludelist="$(find ./ -type f -name '*.go' | xargs grep -l 'DONTCOVER')"
+            excludelist+=" $(find ./ -type f -name '*.pb.go')"
+            excludelist+=" $(find ./ -type f -path './tests/mocks/*.go')"
             for filename in ${excludelist}; do
               filename=$(echo $filename | sed 's/^./github.com\/cosmos\/cosmos-sdk/g')
               echo "Excluding ${filename} from coverage report..."


### PR DESCRIPTION
`.codecov.yml` is not working. We should filter out all
generated code that we don't want to be included in
the coverage report.

______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added  relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

______

For admin use:

- [ ] Added appropriate labels to PR (ex. `WIP`, `R4R`, `docs`, etc)
- [ ] Reviewers assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
