### PR TITLE
Ethanfrey/4938 better gas estimation

### DIFF
--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -503,6 +503,8 @@ func (app *BaseApp) getContextForTx(mode runTxMode, txBytes []byte) sdk.Context 
 		ctx = ctx.WithIsReCheckTx(true)
 	}
 	if mode == runTxModeSimulate {
+		// Note: if I remove this, I get errors....
+		// Both simulation results changing, as well as Check rejecting the signatures later
 		ctx, _ = ctx.CacheContext()
 	}
 
@@ -648,7 +650,7 @@ func (app *BaseApp) runTx(mode runTxMode, txBytes []byte, tx sdk.Tx) (gInfo sdk.
 	// and we're in DeliverTx. Note, runMsgs will never return a reference to a
 	// Result if any single message fails or does not have a registered Handler.
 	result, err = app.runMsgs(runMsgCtx, msgs, mode)
-	if err == nil && mode == runTxModeDeliver {
+	if err == nil && (mode == runTxModeDeliver || mode == runTxModeSimulate) {
 		msCache.Write()
 	}
 

--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -487,10 +487,8 @@ func (app *BaseApp) getState(mode runTxMode) *state {
 		return app.deliverState
 	case runTxModeSimulate:
 		return app.simulateState
-	case runTxModeCheck, runTxModeReCheck:
-		return app.checkState
 	default:
-		panic("Unknown mode - not check, deliver, or simulate")
+		return app.checkState
 	}
 }
 

--- a/x/bank/gas_estimate_test.go
+++ b/x/bank/gas_estimate_test.go
@@ -1,0 +1,58 @@
+package bank_test
+
+import (
+	"fmt"
+	"github.com/cosmos/cosmos-sdk/simapp"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/auth"
+	authexported "github.com/cosmos/cosmos-sdk/x/auth/exported"
+	"github.com/cosmos/cosmos-sdk/x/bank/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	abci "github.com/tendermint/tendermint/abci/types"
+	"github.com/tendermint/tendermint/crypto/secp256k1"
+	"testing"
+)
+
+func getAccount(t *testing.T, app *simapp.SimApp, addr sdk.AccAddress) *auth.BaseAccount {
+	ctxCheck := app.BaseApp.NewContext(true, abci.Header{})
+	res := app.AccountKeeper.GetAccount(ctxCheck, addr)
+	require.NotNil(t, res)
+	return res.(*auth.BaseAccount)
+}
+
+func TestSendGasEstimates(t *testing.T) {
+	// some test accounts - addr1 has tokens
+	priv1 := secp256k1.GenPrivKey()
+	addr1 := sdk.AccAddress(priv1.PubKey().Address())
+	priv2 := secp256k1.GenPrivKey()
+	addr2 := sdk.AccAddress(priv2.PubKey().Address())
+
+	initCoins := sdk.Coins{sdk.NewInt64Coin("uatom", 12345678)}
+	acc := &auth.BaseAccount{
+		Address: addr1,
+		Coins:   initCoins,
+	}
+
+	genAccs := []authexported.GenesisAccount{acc}
+	app := simapp.SetupWithGenesisAccounts(genAccs)
+
+	// ensure proper balance
+	acct := getAccount(t, app, addr1)
+	require.Equal(t, acc, acct)
+	simapp.CheckBalance(t, app, addr1, initCoins)
+
+	send := sdk.Coins{sdk.NewInt64Coin("uatom", 5678)}
+	sendMsg := types.NewMsgSend(addr1, addr2, send)
+	header := abci.Header{Height: app.LastBlockHeight() + 1}
+
+	gas, res, err := simapp.SignCheckDeliver(t, app.Codec(), app.BaseApp, header, []sdk.Msg{sendMsg}, []uint64{acct.GetAccountNumber()}, []uint64{acct.GetSequence()}, true, true, priv1)
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	// We have wanted 1 million, used ~53k
+	fmt.Printf("wanted: %d / used: %d\n", gas.GasWanted, gas.GasUsed)
+	// sanity checks for reasonable gas values
+	assert.Less(t, uint64(40000), gas.GasUsed)
+	assert.Less(t, gas.GasUsed, uint64(80000))
+}
+

--- a/x/bank/gas_estimate_test.go
+++ b/x/bank/gas_estimate_test.go
@@ -102,6 +102,10 @@ func TestSendGasEstimates(t *testing.T) {
 	simGas2 := simulatedGas(t, app, tx2)
 	fmt.Printf("Sim 1 used: %d\n", simGas2)
 
+	// let's simulate a second time, to see diff
+	simGas3 := simulatedGas(t, app, tx)
+	fmt.Printf("Re-Sim 0 (no check) used: %d\n", simGas3)
+
 	// let's run some CheckTx and see if they modify the values
 	_, _, err := app.Check(tx)
 	require.NoError(t, err)
@@ -110,7 +114,7 @@ func TestSendGasEstimates(t *testing.T) {
 
 	// now, try the simulations again
 	resimGas := simulatedGas(t, app, tx)
-	fmt.Printf("Re-Sim 0 used: %d\n", resimGas)
+	fmt.Printf("Re-Sim 0 (after check) used: %d\n", resimGas)
 	assert.Equal(t, simGas, resimGas)
 
 	// deliver the tx with the gas returned from simulate

--- a/x/bank/gas_estimate_test.go
+++ b/x/bank/gas_estimate_test.go
@@ -3,6 +3,7 @@ package bank_test
 import (
 	"fmt"
 	"github.com/cosmos/cosmos-sdk/simapp"
+	"github.com/cosmos/cosmos-sdk/simapp/helpers"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/auth"
 	authexported "github.com/cosmos/cosmos-sdk/x/auth/exported"
@@ -46,13 +47,45 @@ func TestSendGasEstimates(t *testing.T) {
 	sendMsg := types.NewMsgSend(addr1, addr2, send)
 	header := abci.Header{Height: app.LastBlockHeight() + 1}
 
-	gas, res, err := simapp.SignCheckDeliver(t, app.Codec(), app.BaseApp, header, []sdk.Msg{sendMsg}, []uint64{acct.GetAccountNumber()}, []uint64{acct.GetSequence()}, true, true, priv1)
+	// this will build proper tx
+	buildTx := func(expectedGas uint64) sdk.Tx {
+		return helpers.GenTx(
+			[]sdk.Msg{sendMsg},
+			sdk.Coins{sdk.NewInt64Coin(sdk.DefaultBondDenom, 0)},
+			expectedGas,
+			"",
+			[]uint64{acct.GetAccountNumber()},
+			[]uint64{acct.GetSequence()},
+			priv1,
+		)
+	}
+
+	// run simulation
+	tx := buildTx(200_000)
+	txBytes, err := app.Codec().MarshalBinaryLengthPrefixed(tx)
+	require.NoError(t, err)
+	simGas, res, err := app.Simulate(txBytes, tx)
 	require.NoError(t, err)
 	require.NotNil(t, res)
+	fmt.Printf("(SIM) wanted: %d / used: %d\n", simGas.GasWanted, simGas.GasUsed)
+
+	// deliver the tx with the gas returned from simulate (plus 10%)
+	tx = buildTx(simGas.GasUsed + simGas.GasUsed / 10)
+	app.BeginBlock(abci.RequestBeginBlock{Header: header})
+	gas, res, err := app.Deliver(tx)
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	app.EndBlock(abci.RequestEndBlock{})
+	app.Commit()
+
 	// We have wanted 1 million, used ~53k
 	fmt.Printf("wanted: %d / used: %d\n", gas.GasWanted, gas.GasUsed)
 	// sanity checks for reasonable gas values
 	assert.Less(t, uint64(40000), gas.GasUsed)
 	assert.Less(t, gas.GasUsed, uint64(80000))
 }
+
+
+/// these pieces are taken from simapp to give us a bit more control
+
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

This is a WIP - investigation to share.

Closes #4938 


## Findings

To reproduce:

```
cd x/bank
go test -v . -run TestSendGas
```

I made a test in bank to simulate tx and submit it. The gas numbers from simulation were (very slightly) higher than the real gas numbers from deliver. I tried two tx and there was a clear difference due to the first having the public key and slightly larger txbytes.

However, I tried running:

```go
simGas0 := Simulate(tx)
simGas1 := Simulate(tx2)

Check(tx)
Check(tx2)

resimGas0 := Simulate(tx)
resimGas1 := SImulate(tx2)
```

`simGas0 - simGas1 = 300 (txbytes)`

`resimGas0 - resimGas1 = 300 (txBytes)`

`simGas0 - resimGas0 = 4400` (why?) 

```
< --- consumed 135 gas for 'ReadPerByte' ---
< --- consumed 2000 gas for 'WriteFlat' ---
< --- consumed 2550 gas for 'WritePerByte' ---
---
> --- consumed 261 gas for 'ReadPerByte' ---
39c37
< --- consumed 255 gas for 'ReadPerByte' ---
---
> --- consumed 261 gas for 'ReadPerByte' ---
51c49
< --- consumed 255 gas for 'ReadPerByte' ---
---
> --- consumed 261 gas for 'ReadPerByte' ---
54c52
< --- consumed 255 gas for 'ReadPerByte' ---
---
> --- consumed 261 gas for 'ReadPerByte' ---
56c54
< --- consumed 255 gas for 'ReadPerByte' ---
---
> --- consumed 261 gas for 'ReadPerByte' ---
77c75
< Sim 0 used: 55951
---
> Re-Sim 0 (after check) used: 51551
```

It seems like something being read a lot is slightly smaller (and why do we read it so much)?
It also seems like there is a large write that is not triggered after a CheckTx has run: `consumed 2000 gas for 'WriteFlat' ---
consumed 2550 gas for 'WritePerByte'`. 

This is all a bit more confusing than the original issue suggests and I think writing the cache will not do anything (I did add a separate simulateState, that was parallel to checkState, but that didn't help - got some sequence errors when I removed a level of caching even.

Anyway... if someone else wants to wrack their brains....
---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
