### PR TITLE
Make CommitmentOp generic over all ics23 specs

### DIFF
--- a/store/iavl/proof.go
+++ b/store/iavl/proof.go
@@ -8,20 +8,37 @@ import (
 	"github.com/tendermint/tendermint/crypto/merkle"
 )
 
-const ProofOpIAVLCommitment = "iavlstore"
+const ProofOpIAVLCommitment = "ics23:iavl"
+const ProofOpSimpleMerkleCommitment = "ics23:simple"
 
-// IavlOP implements merkle.ProofOperator by wrapping an ics23 CommitmentProof
+// CommitmentOp implements merkle.ProofOperator by wrapping an ics23 CommitmentProof
 // It also contains a Key field to determine which key the proof is proving.
 // NOTE: CommitmentProof currently can either be ExistenceProof or NonexistenceProof
+//
+// Type and Spec are classified by the kind of merkle proof it represents allowing
+// the code to be reused by more types. Spec is never on the wire, but mapped from type in the code.
 type CommitmentOp struct {
+	Type  string
+	Spec  *ics23.ProofSpec
 	Key   []byte
 	Proof *ics23.CommitmentProof
 }
 
 var _ merkle.ProofOperator = CommitmentOp{}
 
-func NewCommitmentOp(key []byte, proof *ics23.CommitmentProof) CommitmentOp {
+func NewIavlCommitmentOp(key []byte, proof *ics23.CommitmentProof) CommitmentOp {
 	return CommitmentOp{
+		Type:  ProofOpIAVLCommitment,
+		Spec:  ics23.IavlSpec,
+		Key:   key,
+		Proof: proof,
+	}
+}
+
+func NewSimpleMerkleCommitmentOp(key []byte, proof *ics23.CommitmentProof) CommitmentOp {
+	return CommitmentOp{
+		Type:  ProofOpSimpleMerkleCommitment,
+		Spec:  ics23.TendermintSpec,
 		Key:   key,
 		Proof: proof,
 	}
@@ -31,24 +48,26 @@ func NewCommitmentOp(key []byte, proof *ics23.CommitmentProof) CommitmentOp {
 // The proofOp.Data is just a marshalled CommitmentProof. The Key of the CommitmentOp is extracted
 // from the unmarshalled proof
 func CommitmentOpDecoder(pop merkle.ProofOp) (merkle.ProofOperator, error) {
-	if pop.Type != ProofOpIAVLCommitment {
-		return nil, fmt.Errorf("unexpected ProofOp.Type; got %v, want %v", pop.Type, ProofOpIAVLCommitment)
+	var spec *ics23.ProofSpec
+	if pop.Type == ProofOpIAVLCommitment {
+		spec = ics23.IavlSpec
+	} else if pop.Type == ProofOpSimpleMerkleCommitment {
+		spec = ics23.TendermintSpec
+	} else {
+		return nil, fmt.Errorf("unexpected ProofOp.Type; got %v, want supported ics23 subtype", pop.Type)
 	}
-	var op CommitmentOp
+
 	proof := &ics23.CommitmentProof{}
 	err := proof.Unmarshal(pop.Data)
 	if err != nil {
 		return nil, err
 	}
-	op.Proof = proof
 
-	// Get Key from proof for now
-	if existProof, ok := op.Proof.Proof.(*ics23.CommitmentProof_Exist); ok {
-		op.Key = existProof.Exist.Key
-	} else if nonexistProof, ok := op.Proof.Proof.(*ics23.CommitmentProof_Nonexist); ok {
-		op.Key = nonexistProof.Nonexist.Key
-	} else {
-		return nil, errors.New("proof type unsupported")
+	op := CommitmentOp{
+		Type:  pop.Type,
+		Key:   pop.Key,
+		Spec:  spec,
+		Proof: proof,
 	}
 	return op, nil
 }
@@ -78,7 +97,7 @@ func (op CommitmentOp) Run(args [][]byte) ([][]byte, error) {
 			}
 		}
 
-		absent := ics23.VerifyNonMembership(ics23.IavlSpec, root, op.Proof, op.Key)
+		absent := ics23.VerifyNonMembership(op.Spec, root, op.Proof, op.Key)
 		if !absent {
 			return nil, fmt.Errorf("proof did not verify absence of key: %s", string(op.Key))
 		}
@@ -98,7 +117,7 @@ func (op CommitmentOp) Run(args [][]byte) ([][]byte, error) {
 			return nil, errors.New("could not calculate root from existence proof")
 		}
 
-		exists := ics23.VerifyMembership(ics23.IavlSpec, root, op.Proof, op.Key, args[0])
+		exists := ics23.VerifyMembership(op.Spec, root, op.Proof, op.Key, args[0])
 		if !exists {
 			return nil, fmt.Errorf("proof did not verify existence of key %s with given value %x", op.Key, args[0])
 		}
@@ -115,7 +134,7 @@ func (op CommitmentOp) ProofOp() merkle.ProofOp {
 		panic(err.Error())
 	}
 	return merkle.ProofOp{
-		Type: ProofOpIAVLCommitment,
+		Type: op.Type,
 		Key:  op.Key,
 		Data: bz,
 	}

--- a/store/iavl/proof.go
+++ b/store/iavl/proof.go
@@ -49,11 +49,12 @@ func NewSimpleMerkleCommitmentOp(key []byte, proof *ics23.CommitmentProof) Commi
 // from the unmarshalled proof
 func CommitmentOpDecoder(pop merkle.ProofOp) (merkle.ProofOperator, error) {
 	var spec *ics23.ProofSpec
-	if pop.Type == ProofOpIAVLCommitment {
+	switch pop.Type {
+	case ProofOpIAVLCommitment:
 		spec = ics23.IavlSpec
-	} else if pop.Type == ProofOpSimpleMerkleCommitment {
+	case ProofOpSimpleMerkleCommitment:
 		spec = ics23.TendermintSpec
-	} else {
+	default:
 		return nil, fmt.Errorf("unexpected ProofOp.Type; got %v, want supported ics23 subtype", pop.Type)
 	}
 

--- a/store/iavl/store.go
+++ b/store/iavl/store.go
@@ -307,7 +307,7 @@ func (st *Store) Query(req abci.RequestQuery) (res abci.ResponseQuery) {
 				panic(fmt.Sprintf("unexpected empty absence proof: %s", err.Error()))
 			}
 		}
-		op := NewCommitmentOp(req.Data, commitmentProof)
+		op := NewIavlCommitmentOp(req.Data, commitmentProof)
 		res.Proof = &merkle.Proof{Ops: []merkle.ProofOp{op.ProofOp()}}
 	case "/subspace":
 		var KVs []types.KVPair

--- a/store/rootmulti/proof.go
+++ b/store/rootmulti/proof.go
@@ -129,7 +129,9 @@ func (op MultiStoreProofOp) Run(args [][]byte) ([][]byte, error) {
 func DefaultProofRuntime() (prt *merkle.ProofRuntime) {
 	prt = merkle.NewProofRuntime()
 	prt.RegisterOpDecoder(merkle.ProofOpSimpleValue, merkle.SimpleValueOpDecoder)
+	// they both use the same decoder, which can handle any registered spec for ics23 CommitmentProofs
 	prt.RegisterOpDecoder(iavlstore.ProofOpIAVLCommitment, iavlstore.CommitmentOpDecoder)
+	prt.RegisterOpDecoder(iavlstore.ProofOpSimpleMerkleCommitment, iavlstore.CommitmentOpDecoder)
 	prt.RegisterOpDecoder(ProofOpMultiStore, MultiStoreProofOpDecoder)
 	return
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

This extends the great work in https://github.com/cosmos/cosmos-sdk/pull/6324 and allows the same code to be reused for ics23 proofs derived from `merkle.SimpleProof` as well as the current `iavl.RangeProof`. It just adds some settings to use the serialized type to select a registered ProofSpec.

If you like this, please merge into your PR before finalizing it. Once that is done, and https://github.com/cosmos/cosmos-sdk/pull/6323 is merged, then adding ics23 support for the root multistore proof should be quite easy with no code duplication.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #XXXX

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

---

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
