### PR TITLE
client/keys: make add command's output parseable

### DIFF
--- a/client/input/input.go
+++ b/client/input/input.go
@@ -41,7 +41,7 @@ func GetPassword(prompt string, buf *bufio.Reader) (pass string, err error) {
 // If the input is not recognized, it returns false and a nil error.
 func GetConfirmation(prompt string, r *bufio.Reader, w io.Writer) (bool, error) {
 	if inputIsTty() {
-		fmt.Printf("%s [y/N]: ", prompt)
+		fmt.Fprintf(w, "%s [y/N]: ", prompt)
 	}
 
 	response, err := readLineFromBuf(r)

--- a/client/keys/add.go
+++ b/client/keys/add.go
@@ -80,6 +80,9 @@ the flag --nosort is set.
 	cmd.Flags().Uint32(flagIndex, 0, "Address index number for HD derivation")
 	cmd.Flags().String(flagKeyAlgo, string(hd.Secp256k1Type), "Key signing algorithm to generate keys for")
 
+	cmd.SetOut(cmd.OutOrStdout())
+	cmd.SetErr(cmd.ErrOrStderr())
+
 	return cmd
 }
 
@@ -115,7 +118,6 @@ func RunAddCmd(cmd *cobra.Command, args []string, kb keyring.Keyring, inBuf *buf
 	var err error
 
 	name := args[0]
-
 	interactive := viper.GetBool(flagInteractive)
 	showMnemonic := !viper.GetBool(flagNoBackup)
 
@@ -295,10 +297,11 @@ func printCreate(cmd *cobra.Command, info keyring.Info, showMnemonic bool, mnemo
 
 		// print mnemonic unless requested not to.
 		if showMnemonic {
-			cmd.PrintErrln("\n**Important** write this mnemonic phrase in a safe place.")
-			cmd.PrintErrln("It is the only way to recover your account if you ever forget your password.")
-			cmd.PrintErrln("")
-			cmd.PrintErrln(mnemonic)
+			fmt.Fprintln(cmd.ErrOrStderr(), "\n**Important** write this mnemonic phrase in a safe place.")
+			fmt.Fprintln(cmd.ErrOrStderr(), "\n**Important** write this mnemonic phrase in a safe place.")
+			fmt.Fprintln(cmd.ErrOrStderr(), "It is the only way to recover your account if you ever forget your password.")
+			fmt.Fprintln(cmd.ErrOrStderr(), "")
+			fmt.Fprintln(cmd.ErrOrStderr(), mnemonic)
 		}
 	case OutputFormatJSON:
 		out, err := keyring.Bech32KeyOutput(info)
@@ -315,7 +318,7 @@ func printCreate(cmd *cobra.Command, info keyring.Info, showMnemonic bool, mnemo
 			return err
 		}
 
-		cmd.PrintErrln(string(jsonString))
+		cmd.Println(string(jsonString))
 
 	default:
 		return fmt.Errorf("invalid output format %s", output)


### PR DESCRIPTION
client/input/input.go: GetConfirmation() should communicate
with the user via the io.Writer instance passed in as
argument.

client/keys/add.go: replace cmd.PrintErrln() calls with
fmt.Fprintln(cmd.ErrOrStderr(), ...) because of cobra's
PrintErr* functions broken behaviour. For more information
please see https://github.com/spf13/cobra/pull/894

Closes: #6601
Thanks: @noandrea for pointing this out.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
