### PR TITLE
x/auth: update NewAccountKeeper docs

### DIFF
--- a/x/auth/keeper/keeper.go
+++ b/x/auth/keeper/keeper.go
@@ -60,6 +60,10 @@ var _ AccountKeeperI = &AccountKeeper{}
 
 // NewAccountKeeper returns a new AccountKeeperI that uses go-amino to
 // (binary) encode and decode concrete sdk.Accounts.
+// `maccPerms` is a map of module account to list of permissisons. It's used to construct
+// types.PermissionsForAddress and used in keeper.ValidatePermissions. Permissions is a string,
+// without any specific structure. It's not use internally by this module (x/auth) but may
+// be used by other modules using auth.Keeper to check against configured permissions.
 func NewAccountKeeper(
 	cdc codec.BinaryMarshaler, key sdk.StoreKey, paramstore paramtypes.Subspace, proto func() types.AccountI,
 	maccPerms map[string][]string,

--- a/x/auth/keeper/keeper.go
+++ b/x/auth/keeper/keeper.go
@@ -60,9 +60,9 @@ var _ AccountKeeperI = &AccountKeeper{}
 
 // NewAccountKeeper returns a new AccountKeeperI that uses go-amino to
 // (binary) encode and decode concrete sdk.Accounts.
-// `maccPerms` is a map of module account to list of permissisons. It's used to construct
-// types.PermissionsForAddress and used in keeper.ValidatePermissions. Permissions is a string,
-// without any specific structure. It's not use internally by this module (x/auth) but may
+// `maccPerms` is a map of the module account to a list of permissions. This map is used to construct
+// types.PermissionsForAddress and is used in keeper.ValidatePermissions. Permissions is a string,
+// without any specific structure. It's not used internally by this module (x/auth) but may
 // be used by other modules using auth.Keeper to check against configured permissions.
 func NewAccountKeeper(
 	cdc codec.BinaryMarshaler, key sdk.StoreKey, paramstore paramtypes.Subspace, proto func() types.AccountI,

--- a/x/auth/keeper/keeper.go
+++ b/x/auth/keeper/keeper.go
@@ -60,7 +60,7 @@ var _ AccountKeeperI = &AccountKeeper{}
 
 // NewAccountKeeper returns a new AccountKeeperI that uses go-amino to
 // (binary) encode and decode concrete sdk.Accounts.
-// `maccPerms` is a map of the module account to a list of permissions. This map is used to construct
+// `maccPerms` is a map that takes accounts' addresses as keys, and their respective permissions as values. This map is used to construct
 // types.PermissionsForAddress and is used in keeper.ValidatePermissions. Permissions is a string,
 // without any specific structure. It's not used internally by this module (x/auth) but may
 // be used by other modules using auth.Keeper to check against configured permissions.

--- a/x/auth/keeper/keeper.go
+++ b/x/auth/keeper/keeper.go
@@ -61,9 +61,9 @@ var _ AccountKeeperI = &AccountKeeper{}
 // NewAccountKeeper returns a new AccountKeeperI that uses go-amino to
 // (binary) encode and decode concrete sdk.Accounts.
 // `maccPerms` is a map that takes accounts' addresses as keys, and their respective permissions as values. This map is used to construct
-// types.PermissionsForAddress and is used in keeper.ValidatePermissions. Permissions is a string,
-// without any specific structure. It's not used internally by this module (x/auth) but may
-// be used by other modules using auth.Keeper to check against configured permissions.
+// types.PermissionsForAddress and is used in keeper.ValidatePermissions. Permissions are plain strings,
+// and don't have to fit into any predefined structure. This auth module does not use account permissions internally, though other modules
+// may use auth.Keeper to access the accounts permissions map.
 func NewAccountKeeper(
 	cdc codec.BinaryMarshaler, key sdk.StoreKey, paramstore paramtypes.Subspace, proto func() types.AccountI,
 	maccPerms map[string][]string,


### PR DESCRIPTION
## Description

Updates documentation about `maccPerms` parameter for `NewAccountKeeper`

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
