### PR TITLE
x/auth: use validateMaxMemoCharacters() for memo fields

### DIFF
--- a/x/auth/types/params.go
+++ b/x/auth/types/params.go
@@ -156,7 +156,7 @@ func (p Params) Validate() error {
 	if err := validateSigVerifyCostSecp256k1(p.SigVerifyCostSecp256k1); err != nil {
 		return err
 	}
-	if err := validateSigVerifyCostSecp256k1(p.MaxMemoCharacters); err != nil {
+	if err := validateMaxMemoCharacters(p.MaxMemoCharacters); err != nil {
 		return err
 	}
 	if err := validateTxSizeCostPerByte(p.TxSizeCostPerByte); err != nil {

--- a/x/auth/types/params_test.go
+++ b/x/auth/types/params_test.go
@@ -1,16 +1,49 @@
-package types
+package types_test
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/cosmos/cosmos-sdk/x/auth/types"
 	"github.com/stretchr/testify/require"
 )
 
 func TestParamsEqual(t *testing.T) {
-	p1 := DefaultParams()
-	p2 := DefaultParams()
+	p1 := types.DefaultParams()
+	p2 := types.DefaultParams()
 	require.Equal(t, p1, p2)
 
 	p1.TxSigLimit += 10
 	require.NotEqual(t, p1, p2)
+}
+
+func TestParams_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		params  types.Params
+		wantErr error
+	}{
+		{"default params", types.DefaultParams(), nil},
+		{"invalid tx signature limit", types.NewParams(types.DefaultMaxMemoCharacters, 0, types.DefaultTxSizeCostPerByte,
+			types.DefaultSigVerifyCostED25519, types.DefaultSigVerifyCostSecp256k1), fmt.Errorf("invalid tx signature limit: 0")},
+		{"invalid ED25519 signature verification cost", types.NewParams(types.DefaultMaxMemoCharacters, types.DefaultTxSigLimit, types.DefaultTxSizeCostPerByte,
+			0, types.DefaultSigVerifyCostSecp256k1), fmt.Errorf("invalid ED25519 signature verification cost: 0")},
+		{"invalid SECK256k1 signature verification cost", types.NewParams(types.DefaultMaxMemoCharacters, types.DefaultTxSigLimit, types.DefaultTxSizeCostPerByte,
+			types.DefaultSigVerifyCostED25519, 0), fmt.Errorf("invalid SECK256k1 signature verification cost: 0")},
+		{"invalid max memo characters", types.NewParams(0, types.DefaultTxSigLimit, types.DefaultTxSizeCostPerByte,
+			types.DefaultSigVerifyCostED25519, types.DefaultSigVerifyCostSecp256k1), fmt.Errorf("invalid max memo characters: 0")},
+		{"invalid tx size cost per byte", types.NewParams(types.DefaultMaxMemoCharacters, types.DefaultTxSigLimit, 0,
+			types.DefaultSigVerifyCostED25519, types.DefaultSigVerifyCostSecp256k1), fmt.Errorf("invalid tx size cost per byte: 0")},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.params.Validate()
+			if tt.wantErr == nil {
+				require.NoError(t, got)
+				return
+			}
+			require.Equal(t, tt.wantErr, got)
+		})
+	}
 }


### PR DESCRIPTION
Add few test cases.

______

For contributor use:

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added  relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

______

For admin use:

- [ ] Added appropriate labels to PR (ex. `WIP`, `R4R`, `docs`, etc)
- [ ] Reviewers assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
