### PR TITLE
Fix IBC genesis handling

### DIFF
--- a/x/ibc/genesis_test.go
+++ b/x/ibc/genesis_test.go
@@ -1,7 +1,15 @@
 package ibc_test
 
 import (
+	"fmt"
+
+	abci "github.com/tendermint/tendermint/abci/types"
+
+	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/simapp"
+	"github.com/cosmos/cosmos-sdk/x/ibc"
 	"github.com/cosmos/cosmos-sdk/x/ibc/02-client/exported"
+	clientexported "github.com/cosmos/cosmos-sdk/x/ibc/02-client/exported"
 	clienttypes "github.com/cosmos/cosmos-sdk/x/ibc/02-client/types"
 	connectiontypes "github.com/cosmos/cosmos-sdk/x/ibc/03-connection/types"
 	channeltypes "github.com/cosmos/cosmos-sdk/x/ibc/04-channel/types"
@@ -141,5 +149,129 @@ func (suite *IBCTestSuite) TestValidateGenesis() {
 		} else {
 			suite.Require().Error(err, tc.name)
 		}
+	}
+}
+
+func (suite *IBCTestSuite) TestInitGenesis() {
+	testCases := []struct {
+		name     string
+		genState types.GenesisState
+	}{
+		{
+			name:     "default",
+			genState: types.DefaultGenesisState(),
+		},
+		{
+			name: "valid genesis",
+			genState: types.GenesisState{
+				ClientGenesis: clienttypes.NewGenesisState(
+					[]clienttypes.GenesisClientState{
+						clienttypes.NewGenesisClientState(
+							clientID, ibctmtypes.NewClientState(chainID, ibctmtypes.DefaultTrustLevel, trustingPeriod, ubdPeriod, maxClockDrift, height, commitmenttypes.GetSDKSpecs()),
+						),
+						clienttypes.NewGenesisClientState(
+							exported.ClientTypeLocalHost, localhosttypes.NewClientState("chaindID", 10),
+						),
+					},
+					[]clienttypes.ClientConsensusStates{
+						clienttypes.NewClientConsensusStates(
+							clientID,
+							[]exported.ConsensusState{
+								ibctmtypes.NewConsensusState(
+									suite.header.Time, commitmenttypes.NewMerkleRoot(suite.header.AppHash), suite.header.GetHeight(), suite.header.ValidatorSet.Hash(), suite.header.ValidatorSet,
+								),
+							},
+						),
+					},
+					true,
+				),
+				ConnectionGenesis: connectiontypes.NewGenesisState(
+					[]connectiontypes.IdentifiedConnection{
+						connectiontypes.NewIdentifiedConnection(connectionID, connectiontypes.NewConnectionEnd(connectiontypes.INIT, clientID, connectiontypes.NewCounterparty(clientID2, connectionID2, commitmenttypes.NewMerklePrefix([]byte("prefix"))), []string{ibctesting.ConnectionVersion})),
+					},
+					[]connectiontypes.ConnectionPaths{
+						connectiontypes.NewConnectionPaths(clientID, []string{host.ConnectionPath(connectionID)}),
+					},
+				),
+				ChannelGenesis: channeltypes.NewGenesisState(
+					[]channeltypes.IdentifiedChannel{
+						channeltypes.NewIdentifiedChannel(
+							port1, channel1, channeltypes.NewChannel(
+								channeltypes.INIT, channelOrder,
+								channeltypes.NewCounterparty(port2, channel2), []string{connectionID}, channelVersion,
+							),
+						),
+					},
+					[]channeltypes.PacketAckCommitment{
+						channeltypes.NewPacketAckCommitment(port2, channel2, 1, []byte("ack")),
+					},
+					[]channeltypes.PacketAckCommitment{
+						channeltypes.NewPacketAckCommitment(port1, channel1, 1, []byte("commit_hash")),
+					},
+					[]channeltypes.PacketSequence{
+						channeltypes.NewPacketSequence(port1, channel1, 1),
+					},
+					[]channeltypes.PacketSequence{
+						channeltypes.NewPacketSequence(port2, channel2, 1),
+					},
+					[]channeltypes.PacketSequence{
+						channeltypes.NewPacketSequence(port2, channel2, 1),
+					},
+				),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		app := simapp.Setup(false)
+
+		suite.NotPanics(func() {
+			ibc.InitGenesis(app.BaseApp.NewContext(false, abci.Header{Height: 1}), *app.IBCKeeper, true, tc.genState)
+		})
+	}
+}
+
+// TODO: HandlerTestSuite should replace IBCTestSuite
+func (suite *HandlerTestSuite) TestExportGenesis() {
+	testCases := []struct {
+		msg      string
+		malleate func()
+	}{
+		{
+			"success",
+			func() {
+				// creates clients
+				suite.coordinator.Setup(suite.chainA, suite.chainB)
+				// create extra clients
+				suite.coordinator.CreateClient(suite.chainA, suite.chainB, clientexported.Tendermint)
+				suite.coordinator.CreateClient(suite.chainA, suite.chainB, clientexported.Tendermint)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		suite.Run(fmt.Sprintf("Case %s", tc.msg), func() {
+			suite.SetupTest()
+
+			tc.malleate()
+
+			var gs types.GenesisState
+			suite.NotPanics(func() {
+				gs = ibc.ExportGenesis(suite.chainA.GetContext(), *suite.chainA.App.IBCKeeper)
+			})
+
+			// init genesis based on export
+			suite.NotPanics(func() {
+				ibc.InitGenesis(suite.chainA.GetContext(), *suite.chainA.App.IBCKeeper, true, gs)
+			})
+
+			genState := codec.MustMarshalJSONIndent(suite.chainA.App.Codec(), gs)
+			suite.chainA.App.Codec().MustUnmarshalJSON(genState, &gs)
+
+			// init genesis based on marshal and unmarshal
+			suite.NotPanics(func() {
+				ibc.InitGenesis(suite.chainA.GetContext(), *suite.chainA.App.IBCKeeper, true, gs)
+			})
+		})
 	}
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Following the merge of #6948 we noticed sims were breaking. This is because we need to use `Any` on genesis state. I added some tests to replicate the error. You'll notice looking at the build that, init and export work fine until the genesis state is marshalled and unmarshalled, then it panics on init genesis because the client state is not a pointer 

closes: #XXXX

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
