### PR TITLE
IBC: Allow `onRecvPacket` to bypass synchronous call of `PacketExecuted`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -206,6 +206,7 @@ invalid or incomplete requests.
 * (x/genutil) [\#5938](https://github.com/cosmos/cosmos-sdk/pull/5938) Fix `InitializeNodeValidatorFiles` error handling.
 * (x/staking) [\#5949](https://github.com/cosmos/cosmos-sdk/pull/5949) Skip staking `HistoricalInfoKey` in simulations as headers are not exported.
 * (client) [\#5964](https://github.com/cosmos/cosmos-sdk/issues/5964) `--trust-node` is now false by default - for real. Users must ensure it is set to true if they don't want to enable the verifier.
+* (x/ibc) [\#7200](https://github.com/cosmos/cosmos-sdk/pull/7200) an `OnRecvPacket` callback can declare that it will do its own `PacketExecuted` if the callback returns an acknowledgment of `[]byte(nil)`.
 
 ### State Machine Breaking
 

--- a/x/ibc/handler.go
+++ b/x/ibc/handler.go
@@ -192,9 +192,12 @@ func NewHandler(k keeper.Keeper) sdk.Handler {
 				return nil, sdkerrors.Wrap(err, "receive packet callback failed")
 			}
 
-			// Set packet acknowledgement
-			if err = k.ChannelKeeper.PacketExecuted(ctx, cap, msg.Packet, ack); err != nil {
-				return nil, err
+			// If the caller returned a nil ack, it intends to do its own PacketExecuted.
+			if ack != nil {
+				// Set packet acknowledgement
+				if err = k.ChannelKeeper.PacketExecuted(ctx, cap, msg.Packet, ack); err != nil {
+					return nil, err
+				}
 			}
 
 			return res, nil


### PR DESCRIPTION
## Description

**NOTE: This PR is superseded by cosmos/ics#478**

~~Allow an `OnRecvPacket` callback to prevent the automatic synchronous calling of `PacketExecuted` by returning a `nil` acknowledgement.~~

~~This bypasses the synchronous call to PacketExecuted and allows
the application module to call it at a later time.~~

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [x] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
