### PR TITLE
fix tests build failures with go1.15

### DIFF
--- a/types/coin_benchmark_test.go
+++ b/types/coin_benchmark_test.go
@@ -12,10 +12,10 @@ func BenchmarkCoinsAdditionIntersect(b *testing.B) {
 			coinsB := Coins(make([]Coin, numCoinsB))
 
 			for i := 0; i < numCoinsA; i++ {
-				coinsA[i] = NewCoin("COINZ_"+string(i), NewInt(int64(i)))
+				coinsA[i] = NewCoin("COINZ_"+fmt.Sprint(i), NewInt(int64(i)))
 			}
 			for i := 0; i < numCoinsB; i++ {
-				coinsB[i] = NewCoin("COINZ_"+string(i), NewInt(int64(i)))
+				coinsB[i] = NewCoin("COINZ_"+fmt.Sprint(i), NewInt(int64(i)))
 			}
 
 			b.ResetTimer()
@@ -41,10 +41,10 @@ func BenchmarkCoinsAdditionNoIntersect(b *testing.B) {
 			coinsB := Coins(make([]Coin, numCoinsB))
 
 			for i := 0; i < numCoinsA; i++ {
-				coinsA[i] = NewCoin("COINZ_"+string(numCoinsB+i), NewInt(int64(i)))
+				coinsA[i] = NewCoin("COINZ_"+fmt.Sprint(numCoinsB+i), NewInt(int64(i)))
 			}
 			for i := 0; i < numCoinsB; i++ {
-				coinsB[i] = NewCoin("COINZ_"+string(i), NewInt(int64(i)))
+				coinsB[i] = NewCoin("COINZ_"+fmt.Sprint(i), NewInt(int64(i)))
 			}
 
 			b.ResetTimer()


### PR DESCRIPTION
Go1.15 has become stricter with conversions from string.
See https://golang.org/doc/go1.15#vet

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
