### PR TITLE
client/keys/parse.go: honor config changes

### DIFF
--- a/client/keys/parse_test.go
+++ b/client/keys/parse_test.go
@@ -3,12 +3,15 @@ package keys
 import (
 	"testing"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/require"
 )
 
 func TestParseKey(t *testing.T) {
 	bech32str := "cosmos104ytdpvrx9284zd50v9ep8c6j7pua7dkk0x3ek"
 	hexstr := "EB5AE9872103497EC092EF901027049E4F39200C60040D3562CD7F104A39F62E6E5A39A818F4"
+
+	config := sdk.NewConfig()
 
 	tests := []struct {
 		name    string
@@ -23,7 +26,7 @@ func TestParseKey(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.wantErr, parseKey(ParseKeyStringCommand(), tt.args) != nil)
+			require.Equal(t, tt.wantErr, doParseKey(ParseKeyStringCommand(), config, tt.args) != nil)
 		})
 	}
 }

--- a/types/config_test.go
+++ b/types/config_test.go
@@ -10,8 +10,9 @@ import (
 )
 
 func TestConfig_SetCoinType(t *testing.T) {
-	config := &sdk.Config{}
-	require.Equal(t, uint32(0), config.GetCoinType())
+	config := sdk.NewConfig()
+	config.SetCoinType(1)
+	require.Equal(t, uint32(1), config.GetCoinType())
 	config.SetCoinType(99)
 	require.Equal(t, uint32(99), config.GetCoinType())
 
@@ -21,7 +22,7 @@ func TestConfig_SetCoinType(t *testing.T) {
 
 func TestConfig_SetTxEncoder(t *testing.T) {
 	mockErr := errors.New("test")
-	config := &sdk.Config{}
+	config := sdk.NewConfig()
 	require.Nil(t, config.GetTxEncoder())
 	encFunc := sdk.TxEncoder(func(tx sdk.Tx) ([]byte, error) { return nil, nil })
 	config.SetTxEncoder(encFunc)
@@ -33,10 +34,12 @@ func TestConfig_SetTxEncoder(t *testing.T) {
 }
 
 func TestConfig_SetFullFundraiserPath(t *testing.T) {
-	config := &sdk.Config{}
-	require.Equal(t, "", config.GetFullFundraiserPath())
+	config := sdk.NewConfig()
 	config.SetFullFundraiserPath("test/path")
 	require.Equal(t, "test/path", config.GetFullFundraiserPath())
+
+	config.SetFullFundraiserPath("test/poth")
+	require.Equal(t, "test/poth", config.GetFullFundraiserPath())
 
 	config.Seal()
 	require.Panics(t, func() { config.SetFullFundraiserPath("x/test/path") })


### PR DESCRIPTION
`keys parse` uses the global configuration before
before client applications have had a chance to
apply their settings.

This change adds a `GetSealedConfig()` helper
that waits for the config to be sealed before
returning it.

fixes #5091
addresses #5283