### PR TITLE
module/types code hygiene - utilize map access 2nd return value

### DIFF
--- a/simapp/app_test.go
+++ b/simapp/app_test.go
@@ -218,7 +218,6 @@ func TestInitGenesisOnMigration(t *testing.T) {
 	// modules, we put their latest ConsensusVersion to skip migrations.
 	_, err := app.mm.RunMigrations(ctx, app.configurator,
 		module.VersionMap{
-			"mock":         0,
 			"bank":         bank.AppModule{}.ConsensusVersion(),
 			"auth":         auth.AppModule{}.ConsensusVersion(),
 			"authz":        authz.AppModule{}.ConsensusVersion(),

--- a/simapp/app_test.go
+++ b/simapp/app_test.go
@@ -213,9 +213,8 @@ func TestInitGenesisOnMigration(t *testing.T) {
 
 	app.mm.Modules["mock"] = mockModule
 
-	// Run migrations only for "mock" module. That's why we put the initial
-	// version for bank as 0 (to run its InitGenesis), and for all other
-	// modules, we put their latest ConsensusVersion to skip migrations.
+	// Run migrations only for "mock" module. We exclude it from
+	// the VersionMap to simulate upgrading with a new module.
 	_, err := app.mm.RunMigrations(ctx, app.configurator,
 		module.VersionMap{
 			"bank":         bank.AppModule{}.ConsensusVersion(),

--- a/types/module/module.go
+++ b/types/module/module.go
@@ -356,7 +356,7 @@ type VersionMap map[string]uint64
 // - make a diff of `fromVM` and `udpatedVM`, and for each module:
 //    - if the module's `fromVM` version is less than its `updatedVM` version,
 //      then run in-place store migrations for that module between those versions.
-//    - if the module's `fromVM` is 0 (which means that it's a new module,
+//    - if the module does not exist in the `fromVM` (which means that it's a new module,
 //      because it was not in the previous x/upgrade's store), then run
 //      `InitGenesis` on that module.
 // - return the `updatedVM` to be persisted in the x/upgrade's store.
@@ -372,7 +372,7 @@ type VersionMap map[string]uint64
 //   app.UpgradeKeeper.SetUpgradeHandler("my-plan", func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
 //       // Assume "foo" is a new module.
 //       // `fromVM` is fetched from existing x/upgrade store. Since foo didn't exist
-//       // before this upgrade, `fromVM["foo"] == 0`, and RunMigration will by default
+//       // before this upgrade, `v, exists := fromVM["foo"]; exists == false`, and RunMigration will by default
 //       // run InitGenesis on foo.
 //       // To skip running foo's InitGenesis, you need set `fromVM`'s foo to its latest
 //       // consensus version:
@@ -390,19 +390,18 @@ func (m Manager) RunMigrations(ctx sdk.Context, cfg Configurator, fromVM Version
 
 	updatedVM := make(VersionMap)
 	for moduleName, module := range m.Modules {
-		fromVersion := fromVM[moduleName]
+		fromVersion, exists := fromVM[moduleName]
 		toVersion := module.ConsensusVersion()
 
-		// Only run migrations when the fromVersion is > 0, or run InitGenesis
-		// if fromVersion == 0.
+		// Only run migrations when the module exists in the fromVM.
+		// Run InitGenesis otherwise.
 		//
-		// fromVersion will be 0 in two cases:
-		// 1. If a new module is added. In this case we run InitGenesis with an
+		// the module won't exist in the fromVM in two cases:
+		// 1. A new module is added. In this case we run InitGenesis with an
 		// empty genesis state.
-		// 2. If the app developer is running in-place store migrations for the
-		// first time. In this case, it is the app developer's responsibility
-		// to set their module's fromVersions to a version that suits them.
-		if fromVersion > 0 {
+		// 2. An existing chain is upgrading to v043 for the first time. In this case,
+		// all modules have yet to be added to x/upgrade's VersionMap store.
+		if exists {
 			err := c.runModuleMigrations(ctx, moduleName, fromVersion, toVersion)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

This PR cleans up a small snippet of code in types/module/module.go 

Currently, to check if a module exists in the fromVM map, we check for the default/nil value in the map. 

This PR utilizes the 2nd return value from map accesses, a boolean, which is true if the key exists in the map, false otherwise. This makes not only the code a bit more readable, but also the documentation surrounding it. Ref: [In-Place store migration docs](https://github.com/cosmos/cosmos-sdk/pull/8967/files#diff-7919f886ac1c280f5bc85e12992892df7f160c4ab535e878d2f1510f6d11489cR79-R81). 

closes: N/A

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
