### PR TITLE
run sims on master

### DIFF
--- a/.github/workflows/sims.yml
+++ b/.github/workflows/sims.yml
@@ -3,6 +3,10 @@ name: Sims
 # This workflow will run on all Pull Requests, if a .go, .mod or .sum file have been changed
 on:
   pull_request:
+  push:
+    branches:
+      - master
+
 jobs:
   cleanup-runs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
prs have been getting merged prior to completing sims in ci. We should just run on master to be safe