### PR TITLE
Change address type to string

### DIFF
--- a/x/ibc/20-transfer/client/cli/tx.go
+++ b/x/ibc/20-transfer/client/cli/tx.go
@@ -44,10 +44,6 @@ func GetTransferTxCmd(cdc *codec.Codec) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			receiver, err := sdk.AccAddressFromBech32(args[3])
-			if err != nil {
-				return err
-			}
 
 			// parse coin trying to be sent
 			coins, err := sdk.ParseCoins(args[4])
@@ -55,7 +51,7 @@ func GetTransferTxCmd(cdc *codec.Codec) *cobra.Command {
 				return err
 			}
 
-			msg := types.NewMsgTransfer(srcPort, srcChannel, uint64(destHeight), coins, sender, receiver)
+			msg := types.NewMsgTransfer(srcPort, srcChannel, uint64(destHeight), coins, sender, args[3])
 			if err := msg.ValidateBasic(); err != nil {
 				return err
 			}

--- a/x/ibc/20-transfer/client/rest/rest.go
+++ b/x/ibc/20-transfer/client/rest/rest.go
@@ -21,8 +21,8 @@ func RegisterRoutes(cliCtx context.CLIContext, r *mux.Router) {
 
 // TransferTxReq defines the properties of a transfer tx request's body.
 type TransferTxReq struct {
-	BaseReq    rest.BaseReq   `json:"base_req" yaml:"base_req"`
-	DestHeight uint64         `json:"dest_height" yaml:"dest_height"`
-	Amount     sdk.Coins      `json:"amount" yaml:"amount"`
-	Receiver   sdk.AccAddress `json:"receiver" yaml:"receiver"`
+	BaseReq    rest.BaseReq `json:"base_req" yaml:"base_req"`
+	DestHeight uint64       `json:"dest_height" yaml:"dest_height"`
+	Amount     sdk.Coins    `json:"amount" yaml:"amount"`
+	Receiver   string       `json:"receiver" yaml:"receiver"`
 }

--- a/x/ibc/20-transfer/handler.go
+++ b/x/ibc/20-transfer/handler.go
@@ -30,7 +30,7 @@ func handleMsgTransfer(ctx sdk.Context, k Keeper, msg MsgTransfer) (*sdk.Result,
 			sdk.EventTypeMessage,
 			sdk.NewAttribute(sdk.AttributeKeyModule, AttributeValueCategory),
 			sdk.NewAttribute(sdk.AttributeKeySender, msg.Sender.String()),
-			sdk.NewAttribute(AttributeKeyReceiver, msg.Receiver.String()),
+			sdk.NewAttribute(AttributeKeyReceiver, msg.Receiver),
 		),
 	)
 

--- a/x/ibc/20-transfer/handler_test.go
+++ b/x/ibc/20-transfer/handler_test.go
@@ -77,7 +77,7 @@ func (suite *HandlerTestSuite) TestHandleMsgTransfer() {
 	suite.Require().Nil(err, "transfer module could not claim capability")
 
 	ctx := suite.chainA.GetContext()
-	msg := transfer.NewMsgTransfer(testPort1, testChannel1, 10, testPrefixedCoins2, testAddr1, testAddr2)
+	msg := transfer.NewMsgTransfer(testPort1, testChannel1, 10, testPrefixedCoins2, testAddr1, testAddr2.String())
 	res, err := handler(ctx, msg)
 	suite.Require().Error(err)
 	suite.Require().Nil(res, "%+v", res) // channel does not exist
@@ -103,14 +103,14 @@ func (suite *HandlerTestSuite) TestHandleMsgTransfer() {
 	suite.Require().NotNil(res, "%+v", res) // successfully executed
 
 	// test when the source is false
-	msg = transfer.NewMsgTransfer(testPort1, testChannel1, 10, testPrefixedCoins2, testAddr1, testAddr2)
+	msg = transfer.NewMsgTransfer(testPort1, testChannel1, 10, testPrefixedCoins2, testAddr1, testAddr2.String())
 	_ = suite.chainA.App.BankKeeper.SetBalances(ctx, testAddr1, testPrefixedCoins2)
 
 	res, err = handler(ctx, msg)
 	suite.Require().Error(err)
 	suite.Require().Nil(res, "%+v", res) // incorrect denom prefix
 
-	msg = transfer.NewMsgTransfer(testPort1, testChannel1, 10, testPrefixedCoins1, testAddr1, testAddr2)
+	msg = transfer.NewMsgTransfer(testPort1, testChannel1, 10, testPrefixedCoins1, testAddr1, testAddr2.String())
 	suite.chainA.App.SupplyKeeper.SetSupply(ctx, supply.NewSupply(testPrefixedCoins1))
 	_ = suite.chainA.App.BankKeeper.SetBalances(ctx, testAddr1, testPrefixedCoins1)
 

--- a/x/ibc/20-transfer/keeper/keeper_test.go
+++ b/x/ibc/20-transfer/keeper/keeper_test.go
@@ -41,8 +41,8 @@ const (
 
 // define variables used for testing
 var (
-	testAddr1 = sdk.AccAddress([]byte("testaddr1"))
-	testAddr2 = sdk.AccAddress([]byte("testaddr2"))
+	testAddr1, _ = sdk.AccAddressFromBech32("cosmos1scqhwpgsmr6vmztaa7suurfl52my6nd2kmrudl")
+	testAddr2, _ = sdk.AccAddressFromBech32("cosmos1scqhwpgsmr6vmztaa7suurfl52my6nd2kmrujl")
 
 	testCoins, _ = sdk.ParseCoins("100atom")
 	prefixCoins  = sdk.NewCoins(sdk.NewCoin("bank/firstchannel/atom", sdk.NewInt(100)))

--- a/x/ibc/20-transfer/keeper/relay_test.go
+++ b/x/ibc/20-transfer/keeper/relay_test.go
@@ -94,7 +94,7 @@ func (suite *KeeperTestSuite) TestSendTransfer() {
 			tc.malleate()
 
 			err = suite.chainA.App.TransferKeeper.SendTransfer(
-				suite.chainA.GetContext(), testPort1, testChannel1, 100, tc.amount, testAddr1, testAddr2,
+				suite.chainA.GetContext(), testPort1, testChannel1, 100, tc.amount, testAddr1, testAddr2.String(),
 			)
 
 			if tc.expPass {
@@ -107,7 +107,7 @@ func (suite *KeeperTestSuite) TestSendTransfer() {
 }
 
 func (suite *KeeperTestSuite) TestOnRecvPacket() {
-	data := types.NewFungibleTokenPacketData(prefixCoins2, testAddr1, testAddr2)
+	data := types.NewFungibleTokenPacketData(prefixCoins2, testAddr1.String(), testAddr2.String())
 
 	testCases := []struct {
 		msg      string
@@ -164,7 +164,7 @@ func (suite *KeeperTestSuite) TestOnRecvPacket() {
 // TestOnAcknowledgementPacket tests that successful acknowledgement is a no-op
 // and failure acknowledment leads to refund
 func (suite *KeeperTestSuite) TestOnAcknowledgementPacket() {
-	data := types.NewFungibleTokenPacketData(prefixCoins, testAddr1, testAddr2)
+	data := types.NewFungibleTokenPacketData(prefixCoins, testAddr1.String(), testAddr2.String())
 	testCoins2 := sdk.NewCoins(sdk.NewCoin("testportid/secondchannel/atom", sdk.NewInt(100)))
 
 	successAck := types.FungibleTokenPacketAcknowledgement{
@@ -233,7 +233,7 @@ func (suite *KeeperTestSuite) TestOnAcknowledgementPacket() {
 
 // TestOnTimeoutPacket test private refundPacket function since it is a simple wrapper over it
 func (suite *KeeperTestSuite) TestOnTimeoutPacket() {
-	data := types.NewFungibleTokenPacketData(prefixCoins, testAddr1, testAddr2)
+	data := types.NewFungibleTokenPacketData(prefixCoins, testAddr1.String(), testAddr2.String())
 	testCoins2 := sdk.NewCoins(sdk.NewCoin("testportid/secondchannel/atom", sdk.NewInt(100)))
 
 	testCases := []struct {

--- a/x/ibc/20-transfer/module.go
+++ b/x/ibc/20-transfer/module.go
@@ -259,7 +259,7 @@ func (am AppModule) OnRecvPacket(
 		sdk.NewEvent(
 			EventTypePacket,
 			sdk.NewAttribute(sdk.AttributeKeyModule, AttributeValueCategory),
-			sdk.NewAttribute(AttributeKeyReceiver, data.Receiver.String()),
+			sdk.NewAttribute(AttributeKeyReceiver, data.Receiver),
 			sdk.NewAttribute(AttributeKeyValue, data.Amount.String()),
 		),
 	)
@@ -291,7 +291,7 @@ func (am AppModule) OnAcknowledgementPacket(
 		sdk.NewEvent(
 			EventTypePacket,
 			sdk.NewAttribute(sdk.AttributeKeyModule, AttributeValueCategory),
-			sdk.NewAttribute(AttributeKeyReceiver, data.Receiver.String()),
+			sdk.NewAttribute(AttributeKeyReceiver, data.Receiver),
 			sdk.NewAttribute(AttributeKeyValue, data.Amount.String()),
 			sdk.NewAttribute(AttributeKeyAckSuccess, fmt.Sprintf("%t", ack.Success)),
 		),
@@ -327,7 +327,7 @@ func (am AppModule) OnTimeoutPacket(
 	ctx.EventManager().EmitEvent(
 		sdk.NewEvent(
 			EventTypeTimeout,
-			sdk.NewAttribute(AttributeKeyRefundReceiver, data.Sender.String()),
+			sdk.NewAttribute(AttributeKeyRefundReceiver, data.Sender),
 			sdk.NewAttribute(AttributeKeyRefundValue, data.Amount.String()),
 			sdk.NewAttribute(sdk.AttributeKeyModule, AttributeValueCategory),
 		),

--- a/x/ibc/20-transfer/types/msgs.go
+++ b/x/ibc/20-transfer/types/msgs.go
@@ -14,12 +14,12 @@ type MsgTransfer struct {
 	DestHeight    uint64         `json:"dest_height" yaml:"dest_height"`       // the current height of the destination chain
 	Amount        sdk.Coins      `json:"amount" yaml:"amount"`                 // the tokens to be transferred
 	Sender        sdk.AccAddress `json:"sender" yaml:"sender"`                 // the sender address
-	Receiver      sdk.AccAddress `json:"receiver" yaml:"receiver"`             // the recipient address on the destination chain
+	Receiver      string         `json:"receiver" yaml:"receiver"`             // the recipient address on the destination chain
 }
 
 // NewMsgTransfer creates a new MsgTransfer instance
 func NewMsgTransfer(
-	sourcePort, sourceChannel string, destHeight uint64, amount sdk.Coins, sender, receiver sdk.AccAddress,
+	sourcePort, sourceChannel string, destHeight uint64, amount sdk.Coins, sender sdk.AccAddress, receiver string,
 ) MsgTransfer {
 	return MsgTransfer{
 		SourcePort:    sourcePort,
@@ -58,7 +58,7 @@ func (msg MsgTransfer) ValidateBasic() error {
 	if msg.Sender.Empty() {
 		return sdkerrors.Wrap(sdkerrors.ErrInvalidAddress, "missing sender address")
 	}
-	if msg.Receiver.Empty() {
+	if msg.Receiver == "" {
 		return sdkerrors.Wrap(sdkerrors.ErrInvalidAddress, "missing recipient address")
 	}
 	return nil

--- a/x/ibc/20-transfer/types/msgs_test.go
+++ b/x/ibc/20-transfer/types/msgs_test.go
@@ -24,7 +24,7 @@ const (
 
 var (
 	addr1     = sdk.AccAddress("testaddr1")
-	addr2     = sdk.AccAddress("testaddr2")
+	addr2     = sdk.AccAddress("testaddr2").String()
 	emptyAddr sdk.AccAddress
 
 	coins, _          = sdk.ParseCoins("100atom")
@@ -59,7 +59,7 @@ func TestMsgTransferValidation(t *testing.T) {
 		NewMsgTransfer(validPort, validChannel, 10, invalidDenomCoins, addr1, addr2), // invalid amount
 		NewMsgTransfer(validPort, validChannel, 10, negativeCoins, addr1, addr2),     // amount contains negative coin
 		NewMsgTransfer(validPort, validChannel, 10, coins, emptyAddr, addr2),         // missing sender address
-		NewMsgTransfer(validPort, validChannel, 10, coins, addr1, emptyAddr),         // missing recipient address
+		NewMsgTransfer(validPort, validChannel, 10, coins, addr1, ""),                // missing recipient address
 		NewMsgTransfer(validPort, validChannel, 10, sdk.Coins{}, addr1, addr2),       // not possitive coin
 	}
 

--- a/x/ibc/20-transfer/types/packet.go
+++ b/x/ibc/20-transfer/types/packet.go
@@ -10,14 +10,14 @@ import (
 // FungibleTokenPacketData defines a struct for the packet payload
 // See FungibleTokenPacketData spec: https://github.com/cosmos/ics/tree/master/spec/ics-020-fungible-token-transfer#data-structures
 type FungibleTokenPacketData struct {
-	Amount   sdk.Coins      `json:"amount" yaml:"amount"`     // the tokens to be transferred
-	Sender   sdk.AccAddress `json:"sender" yaml:"sender"`     // the sender address
-	Receiver sdk.AccAddress `json:"receiver" yaml:"receiver"` // the recipient address on the destination chain
+	Amount   sdk.Coins `json:"amount" yaml:"amount"`     // the tokens to be transferred
+	Sender   string    `json:"sender" yaml:"sender"`     // the sender address
+	Receiver string    `json:"receiver" yaml:"receiver"` // the recipient address on the destination chain
 }
 
 // NewFungibleTokenPacketData contructs a new FungibleTokenPacketData instance
 func NewFungibleTokenPacketData(
-	amount sdk.Coins, sender, receiver sdk.AccAddress) FungibleTokenPacketData {
+	amount sdk.Coins, sender, receiver string) FungibleTokenPacketData {
 	return FungibleTokenPacketData{
 		Amount:   amount,
 		Sender:   sender,
@@ -45,10 +45,10 @@ func (ftpd FungibleTokenPacketData) ValidateBasic() error {
 	if !ftpd.Amount.IsValid() {
 		return sdkerrors.ErrInvalidCoins
 	}
-	if ftpd.Sender.Empty() {
+	if ftpd.Sender == "" {
 		return sdkerrors.Wrap(sdkerrors.ErrInvalidAddress, "missing sender address")
 	}
-	if ftpd.Receiver.Empty() {
+	if ftpd.Receiver == "" {
 		return sdkerrors.Wrap(sdkerrors.ErrInvalidAddress, "missing receiver address")
 	}
 	return nil

--- a/x/ibc/20-transfer/types/packet_test.go
+++ b/x/ibc/20-transfer/types/packet_test.go
@@ -9,11 +9,11 @@ import (
 // TestFungibleTokenPacketDataValidateBasic tests ValidateBasic for FungibleTokenPacketData
 func TestFungibleTokenPacketDataValidateBasic(t *testing.T) {
 	testPacketDataTransfer := []FungibleTokenPacketData{
-		NewFungibleTokenPacketData(coins, addr1, addr2),             // valid msg
-		NewFungibleTokenPacketData(invalidDenomCoins, addr1, addr2), // invalid amount
-		NewFungibleTokenPacketData(negativeCoins, addr1, addr2),     // amount contains negative coin
-		NewFungibleTokenPacketData(coins, emptyAddr, addr2),         // missing sender address
-		NewFungibleTokenPacketData(coins, addr1, emptyAddr),         // missing recipient address
+		NewFungibleTokenPacketData(coins, addr1.String(), addr2),              // valid msg
+		NewFungibleTokenPacketData(invalidDenomCoins, addr1.String(), addr2),  // invalid amount
+		NewFungibleTokenPacketData(negativeCoins, addr1.String(), addr2),      // amount contains negative coin
+		NewFungibleTokenPacketData(coins, emptyAddr.String(), addr2),          // missing sender address
+		NewFungibleTokenPacketData(coins, addr1.String(), emptyAddr.String()), // missing recipient address
 	}
 
 	testCases := []struct {


### PR DESCRIPTION
Closes https://github.com/cosmos/cosmos-sdk/issues/5977

I think it will work to leave `msg.Sender` as an `sdk.AccAddress`, since that's just for the tx.