### PR TITLE
fix: rollback height->Height in x/upgrade plan.DueAt formatting

### DIFF
--- a/x/upgrade/abci_test.go
+++ b/x/upgrade/abci_test.go
@@ -212,12 +212,12 @@ func TestNoSpuriousUpgrades(t *testing.T) {
 func TestPlanStringer(t *testing.T) {
 	require.Equal(t, `Upgrade Plan
   Name: test
-  Height: 100
+  height: 100
   Info: .`, types.Plan{Name: "test", Height: 100, Info: ""}.String())
 
 	require.Equal(t, fmt.Sprintf(`Upgrade Plan
   Name: test
-  Height: 100
+  height: 100
   Info: .`), types.Plan{Name: "test", Height: 100, Info: ""}.String())
 }
 

--- a/x/upgrade/types/plan.go
+++ b/x/upgrade/types/plan.go
@@ -37,5 +37,5 @@ func (p Plan) ShouldExecute(ctx sdk.Context) bool {
 
 // DueAt is a string representation of when this plan is due to be executed
 func (p Plan) DueAt() string {
-	return fmt.Sprintf("Height: %d", p.Height)
+	return fmt.Sprintf("height: %d", p.Height)
 }

--- a/x/upgrade/types/plan_test.go
+++ b/x/upgrade/types/plan_test.go
@@ -33,13 +33,13 @@ func TestPlanString(t *testing.T) {
 				Info:   "https://foo.bar/baz",
 				Height: 7890,
 			},
-			expect: "Upgrade Plan\n  Name: by height\n  Height: 7890\n  Info: https://foo.bar/baz.",
+			expect: "Upgrade Plan\n  Name: by height\n  height: 7890\n  Info: https://foo.bar/baz.",
 		},
 		"neither": {
 			p: types.Plan{
 				Name: "almost-empty",
 			},
-			expect: "Upgrade Plan\n  Name: almost-empty\n  Height: 0\n  Info: .",
+			expect: "Upgrade Plan\n  Name: almost-empty\n  height: 0\n  Info: .",
 		},
 	}
 


### PR DESCRIPTION
## Description

Closes: #9413

In https://github.com/cosmos/cosmos-sdk/pull/9415 an update to cosmvisor was proposed related in order to fix the cosmvisor for the following change:
```
c6af0ed87ed x/upgrade/types/plan.go          (2021-03-13 40) 	return fmt.Sprintf("Height: %d", p.Height)
``` 

I propose to rollback the above change rather than updating cosmvisor. 

Note: we don't need to update documentation or regexp, because these are correct (it was not changed in c6af0ed87ed)

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [x] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
