### PR TITLE
Fix `keys migrate` command

### DIFF
--- a/codec/legacy/codec.go
+++ b/codec/legacy/codec.go
@@ -3,7 +3,6 @@ package legacy
 import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	cryptocodec "github.com/cosmos/cosmos-sdk/crypto/codec"
-	"github.com/cosmos/cosmos-sdk/crypto/keys/multisig"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 )
 
@@ -27,12 +26,6 @@ func PrivKeyFromBytes(privKeyBytes []byte) (privKey cryptotypes.PrivKey, err err
 
 // PubKeyFromBytes unmarshals public key bytes and returns a PubKey
 func PubKeyFromBytes(pubKeyBytes []byte) (pubKey cryptotypes.PubKey, err error) {
-	err = Cdc.UnmarshalBinaryBare(pubKeyBytes, &pubKey)
-	return
-}
-
-// AminoPubKeyFromBytes unmarshals public key bytes and returns a PubKey
-func AminoPubKeyFromBytes(pubKeyBytes []byte) (pubKey multisig.LegacyAminoPubKey, err error) {
 	err = Cdc.UnmarshalBinaryBare(pubKeyBytes, &pubKey)
 	return
 }

--- a/crypto/keyring/keyring.go
+++ b/crypto/keyring/keyring.go
@@ -113,7 +113,8 @@ type Importer interface {
 	ImportPubKey(uid string, armor string, keyType KeyType) error
 
 	// MigrateInfo takes a keyring.Info (in practise, from an old keyring), and
-	// writes it to the current keyring.
+	// writes it to the current keyring. We use it to migrate Type{Multi,Ledger,Offline}
+	// keyring.Infos.
 	MigrateInfo(oldInfo Info) error
 }
 

--- a/crypto/keyring/keyring.go
+++ b/crypto/keyring/keyring.go
@@ -111,6 +111,10 @@ type Importer interface {
 
 	// ImportPubKey imports ASCII armored public keys.
 	ImportPubKey(uid string, armor string, keyType KeyType) error
+
+	// MigrateInfo takes a keyring.Info (in practise, from an old keyring), and
+	// writes it to the current keyring.
+	MigrateInfo(oldInfo Info) error
 }
 
 // Exporter is implemented by key stores that support export of public and private keys.
@@ -305,26 +309,35 @@ func (ks keystore) ImportPubKey(uid string, armor string, keyType KeyType) error
 		return err
 	}
 
-	pubKey, err := legacy.AminoPubKeyFromBytes(pubBytes)
+	pubKey, err := legacy.PubKeyFromBytes(pubBytes)
 	if err != nil {
 		return err
 	}
 
 	if keyType == TypeMulti {
-		_, err = ks.writeMultisigKey(uid, &pubKey)
+		_, err = ks.writeMultisigKey(uid, pubKey)
 		if err != nil {
 			return err
 		}
 	}
 
 	if keyType == TypeOffline || keyType == TypeLedger {
-		_, err = ks.writeOfflineKey(uid, &pubKey, hd.PubKeyType(algo))
+		_, err = ks.writeOfflineKey(uid, pubKey, hd.PubKeyType(algo))
 		if err != nil {
 			return err
 		}
 	}
 
 	return nil
+}
+
+// MigrateInfo implements Importer.MigrateInfo.
+func (ks keystore) MigrateInfo(oldInfo Info) error {
+	if _, err := ks.Key(oldInfo.GetName()); err == nil {
+		return fmt.Errorf("cannot overwrite key: %s", oldInfo.GetName())
+	}
+
+	return ks.writeInfo(oldInfo)
 }
 
 func (ks keystore) Sign(uid string, msg []byte) ([]byte, types.PubKey, error) {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

ref: #8639 

I have no idea what the `keys migrate` was doing, but imo it was bugged for multiple reasons:
- imo we should have two `--home` flags: one for the location of the old keyring, and one for the location of the new keyring. I added a `--old-home` flag to it.
  - In practise for Gaia, we would have `--old-home ~/.gaiacli --home ~/.gaiad`
  - If both are same, then it's an in-place migration
- the previous version migrated a `TypeLocal` to a `TypeLocal` (that's correct), a `TypeOffline` to a `TypeOffline` (correct too), but migrated `Type{Ledger,Multi}` both to `TypeOffline` (why???). Anyways, now the migration migrates to the correct keyring type.

## Tests

I followed Sahith's test steps with a ledger key, and could migrate & sign with a tx with the new keyring

We should test:
- [ ] ledger
    - [x] checked by @amaurym 
- [ ] offline
    - [x] checked by @jgimeno  
- [ ] multisig
- [ ] local
    - [x] checked by @amaurym  
    - [x] checked by @jgimeno  

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
