### PR TITLE
Fix creation of local RPC node in clientCtx

### DIFF
--- a/server/start.go
+++ b/server/start.go
@@ -252,8 +252,15 @@ func startInProcess(ctx *Context, clientCtx client.Context, appCreator types.App
 	}
 	ctx.Logger.Debug("Initialization: tmNode started")
 
-	// Add the tx service to the gRPC router.
-	app.RegisterTxService(clientCtx)
+	// Add the tx service to the gRPC router. We only need to register this
+	// service if API or gRPC is enabled, and avoid doing so in the general
+	// case, because it spawns a new local tendermint RPC client.
+	if config.API.Enable || config.GRPC.Enable {
+		clientCtx = clientCtx.
+			WithClient(local.New(tmNode))
+
+		app.RegisterTxService(clientCtx)
+	}
 
 	var apiSrv *api.Server
 
@@ -266,8 +273,7 @@ func startInProcess(ctx *Context, clientCtx client.Context, appCreator types.App
 
 		clientCtx := clientCtx.
 			WithHomeDir(home).
-			WithChainID(genDoc.ChainID).
-			WithClient(local.New(tmNode))
+			WithChainID(genDoc.ChainID)
 
 		apiSrv = api.New(clientCtx, ctx.Logger.With("module", "api-server"))
 		app.RegisterAPIRoutes(apiSrv, config.API)

--- a/server/start.go
+++ b/server/start.go
@@ -252,6 +252,8 @@ func startInProcess(ctx *Context, clientCtx client.Context, appCreator types.App
 	}
 	ctx.Logger.Debug("Initialization: tmNode started")
 
+	config := config.GetConfig(ctx.Viper)
+
 	// Add the tx service to the gRPC router. We only need to register this
 	// service if API or gRPC is enabled, and avoid doing so in the general
 	// case, because it spawns a new local tendermint RPC client.
@@ -264,7 +266,6 @@ func startInProcess(ctx *Context, clientCtx client.Context, appCreator types.App
 
 	var apiSrv *api.Server
 
-	config := config.GetConfig(ctx.Viper)
 	if config.API.Enable {
 		genDoc, err := genDocProvider()
 		if err != nil {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: discord issue

before: Only created a local TM rpc client when API is enabled
now: Creates a local TM rpc client when API or gRPC is enabled. Only RegisterTxService in that case.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
