### PR TITLE
Start global capability index at 1

### DIFF
--- a/simapp/app.go
+++ b/simapp/app.go
@@ -288,8 +288,11 @@ func NewSimApp(
 
 	// NOTE: The genutils moodule must occur after staking so that pools are
 	// properly initialized with tokens from genesis accounts.
+	// NOTE: Capability module must occur first so that it can initialize any capabilities
+	// so that other modules that want to create or claim capabilities afterwards in InitChain
+	// can do so safely.
 	app.mm.SetOrderInitGenesis(
-		auth.ModuleName, distr.ModuleName, staking.ModuleName, bank.ModuleName,
+		capability.ModuleName, auth.ModuleName, distr.ModuleName, staking.ModuleName, bank.ModuleName,
 		slashing.ModuleName, gov.ModuleName, mint.ModuleName, crisis.ModuleName,
 		ibc.ModuleName, genutil.ModuleName, evidence.ModuleName, transfer.ModuleName,
 	)
@@ -338,6 +341,8 @@ func NewSimApp(
 	// Initialize and seal the capability keeper so all persistent capabilities
 	// are loaded in-memory and prevent any further modules from creating scoped
 	// sub-keepers.
+	// This must be done during creation of baseapp rather than in InitChain so
+	// that in-memory capabilities get regenerated on app restart
 	ctx := app.BaseApp.NewContext(true, abci.Header{})
 	app.CapabilityKeeper.InitializeAndSeal(ctx)
 

--- a/x/capability/keeper/keeper.go
+++ b/x/capability/keeper/keeper.go
@@ -135,10 +135,11 @@ func (k *Keeper) InitializeAndSeal(ctx sdk.Context) {
 func (k Keeper) InitializeIndex(ctx sdk.Context) {
 	// set the global index to start at 1 if it is unset
 	index := k.GetLatestIndex(ctx)
-	if index == 0 {
-		store := ctx.KVStore(k.storeKey)
-		store.Set(types.KeyIndex, types.IndexToKey(1))
+	if index != 0 {
+		return
 	}
+	store := ctx.KVStore(k.storeKey)
+	store.Set(types.KeyIndex, types.IndexToKey(1))
 }
 
 // GetLatestIndex returns the latest index of the CapabilityKeeper

--- a/x/capability/keeper/keeper.go
+++ b/x/capability/keeper/keeper.go
@@ -130,6 +130,17 @@ func (k *Keeper) InitializeAndSeal(ctx sdk.Context) {
 	k.sealed = true
 }
 
+// InitializeIndex sets the index to one in InitChain
+// Since it is an exported function, we check that index is indeed unset, before initializing
+func (k Keeper) InitializeIndex(ctx sdk.Context) {
+	// set the global index to start at 1 if it is unset
+	index := k.GetLatestIndex(ctx)
+	if index == 0 {
+		store := ctx.KVStore(k.storeKey)
+		store.Set(types.KeyIndex, types.IndexToKey(1))
+	}
+}
+
 // GetLatestIndex returns the latest index of the CapabilityKeeper
 func (k Keeper) GetLatestIndex(ctx sdk.Context) uint64 {
 	store := ctx.KVStore(k.storeKey)

--- a/x/capability/module.go
+++ b/x/capability/module.go
@@ -98,7 +98,10 @@ func (am AppModule) RegisterInvariants(_ sdk.InvariantRegistry) {}
 
 // InitGenesis performs the capability module's genesis initialization It returns
 // no validator updates.
-func (am AppModule) InitGenesis(_ sdk.Context, _ codec.JSONMarshaler, _ json.RawMessage) []abci.ValidatorUpdate {
+func (am AppModule) InitGenesis(ctx sdk.Context, _ codec.JSONMarshaler, _ json.RawMessage) []abci.ValidatorUpdate {
+	// Initialize global index to 1
+	am.keeper.InitializeIndex(ctx)
+
 	return []abci.ValidatorUpdate{}
 }
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #6039

## Description

An annoying quirk in the capability testing setup prevented us from catching the bug reported above. Created a new testcase `TestOriginalCapabilityKeeper` that reproduced the failure above and is now passing.

Created `InitGenesis` logic to set initial global index to 1

______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added  relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

______

For admin use:

- [ ] Added appropriate labels to PR (ex. `WIP`, `R4R`, `docs`, etc)
- [ ] Reviewers assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
