### PR TITLE
reintroduce rule to cross-build a linux binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,9 @@ simd:
 	mkdir -p $(BUILDDIR)
 	go build -mod=readonly $(BUILD_FLAGS) -o $(BUILDDIR) ./simapp/simd
 
+simd-linux: go.sum
+	$(MAKE) simd GOOS=linux GOARCH=amd64 LEDGER_ENABLED=false
+
 build-simd-all: go.sum
 	$(if $(shell docker inspect -f '{{ .Id }}' cosmossdk/rbuilder 2>/dev/null),$(info found image cosmossdk/rbuilder),docker pull cosmossdk/rbuilder:latest)
 	docker rm latest-build || true
@@ -433,7 +436,7 @@ proto-update-deps:
 ###############################################################################
 
 # Run a 4-node testnet locally
-localnet-start: build-simd-linux localnet-stop
+localnet-start: $(BUILDDIR)/simd localnet-stop
 	$(if $(shell docker inspect -f '{{ .Id }}' cosmossdk/simd-env 2>/dev/null),$(info found image cosmossdk/simd-env),$(MAKE) -C contrib/images simd-env)
 	if ! [ -f build/node0/simd/config/genesis.json ]; then docker run --rm \
 		--user $(shell id -u):$(shell id -g) \


### PR DESCRIPTION
closes: #7333

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
