### PR TITLE
types: remove unused CanonicalSignBytes

### DIFF
--- a/docs/architecture/adr-020-protobuf-transaction-encoding.md
+++ b/docs/architecture/adr-020-protobuf-transaction-encoding.md
@@ -338,8 +338,6 @@ type TxBuilder interface {
   SetFee(sdk.Fee)
   GetMemo() string
   SetMemo(string)
-
-  CanonicalSignBytes(cid string, num, seq uint64) ([]byte, error)
 }
 ```
 

--- a/types/codec.go
+++ b/types/codec.go
@@ -1,8 +1,6 @@
 package types
 
 import (
-	jsonc "github.com/gibson042/canonicaljson-go"
-
 	"github.com/cosmos/cosmos-sdk/codec/types"
 
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -17,26 +15,4 @@ func RegisterCodec(cdc *codec.Codec) {
 // Register the sdk message type
 func RegisterInterfaces(registry types.InterfaceRegistry) {
 	registry.RegisterInterface("cosmos_sdk.v1.Msg", (*Msg)(nil))
-}
-
-// CanonicalSignBytes returns a canonical JSON encoding of a Proto message that
-// can be signed over. The JSON encoding ensures all field names adhere to their
-// Proto definition, default values are omitted, and follows the JSON Canonical
-// Form.
-func CanonicalSignBytes(msg codec.ProtoMarshaler) ([]byte, error) {
-	// first, encode via canonical Proto3 JSON
-	bz, err := codec.ProtoMarshalJSON(msg)
-	if err != nil {
-		return nil, err
-	}
-
-	genericJSON := make(map[string]interface{})
-
-	// decode canonical proto encoding into a generic map
-	if err := jsonc.Unmarshal(bz, &genericJSON); err != nil {
-		return nil, err
-	}
-
-	// finally, return the canonical JSON encoding via JSON Canonical Form
-	return jsonc.Marshal(genericJSON)
 }


### PR DESCRIPTION
Removes all vestiges of CanonicalSignBytes, which is unused
and untested.

Closes #6679


---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [X] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [X] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [X] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
