### PR TITLE
x/genutil: use HomeDir stored in ClientCtx

### DIFF
--- a/x/genutil/client/cli/gentx.go
+++ b/x/genutil/client/cli/gentx.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	tmcli "github.com/tendermint/tendermint/libs/cli"
 	tmos "github.com/tendermint/tendermint/libs/os"
 	tmtypes "github.com/tendermint/tendermint/types"
 
@@ -92,11 +91,8 @@ func GenTxCmd(mbm module.BasicManager, genBalIterator types.GenesisBalancesItera
 			}
 
 			keyringBackend, _ := cmd.Flags().GetString(flags.FlagKeyringBackend)
-
-			clientHome, _ := cmd.Flags().GetString(tmcli.HomeFlag)
-
 			inBuf := bufio.NewReader(cmd.InOrStdin())
-			kb, err := keyring.New(sdk.KeyringServiceName(), keyringBackend, clientHome, inBuf)
+			kb, err := keyring.New(sdk.KeyringServiceName(), keyringBackend, clientCtx.HomeDir, inBuf)
 			if err != nil {
 				return errors.Wrap(err, "failed to initialize keybase")
 			}
@@ -127,7 +123,7 @@ func GenTxCmd(mbm module.BasicManager, genBalIterator types.GenesisBalancesItera
 				return errors.Wrap(err, "failed to validate account in genesis")
 			}
 
-			txBldr, err := authtypes.NewTxBuilderFromFlags(inBuf, cmd.Flags(), clientHome)
+			txBldr, err := authtypes.NewTxBuilderFromFlags(inBuf, cmd.Flags(), clientCtx.HomeDir)
 			if err != nil {
 				return errors.Wrap(err, "error creating tx builder")
 			}


### PR DESCRIPTION
Follow-up of #6636

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
