### PR TITLE
x/params/types: make KeyTable.RegisterType fully dereference pointers

### DIFF
--- a/x/params/types/deref_test.go
+++ b/x/params/types/deref_test.go
@@ -1,0 +1,27 @@
+package types
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestKeyTableUnfurlsPointers(t *testing.T) {
+	tbl := NewKeyTable()
+	validator := func(_ interface{}) error {
+		return nil
+	}
+	tbl = tbl.RegisterType(ParamSetPair{
+		Key:         []byte("key"),
+		Value:       (*****string)(nil),
+		ValidatorFn: validator,
+	})
+
+	got := tbl.m["key"]
+	want := attribute{
+		vfn: validator,
+		ty:  reflect.ValueOf("").Type(),
+	}
+	require.Equal(t, got.ty, want.ty)
+}

--- a/x/params/types/table.go
+++ b/x/params/types/table.go
@@ -48,7 +48,7 @@ func (t KeyTable) RegisterType(psp ParamSetPair) KeyTable {
 	rty := reflect.TypeOf(psp.Value)
 
 	// indirect rty if it is a pointer
-	if rty.Kind() == reflect.Ptr {
+	for rty.Kind() == reflect.Ptr {
 		rty = rty.Elem()
 	}
 


### PR DESCRIPTION
Use a for loop to correctly and fully dereference and
extract the type for the type of ParamSetPair.Value.

Fixes #6785

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [X] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [x] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
