### PR TITLE
fuzz/crypto: fix wrong panic for CompactUnmarshal

### DIFF
--- a/fuzz/crypto/types/compactbitarray/marshalunmarshal/main.go
+++ b/fuzz/crypto/types/compactbitarray/marshalunmarshal/main.go
@@ -9,7 +9,7 @@ func Fuzz(data []byte) int {
 	if err != nil {
 		return 0
 	}
-	if cba == nil {
+	if cba == nil && string(data) != "null" {
 		panic("Inconsistency, no error, yet BitArray is nil")
 	}
 	if cba.SetIndex(-1, true) {


### PR DESCRIPTION


<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

CompactUnmarshal returns a nil compact bitarray for "null", it causes
false positive alert reported by oss-fuzz.

See: https://oss-fuzz.com/testcase-detail/6372206180433920

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
