### PR TITLE
store/cachekv: reduce allocation when convert []byte -> string in map key

### DIFF
--- a/store/cachekv/store.go
+++ b/store/cachekv/store.go
@@ -59,7 +59,7 @@ func (store *Store) Get(key []byte) (value []byte) {
 
 	types.AssertValidKey(key)
 
-	cacheValue, ok := store.cache[string(key)]
+	cacheValue, ok := store.cache[conv.UnsafeBytesToStr(key)]
 	if !ok {
 		value = store.parent.Get(key)
 		store.setCacheValue(key, value, false, false)
@@ -238,12 +238,12 @@ func (store *Store) dirtyItems(start, end []byte) {
 
 // Only entrypoint to mutate store.cache.
 func (store *Store) setCacheValue(key, value []byte, deleted bool, dirty bool) {
-	store.cache[string(key)] = &cValue{
+	store.cache[conv.UnsafeBytesToStr(key)] = &cValue{
 		value:   value,
 		deleted: deleted,
 		dirty:   dirty,
 	}
 	if dirty {
-		store.unsortedCache[string(key)] = struct{}{}
+		store.unsortedCache[conv.UnsafeBytesToStr(key)] = struct{}{}
 	}
 }


### PR DESCRIPTION


<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Benchmark for store/cachekv:

```
name                          old time/op    new time/op    delta
CacheKVStoreIterator500-8       23.4µs ± 1%    23.3µs ± 1%     ~     (p=0.095 n=5+5)
CacheKVStoreIterator1000-8      46.7µs ± 1%    46.2µs ± 0%   -0.96%  (p=0.008 n=5+5)
CacheKVStoreIterator10000-8      457µs ± 1%     455µs ± 1%     ~     (p=1.000 n=5+5)
CacheKVStoreIterator50000-8     2.59ms ± 2%    2.47ms ± 1%   -4.64%  (p=0.008 n=5+5)
CacheKVStoreIterator100000-8    7.33ms ± 3%    6.91ms ± 1%   -5.75%  (p=0.008 n=5+5)
CacheKVStoreGetNoKeyFound-8      423ns ± 1%     391ns ± 2%   -7.41%  (p=0.008 n=5+5)
CacheKVStoreGetKeyFound-8        267ns ± 3%     264ns ± 2%     ~     (p=0.595 n=5+5)

name                          old alloc/op   new alloc/op   delta
CacheKVStoreIterator500-8       5.18kB ± 0%    5.18kB ± 0%     ~     (all equal)
CacheKVStoreIterator1000-8      9.29kB ± 0%    9.29kB ± 0%     ~     (p=0.079 n=4+5)
CacheKVStoreIterator10000-8     85.2kB ± 0%    84.9kB ± 0%   -0.30%  (p=0.008 n=5+5)
CacheKVStoreIterator50000-8      468kB ± 1%     458kB ± 0%   -2.17%  (p=0.008 n=5+5)
CacheKVStoreIterator100000-8    1.16MB ± 1%    1.10MB ± 0%   -5.34%  (p=0.008 n=5+5)
CacheKVStoreGetNoKeyFound-8       222B ± 1%      214B ± 0%   -3.78%  (p=0.008 n=5+5)
CacheKVStoreGetKeyFound-8        51.0B ± 0%     51.0B ± 0%     ~     (all equal)

name                          old allocs/op  new allocs/op  delta
CacheKVStoreIterator500-8         13.0 ± 0%      13.0 ± 0%     ~     (all equal)
CacheKVStoreIterator1000-8        13.0 ± 0%      13.0 ± 0%     ~     (all equal)
CacheKVStoreIterator10000-8       51.0 ± 0%      43.0 ± 0%  -15.69%  (p=0.008 n=5+5)
CacheKVStoreIterator50000-8      1.22k ± 4%     0.94k ± 1%  -23.04%  (p=0.008 n=5+5)
CacheKVStoreIterator100000-8     6.48k ± 4%     4.85k ± 1%  -25.12%  (p=0.008 n=5+5)
CacheKVStoreGetNoKeyFound-8       5.00 ± 0%      4.00 ± 0%  -20.00%  (p=0.008 n=5+5)
CacheKVStoreGetKeyFound-8         2.00 ± 0%      2.00 ± 0%     ~     (all equal)
```

Benchmark for x/auth/keeper:

```
name                            old time/op    new time/op    delta
AccountMapperGetAccountFound-8    1.27µs ± 3%    1.26µs ± 1%    ~     (p=0.270 n=5+5)
AccountMapperSetAccount-8         3.53µs ± 0%    3.44µs ± 1%  -2.59%  (p=0.008 n=5+5)

name                            old alloc/op   new alloc/op   delta
AccountMapperGetAccountFound-8      440B ± 0%      440B ± 0%    ~     (all equal)
AccountMapperSetAccount-8         2.13kB ± 0%    2.08kB ± 0%  -2.31%  (p=0.008 n=5+5)

name                            old allocs/op  new allocs/op  delta
AccountMapperGetAccountFound-8      10.0 ± 0%      10.0 ± 0%    ~     (all equal)
AccountMapperSetAccount-8           42.0 ± 0%      38.0 ± 0%  -9.52%  (p=0.008 n=5+5)
```

Fixes #9274

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
