### PR TITLE
Remove source field from ICS 20 packet & message types per latest spec

### DIFF
--- a/x/ibc/20-transfer/client/cli/tx.go
+++ b/x/ibc/20-transfer/client/cli/tx.go
@@ -5,7 +5,6 @@ import (
 	"strconv"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 
 	"github.com/cosmos/cosmos-sdk/client/context"
 	"github.com/cosmos/cosmos-sdk/client/flags"
@@ -18,7 +17,6 @@ import (
 
 // IBC transfer flags
 var (
-	FlagSource   = "source"
 	FlagNode1    = "node1"
 	FlagNode2    = "node2"
 	FlagFrom1    = "from1"
@@ -57,9 +55,7 @@ func GetTransferTxCmd(cdc *codec.Codec) *cobra.Command {
 				return err
 			}
 
-			source := viper.GetBool(FlagSource)
-
-			msg := types.NewMsgTransfer(srcPort, srcChannel, uint64(destHeight), coins, sender, receiver, source)
+			msg := types.NewMsgTransfer(srcPort, srcChannel, uint64(destHeight), coins, sender, receiver)
 			if err := msg.ValidateBasic(); err != nil {
 				return err
 			}
@@ -67,6 +63,5 @@ func GetTransferTxCmd(cdc *codec.Codec) *cobra.Command {
 			return authclient.GenerateOrBroadcastMsgs(cliCtx, txBldr, []sdk.Msg{msg})
 		},
 	}
-	cmd.Flags().Bool(FlagSource, false, "Pass flag for sending token from the source chain")
 	return cmd
 }

--- a/x/ibc/20-transfer/client/rest/rest.go
+++ b/x/ibc/20-transfer/client/rest/rest.go
@@ -25,5 +25,4 @@ type TransferTxReq struct {
 	DestHeight uint64         `json:"dest_height" yaml:"dest_height"`
 	Amount     sdk.Coins      `json:"amount" yaml:"amount"`
 	Receiver   sdk.AccAddress `json:"receiver" yaml:"receiver"`
-	Source     bool           `json:"source" yaml:"source"`
 }

--- a/x/ibc/20-transfer/client/rest/tx.go
+++ b/x/ibc/20-transfer/client/rest/tx.go
@@ -60,7 +60,6 @@ func transferHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 			req.Amount,
 			fromAddr,
 			req.Receiver,
-			req.Source,
 		)
 
 		if err := msg.ValidateBasic(); err != nil {

--- a/x/ibc/20-transfer/handler.go
+++ b/x/ibc/20-transfer/handler.go
@@ -35,7 +35,7 @@ func NewHandler(k Keeper) sdk.Handler {
 // See createOutgoingPacket in spec:https://github.com/cosmos/ics/tree/master/spec/ics-020-fungible-token-transfer#packet-relay
 func handleMsgTransfer(ctx sdk.Context, k Keeper, msg MsgTransfer) (*sdk.Result, error) {
 	if err := k.SendTransfer(
-		ctx, msg.SourcePort, msg.SourceChannel, msg.DestHeight, msg.Amount, msg.Sender, msg.Receiver, msg.Source,
+		ctx, msg.SourcePort, msg.SourceChannel, msg.DestHeight, msg.Amount, msg.Sender, msg.Receiver,
 	); err != nil {
 		return nil, err
 	}

--- a/x/ibc/20-transfer/handler_test.go
+++ b/x/ibc/20-transfer/handler_test.go
@@ -89,12 +89,10 @@ func (suite *HandlerTestSuite) queryProof(key []byte) (proof commitmenttypes.Mer
 }
 
 func (suite *HandlerTestSuite) TestHandleMsgTransfer() {
-	source := true
-
 	handler := transfer.NewHandler(suite.chainA.App.TransferKeeper)
 
 	ctx := suite.chainA.GetContext()
-	msg := transfer.NewMsgTransfer(testPort1, testChannel1, 10, testCoins, testAddr1, testAddr2, source)
+	msg := transfer.NewMsgTransfer(testPort1, testChannel1, 10, testPrefixedCoins2, testAddr1, testAddr2)
 	res, err := handler(ctx, msg)
 	suite.Require().Error(err)
 	suite.Require().Nil(res, "%+v", res) // channel does not exist
@@ -120,16 +118,14 @@ func (suite *HandlerTestSuite) TestHandleMsgTransfer() {
 	suite.Require().NotNil(res, "%+v", res) // successfully executed
 
 	// test when the source is false
-	source = false
-
-	msg = transfer.NewMsgTransfer(testPort1, testChannel1, 10, testPrefixedCoins2, testAddr1, testAddr2, source)
+	msg = transfer.NewMsgTransfer(testPort1, testChannel1, 10, testPrefixedCoins2, testAddr1, testAddr2)
 	_ = suite.chainA.App.BankKeeper.SetBalances(ctx, testAddr1, testPrefixedCoins2)
 
 	res, err = handler(ctx, msg)
 	suite.Require().Error(err)
 	suite.Require().Nil(res, "%+v", res) // incorrect denom prefix
 
-	msg = transfer.NewMsgTransfer(testPort1, testChannel1, 10, testPrefixedCoins1, testAddr1, testAddr2, source)
+	msg = transfer.NewMsgTransfer(testPort1, testChannel1, 10, testPrefixedCoins1, testAddr1, testAddr2)
 	suite.chainA.App.SupplyKeeper.SetSupply(ctx, supply.NewSupply(testPrefixedCoins1))
 	_ = suite.chainA.App.BankKeeper.SetBalances(ctx, testAddr1, testPrefixedCoins1)
 

--- a/x/ibc/20-transfer/keeper/relay.go
+++ b/x/ibc/20-transfer/keeper/relay.go
@@ -27,7 +27,6 @@ func (k Keeper) SendTransfer(
 	amount sdk.Coins,
 	sender,
 	receiver sdk.AccAddress,
-	isSourceChain bool, // is the packet sender the source chain of the token?
 ) error {
 	sourceChannelEnd, found := k.channelKeeper.GetChannel(ctx, sourcePort, sourceChannel)
 	if !found {
@@ -43,7 +42,7 @@ func (k Keeper) SendTransfer(
 		return channel.ErrSequenceSendNotFound
 	}
 
-	return k.createOutgoingPacket(ctx, sequence, sourcePort, sourceChannel, destinationPort, destinationChannel, destHeight, amount, sender, receiver, isSourceChain)
+	return k.createOutgoingPacket(ctx, sequence, sourcePort, sourceChannel, destinationPort, destinationChannel, destHeight, amount, sender, receiver)
 }
 
 // ReceiveTransfer handles transfer receiving logic.
@@ -65,7 +64,6 @@ func (k Keeper) createOutgoingPacket(
 	destHeight uint64,
 	amount sdk.Coins,
 	sender, receiver sdk.AccAddress,
-	isSourceChain bool,
 ) error {
 	// NOTE:
 	// - Coins transferred from the destination chain should have their denomination
@@ -74,12 +72,16 @@ func (k Keeper) createOutgoingPacket(
 	// clear from prefixes when transferred to the escrow account (i.e when they are
 	// locked) BUT MUST have the destination port and channel ID when constructing
 	// the packet data.
-	var prefix string
+	if len(amount) != 1 {
+		return sdkerrors.Wrapf(types.ErrOnlyOneDenomAllowed, "%d denoms included", len(amount))
+	}
 
-	if isSourceChain {
+	prefix := types.GetDenomPrefix(destinationPort, destinationChannel)
+	source := amount[0].Denom[len(prefix):] == prefix
+
+	if source {
 		// clear the denomination from the prefix to send the coins to the escrow account
 		coins := make(sdk.Coins, len(amount))
-		prefix = types.GetDenomPrefix(destinationPort, destinationChannel)
 		for i, coin := range amount {
 			if strings.HasPrefix(coin.Denom, prefix) {
 				coins[i] = sdk.NewCoin(coin.Denom[len(prefix):], coin.Amount)
@@ -101,9 +103,9 @@ func (k Keeper) createOutgoingPacket(
 	} else {
 		// build the receiving denomination prefix if it's not present
 		prefix = types.GetDenomPrefix(sourcePort, sourceChannel)
-		for i, coin := range amount {
+		for _, coin := range amount {
 			if !strings.HasPrefix(coin.Denom, prefix) {
-				amount[i] = sdk.NewCoin(prefix+coin.Denom, coin.Amount)
+				return sdkerrors.Wrapf(types.ErrInvalidDenomForTransfer, "denom was: %s", coin.Denom)
 			}
 		}
 
@@ -126,7 +128,7 @@ func (k Keeper) createOutgoingPacket(
 	}
 
 	packetData := types.NewFungibleTokenPacketData(
-		amount, sender, receiver, isSourceChain,
+		amount, sender, receiver,
 	)
 
 	packet := channel.NewPacket(
@@ -145,17 +147,14 @@ func (k Keeper) createOutgoingPacket(
 func (k Keeper) onRecvPacket(ctx sdk.Context, packet channel.Packet, data types.FungibleTokenPacketData) error {
 	// NOTE: packet data type already checked in handler.go
 
-	if data.Source {
-		prefix := types.GetDenomPrefix(packet.GetDestPort(), packet.GetDestChannel())
-		for _, coin := range data.Amount {
-			if !strings.HasPrefix(coin.Denom, prefix) {
-				return sdkerrors.Wrapf(
-					sdkerrors.ErrInvalidCoins,
-					"%s doesn't contain the prefix '%s'", coin.Denom, prefix,
-				)
-			}
-		}
+	if len(data.Amount) != 1 {
+		return sdkerrors.Wrapf(types.ErrOnlyOneDenomAllowed, "%d denoms included", len(data.Amount))
+	}
 
+	prefix := types.GetDenomPrefix(packet.GetDestPort(), packet.GetDestChannel())
+	source := data.Amount[0].Denom[:len(prefix)] == prefix
+
+	if source {
 		// mint new tokens if the source of the transfer is the same chain
 		if err := k.supplyKeeper.MintCoins(
 			ctx, types.GetModuleAccountName(), data.Amount,
@@ -170,7 +169,7 @@ func (k Keeper) onRecvPacket(ctx sdk.Context, packet channel.Packet, data types.
 	}
 
 	// check the denom prefix
-	prefix := types.GetDenomPrefix(packet.GetSourcePort(), packet.GetSourceChannel())
+	prefix = types.GetDenomPrefix(packet.GetSourcePort(), packet.GetSourceChannel())
 	coins := make(sdk.Coins, len(data.Amount))
 	for i, coin := range data.Amount {
 		if !strings.HasPrefix(coin.Denom, prefix) {
@@ -190,19 +189,24 @@ func (k Keeper) onRecvPacket(ctx sdk.Context, packet channel.Packet, data types.
 func (k Keeper) onTimeoutPacket(ctx sdk.Context, packet channel.Packet, data types.FungibleTokenPacketData) error {
 	// NOTE: packet data type already checked in handler.go
 
-	// check the denom prefix
-	prefix := types.GetDenomPrefix(packet.GetSourcePort(), packet.GetSourceChannel())
-	coins := make(sdk.Coins, len(data.Amount))
-
-	for i, coin := range data.Amount {
-		coin := coin
-		if !strings.HasPrefix(coin.Denom, prefix) {
-			return sdkerrors.Wrapf(sdkerrors.ErrInvalidCoins, "%s doesn't contain the prefix '%s'", coin.Denom, prefix)
-		}
-		coins[i] = sdk.NewCoin(coin.Denom[len(prefix):], coin.Amount)
+	if len(data.Amount) != 1 {
+		return sdkerrors.Wrapf(types.ErrOnlyOneDenomAllowed, "%d denoms included", len(data.Amount))
 	}
 
-	if data.Source {
+	// check the denom prefix
+	prefix := types.GetDenomPrefix(packet.GetSourcePort(), packet.GetSourceChannel())
+	source := data.Amount[0].Denom[:len(prefix)] == prefix
+
+	if source {
+		coins := make(sdk.Coins, len(data.Amount))
+		for i, coin := range data.Amount {
+			coin := coin
+			if !strings.HasPrefix(coin.Denom, prefix) {
+				return sdkerrors.Wrapf(sdkerrors.ErrInvalidCoins, "%s doesn't contain the prefix '%s'", coin.Denom, prefix)
+			}
+			coins[i] = sdk.NewCoin(coin.Denom[len(prefix):], coin.Amount)
+		}
+
 		// unescrow tokens back to sender
 		escrowAddress := types.GetEscrowAddress(packet.GetDestPort(), packet.GetDestChannel())
 		return k.bankKeeper.SendCoins(ctx, escrowAddress, data.Sender, coins)

--- a/x/ibc/20-transfer/keeper/relay.go
+++ b/x/ibc/20-transfer/keeper/relay.go
@@ -77,7 +77,7 @@ func (k Keeper) createOutgoingPacket(
 	}
 
 	prefix := types.GetDenomPrefix(destinationPort, destinationChannel)
-	source := amount[0].Denom[len(prefix):] == prefix
+	source := strings.HasPrefix(amount[0].Denom, prefix)
 
 	if source {
 		// clear the denomination from the prefix to send the coins to the escrow account
@@ -152,7 +152,7 @@ func (k Keeper) onRecvPacket(ctx sdk.Context, packet channel.Packet, data types.
 	}
 
 	prefix := types.GetDenomPrefix(packet.GetDestPort(), packet.GetDestChannel())
-	source := data.Amount[0].Denom[:len(prefix)] == prefix
+	source := strings.HasPrefix(data.Amount[0].Denom, prefix)
 
 	if source {
 		// mint new tokens if the source of the transfer is the same chain
@@ -195,7 +195,7 @@ func (k Keeper) onTimeoutPacket(ctx sdk.Context, packet channel.Packet, data typ
 
 	// check the denom prefix
 	prefix := types.GetDenomPrefix(packet.GetSourcePort(), packet.GetSourceChannel())
-	source := data.Amount[0].Denom[:len(prefix)] == prefix
+	source := strings.HasPrefix(data.Amount[0].Denom, prefix)
 
 	if source {
 		coins := make(sdk.Coins, len(data.Amount))

--- a/x/ibc/20-transfer/types/errors.go
+++ b/x/ibc/20-transfer/types/errors.go
@@ -6,5 +6,7 @@ import (
 
 // IBC channel sentinel errors
 var (
-	ErrInvalidPacketTimeout = sdkerrors.Register(ModuleName, 1, "invalid packet timeout")
+	ErrInvalidPacketTimeout    = sdkerrors.Register(ModuleName, 2, "invalid packet timeout")
+	ErrOnlyOneDenomAllowed     = sdkerrors.Register(ModuleName, 3, "only one denom allowed")
+	ErrInvalidDenomForTransfer = sdkerrors.Register(ModuleName, 4, "invalid denomination for cross-chain transfer")
 )

--- a/x/ibc/20-transfer/types/msgs.go
+++ b/x/ibc/20-transfer/types/msgs.go
@@ -15,12 +15,11 @@ type MsgTransfer struct {
 	Amount        sdk.Coins      `json:"amount" yaml:"amount"`                 // the tokens to be transferred
 	Sender        sdk.AccAddress `json:"sender" yaml:"sender"`                 // the sender address
 	Receiver      sdk.AccAddress `json:"receiver" yaml:"receiver"`             // the recipient address on the destination chain
-	Source        bool           `json:"source" yaml:"source"`                 // indicates if the sending chain is the source chain of the tokens to be transferred
 }
 
 // NewMsgTransfer creates a new MsgTransfer instance
 func NewMsgTransfer(
-	sourcePort, sourceChannel string, destHeight uint64, amount sdk.Coins, sender, receiver sdk.AccAddress, source bool,
+	sourcePort, sourceChannel string, destHeight uint64, amount sdk.Coins, sender, receiver sdk.AccAddress,
 ) MsgTransfer {
 	return MsgTransfer{
 		SourcePort:    sourcePort,
@@ -29,7 +28,6 @@ func NewMsgTransfer(
 		Amount:        amount,
 		Sender:        sender,
 		Receiver:      receiver,
-		Source:        source,
 	}
 }
 

--- a/x/ibc/20-transfer/types/msgs_test.go
+++ b/x/ibc/20-transfer/types/msgs_test.go
@@ -34,14 +34,14 @@ var (
 
 // TestMsgTransferRoute tests Route for MsgTransfer
 func TestMsgTransferRoute(t *testing.T) {
-	msg := NewMsgTransfer(validPort, validChannel, 10, coins, addr1, addr2, true)
+	msg := NewMsgTransfer(validPort, validChannel, 10, coins, addr1, addr2)
 
 	require.Equal(t, RouterKey, msg.Route())
 }
 
 // TestMsgTransferType tests Type for MsgTransfer
 func TestMsgTransferType(t *testing.T) {
-	msg := NewMsgTransfer(validPort, validChannel, 10, coins, addr1, addr2, true)
+	msg := NewMsgTransfer(validPort, validChannel, 10, coins, addr1, addr2)
 
 	require.Equal(t, "transfer", msg.Type())
 }
@@ -49,18 +49,18 @@ func TestMsgTransferType(t *testing.T) {
 // TestMsgTransferValidation tests ValidateBasic for MsgTransfer
 func TestMsgTransferValidation(t *testing.T) {
 	testMsgs := []MsgTransfer{
-		NewMsgTransfer(validPort, validChannel, 10, coins, addr1, addr2, true),              // valid msg
-		NewMsgTransfer(invalidShortPort, validChannel, 10, coins, addr1, addr2, true),       // too short port id
-		NewMsgTransfer(invalidLongPort, validChannel, 10, coins, addr1, addr2, true),        // too long port id
-		NewMsgTransfer(invalidPort, validChannel, 10, coins, addr1, addr2, true),            // port id contains non-alpha
-		NewMsgTransfer(validPort, invalidShortChannel, 10, coins, addr1, addr2, true),       // too short channel id
-		NewMsgTransfer(validPort, invalidLongChannel, 10, coins, addr1, addr2, false),       // too long channel id
-		NewMsgTransfer(validPort, invalidChannel, 10, coins, addr1, addr2, false),           // channel id contains non-alpha
-		NewMsgTransfer(validPort, validChannel, 10, invalidDenomCoins, addr1, addr2, false), // invalid amount
-		NewMsgTransfer(validPort, validChannel, 10, negativeCoins, addr1, addr2, false),     // amount contains negative coin
-		NewMsgTransfer(validPort, validChannel, 10, coins, emptyAddr, addr2, false),         // missing sender address
-		NewMsgTransfer(validPort, validChannel, 10, coins, addr1, emptyAddr, false),         // missing recipient address
-		NewMsgTransfer(validPort, validChannel, 10, sdk.Coins{}, addr1, addr2, false),       // not possitive coin
+		NewMsgTransfer(validPort, validChannel, 10, coins, addr1, addr2),             // valid msg
+		NewMsgTransfer(invalidShortPort, validChannel, 10, coins, addr1, addr2),      // too short port id
+		NewMsgTransfer(invalidLongPort, validChannel, 10, coins, addr1, addr2),       // too long port id
+		NewMsgTransfer(invalidPort, validChannel, 10, coins, addr1, addr2),           // port id contains non-alpha
+		NewMsgTransfer(validPort, invalidShortChannel, 10, coins, addr1, addr2),      // too short channel id
+		NewMsgTransfer(validPort, invalidLongChannel, 10, coins, addr1, addr2),       // too long channel id
+		NewMsgTransfer(validPort, invalidChannel, 10, coins, addr1, addr2),           // channel id contains non-alpha
+		NewMsgTransfer(validPort, validChannel, 10, invalidDenomCoins, addr1, addr2), // invalid amount
+		NewMsgTransfer(validPort, validChannel, 10, negativeCoins, addr1, addr2),     // amount contains negative coin
+		NewMsgTransfer(validPort, validChannel, 10, coins, emptyAddr, addr2),         // missing sender address
+		NewMsgTransfer(validPort, validChannel, 10, coins, addr1, emptyAddr),         // missing recipient address
+		NewMsgTransfer(validPort, validChannel, 10, sdk.Coins{}, addr1, addr2),       // not possitive coin
 	}
 
 	testCases := []struct {
@@ -93,7 +93,7 @@ func TestMsgTransferValidation(t *testing.T) {
 
 // TestMsgTransferGetSignBytes tests GetSignBytes for MsgTransfer
 func TestMsgTransferGetSignBytes(t *testing.T) {
-	msg := NewMsgTransfer(validPort, validChannel, 10, coins, addr1, addr2, true)
+	msg := NewMsgTransfer(validPort, validChannel, 10, coins, addr1, addr2)
 	res := msg.GetSignBytes()
 
 	expected := `{"type":"ibc/transfer/MsgTransfer","value":{"amount":[{"amount":"100","denom":"atom"}],"dest_height":"10","receiver":"cosmos1w3jhxarpv3j8yvs7f9y7g","sender":"cosmos1w3jhxarpv3j8yvg4ufs4x","source":true,"source_channel":"testchannel","source_port":"testportid"}}`
@@ -102,7 +102,7 @@ func TestMsgTransferGetSignBytes(t *testing.T) {
 
 // TestMsgTransferGetSigners tests GetSigners for MsgTransfer
 func TestMsgTransferGetSigners(t *testing.T) {
-	msg := NewMsgTransfer(validPort, validChannel, 10, coins, addr1, addr2, true)
+	msg := NewMsgTransfer(validPort, validChannel, 10, coins, addr1, addr2)
 	res := msg.GetSigners()
 
 	expected := "[746573746164647231]"

--- a/x/ibc/20-transfer/types/msgs_test.go
+++ b/x/ibc/20-transfer/types/msgs_test.go
@@ -96,7 +96,7 @@ func TestMsgTransferGetSignBytes(t *testing.T) {
 	msg := NewMsgTransfer(validPort, validChannel, 10, coins, addr1, addr2)
 	res := msg.GetSignBytes()
 
-	expected := `{"type":"ibc/transfer/MsgTransfer","value":{"amount":[{"amount":"100","denom":"atom"}],"dest_height":"10","receiver":"cosmos1w3jhxarpv3j8yvs7f9y7g","sender":"cosmos1w3jhxarpv3j8yvg4ufs4x","source":true,"source_channel":"testchannel","source_port":"testportid"}}`
+	expected := `{"type":"ibc/transfer/MsgTransfer","value":{"amount":[{"amount":"100","denom":"atom"}],"dest_height":"10","receiver":"cosmos1w3jhxarpv3j8yvs7f9y7g","sender":"cosmos1w3jhxarpv3j8yvg4ufs4x","source_channel":"testchannel","source_port":"testportid"}}`
 	require.Equal(t, expected, string(res))
 }
 

--- a/x/ibc/20-transfer/types/packet.go
+++ b/x/ibc/20-transfer/types/packet.go
@@ -13,18 +13,15 @@ type FungibleTokenPacketData struct {
 	Amount   sdk.Coins      `json:"amount" yaml:"amount"`     // the tokens to be transferred
 	Sender   sdk.AccAddress `json:"sender" yaml:"sender"`     // the sender address
 	Receiver sdk.AccAddress `json:"receiver" yaml:"receiver"` // the recipient address on the destination chain
-	Source   bool           `json:"source" yaml:"source"`     // indicates if the sending chain is the source chain of the tokens to be transferred
 }
 
 // NewFungibleTokenPacketData contructs a new FungibleTokenPacketData instance
 func NewFungibleTokenPacketData(
-	amount sdk.Coins, sender, receiver sdk.AccAddress,
-	source bool) FungibleTokenPacketData {
+	amount sdk.Coins, sender, receiver sdk.AccAddress) FungibleTokenPacketData {
 	return FungibleTokenPacketData{
 		Amount:   amount,
 		Sender:   sender,
 		Receiver: receiver,
-		Source:   source,
 	}
 }
 
@@ -33,12 +30,10 @@ func (ftpd FungibleTokenPacketData) String() string {
 	return fmt.Sprintf(`FungibleTokenPacketData:
 	Amount:               %s
 	Sender:               %s
-	Receiver:             %s
-	Source:               %v`,
+	Receiver:             %s`,
 		ftpd.Amount.String(),
 		ftpd.Sender,
 		ftpd.Receiver,
-		ftpd.Source,
 	)
 }
 

--- a/x/ibc/20-transfer/types/packet_test.go
+++ b/x/ibc/20-transfer/types/packet_test.go
@@ -9,11 +9,11 @@ import (
 // TestFungibleTokenPacketDataValidateBasic tests ValidateBasic for FungibleTokenPacketData
 func TestFungibleTokenPacketDataValidateBasic(t *testing.T) {
 	testPacketDataTransfer := []FungibleTokenPacketData{
-		NewFungibleTokenPacketData(coins, addr1, addr2, true),             // valid msg
-		NewFungibleTokenPacketData(invalidDenomCoins, addr1, addr2, true), // invalid amount
-		NewFungibleTokenPacketData(negativeCoins, addr1, addr2, false),    // amount contains negative coin
-		NewFungibleTokenPacketData(coins, emptyAddr, addr2, false),        // missing sender address
-		NewFungibleTokenPacketData(coins, addr1, emptyAddr, false),        // missing recipient address
+		NewFungibleTokenPacketData(coins, addr1, addr2),             // valid msg
+		NewFungibleTokenPacketData(invalidDenomCoins, addr1, addr2), // invalid amount
+		NewFungibleTokenPacketData(negativeCoins, addr1, addr2),     // amount contains negative coin
+		NewFungibleTokenPacketData(coins, emptyAddr, addr2),         // missing sender address
+		NewFungibleTokenPacketData(coins, addr1, emptyAddr),         // missing recipient address
 	}
 
 	testCases := []struct {


### PR DESCRIPTION
Remove "source" field from packets & messages, it is now inferred from the denom.

Closes https://github.com/cosmos/cosmos-sdk/issues/5812