### PR TITLE
test: Use the bond denomination from the configuration, not the default

### DIFF
--- a/testutil/network/network.go
+++ b/testutil/network/network.go
@@ -298,7 +298,7 @@ func New(t *testing.T, cfg Config) *Network {
 		createValMsg, err := stakingtypes.NewMsgCreateValidator(
 			sdk.ValAddress(addr),
 			valPubKeys[i],
-			sdk.NewCoin(sdk.DefaultBondDenom, cfg.BondedTokens),
+			sdk.NewCoin(cfg.BondDenom, cfg.BondedTokens),
 			stakingtypes.NewDescription(nodeDirName, "", "", "", ""),
 			stakingtypes.NewCommissionRates(commission, sdk.OneDec(), sdk.OneDec()),
 			sdk.OneInt(),


### PR DESCRIPTION
This is a 1 line change to fix something I found a while back

closes: #8000 