### PR TITLE
testutil: new TempFile function, simplify WriteToNewTempFile

### DIFF
--- a/testutil/ioutil.go
+++ b/testutil/ioutil.go
@@ -52,15 +52,22 @@ func ApplyMockIODiscardOutErr(c *cobra.Command) BufferReader {
 }
 
 // Write the given string to a new temporary file.
-// Returns an open file and a clean up function that
-// the caller must call to remove the file when it is
-// no longer needed.
-func WriteToNewTempFile(t testing.TB, s string) (*os.File, func()) {
-	fp, err := ioutil.TempFile("", strings.ReplaceAll(t.Name(), "/", "_")+"_")
+// Returns an open file for the test to use.
+func WriteToNewTempFile(t testing.TB, s string) *os.File {
+	t.Helper()
+
+	fp, err := TempFile(t)
 	require.Nil(t, err)
 
 	_, err = fp.WriteString(s)
 	require.Nil(t, err)
 
-	return fp, func() { os.Remove(fp.Name()) }
+	return fp
+}
+
+// TempFile returns a writable temporary file for the test to use.
+func TempFile(t testing.TB) (*os.File, error) {
+	t.Helper()
+
+	return ioutil.TempFile(t.TempDir(), "")
 }

--- a/testutil/ioutil_test.go
+++ b/testutil/ioutil_test.go
@@ -25,16 +25,12 @@ func TestApplyMockIO(t *testing.T) {
 }
 
 func TestWriteToNewTempFile(t *testing.T) {
-	tempfile, cleanup := testutil.WriteToNewTempFile(t, "test string")
+	tempfile := testutil.WriteToNewTempFile(t, "test string")
 	tempfile.Close()
 
 	bs, err := ioutil.ReadFile(tempfile.Name())
 	require.NoError(t, err)
 	require.Equal(t, "test string", string(bs))
-
-	cleanup()
-
-	require.NoFileExists(t, tempfile.Name())
 }
 
 func TestApplyMockIODiscardOutErr(t *testing.T) {

--- a/x/auth/client/cli/encode_test.go
+++ b/x/auth/client/cli/encode_test.go
@@ -33,9 +33,8 @@ func TestGetCommandEncode(t *testing.T) {
 	jsonEncoded, err := txCfg.TxJSONEncoder()(builder.GetTx())
 	require.NoError(t, err)
 
-	txFile, cleanup := testutil.WriteToNewTempFile(t, string(jsonEncoded))
+	txFile := testutil.WriteToNewTempFile(t, string(jsonEncoded))
 	txFileName := txFile.Name()
-	t.Cleanup(cleanup)
 
 	ctx := context.Background()
 	clientCtx := client.Context{}.

--- a/x/auth/client/rest/rest_test.go
+++ b/x/auth/client/rest/rest_test.go
@@ -453,9 +453,8 @@ func (s *IntegrationTestSuite) testQueryIBCTx(txRes sdk.TxResponse, cmd *cobra.C
 	out, err := clitestutil.ExecTestCLICmd(val.ClientCtx, cmd, args)
 	s.Require().NoError(err)
 
-	txFile, cleanup := testutil.WriteToNewTempFile(s.T(), string(out.Bytes()))
+	txFile := testutil.WriteToNewTempFile(s.T(), string(out.Bytes()))
 	txFileName := txFile.Name()
-	s.T().Cleanup(cleanup)
 
 	// encode the generated txn.
 	out, err = clitestutil.ExecTestCLICmd(val.ClientCtx, authcli.GetEncodeCommand(), []string{txFileName})
@@ -482,11 +481,10 @@ func (s *IntegrationTestSuite) TestLegacyRestErrMessages() {
 	val := s.network.Validators[0]
 
 	// Write consensus json to temp file, used for an IBC message.
-	consensusJSON, cleanup := testutil.WriteToNewTempFile(
+	consensusJSON := testutil.WriteToNewTempFile(
 		s.T(),
 		`{"public_key":{"@type":"/cosmos.crypto.secp256k1.PubKey","key":"A/3SXL2ONYaOkxpdR5P8tHTlSlPv1AwQwSFxKRee5JQW"},"diversifier":"diversifier","timestamp":"10"}`,
 	)
-	defer cleanup()
 
 	testCases := []struct {
 		desc string

--- a/x/auth/client/tx_test.go
+++ b/x/auth/client/tx_test.go
@@ -74,9 +74,8 @@ func TestReadTxFromFile(t *testing.T) {
 	// Write it to the file
 	encodedTx, err := txCfg.TxJSONEncoder()(txBuilder.GetTx())
 	require.NoError(t, err)
-	jsonTxFile, cleanup := testutil.WriteToNewTempFile(t, string(encodedTx))
-	t.Cleanup(cleanup)
 
+	jsonTxFile := testutil.WriteToNewTempFile(t, string(encodedTx))
 	// Read it back
 	decodedTx, err := authclient.ReadTxFromFile(clientCtx, jsonTxFile.Name())
 	require.NoError(t, err)

--- a/x/distribution/client/cli/tx_test.go
+++ b/x/distribution/client/cli/tx_test.go
@@ -67,7 +67,7 @@ func Test_splitAndCall_Splitting(t *testing.T) {
 func TestParseProposal(t *testing.T) {
 	encodingConfig := params.MakeTestEncodingConfig()
 
-	okJSON, cleanup := testutil.WriteToNewTempFile(t, `
+	okJSON := testutil.WriteToNewTempFile(t, `
 {
   "title": "Community Pool Spend",
   "description": "Pay me some Atoms!",
@@ -76,7 +76,6 @@ func TestParseProposal(t *testing.T) {
   "deposit": "1000stake"
 }
 `)
-	t.Cleanup(cleanup)
 
 	proposal, err := ParseCommunityPoolSpendProposalWithDeposit(encodingConfig.Marshaler, okJSON.Name())
 	require.NoError(t, err)

--- a/x/gov/client/cli/parse_test.go
+++ b/x/gov/client/cli/parse_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestParseSubmitProposalFlags(t *testing.T) {
-	okJSON, cleanup1 := testutil.WriteToNewTempFile(t, `
+	okJSON := testutil.WriteToNewTempFile(t, `
 {
   "title": "Test Proposal",
   "description": "My awesome proposal",
@@ -17,11 +17,8 @@ func TestParseSubmitProposalFlags(t *testing.T) {
   "deposit": "1000test"
 }
 `)
-	t.Cleanup(cleanup1)
 
-	badJSON, cleanup2 := testutil.WriteToNewTempFile(t, "bad json")
-	t.Cleanup(cleanup2)
-
+	badJSON := testutil.WriteToNewTempFile(t, "bad json")
 	fs := NewCmdSubmitProposal().Flags()
 
 	// nonexistent json

--- a/x/params/client/cli/tx_test.go
+++ b/x/params/client/cli/tx_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestParseProposal(t *testing.T) {
 	cdc := codec.NewLegacyAmino()
-	okJSON, cleanup := testutil.WriteToNewTempFile(t, `
+	okJSON := testutil.WriteToNewTempFile(t, `
 {
   "title": "Staking Param Change",
   "description": "Update max validators",
@@ -26,8 +26,6 @@ func TestParseProposal(t *testing.T) {
   "deposit": "1000stake"
 }
 `)
-	t.Cleanup(cleanup)
-
 	proposal, err := utils.ParseParamChangeProposalJSON(cdc, okJSON.Name())
 	require.NoError(t, err)
 


### PR DESCRIPTION
Files returned by WriteToNewTempFile are cleaned up
automatically at the end of a test case execution.
WriteToNewTempFile now relies on the TB.TempDir()
function provided by the testing std package.

TempFile returns a temporary file that can be used
within a test case and is automatically removed
at the end of the test execution.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
