### PR TITLE
Fix IBC Timeout verification bug

### DIFF
--- a/x/ibc/core/04-channel/keeper/keeper.go
+++ b/x/ibc/core/04-channel/keeper/keeper.go
@@ -170,7 +170,7 @@ func (k Keeper) GetPacketReceipt(ctx sdk.Context, portID, channelID string, sequ
 // SetPacketReceipt sets an empty packet receipt to the store
 func (k Keeper) SetPacketReceipt(ctx sdk.Context, portID, channelID string, sequence uint64) {
 	store := ctx.KVStore(k.storeKey)
-	store.Set(host.PacketReceiptKey(portID, channelID, sequence), []byte(""))
+	store.Set(host.PacketReceiptKey(portID, channelID, sequence), []byte{byte(1)})
 }
 
 // GetPacketCommitment gets the packet commitment hash from the store

--- a/x/ibc/core/04-channel/keeper/keeper_test.go
+++ b/x/ibc/core/04-channel/keeper/keeper_test.go
@@ -166,12 +166,13 @@ func (suite KeeperTestSuite) TestGetAllPacketState() {
 	ack3 := types.NewPacketState(channelA1.PortID, channelA1.ID, 1, []byte("ack"))
 
 	// create channel 0 receipts
-	rec1 := types.NewPacketState(channelA0.PortID, channelA0.ID, 1, []byte(""))
-	rec2 := types.NewPacketState(channelA0.PortID, channelA0.ID, 2, []byte(""))
+	receipt := string([]byte{byte(1)})
+	rec1 := types.NewPacketState(channelA0.PortID, channelA0.ID, 1, []byte(receipt))
+	rec2 := types.NewPacketState(channelA0.PortID, channelA0.ID, 2, []byte(receipt))
 
 	// channel 1 receipts
-	rec3 := types.NewPacketState(channelA1.PortID, channelA1.ID, 1, []byte(""))
-	rec4 := types.NewPacketState(channelA1.PortID, channelA1.ID, 2, []byte(""))
+	rec3 := types.NewPacketState(channelA1.PortID, channelA1.ID, 1, []byte(receipt))
+	rec4 := types.NewPacketState(channelA1.PortID, channelA1.ID, 2, []byte(receipt))
 
 	// channel 0 packet commitments
 	comm1 := types.NewPacketState(channelA0.PortID, channelA0.ID, 1, []byte("hash"))

--- a/x/ibc/core/04-channel/keeper/packet_test.go
+++ b/x/ibc/core/04-channel/keeper/packet_test.go
@@ -381,7 +381,7 @@ func (suite *KeeperTestSuite) TestRecvPacket() {
 				} else {
 					suite.Require().Equal(uint64(1), nextSeqRecv, "sequence incremented for UNORDERED channel")
 					suite.Require().True(receiptStored, "packet receipt not stored after RecvPacket in UNORDERED channel")
-					suite.Require().Equal("", receipt, "packet receipt is not empty string")
+					suite.Require().Equal(string([]byte{byte(1)}), receipt, "packet receipt is not empty string")
 				}
 			} else {
 				suite.Require().Error(err)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Thanks @ancazamfir for alerting us to this bug!!!!

Here is the explanation from @AdityaSripal on why this is a bug
```
Thanks to @Anca’s report we found a bug in the timeout logic. We sometimes could not prove timeouts on UNORDERED channels if packets had already been relayed on the channel.
This is because the nonexistence proof for the packet receipt would contain a left proof which would prove the existence of a receipt at an earlier sequence
However, this proof would fail on Calculate since we cannot calculate the root of a proof that had an empty leaf value. And currently, packet receipts are simply empty byte strings stored on chain.
This would fail on VerifyNonmembership through the following sequence:
```

I have manually tested this fix with the relayer for both a clean channel with a timeout first and a clean channel with a recv then a timeout

closes: #XXXX

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
