### PR TITLE
Backport 0.39.1: Remove Custom JSON Marshaling for Accounts

### DIFF
--- a/x/auth/vesting/types/vesting_account.go
+++ b/x/auth/vesting/types/vesting_account.go
@@ -1,7 +1,6 @@
 package types
 
 import (
-	"encoding/json"
 	"errors"
 	"time"
 
@@ -10,7 +9,6 @@ import (
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	vestexported "github.com/cosmos/cosmos-sdk/x/auth/vesting/exported"
 
-	"github.com/tendermint/tendermint/crypto"
 	"gopkg.in/yaml.v2"
 )
 
@@ -236,59 +234,6 @@ func (bva BaseVestingAccount) MarshalYAML() (interface{}, error) {
 	return string(bz), err
 }
 
-// MarshalJSON returns the JSON representation of a BaseVestingAccount.
-func (bva BaseVestingAccount) MarshalJSON() ([]byte, error) {
-	alias := vestingAccountPretty{
-		Address:          bva.Address,
-		Coins:            bva.Coins,
-		AccountNumber:    bva.AccountNumber,
-		Sequence:         bva.Sequence,
-		OriginalVesting:  bva.OriginalVesting,
-		DelegatedFree:    bva.DelegatedFree,
-		DelegatedVesting: bva.DelegatedVesting,
-		EndTime:          bva.EndTime,
-	}
-
-	if bva.PubKey != nil {
-		pks, err := sdk.Bech32ifyPubKey(sdk.Bech32PubKeyTypeAccPub, bva.PubKey)
-		if err != nil {
-			return nil, err
-		}
-
-		alias.PubKey = pks
-	}
-
-	return json.Marshal(alias)
-}
-
-// UnmarshalJSON unmarshals raw JSON bytes into a BaseVestingAccount.
-func (bva *BaseVestingAccount) UnmarshalJSON(bz []byte) error {
-	var alias vestingAccountPretty
-	if err := json.Unmarshal(bz, &alias); err != nil {
-		return err
-	}
-
-	var (
-		pk  crypto.PubKey
-		err error
-	)
-
-	if alias.PubKey != "" {
-		pk, err = sdk.GetPubKeyFromBech32(sdk.Bech32PubKeyTypeAccPub, alias.PubKey)
-		if err != nil {
-			return err
-		}
-	}
-
-	bva.BaseAccount = authtypes.NewBaseAccount(alias.Address, alias.Coins, pk, alias.AccountNumber, alias.Sequence)
-	bva.OriginalVesting = alias.OriginalVesting
-	bva.DelegatedFree = alias.DelegatedFree
-	bva.DelegatedVesting = alias.DelegatedVesting
-	bva.EndTime = alias.EndTime
-
-	return nil
-}
-
 //-----------------------------------------------------------------------------
 // Continuous Vesting Account
 
@@ -420,63 +365,6 @@ func (cva ContinuousVestingAccount) MarshalYAML() (interface{}, error) {
 	}
 
 	return string(bz), err
-}
-
-// MarshalJSON returns the JSON representation of a ContinuousVestingAccount.
-func (cva ContinuousVestingAccount) MarshalJSON() ([]byte, error) {
-	alias := vestingAccountPretty{
-		Address:          cva.Address,
-		Coins:            cva.Coins,
-		AccountNumber:    cva.AccountNumber,
-		Sequence:         cva.Sequence,
-		OriginalVesting:  cva.OriginalVesting,
-		DelegatedFree:    cva.DelegatedFree,
-		DelegatedVesting: cva.DelegatedVesting,
-		EndTime:          cva.EndTime,
-		StartTime:        cva.StartTime,
-	}
-
-	if cva.PubKey != nil {
-		pks, err := sdk.Bech32ifyPubKey(sdk.Bech32PubKeyTypeAccPub, cva.PubKey)
-		if err != nil {
-			return nil, err
-		}
-
-		alias.PubKey = pks
-	}
-
-	return json.Marshal(alias)
-}
-
-// UnmarshalJSON unmarshals raw JSON bytes into a ContinuousVestingAccount.
-func (cva *ContinuousVestingAccount) UnmarshalJSON(bz []byte) error {
-	var alias vestingAccountPretty
-	if err := json.Unmarshal(bz, &alias); err != nil {
-		return err
-	}
-
-	var (
-		pk  crypto.PubKey
-		err error
-	)
-
-	if alias.PubKey != "" {
-		pk, err = sdk.GetPubKeyFromBech32(sdk.Bech32PubKeyTypeAccPub, alias.PubKey)
-		if err != nil {
-			return err
-		}
-	}
-
-	cva.BaseVestingAccount = &BaseVestingAccount{
-		BaseAccount:      authtypes.NewBaseAccount(alias.Address, alias.Coins, pk, alias.AccountNumber, alias.Sequence),
-		OriginalVesting:  alias.OriginalVesting,
-		DelegatedFree:    alias.DelegatedFree,
-		DelegatedVesting: alias.DelegatedVesting,
-		EndTime:          alias.EndTime,
-	}
-	cva.StartTime = alias.StartTime
-
-	return nil
 }
 
 //-----------------------------------------------------------------------------
@@ -638,65 +526,6 @@ func (pva PeriodicVestingAccount) MarshalYAML() (interface{}, error) {
 	return string(bz), err
 }
 
-// MarshalJSON returns the JSON representation of a PeriodicVestingAccount.
-func (pva PeriodicVestingAccount) MarshalJSON() ([]byte, error) {
-	alias := vestingAccountPretty{
-		Address:          pva.Address,
-		Coins:            pva.Coins,
-		AccountNumber:    pva.AccountNumber,
-		Sequence:         pva.Sequence,
-		OriginalVesting:  pva.OriginalVesting,
-		DelegatedFree:    pva.DelegatedFree,
-		DelegatedVesting: pva.DelegatedVesting,
-		EndTime:          pva.EndTime,
-		StartTime:        pva.StartTime,
-		VestingPeriods:   pva.VestingPeriods,
-	}
-
-	if pva.PubKey != nil {
-		pks, err := sdk.Bech32ifyPubKey(sdk.Bech32PubKeyTypeAccPub, pva.PubKey)
-		if err != nil {
-			return nil, err
-		}
-
-		alias.PubKey = pks
-	}
-
-	return json.Marshal(alias)
-}
-
-// UnmarshalJSON unmarshals raw JSON bytes into a PeriodicVestingAccount.
-func (pva *PeriodicVestingAccount) UnmarshalJSON(bz []byte) error {
-	var alias vestingAccountPretty
-	if err := json.Unmarshal(bz, &alias); err != nil {
-		return err
-	}
-
-	var (
-		pk  crypto.PubKey
-		err error
-	)
-
-	if alias.PubKey != "" {
-		pk, err = sdk.GetPubKeyFromBech32(sdk.Bech32PubKeyTypeAccPub, alias.PubKey)
-		if err != nil {
-			return err
-		}
-	}
-
-	pva.BaseVestingAccount = &BaseVestingAccount{
-		BaseAccount:      authtypes.NewBaseAccount(alias.Address, alias.Coins, pk, alias.AccountNumber, alias.Sequence),
-		OriginalVesting:  alias.OriginalVesting,
-		DelegatedFree:    alias.DelegatedFree,
-		DelegatedVesting: alias.DelegatedVesting,
-		EndTime:          alias.EndTime,
-	}
-	pva.StartTime = alias.StartTime
-	pva.VestingPeriods = alias.VestingPeriods
-
-	return nil
-}
-
 //-----------------------------------------------------------------------------
 // Delayed Vesting Account
 
@@ -765,59 +594,4 @@ func (dva DelayedVestingAccount) GetStartTime() int64 {
 // Validate checks for errors on the account fields
 func (dva DelayedVestingAccount) Validate() error {
 	return dva.BaseVestingAccount.Validate()
-}
-
-// MarshalJSON returns the JSON representation of a DelayedVestingAccount.
-func (dva DelayedVestingAccount) MarshalJSON() ([]byte, error) {
-	alias := vestingAccountPretty{
-		Address:          dva.Address,
-		Coins:            dva.Coins,
-		AccountNumber:    dva.AccountNumber,
-		Sequence:         dva.Sequence,
-		OriginalVesting:  dva.OriginalVesting,
-		DelegatedFree:    dva.DelegatedFree,
-		DelegatedVesting: dva.DelegatedVesting,
-		EndTime:          dva.EndTime,
-	}
-
-	if dva.PubKey != nil {
-		pks, err := sdk.Bech32ifyPubKey(sdk.Bech32PubKeyTypeAccPub, dva.PubKey)
-		if err != nil {
-			return nil, err
-		}
-
-		alias.PubKey = pks
-	}
-
-	return json.Marshal(alias)
-}
-
-// UnmarshalJSON unmarshals raw JSON bytes into a DelayedVestingAccount.
-func (dva *DelayedVestingAccount) UnmarshalJSON(bz []byte) error {
-	var alias vestingAccountPretty
-	if err := json.Unmarshal(bz, &alias); err != nil {
-		return err
-	}
-
-	var (
-		pk  crypto.PubKey
-		err error
-	)
-
-	if alias.PubKey != "" {
-		pk, err = sdk.GetPubKeyFromBech32(sdk.Bech32PubKeyTypeAccPub, alias.PubKey)
-		if err != nil {
-			return err
-		}
-	}
-
-	dva.BaseVestingAccount = &BaseVestingAccount{
-		BaseAccount:      authtypes.NewBaseAccount(alias.Address, alias.Coins, pk, alias.AccountNumber, alias.Sequence),
-		OriginalVesting:  alias.OriginalVesting,
-		DelegatedFree:    alias.DelegatedFree,
-		DelegatedVesting: alias.DelegatedVesting,
-		EndTime:          alias.EndTime,
-	}
-
-	return nil
 }

--- a/x/auth/vesting/types/vesting_account_test.go
+++ b/x/auth/vesting/types/vesting_account_test.go
@@ -1,7 +1,6 @@
 package types
 
 import (
-	"encoding/json"
 	"errors"
 	"testing"
 	"time"
@@ -732,87 +731,4 @@ func TestGenesisAccountValidate(t *testing.T) {
 			require.Equal(t, tt.expErr, err)
 		})
 	}
-}
-
-func TestBaseVestingAccountJSON(t *testing.T) {
-	pubkey := secp256k1.GenPrivKey().PubKey()
-	addr := sdk.AccAddress(pubkey.Address())
-	coins := sdk.NewCoins(sdk.NewInt64Coin("test", 5))
-	baseAcc := authtypes.NewBaseAccount(addr, coins, pubkey, 10, 50)
-
-	acc, err := NewBaseVestingAccount(baseAcc, coins, time.Now().Unix())
-	require.NoError(t, err)
-
-	bz, err := json.Marshal(acc)
-	require.NoError(t, err)
-
-	bz1, err := acc.MarshalJSON()
-	require.NoError(t, err)
-	require.Equal(t, string(bz1), string(bz))
-
-	var a BaseVestingAccount
-	require.NoError(t, json.Unmarshal(bz, &a))
-	require.Equal(t, acc.String(), a.String())
-}
-
-func TestContinuousVestingAccountJSON(t *testing.T) {
-	pubkey := secp256k1.GenPrivKey().PubKey()
-	addr := sdk.AccAddress(pubkey.Address())
-	coins := sdk.NewCoins(sdk.NewInt64Coin("test", 5))
-	baseAcc := authtypes.NewBaseAccount(addr, coins, pubkey, 10, 50)
-
-	baseVesting, err := NewBaseVestingAccount(baseAcc, coins, time.Now().Unix())
-	acc := NewContinuousVestingAccountRaw(baseVesting, baseVesting.EndTime)
-	require.NoError(t, err)
-
-	bz, err := json.Marshal(acc)
-	require.NoError(t, err)
-
-	bz1, err := acc.MarshalJSON()
-	require.NoError(t, err)
-	require.Equal(t, string(bz1), string(bz))
-
-	var a ContinuousVestingAccount
-	require.NoError(t, json.Unmarshal(bz, &a))
-	require.Equal(t, acc.String(), a.String())
-}
-
-func TestPeriodicVestingAccountJSON(t *testing.T) {
-	pubkey := secp256k1.GenPrivKey().PubKey()
-	addr := sdk.AccAddress(pubkey.Address())
-	coins := sdk.NewCoins(sdk.NewInt64Coin("test", 5))
-	baseAcc := authtypes.NewBaseAccount(addr, coins, pubkey, 10, 50)
-
-	acc := NewPeriodicVestingAccount(baseAcc, time.Now().Unix(), Periods{Period{3600, coins}})
-
-	bz, err := json.Marshal(acc)
-	require.NoError(t, err)
-
-	bz1, err := acc.MarshalJSON()
-	require.NoError(t, err)
-	require.Equal(t, string(bz1), string(bz))
-
-	var a PeriodicVestingAccount
-	require.NoError(t, json.Unmarshal(bz, &a))
-	require.Equal(t, acc.String(), a.String())
-}
-
-func TestDelayedVestingAccountJSON(t *testing.T) {
-	pubkey := secp256k1.GenPrivKey().PubKey()
-	addr := sdk.AccAddress(pubkey.Address())
-	coins := sdk.NewCoins(sdk.NewInt64Coin("test", 5))
-	baseAcc := authtypes.NewBaseAccount(addr, coins, pubkey, 10, 50)
-
-	acc := NewDelayedVestingAccount(baseAcc, time.Now().Unix())
-
-	bz, err := json.Marshal(acc)
-	require.NoError(t, err)
-
-	bz1, err := acc.MarshalJSON()
-	require.NoError(t, err)
-	require.Equal(t, string(bz1), string(bz))
-
-	var a DelayedVestingAccount
-	require.NoError(t, json.Unmarshal(bz, &a))
-	require.Equal(t, acc.String(), a.String())
 }

--- a/x/supply/internal/types/account.go
+++ b/x/supply/internal/types/account.go
@@ -1,7 +1,6 @@
 package types
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -146,31 +145,4 @@ func (ma ModuleAccount) MarshalYAML() (interface{}, error) {
 	}
 
 	return string(bs), nil
-}
-
-// MarshalJSON returns the JSON representation of a ModuleAccount.
-func (ma ModuleAccount) MarshalJSON() ([]byte, error) {
-	return json.Marshal(moduleAccountPretty{
-		Address:       ma.Address,
-		Coins:         ma.Coins,
-		PubKey:        "",
-		AccountNumber: ma.AccountNumber,
-		Sequence:      ma.Sequence,
-		Name:          ma.Name,
-		Permissions:   ma.Permissions,
-	})
-}
-
-// UnmarshalJSON unmarshals raw JSON bytes into a ModuleAccount.
-func (ma *ModuleAccount) UnmarshalJSON(bz []byte) error {
-	var alias moduleAccountPretty
-	if err := json.Unmarshal(bz, &alias); err != nil {
-		return err
-	}
-
-	ma.BaseAccount = authtypes.NewBaseAccount(alias.Address, alias.Coins, nil, alias.AccountNumber, alias.Sequence)
-	ma.Name = alias.Name
-	ma.Permissions = alias.Permissions
-
-	return nil
 }

--- a/x/supply/internal/types/account_test.go
+++ b/x/supply/internal/types/account_test.go
@@ -1,7 +1,6 @@
 package types
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"testing"
@@ -81,23 +80,4 @@ func TestValidate(t *testing.T) {
 			require.Equal(t, tt.expErr, err)
 		})
 	}
-}
-
-func TestModuleAccountJSON(t *testing.T) {
-	pubkey := secp256k1.GenPrivKey().PubKey()
-	addr := sdk.AccAddress(pubkey.Address())
-	coins := sdk.NewCoins(sdk.NewInt64Coin("test", 5))
-	baseAcc := authtypes.NewBaseAccount(addr, coins, nil, 10, 50)
-	acc := NewModuleAccount(baseAcc, "test", "burner")
-
-	bz, err := json.Marshal(acc)
-	require.NoError(t, err)
-
-	bz1, err := acc.MarshalJSON()
-	require.NoError(t, err)
-	require.Equal(t, string(bz1), string(bz))
-
-	var a ModuleAccount
-	require.NoError(t, json.Unmarshal(bz, &a))
-	require.Equal(t, acc.String(), a.String())
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Right before we released 0.39, we last minute introduced the removal of custom JSON marshaling for `BaseAccount` and rightfully so. However, I forgot to do the same for the remaining account types. 

Remove custom JSON marshaling for accounts. Note, this is genesis and client breaking, but worth the change in order to get migration to function properly.

/cc @alessio @ethanfrey 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
