### PR TITLE
feat: allow "any" to specify a "binary" with no arch/os dependencies

### DIFF
--- a/cosmovisor/README.md
+++ b/cosmovisor/README.md
@@ -122,6 +122,7 @@ as JSON under the `"binaries"` key, eg:
   }
 }
 ```
+The `"any"` key, if it exists, will be used as a default if there is not a specific os/architecture key.
 2. Store a link to a file that contains all information in the above format (eg. if you want
 to specify lots of binaries, changelog info, etc without filling up the blockchain).
 

--- a/cosmovisor/upgrade.go
+++ b/cosmovisor/upgrade.go
@@ -121,7 +121,10 @@ func GetDownloadURL(info *UpgradeInfo) (string, error) {
 	if err := json.Unmarshal([]byte(doc), &config); err == nil {
 		url, ok := config.Binaries[osArch()]
 		if !ok {
-			return "", fmt.Errorf("cannot find binary for os/arch: %s", osArch())
+			url, ok = config.Binaries["any"]
+		}
+		if !ok {
+			return "", fmt.Errorf("cannot find binary for os/arch: neither %s, nor any", osArch())
 		}
 
 		return url, nil

--- a/cosmovisor/upgrade_test.go
+++ b/cosmovisor/upgrade_test.go
@@ -159,6 +159,14 @@ func TestGetDownloadURL(t *testing.T) {
 			info: `{"binaries": {"linux/amd64": "https://foo.bar/", "windows/amd64": "https://something.else"}}`,
 			url:  "https://foo.bar/",
 		},
+		"any architecture not used": {
+			info: `{"binaries": {"linux/amd64": "https://foo.bar/", "*": "https://something.else"}}`,
+			url:  "https://foo.bar/",
+		},
+		"any architecture used": {
+			info: `{"binaries": {"linux/arm": "https://foo.bar/arm-only", "any": "https://foo.bar/portable"}}`,
+			url:  "https://foo.bar/portable",
+		},
 		"missing binary": {
 			info:  `{"binaries": {"linux/arm": "https://foo.bar/"}}`,
 			isErr: true,


### PR DESCRIPTION
## Description

This is a tiny feature for `cosmovisor` to allow the "binary" info to specify a portable
script by using "any" as the default architecture if there is no specific match.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [x] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
