### PR TITLE
Revert `SetSignerInfo`

### DIFF
--- a/client/tx/tx.go
+++ b/client/tx/tx.go
@@ -18,7 +18,6 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/cosmos-sdk/types/rest"
-	txtypes "github.com/cosmos/cosmos-sdk/types/tx"
 	"github.com/cosmos/cosmos-sdk/types/tx/signing"
 	authsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
 )
@@ -314,16 +313,6 @@ func getSignBytes(
 	signMode signing.SignMode, signerData authsigning.SignerData,
 	txBuilder client.TxBuilder, pubKey crypto.PubKey, txConfig client.TxConfig,
 ) ([]byte, error) {
-	// Set signer info, we only support single signature in this function.
-	err := txBuilder.SetSignerInfo(pubKey, &txtypes.ModeInfo{
-		Sum: &txtypes.ModeInfo_Single_{
-			Single: &txtypes.ModeInfo_Single{Mode: signMode},
-		},
-	})
-	if err != nil {
-		return nil, err
-	}
-
 	// generate the bytes to be signed
 	signBytes, err := txConfig.SignModeHandler().GetSignBytes(signMode, signerData, txBuilder.GetTx())
 	if err != nil {
@@ -339,11 +328,10 @@ func SignWithPrivKey(
 	signMode signing.SignMode, signerData authsigning.SignerData,
 	txBuilder client.TxBuilder, priv crypto.PrivKey, txConfig client.TxConfig,
 ) (signing.SignatureV2, error) {
-
 	var sigV2 signing.SignatureV2
 
-	// Generate the bytes to be signed
-	signBytes, err := getSignBytes(signMode, signerData, txBuilder, priv.PubKey(), txConfig)
+	// Generate the bytes to be signed.
+	signBytes, err := txConfig.SignModeHandler().GetSignBytes(signMode, signerData, txBuilder.GetTx())
 	if err != nil {
 		return sigV2, err
 	}
@@ -394,8 +382,28 @@ func Sign(txf Factory, name string, txBuilder client.TxBuilder) error {
 		AccountSequence: txf.sequence,
 	}
 
-	// Generate the bytes to be signed
-	signBytes, err := getSignBytes(signMode, signerData, txBuilder, pubKey, txf.txConfig)
+	// For SIGN_MODE_DIRECT, calling SetSignatures calls SetSignerInfos on
+	// TxBuilder under the hood, and SignerInfos is needed to generated the
+	// sign bytes. This is the reason for setting SetSignatures here, with a
+	// nil signature.
+	//
+	// Note: this line is not needed for SIGN_MODE_LEGACY_AMINO, but putting it
+	// also doesn't affect its generated sign bytes, so for code's simplicity
+	// sake, we put it here.
+	sigData := signing.SingleSignatureData{
+		SignMode:  signMode,
+		Signature: nil,
+	}
+	sig := signing.SignatureV2{
+		PubKey: pubKey,
+		Data:   &sigData,
+	}
+	if err := txBuilder.SetSignatures(sig); err != nil {
+		return err
+	}
+
+	// Generate the bytes to be signed.
+	signBytes, err := txf.txConfig.SignModeHandler().GetSignBytes(signMode, signerData, txBuilder.GetTx())
 	if err != nil {
 		return err
 	}
@@ -407,11 +415,11 @@ func Sign(txf Factory, name string, txBuilder client.TxBuilder) error {
 	}
 
 	// Construct the SignatureV2 struct
-	sigData := signing.SingleSignatureData{
+	sigData = signing.SingleSignatureData{
 		SignMode:  signMode,
 		Signature: sigBytes,
 	}
-	sig := signing.SignatureV2{
+	sig = signing.SignatureV2{
 		PubKey: pubKey,
 		Data:   &sigData,
 	}

--- a/client/tx/tx.go
+++ b/client/tx/tx.go
@@ -308,20 +308,6 @@ func PrepareFactory(clientCtx client.Context, txf Factory) (Factory, error) {
 	return txf, nil
 }
 
-// Helper function to retrieve sign bytes.
-func getSignBytes(
-	signMode signing.SignMode, signerData authsigning.SignerData,
-	txBuilder client.TxBuilder, pubKey crypto.PubKey, txConfig client.TxConfig,
-) ([]byte, error) {
-	// generate the bytes to be signed
-	signBytes, err := txConfig.SignModeHandler().GetSignBytes(signMode, signerData, txBuilder.GetTx())
-	if err != nil {
-		return nil, err
-	}
-
-	return signBytes, nil
-}
-
 // SignWithPrivKey signs a given tx with the given private key, and returns the
 // corresponding SignatureV2 if the signing is successful.
 func SignWithPrivKey(

--- a/client/tx_generator.go
+++ b/client/tx_generator.go
@@ -1,10 +1,7 @@
 package client
 
 import (
-	"github.com/tendermint/tendermint/crypto"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	txtypes "github.com/cosmos/cosmos-sdk/types/tx"
 	signingtypes "github.com/cosmos/cosmos-sdk/types/tx/signing"
 	"github.com/cosmos/cosmos-sdk/x/auth/signing"
 )
@@ -40,7 +37,6 @@ type (
 		GetTx() signing.SigFeeMemoTx
 
 		SetMsgs(msgs ...sdk.Msg) error
-		SetSignerInfo(pubKey crypto.PubKey, modeInfo *txtypes.ModeInfo) error
 		SetSignatures(signatures ...signingtypes.SignatureV2) error
 		SetMemo(memo string)
 		SetFeeAmount(amount sdk.Coins)

--- a/x/auth/tx/builder_test.go
+++ b/x/auth/tx/builder_test.go
@@ -1,12 +1,9 @@
 package tx
 
 import (
-	"errors"
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/tendermint/tendermint/crypto"
 
 	"github.com/cosmos/cosmos-sdk/codec"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
@@ -232,105 +229,4 @@ func TestBuilderValidateBasic(t *testing.T) {
 	txBuilder.tx = nil
 	err = txBuilder.ValidateBasic()
 	require.Error(t, err)
-}
-
-func TestBuilderSetSignerInfo(t *testing.T) {
-	// keys and addresses
-	_, pubKey1, addr1 := testdata.KeyTestPubAddr()
-	_, pubKey2, addr2 := testdata.KeyTestPubAddr()
-
-	// msg and signatures
-	msg1 := testdata.NewTestMsg(addr1)
-	msg2 := testdata.NewTestMsg(addr2)
-
-	// Variable data for each test
-	var (
-		pubKey    crypto.PubKey
-		modeInfo  txtypes.ModeInfo
-		txBuilder *builder
-	)
-
-	testCases := []struct {
-		desc     string
-		malleate func()
-		expPass  bool
-		expErr   error
-	}{
-		{
-			"should fail if no msgs",
-			func() {
-				pubKey = pubKey1
-			},
-			false, sdkerrors.ErrInvalidPubKey,
-		},
-		{
-			"should fail if no public key",
-			func() {
-				pubKey = nil
-				txBuilder.SetMsgs(msg1)
-			},
-			false, sdkerrors.ErrInvalidPubKey,
-		},
-		{
-			"should fail if signer not in msgs",
-			func() {
-				_, pubKey, _ = testdata.KeyTestPubAddr()
-				txBuilder.SetMsgs(msg1, msg2)
-			},
-			false, sdkerrors.ErrInvalidPubKey,
-		},
-		{
-			"should pass with 2 signers",
-			func() {
-				// Run manually for signer 1.
-				txBuilder.SetMsgs(msg1, msg2)
-				modeInfo = txtypes.ModeInfo{Sum: &txtypes.ModeInfo_Single_{Single: &txtypes.ModeInfo_Single{Mode: signing.SignMode_SIGN_MODE_DIRECT}}}
-				txBuilder.SetSignerInfo(pubKey1, &modeInfo)
-
-				// Test case will handle signer 2.
-				pubKey = pubKey2
-			},
-			true, nil,
-		},
-		{
-			"should reset cached authInfoBz and pubKeys bytes after each call",
-			func() {
-				// Run manually for signer 1.
-				txBuilder.SetMsgs(msg1, msg2)
-				modeInfo = txtypes.ModeInfo{Sum: &txtypes.ModeInfo_Single_{Single: &txtypes.ModeInfo_Single{Mode: signing.SignMode_SIGN_MODE_DIRECT}}}
-				txBuilder.SetSignerInfo(pubKey1, &modeInfo)
-
-				// This populates the cached bytes.
-				_, _ = txBuilder.GetAuthInfoBytes(), txBuilder.GetPubKeys()
-				require.NotNil(t, txBuilder.authInfoBz)
-				require.NotNil(t, txBuilder.pubKeys)
-
-				// Run again, for signer 2. It should reset the cached bytes
-				// to nil.
-				txBuilder.SetSignerInfo(pubKey2, &modeInfo)
-				require.Nil(t, txBuilder.authInfoBz)
-				require.Nil(t, txBuilder.pubKeys)
-
-				// Run the test case, for fun.
-				pubKey = pubKey2
-			},
-			true, nil,
-		},
-	}
-
-	for _, tc := range testCases {
-		// Fresh txBuilder for each test case
-		txBuilder = newBuilder(std.DefaultPublicKeyCodec{})
-
-		tc.malleate()
-
-		fmt.Println(modeInfo)
-		err := txBuilder.SetSignerInfo(pubKey, &modeInfo)
-		if tc.expPass {
-			require.Nil(t, err, tc.desc)
-		} else {
-			require.Error(t, err, tc.desc)
-			require.True(t, errors.Is(tc.expErr, err), tc.desc)
-		}
-	}
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Revert the `SetSignerInfo` function introduced in #6845.

### Rationale

SetSignerInfo doesn't work well with MultiSig. Here's what happens:
- you set a Msg with the multisig account (let's say with 2 accounts) as signer
- you want account1 to sign
- the current txfactory Sign does SetSignerInfo(account1, signerInfo1)
- and SetSignerInfo shouts because account1 is not in the tx's GetSigners

### Possible Solutions

1. Revert to the status quo before #6845, with the "empty signature hack"
2. Replace `SetSignerInfo` with `SetSignerInfos` (with an s).
    - This should work, but after playing around for ~1h, I thought it was too big a refactor, and in part related to https://github.com/cosmos/cosmos-sdk/issues/6896.

This PR implements 1.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Review `Codecov Report` in the comment section below once CI passes
