### PR TITLE
BugFix: Purge the EventManager context after processing each message.

### DIFF
--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -631,6 +631,9 @@ func (app *BaseApp) runMsgs(ctx sdk.Context, msgs []sdk.Msg, mode runTxMode) (*s
 
 		data = append(data, msgResult.Data...)
 		msgLogs = append(msgLogs, sdk.NewABCIMessageLog(uint16(i), msgResult.Log, msgEvents))
+		//Flush the event manager after processing every message
+		em := sdk.EventManager{}
+		ctx.WithEventManager(&em)
 	}
 
 	return &sdk.Result{

--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -633,7 +633,7 @@ func (app *BaseApp) runMsgs(ctx sdk.Context, msgs []sdk.Msg, mode runTxMode) (*s
 		msgLogs = append(msgLogs, sdk.NewABCIMessageLog(uint16(i), msgResult.Log, msgEvents))
 		//Flush the event manager after processing every message
 		em := sdk.EventManager{}
-		ctx.WithEventManager(&em)
+		ctx = ctx.WithEventManager(&em)
 	}
 
 	return &sdk.Result{


### PR DESCRIPTION
The Microtick team reported behavior where events from previous messages processed in the same block were being outputted as the results of subsequent messages for the same block.

I think we should be purging the EventManager in the context after processing each message.




For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added  relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

______

For admin use:

- [ ] Added appropriate labels to PR (ex. `WIP`, `R4R`, `docs`, etc)
- [ ] Reviewers assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
