### PR TITLE
fix: add missing nil check in store.GetStore

### DIFF
--- a/store/cachemulti/store.go
+++ b/store/cachemulti/store.go
@@ -173,13 +173,17 @@ func (cms Store) CacheMultiStoreWithVersion(_ int64) (types.CacheMultiStore, err
 
 // GetStore returns an underlying Store by key.
 func (cms Store) GetStore(key types.StoreKey) types.Store {
-	return cms.stores[key].(types.Store)
+	s := cms.stores[key]
+	if key == nil || s == nil {
+		panic(fmt.Sprintf("kv store with key %v has not been registered in stores", key))
+	}
+	return s.(types.Store)
 }
 
 // GetKVStore returns an underlying KVStore by key.
 func (cms Store) GetKVStore(key types.StoreKey) types.KVStore {
 	store := cms.stores[key]
-	if key == nil {
+	if key == nil || store == nil {
 		panic(fmt.Sprintf("kv store with key %v has not been registered in stores", key))
 	}
 	return store.(types.KVStore)

--- a/store/cachemulti/store_test.go
+++ b/store/cachemulti/store_test.go
@@ -1,0 +1,23 @@
+package cachemulti
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/cosmos/cosmos-sdk/store/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStoreGetKVStore(t *testing.T) {
+	require := require.New(t)
+
+	s := Store{stores: map[types.StoreKey]types.CacheWrap{}}
+	key := types.NewKVStoreKey("abc")
+	errMsg := fmt.Sprintf("kv store with key %v has not been registered in stores", key)
+
+	require.PanicsWithValue(errMsg,
+		func() { s.GetStore(key) })
+
+	require.PanicsWithValue(errMsg,
+		func() { s.GetKVStore(key) })
+}

--- a/store/rootmulti/store.go
+++ b/store/rootmulti/store.go
@@ -492,7 +492,11 @@ func (rs *Store) GetStore(key types.StoreKey) types.Store {
 // NOTE: The returned KVStore may be wrapped in an inter-block cache if it is
 // set on the root store.
 func (rs *Store) GetKVStore(key types.StoreKey) types.KVStore {
-	store := rs.stores[key].(types.KVStore)
+	s := rs.stores[key]
+	if s == nil {
+		panic(fmt.Sprintf("store does not exist for key: %s", key.Name()))
+	}
+	store := s.(types.KVStore)
 
 	if rs.TracingEnabled() {
 		store = tracekv.NewStore(store, rs.traceWriter, rs.traceContext)


### PR DESCRIPTION
## Description

Both `store.GetStore` and `store.GetKVStore` are missing `nil` checks which yield to more ugly panics.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
