### PR TITLE
internal/conv: fix wrong string to bytes implementation

### DIFF
--- a/internal/conv/string.go
+++ b/internal/conv/string.go
@@ -8,8 +8,12 @@ import (
 // UnsafeStrToBytes uses unsafe to convert string into byte array. Returned bytes
 // must not be altered after this function is called as it will cause a segmentation fault.
 func UnsafeStrToBytes(s string) []byte {
-	var buf = *(*[]byte)(unsafe.Pointer(&s))
-	(*reflect.SliceHeader)(unsafe.Pointer(&buf)).Cap = len(s)
+	var buf []byte
+	sHdr := (*reflect.StringHeader)(unsafe.Pointer(&s))
+	bufHdr := (*reflect.SliceHeader)(unsafe.Pointer(&buf))
+	bufHdr.Data = sHdr.Data
+	bufHdr.Cap = sHdr.Len
+	bufHdr.Len = sHdr.Len
 	return buf
 }
 
@@ -18,6 +22,5 @@ func UnsafeStrToBytes(s string) []byte {
 // to be used generally, but for a specific pattern to delete keys
 // from a map.
 func UnsafeBytesToStr(b []byte) string {
-	hdr := (*reflect.StringHeader)(unsafe.Pointer(&b))
-	return *(*string)(unsafe.Pointer(hdr))
+	return *(*string)(unsafe.Pointer(&b))
 }

--- a/internal/conv/string_test.go
+++ b/internal/conv/string_test.go
@@ -2,6 +2,7 @@ package conv
 
 import (
 	"runtime"
+	"strconv"
 	"testing"
 	"time"
 
@@ -43,5 +44,11 @@ func (s *StringSuite) TestUnsafeBytesToStr() {
 		runtime.GC()
 		<-time.NewTimer(2 * time.Millisecond).C
 		s.Equal("abc", str)
+	}
+}
+
+func BenchmarkUnsafeStrToBytes(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		UnsafeStrToBytes(strconv.Itoa(i))
 	}
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

UnsafeStrToBytes is currently not safe for -d=checkptr=2, since when it
cast from smaller struct (string) to bigger struct ([]byte). That causes
checkptr complains as the casting straddle multiple heap objects.

To fix this, we have to get the string header first, then use its fields
to construct the slice.

New implementation performs the same speed with the old (wrong) one.

```
name                old time/op    new time/op    delta
UnsafeStrToBytes-8    25.7ns ± 1%    25.7ns ± 3%   ~     (p=0.931 n=10+17)

name                old alloc/op   new alloc/op   delta
UnsafeStrToBytes-8     7.00B ± 0%     7.00B ± 0%   ~     (all equal)

name                old allocs/op  new allocs/op  delta
UnsafeStrToBytes-8      0.00           0.00        ~     (all equal)
```

While at it, also simplify UnsafeBytesToStr implementation, since when
we can pass the slice directly to unsafe.Pointer, instead of getting the
slice header first.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [x] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
