### PR TITLE
Use nil instead of protobuf.Empty in genesis BaseAccount

### DIFF
--- a/x/auth/legacy/v040/migrate.go
+++ b/x/auth/legacy/v040/migrate.go
@@ -4,14 +4,27 @@ import (
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	v039auth "github.com/cosmos/cosmos-sdk/x/auth/legacy/v039"
+	"github.com/cosmos/cosmos-sdk/x/auth/tx"
 	v040auth "github.com/cosmos/cosmos-sdk/x/auth/types"
 	v040vesting "github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
 )
 
 // convertBaseAccount converts a 0.39 BaseAccount to a 0.40 BaseAccount.
 func convertBaseAccount(old *v039auth.BaseAccount) *v040auth.BaseAccount {
+	var any *codectypes.Any
+	// If the old genesis had a pubkey, we pack it inside an Any. Or else, we
+	// just leave it nil.
+	if old.PubKey != nil {
+		var err error
+		any, err = tx.PubKeyToAny(old.PubKey)
+		if err != nil {
+			panic(err)
+		}
+	}
+
 	return &v040auth.BaseAccount{
 		Address:       old.Address.String(),
+		PubKey:        any,
 		AccountNumber: old.AccountNumber,
 		Sequence:      old.Sequence,
 	}

--- a/x/auth/legacy/v040/migrate.go
+++ b/x/auth/legacy/v040/migrate.go
@@ -1,37 +1,17 @@
 package v040
 
 import (
-	pt "github.com/gogo/protobuf/types"
-
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	v039auth "github.com/cosmos/cosmos-sdk/x/auth/legacy/v039"
-	"github.com/cosmos/cosmos-sdk/x/auth/tx"
 	v040auth "github.com/cosmos/cosmos-sdk/x/auth/types"
 	v040vesting "github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
 )
 
 // convertBaseAccount converts a 0.39 BaseAccount to a 0.40 BaseAccount.
 func convertBaseAccount(old *v039auth.BaseAccount) *v040auth.BaseAccount {
-	// In `x/auth/legacy/v038/migrate.go`, when creating a BaseAccount, we
-	// explicitly set the PublicKey field to nil. This propagates until 0.40,
-	// and we don't know the PubKey for those accounts, so we just put an empty
-	// string inside the Any.
-	var any *codectypes.Any
-	var err error
-	if old.PubKey != nil {
-		any, err = tx.PubKeyToAny(old.PubKey)
-	} else {
-		s := pt.Empty{}
-		any, err = codectypes.NewAnyWithValue(&s)
-	}
-	if err != nil {
-		panic(err)
-	}
-
 	return &v040auth.BaseAccount{
 		Address:       old.Address.String(),
-		PubKey:        any,
 		AccountNumber: old.AccountNumber,
 		Sequence:      old.Sequence,
 	}

--- a/x/auth/legacy/v040/migrate_test.go
+++ b/x/auth/legacy/v040/migrate_test.go
@@ -89,7 +89,10 @@ func TestMigrate(t *testing.T) {
       "@type": "/cosmos.auth.v1beta1.BaseAccount",
       "account_number": "1",
       "address": "cosmos13syh7de9xndv9wmklccpfvc0d8dcyvay4s6z6l",
-      "pub_key": null,
+      "pub_key": {
+        "@type": "/cosmos.crypto.secp256k1.PubKey",
+        "key": "A8oWyJkohwy8XZ0Df92jFMBTtTPMvYJplYIrlEHTKPYk"
+      },
       "sequence": "0"
     },
     {
@@ -97,7 +100,10 @@ func TestMigrate(t *testing.T) {
       "base_account": {
         "account_number": "1",
         "address": "cosmos1v57fx2l2rt6ehujuu99u2fw05779m5e2ux4z2h",
-        "pub_key": null,
+        "pub_key": {
+          "@type": "/cosmos.crypto.secp256k1.PubKey",
+          "key": "AruDygh5HprMOpHOEato85dLgAsybMJVyxBGUa3KuWCr"
+        },
         "sequence": "0"
       },
       "name": "module2",
@@ -110,7 +116,10 @@ func TestMigrate(t *testing.T) {
       "base_account": {
         "account_number": "1",
         "address": "cosmos18hnp9fjflrkeeqn4gmhjhzljusxzmjeartdckw",
-        "pub_key": null,
+        "pub_key": {
+          "@type": "/cosmos.crypto.secp256k1.PubKey",
+          "key": "A5aEFDIdQHh0OYmNXNv1sHBNURDWWgVkXC2IALcWLLwJ"
+        },
         "sequence": "0"
       },
       "delegated_free": [
@@ -139,7 +148,10 @@ func TestMigrate(t *testing.T) {
         "base_account": {
           "account_number": "1",
           "address": "cosmos1t9kvvejvk6hjtddx6antck39s206csqduq3ke3",
-          "pub_key": null,
+          "pub_key": {
+            "@type": "/cosmos.crypto.secp256k1.PubKey",
+            "key": "AoXDzxwTnljemHxfnJcwrKqODBP6Q2l3K3U3UhVDzyah"
+          },
           "sequence": "0"
         },
         "delegated_free": [],
@@ -160,7 +172,10 @@ func TestMigrate(t *testing.T) {
         "base_account": {
           "account_number": "1",
           "address": "cosmos1s4ss9zquz7skvguechzlk3na635jdrecl0sgy2",
-          "pub_key": null,
+          "pub_key": {
+            "@type": "/cosmos.crypto.secp256k1.PubKey",
+            "key": "A2a4P4TQ1OKzpfu0eKnCoEtmTvoiclSx0G9higenUGws"
+          },
           "sequence": "0"
         },
         "delegated_free": [],
@@ -192,7 +207,10 @@ func TestMigrate(t *testing.T) {
         "base_account": {
           "account_number": "1",
           "address": "cosmos1mcc6rwrj4hswf8p9ct82c7lmf77w9tuk07rha4",
-          "pub_key": null,
+          "pub_key": {
+            "@type": "/cosmos.crypto.secp256k1.PubKey",
+            "key": "A4tuAfmZlhjK5cjp6ImR704miybHnITVNOyJORdDPFu3"
+          },
           "sequence": "0"
         },
         "delegated_free": [],

--- a/x/auth/legacy/v040/migrate_test.go
+++ b/x/auth/legacy/v040/migrate_test.go
@@ -89,10 +89,7 @@ func TestMigrate(t *testing.T) {
       "@type": "/cosmos.auth.v1beta1.BaseAccount",
       "account_number": "1",
       "address": "cosmos13syh7de9xndv9wmklccpfvc0d8dcyvay4s6z6l",
-      "pub_key": {
-        "@type": "/cosmos.crypto.secp256k1.PubKey",
-        "key": "A8oWyJkohwy8XZ0Df92jFMBTtTPMvYJplYIrlEHTKPYk"
-      },
+      "pub_key": null,
       "sequence": "0"
     },
     {
@@ -100,10 +97,7 @@ func TestMigrate(t *testing.T) {
       "base_account": {
         "account_number": "1",
         "address": "cosmos1v57fx2l2rt6ehujuu99u2fw05779m5e2ux4z2h",
-        "pub_key": {
-          "@type": "/cosmos.crypto.secp256k1.PubKey",
-          "key": "AruDygh5HprMOpHOEato85dLgAsybMJVyxBGUa3KuWCr"
-        },
+        "pub_key": null,
         "sequence": "0"
       },
       "name": "module2",
@@ -116,10 +110,7 @@ func TestMigrate(t *testing.T) {
       "base_account": {
         "account_number": "1",
         "address": "cosmos18hnp9fjflrkeeqn4gmhjhzljusxzmjeartdckw",
-        "pub_key": {
-          "@type": "/cosmos.crypto.secp256k1.PubKey",
-          "key": "A5aEFDIdQHh0OYmNXNv1sHBNURDWWgVkXC2IALcWLLwJ"
-        },
+        "pub_key": null,
         "sequence": "0"
       },
       "delegated_free": [
@@ -148,10 +139,7 @@ func TestMigrate(t *testing.T) {
         "base_account": {
           "account_number": "1",
           "address": "cosmos1t9kvvejvk6hjtddx6antck39s206csqduq3ke3",
-          "pub_key": {
-            "@type": "/cosmos.crypto.secp256k1.PubKey",
-            "key": "AoXDzxwTnljemHxfnJcwrKqODBP6Q2l3K3U3UhVDzyah"
-          },
+          "pub_key": null,
           "sequence": "0"
         },
         "delegated_free": [],
@@ -172,10 +160,7 @@ func TestMigrate(t *testing.T) {
         "base_account": {
           "account_number": "1",
           "address": "cosmos1s4ss9zquz7skvguechzlk3na635jdrecl0sgy2",
-          "pub_key": {
-            "@type": "/cosmos.crypto.secp256k1.PubKey",
-            "key": "A2a4P4TQ1OKzpfu0eKnCoEtmTvoiclSx0G9higenUGws"
-          },
+          "pub_key": null,
           "sequence": "0"
         },
         "delegated_free": [],
@@ -207,10 +192,7 @@ func TestMigrate(t *testing.T) {
         "base_account": {
           "account_number": "1",
           "address": "cosmos1mcc6rwrj4hswf8p9ct82c7lmf77w9tuk07rha4",
-          "pub_key": {
-            "@type": "/cosmos.crypto.secp256k1.PubKey",
-            "key": "A4tuAfmZlhjK5cjp6ImR704miybHnITVNOyJORdDPFu3"
-          },
+          "pub_key": null,
           "sequence": "0"
         },
         "delegated_free": [],
@@ -228,10 +210,7 @@ func TestMigrate(t *testing.T) {
       "@type": "/cosmos.auth.v1beta1.BaseAccount",
       "account_number": "1",
       "address": "cosmos16ydaqh0fcnh4qt7a3jme4mmztm2qel5axcpw00",
-      "pub_key": {
-        "@type": "/google.protobuf.Empty",
-        "value": {}
-      },
+      "pub_key": null,
       "sequence": "0"
     }
   ],

--- a/x/auth/types/codec.go
+++ b/x/auth/types/codec.go
@@ -19,7 +19,7 @@ func RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
 	legacytx.RegisterLegacyAminoCodec(cdc)
 }
 
-// RegisterInterface associates protoName with AccountI interface
+// RegisterInterfaces associates protoName with AccountI interface
 // and creates a registry of it's concrete implementations
 func RegisterInterfaces(registry types.InterfaceRegistry) {
 	registry.RegisterInterface(


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Accounts in the 0.37 exported state don't have pubkeys. When migrating these accounts to 0.40, we were packing a protobuf's Empty inside the BaseAccount's pubkey Any field.

It would be much simpler to just pack a `nil`, which outputs as `null` in the JSON.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
