### PR TITLE
Rename InfoImporter -> LegacyInfoImporter

### DIFF
--- a/client/keys/migrate.go
+++ b/client/keys/migrate.go
@@ -111,7 +111,7 @@ func runMigrateCmd(cmd *cobra.Command, args []string) error {
 		// TypeLocal needs an additional step to ask password.
 		// The other keyring types are handled by ImportInfo.
 		if keyType != keyring.TypeLocal {
-			infoImporter, ok := migrator.(keyring.InfoImporter)
+			infoImporter, ok := migrator.(keyring.LegacyInfoImporter)
 			if !ok {
 				return fmt.Errorf("the Keyring implementation does not support import operations of Info types")
 			}

--- a/crypto/keyring/keyring.go
+++ b/crypto/keyring/keyring.go
@@ -116,8 +116,8 @@ type Importer interface {
 	ImportPubKey(uid string, armor string) error
 }
 
-// InfoImporter is implemented by key stores that support import of Info types.
-type InfoImporter interface {
+// LegacyInfoImporter is implemented by key stores that support import of Info types.
+type LegacyInfoImporter interface {
 	// ImportInfo import a keyring.Info into the current keyring.
 	// It is used to migrate multisig, ledger, and public key Info structure.
 	ImportInfo(oldInfo Info) error


### PR DESCRIPTION
Avoid namespace clash with the InfoImporter interface
that already exists in the v0.41 release series.


---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
