### PR TITLE
linter: ignore false positives in types/address

### DIFF
--- a/types/address/hash.go
+++ b/types/address/hash.go
@@ -67,8 +67,8 @@ func Module(moduleName string, key []byte) []byte {
 // unsafeStrToByteArray uses unsafe to convert string into byte array. Returned array
 // cannot be altered after this functions is called
 func unsafeStrToByteArray(s string) []byte {
-	sh := *(*reflect.SliceHeader)(unsafe.Pointer(&s))
+	sh := *(*reflect.SliceHeader)(unsafe.Pointer(&s)) // nolint:govet
 	sh.Cap = sh.Len
-	bs := *(*[]byte)(unsafe.Pointer(&sh))
+	bs := *(*[]byte)(unsafe.Pointer(&sh)) // nolint:govet
 	return bs
 }


### PR DESCRIPTION
## Description

Recent linter update created new issues in master. This solves issues in types/address - which in fact are false positives.

closes: #8670

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [x] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [x] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Review `Codecov Report` in the comment section below once CI passes
