### PR TITLE
Return error instead of panic for unregistered parameter key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (crypto/keys) [\#7838](https://github.com/cosmos/cosmos-sdk/pull/7838) Add support for TM secp256k1 keys back to the
     SDK for consensus pubkeys
 * (x/auth/client/cli) [\#8106](https://github.com/cosmos/cosmos-sdk/pull/8106) fixing regression bugs in transaction signing.
+* (x/params) [\#8244](https://github.com/cosmos/cosmos-sdk/pull/8244) fix panic on parameter update with unregistered key
 
 ## [v0.40.0-rc4](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.40.0-rc4) - 2020-11-30
 

--- a/x/params/types/proposal/errors.go
+++ b/x/params/types/proposal/errors.go
@@ -12,5 +12,4 @@ var (
 	ErrEmptySubspace    = sdkerrors.Register(ModuleName, 5, "parameter subspace is empty")
 	ErrEmptyKey         = sdkerrors.Register(ModuleName, 6, "parameter key is empty")
 	ErrEmptyValue       = sdkerrors.Register(ModuleName, 7, "parameter value is empty")
-	ErrUnregisteredKey  = sdkerrors.Register(ModuleName, 8, "parameter key is unregistered")
 )

--- a/x/params/types/proposal/errors.go
+++ b/x/params/types/proposal/errors.go
@@ -12,4 +12,5 @@ var (
 	ErrEmptySubspace    = sdkerrors.Register(ModuleName, 5, "parameter subspace is empty")
 	ErrEmptyKey         = sdkerrors.Register(ModuleName, 6, "parameter key is empty")
 	ErrEmptyValue       = sdkerrors.Register(ModuleName, 7, "parameter value is empty")
+	ErrUnregisteredKey  = sdkerrors.Register(ModuleName, 8, "parameter key is unregistered")
 )

--- a/x/params/types/subspace.go
+++ b/x/params/types/subspace.go
@@ -184,15 +184,15 @@ func (s Subspace) Set(ctx sdk.Context, key []byte, value interface{}) {
 }
 
 // Update stores an updated raw value for a given parameter key assuming the
-// parameter type has been registered. It will panic if the parameter type has
-// not been registered or if the value cannot be encoded. An error is returned
+// parameter type has been registered. It will panic if the value cannot be
+// encoded. An error is returned if the parameter type has not been registered or
 // if the raw value is not compatible with the registered type for the parameter
 // key or if the new value is invalid as determined by the registered type's
 // validation function.
 func (s Subspace) Update(ctx sdk.Context, key, value []byte) error {
 	attr, ok := s.table.m[string(key)]
 	if !ok {
-		panic(fmt.Sprintf("parameter %s not registered", string(key)))
+		return fmt.Errorf("parameter %s not registered", string(key))
 	}
 
 	ty := attr.ty

--- a/x/params/types/subspace_test.go
+++ b/x/params/types/subspace_test.go
@@ -113,9 +113,10 @@ func (suite *SubspaceTestSuite) TestModified() {
 }
 
 func (suite *SubspaceTestSuite) TestUpdate() {
-	suite.Require().Panics(func() {
-		suite.ss.Update(suite.ctx, []byte("invalid_key"), nil) // nolint:errcheck
+	suite.Require().NotPanics(func() {
+		suite.ss.Update(suite.ctx, []byte("invalid_key"), nil)
 	})
+	suite.Require().Error(suite.ss.Update(suite.ctx, []byte("invalid_key"), nil))
 
 	t := time.Hour * 48
 	suite.Require().NotPanics(func() {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #8185 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [x] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [x] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
