### PR TITLE
fix: CI Liveliness test 

### DIFF
--- a/contrib/images/simd-env/Dockerfile
+++ b/contrib/images/simd-env/Dockerfile
@@ -8,7 +8,7 @@ ARG UID=1000
 ARG GID=1000
 
 USER ${UID}:${GID}
-VOLUME [ /simd ]
+VOLUME [ "/simd" ]
 WORKDIR /simd
 EXPOSE 26656 26657
 ENTRYPOINT ["/usr/bin/wrapper.sh"]


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description
This PR fixes the following error that was raised when running the `liveliness-test` workflow: 

```
docker: Error response from daemon: OCI runtime create failed: invalid mount {Destination:[ Type:bind Source:/var/lib/docker/volumes/76458935a8a7eefe579a08a9df14debff7251d8c7c70a52aa4f76bfe6962cb94/_data Options:[rbind]}: mount destination [ not absolute: unknown.
```

This was due to the fact that the volumes enclosed inside the Dockerfile should be written between double quotes (`"`). This can be read from the [Docker documentation](https://docs.docker.com/engine/reference/builder/#notes-about-specifying-volumes):

> Keep the following things in mind about volumes in the `Dockerfile`.
> 
> - [...]
> - **JSON formatting**: The list is parsed as a JSON array. You must enclose words with double quotes (`"`) rather than single quotes (`'`).

We had the same error inside Desmos ad it was fixed with desmos-labs/desmos#443 (you can see the checks passing there)

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
