### PR TITLE
update path validator to enforce no beginning or ending of the separator

### DIFF
--- a/x/ibc/24-host/validate.go
+++ b/x/ibc/24-host/validate.go
@@ -1,7 +1,6 @@
 package host
 
 import (
-	"fmt"
 	"regexp"
 	"strings"
 
@@ -85,14 +84,11 @@ func NewPathValidator(idValidator ValidateFn) ValidateFn {
 			return sdkerrors.Wrapf(ErrInvalidPath, "path %s doesn't contain any separator '/'", path)
 		}
 
-		allEmptyItems := true
 		for _, p := range pathArr {
-			// NOTE: for some reason an empty string is added after Split
+			// a path beginning or ending in a separator returns empty string elements.
 			if p == "" {
-				continue
+				return sdkerrors.Wrapf(ErrInvalidPath, "path %s cannot begin or end with '/'", path)
 			}
-
-			allEmptyItems = false
 
 			if err := idValidator(p); err != nil {
 				return err
@@ -101,10 +97,6 @@ func NewPathValidator(idValidator ValidateFn) ValidateFn {
 			if err := defaultIdentifierValidator(p, 1, 20); err != nil {
 				return sdkerrors.Wrapf(err, "path %s contains an invalid identifier: '%s'", path, p)
 			}
-		}
-
-		if allEmptyItems {
-			return fmt.Errorf("path %s must contain at least one identifier", path)
 		}
 
 		return nil
@@ -119,14 +111,11 @@ func PathValidator(path string) error {
 		return sdkerrors.Wrapf(ErrInvalidPath, "path %s doesn't contain any separator '/'", path)
 	}
 
-	allEmptyItems := true
 	for _, p := range pathArr {
-		// NOTE: for some reason an empty string is added after Split
+		// a path beginning or ending in a separator returns empty string elements.
 		if p == "" {
-			continue
+			return sdkerrors.Wrapf(ErrInvalidPath, "path %s cannot begin or end with '/'", path)
 		}
-
-		allEmptyItems = false
 
 		// Each path element must be a valid identifier or constant number
 		if err := defaultIdentifierValidator(p, 1, 20); err != nil {
@@ -134,8 +123,5 @@ func PathValidator(path string) error {
 		}
 	}
 
-	if allEmptyItems {
-		return fmt.Errorf("path %s must contain at least one identifier", path)
-	}
 	return nil
 }

--- a/x/ibc/24-host/validate_test.go
+++ b/x/ibc/24-host/validate_test.go
@@ -56,7 +56,7 @@ func TestPathValidator(t *testing.T) {
 		{"valid id special chars", "p/._+-#[]<>._+-#[]<>", true},
 		{"valid id lower and special chars", "lower/._+-#[]<>", true},
 		{"id length out of range", "p/l", true},
-		{"uppercase id", "NOT/LOWERCASE", true},
+		{"uppercase id", "p/NOTLOWERCASE", true},
 		{"invalid path", "lowercaseid", false},
 		{"blank id", "p/               ", false},
 		{"id length out of range", "p/123456789012345678901", false},

--- a/x/ibc/24-host/validate_test.go
+++ b/x/ibc/24-host/validate_test.go
@@ -51,19 +51,24 @@ func TestDefaultIdentifierValidator(t *testing.T) {
 
 func TestPathValidator(t *testing.T) {
 	testCases := []testCase{
-		{"valid lowercase", "/lowercaseid", true},
-		{"numeric path", "/239123", true},
-		{"valid id special chars", "/._+-#[]<>._+-#[]<>", true},
+		{"valid lowercase", "p/lowercaseid", true},
+		{"numeric path", "p/239123", true},
+		{"valid id special chars", "p/._+-#[]<>._+-#[]<>", true},
 		{"valid id lower and special chars", "lower/._+-#[]<>", true},
-		{"id length out of range", "/l", true},
-		{"uppercase id", "/NOTLOWERCASE", true},
+		{"id length out of range", "p/l", true},
+		{"uppercase id", "NOT/LOWERCASE", true},
 		{"invalid path", "lowercaseid", false},
-		{"blank id", "/               ", false},
-		{"id length out of range", "/123456789012345678901", false},
-		{"invalid id", "/(clientid)", false},
+		{"blank id", "p/               ", false},
+		{"id length out of range", "p/123456789012345678901", false},
+		{"invalid id", "p/(clientid)", false},
 		{"empty string", "", false},
 		{"separators only", "////", false},
 		{"just separator", "/", false},
+		{"begins with separator", "/id", false},
+		{"blank before separator", "    /id", false},
+		{"ends with separator", "id/", false},
+		{"blank after separator", "id/       ", false},
+		{"blanks with separator", "  /  ", false},
 	}
 
 	for _, tc := range testCases {
@@ -87,12 +92,14 @@ func TestCustomPathValidator(t *testing.T) {
 	})
 
 	testCases := []testCase{
-		{"valid custom path", "/id_client/id_one", true},
+		{"valid custom path", "id_client/id_one", true},
 		{"invalid path", "client", false},
-		{"invalid custom path", "/client", false},
-		{"invalid identifier", "/id_client/id_123456789012345678901", false},
+		{"invalid custom path", "id_one/client", false},
+		{"invalid identifier", "id_client/id_123456789012345678901", false},
 		{"separators only", "////", false},
 		{"just separator", "/", false},
+		{"ends with separator", "id_client/id_one/", false},
+		{"beings with separator", "/id_client/id_one", false},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->
Updates path validator to enforce that no path can begin or end with the separator. Previously both were allowed, but I believe this goes against the [ICS spec](https://github.com/cosmos/ics/tree/master/spec/ics-024-host-requirements) which states:
```
The separator "/" is used to separate and concatenate two identifiers or an identifier and a constant bytestring. Identifiers MUST NOT contain the "/" character, which prevents ambiguity.
```
IMO beginning or ending with the separator is ambiguous to whether the separator is apart of the identifier name (which isn't allowed) or if the second identifier is an empty string (again not allowed). It is also more logical that a separator is always used to separate either two identifiers or an identifier and a constant byte string. 

continuation of #6227 
