### PR TITLE
x/bank/types: fix AddressFromBalancesStore address length overflow

### DIFF
--- a/x/bank/types/key.go
+++ b/x/bank/types/key.go
@@ -44,12 +44,11 @@ func AddressFromBalancesStore(key []byte) (sdk.AccAddress, error) {
 		return nil, ErrInvalidKey
 	}
 	addrLen := key[0]
-	if len(key[1:]) < int(addrLen) {
+	bound := int(addrLen)
+	if len(key)-1 < bound {
 		return nil, ErrInvalidKey
 	}
-	addr := key[1 : addrLen+1]
-
-	return sdk.AccAddress(addr), nil
+	return key[1 : bound+1], nil
 }
 
 // CreateAccountBalancesPrefix creates the prefix for an account's balances.

--- a/x/bank/types/key_test.go
+++ b/x/bank/types/key_test.go
@@ -24,29 +24,34 @@ func TestAddressFromBalancesStore(t *testing.T) {
 	require.NoError(t, err)
 	addrLen := len(addr)
 	require.Equal(t, 20, addrLen)
-
 	key := cloneAppend(address.MustLengthPrefix(addr), []byte("stake"))
-	res, err := types.AddressFromBalancesStore(key)
-	require.NoError(t, err)
-	require.Equal(t, res, addr)
-}
 
-func TestInvalidAddressFromBalancesStore(t *testing.T) {
 	tests := []struct {
-		name string
-		key  []byte
+		name        string
+		key         []byte
+		wantErr     bool
+		expectedKey sdk.AccAddress
 	}{
-		{"empty", []byte("")},
-		{"invalid", []byte("3AA")},
+		{"valid", key, false, addr},
+		{"#9111", []byte("\xff000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"), false, nil},
+		{"empty", []byte(""), true, nil},
+		{"invalid", []byte("3AA"), true, nil},
 	}
 
 	for _, tc := range tests {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			_, err := types.AddressFromBalancesStore(tc.key)
-			assert.Error(t, err)
-			assert.True(t, errors.Is(types.ErrInvalidKey, err))
+			addr, err := types.AddressFromBalancesStore(tc.key)
+			if tc.wantErr {
+				assert.Error(t, err)
+				assert.True(t, errors.Is(types.ErrInvalidKey, err))
+			} else {
+				assert.NoError(t, err)
+			}
+			if len(tc.expectedKey) > 0 {
+				assert.Equal(t, tc.expectedKey, addr)
+			}
 		})
 	}
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

addrLen is encoded in a byte, so it's an uint8. The code in
AddressFromBalancesStore cast it to int for bound checking, but wrongly
use "addrLen+1", which can be overflow.

To fix this, just cast addrLen once and use it in all places.

Found by fuzzing added in #9060.

Fixes #9111

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [x] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
