### PR TITLE
feat(types): add codespace to broadcast(sync/async) response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -233,6 +233,7 @@ functionality that requires an online connection.
 * (x/staking) [\#6059](https://github.com/cosmos/cosmos-sdk/pull/6059) Updated `HistoricalEntries` parameter default to 100.
 * (x/ibc) [\#5948](https://github.com/cosmos/cosmos-sdk/issues/5948) Add `InitGenesis` and `ExportGenesis` functions for `ibc` module.
 * (types) [\#6128](https://github.com/cosmos/cosmos-sdk/pull/6137) Add `String()` method to `GasMeter`.
+* (types) [\#6195](https://github.com/cosmos/cosmos-sdk/pull/6195) Add codespace to broadcast(sync/async) response.
 
 ## [v0.38.3] - 2020-04-09
 

--- a/client/context/broadcast.go
+++ b/client/context/broadcast.go
@@ -53,20 +53,23 @@ func CheckTendermintError(err error, txBytes []byte) *sdk.TxResponse {
 	switch {
 	case strings.Contains(errStr, strings.ToLower(mempool.ErrTxInCache.Error())):
 		return &sdk.TxResponse{
-			Code:   sdkerrors.ErrTxInMempoolCache.ABCICode(),
-			TxHash: txHash,
+			Code:      sdkerrors.ErrTxInMempoolCache.ABCICode(),
+			Codespace: sdkerrors.ErrTxInMempoolCache.Codespace(),
+			TxHash:    txHash,
 		}
 
 	case strings.Contains(errStr, "mempool is full"):
 		return &sdk.TxResponse{
-			Code:   sdkerrors.ErrMempoolIsFull.ABCICode(),
-			TxHash: txHash,
+			Code:      sdkerrors.ErrMempoolIsFull.ABCICode(),
+			Codespace: sdkerrors.ErrMempoolIsFull.Codespace(),
+			TxHash:    txHash,
 		}
 
 	case strings.Contains(errStr, "tx too large"):
 		return &sdk.TxResponse{
-			Code:   sdkerrors.ErrTxTooLarge.ABCICode(),
-			TxHash: txHash,
+			Code:      sdkerrors.ErrTxTooLarge.ABCICode(),
+			Codespace: sdkerrors.ErrTxTooLarge.Codespace(),
+			TxHash:    txHash,
 		}
 
 	default:

--- a/client/context/broadcast_test.go
+++ b/client/context/broadcast_test.go
@@ -62,6 +62,7 @@ func TestBroadcastError(t *testing.T) {
 			resp, returnedErr := ctx.BroadcastTx(txBytes)
 			require.NoError(t, returnedErr)
 			require.Equal(t, code, resp.Code)
+			require.NotEmpty(t, resp.Codespace)
 			require.Equal(t, txHash, resp.TxHash)
 		}
 	}

--- a/types/result.go
+++ b/types/result.go
@@ -182,11 +182,12 @@ func NewResponseFormatBroadcastTx(res *ctypes.ResultBroadcastTx) TxResponse {
 	parsedLogs, _ := ParseABCILogs(res.Log)
 
 	return TxResponse{
-		Code:   res.Code,
-		Data:   res.Data.String(),
-		RawLog: res.Log,
-		Logs:   parsedLogs,
-		TxHash: res.Hash.String(),
+		Code:      res.Code,
+		Codespace: res.Codespace,
+		Data:      res.Data.String(),
+		RawLog:    res.Log,
+		Logs:      parsedLogs,
+		TxHash:    res.Hash.String(),
 	}
 }
 

--- a/types/result_test.go
+++ b/types/result_test.go
@@ -113,17 +113,19 @@ func TestResponseResultTx(t *testing.T) {
 	require.False(t, want.Empty())
 
 	resultBroadcastTx := &ctypes.ResultBroadcastTx{
-		Code: 1,
-		Data: []byte("data"),
-		Log:  `[]`,
-		Hash: bytes.HexBytes([]byte("test")),
+		Code:      1,
+		Codespace: "codespace",
+		Data:      []byte("data"),
+		Log:       `[]`,
+		Hash:      bytes.HexBytes([]byte("test")),
 	}
 	require.Equal(t, sdk.TxResponse{
-		Code:   1,
-		Data:   "64617461",
-		RawLog: `[]`,
-		Logs:   logs,
-		TxHash: "74657374",
+		Code:      1,
+		Codespace: "codespace",
+		Data:      "64617461",
+		RawLog:    `[]`,
+		Logs:      logs,
+		TxHash:    "74657374",
 	}, sdk.NewResponseFormatBroadcastTx(resultBroadcastTx))
 	require.Equal(t, sdk.TxResponse{}, sdk.NewResponseFormatBroadcastTx(nil))
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Adds codespace to responses of broadcast SYNC and ASYNC.
- add codespace in case of mempool errors
- set codespace from  the ABCI ResultBroadcastTx

closes: #5859 
