### PR TITLE
cmd/simd: Use server.GetPruningOptionsFromFlags

### DIFF
--- a/simapp/cmd/simd/main.go
+++ b/simapp/cmd/simd/main.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/server"
 	"github.com/cosmos/cosmos-sdk/simapp"
 	"github.com/cosmos/cosmos-sdk/store"
-	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	genutilcli "github.com/cosmos/cosmos-sdk/x/genutil/client/cli"
@@ -84,17 +83,9 @@ func newApp(logger log.Logger, db dbm.DB, traceStore io.Writer) server.Applicati
 		skipUpgradeHeights[int64(h)] = true
 	}
 
-	pruningStr := viper.GetString(server.FlagPruning)
-	pruningOpts := storetypes.NewPruningOptionsFromString(pruningStr)
-
-	// If 'custom' strategy is provided, we construct the options from individual
-	// flags. We assume the values have been verified already.
-	if pruningStr == storetypes.PruningOptionCustom {
-		pruningOpts = storetypes.NewPruningOptions(
-			viper.GetUint64(server.FlagPruningKeepRecent),
-			viper.GetUint64(server.FlagPruningKeepEvery),
-			viper.GetUint64(server.FlagPruningInterval),
-		)
+	pruningOpts, err := server.GetPruningOptionsFromFlags()
+	if err != nil {
+		panic(err)
 	}
 
 	// TODO: Make sure custom pruning works.


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Completely forgot we could've used the already existing function to get pruning opts from config/CLI.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
