### PR TITLE
types: fix invalid int->string conversion in benchmarks

### DIFF
--- a/types/coin_benchmark_test.go
+++ b/types/coin_benchmark_test.go
@@ -5,6 +5,10 @@ import (
 	"testing"
 )
 
+func coinName(suffix int) string {
+	return fmt.Sprintf("COINZ_%d", suffix)
+}
+
 func BenchmarkCoinsAdditionIntersect(b *testing.B) {
 	benchmarkingFunc := func(numCoinsA int, numCoinsB int) func(b *testing.B) {
 		return func(b *testing.B) {
@@ -12,10 +16,10 @@ func BenchmarkCoinsAdditionIntersect(b *testing.B) {
 			coinsB := Coins(make([]Coin, numCoinsB))
 
 			for i := 0; i < numCoinsA; i++ {
-				coinsA[i] = NewCoin("COINZ_"+string(i), NewInt(int64(i)))
+				coinsA[i] = NewCoin(coinName(i), NewInt(int64(i)))
 			}
 			for i := 0; i < numCoinsB; i++ {
-				coinsB[i] = NewCoin("COINZ_"+string(i), NewInt(int64(i)))
+				coinsB[i] = NewCoin(coinName(i), NewInt(int64(i)))
 			}
 
 			b.ResetTimer()
@@ -41,10 +45,10 @@ func BenchmarkCoinsAdditionNoIntersect(b *testing.B) {
 			coinsB := Coins(make([]Coin, numCoinsB))
 
 			for i := 0; i < numCoinsA; i++ {
-				coinsA[i] = NewCoin("COINZ_"+string(numCoinsB+i), NewInt(int64(i)))
+				coinsA[i] = NewCoin(coinName(numCoinsB+i), NewInt(int64(i)))
 			}
 			for i := 0; i < numCoinsB; i++ {
-				coinsB[i] = NewCoin("COINZ_"+string(i), NewInt(int64(i)))
+				coinsB[i] = NewCoin(coinName(i), NewInt(int64(i)))
 			}
 
 			b.ResetTimer()


### PR DESCRIPTION
Fixes an invalid int->string conversion that will become
a vet error for Go1.15. The correct conversion was to use

    fmt.Sprintf("COINZ_%d", i)

instead of

    "COINZ_" + string(i)

Noticed during a coverage audit.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [X] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [X] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [X] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [X] Re-reviewed `Files changed` in the Github PR explorer
- [X] Review `Codecov Report` in the comment section below once CI passes
