### PR TITLE
codecs: rename MakeCodecs rename and docs update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,8 @@ Ref: https://keepachangelog.com/en/1.0.0/
   + added `overwriteSig` argument to `x/auth/client.SignTx` and `client/tx.Sign` functions.
   + removed `x/auth/tx.go:wrapper.GetSignatures`. The `wrapper` provides `TxBuilder` functionality, and it's a private
     structure. That function was not used at all and it's not exposed through the `TxBuilder` interface.
+* [\#8245](https://github.com/cosmos/cosmos-sdk/pull/8245) Marked deprecated `simapp.MakeCodecs` and renamed to `MakeTestCodecs`.
+
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,7 +95,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
   + added `overwriteSig` argument to `x/auth/client.SignTx` and `client/tx.Sign` functions.
   + removed `x/auth/tx.go:wrapper.GetSignatures`. The `wrapper` provides `TxBuilder` functionality, and it's a private
     structure. That function was not used at all and it's not exposed through the `TxBuilder` interface.
-* [\#8245](https://github.com/cosmos/cosmos-sdk/pull/8245) Marked deprecated `simapp.MakeCodecs` and renamed to `MakeTestCodecs`.
+* [\#8245](https://github.com/cosmos/cosmos-sdk/pull/8245) Removed `simapp.MakeCodecs` and use `simapp.MakeTestEncodingConfig` instead.
 
 
 ### Bug Fixes

--- a/codec/amino_codec_test.go
+++ b/codec/amino_codec_test.go
@@ -121,7 +121,7 @@ func TestAminoCodecUnpackAnyFails(t *testing.T) {
 func TestAminoCodecFullDecodeAndEncode(t *testing.T) {
 	// This tx comes from https://github.com/cosmos/cosmos-sdk/issues/8117.
 	txSigned := `{"type":"cosmos-sdk/StdTx","value":{"msg":[{"type":"cosmos-sdk/MsgCreateValidator","value":{"description":{"moniker":"fulltest","identity":"satoshi","website":"example.com","details":"example inc"},"commission":{"rate":"0.500000000000000000","max_rate":"1.000000000000000000","max_change_rate":"0.200000000000000000"},"min_self_delegation":"1000000","delegator_address":"cosmos14pt0q5cwf38zt08uu0n6yrstf3rndzr5057jys","validator_address":"cosmosvaloper14pt0q5cwf38zt08uu0n6yrstf3rndzr52q28gr","pubkey":{"type":"tendermint/PubKeyEd25519","value":"CYrOiM3HtS7uv1B1OAkknZnFYSRpQYSYII8AtMMtev0="},"value":{"denom":"umuon","amount":"700000000"}}}],"fee":{"amount":[{"denom":"umuon","amount":"6000"}],"gas":"160000"},"signatures":[{"pub_key":{"type":"tendermint/PubKeySecp256k1","value":"AwAOXeWgNf1FjMaayrSnrOOKz+Fivr6DiI/i0x0sZCHw"},"signature":"RcnfS/u2yl7uIShTrSUlDWvsXo2p2dYu6WJC8VDVHMBLEQZWc8bsINSCjOnlsIVkUNNe1q/WCA9n3Gy1+0zhYA=="}],"memo":"","timeout_height":"0"}}`
-	_, legacyCdc := simapp.MakeCodecs()
+	_, legacyCdc := simapp.MakeTestCodecs()
 
 	var tx legacytx.StdTx
 	err := legacyCdc.UnmarshalJSON([]byte(txSigned), &tx)

--- a/codec/amino_codec_test.go
+++ b/codec/amino_codec_test.go
@@ -121,8 +121,7 @@ func TestAminoCodecUnpackAnyFails(t *testing.T) {
 func TestAminoCodecFullDecodeAndEncode(t *testing.T) {
 	// This tx comes from https://github.com/cosmos/cosmos-sdk/issues/8117.
 	txSigned := `{"type":"cosmos-sdk/StdTx","value":{"msg":[{"type":"cosmos-sdk/MsgCreateValidator","value":{"description":{"moniker":"fulltest","identity":"satoshi","website":"example.com","details":"example inc"},"commission":{"rate":"0.500000000000000000","max_rate":"1.000000000000000000","max_change_rate":"0.200000000000000000"},"min_self_delegation":"1000000","delegator_address":"cosmos14pt0q5cwf38zt08uu0n6yrstf3rndzr5057jys","validator_address":"cosmosvaloper14pt0q5cwf38zt08uu0n6yrstf3rndzr52q28gr","pubkey":{"type":"tendermint/PubKeyEd25519","value":"CYrOiM3HtS7uv1B1OAkknZnFYSRpQYSYII8AtMMtev0="},"value":{"denom":"umuon","amount":"700000000"}}}],"fee":{"amount":[{"denom":"umuon","amount":"6000"}],"gas":"160000"},"signatures":[{"pub_key":{"type":"tendermint/PubKeySecp256k1","value":"AwAOXeWgNf1FjMaayrSnrOOKz+Fivr6DiI/i0x0sZCHw"},"signature":"RcnfS/u2yl7uIShTrSUlDWvsXo2p2dYu6WJC8VDVHMBLEQZWc8bsINSCjOnlsIVkUNNe1q/WCA9n3Gy1+0zhYA=="}],"memo":"","timeout_height":"0"}}`
-	_, legacyCdc := simapp.MakeTestCodecs()
-
+	var legacyCdc = simapp.MakeTestEncodingConfig().Amino
 	var tx legacytx.StdTx
 	err := legacyCdc.UnmarshalJSON([]byte(txSigned), &tx)
 	require.NoError(t, err)

--- a/docs/basics/app-anatomy.md
+++ b/docs/basics/app-anatomy.md
@@ -121,7 +121,7 @@ Here are descriptions of what each of the four fields means:
 - `Amino`: Some legacy parts of the SDK still use Amino for backwards-compatibility. Each module exposes a `RegisterLegacyAmino` method to register the module's specific types within Amino. This `Amino` codec should not be used by app developers anymore, and will be removed in future releases.
 
 The SDK exposes a `MakeTestEncodingConfig` function used to create a `EncodingConfig` for the app  constructor (`NewApp`). It uses Protobuf as a default `Marshaler`.
-NOTE: this function is market deprecated and should only be used to create an app or in tests. We are working on refactoring codec management in a post Stargate release.
+NOTE: this function is marked deprecated and should only be used to create an app or in tests. We are working on refactoring codec management in a post Stargate release.
 
 See an example of a `MakeTestEncodingConfig` from `simapp`:
 

--- a/docs/basics/app-anatomy.md
+++ b/docs/basics/app-anatomy.md
@@ -113,17 +113,19 @@ The `EncodingConfig` structure is the last important part of the `app.go` file. 
 
 Here are descriptions of what each of the four fields means:
 
-- `InterfaceRegistry`: The `InterfaceRegistry` is used by the Protobuf codec to handle interfaces, which are encoded and decoded (we also say "unpacked") using [`google.protobuf.Any`](https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/any.proto). `Any` could be thought as a struct which contains a `type_url` (the concrete type of the interface) and a `value` (its encoded bytes). `InterfaceRegistry` provides a mechanism for registering interfaces and implementations that can be safely unpacked from `Any`. Each of the application's modules implements the `RegisterInterfaces` method, which can be used to register the module's own interfaces and implementations.
+- `InterfaceRegistry`: The `InterfaceRegistry` is used by the Protobuf codec to handle interfaces, which are encoded and decoded (we also say "unpacked") using [`google.protobuf.Any`](https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/any.proto). `Any` could be thought as a struct which contains a `type_url` (name of a concrete type implementing the interface) and a `value` (its encoded bytes). `InterfaceRegistry` provides a mechanism for registering interfaces and implementations that can be safely unpacked from `Any`. Each of the application's modules implements the `RegisterInterfaces` method, which can be used to register the module's own interfaces and implementations.
+  - You can read more about Any in [ADR-19](https://github.com/cosmos/cosmos-sdk/blob/master/docs/architecture/adr-019-protobuf-state-encoding.md#usage-of-any-to-encode-interfaces).
   - To go more into details, the SDK uses an implementation of the Protobuf specification called [`gogoprotobuf`](https://github.com/gogo/protobuf). By default, the [gogo protobuf implementation of `Any`](https://godoc.org/github.com/gogo/protobuf/types) uses [global type registration](https://github.com/gogo/protobuf/blob/master/proto/properties.go#L540) to decode values packed in `Any` into concrete Go types. This introduces a vulnerability where any malicious module in the dependency tree could registry a type with the global protobuf registry and cause it to be loaded and unmarshaled by a transaction that referenced it in the `type_url` field. For more information, please refer to [ADR-019](../architecture/adr-019-protobuf-state-encoding.md).
-- `Marshaler`: The `Marshaler` is the default codec used throughout the SDK. It is composed of a `BinaryMarshaler` used to encode and decode state, and a `JSONMarshaler` used to output data to the users (for example in the [CLI](#cli)). By default, the SDK uses Protobuf as `Marshaler`.
+- `Marshaler`: the default codec used throughout the SDK. It is composed of a `BinaryMarshaler` used to encode and decode state, and a `JSONMarshaler` used to output data to the users (for example in the [CLI](#cli)). By default, the SDK uses Protobuf as `Marshaler`.
 - `TxConfig`: `TxConfig` defines an interface a client can utilize to generate an application-defined concrete transaction type. Currently, the SDK handles two transaction types: `SIGN_MODE_DIRECT` (which uses Protobuf binary as over-the-wire encoding) and `SIGN_MODE_LEGACY_AMINO_JSON` (which depends on Amino). Read more about transactions [here](../core/transactions.md).
 - `Amino`: Some legacy parts of the SDK still use Amino for backwards-compatibility. Each module exposes a `RegisterLegacyAmino` method to register the module's specific types within Amino. This `Amino` codec should not be used by app developers anymore, and will be removed in future releases.
 
-The SDK exposes a `MakeCodecs` function used to create a `EncodingConfig`. It uses Protobuf as default `Marshaler`, and passes it down to the app's `appCodec` field. It also instantiates a legacy `Amino` codec inside the app's `legacyAmino` field.
+The SDK exposes a `MakeTestEncodingConfig` function used to create a `EncodingConfig` for the app  constructor (`NewApp`). It uses Protobuf as a default `Marshaler`.
+NOTE: this function is market deprecated and should only be used to create an app or in tests. We are working on refactoring codec management in a post Stargate release.
 
-See an example of a `MakeCodecs` from `simapp`:
+See an example of a `MakeTestEncodingConfig` from `simapp`:
 
-+++ https://github.com/cosmos/cosmos-sdk/blob/v0.40.0-rc3/simapp/app.go#L429-L435
++++ https://github.com/cosmos/cosmos-sdk/blob/v0.40.0-rc3/simapp/simd/cmd/root.go#L179-196
 
 ## Modules
 

--- a/simapp/app.go
+++ b/simapp/app.go
@@ -203,7 +203,6 @@ func NewSimApp(
 	appOpts servertypes.AppOptions, baseAppOptions ...func(*baseapp.BaseApp),
 ) *SimApp {
 
-	// TODO: Remove cdc in favor of appCodec once all modules are migrated.
 	appCodec := encodingConfig.Marshaler
 	legacyAmino := encodingConfig.Amino
 	interfaceRegistry := encodingConfig.InterfaceRegistry
@@ -439,14 +438,6 @@ func NewSimApp(
 	app.ScopedIBCMockKeeper = scopedIBCMockKeeper
 
 	return app
-}
-
-// MakeCodecs constructs the *std.Codec and *codec.LegacyAmino instances used by
-// simapp. It is useful for tests and clients who do not want to construct the
-// full simapp
-func MakeCodecs() (codec.Marshaler, *codec.LegacyAmino) {
-	config := MakeTestEncodingConfig()
-	return config.Marshaler, config.Amino
 }
 
 // Name returns the name of the App

--- a/simapp/encoding.go
+++ b/simapp/encoding.go
@@ -1,13 +1,14 @@
 package simapp
 
 import (
+	"github.com/cosmos/cosmos-sdk/codec"
 	simappparams "github.com/cosmos/cosmos-sdk/simapp/params"
 	"github.com/cosmos/cosmos-sdk/std"
 )
 
 // MakeTestEncodingConfig creates an EncodingConfig for testing.
 // This function should be used only internally (in the SDK).
-// App user should'nt create new codecs - use the app.AppCodec instead.
+// App user shouldn't create new codecs - use the app.AppCodec instead.
 // [DEPRECATED]
 func MakeTestEncodingConfig() simappparams.EncodingConfig {
 	encodingConfig := simappparams.MakeTestEncodingConfig()
@@ -16,4 +17,13 @@ func MakeTestEncodingConfig() simappparams.EncodingConfig {
 	ModuleBasics.RegisterLegacyAminoCodec(encodingConfig.Amino)
 	ModuleBasics.RegisterInterfaces(encodingConfig.InterfaceRegistry)
 	return encodingConfig
+}
+
+// MakeTestCodecs is a helper function which uses MakeTestEncodingConfig to
+// construct new *std.Codec and *codec.LegacyAmino instances.
+// It must not be used in non test files, instead app.AppCodec should be used.
+// [DEPRECATED]
+func MakeTestCodecs() (codec.Marshaler, *codec.LegacyAmino) {
+	config := MakeTestEncodingConfig()
+	return config.Marshaler, config.Amino
 }

--- a/simapp/encoding.go
+++ b/simapp/encoding.go
@@ -1,13 +1,12 @@
 package simapp
 
 import (
-	"github.com/cosmos/cosmos-sdk/codec"
 	simappparams "github.com/cosmos/cosmos-sdk/simapp/params"
 	"github.com/cosmos/cosmos-sdk/std"
 )
 
-// MakeTestEncodingConfig creates an EncodingConfig for testing.
-// This function should be used only internally (in the SDK).
+// MakeTestEncodingConfig creates an EncodingConfig for testing. This function
+// should be used only in tests or when creating a new app instance (NewApp*()).
 // App user shouldn't create new codecs - use the app.AppCodec instead.
 // [DEPRECATED]
 func MakeTestEncodingConfig() simappparams.EncodingConfig {
@@ -17,13 +16,4 @@ func MakeTestEncodingConfig() simappparams.EncodingConfig {
 	ModuleBasics.RegisterLegacyAminoCodec(encodingConfig.Amino)
 	ModuleBasics.RegisterInterfaces(encodingConfig.InterfaceRegistry)
 	return encodingConfig
-}
-
-// MakeTestCodecs is a helper function which uses MakeTestEncodingConfig to
-// construct new *std.Codec and *codec.LegacyAmino instances.
-// It must not be used in non test files, instead app.AppCodec should be used.
-// [DEPRECATED]
-func MakeTestCodecs() (codec.Marshaler, *codec.LegacyAmino) {
-	config := MakeTestEncodingConfig()
-	return config.Marshaler, config.Amino
 }

--- a/simapp/simd/cmd/genaccounts_test.go
+++ b/simapp/simd/cmd/genaccounts_test.go
@@ -58,7 +58,7 @@ func TestAddGenesisAccountCmd(t *testing.T) {
 			cfg, err := genutiltest.CreateDefaultTendermintConfig(home)
 			require.NoError(t, err)
 
-			appCodec, _ := simapp.MakeCodecs()
+			appCodec, _ := simapp.MakeTestCodecs()
 			err = genutiltest.ExecInitCmd(testMbm, home, appCodec)
 			require.NoError(t, err)
 

--- a/simapp/simd/cmd/genaccounts_test.go
+++ b/simapp/simd/cmd/genaccounts_test.go
@@ -58,7 +58,7 @@ func TestAddGenesisAccountCmd(t *testing.T) {
 			cfg, err := genutiltest.CreateDefaultTendermintConfig(home)
 			require.NoError(t, err)
 
-			appCodec, _ := simapp.MakeTestCodecs()
+			appCodec := simapp.MakeTestEncodingConfig().Marshaler
 			err = genutiltest.ExecInitCmd(testMbm, home, appCodec)
 			require.NoError(t, err)
 

--- a/simapp/simd/cmd/root.go
+++ b/simapp/simd/cmd/root.go
@@ -180,7 +180,7 @@ func newApp(logger log.Logger, db dbm.DB, traceStore io.Writer, appOpts serverty
 		logger, db, traceStore, true, skipUpgradeHeights,
 		cast.ToString(appOpts.Get(flags.FlagHome)),
 		cast.ToUint(appOpts.Get(server.FlagInvCheckPeriod)),
-		simapp.MakeTestEncodingConfig(), // Ideally, we would reuse the one created by NewRootCmd.
+		simapp.MakeTestEncodingConfig(), // TODO: reuse the one created by NewRootCmd.
 		appOpts,
 		baseapp.SetPruning(pruningOpts),
 		baseapp.SetMinGasPrices(cast.ToString(appOpts.Get(server.FlagMinGasPrices))),

--- a/x/auth/ante/sigverify_test.go
+++ b/x/auth/ante/sigverify_test.go
@@ -67,7 +67,7 @@ func (suite *AnteTestSuite) TestSetPubKey() {
 func (suite *AnteTestSuite) TestConsumeSignatureVerificationGas() {
 	params := types.DefaultParams()
 	msg := []byte{1, 2, 3, 4}
-	_, cdc := simapp.MakeCodecs()
+	_, cdc := simapp.MakeTestCodecs()
 
 	pkSet1, sigSet1 := generatePubKeysAndSignatures(5, msg, false)
 	multisigKey1 := kmultisig.NewLegacyAminoPubKey(2, pkSet1)

--- a/x/auth/ante/sigverify_test.go
+++ b/x/auth/ante/sigverify_test.go
@@ -67,7 +67,7 @@ func (suite *AnteTestSuite) TestSetPubKey() {
 func (suite *AnteTestSuite) TestConsumeSignatureVerificationGas() {
 	params := types.DefaultParams()
 	msg := []byte{1, 2, 3, 4}
-	_, cdc := simapp.MakeTestCodecs()
+	cdc := simapp.MakeTestEncodingConfig().Amino
 
 	pkSet1, sigSet1 := generatePubKeysAndSignatures(5, msg, false)
 	multisigKey1 := kmultisig.NewLegacyAminoPubKey(2, pkSet1)

--- a/x/auth/keeper/keeper_test.go
+++ b/x/auth/keeper/keeper_test.go
@@ -129,7 +129,7 @@ func TestSupply_ValidatePermissions(t *testing.T) {
 	maccPerms[multiPerm] = []string{types.Burner, types.Minter, types.Staking}
 	maccPerms[randomPerm] = []string{"random"}
 
-	cdc, _ := simapp.MakeCodecs()
+	cdc, _ := simapp.MakeTestCodecs()
 	keeper := keeper.NewAccountKeeper(
 		cdc, app.GetKey(types.StoreKey), app.GetSubspace(types.ModuleName),
 		types.ProtoBaseAccount, maccPerms,

--- a/x/auth/keeper/keeper_test.go
+++ b/x/auth/keeper/keeper_test.go
@@ -129,7 +129,7 @@ func TestSupply_ValidatePermissions(t *testing.T) {
 	maccPerms[multiPerm] = []string{types.Burner, types.Minter, types.Staking}
 	maccPerms[randomPerm] = []string{"random"}
 
-	cdc, _ := simapp.MakeTestCodecs()
+	cdc := simapp.MakeTestEncodingConfig().Marshaler
 	keeper := keeper.NewAccountKeeper(
 		cdc, app.GetKey(types.StoreKey), app.GetSubspace(types.ModuleName),
 		types.ProtoBaseAccount, maccPerms,

--- a/x/auth/simulation/decoder_test.go
+++ b/x/auth/simulation/decoder_test.go
@@ -22,7 +22,7 @@ var (
 
 func TestDecodeStore(t *testing.T) {
 	app := simapp.Setup(false)
-	cdc, _ := simapp.MakeTestCodecs()
+	cdc := simapp.MakeTestEncodingConfig().Marshaler
 	acc := types.NewBaseAccountWithAddress(delAddr1)
 	dec := simulation.NewDecodeStore(app.AccountKeeper)
 

--- a/x/auth/simulation/decoder_test.go
+++ b/x/auth/simulation/decoder_test.go
@@ -22,7 +22,7 @@ var (
 
 func TestDecodeStore(t *testing.T) {
 	app := simapp.Setup(false)
-	cdc, _ := simapp.MakeCodecs()
+	cdc, _ := simapp.MakeTestCodecs()
 	acc := types.NewBaseAccountWithAddress(delAddr1)
 	dec := simulation.NewDecodeStore(app.AccountKeeper)
 

--- a/x/auth/types/common_test.go
+++ b/x/auth/types/common_test.go
@@ -6,5 +6,6 @@ import (
 
 var (
 	app                   = simapp.Setup(false)
-	appCodec, legacyAmino = simapp.MakeTestCodecs()
+	ecdc                  = simapp.MakeTestEncodingConfig()
+	appCodec, legacyAmino = ecdc.Marshaler, ecdc.Amino
 )

--- a/x/auth/types/common_test.go
+++ b/x/auth/types/common_test.go
@@ -6,5 +6,5 @@ import (
 
 var (
 	app                   = simapp.Setup(false)
-	appCodec, legacyAmino = simapp.MakeCodecs()
+	appCodec, legacyAmino = simapp.MakeTestCodecs()
 )

--- a/x/auth/vesting/types/common_test.go
+++ b/x/auth/vesting/types/common_test.go
@@ -5,6 +5,6 @@ import (
 )
 
 var (
-	app         = simapp.Setup(false)
-	appCodec, _ = simapp.MakeTestCodecs()
+	app      = simapp.Setup(false)
+	appCodec = simapp.MakeTestEncodingConfig().Marshaler
 )

--- a/x/auth/vesting/types/common_test.go
+++ b/x/auth/vesting/types/common_test.go
@@ -6,5 +6,5 @@ import (
 
 var (
 	app         = simapp.Setup(false)
-	appCodec, _ = simapp.MakeCodecs()
+	appCodec, _ = simapp.MakeTestCodecs()
 )

--- a/x/bank/keeper/keeper_test.go
+++ b/x/bank/keeper/keeper_test.go
@@ -215,7 +215,7 @@ func (suite *IntegrationTestSuite) TestSupply_MintCoins() {
 func (suite *IntegrationTestSuite) TestSupply_BurnCoins() {
 	app := simapp.Setup(false)
 	ctx := app.BaseApp.NewContext(false, tmproto.Header{Height: 1})
-	appCodec, _ := simapp.MakeCodecs()
+	appCodec, _ := simapp.MakeTestCodecs()
 
 	// add module accounts to supply keeper
 	maccPerms := simapp.GetMaccPerms()

--- a/x/bank/keeper/keeper_test.go
+++ b/x/bank/keeper/keeper_test.go
@@ -215,7 +215,7 @@ func (suite *IntegrationTestSuite) TestSupply_MintCoins() {
 func (suite *IntegrationTestSuite) TestSupply_BurnCoins() {
 	app := simapp.Setup(false)
 	ctx := app.BaseApp.NewContext(false, tmproto.Header{Height: 1})
-	appCodec, _ := simapp.MakeTestCodecs()
+	appCodec := simapp.MakeTestEncodingConfig().Marshaler
 
 	// add module accounts to supply keeper
 	maccPerms := simapp.GetMaccPerms()

--- a/x/capability/simulation/decoder_test.go
+++ b/x/capability/simulation/decoder_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestDecodeStore(t *testing.T) {
-	cdc, _ := simapp.MakeCodecs()
+	cdc, _ := simapp.MakeTestCodecs()
 	dec := simulation.NewDecodeStore(cdc)
 
 	capOwners := types.CapabilityOwners{

--- a/x/capability/simulation/decoder_test.go
+++ b/x/capability/simulation/decoder_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestDecodeStore(t *testing.T) {
-	cdc, _ := simapp.MakeTestCodecs()
+	cdc := simapp.MakeTestEncodingConfig().Marshaler
 	dec := simulation.NewDecodeStore(cdc)
 
 	capOwners := types.CapabilityOwners{

--- a/x/distribution/simulation/decoder_test.go
+++ b/x/distribution/simulation/decoder_test.go
@@ -22,7 +22,7 @@ var (
 )
 
 func TestDecodeDistributionStore(t *testing.T) {
-	cdc, _ := simapp.MakeCodecs()
+	cdc, _ := simapp.MakeTestCodecs()
 	dec := simulation.NewDecodeStore(cdc)
 
 	decCoins := sdk.DecCoins{sdk.NewDecCoinFromDec(sdk.DefaultBondDenom, sdk.OneDec())}

--- a/x/distribution/simulation/decoder_test.go
+++ b/x/distribution/simulation/decoder_test.go
@@ -22,7 +22,7 @@ var (
 )
 
 func TestDecodeDistributionStore(t *testing.T) {
-	cdc, _ := simapp.MakeTestCodecs()
+	cdc := simapp.MakeTestEncodingConfig().Marshaler
 	dec := simulation.NewDecodeStore(cdc)
 
 	decCoins := sdk.DecCoins{sdk.NewDecCoinFromDec(sdk.DefaultBondDenom, sdk.OneDec())}

--- a/x/evidence/keeper/querier_test.go
+++ b/x/evidence/keeper/querier_test.go
@@ -18,12 +18,12 @@ const (
 func (suite *KeeperTestSuite) TestQuerier_QueryEvidence_Existing() {
 	ctx := suite.ctx.WithIsCheckTx(false)
 	numEvidence := 100
-	_, cdc := simapp.MakeTestCodecs()
+	legacyCdc := simapp.MakeTestEncodingConfig().Amino
 
 	evidence := suite.populateEvidence(ctx, numEvidence)
 	query := abci.RequestQuery{
 		Path: strings.Join([]string{custom, types.QuerierRoute, types.QueryEvidence}, "/"),
-		Data: cdc.MustMarshalJSON(types.NewQueryEvidenceRequest(evidence[0].Hash())),
+		Data: legacyCdc.MustMarshalJSON(types.NewQueryEvidenceRequest(evidence[0].Hash())),
 	}
 
 	bz, err := suite.querier(ctx, []string{types.QueryEvidence}, query)
@@ -31,13 +31,13 @@ func (suite *KeeperTestSuite) TestQuerier_QueryEvidence_Existing() {
 	suite.NotNil(bz)
 
 	var e exported.Evidence
-	suite.Nil(cdc.UnmarshalJSON(bz, &e))
+	suite.Nil(legacyCdc.UnmarshalJSON(bz, &e))
 	suite.Equal(evidence[0], e)
 }
 
 func (suite *KeeperTestSuite) TestQuerier_QueryEvidence_NonExisting() {
 	ctx := suite.ctx.WithIsCheckTx(false)
-	cdc, _ := simapp.MakeTestCodecs()
+	cdc := simapp.MakeTestEncodingConfig().Marshaler
 	numEvidence := 100
 
 	suite.populateEvidence(ctx, numEvidence)
@@ -53,7 +53,7 @@ func (suite *KeeperTestSuite) TestQuerier_QueryEvidence_NonExisting() {
 
 func (suite *KeeperTestSuite) TestQuerier_QueryAllEvidence() {
 	ctx := suite.ctx.WithIsCheckTx(false)
-	_, cdc := simapp.MakeTestCodecs()
+	cdc := simapp.MakeTestEncodingConfig().Amino
 	numEvidence := 100
 
 	suite.populateEvidence(ctx, numEvidence)
@@ -73,7 +73,7 @@ func (suite *KeeperTestSuite) TestQuerier_QueryAllEvidence() {
 
 func (suite *KeeperTestSuite) TestQuerier_QueryAllEvidence_InvalidPagination() {
 	ctx := suite.ctx.WithIsCheckTx(false)
-	_, cdc := simapp.MakeTestCodecs()
+	cdc := simapp.MakeTestEncodingConfig().Amino
 	numEvidence := 100
 
 	suite.populateEvidence(ctx, numEvidence)

--- a/x/evidence/keeper/querier_test.go
+++ b/x/evidence/keeper/querier_test.go
@@ -18,7 +18,7 @@ const (
 func (suite *KeeperTestSuite) TestQuerier_QueryEvidence_Existing() {
 	ctx := suite.ctx.WithIsCheckTx(false)
 	numEvidence := 100
-	_, cdc := simapp.MakeCodecs()
+	_, cdc := simapp.MakeTestCodecs()
 
 	evidence := suite.populateEvidence(ctx, numEvidence)
 	query := abci.RequestQuery{
@@ -37,7 +37,7 @@ func (suite *KeeperTestSuite) TestQuerier_QueryEvidence_Existing() {
 
 func (suite *KeeperTestSuite) TestQuerier_QueryEvidence_NonExisting() {
 	ctx := suite.ctx.WithIsCheckTx(false)
-	cdc, _ := simapp.MakeCodecs()
+	cdc, _ := simapp.MakeTestCodecs()
 	numEvidence := 100
 
 	suite.populateEvidence(ctx, numEvidence)
@@ -53,7 +53,7 @@ func (suite *KeeperTestSuite) TestQuerier_QueryEvidence_NonExisting() {
 
 func (suite *KeeperTestSuite) TestQuerier_QueryAllEvidence() {
 	ctx := suite.ctx.WithIsCheckTx(false)
-	_, cdc := simapp.MakeCodecs()
+	_, cdc := simapp.MakeTestCodecs()
 	numEvidence := 100
 
 	suite.populateEvidence(ctx, numEvidence)
@@ -73,7 +73,7 @@ func (suite *KeeperTestSuite) TestQuerier_QueryAllEvidence() {
 
 func (suite *KeeperTestSuite) TestQuerier_QueryAllEvidence_InvalidPagination() {
 	ctx := suite.ctx.WithIsCheckTx(false)
-	_, cdc := simapp.MakeCodecs()
+	_, cdc := simapp.MakeTestCodecs()
 	numEvidence := 100
 
 	suite.populateEvidence(ctx, numEvidence)

--- a/x/gov/keeper/common_test.go
+++ b/x/gov/keeper/common_test.go
@@ -22,7 +22,7 @@ func createValidators(t *testing.T, ctx sdk.Context, app *simapp.SimApp, powers 
 	valAddrs := simapp.ConvertAddrsToValAddrs(addrs)
 	pks := simapp.CreateTestPubKeys(5)
 
-	appCodec, _ := simapp.MakeCodecs()
+	appCodec, _ := simapp.MakeTestCodecs()
 	app.StakingKeeper = stakingkeeper.NewKeeper(
 		appCodec,
 		app.GetKey(stakingtypes.StoreKey),

--- a/x/gov/keeper/common_test.go
+++ b/x/gov/keeper/common_test.go
@@ -21,10 +21,10 @@ func createValidators(t *testing.T, ctx sdk.Context, app *simapp.SimApp, powers 
 	addrs := simapp.AddTestAddrsIncremental(app, ctx, 5, sdk.NewInt(30000000))
 	valAddrs := simapp.ConvertAddrsToValAddrs(addrs)
 	pks := simapp.CreateTestPubKeys(5)
+	cdc := simapp.MakeTestEncodingConfig().Marshaler
 
-	appCodec, _ := simapp.MakeTestCodecs()
 	app.StakingKeeper = stakingkeeper.NewKeeper(
-		appCodec,
+		cdc,
 		app.GetKey(stakingtypes.StoreKey),
 		app.AccountKeeper,
 		app.BankKeeper,

--- a/x/gov/simulation/decoder_test.go
+++ b/x/gov/simulation/decoder_test.go
@@ -22,11 +22,10 @@ var (
 )
 
 func TestDecodeStore(t *testing.T) {
-	cdc, _ := simapp.MakeTestCodecs()
+	cdc := simapp.MakeTestEncodingConfig().Marshaler
 	dec := simulation.NewDecodeStore(cdc)
 
 	endTime := time.Now().UTC()
-
 	content := types.ContentFromProposalType("test", "test", types.ProposalTypeText)
 	proposal, err := types.NewProposal(content, 1, endTime, endTime.Add(24*time.Hour))
 	require.NoError(t, err)

--- a/x/gov/simulation/decoder_test.go
+++ b/x/gov/simulation/decoder_test.go
@@ -22,7 +22,7 @@ var (
 )
 
 func TestDecodeStore(t *testing.T) {
-	cdc, _ := simapp.MakeCodecs()
+	cdc, _ := simapp.MakeTestCodecs()
 	dec := simulation.NewDecodeStore(cdc)
 
 	endTime := time.Now().UTC()

--- a/x/mint/simulation/decoder_test.go
+++ b/x/mint/simulation/decoder_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestDecodeStore(t *testing.T) {
-	cdc, _ := simapp.MakeCodecs()
+	cdc, _ := simapp.MakeTestCodecs()
 	dec := simulation.NewDecodeStore(cdc)
 
 	minter := types.NewMinter(sdk.OneDec(), sdk.NewDec(15))

--- a/x/mint/simulation/decoder_test.go
+++ b/x/mint/simulation/decoder_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestDecodeStore(t *testing.T) {
-	cdc, _ := simapp.MakeTestCodecs()
+	cdc := simapp.MakeTestEncodingConfig().Marshaler
 	dec := simulation.NewDecodeStore(cdc)
 
 	minter := types.NewMinter(sdk.OneDec(), sdk.NewDec(15))

--- a/x/slashing/simulation/decoder_test.go
+++ b/x/slashing/simulation/decoder_test.go
@@ -25,7 +25,7 @@ var (
 )
 
 func TestDecodeStore(t *testing.T) {
-	cdc, _ := simapp.MakeCodecs()
+	cdc, _ := simapp.MakeTestCodecs()
 	dec := simulation.NewDecodeStore(cdc)
 
 	info := types.NewValidatorSigningInfo(consAddr1, 0, 1, time.Now().UTC(), false, 0)

--- a/x/slashing/simulation/decoder_test.go
+++ b/x/slashing/simulation/decoder_test.go
@@ -25,7 +25,7 @@ var (
 )
 
 func TestDecodeStore(t *testing.T) {
-	cdc, _ := simapp.MakeTestCodecs()
+	cdc := simapp.MakeTestEncodingConfig().Marshaler
 	dec := simulation.NewDecodeStore(cdc)
 
 	info := types.NewValidatorSigningInfo(consAddr1, 0, 1, time.Now().UTC(), false, 0)

--- a/x/staking/keeper/grpc_query_test.go
+++ b/x/staking/keeper/grpc_query_test.go
@@ -732,10 +732,9 @@ func createValidators(t *testing.T, ctx sdk.Context, app *simapp.SimApp, powers 
 	addrs := simapp.AddTestAddrsIncremental(app, ctx, 5, sdk.TokensFromConsensusPower(300))
 	valAddrs := simapp.ConvertAddrsToValAddrs(addrs)
 	pks := simapp.CreateTestPubKeys(5)
-
-	appCodec, _ := simapp.MakeTestCodecs()
+	cdc := simapp.MakeTestEncodingConfig().Marshaler
 	app.StakingKeeper = keeper.NewKeeper(
-		appCodec,
+		cdc,
 		app.GetKey(types.StoreKey),
 		app.AccountKeeper,
 		app.BankKeeper,

--- a/x/staking/keeper/grpc_query_test.go
+++ b/x/staking/keeper/grpc_query_test.go
@@ -733,7 +733,7 @@ func createValidators(t *testing.T, ctx sdk.Context, app *simapp.SimApp, powers 
 	valAddrs := simapp.ConvertAddrsToValAddrs(addrs)
 	pks := simapp.CreateTestPubKeys(5)
 
-	appCodec, _ := simapp.MakeCodecs()
+	appCodec, _ := simapp.MakeTestCodecs()
 	app.StakingKeeper = keeper.NewKeeper(
 		appCodec,
 		app.GetKey(types.StoreKey),

--- a/x/staking/simulation/decoder_test.go
+++ b/x/staking/simulation/decoder_test.go
@@ -32,7 +32,7 @@ func makeTestCodec() (cdc *codec.LegacyAmino) {
 }
 
 func TestDecodeStore(t *testing.T) {
-	cdc, _ := simapp.MakeCodecs()
+	cdc, _ := simapp.MakeTestCodecs()
 	dec := simulation.NewDecodeStore(cdc)
 
 	bondTime := time.Now().UTC()

--- a/x/staking/simulation/decoder_test.go
+++ b/x/staking/simulation/decoder_test.go
@@ -32,9 +32,8 @@ func makeTestCodec() (cdc *codec.LegacyAmino) {
 }
 
 func TestDecodeStore(t *testing.T) {
-	cdc, _ := simapp.MakeTestCodecs()
+	cdc := simapp.MakeTestEncodingConfig().Marshaler
 	dec := simulation.NewDecodeStore(cdc)
-
 	bondTime := time.Now().UTC()
 
 	val, err := types.NewValidator(valAddr1, delPk1, types.NewDescription("test", "test", "test", "test", "test"))


### PR DESCRIPTION
## Description

in https://github.com/cosmos/cosmos-sdk/commit/9bd42ace6b we renamed and market deprecated the `simapp.MakeEncodingConfig` function. We forgot about `MakeCodecs`, which is used only in tests. Also the SDK documentation with regards to `MakeCodecs` was outdated. 

Related to: https://github.com/cosmos/cosmos-sdk/issues/7642

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [x] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [x] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Review `Codecov Report` in the comment section below once CI passes
