### PR TITLE
Remove Get* Prefixes from Key Construction Functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ older clients.
 
 ### API Breaking Changes
 
+* [\#6212](https://github.com/cosmos/cosmos-sdk/pull/6212) Remove `Get*` prefixes from key construction functions
 * [\#6079](https://github.com/cosmos/cosmos-sdk/pull/6079) Remove `UpgradeOldPrivValFile` (deprecated in Tendermint Core v0.28).
 * (modules) [\#5664](https://github.com/cosmos/cosmos-sdk/pull/5664) Remove amino `Codec` from simulation `StoreDecoder`, which now returns a function closure in order to unmarshal the key-value pairs.
 * (x/auth) [\#6029](https://github.com/cosmos/cosmos-sdk/pull/6029) Module accounts have been moved from `x/supply` to `x/auth`.

--- a/x/slashing/alias.go
+++ b/x/slashing/alias.go
@@ -32,46 +32,46 @@ const (
 
 var (
 	// functions aliases
-	NewKeeper                                = keeper.NewKeeper
-	NewQuerier                               = keeper.NewQuerier
-	RegisterCodec                            = types.RegisterCodec
-	ErrNoValidatorForAddress                 = types.ErrNoValidatorForAddress
-	ErrBadValidatorAddr                      = types.ErrBadValidatorAddr
-	ErrValidatorJailed                       = types.ErrValidatorJailed
-	ErrValidatorNotJailed                    = types.ErrValidatorNotJailed
-	ErrMissingSelfDelegation                 = types.ErrMissingSelfDelegation
-	ErrSelfDelegationTooLowToUnjail          = types.ErrSelfDelegationTooLowToUnjail
-	ErrNoSigningInfoFound                    = types.ErrNoSigningInfoFound
-	NewGenesisState                          = types.NewGenesisState
-	NewMissedBlock                           = types.NewMissedBlock
-	DefaultGenesisState                      = types.DefaultGenesisState
-	ValidateGenesis                          = types.ValidateGenesis
-	GetValidatorSigningInfoKey               = types.GetValidatorSigningInfoKey
-	GetValidatorSigningInfoAddress           = types.GetValidatorSigningInfoAddress
-	GetValidatorMissedBlockBitArrayPrefixKey = types.GetValidatorMissedBlockBitArrayPrefixKey
-	GetValidatorMissedBlockBitArrayKey       = types.GetValidatorMissedBlockBitArrayKey
-	GetAddrPubkeyRelationKey                 = types.GetAddrPubkeyRelationKey
-	NewMsgUnjail                             = types.NewMsgUnjail
-	ParamKeyTable                            = types.ParamKeyTable
-	NewParams                                = types.NewParams
-	DefaultParams                            = types.DefaultParams
-	NewQuerySigningInfoParams                = types.NewQuerySigningInfoParams
-	NewQuerySigningInfosParams               = types.NewQuerySigningInfosParams
-	NewValidatorSigningInfo                  = types.NewValidatorSigningInfo
+	NewKeeper                             = keeper.NewKeeper
+	NewQuerier                            = keeper.NewQuerier
+	RegisterCodec                         = types.RegisterCodec
+	ErrNoValidatorForAddress              = types.ErrNoValidatorForAddress
+	ErrBadValidatorAddr                   = types.ErrBadValidatorAddr
+	ErrValidatorJailed                    = types.ErrValidatorJailed
+	ErrValidatorNotJailed                 = types.ErrValidatorNotJailed
+	ErrMissingSelfDelegation              = types.ErrMissingSelfDelegation
+	ErrSelfDelegationTooLowToUnjail       = types.ErrSelfDelegationTooLowToUnjail
+	ErrNoSigningInfoFound                 = types.ErrNoSigningInfoFound
+	NewGenesisState                       = types.NewGenesisState
+	NewMissedBlock                        = types.NewMissedBlock
+	DefaultGenesisState                   = types.DefaultGenesisState
+	ValidateGenesis                       = types.ValidateGenesis
+	ValidatorSigningInfoKey               = types.ValidatorSigningInfoKey
+	ValidatorSigningInfoAddress           = types.ValidatorSigningInfoAddress
+	ValidatorMissedBlockBitArrayPrefixKey = types.ValidatorMissedBlockBitArrayPrefixKey
+	ValidatorMissedBlockBitArrayKey       = types.ValidatorMissedBlockBitArrayKey
+	AddrPubkeyRelationKey                 = types.AddrPubkeyRelationKey
+	NewMsgUnjail                          = types.NewMsgUnjail
+	ParamKeyTable                         = types.ParamKeyTable
+	NewParams                             = types.NewParams
+	DefaultParams                         = types.DefaultParams
+	NewQuerySigningInfoParams             = types.NewQuerySigningInfoParams
+	NewQuerySigningInfosParams            = types.NewQuerySigningInfosParams
+	NewValidatorSigningInfo               = types.NewValidatorSigningInfo
 
 	// variable aliases
-	ModuleCdc                       = types.ModuleCdc
-	ValidatorSigningInfoKey         = types.ValidatorSigningInfoKey
-	ValidatorMissedBlockBitArrayKey = types.ValidatorMissedBlockBitArrayKey
-	AddrPubkeyRelationKey           = types.AddrPubkeyRelationKey
-	DefaultMinSignedPerWindow       = types.DefaultMinSignedPerWindow
-	DefaultSlashFractionDoubleSign  = types.DefaultSlashFractionDoubleSign
-	DefaultSlashFractionDowntime    = types.DefaultSlashFractionDowntime
-	KeySignedBlocksWindow           = types.KeySignedBlocksWindow
-	KeyMinSignedPerWindow           = types.KeyMinSignedPerWindow
-	KeyDowntimeJailDuration         = types.KeyDowntimeJailDuration
-	KeySlashFractionDoubleSign      = types.KeySlashFractionDoubleSign
-	KeySlashFractionDowntime        = types.KeySlashFractionDowntime
+	ModuleCdc                             = types.ModuleCdc
+	ValidatorSigningInfoKeyPrefix         = types.ValidatorSigningInfoKeyPrefix
+	ValidatorMissedBlockBitArrayKeyPrefix = types.ValidatorMissedBlockBitArrayKeyPrefix
+	AddrPubkeyRelationKeyPrefix           = types.AddrPubkeyRelationKeyPrefix
+	DefaultMinSignedPerWindow             = types.DefaultMinSignedPerWindow
+	DefaultSlashFractionDoubleSign        = types.DefaultSlashFractionDoubleSign
+	DefaultSlashFractionDowntime          = types.DefaultSlashFractionDowntime
+	KeySignedBlocksWindow                 = types.KeySignedBlocksWindow
+	KeyMinSignedPerWindow                 = types.KeyMinSignedPerWindow
+	KeyDowntimeJailDuration               = types.KeyDowntimeJailDuration
+	KeySlashFractionDoubleSign            = types.KeySlashFractionDoubleSign
+	KeySlashFractionDowntime              = types.KeySlashFractionDowntime
 )
 
 type (

--- a/x/slashing/client/cli/query.go
+++ b/x/slashing/client/cli/query.go
@@ -56,7 +56,7 @@ $ <appcli> query slashing signing-info cosmosvalconspub1zcjduepqfhvwcmt7p06fvdge
 			}
 
 			consAddr := sdk.ConsAddress(pk.Address())
-			key := types.GetValidatorSigningInfoKey(consAddr)
+			key := types.ValidatorSigningInfoKey(consAddr)
 
 			res, _, err := cliCtx.QueryStore(key, storeName)
 			if err != nil {

--- a/x/slashing/keeper/keeper.go
+++ b/x/slashing/keeper/keeper.go
@@ -58,7 +58,7 @@ func (k Keeper) GetPubkey(ctx sdk.Context, address crypto.Address) (crypto.PubKe
 	store := ctx.KVStore(k.storeKey)
 
 	var pubkey gogotypes.StringValue
-	err := k.cdc.UnmarshalBinaryBare(store.Get(types.GetAddrPubkeyRelationKey(address)), &pubkey)
+	err := k.cdc.UnmarshalBinaryBare(store.Get(types.AddrPubkeyRelationKey(address)), &pubkey)
 	if err != nil {
 		return nil, fmt.Errorf("address %s not found", sdk.ConsAddress(address))
 	}
@@ -103,10 +103,10 @@ func (k Keeper) setAddrPubkeyRelation(ctx sdk.Context, addr crypto.Address, pubk
 	store := ctx.KVStore(k.storeKey)
 
 	bz := k.cdc.MustMarshalBinaryBare(&gogotypes.StringValue{Value: pubkey})
-	store.Set(types.GetAddrPubkeyRelationKey(addr), bz)
+	store.Set(types.AddrPubkeyRelationKey(addr), bz)
 }
 
 func (k Keeper) deleteAddrPubkeyRelation(ctx sdk.Context, addr crypto.Address) {
 	store := ctx.KVStore(k.storeKey)
-	store.Delete(types.GetAddrPubkeyRelationKey(addr))
+	store.Delete(types.AddrPubkeyRelationKey(addr))
 }

--- a/x/slashing/keeper/signing_info.go
+++ b/x/slashing/keeper/signing_info.go
@@ -13,7 +13,7 @@ import (
 // ConsAddress
 func (k Keeper) GetValidatorSigningInfo(ctx sdk.Context, address sdk.ConsAddress) (info types.ValidatorSigningInfo, found bool) {
 	store := ctx.KVStore(k.storeKey)
-	bz := store.Get(types.GetValidatorSigningInfoKey(address))
+	bz := store.Get(types.ValidatorSigningInfoKey(address))
 	if bz == nil {
 		found = false
 		return
@@ -34,7 +34,7 @@ func (k Keeper) HasValidatorSigningInfo(ctx sdk.Context, consAddr sdk.ConsAddres
 func (k Keeper) SetValidatorSigningInfo(ctx sdk.Context, address sdk.ConsAddress, info types.ValidatorSigningInfo) {
 	store := ctx.KVStore(k.storeKey)
 	bz := k.cdc.MustMarshalBinaryBare(&info)
-	store.Set(types.GetValidatorSigningInfoKey(address), bz)
+	store.Set(types.ValidatorSigningInfoKey(address), bz)
 }
 
 // IterateValidatorSigningInfos iterates over the stored ValidatorSigningInfo
@@ -42,10 +42,10 @@ func (k Keeper) IterateValidatorSigningInfos(ctx sdk.Context,
 	handler func(address sdk.ConsAddress, info types.ValidatorSigningInfo) (stop bool)) {
 
 	store := ctx.KVStore(k.storeKey)
-	iter := sdk.KVStorePrefixIterator(store, types.ValidatorSigningInfoKey)
+	iter := sdk.KVStorePrefixIterator(store, types.ValidatorSigningInfoKeyPrefix)
 	defer iter.Close()
 	for ; iter.Valid(); iter.Next() {
-		address := types.GetValidatorSigningInfoAddress(iter.Key())
+		address := types.ValidatorSigningInfoAddress(iter.Key())
 		var info types.ValidatorSigningInfo
 		k.cdc.MustUnmarshalBinaryBare(iter.Value(), &info)
 		if handler(address, info) {
@@ -57,7 +57,7 @@ func (k Keeper) IterateValidatorSigningInfos(ctx sdk.Context,
 // GetValidatorMissedBlockBitArray gets the bit for the missed blocks array
 func (k Keeper) GetValidatorMissedBlockBitArray(ctx sdk.Context, address sdk.ConsAddress, index int64) bool {
 	store := ctx.KVStore(k.storeKey)
-	bz := store.Get(types.GetValidatorMissedBlockBitArrayKey(address, index))
+	bz := store.Get(types.ValidatorMissedBlockBitArrayKey(address, index))
 	var missed gogotypes.BoolValue
 	if bz == nil {
 		// lazy: treat empty key as not missed
@@ -78,7 +78,7 @@ func (k Keeper) IterateValidatorMissedBlockBitArray(ctx sdk.Context,
 	// Array may be sparse
 	for ; index < k.SignedBlocksWindow(ctx); index++ {
 		var missed gogotypes.BoolValue
-		bz := store.Get(types.GetValidatorMissedBlockBitArrayKey(address, index))
+		bz := store.Get(types.ValidatorMissedBlockBitArrayKey(address, index))
 		if bz == nil {
 			continue
 		}
@@ -133,13 +133,13 @@ func (k Keeper) IsTombstoned(ctx sdk.Context, consAddr sdk.ConsAddress) bool {
 func (k Keeper) SetValidatorMissedBlockBitArray(ctx sdk.Context, address sdk.ConsAddress, index int64, missed bool) {
 	store := ctx.KVStore(k.storeKey)
 	bz := k.cdc.MustMarshalBinaryBare(&gogotypes.BoolValue{Value: missed})
-	store.Set(types.GetValidatorMissedBlockBitArrayKey(address, index), bz)
+	store.Set(types.ValidatorMissedBlockBitArrayKey(address, index), bz)
 }
 
 // clearValidatorMissedBlockBitArray deletes every instance of ValidatorMissedBlockBitArray in the store
 func (k Keeper) clearValidatorMissedBlockBitArray(ctx sdk.Context, address sdk.ConsAddress) {
 	store := ctx.KVStore(k.storeKey)
-	iter := sdk.KVStorePrefixIterator(store, types.GetValidatorMissedBlockBitArrayPrefixKey(address))
+	iter := sdk.KVStorePrefixIterator(store, types.ValidatorMissedBlockBitArrayPrefixKey(address))
 	defer iter.Close()
 	for ; iter.Valid(); iter.Next() {
 		store.Delete(iter.Key())

--- a/x/slashing/simulation/decoder.go
+++ b/x/slashing/simulation/decoder.go
@@ -16,19 +16,19 @@ import (
 func NewDecodeStore(cdc codec.Marshaler) func(kvA, kvB tmkv.Pair) string {
 	return func(kvA, kvB tmkv.Pair) string {
 		switch {
-		case bytes.Equal(kvA.Key[:1], types.ValidatorSigningInfoKey):
+		case bytes.Equal(kvA.Key[:1], types.ValidatorSigningInfoKeyPrefix):
 			var infoA, infoB types.ValidatorSigningInfo
 			cdc.MustUnmarshalBinaryBare(kvA.Value, &infoA)
 			cdc.MustUnmarshalBinaryBare(kvB.Value, &infoB)
 			return fmt.Sprintf("%v\n%v", infoA, infoB)
 
-		case bytes.Equal(kvA.Key[:1], types.ValidatorMissedBlockBitArrayKey):
+		case bytes.Equal(kvA.Key[:1], types.ValidatorMissedBlockBitArrayKeyPrefix):
 			var missedA, missedB gogotypes.BoolValue
 			cdc.MustUnmarshalBinaryBare(kvA.Value, &missedA)
 			cdc.MustUnmarshalBinaryBare(kvB.Value, &missedB)
 			return fmt.Sprintf("missedA: %v\nmissedB: %v", missedA.Value, missedB.Value)
 
-		case bytes.Equal(kvA.Key[:1], types.AddrPubkeyRelationKey):
+		case bytes.Equal(kvA.Key[:1], types.AddrPubkeyRelationKeyPrefix):
 			var pubKeyA, pubKeyB gogotypes.StringValue
 			cdc.MustUnmarshalBinaryBare(kvA.Value, &pubKeyA)
 			cdc.MustUnmarshalBinaryBare(kvB.Value, &pubKeyB)

--- a/x/slashing/simulation/decoder_test.go
+++ b/x/slashing/simulation/decoder_test.go
@@ -35,9 +35,9 @@ func TestDecodeStore(t *testing.T) {
 	missed := gogotypes.BoolValue{Value: true}
 
 	kvPairs := tmkv.Pairs{
-		tmkv.Pair{Key: types.GetValidatorSigningInfoKey(consAddr1), Value: cdc.MustMarshalBinaryBare(&info)},
-		tmkv.Pair{Key: types.GetValidatorMissedBlockBitArrayKey(consAddr1, 6), Value: cdc.MustMarshalBinaryBare(&missed)},
-		tmkv.Pair{Key: types.GetAddrPubkeyRelationKey(delAddr1), Value: cdc.MustMarshalBinaryBare(&gogotypes.StringValue{Value: bechPK})},
+		tmkv.Pair{Key: types.ValidatorSigningInfoKey(consAddr1), Value: cdc.MustMarshalBinaryBare(&info)},
+		tmkv.Pair{Key: types.ValidatorMissedBlockBitArrayKey(consAddr1, 6), Value: cdc.MustMarshalBinaryBare(&missed)},
+		tmkv.Pair{Key: types.AddrPubkeyRelationKey(delAddr1), Value: cdc.MustMarshalBinaryBare(&gogotypes.StringValue{Value: bechPK})},
 		tmkv.Pair{Key: []byte{0x99}, Value: []byte{0x99}},
 	}
 

--- a/x/slashing/types/keys.go
+++ b/x/slashing/types/keys.go
@@ -29,18 +29,18 @@ const (
 //
 // - 0x03<accAddr_Bytes>: crypto.PubKey
 var (
-	ValidatorSigningInfoKey         = []byte{0x01} // Prefix for signing info
-	ValidatorMissedBlockBitArrayKey = []byte{0x02} // Prefix for missed block bit array
-	AddrPubkeyRelationKey           = []byte{0x03} // Prefix for address-pubkey relation
+	ValidatorSigningInfoKeyPrefix         = []byte{0x01} // Prefix for signing info
+	ValidatorMissedBlockBitArrayKeyPrefix = []byte{0x02} // Prefix for missed block bit array
+	AddrPubkeyRelationKeyPrefix           = []byte{0x03} // Prefix for address-pubkey relation
 )
 
-// GetValidatorSigningInfoKey - stored by *Consensus* address (not operator address)
-func GetValidatorSigningInfoKey(v sdk.ConsAddress) []byte {
-	return append(ValidatorSigningInfoKey, v.Bytes()...)
+// ValidatorSigningInfoKey - stored by *Consensus* address (not operator address)
+func ValidatorSigningInfoKey(v sdk.ConsAddress) []byte {
+	return append(ValidatorSigningInfoKeyPrefix, v.Bytes()...)
 }
 
-// GetValidatorSigningInfoAddress - extract the address from a validator signing info key
-func GetValidatorSigningInfoAddress(key []byte) (v sdk.ConsAddress) {
+// ValidatorSigningInfoAddress - extract the address from a validator signing info key
+func ValidatorSigningInfoAddress(key []byte) (v sdk.ConsAddress) {
 	addr := key[1:]
 	if len(addr) != sdk.AddrLen {
 		panic("unexpected key length")
@@ -48,19 +48,19 @@ func GetValidatorSigningInfoAddress(key []byte) (v sdk.ConsAddress) {
 	return sdk.ConsAddress(addr)
 }
 
-// GetValidatorMissedBlockBitArrayPrefixKey - stored by *Consensus* address (not operator address)
-func GetValidatorMissedBlockBitArrayPrefixKey(v sdk.ConsAddress) []byte {
-	return append(ValidatorMissedBlockBitArrayKey, v.Bytes()...)
+// ValidatorMissedBlockBitArrayPrefixKey - stored by *Consensus* address (not operator address)
+func ValidatorMissedBlockBitArrayPrefixKey(v sdk.ConsAddress) []byte {
+	return append(ValidatorMissedBlockBitArrayKeyPrefix, v.Bytes()...)
 }
 
-// GetValidatorMissedBlockBitArrayKey - stored by *Consensus* address (not operator address)
-func GetValidatorMissedBlockBitArrayKey(v sdk.ConsAddress, i int64) []byte {
+// ValidatorMissedBlockBitArrayKey - stored by *Consensus* address (not operator address)
+func ValidatorMissedBlockBitArrayKey(v sdk.ConsAddress, i int64) []byte {
 	b := make([]byte, 8)
 	binary.LittleEndian.PutUint64(b, uint64(i))
-	return append(GetValidatorMissedBlockBitArrayPrefixKey(v), b...)
+	return append(ValidatorMissedBlockBitArrayPrefixKey(v), b...)
 }
 
-// GetAddrPubkeyRelationKey gets pubkey relation key used to get the pubkey from the address
-func GetAddrPubkeyRelationKey(address []byte) []byte {
-	return append(AddrPubkeyRelationKey, address...)
+// AddrPubkeyRelationKey gets pubkey relation key used to get the pubkey from the address
+func AddrPubkeyRelationKey(address []byte) []byte {
+	return append(AddrPubkeyRelationKeyPrefix, address...)
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Remove Get* prefix from key construction functions:
GetValidatorSigningInfoKey => ValidatorSigningInfoKey

Add *Prefix to constant prefixes:
ValidatorSigningInfoKey => ValidatorSigningInfoKeyPrefix

closes: #2747
