### PR TITLE
Use simple merkle proof for commit info

### DIFF
--- a/store/rootmulti/proof.go
+++ b/store/rootmulti/proof.go
@@ -1,30 +1,9 @@
 package rootmulti
 
 import (
-	"bytes"
-	"errors"
-	"fmt"
-
 	"github.com/tendermint/iavl"
 	"github.com/tendermint/tendermint/crypto/merkle"
 )
-
-// MultiStoreProof defines a collection of store proofs in a multi-store
-type MultiStoreProof struct {
-	StoreInfos []storeInfo
-}
-
-func NewMultiStoreProof(storeInfos []storeInfo) *MultiStoreProof {
-	return &MultiStoreProof{StoreInfos: storeInfos}
-}
-
-// ComputeRootHash returns the root hash for a given multi-store proof.
-func (proof *MultiStoreProof) ComputeRootHash() []byte {
-	ci := commitInfo{
-		StoreInfos: proof.StoreInfos,
-	}
-	return ci.Hash()
-}
 
 // RequireProof returns whether proof is required for the subpath.
 func RequireProof(subpath string) bool {
@@ -37,92 +16,6 @@ func RequireProof(subpath string) bool {
 
 //-----------------------------------------------------------------------------
 
-var _ merkle.ProofOperator = MultiStoreProofOp{}
-
-// the multi-store proof operation constant value
-const ProofOpMultiStore = "multistore"
-
-// TODO: document
-type MultiStoreProofOp struct {
-	// Encoded in ProofOp.Key
-	key []byte
-
-	// To encode in ProofOp.Data.
-	Proof *MultiStoreProof `json:"proof"`
-}
-
-func NewMultiStoreProofOp(key []byte, proof *MultiStoreProof) MultiStoreProofOp {
-	return MultiStoreProofOp{
-		key:   key,
-		Proof: proof,
-	}
-}
-
-// MultiStoreProofOpDecoder returns a multi-store merkle proof operator from a
-// given proof operation.
-func MultiStoreProofOpDecoder(pop merkle.ProofOp) (merkle.ProofOperator, error) {
-	if pop.Type != ProofOpMultiStore {
-		return nil, fmt.Errorf("unexpected ProofOp.Type; got %v, want %v", pop.Type, ProofOpMultiStore)
-	}
-
-	// XXX: a bit strange as we'll discard this, but it works
-	var op MultiStoreProofOp
-
-	err := cdc.UnmarshalBinaryBare(pop.Data, &op)
-	if err != nil {
-		return nil, fmt.Errorf("decoding ProofOp.Data into MultiStoreProofOp: %w", err)
-	}
-
-	return NewMultiStoreProofOp(pop.Key, op.Proof), nil
-}
-
-// ProofOp return a merkle proof operation from a given multi-store proof
-// operation.
-func (op MultiStoreProofOp) ProofOp() merkle.ProofOp {
-	bz := cdc.MustMarshalBinaryBare(op)
-	return merkle.ProofOp{
-		Type: ProofOpMultiStore,
-		Key:  op.key,
-		Data: bz,
-	}
-}
-
-// String implements the Stringer interface for a mult-store proof operation.
-func (op MultiStoreProofOp) String() string {
-	return fmt.Sprintf("MultiStoreProofOp{%v}", op.GetKey())
-}
-
-// GetKey returns the key for a multi-store proof operation.
-func (op MultiStoreProofOp) GetKey() []byte {
-	return op.key
-}
-
-// Run executes a multi-store proof operation for a given value. It returns
-// the root hash if the value matches all the store's commitID's hash or an
-// error otherwise.
-func (op MultiStoreProofOp) Run(args [][]byte) ([][]byte, error) {
-	if len(args) != 1 {
-		return nil, errors.New("value size is not 1")
-	}
-
-	value := args[0]
-	root := op.Proof.ComputeRootHash()
-
-	for _, si := range op.Proof.StoreInfos {
-		if si.Name == string(op.key) {
-			if bytes.Equal(value, si.Core.CommitID.Hash) {
-				return [][]byte{root}, nil
-			}
-
-			return nil, fmt.Errorf("hash mismatch for substore %v: %X vs %X", si.Name, si.Core.CommitID.Hash, value)
-		}
-	}
-
-	return nil, fmt.Errorf("key %v not found in multistore proof", op.key)
-}
-
-//-----------------------------------------------------------------------------
-
 // XXX: This should be managed by the rootMultiStore which may want to register
 // more proof ops?
 func DefaultProofRuntime() (prt *merkle.ProofRuntime) {
@@ -130,6 +23,5 @@ func DefaultProofRuntime() (prt *merkle.ProofRuntime) {
 	prt.RegisterOpDecoder(merkle.ProofOpSimpleValue, merkle.SimpleValueOpDecoder)
 	prt.RegisterOpDecoder(iavl.ProofOpIAVLValue, iavl.ValueOpDecoder)
 	prt.RegisterOpDecoder(iavl.ProofOpIAVLAbsence, iavl.AbsenceOpDecoder)
-	prt.RegisterOpDecoder(ProofOpMultiStore, MultiStoreProofOpDecoder)
 	return
 }

--- a/store/rootmulti/store.go
+++ b/store/rootmulti/store.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/pkg/errors"
 	abci "github.com/tendermint/tendermint/abci/types"
-	"github.com/tendermint/tendermint/crypto/tmhash"
 	dbm "github.com/tendermint/tm-db"
 
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -608,20 +607,12 @@ type storeCore struct {
 	// ... maybe add more state
 }
 
-// Implements merkle.Hasher.
+// Hash is the value we commit to in SimpleHashFromMap
+// Which should equal the root hash of the substore
 func (si storeInfo) Hash() []byte {
 	// Doesn't write Name, since SimpleHashFromMap() will
 	// include them via the keys.
-	bz := si.Core.CommitID.Hash
-	hasher := tmhash.New()
-
-	_, err := hasher.Write(bz)
-	if err != nil {
-		// TODO: Handle with #870
-		panic(err)
-	}
-
-	return hasher.Sum(nil)
+	return si.Core.CommitID.Hash
 }
 
 //----------------------------------------

--- a/store/rootmulti/store.go
+++ b/store/rootmulti/store.go
@@ -2,12 +2,12 @@ package rootmulti
 
 import (
 	"fmt"
-	"github.com/tendermint/tendermint/crypto/merkle"
 	"io"
 	"strings"
 
 	"github.com/pkg/errors"
 	abci "github.com/tendermint/tendermint/abci/types"
+	"github.com/tendermint/tendermint/crypto/merkle"
 	dbm "github.com/tendermint/tm-db"
 
 	"github.com/cosmos/cosmos-sdk/codec"

--- a/store/rootmulti/store.go
+++ b/store/rootmulti/store.go
@@ -559,7 +559,7 @@ type commitInfo struct {
 func (ci commitInfo) toMap() map[string][]byte {
 	m := make(map[string][]byte, len(ci.StoreInfos))
 	for _, storeInfo := range ci.StoreInfos {
-		m[storeInfo.Name] = storeInfo.Hash()
+		m[storeInfo.Name] = storeInfo.GetHash()
 	}
 	return m
 }
@@ -607,11 +607,14 @@ type storeCore struct {
 	// ... maybe add more state
 }
 
-// Hash is the value we commit to in SimpleHashFromMap
-// Which should equal the root hash of the substore
-func (si storeInfo) Hash() []byte {
-	// Doesn't write Name, since SimpleHashFromMap() will
-	// include them via the keys.
+// GetHash returns the GetHash from the CommitID.
+// This is used in CommitInfo.Hash()
+//
+// When we commit to this in a merkle proof, we create a map of storeInfo.Name -> storeInfo.GetHash()
+// and build a merkle proof from that.
+// This is then chained with the substore proof, so we prove the root hash from the substore before this
+// and need to pass that (unmodified) as the leaf value of the multistore proof.
+func (si storeInfo) GetHash() []byte {
 	return si.Core.CommitID.Hash
 }
 

--- a/store/rootmulti/store_test.go
+++ b/store/rootmulti/store_test.go
@@ -516,7 +516,7 @@ func hashStores(stores map[types.StoreKey]types.CommitKVStore) []byte {
 				CommitID: store.LastCommitID(),
 				// StoreType: store.GetStoreType(),
 			},
-		}.Hash()
+		}.GetHash()
 	}
 	return SimpleHashFromMap(m)
 }

--- a/x/evidence/types/params.go
+++ b/x/evidence/types/params.go
@@ -6,6 +6,6 @@ import (
 
 // DONTCOVER
 
-// The Double Sign Jail period ends at Max Time supported by Amino
+// DoubleSignJailEndTime period ends at Max Time supported by Amino
 // (Dec 31, 9999 - 23:59:59 GMT).
 var DoubleSignJailEndTime = time.Unix(253402300799, 0)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Pulling out one part of the logic from #6178 and simplifying the changes 

One step towards https://github.com/cosmos/cosmos-sdk/issues/5842

Currently we serialize the entire `commitInfo` in the root multistore proofs. This is not even a merkle proof, just all data. Before we can move to ics23 proofs, we need to use merkle proofs that can be transformed to that format (it is just an encoding, not the logic).

As discussed a few times with @cwgoes and now @AdityaSripal we use `merkle.SimpleProofsFromMap` to produce the commitment of the root multi store. This can later be converted into ics23 format, but this is a valid, testable step that can be merged to master and is an improvement over current state.


closes: #XXXX

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

---

For contributor use:

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
