### PR TITLE
Revert "Backport 0.39.1: Remove Custom JSON Marshaling for Accounts"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,12 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 # Changelog
 
+## [v0.39.1]
+
+### Client Breaking Changes
+
+* (x/auth) [\#6861](https://github.com/cosmos/cosmos-sdk/pull/6861) Remove public key Bech32 encoding for all account types for JSON serialization, instead relying on direct Amino encoding. In addition, JSON serialization utilizes Amino instead of the Go stdlib, so integers are treated as strings.
+
 ## [v0.39.0]
 
 ### Improvements
@@ -2949,7 +2955,9 @@ BUG FIXES:
 
 <!-- Release links -->
 
-[Unreleased]: https://github.com/cosmos/cosmos-sdk/compare/v0.38.2...HEAD
+[Unreleased]: https://github.com/cosmos/cosmos-sdk/compare/v0.39.1...HEAD
+[v0.39.1]: https://github.com/cosmos/cosmos-sdk/releases/tag/v0.39.1
+[v0.39.0]: https://github.com/cosmos/cosmos-sdk/releases/tag/v0.39.0
 [v0.38.2]: https://github.com/cosmos/cosmos-sdk/releases/tag/v0.38.2
 [v0.38.1]: https://github.com/cosmos/cosmos-sdk/releases/tag/v0.38.1
 [v0.38.0]: https://github.com/cosmos/cosmos-sdk/releases/tag/v0.38.0

--- a/x/auth/vesting/types/vesting_account.go
+++ b/x/auth/vesting/types/vesting_account.go
@@ -226,6 +226,7 @@ func (bva BaseVestingAccount) String() string {
 func (bva BaseVestingAccount) MarshalYAML() (interface{}, error) {
 	alias := vestingAccountYAML{
 		Address:          bva.Address,
+		Coins:            bva.Coins,
 		AccountNumber:    bva.AccountNumber,
 		Sequence:         bva.Sequence,
 		OriginalVesting:  bva.OriginalVesting,
@@ -256,7 +257,7 @@ func (bva BaseVestingAccount) MarshalYAML() (interface{}, error) {
 func (bva BaseVestingAccount) MarshalJSON() ([]byte, error) {
 	alias := vestingAccountJSON{
 		Address:          bva.Address,
-		Coins:            cva.Coins,
+		Coins:            bva.Coins,
 		PubKey:           bva.GetPubKey(),
 		AccountNumber:    bva.AccountNumber,
 		Sequence:         bva.Sequence,
@@ -391,6 +392,7 @@ func (cva ContinuousVestingAccount) String() string {
 func (cva ContinuousVestingAccount) MarshalYAML() (interface{}, error) {
 	alias := vestingAccountYAML{
 		Address:          cva.Address,
+		Coins:            cva.Coins,
 		AccountNumber:    cva.AccountNumber,
 		Sequence:         cva.Sequence,
 		OriginalVesting:  cva.OriginalVesting,
@@ -586,6 +588,7 @@ func (pva PeriodicVestingAccount) String() string {
 func (pva PeriodicVestingAccount) MarshalYAML() (interface{}, error) {
 	alias := vestingAccountYAML{
 		Address:          pva.Address,
+		Coins:            pva.Coins,
 		AccountNumber:    pva.AccountNumber,
 		Sequence:         pva.Sequence,
 		OriginalVesting:  pva.OriginalVesting,
@@ -618,7 +621,7 @@ func (pva PeriodicVestingAccount) MarshalYAML() (interface{}, error) {
 func (pva PeriodicVestingAccount) MarshalJSON() ([]byte, error) {
 	alias := vestingAccountJSON{
 		Address:          pva.Address,
-		Coins:            cva.Coins,
+		Coins:            pva.Coins,
 		PubKey:           pva.GetPubKey(),
 		AccountNumber:    pva.AccountNumber,
 		Sequence:         pva.Sequence,
@@ -727,7 +730,7 @@ func (dva DelayedVestingAccount) Validate() error {
 func (dva DelayedVestingAccount) MarshalJSON() ([]byte, error) {
 	alias := vestingAccountJSON{
 		Address:          dva.Address,
-		Coins:            cva.Coins,
+		Coins:            dva.Coins,
 		PubKey:           dva.GetPubKey(),
 		AccountNumber:    dva.AccountNumber,
 		Sequence:         dva.Sequence,

--- a/x/auth/vesting/types/vesting_account.go
+++ b/x/auth/vesting/types/vesting_account.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"encoding/json"
 	"errors"
 	"time"
 
@@ -9,6 +10,7 @@ import (
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	vestexported "github.com/cosmos/cosmos-sdk/x/auth/vesting/exported"
 
+	"github.com/tendermint/tendermint/crypto"
 	"gopkg.in/yaml.v2"
 )
 
@@ -234,6 +236,59 @@ func (bva BaseVestingAccount) MarshalYAML() (interface{}, error) {
 	return string(bz), err
 }
 
+// MarshalJSON returns the JSON representation of a BaseVestingAccount.
+func (bva BaseVestingAccount) MarshalJSON() ([]byte, error) {
+	alias := vestingAccountPretty{
+		Address:          bva.Address,
+		Coins:            bva.Coins,
+		AccountNumber:    bva.AccountNumber,
+		Sequence:         bva.Sequence,
+		OriginalVesting:  bva.OriginalVesting,
+		DelegatedFree:    bva.DelegatedFree,
+		DelegatedVesting: bva.DelegatedVesting,
+		EndTime:          bva.EndTime,
+	}
+
+	if bva.PubKey != nil {
+		pks, err := sdk.Bech32ifyPubKey(sdk.Bech32PubKeyTypeAccPub, bva.PubKey)
+		if err != nil {
+			return nil, err
+		}
+
+		alias.PubKey = pks
+	}
+
+	return json.Marshal(alias)
+}
+
+// UnmarshalJSON unmarshals raw JSON bytes into a BaseVestingAccount.
+func (bva *BaseVestingAccount) UnmarshalJSON(bz []byte) error {
+	var alias vestingAccountPretty
+	if err := json.Unmarshal(bz, &alias); err != nil {
+		return err
+	}
+
+	var (
+		pk  crypto.PubKey
+		err error
+	)
+
+	if alias.PubKey != "" {
+		pk, err = sdk.GetPubKeyFromBech32(sdk.Bech32PubKeyTypeAccPub, alias.PubKey)
+		if err != nil {
+			return err
+		}
+	}
+
+	bva.BaseAccount = authtypes.NewBaseAccount(alias.Address, alias.Coins, pk, alias.AccountNumber, alias.Sequence)
+	bva.OriginalVesting = alias.OriginalVesting
+	bva.DelegatedFree = alias.DelegatedFree
+	bva.DelegatedVesting = alias.DelegatedVesting
+	bva.EndTime = alias.EndTime
+
+	return nil
+}
+
 //-----------------------------------------------------------------------------
 // Continuous Vesting Account
 
@@ -365,6 +420,63 @@ func (cva ContinuousVestingAccount) MarshalYAML() (interface{}, error) {
 	}
 
 	return string(bz), err
+}
+
+// MarshalJSON returns the JSON representation of a ContinuousVestingAccount.
+func (cva ContinuousVestingAccount) MarshalJSON() ([]byte, error) {
+	alias := vestingAccountPretty{
+		Address:          cva.Address,
+		Coins:            cva.Coins,
+		AccountNumber:    cva.AccountNumber,
+		Sequence:         cva.Sequence,
+		OriginalVesting:  cva.OriginalVesting,
+		DelegatedFree:    cva.DelegatedFree,
+		DelegatedVesting: cva.DelegatedVesting,
+		EndTime:          cva.EndTime,
+		StartTime:        cva.StartTime,
+	}
+
+	if cva.PubKey != nil {
+		pks, err := sdk.Bech32ifyPubKey(sdk.Bech32PubKeyTypeAccPub, cva.PubKey)
+		if err != nil {
+			return nil, err
+		}
+
+		alias.PubKey = pks
+	}
+
+	return json.Marshal(alias)
+}
+
+// UnmarshalJSON unmarshals raw JSON bytes into a ContinuousVestingAccount.
+func (cva *ContinuousVestingAccount) UnmarshalJSON(bz []byte) error {
+	var alias vestingAccountPretty
+	if err := json.Unmarshal(bz, &alias); err != nil {
+		return err
+	}
+
+	var (
+		pk  crypto.PubKey
+		err error
+	)
+
+	if alias.PubKey != "" {
+		pk, err = sdk.GetPubKeyFromBech32(sdk.Bech32PubKeyTypeAccPub, alias.PubKey)
+		if err != nil {
+			return err
+		}
+	}
+
+	cva.BaseVestingAccount = &BaseVestingAccount{
+		BaseAccount:      authtypes.NewBaseAccount(alias.Address, alias.Coins, pk, alias.AccountNumber, alias.Sequence),
+		OriginalVesting:  alias.OriginalVesting,
+		DelegatedFree:    alias.DelegatedFree,
+		DelegatedVesting: alias.DelegatedVesting,
+		EndTime:          alias.EndTime,
+	}
+	cva.StartTime = alias.StartTime
+
+	return nil
 }
 
 //-----------------------------------------------------------------------------
@@ -526,6 +638,65 @@ func (pva PeriodicVestingAccount) MarshalYAML() (interface{}, error) {
 	return string(bz), err
 }
 
+// MarshalJSON returns the JSON representation of a PeriodicVestingAccount.
+func (pva PeriodicVestingAccount) MarshalJSON() ([]byte, error) {
+	alias := vestingAccountPretty{
+		Address:          pva.Address,
+		Coins:            pva.Coins,
+		AccountNumber:    pva.AccountNumber,
+		Sequence:         pva.Sequence,
+		OriginalVesting:  pva.OriginalVesting,
+		DelegatedFree:    pva.DelegatedFree,
+		DelegatedVesting: pva.DelegatedVesting,
+		EndTime:          pva.EndTime,
+		StartTime:        pva.StartTime,
+		VestingPeriods:   pva.VestingPeriods,
+	}
+
+	if pva.PubKey != nil {
+		pks, err := sdk.Bech32ifyPubKey(sdk.Bech32PubKeyTypeAccPub, pva.PubKey)
+		if err != nil {
+			return nil, err
+		}
+
+		alias.PubKey = pks
+	}
+
+	return json.Marshal(alias)
+}
+
+// UnmarshalJSON unmarshals raw JSON bytes into a PeriodicVestingAccount.
+func (pva *PeriodicVestingAccount) UnmarshalJSON(bz []byte) error {
+	var alias vestingAccountPretty
+	if err := json.Unmarshal(bz, &alias); err != nil {
+		return err
+	}
+
+	var (
+		pk  crypto.PubKey
+		err error
+	)
+
+	if alias.PubKey != "" {
+		pk, err = sdk.GetPubKeyFromBech32(sdk.Bech32PubKeyTypeAccPub, alias.PubKey)
+		if err != nil {
+			return err
+		}
+	}
+
+	pva.BaseVestingAccount = &BaseVestingAccount{
+		BaseAccount:      authtypes.NewBaseAccount(alias.Address, alias.Coins, pk, alias.AccountNumber, alias.Sequence),
+		OriginalVesting:  alias.OriginalVesting,
+		DelegatedFree:    alias.DelegatedFree,
+		DelegatedVesting: alias.DelegatedVesting,
+		EndTime:          alias.EndTime,
+	}
+	pva.StartTime = alias.StartTime
+	pva.VestingPeriods = alias.VestingPeriods
+
+	return nil
+}
+
 //-----------------------------------------------------------------------------
 // Delayed Vesting Account
 
@@ -594,4 +765,59 @@ func (dva DelayedVestingAccount) GetStartTime() int64 {
 // Validate checks for errors on the account fields
 func (dva DelayedVestingAccount) Validate() error {
 	return dva.BaseVestingAccount.Validate()
+}
+
+// MarshalJSON returns the JSON representation of a DelayedVestingAccount.
+func (dva DelayedVestingAccount) MarshalJSON() ([]byte, error) {
+	alias := vestingAccountPretty{
+		Address:          dva.Address,
+		Coins:            dva.Coins,
+		AccountNumber:    dva.AccountNumber,
+		Sequence:         dva.Sequence,
+		OriginalVesting:  dva.OriginalVesting,
+		DelegatedFree:    dva.DelegatedFree,
+		DelegatedVesting: dva.DelegatedVesting,
+		EndTime:          dva.EndTime,
+	}
+
+	if dva.PubKey != nil {
+		pks, err := sdk.Bech32ifyPubKey(sdk.Bech32PubKeyTypeAccPub, dva.PubKey)
+		if err != nil {
+			return nil, err
+		}
+
+		alias.PubKey = pks
+	}
+
+	return json.Marshal(alias)
+}
+
+// UnmarshalJSON unmarshals raw JSON bytes into a DelayedVestingAccount.
+func (dva *DelayedVestingAccount) UnmarshalJSON(bz []byte) error {
+	var alias vestingAccountPretty
+	if err := json.Unmarshal(bz, &alias); err != nil {
+		return err
+	}
+
+	var (
+		pk  crypto.PubKey
+		err error
+	)
+
+	if alias.PubKey != "" {
+		pk, err = sdk.GetPubKeyFromBech32(sdk.Bech32PubKeyTypeAccPub, alias.PubKey)
+		if err != nil {
+			return err
+		}
+	}
+
+	dva.BaseVestingAccount = &BaseVestingAccount{
+		BaseAccount:      authtypes.NewBaseAccount(alias.Address, alias.Coins, pk, alias.AccountNumber, alias.Sequence),
+		OriginalVesting:  alias.OriginalVesting,
+		DelegatedFree:    alias.DelegatedFree,
+		DelegatedVesting: alias.DelegatedVesting,
+		EndTime:          alias.EndTime,
+	}
+
+	return nil
 }

--- a/x/auth/vesting/types/vesting_account.go
+++ b/x/auth/vesting/types/vesting_account.go
@@ -256,6 +256,7 @@ func (bva BaseVestingAccount) MarshalYAML() (interface{}, error) {
 func (bva BaseVestingAccount) MarshalJSON() ([]byte, error) {
 	alias := vestingAccountJSON{
 		Address:          bva.Address,
+		Coins:            cva.Coins,
 		PubKey:           bva.GetPubKey(),
 		AccountNumber:    bva.AccountNumber,
 		Sequence:         bva.Sequence,
@@ -421,6 +422,7 @@ func (cva ContinuousVestingAccount) MarshalYAML() (interface{}, error) {
 func (cva ContinuousVestingAccount) MarshalJSON() ([]byte, error) {
 	alias := vestingAccountJSON{
 		Address:          cva.Address,
+		Coins:            cva.Coins,
 		PubKey:           cva.GetPubKey(),
 		AccountNumber:    cva.AccountNumber,
 		Sequence:         cva.Sequence,
@@ -616,6 +618,7 @@ func (pva PeriodicVestingAccount) MarshalYAML() (interface{}, error) {
 func (pva PeriodicVestingAccount) MarshalJSON() ([]byte, error) {
 	alias := vestingAccountJSON{
 		Address:          pva.Address,
+		Coins:            cva.Coins,
 		PubKey:           pva.GetPubKey(),
 		AccountNumber:    pva.AccountNumber,
 		Sequence:         pva.Sequence,
@@ -724,6 +727,7 @@ func (dva DelayedVestingAccount) Validate() error {
 func (dva DelayedVestingAccount) MarshalJSON() ([]byte, error) {
 	alias := vestingAccountJSON{
 		Address:          dva.Address,
+		Coins:            cva.Coins,
 		PubKey:           dva.GetPubKey(),
 		AccountNumber:    dva.AccountNumber,
 		Sequence:         dva.Sequence,

--- a/x/auth/vesting/types/vesting_account_test.go
+++ b/x/auth/vesting/types/vesting_account_test.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"encoding/json"
 	"errors"
 	"testing"
 	"time"
@@ -731,4 +732,87 @@ func TestGenesisAccountValidate(t *testing.T) {
 			require.Equal(t, tt.expErr, err)
 		})
 	}
+}
+
+func TestBaseVestingAccountJSON(t *testing.T) {
+	pubkey := secp256k1.GenPrivKey().PubKey()
+	addr := sdk.AccAddress(pubkey.Address())
+	coins := sdk.NewCoins(sdk.NewInt64Coin("test", 5))
+	baseAcc := authtypes.NewBaseAccount(addr, coins, pubkey, 10, 50)
+
+	acc, err := NewBaseVestingAccount(baseAcc, coins, time.Now().Unix())
+	require.NoError(t, err)
+
+	bz, err := json.Marshal(acc)
+	require.NoError(t, err)
+
+	bz1, err := acc.MarshalJSON()
+	require.NoError(t, err)
+	require.Equal(t, string(bz1), string(bz))
+
+	var a BaseVestingAccount
+	require.NoError(t, json.Unmarshal(bz, &a))
+	require.Equal(t, acc.String(), a.String())
+}
+
+func TestContinuousVestingAccountJSON(t *testing.T) {
+	pubkey := secp256k1.GenPrivKey().PubKey()
+	addr := sdk.AccAddress(pubkey.Address())
+	coins := sdk.NewCoins(sdk.NewInt64Coin("test", 5))
+	baseAcc := authtypes.NewBaseAccount(addr, coins, pubkey, 10, 50)
+
+	baseVesting, err := NewBaseVestingAccount(baseAcc, coins, time.Now().Unix())
+	acc := NewContinuousVestingAccountRaw(baseVesting, baseVesting.EndTime)
+	require.NoError(t, err)
+
+	bz, err := json.Marshal(acc)
+	require.NoError(t, err)
+
+	bz1, err := acc.MarshalJSON()
+	require.NoError(t, err)
+	require.Equal(t, string(bz1), string(bz))
+
+	var a ContinuousVestingAccount
+	require.NoError(t, json.Unmarshal(bz, &a))
+	require.Equal(t, acc.String(), a.String())
+}
+
+func TestPeriodicVestingAccountJSON(t *testing.T) {
+	pubkey := secp256k1.GenPrivKey().PubKey()
+	addr := sdk.AccAddress(pubkey.Address())
+	coins := sdk.NewCoins(sdk.NewInt64Coin("test", 5))
+	baseAcc := authtypes.NewBaseAccount(addr, coins, pubkey, 10, 50)
+
+	acc := NewPeriodicVestingAccount(baseAcc, time.Now().Unix(), Periods{Period{3600, coins}})
+
+	bz, err := json.Marshal(acc)
+	require.NoError(t, err)
+
+	bz1, err := acc.MarshalJSON()
+	require.NoError(t, err)
+	require.Equal(t, string(bz1), string(bz))
+
+	var a PeriodicVestingAccount
+	require.NoError(t, json.Unmarshal(bz, &a))
+	require.Equal(t, acc.String(), a.String())
+}
+
+func TestDelayedVestingAccountJSON(t *testing.T) {
+	pubkey := secp256k1.GenPrivKey().PubKey()
+	addr := sdk.AccAddress(pubkey.Address())
+	coins := sdk.NewCoins(sdk.NewInt64Coin("test", 5))
+	baseAcc := authtypes.NewBaseAccount(addr, coins, pubkey, 10, 50)
+
+	acc := NewDelayedVestingAccount(baseAcc, time.Now().Unix())
+
+	bz, err := json.Marshal(acc)
+	require.NoError(t, err)
+
+	bz1, err := acc.MarshalJSON()
+	require.NoError(t, err)
+	require.Equal(t, string(bz1), string(bz))
+
+	var a DelayedVestingAccount
+	require.NoError(t, json.Unmarshal(bz, &a))
+	require.Equal(t, acc.String(), a.String())
 }

--- a/x/auth/vesting/types/vesting_account_test.go
+++ b/x/auth/vesting/types/vesting_account_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/tendermint/tendermint/crypto/secp256k1"
 	tmtime "github.com/tendermint/tendermint/types/time"
 
+	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authexported "github.com/cosmos/cosmos-sdk/x/auth/exported"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
@@ -743,7 +744,7 @@ func TestBaseVestingAccountJSON(t *testing.T) {
 	acc, err := NewBaseVestingAccount(baseAcc, coins, time.Now().Unix())
 	require.NoError(t, err)
 
-	bz, err := json.Marshal(acc)
+	bz, err := codec.Cdc.MarshalJSON(acc)
 	require.NoError(t, err)
 
 	bz1, err := acc.MarshalJSON()

--- a/x/supply/internal/types/account.go
+++ b/x/supply/internal/types/account.go
@@ -1,7 +1,6 @@
 package types
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -10,6 +9,7 @@ import (
 
 	"github.com/tendermint/tendermint/crypto"
 
+	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authexported "github.com/cosmos/cosmos-sdk/x/auth/exported"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
@@ -150,7 +150,7 @@ func (ma ModuleAccount) MarshalYAML() (interface{}, error) {
 
 // MarshalJSON returns the JSON representation of a ModuleAccount.
 func (ma ModuleAccount) MarshalJSON() ([]byte, error) {
-	return json.Marshal(moduleAccountPretty{
+	return codec.Cdc.MarshalJSON(moduleAccountPretty{
 		Address:       ma.Address,
 		Coins:         ma.Coins,
 		PubKey:        "",
@@ -164,7 +164,7 @@ func (ma ModuleAccount) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON unmarshals raw JSON bytes into a ModuleAccount.
 func (ma *ModuleAccount) UnmarshalJSON(bz []byte) error {
 	var alias moduleAccountPretty
-	if err := json.Unmarshal(bz, &alias); err != nil {
+	if err := codec.Cdc.UnmarshalJSON(bz, &alias); err != nil {
 		return err
 	}
 

--- a/x/supply/internal/types/account.go
+++ b/x/supply/internal/types/account.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -145,4 +146,31 @@ func (ma ModuleAccount) MarshalYAML() (interface{}, error) {
 	}
 
 	return string(bs), nil
+}
+
+// MarshalJSON returns the JSON representation of a ModuleAccount.
+func (ma ModuleAccount) MarshalJSON() ([]byte, error) {
+	return json.Marshal(moduleAccountPretty{
+		Address:       ma.Address,
+		Coins:         ma.Coins,
+		PubKey:        "",
+		AccountNumber: ma.AccountNumber,
+		Sequence:      ma.Sequence,
+		Name:          ma.Name,
+		Permissions:   ma.Permissions,
+	})
+}
+
+// UnmarshalJSON unmarshals raw JSON bytes into a ModuleAccount.
+func (ma *ModuleAccount) UnmarshalJSON(bz []byte) error {
+	var alias moduleAccountPretty
+	if err := json.Unmarshal(bz, &alias); err != nil {
+		return err
+	}
+
+	ma.BaseAccount = authtypes.NewBaseAccount(alias.Address, alias.Coins, nil, alias.AccountNumber, alias.Sequence)
+	ma.Name = alias.Name
+	ma.Permissions = alias.Permissions
+
+	return nil
 }

--- a/x/supply/internal/types/account_test.go
+++ b/x/supply/internal/types/account_test.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"testing"
@@ -80,4 +81,23 @@ func TestValidate(t *testing.T) {
 			require.Equal(t, tt.expErr, err)
 		})
 	}
+}
+
+func TestModuleAccountJSON(t *testing.T) {
+	pubkey := secp256k1.GenPrivKey().PubKey()
+	addr := sdk.AccAddress(pubkey.Address())
+	coins := sdk.NewCoins(sdk.NewInt64Coin("test", 5))
+	baseAcc := authtypes.NewBaseAccount(addr, coins, nil, 10, 50)
+	acc := NewModuleAccount(baseAcc, "test", "burner")
+
+	bz, err := json.Marshal(acc)
+	require.NoError(t, err)
+
+	bz1, err := acc.MarshalJSON()
+	require.NoError(t, err)
+	require.Equal(t, string(bz1), string(bz))
+
+	var a ModuleAccount
+	require.NoError(t, json.Unmarshal(bz, &a))
+	require.Equal(t, acc.String(), a.String())
 }


### PR DESCRIPTION
Reverts cosmos/cosmos-sdk#6842 because we still need custom JSON marshaling for vesting accounts because otherwise, we get ugly nesting. **However, we keep bech32 removed.**

/cc @ethanfrey 