### PR TITLE
cosmovisor: move binary to UpgradeBin from directory (fix #8494)

### DIFF
--- a/cosmovisor/upgrade.go
+++ b/cosmovisor/upgrade.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/go-getter"
+	"github.com/otiai10/copy"
 )
 
 // DoUpgrade will be called after the log message has been parsed and the process has terminated.
@@ -62,10 +63,19 @@ func DownloadBinary(cfg *Config, info *UpgradeInfo) error {
 	if err != nil {
 		dirPath := cfg.UpgradeDir(info.Name)
 		err = getter.Get(dirPath, url)
+		if err != nil {
+			return err
+		}
+		err = EnsureBinary(binPath)
+		// copy binary to binPath from dirPath if zipped directory don't contain bin directory to wrap the binary
+		if err != nil {
+			err = copy.Copy(filepath.Join(dirPath, cfg.Name), binPath)
+			if err != nil {
+				return err
+			}
+		}
 	}
-	if err != nil {
-		return err
-	}
+
 	// if it is successful, let's ensure the binary is executable
 	return MarkExecutable(binPath)
 }


### PR DESCRIPTION
## Description

currently, `getter.Get` require compressed zip to have `bin` directory to wrap the binary.
But, for some download url from github release of cosmos sdk chain, they may not have this structure.

closes: #8494

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
