### PR TITLE
fix docs build failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,10 +38,10 @@ jobs:
       - checkout
       - run:
           name: "Build docs"
-          command: make build-docs
+          command: make build-docs LEDGER_ENABLED=false
       - run:
           name: "Upload docs to S3"
-          command: make sync-docs
+          command: make sync-docs LEDGER_ENABLED=false
 
 workflows:
   version: 2


### PR DESCRIPTION
The build failed due to the Makefile's recent changes:
https://circleci.com/gh/cosmos/cosmos-sdk/177400?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
