### PR TITLE
R4R: Fix ics20 event bug

### DIFF
--- a/x/ibc-transfer/handler.go
+++ b/x/ibc-transfer/handler.go
@@ -8,6 +8,8 @@ import (
 // NewHandler returns sdk.Handler for IBC token transfer module messages
 func NewHandler(k Keeper) sdk.Handler {
 	return func(ctx sdk.Context, msg sdk.Msg) (*sdk.Result, error) {
+		ctx = ctx.WithEventManager(sdk.NewEventManager())
+
 		switch msg := msg.(type) {
 		case MsgTransfer:
 			return handleMsgTransfer(ctx, k, msg)


### PR DESCRIPTION
# EVENT BUG

This is one of the BUGs that IRISnet team reported to [security@cosmosnetwork.dev](http://security@cosmosnetwork.dev/), but it seems that it has not been fixed. Hacker can use this bug to attack other nodes in the network, thereby improving its ranking in the game (however we did not do so), this bug has a very serious impact on the entire schedule of GoZ!

## Bug Description

When a Tx contains multiple ICS-20 messages, the events will be abnormal. The reason is that the following msg events will contain all the previous msg events. You can see the event `logs.events.type='send_packet'` here: https://gist.github.com/SegueII/401de4d690a0a40038ad21a4ed2536ea
This is an example using one, two and three MSGs in one Tx.

Because of event error，so `relayPacketFromQueryResponse(...)` can't get the correct result. https://github.com/iqlusioninc/relayer/blob/master/relayer/naive-strategy.go#L320
We fixed this problem in relayer, making it possible to query the packet correctly. __But more serious problems were found in the next test__: When there are fewer msgs in one Tx, no exception will occur, but if the number of MSGs in a single Tx is big, the event data will be very, very large, and even cause node memory overflow during query.

```go
// tendermint/rpc/client/interface.go

type SignClient interface {
    ...
    TxSearch(query string, prove bool, page, perPage int, orderBy string) (*ctypes.ResultTxSearch, error)
}

// query str => `send_packet.packet_src_channel='<channel-id>' AND send_packet.packet_sequence='<seq>'`
```

If a Tx contains dozens or even hundreds of MSGs, when using multi-goroutine call `TxSearch(...)`, the following error will be caused, and the node memory will explode. In my PC, gaia's memory usage will exceed __20G__.

You can see the err log here: https://gist.github.com/SegueII/d9c543c92cc6dde7d8d5a75e6eae6ba1

In `phase-1b`, this BUG can be used to attack the public RPC nodes, which will have a greater impact on the game results. Attacks can also be easily launched in `phase-2` and `phase-3`, by sending transactions containing a large number of MSGs to the channels of other teams, making their relayer query timeout and unable to relay packet.

The fix method is very simple, just add `ctx = ctx.WithEventManager(sdk.NewEventManager())` to `NewHandler()` in ICS-20 module.

```go
// NewHandler returns sdk.Handler for IBC token transfer module messages
func NewHandler(k Keeper) sdk.Handler {
    return func(ctx sdk.Context, msg sdk.Msg) (*sdk.Result, error) {

        // ==================================================
        ctx = ctx.WithEventManager(sdk.NewEventManager())
        // ==================================================

        switch msg := msg.(type) {
        case MsgTransfer:
            return handleMsgTransfer(ctx, k, msg)
        default:
            return nil, sdkerrors.Wrapf(sdkerrors.ErrUnknownRequest, "unrecognized ICS-20 transfer message type: %T", msg)
        }
    }
}
```
