### PR TITLE
x/staking: add ValidateGenesis benchmark

### DIFF
--- a/x/staking/bench_test.go
+++ b/x/staking/bench_test.go
@@ -1,0 +1,56 @@
+package staking_test
+
+import (
+	"testing"
+
+	"github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/staking"
+	"github.com/cosmos/cosmos-sdk/x/staking/teststaking"
+	"github.com/cosmos/cosmos-sdk/x/staking/types"
+)
+
+func BenchmarkValidateGenesis10Validators(b *testing.B) {
+	benchmarkValidateGenesis(b, 10)
+}
+
+func BenchmarkValidateGenesis100Validators(b *testing.B) {
+	benchmarkValidateGenesis(b, 100)
+}
+
+func BenchmarkValidateGenesis400Validators(b *testing.B) {
+	benchmarkValidateGenesis(b, 400)
+}
+
+func benchmarkValidateGenesis(b *testing.B, n int) {
+	b.ReportAllocs()
+
+	validators := make([]types.Validator, 0, n)
+	addressL, pubKeyL := makeRandomAddressesAndPublicKeys(n)
+	for i := 0; i < n; i++ {
+		addr, pubKey := addressL[i], pubKeyL[i]
+		validator := teststaking.NewValidator(b, addr, pubKey)
+		ni := int64(i + 1)
+		validator.Tokens = sdk.NewInt(ni)
+		validator.DelegatorShares = sdk.NewDec(ni)
+		validators = append(validators, validator)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		genesisState := types.DefaultGenesisState()
+		genesisState.Validators = validators
+		if err := staking.ValidateGenesis(genesisState); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func makeRandomAddressesAndPublicKeys(n int) (accL []sdk.ValAddress, pkL []*ed25519.PubKey) {
+	for i := 0; i < n; i++ {
+		pk := ed25519.GenPrivKey().PubKey().(*ed25519.PubKey)
+		pkL = append(pkL, pk)
+		accL = append(accL, sdk.ValAddress(pk.Address()))
+	}
+	return accL, pkL
+}


### PR DESCRIPTION
This benchmark examines how ValidateGenesis behaves.
In a follow-up issue, I'll show how it reveals an inefficiency
that'll affect trying to load repeatedly retrieve Validators'
ConsAddress values.

Updates #8744

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [x] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
