### PR TITLE
Remove home flag which clashed with global flag

### DIFF
--- a/x/auth/client/cli/tx_sign.go
+++ b/x/auth/client/cli/tx_sign.go
@@ -186,7 +186,6 @@ be generated via the 'multisign' command.
 	cmd.Flags().Bool(flagAppend, true, "Append the signature to the existing ones. If disabled, old signatures would be overwritten. Ignored if --multisig is on")
 	cmd.Flags().Bool(flagSigOnly, false, "Print only the generated signature, then exit")
 	cmd.Flags().String(flags.FlagOutputDocument, "", "The document will be written to the given file instead of STDOUT")
-	cmd.Flags().String(flags.FlagHome, "", "The application home directory")
 	cmd.Flags().String(flags.FlagChainID, "", "The network chain ID")
 	cmd.MarkFlagRequired(flags.FlagFrom)
 	flags.AddTxFlagsToCmd(cmd)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

The `--home` flag is [defined here](https://github.com/tendermint/tendermint/blob/v0.33.7/libs/cli/setup.go#L30) and there is no reason to define it on the commands. In fact doing so caused a panic as the homedir got set to "".

This only affected the `simd tx sign` command.

Try the following on master:

```
$ simd tx bank send --generate-only --chain-id simd-testing cosmos1pkptre7fdkl6gfrzlesjjvhxhlc3r4gmmk8rs6 cosmos1qypqxpq9qcrsszg2pvxq6rs0zqg3yyc5lzv7xu 1234567ucosm > unsigned_tx.json
$ simd tx sign --from testgen --chain-id simd-testing --sign-mode direct unsigned_tx.json > signed_tx.json
panic: could not create directory : mkdir : no such file or directory

goroutine 1 [running]:
github.com/tendermint/tendermint/config.EnsureRoot(0x0, 0x0)
        github.com/tendermint/tendermint@v0.33.7/config/toml.go:31 +0x2fe
github.com/cosmos/cosmos-sdk/server.interceptConfigs(0xc000f2bd00, 0xc000f4a6c0, 0xc000f3e100, 0x0, 0x0)
        github.com/cosmos/cosmos-sdk/server/util.go:124 +0x7da
github.com/cosmos/cosmos-sdk/server.InterceptConfigsPreRunHandler(0xc000ee3600, 0x0, 0x0)
        github.com/cosmos/cosmos-sdk/server/util.go:66 +0x20a
github.com/cosmos/cosmos-sdk/simapp/simd/cmd.glob..func1(0xc000ee3600, 0xc000e63340, 0x1, 0x7, 0x0, 0x0)
        github.com/cosmos/cosmos-sdk/simapp/simd/cmd/root.go:44 +0xaa
github.com/tendermint/tendermint/libs/cli.concatCobraCmdFuncs.func1(0xc000ee3600, 0xc000e63340, 0x1, 0x7, 0x0, 0x0)
        github.com/tendermint/tendermint@v0.33.7/libs/cli/setup.go:115 +0x7d
github.com/spf13/cobra.(*Command).execute(0xc000ee3600, 0xc000e632d0, 0x7, 0x7, 0xc000ee3600, 0xc000e632d0)
        github.com/spf13/cobra@v1.0.0/command.go:821 +0x55e
github.com/spf13/cobra.(*Command).ExecuteC(0x2a4a260, 0x0, 0x0, 0xc000e57740)
        github.com/spf13/cobra@v1.0.0/command.go:950 +0x349
github.com/spf13/cobra.(*Command).Execute(...)
        github.com/spf13/cobra@v1.0.0/command.go:887
github.com/spf13/cobra.(*Command).ExecuteContext(...)
        github.com/spf13/cobra@v1.0.0/command.go:880
github.com/cosmos/cosmos-sdk/simapp/simd/cmd.Execute(0x7ae00, 0xc00004c178)
        github.com/cosmos/cosmos-sdk/simapp/simd/cmd/root.go:73 +0x157
main.main()
        github.com/cosmos/cosmos-sdk/simapp/simd/main.go:10 +0x22
```

After this patch, I simply get a success

```
$ simd tx sign --from testgen --chain-id simd-testing --sign-mode direct unsigned_tx.json | jq
```

```json
{
  "body": {
    "messages": [
      {
        "@type": "/cosmos.bank.MsgSend",
        "from_address": "cosmos1pkptre7fdkl6gfrzlesjjvhxhlc3r4gmmk8rs6",
        "to_address": "cosmos1qypqxpq9qcrsszg2pvxq6rs0zqg3yyc5lzv7xu",
        "amount": [
          {
            "denom": "ucosm",
            "amount": "1234567"
          }
        ]
      }
    ]
  },
  "auth_info": {
    "signer_infos": [
      {
        "public_key": {
          "secp256k1": "A08EGB7ro1ORuFhjOnZcSgwYlpe0DSFjVNUIkNNQxwKQ"
        },
        "mode_info": {
          "single": {
            "mode": "SIGN_MODE_DIRECT"
          }
        }
      }
    ],
    "fee": {
      "gas_limit": "200000"
    }
  },
  "signatures": [
    "aS2I9oHV1pkkpTZo6OzsU1ygyhcNH+v7Hdh96ZWbBzQEJ9a7oiUm1sMMxiLyfcXrHOBM/A/5hxYVQGbsadti5Q=="
  ]
}
```

closes: #XXXX

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
