### PR TITLE
rootmulti/internal/maps: remove duplicated code, simplify and speed up KVPPair

### DIFF
--- a/store/rootmulti/internal/maps/bench_test.go
+++ b/store/rootmulti/internal/maps/bench_test.go
@@ -1,0 +1,13 @@
+package maps
+
+import "testing"
+
+func BenchmarkKVPairBytes(b *testing.B) {
+	kvp := NewKVPair(make([]byte, 128), make([]byte, 1e6))
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		b.SetBytes(int64(len(kvp.Bytes())))
+	}
+}


### PR DESCRIPTION
Noticed during an audit, we've got duplicated code that's unused.
There were 2 type definitions:
* type kvPair types.Pair
* type KVPair types.Pair

and each had a .bytes() and .Bytes() method respectively that
then used some extra code.

This change deletes the duplicated/unnecessary code but also
while here improves the performance by removing the use of a
bytes.Buffer which is unnecessary given that we are only
length prefixed the key, length prefixing the value hence
the various helpers are unnecessary.

The added benchmarks shows the performance boost
```shell
$ benchstat before after
name           old time/op    new time/op    delta
KVPairBytes-8     146µs ± 1%     142µs ± 2%   -3.05%  (p=0.000 n=18+17)

name           old speed      new speed      delta
KVPairBytes-8  6.84GB/s ± 1%  7.06GB/s ± 2%   +3.15%  (p=0.000 n=18+17)

name           old alloc/op   new alloc/op   delta
KVPairBytes-8    1.01MB ± 0%    1.01MB ± 0%   -0.04%  (p=0.000 n=17+20)

name           old allocs/op  new allocs/op  delta
KVPairBytes-8      6.00 ± 0%      1.00 ± 0%  -83.33%  (p=0.000 n=20+20)
```

Fixes #6688

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [X] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [X] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [X] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [X] Re-reviewed `Files changed` in the Github PR explorer
- [X] Review `Codecov Report` in the comment section below once CI passes
