### PR TITLE
scripts: indent multiline commands

### DIFF
--- a/scripts/protoc-swagger-gen.sh
+++ b/scripts/protoc-swagger-gen.sh
@@ -10,11 +10,11 @@ for dir in $proto_dirs; do
   query_file=$(find "${dir}" -maxdepth 1 \( -name 'query.proto' -o -name 'service.proto' \))
   if [[ ! -z "$query_file" ]]; then
     buf protoc  \
-    -I "proto" \
-    -I "third_party/proto" \
-    "$query_file" \
-    --swagger_out=./tmp-swagger-gen \
-    --swagger_opt=logtostderr=true --swagger_opt=fqn_for_swagger_name=true --swagger_opt=simple_operation_ids=true
+      -I "proto" \
+      -I "third_party/proto" \
+      "$query_file" \
+      --swagger_out=./tmp-swagger-gen \
+      --swagger_opt=logtostderr=true --swagger_opt=fqn_for_swagger_name=true --swagger_opt=simple_operation_ids=true
   fi
 done
 

--- a/scripts/protocgen.sh
+++ b/scripts/protocgen.sh
@@ -16,22 +16,22 @@ protoc_gen_gocosmos
 proto_dirs=$(find ./proto -path -prune -o -name '*.proto' -print0 | xargs -0 -n1 dirname | sort | uniq)
 for dir in $proto_dirs; do
   buf protoc \
-  -I "proto" \
-  -I "third_party/proto" \
-  --gocosmos_out=plugins=interfacetype+grpc,\
+    -I "proto" \
+    -I "third_party/proto" \
+    --gocosmos_out=plugins=interfacetype+grpc,\
 Mgoogle/protobuf/any.proto=github.com/cosmos/cosmos-sdk/codec/types:. \
-  --grpc-gateway_out=logtostderr=true,allow_colon_final_segments=true:. \
+    --grpc-gateway_out=logtostderr=true,allow_colon_final_segments=true:. \
   $(find "${dir}" -maxdepth 1 -name '*.proto')
 
 done
 
 # command to generate docs using protoc-gen-doc
 buf protoc \
--I "proto" \
--I "third_party/proto" \
---doc_out=./docs/core \
---doc_opt=./docs/protodoc-markdown.tmpl,proto-docs.md \
-$(find "$(pwd)/proto" -maxdepth 5 -name '*.proto')
+  -I "proto" \
+  -I "third_party/proto" \
+  --doc_out=./docs/core \
+  --doc_opt=./docs/protodoc-markdown.tmpl,proto-docs.md \
+  $(find "$(pwd)/proto" -maxdepth 5 -name '*.proto')
 go mod tidy
 
 # generate codec/testdata proto code


### PR DESCRIPTION
## Description

Adding indentation to multi-line commands - to make it more clear that a command has multiple lines.

Context: https://github.com/cosmos/cosmos-sdk/pull/8559#discussion_r582921803  
When temporally removing some section from the scripts they got indented and made changes in other PR.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
