### PR TITLE
Refactor RegisterQueryServices -> RegisterServices

### DIFF
--- a/simapp/app.go
+++ b/simapp/app.go
@@ -359,7 +359,7 @@ func NewSimApp(
 
 	app.mm.RegisterInvariants(&app.CrisisKeeper)
 	app.mm.RegisterRoutes(app.Router(), app.QueryRouter(), encodingConfig.Amino)
-	app.mm.RegisterServices(app.GRPCQueryRouter())
+	app.mm.RegisterServices(module.NewConfigurator(app.GRPCQueryRouter()))
 
 	// add test gRPC service for testing gRPC queries in isolation
 	testdata.RegisterTestServiceServer(app.GRPCQueryRouter(), testdata.TestServiceImpl{})

--- a/simapp/app.go
+++ b/simapp/app.go
@@ -359,7 +359,7 @@ func NewSimApp(
 
 	app.mm.RegisterInvariants(&app.CrisisKeeper)
 	app.mm.RegisterRoutes(app.Router(), app.QueryRouter(), encodingConfig.Amino)
-	app.mm.RegisterQueryServices(app.GRPCQueryRouter())
+	app.mm.RegisterServices(app.GRPCQueryRouter())
 
 	// add test gRPC service for testing gRPC queries in isolation
 	testdata.RegisterTestServiceServer(app.GRPCQueryRouter(), testdata.TestServiceImpl{})

--- a/tests/mocks/types_module_module.go
+++ b/tests/mocks/types_module_module.go
@@ -10,10 +10,10 @@ import (
 	codec "github.com/cosmos/cosmos-sdk/codec"
 	types "github.com/cosmos/cosmos-sdk/codec/types"
 	types0 "github.com/cosmos/cosmos-sdk/types"
-	grpc "github.com/gogo/protobuf/grpc"
+	module "github.com/cosmos/cosmos-sdk/types/module"
 	gomock "github.com/golang/mock/gomock"
 	mux "github.com/gorilla/mux"
-	"github.com/grpc-ecosystem/grpc-gateway/runtime"
+	runtime "github.com/grpc-ecosystem/grpc-gateway/runtime"
 	cobra "github.com/spf13/cobra"
 	types1 "github.com/tendermint/tendermint/abci/types"
 	reflect "reflect"
@@ -264,7 +264,7 @@ func (mr *MockAppModuleGenesisMockRecorder) RegisterRESTRoutes(arg0, arg1 interf
 // RegisterGRPCRoutes mocks base method
 func (m *MockAppModuleGenesis) RegisterGRPCRoutes(arg0 client.Context, arg1 *runtime.ServeMux) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "RegisterRESTRoutes", arg0, arg1)
+	m.ctrl.Call(m, "RegisterGRPCRoutes", arg0, arg1)
 }
 
 // RegisterGRPCRoutes indicates an expected call of RegisterGRPCRoutes
@@ -539,29 +539,29 @@ func (mr *MockAppModuleMockRecorder) QuerierRoute() *gomock.Call {
 }
 
 // LegacyQuerierHandler mocks base method
-func (m *MockAppModule) LegacyQuerierHandler(*codec.LegacyAmino) types0.Querier {
+func (m *MockAppModule) LegacyQuerierHandler(arg0 *codec.LegacyAmino) types0.Querier {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "LegacyQuerierHandler")
+	ret := m.ctrl.Call(m, "LegacyQuerierHandler", arg0)
 	ret0, _ := ret[0].(types0.Querier)
 	return ret0
 }
 
 // LegacyQuerierHandler indicates an expected call of LegacyQuerierHandler
-func (mr *MockAppModuleMockRecorder) NewQuerierHandler() *gomock.Call {
+func (mr *MockAppModuleMockRecorder) LegacyQuerierHandler(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LegacyQuerierHandler", reflect.TypeOf((*MockAppModule)(nil).LegacyQuerierHandler))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LegacyQuerierHandler", reflect.TypeOf((*MockAppModule)(nil).LegacyQuerierHandler), arg0)
 }
 
-// RegisterQueryService mocks base method
-func (m *MockAppModule) RegisterQueryService(arg0 grpc.Server) {
+// RegisterServices mocks base method
+func (m *MockAppModule) RegisterServices(arg0 module.Configurator) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "RegisterQueryService", arg0)
+	m.ctrl.Call(m, "RegisterServices", arg0)
 }
 
-// RegisterQueryService indicates an expected call of RegisterQueryService
-func (mr *MockAppModuleMockRecorder) RegisterQueryService(arg0 interface{}) *gomock.Call {
+// RegisterServices indicates an expected call of RegisterServices
+func (mr *MockAppModuleMockRecorder) RegisterServices(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterQueryService", reflect.TypeOf((*MockAppModule)(nil).RegisterQueryService), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterServices", reflect.TypeOf((*MockAppModule)(nil).RegisterServices), arg0)
 }
 
 // BeginBlock mocks base method

--- a/types/module/configurator.go
+++ b/types/module/configurator.go
@@ -1,0 +1,21 @@
+package module
+
+import "github.com/gogo/protobuf/grpc"
+
+type Configurator interface {
+	QueryServer() grpc.Server
+}
+
+type configurator struct {
+	queryServer grpc.Server
+}
+
+func NewConfigurator(queryServer grpc.Server) Configurator {
+	return configurator{queryServer: queryServer}
+}
+
+var _ Configurator = configurator{}
+
+func (c configurator) QueryServer() grpc.Server {
+	return c.queryServer
+}

--- a/types/module/configurator.go
+++ b/types/module/configurator.go
@@ -2,6 +2,10 @@ package module
 
 import "github.com/gogo/protobuf/grpc"
 
+// Configurator provides the hooks to allow modules to configure and register
+// their services in the RegisterServices method. It is designed to eventually
+// support module object capabilities isolation as described in
+// https://github.com/cosmos/cosmos-sdk/issues/7093
 type Configurator interface {
 	QueryServer() grpc.Server
 }
@@ -10,12 +14,14 @@ type configurator struct {
 	queryServer grpc.Server
 }
 
+// NewConfigurator returns a new Configurator instance
 func NewConfigurator(queryServer grpc.Server) Configurator {
 	return configurator{queryServer: queryServer}
 }
 
 var _ Configurator = configurator{}
 
+// QueryServer implements the Configurator.QueryServer method
 func (c configurator) QueryServer() grpc.Server {
 	return c.queryServer
 }

--- a/types/module/module.go
+++ b/types/module/module.go
@@ -31,7 +31,6 @@ package module
 import (
 	"encoding/json"
 
-	"github.com/gogo/protobuf/grpc"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 
 	"github.com/gorilla/mux"
@@ -207,7 +206,7 @@ func (GenesisOnlyAppModule) QuerierRoute() string { return "" }
 // LegacyQuerierHandler returns an empty module querier
 func (gam GenesisOnlyAppModule) LegacyQuerierHandler(*codec.LegacyAmino) sdk.Querier { return nil }
 
-// RegisterQueryService registers all gRPC query services.
+// RegisterServices registers all services.
 func (gam GenesisOnlyAppModule) RegisterServices(Configurator) {}
 
 // BeginBlock returns an empty module begin-block
@@ -289,8 +288,7 @@ func (m *Manager) RegisterRoutes(router sdk.Router, queryRouter sdk.QueryRouter,
 }
 
 // RegisterServices registers all module services
-func (m *Manager) RegisterServices(queryRouter grpc.Server) {
-	cfg := NewConfigurator(queryRouter)
+func (m *Manager) RegisterServices(cfg Configurator) {
 	for _, module := range m.Modules {
 		module.RegisterServices(cfg)
 	}

--- a/types/module/module.go
+++ b/types/module/module.go
@@ -173,8 +173,8 @@ type AppModule interface {
 	// Deprecated: use RegisterQueryService
 	LegacyQuerierHandler(*codec.LegacyAmino) sdk.Querier
 
-	// RegisterQueryService allows a module to register a gRPC query service
-	RegisterQueryService(grpc.Server)
+	// RegisterServices allows a module to register services
+	RegisterServices(Configurator)
 
 	// ABCI
 	BeginBlock(sdk.Context, abci.RequestBeginBlock)
@@ -208,7 +208,7 @@ func (GenesisOnlyAppModule) QuerierRoute() string { return "" }
 func (gam GenesisOnlyAppModule) LegacyQuerierHandler(*codec.LegacyAmino) sdk.Querier { return nil }
 
 // RegisterQueryService registers all gRPC query services.
-func (gam GenesisOnlyAppModule) RegisterQueryService(grpc.Server) {}
+func (gam GenesisOnlyAppModule) RegisterServices(Configurator) {}
 
 // BeginBlock returns an empty module begin-block
 func (gam GenesisOnlyAppModule) BeginBlock(ctx sdk.Context, req abci.RequestBeginBlock) {}
@@ -288,10 +288,11 @@ func (m *Manager) RegisterRoutes(router sdk.Router, queryRouter sdk.QueryRouter,
 	}
 }
 
-// RegisterQueryServices registers all module query services
-func (m *Manager) RegisterQueryServices(grpcRouter grpc.Server) {
+// RegisterServices registers all module services
+func (m *Manager) RegisterServices(queryRouter grpc.Server) {
+	cfg := NewConfigurator(queryRouter)
 	for _, module := range m.Modules {
-		module.RegisterQueryService(grpcRouter)
+		module.RegisterServices(cfg)
 	}
 }
 

--- a/types/module/module_test.go
+++ b/types/module/module_test.go
@@ -182,10 +182,10 @@ func TestManager_RegisterQueryServices(t *testing.T) {
 	require.Equal(t, 2, len(mm.Modules))
 
 	queryRouter := mocks.NewMockServer(mockCtrl)
-	mockAppModule1.EXPECT().RegisterQueryService(queryRouter).Times(1)
-	mockAppModule2.EXPECT().RegisterQueryService(queryRouter).Times(1)
+	mockAppModule1.EXPECT().RegisterServices(queryRouter).Times(1)
+	mockAppModule2.EXPECT().RegisterServices(queryRouter).Times(1)
 
-	mm.RegisterQueryServices(queryRouter)
+	mm.RegisterServices(queryRouter)
 }
 
 func TestManager_InitGenesis(t *testing.T) {

--- a/types/module/module_test.go
+++ b/types/module/module_test.go
@@ -162,10 +162,10 @@ func TestManager_RegisterRoutes(t *testing.T) {
 	mockAppModule1.EXPECT().QuerierRoute().Times(2).Return("querierRoute1")
 	mockAppModule2.EXPECT().QuerierRoute().Times(1).Return("")
 	handler3 := sdk.Querier(nil)
-	mockAppModule1.EXPECT().NewQuerierHandler().Times(1).Return(handler3)
+	amino := codec.NewLegacyAmino()
+	mockAppModule1.EXPECT().LegacyQuerierHandler(amino).Times(1).Return(handler3)
 	queryRouter.EXPECT().AddRoute(gomock.Eq("querierRoute1"), gomock.Eq(handler3)).Times(1)
 
-	amino := codec.NewLegacyAmino()
 	mm.RegisterRoutes(router, queryRouter, amino)
 }
 
@@ -182,10 +182,11 @@ func TestManager_RegisterQueryServices(t *testing.T) {
 	require.Equal(t, 2, len(mm.Modules))
 
 	queryRouter := mocks.NewMockServer(mockCtrl)
-	mockAppModule1.EXPECT().RegisterServices(queryRouter).Times(1)
-	mockAppModule2.EXPECT().RegisterServices(queryRouter).Times(1)
+	cfg := module.NewConfigurator(queryRouter)
+	mockAppModule1.EXPECT().RegisterServices(cfg).Times(1)
+	mockAppModule2.EXPECT().RegisterServices(cfg).Times(1)
 
-	mm.RegisterServices(queryRouter)
+	mm.RegisterServices(cfg)
 }
 
 func TestManager_InitGenesis(t *testing.T) {

--- a/x/auth/module.go
+++ b/x/auth/module.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"math/rand"
 
-	"github.com/gogo/protobuf/grpc"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 
 	"github.com/gorilla/mux"
@@ -128,8 +127,8 @@ func (am AppModule) LegacyQuerierHandler(legacyQuerierCdc *codec.LegacyAmino) sd
 
 // RegisterQueryService registers a GRPC query service to respond to the
 // module-specific GRPC queries.
-func (am AppModule) RegisterQueryService(server grpc.Server) {
-	types.RegisterQueryServer(server, am.accountKeeper)
+func (am AppModule) RegisterServices(cfg module.Configurator) {
+	types.RegisterQueryServer(cfg.QueryServer(), am.accountKeeper)
 }
 
 // InitGenesis performs genesis initialization for the auth module. It returns

--- a/x/auth/vesting/module.go
+++ b/x/auth/vesting/module.go
@@ -3,7 +3,6 @@ package vesting
 import (
 	"encoding/json"
 
-	"github.com/gogo/protobuf/grpc"
 	"github.com/gorilla/mux"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/spf13/cobra"
@@ -102,7 +101,7 @@ func (am AppModule) Route() sdk.Route {
 func (AppModule) QuerierRoute() string { return "" }
 
 // RegisterQueryService performs a no-op.
-func (am AppModule) RegisterQueryService(_ grpc.Server) {}
+func (am AppModule) RegisterServices(_ module.Configurator) {}
 
 // LegacyQuerierHandler performs a no-op.
 func (am AppModule) LegacyQuerierHandler(_ *codec.LegacyAmino) sdk.Querier {

--- a/x/bank/module.go
+++ b/x/bank/module.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"math/rand"
 
-	"github.com/gogo/protobuf/grpc"
 	"github.com/gorilla/mux"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/spf13/cobra"
@@ -97,8 +96,8 @@ type AppModule struct {
 
 // RegisterQueryService registers a GRPC query service to respond to the
 // module-specific GRPC queries.
-func (am AppModule) RegisterQueryService(server grpc.Server) {
-	types.RegisterQueryServer(server, am.keeper)
+func (am AppModule) RegisterServices(cfg module.Configurator) {
+	types.RegisterQueryServer(cfg.QueryServer(), am.keeper)
 }
 
 // NewAppModule creates a new AppModule object

--- a/x/capability/module.go
+++ b/x/capability/module.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"math/rand"
 
-	"github.com/gogo/protobuf/grpc"
 	"github.com/gorilla/mux"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/spf13/cobra"
@@ -114,7 +113,7 @@ func (am AppModule) LegacyQuerierHandler(*codec.LegacyAmino) sdk.Querier { retur
 
 // RegisterQueryService registers a GRPC query service to respond to the
 // module-specific GRPC queries.
-func (am AppModule) RegisterQueryService(grpc.Server) {}
+func (am AppModule) RegisterServices(module.Configurator) {}
 
 // RegisterInvariants registers the capability module's invariants.
 func (am AppModule) RegisterInvariants(_ sdk.InvariantRegistry) {}

--- a/x/crisis/module.go
+++ b/x/crisis/module.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/gogo/protobuf/grpc"
 	"github.com/gorilla/mux"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/spf13/cobra"
@@ -115,7 +114,7 @@ func (AppModule) LegacyQuerierHandler(*codec.LegacyAmino) sdk.Querier { return n
 
 // RegisterQueryService registers a GRPC query service to respond to the
 // module-specific GRPC queries.
-func (am AppModule) RegisterQueryService(grpc.Server) {}
+func (am AppModule) RegisterServices(module.Configurator) {}
 
 // InitGenesis performs genesis initialization for the crisis module. It returns
 // no validator updates.

--- a/x/distribution/module.go
+++ b/x/distribution/module.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"math/rand"
 
-	"github.com/gogo/protobuf/grpc"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 
 	"github.com/gorilla/mux"
@@ -142,8 +141,8 @@ func (am AppModule) LegacyQuerierHandler(legacyQuerierCdc *codec.LegacyAmino) sd
 
 // RegisterQueryService registers a GRPC query service to respond to the
 // module-specific GRPC queries.
-func (am AppModule) RegisterQueryService(server grpc.Server) {
-	types.RegisterQueryServer(server, am.keeper)
+func (am AppModule) RegisterServices(cfg module.Configurator) {
+	types.RegisterQueryServer(cfg.QueryServer(), am.keeper)
 }
 
 // InitGenesis performs genesis initialization for the distribution module. It returns

--- a/x/evidence/module.go
+++ b/x/evidence/module.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"math/rand"
 
-	"github.com/gogo/protobuf/grpc"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 
 	"github.com/gorilla/mux"
@@ -151,8 +150,8 @@ func (am AppModule) LegacyQuerierHandler(legacyQuerierCdc *codec.LegacyAmino) sd
 
 // RegisterQueryService registers a GRPC query service to respond to the
 // module-specific GRPC queries.
-func (am AppModule) RegisterQueryService(server grpc.Server) {
-	types.RegisterQueryServer(server, am.keeper)
+func (am AppModule) RegisterServices(cfg module.Configurator) {
+	types.RegisterQueryServer(cfg.QueryServer(), am.keeper)
 }
 
 // RegisterInvariants registers the evidence module's invariants.

--- a/x/gov/module.go
+++ b/x/gov/module.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"math/rand"
 
-	"github.com/gogo/protobuf/grpc"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 
 	"github.com/gorilla/mux"
@@ -158,8 +157,8 @@ func (am AppModule) LegacyQuerierHandler(legacyQuerierCdc *codec.LegacyAmino) sd
 
 // RegisterQueryService registers a GRPC query service to respond to the
 // module-specific GRPC queries.
-func (am AppModule) RegisterQueryService(server grpc.Server) {
-	types.RegisterQueryServer(server, am.keeper)
+func (am AppModule) RegisterServices(cfg module.Configurator) {
+	types.RegisterQueryServer(cfg.QueryServer(), am.keeper)
 }
 
 // InitGenesis performs genesis initialization for the gov module. It returns

--- a/x/ibc/applications/transfer/module.go
+++ b/x/ibc/applications/transfer/module.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"math/rand"
 
-	"github.com/gogo/protobuf/grpc"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 
 	"github.com/gorilla/mux"
@@ -123,8 +122,8 @@ func (am AppModule) LegacyQuerierHandler(*codec.LegacyAmino) sdk.Querier {
 
 // RegisterQueryService registers a GRPC query service to respond to the
 // module-specific GRPC queries.
-func (am AppModule) RegisterQueryService(server grpc.Server) {
-	types.RegisterQueryServer(server, am.keeper)
+func (am AppModule) RegisterServices(cfg module.Configurator) {
+	types.RegisterQueryServer(cfg.QueryServer(), am.keeper)
 }
 
 // InitGenesis performs genesis initialization for the ibc-transfer module. It returns

--- a/x/ibc/core/module.go
+++ b/x/ibc/core/module.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"math/rand"
 
-	"github.com/gogo/protobuf/grpc"
 	"github.com/gorilla/mux"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/spf13/cobra"
@@ -132,8 +131,8 @@ func (am AppModule) LegacyQuerierHandler(legacyQuerierCdc *codec.LegacyAmino) sd
 }
 
 // RegisterQueryService registers the gRPC query service for the ibc module.
-func (am AppModule) RegisterQueryService(server grpc.Server) {
-	types.RegisterQueryService(server, am.keeper)
+func (am AppModule) RegisterServices(cfg module.Configurator) {
+	types.RegisterQueryService(cfg.QueryServer(), am.keeper)
 }
 
 // InitGenesis performs genesis initialization for the ibc module. It returns

--- a/x/ibc/testing/mock/mock.go
+++ b/x/ibc/testing/mock/mock.go
@@ -3,7 +3,8 @@ package mock
 import (
 	"encoding/json"
 
-	"github.com/gogo/protobuf/grpc"
+	"github.com/cosmos/cosmos-sdk/types/module"
+
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 
 	"github.com/gorilla/mux"
@@ -102,7 +103,7 @@ func (am AppModule) LegacyQuerierHandler(*codec.LegacyAmino) sdk.Querier {
 }
 
 // RegisterQueryService implements the AppModule interface.
-func (am AppModule) RegisterQueryService(server grpc.Server) {}
+func (am AppModule) RegisterServices(server module.Configurator) {}
 
 // InitGenesis implements the AppModule interface.
 func (am AppModule) InitGenesis(ctx sdk.Context, cdc codec.JSONMarshaler, data json.RawMessage) []abci.ValidatorUpdate {

--- a/x/ibc/testing/mock/mock.go
+++ b/x/ibc/testing/mock/mock.go
@@ -103,7 +103,7 @@ func (am AppModule) LegacyQuerierHandler(*codec.LegacyAmino) sdk.Querier {
 }
 
 // RegisterQueryService implements the AppModule interface.
-func (am AppModule) RegisterServices(server module.Configurator) {}
+func (am AppModule) RegisterServices(module.Configurator) {}
 
 // InitGenesis implements the AppModule interface.
 func (am AppModule) InitGenesis(ctx sdk.Context, cdc codec.JSONMarshaler, data json.RawMessage) []abci.ValidatorUpdate {

--- a/x/mint/module.go
+++ b/x/mint/module.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"math/rand"
 
-	"github.com/gogo/protobuf/grpc"
 	"github.com/gorilla/mux"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/spf13/cobra"
@@ -126,8 +125,8 @@ func (am AppModule) LegacyQuerierHandler(legacyQuerierCdc *codec.LegacyAmino) sd
 
 // RegisterQueryService registers a gRPC query service to respond to the
 // module-specific gRPC queries.
-func (am AppModule) RegisterQueryService(server grpc.Server) {
-	types.RegisterQueryServer(server, am.keeper)
+func (am AppModule) RegisterServices(cfg module.Configurator) {
+	types.RegisterQueryServer(cfg.QueryServer(), am.keeper)
 }
 
 // InitGenesis performs genesis initialization for the mint module. It returns

--- a/x/params/module.go
+++ b/x/params/module.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"math/rand"
 
-	"github.com/gogo/protobuf/grpc"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 
 	"github.com/gorilla/mux"
@@ -112,8 +111,8 @@ func (am AppModule) LegacyQuerierHandler(legacyQuerierCdc *codec.LegacyAmino) sd
 
 // RegisterQueryService registers a gRPC query service to respond to the
 // module-specific gRPC queries.
-func (am AppModule) RegisterQueryService(server grpc.Server) {
-	proposal.RegisterQueryServer(server, am.keeper)
+func (am AppModule) RegisterServices(cfg module.Configurator) {
+	proposal.RegisterQueryServer(cfg.QueryServer(), am.keeper)
 }
 
 // ProposalContents returns all the params content functions used to

--- a/x/slashing/module.go
+++ b/x/slashing/module.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"math/rand"
 
-	"github.com/gogo/protobuf/grpc"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 
 	"github.com/gorilla/mux"
@@ -140,8 +139,8 @@ func (am AppModule) LegacyQuerierHandler(legacyQuerierCdc *codec.LegacyAmino) sd
 
 // RegisterQueryService registers a GRPC query service to respond to the
 // module-specific GRPC queries.
-func (am AppModule) RegisterQueryService(server grpc.Server) {
-	types.RegisterQueryServer(server, am.keeper)
+func (am AppModule) RegisterServices(cfg module.Configurator) {
+	types.RegisterQueryServer(cfg.QueryServer(), am.keeper)
 }
 
 // InitGenesis performs genesis initialization for the slashing module. It returns

--- a/x/staking/module.go
+++ b/x/staking/module.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"math/rand"
 
-	"github.com/gogo/protobuf/grpc"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 
 	"github.com/gorilla/mux"
@@ -136,9 +135,9 @@ func (am AppModule) LegacyQuerierHandler(legacyQuerierCdc *codec.LegacyAmino) sd
 
 // RegisterQueryService registers a GRPC query service to respond to the
 // module-specific GRPC queries.
-func (am AppModule) RegisterQueryService(server grpc.Server) {
+func (am AppModule) RegisterServices(cfg module.Configurator) {
 	querier := keeper.Querier{Keeper: am.keeper}
-	types.RegisterQueryServer(server, querier)
+	types.RegisterQueryServer(cfg.QueryServer(), querier)
 }
 
 // InitGenesis performs genesis initialization for the staking module. It returns

--- a/x/upgrade/module.go
+++ b/x/upgrade/module.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/gogo/protobuf/grpc"
 	"github.com/gorilla/mux"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/spf13/cobra"
@@ -97,8 +96,8 @@ func (am AppModule) LegacyQuerierHandler(legacyQuerierCdc *codec.LegacyAmino) sd
 
 // RegisterQueryService registers a GRPC query service to respond to the
 // module-specific GRPC queries.
-func (am AppModule) RegisterQueryService(server grpc.Server) {
-	types.RegisterQueryServer(server, am.keeper)
+func (am AppModule) RegisterServices(cfg module.Configurator) {
+	types.RegisterQueryServer(cfg.QueryServer(), am.keeper)
 }
 
 // InitGenesis is ignored, no sense in serializing future upgrades


### PR DESCRIPTION
ref: #7500

* refactors `AppModule.RegisterQueryServices` -> `AppModule.RegisterServices`
* adds the `module.Configurator` object for use in `RegisterServices`

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [x] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
