### PR TITLE
Add TimeIotaMs to export GenesisFile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,7 +170,7 @@ be used to retrieve the actual proposal `Content`. Also the `NewMsgSubmitProposa
 
 ### Bug Fixes
 
-* (export) [\#6510](https://github.com/cosmos/cosmos-sdk/pull/6510/) Field TimeIotaMs now is included in genesis file while importing.
+* (export) [\#6510](https://github.com/cosmos/cosmos-sdk/pull/6510/) Field TimeIotaMs now is included in genesis file while exporting.
 * (client) [\#6402](https://github.com/cosmos/cosmos-sdk/issues/6402) Fix `keys add` `--algo` flag which only worked for Tendermint's `secp256k1` default key signing algorithm.
 * (x/bank) [\#6283](https://github.com/cosmos/cosmos-sdk/pull/6283) Create account if recipient does not exist on handing `MsgMultiSend`.
 * (x/distribution) [\#6210](https://github.com/cosmos/cosmos-sdk/pull/6210) Register `MsgFundCommunityPool` in distribution amino codec.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,6 +170,7 @@ be used to retrieve the actual proposal `Content`. Also the `NewMsgSubmitProposa
 
 ### Bug Fixes
 
+* (export) [\#6510](https://github.com/cosmos/cosmos-sdk/pull/6510/) Field TimeIotaMs now is included in genesis file while importing.
 * (client) [\#6402](https://github.com/cosmos/cosmos-sdk/issues/6402) Fix `keys add` `--algo` flag which only worked for Tendermint's `secp256k1` default key signing algorithm.
 * (x/bank) [\#6283](https://github.com/cosmos/cosmos-sdk/pull/6283) Create account if recipient does not exist on handing `MsgMultiSend`.
 * (x/distribution) [\#6210](https://github.com/cosmos/cosmos-sdk/pull/6210) Register `MsgFundCommunityPool` in distribution amino codec.

--- a/go.sum
+++ b/go.sum
@@ -506,8 +506,6 @@ github.com/tendermint/go-amino v0.14.1/go.mod h1:i/UKE5Uocn+argJJBb12qTZsCDBcAYM
 github.com/tendermint/go-amino v0.15.1 h1:D2uk35eT4iTsvJd9jWIetzthE5C0/k2QmMFkCN+4JgQ=
 github.com/tendermint/go-amino v0.15.1/go.mod h1:TQU0M1i/ImAo+tYpZi73AU3V/dKeCoMC9Sphe2ZwGME=
 github.com/tendermint/iavl v0.13.2/go.mod h1:vE1u0XAGXYjHykd4BLp8p/yivrw2PF1TuoljBcsQoGA=
-github.com/tendermint/iavl v0.13.4-0.20200624161209-9b7a26e81d73 h1:M8vEzWkkYJP1AZid5/A3uZ64qoOiscaMxpDKf6yd7io=
-github.com/tendermint/iavl v0.13.4-0.20200624161209-9b7a26e81d73/go.mod h1:+Gx6emqDjFJhlCAuJpJqWautrknAq4dEqVD+NTRV5FE=
 github.com/tendermint/iavl v0.14.0-rc1 h1:Hovc8HqlMtvYcwUOEh3GK61iOSf31Qh56L8O5+0Xfvc=
 github.com/tendermint/iavl v0.14.0-rc1/go.mod h1:+Gx6emqDjFJhlCAuJpJqWautrknAq4dEqVD+NTRV5FE=
 github.com/tendermint/tendermint v0.33.2 h1:NzvRMTuXJxqSsFed2J7uHmMU5N1CVzSpfi3nCc882KY=

--- a/server/export.go
+++ b/server/export.go
@@ -75,8 +75,9 @@ func ExportCmd(ctx *Context, cdc codec.JSONMarshaler, appExporter AppExporter) *
 			doc.Validators = validators
 			doc.ConsensusParams = &tmtypes.ConsensusParams{
 				Block: tmtypes.BlockParams{
-					MaxBytes: cp.Block.MaxBytes,
-					MaxGas:   cp.Block.MaxGas,
+					MaxBytes:   cp.Block.MaxBytes,
+					MaxGas:     cp.Block.MaxGas,
+					TimeIotaMs: doc.ConsensusParams.Block.TimeIotaMs,
 				},
 				Evidence: tmtypes.EvidenceParams{
 					MaxAgeNumBlocks: cp.Evidence.MaxAgeNumBlocks,

--- a/server/export.go
+++ b/server/export.go
@@ -93,7 +93,7 @@ func ExportCmd(ctx *Context, cdc codec.JSONMarshaler, appExporter AppExporter) *
 				return err
 			}
 
-			fmt.Println(string(sdk.MustSortJSON(encoded)))
+			cmd.Println(string(sdk.MustSortJSON(encoded)))
 			return nil
 		},
 	}
@@ -101,6 +101,8 @@ func ExportCmd(ctx *Context, cdc codec.JSONMarshaler, appExporter AppExporter) *
 	cmd.Flags().Int64(flagHeight, -1, "Export state from a particular height (-1 means latest height)")
 	cmd.Flags().Bool(flagForZeroHeight, false, "Export state to start at height zero (perform preproccessing)")
 	cmd.Flags().StringSlice(flagJailWhitelist, []string{}, "List of validators to not jail state export")
+	cmd.SetOut(cmd.OutOrStdout())
+	cmd.SetErr(cmd.OutOrStderr())
 
 	return cmd
 }

--- a/server/export_test.go
+++ b/server/export_test.go
@@ -1,0 +1,115 @@
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/spf13/viper"
+
+	abci "github.com/tendermint/tendermint/abci/types"
+	"github.com/tendermint/tendermint/libs/log"
+	tmtypes "github.com/tendermint/tendermint/types"
+	dbm "github.com/tendermint/tm-db"
+
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/simapp"
+	"github.com/cosmos/cosmos-sdk/tests"
+	"github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/cosmos/cosmos-sdk/x/genutil"
+)
+
+func TestExportCmd_ConsensusParams(t *testing.T) {
+	tempDir, clean := tests.NewTestCaseDir(t)
+	defer clean()
+
+	err := createConfigFolder(tempDir)
+	if err != nil {
+		t.Fatalf("error creating config folder: %s", err)
+	}
+
+	db := dbm.NewMemDB()
+	app := simapp.NewSimApp(log.NewTMLogger(log.NewSyncWriter(os.Stdout)), db, nil, true, map[int64]bool{}, tempDir, 0)
+
+	ctx := NewDefaultContext()
+	ctx.Config.RootDir = tempDir
+
+	genDoc := newDefaultGenesisDoc(app.Codec())
+	err = saveGenesisFile(genDoc, ctx.Config.GenesisFile())
+
+	app.InitChain(
+		abci.RequestInitChain{
+			Validators:      []abci.ValidatorUpdate{},
+			ConsensusParams: simapp.DefaultConsensusParams,
+			AppStateBytes:   genDoc.AppState,
+		},
+	)
+
+	app.Commit()
+
+	cmd := ExportCmd(
+		ctx,
+		app.Codec(),
+		func(logger log.Logger, db dbm.DB, writer io.Writer, i int64, b bool, strings []string) (json.RawMessage, []tmtypes.GenesisValidator, *abci.ConsensusParams, error) {
+			return app.ExportAppStateAndValidators(true, []string{})
+		})
+
+	output := &bytes.Buffer{}
+	cmd.SetOut(output)
+
+	viper.Set(flags.FlagHome, tempDir)
+	err = cmd.RunE(cmd, []string{})
+	if err != nil {
+		t.Errorf("error: %s", err)
+	}
+
+	var exportedGenDoc tmtypes.GenesisDoc
+	err = app.Codec().UnmarshalJSON(output.Bytes(), &exportedGenDoc)
+	if err != nil {
+		t.Fatalf("error unmarshaling exported genesis doc: %s", err)
+	}
+
+	require.Equal(t, genDoc.ConsensusParams.Block.TimeIotaMs, exportedGenDoc.ConsensusParams.Block.TimeIotaMs)
+	require.Equal(t, simapp.DefaultConsensusParams.Block.MaxBytes, exportedGenDoc.ConsensusParams.Block.MaxBytes)
+	require.Equal(t, simapp.DefaultConsensusParams.Block.MaxGas, exportedGenDoc.ConsensusParams.Block.MaxGas)
+
+	require.Equal(t, simapp.DefaultConsensusParams.Evidence.MaxAgeDuration, exportedGenDoc.ConsensusParams.Evidence.MaxAgeDuration)
+	require.Equal(t, simapp.DefaultConsensusParams.Evidence.MaxAgeNumBlocks, exportedGenDoc.ConsensusParams.Evidence.MaxAgeNumBlocks)
+
+	require.Equal(t, simapp.DefaultConsensusParams.Validator.PubKeyTypes, exportedGenDoc.ConsensusParams.Validator.PubKeyTypes)
+}
+
+func createConfigFolder(dir string) error {
+	return os.Mkdir(path.Join(dir, "config"), 0700)
+}
+
+func newDefaultGenesisDoc(cdc *codec.Codec) *tmtypes.GenesisDoc {
+	genesisState := simapp.NewDefaultGenesisState()
+
+	stateBytes, err := codec.MarshalJSONIndent(cdc, genesisState)
+	if err != nil {
+		panic(err)
+	}
+
+	genDoc := &tmtypes.GenesisDoc{}
+	genDoc.ChainID = "theChainId"
+	genDoc.Validators = nil
+	genDoc.AppState = stateBytes
+
+	return genDoc
+}
+
+func saveGenesisFile(genDoc *tmtypes.GenesisDoc, dir string) error {
+	err := genutil.ExportGenesisFile(genDoc, dir)
+	if err != nil {
+		return errors.Wrap(err, "error creating file")
+	}
+
+	return nil
+}

--- a/x/ibc/07-tendermint/client/cli/tx.go
+++ b/x/ibc/07-tendermint/client/cli/tx.go
@@ -42,8 +42,8 @@ func GetCmdCreateClient(cdc *codec.Codec) *cobra.Command {
 		Short: "create new tendermint client",
 		Long: `Create a new tendermint IBC client. 
   - 'trust-level' flag can be a fraction (eg: '1/3') or 'default'
-  - 'proof-specs' flag can be a comma-separated list of strings (eg: 'ics23:simple,ics23:iavl') or 'default'`,
-		Example: fmt.Sprintf("%s tx ibc %s create [client-id] [path/to/consensus_state.json] [trusting_period] [unbonding_period] [max_clock_drift] --trust-level default --from node0 --home ../node0/<app>cli --chain-id $CID", version.ClientName, ibctmtypes.SubModuleName),
+  - 'proof-specs' flag can be JSON input, a path to a .json file or 'default'`,
+		Example: fmt.Sprintf("%s tx ibc %s create [client-id] [path/to/consensus_state.json] [trusting_period] [unbonding_period] [max_clock_drift] --trust-level default --proof-specs [path/to/proof-specs.json] --from node0 --home ../node0/<app>cli --chain-id $CID", version.ClientName, ibctmtypes.SubModuleName),
 		Args:    cobra.ExactArgs(5),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			inBuf := bufio.NewReader(cmd.InOrStdin())
@@ -57,7 +57,7 @@ func GetCmdCreateClient(cdc *codec.Codec) *cobra.Command {
 				// check for file path if JSON input is not provided
 				contents, err := ioutil.ReadFile(args[1])
 				if err != nil {
-					return errors.New("neither JSON input nor path to .json file were provided")
+					return errors.New("neither JSON input nor path to .json file were provided for consensus header")
 				}
 				if err := cdc.UnmarshalJSON(contents, &header); err != nil {
 					return errors.Wrap(err, "error unmarshalling consensus header file")
@@ -97,15 +97,17 @@ func GetCmdCreateClient(cdc *codec.Codec) *cobra.Command {
 			}
 
 			spc := viper.GetString(flagProofSpecs)
-
-			// Currently supports SDK chain or simple kvstore tendermint chain
-			switch spc {
-			case "default":
+			if spc == "default" {
 				specs = commitmenttypes.GetSDKSpecs()
-			case "simple":
-				specs = []*ics23.ProofSpec{ics23.TendermintSpec}
-			default:
-				return fmt.Errorf("proof spec: %s isn't supported", spc)
+			} else if err := cdc.UnmarshalJSON([]byte(spc), &specs); err != nil {
+				// check for file path if JSON input not provided
+				contents, err := ioutil.ReadFile(spc)
+				if err != nil {
+					return errors.New("neither JSON input nor path to .json file was provided for proof specs flag")
+				}
+				if err := cdc.UnmarshalJSON(contents, &specs); err != nil {
+					return errors.Wrap(err, "error unmarshalling proof specs file")
+				}
 			}
 
 			msg := ibctmtypes.NewMsgCreateClient(


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Before we did not include the field time_iota_ms into the genesis file while exporting, now we do. 

closes: #https://github.com/cosmos/cosmos-sdk/issues/6446

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
