### PR TITLE
types/Coin: compile and reuse Regexps to reduce massive RAM+CPU burn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Features
 
-* (types/coin.go) [\#6755](https://github.com/cosmos/cosmos-sdk/pull/6755) Add custom regex validation for `Coin` denom by overwriting `CoinDenomRegex` when using `/types/coin.go`.
+* (types/coin.go) [\#6755](https://github.com/cosmos/cosmos-sdk/pull/6755) [\#8001](https://github.com/cosmos/cosmos-sdk/pull/8001) Allow custom regex validation for `Coin` denom through `SetCoinDenomRegex()`.
 * (version) [\#7835](https://github.com/cosmos/cosmos-sdk/issues/7835) [\#7940](https://github.com/cosmos/cosmos-sdk/issues/7940) The version --long command now shows the list of build dependencies and their versioning information.
 
 ### Improvements

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,8 +6,8 @@ See the [Cosmos SDK 0.39.2 milestone](https://github.com/cosmos/cosmos-sdk/miles
 
 ## Allow ValidateDenom() to be customised per application
 
-Applications can now customise `types.Coin` denomination validation by
-replacing `types.CoinDenomRegex` with their application-specific validation function.
+Applications can now customise `types.Coin` denomination validation by passing
+their application-specific validation function to `types.SetCoinDenomRegex()`.
 
 ## Upgrade queries don't work after upgrade
 

--- a/types/bench_test.go
+++ b/types/bench_test.go
@@ -1,0 +1,30 @@
+package types_test
+
+import (
+	"testing"
+
+	"github.com/cosmos/cosmos-sdk/types"
+)
+
+var coinStrs = []string{
+	"2000ATM",
+	"5000AMX",
+	"192XXX",
+	"1e9BTC",
+}
+
+func BenchmarkParseCoin(b *testing.B) {
+	var blankCoin types.Coin
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		for _, coinStr := range coinStrs {
+			coin, err := types.ParseCoin(coinStr)
+			if err != nil {
+				b.Fatal(err)
+			}
+			if coin == blankCoin {
+				b.Fatal("Unexpectedly returned a blank coin")
+			}
+		}
+	}
+}

--- a/types/coin.go
+++ b/types/coin.go
@@ -599,19 +599,13 @@ var (
 	reAmt       = `[[:digit:]]+`
 	reDecAmt    = `[[:digit:]]*\.[[:digit:]]+`
 	reSpc       = `[[:space:]]*`
-	reDnm       = returnReDnm
-	reCoin      = returnReCoin
-	reDecCoin   = returnDecCoin
+	reDnm       *regexp.Regexp
+	reCoin      *regexp.Regexp
+	reDecCoin   *regexp.Regexp
 )
 
-func returnDecCoin() *regexp.Regexp {
-	return regexp.MustCompile(fmt.Sprintf(`^(%s)%s(%s)$`, reDecAmt, reSpc, CoinDenomRegex()))
-}
-func returnReCoin() *regexp.Regexp {
-	return regexp.MustCompile(fmt.Sprintf(`^(%s)%s(%s)$`, reAmt, reSpc, CoinDenomRegex()))
-}
-func returnReDnm() *regexp.Regexp {
-	return regexp.MustCompile(fmt.Sprintf(`^%s$`, CoinDenomRegex()))
+func init() {
+	SetCoinDenomRegex(DefaultCoinDenomRegex)
 }
 
 // DefaultCoinDenomRegex returns the default regex string
@@ -619,13 +613,23 @@ func DefaultCoinDenomRegex() string {
 	return reDnmString
 }
 
-// CoinDenomRegex returns the current regex string and can be overwritten for custom validation
-var CoinDenomRegex = DefaultCoinDenomRegex
+// coinDenomRegex returns the current regex string and can be overwritten for custom validation
+var coinDenomRegex = DefaultCoinDenomRegex
+
+// SetCoinDenomRegex allows for coin's custom validation by overriding the regular
+// expression string used for denom validation.
+func SetCoinDenomRegex(reFn func() string) {
+	coinDenomRegex = reFn
+
+	reDnm = regexp.MustCompile(fmt.Sprintf(`^%s$`, coinDenomRegex()))
+	reCoin = regexp.MustCompile(fmt.Sprintf(`^(%s)%s(%s)$`, reAmt, reSpc, coinDenomRegex()))
+	reDecCoin = regexp.MustCompile(fmt.Sprintf(`^(%s)%s(%s)$`, reDecAmt, reSpc, coinDenomRegex()))
+}
 
 // ValidateDenom validates a denomination string returning an error if it is
 // invalid.
 func ValidateDenom(denom string) error {
-	if !reDnm().MatchString(denom) {
+	if !reDnm.MatchString(denom) {
 		return fmt.Errorf("invalid denom: %s", denom)
 	}
 	return nil
@@ -642,7 +646,7 @@ func mustValidateDenom(denom string) {
 func ParseCoin(coinStr string) (coin Coin, err error) {
 	coinStr = strings.TrimSpace(coinStr)
 
-	matches := reCoin().FindStringSubmatch(coinStr)
+	matches := reCoin.FindStringSubmatch(coinStr)
 	if matches == nil {
 		return Coin{}, fmt.Errorf("invalid coin expression: %s", coinStr)
 	}

--- a/types/coin.go
+++ b/types/coin.go
@@ -613,7 +613,7 @@ func DefaultCoinDenomRegex() string {
 	return reDnmString
 }
 
-// coinDenomRegex returns the current regex string and can be overwritten for custom validation
+// coinDenomRegex returns the current regex string and can be overwritten through the SetCoinDenomRegex accessor.
 var coinDenomRegex = DefaultCoinDenomRegex
 
 // SetCoinDenomRegex allows for coin's custom validation by overriding the regular

--- a/types/coin_test.go
+++ b/types/coin_test.go
@@ -73,9 +73,9 @@ func TestCoinIsValid(t *testing.T) {
 func TestCustomValidation(t *testing.T) {
 
 	newDnmRegex := `[\x{1F600}-\x{1F6FF}]`
-	CoinDenomRegex = func() string {
+	SetCoinDenomRegex(func() string {
 		return newDnmRegex
-	}
+	})
 
 	cases := []struct {
 		coin       Coin
@@ -92,7 +92,7 @@ func TestCustomValidation(t *testing.T) {
 	for i, tc := range cases {
 		require.Equal(t, tc.expectPass, tc.coin.IsValid(), "unexpected result for IsValid, tc #%d", i)
 	}
-	CoinDenomRegex = DefaultCoinDenomRegex
+	SetCoinDenomRegex(DefaultCoinDenomRegex)
 }
 
 func TestAddCoin(t *testing.T) {

--- a/types/dec_coin.go
+++ b/types/dec_coin.go
@@ -600,7 +600,7 @@ func (coins DecCoins) Sort() DecCoins {
 func ParseDecCoin(coinStr string) (coin DecCoin, err error) {
 	coinStr = strings.TrimSpace(coinStr)
 
-	matches := reDecCoin().FindStringSubmatch(coinStr)
+	matches := reDecCoin.FindStringSubmatch(coinStr)
 	if matches == nil {
 		return DecCoin{}, fmt.Errorf("invalid decimal coin expression: %s", coinStr)
 	}


### PR DESCRIPTION
**This patch brings a client code breaking change. As such it requires a Stable Release Exception to be granted by the Stable Release Managers.** @clevinson @ethanfrey 

From: #7989
Closes: #7986

Co-authored-by: Federico Kunze <31522760+fedekunze@users.noreply.github.com>
Co-authored-by: Alessio Treglia <alessio@tendermint.com>


#### Impact

The changes introduced in #7450 to support denoms custom validation
caused a significance performance hit due to the use of closures
instead of compiled regular expressions. As the reporter described in #7986,
this represents a security threat since many ParseCoin invocations made
concurrently could cause the client application to run out of RAM.

#### Test Case

The bug becomes visible by invoking ParseCoin concurrently 1000 times.
A benchmark test case is included in this PR.

#### Regression Potential

Regressions could manifest if the `CoinDenomRegex` was left publicly exposed
as any modification to it by the client would not trigger the recompilation of the
regular expressions that depend on it. The original patch addresses potential
regressions by replacing `CoinDenomRegex` with the accessor `SetCoinDenomRegex()`
in the the `types` package public interface.



---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
