### PR TITLE
types: precisely simplify Coins.safeAdd

### DIFF
--- a/types/coin_test.go
+++ b/types/coin_test.go
@@ -290,6 +290,7 @@ func TestAddCoins(t *testing.T) {
 		{Coins{{testDenom1, zero}, {testDenom2, one}}, Coins{{testDenom1, zero}, {testDenom2, zero}}, Coins{{testDenom2, one}}},
 		{Coins{{testDenom1, two}}, Coins{{testDenom2, zero}}, Coins{{testDenom1, two}}},
 		{Coins{{testDenom1, one}}, Coins{{testDenom1, one}, {testDenom2, two}}, Coins{{testDenom1, two}, {testDenom2, two}}},
+		{Coins{{testDenom1, one}, {testDenom2, two}}, Coins{{testDenom1, one}}, Coins{{testDenom1, two}, {testDenom2, two}}},
 		{Coins{{testDenom1, zero}, {testDenom2, zero}}, Coins{{testDenom1, zero}, {testDenom2, zero}}, Coins(nil)},
 	}
 


### PR DESCRIPTION
Noticed during an audit that the logic for Coins.safeAdd is quite
complex and hard to check for correctness, except by looking
at the tests -- this is elusive and brittle.

Following the word description of the algorithm aka

    Our goal is to add 2 slices of coins of various denominations

the problem then directly translates to adding up coins whose
denominations match, thus a map grouping problem.

Fixes #6727

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [X] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [X] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [X] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [X] Re-reviewed `Files changed` in the Github PR explorer
- [X] Review `Codecov Report` in the comment section below once CI passes
