### PR TITLE
Correct the error message to reflect the actual file that is being re…

### DIFF
--- a/server/util.go
+++ b/server/util.go
@@ -134,7 +134,7 @@ func interceptConfigs(ctx *Context, rootViper *viper.Viper) (*tmcfg.Config, erro
 		rootViper.SetConfigName("config")
 		rootViper.AddConfigPath(configPath)
 		if err := rootViper.ReadInConfig(); err != nil {
-			return nil, fmt.Errorf("failed to read in app.toml: %w", err)
+			return nil, fmt.Errorf("failed to read in config.toml: %w", err)
 		}
 
 		if err := rootViper.Unmarshal(conf); err != nil {


### PR DESCRIPTION
I was reviewing  this function to get a better grasp on how it works. The `viper` instance that is used here is set to a config name of "Config" and a type of "toml". If I understand `viper` correctly it will try and read `config.toml`. So if `rootViper.ReadInConfig` returns an error then the message should indicate it failed trying to read `config.toml`, not `app.toml`.

@jackzampolin 
