### PR TITLE
Switch LogFormat to Plain by default

### DIFF
--- a/simapp/simd/cmd/root.go
+++ b/simapp/simd/cmd/root.go
@@ -82,7 +82,7 @@ func Execute(rootCmd *cobra.Command) error {
 	ctx = context.WithValue(ctx, server.ServerContextKey, srvCtx)
 
 	rootCmd.PersistentFlags().String(flags.FlagLogLevel, zerolog.InfoLevel.String(), "The logging level (trace|debug|info|warn|error|fatal|panic)")
-	rootCmd.PersistentFlags().String(flags.FlagLogFormat, tmcfg.LogFormatJSON, "The logging format (json|plain)")
+	rootCmd.PersistentFlags().String(flags.FlagLogFormat, tmcfg.LogFormatPlain, "The logging format (json|plain)")
 
 	executor := tmcli.PrepareBaseCmd(rootCmd, "", simapp.DefaultNodeHome)
 	return executor.ExecuteContext(ctx)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Before:

```
➜  cosmos-sdk git:(master) ./build/simd start
{"level":"info","time":"2020-12-10T11:53:02+01:00","message":"starting ABCI with Tendermint"}
{"level":"info","module":"proxy","impl":{"Logger":{}},"time":"2020-12-10T11:53:02+01:00","message":"Starting multiAppConn service"}
{"level":"info","module":"proxy","connection":"query","module":"abci-client","impl":"marshaling error: json: unsupported type: abcicli.Callback","time":"2020-12-10T11:53:02+01:00","message":"Starting localClient service"}
{"level":"info","module":"proxy","connection":"snapshot","module":"abci-client","impl":"marshaling error: json: unsupported type: abcicli.Callback","time":"2020-12-10T11:53:02+01:00","message":"Starting localClient service"}
{"level":"info","module":"proxy","connection":"mempool","module":"abci-client","impl":"marshaling error: json: unsupported type: abcicli.Callback","time":"2020-12-10T11:53:02+01:00","message":"Starting localClient service"}
{"level":"info","module":"proxy","connection":"consensus","module":"abci-client","impl":"marshaling error: json: unsupported type: abcicli.Callback","time":"2020-12-10T11:53:02+01:00","message":"Starting localClient service"}
{"level":"info","module":"events","impl":{"Logger":{}},"time":"2020-12-10T11:53:02+01:00","message":"Starting EventBus service"}
{"level":"info","module":"events","module":"pubsub","impl":{"Logger":{}},"time":"2020-12-10T11:53:02+01:00","message":"Starting PubSub service"}
```

After (there are even colors!):

```
➜  cosmos-sdk git:(am-change-log-level) ./build/simd start
11:55AM INF starting ABCI with Tendermint
11:55AM INF Starting multiAppConn service impl={"Logger":{}} module=proxy
11:55AM INF Starting localClient service connection=query impl="marshaling error: json: unsupported type: abcicli.Callback" module=abci-client
11:55AM INF Starting localClient service connection=snapshot impl="marshaling error: json: unsupported type: abcicli.Callback" module=abci-client
11:55AM INF Starting localClient service connection=mempool impl="marshaling error: json: unsupported type: abcicli.Callback" module=abci-client
11:55AM INF Starting localClient service connection=consensus impl="marshaling error: json: unsupported type: abcicli.Callback" module=abci-client
11:55AM INF Starting EventBus service impl={"Logger":{}} module=events
11:55AM INF Starting PubSub service impl={"Logger":{}} module=pubsub
11:55AM INF Starting IndexerService service impl={"Logger":{}} module=txindex
11:55AM INF ABCI Handshake App Info hash= height=0 module=consensus protocol-version=0 software-version=
11:55AM INF ABCI Replay Blocks appHeight=0 module=consensus stateHeight=0 storeHeight=0
11:55AM INF asserting crisis invariants inv=0/11 module=x/crisis
```

I'm not sure if JSON was put as default on purpose, but I think plain is better for readability.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
