### PR TITLE
docs: added deprecation notes for non English docs.

### DIFF
--- a/docs/cn/README.md
+++ b/docs/cn/README.md
@@ -5,6 +5,12 @@ parent:
 
 # Cosmos SDK 文档
 
+::: warning
+**DEPRECATED**
+This documentation is not complete and it's outdated. Please use the English version.
+:::
+
+
 ## 开始
 
 - **[SDK 介绍](./intro/README.md)**：Cosmos SDK 的总体概览

--- a/docs/cn/basics/README.md
+++ b/docs/cn/basics/README.md
@@ -1,5 +1,11 @@
 # 基础文档
 
+::: warning
+**DEPRECATED**
+This documentation is not complete and it's outdated. Please use the English version.
+:::
+
+
 此目录包含对 cosmos sdk 的基础概念介绍
 
 1. [SDK 应用解析](./app-anatomy.md)

--- a/docs/kr/README.md
+++ b/docs/kr/README.md
@@ -3,10 +3,15 @@ parent:
   order: false
 ---
 
-# 코스모스 SDK 문서에 오신 걸 환영합니다! 
+# 코스모스 SDK 문서에 오신 걸 환영합니다!
 
 ::: warning
-번역된 문서는 **참고용**으로 번역되었습니다. 다수의 오타, 오류가 존재할 수 있으며, 영문 업데이트보다 번역이 느리게 진행될 수 있다는 점을 인지하시기 바랍니다. 
+**DEPRECATED**
+This documentation is not complete and it's outdated. Please use the English version.
+:::
+
+::: warning
+번역된 문서는 **참고용**으로 번역되었습니다. 다수의 오타, 오류가 존재할 수 있으며, 영문 업데이트보다 번역이 느리게 진행될 수 있다는 점을 인지하시기 바랍니다.
 
 코스모스 관련 가장 정확한 정보를 확인하시기 위해서는 영어 원문을 참고하시기 바랍니다.
 :::

--- a/docs/ru/readme.md
+++ b/docs/ru/readme.md
@@ -4,3 +4,8 @@ parent:
 ---
 
 # RU
+
+::: warning
+**DEPRECATED**
+This documentation is not complete and it's outdated. Please use the English version.
+:::


### PR DESCRIPTION
## Description

For Stargate we only updated the English documentation. Which means, the Korean, Chinese and Russian documentation is outdated. In this PR I propose to add deprecation notes. 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
