### PR TITLE
store: change PruningDefault to KeepEvery:100

### DIFF
--- a/store/types/pruning.go
+++ b/store/types/pruning.go
@@ -12,9 +12,9 @@ const (
 
 var (
 	// PruneDefault defines a pruning strategy where the last 100 heights are kept
-	// in addition to every 500th and where to-be pruned heights are pruned at
+	// in addition to every 100th and where to-be pruned heights are pruned at
 	// every 10th height.
-	PruneDefault = NewPruningOptions(100, 500, 10)
+	PruneDefault = NewPruningOptions(100, 100, 10)
 
 	// PruneEverything defines a pruning strategy where all committed heights are
 	// deleted, storing only the current height and where to-be pruned heights are


### PR DESCRIPTION
Change the default pruning strategy to KeepEvery:100, the same as 0.38.4. This is to reduce the chance of data loss for users blindly upgrading from 0.38.0-0.38.4, due to bugs in the IAVL pruning implementation. See 0.38.5 change log for details.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
