### PR TITLE
client: remove redundant/repeated code

### DIFF
--- a/client/broadcast.go
+++ b/client/broadcast.go
@@ -95,23 +95,14 @@ func (ctx Context) BroadcastTxCommit(txBytes []byte) (*sdk.TxResponse, error) {
 	}
 
 	res, err := node.BroadcastTxCommit(context.Background(), txBytes)
-	if err != nil {
-		if errRes := CheckTendermintError(err, txBytes); errRes != nil {
-			return errRes, nil
-		}
-
-		return sdk.NewResponseFormatBroadcastTxCommit(res), err
-	}
-
-	if !res.CheckTx.IsOK() {
+	if err == nil {
 		return sdk.NewResponseFormatBroadcastTxCommit(res), nil
 	}
 
-	if !res.DeliverTx.IsOK() {
-		return sdk.NewResponseFormatBroadcastTxCommit(res), nil
+	if errRes := CheckTendermintError(err, txBytes); errRes != nil {
+		return errRes, nil
 	}
-
-	return sdk.NewResponseFormatBroadcastTxCommit(res), nil
+	return sdk.NewResponseFormatBroadcastTxCommit(res), err
 }
 
 // BroadcastTxSync broadcasts transaction bytes to a Tendermint node


### PR DESCRIPTION
Follows up PR #4876 which removed the return on non-nil errors
to always return a non-nil REST response regardless of error.
The checks performed seem benign and the return result is the
same.
This change uses the reverse conditional refactoring method
to gut out nesting and many conditions.
Noticed while hunting through types.ParseABCILogs.

Fixes #8181

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
