### PR TITLE
client: fix keys add interactive command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### Bug Fixes
 
 * (types) [\#7084](https://github.com/cosmos/cosmos-sdk/pull/7084) Fix panic when calling `BigInt()` on an uninitialized `Int`.
+* (client) [\#7048](https://github.com/cosmos/cosmos-sdk/issues/7048) Fix client `keys add` failure when generating mnemonic in interactive mode.
 
 ## [v0.39.1]
 

--- a/client/keys/add.go
+++ b/client/keys/add.go
@@ -216,21 +216,25 @@ func RunAddCmd(cmd *cobra.Command, args []string, kb keys.Keybase, inBuf *bufio.
 	}
 
 	// Get bip39 mnemonic
-	var mnemonic string
-	var bip39Passphrase string
+	var mnemonic, bip39Passphrase string
 
-	if interactive || viper.GetBool(flagRecover) {
-		bip39Message := "Enter your bip39 mnemonic"
-		if !viper.GetBool(flagRecover) {
-			bip39Message = "Enter your bip39 mnemonic, or hit enter to generate one."
-		}
-
-		mnemonic, err = input.GetString(bip39Message, inBuf)
+	recover, _ := cmd.Flags().GetBool(flagRecover)
+	if recover {
+		mnemonic, err = input.GetString("Enter your bip39 mnemonic", inBuf)
 		if err != nil {
 			return err
 		}
 
 		if !bip39.IsMnemonicValid(mnemonic) {
+			return errors.New("invalid mnemonic")
+		}
+	} else if interactive {
+		mnemonic, err = input.GetString("Enter your bip39 mnemonic, or hit enter to generate one.", inBuf)
+		if err != nil {
+			return err
+		}
+
+		if !bip39.IsMnemonicValid(mnemonic) && mnemonic != "" {
 			return errors.New("invalid mnemonic")
 		}
 	}

--- a/client/keys/add_test.go
+++ b/client/keys/add_test.go
@@ -1,6 +1,7 @@
 package keys
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/spf13/viper"
@@ -54,4 +55,35 @@ func Test_runAddCmdBasic(t *testing.T) {
 	}
 	err := runAddCmd(cmd, []string{"keyname2"})
 	assert.NoError(t, err)
+
+	// In recovery mode
+	cmd.SetArgs([]string{
+		"keyname6",
+		fmt.Sprintf("--%s=true", flagRecover),
+	})
+
+	// use valid mnemonic and complete recovery key generation successfully
+	mockIn.Reset("decide praise business actor peasant farm drastic weather extend front hurt later song give verb rhythm worry fun pond reform school tumble august one\n")
+	require.NoError(t, cmd.Execute())
+
+	// use invalid mnemonic and fail recovery key generation
+	mockIn.Reset("invalid mnemonic\n")
+	require.Error(t, cmd.Execute())
+
+	// In interactive mode
+	cmd.SetArgs([]string{
+		"keyname7",
+		"-i",
+		fmt.Sprintf("--%s=false", flagRecover),
+	})
+
+	const password = "password1!"
+
+	// set password and complete interactive key generation successfully
+	mockIn.Reset("\n" + password + "\n" + password + "\n")
+	require.NoError(t, cmd.Execute())
+
+	// passwords don't match and fail interactive key generation
+	mockIn.Reset("\n" + password + "\n" + "fail" + "\n")
+	require.Error(t, cmd.Execute())
 }


### PR DESCRIPTION
Fix the command line `keys add` interactive mode
that fails when asked to generate new mnemonic.

From: https://github.com/cosmos/cosmos-sdk/pull/7049, https://github.com/cosmos/cosmos-sdk/pull/7183
Closes: #7048
Thanks: @puneet2019 for the original patch.
Thanks: @PaddyMc for the backport.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
