### PR TITLE
Different db support

### DIFF
--- a/types/utils.go
+++ b/types/utils.go
@@ -12,7 +12,14 @@ import (
 var (
 	// This is set at compile time. Could be cleveldb, defaults is goleveldb.
 	DBBackend = ""
+	backend   = dbm.GoLevelDBBackend
 )
+
+func init() {
+	if len(DBBackend) != 0 {
+		backend = dbm.BackendType(DBBackend)
+	}
+}
 
 // SortedJSON takes any JSON and returns it sorted by keys. Also, all white-spaces
 // are removed.
@@ -79,10 +86,6 @@ func ParseTimeBytes(bz []byte) (time.Time, error) {
 
 // NewLevelDB instantiate a new LevelDB instance according to DBBackend.
 func NewLevelDB(name, dir string) (db dbm.DB, err error) {
-	backend := dbm.GoLevelDBBackend
-	if len(DBBackend) != 0 {
-		backend = dbm.BackendType(DBBackend)
-	}
 	defer func() {
 		if r := recover(); r != nil {
 			err = fmt.Errorf("couldn't create db: %v", r)

--- a/types/utils.go
+++ b/types/utils.go
@@ -80,8 +80,8 @@ func ParseTimeBytes(bz []byte) (time.Time, error) {
 // NewLevelDB instantiate a new LevelDB instance according to DBBackend.
 func NewLevelDB(name, dir string) (db dbm.DB, err error) {
 	backend := dbm.GoLevelDBBackend
-	if DBBackend == string(dbm.CLevelDBBackend) {
-		backend = dbm.CLevelDBBackend
+	if len(DBBackend) != 0 {
+		backend = dbm.BackendType(DBBackend)
 	}
 	defer func() {
 		if r := recover(); r != nil {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description
Adds the ability to use any of the database backend engines supported by Tendermint while creating new Cosmos databases.

closes: #6218
