### PR TITLE
feat: add header hash to `Context`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,7 @@ if input key is empty, or input data contains empty key.
 
 ### Improvements
 
+* (baseapp, types) [#\9390](https://github.com/cosmos/cosmos-sdk/pull/9390) Add current block header hash to `Context`
 * (x/bank) [\#8614](https://github.com/cosmos/cosmos-sdk/issues/8614) Add `Name` and `Symbol` fields to denom metadata
 * (x/auth) [\#8522](https://github.com/cosmos/cosmos-sdk/pull/8522) Allow to query all stored accounts
 * (crypto/types) [\#8600](https://github.com/cosmos/cosmos-sdk/pull/8600) `CompactBitArray`: optimize the `NumTrueBitsBefore` method and add an `Equal` method.

--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -164,7 +164,8 @@ func (app *BaseApp) BeginBlock(req abci.RequestBeginBlock) (res abci.ResponseBeg
 		// by InitChain. Context is now updated with Header information.
 		app.deliverState.ctx = app.deliverState.ctx.
 			WithBlockHeader(req.Header).
-			WithBlockHeight(req.Header.Height)
+			WithBlockHeight(req.Header.Height).
+			WithHeaderHash(req.Hash)
 	}
 
 	// add block gas meter

--- a/types/context.go
+++ b/types/context.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	abci "github.com/tendermint/tendermint/abci/types"
+	tmbytes "github.com/tendermint/tendermint/libs/bytes"
 	"github.com/tendermint/tendermint/libs/log"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 
@@ -25,6 +26,7 @@ type Context struct {
 	ctx           context.Context
 	ms            MultiStore
 	header        tmproto.Header
+	headerHash    tmbytes.HexBytes
 	chainID       string
 	txBytes       []byte
 	logger        log.Logger
@@ -61,6 +63,13 @@ func (c Context) EventManager() *EventManager { return c.eventManager }
 func (c Context) BlockHeader() tmproto.Header {
 	var msg = proto.Clone(&c.header).(*tmproto.Header)
 	return *msg
+}
+
+// HeaderHash returns a copy of the header hash obtained during abci.RequestBeginBlock
+func (c Context) HeaderHash() tmbytes.HexBytes {
+	hash := make([]byte, len(c.headerHash))
+	copy(hash, c.headerHash)
+	return hash
 }
 
 func (c Context) ConsensusParams() *abci.ConsensusParams {
@@ -101,6 +110,15 @@ func (c Context) WithBlockHeader(header tmproto.Header) Context {
 	// https://github.com/gogo/protobuf/issues/519
 	header.Time = header.Time.UTC()
 	c.header = header
+	return c
+}
+
+// WithHeaderHash returns a Context with an updated tendermint block header hash.
+func (c Context) WithHeaderHash(hash []byte) Context {
+	temp := make([]byte, len(hash))
+	copy(temp, hash)
+
+	c.headerHash = temp
 	return c
 }
 

--- a/types/context_test.go
+++ b/types/context_test.go
@@ -92,6 +92,7 @@ func (s *contextTestSuite) TestContextWithCustom() {
 	meter := types.NewGasMeter(10000)
 	blockGasMeter := types.NewGasMeter(20000)
 	minGasPrices := types.DecCoins{types.NewInt64DecCoin("feetoken", 1)}
+	headerHash := []byte("headerHash")
 
 	ctx = types.NewContext(nil, header, ischeck, logger)
 	s.Require().Equal(header, ctx.BlockHeader())
@@ -103,7 +104,8 @@ func (s *contextTestSuite) TestContextWithCustom() {
 		WithVoteInfos(voteinfos).
 		WithGasMeter(meter).
 		WithMinGasPrices(minGasPrices).
-		WithBlockGasMeter(blockGasMeter)
+		WithBlockGasMeter(blockGasMeter).
+		WithHeaderHash(headerHash)
 	s.Require().Equal(height, ctx.BlockHeight())
 	s.Require().Equal(chainid, ctx.ChainID())
 	s.Require().Equal(ischeck, ctx.IsCheckTx())
@@ -113,6 +115,7 @@ func (s *contextTestSuite) TestContextWithCustom() {
 	s.Require().Equal(meter, ctx.GasMeter())
 	s.Require().Equal(minGasPrices, ctx.MinGasPrices())
 	s.Require().Equal(blockGasMeter, ctx.BlockGasMeter())
+	s.Require().Equal(headerHash, ctx.HeaderHash().Bytes())
 	s.Require().False(ctx.WithIsCheckTx(false).IsCheckTx())
 
 	// test IsReCheckTx


### PR DESCRIPTION
Adds the current block header hash obtained during `abci.RequestBeginBlock` to the `Context`