### PR TITLE
Removed GetValidator caching to fix concurrency error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,6 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (x/bank) [\#8479](https://github.com/cosmos/cosmos-sdk/pull/8479) Adittional client denom metadata validation for `base` and `display` denoms.
 * (x/ibc) [\#8404](https://github.com/cosmos/cosmos-sdk/pull/8404) Reorder IBC `ChanOpenAck` and `ChanOpenConfirm` handler execution to perform core handler first, followed by application callbacks.
 * [\#8396](https://github.com/cosmos/cosmos-sdk/pull/8396) Add support for ARM platform
-* (x/staking) [\#8546](https://github.com/cosmos/cosmos-sdk/pull/8546) Allow GetValidator to be called concurrently
 
 ### Bug Fixes
 
@@ -68,6 +67,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (client/keys) [\#8436](https://github.com/cosmos/cosmos-sdk/pull/8436) Fix key migration issue
 * (server) [\#8481](https://github.com/cosmos/cosmos-sdk/pull/8481) Don't create
   files when running `{appd} tendermint show-*` subcommands
+* (x/staking) [\#8546](https://github.com/cosmos/cosmos-sdk/pull/8546) Allow GetValidator to be called concurrently
 
 ## [v0.40.1](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.40.1) - 2021-01-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (x/bank) [\#8479](https://github.com/cosmos/cosmos-sdk/pull/8479) Adittional client denom metadata validation for `base` and `display` denoms.
 * (x/ibc) [\#8404](https://github.com/cosmos/cosmos-sdk/pull/8404) Reorder IBC `ChanOpenAck` and `ChanOpenConfirm` handler execution to perform core handler first, followed by application callbacks.
 * [\#8396](https://github.com/cosmos/cosmos-sdk/pull/8396) Add support for ARM platform
+* (x/staking) [\#8546](https://github.com/cosmos/cosmos-sdk/pull/8546) Allow GetValidator to be called concurrently
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (client/keys) [\#8436](https://github.com/cosmos/cosmos-sdk/pull/8436) Fix key migration issue
 * (server) [\#8481](https://github.com/cosmos/cosmos-sdk/pull/8481) Don't create
   files when running `{appd} tendermint show-*` subcommands
-* (x/staking) [\#8546](https://github.com/cosmos/cosmos-sdk/pull/8546) Allow GetValidator to be called concurrently
+* (x/staking) [\#8546](https://github.com/cosmos/cosmos-sdk/pull/8546) Fix caching bug where concurrent calls to GetValidator could cause a node to crash
 
 ## [v0.40.1](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.40.1) - 2021-01-19
 

--- a/x/staking/keeper/keeper.go
+++ b/x/staking/keeper/keeper.go
@@ -12,8 +12,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/staking/types"
 )
 
-const aminoCacheSize = 500
-
 // Implements ValidatorSet interface
 var _ types.ValidatorSet = Keeper{}
 
@@ -28,7 +26,6 @@ type Keeper struct {
 	bankKeeper         types.BankKeeper
 	hooks              types.StakingHooks
 	paramstore         paramtypes.Subspace
-	validatorCache     map[string]cachedValidator
 	validatorCacheList *list.List
 }
 
@@ -58,7 +55,6 @@ func NewKeeper(
 		bankKeeper:         bk,
 		paramstore:         ps,
 		hooks:              nil,
-		validatorCache:     make(map[string]cachedValidator, aminoCacheSize),
 		validatorCacheList: list.New(),
 	}
 }

--- a/x/staking/keeper/validator.go
+++ b/x/staking/keeper/validator.go
@@ -35,21 +35,7 @@ func (k Keeper) GetValidator(ctx sdk.Context, addr sdk.ValAddress) (validator ty
 		return validator, false
 	}
 
-	// If these amino encoded bytes are in the cache, return the cached validator
-	strValue := string(value)
-	if val, ok := k.validatorCache[strValue]; ok {
-		valToReturn := val.val
-		// Doesn't mutate the cache's value
-		valToReturn.OperatorAddress = addr.String()
-
-		return valToReturn, true
-	}
-
-	// amino bytes weren't found in cache, so amino unmarshal and add it to the cache
 	validator = types.MustUnmarshalValidator(k.cdc, value)
-	cachedVal := newCachedValidator(validator, strValue)
-	k.validatorCache[strValue] = newCachedValidator(validator, strValue)
-	k.validatorCacheList.PushBack(cachedVal)
 
 	// if the cache is too big, pop off the last element from it
 	if k.validatorCacheList.Len() > aminoCacheSize {

--- a/x/staking/keeper/validator_bench_test.go
+++ b/x/staking/keeper/validator_bench_test.go
@@ -1,0 +1,29 @@
+package keeper_test
+
+import "testing"
+
+func BenchmarkGetValidator(b *testing.B) {
+	// 900 is the max number we are allowed to use in order to avoid simapp.CreateTestPubKeys
+	// panic: encoding/hex: odd length hex string
+	var powersNumber = 900
+
+	var totalPower int64 = 0
+	var powers = make([]int64, powersNumber)
+	for i := range powers {
+		powers[i] = int64(i)
+		totalPower += int64(i)
+	}
+
+	app, ctx, _, valAddrs, vals := initValidators(b, totalPower, len(powers), powers)
+
+	for _, validator := range vals {
+		app.StakingKeeper.SetValidator(ctx, validator)
+	}
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		for _, addr := range valAddrs {
+			_, _ = app.StakingKeeper.GetValidator(ctx, addr)
+		}
+	}
+}

--- a/x/staking/keeper/validator_test.go
+++ b/x/staking/keeper/validator_test.go
@@ -56,32 +56,6 @@ func initValidators(t testing.TB, power int64, numAddrs int, powers []int64) (*s
 	return app, ctx, addrs, valAddrs, vs
 }
 
-func BenchmarkGetValidator(b *testing.B) {
-	// 900 is the max number we are allowed to use in order to avoid simapp.CreateTestPubKeys
-	// panic: encoding/hex: odd length hex string
-	var powersNumber = 900
-
-	var totalPower int64 = 0
-	var powers = make([]int64, powersNumber)
-	for i := range powers {
-		powers[i] = int64(i)
-		totalPower += int64(i)
-	}
-
-	app, ctx, _, valAddrs, vals := initValidators(b, totalPower, len(powers), powers)
-
-	for _, validator := range vals {
-		app.StakingKeeper.SetValidator(ctx, validator)
-	}
-
-	b.ResetTimer()
-	for n := 0; n < b.N; n++ {
-		for _, addr := range valAddrs {
-			_, _ = app.StakingKeeper.GetValidator(ctx, addr)
-		}
-	}
-}
-
 func TestSetValidator(t *testing.T) {
 	app, ctx, _, _ := bootstrapValidatorTest(t, 10, 100)
 

--- a/x/staking/keeper/validator_test.go
+++ b/x/staking/keeper/validator_test.go
@@ -19,13 +19,13 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/staking/types"
 )
 
-func newMonikerValidator(t *testing.T, operator sdk.ValAddress, pubKey cryptotypes.PubKey, moniker string) types.Validator {
+func newMonikerValidator(t testing.TB, operator sdk.ValAddress, pubKey cryptotypes.PubKey, moniker string) types.Validator {
 	v, err := types.NewValidator(operator, pubKey, types.Description{Moniker: moniker})
 	require.NoError(t, err)
 	return v
 }
 
-func bootstrapValidatorTest(t *testing.T, power int64, numAddrs int) (*simapp.SimApp, sdk.Context, []sdk.AccAddress, []sdk.ValAddress) {
+func bootstrapValidatorTest(t testing.TB, power int64, numAddrs int) (*simapp.SimApp, sdk.Context, []sdk.AccAddress, []sdk.ValAddress) {
 	_, app, ctx := createTestInput()
 
 	addrDels, addrVals := generateAddresses(app, ctx, numAddrs)
@@ -43,16 +43,43 @@ func bootstrapValidatorTest(t *testing.T, power int64, numAddrs int) (*simapp.Si
 	return app, ctx, addrDels, addrVals
 }
 
-func initValidators(t *testing.T, power int64, numAddrs int, powers []int64) (*simapp.SimApp, sdk.Context, []sdk.AccAddress, []sdk.ValAddress, []types.Validator) {
-	app, ctx, addrs, valAddrs := bootstrapValidatorTest(t, 1000, 20)
+func initValidators(t testing.TB, power int64, numAddrs int, powers []int64) (*simapp.SimApp, sdk.Context, []sdk.AccAddress, []sdk.ValAddress, []types.Validator) {
+	app, ctx, addrs, valAddrs := bootstrapValidatorTest(t, power, numAddrs)
+	pks := simapp.CreateTestPubKeys(numAddrs)
 
 	vs := make([]types.Validator, len(powers))
 	for i, power := range powers {
-		vs[i] = teststaking.NewValidator(t, sdk.ValAddress(addrs[i]), PKs[i])
+		vs[i] = teststaking.NewValidator(t, sdk.ValAddress(addrs[i]), pks[i])
 		tokens := sdk.TokensFromConsensusPower(power)
 		vs[i], _ = vs[i].AddTokensFromDel(tokens)
 	}
 	return app, ctx, addrs, valAddrs, vs
+}
+
+func BenchmarkGetValidator(b *testing.B) {
+	// 900 is the max number we are allowed to use in order to avoid simapp.CreateTestPubKeys
+	// panic: encoding/hex: odd length hex string
+	var powersNumber = 900
+
+	var totalPower int64 = 0
+	var powers = make([]int64, powersNumber)
+	for i := range powers {
+		powers[i] = int64(i)
+		totalPower += int64(i)
+	}
+
+	app, ctx, _, valAddrs, vals := initValidators(b, totalPower, len(powers), powers)
+
+	for _, validator := range vals {
+		app.StakingKeeper.SetValidator(ctx, validator)
+	}
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		for _, addr := range valAddrs {
+			_, _ = app.StakingKeeper.GetValidator(ctx, addr)
+		}
+	}
 }
 
 func TestSetValidator(t *testing.T) {

--- a/x/staking/teststaking/validator.go
+++ b/x/staking/teststaking/validator.go
@@ -11,7 +11,7 @@ import (
 )
 
 // NewValidator is a testing helper method to create validators in tests
-func NewValidator(t *testing.T, operator sdk.ValAddress, pubKey cryptotypes.PubKey) types.Validator {
+func NewValidator(t testing.TB, operator sdk.ValAddress, pubKey cryptotypes.PubKey) types.Validator {
 	v, err := types.NewValidator(operator, pubKey, types.Description{})
 	require.NoError(t, err)
 	return v


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description
This PR removes the `GetValidator` caching that is currently present, allowing for concurrent queries. As shown inside #8545, the removal of the caching does not impact performances in a negative way. Indeed, it improves them by quite a lot (~ 52% increase in ns/op).

Closes: #8545

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
