### PR TITLE
fix: cosmovisor scanner regex 

### DIFF
--- a/cosmovisor/cmd/cosmovisor/main.go
+++ b/cosmovisor/cmd/cosmovisor/main.go
@@ -21,15 +21,9 @@ func Run(args []string) error {
 		return err
 	}
 
-	// clone args to prevent attaching useless --unsafe-skip-upgrades flags a lot
-	originArgs := args
-
 	var doUpgrade bool
-	var height string
 	for {
-		if doUpgrade, height, err = cosmovisor.LaunchProcess(cfg, args, os.Stdout, os.Stderr); cfg.RestartAfterUpgrade && err == nil && doUpgrade {
-			args = append(originArgs, fmt.Sprintf("--unsafe-skip-upgrades=%s", height))
-		} else {
+		if doUpgrade, err = cosmovisor.LaunchProcess(cfg, args, os.Stdout, os.Stderr); !cfg.RestartAfterUpgrade || err != nil || !doUpgrade {
 			break
 		}
 	}

--- a/cosmovisor/process.go
+++ b/cosmovisor/process.go
@@ -15,25 +15,25 @@ import (
 
 // LaunchProcess runs a subprocess and returns when the subprocess exits,
 // either when it dies, or *after* a successful upgrade.
-func LaunchProcess(cfg *Config, args []string, stdout, stderr io.Writer) (bool, string, error) {
+func LaunchProcess(cfg *Config, args []string, stdout, stderr io.Writer) (bool, error) {
 	bin, err := cfg.CurrentBin()
 	if err != nil {
-		return false, "", fmt.Errorf("error creating symlink to genesis: %w", err)
+		return false, fmt.Errorf("error creating symlink to genesis: %w", err)
 	}
 
 	if err := EnsureBinary(bin); err != nil {
-		return false, "", fmt.Errorf("current binary invalid: %w", err)
+		return false, fmt.Errorf("current binary invalid: %w", err)
 	}
 
 	cmd := exec.Command(bin, args...)
 	outpipe, err := cmd.StdoutPipe()
 	if err != nil {
-		return false, "", err
+		return false, err
 	}
 
 	errpipe, err := cmd.StderrPipe()
 	if err != nil {
-		return false, "", err
+		return false, err
 	}
 
 	scanOut := bufio.NewScanner(io.TeeReader(outpipe, stdout))
@@ -51,7 +51,7 @@ func LaunchProcess(cfg *Config, args []string, stdout, stderr io.Writer) (bool, 
 	scanErr.Buffer(bufErr, maxCapacity)
 
 	if err := cmd.Start(); err != nil {
-		return false, "", fmt.Errorf("launching process %s %s: %w", bin, strings.Join(args, " "), err)
+		return false, fmt.Errorf("launching process %s %s: %w", bin, strings.Join(args, " "), err)
 	}
 
 	sigs := make(chan os.Signal, 1)
@@ -66,14 +66,14 @@ func LaunchProcess(cfg *Config, args []string, stdout, stderr io.Writer) (bool, 
 	// three ways to exit - command ends, find regexp in scanOut, find regexp in scanErr
 	upgradeInfo, err := WaitForUpgradeOrExit(cmd, scanOut, scanErr)
 	if err != nil {
-		return false, "", err
+		return false, err
 	}
 
 	if upgradeInfo != nil {
-		return true, upgradeInfo.Height, DoUpgrade(cfg, upgradeInfo)
+		return true, DoUpgrade(cfg, upgradeInfo)
 	}
 
-	return false, "", nil
+	return false, nil
 }
 
 // WaitResult is used to wrap feedback on cmd state with some mutex logic.

--- a/cosmovisor/process_test.go
+++ b/cosmovisor/process_test.go
@@ -37,7 +37,7 @@ func (s *processTestSuite) TestLaunchProcess() {
 	s.Require().NoError(err)
 	s.Require().True(doUpgrade)
 	s.Require().Equal("", stderr.String())
-	s.Require().Equal("Genesis foo bar 1234\nUPGRADE \"chain2\" NEEDED at height: 49: {}\n", stdout.String())
+	s.Require().Equal("Genesis foo bar 1234\nUPGRADE \"chain2\" NEEDED at Height: 49: {}\n", stdout.String())
 
 	// ensure this is upgraded now and produces new output
 
@@ -78,7 +78,7 @@ func (s *processTestSuite) TestLaunchProcessWithDownloads() {
 	s.Require().NoError(err)
 	s.Require().True(doUpgrade)
 	s.Require().Equal("", stderr.String())
-	s.Require().Equal("Preparing auto-download some args\n"+`ERROR: UPGRADE "chain2" NEEDED at height: 49: {"binaries":{"linux/amd64":"https://github.com/cosmos/cosmos-sdk/raw/51249cb93130810033408934454841c98423ed4b/cosmovisor/testdata/repo/zip_binary/autod.zip?checksum=sha256:dc48829b4126ae95bc0db316c66d4e9da5f3db95e212665b6080638cca77e998"}} module=main`+"\n", stdout.String())
+	s.Require().Equal("Preparing auto-download some args\n"+`ERROR: UPGRADE "chain2" NEEDED at Height: 49: {"binaries":{"linux/amd64":"https://github.com/cosmos/cosmos-sdk/raw/51249cb93130810033408934454841c98423ed4b/cosmovisor/testdata/repo/zip_binary/autod.zip?checksum=sha256:dc48829b4126ae95bc0db316c66d4e9da5f3db95e212665b6080638cca77e998"}} module=main`+"\n", stdout.String())
 
 	// ensure this is upgraded now and produces new output
 	currentBin, err = cfg.CurrentBin()
@@ -91,7 +91,7 @@ func (s *processTestSuite) TestLaunchProcessWithDownloads() {
 	s.Require().NoError(err)
 	s.Require().True(doUpgrade)
 	s.Require().Equal("", stderr.String())
-	s.Require().Equal("Chain 2 from zipped binary link to referral\nArgs: run --fast\n"+`ERROR: UPGRADE "chain3" NEEDED at height: 936: https://github.com/cosmos/cosmos-sdk/raw/0eae1a50612b8bf803336d35055896fbddaa1ddd/cosmovisor/testdata/repo/ref_zipped?checksum=sha256:0a428575de718ed3cf0771c9687eefaf6f19359977eca4d94a0abd0e11ef8e64 module=main`+"\n", stdout.String())
+	s.Require().Equal("Chain 2 from zipped binary link to referral\nArgs: run --fast\n"+`ERROR: UPGRADE "chain3" NEEDED at Height: 936: https://github.com/cosmos/cosmos-sdk/raw/0eae1a50612b8bf803336d35055896fbddaa1ddd/cosmovisor/testdata/repo/ref_zipped?checksum=sha256:0a428575de718ed3cf0771c9687eefaf6f19359977eca4d94a0abd0e11ef8e64 module=main`+"\n", stdout.String())
 
 	// ended with one more upgrade
 	currentBin, err = cfg.CurrentBin()

--- a/cosmovisor/scanner.go
+++ b/cosmovisor/scanner.go
@@ -14,9 +14,8 @@ var upgradeRegex = regexp.MustCompile(`UPGRADE "(.*)" NEEDED at ((Height): (\d+)
 
 // UpgradeInfo is the details from the regexp
 type UpgradeInfo struct {
-	Name   string
-	Height string
-	Info   string
+	Name string
+	Info string
 }
 
 // WaitForUpdate will listen to the scanner until a line matches upgradeRegexp.
@@ -29,9 +28,8 @@ func WaitForUpdate(scanner *bufio.Scanner) (*UpgradeInfo, error) {
 		if upgradeRegex.MatchString(line) {
 			subs := upgradeRegex.FindStringSubmatch(line)
 			info := UpgradeInfo{
-				Name:   subs[1],
-				Height: subs[4],
-				Info:   subs[5],
+				Name: subs[1],
+				Info: subs[5],
 			}
 			return &info, nil
 		}

--- a/cosmovisor/scanner.go
+++ b/cosmovisor/scanner.go
@@ -6,20 +6,17 @@ import (
 )
 
 // Trim off whitespace around the info - match least greedy, grab as much space on both sides
-// Defined here: https://github.com/cosmos/cosmos-sdk/blob/release/v0.38.2/x/upgrade/abci.go#L38
-//  fmt.Sprintf("UPGRADE \"%s\" NEEDED at %s: %s", plan.Name, plan.DueAt(), plan.Info)
-// DueAt defined here: https://github.com/cosmos/cosmos-sdk/blob/release/v0.38.2/x/upgrade/internal/types/plan.go#L73-L78
-//
-//    if !p.Time.IsZero() {
-//      return fmt.Sprintf("time: %s", p.Time.UTC().Format(time.RFC3339))
-//    }
-//    return fmt.Sprintf("height: %d", p.Height)
-var upgradeRegex = regexp.MustCompile(`UPGRADE "(.*)" NEEDED at ((height): (\d+)|(time): (\S+)):\s+(\S*)`)
+// Defined here: https://github.com/cosmos/cosmos-sdk/blob/cb66c99eab17d0763ea900d8d7bf2d970e4add22/x/upgrade/abci.go#L73-L75
+//    return fmt.Sprintf("UPGRADE \"%s\" NEEDED at %s: %s", plan.Name, plan.DueAt(), plan.Info)
+// DueAt defined here: https://github.com/cosmos/cosmos-sdk/blob/cb66c99eab17d0763ea900d8d7bf2d970e4add22/x/upgrade/types/plan.go#L39-L41
+//    return fmt.Sprintf("Height: %d", p.Height)
+var upgradeRegex = regexp.MustCompile(`UPGRADE "(.*)" NEEDED at ((Height): (\d+)):\s+(\S*)`)
 
 // UpgradeInfo is the details from the regexp
 type UpgradeInfo struct {
-	Name string
-	Info string
+	Name   string
+	Height string
+	Info   string
 }
 
 // WaitForUpdate will listen to the scanner until a line matches upgradeRegexp.
@@ -32,8 +29,9 @@ func WaitForUpdate(scanner *bufio.Scanner) (*UpgradeInfo, error) {
 		if upgradeRegex.MatchString(line) {
 			subs := upgradeRegex.FindStringSubmatch(line)
 			info := UpgradeInfo{
-				Name: subs[1],
-				Info: subs[7],
+				Name:   subs[1],
+				Height: subs[4],
+				Info:   subs[5],
 			}
 			return &info, nil
 		}

--- a/cosmovisor/scanner_test.go
+++ b/cosmovisor/scanner_test.go
@@ -20,17 +20,19 @@ func TestWaitForInfo(t *testing.T) {
 			write: []string{"some", "random\ninfo\n"},
 		},
 		"match name with no info": {
-			write: []string{"first line\n", `UPGRADE "myname" NEEDED at height: 123: `, "\nnext line\n"},
+			write: []string{"first line\n", `UPGRADE "myname" NEEDED at Height: 125: `, "\nnext line\n"},
 			expectUpgrade: &cosmovisor.UpgradeInfo{
-				Name: "myname",
-				Info: "",
+				Name:   "myname",
+				Height: "125",
+				Info:   "",
 			},
 		},
 		"match name with info": {
-			write: []string{"first line\n", `UPGRADE "take2" NEEDED at height: 123:   DownloadData here!`, "\nnext line\n"},
+			write: []string{"first line\n", `UPGRADE "take2" NEEDED at Height: 123:   DownloadData here!`, "\nnext line\n"},
 			expectUpgrade: &cosmovisor.UpgradeInfo{
-				Name: "take2",
-				Info: "DownloadData",
+				Name:   "take2",
+				Height: "123",
+				Info:   "DownloadData",
 			},
 		},
 	}

--- a/cosmovisor/scanner_test.go
+++ b/cosmovisor/scanner_test.go
@@ -22,17 +22,15 @@ func TestWaitForInfo(t *testing.T) {
 		"match name with no info": {
 			write: []string{"first line\n", `UPGRADE "myname" NEEDED at Height: 125: `, "\nnext line\n"},
 			expectUpgrade: &cosmovisor.UpgradeInfo{
-				Name:   "myname",
-				Height: "125",
-				Info:   "",
+				Name: "myname",
+				Info: "",
 			},
 		},
 		"match name with info": {
 			write: []string{"first line\n", `UPGRADE "take2" NEEDED at Height: 123:   DownloadData here!`, "\nnext line\n"},
 			expectUpgrade: &cosmovisor.UpgradeInfo{
-				Name:   "take2",
-				Height: "123",
-				Info:   "DownloadData",
+				Name: "take2",
+				Info: "DownloadData",
 			},
 		},
 	}

--- a/cosmovisor/testdata/download/cosmovisor/genesis/bin/autod
+++ b/cosmovisor/testdata/download/cosmovisor/genesis/bin/autod
@@ -2,6 +2,6 @@
 
 echo Preparing auto-download $@
 sleep 1
-echo 'ERROR: UPGRADE "chain2" NEEDED at height: 49: {"binaries":{"linux/amd64":"https://github.com/cosmos/cosmos-sdk/raw/51249cb93130810033408934454841c98423ed4b/cosmovisor/testdata/repo/zip_binary/autod.zip?checksum=sha256:dc48829b4126ae95bc0db316c66d4e9da5f3db95e212665b6080638cca77e998"}} module=main'
+echo 'ERROR: UPGRADE "chain2" NEEDED at Height: 49: {"binaries":{"linux/amd64":"https://github.com/cosmos/cosmos-sdk/raw/51249cb93130810033408934454841c98423ed4b/cosmovisor/testdata/repo/zip_binary/autod.zip?checksum=sha256:dc48829b4126ae95bc0db316c66d4e9da5f3db95e212665b6080638cca77e998"}} module=main'
 sleep 4
 echo Never should be printed!!!

--- a/cosmovisor/testdata/repo/zip_binary/autod
+++ b/cosmovisor/testdata/repo/zip_binary/autod
@@ -3,6 +3,6 @@
 echo Chain 2 from zipped binary link to referral
 echo Args: $@
 # note that we just have a url (follow the ref), not a full link
-echo 'ERROR: UPGRADE "chain3" NEEDED at height: 936: https://github.com/cosmos/cosmos-sdk/raw/0eae1a50612b8bf803336d35055896fbddaa1ddd/cosmovisor/testdata/repo/ref_zipped?checksum=sha256:0a428575de718ed3cf0771c9687eefaf6f19359977eca4d94a0abd0e11ef8e64 module=main'
+echo 'ERROR: UPGRADE "chain3" NEEDED at Height: 936: https://github.com/cosmos/cosmos-sdk/raw/0eae1a50612b8bf803336d35055896fbddaa1ddd/cosmovisor/testdata/repo/ref_zipped?checksum=sha256:0a428575de718ed3cf0771c9687eefaf6f19359977eca4d94a0abd0e11ef8e64 module=main'
 sleep 4
 echo 'Do not print'

--- a/cosmovisor/testdata/validate/cosmovisor/genesis/bin/dummyd
+++ b/cosmovisor/testdata/validate/cosmovisor/genesis/bin/dummyd
@@ -2,6 +2,6 @@
 
 echo Genesis $@
 sleep 1
-echo 'UPGRADE "chain2" NEEDED at height: 49: {}'
+echo 'UPGRADE "chain2" NEEDED at Height: 49: {}'
 sleep 2
 echo Never should be printed!!!


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

closes: #9413 

This fixes the scanner regex & also adopt loop to support continuous process restart after multiple upgrades.

In current implementation, it support restart after only one upgrade plan. When we try full sync from the genesis, It has to support restart again again util reach latest height even if there are multiple upgrade plans.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
