### PR TITLE
Start account and sequence numbers from 1

### DIFF
--- a/client/flags/flags.go
+++ b/client/flags/flags.go
@@ -85,8 +85,8 @@ func AddQueryFlagsToCmd(cmd *cobra.Command) {
 // AddTxFlagsToCmd adds common flags to a module tx command.
 func AddTxFlagsToCmd(cmd *cobra.Command) {
 	cmd.Flags().String(FlagFrom, "", "Name or address of private key with which to sign")
-	cmd.Flags().Uint64P(FlagAccountNumber, "a", 0, "The account number of the signing account (offline mode only)")
-	cmd.Flags().Uint64P(FlagSequence, "s", 0, "The sequence number of the signing account (offline mode only)")
+	cmd.Flags().Uint64P(FlagAccountNumber, "a", 1, "The account number of the signing account (offline mode only)")
+	cmd.Flags().Uint64P(FlagSequence, "s", 1, "The sequence number of the signing account (offline mode only)")
 	cmd.Flags().String(FlagMemo, "", "Memo to send along with transaction")
 	cmd.Flags().String(FlagFees, "", "Fees to pay along with transaction; eg: 10uatom")
 	cmd.Flags().String(FlagGasPrices, "", "Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom)")

--- a/client/tx/tx.go
+++ b/client/tx/tx.go
@@ -369,10 +369,19 @@ func Sign(txf Factory, name string, txBuilder client.TxBuilder) error {
 	}
 
 	pubKey := key.GetPubKey()
+	accNum := txf.accountNumber
+	// start account and sequence numbers from 1
+	if accNum == 0 {
+		accNum = 1
+	}
+	accSeq := txf.sequence
+	if accSeq == 0 {
+		accSeq = 1
+	}
 	signerData := authsigning.SignerData{
 		ChainID:         txf.chainID,
-		AccountNumber:   txf.accountNumber,
-		AccountSequence: txf.sequence,
+		AccountNumber:   accNum,
+		AccountSequence: accSeq,
 	}
 
 	// For SIGN_MODE_DIRECT, calling SetSignatures calls SetSignerInfos on

--- a/simapp/genesis_account_test.go
+++ b/simapp/genesis_account_test.go
@@ -20,7 +20,7 @@ func TestSimGenesisAccountValidate(t *testing.T) {
 	vestingStart := time.Now().UTC()
 
 	coins := sdk.NewCoins(sdk.NewInt64Coin("test", 1000))
-	baseAcc := authtypes.NewBaseAccount(addr, pubkey, 0, 0)
+	baseAcc := authtypes.NewBaseAccount(addr, pubkey, 1, 1)
 
 	testCases := []struct {
 		name    string
@@ -37,14 +37,14 @@ func TestSimGenesisAccountValidate(t *testing.T) {
 		{
 			"invalid basic account with mismatching address/pubkey",
 			simapp.SimGenesisAccount{
-				BaseAccount: authtypes.NewBaseAccount(addr, secp256k1.GenPrivKey().PubKey(), 0, 0),
+				BaseAccount: authtypes.NewBaseAccount(addr, secp256k1.GenPrivKey().PubKey(), 1, 1),
 			},
 			true,
 		},
 		{
 			"valid basic account with module name",
 			simapp.SimGenesisAccount{
-				BaseAccount: authtypes.NewBaseAccount(sdk.AccAddress(crypto.AddressHash([]byte("testmod"))), nil, 0, 0),
+				BaseAccount: authtypes.NewBaseAccount(sdk.AccAddress(crypto.AddressHash([]byte("testmod"))), nil, 1, 1),
 				ModuleName:  "testmod",
 			},
 			false,

--- a/simapp/simd/cmd/genaccounts.go
+++ b/simapp/simd/cmd/genaccounts.go
@@ -84,7 +84,7 @@ contain valid denominations. Accounts may optionally be supplied with vesting pa
 			var genAccount authtypes.GenesisAccount
 
 			balances := banktypes.Balance{Address: addr, Coins: coins.Sort()}
-			baseAccount := authtypes.NewBaseAccount(addr, nil, 0, 0)
+			baseAccount := authtypes.NewBaseAccount(addr, nil, 1, 1)
 
 			if !vestingAmt.IsZero() {
 				baseVestingAccount := authvesting.NewBaseVestingAccount(baseAccount, vestingAmt.Sort(), vestingEnd)

--- a/simapp/simd/cmd/testnet.go
+++ b/simapp/simd/cmd/testnet.go
@@ -194,7 +194,7 @@ func InitTestnet(
 		}
 
 		genBalances = append(genBalances, banktypes.Balance{Address: addr, Coins: coins.Sort()})
-		genAccounts = append(genAccounts, authtypes.NewBaseAccount(addr, nil, 0, 0))
+		genAccounts = append(genAccounts, authtypes.NewBaseAccount(addr, nil, 1, 1))
 
 		valTokens := sdk.TokensFromConsensusPower(100)
 		createValMsg := stakingtypes.NewMsgCreateValidator(

--- a/testutil/network/network.go
+++ b/testutil/network/network.go
@@ -271,7 +271,7 @@ func New(t *testing.T, cfg Config) *Network {
 
 		genFiles = append(genFiles, tmCfg.GenesisFile())
 		genBalances = append(genBalances, banktypes.Balance{Address: addr, Coins: balances.Sort()})
-		genAccounts = append(genAccounts, authtypes.NewBaseAccount(addr, nil, 0, 0))
+		genAccounts = append(genAccounts, authtypes.NewBaseAccount(addr, nil, 1, 1))
 
 		commission, err := sdk.NewDecFromStr("0.5")
 		require.NoError(t, err)

--- a/x/auth/ante/sigverify.go
+++ b/x/auth/ante/sigverify.go
@@ -215,7 +215,7 @@ func (svd SigVerificationDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simul
 		// retrieve signer data
 		genesis := ctx.BlockHeight() == 0
 		chainID := ctx.ChainID()
-		var accNum uint64
+		var accNum uint64 = 1
 		if !genesis {
 			accNum = acc.GetAccountNumber()
 		}

--- a/x/auth/keeper/keeper.go
+++ b/x/auth/keeper/keeper.go
@@ -86,7 +86,13 @@ func (ak AccountKeeper) GetNextAccountNumber(ctx sdk.Context) uint64 {
 	bz := store.Get(types.GlobalAccountNumberKey)
 	if bz == nil {
 		// initialize the account numbers
-		accNumber = 0
+		// it may seem counter-intuitive, but we start account numbers with 2 for two reasons:
+		// - we do not want clients to have to encode 0 into SignDoc with protobuf because encoding of default values
+		//   varies from client to client (see ADR 020)
+		// - we want to have a zero value for account numbers to allow for certain situations (ex. fee grants) where
+		//   accounts that are not present in state are signing transactions. Given the above, that zero value should
+		//   actually be 1 and thus the first real account will be number 2, weird I know
+		accNumber = 2
 	} else {
 		val := gogotypes.UInt64Value{}
 

--- a/x/auth/types/account.go
+++ b/x/auth/types/account.go
@@ -35,7 +35,10 @@ func NewBaseAccount(address sdk.AccAddress, pubKey crypto.PubKey, accountNumber,
 
 // ProtoBaseAccount - a prototype function for BaseAccount
 func ProtoBaseAccount() AccountI {
-	return &BaseAccount{}
+	return &BaseAccount{
+		AccountNumber: 1,
+		Sequence:      1,
+	}
 }
 
 // NewBaseAccountWithAddress - returns a new base account with a given address
@@ -108,6 +111,14 @@ func (acc BaseAccount) Validate() error {
 	if len(acc.PubKey) != 0 && acc.Address != nil &&
 		!bytes.Equal(acc.GetPubKey().Address().Bytes(), acc.Address.Bytes()) {
 		return errors.New("account address and pubkey address do not match")
+	}
+
+	if acc.AccountNumber == 0 {
+		return errors.New("account number should be non-zero")
+	}
+
+	if acc.Sequence == 0 {
+		return errors.New("account sequence should be non-zero")
 	}
 
 	return nil

--- a/x/auth/types/account_test.go
+++ b/x/auth/types/account_test.go
@@ -84,7 +84,7 @@ func TestBaseAccountMarshal(t *testing.T) {
 func TestGenesisAccountValidate(t *testing.T) {
 	pubkey := secp256k1.GenPrivKey().PubKey()
 	addr := sdk.AccAddress(pubkey.Address())
-	baseAcc := types.NewBaseAccount(addr, pubkey, 0, 0)
+	baseAcc := types.NewBaseAccount(addr, pubkey, 1, 1)
 
 	tests := []struct {
 		name   string
@@ -98,7 +98,7 @@ func TestGenesisAccountValidate(t *testing.T) {
 		},
 		{
 			"invalid base valid account",
-			types.NewBaseAccount(addr, secp256k1.GenPrivKey().PubKey(), 0, 0),
+			types.NewBaseAccount(addr, secp256k1.GenPrivKey().PubKey(), 1, 1),
 			true,
 		},
 	}
@@ -147,7 +147,7 @@ func TestHasPermissions(t *testing.T) {
 
 func TestValidate(t *testing.T) {
 	addr := sdk.AccAddress(secp256k1.GenPrivKey().PubKey().Address())
-	baseAcc := types.NewBaseAccount(addr, nil, 0, 0)
+	baseAcc := types.NewBaseAccount(addr, nil, 1, 1)
 	tests := []struct {
 		name   string
 		acc    types.GenesisAccount
@@ -199,7 +199,7 @@ func TestModuleAccountJSON(t *testing.T) {
 func TestGenesisAccountsContains(t *testing.T) {
 	pubkey := secp256k1.GenPrivKey().PubKey()
 	addr := sdk.AccAddress(pubkey.Address())
-	acc := types.NewBaseAccount(addr, secp256k1.GenPrivKey().PubKey(), 0, 0)
+	acc := types.NewBaseAccount(addr, secp256k1.GenPrivKey().PubKey(), 1, 1)
 
 	genAccounts := types.GenesisAccounts{}
 	require.False(t, genAccounts.Contains(acc.GetAddress()))

--- a/x/auth/vesting/types/vesting_account_test.go
+++ b/x/auth/vesting/types/vesting_account_test.go
@@ -582,7 +582,7 @@ func TestTrackUndelegationPeriodicVestingAcc(t *testing.T) {
 func TestGenesisAccountValidate(t *testing.T) {
 	pubkey := secp256k1.GenPrivKey().PubKey()
 	addr := sdk.AccAddress(pubkey.Address())
-	baseAcc := authtypes.NewBaseAccount(addr, pubkey, 0, 0)
+	baseAcc := authtypes.NewBaseAccount(addr, pubkey, 1, 1)
 	initialVesting := sdk.NewCoins(sdk.NewInt64Coin(sdk.DefaultBondDenom, 50))
 	baseVestingWithCoins := types.NewBaseVestingAccount(baseAcc, initialVesting, 100)
 	tests := []struct {
@@ -597,7 +597,7 @@ func TestGenesisAccountValidate(t *testing.T) {
 		},
 		{
 			"invalid base valid account",
-			authtypes.NewBaseAccount(addr, secp256k1.GenPrivKey().PubKey(), 0, 0),
+			authtypes.NewBaseAccount(addr, secp256k1.GenPrivKey().PubKey(), 1, 1),
 			true,
 		},
 		{

--- a/x/evidence/keeper/keeper_test.go
+++ b/x/evidence/keeper/keeper_test.go
@@ -101,7 +101,7 @@ func (suite *KeeperTestSuite) SetupTest() {
 
 	for i, addr := range valAddresses {
 		addr := sdk.AccAddress(addr)
-		app.AccountKeeper.SetAccount(suite.ctx, authtypes.NewBaseAccount(addr, pubkeys[i], uint64(i), 0))
+		app.AccountKeeper.SetAccount(suite.ctx, authtypes.NewBaseAccount(addr, pubkeys[i], uint64(i)+1, 1))
 	}
 
 	queryHelper := baseapp.NewQueryServerTestHelper(suite.ctx, app.InterfaceRegistry())

--- a/x/ibc/testing/chain.go
+++ b/x/ibc/testing/chain.go
@@ -105,7 +105,7 @@ func NewTestChain(t *testing.T, chainID string) *TestChain {
 
 	// generate genesis account
 	senderPrivKey := secp256k1.GenPrivKey()
-	acc := authtypes.NewBaseAccount(senderPrivKey.PubKey().Address().Bytes(), senderPrivKey.PubKey(), 0, 0)
+	acc := authtypes.NewBaseAccount(senderPrivKey.PubKey().Address().Bytes(), senderPrivKey.PubKey(), 1, 1)
 	balance := banktypes.Balance{
 		Address: acc.GetAddress(),
 		Coins:   sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(100000000000000))),


### PR DESCRIPTION
ref: #6213 

In ADR 020 (#6111) we decided to start account and sequence numbers from `1` to avoid needing to deal with differences in how 
protobuf implementations encode `0`.

This PR makes in-state account numbers start from `2` and uses `1` as the "zero" value that is used for genesis transactions (and potentially fee grant transactions in the future https://github.com/cosmos/cosmos-sdk/pull/5768/files#r465244086)

***I do want to note that I have reservations about merging this.*** It has been noted that there could be unintended consequences to this change. For instance, we would likely need to increment all existing account numbers. So I think before we move forward with this we should really think through what all the consequences of this are and if it worth it.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
