### PR TITLE
Migrate 02-client to use proto encoded/decoded client states 

### DIFF
--- a/x/ibc-transfer/module.go
+++ b/x/ibc-transfer/module.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/codec"
-	cdctypes "github.com/cosmos/cosmos-sdk/codec/types"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/cosmos-sdk/types/module"
@@ -79,7 +79,7 @@ func (AppModuleBasic) GetQueryCmd() *cobra.Command {
 }
 
 // RegisterInterfaces registers module concrete types into protobuf Any.
-func (AppModuleBasic) RegisterInterfaces(registry cdctypes.InterfaceRegistry) {
+func (AppModuleBasic) RegisterInterfaces(registry codectypes.InterfaceRegistry) {
 	types.RegisterInterfaces(registry)
 }
 

--- a/x/ibc-transfer/types/codec.go
+++ b/x/ibc-transfer/types/codec.go
@@ -2,13 +2,13 @@ package types
 
 import (
 	"github.com/cosmos/cosmos-sdk/codec"
-	cdctypes "github.com/cosmos/cosmos-sdk/codec/types"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 // RegisterInterfaces register the ibc transfer module interfaces to protobuf
 // Any.
-func RegisterInterfaces(registry cdctypes.InterfaceRegistry) {
+func RegisterInterfaces(registry codectypes.InterfaceRegistry) {
 	registry.RegisterImplementations((*sdk.Msg)(nil), &MsgTransfer{})
 }
 
@@ -18,5 +18,5 @@ var (
 	//
 	// The actual codec used for serialization should be provided to x/ibc-transfer and
 	// defined at the application level.
-	ModuleCdc = codec.NewProtoCodec(cdctypes.NewInterfaceRegistry())
+	ModuleCdc = codec.NewProtoCodec(codectypes.NewInterfaceRegistry())
 )

--- a/x/ibc/02-client/keeper/client_test.go
+++ b/x/ibc/02-client/keeper/client_test.go
@@ -69,7 +69,7 @@ func (suite *KeeperTestSuite) TestUpdateClientTendermint() {
 	}
 	var (
 		updateHeader ibctmtypes.Header
-		clientState  ibctmtypes.ClientState
+		clientState  *ibctmtypes.ClientState
 	)
 
 	cases := []struct {
@@ -128,7 +128,7 @@ func (suite *KeeperTestSuite) TestUpdateClientTendermint() {
 			return nil
 		}, false},
 		{"frozen client before update", func() error {
-			clientState = ibctmtypes.ClientState{FrozenHeight: 1, LatestHeight: testClientHeight}
+			clientState = &ibctmtypes.ClientState{FrozenHeight: 1, LatestHeight: testClientHeight}
 			suite.keeper.SetClientState(suite.ctx, testClientID, clientState)
 			suite.keeper.SetClientType(suite.ctx, testClientID, exported.Tendermint)
 			updateHeader = createFutureUpdateFn(suite)
@@ -309,7 +309,7 @@ func (suite *KeeperTestSuite) TestCheckMisbehaviourAndUpdateState() {
 				ClientID: testClientID,
 			},
 			func() error {
-				clientState := ibctmtypes.ClientState{FrozenHeight: 1, LatestHeight: testClientHeight}
+				clientState := &ibctmtypes.ClientState{FrozenHeight: 1, LatestHeight: testClientHeight}
 				suite.keeper.SetClientState(suite.ctx, testClientID, clientState)
 				return nil
 			},
@@ -324,7 +324,7 @@ func (suite *KeeperTestSuite) TestCheckMisbehaviourAndUpdateState() {
 				ClientID: testClientID,
 			},
 			func() error {
-				clientState := ibctmtypes.ClientState{FrozenHeight: 1, LatestHeight: testClientHeight}
+				clientState := &ibctmtypes.ClientState{FrozenHeight: 1, LatestHeight: testClientHeight}
 				suite.keeper.SetClientState(suite.ctx, testClientID, clientState)
 				return nil
 			},

--- a/x/ibc/02-client/keeper/encoding.go
+++ b/x/ibc/02-client/keeper/encoding.go
@@ -31,7 +31,7 @@ func (k Keeper) MustMarshalClientState(clientState exported.ClientState) []byte 
 
 // MarshalClientState marshals an ClientState interface. If the given type implements
 // the Marshaler interface, it is treated as a Proto-defined message and
-// serialized that way. Otherwise, it falls back on the internal Amino codec.
+// serialized that way.
 func (k Keeper) MarshalClientState(clientStateI exported.ClientState) ([]byte, error) {
 	return codec.MarshalAny(k.cdc, clientStateI)
 }

--- a/x/ibc/02-client/keeper/encoding.go
+++ b/x/ibc/02-client/keeper/encoding.go
@@ -1,0 +1,49 @@
+package keeper
+
+import (
+	"fmt"
+
+	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/x/ibc/02-client/exported"
+)
+
+// MustUnmarshalClientState attempts to decode and return an ClientState object from
+// raw encoded bytes. It panics on error.
+func (k Keeper) MustUnmarshalClientState(bz []byte) exported.ClientState {
+	clientState, err := k.UnmarshalClientState(bz)
+	if err != nil {
+		panic(fmt.Errorf("failed to decode client state: %w", err))
+	}
+
+	return clientState
+}
+
+// MustMarshalClientState attempts to encode an ClientState object and returns the
+// raw encoded bytes. It panics on error.
+func (k Keeper) MustMarshalClientState(clientState exported.ClientState) []byte {
+	bz, err := k.MarshalClientState(clientState)
+	if err != nil {
+		panic(fmt.Errorf("failed to encode client state: %w", err))
+	}
+
+	return bz
+}
+
+// MarshalClientState marshals an ClientState interface. If the given type implements
+// the Marshaler interface, it is treated as a Proto-defined message and
+// serialized that way. Otherwise, it falls back on the internal Amino codec.
+func (k Keeper) MarshalClientState(clientStateI exported.ClientState) ([]byte, error) {
+	return codec.MarshalAny(k.cdc, clientStateI)
+}
+
+// UnmarshalClientState returns an ClientState interface from raw encoded clientState
+// bytes of a Proto-based ClientState type. An error is returned upon decoding
+// failure.
+func (k Keeper) UnmarshalClientState(bz []byte) (exported.ClientState, error) {
+	var clientState exported.ClientState
+	if err := codec.UnmarshalAny(k.cdc, &clientState, bz); err != nil {
+		return nil, err
+	}
+
+	return clientState, nil
+}

--- a/x/ibc/02-client/keeper/keeper_test.go
+++ b/x/ibc/02-client/keeper/keeper_test.go
@@ -38,7 +38,8 @@ const (
 type KeeperTestSuite struct {
 	suite.Suite
 
-	cdc            *codec.Codec
+	cdc            codec.Marshaler
+	aminoCdc       *codec.Codec
 	ctx            sdk.Context
 	keeper         *keeper.Keeper
 	consensusState ibctmtypes.ConsensusState
@@ -56,7 +57,8 @@ func (suite *KeeperTestSuite) SetupTest() {
 	now2 := suite.now.Add(time.Hour)
 	app := simapp.Setup(isCheckTx)
 
-	suite.cdc = app.Codec()
+	suite.cdc = app.AppCodec()
+	suite.aminoCdc = app.Codec()
 	suite.ctx = app.BaseApp.NewContext(isCheckTx, abci.Header{Height: testClientHeight, ChainID: testClientID, Time: now2})
 	suite.keeper = &app.IBCKeeper.ClientKeeper
 	suite.privVal = tmtypes.NewMockPV()

--- a/x/ibc/02-client/types/codec.go
+++ b/x/ibc/02-client/types/codec.go
@@ -8,6 +8,7 @@ import (
 
 // RegisterCodec registers the IBC client interfaces and types
 func RegisterCodec(cdc *codec.Codec) {
+	cdc.RegisterInterface((*exported.ClientState)(nil), nil) // remove when exporting uses proto
 	cdc.RegisterInterface((*exported.MsgCreateClient)(nil), nil)
 	cdc.RegisterInterface((*exported.MsgUpdateClient)(nil), nil)
 	cdc.RegisterInterface((*exported.ConsensusState)(nil), nil)

--- a/x/ibc/02-client/types/codec.go
+++ b/x/ibc/02-client/types/codec.go
@@ -16,6 +16,7 @@ func RegisterCodec(cdc *codec.Codec) {
 	cdc.RegisterInterface((*exported.Misbehaviour)(nil), nil)
 }
 
+// RegisterInterfaces registers the client interfaces to protobuf Any.
 func RegisterInterfaces(registry codectypes.InterfaceRegistry) {
 	registry.RegisterInterface(
 		"cosmos_sdk.ibc.v1.client.ClientState",

--- a/x/ibc/02-client/types/codec.go
+++ b/x/ibc/02-client/types/codec.go
@@ -8,7 +8,7 @@ import (
 
 // RegisterCodec registers the IBC client interfaces and types
 func RegisterCodec(cdc *codec.Codec) {
-	cdc.RegisterInterface((*exported.ClientState)(nil), nil) // remove when exporting uses proto
+	cdc.RegisterInterface((*exported.ClientState)(nil), nil) // remove after genesis migration
 	cdc.RegisterInterface((*exported.MsgCreateClient)(nil), nil)
 	cdc.RegisterInterface((*exported.MsgUpdateClient)(nil), nil)
 	cdc.RegisterInterface((*exported.ConsensusState)(nil), nil)

--- a/x/ibc/02-client/types/codec.go
+++ b/x/ibc/02-client/types/codec.go
@@ -2,25 +2,39 @@ package types
 
 import (
 	"github.com/cosmos/cosmos-sdk/codec"
-	cryptocodec "github.com/cosmos/cosmos-sdk/crypto/codec"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/cosmos/cosmos-sdk/x/ibc/02-client/exported"
 )
 
-// SubModuleCdc defines the IBC client codec.
-var SubModuleCdc *codec.Codec
-
-func init() {
-	SubModuleCdc = codec.New()
-	cryptocodec.RegisterCrypto(SubModuleCdc)
-	RegisterCodec(SubModuleCdc)
-}
-
 // RegisterCodec registers the IBC client interfaces and types
 func RegisterCodec(cdc *codec.Codec) {
-	cdc.RegisterInterface((*exported.ClientState)(nil), nil)
 	cdc.RegisterInterface((*exported.MsgCreateClient)(nil), nil)
 	cdc.RegisterInterface((*exported.MsgUpdateClient)(nil), nil)
 	cdc.RegisterInterface((*exported.ConsensusState)(nil), nil)
 	cdc.RegisterInterface((*exported.Header)(nil), nil)
 	cdc.RegisterInterface((*exported.Misbehaviour)(nil), nil)
+}
+
+func RegisterInterfaces(registry codectypes.InterfaceRegistry) {
+	registry.RegisterInterface(
+		"cosmos_sdk.ibc.v1.client.ClientState",
+		(*exported.ClientState)(nil),
+	)
+}
+
+var (
+	amino = codec.New()
+
+	// SubModuleCdc references the global x/ibc/02-client module codec. Note, the codec should
+	// ONLY be used in certain instances of tests and for JSON encoding as Amino is
+	// still used for that purpose.
+	//
+	// The actual codec used for serialization should be provided to x/ibc/02-client and
+	// defined at the application level.
+	SubModuleCdc = codec.NewHybridCodec(amino, codectypes.NewInterfaceRegistry())
+)
+
+func init() {
+	RegisterCodec(amino)
+	amino.Seal()
 }

--- a/x/ibc/03-connection/types/codec.go
+++ b/x/ibc/03-connection/types/codec.go
@@ -2,13 +2,13 @@ package types
 
 import (
 	"github.com/cosmos/cosmos-sdk/codec"
-	cdctypes "github.com/cosmos/cosmos-sdk/codec/types"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 // RegisterInterfaces register the ibc interfaces submodule implementations to protobuf
 // Any.
-func RegisterInterfaces(registry cdctypes.InterfaceRegistry) {
+func RegisterInterfaces(registry codectypes.InterfaceRegistry) {
 	registry.RegisterImplementations(
 		(*sdk.Msg)(nil),
 		&MsgConnectionOpenInit{},
@@ -24,5 +24,5 @@ var (
 	//
 	// The actual codec used for serialization should be provided to x/ibc/03-connectionl and
 	// defined at the application level.
-	SubModuleCdc = codec.NewProtoCodec(cdctypes.NewInterfaceRegistry())
+	SubModuleCdc = codec.NewProtoCodec(codectypes.NewInterfaceRegistry())
 )

--- a/x/ibc/04-channel/types/codec.go
+++ b/x/ibc/04-channel/types/codec.go
@@ -2,13 +2,13 @@ package types
 
 import (
 	"github.com/cosmos/cosmos-sdk/codec"
-	cdctypes "github.com/cosmos/cosmos-sdk/codec/types"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 // RegisterInterfaces register the ibc channel submodule interfaces to protobuf
 // Any.
-func RegisterInterfaces(registry cdctypes.InterfaceRegistry) {
+func RegisterInterfaces(registry codectypes.InterfaceRegistry) {
 	registry.RegisterImplementations(
 		(*sdk.Msg)(nil),
 		&MsgChannelOpenInit{},
@@ -28,4 +28,4 @@ func RegisterInterfaces(registry cdctypes.InterfaceRegistry) {
 //
 // The actual codec used for serialization should be provided to x/ibc/04-channel and
 // defined at the application level.
-var SubModuleCdc = codec.NewProtoCodec(cdctypes.NewInterfaceRegistry())
+var SubModuleCdc = codec.NewProtoCodec(codectypes.NewInterfaceRegistry())

--- a/x/ibc/07-tendermint/misbehaviour.go
+++ b/x/ibc/07-tendermint/misbehaviour.go
@@ -26,7 +26,7 @@ func CheckMisbehaviourAndUpdateState(
 ) (clientexported.ClientState, error) {
 
 	// cast the interface to specific types before checking for misbehaviour
-	tmClientState, ok := clientState.(types.ClientState)
+	tmClientState, ok := clientState.(*types.ClientState)
 	if !ok {
 		return nil, sdkerrors.Wrapf(clienttypes.ErrInvalidClientType, "expected type %T, got %T", types.ClientState{}, clientState)
 	}
@@ -59,7 +59,7 @@ func CheckMisbehaviourAndUpdateState(
 
 // checkMisbehaviour checks if the evidence provided is a valid light client misbehaviour
 func checkMisbehaviour(
-	clientState types.ClientState, consensusState types.ConsensusState, evidence types.Evidence,
+	clientState *types.ClientState, consensusState types.ConsensusState, evidence types.Evidence,
 	height uint64, currentTimestamp time.Time, consensusParams *abci.ConsensusParams,
 ) error {
 	// calculate the age of the misbehaviour evidence

--- a/x/ibc/07-tendermint/types/client_state.go
+++ b/x/ibc/07-tendermint/types/client_state.go
@@ -21,7 +21,7 @@ import (
 	host "github.com/cosmos/cosmos-sdk/x/ibc/24-host"
 )
 
-var _ clientexported.ClientState = ClientState{}
+var _ clientexported.ClientState = (*ClientState)(nil)
 
 // InitializeFromMsg creates a tendermint client state from a CreateClientMsg
 func InitializeFromMsg(msg *MsgCreateClient) ClientState {

--- a/x/ibc/07-tendermint/types/client_state.go
+++ b/x/ibc/07-tendermint/types/client_state.go
@@ -24,7 +24,7 @@ import (
 var _ clientexported.ClientState = (*ClientState)(nil)
 
 // InitializeFromMsg creates a tendermint client state from a CreateClientMsg
-func InitializeFromMsg(msg *MsgCreateClient) ClientState {
+func InitializeFromMsg(msg *MsgCreateClient) *ClientState {
 	return NewClientState(msg.Header.ChainID, msg.TrustLevel,
 		msg.TrustingPeriod, msg.UnbondingPeriod, msg.MaxClockDrift,
 		uint64(msg.Header.Height), msg.ProofSpecs,
@@ -36,8 +36,8 @@ func NewClientState(
 	chainID string, trustLevel Fraction,
 	trustingPeriod, ubdPeriod, maxClockDrift time.Duration,
 	latestHeight uint64, specs []*ics23.ProofSpec,
-) ClientState {
-	return ClientState{
+) *ClientState {
+	return &ClientState{
 		ChainID:         chainID,
 		TrustLevel:      trustLevel,
 		TrustingPeriod:  trustingPeriod,

--- a/x/ibc/07-tendermint/types/client_state_test.go
+++ b/x/ibc/07-tendermint/types/client_state_test.go
@@ -21,7 +21,7 @@ const (
 func (suite *TendermintTestSuite) TestValidate() {
 	testCases := []struct {
 		name        string
-		clientState types.ClientState
+		clientState *types.ClientState
 		expPass     bool
 	}{
 		{
@@ -89,7 +89,7 @@ func (suite *TendermintTestSuite) TestValidate() {
 func (suite *TendermintTestSuite) TestVerifyClientConsensusState() {
 	testCases := []struct {
 		name           string
-		clientState    ibctmtypes.ClientState
+		clientState    *ibctmtypes.ClientState
 		consensusState ibctmtypes.ConsensusState
 		prefix         commitmenttypes.MerklePrefix
 		proof          []byte
@@ -125,7 +125,7 @@ func (suite *TendermintTestSuite) TestVerifyClientConsensusState() {
 		},
 		{
 			name:        "client is frozen",
-			clientState: ibctmtypes.ClientState{LatestHeight: height, FrozenHeight: height - 1},
+			clientState: &ibctmtypes.ClientState{LatestHeight: height, FrozenHeight: height - 1},
 			consensusState: ibctmtypes.ConsensusState{
 				Root: commitmenttypes.NewMerkleRoot(suite.header.AppHash),
 			},
@@ -166,7 +166,7 @@ func (suite *TendermintTestSuite) TestVerifyConnectionState() {
 
 	testCases := []struct {
 		name           string
-		clientState    ibctmtypes.ClientState
+		clientState    *ibctmtypes.ClientState
 		connection     connectiontypes.ConnectionEnd
 		consensusState ibctmtypes.ConsensusState
 		prefix         commitmenttypes.MerklePrefix
@@ -206,7 +206,7 @@ func (suite *TendermintTestSuite) TestVerifyConnectionState() {
 		},
 		{
 			name:        "client is frozen",
-			clientState: ibctmtypes.ClientState{LatestHeight: height, FrozenHeight: height - 1},
+			clientState: &ibctmtypes.ClientState{LatestHeight: height, FrozenHeight: height - 1},
 			connection:  conn,
 			consensusState: ibctmtypes.ConsensusState{
 				Root: commitmenttypes.NewMerkleRoot(suite.header.AppHash),
@@ -249,7 +249,7 @@ func (suite *TendermintTestSuite) TestVerifyChannelState() {
 
 	testCases := []struct {
 		name           string
-		clientState    ibctmtypes.ClientState
+		clientState    *ibctmtypes.ClientState
 		channel        channeltypes.Channel
 		consensusState ibctmtypes.ConsensusState
 		prefix         commitmenttypes.MerklePrefix
@@ -289,7 +289,7 @@ func (suite *TendermintTestSuite) TestVerifyChannelState() {
 		},
 		{
 			name:        "client is frozen",
-			clientState: ibctmtypes.ClientState{LatestHeight: height, FrozenHeight: height - 1},
+			clientState: &ibctmtypes.ClientState{LatestHeight: height, FrozenHeight: height - 1},
 			channel:     ch,
 			consensusState: ibctmtypes.ConsensusState{
 				Root: commitmenttypes.NewMerkleRoot(suite.header.AppHash),
@@ -329,7 +329,7 @@ func (suite *TendermintTestSuite) TestVerifyChannelState() {
 func (suite *TendermintTestSuite) TestVerifyPacketCommitment() {
 	testCases := []struct {
 		name           string
-		clientState    ibctmtypes.ClientState
+		clientState    *ibctmtypes.ClientState
 		commitment     []byte
 		consensusState ibctmtypes.ConsensusState
 		prefix         commitmenttypes.MerklePrefix
@@ -369,7 +369,7 @@ func (suite *TendermintTestSuite) TestVerifyPacketCommitment() {
 		},
 		{
 			name:        "client is frozen",
-			clientState: ibctmtypes.ClientState{LatestHeight: height, FrozenHeight: height - 1},
+			clientState: &ibctmtypes.ClientState{LatestHeight: height, FrozenHeight: height - 1},
 			commitment:  []byte{},
 			consensusState: ibctmtypes.ConsensusState{
 				Root: commitmenttypes.NewMerkleRoot(suite.header.AppHash),
@@ -409,7 +409,7 @@ func (suite *TendermintTestSuite) TestVerifyPacketCommitment() {
 func (suite *TendermintTestSuite) TestVerifyPacketAcknowledgement() {
 	testCases := []struct {
 		name           string
-		clientState    ibctmtypes.ClientState
+		clientState    *ibctmtypes.ClientState
 		ack            []byte
 		consensusState ibctmtypes.ConsensusState
 		prefix         commitmenttypes.MerklePrefix
@@ -449,7 +449,7 @@ func (suite *TendermintTestSuite) TestVerifyPacketAcknowledgement() {
 		},
 		{
 			name:        "client is frozen",
-			clientState: ibctmtypes.ClientState{LatestHeight: height, FrozenHeight: height - 1},
+			clientState: &ibctmtypes.ClientState{LatestHeight: height, FrozenHeight: height - 1},
 			ack:         []byte{},
 			consensusState: ibctmtypes.ConsensusState{
 				Root: commitmenttypes.NewMerkleRoot(suite.header.AppHash),
@@ -489,7 +489,7 @@ func (suite *TendermintTestSuite) TestVerifyPacketAcknowledgement() {
 func (suite *TendermintTestSuite) TestVerifyPacketAcknowledgementAbsence() {
 	testCases := []struct {
 		name           string
-		clientState    ibctmtypes.ClientState
+		clientState    *ibctmtypes.ClientState
 		consensusState ibctmtypes.ConsensusState
 		prefix         commitmenttypes.MerklePrefix
 		proof          []byte
@@ -526,7 +526,7 @@ func (suite *TendermintTestSuite) TestVerifyPacketAcknowledgementAbsence() {
 		},
 		{
 			name:        "client is frozen",
-			clientState: ibctmtypes.ClientState{LatestHeight: height, FrozenHeight: height - 1},
+			clientState: &ibctmtypes.ClientState{LatestHeight: height, FrozenHeight: height - 1},
 			consensusState: ibctmtypes.ConsensusState{
 				Root: commitmenttypes.NewMerkleRoot(suite.header.AppHash),
 			},
@@ -564,7 +564,7 @@ func (suite *TendermintTestSuite) TestVerifyPacketAcknowledgementAbsence() {
 func (suite *TendermintTestSuite) TestVerifyNextSeqRecv() {
 	testCases := []struct {
 		name           string
-		clientState    ibctmtypes.ClientState
+		clientState    *ibctmtypes.ClientState
 		consensusState ibctmtypes.ConsensusState
 		prefix         commitmenttypes.MerklePrefix
 		proof          []byte
@@ -601,7 +601,7 @@ func (suite *TendermintTestSuite) TestVerifyNextSeqRecv() {
 		},
 		{
 			name:        "client is frozen",
-			clientState: ibctmtypes.ClientState{LatestHeight: height, FrozenHeight: height - 1},
+			clientState: &ibctmtypes.ClientState{LatestHeight: height, FrozenHeight: height - 1},
 			consensusState: ibctmtypes.ConsensusState{
 				Root: commitmenttypes.NewMerkleRoot(suite.header.AppHash),
 			},

--- a/x/ibc/07-tendermint/types/codec.go
+++ b/x/ibc/07-tendermint/types/codec.go
@@ -10,6 +10,7 @@ import (
 // RegisterCodec registers the necessary x/ibc/07-tendermint interfaces and conrete types
 // on the provided Amino codec. These types are used for Amino JSON serialization.
 func RegisterCodec(cdc *codec.Codec) {
+	cdc.RegisterConcrete(ClientState{}, "ibc/client/tendermint/ClientState", nil)
 	cdc.RegisterConcrete(ConsensusState{}, "ibc/client/tendermint/ConsensusState", nil)
 	cdc.RegisterConcrete(Header{}, "ibc/client/tendermint/Header", nil)
 	cdc.RegisterConcrete(Evidence{}, "ibc/client/tendermint/Evidence", nil)

--- a/x/ibc/07-tendermint/types/codec.go
+++ b/x/ibc/07-tendermint/types/codec.go
@@ -10,7 +10,6 @@ import (
 // RegisterCodec registers the necessary x/ibc/07-tendermint interfaces and conrete types
 // on the provided Amino codec. These types are used for Amino JSON serialization.
 func RegisterCodec(cdc *codec.Codec) {
-	cdc.RegisterConcrete(ClientState{}, "ibc/client/tendermint/ClientState", nil)
 	cdc.RegisterConcrete(ConsensusState{}, "ibc/client/tendermint/ConsensusState", nil)
 	cdc.RegisterConcrete(Header{}, "ibc/client/tendermint/Header", nil)
 	cdc.RegisterConcrete(Evidence{}, "ibc/client/tendermint/Evidence", nil)

--- a/x/ibc/07-tendermint/types/codec.go
+++ b/x/ibc/07-tendermint/types/codec.go
@@ -2,7 +2,7 @@ package types
 
 import (
 	"github.com/cosmos/cosmos-sdk/codec"
-	cdctypes "github.com/cosmos/cosmos-sdk/codec/types"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	cryptocodec "github.com/cosmos/cosmos-sdk/crypto/codec"
 	clientexported "github.com/cosmos/cosmos-sdk/x/ibc/02-client/exported"
 )
@@ -21,7 +21,7 @@ func RegisterCodec(cdc *codec.Codec) {
 
 // RegisterInterfaces registers the tendermint concrete evidence and client-related
 // implementations and interfaces.
-func RegisterInterfaces(registry cdctypes.InterfaceRegistry) {
+func RegisterInterfaces(registry codectypes.InterfaceRegistry) {
 	registry.RegisterImplementations(
 		(*clientexported.ClientState)(nil),
 		&ClientState{},
@@ -37,7 +37,7 @@ var (
 	//
 	// The actual codec used for serialization should be provided to x/ibc/07-tendermint and
 	// defined at the application level.
-	SubModuleCdc = codec.NewHybridCodec(amino, cdctypes.NewInterfaceRegistry())
+	SubModuleCdc = codec.NewHybridCodec(amino, codectypes.NewInterfaceRegistry())
 )
 
 func init() {

--- a/x/ibc/07-tendermint/types/evidence.go
+++ b/x/ibc/07-tendermint/types/evidence.go
@@ -18,8 +18,8 @@ import (
 )
 
 var (
-	_ evidenceexported.Evidence   = Evidence{}
-	_ clientexported.Misbehaviour = Evidence{}
+	_ evidenceexported.Evidence   = &Evidence{}
+	_ clientexported.Misbehaviour = &Evidence{}
 )
 
 // Evidence is a wrapper over tendermint's DuplicateVoteEvidence

--- a/x/ibc/07-tendermint/types/evidence.go
+++ b/x/ibc/07-tendermint/types/evidence.go
@@ -18,8 +18,8 @@ import (
 )
 
 var (
-	_ evidenceexported.Evidence   = &Evidence{}
-	_ clientexported.Misbehaviour = &Evidence{}
+	_ evidenceexported.Evidence   = Evidence{}
+	_ clientexported.Misbehaviour = Evidence{}
 )
 
 // Evidence is a wrapper over tendermint's DuplicateVoteEvidence

--- a/x/ibc/07-tendermint/update.go
+++ b/x/ibc/07-tendermint/update.go
@@ -36,7 +36,7 @@ func CheckValidityAndUpdateState(
 	clientState clientexported.ClientState, consState clientexported.ConsensusState,
 	header clientexported.Header, currentTimestamp time.Time,
 ) (clientexported.ClientState, clientexported.ConsensusState, error) {
-	tmClientState, ok := clientState.(types.ClientState)
+	tmClientState, ok := clientState.(*types.ClientState)
 	if !ok {
 		return nil, nil, sdkerrors.Wrapf(
 			clienttypes.ErrInvalidClientType, "expected type %T, got %T", types.ClientState{}, clientState,
@@ -67,7 +67,7 @@ func CheckValidityAndUpdateState(
 
 // checkValidity checks if the Tendermint header is valid.
 func checkValidity(
-	clientState types.ClientState, consState types.ConsensusState, header types.Header, currentTimestamp time.Time,
+	clientState *types.ClientState, consState types.ConsensusState, header types.Header, currentTimestamp time.Time,
 ) error {
 	// assert trusting period has not yet passed
 	if currentTimestamp.Sub(consState.Timestamp) >= clientState.TrustingPeriod {
@@ -127,7 +127,7 @@ func checkValidity(
 }
 
 // update the consensus state from a new header
-func update(clientState types.ClientState, header types.Header) (types.ClientState, types.ConsensusState) {
+func update(clientState *types.ClientState, header types.Header) (*types.ClientState, types.ConsensusState) {
 	if uint64(header.Height) > clientState.LatestHeight {
 		clientState.LatestHeight = uint64(header.Height)
 	}

--- a/x/ibc/07-tendermint/update_test.go
+++ b/x/ibc/07-tendermint/update_test.go
@@ -13,7 +13,7 @@ import (
 
 func (suite *TendermintTestSuite) TestCheckValidity() {
 	var (
-		clientState    types.ClientState
+		clientState    *types.ClientState
 		consensusState types.ConsensusState
 		newHeader      types.Header
 		currentTime    time.Time

--- a/x/ibc/09-localhost/types/client_state.go
+++ b/x/ibc/09-localhost/types/client_state.go
@@ -24,8 +24,8 @@ import (
 var _ clientexported.ClientState = (*ClientState)(nil)
 
 // NewClientState creates a new ClientState instance
-func NewClientState(chainID string, height int64) ClientState {
-	return ClientState{
+func NewClientState(chainID string, height int64) *ClientState {
+	return &ClientState{
 		ChainID: chainID,
 		Height:  uint64(height),
 	}

--- a/x/ibc/09-localhost/types/client_state_test.go
+++ b/x/ibc/09-localhost/types/client_state_test.go
@@ -17,7 +17,7 @@ const (
 func (suite *LocalhostTestSuite) TestValidate() {
 	testCases := []struct {
 		name        string
-		clientState types.ClientState
+		clientState *types.ClientState
 		expPass     bool
 	}{
 		{
@@ -61,7 +61,7 @@ func (suite *LocalhostTestSuite) TestVerifyConnectionState() {
 
 	testCases := []struct {
 		name        string
-		clientState types.ClientState
+		clientState *types.ClientState
 		connection  connectiontypes.ConnectionEnd
 		prefix      commitmenttypes.MerklePrefix
 		proof       []byte
@@ -105,7 +105,7 @@ func (suite *LocalhostTestSuite) TestVerifyChannelState() {
 
 	testCases := []struct {
 		name        string
-		clientState types.ClientState
+		clientState *types.ClientState
 		channel     channeltypes.Channel
 		prefix      commitmenttypes.MerklePrefix
 		proof       []byte
@@ -153,7 +153,7 @@ func (suite *LocalhostTestSuite) TestVerifyChannelState() {
 func (suite *LocalhostTestSuite) TestVerifyPacketCommitment() {
 	testCases := []struct {
 		name        string
-		clientState types.ClientState
+		clientState *types.ClientState
 		commitment  []byte
 		prefix      commitmenttypes.MerklePrefix
 		proof       []byte
@@ -208,7 +208,7 @@ func (suite *LocalhostTestSuite) TestVerifyPacketCommitment() {
 func (suite *LocalhostTestSuite) TestVerifyPacketAcknowledgement() {
 	testCases := []struct {
 		name        string
-		clientState types.ClientState
+		clientState *types.ClientState
 		ack         []byte
 		prefix      commitmenttypes.MerklePrefix
 		proof       []byte
@@ -263,7 +263,7 @@ func (suite *LocalhostTestSuite) TestVerifyPacketAcknowledgement() {
 func (suite *LocalhostTestSuite) TestVerifyPacketAcknowledgementAbsence() {
 	testCases := []struct {
 		name        string
-		clientState types.ClientState
+		clientState *types.ClientState
 		prefix      commitmenttypes.MerklePrefix
 		proof       []byte
 		expPass     bool
@@ -294,7 +294,7 @@ func (suite *LocalhostTestSuite) TestVerifyPacketAcknowledgementAbsence() {
 func (suite *LocalhostTestSuite) TestVerifyNextSeqRecv() {
 	testCases := []struct {
 		name        string
-		clientState types.ClientState
+		clientState *types.ClientState
 		prefix      commitmenttypes.MerklePrefix
 		proof       []byte
 		expPass     bool

--- a/x/ibc/09-localhost/types/codec.go
+++ b/x/ibc/09-localhost/types/codec.go
@@ -7,6 +7,13 @@ import (
 	clientexported "github.com/cosmos/cosmos-sdk/x/ibc/02-client/exported"
 )
 
+// RegisterCodec registers client state on the provided Amino codec. This type is used for
+// Amino JSON serialization.
+// TODO: remove after genesis and exporting use proto
+func RegisterCodec(cdc *codec.Codec) {
+	cdc.RegisterConcrete(ClientState{}, "ibc/client/localhost/ClientState", nil)
+}
+
 // RegisterInterfaces register the ibc interfaces submodule implementations to protobuf
 // Any.
 func RegisterInterfaces(registry codectypes.InterfaceRegistry) {

--- a/x/ibc/09-localhost/types/codec.go
+++ b/x/ibc/09-localhost/types/codec.go
@@ -2,20 +2,14 @@ package types
 
 import (
 	"github.com/cosmos/cosmos-sdk/codec"
-	cdctypes "github.com/cosmos/cosmos-sdk/codec/types"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	clientexported "github.com/cosmos/cosmos-sdk/x/ibc/02-client/exported"
 )
 
-// RegisterCodec registers client state on the provided Amino codec. This type is used for
-// Amino JSON serialization.
-func RegisterCodec(cdc *codec.Codec) {
-	cdc.RegisterConcrete(ClientState{}, "ibc/client/localhost/ClientState", nil)
-}
-
 // RegisterInterfaces register the ibc interfaces submodule implementations to protobuf
 // Any.
-func RegisterInterfaces(registry cdctypes.InterfaceRegistry) {
+func RegisterInterfaces(registry codectypes.InterfaceRegistry) {
 	registry.RegisterImplementations(
 		(*sdk.Msg)(nil),
 		&MsgCreateClient{},
@@ -27,17 +21,10 @@ func RegisterInterfaces(registry cdctypes.InterfaceRegistry) {
 }
 
 var (
-	amino = codec.New()
-
 	// SubModuleCdc references the global x/ibc/09-localhost module codec. Note, the codec should
 	// ONLY be used in certain instances of tests and for JSON encoding.
 	//
 	// The actual codec used for serialization should be provided to x/ibc/09-localhost and
 	// defined at the application level.
-	SubModuleCdc = codec.NewHybridCodec(amino, cdctypes.NewInterfaceRegistry())
+	SubModuleCdc = codec.NewProtoCodec(codectypes.NewInterfaceRegistry())
 )
-
-func init() {
-	RegisterCodec(amino)
-	amino.Seal()
-}

--- a/x/ibc/23-commitment/types/codec.go
+++ b/x/ibc/23-commitment/types/codec.go
@@ -2,12 +2,12 @@ package types
 
 import (
 	"github.com/cosmos/cosmos-sdk/codec"
-	cdctypes "github.com/cosmos/cosmos-sdk/codec/types"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/cosmos/cosmos-sdk/x/ibc/23-commitment/exported"
 )
 
 // RegisterInterfaces registers the commitment interfaces to protobuf Any.
-func RegisterInterfaces(registry cdctypes.InterfaceRegistry) {
+func RegisterInterfaces(registry codectypes.InterfaceRegistry) {
 	registry.RegisterInterface(
 		"cosmos.ibc.commitment.Root",
 		(*exported.Root)(nil),
@@ -66,7 +66,7 @@ var (
 	//
 	// The actual codec used for serialization should be provided to x/ibc/23-commitmentl and
 	// defined at the application level.
-	SubModuleCdc = codec.NewHybridCodec(amino, cdctypes.NewInterfaceRegistry())
+	SubModuleCdc = codec.NewHybridCodec(amino, codectypes.NewInterfaceRegistry())
 )
 
 func init() {

--- a/x/ibc/keeper/keeper.go
+++ b/x/ibc/keeper/keeper.go
@@ -34,7 +34,7 @@ type Keeper struct {
 func NewKeeper(
 	aminoCdc *codec.Codec, cdc codec.BinaryMarshaler, key sdk.StoreKey, stakingKeeper clienttypes.StakingKeeper, scopedKeeper capabilitykeeper.ScopedKeeper,
 ) *Keeper {
-	clientKeeper := clientkeeper.NewKeeper(aminoCdc, key, stakingKeeper)
+	clientKeeper := clientkeeper.NewKeeper(cdc, aminoCdc, key, stakingKeeper)
 	connectionKeeper := connectionkeeper.NewKeeper(aminoCdc, cdc, key, clientKeeper)
 	portKeeper := portkeeper.NewKeeper(scopedKeeper)
 	channelKeeper := channelkeeper.NewKeeper(cdc, key, clientKeeper, connectionKeeper, portKeeper, scopedKeeper)

--- a/x/ibc/module.go
+++ b/x/ibc/module.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/codec"
-	cdctypes "github.com/cosmos/cosmos-sdk/codec/types"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
@@ -79,7 +79,7 @@ func (AppModuleBasic) GetQueryCmd() *cobra.Command {
 }
 
 // RegisterInterfaces registers module concrete types into protobuf Any.
-func (AppModuleBasic) RegisterInterfaces(registry cdctypes.InterfaceRegistry) {
+func (AppModuleBasic) RegisterInterfaces(registry codectypes.InterfaceRegistry) {
 	types.RegisterInterfaces(registry)
 }
 

--- a/x/ibc/types/codec.go
+++ b/x/ibc/types/codec.go
@@ -2,7 +2,7 @@ package types
 
 import (
 	"github.com/cosmos/cosmos-sdk/codec"
-	cdctypes "github.com/cosmos/cosmos-sdk/codec/types"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	clienttypes "github.com/cosmos/cosmos-sdk/x/ibc/02-client/types"
 	connectiontypes "github.com/cosmos/cosmos-sdk/x/ibc/03-connection/types"
 	channeltypes "github.com/cosmos/cosmos-sdk/x/ibc/04-channel/types"
@@ -21,7 +21,7 @@ func RegisterCodec(cdc *codec.Codec) {
 }
 
 // RegisterInterfaces registers x/ibc interfaces into protobuf Any.
-func RegisterInterfaces(registry cdctypes.InterfaceRegistry) {
+func RegisterInterfaces(registry codectypes.InterfaceRegistry) {
 	clienttypes.RegisterInterfaces(registry)
 	connectiontypes.RegisterInterfaces(registry)
 	channeltypes.RegisterInterfaces(registry)

--- a/x/ibc/types/codec.go
+++ b/x/ibc/types/codec.go
@@ -16,6 +16,7 @@ import (
 func RegisterCodec(cdc *codec.Codec) {
 	clienttypes.RegisterCodec(cdc)
 	ibctmtypes.RegisterCodec(cdc)
+	localhosttypes.RegisterCodec(cdc)
 	commitmenttypes.RegisterCodec(cdc)
 }
 

--- a/x/ibc/types/codec.go
+++ b/x/ibc/types/codec.go
@@ -16,13 +16,15 @@ import (
 func RegisterCodec(cdc *codec.Codec) {
 	clienttypes.RegisterCodec(cdc)
 	ibctmtypes.RegisterCodec(cdc)
-	localhosttypes.RegisterCodec(cdc)
 	commitmenttypes.RegisterCodec(cdc)
 }
 
 // RegisterInterfaces registers x/ibc interfaces into protobuf Any.
 func RegisterInterfaces(registry cdctypes.InterfaceRegistry) {
+	clienttypes.RegisterInterfaces(registry)
 	connectiontypes.RegisterInterfaces(registry)
 	channeltypes.RegisterInterfaces(registry)
+	ibctmtypes.RegisterInterfaces(registry)
+	localhosttypes.RegisterInterfaces(registry)
 	commitmenttypes.RegisterInterfaces(registry)
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Followup to #6932 

Migrates client states to use `codec.BinaryMarshaler` in `02-client`. `ClientState` will now be passed around as a pointer. We need to maintain the amino codec registration until the flip is switched on amino encoding genesis, which will occur once IBC genesis is migrated (after consensus states migration).

Consensus state migration should be able to occur after we change the validator set to be a hash in the tendermint client: #6942. I'll probably do this change in 2 steps like client state, migrate tendermint consensus state, then flip the switch in 02-client

ref: #6254 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
