### PR TITLE
enrich version --long's output with build deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### Features
 
 * (types/coin.go) [\#6755](https://github.com/cosmos/cosmos-sdk/pull/6755) Add custom regex validation for `Coin` denom by overwriting `CoinDenomRegex` when using `/types/coin.go`.
+* (version) [\#7835](https://github.com/cosmos/cosmos-sdk/issues/7835) The version --long command now shows the list of build dependencies and their versioning information.
 
 ### Bug Fixes
 

--- a/version/version.go
+++ b/version/version.go
@@ -18,8 +18,10 @@
 package version
 
 import (
+	"encoding/json"
 	"fmt"
 	"runtime"
+	"runtime/debug"
 )
 
 var (
@@ -39,13 +41,14 @@ var (
 
 // Info defines the application version information.
 type Info struct {
-	Name       string `json:"name" yaml:"name"`
-	ServerName string `json:"server_name" yaml:"server_name"`
-	ClientName string `json:"client_name" yaml:"client_name"`
-	Version    string `json:"version" yaml:"version"`
-	GitCommit  string `json:"commit" yaml:"commit"`
-	BuildTags  string `json:"build_tags" yaml:"build_tags"`
-	GoVersion  string `json:"go" yaml:"go"`
+	Name       string     `json:"name" yaml:"name"`
+	ServerName string     `json:"server_name" yaml:"server_name"`
+	ClientName string     `json:"client_name" yaml:"client_name"`
+	Version    string     `json:"version" yaml:"version"`
+	GitCommit  string     `json:"commit" yaml:"commit"`
+	BuildTags  string     `json:"build_tags" yaml:"build_tags"`
+	GoVersion  string     `json:"go" yaml:"go"`
+	BuildDeps  []buildDep `json:"build_deps" yaml:"build_deps"`
 }
 
 func NewInfo() Info {
@@ -57,6 +60,7 @@ func NewInfo() Info {
 		GitCommit:  Commit,
 		BuildTags:  BuildTags,
 		GoVersion:  fmt.Sprintf("go version %s %s/%s", runtime.Version(), runtime.GOOS, runtime.GOARCH),
+		BuildDeps:  depsFromBuildInfo(),
 	}
 }
 
@@ -68,3 +72,24 @@ build tags: %s
 		vi.Name, vi.Version, vi.GitCommit, vi.BuildTags, vi.GoVersion,
 	)
 }
+
+func depsFromBuildInfo() (deps []buildDep) {
+	buildInfo, ok := debug.ReadBuildInfo()
+	if !ok {
+		return nil
+	}
+
+	for _, dep := range buildInfo.Deps {
+		deps = append(deps, buildDep{dep})
+	}
+
+	return
+}
+
+type buildDep struct {
+	*debug.Module
+}
+
+func (d buildDep) String() string                    { return fmt.Sprintf("%s@%s", d.Path, d.Version) }
+func (d buildDep) MarshalJSON() ([]byte, error)      { return json.Marshal(d.String()) }
+func (d buildDep) MarshalYAML() (interface{}, error) { return d.String(), nil }


### PR DESCRIPTION
The output of the version --long command now shows
the list of build dependencies.

From: #7848
Closes: #7835

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
