### PR TITLE
Migrate Consensus State to being proto encoded/decoded in 02-client

### DIFF
--- a/x/ibc/02-client/client/utils/utils.go
+++ b/x/ibc/02-client/client/utils/utils.go
@@ -124,31 +124,31 @@ func QueryTendermintHeader(clientCtx client.Context) (ibctmtypes.Header, int64, 
 
 // QueryNodeConsensusState takes a client context and returns the appropriate
 // tendermint consensus state
-func QueryNodeConsensusState(clientCtx client.Context) (ibctmtypes.ConsensusState, int64, error) {
+func QueryNodeConsensusState(clientCtx client.Context) (*ibctmtypes.ConsensusState, int64, error) {
 	node, err := clientCtx.GetNode()
 	if err != nil {
-		return ibctmtypes.ConsensusState{}, 0, err
+		return &ibctmtypes.ConsensusState{}, 0, err
 	}
 
 	info, err := node.ABCIInfo()
 	if err != nil {
-		return ibctmtypes.ConsensusState{}, 0, err
+		return &ibctmtypes.ConsensusState{}, 0, err
 	}
 
 	height := info.Response.LastBlockHeight
 
 	commit, err := node.Commit(&height)
 	if err != nil {
-		return ibctmtypes.ConsensusState{}, 0, err
+		return &ibctmtypes.ConsensusState{}, 0, err
 	}
 
 	nextHeight := height + 1
 	nextVals, err := node.Validators(&nextHeight, 0, 10000)
 	if err != nil {
-		return ibctmtypes.ConsensusState{}, 0, err
+		return &ibctmtypes.ConsensusState{}, 0, err
 	}
 
-	state := ibctmtypes.ConsensusState{
+	state := &ibctmtypes.ConsensusState{
 		Timestamp:          commit.Time,
 		Root:               commitmenttypes.NewMerkleRoot(commit.AppHash),
 		NextValidatorsHash: tmtypes.NewValidatorSet(nextVals.Validators).Hash(),

--- a/x/ibc/02-client/exported/exported.go
+++ b/x/ibc/02-client/exported/exported.go
@@ -30,7 +30,6 @@ type ClientState interface {
 	VerifyClientConsensusState(
 		store sdk.KVStore,
 		cdc codec.BinaryMarshaler,
-		aminoCdc *codec.Codec,
 		root commitmentexported.Root,
 		height uint64,
 		counterpartyClientIdentifier string,

--- a/x/ibc/02-client/keeper/client_test.go
+++ b/x/ibc/02-client/keeper/client_test.go
@@ -82,7 +82,7 @@ func (suite *KeeperTestSuite) TestUpdateClientTendermint() {
 			_, err := suite.keeper.CreateClient(suite.ctx, testClientID, clientState, suite.consensusState)
 
 			// store intermediate consensus state to check that trustedHeight does not need to be highest consensus state before header height
-			intermediateConsState := ibctmtypes.ConsensusState{
+			intermediateConsState := &ibctmtypes.ConsensusState{
 				Height:             testClientHeight + 1,
 				Timestamp:          suite.now.Add(time.Minute),
 				NextValidatorsHash: suite.valSetHash,
@@ -101,7 +101,7 @@ func (suite *KeeperTestSuite) TestUpdateClientTendermint() {
 			suite.Require().NoError(err)
 
 			// store previous consensus state
-			prevConsState := ibctmtypes.ConsensusState{
+			prevConsState := &ibctmtypes.ConsensusState{
 				Height:             1,
 				Timestamp:          suite.past,
 				NextValidatorsHash: suite.valSetHash,
@@ -109,7 +109,7 @@ func (suite *KeeperTestSuite) TestUpdateClientTendermint() {
 			suite.keeper.SetClientConsensusState(suite.ctx, testClientID, 1, prevConsState)
 
 			// store intermediate consensus state to check that trustedHeight does not need to be hightest consensus state before header height
-			intermediateConsState := ibctmtypes.ConsensusState{
+			intermediateConsState := &ibctmtypes.ConsensusState{
 				Height:             2,
 				Timestamp:          suite.past.Add(time.Minute),
 				NextValidatorsHash: suite.valSetHash,
@@ -161,7 +161,7 @@ func (suite *KeeperTestSuite) TestUpdateClientTendermint() {
 			suite.Require().NoError(err)
 
 			// store previous consensus state
-			prevConsState := ibctmtypes.ConsensusState{
+			prevConsState := &ibctmtypes.ConsensusState{
 				Height:             1,
 				Timestamp:          suite.past,
 				NextValidatorsHash: suite.valSetHash,
@@ -199,7 +199,7 @@ func (suite *KeeperTestSuite) TestUpdateClientTendermint() {
 			if tc.expPass {
 				suite.Require().NoError(err, err)
 
-				expConsensusState := ibctmtypes.ConsensusState{
+				expConsensusState := &ibctmtypes.ConsensusState{
 					Height:             updateHeader.GetHeight(),
 					Timestamp:          updateHeader.Time,
 					Root:               commitmenttypes.NewMerkleRoot(updateHeader.AppHash),
@@ -303,7 +303,7 @@ func (suite *KeeperTestSuite) TestCheckMisbehaviourAndUpdateState() {
 				_, err := suite.keeper.CreateClient(suite.ctx, testClientID, clientState, suite.consensusState)
 
 				// store intermediate consensus state to check that trustedHeight does not need to be highest consensus state before header height
-				intermediateConsState := ibctmtypes.ConsensusState{
+				intermediateConsState := &ibctmtypes.ConsensusState{
 					Height:             testClientHeight + 3,
 					Timestamp:          suite.now.Add(time.Minute),
 					NextValidatorsHash: suite.valSetHash,

--- a/x/ibc/02-client/keeper/encoding.go
+++ b/x/ibc/02-client/keeper/encoding.go
@@ -47,3 +47,44 @@ func (k Keeper) UnmarshalClientState(bz []byte) (exported.ClientState, error) {
 
 	return clientState, nil
 }
+
+// MustUnmarshalConsensusState attempts to decode and return an ConsensusState object from
+// raw encoded bytes. It panics on error.
+func (k Keeper) MustUnmarshalConsensusState(bz []byte) exported.ConsensusState {
+	consensusState, err := k.UnmarshalConsensusState(bz)
+	if err != nil {
+		panic(fmt.Errorf("failed to decode consensus state: %w", err))
+	}
+
+	return consensusState
+}
+
+// MustMarshalConsensusState attempts to encode an ConsensusState object and returns the
+// raw encoded bytes. It panics on error.
+func (k Keeper) MustMarshalConsensusState(consensusState exported.ConsensusState) []byte {
+	bz, err := k.MarshalConsensusState(consensusState)
+	if err != nil {
+		panic(fmt.Errorf("failed to encode consensus state: %w", err))
+	}
+
+	return bz
+}
+
+// MarshalConsensusState marshals an ConsensusState interface. If the given type implements
+// the Marshaler interface, it is treated as a Proto-defined message and
+// serialized that way.
+func (k Keeper) MarshalConsensusState(consensusStateI exported.ConsensusState) ([]byte, error) {
+	return codec.MarshalAny(k.cdc, consensusStateI)
+}
+
+// UnmarshalConsensusState returns an ConsensusState interface from raw encoded clientState
+// bytes of a Proto-based ConsensusState type. An error is returned upon decoding
+// failure.
+func (k Keeper) UnmarshalConsensusState(bz []byte) (exported.ConsensusState, error) {
+	var consensusState exported.ConsensusState
+	if err := codec.UnmarshalAny(k.cdc, &consensusState, bz); err != nil {
+		return nil, err
+	}
+
+	return consensusState, nil
+}

--- a/x/ibc/02-client/keeper/keeper.go
+++ b/x/ibc/02-client/keeper/keeper.go
@@ -201,7 +201,7 @@ func (k Keeper) GetSelfConsensusState(ctx sdk.Context, height uint64) (exported.
 		return nil, false
 	}
 
-	consensusState := ibctmtypes.ConsensusState{
+	consensusState := &ibctmtypes.ConsensusState{
 		Height:             height,
 		Timestamp:          histInfo.Header.Time,
 		Root:               commitmenttypes.NewMerkleRoot(histInfo.Header.AppHash),

--- a/x/ibc/02-client/keeper/keeper_test.go
+++ b/x/ibc/02-client/keeper/keeper_test.go
@@ -70,12 +70,7 @@ func (suite *KeeperTestSuite) SetupTest() {
 	suite.valSet = tmtypes.NewValidatorSet([]*tmtypes.Validator{validator})
 	suite.valSetHash = suite.valSet.Hash()
 	suite.header = ibctmtypes.CreateTestHeader(testChainID, testClientHeight, testClientHeight-1, now2, suite.valSet, suite.valSet, []tmtypes.PrivValidator{suite.privVal})
-	suite.consensusState = &ibctmtypes.ConsensusState{
-		Height:             testClientHeight,
-		Timestamp:          suite.now,
-		Root:               commitmenttypes.NewMerkleRoot([]byte("hash")),
-		NextValidatorsHash: suite.valSetHash,
-	}
+	suite.consensusState = ibctmtypes.NewConsensusState(suite.now, commitmenttypes.NewMerkleRoot([]byte("hash")), testClientHeight, suite.valSetHash)
 
 	var validators stakingtypes.Validators
 	for i := 1; i < 11; i++ {
@@ -207,12 +202,7 @@ func (suite KeeperTestSuite) TestConsensusStateHelpers() {
 	suite.keeper.SetClientState(suite.ctx, testClientID, clientState)
 	suite.keeper.SetClientConsensusState(suite.ctx, testClientID, testClientHeight, suite.consensusState)
 
-	nextState := &ibctmtypes.ConsensusState{
-		Height:             testClientHeight + 5,
-		Timestamp:          suite.now,
-		Root:               commitmenttypes.NewMerkleRoot([]byte("next")),
-		NextValidatorsHash: suite.valSetHash,
-	}
+	nextState := ibctmtypes.NewConsensusState(suite.now, commitmenttypes.NewMerkleRoot([]byte("next")), testClientHeight+5, suite.valSetHash)
 
 	header := ibctmtypes.CreateTestHeader(testClientID, testClientHeight+5, testClientHeight, suite.header.Time.Add(time.Minute),
 		suite.valSet, suite.valSet, []tmtypes.PrivValidator{suite.privVal})

--- a/x/ibc/02-client/types/codec.go
+++ b/x/ibc/02-client/types/codec.go
@@ -22,6 +22,10 @@ func RegisterInterfaces(registry codectypes.InterfaceRegistry) {
 		"cosmos_sdk.ibc.v1.client.ClientState",
 		(*exported.ClientState)(nil),
 	)
+	registry.RegisterInterface(
+		"cosmos_sdk.ibc.v1.client.ConsensusState",
+		(*exported.ConsensusState)(nil),
+	)
 }
 
 var (

--- a/x/ibc/03-connection/keeper/handshake_test.go
+++ b/x/ibc/03-connection/keeper/handshake_test.go
@@ -116,7 +116,7 @@ func (suite *KeeperTestSuite) TestConnOpenTry() {
 			consState, found := suite.chainA.App.IBCKeeper.ClientKeeper.GetLatestClientConsensusState(suite.chainA.GetContext(), clientA)
 			suite.Require().True(found)
 
-			tmConsState, ok := consState.(ibctmtypes.ConsensusState)
+			tmConsState, ok := consState.(*ibctmtypes.ConsensusState)
 			suite.Require().True(ok)
 
 			tmConsState.Timestamp = time.Now()
@@ -304,7 +304,7 @@ func (suite *KeeperTestSuite) TestConnOpenAck() {
 			consState, found := suite.chainB.App.IBCKeeper.ClientKeeper.GetLatestClientConsensusState(suite.chainB.GetContext(), clientB)
 			suite.Require().True(found)
 
-			tmConsState, ok := consState.(ibctmtypes.ConsensusState)
+			tmConsState, ok := consState.(*ibctmtypes.ConsensusState)
 			suite.Require().True(ok)
 
 			tmConsState.Timestamp = time.Now()

--- a/x/ibc/03-connection/keeper/keeper.go
+++ b/x/ibc/03-connection/keeper/keeper.go
@@ -22,16 +22,14 @@ type Keeper struct {
 	types.QueryServer
 
 	storeKey     sdk.StoreKey
-	aminoCdc     *codec.Codec // amino codec. TODO: remove after clients have been migrated to proto
 	cdc          codec.BinaryMarshaler
 	clientKeeper types.ClientKeeper
 }
 
 // NewKeeper creates a new IBC connection Keeper instance
-func NewKeeper(aminoCdc *codec.Codec, cdc codec.BinaryMarshaler, key sdk.StoreKey, ck types.ClientKeeper) Keeper {
+func NewKeeper(cdc codec.BinaryMarshaler, key sdk.StoreKey, ck types.ClientKeeper) Keeper {
 	return Keeper{
 		storeKey:     key,
-		aminoCdc:     aminoCdc,
 		cdc:          cdc,
 		clientKeeper: ck,
 	}

--- a/x/ibc/03-connection/keeper/verify.go
+++ b/x/ibc/03-connection/keeper/verify.go
@@ -31,7 +31,7 @@ func (k Keeper) VerifyClientConsensusState(
 	}
 
 	if err := clientState.VerifyClientConsensusState(
-		k.clientKeeper.ClientStore(ctx, clientID), k.cdc, k.aminoCdc, targetConsState.GetRoot(), height,
+		k.clientKeeper.ClientStore(ctx, clientID), k.cdc, targetConsState.GetRoot(), height,
 		connection.GetCounterparty().GetClientID(), consensusHeight, connection.GetCounterparty().GetPrefix(), proof, consensusState,
 	); err != nil {
 		return sdkerrors.Wrap(err, "failed consensus state verification")

--- a/x/ibc/03-connection/keeper/verify_test.go
+++ b/x/ibc/03-connection/keeper/verify_test.go
@@ -48,7 +48,7 @@ func (suite *KeeperTestSuite) TestVerifyClientConsensusState() {
 			consState, found := suite.chainB.App.IBCKeeper.ClientKeeper.GetLatestClientConsensusState(suite.chainB.GetContext(), clientB)
 			suite.Require().True(found)
 
-			tmConsState, ok := consState.(ibctmtypes.ConsensusState)
+			tmConsState, ok := consState.(*ibctmtypes.ConsensusState)
 			suite.Require().True(ok)
 
 			tmConsState.Timestamp = time.Now()

--- a/x/ibc/03-connection/types/codec.go
+++ b/x/ibc/03-connection/types/codec.go
@@ -19,7 +19,7 @@ func RegisterInterfaces(registry codectypes.InterfaceRegistry) {
 }
 
 var (
-	// SubModuleCdc references the global x/ibc/03-connectionl module codec. Note, the codec should
+	// SubModuleCdc references the global x/ibc/03-connection module codec. Note, the codec should
 	// ONLY be used in certain instances of tests and for JSON encoding.
 	//
 	// The actual codec used for serialization should be provided to x/ibc/03-connectionl and

--- a/x/ibc/07-tendermint/misbehaviour.go
+++ b/x/ibc/07-tendermint/misbehaviour.go
@@ -29,7 +29,7 @@ func CheckMisbehaviourAndUpdateState(
 	// cast the interface to specific types before checking for misbehaviour
 	tmClientState, ok := clientState.(*types.ClientState)
 	if !ok {
-		return nil, sdkerrors.Wrapf(clienttypes.ErrInvalidClientType, "expected type %T, got %T", types.ClientState{}, clientState)
+		return nil, sdkerrors.Wrapf(clienttypes.ErrInvalidClientType, "expected type %T, got %T", &types.ClientState{}, clientState)
 	}
 
 	// If client is already frozen at earlier height than evidence, return with error
@@ -38,9 +38,9 @@ func CheckMisbehaviourAndUpdateState(
 			"client is already frozen at earlier height %d than misbehaviour height %d", tmClientState.FrozenHeight, misbehaviour.GetHeight())
 	}
 
-	tmConsensusState, ok := consensusState.(types.ConsensusState)
+	tmConsensusState, ok := consensusState.(*types.ConsensusState)
 	if !ok {
-		return nil, sdkerrors.Wrapf(clienttypes.ErrInvalidClientType, "expected type %T, got %T", consensusState, types.ConsensusState{})
+		return nil, sdkerrors.Wrapf(clienttypes.ErrInvalidClientType, "expected type %T, got %T", &types.ConsensusState{}, consensusState)
 	}
 
 	tmEvidence, ok := misbehaviour.(types.Evidence)
@@ -60,7 +60,7 @@ func CheckMisbehaviourAndUpdateState(
 
 // checkMisbehaviour checks if the evidence provided is a valid light client misbehaviour
 func checkMisbehaviour(
-	clientState *types.ClientState, consensusState types.ConsensusState, evidence types.Evidence,
+	clientState *types.ClientState, consensusState *types.ConsensusState, evidence types.Evidence,
 	height uint64, currentTimestamp time.Time, consensusParams *abci.ConsensusParams,
 ) error {
 	// calculate the age of the misbehaviour evidence

--- a/x/ibc/07-tendermint/misbehaviour_test.go
+++ b/x/ibc/07-tendermint/misbehaviour_test.go
@@ -55,7 +55,7 @@ func (suite *TendermintTestSuite) TestCheckMisbehaviour() {
 		{
 			"valid misbehavior evidence",
 			types.NewClientState(chainID, types.DefaultTrustLevel, trustingPeriod, ubdPeriod, maxClockDrift, height, commitmenttypes.GetSDKSpecs()),
-			types.ConsensusState{Timestamp: suite.now, Root: commitmenttypes.NewMerkleRoot(tmhash.Sum([]byte("app_hash"))), NextValidatorsHash: bothValsHash},
+			types.NewConsensusState(suite.now, commitmenttypes.NewMerkleRoot(tmhash.Sum([]byte("app_hash"))), height, bothValsHash),
 			types.Evidence{
 				Header1:  types.CreateTestHeader(chainID, height, height, suite.now, bothValSet, bothValSet, bothSigners),
 				Header2:  types.CreateTestHeader(chainID, height, height, suite.now.Add(time.Minute), bothValSet, bothValSet, bothSigners),
@@ -70,7 +70,7 @@ func (suite *TendermintTestSuite) TestCheckMisbehaviour() {
 		{
 			"valid misbehavior at height greater than last consensusState",
 			types.NewClientState(chainID, types.DefaultTrustLevel, trustingPeriod, ubdPeriod, maxClockDrift, height, commitmenttypes.GetSDKSpecs()),
-			types.ConsensusState{Timestamp: suite.now, Height: height - 1, Root: commitmenttypes.NewMerkleRoot(tmhash.Sum([]byte("app_hash"))), NextValidatorsHash: bothValsHash},
+			types.NewConsensusState(suite.now, commitmenttypes.NewMerkleRoot(tmhash.Sum([]byte("app_hash"))), height-1, bothValsHash),
 			types.Evidence{
 				Header1:  types.CreateTestHeader(chainID, height, height-1, suite.now, bothValSet, bothValSet, bothSigners),
 				Header2:  types.CreateTestHeader(chainID, height, height-1, suite.now.Add(time.Minute), bothValSet, bothValSet, bothSigners),
@@ -85,7 +85,7 @@ func (suite *TendermintTestSuite) TestCheckMisbehaviour() {
 		{
 			"consensus state's valset hash different from evidence should still pass",
 			types.NewClientState(chainID, types.DefaultTrustLevel, trustingPeriod, ubdPeriod, maxClockDrift, height, commitmenttypes.GetSDKSpecs()),
-			types.ConsensusState{Timestamp: suite.now, Height: height, Root: commitmenttypes.NewMerkleRoot(tmhash.Sum([]byte("app_hash"))), NextValidatorsHash: suite.valsHash},
+			types.NewConsensusState(suite.now, commitmenttypes.NewMerkleRoot(tmhash.Sum([]byte("app_hash"))), height, suite.valsHash),
 			types.Evidence{
 				Header1:  types.CreateTestHeader(chainID, height, height, suite.now, bothValSet, suite.valSet, bothSigners),
 				Header2:  types.CreateTestHeader(chainID, height, height, suite.now.Add(time.Minute), bothValSet, suite.valSet, bothSigners),
@@ -100,7 +100,7 @@ func (suite *TendermintTestSuite) TestCheckMisbehaviour() {
 		{
 			"invalid tendermint client state",
 			nil,
-			types.ConsensusState{Timestamp: suite.now, Root: commitmenttypes.NewMerkleRoot(tmhash.Sum([]byte("app_hash"))), NextValidatorsHash: bothValsHash},
+			types.NewConsensusState(suite.now, commitmenttypes.NewMerkleRoot(tmhash.Sum([]byte("app_hash"))), height, bothValsHash),
 			types.Evidence{
 				Header1:  types.CreateTestHeader(chainID, height, height, suite.now, bothValSet, bothValSet, bothSigners),
 				Header2:  types.CreateTestHeader(chainID, height, height, suite.now.Add(time.Minute), bothValSet, altValSet, bothSigners),
@@ -114,8 +114,8 @@ func (suite *TendermintTestSuite) TestCheckMisbehaviour() {
 		},
 		{
 			"already frozen client state",
-			types.ClientState{FrozenHeight: 1},
-			types.ConsensusState{Timestamp: suite.now, Root: commitmenttypes.NewMerkleRoot(tmhash.Sum([]byte("app_hash"))), NextValidatorsHash: bothValsHash},
+			&types.ClientState{FrozenHeight: 1},
+			types.NewConsensusState(suite.now, commitmenttypes.NewMerkleRoot(tmhash.Sum([]byte("app_hash"))), height, bothValsHash),
 			types.Evidence{
 				Header1:  types.CreateTestHeader(chainID, height, height, suite.now, bothValSet, bothValSet, bothSigners),
 				Header2:  types.CreateTestHeader(chainID, height, height, suite.now.Add(time.Minute), bothValSet, bothValSet, bothSigners),
@@ -145,7 +145,7 @@ func (suite *TendermintTestSuite) TestCheckMisbehaviour() {
 		{
 			"invalid tendermint misbehaviour evidence",
 			types.NewClientState(chainID, types.DefaultTrustLevel, trustingPeriod, ubdPeriod, maxClockDrift, height, commitmenttypes.GetSDKSpecs()),
-			types.ConsensusState{Timestamp: suite.now, Root: commitmenttypes.NewMerkleRoot(tmhash.Sum([]byte("app_hash"))), NextValidatorsHash: bothValsHash},
+			types.NewConsensusState(suite.now, commitmenttypes.NewMerkleRoot(tmhash.Sum([]byte("app_hash"))), height, bothValsHash),
 			nil,
 			simapp.DefaultConsensusParams,
 			height,
@@ -155,7 +155,7 @@ func (suite *TendermintTestSuite) TestCheckMisbehaviour() {
 		{
 			"rejected misbehaviour due to expired age",
 			types.NewClientState(chainID, types.DefaultTrustLevel, trustingPeriod, ubdPeriod, maxClockDrift, height, commitmenttypes.GetSDKSpecs()),
-			types.ConsensusState{Timestamp: suite.now, Root: commitmenttypes.NewMerkleRoot(tmhash.Sum([]byte("app_hash"))), NextValidatorsHash: bothValsHash},
+			types.NewConsensusState(suite.now, commitmenttypes.NewMerkleRoot(tmhash.Sum([]byte("app_hash"))), height, bothValsHash),
 			types.Evidence{
 				Header1: types.CreateTestHeader(chainID, int64(2*height+uint64(simapp.DefaultConsensusParams.Evidence.MaxAgeNumBlocks)), height,
 					suite.now, bothValSet, bothValSet, bothSigners),
@@ -172,7 +172,7 @@ func (suite *TendermintTestSuite) TestCheckMisbehaviour() {
 		{
 			"provided height > header height",
 			types.NewClientState(chainID, types.DefaultTrustLevel, trustingPeriod, ubdPeriod, maxClockDrift, height, commitmenttypes.GetSDKSpecs()),
-			types.ConsensusState{Timestamp: suite.now, Root: commitmenttypes.NewMerkleRoot(tmhash.Sum([]byte("app_hash"))), NextValidatorsHash: bothValsHash},
+			types.NewConsensusState(suite.now, commitmenttypes.NewMerkleRoot(tmhash.Sum([]byte("app_hash"))), height, bothValsHash),
 			types.Evidence{
 				Header1:  types.CreateTestHeader(chainID, height, height-1, suite.now, bothValSet, bothValSet, bothSigners),
 				Header2:  types.CreateTestHeader(chainID, height, height-1, suite.now.Add(time.Minute), bothValSet, bothValSet, bothSigners),
@@ -187,7 +187,7 @@ func (suite *TendermintTestSuite) TestCheckMisbehaviour() {
 		{
 			"unbonding period expired",
 			types.NewClientState(chainID, types.DefaultTrustLevel, trustingPeriod, ubdPeriod, maxClockDrift, height, commitmenttypes.GetSDKSpecs()),
-			types.ConsensusState{Timestamp: time.Time{}, Root: commitmenttypes.NewMerkleRoot(tmhash.Sum([]byte("app_hash"))), NextValidatorsHash: bothValsHash},
+			types.NewConsensusState(time.Time{}, commitmenttypes.NewMerkleRoot(tmhash.Sum([]byte("app_hash"))), height, bothValsHash),
 			types.Evidence{
 				Header1:  types.CreateTestHeader(chainID, height, height, suite.now, bothValSet, bothValSet, bothSigners),
 				Header2:  types.CreateTestHeader(chainID, height, height, suite.now.Add(time.Minute), bothValSet, bothValSet, bothSigners),
@@ -202,7 +202,7 @@ func (suite *TendermintTestSuite) TestCheckMisbehaviour() {
 		{
 			"trusted validators is incorrect for given consensus state",
 			types.NewClientState(chainID, types.DefaultTrustLevel, trustingPeriod, ubdPeriod, maxClockDrift, height, commitmenttypes.GetSDKSpecs()),
-			types.ConsensusState{Timestamp: suite.now, Root: commitmenttypes.NewMerkleRoot(tmhash.Sum([]byte("app_hash"))), NextValidatorsHash: bothValsHash},
+			types.NewConsensusState(suite.now, commitmenttypes.NewMerkleRoot(tmhash.Sum([]byte("app_hash"))), height, bothValsHash),
 			types.Evidence{
 				Header1:  types.CreateTestHeader(chainID, height, height, suite.now, bothValSet, suite.valSet, bothSigners),
 				Header2:  types.CreateTestHeader(chainID, height, height, suite.now.Add(time.Minute), bothValSet, suite.valSet, bothSigners),
@@ -217,7 +217,7 @@ func (suite *TendermintTestSuite) TestCheckMisbehaviour() {
 		{
 			"first valset has too much change",
 			types.NewClientState(chainID, types.DefaultTrustLevel, trustingPeriod, ubdPeriod, maxClockDrift, height, commitmenttypes.GetSDKSpecs()),
-			types.ConsensusState{Timestamp: suite.now, Root: commitmenttypes.NewMerkleRoot(tmhash.Sum([]byte("app_hash"))), NextValidatorsHash: bothValsHash},
+			types.NewConsensusState(suite.now, commitmenttypes.NewMerkleRoot(tmhash.Sum([]byte("app_hash"))), height, bothValsHash),
 			types.Evidence{
 				Header1:  types.CreateTestHeader(chainID, height, height, suite.now, altValSet, bothValSet, altSigners),
 				Header2:  types.CreateTestHeader(chainID, height, height, suite.now.Add(time.Minute), bothValSet, bothValSet, bothSigners),
@@ -232,7 +232,7 @@ func (suite *TendermintTestSuite) TestCheckMisbehaviour() {
 		{
 			"second valset has too much change",
 			types.NewClientState(chainID, types.DefaultTrustLevel, trustingPeriod, ubdPeriod, maxClockDrift, height, commitmenttypes.GetSDKSpecs()),
-			types.ConsensusState{Timestamp: suite.now, Root: commitmenttypes.NewMerkleRoot(tmhash.Sum([]byte("app_hash"))), NextValidatorsHash: bothValsHash},
+			types.NewConsensusState(suite.now, commitmenttypes.NewMerkleRoot(tmhash.Sum([]byte("app_hash"))), height, bothValsHash),
 			types.Evidence{
 				Header1:  types.CreateTestHeader(chainID, height, height, suite.now, bothValSet, bothValSet, bothSigners),
 				Header2:  types.CreateTestHeader(chainID, height, height, suite.now.Add(time.Minute), altValSet, bothValSet, altSigners),
@@ -247,7 +247,7 @@ func (suite *TendermintTestSuite) TestCheckMisbehaviour() {
 		{
 			"both valsets have too much change",
 			types.NewClientState(chainID, types.DefaultTrustLevel, trustingPeriod, ubdPeriod, maxClockDrift, height, commitmenttypes.GetSDKSpecs()),
-			types.ConsensusState{Timestamp: suite.now, Root: commitmenttypes.NewMerkleRoot(tmhash.Sum([]byte("app_hash"))), NextValidatorsHash: bothValsHash},
+			types.NewConsensusState(suite.now, commitmenttypes.NewMerkleRoot(tmhash.Sum([]byte("app_hash"))), height, bothValsHash),
 			types.Evidence{
 				Header1:  types.CreateTestHeader(chainID, height, height, suite.now, altValSet, bothValSet, altSigners),
 				Header2:  types.CreateTestHeader(chainID, height, height, suite.now.Add(time.Minute), altValSet, bothValSet, altSigners),

--- a/x/ibc/07-tendermint/types/client_state.go
+++ b/x/ibc/07-tendermint/types/client_state.go
@@ -144,12 +144,7 @@ func (cs ClientState) VerifyClientConsensusState(
 		return err
 	}
 
-	consState, ok := consensusState.(*ConsensusState)
-	if !ok {
-		return sdkerrors.Wrapf(clienttypes.ErrInvalidConsensus, "invalid consensus type %T, expected %T", consensusState, &ConsensusState{})
-	}
-
-	bz, err := cdc.MarshalBinaryBare(consState)
+	bz, err := codec.MarshalAny(cdc, consensusState)
 	if err != nil {
 		return err
 	}

--- a/x/ibc/07-tendermint/types/client_state_test.go
+++ b/x/ibc/07-tendermint/types/client_state_test.go
@@ -149,7 +149,7 @@ func (suite *TendermintTestSuite) TestVerifyClientConsensusState() {
 		tc := tc
 
 		err := tc.clientState.VerifyClientConsensusState(
-			nil, suite.cdc, suite.aminoCdc, tc.consensusState.Root, height, "chainA", tc.consensusState.GetHeight(), tc.prefix, tc.proof, tc.consensusState,
+			nil, suite.cdc, tc.consensusState.Root, height, "chainA", tc.consensusState.GetHeight(), tc.prefix, tc.proof, tc.consensusState,
 		)
 
 		if tc.expPass {

--- a/x/ibc/07-tendermint/types/consensus_state.go
+++ b/x/ibc/07-tendermint/types/consensus_state.go
@@ -17,8 +17,8 @@ import (
 func NewConsensusState(
 	timestamp time.Time, root commitmenttypes.MerkleRoot, height uint64,
 	nextValsHash tmbytes.HexBytes,
-) ConsensusState {
-	return ConsensusState{
+) *ConsensusState {
+	return &ConsensusState{
 		Timestamp:          timestamp,
 		Root:               root,
 		Height:             height,

--- a/x/ibc/07-tendermint/types/consensus_state_test.go
+++ b/x/ibc/07-tendermint/types/consensus_state_test.go
@@ -4,18 +4,18 @@ import (
 	"time"
 
 	clientexported "github.com/cosmos/cosmos-sdk/x/ibc/02-client/exported"
-	ibctmtypes "github.com/cosmos/cosmos-sdk/x/ibc/07-tendermint/types"
+	"github.com/cosmos/cosmos-sdk/x/ibc/07-tendermint/types"
 	commitmenttypes "github.com/cosmos/cosmos-sdk/x/ibc/23-commitment/types"
 )
 
 func (suite *TendermintTestSuite) TestConsensusStateValidateBasic() {
 	testCases := []struct {
 		msg            string
-		consensusState ibctmtypes.ConsensusState
+		consensusState *types.ConsensusState
 		expectPass     bool
 	}{
 		{"success",
-			ibctmtypes.ConsensusState{
+			&types.ConsensusState{
 				Timestamp:          suite.now,
 				Height:             height,
 				Root:               commitmenttypes.NewMerkleRoot([]byte("app_hash")),
@@ -23,7 +23,7 @@ func (suite *TendermintTestSuite) TestConsensusStateValidateBasic() {
 			},
 			true},
 		{"root is nil",
-			ibctmtypes.ConsensusState{
+			&types.ConsensusState{
 				Timestamp:          suite.now,
 				Height:             height,
 				Root:               commitmenttypes.MerkleRoot{},
@@ -31,7 +31,7 @@ func (suite *TendermintTestSuite) TestConsensusStateValidateBasic() {
 			},
 			false},
 		{"root is empty",
-			ibctmtypes.ConsensusState{
+			&types.ConsensusState{
 				Timestamp:          suite.now,
 				Height:             height,
 				Root:               commitmenttypes.MerkleRoot{},
@@ -39,7 +39,7 @@ func (suite *TendermintTestSuite) TestConsensusStateValidateBasic() {
 			},
 			false},
 		{"nextvalshash is invalid",
-			ibctmtypes.ConsensusState{
+			&types.ConsensusState{
 				Timestamp:          suite.now,
 				Height:             height,
 				Root:               commitmenttypes.NewMerkleRoot([]byte("app_hash")),
@@ -48,7 +48,7 @@ func (suite *TendermintTestSuite) TestConsensusStateValidateBasic() {
 			false},
 
 		{"height is 0",
-			ibctmtypes.ConsensusState{
+			&types.ConsensusState{
 				Timestamp:          suite.now,
 				Height:             0,
 				Root:               commitmenttypes.NewMerkleRoot([]byte("app_hash")),
@@ -56,7 +56,7 @@ func (suite *TendermintTestSuite) TestConsensusStateValidateBasic() {
 			},
 			false},
 		{"timestamp is zero",
-			ibctmtypes.ConsensusState{
+			&types.ConsensusState{
 				Timestamp:          time.Time{},
 				Height:             height,
 				Root:               commitmenttypes.NewMerkleRoot([]byte("app_hash")),

--- a/x/ibc/07-tendermint/types/header.go
+++ b/x/ibc/07-tendermint/types/header.go
@@ -36,8 +36,8 @@ func (h Header) ClientType() clientexported.ClientType {
 }
 
 // ConsensusState returns the updated consensus state associated with the header
-func (h Header) ConsensusState() ConsensusState {
-	return ConsensusState{
+func (h Header) ConsensusState() *ConsensusState {
+	return &ConsensusState{
 		Height:             uint64(h.Height),
 		Timestamp:          h.Time,
 		Root:               commitmenttypes.NewMerkleRoot(h.AppHash),

--- a/x/ibc/07-tendermint/types/msgs.go
+++ b/x/ibc/07-tendermint/types/msgs.go
@@ -140,7 +140,7 @@ func (msg MsgCreateClient) GetClientType() string {
 func (msg MsgCreateClient) GetConsensusState() clientexported.ConsensusState {
 	// Construct initial consensus state from provided Header
 	root := commitmenttypes.NewMerkleRoot(msg.Header.AppHash)
-	return ConsensusState{
+	return &ConsensusState{
 		Timestamp:          msg.Header.Time,
 		Root:               root,
 		Height:             uint64(msg.Header.Height),

--- a/x/ibc/07-tendermint/update.go
+++ b/x/ibc/07-tendermint/update.go
@@ -44,7 +44,7 @@ func CheckValidityAndUpdateState(
 		)
 	}
 
-	tmConsState, ok := consState.(types.ConsensusState)
+	tmConsState, ok := consState.(*types.ConsensusState)
 	if !ok {
 		return nil, nil, sdkerrors.Wrapf(
 			clienttypes.ErrInvalidConsensus, "expected type %T, got %T", types.ConsensusState{}, consState,
@@ -69,7 +69,7 @@ func CheckValidityAndUpdateState(
 // checkValidity checks if the Tendermint header is valid.
 // CONTRACT: consState.Height == header.TrustedHeight
 func checkValidity(
-	clientState *types.ClientState, consState types.ConsensusState,
+	clientState *types.ClientState, consState *types.ConsensusState,
 	header types.Header, currentTimestamp time.Time,
 ) error {
 	// assert that trustedVals is NextValidators of last trusted header
@@ -140,11 +140,11 @@ func checkValidity(
 }
 
 // update the consensus state from a new header
-func update(clientState *types.ClientState, header types.Header) (*types.ClientState, types.ConsensusState) {
+func update(clientState *types.ClientState, header types.Header) (*types.ClientState, *types.ConsensusState) {
 	if uint64(header.Height) > clientState.LatestHeight {
 		clientState.LatestHeight = uint64(header.Height)
 	}
-	consensusState := types.ConsensusState{
+	consensusState := &types.ConsensusState{
 		Height:             uint64(header.Height),
 		Timestamp:          header.Time,
 		Root:               commitmenttypes.NewMerkleRoot(header.AppHash),

--- a/x/ibc/07-tendermint/update_test.go
+++ b/x/ibc/07-tendermint/update_test.go
@@ -14,7 +14,7 @@ import (
 func (suite *TendermintTestSuite) TestCheckValidity() {
 	var (
 		clientState    *types.ClientState
-		consensusState types.ConsensusState
+		consensusState *types.ConsensusState
 		newHeader      types.Header
 		currentTime    time.Time
 	)
@@ -192,7 +192,7 @@ func (suite *TendermintTestSuite) TestCheckValidity() {
 		// setup test
 		tc.setup()
 
-		expectedConsensus := types.ConsensusState{
+		expectedConsensus := &types.ConsensusState{
 			Height:             uint64(newHeader.Height),
 			Timestamp:          newHeader.Time,
 			Root:               commitmenttypes.NewMerkleRoot(newHeader.AppHash),

--- a/x/ibc/09-localhost/types/client_state.go
+++ b/x/ibc/09-localhost/types/client_state.go
@@ -75,7 +75,7 @@ func (cs ClientState) GetProofSpecs() []*ics23.ProofSpec {
 // VerifyClientConsensusState returns an error since a local host client does not store consensus
 // states.
 func (cs ClientState) VerifyClientConsensusState(
-	sdk.KVStore, codec.BinaryMarshaler, *codec.Codec, commitmentexported.Root,
+	sdk.KVStore, codec.BinaryMarshaler, commitmentexported.Root,
 	uint64, string, uint64, commitmentexported.Prefix, []byte, clientexported.ConsensusState,
 ) error {
 	return ErrConsensusStatesNotStored

--- a/x/ibc/09-localhost/types/client_state_test.go
+++ b/x/ibc/09-localhost/types/client_state_test.go
@@ -50,7 +50,7 @@ func (suite *LocalhostTestSuite) TestValidate() {
 func (suite *LocalhostTestSuite) TestVerifyClientConsensusState() {
 	clientState := types.NewClientState("chainID", 10)
 	err := clientState.VerifyClientConsensusState(
-		nil, nil, nil, nil, 0, "", 0, nil, nil, nil,
+		nil, nil, nil, 0, "", 0, nil, nil, nil,
 	)
 	suite.Require().Error(err)
 }

--- a/x/ibc/keeper/keeper.go
+++ b/x/ibc/keeper/keeper.go
@@ -35,7 +35,7 @@ func NewKeeper(
 	aminoCdc *codec.Codec, cdc codec.BinaryMarshaler, key sdk.StoreKey, stakingKeeper clienttypes.StakingKeeper, scopedKeeper capabilitykeeper.ScopedKeeper,
 ) *Keeper {
 	clientKeeper := clientkeeper.NewKeeper(cdc, key, stakingKeeper)
-	connectionKeeper := connectionkeeper.NewKeeper(aminoCdc, cdc, key, clientKeeper)
+	connectionKeeper := connectionkeeper.NewKeeper(cdc, key, clientKeeper)
 	portKeeper := portkeeper.NewKeeper(scopedKeeper)
 	channelKeeper := channelkeeper.NewKeeper(cdc, key, clientKeeper, connectionKeeper, portKeeper, scopedKeeper)
 

--- a/x/ibc/keeper/keeper.go
+++ b/x/ibc/keeper/keeper.go
@@ -34,7 +34,7 @@ type Keeper struct {
 func NewKeeper(
 	aminoCdc *codec.Codec, cdc codec.BinaryMarshaler, key sdk.StoreKey, stakingKeeper clienttypes.StakingKeeper, scopedKeeper capabilitykeeper.ScopedKeeper,
 ) *Keeper {
-	clientKeeper := clientkeeper.NewKeeper(cdc, aminoCdc, key, stakingKeeper)
+	clientKeeper := clientkeeper.NewKeeper(cdc, key, stakingKeeper)
 	connectionKeeper := connectionkeeper.NewKeeper(aminoCdc, cdc, key, clientKeeper)
 	portKeeper := portkeeper.NewKeeper(scopedKeeper)
 	channelKeeper := channelkeeper.NewKeeper(cdc, key, clientKeeper, connectionKeeper, portKeeper, scopedKeeper)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Proto encodes consensus state in `02-client`. Removes amino from client keeper and connection keeper. `ConsensusState` is now being passed around by reference. Genesis migration will ocurr in #6878 

ref: #6254

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
