### PR TITLE
crypto/types: check for overflow and unreasonably large element count

### DIFF
--- a/crypto/types/compact_bit_array_test.go
+++ b/crypto/types/compact_bit_array_test.go
@@ -2,6 +2,8 @@ package types
 
 import (
 	"encoding/json"
+	"fmt"
+	"math"
 	"math/rand"
 	"testing"
 
@@ -238,4 +240,36 @@ func BenchmarkNumTrueBitsBefore(b *testing.B) {
 			ba.NumTrueBitsBefore(90)
 		}
 	})
+}
+
+func TestNewCompactBitArrayCrashWithLimits(t *testing.T) {
+	if testing.Short() {
+		t.Skip("This test can be expensive in memory")
+	}
+	tests := []struct {
+		in       int
+		mustPass bool
+	}{
+		{int(^uint(0) >> 30), false},
+		{int(^uint(0) >> 1), false},
+		{int(^uint(0) >> 2), false},
+		{int(math.MaxInt32), true},
+		{int(math.MaxInt32) + 1, true},
+		{int(math.MaxInt32) + 2, true},
+		{int(math.MaxInt32) - 7, true},
+		{int(math.MaxInt32) + 24, true},
+		{int(math.MaxInt32) * 9, false}, // results in >=maxint after (bits+7)/8
+		{1, true},
+		{0, false},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(fmt.Sprintf("%d", tt.in), func(t *testing.T) {
+			got := NewCompactBitArray(tt.in)
+			if g := got != nil; g != tt.mustPass {
+				t.Fatalf("got!=nil=%t, want=%t", g, tt.mustPass)
+			}
+		})
+	}
 }


### PR DESCRIPTION
Ensure that we don't pass overflowed values into make, because
a clever attacker could see that to cause:

    (bits+7)/8

to become negative, they just have to make (bits+7) become negative
simply by >=maxint-6

but also reject unreasonably large element count like >2**32, which
while arbitrary is super duper large for a bit array.

Fixes #9162

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [x] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
