### PR TITLE
Add options in order to make java protobuf generator generate multiple classes.

### DIFF
--- a/proto/cosmos/auth/v1beta1/auth.proto
+++ b/proto/cosmos/auth/v1beta1/auth.proto
@@ -6,6 +6,7 @@ import "gogoproto/gogo.proto";
 import "google/protobuf/any.proto";
 
 option go_package = "github.com/cosmos/cosmos-sdk/x/auth/types";
+option java_multiple_files = true;
 
 // BaseAccount defines a base account type. It contains all the necessary fields
 // for basic account functionality. Any custom account type should extend this

--- a/proto/cosmos/auth/v1beta1/genesis.proto
+++ b/proto/cosmos/auth/v1beta1/genesis.proto
@@ -6,6 +6,7 @@ import "gogoproto/gogo.proto";
 import "cosmos/auth/v1beta1/auth.proto";
 
 option go_package = "github.com/cosmos/cosmos-sdk/x/auth/types";
+option java_multiple_files = true;
 
 // GenesisState defines the auth module's genesis state.
 message GenesisState {

--- a/proto/cosmos/auth/v1beta1/query.proto
+++ b/proto/cosmos/auth/v1beta1/query.proto
@@ -9,6 +9,7 @@ import "cosmos/auth/v1beta1/auth.proto";
 import "cosmos_proto/cosmos.proto";
 
 option go_package = "github.com/cosmos/cosmos-sdk/x/auth/types";
+option java_multiple_files = true;
 
 // Query defines the gRPC querier service.
 service Query {

--- a/proto/cosmos/authz/v1beta1/authz.proto
+++ b/proto/cosmos/authz/v1beta1/authz.proto
@@ -7,6 +7,7 @@ import "gogoproto/gogo.proto";
 import "google/protobuf/any.proto";
 
 option go_package = "github.com/cosmos/cosmos-sdk/x/authz/types";
+option java_multiple_files = true;
 
 // GenericAuthorization gives the grantee unrestricted permissions to execute
 // the provided method on behalf of the granter's account.

--- a/proto/cosmos/authz/v1beta1/genesis.proto
+++ b/proto/cosmos/authz/v1beta1/genesis.proto
@@ -7,6 +7,7 @@ import "gogoproto/gogo.proto";
 import "cosmos_proto/cosmos.proto";
 
 option go_package = "github.com/cosmos/cosmos-sdk/x/authz/types";
+option java_multiple_files = true;
 
 // GenesisState defines the authz module's genesis state.
 message GenesisState {

--- a/proto/cosmos/authz/v1beta1/query.proto
+++ b/proto/cosmos/authz/v1beta1/query.proto
@@ -6,6 +6,7 @@ import "cosmos/base/query/v1beta1/pagination.proto";
 import "cosmos/authz/v1beta1/authz.proto";
 
 option go_package = "github.com/cosmos/cosmos-sdk/x/authz/types";
+option java_multiple_files = true;
 
 // Query defines the gRPC querier service.
 service Query {

--- a/proto/cosmos/authz/v1beta1/tx.proto
+++ b/proto/cosmos/authz/v1beta1/tx.proto
@@ -7,6 +7,7 @@ import "google/protobuf/timestamp.proto";
 import "google/protobuf/any.proto";
 import "cosmos/base/abci/v1beta1/abci.proto";
 option go_package = "github.com/cosmos/cosmos-sdk/x/authz/types";
+option java_multiple_files = true;
 
 // Msg defines the authz Msg service.
 service Msg {

--- a/proto/cosmos/bank/v1beta1/authz.proto
+++ b/proto/cosmos/bank/v1beta1/authz.proto
@@ -6,6 +6,7 @@ import "cosmos_proto/cosmos.proto";
 import "cosmos/base/v1beta1/coin.proto";
 
 option go_package = "github.com/cosmos/cosmos-sdk/x/bank/types";
+option java_multiple_files = true;
 
 // SendAuthorization allows the grantee to spend up to spend_limit coins from
 // the granter's account.

--- a/proto/cosmos/bank/v1beta1/bank.proto
+++ b/proto/cosmos/bank/v1beta1/bank.proto
@@ -6,6 +6,7 @@ import "cosmos_proto/cosmos.proto";
 import "cosmos/base/v1beta1/coin.proto";
 
 option go_package = "github.com/cosmos/cosmos-sdk/x/bank/types";
+option java_multiple_files = true;
 
 // Params defines the parameters for the bank module.
 message Params {

--- a/proto/cosmos/bank/v1beta1/genesis.proto
+++ b/proto/cosmos/bank/v1beta1/genesis.proto
@@ -6,6 +6,7 @@ import "cosmos/base/v1beta1/coin.proto";
 import "cosmos/bank/v1beta1/bank.proto";
 
 option go_package = "github.com/cosmos/cosmos-sdk/x/bank/types";
+option java_multiple_files = true;
 
 // GenesisState defines the bank module's genesis state.
 message GenesisState {

--- a/proto/cosmos/bank/v1beta1/query.proto
+++ b/proto/cosmos/bank/v1beta1/query.proto
@@ -8,6 +8,7 @@ import "cosmos/base/v1beta1/coin.proto";
 import "cosmos/bank/v1beta1/bank.proto";
 
 option go_package = "github.com/cosmos/cosmos-sdk/x/bank/types";
+option java_multiple_files = true;
 
 // Query defines the gRPC querier service.
 service Query {

--- a/proto/cosmos/bank/v1beta1/tx.proto
+++ b/proto/cosmos/bank/v1beta1/tx.proto
@@ -6,6 +6,7 @@ import "cosmos/base/v1beta1/coin.proto";
 import "cosmos/bank/v1beta1/bank.proto";
 
 option go_package = "github.com/cosmos/cosmos-sdk/x/bank/types";
+option java_multiple_files = true;
 
 // Msg defines the bank Msg service.
 service Msg {

--- a/proto/cosmos/base/abci/v1beta1/abci.proto
+++ b/proto/cosmos/base/abci/v1beta1/abci.proto
@@ -6,6 +6,7 @@ import "tendermint/abci/types.proto";
 import "google/protobuf/any.proto";
 
 option go_package                       = "github.com/cosmos/cosmos-sdk/types";
+option java_multiple_files = true;
 option (gogoproto.goproto_stringer_all) = false;
 
 // TxResponse defines a structure containing relevant tx data and metadata. The

--- a/proto/cosmos/base/kv/v1beta1/kv.proto
+++ b/proto/cosmos/base/kv/v1beta1/kv.proto
@@ -4,6 +4,7 @@ package cosmos.base.kv.v1beta1;
 import "gogoproto/gogo.proto";
 
 option go_package = "github.com/cosmos/cosmos-sdk/types/kv";
+option java_multiple_files = true;
 
 // Pairs defines a repeated slice of Pair objects.
 message Pairs {

--- a/proto/cosmos/base/query/v1beta1/pagination.proto
+++ b/proto/cosmos/base/query/v1beta1/pagination.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 package cosmos.base.query.v1beta1;
 
 option go_package = "github.com/cosmos/cosmos-sdk/types/query";
+option java_multiple_files = true;
 
 // PageRequest is to be embedded in gRPC request messages for efficient
 // pagination. Ex:

--- a/proto/cosmos/base/reflection/v1beta1/reflection.proto
+++ b/proto/cosmos/base/reflection/v1beta1/reflection.proto
@@ -4,6 +4,7 @@ package cosmos.base.reflection.v1beta1;
 import "google/api/annotations.proto";
 
 option go_package = "github.com/cosmos/cosmos-sdk/client/grpc/reflection";
+option java_multiple_files = true;
 
 // ReflectionService defines a service for interface reflection.
 service ReflectionService {

--- a/proto/cosmos/base/reflection/v2alpha1/reflection.proto
+++ b/proto/cosmos/base/reflection/v2alpha1/reflection.proto
@@ -4,6 +4,7 @@ package cosmos.base.reflection.v2alpha1;
 import "google/api/annotations.proto";
 
 option go_package = "github.com/cosmos/cosmos-sdk/server/grpc/reflection/v2alpha1";
+option java_multiple_files = true;
 
 // AppDescriptor describes a cosmos-sdk based application
 message AppDescriptor {

--- a/proto/cosmos/base/snapshots/v1beta1/snapshot.proto
+++ b/proto/cosmos/base/snapshots/v1beta1/snapshot.proto
@@ -4,6 +4,7 @@ package cosmos.base.snapshots.v1beta1;
 import "gogoproto/gogo.proto";
 
 option go_package = "github.com/cosmos/cosmos-sdk/snapshots/types";
+option java_multiple_files = true;
 
 // Snapshot contains Tendermint state sync snapshot info.
 message Snapshot {

--- a/proto/cosmos/base/store/v1beta1/commit_info.proto
+++ b/proto/cosmos/base/store/v1beta1/commit_info.proto
@@ -4,6 +4,7 @@ package cosmos.base.store.v1beta1;
 import "gogoproto/gogo.proto";
 
 option go_package = "github.com/cosmos/cosmos-sdk/store/types";
+option java_multiple_files = true;
 
 // CommitInfo defines commit information used by the multi-store when committing
 // a version/height.

--- a/proto/cosmos/base/store/v1beta1/listening.proto
+++ b/proto/cosmos/base/store/v1beta1/listening.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 package cosmos.base.store.v1beta1;
 
 option go_package = "github.com/cosmos/cosmos-sdk/store/types";
+option java_multiple_files = true;
 
 // StoreKVPair is a KVStore KVPair used for listening to state changes (Sets and Deletes)
 // It optionally includes the StoreKey for the originating KVStore and a Boolean flag to distinguish between Sets and Deletes

--- a/proto/cosmos/base/store/v1beta1/snapshot.proto
+++ b/proto/cosmos/base/store/v1beta1/snapshot.proto
@@ -4,6 +4,7 @@ package cosmos.base.store.v1beta1;
 import "gogoproto/gogo.proto";
 
 option go_package = "github.com/cosmos/cosmos-sdk/store/types";
+option java_multiple_files = true;
 
 // SnapshotItem is an item contained in a rootmulti.Store snapshot.
 message SnapshotItem {

--- a/proto/cosmos/base/tendermint/v1beta1/query.proto
+++ b/proto/cosmos/base/tendermint/v1beta1/query.proto
@@ -10,6 +10,7 @@ import "tendermint/types/types.proto";
 import "cosmos/base/query/v1beta1/pagination.proto";
 
 option go_package = "github.com/cosmos/cosmos-sdk/client/grpc/tmservice";
+option java_multiple_files = true;
 
 // Service defines the gRPC querier service for tendermint queries.
 service Service {

--- a/proto/cosmos/base/v1beta1/coin.proto
+++ b/proto/cosmos/base/v1beta1/coin.proto
@@ -4,6 +4,7 @@ package cosmos.base.v1beta1;
 import "gogoproto/gogo.proto";
 
 option go_package                       = "github.com/cosmos/cosmos-sdk/types";
+option java_multiple_files = true;
 option (gogoproto.goproto_stringer_all) = false;
 option (gogoproto.stringer_all)         = false;
 

--- a/proto/cosmos/capability/v1beta1/capability.proto
+++ b/proto/cosmos/capability/v1beta1/capability.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 package cosmos.capability.v1beta1;
 
 option go_package = "github.com/cosmos/cosmos-sdk/x/capability/types";
+option java_multiple_files = true;
 
 import "gogoproto/gogo.proto";
 

--- a/proto/cosmos/capability/v1beta1/genesis.proto
+++ b/proto/cosmos/capability/v1beta1/genesis.proto
@@ -5,6 +5,7 @@ import "gogoproto/gogo.proto";
 import "cosmos/capability/v1beta1/capability.proto";
 
 option go_package = "github.com/cosmos/cosmos-sdk/x/capability/types";
+option java_multiple_files = true;
 
 // GenesisOwners defines the capability owners with their corresponding index.
 message GenesisOwners {

--- a/proto/cosmos/crisis/v1beta1/genesis.proto
+++ b/proto/cosmos/crisis/v1beta1/genesis.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 package cosmos.crisis.v1beta1;
 
 option go_package = "github.com/cosmos/cosmos-sdk/x/crisis/types";
+option java_multiple_files = true;
 
 import "gogoproto/gogo.proto";
 import "cosmos/base/v1beta1/coin.proto";

--- a/proto/cosmos/crisis/v1beta1/tx.proto
+++ b/proto/cosmos/crisis/v1beta1/tx.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 package cosmos.crisis.v1beta1;
 
 option go_package = "github.com/cosmos/cosmos-sdk/x/crisis/types";
+option java_multiple_files = true;
 
 import "gogoproto/gogo.proto";
 

--- a/proto/cosmos/crypto/ed25519/keys.proto
+++ b/proto/cosmos/crypto/ed25519/keys.proto
@@ -4,6 +4,7 @@ package cosmos.crypto.ed25519;
 import "gogoproto/gogo.proto";
 
 option go_package = "github.com/cosmos/cosmos-sdk/crypto/keys/ed25519";
+option java_multiple_files = true;
 
 // PubKey is an ed25519 public key for handling Tendermint keys in SDK.
 // It's needed for Any serialization and SDK compatibility.

--- a/proto/cosmos/crypto/multisig/keys.proto
+++ b/proto/cosmos/crypto/multisig/keys.proto
@@ -5,6 +5,7 @@ import "gogoproto/gogo.proto";
 import "google/protobuf/any.proto";
 
 option go_package = "github.com/cosmos/cosmos-sdk/crypto/keys/multisig";
+option java_multiple_files = true;
 
 // LegacyAminoPubKey specifies a public key type
 // which nests multiple public keys and a threshold,

--- a/proto/cosmos/crypto/multisig/v1beta1/multisig.proto
+++ b/proto/cosmos/crypto/multisig/v1beta1/multisig.proto
@@ -4,6 +4,7 @@ package cosmos.crypto.multisig.v1beta1;
 import "gogoproto/gogo.proto";
 
 option go_package = "github.com/cosmos/cosmos-sdk/crypto/types";
+option java_multiple_files = true;
 
 // MultiSignature wraps the signatures from a multisig.LegacyAminoPubKey.
 // See cosmos.tx.v1betata1.ModeInfo.Multi for how to specify which signers

--- a/proto/cosmos/crypto/secp256k1/keys.proto
+++ b/proto/cosmos/crypto/secp256k1/keys.proto
@@ -4,6 +4,7 @@ package cosmos.crypto.secp256k1;
 import "gogoproto/gogo.proto";
 
 option go_package = "github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1";
+option java_multiple_files = true;
 
 // PubKey defines a secp256k1 public key
 // Key is the compressed form of the pubkey. The first byte depends is a 0x02 byte

--- a/proto/cosmos/crypto/secp256r1/keys.proto
+++ b/proto/cosmos/crypto/secp256r1/keys.proto
@@ -4,6 +4,7 @@ package cosmos.crypto.secp256r1;
 import "gogoproto/gogo.proto";
 
 option go_package = "github.com/cosmos/cosmos-sdk/crypto/keys/secp256r1";
+option java_multiple_files = true;
 option (gogoproto.messagename_all) = true;
 option (gogoproto.goproto_stringer_all) = false;
 option (gogoproto.goproto_getters_all) = false;

--- a/proto/cosmos/distribution/v1beta1/distribution.proto
+++ b/proto/cosmos/distribution/v1beta1/distribution.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 package cosmos.distribution.v1beta1;
 
 option go_package            = "github.com/cosmos/cosmos-sdk/x/distribution/types";
+option java_multiple_files = true;
 option (gogoproto.equal_all) = true;
 
 import "gogoproto/gogo.proto";

--- a/proto/cosmos/distribution/v1beta1/genesis.proto
+++ b/proto/cosmos/distribution/v1beta1/genesis.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 package cosmos.distribution.v1beta1;
 
 option go_package            = "github.com/cosmos/cosmos-sdk/x/distribution/types";
+option java_multiple_files = true;
 option (gogoproto.equal_all) = true;
 
 import "gogoproto/gogo.proto";

--- a/proto/cosmos/distribution/v1beta1/query.proto
+++ b/proto/cosmos/distribution/v1beta1/query.proto
@@ -8,6 +8,7 @@ import "cosmos/base/v1beta1/coin.proto";
 import "cosmos/distribution/v1beta1/distribution.proto";
 
 option go_package = "github.com/cosmos/cosmos-sdk/x/distribution/types";
+option java_multiple_files = true;
 
 // Query defines the gRPC querier service for distribution module.
 service Query {

--- a/proto/cosmos/distribution/v1beta1/tx.proto
+++ b/proto/cosmos/distribution/v1beta1/tx.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 package cosmos.distribution.v1beta1;
 
 option go_package            = "github.com/cosmos/cosmos-sdk/x/distribution/types";
+option java_multiple_files = true;
 option (gogoproto.equal_all) = true;
 
 import "gogoproto/gogo.proto";

--- a/proto/cosmos/evidence/v1beta1/evidence.proto
+++ b/proto/cosmos/evidence/v1beta1/evidence.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 package cosmos.evidence.v1beta1;
 
 option go_package            = "github.com/cosmos/cosmos-sdk/x/evidence/types";
+option java_multiple_files = true;
 option (gogoproto.equal_all) = true;
 
 import "gogoproto/gogo.proto";

--- a/proto/cosmos/evidence/v1beta1/genesis.proto
+++ b/proto/cosmos/evidence/v1beta1/genesis.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 package cosmos.evidence.v1beta1;
 
 option go_package = "github.com/cosmos/cosmos-sdk/x/evidence/types";
+option java_multiple_files = true;
 
 import "google/protobuf/any.proto";
 

--- a/proto/cosmos/evidence/v1beta1/query.proto
+++ b/proto/cosmos/evidence/v1beta1/query.proto
@@ -7,6 +7,7 @@ import "google/protobuf/any.proto";
 import "google/api/annotations.proto";
 
 option go_package = "github.com/cosmos/cosmos-sdk/x/evidence/types";
+option java_multiple_files = true;
 
 // Query defines the gRPC querier service.
 service Query {

--- a/proto/cosmos/evidence/v1beta1/tx.proto
+++ b/proto/cosmos/evidence/v1beta1/tx.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 package cosmos.evidence.v1beta1;
 
 option go_package            = "github.com/cosmos/cosmos-sdk/x/evidence/types";
+option java_multiple_files = true;
 option (gogoproto.equal_all) = true;
 
 import "gogoproto/gogo.proto";

--- a/proto/cosmos/feegrant/v1beta1/feegrant.proto
+++ b/proto/cosmos/feegrant/v1beta1/feegrant.proto
@@ -9,6 +9,7 @@ import "google/protobuf/timestamp.proto";
 import "google/protobuf/duration.proto";
 
 option go_package = "github.com/cosmos/cosmos-sdk/x/feegrant/types";
+option java_multiple_files = true;
 
 // BasicFeeAllowance implements FeeAllowance with a one-time grant of tokens
 // that optionally expires. The delegatee can use up to SpendLimit to cover fees.

--- a/proto/cosmos/feegrant/v1beta1/genesis.proto
+++ b/proto/cosmos/feegrant/v1beta1/genesis.proto
@@ -5,6 +5,7 @@ import "gogoproto/gogo.proto";
 import "cosmos/feegrant/v1beta1/feegrant.proto";
 
 option go_package = "github.com/cosmos/cosmos-sdk/x/feegrant/types";
+option java_multiple_files = true;
 
 // GenesisState contains a set of fee allowances, persisted from the store
 message GenesisState {

--- a/proto/cosmos/feegrant/v1beta1/query.proto
+++ b/proto/cosmos/feegrant/v1beta1/query.proto
@@ -7,6 +7,7 @@ import "cosmos/base/query/v1beta1/pagination.proto";
 import "google/api/annotations.proto";
 
 option go_package = "github.com/cosmos/cosmos-sdk/x/feegrant/types";
+option java_multiple_files = true;
 
 // Query defines the gRPC querier service.
 service Query {

--- a/proto/cosmos/feegrant/v1beta1/tx.proto
+++ b/proto/cosmos/feegrant/v1beta1/tx.proto
@@ -6,6 +6,7 @@ import "google/protobuf/any.proto";
 import "cosmos_proto/cosmos.proto";
 
 option go_package = "github.com/cosmos/cosmos-sdk/x/feegrant/types";
+option java_multiple_files = true;
 
 // Msg defines the feegrant msg service.
 service Msg {

--- a/proto/cosmos/genutil/v1beta1/genesis.proto
+++ b/proto/cosmos/genutil/v1beta1/genesis.proto
@@ -4,6 +4,7 @@ package cosmos.genutil.v1beta1;
 import "gogoproto/gogo.proto";
 
 option go_package = "github.com/cosmos/cosmos-sdk/x/genutil/types";
+option java_multiple_files = true;
 
 // GenesisState defines the raw genesis transaction in JSON.
 message GenesisState {

--- a/proto/cosmos/gov/v1beta1/genesis.proto
+++ b/proto/cosmos/gov/v1beta1/genesis.proto
@@ -6,6 +6,7 @@ import "gogoproto/gogo.proto";
 import "cosmos/gov/v1beta1/gov.proto";
 
 option go_package = "github.com/cosmos/cosmos-sdk/x/gov/types";
+option java_multiple_files = true;
 
 // GenesisState defines the gov module's genesis state.
 message GenesisState {

--- a/proto/cosmos/gov/v1beta1/gov.proto
+++ b/proto/cosmos/gov/v1beta1/gov.proto
@@ -9,6 +9,7 @@ import "google/protobuf/any.proto";
 import "google/protobuf/duration.proto";
 
 option go_package                       = "github.com/cosmos/cosmos-sdk/x/gov/types";
+option java_multiple_files = true;
 option (gogoproto.goproto_stringer_all) = false;
 option (gogoproto.stringer_all)         = false;
 option (gogoproto.goproto_getters_all)  = false;

--- a/proto/cosmos/gov/v1beta1/query.proto
+++ b/proto/cosmos/gov/v1beta1/query.proto
@@ -7,6 +7,7 @@ import "google/api/annotations.proto";
 import "cosmos/gov/v1beta1/gov.proto";
 
 option go_package = "github.com/cosmos/cosmos-sdk/x/gov/types";
+option java_multiple_files = true;
 
 // Query defines the gRPC querier service for gov module
 service Query {

--- a/proto/cosmos/gov/v1beta1/tx.proto
+++ b/proto/cosmos/gov/v1beta1/tx.proto
@@ -8,6 +8,7 @@ import "gogoproto/gogo.proto";
 import "google/protobuf/any.proto";
 
 option go_package = "github.com/cosmos/cosmos-sdk/x/gov/types";
+option java_multiple_files = true;
 
 // Msg defines the bank Msg service.
 service Msg {

--- a/proto/cosmos/mint/v1beta1/genesis.proto
+++ b/proto/cosmos/mint/v1beta1/genesis.proto
@@ -5,6 +5,7 @@ import "gogoproto/gogo.proto";
 import "cosmos/mint/v1beta1/mint.proto";
 
 option go_package = "github.com/cosmos/cosmos-sdk/x/mint/types";
+option java_multiple_files = true;
 
 // GenesisState defines the mint module's genesis state.
 message GenesisState {

--- a/proto/cosmos/mint/v1beta1/mint.proto
+++ b/proto/cosmos/mint/v1beta1/mint.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 package cosmos.mint.v1beta1;
 
 option go_package = "github.com/cosmos/cosmos-sdk/x/mint/types";
+option java_multiple_files = true;
 
 import "gogoproto/gogo.proto";
 

--- a/proto/cosmos/mint/v1beta1/query.proto
+++ b/proto/cosmos/mint/v1beta1/query.proto
@@ -6,6 +6,7 @@ import "google/api/annotations.proto";
 import "cosmos/mint/v1beta1/mint.proto";
 
 option go_package = "github.com/cosmos/cosmos-sdk/x/mint/types";
+option java_multiple_files = true;
 
 // Query provides defines the gRPC querier service.
 service Query {

--- a/proto/cosmos/params/v1beta1/params.proto
+++ b/proto/cosmos/params/v1beta1/params.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 package cosmos.params.v1beta1;
 
 option go_package            = "github.com/cosmos/cosmos-sdk/x/params/types/proposal";
+option java_multiple_files = true;
 option (gogoproto.equal_all) = true;
 
 import "gogoproto/gogo.proto";

--- a/proto/cosmos/params/v1beta1/query.proto
+++ b/proto/cosmos/params/v1beta1/query.proto
@@ -6,6 +6,7 @@ import "google/api/annotations.proto";
 import "cosmos/params/v1beta1/params.proto";
 
 option go_package = "github.com/cosmos/cosmos-sdk/x/params/types/proposal";
+option java_multiple_files = true;
 
 // Query defines the gRPC querier service.
 service Query {

--- a/proto/cosmos/slashing/v1beta1/genesis.proto
+++ b/proto/cosmos/slashing/v1beta1/genesis.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 package cosmos.slashing.v1beta1;
 
 option go_package = "github.com/cosmos/cosmos-sdk/x/slashing/types";
+option java_multiple_files = true;
 
 import "gogoproto/gogo.proto";
 import "cosmos/slashing/v1beta1/slashing.proto";

--- a/proto/cosmos/slashing/v1beta1/query.proto
+++ b/proto/cosmos/slashing/v1beta1/query.proto
@@ -7,6 +7,7 @@ import "google/api/annotations.proto";
 import "cosmos/slashing/v1beta1/slashing.proto";
 
 option go_package = "github.com/cosmos/cosmos-sdk/x/slashing/types";
+option java_multiple_files = true;
 
 // Query provides defines the gRPC querier service
 service Query {

--- a/proto/cosmos/slashing/v1beta1/slashing.proto
+++ b/proto/cosmos/slashing/v1beta1/slashing.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 package cosmos.slashing.v1beta1;
 
 option go_package            = "github.com/cosmos/cosmos-sdk/x/slashing/types";
+option java_multiple_files = true;
 option (gogoproto.equal_all) = true;
 
 import "gogoproto/gogo.proto";

--- a/proto/cosmos/slashing/v1beta1/tx.proto
+++ b/proto/cosmos/slashing/v1beta1/tx.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 package cosmos.slashing.v1beta1;
 
 option go_package            = "github.com/cosmos/cosmos-sdk/x/slashing/types";
+option java_multiple_files = true;
 option (gogoproto.equal_all) = true;
 
 import "gogoproto/gogo.proto";

--- a/proto/cosmos/staking/v1beta1/authz.proto
+++ b/proto/cosmos/staking/v1beta1/authz.proto
@@ -6,6 +6,7 @@ import "cosmos_proto/cosmos.proto";
 import "cosmos/base/v1beta1/coin.proto";
 
 option go_package = "github.com/cosmos/cosmos-sdk/x/staking/types";
+option java_multiple_files = true;
 
 // StakeAuthorization defines authorization for delegate/undelegate/redelegate.
 message StakeAuthorization {

--- a/proto/cosmos/staking/v1beta1/genesis.proto
+++ b/proto/cosmos/staking/v1beta1/genesis.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 package cosmos.staking.v1beta1;
 
 option go_package = "github.com/cosmos/cosmos-sdk/x/staking/types";
+option java_multiple_files = true;
 
 import "gogoproto/gogo.proto";
 import "cosmos/staking/v1beta1/staking.proto";

--- a/proto/cosmos/staking/v1beta1/query.proto
+++ b/proto/cosmos/staking/v1beta1/query.proto
@@ -7,6 +7,7 @@ import "google/api/annotations.proto";
 import "cosmos/staking/v1beta1/staking.proto";
 
 option go_package = "github.com/cosmos/cosmos-sdk/x/staking/types";
+option java_multiple_files = true;
 
 // Query defines the gRPC querier service.
 service Query {

--- a/proto/cosmos/staking/v1beta1/staking.proto
+++ b/proto/cosmos/staking/v1beta1/staking.proto
@@ -11,6 +11,7 @@ import "cosmos/base/v1beta1/coin.proto";
 import "tendermint/types/types.proto";
 
 option go_package = "github.com/cosmos/cosmos-sdk/x/staking/types";
+option java_multiple_files = true;
 
 // HistoricalInfo contains header and validator information for a given block.
 // It is stored as part of staking module's state, which persists the `n` most

--- a/proto/cosmos/staking/v1beta1/tx.proto
+++ b/proto/cosmos/staking/v1beta1/tx.proto
@@ -10,6 +10,7 @@ import "cosmos/base/v1beta1/coin.proto";
 import "cosmos/staking/v1beta1/staking.proto";
 
 option go_package = "github.com/cosmos/cosmos-sdk/x/staking/types";
+option java_multiple_files = true;
 
 // Msg defines the staking Msg service.
 service Msg {

--- a/proto/cosmos/tx/signing/v1beta1/signing.proto
+++ b/proto/cosmos/tx/signing/v1beta1/signing.proto
@@ -5,6 +5,7 @@ import "cosmos/crypto/multisig/v1beta1/multisig.proto";
 import "google/protobuf/any.proto";
 
 option go_package = "github.com/cosmos/cosmos-sdk/types/tx/signing";
+option java_multiple_files = true;
 
 // SignMode represents a signing mode with its own security guarantees.
 enum SignMode {

--- a/proto/cosmos/tx/v1beta1/service.proto
+++ b/proto/cosmos/tx/v1beta1/service.proto
@@ -9,6 +9,7 @@ import "cosmos/base/query/v1beta1/pagination.proto";
 
 option (gogoproto.goproto_registration) = true;
 option go_package = "github.com/cosmos/cosmos-sdk/types/tx";
+option java_multiple_files = true;
 
 // Service defines a gRPC service for interacting with transactions.
 service Service {

--- a/proto/cosmos/tx/v1beta1/tx.proto
+++ b/proto/cosmos/tx/v1beta1/tx.proto
@@ -8,6 +8,7 @@ import "cosmos/tx/signing/v1beta1/signing.proto";
 import "google/protobuf/any.proto";
 
 option go_package = "github.com/cosmos/cosmos-sdk/types/tx";
+option java_multiple_files = true;
 
 // Tx is the standard type used for broadcasting transactions.
 message Tx {

--- a/proto/cosmos/upgrade/v1beta1/query.proto
+++ b/proto/cosmos/upgrade/v1beta1/query.proto
@@ -6,6 +6,7 @@ import "google/api/annotations.proto";
 import "cosmos/upgrade/v1beta1/upgrade.proto";
 
 option go_package = "github.com/cosmos/cosmos-sdk/x/upgrade/types";
+option java_multiple_files = true;
 
 // Query defines the gRPC upgrade querier service.
 service Query {

--- a/proto/cosmos/upgrade/v1beta1/upgrade.proto
+++ b/proto/cosmos/upgrade/v1beta1/upgrade.proto
@@ -6,6 +6,7 @@ import "gogoproto/gogo.proto";
 import "google/protobuf/timestamp.proto";
 
 option go_package                       = "github.com/cosmos/cosmos-sdk/x/upgrade/types";
+option java_multiple_files = true;
 option (gogoproto.goproto_stringer_all) = false;
 option (gogoproto.goproto_getters_all)  = false;
 

--- a/proto/cosmos/vesting/v1beta1/tx.proto
+++ b/proto/cosmos/vesting/v1beta1/tx.proto
@@ -5,6 +5,7 @@ import "gogoproto/gogo.proto";
 import "cosmos/base/v1beta1/coin.proto";
 
 option go_package = "github.com/cosmos/cosmos-sdk/x/auth/vesting/types";
+option java_multiple_files = true;
 
 // Msg defines the bank Msg service.
 service Msg {

--- a/proto/cosmos/vesting/v1beta1/vesting.proto
+++ b/proto/cosmos/vesting/v1beta1/vesting.proto
@@ -6,6 +6,7 @@ import "cosmos/base/v1beta1/coin.proto";
 import "cosmos/auth/v1beta1/auth.proto";
 
 option go_package = "github.com/cosmos/cosmos-sdk/x/auth/vesting/types";
+option java_multiple_files = true;
 
 // BaseVestingAccount implements the VestingAccount interface. It contains all
 // the necessary fields needed for any vesting account implementation.

--- a/testutil/testdata/query.proto
+++ b/testutil/testdata/query.proto
@@ -5,6 +5,7 @@ import "google/protobuf/any.proto";
 import "testdata.proto";
 
 option go_package = "github.com/cosmos/cosmos-sdk/testutil/testdata";
+option java_multiple_files = true;
 
 // Query tests the protobuf Query service as defined in
 // https://github.com/cosmos/cosmos-sdk/issues/5921.

--- a/testutil/testdata/testdata.proto
+++ b/testutil/testdata/testdata.proto
@@ -5,6 +5,7 @@ import "gogoproto/gogo.proto";
 import "google/protobuf/any.proto";
 
 option go_package = "github.com/cosmos/cosmos-sdk/testutil/testdata";
+option java_multiple_files = true;
 
 message Dog {
   string size = 1;

--- a/testutil/testdata/tx.proto
+++ b/testutil/testdata/tx.proto
@@ -5,6 +5,7 @@ import "gogoproto/gogo.proto";
 import "testdata.proto";
 
 option go_package = "github.com/cosmos/cosmos-sdk/testutil/testdata";
+option java_multiple_files = true;
 
 // Msg tests the Protobuf message service as defined in
 // https://github.com/cosmos/cosmos-sdk/issues/7500.

--- a/testutil/testdata/unknonwnproto.proto
+++ b/testutil/testdata/unknonwnproto.proto
@@ -6,6 +6,7 @@ import "google/protobuf/any.proto";
 import "cosmos/tx/v1beta1/tx.proto";
 
 option go_package = "github.com/cosmos/cosmos-sdk/testutil/testdata";
+option java_multiple_files = true;
 
 message Customer1 {
   int32  id               = 1;

--- a/third_party/proto/confio/proofs.proto
+++ b/third_party/proto/confio/proofs.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 package ics23;
 option go_package = "github.com/confio/ics23/go";
+option java_multiple_files = true;
 
 enum HashOp {
     // NO_HASH is the default if no data passed. Note this is an illegal argument some places.

--- a/third_party/proto/cosmos_proto/cosmos.proto
+++ b/third_party/proto/cosmos_proto/cosmos.proto
@@ -4,6 +4,7 @@ package cosmos_proto;
 import "google/protobuf/descriptor.proto";
 
 option go_package = "github.com/regen-network/cosmos-proto";
+option java_multiple_files = true;
 
 extend google.protobuf.MessageOptions {
     string interface_type = 93001;

--- a/third_party/proto/gogoproto/gogo.proto
+++ b/third_party/proto/gogoproto/gogo.proto
@@ -34,6 +34,7 @@ import "google/protobuf/descriptor.proto";
 option java_package = "com.google.protobuf";
 option java_outer_classname = "GoGoProtos";
 option go_package = "github.com/gogo/protobuf/gogoproto";
+option java_multiple_files = true;
 
 extend google.protobuf.EnumOptions {
 	optional bool goproto_enum_prefix = 62001;

--- a/third_party/proto/google/api/annotations.proto
+++ b/third_party/proto/google/api/annotations.proto
@@ -21,7 +21,6 @@ import "google/protobuf/descriptor.proto";
 
 option go_package = "google.golang.org/genproto/googleapis/api/annotations;annotations";
 option java_multiple_files = true;
-option java_multiple_files = true;
 option java_outer_classname = "AnnotationsProto";
 option java_package = "com.google.api";
 option objc_class_prefix = "GAPI";

--- a/third_party/proto/google/api/annotations.proto
+++ b/third_party/proto/google/api/annotations.proto
@@ -21,6 +21,7 @@ import "google/protobuf/descriptor.proto";
 
 option go_package = "google.golang.org/genproto/googleapis/api/annotations;annotations";
 option java_multiple_files = true;
+option java_multiple_files = true;
 option java_outer_classname = "AnnotationsProto";
 option java_package = "com.google.api";
 option objc_class_prefix = "GAPI";

--- a/third_party/proto/google/api/http.proto
+++ b/third_party/proto/google/api/http.proto
@@ -19,6 +19,7 @@ package google.api;
 option cc_enable_arenas = true;
 option go_package = "google.golang.org/genproto/googleapis/api/annotations;annotations";
 option java_multiple_files = true;
+option java_multiple_files = true;
 option java_outer_classname = "HttpProto";
 option java_package = "com.google.api";
 option objc_class_prefix = "GAPI";

--- a/third_party/proto/google/api/http.proto
+++ b/third_party/proto/google/api/http.proto
@@ -19,7 +19,6 @@ package google.api;
 option cc_enable_arenas = true;
 option go_package = "google.golang.org/genproto/googleapis/api/annotations;annotations";
 option java_multiple_files = true;
-option java_multiple_files = true;
 option java_outer_classname = "HttpProto";
 option java_package = "com.google.api";
 option objc_class_prefix = "GAPI";

--- a/third_party/proto/google/api/httpbody.proto
+++ b/third_party/proto/google/api/httpbody.proto
@@ -22,7 +22,6 @@ import "google/protobuf/any.proto";
 option cc_enable_arenas = true;
 option go_package = "google.golang.org/genproto/googleapis/api/httpbody;httpbody";
 option java_multiple_files = true;
-option java_multiple_files = true;
 option java_outer_classname = "HttpBodyProto";
 option java_package = "com.google.api";
 option objc_class_prefix = "GAPI";

--- a/third_party/proto/google/api/httpbody.proto
+++ b/third_party/proto/google/api/httpbody.proto
@@ -22,6 +22,7 @@ import "google/protobuf/any.proto";
 option cc_enable_arenas = true;
 option go_package = "google.golang.org/genproto/googleapis/api/httpbody;httpbody";
 option java_multiple_files = true;
+option java_multiple_files = true;
 option java_outer_classname = "HttpBodyProto";
 option java_package = "com.google.api";
 option objc_class_prefix = "GAPI";

--- a/third_party/proto/google/protobuf/any.proto
+++ b/third_party/proto/google/protobuf/any.proto
@@ -39,7 +39,6 @@ option go_package = "types";
 option java_multiple_files = true;
 option java_package = "com.google.protobuf";
 option java_outer_classname = "AnyProto";
-option java_multiple_files = true;
 option objc_class_prefix = "GPB";
 
 // `Any` contains an arbitrary serialized protocol buffer message along with a

--- a/third_party/proto/google/protobuf/any.proto
+++ b/third_party/proto/google/protobuf/any.proto
@@ -36,6 +36,7 @@ import "gogoproto/gogo.proto";
 
 option csharp_namespace = "Google.Protobuf.WellKnownTypes";
 option go_package = "types";
+option java_multiple_files = true;
 option java_package = "com.google.protobuf";
 option java_outer_classname = "AnyProto";
 option java_multiple_files = true;

--- a/third_party/proto/tendermint/abci/types.proto
+++ b/third_party/proto/tendermint/abci/types.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 package tendermint.abci;
 
 option go_package = "github.com/tendermint/tendermint/abci/types";
+option java_multiple_files = true;
 
 // For more information on gogo.proto, see:
 // https://github.com/gogo/protobuf/blob/master/extensions.md

--- a/third_party/proto/tendermint/crypto/keys.proto
+++ b/third_party/proto/tendermint/crypto/keys.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 package tendermint.crypto;
 
 option go_package = "github.com/tendermint/tendermint/proto/tendermint/crypto";
+option java_multiple_files = true;
 
 import "gogoproto/gogo.proto";
 

--- a/third_party/proto/tendermint/crypto/proof.proto
+++ b/third_party/proto/tendermint/crypto/proof.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 package tendermint.crypto;
 
 option go_package = "github.com/tendermint/tendermint/proto/tendermint/crypto";
+option java_multiple_files = true;
 
 import "gogoproto/gogo.proto";
 

--- a/third_party/proto/tendermint/libs/bits/types.proto
+++ b/third_party/proto/tendermint/libs/bits/types.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 package tendermint.libs.bits;
 
 option go_package = "github.com/tendermint/tendermint/proto/tendermint/libs/bits";
+option java_multiple_files = true;
 
 message BitArray {
   int64           bits  = 1;

--- a/third_party/proto/tendermint/p2p/types.proto
+++ b/third_party/proto/tendermint/p2p/types.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 package tendermint.p2p;
 
 option go_package = "github.com/tendermint/tendermint/proto/tendermint/p2p";
+option java_multiple_files = true;
 
 import "gogoproto/gogo.proto";
 

--- a/third_party/proto/tendermint/types/block.proto
+++ b/third_party/proto/tendermint/types/block.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 package tendermint.types;
 
 option go_package = "github.com/tendermint/tendermint/proto/tendermint/types";
+option java_multiple_files = true;
 
 import "gogoproto/gogo.proto";
 import "tendermint/types/types.proto";

--- a/third_party/proto/tendermint/types/evidence.proto
+++ b/third_party/proto/tendermint/types/evidence.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 package tendermint.types;
 
 option go_package = "github.com/tendermint/tendermint/proto/tendermint/types";
+option java_multiple_files = true;
 
 import "gogoproto/gogo.proto";
 import "google/protobuf/timestamp.proto";

--- a/third_party/proto/tendermint/types/params.proto
+++ b/third_party/proto/tendermint/types/params.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 package tendermint.types;
 
 option go_package = "github.com/tendermint/tendermint/proto/tendermint/types";
+option java_multiple_files = true;
 
 import "gogoproto/gogo.proto";
 import "google/protobuf/duration.proto";

--- a/third_party/proto/tendermint/types/types.proto
+++ b/third_party/proto/tendermint/types/types.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 package tendermint.types;
 
 option go_package = "github.com/tendermint/tendermint/proto/tendermint/types";
+option java_multiple_files = true;
 
 import "gogoproto/gogo.proto";
 import "google/protobuf/timestamp.proto";

--- a/third_party/proto/tendermint/types/validator.proto
+++ b/third_party/proto/tendermint/types/validator.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 package tendermint.types;
 
 option go_package = "github.com/tendermint/tendermint/proto/tendermint/types";
+option java_multiple_files = true;
 
 import "gogoproto/gogo.proto";
 import "tendermint/crypto/keys.proto";

--- a/third_party/proto/tendermint/version/types.proto
+++ b/third_party/proto/tendermint/version/types.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 package tendermint.version;
 
 option go_package = "github.com/tendermint/tendermint/proto/tendermint/version";
+option java_multiple_files = true;
 
 import "gogoproto/gogo.proto";
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

      When generating java artifacts the default option creates huge java classes. In the general guidelanis of the Java development, it is better to have one class per file etc. 
      Adding the proper option in protobuf files will allow the generator to handle that. 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
