### PR TITLE
R4R: Save account for multi sending

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,7 @@ be used to retrieve the actual proposal `Content`. Also the `NewMsgSubmitProposa
 
 ### Bug Fixes
 
+* (x/bank) [\#6283](https://github.com/cosmos/cosmos-sdk/pull/6283) Create account if recipient does not exist on handing `MsgMultiSend`.
 * (x/distribution) [\#6210](https://github.com/cosmos/cosmos-sdk/pull/6210) Register `MsgFundCommunityPool` in distribution amino codec.
 * (x/staking) [\#6061](https://github.com/cosmos/cosmos-sdk/pull/6061) Allow a validator to immediately unjail when no signing info is present due to
 falling below their minimum self-delegation and never having been bonded. The validator may immediately unjail once they've met their minimum self-delegation.
@@ -149,6 +150,7 @@ invalid or incomplete requests.
 
 ### State Machine Breaking
 
+* (x/bank) [\#6283](https://github.com/cosmos/cosmos-sdk/pull/6283) Create account if recipient does not exist on handing `MsgMultiSend`.
 * (x/staking) [\#6061](https://github.com/cosmos/cosmos-sdk/pull/6061) Allow a validator to immediately unjail when no signing info is present due to
 falling below their minimum self-delegation and never having been bonded. The validator may immediately unjail once they've met their minimum self-delegation.
 * (x/supply) [\#6010](https://github.com/cosmos/cosmos-sdk/pull/6010) Removed the `x/supply` module by merging the existing types and APIs into the `x/bank` module.

--- a/x/bank/keeper/keeper_test.go
+++ b/x/bank/keeper/keeper_test.go
@@ -284,6 +284,38 @@ func (suite *IntegrationTestSuite) TestSendCoinsNewAccount() {
 	suite.Require().NotNil(app.AccountKeeper.GetAccount(ctx, addr2))
 }
 
+func (suite *IntegrationTestSuite) TestInputOutputNewAccount() {
+	app, ctx := suite.app, suite.ctx
+
+	balances := sdk.NewCoins(newFooCoin(100), newBarCoin(50))
+	addr1 := sdk.AccAddress([]byte("addr1"))
+	acc1 := app.AccountKeeper.NewAccountWithAddress(ctx, addr1)
+	app.AccountKeeper.SetAccount(ctx, acc1)
+	suite.Require().NoError(app.BankKeeper.SetBalances(ctx, addr1, balances))
+
+	acc1Balances := app.BankKeeper.GetAllBalances(ctx, addr1)
+	suite.Require().Equal(balances, acc1Balances)
+
+	addr2 := sdk.AccAddress([]byte("addr2"))
+
+	suite.Require().Nil(app.AccountKeeper.GetAccount(ctx, addr2))
+	suite.Require().Empty(app.BankKeeper.GetAllBalances(ctx, addr2))
+
+	inputs := []types.Input{
+		{Address: addr1, Coins: sdk.NewCoins(newFooCoin(30), newBarCoin(10))},
+	}
+	outputs := []types.Output{
+		{Address: addr2, Coins: sdk.NewCoins(newFooCoin(30), newBarCoin(10))},
+	}
+
+	suite.Require().NoError(app.BankKeeper.InputOutputCoins(ctx, inputs, outputs))
+
+	expected := sdk.NewCoins(newFooCoin(30), newBarCoin(10))
+	acc2Balances := app.BankKeeper.GetAllBalances(ctx, addr2)
+	suite.Require().Equal(expected, acc2Balances)
+	suite.Require().NotNil(app.AccountKeeper.GetAccount(ctx, addr2))
+}
+
 func (suite *IntegrationTestSuite) TestInputOutputCoins() {
 	app, ctx := suite.app, suite.ctx
 	balances := sdk.NewCoins(newFooCoin(90), newBarCoin(30))

--- a/x/bank/keeper/send.go
+++ b/x/bank/keeper/send.go
@@ -96,6 +96,15 @@ func (k BaseSendKeeper) InputOutputCoins(ctx sdk.Context, inputs []types.Input, 
 				sdk.NewAttribute(sdk.AttributeKeyAmount, out.Coins.String()),
 			),
 		)
+
+		// Create account if recipient does not exist.
+		//
+		// NOTE: This should ultimately be removed in favor a more flexible approach
+		// such as delegated fee messages.
+		acc := k.ak.GetAccount(ctx, out.Address)
+		if acc == nil {
+			k.ak.SetAccount(ctx, k.ak.NewAccountWithAddress(ctx, out.Address))
+		}
 	}
 
 	return nil


### PR DESCRIPTION
If the recipient account does not exist when handing `MsgSend`, we will save it. And we should also do this for `MsgMultiSend`.