### PR TITLE
enrich versioning with build deps

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -595,8 +595,6 @@ github.com/tendermint/crypto v0.0.0-20191022145703-50d29ede1e15/go.mod h1:z4YtwM
 github.com/tendermint/go-amino v0.16.0 h1:GyhmgQKvqF82e2oZeuMSp9JTN0N09emoSZlb2lyGa2E=
 github.com/tendermint/go-amino v0.16.0/go.mod h1:TQU0M1i/ImAo+tYpZi73AU3V/dKeCoMC9Sphe2ZwGME=
 github.com/tendermint/tendermint v0.34.0-rc4/go.mod h1:yotsojf2C1QBOw4dZrTcxbyxmPUrT4hNuOQWX9XUwB4=
-github.com/tendermint/tendermint v0.34.0-rc5 h1:2bnQfWyOMfTCbol5pwB8CgM2nxi6/Kz6zqlS6Udm/Cg=
-github.com/tendermint/tendermint v0.34.0-rc5/go.mod h1:yotsojf2C1QBOw4dZrTcxbyxmPUrT4hNuOQWX9XUwB4=
 github.com/tendermint/tendermint v0.34.0-rc6 h1:SVuKGvvE22KxfuK8QUHctUrmOWJsncZSYXIYtcnoKN0=
 github.com/tendermint/tendermint v0.34.0-rc6/go.mod h1:ugzyZO5foutZImv0Iyx/gOFCX6mjJTgbLHTwi17VDVg=
 github.com/tendermint/tm-db v0.6.2 h1:DOn8jwCdjJblrCFJbtonEIPD1IuJWpbRUUdR8GWE4RM=

--- a/version/command.go
+++ b/version/command.go
@@ -17,6 +17,7 @@ func NewVersionCommand() *cobra.Command {
 		Short: "Print the application binary version information",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			verInfo := NewInfo()
+			cmd.SetOut(cmd.OutOrStdout())
 
 			if long, _ := cmd.Flags().GetBool(flagLong); !long {
 				cmd.Println(verInfo.Version)

--- a/version/version.go
+++ b/version/version.go
@@ -17,8 +17,10 @@
 package version
 
 import (
+	"encoding/json"
 	"fmt"
 	"runtime"
+	"runtime/debug"
 )
 
 var (
@@ -36,12 +38,13 @@ var (
 
 // Info defines the application version information.
 type Info struct {
-	Name      string `json:"name" yaml:"name"`
-	AppName   string `json:"server_name" yaml:"server_name"`
-	Version   string `json:"version" yaml:"version"`
-	GitCommit string `json:"commit" yaml:"commit"`
-	BuildTags string `json:"build_tags" yaml:"build_tags"`
-	GoVersion string `json:"go" yaml:"go"`
+	Name      string     `json:"name" yaml:"name"`
+	AppName   string     `json:"server_name" yaml:"server_name"`
+	Version   string     `json:"version" yaml:"version"`
+	GitCommit string     `json:"commit" yaml:"commit"`
+	BuildTags string     `json:"build_tags" yaml:"build_tags"`
+	GoVersion string     `json:"go" yaml:"go"`
+	BuildDeps []buildDep `json:"build_deps" yaml:"build_deps"`
 }
 
 func NewInfo() Info {
@@ -52,6 +55,7 @@ func NewInfo() Info {
 		GitCommit: Commit,
 		BuildTags: BuildTags,
 		GoVersion: fmt.Sprintf("go version %s %s/%s", runtime.Version(), runtime.GOOS, runtime.GOARCH),
+		BuildDeps: depsFromBuildInfo(),
 	}
 }
 
@@ -63,3 +67,24 @@ build tags: %s
 		vi.Name, vi.Version, vi.GitCommit, vi.BuildTags, vi.GoVersion,
 	)
 }
+
+func depsFromBuildInfo() (deps []buildDep) {
+	buildInfo, ok := debug.ReadBuildInfo()
+	if !ok {
+		return nil
+	}
+
+	for _, dep := range buildInfo.Deps {
+		deps = append(deps, buildDep{dep})
+	}
+
+	return
+}
+
+type buildDep struct {
+	*debug.Module
+}
+
+func (d buildDep) String() string                    { return fmt.Sprintf("%s@%s", d.Path, d.Version) }
+func (d buildDep) MarshalJSON() ([]byte, error)      { return json.Marshal(d.String()) }
+func (d buildDep) MarshalYAML() (interface{}, error) { return d.String(), nil }

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -1,4 +1,4 @@
-package version
+package version_test
 
 import (
 	"encoding/json"
@@ -11,10 +11,11 @@ import (
 	"github.com/tendermint/tendermint/libs/cli"
 
 	"github.com/cosmos/cosmos-sdk/testutil"
+	"github.com/cosmos/cosmos-sdk/version"
 )
 
 func TestNewInfo(t *testing.T) {
-	info := NewInfo()
+	info := version.NewInfo()
 	want := fmt.Sprintf(`: 
 git commit: 
 build tags: 
@@ -23,7 +24,7 @@ build tags:
 }
 
 func TestInfo_String(t *testing.T) {
-	info := Info{
+	info := version.Info{
 		Name:      "testapp",
 		AppName:   "testappd",
 		Version:   "1.0.0",
@@ -39,12 +40,12 @@ go version go1.14 linux/amd64`
 }
 
 func Test_runVersionCmd(t *testing.T) {
-	cmd := NewVersionCommand()
+	cmd := version.NewVersionCommand()
 	_, mockOut := testutil.ApplyMockIO(cmd)
 
 	cmd.SetArgs([]string{
 		fmt.Sprintf("--%s=''", cli.OutputFlag),
-		fmt.Sprintf("--%s=false", flagLong),
+		"--long=false",
 	})
 
 	require.NoError(t, cmd.Execute())
@@ -52,11 +53,10 @@ func Test_runVersionCmd(t *testing.T) {
 	mockOut.Reset()
 
 	cmd.SetArgs([]string{
-		fmt.Sprintf("--%s=json", cli.OutputFlag),
-		fmt.Sprintf("--%s=true", flagLong),
+		fmt.Sprintf("--%s=json", cli.OutputFlag), "--long=true",
 	})
 
-	info := NewInfo()
+	info := version.NewInfo()
 	stringInfo, err := json.Marshal(info)
 	require.NoError(t, err)
 	require.NoError(t, cmd.Execute())


### PR DESCRIPTION
The version command now displays the list of
build dependencies.

Also fix version's command output stream.

version's output should go to stdout as it's the command's
objective to actually display versioning information.

closes: #7835

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
