### PR TITLE
Fix gRPC flaky test

### DIFF
--- a/server/grpc/server_test.go
+++ b/server/grpc/server_test.go
@@ -68,8 +68,8 @@ func (s *IntegrationTestSuite) TestGRPC() {
 		sdk.NewCoin(denom, s.network.Config.AccountTokens),
 		*bankRes.GetBalance(),
 	)
-	blockHeight := header.Get(servergrpc.GRPCBlockHeightHeader)
-	s.Require().Equal([]string{"2"}, blockHeight)
+	blockHeight := header.Get(servergrpc.GRPCBlockHeightHeader) // Returns a []string
+	s.Require().NotNil(blockHeight[0])
 
 	// Request metadata should work
 	bankRes, err = bankClient.Balance(

--- a/server/grpc/server_test.go
+++ b/server/grpc/server_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/suite"
 	"google.golang.org/grpc"
@@ -30,7 +31,7 @@ func (s *IntegrationTestSuite) SetupSuite() {
 	s.network = network.New(s.T(), network.DefaultConfig())
 	s.Require().NotNil(s.network)
 
-	_, err := s.network.WaitForHeight(2)
+	_, err := s.network.WaitForHeightWithTimeout(2, 60*time.Second)
 	s.Require().NoError(err)
 }
 

--- a/server/grpc/server_test.go
+++ b/server/grpc/server_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/suite"
 	"google.golang.org/grpc"
@@ -31,7 +30,7 @@ func (s *IntegrationTestSuite) SetupSuite() {
 	s.network = network.New(s.T(), network.DefaultConfig())
 	s.Require().NotNil(s.network)
 
-	_, err := s.network.WaitForHeightWithTimeout(2, 60*time.Second)
+	_, err := s.network.WaitForHeight(2)
 	s.Require().NoError(err)
 }
 

--- a/server/grpc/server_test.go
+++ b/server/grpc/server_test.go
@@ -67,8 +67,8 @@ func (s *IntegrationTestSuite) TestGRPC() {
 		sdk.NewCoin(denom, s.network.Config.AccountTokens),
 		*bankRes.GetBalance(),
 	)
-	blockHeight := header.Get(servergrpc.GRPCBlockHeightHeader) // Returns a []string
-	s.Require().NotNil(blockHeight[0])
+	blockHeight := header.Get(servergrpc.GRPCBlockHeightHeader)
+	s.Require().NotEqual("", blockHeight[0]) // Should contain the block height
 
 	// Request metadata should work
 	bankRes, err = bankClient.Balance(


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Some of you may have noticed flaky tests on TestGRPC, e.g. [this one](https://github.com/cosmos/cosmos-sdk/runs/928172361#step:5:118). The SetupSuite waits until block height 2, but it seems when the test is run, the block height can vary.

This PR just checks that the header is not empty

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Review `Codecov Report` in the comment section below once CI passes
