### PR TITLE
x/gov/keeper: fix flaky TestPaginatedVotesQuery

### DIFF
--- a/x/gov/keeper/querier_test.go
+++ b/x/gov/keeper/querier_test.go
@@ -316,13 +316,23 @@ func TestPaginatedVotesQuery(t *testing.T) {
 	app.GovKeeper.SetProposal(ctx, proposal)
 
 	votes := make([]types.Vote, 20)
-	rand := rand.New(rand.NewSource(time.Now().UnixNano()))
-	addr := make(sdk.AccAddress, 20)
+	random := rand.New(rand.NewSource(time.Now().UnixNano()))
+	addrMap := make(map[string]struct{})
+	genAddr := func() string {
+		addr := make(sdk.AccAddress, 20)
+		for {
+			random.Read(addr)
+			addrStr := addr.String()
+			if _, ok := addrMap[addrStr]; !ok {
+				addrMap[addrStr] = struct{}{}
+				return addrStr
+			}
+		}
+	}
 	for i := range votes {
-		rand.Read(addr)
 		vote := types.Vote{
 			ProposalId: proposal.ProposalId,
-			Voter:      addr.String(),
+			Voter:      genAddr(),
 			Options:    types.NewNonSplitVoteOption(types.OptionYes),
 		}
 		votes[i] = vote


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

When testing with -race, sometimes the random source generate the same
string for consecutive calls, causing duplicated voter address. So the
number of votes in DB is not 20.

To fix this, we ensure unique addresses are generated, by using a map
for tracking which one was produced, and skip the duplicated address and
generated new one. Testing with:

```
go test -race -v -count=1000 -run=TestPaginatedVotesQuery
```

now passes.

Updates #9010

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [x] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
