### PR TITLE
fix: note flag description

### DIFF
--- a/client/flags/flags.go
+++ b/client/flags/flags.go
@@ -97,7 +97,7 @@ func AddTxFlagsToCmd(cmd *cobra.Command) {
 	cmd.Flags().String(FlagFrom, "", "Name or address of private key with which to sign")
 	cmd.Flags().Uint64P(FlagAccountNumber, "a", 0, "The account number of the signing account (offline mode only)")
 	cmd.Flags().Uint64P(FlagSequence, "s", 0, "The sequence number of the signing account (offline mode only)")
-	cmd.Flags().String(FlagNote, "", "Note to add a description to the transaction (previously `--memo`)")
+	cmd.Flags().String(FlagNote, "", "Note to add a description to the transaction (previously --memo)")
 	cmd.Flags().String(FlagFees, "", "Fees to pay along with transaction; eg: 10uatom")
 	cmd.Flags().String(FlagGasPrices, "", "Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom)")
 	cmd.Flags().String(FlagNode, "tcp://localhost:26657", "<host>:<port> to tendermint rpc interface for this chain")


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

This is a follow up pull request to #9134 / #9122.

The use of backticks around `--memo` in the flag description causes the input type to show up as `--memo`:

```
regen tx bank send -h

--note --memo              Note to add a description to the transaction (previously --memo)
```

And without backticks around `--memo`:

```
regen tx bank send -h

--note string              Note to add a description to the transaction (previously --memo)
```

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md). -**n/a**
- [x] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing) -**n/a**
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`) -**n/a**
- [x] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code). -**n/a**
- [x] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md` -**n/a**
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Review `Codecov Report` in the comment section below once CI passes
