### PR TITLE
Split proto CI into lint and breakage checks

### DIFF
--- a/.github/workflows/proto.yml
+++ b/.github/workflows/proto.yml
@@ -1,7 +1,7 @@
-name: Proto check
+name: Protobuf
 on: [pull_request]
 jobs:
-  proto-lint:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
@@ -14,7 +14,7 @@ jobs:
       - name: lint
         run: make proto-lint-docker
         if: "env.GIT_DIFF != ''"
-  proto-breakage:
+  breakage:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master

--- a/.github/workflows/proto.yml
+++ b/.github/workflows/proto.yml
@@ -1,7 +1,7 @@
 name: Proto check
 on: [pull_request]
 jobs:
-  proto-checks:
+  proto-lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
@@ -14,6 +14,16 @@ jobs:
       - name: lint
         run: make proto-lint-docker
         if: "env.GIT_DIFF != ''"
+  proto-breakage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: technote-space/get-diff-action@v1
+        id: git_diff
+        with:
+          SUFFIX_FILTER: .proto
+          SET_ENV_NAME_INSERTIONS: 1
+          SET_ENV_NAME_LINES: 1
       - name: check-breakage
         run: make proto-check-breaking-docker
         if: "env.GIT_DIFF != ''"


### PR DESCRIPTION
## Description

At least for me, it's helpful to split proto CI into separate lint and breakage steps. Right now before 0.39 we may be making lots of breaking changes but we always want lint to pass. Later, we will likely want to both to always pass.

______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added  relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

______

For admin use:

- [x] Added appropriate labels to PR (ex. `WIP`, `R4R`, `docs`, etc)
- [ ] Reviewers assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
