### PR TITLE
Makefile: drop gofmt in favor of golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,7 +6,6 @@ run:
 linters:
   disable:
     - errcheck
-    - wsl
     - varcheck
   enable:
     - bodyclose

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,13 +4,15 @@ run:
 #   timeout: 5m
 
 linters:
-  disable-all: true
+  disable:
+    - errcheck
+    - wsl
+    - varcheck
   enable:
     - bodyclose
     - deadcode
     - depguard
     - dogsled
-    # - errcheck
     - goconst
     - gocritic
     - gofmt
@@ -34,7 +36,6 @@ linters:
     - unused
     - unparam
     - misspell
-    # - wsl
     - nolintlint
 
 issues:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,14 +4,13 @@ run:
 #   timeout: 5m
 
 linters:
-  disable:
-    - errcheck
-    - varcheck
+  disable-all: true
   enable:
     - bodyclose
     - deadcode
     - depguard
     - dogsled
+    # - errcheck
     - goconst
     - gocritic
     - gofmt
@@ -35,6 +34,7 @@ linters:
     - unused
     - unparam
     - misspell
+    # - wsl
     - nolintlint
 
 issues:

--- a/Makefile
+++ b/Makefile
@@ -310,13 +310,15 @@ benchmark:
 
 lint:
 	golangci-lint run --out-format=tab --issues-exit-code=0
-	find . -name '*.go' -type f -not -path "./vendor*" -not -path "*.git*" -not -name '*.pb.go' | xargs gofmt -d -s
-.PHONY: lint
+
+lint-fix:
+	golangci-lint run --fix --out-format=tab --issues-exit-code=0
+.PHONY: lint lint-fix
 
 format:
-	find . -name '*.go' -type f -not -path "./vendor*" -not -path "*.git*" -not -path "./client/docs/statik/statik.go" -not -path "./tests/mocks/*" -not -name '*.pb.go' | xargs gofmt -w -s
-	find . -name '*.go' -type f -not -path "./vendor*" -not -path "*.git*" -not -path "./client/docs/statik/statik.go" -not -path "./tests/mocks/*" -not -name '*.pb.go' | xargs misspell -w
-	find . -name '*.go' -type f -not -path "./vendor*" -not -path "*.git*" -not -path "./client/docs/statik/statik.go" -not -path "./tests/mocks/*" -not -name '*.pb.go' | xargs goimports -w -local github.com/cosmos/cosmos-sdk
+	find . -name '*.go' -type f -not -path "*.git*" -not -path "./client/docs/statik/statik.go" -not -path "./tests/mocks/*" -not -name '*.pb.go' | xargs gofmt -w -s
+	find . -name '*.go' -type f -not -path "*.git*" -not -path "./client/docs/statik/statik.go" -not -path "./tests/mocks/*" -not -name '*.pb.go' | xargs misspell -w
+	find . -name '*.go' -type f -not -path "*.git*" -not -path "./client/docs/statik/statik.go" -not -path "./tests/mocks/*" -not -name '*.pb.go' | xargs goimports -w -local github.com/cosmos/cosmos-sdk
 .PHONY: format
 
 ###############################################################################

--- a/Makefile
+++ b/Makefile
@@ -316,9 +316,9 @@ lint-fix:
 .PHONY: lint lint-fix
 
 format:
-	find . -name '*.go' -type f -not -path "*.git*" -not -path "./client/docs/statik/statik.go" -not -path "./tests/mocks/*" -not -name '*.pb.go' | xargs gofmt -w -s
-	find . -name '*.go' -type f -not -path "*.git*" -not -path "./client/docs/statik/statik.go" -not -path "./tests/mocks/*" -not -name '*.pb.go' | xargs misspell -w
-	find . -name '*.go' -type f -not -path "*.git*" -not -path "./client/docs/statik/statik.go" -not -path "./tests/mocks/*" -not -name '*.pb.go' | xargs goimports -w -local github.com/cosmos/cosmos-sdk
+	find . -name '*.go' -type f -not -path "./vendor*" -not -path "*.git*" -not -path "./client/docs/statik/statik.go" -not -path "./tests/mocks/*" -not -name '*.pb.go' | xargs gofmt -w -s
+	find . -name '*.go' -type f -not -path "./vendor*" -not -path "*.git*" -not -path "./client/docs/statik/statik.go" -not -path "./tests/mocks/*" -not -name '*.pb.go' | xargs misspell -w
+	find . -name '*.go' -type f -not -path "./vendor*" -not -path "*.git*" -not -path "./client/docs/statik/statik.go" -not -path "./tests/mocks/*" -not -name '*.pb.go' | xargs goimports -w -local github.com/cosmos/cosmos-sdk
 .PHONY: format
 
 ###############################################################################

--- a/Makefile
+++ b/Makefile
@@ -309,7 +309,7 @@ benchmark:
 ###############################################################################
 
 lint:
-	golangci-lint run --out-format=tab --issues-exit-code=0
+	golangci-lint run --out-format=tab
 
 lint-fix:
 	golangci-lint run --fix --out-format=tab --issues-exit-code=0

--- a/x/staking/types/data_test.go
+++ b/x/staking/types/data_test.go
@@ -7,7 +7,6 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
-// nolint:deadcode,unused
 var (
 	pk1      = ed25519.GenPrivKey().PubKey()
 	pk2      = ed25519.GenPrivKey().PubKey()


### PR DESCRIPTION
## Description

It's better to explicitly disable default lint checkers rather then disable all of them. The main reason is that if we `golangci-lint` will have a very good and useful checker we may skip him.

Other changes:
+ removed `gofmt` command from `make lint`. It's not needed because `golangci-lint` is handling it (and it's doing it faster because gofmt doesn't need to re-read files).
+ removed `.vendor` patterns - we don't use patterns any more

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
