### PR TITLE
Fix tendermint query proto scoping

### DIFF
--- a/proto/cosmos/base/tendermint/v1beta1/query.proto
+++ b/proto/cosmos/base/tendermint/v1beta1/query.proto
@@ -84,8 +84,8 @@ message GetBlockByHeightRequest {
 
 // GetBlockByHeightResponse is the response type for the Query/GetBlockByHeight RPC method.
 message GetBlockByHeightResponse {
-  tendermint.types.BlockID block_id = 1;
-  tendermint.types.Block   block    = 2;
+  .tendermint.types.BlockID block_id = 1;
+  .tendermint.types.Block   block    = 2;
 }
 
 // GetLatestBlockRequest is the request type for the Query/GetLatestBlock RPC method.
@@ -93,8 +93,8 @@ message GetLatestBlockRequest {}
 
 // GetLatestBlockResponse is the response type for the Query/GetLatestBlock RPC method.
 message GetLatestBlockResponse {
-  tendermint.types.BlockID block_id = 1;
-  tendermint.types.Block   block    = 2;
+  .tendermint.types.BlockID block_id = 1;
+  .tendermint.types.Block   block    = 2;
 }
 
 // GetSyncingRequest is the request type for the Query/GetSyncing RPC method.
@@ -110,8 +110,8 @@ message GetNodeInfoRequest {}
 
 // GetNodeInfoResponse is the request type for the Query/GetNodeInfo RPC method.
 message GetNodeInfoResponse {
-  tendermint.p2p.DefaultNodeInfo default_node_info   = 1;
-  VersionInfo                    application_version = 2;
+  .tendermint.p2p.DefaultNodeInfo default_node_info   = 1;
+  VersionInfo                     application_version = 2;
 }
 
 // VersionInfo is the type for the GetNodeInfoResponse message.


### PR DESCRIPTION
The following errors are occurring when these protos are compiling because they exist in a sub-package `cosmos.base.tendermint` but are trying to refer to toplevel `.tendermint` types:

```
cosmos/base/tendermint/v1beta1/query.proto:87:3: "tendermint.types.BlockID" is resolved to "cosmos.base.tendermint.types.BlockID", which is not defined. The innermost scope is searched first in name resolution. Consider using a leading '.'(i.e., ".tendermint.types.BlockID") to start from the outermost scope.
cosmos/base/tendermint/v1beta1/query.proto:88:3: "tendermint.types.Block" is resolved to "cosmos.base.tendermint.types.Block", which is not defined. The innermost scope is searched first in name resolution. Consider using a leading '.'(i.e., ".tendermint.types.Block") to start from the outermost scope.
cosmos/base/tendermint/v1beta1/query.proto:96:3: "tendermint.types.BlockID" is resolved to "cosmos.base.tendermint.types.BlockID", which is not defined. The innermost scope is searched first in name resolution. Consider using a leading '.'(i.e., ".tendermint.types.BlockID") to start from the outermost scope.
cosmos/base/tendermint/v1beta1/query.proto:97:3: "tendermint.types.Block" is resolved to "cosmos.base.tendermint.types.Block", which is not defined. The innermost scope is searched first in name resolution. Consider using a leading '.'(i.e., ".tendermint.types.Block") to start from the outermost scope.
cosmos/base/tendermint/v1beta1/query.proto:113:3: "tendermint.p2p.DefaultNodeInfo" is resolved to "cosmos.base.tendermint.p2p.DefaultNodeInfo", which is not defined. The innermost scope is searched first in name resolution. Consider using a leading '.'(i.e., ".tendermint.p2p.DefaultNodeInfo") to start from the outermost scope.
```

With linewrapping for better readability:
> cosmos/base/tendermint/v1beta1/query.proto:87:3: "tendermint.types.BlockID" is resolved to "cosmos.base.tendermint.types.BlockID", which is not defined.
> The innermost scope is searched first in name resolution.
> Consider using a leading '.'(i.e., ".tendermint.types.BlockID") to start from the outermost scope.

Here is one issue where I observed these errors:

https://github.com/cosmos/cosmos-sdk/issues/8171

However note it is also breaking the build on `cosmos-rust`:

https://github.com/cosmos/cosmos-rust/issues/23

Adding a `.` before `tendermint` references the package in toplevel scope, which appears to be what is intended.