### PR TITLE
x/ibc: fix int overflow

### DIFF
--- a/x/ibc/07-tendermint/types/test_utils.go
+++ b/x/ibc/07-tendermint/types/test_utils.go
@@ -1,13 +1,14 @@
 package types
 
 import (
-	"math"
 	"time"
 
 	"github.com/tendermint/tendermint/crypto/tmhash"
 	tmtypes "github.com/tendermint/tendermint/types"
 	"github.com/tendermint/tendermint/version"
 )
+
+const maxInt = int(^uint(0) >> 1)
 
 // Copied unimported test functions from tmtypes to use them here
 func MakeBlockID(hash []byte, partSetSize int, partSetHash []byte) tmtypes.BlockID {
@@ -28,7 +29,7 @@ func CreateTestHeader(chainID string, height int64, timestamp time.Time, valSet 
 		ChainID:            chainID,
 		Height:             height,
 		Time:               timestamp,
-		LastBlockID:        MakeBlockID(make([]byte, tmhash.Size), math.MaxInt64, make([]byte, tmhash.Size)),
+		LastBlockID:        MakeBlockID(make([]byte, tmhash.Size), maxInt, make([]byte, tmhash.Size)),
 		LastCommitHash:     tmhash.Sum([]byte("last_commit_hash")),
 		DataHash:           tmhash.Sum([]byte("data_hash")),
 		ValidatorsHash:     vsetHash,


### PR DESCRIPTION
x/ibc/07-tendermint/types/test_utils.go: Calculate and use
machine-dependent maxInt instead of causing int overflow by
passing math.MaxInt64.

Closes: #6130

This mitigation should be applied while we wait for tendermint
to migrate away from machine-dependent integers.