### PR TITLE
all: fix some benchmarks panics by honoring skip if set

### DIFF
--- a/simapp/sim_bench_test.go
+++ b/simapp/sim_bench_test.go
@@ -15,9 +15,13 @@ import (
 // /usr/local/go/bin/go test -benchmem -run=^$ github.com/cosmos/cosmos-sdk/simapp -bench ^BenchmarkFullAppSimulation$ -Commit=true -cpuprofile cpu.out
 func BenchmarkFullAppSimulation(b *testing.B) {
 	b.ReportAllocs()
-	config, db, dir, logger, _, err := SetupSimulation("goleveldb-app-sim", "Simulation")
+	config, db, dir, logger, skip, err := SetupSimulation("goleveldb-app-sim", "Simulation")
 	if err != nil {
 		b.Fatalf("simulation setup failed: %s", err.Error())
+	}
+
+	if skip {
+		b.Skip("skipping benchmark application simulation")
 	}
 
 	defer func() {
@@ -59,9 +63,13 @@ func BenchmarkFullAppSimulation(b *testing.B) {
 
 func BenchmarkInvariants(b *testing.B) {
 	b.ReportAllocs()
-	config, db, dir, logger, _, err := SetupSimulation("leveldb-app-invariant-bench", "Simulation")
+	config, db, dir, logger, skip, err := SetupSimulation("leveldb-app-invariant-bench", "Simulation")
 	if err != nil {
 		b.Fatalf("simulation setup failed: %s", err.Error())
+	}
+
+	if skip {
+		b.Skip("skipping benchmark application simulation")
 	}
 
 	config.AllInvariants = false

--- a/types/address_bench_test.go
+++ b/types/address_bench_test.go
@@ -17,7 +17,7 @@ func BenchmarkAccAddressString(b *testing.B) {
 	pk := &ed25519.PubKey{Key: pkBz}
 	a := pk.Address()
 	pk2 := make([]byte, ed25519.PubKeySize)
-	for i := 1; i <= ed25519.PubKeySize; i++ {
+	for i := 1; i < ed25519.PubKeySize; i++ {
 		pk2[i] = byte(i)
 	}
 	a2 := pk.Address()


### PR DESCRIPTION
## Description

Some benchmarks panics.

closes: #8762

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
