### PR TITLE
instantiate verifier when --trust-node is off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,12 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## [v0.37.9] - 2020-04-09
 
+### Bug Fixes
+
+* (client/context) [\#5964](https://github.com/cosmos/cosmos-sdk/issues/5964) Fix incorrect instantiation of tmlite verifier when --trust-node is off.
+
+## [v0.37.9] - 2020-04-09
+
 ### Improvements
 
 * (tendermint) Bump Tendermint version to [v0.32.10](https://github.com/tendermint/tendermint/releases/tag/v0.32.10).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
-## [v0.37.9] - 2020-04-09
+## [v0.37.10] - 2020-04-13
 
 ### Bug Fixes
 

--- a/client/context/context.go
+++ b/client/context/context.go
@@ -74,8 +74,9 @@ func NewCLIContextWithFrom(from string) CLIContext {
 		}
 	}
 
+	trustNode := viper.GetBool(flags.FlagTrustNode)
 	// We need to use a single verifier for all contexts
-	if verifier == nil || verifierHome != viper.GetString(flags.FlagHome) {
+	if !trustNode && (verifier == nil || verifierHome != viper.GetString(flags.FlagHome)) {
 		verifier = createVerifier()
 		verifierHome = viper.GetString(flags.FlagHome)
 	}
@@ -87,7 +88,7 @@ func NewCLIContextWithFrom(from string) CLIContext {
 		From:          viper.GetString(flags.FlagFrom),
 		OutputFormat:  viper.GetString(cli.OutputFlag),
 		Height:        viper.GetInt64(flags.FlagHeight),
-		TrustNode:     viper.GetBool(flags.FlagTrustNode),
+		TrustNode:     trustNode,
 		UseLedger:     viper.GetBool(flags.FlagUseLedger),
 		BroadcastMode: viper.GetString(flags.FlagBroadcastMode),
 		Verifier:      verifier,
@@ -105,16 +106,6 @@ func NewCLIContextWithFrom(from string) CLIContext {
 func NewCLIContext() CLIContext { return NewCLIContextWithFrom(viper.GetString(flags.FlagFrom)) }
 
 func createVerifier() tmlite.Verifier {
-	trustNodeDefined := viper.IsSet(flags.FlagTrustNode)
-	if !trustNodeDefined {
-		return nil
-	}
-
-	trustNode := viper.GetBool(flags.FlagTrustNode)
-	if trustNode {
-		return nil
-	}
-
 	chainID := viper.GetString(flags.FlagChainID)
 	home := viper.GetString(flags.FlagHome)
 	nodeURI := viper.GetString(flags.FlagNode)

--- a/types/rest/rest_test.go
+++ b/types/rest/rest_test.go
@@ -10,11 +10,13 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
 	"github.com/tendermint/tendermint/crypto"
 	"github.com/tendermint/tendermint/crypto/secp256k1"
 
 	"github.com/cosmos/cosmos-sdk/client/context"
+	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/types"
 )
@@ -162,6 +164,7 @@ func TestProcessPostResponse(t *testing.T) {
 		Sequence      uint64           `json:"sequence"`
 	}
 
+	viper.Set(flags.FlagTrustNode, true)
 	// setup
 	ctx := context.NewCLIContext()
 	height := int64(194423)

--- a/x/distribution/client/common/common_test.go
+++ b/x/distribution/client/common/common_test.go
@@ -3,15 +3,17 @@ package common
 import (
 	"testing"
 
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
 
 	"github.com/cosmos/cosmos-sdk/client/context"
+	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/codec"
 )
 
 func TestQueryDelegationRewardsAddrValidation(t *testing.T) {
-	cdc := codec.New()
-	ctx := context.NewCLIContext().WithCodec(cdc)
+	viper.Set(flags.FlagTrustNode, true)
+	ctx := context.NewCLIContext().WithCodec(codec.New())
 	type args struct {
 		delAddr string
 		valAddr string


### PR DESCRIPTION
Maintenance release:

* #5964 Fix incorrect instantiation of tmlite verifier when --trust-node is off.

______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added  relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

______

For admin use:

- [ ] Added appropriate labels to PR (ex. `WIP`, `R4R`, `docs`, etc)
- [ ] Reviewers assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
