### PR TITLE
CLI: `query ibc-transfer escrow-address`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,14 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 # Changelog
 
+## Unreleased
+
+### Features
+
+
+* [\#9383](https://github.com/cosmos/cosmos-sdk/pull/9383) New CLI command `query ibc-transfer escrow-address <port> <channel id>` to get the escrow address for a channel; can be used to then query balance of escrowed tokens
+
+
 ## [v0.42.5](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.42.5) - 2021-05-18
 
 ### Bug Fixes

--- a/x/ibc/applications/transfer/client/cli/cli.go
+++ b/x/ibc/applications/transfer/client/cli/cli.go
@@ -19,6 +19,7 @@ func GetQueryCmd() *cobra.Command {
 		GetCmdQueryDenomTrace(),
 		GetCmdQueryDenomTraces(),
 		GetCmdParams(),
+		GetCmdQueryEscrowAddress(),
 	)
 
 	return queryCmd

--- a/x/ibc/applications/transfer/client/cli/query.go
+++ b/x/ibc/applications/transfer/client/cli/query.go
@@ -107,3 +107,25 @@ func GetCmdParams() *cobra.Command {
 
 	return cmd
 }
+
+// GetCmdParams returns the command handler for ibc-transfer parameter querying.
+func GetCmdQueryEscrowAddress() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "escrow-address",
+		Short:   "Get the escrow address for a channel",
+		Long:    "Get the escrow address for a channel",
+		Args:    cobra.ExactArgs(2),
+		Example: fmt.Sprintf("%s query ibc-transfer escrow-address [port] [channel-id]", version.AppName),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			port := args[0]
+			channel := args[1]
+			addr := types.GetEscrowAddress(port, channel)
+			fmt.Println(addr.String())
+			return nil
+		},
+	}
+
+	flags.AddQueryFlagsToCmd(cmd)
+
+	return cmd
+}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

When coins are sent via IBC MsgTransfer, they are escrowed in a module account specific to the channel. But with current commands it does not appear possible to get the module account address, and thus to query the balance of escrowed coins. This PR fixes that by introducing a new command:

```
gaiad query ibc-transfer escrow-address <port> <channel id>
```

It doesn't actually query a node, just returns the result of calling `GetEscrowAddress`. This could conceivably go under `gaiad debug`, but figured it made sense under `query ibc-transfer`. 

With this you can now easily see how many coins are escrowed on a channel:

```
gaiad query bank balances $(gaiad query ibc-transfer escrow-address transfer channel-119)
```

Note this will need to be back-ported to ibc-go - https://github.com/cosmos/ibc-go/issues/189

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
