### PR TITLE
Remove spurious usage of strings.NewReader

### DIFF
--- a/codec/proto_codec.go
+++ b/codec/proto_codec.go
@@ -1,10 +1,10 @@
 package codec
 
 import (
+	"bytes"
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"bytes"
 
 	"github.com/gogo/protobuf/jsonpb"
 	"github.com/gogo/protobuf/proto"

--- a/codec/proto_codec.go
+++ b/codec/proto_codec.go
@@ -4,7 +4,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"strings"
+	"bytes"
 
 	"github.com/gogo/protobuf/jsonpb"
 	"github.com/gogo/protobuf/proto"
@@ -159,7 +159,7 @@ func (pc *ProtoCodec) UnmarshalJSON(bz []byte, ptr proto.Message) error {
 	}
 
 	unmarshaler := jsonpb.Unmarshaler{AnyResolver: pc.interfaceRegistry}
-	err := unmarshaler.Unmarshal(strings.NewReader(string(bz)), m)
+	err := unmarshaler.Unmarshal(bytes.NewReader(bz), m)
 	if err != nil {
 		return err
 	}

--- a/types/events.go
+++ b/types/events.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"reflect"
 	"sort"
+	"bytes"
 	"strings"
 
 	"github.com/gogo/protobuf/jsonpb"
@@ -130,7 +131,7 @@ func ParseTypedEvent(event abci.Event) (proto.Message, error) {
 		return nil, err
 	}
 
-	err = jsonpb.Unmarshal(strings.NewReader(string(attrBytes)), protoMsg)
+	err = jsonpb.Unmarshal(bytes.NewReader(attrBytes), protoMsg)
 	if err != nil {
 		return nil, err
 	}

--- a/types/events.go
+++ b/types/events.go
@@ -1,11 +1,11 @@
 package types
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"reflect"
 	"sort"
-	"bytes"
 	"strings"
 
 	"github.com/gogo/protobuf/jsonpb"

--- a/x/auth/client/tx.go
+++ b/x/auth/client/tx.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	"strings"
 
 	"github.com/gogo/protobuf/jsonpb"
 
@@ -155,7 +154,7 @@ func GetTxEncoder(cdc *codec.LegacyAmino) (encoder sdk.TxEncoder) {
 
 func ParseQueryResponse(bz []byte) (sdk.SimulationResponse, error) {
 	var simRes sdk.SimulationResponse
-	if err := jsonpb.Unmarshal(strings.NewReader(string(bz)), &simRes); err != nil {
+	if err := jsonpb.Unmarshal(bytes.NewReader(bz), &simRes); err != nil {
 		return sdk.SimulationResponse{}, err
 	}
 


### PR DESCRIPTION
Instead of creating a `io.Reader` from a byte slice casted to string, use
`bytes.NewReader`.

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #XXXX

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
