### PR TITLE
Migrate TM evidence params in CLI `migrate`

### DIFF
--- a/x/genutil/client/cli/migrate.go
+++ b/x/genutil/client/cli/migrate.go
@@ -144,9 +144,9 @@ $ %s migrate v0.36 /path/to/genesis.json --chain-id=cosmoshub-3 --genesis-time=2
 	return cmd
 }
 
-// SanitizeTendermintGenesis makes sure a later version of Tendermint can parse
+// MigrateTendermintGenesis makes sure a later version of Tendermint can parse
 // a JSON blob exported by a previous version of Tendermint.
-func SanitizeTendermintGenesis(jsonBlob []byte) ([]byte, error) {
+func MigrateTendermintGenesis(jsonBlob []byte) ([]byte, error) {
 	var jsonObj map[string]interface{}
 	err := tmjson.Unmarshal(jsonBlob, &jsonObj)
 	if err != nil {

--- a/x/genutil/client/cli/migrate_test.go
+++ b/x/genutil/client/cli/migrate_test.go
@@ -72,7 +72,7 @@ func TestSanitizeTendermintGenesis(t *testing.T) {
 	_, err := tmtypes.GenesisDocFromJSON(v037Exported)
 	require.Error(t, err)
 
-	_, err := cli.SanitizeTendermintGenesis(v037Exported)
+	_, err := cli.MigrateTendermintGenesis(v037Exported)
 	require.NoError(t, err)
 
 	require.True(t, false)

--- a/x/genutil/client/cli/migrate_test.go
+++ b/x/genutil/client/cli/migrate_test.go
@@ -72,7 +72,7 @@ func TestSanitizeTendermintGenesis(t *testing.T) {
 	_, err := tmtypes.GenesisDocFromJSON(v037Exported)
 	require.Error(t, err)
 
-	_, err := cli.MigrateTendermintGenesis(v037Exported)
+	_, err = cli.MigrateTendermintGenesis(v037Exported)
 	require.NoError(t, err)
 
 	require.True(t, false)

--- a/x/genutil/client/cli/migrate_test.go
+++ b/x/genutil/client/cli/migrate_test.go
@@ -2,7 +2,6 @@ package cli_test
 
 import (
 	"context"
-	"fmt"
 	"io/ioutil"
 	"path"
 	"testing"
@@ -73,7 +72,8 @@ func TestSanitizeTendermintGenesis(t *testing.T) {
 	_, err := tmtypes.GenesisDocFromJSON(v037Exported)
 	require.Error(t, err)
 
-	sanitized, err := cli.SanitizeTendermintGenesis(v037Exported)
+	_, err := cli.SanitizeTendermintGenesis(v037Exported)
 	require.NoError(t, err)
-	fmt.Println(string(sanitized))
+
+	require.True(t, false)
 }

--- a/x/genutil/client/cli/migrate_test.go
+++ b/x/genutil/client/cli/migrate_test.go
@@ -2,11 +2,13 @@ package cli_test
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
 	"path"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	tmtypes "github.com/tendermint/tendermint/types"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/testutil"
@@ -44,4 +46,34 @@ func TestMigrateGenesis(t *testing.T) {
 
 	cmd.SetArgs([]string{target, genesisPath})
 	require.NoError(t, cmd.ExecuteContext(ctx))
+}
+
+func TestSanitizeTendermintGenesis(t *testing.T) {
+	// An example exported genesis file from a 0.37 chain. Note that evidence
+	// parameters only contains `max_age`.
+	v037Exported := []byte(`{
+  "app_hash": "",
+  "app_state": {},
+  "chain_id": "test",
+  "consensus_params": {
+    "block": {
+      "max_bytes": "22020096",
+      "max_gas": "-1",
+      "time_iota_ms": "1000"
+    },
+    "evidence": { "max_age": "100000" },
+    "validator": { "pub_key_types": ["ed25519"] }
+  },
+  "genesis_time": "2020-09-29T20:16:29.172362037Z",
+  "validators": []
+}`)
+
+	// We expect an error decoding an older `consensus_params` with the latest
+	// TM.
+	_, err := tmtypes.GenesisDocFromJSON(v037Exported)
+	require.Error(t, err)
+
+	sanitized, err := cli.SanitizeTendermintGenesis(v037Exported)
+	require.NoError(t, err)
+	fmt.Println(string(sanitized))
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

### Repro:

1. Export v0.37 state, e.g. from gaia

Note that the TM's evidence params only contain max_age:

```js
{
  // snip
  "consensus_params": {
    // snip
    "evidence": { "max_age": "100000" },
  },
}
```

2. Using cosmos-sdk latest master, migrate to v0.38

```bash
simd migrate v0.38 <037_exported_state.json>
```

### Expected

No error.

### Actual

```
Error: failed to read genesis document from file sorted_v37_exported_genesis.json: error reading GenesisDoc at sorted_v37_exported_genesis.json: evidenceParams.MaxAgeNumBlocks must be greater than 0. Got 0
```

### Reason

0.37 exported the evidence params using the old struct (with only `max_age`). Now, we updated TM, and TM uses the new struct (with `max_age_num_blocks` & `max_age_duration`) for unmarshalling.

### Solutions

Solution 1. We will have 2 versions of TM inside the cosmos-sdk. The migrate command unmarshals using the old TM (which doesn't expect these 2 fields in evidence params), and marshals again using the new TM.

Solution 2. I manually migrate these two fields by manipulating JSON.

Solution 3. A PR on TM to make GenesisDocFromFile backwards-compatible.

Solution 4. https://github.com/cosmos/cosmos-sdk/pull/7462#issuecomment-704243222

This PR implements solution 2.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
