### PR TITLE
Adding a rule for private files in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,10 @@
 .idea
 *.pyc
 
+# private files
+private[.-]*
+private
+
 # Build
 vendor
 build


### PR DESCRIPTION
In daily work, we have some files, scripts which are not comitable yet useful when working.
Seeing them in git status is annoying. Let's support them in `.gitignore`

Related to: https://github.com/cosmos/cosmos-sdk/pull/7364

