### PR TITLE
ci: use title+body for commit message

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -8,6 +8,7 @@ pull_request_rules:
       merge:
         method: squash
         strict: true
+        commit_message: title+body
   - name: backport patches to v0.42.x branch
     conditions:
       - base=master


### PR DESCRIPTION
## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

Mergify is currently using the default commit message (the first commit message), which does not always include a semantic type prefix and which does not always provide an accurate description. See [commit history](https://github.com/cosmos/cosmos-sdk/commits/master).

This pull request updates the configuration to use `title+body` for the commit message. See Mergify's [merge documentation](https://docs.mergify.io/actions/merge/).

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [x] provided a link to the relevant issue or specification - *n/a*
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
- [ ] confirmed that this PR does not change production code