### PR TITLE
chore: refactor code quality issues

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,0 +1,20 @@
+version = 1
+
+test_patterns = [
+    "tests/**",
+    "**_test.go"
+]
+
+exclude_patterns = [
+    "third_party/proto/**",
+    "testutil/**",
+    "proto/cosmos/**",
+    "contrib/**"
+]
+
+[[analyzers]]
+name = "go"
+enabled = true
+
+  [analyzers.meta]
+  import_paths = ["github.com/cosmos/cosmos-sdk"]

--- a/client/context_test.go
+++ b/client/context_test.go
@@ -51,7 +51,7 @@ func TestContext_PrintObject(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t,
 		`{"animal":{"@type":"/testdata.Dog","size":"big","name":"Spot"},"x":"10"}
-`, string(buf.Bytes()))
+`, buf.String())
 
 	// yaml
 	buf = &bytes.Buffer{}
@@ -65,7 +65,7 @@ func TestContext_PrintObject(t *testing.T) {
   name: Spot
   size: big
 x: "10"
-`, string(buf.Bytes()))
+`, buf.String())
 
 	//
 	// amino
@@ -81,7 +81,7 @@ x: "10"
 	require.NoError(t, err)
 	require.Equal(t,
 		`{"type":"testdata/HasAnimal","value":{"animal":{"type":"testdata/Dog","value":{"size":"big","name":"Spot"}},"x":"10"}}
-`, string(buf.Bytes()))
+`, buf.String())
 
 	// yaml
 	buf = &bytes.Buffer{}
@@ -98,7 +98,7 @@ value:
       name: Spot
       size: big
   x: "10"
-`, string(buf.Bytes()))
+`, buf.String())
 }
 
 func TestCLIQueryConn(t *testing.T) {

--- a/x/auth/ante/ante_test.go
+++ b/x/auth/ante/ante_test.go
@@ -903,8 +903,7 @@ func generatePubKeysAndSignatures(n int, msg []byte, _ bool) (pubkeys []cryptoty
 	pubkeys = make([]cryptotypes.PubKey, n)
 	signatures = make([][]byte, n)
 	for i := 0; i < n; i++ {
-		var privkey cryptotypes.PrivKey
-		privkey = secp256k1.GenPrivKey()
+		var privkey cryptotypes.PrivKey = secp256k1.GenPrivKey()
 
 		// TODO: also generate ed25519 keys as below when ed25519 keys are
 		//  actually supported, https://github.com/cosmos/cosmos-sdk/issues/4789

--- a/x/auth/client/rest/rest_test.go
+++ b/x/auth/client/rest/rest_test.go
@@ -114,7 +114,7 @@ func (s *IntegrationTestSuite) TestEncodeDecode() {
 	err = cdc.UnmarshalJSON(res, &encodeResp)
 	require.NoError(err)
 
-	bz, err = cdc.MarshalJSON(authrest.DecodeReq{Tx: encodeResp.Tx})
+	bz, err = cdc.MarshalJSON(authrest.DecodeReq(encodeResp))
 	require.NoError(err)
 
 	res, err = rest.PostRequest(fmt.Sprintf("%s/txs/decode", val.APIAddress), "application/json", bz)

--- a/x/auth/tx/builder_test.go
+++ b/x/auth/tx/builder_test.go
@@ -40,8 +40,7 @@ func TestTxBuilder(t *testing.T) {
 		Sequence: accSeq,
 	})
 
-	var sig signing.SignatureV2
-	sig = signing.SignatureV2{
+	var sig signing.SignatureV2 = signing.SignatureV2{
 		PubKey: pubkey,
 		Data: &signing.SingleSignatureData{
 			SignMode:  signing.SignMode_SIGN_MODE_DIRECT,

--- a/x/distribution/legacy/v043/store_test.go
+++ b/x/distribution/legacy/v043/store_test.go
@@ -90,7 +90,7 @@ func TestStoreMigration(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			if bytes.Compare(tc.oldKey, tc.newKey) != 0 {
+			if !bytes.Equal(tc.oldKey, tc.newKey) {
 				require.Nil(t, store.Get(tc.oldKey))
 			}
 			require.Equal(t, value, store.Get(tc.newKey))

--- a/x/gov/legacy/v043/store_test.go
+++ b/x/gov/legacy/v043/store_test.go
@@ -82,7 +82,7 @@ func TestStoreMigration(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			if bytes.Compare(tc.oldKey, tc.newKey) != 0 {
+			if !bytes.Equal(tc.oldKey, tc.newKey) {
 				require.Nil(t, store.Get(tc.oldKey))
 			}
 			require.Equal(t, tc.newValue, store.Get(tc.newKey))

--- a/x/slashing/legacy/v043/store_test.go
+++ b/x/slashing/legacy/v043/store_test.go
@@ -59,7 +59,7 @@ func TestStoreMigration(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			if bytes.Compare(tc.oldKey, tc.newKey) != 0 {
+			if !bytes.Equal(tc.oldKey, tc.newKey) {
 				require.Nil(t, store.Get(tc.oldKey))
 			}
 			require.Equal(t, value, store.Get(tc.newKey))

--- a/x/staking/legacy/v043/store_test.go
+++ b/x/staking/legacy/v043/store_test.go
@@ -128,7 +128,7 @@ func TestStoreMigration(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			if bytes.Compare(tc.oldKey, tc.newKey) != 0 {
+			if !bytes.Equal(tc.oldKey, tc.newKey) {
 				require.Nil(t, store.Get(tc.oldKey))
 			}
 			require.Equal(t, value, store.Get(tc.newKey))


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Hey, I'm a Developer Outreach at [DeepSource](https://deepsource.io/) and ran DeepSource analysis on my fork of the repo. It found some interesting [code quality improvements](https://deepsource.io/gh/akshgpt7/cosmos-sdk/) to consider.

This PR fixes a few of the issues detected for you to assess if it is right for you.
Happy to provide the tweaks separately otherwise :)

### Summary of changes
- Clean up copied struct fields with type conversion
- Merge variable declaration with assignment
- Fix unnecessary typecasting on `bytes.Buffer`
- Replace `bytes.Compare` with `bytes.Equal`
- Add `.deepsource.toml` file for continuous analysis on bug risks/performance/code-quality issues on new changes.

---

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Review `Codecov Report` in the comment section below once CI passes
