### PR TITLE
 Re-enable errcheck linter check 

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,7 @@
 run:
   tests: false
 #   # timeout for analysis, e.g. 30s, 5m, default is 1m
-#   timeout: 5m
+  timeout: 4m
 
 linters:
   disable-all: true
@@ -10,7 +10,7 @@ linters:
     - deadcode
     - depguard
     - dogsled
-    # - errcheck
+    - errcheck
     - goconst
     - gocritic
     - gofmt

--- a/baseapp/abci_test.go
+++ b/baseapp/abci_test.go
@@ -112,7 +112,9 @@ func TestGetBlockRentionHeight(t *testing.T) {
 		})
 
 		t.Run(name, func(t *testing.T) {
-			ps.t = t
+			ps2 := ps // copy ps to enable parallel testing if we will need them
+			ps2.t = t
+			tc.bapp.SetParamStore(&ps2)
 			require.Equal(t, tc.expected, tc.bapp.GetBlockRetentionHeight(tc.commitHeight))
 		})
 	}

--- a/baseapp/abci_test.go
+++ b/baseapp/abci_test.go
@@ -101,8 +101,8 @@ func TestGetBlockRentionHeight(t *testing.T) {
 
 	for name, tc := range testCases {
 		tc := tc
-
-		tc.bapp.SetParamStore(&paramStore{db: dbm.NewMemDB()})
+		ps := paramStore{db: dbm.NewMemDB(), t: t}
+		tc.bapp.SetParamStore(&ps)
 		tc.bapp.InitChain(abci.RequestInitChain{
 			ConsensusParams: &abci.ConsensusParams{
 				Evidence: &tmprototypes.EvidenceParams{
@@ -112,6 +112,7 @@ func TestGetBlockRentionHeight(t *testing.T) {
 		})
 
 		t.Run(name, func(t *testing.T) {
+			ps.t = t
 			require.Equal(t, tc.expected, tc.bapp.GetBlockRetentionHeight(tc.commitHeight))
 		})
 	}

--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -426,7 +426,6 @@ func (app *BaseApp) StoreConsensusParams(ctx sdk.Context, cp *abci.ConsensusPara
 	if app.paramStore == nil {
 		panic("cannot store consensus params with no params store set")
 	}
-
 	if cp == nil {
 		return
 	}

--- a/baseapp/baseapp_test.go
+++ b/baseapp/baseapp_test.go
@@ -1480,11 +1480,11 @@ func TestCustomRunTxPanicHandler(t *testing.T) {
 	// Transaction should panic with custom handler above
 	{
 		tx := newTxCounter(0, 0)
-
+		var err error
 		require.PanicsWithValue(t, customPanicMsg, func() {
-			_, _, err := app.Deliver(aminoTxEncoder(), tx)
-			require.Error(t, err)
+			_, _, err = app.Deliver(aminoTxEncoder(), tx)
 		})
+		require.Error(t, err)
 	}
 }
 

--- a/baseapp/baseapp_test.go
+++ b/baseapp/baseapp_test.go
@@ -63,8 +63,7 @@ func (ps *paramStore) Get(_ sdk.Context, key []byte, ptr interface{}) {
 		return
 	}
 
-	err = json.Unmarshal(bz, ptr)
-	require.NoError(ps.t, err)
+	require.NoError(ps.t, json.Unmarshal(bz, ptr))
 }
 
 func defaultLogger() log.Logger {

--- a/baseapp/grpcserver.go
+++ b/baseapp/grpcserver.go
@@ -3,8 +3,10 @@ package baseapp
 import (
 	"context"
 	"strconv"
+	"testing"
 
 	gogogrpc "github.com/gogo/protobuf/grpc"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
@@ -18,7 +20,7 @@ import (
 func (app *BaseApp) GRPCQueryRouter() *GRPCQueryRouter { return app.grpcQueryRouter }
 
 // RegisterGRPCServer registers gRPC services directly with the gRPC server.
-func (app *BaseApp) RegisterGRPCServer(server gogogrpc.Server) {
+func (app *BaseApp) RegisterGRPCServer(t *testing.T, server gogogrpc.Server) {
 	// Define an interceptor for all gRPC queries: this interceptor will create
 	// a new sdk.Context, and pass it into the query handler.
 	interceptor := func(grpcCtx context.Context, req interface{}, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp interface{}, err error) {
@@ -52,7 +54,8 @@ func (app *BaseApp) RegisterGRPCServer(server gogogrpc.Server) {
 			height = sdkCtx.BlockHeight() // If height was not set in the request, set it to the latest
 		}
 		md = metadata.Pairs(grpctypes.GRPCBlockHeightHeader, strconv.FormatInt(height, 10))
-		grpc.SetHeader(grpcCtx, md)
+		err = grpc.SetHeader(grpcCtx, md)
+		require.NoError(t, err)
 
 		return handler(grpcCtx, req)
 	}

--- a/client/flags/flags.go
+++ b/client/flags/flags.go
@@ -76,11 +76,7 @@ func AddQueryFlagsToCmd(cmd *cobra.Command) {
 	cmd.Flags().String(FlagNode, "tcp://localhost:26657", "<host>:<port> to Tendermint RPC interface for this chain")
 	cmd.Flags().Int64(FlagHeight, 0, "Use a specific height to query state at (this can error if the node is pruning state)")
 	cmd.Flags().StringP(tmcli.OutputFlag, "o", "text", "Output format (text|json)")
-
-	err := cmd.MarkFlagRequired(FlagChainID)
-	if err != nil {
-		panic(fmt.Sprintf("Can't make a err"))
-	}
+	markFlagRequired(cmd, FlagChainID)
 
 	cmd.SetErr(cmd.ErrOrStderr())
 	cmd.SetOut(cmd.OutOrStdout())
@@ -110,7 +106,7 @@ func AddTxFlagsToCmd(cmd *cobra.Command) {
 	// --gas can accept integers and "auto"
 	cmd.Flags().String(FlagGas, "", fmt.Sprintf("gas limit to set per-transaction; set to %q to calculate sufficient gas automatically (default %d)", GasFlagAuto, DefaultGasLimit))
 
-	cmd.MarkFlagRequired(FlagChainID)
+	markFlagRequired(cmd, FlagChainID)
 
 	cmd.SetErr(cmd.ErrOrStderr())
 	cmd.SetOut(cmd.OutOrStdout())
@@ -158,5 +154,12 @@ func ParseGasSetting(gasStr string) (GasSetting, error) {
 		}
 
 		return GasSetting{false, gas}, nil
+	}
+}
+
+func markFlagRequired(cmd *cobra.Command, name string) {
+	err := cmd.MarkFlagRequired(name)
+	if err != nil {
+		panic(fmt.Sprintf("Can't make a %q falg required; err: %s", name, err))
 	}
 }

--- a/client/flags/flags.go
+++ b/client/flags/flags.go
@@ -158,8 +158,7 @@ func ParseGasSetting(gasStr string) (GasSetting, error) {
 }
 
 func markFlagRequired(cmd *cobra.Command, name string) {
-	err := cmd.MarkFlagRequired(name)
-	if err != nil {
+	if err := cmd.MarkFlagRequired(name); err != nil {
 		panic(fmt.Sprintf("Can't make a %q falg required; err: %s", name, err))
 	}
 }

--- a/client/flags/flags.go
+++ b/client/flags/flags.go
@@ -159,6 +159,6 @@ func ParseGasSetting(gasStr string) (GasSetting, error) {
 
 func markFlagRequired(cmd *cobra.Command, name string) {
 	if err := cmd.MarkFlagRequired(name); err != nil {
-		panic(fmt.Sprintf("Can't make a %q falg required; err: %s", name, err))
+		panic(fmt.Sprintf("can't mark the flag %q required: %v", name, err))
 	}
 }

--- a/client/flags/flags.go
+++ b/client/flags/flags.go
@@ -77,7 +77,10 @@ func AddQueryFlagsToCmd(cmd *cobra.Command) {
 	cmd.Flags().Int64(FlagHeight, 0, "Use a specific height to query state at (this can error if the node is pruning state)")
 	cmd.Flags().StringP(tmcli.OutputFlag, "o", "text", "Output format (text|json)")
 
-	cmd.MarkFlagRequired(FlagChainID)
+	err := cmd.MarkFlagRequired(FlagChainID)
+	if err != nil {
+		panic(fmt.Sprintf("Can't make a err"))
+	}
 
 	cmd.SetErr(cmd.ErrOrStderr())
 	cmd.SetOut(cmd.OutOrStdout())

--- a/client/grpc/simulate/simulate_test.go
+++ b/client/grpc/simulate/simulate_test.go
@@ -79,8 +79,7 @@ func (s IntegrationTestSuite) TestSimulateService() {
 
 	// Create a txBuilder.
 	txBuilder := s.clientCtx.TxConfig.NewTxBuilder()
-	err = txBuilder.SetMsgs(msg)
-	require.NoError(err)
+	require.NoError(txBuilder.SetMsgs(msg))
 	txBuilder.SetMemo(memo)
 	txBuilder.SetFeeAmount(feeAmount)
 	txBuilder.SetGasLimit(gasLimit)

--- a/client/grpc/simulate/simulate_test.go
+++ b/client/grpc/simulate/simulate_test.go
@@ -91,8 +91,7 @@ func (s IntegrationTestSuite) TestSimulateService() {
 			Signature: nil,
 		},
 	}
-	err = txBuilder.SetSignatures(sigV2)
-	require.NoError(err)
+	require.NoError(txBuilder.SetSignatures(sigV2))
 	// 2nd round: actually sign
 	sigV2, err = tx.SignWithPrivKey(
 		s.clientCtx.TxConfig.SignModeHandler().DefaultMode(),

--- a/client/grpc/simulate/simulate_test.go
+++ b/client/grpc/simulate/simulate_test.go
@@ -99,8 +99,7 @@ func (s IntegrationTestSuite) TestSimulateService() {
 		authsigning.SignerData{ChainID: s.sdkCtx.ChainID(), AccountNumber: accNum, Sequence: accSeq},
 		txBuilder, priv1, s.clientCtx.TxConfig, accSeq,
 	)
-	err = txBuilder.SetSignatures(sigV2)
-	require.NoError(err)
+	require.NoError(txBuilder.SetSignatures(sigV2))
 	any, ok := txBuilder.(codectypes.IntoAny)
 	require.True(ok)
 	cached := any.AsAny().GetCachedValue()

--- a/client/input/input.go
+++ b/client/input/input.go
@@ -41,7 +41,7 @@ func GetPassword(prompt string, buf *bufio.Reader) (pass string, err error) {
 // If the input is not recognized, it returns false and a nil error.
 func GetConfirmation(prompt string, r *bufio.Reader, w io.Writer) (bool, error) {
 	if inputIsTty() {
-		if err := fmt.Fprintf(w, "%s [y/N]: ", prompt); err != nil {
+		if _, err := fmt.Fprintf(w, "%s [y/N]: ", prompt); err != nil {
 			return false, err
 		}
 	}

--- a/client/input/input.go
+++ b/client/input/input.go
@@ -41,7 +41,9 @@ func GetPassword(prompt string, buf *bufio.Reader) (pass string, err error) {
 // If the input is not recognized, it returns false and a nil error.
 func GetConfirmation(prompt string, r *bufio.Reader, w io.Writer) (bool, error) {
 	if inputIsTty() {
-		fmt.Fprintf(w, "%s [y/N]: ", prompt)
+		if err := fmt.Fprintf(w, "%s [y/N]: ", prompt); err != nil {
+			return false, err
+		}
 	}
 
 	response, err := readLineFromBuf(r)

--- a/client/keys/export_test.go
+++ b/client/keys/export_test.go
@@ -27,9 +27,8 @@ func Test_runExportCmd(t *testing.T) {
 	// create a key
 	kb, err := keyring.New(sdk.KeyringServiceName(), keyring.BackendTest, kbHome, mockIn)
 	require.NoError(t, err)
-	t.Cleanup(func() {
-		kb.Delete("keyname1") // nolint:errcheck
-	})
+
+	t.Cleanup(kbCleanup(t, kb, "keyname1"))
 
 	path := sdk.GetConfig().GetFullFundraiserPath()
 	_, err = kb.NewAccount("keyname1", testutil.TestMnemonic, "", path, hd.Secp256k1)

--- a/client/keys/export_test.go
+++ b/client/keys/export_test.go
@@ -28,7 +28,7 @@ func Test_runExportCmd(t *testing.T) {
 	kb, err := keyring.New(sdk.KeyringServiceName(), keyring.BackendTest, kbHome, mockIn)
 	require.NoError(t, err)
 
-	t.Cleanup(kbCleanup(t, kb, "keyname1"))
+	t.Cleanup(cleanupKeys(t, kb, "keyname1"))
 
 	path := sdk.GetConfig().GetFullFundraiserPath()
 	_, err = kb.NewAccount("keyname1", testutil.TestMnemonic, "", path, hd.Secp256k1)

--- a/client/keys/import_test.go
+++ b/client/keys/import_test.go
@@ -29,7 +29,7 @@ func Test_runImportCmd(t *testing.T) {
 	ctx := context.WithValue(context.Background(), client.ClientContextKey, &clientCtx)
 
 	require.NoError(t, err)
-	t.Cleanup(kbCleanup(t, kb, "keyname1"))
+	t.Cleanup(cleanupKeys(t, kb, "keyname1"))
 
 	keyfile := filepath.Join(kbHome, "key.asc")
 	armoredKey := `-----BEGIN TENDERMINT PRIVATE KEY-----

--- a/client/keys/import_test.go
+++ b/client/keys/import_test.go
@@ -29,9 +29,7 @@ func Test_runImportCmd(t *testing.T) {
 	ctx := context.WithValue(context.Background(), client.ClientContextKey, &clientCtx)
 
 	require.NoError(t, err)
-	t.Cleanup(func() {
-		kb.Delete("keyname1") // nolint:errcheck
-	})
+	t.Cleanup(kbCleanup(t, kb, "keyname1"))
 
 	keyfile := filepath.Join(kbHome, "key.asc")
 	armoredKey := `-----BEGIN TENDERMINT PRIVATE KEY-----

--- a/client/keys/list.go
+++ b/client/keys/list.go
@@ -35,8 +35,7 @@ func runListCmd(cmd *cobra.Command, _ []string) error {
 
 	if ok, _ := cmd.Flags().GetBool(flagListNames); !ok {
 		output, _ := cmd.Flags().GetString(cli.OutputFlag)
-		printInfos(cmd.OutOrStdout(), infos, output)
-		return nil
+		return printInfos(cmd.OutOrStdout(), infos, output)
 	}
 
 	for _, info := range infos {

--- a/client/keys/list_test.go
+++ b/client/keys/list_test.go
@@ -16,6 +16,16 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
+func kbCleanup(t *testing.T, kb keyring.Keyring, keys ...string) func() {
+	return func() {
+		for _, k := range keys {
+			if err := kb.Delete(k); err != nil {
+				t.Log("Can't delete KB key ", k, err)
+			}
+		}
+	}
+}
+
 func Test_runListCmd(t *testing.T) {
 	cmd := ListKeysCmd()
 	cmd.Flags().AddFlagSet(Commands("home").PersistentFlags())
@@ -34,9 +44,7 @@ func Test_runListCmd(t *testing.T) {
 	_, err = kb.NewAccount("something", testutil.TestMnemonic, "", path, hd.Secp256k1)
 	require.NoError(t, err)
 
-	t.Cleanup(func() {
-		kb.Delete("something") // nolint:errcheck
-	})
+	t.Cleanup(kbCleanup(t, kb, "something"))
 
 	type args struct {
 		cmd  *cobra.Command

--- a/client/keys/list_test.go
+++ b/client/keys/list_test.go
@@ -16,7 +16,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
-func kbCleanup(t *testing.T, kb keyring.Keyring, keys ...string) func() {
+func cleanupKeys(t *testing.T, kb keyring.Keyring, keys ...string) func() {
 	return func() {
 		for _, k := range keys {
 			if err := kb.Delete(k); err != nil {
@@ -44,7 +44,7 @@ func Test_runListCmd(t *testing.T) {
 	_, err = kb.NewAccount("something", testutil.TestMnemonic, "", path, hd.Secp256k1)
 	require.NoError(t, err)
 
-	t.Cleanup(kbCleanup(t, kb, "something"))
+	t.Cleanup(cleanupKeys(t, kb, "something"))
 
 	type args struct {
 		cmd  *cobra.Command

--- a/client/keys/list_test.go
+++ b/client/keys/list_test.go
@@ -20,7 +20,7 @@ func kbCleanup(t *testing.T, kb keyring.Keyring, keys ...string) func() {
 	return func() {
 		for _, k := range keys {
 			if err := kb.Delete(k); err != nil {
-				t.Log("Can't delete KB key ", k, err)
+				t.Log("can't delete KB key ", k, err)
 			}
 		}
 	}

--- a/client/keys/migrate.go
+++ b/client/keys/migrate.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/input"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
 
 // migratePassphrase is used as a no-op migration key passphrase as a passphrase
@@ -49,7 +50,7 @@ func runMigrateCmd(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	defer legacyKb.Close()
+	defer sdkerrors.CallbackLog(legacyKb.Close)
 
 	// fetch list of keys from legacy keybase
 	oldKeys, err := legacyKb.List()
@@ -71,7 +72,7 @@ func runMigrateCmd(cmd *cobra.Command, args []string) error {
 			return errors.Wrap(err, "failed to create temporary directory for dryrun migration")
 		}
 
-		defer os.RemoveAll(tmpDir)
+		defer sdkerrors.CallbackLog(func() error { return os.RemoveAll(tmpDir) })
 
 		migrator, err = keyring.NewInfoImporter(keyringServiceName, "test", tmpDir, buf)
 	} else {

--- a/client/keys/migrate_test.go
+++ b/client/keys/migrate_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/otiai10/copy"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/tendermint/tendermint/libs/cli"
 
 	"github.com/cosmos/cosmos-sdk/client"
@@ -25,7 +26,7 @@ func Test_runMigrateCmd(t *testing.T) {
 	clientCtx := client.Context{}.WithKeyringDir(kbHome)
 	ctx := context.WithValue(context.Background(), client.ClientContextKey, &clientCtx)
 
-	copy.Copy("testdata", kbHome)
+	require.NoError(t, copy.Copy("testdata", kbHome))
 	cmd.SetArgs([]string{
 		"keyname1",
 		fmt.Sprintf("--%s=%s", cli.OutputFlag, OutputFormatText),

--- a/client/keys/show.go
+++ b/client/keys/show.go
@@ -106,14 +106,16 @@ func runShowCmd(cmd *cobra.Command, args []string) (err error) {
 	}
 
 	output, _ := cmd.Flags().GetString(cli.OutputFlag)
-
 	switch {
 	case isShowAddr:
-		printKeyAddress(cmd.OutOrStdout(), info, bechKeyOut)
+		err = printKeyAddress(cmd.OutOrStdout(), info, bechKeyOut)
 	case isShowPubKey:
-		printPubKey(cmd.OutOrStdout(), info, bechKeyOut)
+		err = printPubKey(cmd.OutOrStdout(), info, bechKeyOut)
 	default:
-		printKeyInfo(cmd.OutOrStdout(), info, bechKeyOut, output)
+		err = printKeyInfo(cmd.OutOrStdout(), info, bechKeyOut, output)
+	}
+	if err != nil {
+		return err
 	}
 
 	if isShowDevice {

--- a/client/keys/show_test.go
+++ b/client/keys/show_test.go
@@ -60,11 +60,7 @@ func Test_runShowCmd(t *testing.T) {
 
 	fakeKeyName1 := "runShowCmd_Key1"
 	fakeKeyName2 := "runShowCmd_Key2"
-
-	t.Cleanup(func() {
-		kb.Delete("runShowCmd_Key1")
-		kb.Delete("runShowCmd_Key2")
-	})
+	t.Cleanup(kbCleanup(t, kb, fakeKeyName1, fakeKeyName2))
 
 	path := hd.NewFundraiserParams(1, sdk.CoinType, 0).String()
 	_, err = kb.NewAccount(fakeKeyName1, testutil.TestMnemonic, "", path, hd.Secp256k1)

--- a/client/keys/show_test.go
+++ b/client/keys/show_test.go
@@ -60,7 +60,7 @@ func Test_runShowCmd(t *testing.T) {
 
 	fakeKeyName1 := "runShowCmd_Key1"
 	fakeKeyName2 := "runShowCmd_Key2"
-	t.Cleanup(kbCleanup(t, kb, fakeKeyName1, fakeKeyName2))
+	t.Cleanup(cleanupKeys(t, kb, fakeKeyName1, fakeKeyName2))
 
 	path := hd.NewFundraiserParams(1, sdk.CoinType, 0).String()
 	_, err = kb.NewAccount(fakeKeyName1, testutil.TestMnemonic, "", path, hd.Secp256k1)

--- a/client/keys/utils.go
+++ b/client/keys/utils.go
@@ -31,30 +31,30 @@ func getLegacyKeyBaseFromDir(rootDir string, opts ...cryptokeyring.KeybaseOption
 	return cryptokeyring.NewLegacy(defaultKeyDBName, filepath.Join(rootDir, "keys"), opts...)
 }
 
-func printKeyInfo(w io.Writer, keyInfo cryptokeyring.Info, bechKeyOut bechKeyOutFn, output string) {
+func printKeyInfo(w io.Writer, keyInfo cryptokeyring.Info, bechKeyOut bechKeyOutFn, output string) error {
 	ko, err := bechKeyOut(keyInfo)
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	switch output {
 	case OutputFormatText:
-		printTextInfos(w, []cryptokeyring.KeyOutput{ko})
+		err = printTextInfos(w, []cryptokeyring.KeyOutput{ko})
 
 	case OutputFormatJSON:
-		out, err := KeysCdc.MarshalJSON(ko)
-		if err != nil {
-			panic(err)
+		out, err2 := KeysCdc.MarshalJSON(ko)
+		if err2 != nil {
+			return err2
 		}
-
-		fmt.Fprintln(w, string(out))
+		_, err = fmt.Fprintln(w, string(out))
 	}
+	return err
 }
 
-func printInfos(w io.Writer, infos []cryptokeyring.Info, output string) {
+func printInfos(w io.Writer, infos []cryptokeyring.Info, output string) error {
 	kos, err := cryptokeyring.Bech32KeysOutput(infos)
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	switch output {
@@ -64,35 +64,38 @@ func printInfos(w io.Writer, infos []cryptokeyring.Info, output string) {
 	case OutputFormatJSON:
 		out, err := KeysCdc.MarshalJSON(kos)
 		if err != nil {
-			panic(err)
+			return err
 		}
-
-		fmt.Fprintf(w, "%s", out)
+		if _, err := fmt.Fprintf(w, "%s", out); err != nil {
+			return err
+		}
 	}
+	return err
 }
 
-func printTextInfos(w io.Writer, kos []cryptokeyring.KeyOutput) {
+func printTextInfos(w io.Writer, kos []cryptokeyring.KeyOutput) error {
 	out, err := yaml.Marshal(&kos)
 	if err != nil {
-		panic(err)
+		return err
 	}
-	fmt.Fprintln(w, string(out))
+	_, err = fmt.Fprintln(w, string(out))
+	return err
 }
 
-func printKeyAddress(w io.Writer, info cryptokeyring.Info, bechKeyOut bechKeyOutFn) {
+func printKeyAddress(w io.Writer, info cryptokeyring.Info, bechKeyOut bechKeyOutFn) error {
 	ko, err := bechKeyOut(info)
 	if err != nil {
 		panic(err)
 	}
-
-	fmt.Fprintln(w, ko.Address)
+	_, err = fmt.Fprintln(w, ko.Address)
+	return err
 }
 
-func printPubKey(w io.Writer, info cryptokeyring.Info, bechKeyOut bechKeyOutFn) {
+func printPubKey(w io.Writer, info cryptokeyring.Info, bechKeyOut bechKeyOutFn) error {
 	ko, err := bechKeyOut(info)
 	if err != nil {
-		panic(err)
+		return err
 	}
-
-	fmt.Fprintln(w, ko.PubKey)
+	_, err = fmt.Fprintln(w, ko.Address)
+	return err
 }

--- a/client/keys/utils.go
+++ b/client/keys/utils.go
@@ -59,16 +59,14 @@ func printInfos(w io.Writer, infos []cryptokeyring.Info, output string) error {
 
 	switch output {
 	case OutputFormatText:
-		printTextInfos(w, kos)
+		err = printTextInfos(w, kos)
 
 	case OutputFormatJSON:
 		out, err := KeysCdc.MarshalJSON(kos)
 		if err != nil {
 			return err
 		}
-		if _, err := fmt.Fprintf(w, "%s", out); err != nil {
-			return err
-		}
+		_, err = fmt.Fprintf(w, "%s", out)
 	}
 	return err
 }

--- a/crypto/keyring/legacy.go
+++ b/crypto/keyring/legacy.go
@@ -65,7 +65,7 @@ func (kb dbKeybase) List() ([]Info, error) {
 		return nil, err
 	}
 
-	defer iter.Close()
+	defer sdkerrors.CallbackLog(iter.Close)
 
 	for ; iter.Valid(); iter.Next() {
 		key := string(iter.Key())

--- a/crypto/keyring/legacy_test.go
+++ b/crypto/keyring/legacy_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/otiai10/copy"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
@@ -27,7 +28,7 @@ func TestLegacyKeybase(t *testing.T) {
 
 	kb, err := keyring.NewLegacy("keys", filepath.Join(dir, "keys"))
 	require.NoError(t, err)
-	t.Cleanup(func() { kb.Close() })
+	t.Cleanup(func() { assert.NoError(t, kb.Close()) })
 
 	keys, err := kb.List()
 	require.NoError(t, err)

--- a/crypto/ledger/encode_test.go
+++ b/crypto/ledger/encode_test.go
@@ -30,7 +30,7 @@ func checkAminoJSON(t *testing.T, src interface{}, dst interface{}, isNil bool) 
 
 // nolint: govet
 func ExamplePrintRegisteredTypes() {
-	cdc.PrintTypes(os.Stdout)
+	cdc.PrintTypes(os.Stdout) // nolint: errcheck
 	// | Type | Name | Prefix | Length | Notes |
 	// | ---- | ---- | ------ | ----- | ------ |
 	// | PrivKeyLedgerSecp256k1 | tendermint/PrivKeyLedgerSecp256k1 | 0x10CAB393 | variable |  |

--- a/go.mod
+++ b/go.mod
@@ -47,6 +47,7 @@ require (
 	github.com/tendermint/go-amino v0.16.0
 	github.com/tendermint/tendermint v0.34.0-rc5
 	github.com/tendermint/tm-db v0.6.2
+	github.com/zeebo/assert v1.1.0
 	golang.org/x/crypto v0.0.0-20201012173705-84dcc777aaee
 	golang.org/x/net v0.0.0-20200930145003-4acb6c075d10 // indirect
 	google.golang.org/genproto v0.0.0-20201014134559-03b6142f0dc9

--- a/go.sum
+++ b/go.sum
@@ -604,6 +604,8 @@ github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijb
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
+github.com/zeebo/assert v1.1.0 h1:hU1L1vLTHsnO8x8c9KAR5GmM5QscxHg5RNU5z5qbUWY=
+github.com/zeebo/assert v1.1.0/go.mod h1:Pq9JiuJQpG8JLJdtkwrJESF0Foym2/D9XMU5ciN/wJ0=
 github.com/zondax/hid v0.9.0 h1:eiT3P6vNxAEVxXMw66eZUAAnU2zD33JBkfG/EnfAKl8=
 github.com/zondax/hid v0.9.0/go.mod h1:l5wttcP0jwtdLjqjMMWFVEE7d1zO0jvSPA9OPZxWpEM=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=

--- a/server/util.go
+++ b/server/util.go
@@ -79,8 +79,12 @@ func InterceptConfigsPreRunHandler(cmd *cobra.Command) error {
 	basename := path.Base(executableName)
 
 	// Configure the viper instance
-	serverCtx.Viper.BindPFlags(cmd.Flags())
-	serverCtx.Viper.BindPFlags(cmd.PersistentFlags())
+	if err = serverCtx.Viper.BindPFlags(cmd.Flags()); err != nil {
+		return err
+	}
+	if err = serverCtx.Viper.BindPFlags(cmd.PersistentFlags()); err != nil {
+		return err
+	}
 	serverCtx.Viper.SetEnvPrefix(basename)
 	serverCtx.Viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_", "-", "_"))
 	serverCtx.Viper.AutomaticEnv()

--- a/server/util_test.go
+++ b/server/util_test.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+	"github.com/zeebo/assert"
 )
 
 var CancelledInPreRun = errors.New("Canelled in prerun")
@@ -275,9 +277,9 @@ func TestInterceptConfigsPreRunHandlerReadsEnvVars(t *testing.T) {
 	basename = strings.ReplaceAll(basename, ".", "_")
 	// This is added by tendermint
 	envVarName := fmt.Sprintf("%s_RPC_LADDR", strings.ToUpper(basename))
-	os.Setenv(envVarName, testAddr)
+	require.NoError(t, os.Setenv(envVarName, testAddr))
 	t.Cleanup(func() {
-		os.Unsetenv(envVarName)
+		assert.NoError(t, os.Unsetenv(envVarName))
 	})
 
 	cmd.PreRunE = preRunETestImpl
@@ -362,7 +364,7 @@ func (v precedenceCommon) setAll(t *testing.T, setFlag *string, setEnvVar *strin
 	}
 
 	if setEnvVar != nil {
-		os.Setenv(v.envVarName, *setEnvVar)
+		require.NoError(t, os.Setenv(v.envVarName, *setEnvVar))
 	}
 
 	if setConfigFile != nil {

--- a/simapp/sim_bench_test.go
+++ b/simapp/sim_bench_test.go
@@ -11,6 +11,12 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/simulation"
 )
 
+func assertNoErr(b *testing.B, err error) {
+	if err != nil {
+		b.Fatal(err)
+	}
+}
+
 // Profile with:
 // /usr/local/go/bin/go test -benchmem -run=^$ github.com/cosmos/cosmos-sdk/simapp -bench ^BenchmarkFullAppSimulation$ -Commit=true -cpuprofile cpu.out
 func BenchmarkFullAppSimulation(b *testing.B) {
@@ -20,11 +26,8 @@ func BenchmarkFullAppSimulation(b *testing.B) {
 	}
 
 	defer func() {
-		db.Close()
-		err = os.RemoveAll(dir)
-		if err != nil {
-			b.Fatal(err)
-		}
+		assertNoErr(b, db.Close())
+		assertNoErr(b, os.RemoveAll(dir))
 	}()
 
 	app := NewSimApp(logger, db, nil, true, map[int64]bool{}, DefaultNodeHome, FlagPeriodValue, MakeTestEncodingConfig(), interBlockCacheOpt())
@@ -65,11 +68,8 @@ func BenchmarkInvariants(b *testing.B) {
 	config.AllInvariants = false
 
 	defer func() {
-		db.Close()
-		err = os.RemoveAll(dir)
-		if err != nil {
-			b.Fatal(err)
-		}
+		assertNoErr(b, db.Close())
+		assertNoErr(b, os.RemoveAll(dir))
 	}()
 
 	app := NewSimApp(logger, db, nil, true, map[int64]bool{}, DefaultNodeHome, FlagPeriodValue, MakeTestEncodingConfig(), interBlockCacheOpt())

--- a/simapp/sim_test.go
+++ b/simapp/sim_test.go
@@ -64,7 +64,7 @@ func TestFullAppSimulation(t *testing.T) {
 	require.NoError(t, err, "simulation setup failed")
 
 	defer func() {
-		db.Close()
+		require.NoError(t, db.Close())
 		require.NoError(t, os.RemoveAll(dir))
 	}()
 
@@ -102,7 +102,7 @@ func TestAppImportExport(t *testing.T) {
 	require.NoError(t, err, "simulation setup failed")
 
 	defer func() {
-		db.Close()
+		require.NoError(t, db.Close())
 		require.NoError(t, os.RemoveAll(dir))
 	}()
 
@@ -142,7 +142,7 @@ func TestAppImportExport(t *testing.T) {
 	require.NoError(t, err, "simulation setup failed")
 
 	defer func() {
-		newDB.Close()
+		require.NoError(t, newDB.Close())
 		require.NoError(t, os.RemoveAll(newDir))
 	}()
 
@@ -199,7 +199,7 @@ func TestAppSimulationAfterImport(t *testing.T) {
 	require.NoError(t, err, "simulation setup failed")
 
 	defer func() {
-		db.Close()
+		require.NoError(t, db.Close())
 		require.NoError(t, os.RemoveAll(dir))
 	}()
 
@@ -244,7 +244,7 @@ func TestAppSimulationAfterImport(t *testing.T) {
 	require.NoError(t, err, "simulation setup failed")
 
 	defer func() {
-		newDB.Close()
+		require.NoError(t, db.Close())
 		require.NoError(t, os.RemoveAll(newDir))
 	}()
 

--- a/snapshots/helpers_test.go
+++ b/snapshots/helpers_test.go
@@ -118,7 +118,7 @@ func setupBusyManager(t *testing.T) (*snapshots.Manager, func()) {
 
 	closer := func() {
 		hung.Close()
-		os.RemoveAll(tempdir)
+		require.NoError(t, os.RemoveAll(tempdir))
 	}
 	return mgr, closer
 }

--- a/snapshots/manager.go
+++ b/snapshots/manager.go
@@ -142,9 +142,13 @@ func (m *Manager) LoadChunk(height uint64, format uint32, chunk uint32) ([]byte,
 	if reader == nil {
 		return nil, nil
 	}
-	defer reader.Close()
 
-	return ioutil.ReadAll(reader)
+	data, err := ioutil.ReadAll(reader)
+	err2 := reader.Close()
+	if err != nil {
+		err = err2
+	}
+	return data, err
 }
 
 // Prune prunes snapshots, if no other operations are in progress.

--- a/snapshots/util.go
+++ b/snapshots/util.go
@@ -59,7 +59,7 @@ func (w *ChunkWriter) CloseWithError(err error) {
 		w.closed = true
 		close(w.ch)
 		if w.pipe != nil {
-			w.pipe.CloseWithError(err)
+			sdkerrors.LogError(w.pipe.CloseWithError(err))
 		}
 	}
 }

--- a/snapshots/util_test.go
+++ b/snapshots/util_test.go
@@ -133,7 +133,7 @@ func TestChunkReader(t *testing.T) {
 	pr, pw := io.Pipe()
 	pch := make(chan io.ReadCloser, 1)
 	pch <- pr
-	pw.CloseWithError(theErr)
+	assert.NoError(t, pw.CloseWithError(theErr))
 
 	chunkReader = snapshots.NewChunkReader(pch)
 	buf = make([]byte, 4)

--- a/store/cachekv/store_bench_test.go
+++ b/store/cachekv/store_bench_test.go
@@ -35,7 +35,9 @@ func benchmarkCacheKVStoreIterator(numKVs int, b *testing.B) {
 		for _ = iter.Key(); iter.Valid(); iter.Next() {
 		}
 
-		iter.Close()
+		if err := iter.Close(); err != nil {
+			b.Fatal(err)
+		}
 	}
 }
 

--- a/store/firstlast.go
+++ b/store/firstlast.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	sdkkv "github.com/cosmos/cosmos-sdk/types/kv"
 )
 
@@ -13,7 +14,7 @@ func First(st KVStore, start, end []byte) (kv sdkkv.Pair, ok bool) {
 	if !iter.Valid() {
 		return kv, false
 	}
-	defer iter.Close()
+	defer sdkerrors.CallbackLog(iter.Close)
 
 	return sdkkv.Pair{Key: iter.Key(), Value: iter.Value()}, true
 }
@@ -27,7 +28,7 @@ func Last(st KVStore, start, end []byte) (kv sdkkv.Pair, ok bool) {
 		}
 		return kv, false
 	}
-	defer iter.Close()
+	defer sdkerrors.CallbackLog(iter.Close)
 
 	if bytes.Equal(iter.Key(), end) {
 		// Skip this one, end is exclusive.

--- a/store/iavl/store.go
+++ b/store/iavl/store.go
@@ -323,7 +323,7 @@ func (st *Store) Query(req abci.RequestQuery) (res abci.ResponseQuery) {
 		for ; iterator.Valid(); iterator.Next() {
 			pairs.Pairs = append(pairs.Pairs, kv.Pair{Key: iterator.Key(), Value: iterator.Value()})
 		}
-		iterator.Close()
+		sdkerrors.LogError(iterator.Close())
 
 		bz, err := pairs.Marshal()
 		if err != nil {

--- a/store/iavl/store_test.go
+++ b/store/iavl/store_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 	abci "github.com/tendermint/tendermint/abci/types"
 	dbm "github.com/tendermint/tm-db"
+	"github.com/zeebo/assert"
 
 	"github.com/cosmos/cosmos-sdk/store/types"
 	"github.com/cosmos/cosmos-sdk/types/kv"
@@ -330,7 +331,7 @@ func TestIAVLPrefixIterator(t *testing.T) {
 		require.EqualValues(t, value, expectedKey)
 		i++
 	}
-	iter.Close()
+	assert.NoError(t, iter.Close())
 	require.Equal(t, len(expected), i)
 
 	iter = types.KVStorePrefixIterator(iavlStore, []byte{byte(55), byte(255), byte(255)})
@@ -346,7 +347,7 @@ func TestIAVLPrefixIterator(t *testing.T) {
 		require.EqualValues(t, value, []byte("test4"))
 		i++
 	}
-	iter.Close()
+	assert.NoError(t, iter.Close())
 	require.Equal(t, len(expected), i)
 
 	iter = types.KVStorePrefixIterator(iavlStore, []byte{byte(255), byte(255)})
@@ -362,7 +363,7 @@ func TestIAVLPrefixIterator(t *testing.T) {
 		require.EqualValues(t, value, []byte("test4"))
 		i++
 	}
-	iter.Close()
+	assert.NoError(t, iter.Close())
 	require.Equal(t, len(expected), i)
 }
 

--- a/store/prefix/store_test.go
+++ b/store/prefix/store_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	dbm "github.com/tendermint/tm-db"
+	"github.com/zeebo/assert"
 
 	tiavl "github.com/cosmos/iavl"
 
@@ -121,8 +122,8 @@ func TestPrefixStoreIterate(t *testing.T) {
 		pIter.Next()
 	}
 
-	bIter.Close()
-	pIter.Close()
+	assert.NoError(t, bIter.Close())
+	assert.NoError(t, pIter.Close())
 }
 
 func incFirstByte(bz []byte) {
@@ -175,7 +176,7 @@ func TestPrefixStoreIteratorEdgeCase(t *testing.T) {
 
 	checkInvalid(t, iter)
 
-	iter.Close()
+	assert.NoError(t, iter.Close())
 }
 
 func TestPrefixStoreReverseIteratorEdgeCase(t *testing.T) {
@@ -204,8 +205,7 @@ func TestPrefixStoreReverseIteratorEdgeCase(t *testing.T) {
 	checkNext(t, iter, false)
 
 	checkInvalid(t, iter)
-
-	iter.Close()
+	assert.NoError(t, iter.Close())
 
 	db = dbm.NewMemDB()
 	baseStore = dbadapter.Store{DB: db}
@@ -232,7 +232,7 @@ func TestPrefixStoreReverseIteratorEdgeCase(t *testing.T) {
 
 	checkInvalid(t, iter)
 
-	iter.Close()
+	assert.NoError(t, iter.Close())
 }
 
 // Tests below are ported from https://github.com/tendermint/tendermint/blob/master/libs/db/prefix_db_test.go
@@ -331,7 +331,7 @@ func TestPrefixDBIterator1(t *testing.T) {
 	checkItem(t, itr, bz("3"), bz("value3"))
 	checkNext(t, itr, false)
 	checkInvalid(t, itr)
-	itr.Close()
+	assert.NoError(t, itr.Close())
 }
 
 func TestPrefixDBIterator2(t *testing.T) {
@@ -341,7 +341,7 @@ func TestPrefixDBIterator2(t *testing.T) {
 	itr := pstore.Iterator(nil, bz(""))
 	checkDomain(t, itr, nil, bz(""))
 	checkInvalid(t, itr)
-	itr.Close()
+	assert.NoError(t, itr.Close())
 }
 
 func TestPrefixDBIterator3(t *testing.T) {
@@ -359,7 +359,7 @@ func TestPrefixDBIterator3(t *testing.T) {
 	checkItem(t, itr, bz("3"), bz("value3"))
 	checkNext(t, itr, false)
 	checkInvalid(t, itr)
-	itr.Close()
+	assert.NoError(t, itr.Close())
 }
 
 func TestPrefixDBIterator4(t *testing.T) {
@@ -369,7 +369,7 @@ func TestPrefixDBIterator4(t *testing.T) {
 	itr := pstore.Iterator(bz(""), bz(""))
 	checkDomain(t, itr, bz(""), bz(""))
 	checkInvalid(t, itr)
-	itr.Close()
+	assert.NoError(t, itr.Close())
 }
 
 func TestPrefixDBReverseIterator1(t *testing.T) {
@@ -387,7 +387,7 @@ func TestPrefixDBReverseIterator1(t *testing.T) {
 	checkItem(t, itr, bz(""), bz("value"))
 	checkNext(t, itr, false)
 	checkInvalid(t, itr)
-	itr.Close()
+	assert.NoError(t, itr.Close())
 }
 
 func TestPrefixDBReverseIterator2(t *testing.T) {
@@ -405,7 +405,7 @@ func TestPrefixDBReverseIterator2(t *testing.T) {
 	checkItem(t, itr, bz(""), bz("value"))
 	checkNext(t, itr, false)
 	checkInvalid(t, itr)
-	itr.Close()
+	assert.NoError(t, itr.Close())
 }
 
 func TestPrefixDBReverseIterator3(t *testing.T) {
@@ -415,7 +415,7 @@ func TestPrefixDBReverseIterator3(t *testing.T) {
 	itr := pstore.ReverseIterator(nil, bz(""))
 	checkDomain(t, itr, nil, bz(""))
 	checkInvalid(t, itr)
-	itr.Close()
+	assert.NoError(t, itr.Close())
 }
 
 func TestPrefixDBReverseIterator4(t *testing.T) {
@@ -424,5 +424,5 @@ func TestPrefixDBReverseIterator4(t *testing.T) {
 
 	itr := pstore.ReverseIterator(bz(""), bz(""))
 	checkInvalid(t, itr)
-	itr.Close()
+	assert.NoError(t, itr.Close())
 }

--- a/store/tracekv/store.go
+++ b/store/tracekv/store.go
@@ -191,9 +191,8 @@ func writeOperation(w io.Writer, op operation, tc types.TraceContext, key, value
 		panic(errors.Wrap(err, "failed to serialize trace operation"))
 	}
 
+	raw = append(raw, '\n')
 	if _, err := w.Write(raw); err != nil {
 		panic(errors.Wrap(err, "failed to write trace operation"))
 	}
-
-	io.WriteString(w, "\n")
 }

--- a/store/types/iterator_test.go
+++ b/store/types/iterator_test.go
@@ -3,6 +3,7 @@ package types_test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	dbm "github.com/tendermint/tm-db"
 
@@ -89,7 +90,9 @@ func TestPaginatedIterator(t *testing.T) {
 			} else {
 				iter = types.KVStorePrefixIteratorPaginated(kvs, nil, tc.page, tc.limit)
 			}
-			defer iter.Close()
+			defer func() {
+				assert.NoError(t, iter.Close())
+			}()
 
 			result := [][]byte{}
 			for ; iter.Valid(); iter.Next() {
@@ -106,14 +109,13 @@ func TestPaginatedIteratorPanicIfInvalid(t *testing.T) {
 	kvs := newMemTestKVStore(t)
 
 	iter := types.KVStorePrefixIteratorPaginated(kvs, nil, 1, 1)
-	defer iter.Close()
 	require.False(t, iter.Valid())
 	require.Panics(t, func() { iter.Next() }) // "iterator is empty"
-
+	assert.NoError(t, iter.Close())
 	kvs.Set([]byte{1}, []byte{})
 
 	iter = types.KVStorePrefixIteratorPaginated(kvs, nil, 1, 0)
-	defer iter.Close()
 	require.False(t, iter.Valid())
 	require.Panics(t, func() { iter.Next() }) // "not empty but limit is zero"
+	assert.NoError(t, iter.Close())
 }

--- a/store/types/utils.go
+++ b/store/types/utils.go
@@ -3,6 +3,7 @@ package types
 import (
 	"bytes"
 
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/cosmos-sdk/types/kv"
 )
 
@@ -20,12 +21,10 @@ func KVStoreReversePrefixIterator(kvs KVStore, prefix []byte) Iterator {
 // that differ from one another. It also skips value comparison for a set of provided prefixes.
 func DiffKVStores(a KVStore, b KVStore, prefixesToSkip [][]byte) (kvAs, kvBs []kv.Pair) {
 	iterA := a.Iterator(nil, nil)
-
-	defer iterA.Close()
+	defer sdkerrors.CallbackLog(iterA.Close)
 
 	iterB := b.Iterator(nil, nil)
-
-	defer iterB.Close()
+	defer sdkerrors.CallbackLog(iterB.Close)
 
 	for {
 		if !iterA.Valid() && !iterB.Valid() {

--- a/types/errors/callbacks.go
+++ b/types/errors/callbacks.go
@@ -1,15 +1,20 @@
 package errors
 
-import "fmt"
+import (
+	"log"
+	"os"
+)
 
-// ErrCallback is a type for a function which returns an error and is used as a callback
-type ErrCallback = func() error
+var logger = log.New(os.Stderr, "defer_callback: ", log.LstdFlags|log.LUTC|log.Llongfile)
+
+// Callback is a type for a function which returns an error and is used as a callback
+type Callback = func() error
 
 // CallbackLog wraps an ErrCallback function which will log an error if it is returned
-func CallbackLog(f ErrCallback) func() {
+func CallbackLog(f Callback) func() {
 	return func() {
 		if err := f(); err != nil {
-			fmt.Println(err)
+			logger.Println(err)
 		}
 	}
 }

--- a/types/errors/callbacks.go
+++ b/types/errors/callbacks.go
@@ -1,0 +1,15 @@
+package errors
+
+import "fmt"
+
+// ErrCallback is a type for a function which returns an error and is used as a callback
+type ErrCallback = func() error
+
+// CallbackLog wraps an ErrCallback function which will log an error if it is returned
+func CallbackLog(f ErrCallback) func() {
+	return func() {
+		if err := f(); err != nil {
+			fmt.Println(err)
+		}
+	}
+}

--- a/types/errors/callbacks.go
+++ b/types/errors/callbacks.go
@@ -18,3 +18,10 @@ func CallbackLog(f Callback) func() {
 		}
 	}
 }
+
+// LogError logs an error if it's not nil
+func LogError(err error) {
+	if err != nil {
+		logger.Println(err)
+	}
+}

--- a/types/errors/callbacks.go
+++ b/types/errors/callbacks.go
@@ -5,6 +5,7 @@ import (
 	"os"
 )
 
+// TODO: use a proper logger here and make it customizable
 var logger = log.New(os.Stderr, "defer_callback: ", log.LstdFlags|log.LUTC|log.Llongfile)
 
 // Callback is a type for a function which returns an error and is used as a callback


### PR DESCRIPTION
## Description
`errcheck` linter asserts that we check all errors returned from functions. It's easy to forget assigning to an error or even checking it. Not checked errors can be a source of vulnerabilities or very nasty issues.

closes: #7258

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
