### PR TITLE
x/auth/signing/direct: increase test coverage to 100% from 83.3%

### DIFF
--- a/x/auth/signing/direct/direct_test.go
+++ b/x/auth/signing/direct/direct_test.go
@@ -1,6 +1,7 @@
 package direct_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/cosmos/cosmos-sdk/x/auth/tx"
@@ -136,4 +137,39 @@ func TestDirectModeHandler(t *testing.T) {
 	expectedSignBytes, err = signDoc.Marshal()
 	require.NoError(t, err)
 	require.NotEqual(t, expectedSignBytes, signBytes)
+}
+
+func TestDirectModeHandler_nonDIRECT_MODE(t *testing.T) {
+	invalidModes := []signingtypes.SignMode{
+		signingtypes.SignMode_SIGN_MODE_TEXTUAL,
+		signingtypes.SignMode_SIGN_MODE_LEGACY_AMINO_JSON,
+		signingtypes.SignMode_SIGN_MODE_UNSPECIFIED,
+	}
+	for _, invalidMode := range invalidModes {
+		t.Run(invalidMode.String(), func(t *testing.T) {
+			var dh direct.ModeHandler
+			var signingData signing.SignerData
+			_, err := dh.GetSignBytes(invalidMode, signingData, nil)
+			require.Error(t, err)
+			wantErr := fmt.Errorf("expected %s, got %s", signingtypes.SignMode_SIGN_MODE_DIRECT, invalidMode)
+			require.Equal(t, err, wantErr)
+		})
+	}
+}
+
+type nonProtoTx int
+
+func (npt *nonProtoTx) GetMsgs() []sdk.Msg   { return nil }
+func (npt *nonProtoTx) ValidateBasic() error { return nil }
+
+var _ sdk.Tx = (*nonProtoTx)(nil)
+
+func TestDirectModeHandler_nonProtoTx(t *testing.T) {
+	var dh direct.ModeHandler
+	var signingData signing.SignerData
+	tx := new(nonProtoTx)
+	_, err := dh.GetSignBytes(signingtypes.SignMode_SIGN_MODE_DIRECT, signingData, tx)
+	require.Error(t, err)
+	wantErr := fmt.Errorf("can only get direct sign bytes for a ProtoTx, got %T", tx)
+	require.Equal(t, err, wantErr)
 }


### PR DESCRIPTION
Ensure that all known routes for GetSignBytes are explored for
DirectHandler.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [X] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [X] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [X] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [X] Re-reviewed `Files changed` in the Github PR explorer
- [X] Review `Codecov Report` in the comment section below once CI passes
