### PR TITLE
Backport: IBC query header/node-state fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,12 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 # Changelog
 
+## Unreleased
+
+### Bug Fixes
+
+* [\#9385](https://github.com/cosmos/cosmos-sdk/pull/9385) Fix IBC `query ibc client header` cli command. Support historical queries for query header/node-state commands. 
+
 ## [v0.42.5](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.42.5) - 2021-05-18
 
 ### Bug Fixes

--- a/x/ibc/core/02-client/client/utils/utils.go
+++ b/x/ibc/core/02-client/client/utils/utils.go
@@ -131,14 +131,19 @@ func QueryTendermintHeader(clientCtx client.Context) (ibctmtypes.Header, int64, 
 		return ibctmtypes.Header{}, 0, err
 	}
 
-	height := info.Response.LastBlockHeight
+	var height int64
+	if clientCtx.Height != 0 {
+		height = clientCtx.Height
+	} else {
+		height = info.Response.LastBlockHeight
+	}
 
 	commit, err := node.Commit(context.Background(), &height)
 	if err != nil {
 		return ibctmtypes.Header{}, 0, err
 	}
 
-	page := 0
+	page := 1
 	count := 10_000
 
 	validators, err := node.Validators(context.Background(), &height, &page, &count)
@@ -173,7 +178,12 @@ func QueryNodeConsensusState(clientCtx client.Context) (*ibctmtypes.ConsensusSta
 		return &ibctmtypes.ConsensusState{}, 0, err
 	}
 
-	height := info.Response.LastBlockHeight
+	var height int64
+	if clientCtx.Height != 0 {
+		height = clientCtx.Height
+	} else {
+		height = info.Response.LastBlockHeight
+	}
 
 	commit, err := node.Commit(context.Background(), &height)
 	if err != nil {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Backport of [ibc-go change](https://github.com/cosmos/ibc-go/pull/192). Fixes the `query ibc client header` command and allows querying by height for the header and node-state command. This allows easier venerability of which IBC tokens belong to which chains 

closes: #XXXX

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Review `Codecov Report` in the comment section below once CI passes
