### PR TITLE
use testutil in test cases

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,6 @@ require (
 	github.com/golang/mock v1.4.4
 	github.com/golang/protobuf v1.4.3
 	github.com/golang/snappy v0.0.2 // indirect
-	github.com/google/go-cmp v0.5.0
 	github.com/gorilla/handlers v1.5.1
 	github.com/gorilla/mux v1.8.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.2.2

--- a/snapshots/manager_test.go
+++ b/snapshots/manager_test.go
@@ -12,8 +12,7 @@ import (
 )
 
 func TestManager_List(t *testing.T) {
-	store, teardown := setupStore(t)
-	defer teardown()
+	store := setupStore(t)
 	manager := snapshots.NewManager(store, nil)
 
 	mgrList, err := manager.List()
@@ -25,16 +24,14 @@ func TestManager_List(t *testing.T) {
 	assert.Equal(t, storeList, mgrList)
 
 	// list should not block or error on busy managers
-	manager, teardown = setupBusyManager(t)
-	defer teardown()
+	manager = setupBusyManager(t)
 	list, err := manager.List()
 	require.NoError(t, err)
 	assert.Equal(t, []*types.Snapshot{}, list)
 }
 
 func TestManager_LoadChunk(t *testing.T) {
-	store, teardown := setupStore(t)
-	defer teardown()
+	store := setupStore(t)
 	manager := snapshots.NewManager(store, nil)
 
 	// Existing chunk should return body
@@ -48,16 +45,14 @@ func TestManager_LoadChunk(t *testing.T) {
 	assert.Nil(t, chunk)
 
 	// LoadChunk should not block or error on busy managers
-	manager, teardown = setupBusyManager(t)
-	defer teardown()
+	manager = setupBusyManager(t)
 	chunk, err = manager.LoadChunk(2, 1, 0)
 	require.NoError(t, err)
 	assert.Nil(t, chunk)
 }
 
 func TestManager_Take(t *testing.T) {
-	store, teardown := setupStore(t)
-	defer teardown()
+	store := setupStore(t)
 	snapshotter := &mockSnapshotter{
 		chunks: [][]byte{
 			{1, 2, 3},
@@ -98,15 +93,13 @@ func TestManager_Take(t *testing.T) {
 	assert.Equal(t, [][]byte{{1, 2, 3}, {4, 5, 6}, {7, 8, 9}}, readChunks(chunks))
 
 	// creating a snapshot while a different snapshot is being created should error
-	manager, teardown = setupBusyManager(t)
-	defer teardown()
+	manager = setupBusyManager(t)
 	_, err = manager.Create(9)
 	require.Error(t, err)
 }
 
 func TestManager_Prune(t *testing.T) {
-	store, teardown := setupStore(t)
-	defer teardown()
+	store := setupStore(t)
 	manager := snapshots.NewManager(store, nil)
 
 	pruned, err := manager.Prune(2)
@@ -118,15 +111,13 @@ func TestManager_Prune(t *testing.T) {
 	assert.Len(t, list, 3)
 
 	// Prune should error while a snapshot is being taken
-	manager, teardown = setupBusyManager(t)
-	defer teardown()
+	manager = setupBusyManager(t)
 	_, err = manager.Prune(2)
 	require.Error(t, err)
 }
 
 func TestManager_Restore(t *testing.T) {
-	store, teardown := setupStore(t)
-	defer teardown()
+	store := setupStore(t)
 	target := &mockSnapshotter{}
 	manager := snapshots.NewManager(store, target)
 

--- a/snapshots/store_test.go
+++ b/snapshots/store_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"io"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -16,12 +15,11 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/snapshots"
 	"github.com/cosmos/cosmos-sdk/snapshots/types"
+	"github.com/cosmos/cosmos-sdk/testutil"
 )
 
-func setupStore(t *testing.T) (*snapshots.Store, func()) {
-	tempdir, err := ioutil.TempDir("", "snapshots")
-	require.NoError(t, err)
-
+func setupStore(t *testing.T) *snapshots.Store {
+	tempdir := t.TempDir()
 	store, err := snapshots.NewStore(db.NewMemDB(), tempdir)
 	require.NoError(t, err)
 
@@ -42,21 +40,13 @@ func setupStore(t *testing.T) (*snapshots.Store, func()) {
 	}))
 	require.NoError(t, err)
 
-	teardown := func() {
-		err := os.RemoveAll(tempdir)
-		if err != nil {
-			t.Logf("Failed to remove tempdir %q: %v", tempdir, err)
-		}
-	}
-	return store, teardown
+	return store
 }
 
 func TestNewStore(t *testing.T) {
-	tempdir, err := ioutil.TempDir("", "snapshots")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempdir)
+	tempdir := t.TempDir()
+	_, err := snapshots.NewStore(db.NewMemDB(), tempdir)
 
-	_, err = snapshots.NewStore(db.NewMemDB(), tempdir)
 	require.NoError(t, err)
 }
 
@@ -66,22 +56,14 @@ func TestNewStore_ErrNoDir(t *testing.T) {
 }
 
 func TestNewStore_ErrDirFailure(t *testing.T) {
-	tempfile, err := ioutil.TempFile("", "snapshots")
-	require.NoError(t, err)
-	defer func() {
-		os.RemoveAll(tempfile.Name())
-		tempfile.Close()
-	}()
-	tempdir := filepath.Join(tempfile.Name(), "subdir")
+	notADir := filepath.Join(testutil.TempFile(t).Name(), "subdir")
 
-	_, err = snapshots.NewStore(db.NewMemDB(), tempdir)
+	_, err := snapshots.NewStore(db.NewMemDB(), notADir)
 	require.Error(t, err)
 }
 
 func TestStore_Delete(t *testing.T) {
-	store, teardown := setupStore(t)
-	defer teardown()
-
+	store := setupStore(t)
 	// Deleting a snapshot should remove it
 	err := store.Delete(2, 2)
 	require.NoError(t, err)
@@ -114,8 +96,7 @@ func TestStore_Delete(t *testing.T) {
 }
 
 func TestStore_Get(t *testing.T) {
-	store, teardown := setupStore(t)
-	defer teardown()
+	store := setupStore(t)
 
 	// Loading a missing snapshot should return nil
 	snapshot, err := store.Get(9, 9)
@@ -140,9 +121,7 @@ func TestStore_Get(t *testing.T) {
 }
 
 func TestStore_GetLatest(t *testing.T) {
-	store, teardown := setupStore(t)
-	defer teardown()
-
+	store := setupStore(t)
 	// Loading a missing snapshot should return nil
 	snapshot, err := store.GetLatest()
 	require.NoError(t, err)
@@ -166,9 +145,7 @@ func TestStore_GetLatest(t *testing.T) {
 }
 
 func TestStore_List(t *testing.T) {
-	store, teardown := setupStore(t)
-	defer teardown()
-
+	store := setupStore(t)
 	snapshots, err := store.List()
 	require.NoError(t, err)
 
@@ -189,9 +166,7 @@ func TestStore_List(t *testing.T) {
 }
 
 func TestStore_Load(t *testing.T) {
-	store, teardown := setupStore(t)
-	defer teardown()
-
+	store := setupStore(t)
 	// Loading a missing snapshot should return nil
 	snapshot, chunks, err := store.Load(9, 9)
 	require.NoError(t, err)
@@ -227,9 +202,7 @@ func TestStore_Load(t *testing.T) {
 }
 
 func TestStore_LoadChunk(t *testing.T) {
-	store, teardown := setupStore(t)
-	defer teardown()
-
+	store := setupStore(t)
 	// Loading a missing snapshot should return nil
 	chunk, err := store.LoadChunk(9, 9, 0)
 	require.NoError(t, err)
@@ -252,9 +225,7 @@ func TestStore_LoadChunk(t *testing.T) {
 }
 
 func TestStore_Prune(t *testing.T) {
-	store, teardown := setupStore(t)
-	defer teardown()
-
+	store := setupStore(t)
 	// Pruning too many snapshots should be fine
 	pruned, err := store.Prune(4)
 	require.NoError(t, err)
@@ -294,9 +265,7 @@ func TestStore_Prune(t *testing.T) {
 }
 
 func TestStore_Save(t *testing.T) {
-	store, teardown := setupStore(t)
-	defer teardown()
-
+	store := setupStore(t)
 	// Saving a snapshot should work
 	snapshot, err := store.Save(4, 1, makeChunks([][]byte{{1}, {2}}))
 	require.NoError(t, err)

--- a/testutil/ioutil.go
+++ b/testutil/ioutil.go
@@ -56,18 +56,20 @@ func ApplyMockIODiscardOutErr(c *cobra.Command) BufferReader {
 func WriteToNewTempFile(t testing.TB, s string) *os.File {
 	t.Helper()
 
-	fp, err := TempFile(t)
-	require.Nil(t, err)
+	fp := TempFile(t)
+	_, err := fp.WriteString(s)
 
-	_, err = fp.WriteString(s)
 	require.Nil(t, err)
 
 	return fp
 }
 
 // TempFile returns a writable temporary file for the test to use.
-func TempFile(t testing.TB) (*os.File, error) {
+func TempFile(t testing.TB) *os.File {
 	t.Helper()
 
-	return ioutil.TempFile(t.TempDir(), "")
+	fp, err := ioutil.TempFile(t.TempDir(), "")
+	require.NoError(t, err)
+
+	return fp
 }

--- a/x/distribution/client/cli/cli_test.go
+++ b/x/distribution/client/cli/cli_test.go
@@ -5,7 +5,6 @@ package cli_test
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"strings"
 	"testing"
 	"time"
@@ -16,6 +15,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/cosmos/cosmos-sdk/testutil"
 	clitestutil "github.com/cosmos/cosmos-sdk/testutil/cli"
 	testnet "github.com/cosmos/cosmos-sdk/testutil/network"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -685,10 +685,6 @@ func (s *IntegrationTestSuite) TestNewFundCommunityPoolCmd() {
 
 func (s *IntegrationTestSuite) TestGetCmdSubmitProposal() {
 	val := s.network.Validators[0]
-
-	invalidPropFile, err := ioutil.TempFile(s.T().TempDir(), "invalid_community_spend_proposal.*.json")
-	s.Require().NoError(err)
-
 	invalidProp := `{
   "title": "",
   "description": "Pay me some Atoms!",
@@ -696,13 +692,7 @@ func (s *IntegrationTestSuite) TestGetCmdSubmitProposal() {
   "amount": "-343foocoin",
   "deposit": -324foocoin
 }`
-
-	_, err = invalidPropFile.WriteString(invalidProp)
-	s.Require().NoError(err)
-
-	validPropFile, err := ioutil.TempFile(s.T().TempDir(), "valid_community_spend_proposal.*.json")
-	s.Require().NoError(err)
-
+	invalidPropFile := testutil.WriteToNewTempFile(s.T(), invalidProp)
 	validProp := fmt.Sprintf(`{
   "title": "Community Pool Spend",
   "description": "Pay me some Atoms!",
@@ -710,10 +700,7 @@ func (s *IntegrationTestSuite) TestGetCmdSubmitProposal() {
   "amount": "%s",
   "deposit": "%s"
 }`, val.Address.String(), sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(5431)), sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(5431)))
-
-	_, err = validPropFile.WriteString(validProp)
-	s.Require().NoError(err)
-
+	validPropFile := testutil.WriteToNewTempFile(s.T(), validProp)
 	testCases := []struct {
 		name         string
 		args         []string

--- a/x/gov/client/cli/cli_test.go
+++ b/x/gov/client/cli/cli_test.go
@@ -4,9 +4,10 @@ package cli_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"strings"
 	"testing"
+
+	"github.com/cosmos/cosmos-sdk/testutil"
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/stretchr/testify/suite"
@@ -265,33 +266,20 @@ func (s *IntegrationTestSuite) TestCmdTally() {
 
 func (s *IntegrationTestSuite) TestNewCmdSubmitProposal() {
 	val := s.network.Validators[0]
-
-	invalidPropFile, err := ioutil.TempFile(s.T().TempDir(), "invalid_text_proposal.*.json")
-	s.Require().NoError(err)
-
 	invalidProp := `{
   "title": "",
 	"description": "Where is the title!?",
 	"type": "Text",
   "deposit": "-324foocoin"
 }`
-
-	_, err = invalidPropFile.WriteString(invalidProp)
-	s.Require().NoError(err)
-
-	validPropFile, err := ioutil.TempFile(s.T().TempDir(), "valid_text_proposal.*.json")
-	s.Require().NoError(err)
-
+	invalidPropFile := testutil.WriteToNewTempFile(s.T(), invalidProp)
 	validProp := fmt.Sprintf(`{
   "title": "Text Proposal",
 	"description": "Hello, World!",
 	"type": "Text",
   "deposit": "%s"
 }`, sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(5431)))
-
-	_, err = validPropFile.WriteString(validProp)
-	s.Require().NoError(err)
-
+	validPropFile := testutil.WriteToNewTempFile(s.T(), validProp)
 	testCases := []struct {
 		name         string
 		args         []string


### PR DESCRIPTION
Also replace defer calls with testing.T.Cleanup()

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
