### PR TITLE
Launchpad: Add sender info to bank transfer event

### DIFF
--- a/x/bank/internal/keeper/keeper.go
+++ b/x/bank/internal/keeper/keeper.go
@@ -219,9 +219,11 @@ func (keeper BaseSendKeeper) InputOutputCoins(ctx sdk.Context, inputs []types.In
 // SendCoins moves coins from one account to another
 func (keeper BaseSendKeeper) SendCoins(ctx sdk.Context, fromAddr sdk.AccAddress, toAddr sdk.AccAddress, amt sdk.Coins) error {
 	ctx.EventManager().EmitEvents(sdk.Events{
+		// This event should have all info (to, from, amount) without looking at other events
 		sdk.NewEvent(
 			types.EventTypeTransfer,
 			sdk.NewAttribute(types.AttributeKeyRecipient, toAddr.String()),
+			sdk.NewAttribute(types.AttributeKeySender, fromAddr.String()),
 			sdk.NewAttribute(sdk.AttributeKeyAmount, amt.String()),
 		),
 		sdk.NewEvent(

--- a/x/bank/internal/keeper/keeper_test.go
+++ b/x/bank/internal/keeper/keeper_test.go
@@ -170,9 +170,8 @@ func TestMsgSendEvents(t *testing.T) {
 	}
 	event1.Attributes = append(
 		event1.Attributes,
-		tmkv.Pair{Key: []byte(types.AttributeKeyRecipient), Value: []byte(addr2.String())})
-	event1.Attributes = append(
-		event1.Attributes,
+		tmkv.Pair{Key: []byte(types.AttributeKeyRecipient), Value: []byte(addr2.String())},
+		tmkv.Pair{Key: []byte(types.AttributeKeySender), Value: []byte(addr.String())},
 		tmkv.Pair{Key: []byte(sdk.AttributeKeyAmount), Value: []byte(newCoins.String())})
 	event2 := sdk.Event{
 		Type:       sdk.EventTypeMessage,


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Currently the bank.send event only has the recipient and amount. It is assumed that the sender of the funds is message.sender. This is often not true when a module call the bank keeper. This may be due to staking distribution, or via a cosmwasm contract that released funds (where I discovered the issue). 

For completeness, it makes sense to contain the entire triple `(sender, recipient, amount)` in the transfer event for easy parsing by clients.

I just add one more attribute to the event and fix some tests.

@alessio @alexanderbez I would like to add this to #6522 Can you please add the `backport/release/v0.38.x` label?

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
