### PR TITLE
ci: Remove "Type: Docs" label from labeler action

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -50,8 +50,5 @@
 "C:CLI":
   - client/**/*
   - x/*/client/**/*
-"Type: Docs":
-  - docs/**/*
-  - x/*/spec/**/*
 "Type: ADR":
-    - docs/architecture/**/*
+  - docs/architecture/**/*


### PR DESCRIPTION
It's just causing noise...

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [x] provided a link to the relevant issue or specification - **n/a**
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [x] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] confirmed all author checklist items have been addressed
- [x] confirmed that this PR does not change production code