### PR TITLE
x/ibc: add the missing path parameter "height" to "/ibc/clients/{client-id}/consensus-state/{height}"

### DIFF
--- a/x/ibc/02-client/client/rest/query.go
+++ b/x/ibc/02-client/client/rest/query.go
@@ -3,7 +3,6 @@ package rest
 import (
 	"fmt"
 	"net/http"
-	"strconv"
 
 	"github.com/gorilla/mux"
 
@@ -105,11 +104,6 @@ func queryConsensusStateHandlerFn(clientCtx client.Context) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		vars := mux.Vars(r)
 		clientID := vars[RestClientID]
-		height, err := strconv.ParseUint(vars[RestRootHeight], 10, 64)
-		if err != nil {
-			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
-			return
-		}
 
 		prove := rest.ParseQueryParamBool(r, flags.FlagProve)
 
@@ -118,7 +112,7 @@ func queryConsensusStateHandlerFn(clientCtx client.Context) http.HandlerFunc {
 			return
 		}
 
-		csRes, err := utils.QueryConsensusState(clientCtx, clientID, height, prove)
+		csRes, err := utils.QueryConsensusState(clientCtx, clientID, uint64(clientCtx.Height), prove)
 		if err != nil {
 			rest.WriteErrorResponse(w, http.StatusInternalServerError, err.Error())
 			return

--- a/x/ibc/02-client/client/rest/rest.go
+++ b/x/ibc/02-client/client/rest/rest.go
@@ -8,8 +8,7 @@ import (
 
 // REST client flags
 const (
-	RestClientID   = "client-id"
-	RestRootHeight = "height"
+	RestClientID = "client-id"
 )
 
 // RegisterRoutes - Central function to define routes that get registered by the main application

--- a/x/ibc/02-client/client/rest/rest.go
+++ b/x/ibc/02-client/client/rest/rest.go
@@ -8,7 +8,8 @@ import (
 
 // REST client flags
 const (
-	RestClientID = "client-id"
+	RestClientID   = "client-id"
+	RestRootHeight = "height"
 )
 
 // RegisterRoutes - Central function to define routes that get registered by the main application


### PR DESCRIPTION
## Description

The "height" path param is required to query consensus state but it's missing.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
    - No, but this PR is just a small/simple fix.
- [x] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
    - No, but also the other REST API impls in x/ibc have no test codes.
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
    - N/A
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
    - N/A
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
    - N/A
- [x] Re-reviewed `Files changed` in the Github PR explorer
