### PR TITLE
crypto: move ledger code to its own subfolder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,6 +150,7 @@ be used to retrieve the actual proposal `Content`. Also the `NewMsgSubmitProposa
   * `SignatureVerificationGasConsumer` now has the signature: `func(meter sdk.GasMeter, sig signing.SignatureV2, params types.Params) error`.
   * The `SigVerifiableTx` interface now has a `GetSignaturesV2() ([]signing.SignatureV2, error)` method and no longer has the `GetSignBytes` method.
 * (client/flags) [\#6632](https://github.com/cosmos/cosmos-sdk/pull/6632) Remove NewCompletionCmd(), the function is now available in tendermint.
+* (crypto) [\#6780](https://github.com/cosmos/cosmos-sdk/issues/6780) Move ledger code to its own package.
 
 ### Features
 

--- a/client/keys/show.go
+++ b/client/keys/show.go
@@ -9,8 +9,8 @@ import (
 	"github.com/tendermint/tendermint/libs/cli"
 
 	"github.com/cosmos/cosmos-sdk/client/flags"
-	"github.com/cosmos/cosmos-sdk/crypto"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
+	"github.com/cosmos/cosmos-sdk/crypto/ledger"
 	"github.com/cosmos/cosmos-sdk/crypto/types/multisig"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
@@ -140,7 +140,7 @@ func runShowCmd(cmd *cobra.Command, args []string) (err error) {
 			return nil
 		}
 
-		return crypto.LedgerShowAddress(*hdpath, info.GetPubKey(), sdk.GetConfig().GetBech32AccountAddrPrefix())
+		return ledger.ShowAddress(*hdpath, info.GetPubKey(), sdk.GetConfig().GetBech32AccountAddrPrefix())
 	}
 
 	return nil

--- a/crypto/keyring/keyring.go
+++ b/crypto/keyring/keyring.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/input"
 	"github.com/cosmos/cosmos-sdk/crypto"
 	"github.com/cosmos/cosmos-sdk/crypto/hd"
+	"github.com/cosmos/cosmos-sdk/crypto/ledger"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
@@ -350,7 +351,7 @@ func (ks keystore) SaveLedgerKey(uid string, algo SignatureAlgo, hrp string, coi
 
 	hdPath := hd.NewFundraiserParams(account, coinType, index)
 
-	priv, _, err := crypto.NewPrivKeyLedgerSecp256k1(*hdPath, hrp)
+	priv, _, err := ledger.NewPrivKeySecp256k1(*hdPath, hrp)
 	if err != nil {
 		return nil, err
 	}
@@ -544,7 +545,7 @@ func SignWithLedger(info Info, msg []byte) (sig []byte, pub tmcrypto.PubKey, err
 		return
 	}
 
-	priv, err := crypto.NewPrivKeyLedgerSecp256k1Unsafe(*path)
+	priv, err := ledger.NewPrivKeySecp256k1Unsafe(*path)
 	if err != nil {
 		return
 	}

--- a/crypto/ledger/amino.go
+++ b/crypto/ledger/amino.go
@@ -1,4 +1,4 @@
-package crypto
+package ledger
 
 import (
 	"github.com/cosmos/cosmos-sdk/codec"

--- a/crypto/ledger/encode_test.go
+++ b/crypto/ledger/encode_test.go
@@ -1,4 +1,4 @@
-package crypto
+package ledger
 
 import (
 	"os"

--- a/crypto/ledger/ledger_mock.go
+++ b/crypto/ledger/ledger_mock.go
@@ -1,6 +1,6 @@
 // +build ledger,test_ledger_mock
 
-package crypto
+package ledger
 
 import (
 	"fmt"
@@ -23,7 +23,7 @@ import (
 // set the discoverLedger function which is responsible for loading the Ledger
 // device at runtime or returning an error.
 func init() {
-	discoverLedger = func() (LedgerSECP256K1, error) {
+	discoverLedger = func() (SECP256K1, error) {
 		return LedgerSECP256K1Mock{}, nil
 	}
 }

--- a/crypto/ledger/ledger_notavail.go
+++ b/crypto/ledger/ledger_notavail.go
@@ -1,7 +1,7 @@
 // +build !cgo !ledger
 // test_ledger_mock
 
-package crypto
+package ledger
 
 import (
 	"github.com/pkg/errors"
@@ -11,7 +11,7 @@ import (
 // set the discoverLedger function which is responsible for loading the Ledger
 // device at runtime or returning an error.
 func init() {
-	discoverLedger = func() (LedgerSECP256K1, error) {
+	discoverLedger = func() (SECP256K1, error) {
 		return nil, errors.New("support for ledger devices is not available in this executable")
 	}
 }

--- a/crypto/ledger/ledger_real.go
+++ b/crypto/ledger/ledger_real.go
@@ -1,6 +1,6 @@
 // +build cgo,ledger,!test_ledger_mock
 
-package crypto
+package ledger
 
 import ledger "github.com/cosmos/ledger-cosmos-go"
 
@@ -8,7 +8,7 @@ import ledger "github.com/cosmos/ledger-cosmos-go"
 // set the discoverLedger function which is responsible for loading the Ledger
 // device at runtime or returning an error.
 func init() {
-	discoverLedger = func() (LedgerSECP256K1, error) {
+	discoverLedger = func() (SECP256K1, error) {
 		device, err := ledger.FindLedgerCosmosUserApp()
 		if err != nil {
 			return nil, err

--- a/crypto/ledger/ledger_secp256k1.go
+++ b/crypto/ledger/ledger_secp256k1.go
@@ -1,4 +1,4 @@
-package crypto
+package ledger
 
 import (
 	"fmt"
@@ -24,10 +24,10 @@ type (
 	// discoverLedgerFn defines a Ledger discovery function that returns a
 	// connected device or an error upon failure. Its allows a method to avoid CGO
 	// dependencies when Ledger support is potentially not enabled.
-	discoverLedgerFn func() (LedgerSECP256K1, error)
+	discoverLedgerFn func() (SECP256K1, error)
 
-	// LedgerSECP256K1 reflects an interface a Ledger API must implement for SECP256K1
-	LedgerSECP256K1 interface {
+	// SECP256K1 reflects an interface a Ledger API must implement for SECP256K1
+	SECP256K1 interface {
 		Close() error
 		// Returns an uncompressed pubkey
 		GetPublicKeySECP256K1([]uint32) ([]byte, error)
@@ -48,13 +48,13 @@ type (
 	}
 )
 
-// NewPrivKeyLedgerSecp256k1Unsafe will generate a new key and store the public key for later use.
+// NewPrivKeySecp256k1Unsafe will generate a new key and store the public key for later use.
 //
 // This function is marked as unsafe as it will retrieve a pubkey without user verification.
 // It can only be used to verify a pubkey but never to create new accounts/keys. In that case,
-// please refer to NewPrivKeyLedgerSecp256k1
-func NewPrivKeyLedgerSecp256k1Unsafe(path hd.BIP44Params) (tmcrypto.PrivKey, error) {
-	device, err := getLedgerDevice()
+// please refer to NewPrivKeySecp256k1
+func NewPrivKeySecp256k1Unsafe(path hd.BIP44Params) (tmcrypto.PrivKey, error) {
+	device, err := getDevice()
 	if err != nil {
 		return nil, err
 	}
@@ -68,10 +68,10 @@ func NewPrivKeyLedgerSecp256k1Unsafe(path hd.BIP44Params) (tmcrypto.PrivKey, err
 	return PrivKeyLedgerSecp256k1{pubKey, path}, nil
 }
 
-// NewPrivKeyLedgerSecp256k1 will generate a new key and store the public key for later use.
+// NewPrivKeySecp256k1 will generate a new key and store the public key for later use.
 // The request will require user confirmation and will show account and index in the device
-func NewPrivKeyLedgerSecp256k1(path hd.BIP44Params, hrp string) (tmcrypto.PrivKey, string, error) {
-	device, err := getLedgerDevice()
+func NewPrivKeySecp256k1(path hd.BIP44Params, hrp string) (tmcrypto.PrivKey, string, error) {
+	device, err := getDevice()
 	if err != nil {
 		return nil, "", err
 	}
@@ -92,7 +92,7 @@ func (pkl PrivKeyLedgerSecp256k1) PubKey() tmcrypto.PubKey {
 
 // Sign returns a secp256k1 signature for the corresponding message
 func (pkl PrivKeyLedgerSecp256k1) Sign(message []byte) ([]byte, error) {
-	device, err := getLedgerDevice()
+	device, err := getDevice()
 	if err != nil {
 		return nil, err
 	}
@@ -101,10 +101,10 @@ func (pkl PrivKeyLedgerSecp256k1) Sign(message []byte) ([]byte, error) {
 	return sign(device, pkl, message)
 }
 
-// LedgerShowAddress triggers a ledger device to show the corresponding address.
-func LedgerShowAddress(path hd.BIP44Params, expectedPubKey tmcrypto.PubKey,
+// ShowAddress triggers a ledger device to show the corresponding address.
+func ShowAddress(path hd.BIP44Params, expectedPubKey tmcrypto.PubKey,
 	accountAddressPrefix string) error {
-	device, err := getLedgerDevice()
+	device, err := getDevice()
 	if err != nil {
 		return err
 	}
@@ -134,7 +134,7 @@ func LedgerShowAddress(path hd.BIP44Params, expectedPubKey tmcrypto.PubKey,
 // ValidateKey allows us to verify the sanity of a public key after loading it
 // from disk.
 func (pkl PrivKeyLedgerSecp256k1) ValidateKey() error {
-	device, err := getLedgerDevice()
+	device, err := getDevice()
 	if err != nil {
 		return err
 	}
@@ -178,7 +178,7 @@ func convertDERtoBER(signatureDER []byte) ([]byte, error) {
 	return sigBER.Serialize(), nil
 }
 
-func getLedgerDevice() (LedgerSECP256K1, error) {
+func getDevice() (SECP256K1, error) {
 	if discoverLedger == nil {
 		return nil, errors.New("no Ledger discovery function defined")
 	}
@@ -191,7 +191,7 @@ func getLedgerDevice() (LedgerSECP256K1, error) {
 	return device, nil
 }
 
-func validateKey(device LedgerSECP256K1, pkl PrivKeyLedgerSecp256k1) error {
+func validateKey(device SECP256K1, pkl PrivKeyLedgerSecp256k1) error {
 	pub, err := getPubKeyUnsafe(device, pkl.Path)
 	if err != nil {
 		return err
@@ -210,7 +210,7 @@ func validateKey(device LedgerSECP256K1, pkl PrivKeyLedgerSecp256k1) error {
 // Communication is checked on NewPrivKeyLedger and PrivKeyFromBytes, returning
 // an error, so this should only trigger if the private key is held in memory
 // for a while before use.
-func sign(device LedgerSECP256K1, pkl PrivKeyLedgerSecp256k1, msg []byte) ([]byte, error) {
+func sign(device SECP256K1, pkl PrivKeyLedgerSecp256k1, msg []byte) ([]byte, error) {
 	err := validateKey(device, pkl)
 	if err != nil {
 		return nil, err
@@ -232,7 +232,7 @@ func sign(device LedgerSECP256K1, pkl PrivKeyLedgerSecp256k1, msg []byte) ([]byt
 //
 // since this involves IO, it may return an error, which is not exposed
 // in the PubKey interface, so this function allows better error handling
-func getPubKeyUnsafe(device LedgerSECP256K1, path hd.BIP44Params) (tmcrypto.PubKey, error) {
+func getPubKeyUnsafe(device SECP256K1, path hd.BIP44Params) (tmcrypto.PubKey, error) {
 	publicKey, err := device.GetPublicKeySECP256K1(path.DerivationPath())
 	if err != nil {
 		return nil, fmt.Errorf("please open Cosmos app on the Ledger device - error: %v", err)
@@ -256,7 +256,7 @@ func getPubKeyUnsafe(device LedgerSECP256K1, path hd.BIP44Params) (tmcrypto.PubK
 //
 // Since this involves IO, it may return an error, which is not exposed
 // in the PubKey interface, so this function allows better error handling.
-func getPubKeyAddrSafe(device LedgerSECP256K1, path hd.BIP44Params, hrp string) (tmcrypto.PubKey, string, error) {
+func getPubKeyAddrSafe(device SECP256K1, path hd.BIP44Params, hrp string) (tmcrypto.PubKey, string, error) {
 	publicKey, addr, err := device.GetAddressPubKeySECP256K1(path.DerivationPath(), hrp)
 	if err != nil {
 		return nil, "", fmt.Errorf("address %s rejected", addr)

--- a/crypto/ledger/ledger_test.go
+++ b/crypto/ledger/ledger_test.go
@@ -1,4 +1,4 @@
-package crypto
+package ledger
 
 import (
 	"fmt"
@@ -14,17 +14,17 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
-func TestLedgerErrorHandling(t *testing.T) {
+func TestErrorHandling(t *testing.T) {
 	// first, try to generate a key, must return an error
 	// (no panic)
 	path := *hd.NewParams(44, 555, 0, false, 0)
-	_, err := NewPrivKeyLedgerSecp256k1Unsafe(path)
+	_, err := NewPrivKeySecp256k1Unsafe(path)
 	require.Error(t, err)
 }
 
 func TestPublicKeyUnsafe(t *testing.T) {
 	path := *hd.NewFundraiserParams(0, sdk.CoinType, 0)
-	priv, err := NewPrivKeyLedgerSecp256k1Unsafe(path)
+	priv, err := NewPrivKeySecp256k1Unsafe(path)
 	require.Nil(t, err, "%s", err)
 	require.NotNil(t, priv)
 
@@ -65,7 +65,7 @@ func TestPublicKeyUnsafeHDPath(t *testing.T) {
 		path := *hd.NewFundraiserParams(0, sdk.CoinType, i)
 		fmt.Printf("Checking keys at %v\n", path)
 
-		priv, err := NewPrivKeyLedgerSecp256k1Unsafe(path)
+		priv, err := NewPrivKeySecp256k1Unsafe(path)
 		require.Nil(t, err, "%s", err)
 		require.NotNil(t, priv)
 
@@ -99,12 +99,12 @@ func TestPublicKeyUnsafeHDPath(t *testing.T) {
 
 func TestPublicKeySafe(t *testing.T) {
 	path := *hd.NewFundraiserParams(0, sdk.CoinType, 0)
-	priv, addr, err := NewPrivKeyLedgerSecp256k1(path, "cosmos")
+	priv, addr, err := NewPrivKeySecp256k1(path, "cosmos")
 
 	require.Nil(t, err, "%s", err)
 	require.NotNil(t, priv)
 
-	require.Nil(t, LedgerShowAddress(path, priv.PubKey(), sdk.GetConfig().GetBech32AccountAddrPrefix()))
+	require.Nil(t, ShowAddress(path, priv.PubKey(), sdk.GetConfig().GetBech32AccountAddrPrefix()))
 
 	require.Equal(t, "eb5ae98721034fef9cd7c4c63588d3b03feb5281b9d232cba34d6f3d71aee59211ffbfe1fe87",
 		fmt.Sprintf("%x", priv.PubKey().Bytes()),
@@ -158,7 +158,7 @@ func TestPublicKeyHDPath(t *testing.T) {
 		path := *hd.NewFundraiserParams(0, sdk.CoinType, i)
 		fmt.Printf("Checking keys at %v\n", path)
 
-		priv, addr, err := NewPrivKeyLedgerSecp256k1(path, "cosmos")
+		priv, addr, err := NewPrivKeySecp256k1(path, "cosmos")
 		require.Nil(t, err, "%s", err)
 		require.NotNil(t, addr)
 		require.NotNil(t, priv)
@@ -212,7 +212,7 @@ func TestSignaturesHD(t *testing.T) {
 		path := *hd.NewFundraiserParams(account, sdk.CoinType, account/5)
 		fmt.Printf("Checking signature at %v    ---   PLEASE REVIEW AND ACCEPT IN THE DEVICE\n", path)
 
-		priv, err := NewPrivKeyLedgerSecp256k1Unsafe(path)
+		priv, err := NewPrivKeySecp256k1Unsafe(path)
 		require.Nil(t, err, "%s", err)
 
 		pub := priv.PubKey()
@@ -224,10 +224,10 @@ func TestSignaturesHD(t *testing.T) {
 	}
 }
 
-func TestRealLedgerSecp256k1(t *testing.T) {
+func TestRealDeviceSecp256k1(t *testing.T) {
 	msg := getFakeTx(50)
 	path := *hd.NewFundraiserParams(0, sdk.CoinType, 0)
-	priv, err := NewPrivKeyLedgerSecp256k1Unsafe(path)
+	priv, err := NewPrivKeySecp256k1Unsafe(path)
 	require.Nil(t, err, "%s", err)
 
 	pub := priv.PubKey()


### PR DESCRIPTION
crypto -> crypto/ledger:
- crypto.LedgerShowAddress -> ledger.ShowAddress
- crypto.NewPrivKeyLedgerSecp256k1 - > ledger.NewPrivKeySecp256k1
- crypto.NewPrivKeyLedgerSecp256k1Unsafe -> ledger.NewPrivKeySecp256k1Unsafe

Closes: #6780

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
