### PR TITLE
replace the CoinDenomRegex variable with SetCoinDenomRegex()

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,6 @@ require (
 	github.com/golang/mock v1.4.4
 	github.com/golang/protobuf v1.4.3
 	github.com/golang/snappy v0.0.2 // indirect
-	github.com/google/go-cmp v0.5.0
 	github.com/gorilla/handlers v1.5.1
 	github.com/gorilla/mux v1.8.0
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0

--- a/types/coin_test.go
+++ b/types/coin_test.go
@@ -101,9 +101,9 @@ func (s *coinTestSuite) TestCoinIsValid() {
 func (s *coinTestSuite) TestCustomValidation() {
 
 	newDnmRegex := `[\x{1F600}-\x{1F6FF}]`
-	sdk.CoinDenomRegex = func() string {
+	sdk.SetCoinDenomRegex(func() string {
 		return newDnmRegex
-	}
+	})
 
 	cases := []struct {
 		coin       sdk.Coin
@@ -119,7 +119,7 @@ func (s *coinTestSuite) TestCustomValidation() {
 	for i, tc := range cases {
 		s.Require().Equal(tc.expectPass, tc.coin.IsValid(), "unexpected result for IsValid, tc #%d", i)
 	}
-	sdk.CoinDenomRegex = sdk.DefaultCoinDenomRegex
+	sdk.SetCoinDenomRegex(sdk.DefaultCoinDenomRegex)
 }
 
 func (s *coinTestSuite) TestAddCoin() {


### PR DESCRIPTION
@odeke-em's modifications proposed in #7989 improve performance
quite significantly, yet they seem to break the denoms custom
validation mechanism introduced by @okwme.

This patch introduces a relatively small user-facing change as the client
application would need to call the new `SetCoinDenomRegex()` accessor
instead of the `CoinDenomRegex` variable directly in order to introduce
app-specific denom's validation.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
