### PR TITLE
bank: additional denom metadata test case

### DIFF
--- a/x/bank/types/metadata_test.go
+++ b/x/bank/types/metadata_test.go
@@ -29,6 +29,18 @@ func TestMetadataValidate(t *testing.T) {
 			},
 			false,
 		},
+		{
+			"base coin is display coin",
+			types.Metadata{
+				Description: "The native staking token of the Cosmos Hub.",
+				DenomUnits: []*types.DenomUnit{
+					{"atom", uint32(0), []string{"ATOM"}},
+				},
+				Base:    "atom",
+				Display: "atom",
+			},
+			false,
+		},
 		{"empty metadata", types.Metadata{}, true},
 		{
 			"invalid base denom",


### PR DESCRIPTION
adds an additional test case when the display denom is the base denom (exponent = 0)