### PR TITLE
x/auth: remove unused passphrase arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,13 @@ is now `Any` in concordance with [ADR 019](docs/architecture/adr-019-protobuf-st
 be used to retrieve the actual proposal `Content`. Also the `NewMsgSubmitProposal` constructor now may return an `error`
 * (modules) [\#5989](https://github.com/cosmos/cosmos-sdk/pull/5989) `AppModuleBasic.GetTxCmd` now takes a single `CLIContext` parameter.
 * (x/auth) [\#5989](https://github.com/cosmos/cosmos-sdk/pull/5989) All `AccountRetriever` methods now take `NodeQuerier` as a parameter instead of as a struct member.
+* (x/auth) [\#6270](https://github.com/cosmos/cosmos-sdk/pull/6270) The passphrase argument has been removed from the signature of the following functions and methods:
+  - BuildAndSign
+  - MakeSignature
+  - SignStdTx
+  - TxBuilder.BuildAndSign
+  - TxBuilder.Sign
+  - TxBuilder.SignStdTx
 
 ### Features
 

--- a/x/auth/client/tx.go
+++ b/x/auth/client/tx.go
@@ -15,7 +15,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/context"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/input"
-	"github.com/cosmos/cosmos-sdk/client/keys"
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
@@ -106,7 +105,7 @@ func CompleteAndBroadcastTxCLI(txBldr authtypes.TxBuilder, cliCtx context.CLICon
 	}
 
 	// build and sign the transaction
-	txBytes, err := txBldr.BuildAndSign(fromName, keys.DefaultKeyPass, msgs)
+	txBytes, err := txBldr.BuildAndSign(fromName, msgs)
 	if err != nil {
 		return err
 	}
@@ -204,7 +203,7 @@ func SignStdTx(
 		}
 	}
 
-	return txBldr.SignStdTx(name, keys.DefaultKeyPass, stdTx, appendSig)
+	return txBldr.SignStdTx(name, stdTx, appendSig)
 }
 
 // SignStdTxWithSignerAddress attaches a signature to a StdTx and returns a copy of a it.
@@ -227,7 +226,7 @@ func SignStdTxWithSignerAddress(
 		}
 	}
 
-	return txBldr.SignStdTx(name, keys.DefaultKeyPass, stdTx, false)
+	return txBldr.SignStdTx(name, stdTx, false)
 }
 
 // Read and decode a StdTx from the given filename.  Can pass "-" to read from stdin.

--- a/x/auth/types/txbuilder.go
+++ b/x/auth/types/txbuilder.go
@@ -207,10 +207,10 @@ func (bldr TxBuilder) BuildSignMsg(msgs []sdk.Msg) (StdSignMsg, error) {
 	}, nil
 }
 
-// Sign signs a transaction given a name, passphrase, and a single message to
-// signed. An error is returned if signing fails.
-func (bldr TxBuilder) Sign(name, passphrase string, msg StdSignMsg) ([]byte, error) {
-	sig, err := MakeSignature(bldr.keybase, name, passphrase, msg)
+// Sign signs a transaction given a name and a single message to be signed.
+// Returns error if signing fails.
+func (bldr TxBuilder) Sign(name string, msg StdSignMsg) ([]byte, error) {
+	sig, err := MakeSignature(bldr.keybase, name, msg)
 	if err != nil {
 		return nil, err
 	}
@@ -219,14 +219,14 @@ func (bldr TxBuilder) Sign(name, passphrase string, msg StdSignMsg) ([]byte, err
 }
 
 // BuildAndSign builds a single message to be signed, and signs a transaction
-// with the built message given a name, passphrase, and a set of messages.
-func (bldr TxBuilder) BuildAndSign(name, passphrase string, msgs []sdk.Msg) ([]byte, error) {
+// with the built message given a name and a set of messages.
+func (bldr TxBuilder) BuildAndSign(name string, msgs []sdk.Msg) ([]byte, error) {
 	msg, err := bldr.BuildSignMsg(msgs)
 	if err != nil {
 		return nil, err
 	}
 
-	return bldr.Sign(name, passphrase, msg)
+	return bldr.Sign(name, msg)
 }
 
 // BuildTxForSim creates a StdSignMsg and encodes a transaction with the
@@ -244,12 +244,12 @@ func (bldr TxBuilder) BuildTxForSim(msgs []sdk.Msg) ([]byte, error) {
 
 // SignStdTx appends a signature to a StdTx and returns a copy of it. If append
 // is false, it replaces the signatures already attached with the new signature.
-func (bldr TxBuilder) SignStdTx(name, passphrase string, stdTx StdTx, appendSig bool) (signedStdTx StdTx, err error) {
+func (bldr TxBuilder) SignStdTx(name string, stdTx StdTx, appendSig bool) (signedStdTx StdTx, err error) {
 	if bldr.chainID == "" {
 		return StdTx{}, fmt.Errorf("chain ID required but not specified")
 	}
 
-	stdSignature, err := MakeSignature(bldr.keybase, name, passphrase, StdSignMsg{
+	stdSignature, err := MakeSignature(bldr.keybase, name, StdSignMsg{
 		ChainID:       bldr.chainID,
 		AccountNumber: bldr.accountNumber,
 		Sequence:      bldr.sequence,
@@ -271,18 +271,16 @@ func (bldr TxBuilder) SignStdTx(name, passphrase string, stdTx StdTx, appendSig 
 	return
 }
 
-// MakeSignature builds a StdSignature given keybase, key name, passphrase, and a StdSignMsg.
-func MakeSignature(keybase keyring.Keyring, name, passphrase string,
-	msg StdSignMsg) (sig StdSignature, err error) {
-
-	if keybase == nil {
-		keybase, err = keyring.New(sdk.KeyringServiceName(), viper.GetString(flags.FlagKeyringBackend), viper.GetString(flags.FlagHome), os.Stdin)
+// MakeSignature builds a StdSignature given a keyring, key name, and a StdSignMsg.
+func MakeSignature(kr keyring.Keyring, name string, msg StdSignMsg) (sig StdSignature, err error) {
+	if kr == nil {
+		kr, err = keyring.New(sdk.KeyringServiceName(), viper.GetString(flags.FlagKeyringBackend), viper.GetString(flags.FlagHome), os.Stdin)
 		if err != nil {
 			return
 		}
 	}
 
-	sigBytes, pubkey, err := keybase.Sign(name, msg.Bytes())
+	sigBytes, pubkey, err := kr.Sign(name, msg.Bytes())
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
The new keyring does not handle passphrases directly anymore.

---

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
