### PR TITLE
crypto/keys/internal: use crypto/rand.Reader for generating private key

### DIFF
--- a/crypto/keys/internal/benchmarking/bench.go
+++ b/crypto/keys/internal/benchmarking/bench.go
@@ -1,6 +1,7 @@
 package benchmarking
 
 import (
+	"crypto/rand"
 	"io"
 	"testing"
 
@@ -13,22 +14,12 @@ import (
 // Use of this source code is governed by a BSD-style
 // license that can be found at the bottom of this file.
 
-type zeroReader struct{}
-
-func (zeroReader) Read(buf []byte) (int, error) {
-	for i := range buf {
-		buf[i] = 0
-	}
-	return len(buf), nil
-}
-
 // BenchmarkKeyGeneration benchmarks the given key generation algorithm using
 // a dummy reader.
 func BenchmarkKeyGeneration(b *testing.B, generateKey func(reader io.Reader) types.PrivKey) {
 	b.ReportAllocs()
-	var zero zeroReader
 	for i := 0; i < b.N; i++ {
-		generateKey(zero)
+		generateKey(rand.Reader)
 	}
 }
 


### PR DESCRIPTION
## Description

genPrivKey rejects invalid fieldelems, so we must use a real reader
instead of the zero reader.

closes: #8741

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
