### PR TITLE
Minor doc fix for `missed_blocks` proto field

### DIFF
--- a/proto/cosmos/slashing/v1beta1/genesis.proto
+++ b/proto/cosmos/slashing/v1beta1/genesis.proto
@@ -16,7 +16,7 @@ message GenesisState {
   repeated SigningInfo signing_infos = 2
       [(gogoproto.moretags) = "yaml:\"signing_infos\"", (gogoproto.nullable) = false];
 
-  // signing_infos represents a map between validator addresses and their
+  // missed_blocks represents a map between validator addresses and their
   // missed blocks.
   repeated ValidatorMissedBlocks missed_blocks = 3
       [(gogoproto.moretags) = "yaml:\"missed_blocks\"", (gogoproto.nullable) = false];


### PR DESCRIPTION
Sets the right name of the field in the comment for `missed_blocks`