### PR TITLE
x/gov: fix NormalizeProposalType() return values

### DIFF
--- a/x/gov/client/cli/cli_test.go
+++ b/x/gov/client/cli/cli_test.go
@@ -431,6 +431,14 @@ func (s *IntegrationTestSuite) TestCmdGetProposals() {
 			},
 			false,
 		},
+		{
+			"get proposals with invalid status",
+			[]string{
+				"--status=unknown",
+				fmt.Sprintf("--%s=json", tmcli.OutputFlag),
+			},
+			true,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/x/gov/client/rest/grpc_query_test.go
+++ b/x/gov/client/rest/grpc_query_test.go
@@ -119,10 +119,11 @@ func (s *IntegrationTestSuite) TestGetProposalsGRPC() {
 	val := s.network.Validators[0]
 
 	testCases := []struct {
-		name    string
-		url     string
-		headers map[string]string
-		expErr  bool
+		name             string
+		url              string
+		headers          map[string]string
+		wantNumProposals int
+		expErr           bool
 	}{
 		{
 			"get proposals with height 1",
@@ -130,12 +131,21 @@ func (s *IntegrationTestSuite) TestGetProposalsGRPC() {
 			map[string]string{
 				grpctypes.GRPCBlockHeightHeader: "1",
 			},
+			0,
 			true,
 		},
 		{
 			"valid request",
 			fmt.Sprintf("%s/cosmos/gov/v1beta1/proposals", val.APIAddress),
 			map[string]string{},
+			3,
+			false,
+		},
+		{
+			"valid request with filter by status",
+			fmt.Sprintf("%s/cosmos/gov/v1beta1/proposals?proposal_status=1", val.APIAddress),
+			map[string]string{},
+			1,
 			false,
 		},
 	}
@@ -153,7 +163,7 @@ func (s *IntegrationTestSuite) TestGetProposalsGRPC() {
 				s.Require().Empty(proposals.Proposals)
 			} else {
 				s.Require().NoError(err)
-				s.Require().Len(proposals.Proposals, 3)
+				s.Require().Len(proposals.Proposals, tc.wantNumProposals)
 			}
 		})
 	}

--- a/x/gov/client/utils/utils.go
+++ b/x/gov/client/utils/utils.go
@@ -55,13 +55,13 @@ func NormalizeProposalType(proposalType string) string {
 func NormalizeProposalStatus(status string) string {
 	switch status {
 	case "DepositPeriod", "deposit_period":
-		return "DepositPeriod"
+		return "PROPOSAL_STATUS_DEPOSIT_PERIOD"
 	case "VotingPeriod", "voting_period":
-		return "VotingPeriod"
+		return "PROPOSAL_STATUS_VOTING_PERIOD"
 	case "Passed", "passed":
-		return "Passed"
+		return "PROPOSAL_STATUS_PASSED"
 	case "Rejected", "rejected":
-		return "Rejected"
+		return "PROPOSAL_STATUS_REJECTED"
 	default:
 		return status
 	}

--- a/x/gov/client/utils/utils.go
+++ b/x/gov/client/utils/utils.go
@@ -55,13 +55,13 @@ func NormalizeProposalType(proposalType string) string {
 func NormalizeProposalStatus(status string) string {
 	switch status {
 	case "DepositPeriod", "deposit_period":
-		return "PROPOSAL_STATUS_DEPOSIT_PERIOD"
+		return types.StatusDepositPeriod.String()
 	case "VotingPeriod", "voting_period":
-		return "PROPOSAL_STATUS_VOTING_PERIOD"
+		return types.StatusVotingPeriod.String()
 	case "Passed", "passed":
-		return "PROPOSAL_STATUS_PASSED"
+		return types.StatusPassed.String()
 	case "Rejected", "rejected":
-		return "PROPOSAL_STATUS_REJECTED"
+		return types.StatusRejected.String()
 	default:
 		return status
 	}

--- a/x/gov/client/utils/utils_test.go
+++ b/x/gov/client/utils/utils_test.go
@@ -78,9 +78,7 @@ func TestNormalizeProposalStatus(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := utils.NormalizeProposalStatus(tt.args.status); got != tt.want {
-				t.Errorf("NormalizeProposalStatus() = %v, want %v", got, tt.want)
-			}
+			require.Equal(t, tt.want, utils.NormalizeProposalStatus(tt.args.status))
 		})
 	}
 }

--- a/x/gov/client/utils/utils_test.go
+++ b/x/gov/client/utils/utils_test.go
@@ -1,9 +1,11 @@
-package utils
+package utils_test
 
 import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/cosmos/cosmos-sdk/x/gov/client/utils"
 )
 
 func TestNormalizeWeightedVoteOptions(t *testing.T) {
@@ -50,7 +52,35 @@ func TestNormalizeWeightedVoteOptions(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		normalized := NormalizeWeightedVoteOptions(tc.options)
+		normalized := utils.NormalizeWeightedVoteOptions(tc.options)
 		require.Equal(t, normalized, tc.normalized)
+	}
+}
+
+func TestNormalizeProposalStatus(t *testing.T) {
+	type args struct {
+		status string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{"invalid", args{"unknown"}, "unknown"},
+		{"deposit_period", args{"deposit_period"}, "PROPOSAL_STATUS_DEPOSIT_PERIOD"},
+		{"DepositPeriod", args{"DepositPeriod"}, "PROPOSAL_STATUS_DEPOSIT_PERIOD"},
+		{"voting_period", args{"deposit_period"}, "PROPOSAL_STATUS_DEPOSIT_PERIOD"},
+		{"VotingPeriod", args{"DepositPeriod"}, "PROPOSAL_STATUS_DEPOSIT_PERIOD"},
+		{"passed", args{"passed"}, "PROPOSAL_STATUS_PASSED"},
+		{"Passed", args{"Passed"}, "PROPOSAL_STATUS_PASSED"},
+		{"Rejected", args{"Rejected"}, "PROPOSAL_STATUS_REJECTED"},
+		{"rejected", args{"rejected"}, "PROPOSAL_STATUS_REJECTED"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := utils.NormalizeProposalStatus(tt.args.status); got != tt.want {
+				t.Errorf("NormalizeProposalStatus() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Fix `q gov proposals` command's mishandling of the
--status parameter's values.

Closes: #8806

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
