### PR TITLE
fix multisig account pubkeys migration

### DIFF
--- a/x/auth/legacy/v040/migrate.go
+++ b/x/auth/legacy/v040/migrate.go
@@ -16,6 +16,7 @@ func convertBaseAccount(old *v039auth.BaseAccount) *v040auth.BaseAccount {
 	_, ok := old.PubKey.(*multisigtypes.LegacyAminoPubKey)
 
 	// If pubkey is multisig type, then leave it as nil for now
+	// Ref: https://github.com/cosmos/cosmos-sdk/issues/8776#issuecomment-790552126
 	// Else if the old genesis had a pubkey, we pack it inside an Any.
 	// Or else, we just leave it nil.
 	if ok {

--- a/x/auth/legacy/v040/migrate.go
+++ b/x/auth/legacy/v040/migrate.go
@@ -2,6 +2,7 @@ package v040
 
 import (
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	multisigtypes "github.com/cosmos/cosmos-sdk/crypto/keys/multisig"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	v039auth "github.com/cosmos/cosmos-sdk/x/auth/legacy/v039"
 	v040auth "github.com/cosmos/cosmos-sdk/x/auth/types"
@@ -11,9 +12,15 @@ import (
 // convertBaseAccount converts a 0.39 BaseAccount to a 0.40 BaseAccount.
 func convertBaseAccount(old *v039auth.BaseAccount) *v040auth.BaseAccount {
 	var any *codectypes.Any
-	// If the old genesis had a pubkey, we pack it inside an Any. Or else, we
-	// just leave it nil.
-	if old.PubKey != nil {
+
+	_, ok := old.PubKey.(*multisigtypes.LegacyAminoPubKey)
+
+	// If pubkey is multisig type, then leave it as nil for now
+	// Else if the old genesis had a pubkey, we pack it inside an Any.
+	// Or else, we just leave it nil.
+	if ok {
+		// TODO migrate multisig public_keys
+	} else if old.PubKey != nil {
 		var err error
 		any, err = codectypes.NewAnyWithValue(old.PubKey)
 		if err != nil {


### PR DESCRIPTION
ref: https://github.com/cosmos/cosmos-sdk/issues/8776#issuecomment-790552126

When migrating genesis to v0.40, set pub_key to null if account is multisig as a quick fix

closes: #8776

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
