### PR TITLE
Add Increment method to Height interface

### DIFF
--- a/x/ibc/core/02-client/keeper/client_test.go
+++ b/x/ibc/core/02-client/keeper/client_test.go
@@ -73,7 +73,7 @@ func (suite *KeeperTestSuite) TestUpdateClientTendermint() {
 			clientID, err = suite.keeper.CreateClient(suite.ctx, clientState, suite.consensusState)
 
 			// store intermediate consensus state to check that trustedHeight does not need to be highest consensus state before header height
-			incrementedClientHeight := testClientHeight.Increment()
+			incrementedClientHeight := testClientHeight.Increment().(types.Height)
 			intermediateConsState := &ibctmtypes.ConsensusState{
 				Timestamp:          suite.now.Add(time.Minute),
 				NextValidatorsHash: suite.valSetHash,

--- a/x/ibc/core/02-client/keeper/grpc_query_test.go
+++ b/x/ibc/core/02-client/keeper/grpc_query_test.go
@@ -321,7 +321,7 @@ func (suite *KeeperTestSuite) TestQueryConsensusStates() {
 				// order is swapped because the res is sorted by client id
 				expConsensusStates = []types.ConsensusStateWithHeight{
 					types.NewConsensusStateWithHeight(testClientHeight, cs),
-					types.NewConsensusStateWithHeight(testClientHeight.Increment(), cs2),
+					types.NewConsensusStateWithHeight(testClientHeight.Increment().(types.Height), cs2),
 				}
 				req = &types.QueryConsensusStatesRequest{
 					ClientId: testClientID,

--- a/x/ibc/core/02-client/types/height.go
+++ b/x/ibc/core/02-client/types/height.go
@@ -109,7 +109,7 @@ func (h Height) Decrement() (decremented exported.Height, success bool) {
 
 // Increment will return a height with the same revision number but an
 // incremented revision height
-func (h Height) Increment() Height {
+func (h Height) Increment() exported.Height {
 	return NewHeight(h.RevisionNumber, h.RevisionHeight+1)
 }
 

--- a/x/ibc/core/03-connection/keeper/handshake_test.go
+++ b/x/ibc/core/03-connection/keeper/handshake_test.go
@@ -210,7 +210,7 @@ func (suite *KeeperTestSuite) TestConnOpenTry() {
 			// modify counterparty client without setting in store so it still passes validate but fails proof verification
 			tmClient, ok := counterpartyClient.(*ibctmtypes.ClientState)
 			suite.Require().True(ok)
-			tmClient.LatestHeight = tmClient.LatestHeight.Increment()
+			tmClient.LatestHeight = tmClient.LatestHeight.Increment().(clienttypes.Height)
 		}, false},
 		{"consensus state verification failed", func() {
 			clientA, clientB = suite.coordinator.SetupClients(suite.chainA, suite.chainB, exported.Tendermint)
@@ -562,7 +562,7 @@ func (suite *KeeperTestSuite) TestConnOpenAck() {
 			// modify counterparty client without setting in store so it still passes validate but fails proof verification
 			tmClient, ok := counterpartyClient.(*ibctmtypes.ClientState)
 			suite.Require().True(ok)
-			tmClient.LatestHeight = tmClient.LatestHeight.Increment()
+			tmClient.LatestHeight = tmClient.LatestHeight.Increment().(clienttypes.Height)
 
 			err = suite.coordinator.ConnOpenTry(suite.chainB, suite.chainA, connB, connA)
 			suite.Require().NoError(err)

--- a/x/ibc/core/exported/client.go
+++ b/x/ibc/core/exported/client.go
@@ -204,6 +204,7 @@ type Height interface {
 	GTE(Height) bool
 	GetRevisionNumber() uint64
 	GetRevisionHeight() uint64
+	Increment() Height
 	Decrement() (Height, bool)
 	String() string
 }

--- a/x/ibc/light-clients/07-tendermint/types/header_test.go
+++ b/x/ibc/light-clients/07-tendermint/types/header_test.go
@@ -44,7 +44,7 @@ func (suite *TendermintTestSuite) TestHeaderValidateBasic() {
 			header.SignedHeader.Commit = nil
 		}, false},
 		{"trusted height is greater than header height", func() {
-			header.TrustedHeight = header.GetHeight().(clienttypes.Height).Increment()
+			header.TrustedHeight = header.GetHeight().(clienttypes.Height).Increment().(clienttypes.Height)
 		}, false},
 		{"validator set nil", func() {
 			header.ValidatorSet = nil

--- a/x/ibc/light-clients/07-tendermint/types/proposal_handle_test.go
+++ b/x/ibc/light-clients/07-tendermint/types/proposal_handle_test.go
@@ -23,7 +23,7 @@ func (suite *TendermintTestSuite) TestCheckProposedHeaderAndUpdateStateBasic() {
 	suite.Require().Nil(cs)
 	suite.Require().Nil(consState)
 
-	clientState.LatestHeight = clientState.LatestHeight.Increment()
+	clientState.LatestHeight = clientState.LatestHeight.Increment().(clienttypes.Height)
 
 	// consensus state for latest height does not exist
 	cs, consState, err = clientState.CheckProposedHeaderAndUpdateState(suite.chainA.GetContext(), suite.chainA.App.AppCodec(), clientStore, suite.chainA.LastHeader)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Currently `x/ibc/core/exported.Height` has `Decrement` method but doesn't have `Increment`.

This PR includes a small fix that adds `Increment` method to `Height` interface.

closes: #XXXX

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
