### PR TITLE
testutil cleanup and reorg

### DIFF
--- a/client/keys/add_ledger_test.go
+++ b/client/keys/add_ledger_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/crypto/hd"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
-	"github.com/cosmos/cosmos-sdk/tests"
+	"github.com/cosmos/cosmos-sdk/testutil"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -37,7 +37,7 @@ func Test_runAddCmdLedgerWithCustomCoinType(t *testing.T) {
 	cmd.Flags().AddFlagSet(Commands().PersistentFlags())
 
 	// Prepare a keybase
-	kbHome, kbCleanUp := tests.NewTestCaseDir(t)
+	kbHome, kbCleanUp := testutil.NewTestCaseDir(t)
 	require.NotNil(t, kbHome)
 	t.Cleanup(kbCleanUp)
 
@@ -53,7 +53,7 @@ func Test_runAddCmdLedgerWithCustomCoinType(t *testing.T) {
 		fmt.Sprintf("--%s=%s", flags.FlagKeyringBackend, keyring.BackendTest),
 	})
 
-	mockIn, _, _ := tests.ApplyMockIO(cmd)
+	mockIn, _, _ := testutil.ApplyMockIO(cmd)
 	mockIn.Reset("test1234\ntest1234\n")
 	require.NoError(t, cmd.Execute())
 
@@ -85,10 +85,10 @@ func Test_runAddCmdLedgerWithCustomCoinType(t *testing.T) {
 func Test_runAddCmdLedger(t *testing.T) {
 	cmd := AddKeyCommand()
 	cmd.Flags().AddFlagSet(Commands().PersistentFlags())
-	mockIn, _, _ := tests.ApplyMockIO(cmd)
+	mockIn, _, _ := testutil.ApplyMockIO(cmd)
 
 	// Prepare a keybase
-	kbHome, kbCleanUp := tests.NewTestCaseDir(t)
+	kbHome, kbCleanUp := testutil.NewTestCaseDir(t)
 	require.NotNil(t, kbHome)
 	t.Cleanup(kbCleanUp)
 

--- a/client/keys/add_test.go
+++ b/client/keys/add_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/crypto/hd"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
-	"github.com/cosmos/cosmos-sdk/tests"
+	"github.com/cosmos/cosmos-sdk/testutil"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -19,9 +19,9 @@ func Test_runAddCmdBasic(t *testing.T) {
 	cmd := AddKeyCommand()
 	cmd.Flags().AddFlagSet(Commands().PersistentFlags())
 
-	mockIn, _, _ := tests.ApplyMockIO(cmd)
+	mockIn, _, _ := testutil.ApplyMockIO(cmd)
 
-	kbHome, kbCleanUp := tests.NewTestCaseDir(t)
+	kbHome, kbCleanUp := testutil.NewTestCaseDir(t)
 	require.NotNil(t, kbHome)
 	t.Cleanup(kbCleanUp)
 

--- a/client/keys/delete_test.go
+++ b/client/keys/delete_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/crypto/hd"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
-	"github.com/cosmos/cosmos-sdk/tests"
 	"github.com/cosmos/cosmos-sdk/testutil"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
@@ -36,7 +35,7 @@ func Test_runDeleteCmd(t *testing.T) {
 	kb, err := keyring.New(sdk.KeyringServiceName(), keyring.BackendTest, kbHome, mockIn)
 	require.NoError(t, err)
 
-	_, err = kb.NewAccount(fakeKeyName1, tests.TestMnemonic, "", path, hd.Secp256k1)
+	_, err = kb.NewAccount(fakeKeyName1, testutil.TestMnemonic, "", path, hd.Secp256k1)
 	require.NoError(t, err)
 
 	_, _, err = kb.NewMnemonic(fakeKeyName2, keyring.English, sdk.FullFundraiserPath, hd.Secp256k1)

--- a/client/keys/delete_test.go
+++ b/client/keys/delete_test.go
@@ -10,13 +10,14 @@ import (
 	"github.com/cosmos/cosmos-sdk/crypto/hd"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	"github.com/cosmos/cosmos-sdk/tests"
+	"github.com/cosmos/cosmos-sdk/testutil"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 func Test_runDeleteCmd(t *testing.T) {
 	cmd := DeleteKeyCommand()
 	cmd.Flags().AddFlagSet(Commands().PersistentFlags())
-	mockIn, _, _ := tests.ApplyMockIO(cmd)
+	mockIn, _, _ := testutil.ApplyMockIO(cmd)
 
 	yesF, _ := cmd.Flags().GetBool(flagYes)
 	forceF, _ := cmd.Flags().GetBool(flagForce)
@@ -27,7 +28,7 @@ func Test_runDeleteCmd(t *testing.T) {
 	fakeKeyName1 := "runDeleteCmd_Key1"
 	fakeKeyName2 := "runDeleteCmd_Key2"
 	// Now add a temporary keybase
-	kbHome, cleanUp := tests.NewTestCaseDir(t)
+	kbHome, cleanUp := testutil.NewTestCaseDir(t)
 	t.Cleanup(cleanUp)
 
 	path := sdk.GetConfig().GetFullFundraiserPath()

--- a/client/keys/export_test.go
+++ b/client/keys/export_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/cosmos/cosmos-sdk/crypto/hd"
+	"github.com/cosmos/cosmos-sdk/testutil"
 
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
@@ -17,10 +18,10 @@ import (
 func Test_runExportCmd(t *testing.T) {
 	cmd := ExportKeyCommand()
 	cmd.Flags().AddFlagSet(Commands().PersistentFlags())
-	mockIn, _, _ := tests.ApplyMockIO(cmd)
+	mockIn, _, _ := testutil.ApplyMockIO(cmd)
 
 	// Now add a temporary keybase
-	kbHome, cleanUp := tests.NewTestCaseDir(t)
+	kbHome, cleanUp := testutil.NewTestCaseDir(t)
 	t.Cleanup(cleanUp)
 
 	// create a key

--- a/client/keys/export_test.go
+++ b/client/keys/export_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
-	"github.com/cosmos/cosmos-sdk/tests"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -32,7 +31,7 @@ func Test_runExportCmd(t *testing.T) {
 	})
 
 	path := sdk.GetConfig().GetFullFundraiserPath()
-	_, err = kb.NewAccount("keyname1", tests.TestMnemonic, "", path, hd.Secp256k1)
+	_, err = kb.NewAccount("keyname1", testutil.TestMnemonic, "", path, hd.Secp256k1)
 	require.NoError(t, err)
 
 	// Now enter password

--- a/client/keys/import_test.go
+++ b/client/keys/import_test.go
@@ -10,17 +10,17 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
-	"github.com/cosmos/cosmos-sdk/tests"
+	"github.com/cosmos/cosmos-sdk/testutil"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 func Test_runImportCmd(t *testing.T) {
 	cmd := ImportKeyCommand()
 	cmd.Flags().AddFlagSet(Commands().PersistentFlags())
-	mockIn, _, _ := tests.ApplyMockIO(cmd)
+	mockIn, _, _ := testutil.ApplyMockIO(cmd)
 
 	// Now add a temporary keybase
-	kbHome, cleanUp := tests.NewTestCaseDir(t)
+	kbHome, cleanUp := testutil.NewTestCaseDir(t)
 	t.Cleanup(cleanUp)
 
 	kb, err := keyring.New(sdk.KeyringServiceName(), keyring.BackendTest, kbHome, mockIn)

--- a/client/keys/list_test.go
+++ b/client/keys/list_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/crypto/hd"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
-	"github.com/cosmos/cosmos-sdk/tests"
 	"github.com/cosmos/cosmos-sdk/testutil"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
@@ -30,7 +29,7 @@ func Test_runListCmd(t *testing.T) {
 	require.NoError(t, err)
 
 	path := "" //sdk.GetConfig().GetFullFundraiserPath()
-	_, err = kb.NewAccount("something", tests.TestMnemonic, "", path, hd.Secp256k1)
+	_, err = kb.NewAccount("something", testutil.TestMnemonic, "", path, hd.Secp256k1)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {

--- a/client/keys/list_test.go
+++ b/client/keys/list_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/crypto/hd"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	"github.com/cosmos/cosmos-sdk/tests"
+	"github.com/cosmos/cosmos-sdk/testutil"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -18,13 +19,13 @@ func Test_runListCmd(t *testing.T) {
 	cmd := ListKeysCmd()
 	cmd.Flags().AddFlagSet(Commands().PersistentFlags())
 
-	kbHome1, cleanUp1 := tests.NewTestCaseDir(t)
+	kbHome1, cleanUp1 := testutil.NewTestCaseDir(t)
 	t.Cleanup(cleanUp1)
 
-	kbHome2, cleanUp2 := tests.NewTestCaseDir(t)
+	kbHome2, cleanUp2 := testutil.NewTestCaseDir(t)
 	t.Cleanup(cleanUp2)
 
-	mockIn, _, _ := tests.ApplyMockIO(cmd)
+	mockIn, _, _ := testutil.ApplyMockIO(cmd)
 	kb, err := keyring.New(sdk.KeyringServiceName(), keyring.BackendTest, kbHome2, mockIn)
 	require.NoError(t, err)
 

--- a/client/keys/migrate_test.go
+++ b/client/keys/migrate_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
-	"github.com/cosmos/cosmos-sdk/tests"
+	"github.com/cosmos/cosmos-sdk/testutil"
 )
 
 func Test_runMigrateCmd(t *testing.T) {
@@ -20,7 +20,7 @@ func Test_runMigrateCmd(t *testing.T) {
 	cmd.SetOut(ioutil.Discard)
 	cmd.Flags().AddFlagSet(Commands().PersistentFlags())
 
-	kbHome, kbCleanUp := tests.NewTestCaseDir(t)
+	kbHome, kbCleanUp := testutil.NewTestCaseDir(t)
 	copy.Copy("testdata", kbHome)
 	assert.NotNil(t, kbHome)
 	t.Cleanup(kbCleanUp)
@@ -35,7 +35,7 @@ func Test_runMigrateCmd(t *testing.T) {
 
 	cmd = MigrateCommand()
 	cmd.Flags().AddFlagSet(Commands().PersistentFlags())
-	mockIn, _, _ := tests.ApplyMockIO(cmd)
+	mockIn, _, _ := testutil.ApplyMockIO(cmd)
 
 	cmd.SetArgs([]string{
 		fmt.Sprintf("--%s=%s", flags.FlagHome, kbHome),

--- a/client/keys/mnemonic_test.go
+++ b/client/keys/mnemonic_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/cosmos/cosmos-sdk/tests"
+	"github.com/cosmos/cosmos-sdk/testutil"
 )
 
 func Test_RunMnemonicCmdNormal(t *testing.T) {
@@ -30,7 +30,7 @@ func Test_RunMnemonicCmdUser(t *testing.T) {
 	require.Equal(t, "EOF", err.Error())
 
 	// Try again
-	mockIn, _, _ := tests.ApplyMockIO(cmd)
+	mockIn, _, _ := testutil.ApplyMockIO(cmd)
 	mockIn.Reset("Hi!\n")
 	err = cmd.Execute()
 	require.Error(t, err)

--- a/client/keys/show_test.go
+++ b/client/keys/show_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/crypto/hd"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	"github.com/cosmos/cosmos-sdk/crypto/types/multisig"
-	"github.com/cosmos/cosmos-sdk/tests"
 	"github.com/cosmos/cosmos-sdk/testutil"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
@@ -61,11 +60,11 @@ func Test_runShowCmd(t *testing.T) {
 	})
 
 	path := hd.NewFundraiserParams(1, sdk.CoinType, 0).String()
-	_, err = kb.NewAccount(fakeKeyName1, tests.TestMnemonic, "", path, hd.Secp256k1)
+	_, err = kb.NewAccount(fakeKeyName1, testutil.TestMnemonic, "", path, hd.Secp256k1)
 	require.NoError(t, err)
 
 	path2 := hd.NewFundraiserParams(1, sdk.CoinType, 1).String()
-	_, err = kb.NewAccount(fakeKeyName2, tests.TestMnemonic, "", path2, hd.Secp256k1)
+	_, err = kb.NewAccount(fakeKeyName2, testutil.TestMnemonic, "", path2, hd.Secp256k1)
 	require.NoError(t, err)
 
 	// Now try single key

--- a/client/keys/show_test.go
+++ b/client/keys/show_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	"github.com/cosmos/cosmos-sdk/crypto/types/multisig"
 	"github.com/cosmos/cosmos-sdk/tests"
+	"github.com/cosmos/cosmos-sdk/testutil"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -38,7 +39,7 @@ func Test_showKeysCmd(t *testing.T) {
 func Test_runShowCmd(t *testing.T) {
 	cmd := ShowKeysCmd()
 	cmd.Flags().AddFlagSet(Commands().PersistentFlags())
-	mockIn, _, _ := tests.ApplyMockIO(cmd)
+	mockIn, _, _ := testutil.ApplyMockIO(cmd)
 
 	cmd.SetArgs([]string{"invalid"})
 	require.EqualError(t, cmd.Execute(), "invalid is not a valid name or address: decoding bech32 failed: invalid bech32 string length 7")
@@ -46,7 +47,7 @@ func Test_runShowCmd(t *testing.T) {
 	cmd.SetArgs([]string{"invalid1", "invalid2"})
 	require.EqualError(t, cmd.Execute(), "invalid1 is not a valid name or address: decoding bech32 failed: invalid index of 1")
 
-	kbHome, cleanUp := tests.NewTestCaseDir(t)
+	kbHome, cleanUp := testutil.NewTestCaseDir(t)
 	t.Cleanup(cleanUp)
 
 	fakeKeyName1 := "runShowCmd_Key1"

--- a/client/tx/tx_test.go
+++ b/client/tx/tx_test.go
@@ -4,13 +4,13 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/cosmos/cosmos-sdk/testutil"
 	"github.com/cosmos/cosmos-sdk/x/auth/signing"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/cosmos/cosmos-sdk/crypto/hd"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
-	"github.com/cosmos/cosmos-sdk/tests"
-
-	"github.com/stretchr/testify/require"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/tx"
@@ -115,7 +115,7 @@ func TestBuildUnsignedTx(t *testing.T) {
 }
 
 func TestSign(t *testing.T) {
-	dir, clean := tests.NewTestCaseDir(t)
+	dir, clean := testutil.NewTestCaseDir(t)
 	t.Cleanup(clean)
 
 	path := hd.CreateHDPath(118, 0, 0).String()

--- a/client/verifier_test.go
+++ b/client/verifier_test.go
@@ -1,17 +1,17 @@
 package client_test
 
 import (
-	"io/ioutil"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/testutil"
 )
 
 func TestCreateVerifier(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "example")
-	require.NoError(t, err)
+	tmpDir, cleanup := testutil.NewTestCaseDir(t)
+	t.Cleanup(cleanup)
 
 	testCases := []struct {
 		name      string

--- a/crypto/keyring/keyring_ledger_test.go
+++ b/crypto/keyring/keyring_ledger_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/cosmos/cosmos-sdk/crypto/hd"
-	"github.com/cosmos/cosmos-sdk/tests"
+	"github.com/cosmos/cosmos-sdk/testutil"
 	"github.com/cosmos/cosmos-sdk/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
@@ -52,7 +52,7 @@ func TestInMemoryCreateLedger(t *testing.T) {
 // TestSignVerify does some detailed checks on how we sign and validate
 // signatures
 func TestSignVerifyKeyRingWithLedger(t *testing.T) {
-	dir, cleanup := tests.NewTestCaseDir(t)
+	dir, cleanup := testutil.NewTestCaseDir(t)
 	t.Cleanup(cleanup)
 	kb, err := New("keybasename", "test", dir, nil)
 	require.NoError(t, err)
@@ -89,7 +89,7 @@ func TestSignVerifyKeyRingWithLedger(t *testing.T) {
 }
 
 func TestAltKeyring_SaveLedgerKey(t *testing.T) {
-	dir, clean := tests.NewTestCaseDir(t)
+	dir, clean := testutil.NewTestCaseDir(t)
 	t.Cleanup(clean)
 
 	keyring, err := New(t.Name(), BackendTest, dir, nil)

--- a/crypto/keyring/keyring_test.go
+++ b/crypto/keyring/keyring_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/crypto"
 	"github.com/cosmos/cosmos-sdk/crypto/hd"
 	"github.com/cosmos/cosmos-sdk/crypto/types/multisig"
-	"github.com/cosmos/cosmos-sdk/tests"
+	"github.com/cosmos/cosmos-sdk/testutil"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -30,7 +30,7 @@ func init() {
 }
 
 func TestNewKeyring(t *testing.T) {
-	dir, cleanup := tests.NewTestCaseDir(t)
+	dir, cleanup := testutil.NewTestCaseDir(t)
 	mockIn := strings.NewReader("")
 	t.Cleanup(cleanup)
 	kr, err := New("cosmos", BackendFile, dir, mockIn)
@@ -48,7 +48,7 @@ func TestNewKeyring(t *testing.T) {
 }
 
 func TestKeyManagementKeyRing(t *testing.T) {
-	dir, cleanup := tests.NewTestCaseDir(t)
+	dir, cleanup := testutil.NewTestCaseDir(t)
 	t.Cleanup(cleanup)
 	kb, err := New("keybasename", "test", dir, nil)
 	require.NoError(t, err)
@@ -130,7 +130,7 @@ func TestKeyManagementKeyRing(t *testing.T) {
 }
 
 func TestSignVerifyKeyRing(t *testing.T) {
-	dir, cleanup := tests.NewTestCaseDir(t)
+	dir, cleanup := testutil.NewTestCaseDir(t)
 	t.Cleanup(cleanup)
 
 	kb, err := New("keybasename", "test", dir, nil)
@@ -209,7 +209,7 @@ func TestSignVerifyKeyRing(t *testing.T) {
 }
 
 func TestExportImportKeyRing(t *testing.T) {
-	dir, cleanup := tests.NewTestCaseDir(t)
+	dir, cleanup := testutil.NewTestCaseDir(t)
 	t.Cleanup(cleanup)
 	kb, err := New("keybasename", "test", dir, nil)
 	require.NoError(t, err)
@@ -243,7 +243,7 @@ func TestExportImportKeyRing(t *testing.T) {
 }
 
 func TestExportImportPubKeyKeyRing(t *testing.T) {
-	dir, cleanup := tests.NewTestCaseDir(t)
+	dir, cleanup := testutil.NewTestCaseDir(t)
 	t.Cleanup(cleanup)
 	kb, err := New("keybasename", "test", dir, nil)
 	require.NoError(t, err)
@@ -283,7 +283,7 @@ func TestExportImportPubKeyKeyRing(t *testing.T) {
 }
 
 func TestAdvancedKeyManagementKeyRing(t *testing.T) {
-	dir, cleanup := tests.NewTestCaseDir(t)
+	dir, cleanup := testutil.NewTestCaseDir(t)
 	t.Cleanup(cleanup)
 
 	kb, err := New("keybasename", "test", dir, nil)
@@ -319,7 +319,7 @@ func TestAdvancedKeyManagementKeyRing(t *testing.T) {
 }
 
 func TestSeedPhraseKeyRing(t *testing.T) {
-	dir, cleanup := tests.NewTestCaseDir(t)
+	dir, cleanup := testutil.NewTestCaseDir(t)
 	t.Cleanup(cleanup)
 	kb, err := New("keybasename", "test", dir, nil)
 	require.NoError(t, err)
@@ -350,7 +350,7 @@ func TestSeedPhraseKeyRing(t *testing.T) {
 }
 
 func TestKeyringKeybaseExportImportPrivKey(t *testing.T) {
-	dir, cleanup := tests.NewTestCaseDir(t)
+	dir, cleanup := testutil.NewTestCaseDir(t)
 	t.Cleanup(cleanup)
 	kb, err := New("keybasename", "test", dir, nil)
 	require.NoError(t, err)
@@ -729,7 +729,7 @@ func TestInMemorySeedPhrase(t *testing.T) {
 }
 
 func TestKeyChain_ShouldFailWhenAddingSameGeneratedAccount(t *testing.T) {
-	dir, clean := tests.NewTestCaseDir(t)
+	dir, clean := testutil.NewTestCaseDir(t)
 	t.Cleanup(clean)
 
 	kr, err := New(t.Name(), BackendTest, dir, nil)
@@ -801,7 +801,7 @@ func ExampleNew() {
 }
 
 func TestAltKeyring_List(t *testing.T) {
-	dir, clean := tests.NewTestCaseDir(t)
+	dir, clean := testutil.NewTestCaseDir(t)
 	t.Cleanup(clean)
 
 	keyring, err := New(t.Name(), BackendTest, dir, nil)
@@ -835,7 +835,7 @@ func TestAltKeyring_List(t *testing.T) {
 }
 
 func TestAltKeyring_NewAccount(t *testing.T) {
-	dir, clean := tests.NewTestCaseDir(t)
+	dir, clean := testutil.NewTestCaseDir(t)
 	t.Cleanup(clean)
 
 	keyring, err := New(t.Name(), BackendTest, dir, nil)
@@ -864,7 +864,7 @@ func TestAltKeyring_NewAccount(t *testing.T) {
 }
 
 func TestAltKeyring_Get(t *testing.T) {
-	dir, clean := tests.NewTestCaseDir(t)
+	dir, clean := testutil.NewTestCaseDir(t)
 	t.Cleanup(clean)
 
 	keyring, err := New(t.Name(), BackendTest, dir, nil)
@@ -880,7 +880,7 @@ func TestAltKeyring_Get(t *testing.T) {
 }
 
 func TestAltKeyring_KeyByAddress(t *testing.T) {
-	dir, clean := tests.NewTestCaseDir(t)
+	dir, clean := testutil.NewTestCaseDir(t)
 	t.Cleanup(clean)
 
 	keyring, err := New(t.Name(), BackendTest, dir, nil)
@@ -896,7 +896,7 @@ func TestAltKeyring_KeyByAddress(t *testing.T) {
 }
 
 func TestAltKeyring_Delete(t *testing.T) {
-	dir, clean := tests.NewTestCaseDir(t)
+	dir, clean := testutil.NewTestCaseDir(t)
 	t.Cleanup(clean)
 
 	keyring, err := New(t.Name(), BackendTest, dir, nil)
@@ -919,7 +919,7 @@ func TestAltKeyring_Delete(t *testing.T) {
 }
 
 func TestAltKeyring_DeleteByAddress(t *testing.T) {
-	dir, clean := tests.NewTestCaseDir(t)
+	dir, clean := testutil.NewTestCaseDir(t)
 	t.Cleanup(clean)
 
 	keyring, err := New(t.Name(), BackendTest, dir, nil)
@@ -942,7 +942,7 @@ func TestAltKeyring_DeleteByAddress(t *testing.T) {
 }
 
 func TestAltKeyring_SavePubKey(t *testing.T) {
-	dir, clean := tests.NewTestCaseDir(t)
+	dir, clean := testutil.NewTestCaseDir(t)
 	t.Cleanup(clean)
 
 	keyring, err := New(t.Name(), BackendTest, dir, nil)
@@ -968,7 +968,7 @@ func TestAltKeyring_SavePubKey(t *testing.T) {
 }
 
 func TestAltKeyring_SaveMultisig(t *testing.T) {
-	dir, clean := tests.NewTestCaseDir(t)
+	dir, clean := testutil.NewTestCaseDir(t)
 	t.Cleanup(clean)
 
 	keyring, err := New(t.Name(), BackendTest, dir, nil)
@@ -993,7 +993,7 @@ func TestAltKeyring_SaveMultisig(t *testing.T) {
 }
 
 func TestAltKeyring_Sign(t *testing.T) {
-	dir, clean := tests.NewTestCaseDir(t)
+	dir, clean := testutil.NewTestCaseDir(t)
 	t.Cleanup(clean)
 
 	keyring, err := New(t.Name(), BackendTest, dir, nil)
@@ -1012,7 +1012,7 @@ func TestAltKeyring_Sign(t *testing.T) {
 }
 
 func TestAltKeyring_SignByAddress(t *testing.T) {
-	dir, clean := tests.NewTestCaseDir(t)
+	dir, clean := testutil.NewTestCaseDir(t)
 	t.Cleanup(clean)
 
 	keyring, err := New(t.Name(), BackendTest, dir, nil)
@@ -1031,7 +1031,7 @@ func TestAltKeyring_SignByAddress(t *testing.T) {
 }
 
 func TestAltKeyring_ImportExportPrivKey(t *testing.T) {
-	dir, clean := tests.NewTestCaseDir(t)
+	dir, clean := testutil.NewTestCaseDir(t)
 	t.Cleanup(clean)
 
 	keyring, err := New(t.Name(), BackendTest, dir, nil)
@@ -1060,7 +1060,7 @@ func TestAltKeyring_ImportExportPrivKey(t *testing.T) {
 }
 
 func TestAltKeyring_ImportExportPrivKey_ByAddress(t *testing.T) {
-	dir, clean := tests.NewTestCaseDir(t)
+	dir, clean := testutil.NewTestCaseDir(t)
 	t.Cleanup(clean)
 
 	keyring, err := New(t.Name(), BackendTest, dir, nil)
@@ -1090,7 +1090,7 @@ func TestAltKeyring_ImportExportPrivKey_ByAddress(t *testing.T) {
 }
 
 func TestAltKeyring_ImportExportPubKey(t *testing.T) {
-	dir, clean := tests.NewTestCaseDir(t)
+	dir, clean := testutil.NewTestCaseDir(t)
 	t.Cleanup(clean)
 
 	keyring, err := New(t.Name(), BackendTest, dir, nil)
@@ -1115,7 +1115,7 @@ func TestAltKeyring_ImportExportPubKey(t *testing.T) {
 }
 
 func TestAltKeyring_ImportExportPubKey_ByAddress(t *testing.T) {
-	dir, clean := tests.NewTestCaseDir(t)
+	dir, clean := testutil.NewTestCaseDir(t)
 	t.Cleanup(clean)
 
 	keyring, err := New(t.Name(), BackendTest, dir, nil)
@@ -1140,7 +1140,7 @@ func TestAltKeyring_ImportExportPubKey_ByAddress(t *testing.T) {
 }
 
 func TestAltKeyring_ConstructorSupportedAlgos(t *testing.T) {
-	dir, clean := tests.NewTestCaseDir(t)
+	dir, clean := testutil.NewTestCaseDir(t)
 	t.Cleanup(clean)
 
 	keyring, err := New(t.Name(), BackendTest, dir, nil)
@@ -1155,7 +1155,7 @@ func TestAltKeyring_ConstructorSupportedAlgos(t *testing.T) {
 	require.NoError(t, err)
 
 	// but we can create a new keybase with our provided algos.
-	dir2, clean2 := tests.NewTestCaseDir(t)
+	dir2, clean2 := testutil.NewTestCaseDir(t)
 	t.Cleanup(clean2)
 
 	keyring2, err := New(t.Name(), BackendTest, dir2, nil, func(options *Options) {

--- a/crypto/keyring/legacy_test.go
+++ b/crypto/keyring/legacy_test.go
@@ -9,11 +9,11 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
-	"github.com/cosmos/cosmos-sdk/tests"
+	"github.com/cosmos/cosmos-sdk/testutil"
 )
 
 func TestNewLegacyKeyBase(t *testing.T) {
-	dir, cleanup := tests.NewTestCaseDir(t)
+	dir, cleanup := testutil.NewTestCaseDir(t)
 	t.Cleanup(cleanup)
 	kb, err := keyring.NewLegacy("keybasename", dir)
 	require.NoError(t, err)
@@ -21,7 +21,7 @@ func TestNewLegacyKeyBase(t *testing.T) {
 }
 
 func TestLegacyKeybase(t *testing.T) {
-	dir, cleanup := tests.NewTestCaseDir(t)
+	dir, cleanup := testutil.NewTestCaseDir(t)
 	t.Cleanup(cleanup)
 
 	// Backup testdata

--- a/crypto/ledger_mock.go
+++ b/crypto/ledger_mock.go
@@ -15,7 +15,7 @@ import (
 	bip39 "github.com/cosmos/go-bip39"
 
 	"github.com/cosmos/cosmos-sdk/crypto/hd"
-	"github.com/cosmos/cosmos-sdk/tests"
+	"github.com/cosmos/cosmos-sdk/testutil"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -46,7 +46,7 @@ func (mock LedgerSECP256K1Mock) GetPublicKeySECP256K1(derivationPath []uint32) (
 		return nil, errors.New("Invalid derivation path")
 	}
 
-	seed, err := bip39.NewSeedWithErrorChecking(tests.TestMnemonic, "")
+	seed, err := bip39.NewSeedWithErrorChecking(testutil.TestMnemonic, "")
 	if err != nil {
 		return nil, err
 	}
@@ -87,7 +87,7 @@ func (mock LedgerSECP256K1Mock) GetAddressPubKeySECP256K1(derivationPath []uint3
 
 func (mock LedgerSECP256K1Mock) SignSECP256K1(derivationPath []uint32, message []byte) ([]byte, error) {
 	path := hd.NewParams(derivationPath[0], derivationPath[1], derivationPath[2], derivationPath[3] != 0, derivationPath[4])
-	seed, err := bip39.NewSeedWithErrorChecking(tests.TestMnemonic, "")
+	seed, err := bip39.NewSeedWithErrorChecking(testutil.TestMnemonic, "")
 	if err != nil {
 		return nil, err
 	}

--- a/crypto/ledger_test.go
+++ b/crypto/ledger_test.go
@@ -10,7 +10,7 @@ import (
 
 	cryptoAmino "github.com/cosmos/cosmos-sdk/crypto/codec"
 	"github.com/cosmos/cosmos-sdk/crypto/hd"
-	"github.com/cosmos/cosmos-sdk/tests"
+	"github.com/cosmos/cosmos-sdk/testutil"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -30,16 +30,16 @@ func TestPublicKeyUnsafe(t *testing.T) {
 
 	require.Equal(t, "eb5ae98721034fef9cd7c4c63588d3b03feb5281b9d232cba34d6f3d71aee59211ffbfe1fe87",
 		fmt.Sprintf("%x", priv.PubKey().Bytes()),
-		"Is your device using test mnemonic: %s ?", tests.TestMnemonic)
+		"Is your device using test mnemonic: %s ?", testutil.TestMnemonic)
 
 	pubKeyAddr, err := sdk.Bech32ifyPubKey(sdk.Bech32PubKeyTypeAccPub, priv.PubKey())
 	require.NoError(t, err)
 	require.Equal(t, "cosmospub1addwnpepqd87l8xhcnrrtzxnkql7k55ph8fr9jarf4hn6udwukfprlalu8lgw0urza0",
-		pubKeyAddr, "Is your device using test mnemonic: %s ?", tests.TestMnemonic)
+		pubKeyAddr, "Is your device using test mnemonic: %s ?", testutil.TestMnemonic)
 
 	addr := sdk.AccAddress(priv.PubKey().Address()).String()
 	require.Equal(t, "cosmos1w34k53py5v5xyluazqpq65agyajavep2rflq6h",
-		addr, "Is your device using test mnemonic: %s ?", tests.TestMnemonic)
+		addr, "Is your device using test mnemonic: %s ?", testutil.TestMnemonic)
 }
 
 func TestPublicKeyUnsafeHDPath(t *testing.T) {
@@ -78,7 +78,7 @@ func TestPublicKeyUnsafeHDPath(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t,
 			expectedAnswers[i], pubKeyAddr,
-			"Is your device using test mnemonic: %s ?", tests.TestMnemonic)
+			"Is your device using test mnemonic: %s ?", testutil.TestMnemonic)
 
 		// Store and restore
 		serializedPk := priv.Bytes()
@@ -108,15 +108,15 @@ func TestPublicKeySafe(t *testing.T) {
 
 	require.Equal(t, "eb5ae98721034fef9cd7c4c63588d3b03feb5281b9d232cba34d6f3d71aee59211ffbfe1fe87",
 		fmt.Sprintf("%x", priv.PubKey().Bytes()),
-		"Is your device using test mnemonic: %s ?", tests.TestMnemonic)
+		"Is your device using test mnemonic: %s ?", testutil.TestMnemonic)
 
 	pubKeyAddr, err := sdk.Bech32ifyPubKey(sdk.Bech32PubKeyTypeAccPub, priv.PubKey())
 	require.NoError(t, err)
 	require.Equal(t, "cosmospub1addwnpepqd87l8xhcnrrtzxnkql7k55ph8fr9jarf4hn6udwukfprlalu8lgw0urza0",
-		pubKeyAddr, "Is your device using test mnemonic: %s ?", tests.TestMnemonic)
+		pubKeyAddr, "Is your device using test mnemonic: %s ?", testutil.TestMnemonic)
 
 	require.Equal(t, "cosmos1w34k53py5v5xyluazqpq65agyajavep2rflq6h",
-		addr, "Is your device using test mnemonic: %s ?", tests.TestMnemonic)
+		addr, "Is your device using test mnemonic: %s ?", testutil.TestMnemonic)
 
 	addr2 := sdk.AccAddress(priv.PubKey().Address()).String()
 	require.Equal(t, addr, addr2)
@@ -167,7 +167,7 @@ func TestPublicKeyHDPath(t *testing.T) {
 		require.Equal(t, addr2, addr)
 		require.Equal(t,
 			expectedAddrs[i], addr,
-			"Is your device using test mnemonic: %s ?", tests.TestMnemonic)
+			"Is your device using test mnemonic: %s ?", testutil.TestMnemonic)
 
 		// Check other methods
 		require.NoError(t, priv.(PrivKeyLedgerSecp256k1).ValidateKey())
@@ -178,7 +178,7 @@ func TestPublicKeyHDPath(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t,
 			expectedPubKeys[i], pubKeyAddr,
-			"Is your device using test mnemonic: %s ?", tests.TestMnemonic)
+			"Is your device using test mnemonic: %s ?", testutil.TestMnemonic)
 
 		// Store and restore
 		serializedPk := priv.Bytes()
@@ -220,7 +220,7 @@ func TestSignaturesHD(t *testing.T) {
 		require.Nil(t, err)
 
 		valid := pub.VerifyBytes(msg, sig)
-		require.True(t, valid, "Is your device using test mnemonic: %s ?", tests.TestMnemonic)
+		require.True(t, valid, "Is your device using test mnemonic: %s ?", testutil.TestMnemonic)
 	}
 }
 

--- a/server/constructors_test.go
+++ b/server/constructors_test.go
@@ -6,12 +6,12 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/cosmos/cosmos-sdk/tests"
+	"github.com/cosmos/cosmos-sdk/testutil"
 )
 
 func Test_openDB(t *testing.T) {
 	t.Parallel()
-	dir, cleanup := tests.NewTestCaseDir(t)
+	dir, cleanup := testutil.NewTestCaseDir(t)
 	t.Cleanup(cleanup)
 	_, err := openDB(dir)
 	require.NoError(t, err)
@@ -19,7 +19,7 @@ func Test_openDB(t *testing.T) {
 
 func Test_openTraceWriter(t *testing.T) {
 	t.Parallel()
-	dir, cleanup := tests.NewTestCaseDir(t)
+	dir, cleanup := testutil.NewTestCaseDir(t)
 	t.Cleanup(cleanup)
 	fname := filepath.Join(dir, "logfile")
 	w, err := openTraceWriter(fname)

--- a/server/export_test.go
+++ b/server/export_test.go
@@ -21,13 +21,13 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/simapp"
-	"github.com/cosmos/cosmos-sdk/tests"
+	"github.com/cosmos/cosmos-sdk/testutil"
 	"github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/cosmos-sdk/x/genutil"
 )
 
 func TestExportCmd_ConsensusParams(t *testing.T) {
-	tempDir, clean := tests.NewTestCaseDir(t)
+	tempDir, clean := testutil.NewTestCaseDir(t)
 	defer clean()
 
 	err := createConfigFolder(tempDir)

--- a/server/init_test.go
+++ b/server/init_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/crypto/hd"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	"github.com/cosmos/cosmos-sdk/server"
-	"github.com/cosmos/cosmos-sdk/tests"
+	"github.com/cosmos/cosmos-sdk/testutil"
 	"github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -25,7 +25,7 @@ func TestGenerateCoinKey(t *testing.T) {
 
 func TestGenerateSaveCoinKey(t *testing.T) {
 	t.Parallel()
-	dir, cleanup := tests.NewTestCaseDir(t)
+	dir, cleanup := testutil.NewTestCaseDir(t)
 	t.Cleanup(cleanup)
 
 	kb, err := keyring.New(t.Name(), "test", dir, nil)
@@ -47,7 +47,7 @@ func TestGenerateSaveCoinKey(t *testing.T) {
 
 func TestGenerateSaveCoinKeyOverwriteFlag(t *testing.T) {
 	t.Parallel()
-	dir, cleanup := tests.NewTestCaseDir(t)
+	dir, cleanup := testutil.NewTestCaseDir(t)
 	t.Cleanup(cleanup)
 
 	kb, err := keyring.New(t.Name(), "test", dir, nil)

--- a/tests/util.go
+++ b/tests/util.go
@@ -2,13 +2,9 @@ package tests
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
-	"os"
-	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
 	rpchttp "github.com/tendermint/tendermint/rpc/client/http"
 	ctypes "github.com/tendermint/tendermint/rpc/core/types"
 
@@ -113,15 +109,6 @@ func WaitForStart(url string) {
 	}
 	// still haven't started up?! panic!
 	panic(err)
-}
-
-// NewTestCaseDir creates a new temporary directory for a test case.
-// Returns the directory path and a cleanup function.
-// nolint: errcheck
-func NewTestCaseDir(t testing.TB) (string, func()) {
-	dir, err := ioutil.TempDir("", t.Name()+"_")
-	require.NoError(t, err)
-	return dir, func() { os.RemoveAll(dir) }
 }
 
 var cdc = codec.New()

--- a/testutil/ioutil.go
+++ b/testutil/ioutil.go
@@ -31,7 +31,10 @@ func ApplyMockIO(c *cobra.Command) (*strings.Reader, *bytes.Buffer, *bytes.Buffe
 	return mockIn, mockOut, mockErr
 }
 
-// Write the given string to a new temporary file
+// Write the given string to a new temporary file.
+// Returns an open file and a clean up function that
+// the caller must call to remove the file when it is
+// no longer needed.
 func WriteToNewTempFile(t testing.TB, s string) (*os.File, func()) {
 	fp, err := ioutil.TempFile("", t.Name()+"_")
 	require.Nil(t, err)

--- a/testutil/ioutil_test.go
+++ b/testutil/ioutil_test.go
@@ -1,0 +1,55 @@
+package testutil_test
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cosmos/cosmos-sdk/testutil"
+)
+
+func TestNewTestCaseDir(t *testing.T) {
+	dir1, cleanup1 := testutil.NewTestCaseDir(t)
+	dir2, cleanup2 := testutil.NewTestCaseDir(t)
+
+	require.NotEqual(t, dir1, dir2)
+	require.DirExists(t, dir1)
+	require.DirExists(t, dir2)
+
+	cleanup1()
+
+	require.NoDirExists(t, dir1)
+	require.DirExists(t, dir2)
+
+	cleanup2()
+	require.NoDirExists(t, dir2)
+}
+
+func TestApplyMockIO(t *testing.T) {
+	cmd := &cobra.Command{}
+
+	oldStdin := cmd.InOrStdin()
+	oldStdout := cmd.OutOrStdout()
+	oldStderr := cmd.ErrOrStderr()
+
+	testutil.ApplyMockIO(cmd)
+
+	require.NotEqual(t, cmd.InOrStdin(), oldStdin)
+	require.NotEqual(t, cmd.OutOrStdout(), oldStdout)
+	require.NotEqual(t, cmd.ErrOrStderr(), oldStderr)
+}
+
+func TestWriteToNewTempFile(t *testing.T) {
+	tempfile, cleanup := testutil.WriteToNewTempFile(t, "test string")
+	tempfile.Close()
+
+	bs, err := ioutil.ReadFile(tempfile.Name())
+	require.NoError(t, err)
+	require.Equal(t, "test string", string(bs))
+
+	cleanup()
+
+	require.NoFileExists(t, tempfile.Name())
+}

--- a/testutil/known_values.go
+++ b/testutil/known_values.go
@@ -1,4 +1,4 @@
-package tests
+package testutil
 
 const (
 	// Tests expect a ledger device initialized to the following mnemonic

--- a/testutil/network/doc.go
+++ b/testutil/network/doc.go
@@ -1,14 +1,14 @@
 /*
-Package testutil implements and exposes a fully operational in-process Tendermint
+Package network implements and exposes a fully operational in-process Tendermint
 test network that consists of at least one or potentially many validators. This
 test network can be used primarily for integration tests or unit test suites.
 
-The testnetwork utilizes SimApp as the ABCI application and uses all the modules
+The test network utilizes SimApp as the ABCI application and uses all the modules
 defined in the Cosmos SDK. An in-process test network can be configured with any
 number of validators as well as account funds and even custom genesis state.
 
 When creating a test network, a series of Validator objects are returned. Each
-Validator object has useful information such as their address and pubkey. A
+Validator object has useful information such as their address and public key. A
 Validator will also provide its RPC, P2P, and API addresses that can be useful
 for integration testing. In addition, a Tendermint local RPC client is also provided
 which can be handy for making direct RPC calls to Tendermint.
@@ -35,7 +35,7 @@ A typical testing flow might look like the following:
 		cfg.NumValidators = 1
 
 		s.cfg = cfg
-		s.network = testutil.NewTestNetwork(s.T(), cfg)
+		s.network = testutil.New(s.T(), cfg)
 
 		_, err := s.network.WaitForHeight(1)
 		s.Require().NoError(err)
@@ -62,4 +62,4 @@ A typical testing flow might look like the following:
 		suite.Run(t, new(IntegrationTestSuite))
 	}
 */
-package testutil
+package network

--- a/testutil/network/network.go
+++ b/testutil/network/network.go
@@ -1,4 +1,4 @@
-package testutil
+package network
 
 import (
 	"bufio"
@@ -144,7 +144,7 @@ type (
 	}
 )
 
-func NewTestNetwork(t *testing.T, cfg Config) *Network {
+func New(t *testing.T, cfg Config) *Network {
 	// only one caller/test can create and use a network at a time
 	t.Log("acquiring test network lock")
 	lock.Lock()

--- a/testutil/network/network_test.go
+++ b/testutil/network/network_test.go
@@ -1,22 +1,24 @@
-package testutil
+package network_test
 
 import (
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/suite"
+
+	"github.com/cosmos/cosmos-sdk/testutil/network"
 )
 
 type IntegrationTestSuite struct {
 	suite.Suite
 
-	network *Network
+	network *network.Network
 }
 
 func (s *IntegrationTestSuite) SetupSuite() {
 	s.T().Log("setting up integration test suite")
 
-	s.network = NewTestNetwork(s.T(), DefaultConfig())
+	s.network = network.New(s.T(), network.DefaultConfig())
 	s.Require().NotNil(s.network)
 
 	_, err := s.network.WaitForHeight(1)

--- a/testutil/network/util.go
+++ b/testutil/network/util.go
@@ -1,4 +1,4 @@
-package testutil
+package network
 
 import (
 	"path/filepath"

--- a/testutil/temp.go
+++ b/testutil/temp.go
@@ -1,14 +1,24 @@
-package tests
+package testutil
 
 import (
 	"bytes"
 	"io/ioutil"
 	"os"
 	"strings"
+	"testing"
 
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 )
+
+// NewTestCaseDir creates a new temporary directory for a test case.
+// Returns the directory path and a cleanup function.
+// nolint: errcheck
+func NewTestCaseDir(t testing.TB) (string, func()) {
+	dir, err := ioutil.TempDir("", t.Name()+"_")
+	require.NoError(t, err)
+	return dir, func() { os.RemoveAll(dir) }
+}
 
 // ApplyMockIO replaces stdin/out/err with buffers that can be used during testing.
 func ApplyMockIO(c *cobra.Command) (*strings.Reader, *bytes.Buffer, *bytes.Buffer) {
@@ -22,8 +32,8 @@ func ApplyMockIO(c *cobra.Command) (*strings.Reader, *bytes.Buffer, *bytes.Buffe
 }
 
 // Write the given string to a new temporary file
-func WriteToNewTempFile(t require.TestingT, s string) (*os.File, func()) {
-	fp, err := ioutil.TempFile(os.TempDir(), "cosmos_cli_test_")
+func WriteToNewTempFile(t testing.TB, s string) (*os.File, func()) {
+	fp, err := ioutil.TempFile("", t.Name()+"_")
 	require.Nil(t, err)
 
 	_, err = fp.WriteString(s)
@@ -31,5 +41,3 @@ func WriteToNewTempFile(t require.TestingT, s string) (*os.File, func()) {
 
 	return fp, func() { os.Remove(fp.Name()) }
 }
-
-// DONTCOVER

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/tendermint/tendermint/libs/cli"
 
-	"github.com/cosmos/cosmos-sdk/tests"
+	"github.com/cosmos/cosmos-sdk/testutil"
 )
 
 func TestNewInfo(t *testing.T) {
@@ -40,7 +40,7 @@ go version go1.14 linux/amd64`
 
 func Test_runVersionCmd(t *testing.T) {
 	cmd := NewVersionCommand()
-	_, mockOut, _ := tests.ApplyMockIO(cmd)
+	_, mockOut, _ := testutil.ApplyMockIO(cmd)
 
 	cmd.SetArgs([]string{
 		fmt.Sprintf("--%s=''", cli.OutputFlag),

--- a/x/auth/client/cli/broadcast_test.go
+++ b/x/auth/client/cli/broadcast_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	simappparams "github.com/cosmos/cosmos-sdk/simapp/params"
-	"github.com/cosmos/cosmos-sdk/tests"
+	"github.com/cosmos/cosmos-sdk/testutil"
 )
 
 func TestGetBroadcastCommand_OfflineFlag(t *testing.T) {
@@ -31,7 +31,7 @@ func TestGetBroadcastCommand_WithoutOfflineFlag(t *testing.T) {
 	clientCtx = clientCtx.WithTxGenerator(simappparams.MakeEncodingConfig().TxGenerator)
 	cmd := GetBroadcastCommand(clientCtx)
 
-	testDir, cleanFunc := tests.NewTestCaseDir(t)
+	testDir, cleanFunc := testutil.NewTestCaseDir(t)
 	t.Cleanup(cleanFunc)
 
 	// Create new file with tx

--- a/x/auth/client/cli/cli_test.go
+++ b/x/auth/client/cli/cli_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/tests"
 	"github.com/cosmos/cosmos-sdk/tests/cli"
+	sdktestutil "github.com/cosmos/cosmos-sdk/testutil"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/auth/client/testutil"
 	bankcli "github.com/cosmos/cosmos-sdk/x/bank/client/testutil"
@@ -37,7 +38,7 @@ func TestCLIValidateSignatures(t *testing.T) {
 	require.Empty(t, stderr)
 
 	// write  unsigned tx to file
-	unsignedTxFile, cleanup := tests.WriteToNewTempFile(t, stdout)
+	unsignedTxFile, cleanup := sdktestutil.WriteToNewTempFile(t, stdout)
 	t.Cleanup(cleanup)
 
 	// validate we can successfully sign
@@ -51,7 +52,7 @@ func TestCLIValidateSignatures(t *testing.T) {
 	require.Equal(t, fooAddr.String(), stdTx.GetSigners()[0].String())
 
 	// write signed tx to file
-	signedTxFile, cleanup := tests.WriteToNewTempFile(t, stdout)
+	signedTxFile, cleanup := sdktestutil.WriteToNewTempFile(t, stdout)
 	t.Cleanup(cleanup)
 
 	// validate signatures
@@ -61,7 +62,7 @@ func TestCLIValidateSignatures(t *testing.T) {
 	// modify the transaction
 	stdTx.Memo = "MODIFIED-ORIGINAL-TX-BAD"
 	bz := cli.MarshalStdTx(t, f.Cdc, stdTx)
-	modSignedTxFile, cleanup := tests.WriteToNewTempFile(t, string(bz))
+	modSignedTxFile, cleanup := sdktestutil.WriteToNewTempFile(t, string(bz))
 	t.Cleanup(cleanup)
 
 	// validate signature validation failure due to different transaction sig bytes
@@ -87,7 +88,7 @@ func TestCLISignBatch(t *testing.T) {
 	require.Empty(t, stderr)
 
 	// Write the output to disk
-	batchfile, cleanup1 := tests.WriteToNewTempFile(t, strings.Repeat(generatedStdTx, 3))
+	batchfile, cleanup1 := sdktestutil.WriteToNewTempFile(t, strings.Repeat(generatedStdTx, 3))
 	t.Cleanup(cleanup1)
 
 	// sign-batch file - offline is set but account-number and sequence are not
@@ -107,7 +108,7 @@ func TestCLISignBatch(t *testing.T) {
 	require.Empty(t, stderr)
 	require.Equal(t, 3, len(strings.Split(strings.Trim(stdout, "\n"), "\n")))
 
-	malformedFile, cleanup2 := tests.WriteToNewTempFile(t, fmt.Sprintf("%smalformed", generatedStdTx))
+	malformedFile, cleanup2 := sdktestutil.WriteToNewTempFile(t, fmt.Sprintf("%smalformed", generatedStdTx))
 	t.Cleanup(cleanup2)
 
 	// sign-batch file
@@ -165,7 +166,7 @@ func TestCLISendGenerateSignAndBroadcast(t *testing.T) {
 	require.Equal(t, len(msg.Msgs), 1)
 
 	// Write the output to disk
-	unsignedTxFile, cleanup := tests.WriteToNewTempFile(t, stdout)
+	unsignedTxFile, cleanup := sdktestutil.WriteToNewTempFile(t, stdout)
 	t.Cleanup(cleanup)
 
 	// Test validate-signatures
@@ -193,7 +194,7 @@ func TestCLISendGenerateSignAndBroadcast(t *testing.T) {
 	require.Equal(t, fooAddr.String(), msg.GetSigners()[0].String())
 
 	// Write the output to disk
-	signedTxFile, cleanup := tests.WriteToNewTempFile(t, stdout)
+	signedTxFile, cleanup := sdktestutil.WriteToNewTempFile(t, stdout)
 	t.Cleanup(cleanup)
 
 	// Test validate-signatures
@@ -247,7 +248,7 @@ func TestCLIMultisignInsufficientCosigners(t *testing.T) {
 	require.True(t, success)
 
 	// Write the output to disk
-	unsignedTxFile, cleanup := tests.WriteToNewTempFile(t, stdout)
+	unsignedTxFile, cleanup := sdktestutil.WriteToNewTempFile(t, stdout)
 	t.Cleanup(cleanup)
 
 	// Sign with foo's key
@@ -255,7 +256,7 @@ func TestCLIMultisignInsufficientCosigners(t *testing.T) {
 	require.True(t, success)
 
 	// Write the output to disk
-	fooSignatureFile, cleanup := tests.WriteToNewTempFile(t, stdout)
+	fooSignatureFile, cleanup := sdktestutil.WriteToNewTempFile(t, stdout)
 	t.Cleanup(cleanup)
 
 	// Multisign, not enough signatures
@@ -263,7 +264,7 @@ func TestCLIMultisignInsufficientCosigners(t *testing.T) {
 	require.True(t, success)
 
 	// Write the output to disk
-	signedTxFile, cleanup := tests.WriteToNewTempFile(t, stdout)
+	signedTxFile, cleanup := sdktestutil.WriteToNewTempFile(t, stdout)
 	t.Cleanup(cleanup)
 
 	// Validate the multisignature
@@ -298,7 +299,7 @@ func TestCLIEncode(t *testing.T) {
 	require.Empty(t, stderr)
 
 	// Write it to disk
-	jsonTxFile, cleanup := tests.WriteToNewTempFile(t, stdout)
+	jsonTxFile, cleanup := sdktestutil.WriteToNewTempFile(t, stdout)
 	t.Cleanup(cleanup)
 
 	// Run the encode command
@@ -336,7 +337,7 @@ func TestCLIMultisignSortSignatures(t *testing.T) {
 	require.True(t, success)
 
 	// Write the output to disk
-	unsignedTxFile, cleanup := tests.WriteToNewTempFile(t, stdout)
+	unsignedTxFile, cleanup := sdktestutil.WriteToNewTempFile(t, stdout)
 	t.Cleanup(cleanup)
 
 	// Sign with foo's key
@@ -344,7 +345,7 @@ func TestCLIMultisignSortSignatures(t *testing.T) {
 	require.True(t, success)
 
 	// Write the output to disk
-	fooSignatureFile, cleanup := tests.WriteToNewTempFile(t, stdout)
+	fooSignatureFile, cleanup := sdktestutil.WriteToNewTempFile(t, stdout)
 	t.Cleanup(cleanup)
 
 	// Sign with baz's key
@@ -352,7 +353,7 @@ func TestCLIMultisignSortSignatures(t *testing.T) {
 	require.True(t, success)
 
 	// Write the output to disk
-	bazSignatureFile, cleanup := tests.WriteToNewTempFile(t, stdout)
+	bazSignatureFile, cleanup := sdktestutil.WriteToNewTempFile(t, stdout)
 	t.Cleanup(cleanup)
 
 	// Multisign, keys in different order
@@ -361,7 +362,7 @@ func TestCLIMultisignSortSignatures(t *testing.T) {
 	require.True(t, success)
 
 	// Write the output to disk
-	signedTxFile, cleanup := tests.WriteToNewTempFile(t, stdout)
+	signedTxFile, cleanup := sdktestutil.WriteToNewTempFile(t, stdout)
 	t.Cleanup(cleanup)
 
 	// Validate the multisignature
@@ -402,7 +403,7 @@ func TestCLIMultisign(t *testing.T) {
 	require.Empty(t, stderr)
 
 	// Write the output to disk
-	unsignedTxFile, cleanup := tests.WriteToNewTempFile(t, stdout)
+	unsignedTxFile, cleanup := sdktestutil.WriteToNewTempFile(t, stdout)
 	t.Cleanup(cleanup)
 
 	// Sign with foo's key
@@ -410,7 +411,7 @@ func TestCLIMultisign(t *testing.T) {
 	require.True(t, success)
 
 	// Write the output to disk
-	fooSignatureFile, cleanup := tests.WriteToNewTempFile(t, stdout)
+	fooSignatureFile, cleanup := sdktestutil.WriteToNewTempFile(t, stdout)
 	t.Cleanup(cleanup)
 
 	// Sign with bar's key
@@ -418,7 +419,7 @@ func TestCLIMultisign(t *testing.T) {
 	require.True(t, success)
 
 	// Write the output to disk
-	barSignatureFile, cleanup := tests.WriteToNewTempFile(t, stdout)
+	barSignatureFile, cleanup := sdktestutil.WriteToNewTempFile(t, stdout)
 	t.Cleanup(cleanup)
 
 	// Multisign
@@ -435,7 +436,7 @@ func TestCLIMultisign(t *testing.T) {
 	require.True(t, success)
 
 	// Write the output to disk
-	signedTxFile, cleanup := tests.WriteToNewTempFile(t, stdout)
+	signedTxFile, cleanup := sdktestutil.WriteToNewTempFile(t, stdout)
 	t.Cleanup(cleanup)
 
 	// Validate the multisignature

--- a/x/auth/client/cli/encode_test.go
+++ b/x/auth/client/cli/encode_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/client"
 	simappparams "github.com/cosmos/cosmos-sdk/simapp/params"
-	"github.com/cosmos/cosmos-sdk/tests"
+	"github.com/cosmos/cosmos-sdk/testutil"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 )
@@ -35,7 +35,7 @@ func TestGetCommandEncode(t *testing.T) {
 	JSONEncoded, err := txGen.TxJSONEncoder()(stdTx)
 	require.NoError(t, err)
 
-	txFile, cleanup := tests.WriteToNewTempFile(t, string(JSONEncoded))
+	txFile, cleanup := testutil.WriteToNewTempFile(t, string(JSONEncoded))
 	txFileName := txFile.Name()
 	t.Cleanup(cleanup)
 

--- a/x/auth/client/tx_test.go
+++ b/x/auth/client/tx_test.go
@@ -3,12 +3,11 @@ package client
 import (
 	"encoding/json"
 	"errors"
-	"io/ioutil"
-	"os"
 	"strings"
 	"testing"
 
 	"github.com/cosmos/cosmos-sdk/codec/testdata"
+	"github.com/cosmos/cosmos-sdk/testutil"
 
 	simappparams "github.com/cosmos/cosmos-sdk/simapp/params"
 
@@ -139,8 +138,8 @@ func TestReadStdTxFromFile(t *testing.T) {
 	// Write it to the file
 	encodedTx, err := txGen.TxJSONEncoder()(stdTx)
 	require.NoError(t, err)
-	jsonTxFile := writeToNewTempFile(t, string(encodedTx))
-	defer os.Remove(jsonTxFile.Name())
+	jsonTxFile, cleanup := testutil.WriteToNewTempFile(t, string(encodedTx))
+	t.Cleanup(cleanup)
 
 	// Read it back
 	decodedTx, err := ReadTxFromFile(clientCtx, jsonTxFile.Name())
@@ -247,16 +246,6 @@ func TestPrepareTxBuilder(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, accNum, bldr.AccountNumber())
 	require.Equal(t, accSeq, bldr.Sequence())
-}
-
-func writeToNewTempFile(t *testing.T, data string) *os.File {
-	fp, err := ioutil.TempFile(os.TempDir(), "client_tx_test")
-	require.NoError(t, err)
-
-	_, err = fp.WriteString(data)
-	require.NoError(t, err)
-
-	return fp
 }
 
 func makeCodec() *codec.Codec {

--- a/x/bank/client/cli/cli_test.go
+++ b/x/bank/client/cli/cli_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
-	"github.com/cosmos/cosmos-sdk/testutil"
+	"github.com/cosmos/cosmos-sdk/testutil/network"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/cosmos-sdk/x/bank/client/cli"
@@ -20,18 +20,18 @@ import (
 type IntegrationTestSuite struct {
 	suite.Suite
 
-	cfg     testutil.Config
-	network *testutil.Network
+	cfg     network.Config
+	network *network.Network
 }
 
 func (s *IntegrationTestSuite) SetupSuite() {
 	s.T().Log("setting up integration test suite")
 
-	cfg := testutil.DefaultConfig()
+	cfg := network.DefaultConfig()
 	cfg.NumValidators = 1
 
 	s.cfg = cfg
-	s.network = testutil.NewTestNetwork(s.T(), cfg)
+	s.network = network.New(s.T(), cfg)
 
 	_, err := s.network.WaitForHeight(1)
 	s.Require().NoError(err)

--- a/x/bank/client/rest/query_test.go
+++ b/x/bank/client/rest/query_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/suite"
 
-	"github.com/cosmos/cosmos-sdk/testutil"
+	"github.com/cosmos/cosmos-sdk/testutil/network"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/rest"
 )
@@ -14,18 +14,18 @@ import (
 type IntegrationTestSuite struct {
 	suite.Suite
 
-	cfg     testutil.Config
-	network *testutil.Network
+	cfg     network.Config
+	network *network.Network
 }
 
 func (s *IntegrationTestSuite) SetupSuite() {
 	s.T().Log("setting up integration test suite")
 
-	cfg := testutil.DefaultConfig()
+	cfg := network.DefaultConfig()
 	cfg.NumValidators = 1
 
 	s.cfg = cfg
-	s.network = testutil.NewTestNetwork(s.T(), cfg)
+	s.network = network.New(s.T(), cfg)
 
 	_, err := s.network.WaitForHeight(1)
 	s.Require().NoError(err)

--- a/x/bank/client/rest/tx_test.go
+++ b/x/bank/client/rest/tx_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/cosmos/cosmos-sdk/simapp"
-	"github.com/cosmos/cosmos-sdk/testutil"
+	"github.com/cosmos/cosmos-sdk/testutil/network"
 	"github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/cosmos-sdk/types/rest"
@@ -41,7 +41,7 @@ func (s *IntegrationTestSuite) TestCoinSend() {
 	}, stdTx.GetMsgs())
 }
 
-func submitSendReq(val *testutil.Validator, req bankrest.SendReq) (authtypes.StdTx, error) {
+func submitSendReq(val *network.Validator, req bankrest.SendReq) (authtypes.StdTx, error) {
 	url := fmt.Sprintf("%s/bank/accounts/%s/transfers", val.APIAddress, val.Address)
 
 	bz, err := val.ClientCtx.JSONMarshaler.MarshalJSON(req)
@@ -83,7 +83,7 @@ func generateSendReq(from authtypes.AccountI, amount types.Coins) bankrest.SendR
 	}
 }
 
-func getAccountInfo(val *testutil.Validator) (authtypes.AccountI, error) {
+func getAccountInfo(val *network.Validator) (authtypes.AccountI, error) {
 	url := fmt.Sprintf("%s/auth/accounts/%s", val.APIAddress, val.Address)
 
 	resp, err := rest.GetRequest(url)

--- a/x/crisis/client/cli/cli_test.go
+++ b/x/crisis/client/cli/cli_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
-	"github.com/cosmos/cosmos-sdk/testutil"
+	"github.com/cosmos/cosmos-sdk/testutil/network"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/crisis/client/cli"
 )
@@ -18,18 +18,18 @@ import (
 type IntegrationTestSuite struct {
 	suite.Suite
 
-	cfg     testutil.Config
-	network *testutil.Network
+	cfg     network.Config
+	network *network.Network
 }
 
 func (s *IntegrationTestSuite) SetupSuite() {
 	s.T().Log("setting up integration test suite")
 
-	cfg := testutil.DefaultConfig()
+	cfg := network.DefaultConfig()
 	cfg.NumValidators = 1
 
 	s.cfg = cfg
-	s.network = testutil.NewTestNetwork(s.T(), cfg)
+	s.network = network.New(s.T(), cfg)
 
 	_, err := s.network.WaitForHeight(1)
 	s.Require().NoError(err)

--- a/x/distribution/client/cli/tx_test.go
+++ b/x/distribution/client/cli/tx_test.go
@@ -1,10 +1,10 @@
 package cli
 
 import (
-	"io/ioutil"
 	"testing"
 
 	"github.com/cosmos/cosmos-sdk/codec/testdata"
+	"github.com/cosmos/cosmos-sdk/testutil"
 
 	"github.com/stretchr/testify/require"
 
@@ -64,9 +64,7 @@ func Test_splitAndCall_Splitting(t *testing.T) {
 
 func TestParseProposal(t *testing.T) {
 	cdc := codec.New()
-	okJSON, err := ioutil.TempFile("", "proposal")
-	require.Nil(t, err, "unexpected error")
-	_, err = okJSON.WriteString(`
+	okJSON, cleanup := testutil.WriteToNewTempFile(t, `
 {
   "title": "Community Pool Spend",
   "description": "Pay me some Atoms!",
@@ -75,7 +73,7 @@ func TestParseProposal(t *testing.T) {
   "deposit": "1000stake"
 }
 `)
-	require.NoError(t, err)
+	t.Cleanup(cleanup)
 
 	proposal, err := ParseCommunityPoolSpendProposalJSON(cdc, okJSON.Name())
 	require.NoError(t, err)

--- a/x/genutil/client/cli/init_test.go
+++ b/x/genutil/client/cli/init_test.go
@@ -21,7 +21,7 @@ import (
 	cryptocodec "github.com/cosmos/cosmos-sdk/crypto/codec"
 	"github.com/cosmos/cosmos-sdk/server"
 	"github.com/cosmos/cosmos-sdk/server/mock"
-	"github.com/cosmos/cosmos-sdk/tests"
+	"github.com/cosmos/cosmos-sdk/testutil"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	"github.com/cosmos/cosmos-sdk/x/genutil"
@@ -42,7 +42,7 @@ func createDefaultTendermintConfig(rootDir string) (*tmcfg.Config, error) {
 }
 
 func TestInitCmd(t *testing.T) {
-	home, cleanup := tests.NewTestCaseDir(t)
+	home, cleanup := testutil.NewTestCaseDir(t)
 	t.Cleanup(cleanup)
 
 	logger := log.NewNopLogger()
@@ -63,7 +63,7 @@ func TestInitCmd(t *testing.T) {
 }
 
 func setupClientHome(t *testing.T) func() {
-	clientDir, cleanup := tests.NewTestCaseDir(t)
+	clientDir, cleanup := testutil.NewTestCaseDir(t)
 	viper.Set(cli.HomeFlag, clientDir)
 	return cleanup
 }
@@ -71,7 +71,7 @@ func setupClientHome(t *testing.T) func() {
 func TestEmptyState(t *testing.T) {
 	t.Cleanup(setupClientHome(t))
 
-	home, cleanup := tests.NewTestCaseDir(t)
+	home, cleanup := testutil.NewTestCaseDir(t)
 	t.Cleanup(cleanup)
 
 	logger := log.NewNopLogger()
@@ -117,7 +117,7 @@ func TestEmptyState(t *testing.T) {
 }
 
 func TestStartStandAlone(t *testing.T) {
-	home, cleanup := tests.NewTestCaseDir(t)
+	home, cleanup := testutil.NewTestCaseDir(t)
 	t.Cleanup(cleanup)
 	t.Cleanup(setupClientHome(t))
 
@@ -159,7 +159,7 @@ func TestStartStandAlone(t *testing.T) {
 }
 
 func TestInitNodeValidatorFiles(t *testing.T) {
-	home, cleanup := tests.NewTestCaseDir(t)
+	home, cleanup := testutil.NewTestCaseDir(t)
 	cfg, err := createDefaultTendermintConfig(home)
 	t.Cleanup(cleanup)
 	nodeID, valPubKey, err := genutil.InitializeNodeValidatorFiles(cfg)

--- a/x/genutil/client/cli/migrate_test.go
+++ b/x/genutil/client/cli/migrate_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/cosmos/cosmos-sdk/client"
-	"github.com/cosmos/cosmos-sdk/tests"
+	"github.com/cosmos/cosmos-sdk/testutil"
 )
 
 func TestGetMigrationCallback(t *testing.T) {
@@ -19,7 +19,7 @@ func TestGetMigrationCallback(t *testing.T) {
 }
 
 func TestMigrateGenesis(t *testing.T) {
-	home, cleanup := tests.NewTestCaseDir(t)
+	home, cleanup := testutil.NewTestCaseDir(t)
 	t.Cleanup(cleanup)
 
 	cdc := makeCodec()

--- a/x/genutil/utils_test.go
+++ b/x/genutil/utils_test.go
@@ -6,14 +6,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cosmos/cosmos-sdk/tests"
+	"github.com/cosmos/cosmos-sdk/testutil"
 
 	"github.com/stretchr/testify/require"
 )
 
 func TestExportGenesisFileWithTime(t *testing.T) {
 	t.Parallel()
-	dir, cleanup := tests.NewTestCaseDir(t)
+	dir, cleanup := testutil.NewTestCaseDir(t)
 	t.Cleanup(cleanup)
 
 	fname := filepath.Join(dir, "genesis.json")

--- a/x/gov/client/cli/parse_test.go
+++ b/x/gov/client/cli/parse_test.go
@@ -1,18 +1,16 @@
 package cli
 
 import (
-	"io/ioutil"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/testutil"
 )
 
 func TestParseSubmitProposalFlags(t *testing.T) {
-	okJSON, err := ioutil.TempFile("", "proposal")
-	require.Nil(t, err, "unexpected error")
-	_, err = okJSON.WriteString(`
+	okJSON, cleanup1 := testutil.WriteToNewTempFile(t, `
 {
   "title": "Test Proposal",
   "description": "My awesome proposal",
@@ -20,17 +18,16 @@ func TestParseSubmitProposalFlags(t *testing.T) {
   "deposit": "1000test"
 }
 `)
-	require.NoError(t, err)
+	t.Cleanup(cleanup1)
 
-	badJSON, err := ioutil.TempFile("", "proposal")
-	require.Nil(t, err, "unexpected error")
-	badJSON.WriteString("bad json")
+	badJSON, cleanup2 := testutil.WriteToNewTempFile(t, "bad json")
+	t.Cleanup(cleanup2)
 
 	fs := NewCmdSubmitProposal(client.Context{}).Flags()
 
 	// nonexistent json
 	fs.Set(FlagProposal, "fileDoesNotExist")
-	_, err = parseSubmitProposalFlags(fs)
+	_, err := parseSubmitProposalFlags(fs)
 	require.Error(t, err)
 
 	// invalid json

--- a/x/params/client/cli/tx_test.go
+++ b/x/params/client/cli/tx_test.go
@@ -1,20 +1,18 @@
 package cli
 
 import (
-	"io/ioutil"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/testutil"
 	"github.com/cosmos/cosmos-sdk/x/params/client/utils"
 )
 
 func TestParseProposal(t *testing.T) {
 	cdc := codec.New()
-	okJSON, err := ioutil.TempFile("", "proposal")
-	require.Nil(t, err, "unexpected error")
-	_, err = okJSON.WriteString(`
+	okJSON, cleanup := testutil.WriteToNewTempFile(t, `
 {
   "title": "Staking Param Change",
   "description": "Update max validators",
@@ -28,7 +26,7 @@ func TestParseProposal(t *testing.T) {
   "deposit": "1000stake"
 }
 `)
-	require.NoError(t, err)
+	t.Cleanup(cleanup)
 
 	proposal, err := utils.ParseParamChangeProposalJSON(cdc, okJSON.Name())
 	require.NoError(t, err)

--- a/x/upgrade/types/storeloader_test.go
+++ b/x/upgrade/types/storeloader_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/store/rootmulti"
 	store "github.com/cosmos/cosmos-sdk/store/types"
-	"github.com/cosmos/cosmos-sdk/tests"
+	"github.com/cosmos/cosmos-sdk/testutil"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -66,7 +66,7 @@ func checkStore(t *testing.T, db dbm.DB, ver int64, storeKey string, k, v []byte
 // Test that LoadLatestVersion actually does.
 func TestSetLoader(t *testing.T) {
 	// set a temporary home dir
-	homeDir, cleanup := tests.NewTestCaseDir(t)
+	homeDir, cleanup := testutil.NewTestCaseDir(t)
 	t.Cleanup(cleanup)
 
 	upgradeInfoFilePath := filepath.Join(homeDir, "upgrade-info.json")


### PR DESCRIPTION
Prepare migrating testing auxiliary functions from tests
to testutil.

Remove local duplicates on testutil.WriteToNewTempFile().

Always favor testutil.NewTestCaseDir() over ioutil.TempDir().

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
