### PR TITLE
Fix ics20 client

### DIFF
--- a/x/ibc/20-transfer/client/cli/tx.go
+++ b/x/ibc/20-transfer/client/cli/tx.go
@@ -31,7 +31,7 @@ func GetTransferTxCmd(cdc *codec.Codec) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "transfer [src-port] [src-channel] [dest-height] [receiver] [amount]",
 		Short: "Transfer fungible token through IBC",
-		Args:  cobra.ExactArgs(4),
+		Args:  cobra.ExactArgs(5),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			inBuf := bufio.NewReader(cmd.InOrStdin())
 			txBldr := authtypes.NewTxBuilderFromCLI(inBuf).WithTxEncoder(authclient.GetTxEncoder(cdc))


### PR DESCRIPTION
On `GetTransferTxCmd`, args number should be `5`.