### PR TITLE
New ADR 025 for passive channels

### DIFF
--- a/docs/architecture/adr-023-ibc-passive-channels.md
+++ b/docs/architecture/adr-023-ibc-passive-channels.md
@@ -1,0 +1,88 @@
+# ADR 023: IBC Passive Channels
+
+## Changelog
+
+- 2020-05-18: Initial Draft
+
+## Context
+
+The current "naive" IBC Relayer strategy currently establishes a single predetermined IBC channel atop a single connection between two clients (each potentially of a different chain).  This strategy then detects packets to be relayed by watching for `send_packet` and `recv_packet` events matching that channel, and sends the necessary transactions to relay those packets.
+
+We wish to expand this "naive" strategy to a "passive" one which detects and relays both channel handshake messages and packets on a given connection, without the need to know each channel in advance of relaying it.
+
+In order to accomplish this, we propose adding the following events to expose channel metadata for each transaction sent from the `x/ibc/04-channel/keeper/handshake.go` and `x/ibc/04-channel/keeper/packet.go` modules:
+
+- `channel_meta.src_connection=CONN1` as the only key needing to be indexed
+- `channel_meta.action=ACTION` where `ACTION` is one of:
+  - `open_init`
+  - `open_try`
+  - `open_ack`
+  - `open_confirm`
+  - `send_packet`
+  - `packet_executed`
+  - `close_init`
+  - `close_confirm`
+- `channel_meta.hops=CONN1,CONN2,...`
+- `channel_meta.order=ORDERED`
+- `channel_meta.src_port=PORT1`
+- `channel_meta.src_channel=CHANNEL1`
+- `channel_meta.src_version=VSN1`
+- `channel_meta.dst_port=PORT2`
+- `channel_meta.dst_channel=CHANNEL2`
+- `channel_meta.dst_version=VSN2`
+
+These metadata events capture all the "header" information needed to route IBC channel handshake transactions without requiring the client to keep track of any state except for its connection ID.
+
+### Inversion of Control
+
+The other concern we are trying to address is IBC use-cases where an application module wants to fully control the opening and closing of channels, both initiating these requests and deciding how to proceed with them.
+
+Initiation is straightforward: just emit the above events to allow a relayer to notice them.  Handling of requests needs a different architecture, as the current IBC implementation presumes that the relayer is in control of setting up and tearing down each connection and can unilaterally impose its will on the chain's IBC stack.  The IBC Channel messages are handled directly by the IBC implementation and not reflected to the application until after they have been processed.
+
+We propose that as an alternative to this behaviour, an IBC application module could opt-in to marking a routed IBC port as "controlled".  This flag would prevent the IBC handler from directly calling the various IBC keepers (except for behaviour already defined by the `send_packet` and `recv_packet` events).  Instead "channel handshake" messages provided by the relayer would inform the application of the other side's intentions, allowing the application to decide how and when to call the IBC keepers to continue the handshake.
+
+The `.OnChanHandshake` callback would receive a wrapped `channel.MsgChannelHandshake{}` message:
+
+```go
+typedef MsgChannelHandshake struct {
+  // Initiator is the IBC channel message that the relayer noticed.
+  // This can be any of the MsgChan* messages, populated by the data from
+  // the channel_meta events.
+  Initiator   sdk.Msg
+  // Proof from the sender's ibctypes.KeyChannel(SrcPort, SrcChannel)
+  Proof       commitmentexported.Proof,
+  ProofHeight uint64
+  // The relayer's signature.
+  Signer      sdk.AccAddress
+}
+```
+
+## Decision
+
+- Expose events to allow "passive" connection relayers.
+- Enable application-initiated channels via such passive relayers.
+- Allow ports to opt-in to explicit "channel handshake" messages so they can control their fate.
+
+## Status
+
+Proposed
+
+## Consequences
+
+> This section describes the resulting context, after applying the decision. All consequences should be listed here, not just the "positive" ones. A particular decision may have positive, negative, and neutral consequences, but all of them affect the team and project in the future.
+
+### Positive
+
+{positive consequences}
+
+### Negative
+
+{negative consequences}
+
+### Neutral
+
+{neutral consequences}
+
+## References
+
+- {reference link}

--- a/docs/architecture/adr-025-ibc-passive-channels.md
+++ b/docs/architecture/adr-025-ibc-passive-channels.md
@@ -117,10 +117,12 @@ A passive relayer does not have to know what kind of channel (version string, or
 
 Introduces different SDK paths for "naive" versus "passive" relayers.  It would be cleaner to have only one code path that accomodated both designs, but that would require breaking compatibility.
 
+Increased event size for IBC messages.
+
 ### Neutral
 
 More IBC events are exposed.
 
 ## References
 
-- {reference link}
+- The Agoric VM's IBC handler currently [accomodates `attemptChanOpenTry`](https://github.com/Agoric/agoric-sdk/blob/904b3a0423222a1b32893453e44bbde598473960/packages/cosmic-swingset/lib/ag-solo/vats/ibc.js#L546)

--- a/docs/architecture/adr-025-ibc-passive-channels.md
+++ b/docs/architecture/adr-025-ibc-passive-channels.md
@@ -1,4 +1,4 @@
-# ADR 023: IBC Passive Channels
+# ADR 025: IBC Passive Channels
 
 ## Changelog
 

--- a/docs/architecture/adr-025-ibc-passive-channels.md
+++ b/docs/architecture/adr-025-ibc-passive-channels.md
@@ -2,7 +2,12 @@
 
 ## Changelog
 
+- 2020-05-23: Provide sample Go code and more details
 - 2020-05-18: Initial Draft
+
+## Status
+
+Proposed
 
 ## Context
 
@@ -10,60 +15,124 @@ The current "naive" IBC Relayer strategy currently establishes a single predeter
 
 We wish to expand this "naive" strategy to a "passive" one which detects and relays both channel handshake messages and packets on a given connection, without the need to know each channel in advance of relaying it.
 
-In order to accomplish this, we propose adding the following events to expose channel metadata for each transaction sent from the `x/ibc/04-channel/keeper/handshake.go` and `x/ibc/04-channel/keeper/packet.go` modules:
+In order to accomplish this, we propose adding more comprehensive events to expose channel metadata for each transaction sent from the `x/ibc/04-channel/keeper/handshake.go` and `x/ibc/04-channel/keeper/packet.go` modules.
 
-- `channel_meta.src_connection=CONN1` as the only key needing to be indexed
-- `channel_meta.action=ACTION` where `ACTION` is one of:
-  - `open_init`
-  - `open_try`
-  - `open_ack`
-  - `open_confirm`
-  - `send_packet`
-  - `packet_executed`
-  - `close_init`
-  - `close_confirm`
-- `channel_meta.hops=CONN1,CONN2,...`
-- `channel_meta.order=ORDERED`
-- `channel_meta.src_port=PORT1`
-- `channel_meta.src_channel=CHANNEL1`
-- `channel_meta.src_version=VSN1`
-- `channel_meta.dst_port=PORT2`
-- `channel_meta.dst_channel=CHANNEL2`
-- `channel_meta.dst_version=VSN2`
+Here is an example of what would be in `ChanOpenInit`:
 
-These metadata events capture all the "header" information needed to route IBC channel handshake transactions without requiring the client to keep track of any state except for its connection ID.
+```go
+const (
+  EventTypeChannelMeta = "channel_meta"
+  AttributeKeyAction = "action"
+  AttributeKeyHops = "hops"
+  AttributeKeyOrder = "order"
+  AttributeKeySrcPort = "src_port"
+  AttributeKeySrcChannel = "src_channel"
+  AttributeKeySrcVersion = "src_version"
+  AttributeKeyDstPort = "dst_port"
+  AttributeKeyDstChannel = "dst_channel"
+  AttributeKeyDstVersion = "dst_version"
+)
+// ...
+  // Emit Event with Channel metadata for the relayer to pick up and
+  // relay to the other chain
+  ctx.EventManager().EmitEvents(sdk.Events{
+    sdk.NewEvent(
+      types.EventTypeChannelMeta,
+      sdk.NewAttribute(types.AttributeKeyAction, "open_init"),
+      sdk.NewAttribute(types.AttributeKeySrcConnection, connectionHops[0]),
+      sdk.NewAttribute(types.AttributeKeyHops, strings.Join(connectionHops, ",")),
+      sdk.NewAttribute(types.AttributeKeyOrder, order.String()),
+      sdk.NewAttribute(types.AttributeKeySrcPort, portID),
+      sdk.NewAttribute(types.AttributeKeySrcChannel, chanenlID),
+      sdk.NewAttribute(types.AttributeKeySrcVersion, version),
+      sdk.NewAttribute(types.AttributeKeyDstPort, counterparty.GetPortID()),
+      sdk.NewAttribute(types.AttributeKeyDstChannel, counterparty.GetChannelID()),
+      // The destination version is not yet known, but a value is necessary to pad
+      // the event attribute offsets
+      sdk.NewAttribute(types.AttributeKeyDstVersion, ""),
+    ),
+  })
+```
+
+These metadata events capture all the "header" information needed to route IBC channel handshake transactions without requiring the client to query any data except that of the connection ID that it is willing to relay.  It is intended that `channel_meta.src_connection` is the only event key that needs to be indexed for a passive relayer to function.
 
 ### Accepting Channel Opens
 
-The other concern we are trying to address is IBC use-cases where an application module wants to fully control the opening of channels, by being able to inspect connection init metadata and decide how to complete the handshake.
+In the case of the passive relayer, when one chain sends a `ChanOpenInit`, the relayer should inform the other chain of this open attempt and allow that chain to decide how (and if) it continues the handshake.  Once both chains have actively approved the channel opening, then the rest of the handshake can happen as it does with the current "naive" relayer.
 
-The `handler.OnChanOpenTry` handler would call the `cbs.OnChanOpenAccept` callback with the same arguments as `OnChanOpenTry`.  If this callback is not specified, the default behaviour would be the current one: to call the corresponding `keeper.ChanOpenTry` with the supplied values.  If the `.OnChanOpenAccept` is specified, then it would have the ability to call the `keeper.ChanOpenTry` how and when it would like (if at all).
+To implement this behavior, we propose adding a new callback `cbs.OnChanOpenAccept` which is either returns the version number to be used in the `keeper.ChanOpenTry`, or an error.  If the callback is not supplied, then the default behaviour would be to pass through directly to `channel.HandleMsgChannelOpenTry`, for compatibility with existing chains that expect a "naive" relayer.
+
+Here is how this callback would be used, in the implementation of `x/ibc/handler.go`:
+
+```go
+// Declare an interface for accepting a channel open.
+type ChanOpenAcceptor interface {
+  OnChanOpenAccept(
+    ctx sdk.Context,
+    order channeltypes.Order,
+    connectionHops []string,
+    portID,
+    channelID,
+    counterparty channeltypes.Counterparty,
+    proposedVersion,
+    counterpartyVersion string,
+  ) (string, error)
+}
+// ...
+    case channel.MsgChannelOpenTry:
+      // Lookup module by port capability
+      module, portCap, err := k.PortKeeper.LookupModuleByPort(ctx, msg.PortID)
+      if err != nil {
+              return nil, sdkerrors.Wrap(err, "could not retrieve module from port-id")
+      }
+      // =======================================
+      // NEW CODE: Check if the module defines an OnChanOpenAccept callback.
+      // Retrieve callbacks from router
+      cbs, ok := k.Router.GetRoute(module)
+      if !ok {
+              return nil, sdkerrors.Wrapf(port.ErrInvalidRoute, "route not found to module: %s", module)
+      }
+      // Default behaviour: use the proposed version directly.
+      version := proposedVersion
+      if acceptor, ok := cbs.(ChanOpenAcceptor); ok {
+        // Allow the acceptor to alter the proposed version or reject the connection
+        version, err = acceptor(ctx, msg.Channel.Ordering, msg.Channel.ConnectionHops, msg.PortID, msg.ChannelID, cap, msg.Channel.Counterparty, msg.Channel.Version, msg.CounterpartyVersion)
+        if err != nil {
+          return nil, err
+        }
+      }
+      // END OF NEW CODE
+      // ======================================
+      // Continue the handshake.
+      res, cap, err := channel.HandleMsgChannelOpenTry(ctx, k.ChannelKeeper, portCap, msg)
+      // ...
+```
 
 ## Decision
 
 - Expose events to allow "passive" connection relayers.
 - Enable application-initiated channels via such passive relayers.
-- Allow ports to control which channel open attempts they honour.
-
-## Status
-
-Proposed
+- Allow port modules to control which channel open attempts they honour.
 
 ## Consequences
 
-> This section describes the resulting context, after applying the decision. All consequences should be listed here, not just the "positive" ones. A particular decision may have positive, negative, and neutral consequences, but all of them affect the team and project in the future.
-
 ### Positive
 
-{positive consequences}
+Makes channels into a complete application-level abstraction.
+
+Applications have full control over initiating and accepting channels, rather than expecting a relayer to tell them when to do so.
+
+A passive relayer does not have to know what kind of channel (version string, ordering constraints, firewalling logic) the application supports.  These are negotiated directly between applications.
 
 ### Negative
 
-{negative consequences}
+Introduces different SDK paths for "naive" versus "passive" relayers.  It would be cleaner to have only one code path that accomodated both designs.
+
+It may be better to break compatibility and always require the `OnChanOpenAccept` callback to be defined.
 
 ### Neutral
 
-{neutral consequences}
+More IBC events are exposed.
 
 ## References
 

--- a/docs/architecture/adr-025-ibc-passive-channels.md
+++ b/docs/architecture/adr-025-ibc-passive-channels.md
@@ -61,14 +61,14 @@ These metadata events capture all the "header" information needed to route IBC c
 
 In the case of the passive relayer, when one chain sends a `ChanOpenInit`, the relayer should inform the other chain of this open attempt and allow that chain to decide how (and if) it continues the handshake.  Once both chains have actively approved the channel opening, then the rest of the handshake can happen as it does with the current "naive" relayer.
 
-To implement this behavior, we propose adding a new callback `cbs.OnAttemptedChanOpenTry` which explicitly handles the `MsgChannelOpenTry`, usually by resulting in a call to `keeper.ChanOpenTry`.  If the callback is not supplied, then the default behaviour would be to use `channel.HandleMsgChannelOpenTry`, for compatibility with existing chains that expect a "naive" relayer.
+To implement this behavior, we propose adding a new callback `cbs.OnAttemptChanOpenTry` which explicitly handles the `MsgChannelOpenTry`, usually by resulting in a call to `keeper.ChanOpenTry`.  If the callback is not supplied, then the default behaviour would be to use `channel.HandleMsgChannelOpenTry`, for compatibility with existing chains that expect a "naive" relayer.
 
 Here is how this callback would be used, in the implementation of `x/ibc/handler.go`:
 
 ```go
 // Declare an interface for handling a ChanOpenTry.
-type AttemptedChanOpenTryCallback interface {
-  OnAttemptedChanOpenTry(ctx sdk.Context, k keeper.Keeper, portCap *capability.Capability, msg types.MsgChannelOpenTry) (*sdk.Result, error)
+type AttemptChanOpenTryCallback interface {
+  OnAttemptChanOpenTry(ctx sdk.Context, k keeper.Keeper, portCap *capability.Capability, msg types.MsgChannelOpenTry) (*sdk.Result, error)
 }
 // ...
     case channel.MsgChannelOpenTry:
@@ -84,9 +84,9 @@ type AttemptedChanOpenTryCallback interface {
       if !ok {
               return nil, sdkerrors.Wrapf(port.ErrInvalidRoute, "route not found to module: %s", module)
       }
-      if tryHandler, ok := cbs.(AttemptedChanOpenTryCallback); ok {
+      if tryHandler, ok := cbs.(AttemptChanOpenTryCallback); ok {
         // Allow the port's try handler to override the default OpenTry behaviour.
-        return tryHandler.OnAttemptedChanOpenTry(ctx, k.ChannelKeeper, portCap, msg)
+        return tryHandler.OnAttemptChanOpenTry(ctx, k.ChannelKeeper, portCap, msg)
       }
       // END OF NEW CODE
       // ======================================


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

This ADR is a proposal to enable "passive" IBC relayers (ones that manage a whole connection and detect when channels come and go), as well as an "attempt channel try open" callback to allow an application to decide how and whether to handle inbound channel open handshakes.

closes: #XXXX

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

---

For contributor use:

- [X] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [X] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [X] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [X] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [X] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [X] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [X] Re-reviewed `Files changed` in the Github PR explorer
