### PR TITLE
Add warning notice in changelog for v0.41.x bug (ref: #8461)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,8 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## [v0.41.3](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.41.3) - 2021-02-18
 
+**IMPORTANT:** Due to a bug in the `v0.41.x` series with how evidence handles validator consensus addresses (#8461), SDK based chains that are not using the default bech32 prefix (`cosmos`, aka all chains except for the Cosmos Hub) **should not** use this release or any release in the `v0.41.x` series. Please see #8668 for tracking & timeline for the v0.42.0 release, which will include a fix for this issue.
+
 ### Bug Fixes
 
 * [\#8617](https://github.com/cosmos/cosmos-sdk/pull/8617) Fix build failures caused by a small API breakage introduced in tendermint v0.34.7.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,7 +77,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## [v0.41.3](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.41.3) - 2021-02-18
 
-**IMPORTANT:** Due to a bug in the `v0.41.x` series with how evidence handles validator consensus addresses [\#8461](https://github.com/cosmos/cosmos-sdk/issues/8641), SDK based chains that are not using the default bech32 prefix (`cosmos`, aka all chains except for the Cosmos Hub) **should not** use this release or any release in the `v0.41.x` series. Please see [\#8668](https://github.com/cosmos/cosmos-sdk/issues/8668) for tracking & timeline for the v0.42.0 release, which will include a fix for this issue.
+**IMPORTANT:** Due to a bug in the `v0.41.x` series with how evidence handles validator consensus addresses [\#8461](https://github.com/cosmos/cosmos-sdk/issues/8461), SDK based chains that are not using the default bech32 prefix (`cosmos`, aka all chains except for the Cosmos Hub) **should not** use this release or any release in the `v0.41.x` series. Please see [\#8668](https://github.com/cosmos/cosmos-sdk/issues/8668) for tracking & timeline for the v0.42.0 release, which will include a fix for this issue.
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,7 +77,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## [v0.41.3](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.41.3) - 2021-02-18
 
-**IMPORTANT:** Due to a bug in the `v0.41.x` series with how evidence handles validator consensus addresses (#8461), SDK based chains that are not using the default bech32 prefix (`cosmos`, aka all chains except for the Cosmos Hub) **should not** use this release or any release in the `v0.41.x` series. Please see [\#8641](https://github.com/cosmos/cosmos-sdk/issues/8641) for tracking & timeline for the v0.42.0 release, which will include a fix for this issue.
+**IMPORTANT:** Due to a bug in the `v0.41.x` series with how evidence handles validator consensus addresses [\#8461](https://github.com/cosmos/cosmos-sdk/issues/8641), SDK based chains that are not using the default bech32 prefix (`cosmos`, aka all chains except for the Cosmos Hub) **should not** use this release or any release in the `v0.41.x` series. Please see [\#8668](https://github.com/cosmos/cosmos-sdk/issues/8668) for tracking & timeline for the v0.42.0 release, which will include a fix for this issue.
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,7 +77,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## [v0.41.3](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.41.3) - 2021-02-18
 
-**IMPORTANT:** Due to a bug in the `v0.41.x` series with how evidence handles validator consensus addresses (#8461), SDK based chains that are not using the default bech32 prefix (`cosmos`, aka all chains except for the Cosmos Hub) **should not** use this release or any release in the `v0.41.x` series. Please see #8668 for tracking & timeline for the v0.42.0 release, which will include a fix for this issue.
+**IMPORTANT:** Due to a bug in the `v0.41.x` series with how evidence handles validator consensus addresses (#8461), SDK based chains that are not using the default bech32 prefix (`cosmos`, aka all chains except for the Cosmos Hub) **should not** use this release or any release in the `v0.41.x` series. Please see [\#8641](https://github.com/cosmos/cosmos-sdk/issues/8641) for tracking & timeline for the v0.42.0 release, which will include a fix for this issue.
 
 ### Bug Fixes
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Adds a notice in changelog warning non-hub Cosmos SDK based chains to not use the v0.41.x series due to bug in evidence's usage of bech32 prefixes (#8461).

This has also been added to github release notes [here](http://github.com/cosmos/cosmos-sdk/releases/v0.41.3).

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [x] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
