### PR TITLE
Updates to ADR-020 (protobuf signing)

### DIFF
--- a/docs/architecture/adr-020-protobuf-transaction-encoding.md
+++ b/docs/architecture/adr-020-protobuf-transaction-encoding.md
@@ -56,10 +56,18 @@ package cosmos_sdk.v1;
 message Tx {
     TxBody body = 1;
     AuthInfo auth_info = 2;
+    // A list of signatures that matches the length and order of AuthInfo's signer_infos to
+    // allow connecting signature meta information like public key and signing mode by position.
     repeated bytes signatures = 3;
 }
 
 message TxBody {
+    // A list of messages to be executed. The required signers of those messages define
+    // the number and order of elements in AuthInfo's signer_infos and Tx's signatures.
+    // Each required signer address is added to the list only the first time it occurs.
+    //
+    // By convention, the first required signer (usually from the first message) is referred
+    // to as the primary signer and pays the fee for the whole transaction.
     repeated google.protobuf.Any messages = 1;
     string memo = 2;
     int64 timeout_height = 3;
@@ -67,13 +75,17 @@ message TxBody {
 }
 
 message AuthInfo {
+    // This list defines the signing modes for the required signers. The number
+    // and order of elements must match the required signers from TxBody's messages.
+    // The first element is the primary signer and the one which pays the fee.
     repeated SignerInfo signer_infos = 1;
-    // The first signer is the primary signer and the one which pays the fee
+    // The fee can be calculated by looking into the body and the signer infos.
     Fee fee = 2;
 }
 
 message SignerInfo {
-    // PublicKey key is optional for accounts that already exist in state
+    // The public key is optional for accounts that already exist in state. If unset, the
+    // verifier can use the required signer address for this position and lookup the public key.
     PublicKey public_key = 1;
     // ModeInfo describes the signing mode of the signer and is a nested
     // structure to support nested multisig pubkey's


### PR DESCRIPTION
## Description

This PR makes two independent changes (one commit each) to ADR-020:

1. Explain the source of the signers list, which is hidden implicitely in the list of messages. This implies that a verifier needs to be able to understand each message in order to calculate each message's required signers. Explain how to obtain public keys when left out. Also explain how to connect the signature information spread between messages, signer_infos and signatures.
2. Use the same `SignDoc` for signing and verification. Before the default way was to assume `serialize_signer(a: SignDoc) == serialize_verifier(b: SignDocRaw)`. This not only assumes that two different protobuf implementations produce the same bytes but also that the two document types have the same binary representation, which (even if true in some cases) makes many assumptions on the binary representation of protobuf and is very hard to understand and review. With this change, we just need `serialize_signer(a: SignDoc) == serialize_verifier(b: SignDoc)`, which we agreed is managable to get right in many different implementations. Along the way the outdated types `TxRaw` and `SignDocRaw` got obsolete.


---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
