### PR TITLE
types: unconditionally divide by 2 because of integer truncation ⌊x/2⌋

### DIFF
--- a/types/decimal.go
+++ b/types/decimal.go
@@ -394,12 +394,10 @@ func (d Dec) Power(power uint64) Dec {
 	tmp := OneDec()
 
 	for i := power; i > 1; {
-		if i%2 == 0 {
-			i /= 2
-		} else {
+		if i%2 != 0 {
 			tmp = tmp.Mul(d)
-			i = (i - 1) / 2
 		}
+		i /= 2
 		d = d.Mul(d)
 	}
 


### PR DESCRIPTION
Simplify the code in Dec.Power to unconditionally divide by 2, since:
    x /= 2
is the same result for both even and odd integers, and produces the
floor of the result of x/2 -> ⌊x/2⌋:
```
    99/2 ~> 49.5 ⌊49.5⌋ = 49
    98/2 ~> 49.0 ⌊49.0⌋ = 49
```
aka "integer truncation".

Fixes #7924

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
