### PR TITLE
rework unsafe string -> bytes conversion #8674

### DIFF
--- a/types/address/hash.go
+++ b/types/address/hash.go
@@ -65,7 +65,7 @@ func Module(moduleName string, key []byte) []byte {
 }
 
 // unsafeStrToByteArray uses unsafe to convert string into byte array. Returned bytes
-// MUST NOT be altered after this function is called - this will cause segfault.
+// must not be altered after this function is called as it will cause a segmentation fault.
 func unsafeStrToByteArray(s string) []byte {
 	var buf = *(*[]byte)(unsafe.Pointer(&s))
 	(*reflect.SliceHeader)(unsafe.Pointer(&buf)).Cap = len(s)

--- a/types/address/hash.go
+++ b/types/address/hash.go
@@ -64,8 +64,8 @@ func Module(moduleName string, key []byte) []byte {
 	return Hash("module", append(mKey, key...))
 }
 
-// unsafeStrToByteArray uses unsafe to convert string into byte array. Returned array
-// MUST NOT be altered after this functions is called.
+// unsafeStrToByteArray uses unsafe to convert string into byte array. Returned bytes
+// MUST NOT be altered after this functions is called - this will cause segfault.
 func unsafeStrToByteArray(s string) []byte {
 	var buf = *(*[]byte)(unsafe.Pointer(&s))
 	(*reflect.SliceHeader)(unsafe.Pointer(&buf)).Cap = len(s)

--- a/types/address/hash.go
+++ b/types/address/hash.go
@@ -65,7 +65,7 @@ func Module(moduleName string, key []byte) []byte {
 }
 
 // unsafeStrToByteArray uses unsafe to convert string into byte array. Returned bytes
-// MUST NOT be altered after this functions is called - this will cause segfault.
+// MUST NOT be altered after this function is called - this will cause segfault.
 func unsafeStrToByteArray(s string) []byte {
 	var buf = *(*[]byte)(unsafe.Pointer(&s))
 	(*reflect.SliceHeader)(unsafe.Pointer(&buf)).Cap = len(s)

--- a/types/address/hash.go
+++ b/types/address/hash.go
@@ -67,8 +67,7 @@ func Module(moduleName string, key []byte) []byte {
 // unsafeStrToByteArray uses unsafe to convert string into byte array. Returned array
 // cannot be altered after this functions is called
 func unsafeStrToByteArray(s string) []byte {
-	sh := *(*reflect.SliceHeader)(unsafe.Pointer(&s)) // nolint:govet
-	sh.Cap = sh.Len
-	bs := *(*[]byte)(unsafe.Pointer(&sh)) // nolint:govet
-	return bs
+	var buf = *(*[]byte)(unsafe.Pointer(&s))
+	(*reflect.SliceHeader)(unsafe.Pointer(&buf)).Cap = len(s)
+	return buf
 }

--- a/types/address/hash.go
+++ b/types/address/hash.go
@@ -65,7 +65,7 @@ func Module(moduleName string, key []byte) []byte {
 }
 
 // unsafeStrToByteArray uses unsafe to convert string into byte array. Returned array
-// cannot be altered after this functions is called
+// MUST NOT be altered after this functions is called.
 func unsafeStrToByteArray(s string) []byte {
 	var buf = *(*[]byte)(unsafe.Pointer(&s))
 	(*reflect.SliceHeader)(unsafe.Pointer(&buf)).Cap = len(s)

--- a/types/address/hash_test.go
+++ b/types/address/hash_test.go
@@ -3,6 +3,7 @@ package address
 import (
 	"crypto/sha256"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
@@ -73,6 +74,21 @@ func (suite *AddressSuite) TestModule() {
 	addr3 := Module(modName, []byte{1, 2, 3})
 	assert.NotEqual(addr, addr3, "changing key must change address")
 	assert.NotEqual(addr2, addr3, "changing key must change address")
+}
+
+func unsafeConvertABC() []byte {
+	return unsafeStrToByteArray("abc")
+}
+
+func (suite *AddressSuite) TestUnsafeStrToBytes() {
+	// we convert in other function to trigger GC
+	for i := 0; i < 5; i++ {
+		b := unsafeConvertABC()
+		<-time.NewTimer(5 * time.Millisecond).C
+		b2 := append(b, 'd')
+		suite.Equal("abc", string(b))
+		suite.Equal("abcd", string(b2))
+	}
 }
 
 type addrMock struct {

--- a/types/address/hash_test.go
+++ b/types/address/hash_test.go
@@ -82,7 +82,8 @@ func unsafeConvertABC() []byte {
 }
 
 func (suite *AddressSuite) TestUnsafeStrToBytes() {
-	// we convert in other function to trigger GC
+	// we convert in other function to trigger GC. We want to check that
+	// the underlying array in []bytes is accessible after GC will finish swapping.
 	for i := 0; i < 5; i++ {
 		b := unsafeConvertABC()
 		runtime.GC()

--- a/types/address/hash_test.go
+++ b/types/address/hash_test.go
@@ -2,6 +2,7 @@ package address
 
 import (
 	"crypto/sha256"
+	"runtime"
 	"testing"
 	"time"
 
@@ -84,7 +85,8 @@ func (suite *AddressSuite) TestUnsafeStrToBytes() {
 	// we convert in other function to trigger GC
 	for i := 0; i < 5; i++ {
 		b := unsafeConvertABC()
-		<-time.NewTimer(5 * time.Millisecond).C
+		runtime.GC()
+		<-time.NewTimer(2 * time.Millisecond).C
 		b2 := append(b, 'd')
 		suite.Equal("abc", string(b))
 		suite.Equal("abcd", string(b2))


### PR DESCRIPTION
## Description

Changing the unsafe string -> bytes conversion

closes: #8670

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
