### PR TITLE
Fix 02-client message marshal and unmarshal issues

### DIFF
--- a/x/ibc/02-client/types/msgs.go
+++ b/x/ibc/02-client/types/msgs.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/cosmos-sdk/x/ibc/02-client/exported"
@@ -15,9 +16,10 @@ const (
 )
 
 var (
-	_ sdk.Msg = &MsgCreateClient{}
-	_ sdk.Msg = &MsgUpdateClient{}
-	_ sdk.Msg = &MsgSubmitMisbehaviour{}
+	_ sdk.Msg                            = &MsgCreateClient{}
+	_ codectypes.UnpackInterfacesMessage = MsgCreateClient{}
+	_ sdk.Msg                            = &MsgUpdateClient{}
+	_ sdk.Msg                            = &MsgSubmitMisbehaviour{}
 )
 
 // NewMsgCreateClient creates a new MsgCreateClient instance
@@ -86,6 +88,23 @@ func (msg MsgCreateClient) GetSignBytes() []byte {
 // GetSigners implements sdk.Msg
 func (msg MsgCreateClient) GetSigners() []sdk.AccAddress {
 	return []sdk.AccAddress{msg.Signer}
+}
+
+// UnpackInterfaces implements UnpackInterfacesMessage.UnpackInterfaces
+func (msg MsgCreateClient) UnpackInterfaces(unpacker codectypes.AnyUnpacker) error {
+	var clientState exported.ClientState
+	err := unpacker.UnpackAny(msg.ClientState, &clientState)
+	if err != nil {
+		return err
+	}
+
+	var consensusState exported.ConsensusState
+	err = unpacker.UnpackAny(msg.ConsensusState, &consensusState)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // NewMsgUpdateClient creates a new MsgUpdateClient instance

--- a/x/ibc/02-client/types/msgs.go
+++ b/x/ibc/02-client/types/msgs.go
@@ -16,10 +16,13 @@ const (
 )
 
 var (
-	_ sdk.Msg                            = &MsgCreateClient{}
+	_ sdk.Msg = &MsgCreateClient{}
+	_ sdk.Msg = &MsgUpdateClient{}
+	_ sdk.Msg = &MsgSubmitMisbehaviour{}
+
 	_ codectypes.UnpackInterfacesMessage = MsgCreateClient{}
-	_ sdk.Msg                            = &MsgUpdateClient{}
-	_ sdk.Msg                            = &MsgSubmitMisbehaviour{}
+	_ codectypes.UnpackInterfacesMessage = MsgUpdateClient{}
+	_ codectypes.UnpackInterfacesMessage = MsgSubmitMisbehaviour{}
 )
 
 // NewMsgCreateClient creates a new MsgCreateClient instance
@@ -159,6 +162,17 @@ func (msg MsgUpdateClient) GetSigners() []sdk.AccAddress {
 	return []sdk.AccAddress{msg.Signer}
 }
 
+// UnpackInterfaces implements UnpackInterfacesMessage.UnpackInterfaces
+func (msg MsgUpdateClient) UnpackInterfaces(unpacker codectypes.AnyUnpacker) error {
+	var header exported.Header
+	err := unpacker.UnpackAny(msg.Header, &header)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // NewMsgSubmitMisbehaviour creates a new MsgSubmitMisbehaviour instance.
 func NewMsgSubmitMisbehaviour(clientID string, misbehaviour exported.Misbehaviour, signer sdk.AccAddress) (*MsgSubmitMisbehaviour, error) {
 	anyMisbehaviour, err := PackMisbehaviour(misbehaviour)
@@ -213,4 +227,15 @@ func (msg MsgSubmitMisbehaviour) GetSignBytes() []byte {
 // GetSigners returns the single expected signer for a MsgSubmitMisbehaviour.
 func (msg MsgSubmitMisbehaviour) GetSigners() []sdk.AccAddress {
 	return []sdk.AccAddress{msg.Signer}
+}
+
+// UnpackInterfaces implements UnpackInterfacesMessage.UnpackInterfaces
+func (msg MsgSubmitMisbehaviour) UnpackInterfaces(unpacker codectypes.AnyUnpacker) error {
+	var misbehaviour exported.Misbehaviour
+	err := unpacker.UnpackAny(msg.Misbehaviour, &misbehaviour)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/x/ibc/02-client/types/msgs_test.go
+++ b/x/ibc/02-client/types/msgs_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/golang/protobuf/proto"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/cosmos/cosmos-sdk/x/ibc/02-client/exported"
@@ -65,13 +66,18 @@ func (suite *TypesTestSuite) TestMarshalMsgCreateClient() {
 
 			tc.malleate()
 
+			cdc := suite.chain.App.AppCodec()
+
 			// marshal message
-			bz, err := types.SubModuleCdc.MarshalJSON(msg)
-			suite.Require().NoError(err)
-			// unmarshal message
-			err = types.SubModuleCdc.UnmarshalJSON(bz, msg)
+			bz, err := cdc.MarshalJSON(msg)
 			suite.Require().NoError(err)
 
+			// unmarshal message
+			newMsg := &types.MsgCreateClient{}
+			err = cdc.UnmarshalJSON(bz, newMsg)
+			suite.Require().NoError(err)
+
+			suite.Require().True(proto.Equal(msg, newMsg))
 		})
 	}
 }

--- a/x/ibc/07-tendermint/types/codec.go
+++ b/x/ibc/07-tendermint/types/codec.go
@@ -18,8 +18,8 @@ func RegisterInterfaces(registry codectypes.InterfaceRegistry) {
 		&ConsensusState{},
 	)
 	registry.RegisterImplementations(
-		(*clientexported.Misbehaviour)(nil),
-		&Misbehaviour{},
+		(*clientexported.Header)(nil),
+		&Header{},
 	)
 	registry.RegisterImplementations(
 		(*clientexported.Misbehaviour)(nil),


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Since the client messages each contain `Any` we need to add UnpackInterfaces for each message. I also added tests to ensure they can be marshaled and unmarshaled for solo machine and tendermint types.

closes: #XXXX

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [x] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
