### PR TITLE
all: ensure b.ReportAllocs() in all the benchmarks

### DIFF
--- a/crypto/armor_test.go
+++ b/crypto/armor_test.go
@@ -158,6 +158,8 @@ func TestUnarmorInfoBytesErrors(t *testing.T) {
 }
 
 func BenchmarkBcryptGenerateFromPassword(b *testing.B) {
+	b.ReportAllocs()
+
 	passphrase := []byte("passphrase")
 	for securityParam := 9; securityParam < 16; securityParam++ {
 		param := securityParam

--- a/crypto/keys/internal/benchmarking/bench.go
+++ b/crypto/keys/internal/benchmarking/bench.go
@@ -25,6 +25,7 @@ func (zeroReader) Read(buf []byte) (int, error) {
 // BenchmarkKeyGeneration benchmarks the given key generation algorithm using
 // a dummy reader.
 func BenchmarkKeyGeneration(b *testing.B, generateKey func(reader io.Reader) types.PrivKey) {
+	b.ReportAllocs()
 	var zero zeroReader
 	for i := 0; i < b.N; i++ {
 		generateKey(zero)

--- a/crypto/keys/secp256k1/bench_test.go
+++ b/crypto/keys/secp256k1/bench_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func BenchmarkKeyGeneration(b *testing.B) {
+	b.ReportAllocs()
 	benchmarkKeygenWrapper := func(reader io.Reader) types.PrivKey {
 		priv := genPrivKey(reader)
 		return &PrivKey{Key: priv}
@@ -17,11 +18,13 @@ func BenchmarkKeyGeneration(b *testing.B) {
 }
 
 func BenchmarkSigning(b *testing.B) {
+	b.ReportAllocs()
 	priv := GenPrivKey()
 	benchmarking.BenchmarkSigning(b, priv)
 }
 
 func BenchmarkVerification(b *testing.B) {
+	b.ReportAllocs()
 	priv := GenPrivKey()
 	benchmarking.BenchmarkVerification(b, priv)
 }

--- a/simapp/sim_bench_test.go
+++ b/simapp/sim_bench_test.go
@@ -14,6 +14,7 @@ import (
 // Profile with:
 // /usr/local/go/bin/go test -benchmem -run=^$ github.com/cosmos/cosmos-sdk/simapp -bench ^BenchmarkFullAppSimulation$ -Commit=true -cpuprofile cpu.out
 func BenchmarkFullAppSimulation(b *testing.B) {
+	b.ReportAllocs()
 	config, db, dir, logger, _, err := SetupSimulation("goleveldb-app-sim", "Simulation")
 	if err != nil {
 		b.Fatalf("simulation setup failed: %s", err.Error())
@@ -57,6 +58,7 @@ func BenchmarkFullAppSimulation(b *testing.B) {
 }
 
 func BenchmarkInvariants(b *testing.B) {
+	b.ReportAllocs()
 	config, db, dir, logger, _, err := SetupSimulation("leveldb-app-invariant-bench", "Simulation")
 	if err != nil {
 		b.Fatalf("simulation setup failed: %s", err.Error())

--- a/store/cache/benchmark_test.go
+++ b/store/cache/benchmark_test.go
@@ -22,6 +22,7 @@ func populate(mgr *CommitKVStoreCacheManager) {
 }
 
 func BenchmarkReset(b *testing.B) {
+	b.ReportAllocs()
 	mgr := freshMgr()
 
 	b.ResetTimer()

--- a/store/cachekv/store_bench_test.go
+++ b/store/cachekv/store_bench_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func benchmarkCacheKVStoreIterator(numKVs int, b *testing.B) {
+	b.ReportAllocs()
 	mem := dbadapter.Store{DB: dbm.NewMemDB()}
 	cstore := cachekv.NewStore(mem)
 	keys := make([]string, numKVs)

--- a/store/cachekv/store_test.go
+++ b/store/cachekv/store_test.go
@@ -516,6 +516,7 @@ func (krc *keyRangeCounter) key() int {
 func bz(s string) []byte { return []byte(s) }
 
 func BenchmarkCacheKVStoreGetNoKeyFound(b *testing.B) {
+	b.ReportAllocs()
 	st := newCacheKVStore()
 	b.ResetTimer()
 	// assumes b.N < 2**24
@@ -525,6 +526,7 @@ func BenchmarkCacheKVStoreGetNoKeyFound(b *testing.B) {
 }
 
 func BenchmarkCacheKVStoreGetKeyFound(b *testing.B) {
+	b.ReportAllocs()
 	st := newCacheKVStore()
 	for i := 0; i < b.N; i++ {
 		arr := []byte{byte((i & 0xFF0000) >> 16), byte((i & 0xFF00) >> 8), byte(i & 0xFF)}

--- a/store/iavl/store_test.go
+++ b/store/iavl/store_test.go
@@ -556,6 +556,7 @@ func TestIAVLStoreQuery(t *testing.T) {
 }
 
 func BenchmarkIAVLIteratorNext(b *testing.B) {
+	b.ReportAllocs()
 	db := dbm.NewMemDB()
 	treeSize := 1000
 	tree, err := iavl.NewMutableTree(db, cacheSize)

--- a/store/rootmulti/store_test.go
+++ b/store/rootmulti/store_test.go
@@ -689,6 +689,7 @@ func BenchmarkMultistoreSnapshotRestore1M(b *testing.B) {
 }
 
 func benchmarkMultistoreSnapshot(b *testing.B, stores uint8, storeKeys uint64) {
+	b.ReportAllocs()
 	b.StopTimer()
 	source := newMultiStoreWithGeneratedData(dbm.NewMemDB(), stores, storeKeys)
 	version := source.LastCommitID().Version
@@ -716,6 +717,7 @@ func benchmarkMultistoreSnapshot(b *testing.B, stores uint8, storeKeys uint64) {
 }
 
 func benchmarkMultistoreSnapshotRestore(b *testing.B, stores uint8, storeKeys uint64) {
+	b.ReportAllocs()
 	b.StopTimer()
 	source := newMultiStoreWithGeneratedData(dbm.NewMemDB(), stores, storeKeys)
 	version := uint64(source.LastCommitID().Version)

--- a/types/address_bench_test.go
+++ b/types/address_bench_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func BenchmarkBech32ifyPubKey(b *testing.B) {
+	b.ReportAllocs()
 	pkBz := make([]byte, ed25519.PubKeySize)
 	pk := &ed25519.PubKey{Key: pkBz}
 	rng := rand.New(rand.NewSource(time.Now().Unix()))
@@ -29,6 +30,7 @@ func BenchmarkBech32ifyPubKey(b *testing.B) {
 }
 
 func BenchmarkGetPubKeyFromBech32(b *testing.B) {
+	b.ReportAllocs()
 	pkBz := make([]byte, ed25519.PubKeySize)
 	pk := &ed25519.PubKey{Key: pkBz}
 	rng := rand.New(rand.NewSource(time.Now().Unix()))

--- a/types/coin_benchmark_test.go
+++ b/types/coin_benchmark_test.go
@@ -10,6 +10,7 @@ func coinName(suffix int) string {
 }
 
 func BenchmarkCoinsAdditionIntersect(b *testing.B) {
+	b.ReportAllocs()
 	benchmarkingFunc := func(numCoinsA int, numCoinsB int) func(b *testing.B) {
 		return func(b *testing.B) {
 			coinsA := Coins(make([]Coin, numCoinsA))
@@ -39,6 +40,7 @@ func BenchmarkCoinsAdditionIntersect(b *testing.B) {
 }
 
 func BenchmarkCoinsAdditionNoIntersect(b *testing.B) {
+	b.ReportAllocs()
 	benchmarkingFunc := func(numCoinsA int, numCoinsB int) func(b *testing.B) {
 		return func(b *testing.B) {
 			coinsA := Coins(make([]Coin, numCoinsA))

--- a/types/decimal_test.go
+++ b/types/decimal_test.go
@@ -487,6 +487,7 @@ func (s *decimalTestSuite) TestOperationOrders() {
 }
 
 func BenchmarkMarshalTo(b *testing.B) {
+	b.ReportAllocs()
 	bis := []struct {
 		in   sdk.Dec
 		want []byte

--- a/x/auth/keeper/keeper_bench_test.go
+++ b/x/auth/keeper/keeper_bench_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func BenchmarkAccountMapperGetAccountFound(b *testing.B) {
+	b.ReportAllocs()
 	app, ctx := createTestApp(false)
 
 	// assumes b.N < 2**24

--- a/x/bank/bench_test.go
+++ b/x/bank/bench_test.go
@@ -18,6 +18,7 @@ import (
 var moduleAccAddr = authtypes.NewModuleAddress(stakingtypes.BondedPoolName)
 
 func BenchmarkOneBankSendTxPerBlock(b *testing.B) {
+	b.ReportAllocs()
 	// Add an account at genesis
 	acc := authtypes.BaseAccount{
 		Address: addr1.String(),

--- a/x/mint/types/minter_test.go
+++ b/x/mint/types/minter_test.go
@@ -89,6 +89,7 @@ func TestBlockProvision(t *testing.T) {
 // using sdk.Dec operations: (current implementation)
 // BenchmarkBlockProvision-4 3000000 429 ns/op
 func BenchmarkBlockProvision(b *testing.B) {
+	b.ReportAllocs()
 	minter := InitialMinter(sdk.NewDecWithPrec(1, 1))
 	params := DefaultParams()
 
@@ -105,6 +106,7 @@ func BenchmarkBlockProvision(b *testing.B) {
 // Next inflation benchmarking
 // BenchmarkNextInflation-4 1000000 1828 ns/op
 func BenchmarkNextInflation(b *testing.B) {
+	b.ReportAllocs()
 	minter := InitialMinter(sdk.NewDecWithPrec(1, 1))
 	params := DefaultParams()
 	bondedRatio := sdk.NewDecWithPrec(1, 1)
@@ -119,6 +121,7 @@ func BenchmarkNextInflation(b *testing.B) {
 // Next annual provisions benchmarking
 // BenchmarkNextAnnualProvisions-4 5000000 251 ns/op
 func BenchmarkNextAnnualProvisions(b *testing.B) {
+	b.ReportAllocs()
 	minter := InitialMinter(sdk.NewDecWithPrec(1, 1))
 	params := DefaultParams()
 	totalSupply := sdk.NewInt(100000000000000)


### PR DESCRIPTION
With this change, we'll get details on the number of
allocations performed by code. Later on when we have
continuous benchmarking infrastructure, this change
will prove useful to flag regressions.

Fixes #8459


---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
