### PR TITLE
refactor(client): add client/Context.Codec and deprecate JSONCodec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ if input key is empty, or input data contains empty key.
 * (x/staking) [\#9214](https://github.com/cosmos/cosmos-sdk/pull/9214) Added `new_shares` attribute inside `EventTypeDelegate` event.
 * [\#9382](https://github.com/cosmos/cosmos-sdk/pull/9382) feat: add Dec.Float64() function.
 * [\#9457](https://github.com/cosmos/cosmos-sdk/pull/9457) Add amino support for x/authz and x/feegrant Msgs.
+* [\#9498](https://github.com/cosmos/cosmos-sdk/pull/9498) Added `Codec: codec.Codec` attribute to `client/Context` structure.
 
 ### Client Breaking Changes
 
@@ -155,7 +156,7 @@ if input key is empty, or input data contains empty key.
 ### Deprecated
 
 * (grpc) [\#8926](https://github.com/cosmos/cosmos-sdk/pull/8926) The `tx` field in `SimulateRequest` has been deprecated, prefer to pass `tx_bytes` instead.
-* (sdk types) [\#xxx]() `clientContext.JSONCodec`
+* (sdk types) [\#9498](https://github.com/cosmos/cosmos-sdk/pull/9498) `clientContext.JSONCodec` will be removed in the next version. use `clientContext.Codec` instead.
 
 
 ## [v0.42.4](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.42.4) - 2021-04-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,6 +155,8 @@ if input key is empty, or input data contains empty key.
 ### Deprecated
 
 * (grpc) [\#8926](https://github.com/cosmos/cosmos-sdk/pull/8926) The `tx` field in `SimulateRequest` has been deprecated, prefer to pass `tx_bytes` instead.
+* (sdk types) [\#xxx]() `clientContext.JSONCodec`
+
 
 ## [v0.42.4](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.42.4) - 2021-04-08
 

--- a/client/context.go
+++ b/client/context.go
@@ -77,6 +77,11 @@ func (ctx Context) WithInput(r io.Reader) Context {
 // Deprecated: WithJSONCodec returns a copy of the Context with an updated JSONCodec.
 func (ctx Context) WithJSONCodec(m codec.JSONCodec) Context {
 	ctx.JSONCodec = m
+	// since we are using ctx.Codec everywhere in the SDK, for backward compatibility
+	// we need to try to set it here as well.
+	if c, ok := m.(codec.Codec); ok {
+		ctx.Codec = c
+	}
 	return ctx
 }
 

--- a/client/context.go
+++ b/client/context.go
@@ -22,10 +22,12 @@ import (
 // Context implements a typical context created in SDK modules for transaction
 // handling and queries.
 type Context struct {
-	FromAddress       sdk.AccAddress
-	Client            rpcclient.Client
-	ChainID           string
+	FromAddress sdk.AccAddress
+	Client      rpcclient.Client
+	ChainID     string
+	// Deprecated: JSONCodec codec will be changed to Codec: codec.Codec
 	JSONCodec         codec.JSONCodec
+	Codec             codec.Codec
 	InterfaceRegistry codectypes.InterfaceRegistry
 	Input             io.Reader
 	Keyring           keyring.Keyring
@@ -72,8 +74,15 @@ func (ctx Context) WithInput(r io.Reader) Context {
 	return ctx
 }
 
-// WithJSONCodec returns a copy of the Context with an updated JSONCodec.
+// Deprecated: WithJSONCodec returns a copy of the Context with an updated JSONCodec.
 func (ctx Context) WithJSONCodec(m codec.JSONCodec) Context {
+	ctx.JSONCodec = m
+	return ctx
+}
+
+// WithCodec returns a copy of the Context with an updated Codec.
+func (ctx Context) WithCodec(m codec.Codec) Context {
+	ctx.Codec = m
 	ctx.JSONCodec = m
 	return ctx
 }

--- a/client/context.go
+++ b/client/context.go
@@ -263,7 +263,7 @@ func (ctx Context) PrintBytes(o []byte) error {
 
 // PrintProto outputs toPrint to the ctx.Output based on ctx.OutputFormat which is
 // either text or json. If text, toPrint will be YAML encoded. Otherwise, toPrint
-// will be JSON encoded using ctx.JSONCodec. An error is returned upon failure.
+// will be JSON encoded using ctx.Codec. An error is returned upon failure.
 func (ctx Context) PrintProto(toPrint proto.Message) error {
 	// always serialize JSON initially because proto json can't be directly YAML encoded
 	out, err := ctx.Codec.MarshalJSON(toPrint)

--- a/client/context.go
+++ b/client/context.go
@@ -25,7 +25,7 @@ type Context struct {
 	FromAddress sdk.AccAddress
 	Client      rpcclient.Client
 	ChainID     string
-	// Deprecated: JSONCodec codec will be changed to Codec: codec.Codec
+	// Deprecated: Codec codec will be changed to Codec: codec.Codec
 	JSONCodec         codec.JSONCodec
 	Codec             codec.Codec
 	InterfaceRegistry codectypes.InterfaceRegistry
@@ -82,8 +82,8 @@ func (ctx Context) WithJSONCodec(m codec.JSONCodec) Context {
 
 // WithCodec returns a copy of the Context with an updated Codec.
 func (ctx Context) WithCodec(m codec.Codec) Context {
-	ctx.Codec = m
 	ctx.JSONCodec = m
+	ctx.Codec = m
 	return ctx
 }
 
@@ -266,7 +266,7 @@ func (ctx Context) PrintBytes(o []byte) error {
 // will be JSON encoded using ctx.JSONCodec. An error is returned upon failure.
 func (ctx Context) PrintProto(toPrint proto.Message) error {
 	// always serialize JSON initially because proto json can't be directly YAML encoded
-	out, err := ctx.JSONCodec.MarshalJSON(toPrint)
+	out, err := ctx.Codec.MarshalJSON(toPrint)
 	if err != nil {
 		return err
 	}

--- a/client/context_test.go
+++ b/client/context_test.go
@@ -41,7 +41,7 @@ func TestContext_PrintObject(t *testing.T) {
 	// proto
 	//
 	registry := testdata.NewTestInterfaceRegistry()
-	ctx = ctx.WithJSONCodec(codec.NewProtoCodec(registry))
+	ctx = ctx.WithCodec(codec.NewProtoCodec(registry))
 
 	// json
 	buf := &bytes.Buffer{}

--- a/client/debug/main.go
+++ b/client/debug/main.go
@@ -32,7 +32,7 @@ func Cmd() *cobra.Command {
 // getPubKeyFromString decodes SDK PubKey using JSON marshaler.
 func getPubKeyFromString(ctx client.Context, pkstr string) (cryptotypes.PubKey, error) {
 	var pk cryptotypes.PubKey
-	err := ctx.JSONCodec.UnmarshalInterfaceJSON([]byte(pkstr), &pk)
+	err := ctx.Codec.UnmarshalInterfaceJSON([]byte(pkstr), &pk)
 	return pk, err
 }
 

--- a/client/grpc/tmservice/service_test.go
+++ b/client/grpc/tmservice/service_test.go
@@ -57,7 +57,7 @@ func (s IntegrationTestSuite) TestQueryNodeInfo() {
 	restRes, err := rest.GetRequest(fmt.Sprintf("%s/cosmos/base/tendermint/v1beta1/node_info", val.APIAddress))
 	s.Require().NoError(err)
 	var getInfoRes tmservice.GetNodeInfoResponse
-	s.Require().NoError(val.ClientCtx.JSONCodec.UnmarshalJSON(restRes, &getInfoRes))
+	s.Require().NoError(val.ClientCtx.Codec.UnmarshalJSON(restRes, &getInfoRes))
 	s.Require().Equal(getInfoRes.ApplicationVersion.AppName, version.NewInfo().AppName)
 }
 
@@ -70,7 +70,7 @@ func (s IntegrationTestSuite) TestQuerySyncing() {
 	restRes, err := rest.GetRequest(fmt.Sprintf("%s/cosmos/base/tendermint/v1beta1/syncing", val.APIAddress))
 	s.Require().NoError(err)
 	var syncingRes tmservice.GetSyncingResponse
-	s.Require().NoError(val.ClientCtx.JSONCodec.UnmarshalJSON(restRes, &syncingRes))
+	s.Require().NoError(val.ClientCtx.Codec.UnmarshalJSON(restRes, &syncingRes))
 }
 
 func (s IntegrationTestSuite) TestQueryLatestBlock() {
@@ -82,7 +82,7 @@ func (s IntegrationTestSuite) TestQueryLatestBlock() {
 	restRes, err := rest.GetRequest(fmt.Sprintf("%s/cosmos/base/tendermint/v1beta1/blocks/latest", val.APIAddress))
 	s.Require().NoError(err)
 	var blockInfoRes tmservice.GetLatestBlockResponse
-	s.Require().NoError(val.ClientCtx.JSONCodec.UnmarshalJSON(restRes, &blockInfoRes))
+	s.Require().NoError(val.ClientCtx.Codec.UnmarshalJSON(restRes, &blockInfoRes))
 }
 
 func (s IntegrationTestSuite) TestQueryBlockByHeight() {
@@ -93,7 +93,7 @@ func (s IntegrationTestSuite) TestQueryBlockByHeight() {
 	restRes, err := rest.GetRequest(fmt.Sprintf("%s/cosmos/base/tendermint/v1beta1/blocks/%d", val.APIAddress, 1))
 	s.Require().NoError(err)
 	var blockInfoRes tmservice.GetBlockByHeightResponse
-	s.Require().NoError(val.ClientCtx.JSONCodec.UnmarshalJSON(restRes, &blockInfoRes))
+	s.Require().NoError(val.ClientCtx.Codec.UnmarshalJSON(restRes, &blockInfoRes))
 }
 
 func (s IntegrationTestSuite) TestQueryLatestValidatorSet() {
@@ -124,7 +124,7 @@ func (s IntegrationTestSuite) TestQueryLatestValidatorSet() {
 	restRes, err := rest.GetRequest(fmt.Sprintf("%s/cosmos/base/tendermint/v1beta1/validatorsets/latest?pagination.offset=%d&pagination.limit=%d", val.APIAddress, 0, 1))
 	s.Require().NoError(err)
 	var validatorSetRes tmservice.GetLatestValidatorSetResponse
-	s.Require().NoError(val.ClientCtx.JSONCodec.UnmarshalJSON(restRes, &validatorSetRes))
+	s.Require().NoError(val.ClientCtx.Codec.UnmarshalJSON(restRes, &validatorSetRes))
 	s.Require().Equal(1, len(validatorSetRes.Validators))
 	anyPub, err := codectypes.NewAnyWithValue(val.PubKey)
 	s.Require().NoError(err)
@@ -183,7 +183,7 @@ func (s IntegrationTestSuite) TestLatestValidatorSet_GRPCGateway() {
 				s.Require().Contains(string(res), tc.expErrMsg)
 			} else {
 				var result tmservice.GetLatestValidatorSetResponse
-				err = vals[0].ClientCtx.JSONCodec.UnmarshalJSON(res, &result)
+				err = vals[0].ClientCtx.Codec.UnmarshalJSON(res, &result)
 				s.Require().NoError(err)
 				s.Require().Equal(uint64(len(vals)), result.Pagination.Total)
 				anyPub, err := codectypes.NewAnyWithValue(vals[0].PubKey)
@@ -245,7 +245,7 @@ func (s IntegrationTestSuite) TestValidatorSetByHeight_GRPCGateway() {
 				s.Require().Contains(string(res), tc.expErrMsg)
 			} else {
 				var result tmservice.GetValidatorSetByHeightResponse
-				err = vals[0].ClientCtx.JSONCodec.UnmarshalJSON(res, &result)
+				err = vals[0].ClientCtx.Codec.UnmarshalJSON(res, &result)
 				s.Require().NoError(err)
 				s.Require().Equal(uint64(len(vals)), result.Pagination.Total)
 			}

--- a/client/keys/add.go
+++ b/client/keys/add.go
@@ -172,7 +172,7 @@ func RunAddCmd(ctx client.Context, cmd *cobra.Command, args []string, inBuf *buf
 	pubKey, _ := cmd.Flags().GetString(FlagPublicKey)
 	if pubKey != "" {
 		var pk cryptotypes.PubKey
-		err = ctx.JSONCodec.UnmarshalInterfaceJSON([]byte(pubKey), &pk)
+		err = ctx.Codec.UnmarshalInterfaceJSON([]byte(pubKey), &pk)
 		if err != nil {
 			return err
 		}

--- a/docs/architecture/adr-020-protobuf-transaction-encoding.md
+++ b/docs/architecture/adr-020-protobuf-transaction-encoding.md
@@ -13,7 +13,8 @@
 - 2020 September 25: Remove `PublicKey` type in favor of `secp256k1.PubKey`, `ed25519.PubKey` and `multisig.LegacyAminoPubKey`.
 - 2020 October 15: Add `GetAccount` and `GetAccountWithHeight` methods to the `AccountRetriever` interface.
 - 2021 Feb 24: The SDK does not use Tendermint's `PubKey` interface anymore, but its own `cryptotypes.PubKey`. Updates to reflect this.
-- 2021 May 3: Rename `clientCtx.JSONMarshaler` to `clientCtx.JSONCodec`
+- 2021 May 3: Rename `clientCtx.JSONMarshaler` to `clientCtx.JSONCodec`.
+- 2021 June 10: Add `clientCtx.Codec: codec.Codec`.
 
 ## Status
 
@@ -344,7 +345,7 @@ type TxBuilder interface {
 }
 ```
 
-We then update `Context` to have new fields: `JSONCodec`, `TxGenerator`,
+We then update `Context` to have new fields: `Codec`, `TxGenerator`,
 and `AccountRetriever`, and we update `AppModuleBasic.GetTxCmd` to take
 a `Context` which should have all of these fields pre-populated.
 

--- a/docs/migrations/app_and_modules.md
+++ b/docs/migrations/app_and_modules.md
@@ -146,7 +146,7 @@ clientCtx, err := client.GetClientTxContext(cmd)
 
 Some other flags helper functions are transformed: `flags.PostCommands(cmds ...*cobra.Command) []*cobra.Command` and `flags.GetCommands(...)` usage is now replaced by `flags.AddTxFlagsToCmd(cmd *cobra.Command)` and `flags.AddQueryFlagsToCmd(cmd *cobra.Command)` respectively.
 
-Moreover, new CLI commands don't take any codec as input anymore. Instead, the `clientCtx` can be retrieved from the `cmd` itself using the `GetClient{Query,Tx}Context` function above, and the codec as `clientCtx.JSONCodec`.
+Moreover, new CLI commands don't take any codec as input anymore. Instead, the `clientCtx` can be retrieved from the `cmd` itself using the `GetClient{Query,Tx}Context` function above, and the codec as `clientCtx.Codec`.
 
 ```diff
 // v0.39
@@ -154,10 +154,10 @@ Moreover, new CLI commands don't take any codec as input anymore. Instead, the `
 - 	cdc.MarshalJSON(...)
 - }
 
-// v0.40
+// v0.43
 + func NewSendTxCmd() *cobra.Command {
 +	clientCtx, err := client.GetClientTxContext(cmd)
-+	clientCtx.JSONCodec.MarshalJSON(...)
++	clientCtx.Codec.MarshalJSON(...)
 +}
 ```
 

--- a/server/export_test.go
+++ b/server/export_test.go
@@ -135,7 +135,7 @@ func setupApp(t *testing.T, tempDir string) (*simapp.SimApp, context.Context, *t
 	serverCtx := server.NewDefaultContext()
 	serverCtx.Config.RootDir = tempDir
 
-	clientCtx := client.Context{}.WithJSONCodec(app.AppCodec())
+	clientCtx := client.Context{}.WithCodec(app.AppCodec())
 	genDoc := newDefaultGenesisDoc(encCfg.Marshaler)
 
 	require.NoError(t, saveGenesisFile(genDoc, serverCtx.Config.GenesisFile()))

--- a/server/start.go
+++ b/server/start.go
@@ -347,7 +347,7 @@ func startInProcess(ctx *Context, clientCtx client.Context, appCreator types.App
 			Retries:       config.Rosetta.Retries,
 			Offline:       offlineMode,
 		}
-		conf.WithCodec(clientCtx.InterfaceRegistry, clientCtx.JSONCodec.(*codec.ProtoCodec))
+		conf.WithCodec(clientCtx.InterfaceRegistry, clientCtx.Codec.(*codec.ProtoCodec))
 
 		rosettaSrv, err = rosetta.ServerFromConfig(conf)
 		if err != nil {

--- a/server/tm_cmds.go
+++ b/server/tm_cmds.go
@@ -55,7 +55,7 @@ func ShowValidatorCmd() *cobra.Command {
 				return err
 			}
 			clientCtx := client.GetClientContextFromCmd(cmd)
-			bz, err := clientCtx.JSONCodec.MarshalInterfaceJSON(sdkPK)
+			bz, err := clientCtx.Codec.MarshalInterfaceJSON(sdkPK)
 			if err != nil {
 				return err
 			}

--- a/simapp/params/encoding.go
+++ b/simapp/params/encoding.go
@@ -10,7 +10,7 @@ import (
 // This is provided for compatibility between protobuf and amino implementations.
 type EncodingConfig struct {
 	InterfaceRegistry types.InterfaceRegistry
-	// Deprecated: this field wil lbe renamed to Codec
+	// NOTE: this field wil lbe renamed to Codec
 	Marshaler codec.Codec
 	TxConfig  client.TxConfig
 	Amino     *codec.LegacyAmino

--- a/simapp/params/encoding.go
+++ b/simapp/params/encoding.go
@@ -10,7 +10,7 @@ import (
 // This is provided for compatibility between protobuf and amino implementations.
 type EncodingConfig struct {
 	InterfaceRegistry types.InterfaceRegistry
-	// NOTE: this field wil lbe renamed to Codec
+	// NOTE: this field will be renamed to Codec
 	Marshaler codec.Codec
 	TxConfig  client.TxConfig
 	Amino     *codec.LegacyAmino

--- a/simapp/params/encoding.go
+++ b/simapp/params/encoding.go
@@ -10,7 +10,8 @@ import (
 // This is provided for compatibility between protobuf and amino implementations.
 type EncodingConfig struct {
 	InterfaceRegistry types.InterfaceRegistry
-	Marshaler         codec.Codec
-	TxConfig          client.TxConfig
-	Amino             *codec.LegacyAmino
+	// Deprecated: this field wil lbe renamed to Codec
+	Marshaler codec.Codec
+	TxConfig  client.TxConfig
+	Amino     *codec.LegacyAmino
 }

--- a/simapp/simd/cmd/genaccounts.go
+++ b/simapp/simd/cmd/genaccounts.go
@@ -40,7 +40,7 @@ contain valid denominations. Accounts may optionally be supplied with vesting pa
 		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clientCtx := client.GetClientContextFromCmd(cmd)
-			depCdc := clientCtx.JSONCodec
+			depCdc := clientCtx.Codec
 			cdc := depCdc.(codec.Codec)
 
 			serverCtx := server.GetServerContextFromCmd(cmd)

--- a/simapp/simd/cmd/genaccounts_test.go
+++ b/simapp/simd/cmd/genaccounts_test.go
@@ -63,7 +63,7 @@ func TestAddGenesisAccountCmd(t *testing.T) {
 			require.NoError(t, err)
 
 			serverCtx := server.NewContext(viper.New(), cfg, logger)
-			clientCtx := client.Context{}.WithJSONCodec(appCodec).WithHomeDir(home)
+			clientCtx := client.Context{}.WithCodec(appCodec).WithHomeDir(home)
 
 			ctx := context.Background()
 			ctx = context.WithValue(ctx, client.ClientContextKey, &clientCtx)

--- a/simapp/simd/cmd/root.go
+++ b/simapp/simd/cmd/root.go
@@ -39,7 +39,7 @@ import (
 func NewRootCmd() (*cobra.Command, params.EncodingConfig) {
 	encodingConfig := simapp.MakeTestEncodingConfig()
 	initClientCtx := client.Context{}.
-		WithJSONCodec(encodingConfig.Marshaler).
+		WithCodec(encodingConfig.Marshaler).
 		WithInterfaceRegistry(encodingConfig.InterfaceRegistry).
 		WithTxConfig(encodingConfig.TxConfig).
 		WithLegacyAmino(encodingConfig.Amino).

--- a/simapp/simd/cmd/testnet.go
+++ b/simapp/simd/cmd/testnet.go
@@ -271,11 +271,11 @@ func initGenFiles(
 	genFiles []string, numValidators int,
 ) error {
 
-	appGenState := mbm.DefaultGenesis(clientCtx.JSONCodec)
+	appGenState := mbm.DefaultGenesis(clientCtx.Codec)
 
 	// set the accounts in the genesis state
 	var authGenState authtypes.GenesisState
-	clientCtx.JSONCodec.MustUnmarshalJSON(appGenState[authtypes.ModuleName], &authGenState)
+	clientCtx.Codec.MustUnmarshalJSON(appGenState[authtypes.ModuleName], &authGenState)
 
 	accounts, err := authtypes.PackAccounts(genAccounts)
 	if err != nil {
@@ -283,14 +283,14 @@ func initGenFiles(
 	}
 
 	authGenState.Accounts = accounts
-	appGenState[authtypes.ModuleName] = clientCtx.JSONCodec.MustMarshalJSON(&authGenState)
+	appGenState[authtypes.ModuleName] = clientCtx.Codec.MustMarshalJSON(&authGenState)
 
 	// set the balances in the genesis state
 	var bankGenState banktypes.GenesisState
-	clientCtx.JSONCodec.MustUnmarshalJSON(appGenState[banktypes.ModuleName], &bankGenState)
+	clientCtx.Codec.MustUnmarshalJSON(appGenState[banktypes.ModuleName], &bankGenState)
 
 	bankGenState.Balances = genBalances
-	appGenState[banktypes.ModuleName] = clientCtx.JSONCodec.MustMarshalJSON(&bankGenState)
+	appGenState[banktypes.ModuleName] = clientCtx.Codec.MustMarshalJSON(&bankGenState)
 
 	appGenStateJSON, err := json.MarshalIndent(appGenState, "", "  ")
 	if err != nil {
@@ -337,7 +337,7 @@ func collectGenFiles(
 			return err
 		}
 
-		nodeAppState, err := genutil.GenAppStateFromConfig(clientCtx.JSONCodec, clientCtx.TxConfig, nodeConfig, initCfg, *genDoc, genBalIterator)
+		nodeAppState, err := genutil.GenAppStateFromConfig(clientCtx.Codec, clientCtx.TxConfig, nodeConfig, initCfg, *genDoc, genBalIterator)
 		if err != nil {
 			return err
 		}

--- a/testutil/network/network.go
+++ b/testutil/network/network.go
@@ -346,7 +346,7 @@ func New(t *testing.T, cfg Config) *Network {
 			WithHomeDir(tmCfg.RootDir).
 			WithChainID(cfg.ChainID).
 			WithInterfaceRegistry(cfg.InterfaceRegistry).
-			WithJSONCodec(cfg.Codec).
+			WithCodec(cfg.Codec).
 			WithLegacyAmino(cfg.LegacyAmino).
 			WithTxConfig(cfg.TxConfig).
 			WithAccountRetriever(cfg.AccountRetriever)

--- a/x/auth/client/cli/encode_test.go
+++ b/x/auth/client/cli/encode_test.go
@@ -39,7 +39,7 @@ func TestGetCommandEncode(t *testing.T) {
 	ctx := context.Background()
 	clientCtx := client.Context{}.
 		WithTxConfig(encodingConfig.TxConfig).
-		WithJSONCodec(encodingConfig.Marshaler)
+		WithCodec(encodingConfig.Marshaler)
 	ctx = context.WithValue(ctx, client.ClientContextKey, &clientCtx)
 
 	cmd.SetArgs([]string{txFileName})
@@ -52,7 +52,7 @@ func TestGetCommandDecode(t *testing.T) {
 
 	clientCtx := client.Context{}.
 		WithTxConfig(encodingConfig.TxConfig).
-		WithJSONCodec(encodingConfig.Marshaler)
+		WithCodec(encodingConfig.Marshaler)
 
 	cmd := GetDecodeCommand()
 	_ = testutil.ApplyMockIODiscardOutErr(cmd)

--- a/x/auth/client/rest/rest_test.go
+++ b/x/auth/client/rest/rest_test.go
@@ -258,7 +258,7 @@ func (s *IntegrationTestSuite) TestQueryTx() {
 
 	s.Require().NoError(err)
 	var txRes sdk.TxResponse
-	s.Require().NoError(val.ClientCtx.JSONCodec.UnmarshalJSON(out.Bytes(), &txRes))
+	s.Require().NoError(val.ClientCtx.Codec.UnmarshalJSON(out.Bytes(), &txRes))
 	s.Require().Equal(uint32(0), txRes.Code)
 
 	s.Require().NoError(s.network.WaitForNextBlock())
@@ -411,7 +411,7 @@ func (s *IntegrationTestSuite) testQueryIBCTx(txRes sdk.TxResponse, cmd *cobra.C
 	s.Require().NoError(err)
 
 	var getTxRes txtypes.GetTxResponse
-	s.Require().NoError(val.ClientCtx.JSONCodec.UnmarshalJSON(grpcJSON, &getTxRes))
+	s.Require().NoError(val.ClientCtx.Codec.UnmarshalJSON(grpcJSON, &getTxRes))
 	s.Require().Equal(getTxRes.Tx.Body.Memo, "foobar")
 
 	// generate broadcast only txn.
@@ -522,7 +522,7 @@ func (s *IntegrationTestSuite) TestLegacyMultisig() {
 	s.Require().NoError(s.network.WaitForNextBlock())
 
 	var txRes sdk.TxResponse
-	err = val1.ClientCtx.JSONCodec.UnmarshalJSON(out.Bytes(), &txRes)
+	err = val1.ClientCtx.Codec.UnmarshalJSON(out.Bytes(), &txRes)
 	s.Require().NoError(err)
 	s.Require().Equal(uint32(0), txRes.Code)
 

--- a/x/auth/client/testutil/suite.go
+++ b/x/auth/client/testutil/suite.go
@@ -169,7 +169,7 @@ func (s *IntegrationTestSuite) TestCLISignAminoJSON() {
 	queryResJSON, err := QueryAccountExec(val1.ClientCtx, val1.Address)
 	require.NoError(err)
 	var account authtypes.AccountI
-	require.NoError(val1.ClientCtx.JSONCodec.UnmarshalInterfaceJSON(queryResJSON.Bytes(), &account))
+	require.NoError(val1.ClientCtx.Codec.UnmarshalInterfaceJSON(queryResJSON.Bytes(), &account))
 
 	/****  test signature-only  ****/
 	res, err := TxSignExec(val1.ClientCtx, val1.Address, fileUnsigned.Name(), chainFlag,
@@ -258,7 +258,7 @@ func (s *IntegrationTestSuite) TestCLIQueryTxCmd() {
 	)
 	s.Require().NoError(err)
 	var txRes sdk.TxResponse
-	s.Require().NoError(val.ClientCtx.JSONCodec.UnmarshalJSON(out.Bytes(), &txRes))
+	s.Require().NoError(val.ClientCtx.Codec.UnmarshalJSON(out.Bytes(), &txRes))
 	s.Require().NoError(s.network.WaitForNextBlock())
 
 	testCases := []struct {
@@ -300,7 +300,7 @@ func (s *IntegrationTestSuite) TestCLIQueryTxCmd() {
 				s.Require().NotEqual("internal", err.Error())
 			} else {
 				var result sdk.TxResponse
-				s.Require().NoError(val.ClientCtx.JSONCodec.UnmarshalJSON(out.Bytes(), &result))
+				s.Require().NoError(val.ClientCtx.Codec.UnmarshalJSON(out.Bytes(), &result))
 				s.Require().NotNil(result.Height)
 				s.Require().Contains(result.RawLog, tc.rawLogContains)
 			}
@@ -353,7 +353,7 @@ func (s *IntegrationTestSuite) TestCLISendGenerateSignAndBroadcast() {
 	s.Require().NoError(err)
 
 	var balRes banktypes.QueryAllBalancesResponse
-	err = val1.ClientCtx.JSONCodec.UnmarshalJSON(resp.Bytes(), &balRes)
+	err = val1.ClientCtx.Codec.UnmarshalJSON(resp.Bytes(), &balRes)
 	s.Require().NoError(err)
 	startTokens := balRes.Balances.AmountOf(s.cfg.BondDenom)
 
@@ -414,7 +414,7 @@ func (s *IntegrationTestSuite) TestCLISendGenerateSignAndBroadcast() {
 	resp, err = bankcli.QueryBalancesExec(val1.ClientCtx, val1.Address)
 	s.Require().NoError(err)
 
-	err = val1.ClientCtx.JSONCodec.UnmarshalJSON(resp.Bytes(), &balRes)
+	err = val1.ClientCtx.Codec.UnmarshalJSON(resp.Bytes(), &balRes)
 	s.Require().NoError(err)
 	s.Require().Equal(startTokens, balRes.Balances.AmountOf(s.cfg.BondDenom))
 
@@ -437,7 +437,7 @@ func (s *IntegrationTestSuite) TestCLISendGenerateSignAndBroadcast() {
 	resp, err = bankcli.QueryBalancesExec(val1.ClientCtx, account.GetAddress())
 	s.Require().NoError(err)
 
-	err = val1.ClientCtx.JSONCodec.UnmarshalJSON(resp.Bytes(), &balRes)
+	err = val1.ClientCtx.Codec.UnmarshalJSON(resp.Bytes(), &balRes)
 	s.Require().NoError(err)
 	s.Require().Equal(sendTokens.Amount, balRes.Balances.AmountOf(s.cfg.BondDenom))
 
@@ -445,7 +445,7 @@ func (s *IntegrationTestSuite) TestCLISendGenerateSignAndBroadcast() {
 	resp, err = bankcli.QueryBalancesExec(val1.ClientCtx, val1.Address)
 	s.Require().NoError(err)
 
-	err = val1.ClientCtx.JSONCodec.UnmarshalJSON(resp.Bytes(), &balRes)
+	err = val1.ClientCtx.Codec.UnmarshalJSON(resp.Bytes(), &balRes)
 	s.Require().NoError(err)
 }
 
@@ -554,7 +554,7 @@ func (s *IntegrationTestSuite) TestCLIMultisignSortSignatures() {
 	s.Require().NoError(err)
 
 	var balRes banktypes.QueryAllBalancesResponse
-	err = val1.ClientCtx.JSONCodec.UnmarshalJSON(resp.Bytes(), &balRes)
+	err = val1.ClientCtx.Codec.UnmarshalJSON(resp.Bytes(), &balRes)
 	s.Require().NoError(err)
 	intialCoins := balRes.Balances
 
@@ -572,7 +572,7 @@ func (s *IntegrationTestSuite) TestCLIMultisignSortSignatures() {
 	resp, err = bankcli.QueryBalancesExec(val1.ClientCtx, multisigInfo.GetAddress())
 	s.Require().NoError(err)
 
-	err = val1.ClientCtx.JSONCodec.UnmarshalJSON(resp.Bytes(), &balRes)
+	err = val1.ClientCtx.Codec.UnmarshalJSON(resp.Bytes(), &balRes)
 	s.Require().NoError(err)
 	diff, _ := balRes.Balances.SafeSub(intialCoins)
 	s.Require().Equal(sendTokens.Amount, diff.AmountOf(s.cfg.BondDenom))
@@ -650,7 +650,7 @@ func (s *IntegrationTestSuite) TestCLIMultisign() {
 	s.Require().NoError(err)
 
 	var balRes banktypes.QueryAllBalancesResponse
-	err = val1.ClientCtx.JSONCodec.UnmarshalJSON(resp.Bytes(), &balRes)
+	err = val1.ClientCtx.Codec.UnmarshalJSON(resp.Bytes(), &balRes)
 	s.Require().NoError(err)
 	s.Require().Equal(sendTokens.Amount, balRes.Balances.AmountOf(s.cfg.BondDenom))
 
@@ -805,7 +805,7 @@ func (s *IntegrationTestSuite) TestMultisignBatch() {
 	queryResJSON, err := QueryAccountExec(val.ClientCtx, multisigInfo.GetAddress())
 	s.Require().NoError(err)
 	var account authtypes.AccountI
-	s.Require().NoError(val.ClientCtx.JSONCodec.UnmarshalInterfaceJSON(queryResJSON.Bytes(), &account))
+	s.Require().NoError(val.ClientCtx.Codec.UnmarshalInterfaceJSON(queryResJSON.Bytes(), &account))
 
 	// sign-batch file
 	res, err := TxSignBatchExec(val.ClientCtx, account1.GetAddress(), filename.Name(), fmt.Sprintf("--%s=%s", flags.FlagChainID, val.ClientCtx.ChainID), "--multisig", multisigInfo.GetAddress().String(), fmt.Sprintf("--%s", flags.FlagOffline), fmt.Sprintf("--%s=%s", flags.FlagAccountNumber, fmt.Sprint(account.GetAccountNumber())), fmt.Sprintf("--%s=%s", flags.FlagSequence, fmt.Sprint(account.GetSequence())))
@@ -867,7 +867,7 @@ func (s *IntegrationTestSuite) TestGetAccountCmd() {
 				s.Require().NotEqual("internal", err.Error())
 			} else {
 				var acc authtypes.AccountI
-				s.Require().NoError(val.ClientCtx.JSONCodec.UnmarshalInterfaceJSON(out.Bytes(), &acc))
+				s.Require().NoError(val.ClientCtx.Codec.UnmarshalInterfaceJSON(out.Bytes(), &acc))
 				s.Require().Equal(val.Address, acc.GetAddress())
 			}
 		})
@@ -884,7 +884,7 @@ func (s *IntegrationTestSuite) TestGetAccountsCmd() {
 	s.Require().NoError(err)
 
 	var res authtypes.QueryAccountsResponse
-	s.Require().NoError(val.ClientCtx.JSONCodec.UnmarshalJSON(out.Bytes(), &res))
+	s.Require().NoError(val.ClientCtx.Codec.UnmarshalJSON(out.Bytes(), &res))
 	s.Require().NotEmpty(res.Accounts)
 }
 
@@ -962,7 +962,7 @@ func (s *IntegrationTestSuite) TestQueryParamsCmd() {
 				s.Require().NotEqual("internal", err.Error())
 			} else {
 				var authParams authtypes.Params
-				s.Require().NoError(val.ClientCtx.JSONCodec.UnmarshalJSON(out.Bytes(), &authParams))
+				s.Require().NoError(val.ClientCtx.Codec.UnmarshalJSON(out.Bytes(), &authParams))
 				s.Require().NotNil(authParams.MaxMemoCharacters)
 			}
 		})
@@ -1009,11 +1009,11 @@ func (s *IntegrationTestSuite) TestTxWithoutPublicKey() {
 	// Note: this method is only used for test purposes! In general, one should
 	// use txBuilder and TxEncoder/TxDecoder to manipulate txs.
 	var tx tx.Tx
-	err = val1.ClientCtx.JSONCodec.UnmarshalJSON(signedTx.Bytes(), &tx)
+	err = val1.ClientCtx.Codec.UnmarshalJSON(signedTx.Bytes(), &tx)
 	s.Require().NoError(err)
 	tx.AuthInfo.SignerInfos[0].PublicKey = nil
 	// Re-encode the tx again, to another file.
-	txJSON, err = val1.ClientCtx.JSONCodec.MarshalJSON(&tx)
+	txJSON, err = val1.ClientCtx.Codec.MarshalJSON(&tx)
 	s.Require().NoError(err)
 	signedTxFile := testutil.WriteToNewTempFile(s.T(), string(txJSON))
 	s.Require().True(strings.Contains(string(txJSON), "\"public_key\":null"))
@@ -1023,7 +1023,7 @@ func (s *IntegrationTestSuite) TestTxWithoutPublicKey() {
 	out, err := TxBroadcastExec(val1.ClientCtx, signedTxFile.Name())
 	s.Require().NoError(err)
 	var res sdk.TxResponse
-	s.Require().NoError(val1.ClientCtx.JSONCodec.UnmarshalJSON(out.Bytes(), &res))
+	s.Require().NoError(val1.ClientCtx.Codec.UnmarshalJSON(out.Bytes(), &res))
 	s.Require().NotEqual(0, res.Code)
 }
 
@@ -1081,14 +1081,14 @@ func (s *IntegrationTestSuite) TestSignWithMultiSignersAminoJSON() {
 
 	require.NoError(err)
 	var txRes sdk.TxResponse
-	require.NoError(val0.ClientCtx.JSONCodec.UnmarshalJSON(res.Bytes(), &txRes))
+	require.NoError(val0.ClientCtx.Codec.UnmarshalJSON(res.Bytes(), &txRes))
 	require.Equal(uint32(0), txRes.Code)
 
 	// Make sure the addr1's balance got funded.
 	queryResJSON, err := bankcli.QueryBalancesExec(val0.ClientCtx, addr1)
 	require.NoError(err)
 	var queryRes banktypes.QueryAllBalancesResponse
-	err = val0.ClientCtx.JSONCodec.UnmarshalJSON(queryResJSON.Bytes(), &queryRes)
+	err = val0.ClientCtx.Codec.UnmarshalJSON(queryResJSON.Bytes(), &queryRes)
 	require.NoError(err)
 	require.Equal(sdk.NewCoins(val0Coin, val1Coin), queryRes.Balances)
 }

--- a/x/auth/legacy/v040/migrate_test.go
+++ b/x/auth/legacy/v040/migrate_test.go
@@ -241,7 +241,7 @@ func TestMigrate(t *testing.T) {
   }
 }`
 
-	bz, err := clientCtx.JSONCodec.MarshalJSON(migrated)
+	bz, err := clientCtx.Codec.MarshalJSON(migrated)
 	require.NoError(t, err)
 
 	// Indent the JSON bz correctly.

--- a/x/auth/tx/service_test.go
+++ b/x/auth/tx/service_test.go
@@ -76,7 +76,7 @@ func (s *IntegrationTestSuite) SetupSuite() {
 		fmt.Sprintf("--%s=foobar", flags.FlagNote),
 	)
 	s.Require().NoError(err)
-	s.Require().NoError(val.ClientCtx.JSONCodec.UnmarshalJSON(out.Bytes(), &s.txRes))
+	s.Require().NoError(val.ClientCtx.Codec.UnmarshalJSON(out.Bytes(), &s.txRes))
 	s.Require().Equal(uint32(0), s.txRes.Code)
 
 	s.Require().NoError(s.network.WaitForNextBlock())
@@ -151,7 +151,7 @@ func (s IntegrationTestSuite) TestSimulateTx_GRPCGateway() {
 
 	for _, tc := range testCases {
 		s.Run(tc.name, func() {
-			req, err := val.ClientCtx.JSONCodec.MarshalJSON(tc.req)
+			req, err := val.ClientCtx.Codec.MarshalJSON(tc.req)
 			s.Require().NoError(err)
 			res, err := rest.PostRequest(fmt.Sprintf("%s/cosmos/tx/v1beta1/simulate", val.APIAddress), "application/json", req)
 			s.Require().NoError(err)
@@ -159,7 +159,7 @@ func (s IntegrationTestSuite) TestSimulateTx_GRPCGateway() {
 				s.Require().Contains(string(res), tc.expErrMsg)
 			} else {
 				var result tx.SimulateResponse
-				err = val.ClientCtx.JSONCodec.UnmarshalJSON(res, &result)
+				err = val.ClientCtx.Codec.UnmarshalJSON(res, &result)
 				s.Require().NoError(err)
 				// Check the result and gas used are correct.
 				s.Require().Equal(len(result.GetResult().GetEvents()), 6) // 1 coin recv, 1 coin spent,1 transfer, 3 messages.
@@ -313,7 +313,7 @@ func (s IntegrationTestSuite) TestGetTxEvents_GRPCGateway() {
 				s.Require().Contains(string(res), tc.expErrMsg)
 			} else {
 				var result tx.GetTxsEventResponse
-				err = val.ClientCtx.JSONCodec.UnmarshalJSON(res, &result)
+				err = val.ClientCtx.Codec.UnmarshalJSON(res, &result)
 				s.Require().NoError(err)
 				s.Require().GreaterOrEqual(len(result.Txs), 1)
 				s.Require().Equal("foobar", result.Txs[0].Body.Memo)
@@ -382,7 +382,7 @@ func (s IntegrationTestSuite) TestGetTx_GRPCGateway() {
 				s.Require().Contains(string(res), tc.expErrMsg)
 			} else {
 				var result tx.GetTxResponse
-				err = val.ClientCtx.JSONCodec.UnmarshalJSON(res, &result)
+				err = val.ClientCtx.Codec.UnmarshalJSON(res, &result)
 				s.Require().NoError(err)
 				s.Require().Equal("foobar", result.Tx.Body.Memo)
 				s.Require().NotZero(result.TxResponse.Height)
@@ -459,7 +459,7 @@ func (s IntegrationTestSuite) TestBroadcastTx_GRPCGateway() {
 
 	for _, tc := range testCases {
 		s.Run(tc.name, func() {
-			req, err := val.ClientCtx.JSONCodec.MarshalJSON(tc.req)
+			req, err := val.ClientCtx.Codec.MarshalJSON(tc.req)
 			s.Require().NoError(err)
 			res, err := rest.PostRequest(fmt.Sprintf("%s/cosmos/tx/v1beta1/txs", val.APIAddress), "application/json", req)
 			s.Require().NoError(err)
@@ -467,7 +467,7 @@ func (s IntegrationTestSuite) TestBroadcastTx_GRPCGateway() {
 				s.Require().Contains(string(res), tc.expErrMsg)
 			} else {
 				var result tx.BroadcastTxResponse
-				err = val.ClientCtx.JSONCodec.UnmarshalJSON(res, &result)
+				err = val.ClientCtx.Codec.UnmarshalJSON(res, &result)
 				s.Require().NoError(err)
 				s.Require().Equal(uint32(0), result.TxResponse.Code, "rawlog", result.TxResponse.RawLog)
 			}

--- a/x/auth/vesting/client/testutil/suite.go
+++ b/x/auth/vesting/client/testutil/suite.go
@@ -122,7 +122,7 @@ func (s *IntegrationTestSuite) TestNewMsgCreateVestingAccountCmd() {
 				s.Require().Error(err)
 			} else {
 				s.Require().NoError(err)
-				s.Require().NoError(clientCtx.JSONCodec.UnmarshalJSON(bw.Bytes(), tc.respType), bw.String())
+				s.Require().NoError(clientCtx.Codec.UnmarshalJSON(bw.Bytes(), tc.respType), bw.String())
 
 				txResp := tc.respType.(*sdk.TxResponse)
 				s.Require().Equal(tc.expectedCode, txResp.Code)

--- a/x/authz/client/rest/grpc_query_test.go
+++ b/x/authz/client/rest/grpc_query_test.go
@@ -139,7 +139,7 @@ func (s *IntegrationTestSuite) TestQueryGrantGRPC() {
 				require.Contains(string(resp), tc.errorMsg)
 			} else {
 				var g authz.QueryGrantsResponse
-				err := val.ClientCtx.JSONCodec.UnmarshalJSON(resp, &g)
+				err := val.ClientCtx.Codec.UnmarshalJSON(resp, &g)
 				require.NoError(err)
 				require.Len(g.Grants, 1)
 				g.Grants[0].UnpackInterfaces(val.ClientCtx.InterfaceRegistry)
@@ -223,7 +223,7 @@ func (s *IntegrationTestSuite) TestQueryGrantsGRPC() {
 				s.Require().Contains(string(resp), tc.errMsg)
 			} else {
 				var authorizations authz.QueryGrantsResponse
-				err := val.ClientCtx.JSONCodec.UnmarshalJSON(resp, &authorizations)
+				err := val.ClientCtx.Codec.UnmarshalJSON(resp, &authorizations)
 				s.Require().NoError(err)
 				tc.postRun(&authorizations)
 			}

--- a/x/authz/client/testutil/query.go
+++ b/x/authz/client/testutil/query.go
@@ -85,7 +85,7 @@ func (s *IntegrationTestSuite) TestQueryAuthorizations() {
 			} else {
 				s.Require().NoError(err)
 				var grants authz.QueryGrantsResponse
-				err = val.ClientCtx.JSONCodec.UnmarshalJSON(resp.Bytes(), &grants)
+				err = val.ClientCtx.Codec.UnmarshalJSON(resp.Bytes(), &grants)
 				s.Require().NoError(err)
 			}
 		})

--- a/x/authz/client/testutil/tx.go
+++ b/x/authz/client/testutil/tx.go
@@ -290,7 +290,7 @@ func (s *IntegrationTestSuite) TestCLITxGrantAuthorization() {
 			} else {
 				var txResp sdk.TxResponse
 				s.Require().NoError(err)
-				s.Require().NoError(clientCtx.JSONCodec.UnmarshalJSON(out.Bytes(), &txResp), out.String())
+				s.Require().NoError(clientCtx.Codec.UnmarshalJSON(out.Bytes(), &txResp), out.String())
 				s.Require().Equal(tc.expectedCode, txResp.Code, out.String())
 			}
 		})
@@ -441,7 +441,7 @@ func (s *IntegrationTestSuite) TestCmdRevokeAuthorizations() {
 				s.Require().Error(err)
 			} else {
 				s.Require().NoError(err)
-				s.Require().NoError(clientCtx.JSONCodec.UnmarshalJSON(out.Bytes(), tc.respType), out.String())
+				s.Require().NoError(clientCtx.Codec.UnmarshalJSON(out.Bytes(), tc.respType), out.String())
 
 				txResp := tc.respType.(*sdk.TxResponse)
 				s.Require().Equal(tc.expectedCode, txResp.Code, out.String())
@@ -584,7 +584,7 @@ func (s *IntegrationTestSuite) TestNewExecGenericAuthorized() {
 				s.Require().Error(err)
 			} else {
 				s.Require().NoError(err)
-				s.Require().NoError(clientCtx.JSONCodec.UnmarshalJSON(out.Bytes(), tc.respType), out.String())
+				s.Require().NoError(clientCtx.Codec.UnmarshalJSON(out.Bytes(), tc.respType), out.String())
 				txResp := tc.respType.(*sdk.TxResponse)
 				s.Require().Equal(tc.expectedCode, txResp.Code, out.String())
 			}
@@ -670,7 +670,7 @@ func (s *IntegrationTestSuite) TestNewExecGrantAuthorized() {
 			} else {
 				var response sdk.TxResponse
 				s.Require().NoError(err)
-				s.Require().NoError(clientCtx.JSONCodec.UnmarshalJSON(out.Bytes(), &response), out.String())
+				s.Require().NoError(clientCtx.Codec.UnmarshalJSON(out.Bytes(), &response), out.String())
 				s.Require().Equal(tc.expectedCode, response.Code, out.String())
 			}
 		})
@@ -767,7 +767,7 @@ func (s *IntegrationTestSuite) TestExecDelegateAuthorization() {
 			} else {
 				var response sdk.TxResponse
 				s.Require().NoError(err)
-				s.Require().NoError(clientCtx.JSONCodec.UnmarshalJSON(out.Bytes(), &response), out.String())
+				s.Require().NoError(clientCtx.Codec.UnmarshalJSON(out.Bytes(), &response), out.String())
 				s.Require().Equal(tc.expectedCode, response.Code, out.String())
 			}
 		})
@@ -844,7 +844,7 @@ func (s *IntegrationTestSuite) TestExecDelegateAuthorization() {
 			} else {
 				var response sdk.TxResponse
 				s.Require().NoError(err)
-				s.Require().NoError(clientCtx.JSONCodec.UnmarshalJSON(out.Bytes(), &response), out.String())
+				s.Require().NoError(clientCtx.Codec.UnmarshalJSON(out.Bytes(), &response), out.String())
 				s.Require().Equal(tc.expectedCode, response.Code, out.String())
 			}
 		})
@@ -985,7 +985,7 @@ func (s *IntegrationTestSuite) TestExecUndelegateAuthorization() {
 			} else {
 				var response sdk.TxResponse
 				s.Require().NoError(err)
-				s.Require().NoError(clientCtx.JSONCodec.UnmarshalJSON(out.Bytes(), &response), out.String())
+				s.Require().NoError(clientCtx.Codec.UnmarshalJSON(out.Bytes(), &response), out.String())
 				s.Require().Equal(tc.expectedCode, response.Code, out.String())
 			}
 		})
@@ -1062,7 +1062,7 @@ func (s *IntegrationTestSuite) TestExecUndelegateAuthorization() {
 			} else {
 				var response sdk.TxResponse
 				s.Require().NoError(err)
-				s.Require().NoError(clientCtx.JSONCodec.UnmarshalJSON(out.Bytes(), &response), out.String())
+				s.Require().NoError(clientCtx.Codec.UnmarshalJSON(out.Bytes(), &response), out.String())
 				s.Require().Equal(tc.expectedCode, response.Code, out.String())
 			}
 		})

--- a/x/bank/client/rest/grpc_query_test.go
+++ b/x/bank/client/rest/grpc_query_test.go
@@ -95,7 +95,7 @@ func (s *IntegrationTestSuite) TestTotalSupplyGRPCHandler() {
 			resp, err := testutil.GetRequestWithHeaders(tc.url, tc.headers)
 			s.Require().NoError(err)
 
-			s.Require().NoError(val.ClientCtx.JSONCodec.UnmarshalJSON(resp, tc.respType))
+			s.Require().NoError(val.ClientCtx.Codec.UnmarshalJSON(resp, tc.respType))
 			s.Require().Equal(tc.expected.String(), tc.respType.String())
 		})
 	}
@@ -199,9 +199,9 @@ func (s *IntegrationTestSuite) TestDenomMetadataGRPCHandler() {
 			s.Require().NoError(err)
 
 			if tc.expErr {
-				s.Require().Error(val.ClientCtx.JSONCodec.UnmarshalJSON(resp, tc.respType))
+				s.Require().Error(val.ClientCtx.Codec.UnmarshalJSON(resp, tc.respType))
 			} else {
-				s.Require().NoError(val.ClientCtx.JSONCodec.UnmarshalJSON(resp, tc.respType))
+				s.Require().NoError(val.ClientCtx.Codec.UnmarshalJSON(resp, tc.respType))
 				s.Require().Equal(tc.expected.String(), tc.respType.String())
 			}
 		})
@@ -262,7 +262,7 @@ func (s *IntegrationTestSuite) TestBalancesGRPCHandler() {
 			resp, err := rest.GetRequest(tc.url)
 			s.Require().NoError(err)
 
-			s.Require().NoError(val.ClientCtx.JSONCodec.UnmarshalJSON(resp, tc.respType))
+			s.Require().NoError(val.ClientCtx.Codec.UnmarshalJSON(resp, tc.respType))
 			s.Require().Equal(tc.expected.String(), tc.respType.String())
 		})
 	}

--- a/x/bank/client/testutil/suite.go
+++ b/x/bank/client/testutil/suite.go
@@ -155,7 +155,7 @@ func (s *IntegrationTestSuite) TestGetBalancesCmd() {
 				s.Require().Error(err)
 			} else {
 				s.Require().NoError(err)
-				s.Require().NoError(val.ClientCtx.JSONCodec.UnmarshalJSON(out.Bytes(), tc.respType))
+				s.Require().NoError(val.ClientCtx.Codec.UnmarshalJSON(out.Bytes(), tc.respType))
 				s.Require().Equal(tc.expected.String(), tc.respType.String())
 			}
 		})
@@ -227,7 +227,7 @@ func (s *IntegrationTestSuite) TestGetCmdQueryTotalSupply() {
 				s.Require().Error(err)
 			} else {
 				s.Require().NoError(err)
-				s.Require().NoError(clientCtx.JSONCodec.UnmarshalJSON(out.Bytes(), tc.respType))
+				s.Require().NoError(clientCtx.Codec.UnmarshalJSON(out.Bytes(), tc.respType))
 				s.Require().Equal(tc.expected, tc.respType)
 			}
 		})
@@ -354,7 +354,7 @@ func (s *IntegrationTestSuite) TestGetCmdQueryDenomsMetadata() {
 				s.Require().Error(err)
 			} else {
 				s.Require().NoError(err)
-				s.Require().NoError(clientCtx.JSONCodec.UnmarshalJSON(out.Bytes(), tc.respType))
+				s.Require().NoError(clientCtx.Codec.UnmarshalJSON(out.Bytes(), tc.respType))
 				s.Require().Equal(tc.expected, tc.respType)
 			}
 		})
@@ -462,7 +462,7 @@ func (s *IntegrationTestSuite) TestNewSendTxCmd() {
 			} else {
 				s.Require().NoError(err)
 
-				s.Require().NoError(clientCtx.JSONCodec.UnmarshalJSON(bz.Bytes(), tc.respType), bz.String())
+				s.Require().NoError(clientCtx.Codec.UnmarshalJSON(bz.Bytes(), tc.respType), bz.String())
 				txResp := tc.respType.(*sdk.TxResponse)
 				s.Require().Equal(tc.expectedCode, txResp.Code)
 			}

--- a/x/bank/legacy/v040/migrate_test.go
+++ b/x/bank/legacy/v040/migrate_test.go
@@ -50,7 +50,7 @@ func TestMigrate(t *testing.T) {
 	migrated := v040bank.Migrate(bankGenState, authGenState, supplyGenState)
 	expected := `{"params":{"send_enabled":[],"default_send_enabled":true},"balances":[{"address":"cosmos1xxkueklal9vejv9unqu80w9vptyepfa95pd53u","coins":[{"denom":"stake","amount":"50"}]},{"address":"cosmos15v50ymp6n5dn73erkqtmq0u8adpl8d3ujv2e74","coins":[{"denom":"stake","amount":"50"}]}],"supply":[{"denom":"stake","amount":"1000"}],"denom_metadata":[]}`
 
-	bz, err := clientCtx.JSONCodec.MarshalJSON(migrated)
+	bz, err := clientCtx.Codec.MarshalJSON(migrated)
 	require.NoError(t, err)
 	require.Equal(t, expected, string(bz))
 }

--- a/x/crisis/client/testsuite/suite.go
+++ b/x/crisis/client/testsuite/suite.go
@@ -94,7 +94,7 @@ func (s *IntegrationTestSuite) TestNewMsgVerifyInvariantTxCmd() {
 				s.Require().Error(err)
 			} else {
 				s.Require().NoError(err)
-				s.Require().NoError(clientCtx.JSONCodec.UnmarshalJSON(out.Bytes(), tc.respType), out.String())
+				s.Require().NoError(clientCtx.Codec.UnmarshalJSON(out.Bytes(), tc.respType), out.String())
 
 				txResp := tc.respType.(*sdk.TxResponse)
 				s.Require().Equal(tc.expectedCode, txResp.Code)

--- a/x/distribution/client/cli/tx.go
+++ b/x/distribution/client/cli/tx.go
@@ -293,7 +293,7 @@ Where proposal.json contains:
 			if err != nil {
 				return err
 			}
-			proposal, err := ParseCommunityPoolSpendProposalWithDeposit(clientCtx.JSONCodec, args[0])
+			proposal, err := ParseCommunityPoolSpendProposalWithDeposit(clientCtx.Codec, args[0])
 			if err != nil {
 				return err
 			}

--- a/x/distribution/client/rest/grpc_query_test.go
+++ b/x/distribution/client/rest/grpc_query_test.go
@@ -61,7 +61,7 @@ func (s *IntegrationTestSuite) TestQueryParamsGRPC() {
 		resp, err := rest.GetRequest(tc.url)
 		s.Run(tc.name, func() {
 			s.Require().NoError(err)
-			s.Require().NoError(val.ClientCtx.JSONCodec.UnmarshalJSON(resp, tc.respType))
+			s.Require().NoError(val.ClientCtx.Codec.UnmarshalJSON(resp, tc.respType))
 			s.Require().Equal(tc.expected, tc.respType)
 		})
 	}
@@ -111,10 +111,10 @@ func (s *IntegrationTestSuite) TestQueryOutstandingRewardsGRPC() {
 		resp, err := testutil.GetRequestWithHeaders(tc.url, tc.headers)
 		s.Run(tc.name, func() {
 			if tc.expErr {
-				s.Require().Error(val.ClientCtx.JSONCodec.UnmarshalJSON(resp, tc.respType))
+				s.Require().Error(val.ClientCtx.Codec.UnmarshalJSON(resp, tc.respType))
 			} else {
 				s.Require().NoError(err)
-				s.Require().NoError(val.ClientCtx.JSONCodec.UnmarshalJSON(resp, tc.respType))
+				s.Require().NoError(val.ClientCtx.Codec.UnmarshalJSON(resp, tc.respType))
 				s.Require().Equal(tc.expected.String(), tc.respType.String())
 			}
 		})
@@ -165,10 +165,10 @@ func (s *IntegrationTestSuite) TestQueryValidatorCommissionGRPC() {
 		resp, err := testutil.GetRequestWithHeaders(tc.url, tc.headers)
 		s.Run(tc.name, func() {
 			if tc.expErr {
-				s.Require().Error(val.ClientCtx.JSONCodec.UnmarshalJSON(resp, tc.respType))
+				s.Require().Error(val.ClientCtx.Codec.UnmarshalJSON(resp, tc.respType))
 			} else {
 				s.Require().NoError(err)
-				s.Require().NoError(val.ClientCtx.JSONCodec.UnmarshalJSON(resp, tc.respType))
+				s.Require().NoError(val.ClientCtx.Codec.UnmarshalJSON(resp, tc.respType))
 				s.Require().Equal(tc.expected.String(), tc.respType.String())
 			}
 		})
@@ -224,10 +224,10 @@ func (s *IntegrationTestSuite) TestQuerySlashesGRPC() {
 
 		s.Run(tc.name, func() {
 			if tc.expErr {
-				s.Require().Error(val.ClientCtx.JSONCodec.UnmarshalJSON(resp, tc.respType))
+				s.Require().Error(val.ClientCtx.Codec.UnmarshalJSON(resp, tc.respType))
 			} else {
 				s.Require().NoError(err)
-				s.Require().NoError(val.ClientCtx.JSONCodec.UnmarshalJSON(resp, tc.respType))
+				s.Require().NoError(val.ClientCtx.Codec.UnmarshalJSON(resp, tc.respType))
 				s.Require().Equal(tc.expected.String(), tc.respType.String())
 			}
 		})
@@ -300,10 +300,10 @@ func (s *IntegrationTestSuite) TestQueryDelegatorRewardsGRPC() {
 
 		s.Run(tc.name, func() {
 			if tc.expErr {
-				s.Require().Error(val.ClientCtx.JSONCodec.UnmarshalJSON(resp, tc.respType))
+				s.Require().Error(val.ClientCtx.Codec.UnmarshalJSON(resp, tc.respType))
 			} else {
 				s.Require().NoError(err)
-				s.Require().NoError(val.ClientCtx.JSONCodec.UnmarshalJSON(resp, tc.respType))
+				s.Require().NoError(val.ClientCtx.Codec.UnmarshalJSON(resp, tc.respType))
 				s.Require().Equal(tc.expected.String(), tc.respType.String())
 			}
 		})
@@ -352,10 +352,10 @@ func (s *IntegrationTestSuite) TestQueryDelegatorValidatorsGRPC() {
 
 		s.Run(tc.name, func() {
 			if tc.expErr {
-				s.Require().Error(val.ClientCtx.JSONCodec.UnmarshalJSON(resp, tc.respType))
+				s.Require().Error(val.ClientCtx.Codec.UnmarshalJSON(resp, tc.respType))
 			} else {
 				s.Require().NoError(err)
-				s.Require().NoError(val.ClientCtx.JSONCodec.UnmarshalJSON(resp, tc.respType))
+				s.Require().NoError(val.ClientCtx.Codec.UnmarshalJSON(resp, tc.respType))
 				s.Require().Equal(tc.expected.String(), tc.respType.String())
 			}
 		})
@@ -404,10 +404,10 @@ func (s *IntegrationTestSuite) TestQueryWithdrawAddressGRPC() {
 
 		s.Run(tc.name, func() {
 			if tc.expErr {
-				s.Require().Error(val.ClientCtx.JSONCodec.UnmarshalJSON(resp, tc.respType))
+				s.Require().Error(val.ClientCtx.Codec.UnmarshalJSON(resp, tc.respType))
 			} else {
 				s.Require().NoError(err)
-				s.Require().NoError(val.ClientCtx.JSONCodec.UnmarshalJSON(resp, tc.respType))
+				s.Require().NoError(val.ClientCtx.Codec.UnmarshalJSON(resp, tc.respType))
 				s.Require().Equal(tc.expected.String(), tc.respType.String())
 			}
 		})
@@ -452,7 +452,7 @@ func (s *IntegrationTestSuite) TestQueryValidatorCommunityPoolGRPC() {
 				s.Require().Error(err)
 			} else {
 				s.Require().NoError(err)
-				s.Require().NoError(val.ClientCtx.JSONCodec.UnmarshalJSON(resp, tc.respType))
+				s.Require().NoError(val.ClientCtx.Codec.UnmarshalJSON(resp, tc.respType))
 				s.Require().Equal(tc.expected.String(), tc.respType.String())
 			}
 		})

--- a/x/distribution/client/testutil/suite.go
+++ b/x/distribution/client/testutil/suite.go
@@ -502,7 +502,7 @@ func (s *IntegrationTestSuite) TestNewWithdrawRewardsCmd() {
 				s.Require().Error(err)
 			} else {
 				s.Require().NoError(err)
-				s.Require().NoError(clientCtx.JSONCodec.UnmarshalJSON(bz, tc.respType), string(bz))
+				s.Require().NoError(clientCtx.Codec.UnmarshalJSON(bz, tc.respType), string(bz))
 
 				txResp := tc.respType.(*sdk.TxResponse)
 				s.Require().Equal(tc.expectedCode, txResp.Code)
@@ -555,7 +555,7 @@ func (s *IntegrationTestSuite) TestNewWithdrawAllRewardsCmd() {
 				s.Require().Error(err)
 			} else {
 				s.Require().NoError(err)
-				s.Require().NoError(clientCtx.JSONCodec.UnmarshalJSON(out.Bytes(), tc.respType), out.String())
+				s.Require().NoError(clientCtx.Codec.UnmarshalJSON(out.Bytes(), tc.respType), out.String())
 
 				txResp := tc.respType.(*sdk.TxResponse)
 				s.Require().Equal(tc.expectedCode, txResp.Code)
@@ -610,7 +610,7 @@ func (s *IntegrationTestSuite) TestNewSetWithdrawAddrCmd() {
 				s.Require().Error(err)
 			} else {
 				s.Require().NoError(err)
-				s.Require().NoError(clientCtx.JSONCodec.UnmarshalJSON(out.Bytes(), tc.respType), out.String())
+				s.Require().NoError(clientCtx.Codec.UnmarshalJSON(out.Bytes(), tc.respType), out.String())
 
 				txResp := tc.respType.(*sdk.TxResponse)
 				s.Require().Equal(tc.expectedCode, txResp.Code)
@@ -665,7 +665,7 @@ func (s *IntegrationTestSuite) TestNewFundCommunityPoolCmd() {
 				s.Require().Error(err)
 			} else {
 				s.Require().NoError(err)
-				s.Require().NoError(clientCtx.JSONCodec.UnmarshalJSON(out.Bytes(), tc.respType), out.String())
+				s.Require().NoError(clientCtx.Codec.UnmarshalJSON(out.Bytes(), tc.respType), out.String())
 
 				txResp := tc.respType.(*sdk.TxResponse)
 				s.Require().Equal(tc.expectedCode, txResp.Code)
@@ -739,7 +739,7 @@ func (s *IntegrationTestSuite) TestGetCmdSubmitProposal() {
 				s.Require().Error(err)
 			} else {
 				s.Require().NoError(err)
-				s.Require().NoError(clientCtx.JSONCodec.UnmarshalJSON(out.Bytes(), tc.respType), out.String())
+				s.Require().NoError(clientCtx.Codec.UnmarshalJSON(out.Bytes(), tc.respType), out.String())
 
 				txResp := tc.respType.(*sdk.TxResponse)
 				s.Require().Equal(tc.expectedCode, txResp.Code, out.String())

--- a/x/evidence/client/rest/query.go
+++ b/x/evidence/client/rest/query.go
@@ -47,7 +47,7 @@ func queryEvidenceHandler(clientCtx client.Context) http.HandlerFunc {
 		}
 
 		params := types.NewQueryEvidenceRequest(decodedHash)
-		bz, err := clientCtx.JSONCodec.MarshalJSON(params)
+		bz, err := clientCtx.Codec.MarshalJSON(params)
 		if err != nil {
 			rest.WriteErrorResponse(w, http.StatusBadRequest, fmt.Sprintf("failed to marshal query params: %s", err))
 			return

--- a/x/evidence/legacy/v040/migrate_test.go
+++ b/x/evidence/legacy/v040/migrate_test.go
@@ -34,7 +34,7 @@ func TestMigrate(t *testing.T) {
 	migrated := v040evidence.Migrate(evidenceGenState)
 	expected := `{"evidence":[{"@type":"/cosmos.evidence.v1beta1.Equivocation","height":"20","time":"0001-01-01T00:00:00Z","power":"100","consensus_address":"cosmosvalcons1xxkueklal9vejv9unqu80w9vptyepfa99x2a3w"}]}`
 
-	bz, err := clientCtx.JSONCodec.MarshalJSON(migrated)
+	bz, err := clientCtx.Codec.MarshalJSON(migrated)
 	require.NoError(t, err)
 	require.Equal(t, expected, string(bz))
 }

--- a/x/feegrant/client/testutil/suite.go
+++ b/x/feegrant/client/testutil/suite.go
@@ -178,7 +178,7 @@ func (s *IntegrationTestSuite) TestCmdGetFeeGrant() {
 				s.Require().Contains(err.Error(), tc.expectErrMsg)
 			} else {
 				s.Require().NoError(err)
-				s.Require().NoError(clientCtx.JSONCodec.UnmarshalJSON(out.Bytes(), tc.respType), out.String())
+				s.Require().NoError(clientCtx.Codec.UnmarshalJSON(out.Bytes(), tc.respType), out.String())
 				s.Require().Equal(tc.respType.Grantee, tc.respType.Grantee)
 				s.Require().Equal(tc.respType.Granter, tc.respType.Granter)
 				grant, err := tc.respType.GetGrant()
@@ -243,7 +243,7 @@ func (s *IntegrationTestSuite) TestCmdGetFeeGrants() {
 				s.Require().Error(err)
 			} else {
 				s.Require().NoError(err)
-				s.Require().NoError(clientCtx.JSONCodec.UnmarshalJSON(out.Bytes(), tc.resp), out.String())
+				s.Require().NoError(clientCtx.Codec.UnmarshalJSON(out.Bytes(), tc.resp), out.String())
 				s.Require().Len(tc.resp.Allowances, tc.expectLength)
 			}
 		})
@@ -506,7 +506,7 @@ func (s *IntegrationTestSuite) TestNewCmdFeeGrant() {
 				s.Require().Error(err)
 			} else {
 				s.Require().NoError(err)
-				s.Require().NoError(clientCtx.JSONCodec.UnmarshalJSON(out.Bytes(), tc.respType), out.String())
+				s.Require().NoError(clientCtx.Codec.UnmarshalJSON(out.Bytes(), tc.respType), out.String())
 
 				txResp := tc.respType.(*sdk.TxResponse)
 				s.Require().Equal(tc.expectedCode, txResp.Code, out.String())
@@ -613,7 +613,7 @@ func (s *IntegrationTestSuite) TestNewCmdRevokeFeegrant() {
 				s.Require().Error(err)
 			} else {
 				s.Require().NoError(err)
-				s.Require().NoError(clientCtx.JSONCodec.UnmarshalJSON(out.Bytes(), tc.respType), out.String())
+				s.Require().NoError(clientCtx.Codec.UnmarshalJSON(out.Bytes(), tc.respType), out.String())
 
 				txResp := tc.respType.(*sdk.TxResponse)
 				s.Require().Equal(tc.expectedCode, txResp.Code, out.String())
@@ -667,7 +667,7 @@ func (s *IntegrationTestSuite) TestTxWithFeeGrant() {
 
 	s.Require().NoError(err)
 	var resp sdk.TxResponse
-	s.Require().NoError(clientCtx.JSONCodec.UnmarshalJSON(out.Bytes(), &resp), out.String())
+	s.Require().NoError(clientCtx.Codec.UnmarshalJSON(out.Bytes(), &resp), out.String())
 	s.Require().Equal(uint32(0), resp.Code)
 }
 
@@ -752,7 +752,7 @@ func (s *IntegrationTestSuite) TestFilteredFeeAllowance() {
 				s.Require().Error(err)
 			} else {
 				s.Require().NoError(err)
-				s.Require().NoError(clientCtx.JSONCodec.UnmarshalJSON(out.Bytes(), tc.respType), out.String())
+				s.Require().NoError(clientCtx.Codec.UnmarshalJSON(out.Bytes(), tc.respType), out.String())
 
 				txResp := tc.respType.(*sdk.TxResponse)
 				s.Require().Equal(tc.expectedCode, txResp.Code, out.String())
@@ -773,7 +773,7 @@ func (s *IntegrationTestSuite) TestFilteredFeeAllowance() {
 
 	resp := &feegrant.Grant{}
 
-	s.Require().NoError(clientCtx.JSONCodec.UnmarshalJSON(out.Bytes(), resp), out.String())
+	s.Require().NoError(clientCtx.Codec.UnmarshalJSON(out.Bytes(), resp), out.String())
 	s.Require().Equal(resp.Grantee, resp.Grantee)
 	s.Require().Equal(resp.Granter, resp.Granter)
 
@@ -842,7 +842,7 @@ func (s *IntegrationTestSuite) TestFilteredFeeAllowance() {
 		s.Run(tc.name, func() {
 			out, err := tc.malleate()
 			s.Require().NoError(err)
-			s.Require().NoError(clientCtx.JSONCodec.UnmarshalJSON(out.Bytes(), tc.respType), out.String())
+			s.Require().NoError(clientCtx.Codec.UnmarshalJSON(out.Bytes(), tc.respType), out.String())
 			txResp := tc.respType.(*sdk.TxResponse)
 			s.Require().Equal(tc.expectedCode, txResp.Code, out.String())
 		})

--- a/x/genutil/client/cli/collect.go
+++ b/x/genutil/client/cli/collect.go
@@ -27,7 +27,7 @@ func CollectGenTxsCmd(genBalIterator types.GenesisBalancesIterator, defaultNodeH
 			config := serverCtx.Config
 
 			clientCtx := client.GetClientContextFromCmd(cmd)
-			cdc := clientCtx.JSONCodec
+			cdc := clientCtx.Codec
 
 			config.SetRoot(clientCtx.HomeDir)
 

--- a/x/genutil/client/cli/gentx.go
+++ b/x/genutil/client/cli/gentx.go
@@ -61,7 +61,7 @@ $ %s gentx my-key-name 1000000stake --home=/path/to/home/dir --keyring-backend=o
 			if err != nil {
 				return err
 			}
-			cdc := clientCtx.JSONCodec
+			cdc := clientCtx.Codec
 
 			config := serverCtx.Config
 			config.SetRoot(clientCtx.HomeDir)
@@ -78,7 +78,7 @@ $ %s gentx my-key-name 1000000stake --home=/path/to/home/dir --keyring-backend=o
 
 			// read --pubkey, if empty take it from priv_validator.json
 			if val, _ := cmd.Flags().GetString(cli.FlagPubKey); val != "" {
-				err = clientCtx.JSONCodec.UnmarshalJSON([]byte(val), valPubKey)
+				err = clientCtx.Codec.UnmarshalJSON([]byte(val), valPubKey)
 				if err != nil {
 					return errors.Wrap(err, "failed to unmarshal consensus node public key")
 				}

--- a/x/genutil/client/cli/init.go
+++ b/x/genutil/client/cli/init.go
@@ -72,7 +72,7 @@ func InitCmd(mbm module.BasicManager, defaultNodeHome string) *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clientCtx := client.GetClientContextFromCmd(cmd)
-			cdc := clientCtx.JSONCodec
+			cdc := clientCtx.Codec
 
 			serverCtx := server.GetServerContextFromCmd(cmd)
 			config := serverCtx.Config

--- a/x/genutil/client/cli/init_test.go
+++ b/x/genutil/client/cli/init_test.go
@@ -63,7 +63,7 @@ func TestInitCmd(t *testing.T) {
 			interfaceRegistry := types.NewInterfaceRegistry()
 			marshaler := codec.NewProtoCodec(interfaceRegistry)
 			clientCtx := client.Context{}.
-				WithJSONCodec(marshaler).
+				WithCodec(marshaler).
 				WithLegacyAmino(makeCodec()).
 				WithHomeDir(home)
 
@@ -97,7 +97,7 @@ func TestInitRecover(t *testing.T) {
 	interfaceRegistry := types.NewInterfaceRegistry()
 	marshaler := codec.NewProtoCodec(interfaceRegistry)
 	clientCtx := client.Context{}.
-		WithJSONCodec(marshaler).
+		WithCodec(marshaler).
 		WithLegacyAmino(makeCodec()).
 		WithHomeDir(home)
 
@@ -128,7 +128,7 @@ func TestEmptyState(t *testing.T) {
 	interfaceRegistry := types.NewInterfaceRegistry()
 	marshaler := codec.NewProtoCodec(interfaceRegistry)
 	clientCtx := client.Context{}.
-		WithJSONCodec(marshaler).
+		WithCodec(marshaler).
 		WithLegacyAmino(makeCodec()).
 		WithHomeDir(home)
 

--- a/x/genutil/client/cli/validate_genesis.go
+++ b/x/genutil/client/cli/validate_genesis.go
@@ -24,7 +24,7 @@ func ValidateGenesisCmd(mbm module.BasicManager) *cobra.Command {
 			serverCtx := server.GetServerContextFromCmd(cmd)
 			clientCtx := client.GetClientContextFromCmd(cmd)
 
-			cdc := clientCtx.JSONCodec
+			cdc := clientCtx.Codec
 
 			// Load default if passed no args, otherwise load passed file
 			var genesis string

--- a/x/genutil/client/rest/query.go
+++ b/x/genutil/client/rest/query.go
@@ -32,7 +32,7 @@ func QueryGenesisTxs(clientCtx client.Context, w http.ResponseWriter) {
 		return
 	}
 
-	genState := types.GetGenesisStateFromAppState(clientCtx.JSONCodec, appState)
+	genState := types.GetGenesisStateFromAppState(clientCtx.Codec, appState)
 	genTxs := make([]sdk.Tx, len(genState.GenTxs))
 	for i, tx := range genState.GenTxs {
 		err := clientCtx.LegacyAmino.UnmarshalJSON(tx, &genTxs[i])

--- a/x/genutil/client/testutil/helpers.go
+++ b/x/genutil/client/testutil/helpers.go
@@ -17,7 +17,7 @@ import (
 	genutilcli "github.com/cosmos/cosmos-sdk/x/genutil/client/cli"
 )
 
-func ExecInitCmd(testMbm module.BasicManager, home string, cdc codec.JSONCodec) error {
+func ExecInitCmd(testMbm module.BasicManager, home string, cdc codec.Codec) error {
 	logger := log.NewNopLogger()
 	cfg, err := CreateDefaultTendermintConfig(home)
 	if err != nil {

--- a/x/genutil/client/testutil/helpers.go
+++ b/x/genutil/client/testutil/helpers.go
@@ -26,7 +26,7 @@ func ExecInitCmd(testMbm module.BasicManager, home string, cdc codec.JSONCodec) 
 
 	cmd := genutilcli.InitCmd(testMbm, home)
 	serverCtx := server.NewContext(viper.New(), cfg, logger)
-	clientCtx := client.Context{}.WithJSONCodec(cdc).WithHomeDir(home)
+	clientCtx := client.Context{}.WithCodec(cdc).WithHomeDir(home)
 
 	_, out := testutil.ApplyMockIO(cmd)
 	clientCtx = clientCtx.WithOutput(out)

--- a/x/genutil/legacy/v040/migrate.go
+++ b/x/genutil/legacy/v040/migrate.go
@@ -44,7 +44,7 @@ func Migrate(appState types.AppMap, clientCtx client.Context) types.AppMap {
 	v036params.RegisterLegacyAminoCodec(v039Codec)
 	v038upgrade.RegisterLegacyAminoCodec(v039Codec)
 
-	v040Codec := clientCtx.JSONCodec
+	v040Codec := clientCtx.Codec
 
 	if appState[v038bank.ModuleName] != nil {
 		// unmarshal relative source genesis application state

--- a/x/genutil/legacy/v043/migrate.go
+++ b/x/genutil/legacy/v043/migrate.go
@@ -13,14 +13,14 @@ func Migrate(appState types.AppMap, clientCtx client.Context) types.AppMap {
 	if appState[v040gov.ModuleName] != nil {
 		// unmarshal relative source genesis application state
 		var oldGovState v040gov.GenesisState
-		clientCtx.JSONCodec.MustUnmarshalJSON(appState[v040gov.ModuleName], &oldGovState)
+		clientCtx.Codec.MustUnmarshalJSON(appState[v040gov.ModuleName], &oldGovState)
 
 		// delete deprecated x/gov genesis state
 		delete(appState, v040gov.ModuleName)
 
 		// Migrate relative source genesis application state and marshal it into
 		// the respective key.
-		appState[v043gov.ModuleName] = clientCtx.JSONCodec.MustMarshalJSON(v043gov.MigrateJSON(&oldGovState))
+		appState[v043gov.ModuleName] = clientCtx.Codec.MustMarshalJSON(v043gov.MigrateJSON(&oldGovState))
 	}
 
 	return appState

--- a/x/gov/client/cli/query.go
+++ b/x/gov/client/cli/query.go
@@ -238,7 +238,7 @@ $ %s query gov vote 1 cosmos1skjwj5whet0lpe65qaq4rpq03hjxlwd9nf39lk
 					return err
 				}
 
-				if err := clientCtx.JSONCodec.UnmarshalJSON(resByTxQuery, &vote); err != nil {
+				if err := clientCtx.Codec.UnmarshalJSON(resByTxQuery, &vote); err != nil {
 					return err
 				}
 			}
@@ -387,7 +387,7 @@ $ %s query gov deposit 1 cosmos1skjwj5whet0lpe65qaq4rpq03hjxlwd9nf39lk
 				if err != nil {
 					return err
 				}
-				clientCtx.JSONCodec.MustUnmarshalJSON(resByTxQuery, &deposit)
+				clientCtx.Codec.MustUnmarshalJSON(resByTxQuery, &deposit)
 				return clientCtx.PrintProto(&deposit)
 			}
 

--- a/x/gov/client/rest/grpc_query_test.go
+++ b/x/gov/client/rest/grpc_query_test.go
@@ -103,7 +103,7 @@ func (s *IntegrationTestSuite) TestGetProposalGRPC() {
 			s.Require().NoError(err)
 
 			var proposal types.QueryProposalResponse
-			err = val.ClientCtx.JSONCodec.UnmarshalJSON(resp, &proposal)
+			err = val.ClientCtx.Codec.UnmarshalJSON(resp, &proposal)
 
 			if tc.expErr {
 				s.Require().Error(err)
@@ -157,7 +157,7 @@ func (s *IntegrationTestSuite) TestGetProposalsGRPC() {
 			s.Require().NoError(err)
 
 			var proposals types.QueryProposalsResponse
-			err = val.ClientCtx.JSONCodec.UnmarshalJSON(resp, &proposals)
+			err = val.ClientCtx.Codec.UnmarshalJSON(resp, &proposals)
 
 			if tc.expErr {
 				s.Require().Empty(proposals.Proposals)
@@ -224,7 +224,7 @@ func (s *IntegrationTestSuite) TestGetProposalVoteGRPC() {
 			s.Require().NoError(err)
 
 			var vote types.QueryVoteResponse
-			err = val.ClientCtx.JSONCodec.UnmarshalJSON(resp, &vote)
+			err = val.ClientCtx.Codec.UnmarshalJSON(resp, &vote)
 
 			if tc.expErr {
 				s.Require().Error(err)
@@ -268,7 +268,7 @@ func (s *IntegrationTestSuite) TestGetProposalVotesGRPC() {
 			s.Require().NoError(err)
 
 			var votes types.QueryVotesResponse
-			err = val.ClientCtx.JSONCodec.UnmarshalJSON(resp, &votes)
+			err = val.ClientCtx.Codec.UnmarshalJSON(resp, &votes)
 
 			if tc.expErr {
 				s.Require().Error(err)
@@ -317,7 +317,7 @@ func (s *IntegrationTestSuite) TestGetProposalDepositGRPC() {
 			s.Require().NoError(err)
 
 			var deposit types.QueryDepositResponse
-			err = val.ClientCtx.JSONCodec.UnmarshalJSON(resp, &deposit)
+			err = val.ClientCtx.Codec.UnmarshalJSON(resp, &deposit)
 
 			if tc.expErr {
 				s.Require().Error(err)
@@ -356,7 +356,7 @@ func (s *IntegrationTestSuite) TestGetProposalDepositsGRPC() {
 			s.Require().NoError(err)
 
 			var deposits types.QueryDepositsResponse
-			err = val.ClientCtx.JSONCodec.UnmarshalJSON(resp, &deposits)
+			err = val.ClientCtx.Codec.UnmarshalJSON(resp, &deposits)
 
 			if tc.expErr {
 				s.Require().Error(err)
@@ -401,7 +401,7 @@ func (s *IntegrationTestSuite) TestGetTallyGRPC() {
 			s.Require().NoError(err)
 
 			var tally types.QueryTallyResultResponse
-			err = val.ClientCtx.JSONCodec.UnmarshalJSON(resp, &tally)
+			err = val.ClientCtx.Codec.UnmarshalJSON(resp, &tally)
 
 			if tc.expErr {
 				s.Require().Error(err)
@@ -463,7 +463,7 @@ func (s *IntegrationTestSuite) TestGetParamsGRPC() {
 			resp, err := rest.GetRequest(tc.url)
 			s.Require().NoError(err)
 
-			err = val.ClientCtx.JSONCodec.UnmarshalJSON(resp, tc.respType)
+			err = val.ClientCtx.Codec.UnmarshalJSON(resp, tc.respType)
 
 			if tc.expErr {
 				s.Require().Error(err)

--- a/x/gov/client/testutil/suite.go
+++ b/x/gov/client/testutil/suite.go
@@ -266,7 +266,7 @@ func (s *IntegrationTestSuite) TestCmdTally() {
 				s.Require().Error(err)
 			} else {
 				var tally types.TallyResult
-				s.Require().NoError(clientCtx.JSONCodec.UnmarshalJSON(out.Bytes(), &tally), out.String())
+				s.Require().NoError(clientCtx.Codec.UnmarshalJSON(out.Bytes(), &tally), out.String())
 				s.Require().Equal(tally, tc.expectedOutput)
 			}
 		})
@@ -357,7 +357,7 @@ func (s *IntegrationTestSuite) TestNewCmdSubmitProposal() {
 				s.Require().Error(err)
 			} else {
 				s.Require().NoError(err)
-				s.Require().NoError(clientCtx.JSONCodec.UnmarshalJSON(out.Bytes(), tc.respType), out.String())
+				s.Require().NoError(clientCtx.Codec.UnmarshalJSON(out.Bytes(), tc.respType), out.String())
 				txResp := tc.respType.(*sdk.TxResponse)
 				s.Require().Equal(tc.expectedCode, txResp.Code, out.String())
 			}
@@ -406,7 +406,7 @@ func (s *IntegrationTestSuite) TestCmdGetProposal() {
 			} else {
 				s.Require().NoError(err)
 				var proposal types.Proposal
-				s.Require().NoError(clientCtx.JSONCodec.UnmarshalJSON(out.Bytes(), &proposal), out.String())
+				s.Require().NoError(clientCtx.Codec.UnmarshalJSON(out.Bytes(), &proposal), out.String())
 				s.Require().Equal(title, proposal.GetTitle())
 			}
 		})
@@ -452,7 +452,7 @@ func (s *IntegrationTestSuite) TestCmdGetProposals() {
 				s.Require().NoError(err)
 				var proposals types.QueryProposalsResponse
 
-				s.Require().NoError(clientCtx.JSONCodec.UnmarshalJSON(out.Bytes(), &proposals), out.String())
+				s.Require().NoError(clientCtx.Codec.UnmarshalJSON(out.Bytes(), &proposals), out.String())
 				s.Require().Len(proposals.Proposals, 3)
 			}
 		})
@@ -498,7 +498,7 @@ func (s *IntegrationTestSuite) TestCmdQueryDeposits() {
 				s.Require().NoError(err)
 
 				var deposits types.QueryDepositsResponse
-				s.Require().NoError(clientCtx.JSONCodec.UnmarshalJSON(out.Bytes(), &deposits), out.String())
+				s.Require().NoError(clientCtx.Codec.UnmarshalJSON(out.Bytes(), &deposits), out.String())
 				s.Require().Len(deposits.Deposits, 1)
 			}
 		})
@@ -554,7 +554,7 @@ func (s *IntegrationTestSuite) TestCmdQueryDeposit() {
 				s.Require().NoError(err)
 
 				var deposit types.Deposit
-				s.Require().NoError(clientCtx.JSONCodec.UnmarshalJSON(out.Bytes(), &deposit), out.String())
+				s.Require().NoError(clientCtx.Codec.UnmarshalJSON(out.Bytes(), &deposit), out.String())
 				s.Require().Equal(depositAmount.String(), deposit.Amount.String())
 			}
 		})
@@ -632,7 +632,7 @@ func (s *IntegrationTestSuite) TestNewCmdDeposit() {
 			} else {
 				s.Require().NoError(err)
 
-				s.Require().NoError(clientCtx.JSONCodec.UnmarshalJSON(out.Bytes(), &resp), out.String())
+				s.Require().NoError(clientCtx.Codec.UnmarshalJSON(out.Bytes(), &resp), out.String())
 				s.Require().Equal(tc.expectedCode, resp.Code, out.String())
 			}
 		})
@@ -683,7 +683,7 @@ func (s *IntegrationTestSuite) TestCmdQueryVotes() {
 				s.Require().NoError(err)
 
 				var votes types.QueryVotesResponse
-				s.Require().NoError(clientCtx.JSONCodec.UnmarshalJSON(out.Bytes(), &votes), out.String())
+				s.Require().NoError(clientCtx.Codec.UnmarshalJSON(out.Bytes(), &votes), out.String())
 				s.Require().Len(votes.Votes, 1)
 			}
 		})
@@ -758,7 +758,7 @@ func (s *IntegrationTestSuite) TestCmdQueryVote() {
 				s.Require().NoError(err)
 
 				var vote types.Vote
-				s.Require().NoError(clientCtx.JSONCodec.UnmarshalJSON(out.Bytes(), &vote), out.String())
+				s.Require().NoError(clientCtx.Codec.UnmarshalJSON(out.Bytes(), &vote), out.String())
 				s.Require().Equal(len(vote.Options), len(tc.expVoteOptions))
 				for i, option := range tc.expVoteOptions {
 					s.Require().Equal(option.Option, vote.Options[i].Option)
@@ -822,7 +822,7 @@ func (s *IntegrationTestSuite) TestNewCmdVote() {
 				s.Require().Error(err)
 			} else {
 				s.Require().NoError(err)
-				s.Require().NoError(clientCtx.JSONCodec.UnmarshalJSON(out.Bytes(), &txResp), out.String())
+				s.Require().NoError(clientCtx.Codec.UnmarshalJSON(out.Bytes(), &txResp), out.String())
 				s.Require().Equal(tc.expectedCode, txResp.Code, out.String())
 			}
 		})
@@ -906,7 +906,7 @@ func (s *IntegrationTestSuite) TestNewCmdWeightedVote() {
 				s.Require().Error(err)
 			} else {
 				s.Require().NoError(err)
-				s.Require().NoError(clientCtx.JSONCodec.UnmarshalJSON(out.Bytes(), &txResp), out.String())
+				s.Require().NoError(clientCtx.Codec.UnmarshalJSON(out.Bytes(), &txResp), out.String())
 				s.Require().Equal(tc.expectedCode, txResp.Code, out.String())
 			}
 		})

--- a/x/gov/client/utils/query.go
+++ b/x/gov/client/utils/query.go
@@ -221,7 +221,7 @@ func QueryVoteByTxQuery(clientCtx client.Context, params types.QueryVoteParams) 
 			}
 
 			if vote != nil {
-				bz, err := clientCtx.JSONCodec.MarshalJSON(vote)
+				bz, err := clientCtx.Codec.MarshalJSON(vote)
 				if err != nil {
 					return nil, err
 				}
@@ -245,7 +245,7 @@ func QueryDepositByTxQuery(clientCtx client.Context, params types.QueryDepositPa
 	}
 
 	if !initialDeposit.Amount.IsZero() {
-		bz, err := clientCtx.JSONCodec.MarshalJSON(&initialDeposit)
+		bz, err := clientCtx.Codec.MarshalJSON(&initialDeposit)
 		if err != nil {
 			return nil, err
 		}
@@ -282,7 +282,7 @@ func QueryDepositByTxQuery(clientCtx client.Context, params types.QueryDepositPa
 					Amount:     depMsg.Amount,
 				}
 
-				bz, err := clientCtx.JSONCodec.MarshalJSON(&deposit)
+				bz, err := clientCtx.Codec.MarshalJSON(&deposit)
 				if err != nil {
 					return nil, err
 				}

--- a/x/gov/legacy/v040/migrate_test.go
+++ b/x/gov/legacy/v040/migrate_test.go
@@ -78,7 +78,7 @@ func TestMigrate(t *testing.T) {
 
 	migrated := v040gov.Migrate(govGenState)
 
-	bz, err := clientCtx.JSONCodec.MarshalJSON(migrated)
+	bz, err := clientCtx.Codec.MarshalJSON(migrated)
 	require.NoError(t, err)
 
 	// Indent the JSON bz correctly.

--- a/x/gov/legacy/v043/json_test.go
+++ b/x/gov/legacy/v043/json_test.go
@@ -20,7 +20,7 @@ func TestMigrateJSON(t *testing.T) {
 	clientCtx := client.Context{}.
 		WithInterfaceRegistry(encodingConfig.InterfaceRegistry).
 		WithTxConfig(encodingConfig.TxConfig).
-		WithJSONCodec(encodingConfig.Marshaler)
+		WithCodec(encodingConfig.Marshaler)
 
 	voter, err := sdk.AccAddressFromBech32("cosmos1fl48vsnmsdzcv85q5d2q4z5ajdha8yu34mf0eh")
 	require.NoError(t, err)

--- a/x/gov/legacy/v043/json_test.go
+++ b/x/gov/legacy/v043/json_test.go
@@ -36,7 +36,7 @@ func TestMigrateJSON(t *testing.T) {
 
 	migrated := v043gov.MigrateJSON(govGenState)
 
-	bz, err := clientCtx.JSONCodec.MarshalJSON(migrated)
+	bz, err := clientCtx.Codec.MarshalJSON(migrated)
 	require.NoError(t, err)
 
 	// Indent the JSON bz correctly.

--- a/x/mint/client/rest/grpc_query_test.go
+++ b/x/mint/client/rest/grpc_query_test.go
@@ -101,7 +101,7 @@ func (s *IntegrationTestSuite) TestQueryGRPC() {
 		resp, err := testutil.GetRequestWithHeaders(tc.url, tc.headers)
 		s.Run(tc.name, func() {
 			s.Require().NoError(err)
-			s.Require().NoError(val.ClientCtx.JSONCodec.UnmarshalJSON(resp, tc.respType))
+			s.Require().NoError(val.ClientCtx.Codec.UnmarshalJSON(resp, tc.respType))
 			s.Require().Equal(tc.expected.String(), tc.respType.String())
 		})
 	}

--- a/x/params/client/rest/grpc_query_test.go
+++ b/x/params/client/rest/grpc_query_test.go
@@ -113,7 +113,7 @@ func (s *IntegrationTestSuite) TestQueryParamsGRPC() {
 			resp, err := testutil.GetRequestWithHeaders(tc.url, tc.headers)
 			s.Require().NoError(err)
 
-			err = val.ClientCtx.JSONCodec.UnmarshalJSON(resp, tc.respType)
+			err = val.ClientCtx.Codec.UnmarshalJSON(resp, tc.respType)
 
 			if tc.expErr {
 				s.Require().Error(err)

--- a/x/slashing/client/cli/query.go
+++ b/x/slashing/client/cli/query.go
@@ -50,7 +50,7 @@ $ <appd> query slashing signing-info '{"@type":"/cosmos.crypto.ed25519.PubKey","
 			}
 
 			var pk cryptotypes.PubKey
-			if err := clientCtx.JSONCodec.UnmarshalInterfaceJSON([]byte(args[0]), &pk); err != nil {
+			if err := clientCtx.Codec.UnmarshalInterfaceJSON([]byte(args[0]), &pk); err != nil {
 				return err
 			}
 

--- a/x/slashing/client/rest/grpc_query_test.go
+++ b/x/slashing/client/rest/grpc_query_test.go
@@ -117,7 +117,7 @@ func (s *IntegrationTestSuite) TestGRPCQueries() {
 			resp, err := testutil.GetRequestWithHeaders(tc.url, tc.headers)
 			s.Require().NoError(err)
 
-			err = val.ClientCtx.JSONCodec.UnmarshalJSON(resp, tc.respType)
+			err = val.ClientCtx.Codec.UnmarshalJSON(resp, tc.respType)
 
 			if tc.expErr {
 				s.Require().Error(err)

--- a/x/slashing/client/testutil/suite.go
+++ b/x/slashing/client/testutil/suite.go
@@ -173,7 +173,7 @@ func (s *IntegrationTestSuite) TestNewUnjailTxCmd() {
 				s.Require().Error(err)
 			} else {
 				s.Require().NoError(err)
-				s.Require().NoError(clientCtx.JSONCodec.UnmarshalJSON(out.Bytes(), tc.respType), out.String())
+				s.Require().NoError(clientCtx.Codec.UnmarshalJSON(out.Bytes(), tc.respType), out.String())
 
 				txResp := tc.respType.(*sdk.TxResponse)
 				s.Require().Equal(tc.expectedCode, txResp.Code, out.String())

--- a/x/slashing/legacy/v040/migrate_test.go
+++ b/x/slashing/legacy/v040/migrate_test.go
@@ -126,7 +126,7 @@ func TestMigrate(t *testing.T) {
   ]
 }`
 
-	bz, err := clientCtx.JSONCodec.MarshalJSON(migrated)
+	bz, err := clientCtx.Codec.MarshalJSON(migrated)
 	require.NoError(t, err)
 
 	// Indent the JSON bz correctly.

--- a/x/staking/client/cli/tx.go
+++ b/x/staking/client/cli/tx.go
@@ -291,7 +291,7 @@ func newBuildCreateValidatorMsg(clientCtx client.Context, txf tx.Factory, fs *fl
 	}
 
 	var pk cryptotypes.PubKey
-	if err := clientCtx.JSONCodec.UnmarshalInterfaceJSON([]byte(pkStr), &pk); err != nil {
+	if err := clientCtx.Codec.UnmarshalInterfaceJSON([]byte(pkStr), &pk); err != nil {
 		return txf, nil, err
 	}
 

--- a/x/staking/client/rest/grpc_query_test.go
+++ b/x/staking/client/rest/grpc_query_test.go
@@ -107,7 +107,7 @@ func (s *IntegrationTestSuite) TestQueryValidatorsGRPCHandler() {
 			s.Require().NoError(err)
 
 			var valRes types.QueryValidatorsResponse
-			err = val.ClientCtx.JSONCodec.UnmarshalJSON(resp, &valRes)
+			err = val.ClientCtx.Codec.UnmarshalJSON(resp, &valRes)
 
 			if tc.error {
 				s.Require().Error(err)
@@ -155,7 +155,7 @@ func (s *IntegrationTestSuite) TestQueryValidatorGRPC() {
 			s.Require().NoError(err)
 
 			var validator types.QueryValidatorResponse
-			err = val.ClientCtx.JSONCodec.UnmarshalJSON(resp, &validator)
+			err = val.ClientCtx.Codec.UnmarshalJSON(resp, &validator)
 
 			if tc.error {
 				s.Require().Error(err)
@@ -219,7 +219,7 @@ func (s *IntegrationTestSuite) TestQueryValidatorDelegationsGRPC() {
 			resp, err := testutil.GetRequestWithHeaders(tc.url, tc.headers)
 			s.Require().NoError(err)
 
-			err = val.ClientCtx.JSONCodec.UnmarshalJSON(resp, tc.respType)
+			err = val.ClientCtx.Codec.UnmarshalJSON(resp, tc.respType)
 
 			if tc.error {
 				s.Require().Error(err)
@@ -265,7 +265,7 @@ func (s *IntegrationTestSuite) TestQueryValidatorUnbondingDelegationsGRPC() {
 
 			var ubds types.QueryValidatorUnbondingDelegationsResponse
 
-			err = val.ClientCtx.JSONCodec.UnmarshalJSON(resp, &ubds)
+			err = val.ClientCtx.Codec.UnmarshalJSON(resp, &ubds)
 
 			if tc.error {
 				s.Require().Error(err)
@@ -342,7 +342,7 @@ func (s *IntegrationTestSuite) TestQueryDelegationGRPC() {
 			resp, err := rest.GetRequest(tc.url)
 			s.Require().NoError(err)
 			s.T().Logf("%s", resp)
-			err = val.ClientCtx.JSONCodec.UnmarshalJSON(resp, tc.respType)
+			err = val.ClientCtx.Codec.UnmarshalJSON(resp, tc.respType)
 
 			if tc.error {
 				s.Require().Error(err)
@@ -398,7 +398,7 @@ func (s *IntegrationTestSuite) TestQueryUnbondingDelegationGRPC() {
 
 			var ubd types.QueryUnbondingDelegationResponse
 
-			err = val.ClientCtx.JSONCodec.UnmarshalJSON(resp, &ubd)
+			err = val.ClientCtx.Codec.UnmarshalJSON(resp, &ubd)
 
 			if tc.error {
 				s.Require().Error(err)
@@ -481,7 +481,7 @@ func (s *IntegrationTestSuite) TestQueryDelegatorDelegationsGRPC() {
 			resp, err := testutil.GetRequestWithHeaders(tc.url, tc.headers)
 			s.Require().NoError(err)
 
-			err = val.ClientCtx.JSONCodec.UnmarshalJSON(resp, tc.respType)
+			err = val.ClientCtx.Codec.UnmarshalJSON(resp, tc.respType)
 
 			if tc.error {
 				s.Require().Error(err)
@@ -531,7 +531,7 @@ func (s *IntegrationTestSuite) TestQueryDelegatorUnbondingDelegationsGRPC() {
 
 			var ubds types.QueryDelegatorUnbondingDelegationsResponse
 
-			err = val.ClientCtx.JSONCodec.UnmarshalJSON(resp, &ubds)
+			err = val.ClientCtx.Codec.UnmarshalJSON(resp, &ubds)
 
 			if tc.error {
 				s.Require().Error(err)
@@ -592,7 +592,7 @@ func (s *IntegrationTestSuite) TestQueryRedelegationsGRPC() {
 			s.Require().NoError(err)
 			var redelegations types.QueryRedelegationsResponse
 
-			err = val.ClientCtx.JSONCodec.UnmarshalJSON(resp, &redelegations)
+			err = val.ClientCtx.Codec.UnmarshalJSON(resp, &redelegations)
 
 			if tc.error {
 				s.Require().Error(err)
@@ -642,7 +642,7 @@ func (s *IntegrationTestSuite) TestQueryDelegatorValidatorsGRPC() {
 
 			var validators types.QueryDelegatorValidatorsResponse
 
-			err = val.ClientCtx.JSONCodec.UnmarshalJSON(resp, &validators)
+			err = val.ClientCtx.Codec.UnmarshalJSON(resp, &validators)
 
 			if tc.error {
 				s.Require().Error(err)
@@ -698,7 +698,7 @@ func (s *IntegrationTestSuite) TestQueryDelegatorValidatorGRPC() {
 			s.Require().NoError(err)
 
 			var validator types.QueryDelegatorValidatorResponse
-			err = val.ClientCtx.JSONCodec.UnmarshalJSON(resp, &validator)
+			err = val.ClientCtx.Codec.UnmarshalJSON(resp, &validator)
 
 			if tc.error {
 				s.Require().Error(err)
@@ -745,7 +745,7 @@ func (s *IntegrationTestSuite) TestQueryHistoricalInfoGRPC() {
 
 			var historicalInfo types.QueryHistoricalInfoResponse
 
-			err = val.ClientCtx.JSONCodec.UnmarshalJSON(resp, &historicalInfo)
+			err = val.ClientCtx.Codec.UnmarshalJSON(resp, &historicalInfo)
 
 			if tc.error {
 				s.Require().Error(err)
@@ -782,7 +782,7 @@ func (s *IntegrationTestSuite) TestQueryParamsGRPC() {
 		resp, err := rest.GetRequest(tc.url)
 		s.Run(tc.name, func() {
 			s.Require().NoError(err)
-			s.Require().NoError(val.ClientCtx.JSONCodec.UnmarshalJSON(resp, tc.respType))
+			s.Require().NoError(val.ClientCtx.Codec.UnmarshalJSON(resp, tc.respType))
 			s.Require().Equal(tc.expected, tc.respType)
 		})
 	}
@@ -816,7 +816,7 @@ func (s *IntegrationTestSuite) TestQueryPoolGRPC() {
 		resp, err := rest.GetRequest(tc.url)
 		s.Run(tc.name, func() {
 			s.Require().NoError(err)
-			s.Require().NoError(val.ClientCtx.JSONCodec.UnmarshalJSON(resp, tc.respType))
+			s.Require().NoError(val.ClientCtx.Codec.UnmarshalJSON(resp, tc.respType))
 			s.Require().Equal(tc.expected, tc.respType)
 		})
 	}

--- a/x/staking/client/testutil/suite.go
+++ b/x/staking/client/testutil/suite.go
@@ -200,7 +200,7 @@ func (s *IntegrationTestSuite) TestNewCreateValidatorCmd() {
 				require.Error(err)
 			} else {
 				require.NoError(err, "test: %s\noutput: %s", tc.name, out.String())
-				err = clientCtx.JSONCodec.UnmarshalJSON(out.Bytes(), tc.respType)
+				err = clientCtx.Codec.UnmarshalJSON(out.Bytes(), tc.respType)
 				require.NoError(err, out.String(), "test: %s, output\n:", tc.name, out.String())
 
 				txResp := tc.respType.(*sdk.TxResponse)
@@ -245,7 +245,7 @@ func (s *IntegrationTestSuite) TestGetCmdQueryValidator() {
 				s.Require().NotEqual("internal", err.Error())
 			} else {
 				var result types.Validator
-				s.Require().NoError(clientCtx.JSONCodec.UnmarshalJSON(out.Bytes(), &result))
+				s.Require().NoError(clientCtx.Codec.UnmarshalJSON(out.Bytes(), &result))
 				s.Require().Equal(val.ValAddress.String(), result.OperatorAddress)
 			}
 		})
@@ -286,7 +286,7 @@ func (s *IntegrationTestSuite) TestGetCmdQueryValidators() {
 			s.Require().NoError(err)
 
 			var result types.QueryValidatorsResponse
-			s.Require().NoError(clientCtx.JSONCodec.UnmarshalJSON(out.Bytes(), &result))
+			s.Require().NoError(clientCtx.Codec.UnmarshalJSON(out.Bytes(), &result))
 			s.Require().Equal(tc.minValidatorCount, len(result.Validators))
 		})
 	}
@@ -352,7 +352,7 @@ func (s *IntegrationTestSuite) TestGetCmdQueryDelegation() {
 				s.Require().Error(err)
 			} else {
 				s.Require().NoError(err)
-				s.Require().NoError(clientCtx.JSONCodec.UnmarshalJSON(out.Bytes(), tc.respType), out.String())
+				s.Require().NoError(clientCtx.Codec.UnmarshalJSON(out.Bytes(), tc.respType), out.String())
 				s.Require().Equal(tc.expected.String(), tc.respType.String())
 			}
 		})
@@ -408,7 +408,7 @@ func (s *IntegrationTestSuite) TestGetCmdQueryDelegations() {
 				s.Require().Error(err)
 			} else {
 				s.Require().NoError(err)
-				s.Require().NoError(clientCtx.JSONCodec.UnmarshalJSON(out.Bytes(), tc.respType), out.String())
+				s.Require().NoError(clientCtx.Codec.UnmarshalJSON(out.Bytes(), tc.respType), out.String())
 				s.Require().Equal(tc.expected.String(), tc.respType.String())
 			}
 		})
@@ -464,7 +464,7 @@ func (s *IntegrationTestSuite) TestGetCmdQueryValidatorDelegations() {
 				s.Require().Error(err)
 			} else {
 				s.Require().NoError(err)
-				s.Require().NoError(clientCtx.JSONCodec.UnmarshalJSON(out.Bytes(), tc.respType), out.String())
+				s.Require().NoError(clientCtx.Codec.UnmarshalJSON(out.Bytes(), tc.respType), out.String())
 				s.Require().Equal(tc.expected.String(), tc.respType.String())
 			}
 		})
@@ -509,7 +509,7 @@ func (s *IntegrationTestSuite) TestGetCmdQueryUnbondingDelegations() {
 				s.Require().Error(err)
 			} else {
 				var ubds types.QueryDelegatorUnbondingDelegationsResponse
-				err = val.ClientCtx.JSONCodec.UnmarshalJSON(out.Bytes(), &ubds)
+				err = val.ClientCtx.Codec.UnmarshalJSON(out.Bytes(), &ubds)
 
 				s.Require().NoError(err)
 				s.Require().Len(ubds.UnbondingResponses, 1)
@@ -569,7 +569,7 @@ func (s *IntegrationTestSuite) TestGetCmdQueryUnbondingDelegation() {
 			} else {
 				var ubd types.UnbondingDelegation
 
-				err = val.ClientCtx.JSONCodec.UnmarshalJSON(out.Bytes(), &ubd)
+				err = val.ClientCtx.Codec.UnmarshalJSON(out.Bytes(), &ubd)
 				s.Require().NoError(err)
 				s.Require().Equal(ubd.DelegatorAddress, val.Address.String())
 				s.Require().Equal(ubd.ValidatorAddress, val.ValAddress.String())
@@ -617,7 +617,7 @@ func (s *IntegrationTestSuite) TestGetCmdQueryValidatorUnbondingDelegations() {
 				s.Require().Error(err)
 			} else {
 				var ubds types.QueryValidatorUnbondingDelegationsResponse
-				err = val.ClientCtx.JSONCodec.UnmarshalJSON(out.Bytes(), &ubds)
+				err = val.ClientCtx.Codec.UnmarshalJSON(out.Bytes(), &ubds)
 
 				s.Require().NoError(err)
 				s.Require().Len(ubds.UnbondingResponses, 1)
@@ -666,7 +666,7 @@ func (s *IntegrationTestSuite) TestGetCmdQueryRedelegations() {
 				s.Require().Error(err)
 			} else {
 				var redelegations types.QueryRedelegationsResponse
-				err = val.ClientCtx.JSONCodec.UnmarshalJSON(out.Bytes(), &redelegations)
+				err = val.ClientCtx.Codec.UnmarshalJSON(out.Bytes(), &redelegations)
 
 				s.Require().NoError(err)
 
@@ -743,7 +743,7 @@ func (s *IntegrationTestSuite) TestGetCmdQueryRedelegation() {
 			} else {
 				var redelegations types.QueryRedelegationsResponse
 
-				err = val.ClientCtx.JSONCodec.UnmarshalJSON(out.Bytes(), &redelegations)
+				err = val.ClientCtx.Codec.UnmarshalJSON(out.Bytes(), &redelegations)
 				s.Require().NoError(err)
 
 				s.Require().Len(redelegations.RedelegationResponses, 1)
@@ -794,7 +794,7 @@ func (s *IntegrationTestSuite) TestGetCmdQueryValidatorRedelegations() {
 				s.Require().Error(err)
 			} else {
 				var redelegations types.QueryRedelegationsResponse
-				err = val.ClientCtx.JSONCodec.UnmarshalJSON(out.Bytes(), &redelegations)
+				err = val.ClientCtx.Codec.UnmarshalJSON(out.Bytes(), &redelegations)
 
 				s.Require().NoError(err)
 
@@ -845,7 +845,7 @@ func (s *IntegrationTestSuite) TestGetCmdQueryHistoricalInfo() {
 			} else {
 				var historicalInfo types.HistoricalInfo
 
-				err = val.ClientCtx.JSONCodec.UnmarshalJSON(out.Bytes(), &historicalInfo)
+				err = val.ClientCtx.Codec.UnmarshalJSON(out.Bytes(), &historicalInfo)
 				s.Require().NoError(err)
 				s.Require().NotNil(historicalInfo)
 			}
@@ -1032,7 +1032,7 @@ func (s *IntegrationTestSuite) TestNewEditValidatorCmd() {
 				s.Require().Error(err)
 			} else {
 				s.Require().NoError(err, out.String())
-				s.Require().NoError(clientCtx.JSONCodec.UnmarshalJSON(out.Bytes(), tc.respType), out.String())
+				s.Require().NoError(clientCtx.Codec.UnmarshalJSON(out.Bytes(), tc.respType), out.String())
 
 				txResp := tc.respType.(*sdk.TxResponse)
 				s.Require().Equal(tc.expectedCode, txResp.Code, out.String())
@@ -1114,7 +1114,7 @@ func (s *IntegrationTestSuite) TestNewDelegateCmd() {
 				s.Require().Error(err)
 			} else {
 				s.Require().NoError(err, out.String())
-				s.Require().NoError(clientCtx.JSONCodec.UnmarshalJSON(out.Bytes(), tc.respType), out.String())
+				s.Require().NoError(clientCtx.Codec.UnmarshalJSON(out.Bytes(), tc.respType), out.String())
 
 				txResp := tc.respType.(*sdk.TxResponse)
 				s.Require().Equal(tc.expectedCode, txResp.Code, out.String())
@@ -1200,7 +1200,7 @@ func (s *IntegrationTestSuite) TestNewRedelegateCmd() {
 				s.Require().Error(err)
 			} else {
 				s.Require().NoError(err, out.String())
-				s.Require().NoError(clientCtx.JSONCodec.UnmarshalJSON(out.Bytes(), tc.respType), out.String())
+				s.Require().NoError(clientCtx.Codec.UnmarshalJSON(out.Bytes(), tc.respType), out.String())
 
 				txResp := tc.respType.(*sdk.TxResponse)
 				s.Require().Equal(tc.expectedCode, txResp.Code, out.String())
@@ -1267,7 +1267,7 @@ func (s *IntegrationTestSuite) TestNewUnbondCmd() {
 				s.Require().Error(err)
 			} else {
 				s.Require().NoError(err, out.String())
-				s.Require().NoError(clientCtx.JSONCodec.UnmarshalJSON(out.Bytes(), tc.respType), out.String())
+				s.Require().NoError(clientCtx.Codec.UnmarshalJSON(out.Bytes(), tc.respType), out.String())
 
 				txResp := tc.respType.(*sdk.TxResponse)
 				s.Require().Equal(tc.expectedCode, txResp.Code, out.String())

--- a/x/staking/legacy/v040/migrate_test.go
+++ b/x/staking/legacy/v040/migrate_test.go
@@ -32,7 +32,7 @@ func TestMigrate(t *testing.T) {
 
 	migrated := v040staking.Migrate(stakingGenState)
 
-	bz, err := clientCtx.JSONCodec.MarshalJSON(migrated)
+	bz, err := clientCtx.Codec.MarshalJSON(migrated)
 	require.NoError(t, err)
 
 	// Indent the JSON bz correctly.

--- a/x/staking/legacy/v043/json_test.go
+++ b/x/staking/legacy/v043/json_test.go
@@ -31,7 +31,7 @@ func TestMigrateJSON(t *testing.T) {
 
 	require.True(t, migrated.Params.PowerReduction.Equal(sdk.DefaultPowerReduction))
 
-	bz, err := clientCtx.JSONCodec.MarshalJSON(migrated)
+	bz, err := clientCtx.Codec.MarshalJSON(migrated)
 	require.NoError(t, err)
 
 	// Indent the JSON bz correctly.

--- a/x/upgrade/client/testutil/suite.go
+++ b/x/upgrade/client/testutil/suite.go
@@ -92,7 +92,7 @@ func (s *IntegrationTestSuite) TestModuleVersionsCLI() {
 				pm := types.QueryModuleVersionsResponse{
 					ModuleVersions: expect,
 				}
-				jsonVM, _ := clientCtx.JSONCodec.MarshalJSON(&pm)
+				jsonVM, _ := clientCtx.Codec.MarshalJSON(&pm)
 				expectedRes := string(jsonVM)
 				// append new line to match behaviour of PrintProto
 				expectedRes += "\n"


### PR DESCRIPTION
## Description

Closes: #9490

Going towards v0.44 release cycle, we need to use `codec.Codec` in the `client/contex.Context` object. This deprecates `client/contex.JSONCodec`. To assure smooth transition we add ``client/contex.Codec: codec.Codec` in v0.43 release and use it everywhere in the SDK instead of JSONCodec.

Moreover I added a note that `encCfg.Marshaler` should be renamed to `encCfg.Codec`.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [x] provided a link to the relevant issue or specification
- [x] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [x] added a changelog entry to `CHANGELOG.md`
- [x] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [x] updated the relevant documentation or specification
- [x] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)