### PR TITLE
fix linting

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -56,6 +56,9 @@ issues:
     - text: "ST1016:"
       linters:
         - stylecheck
+    - text: "SA1019: codec.LegacyAmino is deprecated"
+      linters:
+        - staticcheck
   max-issues-per-linter: 10000
   max-same-issues: 10000
 

--- a/client/docs/statik/init.go
+++ b/client/docs/statik/init.go
@@ -1,3 +1,3 @@
 package statik
 
-//This just for fixing the error in importing empty github.com/cosmos/cosmos-sdk/client/docs/statik
+// This just for fixing the error in importing empty github.com/cosmos/cosmos-sdk/client/docs/statik

--- a/client/rest/rest.go
+++ b/client/rest/rest.go
@@ -22,6 +22,7 @@ func addHTTPDeprecationHeaders(h http.Handler) http.Handler {
 	})
 }
 
+// nolint
 // WithHTTPDeprecationHeaders returns a new *mux.Router, identical to its input
 // but with the addition of HTTP Deprecation headers. This is used to mark legacy
 // amino REST endpoints as deprecated in the REST API.

--- a/client/rpc/block.go
+++ b/client/rpc/block.go
@@ -15,7 +15,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/rest"
 )
 
-//BlockCommand returns the verified block data for a given heights
+// BlockCommand returns the verified block data for a given heights
 func BlockCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "block [height]",

--- a/client/rpc/validators.go
+++ b/client/rpc/validators.go
@@ -22,7 +22,7 @@ import (
 
 // TODO these next two functions feel kinda hacky based on their placement
 
-//ValidatorCommand returns the validator set for a given height
+// ValidatorCommand returns the validator set for a given height
 func ValidatorCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "tendermint-validator-set [height]",

--- a/codec/amino.go
+++ b/codec/amino.go
@@ -13,7 +13,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec/types"
 )
 
-// deprecated: LegacyAmino defines a wrapper for an Amino codec that properly handles protobuf
+// Deprecated: LegacyAmino defines a wrapper for an Amino codec that properly handles protobuf
 // types with Any's
 type LegacyAmino struct {
 	Amino *amino.Codec

--- a/crypto/keyring/legacy.go
+++ b/crypto/keyring/legacy.go
@@ -40,6 +40,7 @@ func NewLegacy(name, dir string, opts ...KeybaseOption) (LegacyKeybase, error) {
 
 var _ LegacyKeybase = dbKeybase{}
 
+// nolint
 // dbKeybase combines encryption and storage implementation to provide a
 // full-featured key manager.
 //

--- a/simapp/test_helpers.go
+++ b/simapp/test_helpers.go
@@ -213,9 +213,9 @@ func createIncrementalAccounts(accNum int) []sdk.AccAddress {
 	// start at 100 so we can make up to 999 test addresses with valid test addresses
 	for i := 100; i < (accNum + 100); i++ {
 		numString := strconv.Itoa(i)
-		buffer.WriteString("A58856F0FD53BF058B4909A21AEC019107BA6") //base address string
+		buffer.WriteString("A58856F0FD53BF058B4909A21AEC019107BA6") // base address string
 
-		buffer.WriteString(numString) //adding on final two digits to make addresses unique
+		buffer.WriteString(numString) // adding on final two digits to make addresses unique
 		res, _ := sdk.AccAddressFromHex(buffer.String())
 		bech := res.String()
 		addr, _ := TestAddr(buffer.String(), bech)

--- a/store/gaskv/store.go
+++ b/store/gaskv/store.go
@@ -19,7 +19,6 @@ type Store struct {
 }
 
 // NewStore returns a reference to a new GasKVStore.
-// nolint
 func NewStore(parent types.KVStore, gasMeter types.GasMeter, gasConfig types.GasConfig) *Store {
 	kvs := &Store{
 		gasMeter:  gasMeter,

--- a/types/decimal.go
+++ b/types/decimal.go
@@ -80,7 +80,7 @@ func precisionMultiplier(prec int64) *big.Int {
 	return precisionMultipliers[prec]
 }
 
-//______________________________________________________________________________________________
+// ______________________________________________________________________________________________
 
 // create a new Dec from integer assuming whole number
 func NewDec(i int64) Dec {
@@ -198,8 +198,7 @@ func MustNewDecFromStr(s string) Dec {
 	return dec
 }
 
-//______________________________________________________________________________________________
-//nolint
+// ______________________________________________________________________________________________
 func (d Dec) IsNil() bool       { return d.i == nil }                 // is decimal nil
 func (d Dec) IsZero() bool      { return (d.i).Sign() == 0 }          // is equal to zero
 func (d Dec) IsNegative() bool  { return (d.i).Sign() == -1 }         // is negative
@@ -564,7 +563,7 @@ func (d Dec) RoundInt() Int {
 	return NewIntFromBigInt(chopPrecisionAndRoundNonMutative(d.i))
 }
 
-//___________________________________________________________________________________
+// ___________________________________________________________________________________
 
 // similar to chopPrecisionAndRound, but always rounds down
 func chopPrecisionAndTruncate(d *big.Int) *big.Int {
@@ -615,7 +614,7 @@ func (d Dec) Ceil() Dec {
 	return NewDecFromBigInt(quo.Add(quo, oneInt))
 }
 
-//___________________________________________________________________________________
+// ___________________________________________________________________________________
 
 // MaxSortableDec is the largest Dec that can be passed into SortableDecBytes()
 // Its negative form is the least Dec that can be passed in.
@@ -651,7 +650,7 @@ func SortableDecBytes(dec Dec) []byte {
 	return []byte(fmt.Sprintf(fmt.Sprintf("%%0%ds", Precision*2+1), dec.String()))
 }
 
-//___________________________________________________________________________________
+// ___________________________________________________________________________________
 
 // reuse nil values
 var nilJSON []byte
@@ -761,7 +760,7 @@ func (dp DecProto) String() string {
 	return dp.Dec.String()
 }
 
-//___________________________________________________________________________________
+// ___________________________________________________________________________________
 // helpers
 
 // test if two decimal arrays are equal

--- a/types/decimal_test.go
+++ b/types/decimal_test.go
@@ -29,7 +29,7 @@ func (s *decimalTestSuite) mustNewDecFromStr(str string) (d sdk.Dec) {
 	return d
 }
 
-//_______________________________________
+// _______________________________________
 
 func (s *decimalTestSuite) TestNewDecFromStr() {
 	largeBigInt, success := new(big.Int).SetString("3144605511029693144278234343371835", 10)

--- a/types/errors/errors.go
+++ b/types/errors/errors.go
@@ -15,7 +15,6 @@ const UndefinedCodespace = "undefined"
 
 var (
 	// errInternal should never be exposed, but we reserve this code for non-specified errors
-	//nolint
 	errInternal = Register(UndefinedCodespace, 1, "internal")
 
 	// ErrTxDecode is returned if we cannot parse a transaction

--- a/types/module/module.go
+++ b/types/module/module.go
@@ -42,7 +42,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
-//__________________________________________________________________________________________
+// __________________________________________________________________________________________
 
 // AppModuleBasic is the standard form for basic non-dependant elements of an application module.
 type AppModuleBasic interface {
@@ -145,7 +145,7 @@ func (bm BasicManager) AddQueryCommands(rootQueryCmd *cobra.Command) {
 	}
 }
 
-//_________________________________________________________
+// _________________________________________________________
 
 // AppModuleGenesis is the standard form for an application module genesis functions
 type AppModuleGenesis interface {
@@ -179,7 +179,7 @@ type AppModule interface {
 	EndBlock(sdk.Context, abci.RequestEndBlock) []abci.ValidatorUpdate
 }
 
-//___________________________
+// ___________________________
 
 // GenesisOnlyAppModule is an AppModule that only has import/export functionality
 type GenesisOnlyAppModule struct {
@@ -216,7 +216,7 @@ func (GenesisOnlyAppModule) EndBlock(_ sdk.Context, _ abci.RequestEndBlock) []ab
 	return []abci.ValidatorUpdate{}
 }
 
-//____________________________________________________________________________
+// ____________________________________________________________________________
 
 // Manager defines a module manager that provides the high level utility for managing and executing
 // operations for a group of modules

--- a/types/simulation/config.go
+++ b/types/simulation/config.go
@@ -6,8 +6,8 @@ type Config struct {
 	ParamsFile  string // custom simulation params file which overrides any random params; cannot be used with genesis
 
 	ExportParamsPath   string // custom file path to save the exported params JSON
-	ExportParamsHeight int    //height to which export the randomly generated params
-	ExportStatePath    string //custom file path to save the exported app state JSON
+	ExportParamsHeight int    // height to which export the randomly generated params
+	ExportStatePath    string // custom file path to save the exported app state JSON
 	ExportStatsPath    string // custom file path to save the exported simulation statistics JSON
 
 	Seed               int64  // simulation random seed

--- a/types/simulation/types.go
+++ b/types/simulation/types.go
@@ -114,7 +114,7 @@ func (om OperationMsg) LogEvent(eventLogger func(route, op, evResult string)) {
 	eventLogger(om.Route, om.Name, pass)
 }
 
-//________________________________________________________________________
+// ________________________________________________________________________
 
 // FutureOperation is an operation which will be ran at the beginning of the
 // provided BlockHeight. If both a BlockHeight and BlockTime are specified, it

--- a/types/uint.go
+++ b/types/uint.go
@@ -207,7 +207,7 @@ func (u *Uint) Size() int {
 func (u Uint) MarshalAmino() ([]byte, error)   { return u.Marshal() }
 func (u *Uint) UnmarshalAmino(bz []byte) error { return u.Unmarshal(bz) }
 
-//__________________________________________________________________________
+// __________________________________________________________________________
 
 // UintOverflow returns true if a given unsigned integer overflows and false
 // otherwise.

--- a/x/auth/legacy/v034/types.go
+++ b/x/auth/legacy/v034/types.go
@@ -1,5 +1,4 @@
 // DONTCOVER
-// nolint
 package v034
 
 import (

--- a/x/auth/legacy/v036/migrate.go
+++ b/x/auth/legacy/v036/migrate.go
@@ -1,5 +1,4 @@
 // DONTCOVER
-// nolint
 package v036
 
 import (

--- a/x/auth/legacy/v036/types.go
+++ b/x/auth/legacy/v036/types.go
@@ -1,5 +1,4 @@
 // DONTCOVER
-// nolint
 package v036
 
 import v034auth "github.com/cosmos/cosmos-sdk/x/auth/legacy/v034"

--- a/x/auth/legacy/v038/types.go
+++ b/x/auth/legacy/v038/types.go
@@ -1,7 +1,6 @@
 package v038
 
 // DONTCOVER
-// nolint
 
 import (
 	"bytes"

--- a/x/auth/legacy/v039/types.go
+++ b/x/auth/legacy/v039/types.go
@@ -1,7 +1,6 @@
 package v039
 
 // DONTCOVER
-// nolint
 
 import (
 	"bytes"

--- a/x/auth/module.go
+++ b/x/auth/module.go
@@ -85,7 +85,7 @@ func (AppModuleBasic) RegisterInterfaces(registry codectypes.InterfaceRegistry) 
 	types.RegisterInterfaces(registry)
 }
 
-//____________________________________________________________________________
+// ____________________________________________________________________________
 
 // AppModule implements an application module for the auth module.
 type AppModule struct {
@@ -156,7 +156,7 @@ func (AppModule) EndBlock(_ sdk.Context, _ abci.RequestEndBlock) []abci.Validato
 	return []abci.ValidatorUpdate{}
 }
 
-//____________________________________________________________________________
+// ____________________________________________________________________________
 
 // AppModuleSimulation functions
 

--- a/x/auth/testutil/suite.go
+++ b/x/auth/testutil/suite.go
@@ -16,7 +16,7 @@ import (
 )
 
 // TxConfigTestSuite provides a test suite that can be used to test that a TxConfig implementation is correct
-//nolint:golint  // type name will be used as tx.TxConfigTestSuite by other packages, and that stutters; consider calling this GeneratorTestSuite
+// type name will be used as tx.TxConfigTestSuite by other packages, and that stutters; consider calling this GeneratorTestSuite
 type TxConfigTestSuite struct {
 	suite.Suite
 	TxConfig client.TxConfig

--- a/x/auth/types/account_retriever.go
+++ b/x/auth/types/account_retriever.go
@@ -32,7 +32,6 @@ func (ar AccountRetriever) GetAccount(clientCtx client.Context, addr sdk.AccAddr
 // GetAccountWithHeight queries for an account given an address. Returns the
 // height of the query with the account. An error is returned if the query
 // or decoding fails.
-//nolint:interfacer
 func (ar AccountRetriever) GetAccountWithHeight(clientCtx client.Context, addr sdk.AccAddress) (client.Account, int64, error) {
 	var header metadata.MD
 

--- a/x/auth/types/params.go
+++ b/x/auth/types/params.go
@@ -48,7 +48,6 @@ func ParamKeyTable() paramtypes.KeyTable {
 
 // ParamSetPairs implements the ParamSet interface and returns all the key/value pairs
 // pairs of auth module's parameters.
-// nolint
 func (p *Params) ParamSetPairs() paramtypes.ParamSetPairs {
 	return paramtypes.ParamSetPairs{
 		paramtypes.NewParamSetPair(KeyMaxMemoCharacters, &p.MaxMemoCharacters, validateMaxMemoCharacters),

--- a/x/bank/legacy/v036/types.go
+++ b/x/bank/legacy/v036/types.go
@@ -1,5 +1,4 @@
 // DONTCOVER
-// nolint
 package v036
 
 import (

--- a/x/bank/legacy/v038/types.go
+++ b/x/bank/legacy/v038/types.go
@@ -1,7 +1,6 @@
 package v038
 
 // DONTCOVER
-// nolint
 
 const (
 	ModuleName = "bank"

--- a/x/bank/module.go
+++ b/x/bank/module.go
@@ -86,7 +86,7 @@ func (AppModuleBasic) RegisterInterfaces(registry codectypes.InterfaceRegistry) 
 	types.RegisterInterfaces(registry)
 }
 
-//____________________________________________________________________________
+// ____________________________________________________________________________
 
 // AppModule implements an application module for the bank module.
 type AppModule struct {
@@ -160,7 +160,7 @@ func (AppModule) EndBlock(_ sdk.Context, _ abci.RequestEndBlock) []abci.Validato
 	return []abci.ValidatorUpdate{}
 }
 
-//____________________________________________________________________________
+// ____________________________________________________________________________
 
 // AppModuleSimulation functions
 

--- a/x/bank/simulation/operations.go
+++ b/x/bank/simulation/operations.go
@@ -81,7 +81,6 @@ func SimulateMsgSend(ak types.AccountKeeper, bk keeper.Keeper) simtypes.Operatio
 }
 
 // sendMsgSend sends a transaction with a MsgSend from a provided random account.
-// nolint: interfacer
 func sendMsgSend(
 	r *rand.Rand, app *baseapp.BaseApp, bk keeper.Keeper, ak types.AccountKeeper,
 	msg *types.MsgSend, ctx sdk.Context, chainID string, privkeys []cryptotypes.PrivKey,
@@ -222,8 +221,6 @@ func SimulateMsgMultiSend(ak types.AccountKeeper, bk keeper.Keeper) simtypes.Ope
 }
 
 // sendMsgMultiSend sends a transaction with a MsgMultiSend from a provided random
-// account.
-// nolint: interfacer
 func sendMsgMultiSend(
 	r *rand.Rand, app *baseapp.BaseApp, bk keeper.Keeper, ak types.AccountKeeper,
 	msg *types.MsgMultiSend, ctx sdk.Context, chainID string, privkeys []cryptotypes.PrivKey,
@@ -289,7 +286,6 @@ func sendMsgMultiSend(
 
 // randomSendFields returns the sender and recipient simulation accounts as well
 // as the transferred amount.
-// nolint: interfacer
 func randomSendFields(
 	r *rand.Rand, ctx sdk.Context, accs []simtypes.Account, bk keeper.Keeper, ak types.AccountKeeper,
 ) (simtypes.Account, simtypes.Account, sdk.Coins, bool) {

--- a/x/crisis/handler_test.go
+++ b/x/crisis/handler_test.go
@@ -47,7 +47,7 @@ func createTestApp() (*simapp.SimApp, sdk.Context, []sdk.AccAddress) {
 	return app, ctx, addrs
 }
 
-//____________________________________________________________________________
+// ____________________________________________________________________________
 
 func TestHandleMsgVerifyInvariant(t *testing.T) {
 	app, ctx, addrs := createTestApp()

--- a/x/crisis/keeper/msg_server.go
+++ b/x/crisis/keeper/msg_server.go
@@ -48,14 +48,14 @@ func (k Keeper) VerifyInvariant(goCtx context.Context, msg *types.MsgVerifyInvar
 		// refund is required.
 
 		// TODO uncomment the following code block with implementation of the circuit breaker
-		//// refund constant fee
-		//err := k.distrKeeper.DistributeFromFeePool(ctx, constantFee, msg.Sender)
-		//if err != nil {
-		//// if there are insufficient coins to refund, log the error,
-		//// but still halt the chain.
-		//logger := ctx.Logger().With("module", "x/crisis")
-		//logger.Error(fmt.Sprintf(
-		//"WARNING: insufficient funds to allocate to sender from fee pool, err: %s", err))
+		// // refund constant fee
+		// err := k.distrKeeper.DistributeFromFeePool(ctx, constantFee, msg.Sender)
+		// if err != nil {
+		// // if there are insufficient coins to refund, log the error,
+		// // but still halt the chain.
+		// logger := ctx.Logger().With("module", "x/crisis")
+		// logger.Error(fmt.Sprintf(
+		// "WARNING: insufficient funds to allocate to sender from fee pool, err: %s", err))
 		//}
 
 		// TODO replace with circuit breaker

--- a/x/crisis/module.go
+++ b/x/crisis/module.go
@@ -80,7 +80,7 @@ func (AppModuleBasic) RegisterInterfaces(registry codectypes.InterfaceRegistry) 
 	types.RegisterInterfaces(registry)
 }
 
-//____________________________________________________________________________
+// ____________________________________________________________________________
 
 // AppModule implements an application module for the crisis module.
 type AppModule struct {

--- a/x/distribution/legacy/v034/types.go
+++ b/x/distribution/legacy/v034/types.go
@@ -1,5 +1,4 @@
 // DONTCOVER
-// nolint
 package v034
 
 import (

--- a/x/distribution/legacy/v036/types.go
+++ b/x/distribution/legacy/v036/types.go
@@ -1,5 +1,5 @@
 // DONTCOVER
-// nolint
+
 package v036
 
 import (

--- a/x/distribution/legacy/v038/migrate.go
+++ b/x/distribution/legacy/v038/migrate.go
@@ -1,7 +1,6 @@
 package v038
 
 // DONTCOVER
-// nolint
 
 import (
 	v036distr "github.com/cosmos/cosmos-sdk/x/distribution/legacy/v036"

--- a/x/distribution/legacy/v038/types.go
+++ b/x/distribution/legacy/v038/types.go
@@ -7,7 +7,6 @@ import (
 )
 
 // DONTCOVER
-// nolint
 
 const (
 	ModuleName = "distribution"

--- a/x/distribution/module.go
+++ b/x/distribution/module.go
@@ -88,7 +88,7 @@ func (b AppModuleBasic) RegisterInterfaces(registry cdctypes.InterfaceRegistry) 
 	types.RegisterInterfaces(registry)
 }
 
-//____________________________________________________________________________
+// ____________________________________________________________________________
 
 // AppModule implements an application module for the distribution module.
 type AppModule struct {
@@ -172,7 +172,7 @@ func (AppModule) EndBlock(_ sdk.Context, _ abci.RequestEndBlock) []abci.Validato
 	return []abci.ValidatorUpdate{}
 }
 
-//____________________________________________________________________________
+// ____________________________________________________________________________
 
 // AppModuleSimulation functions
 

--- a/x/evidence/module.go
+++ b/x/evidence/module.go
@@ -186,7 +186,7 @@ func (am AppModule) EndBlock(ctx sdk.Context, _ abci.RequestEndBlock) []abci.Val
 	return []abci.ValidatorUpdate{}
 }
 
-//____________________________________________________________________________
+// ____________________________________________________________________________
 
 // AppModuleSimulation functions
 

--- a/x/genaccounts/legacy/v034/types.go
+++ b/x/genaccounts/legacy/v034/types.go
@@ -1,5 +1,4 @@
 // DONTCOVER
-// nolint
 package v034
 
 import (

--- a/x/genaccounts/legacy/v036/types.go
+++ b/x/genaccounts/legacy/v036/types.go
@@ -1,5 +1,4 @@
 // DONTCOVER
-// nolint
 package v036
 
 import (

--- a/x/genutil/module.go
+++ b/x/genutil/module.go
@@ -66,7 +66,7 @@ func (AppModuleBasic) GetTxCmd() *cobra.Command { return nil }
 // GetQueryCmd returns no root query command for the genutil module.
 func (AppModuleBasic) GetQueryCmd() *cobra.Command { return nil }
 
-//____________________________________________________________________________
+// ____________________________________________________________________________
 
 // AppModule implements an application module for the genutil module.
 type AppModule struct {

--- a/x/gov/client/rest/rest.go
+++ b/x/gov/client/rest/rest.go
@@ -12,7 +12,6 @@ import (
 )
 
 // REST Variable names
-// nolint
 const (
 	RestParamsType     = "type"
 	RestProposalID     = "proposal-id"

--- a/x/gov/client/utils/utils.go
+++ b/x/gov/client/utils/utils.go
@@ -22,7 +22,7 @@ func NormalizeVoteOption(option string) string {
 	}
 }
 
-//NormalizeProposalType - normalize user specified proposal type
+// NormalizeProposalType - normalize user specified proposal type
 func NormalizeProposalType(proposalType string) string {
 	switch proposalType {
 	case "Text", "text":
@@ -33,7 +33,7 @@ func NormalizeProposalType(proposalType string) string {
 	}
 }
 
-//NormalizeProposalStatus - normalize user specified proposal status
+// NormalizeProposalStatus - normalize user specified proposal status
 func NormalizeProposalStatus(status string) string {
 	switch status {
 	case "DepositPeriod", "deposit_period":

--- a/x/gov/legacy/v034/types.go
+++ b/x/gov/legacy/v034/types.go
@@ -1,5 +1,4 @@
 // DONTCOVER
-// nolint
 package v034
 
 import (

--- a/x/gov/legacy/v036/types.go
+++ b/x/gov/legacy/v036/types.go
@@ -1,5 +1,4 @@
 // DONTCOVER
-// nolint
 package v036
 
 import (

--- a/x/gov/module.go
+++ b/x/gov/module.go
@@ -109,7 +109,7 @@ func (a AppModuleBasic) RegisterInterfaces(registry codectypes.InterfaceRegistry
 	types.RegisterInterfaces(registry)
 }
 
-//____________________________________________________________________________
+// ____________________________________________________________________________
 
 // AppModule implements an application module for the gov module.
 type AppModule struct {
@@ -187,7 +187,7 @@ func (am AppModule) EndBlock(ctx sdk.Context, _ abci.RequestEndBlock) []abci.Val
 	return []abci.ValidatorUpdate{}
 }
 
-//____________________________________________________________________________
+// ____________________________________________________________________________
 
 // AppModuleSimulation functions
 

--- a/x/ibc/applications/transfer/module.go
+++ b/x/ibc/applications/transfer/module.go
@@ -154,7 +154,7 @@ func (am AppModule) EndBlock(ctx sdk.Context, req abci.RequestEndBlock) []abci.V
 	return []abci.ValidatorUpdate{}
 }
 
-//____________________________________________________________________________
+// ____________________________________________________________________________
 
 // AppModuleSimulation functions
 
@@ -183,7 +183,7 @@ func (am AppModule) WeightedOperations(_ module.SimulationState) []simtypes.Weig
 	return nil
 }
 
-//____________________________________________________________________________
+// ____________________________________________________________________________
 
 // ValidateTransferChannelParams does validation of a newly created transfer channel. A transfer
 // channel must be UNORDERED, use the correct port (by default 'transfer'), and use the current

--- a/x/ibc/core/module.go
+++ b/x/ibc/core/module.go
@@ -167,7 +167,7 @@ func (am AppModule) EndBlock(ctx sdk.Context, req abci.RequestEndBlock) []abci.V
 	return []abci.ValidatorUpdate{}
 }
 
-//____________________________________________________________________________
+// ____________________________________________________________________________
 
 // AppModuleSimulation functions
 

--- a/x/ibc/testing/mock/mock.go
+++ b/x/ibc/testing/mock/mock.go
@@ -124,7 +124,7 @@ func (am AppModule) EndBlock(ctx sdk.Context, req abci.RequestEndBlock) []abci.V
 	return []abci.ValidatorUpdate{}
 }
 
-//____________________________________________________________________________
+// ____________________________________________________________________________
 
 // OnChanOpenInit implements the IBCModule interface.
 func (am AppModule) OnChanOpenInit(

--- a/x/mint/keeper/keeper.go
+++ b/x/mint/keeper/keeper.go
@@ -45,7 +45,7 @@ func NewKeeper(
 	}
 }
 
-//______________________________________________________________________
+// ______________________________________________________________________
 
 // Logger returns a module-specific logger.
 func (k Keeper) Logger(ctx sdk.Context) log.Logger {
@@ -71,7 +71,7 @@ func (k Keeper) SetMinter(ctx sdk.Context, minter types.Minter) {
 	store.Set(types.MinterKey, b)
 }
 
-//______________________________________________________________________
+// ______________________________________________________________________
 
 // GetParams returns the total set of minting parameters.
 func (k Keeper) GetParams(ctx sdk.Context) (params types.Params) {
@@ -84,7 +84,7 @@ func (k Keeper) SetParams(ctx sdk.Context, params types.Params) {
 	k.paramSpace.SetParamSet(ctx, &params)
 }
 
-//______________________________________________________________________
+// ______________________________________________________________________
 
 // StakingTokenSupply implements an alias call to the underlying staking keeper's
 // StakingTokenSupply to be used in BeginBlocker.

--- a/x/mint/module.go
+++ b/x/mint/module.go
@@ -83,7 +83,7 @@ func (AppModuleBasic) GetQueryCmd() *cobra.Command {
 	return cli.GetQueryCmd()
 }
 
-//____________________________________________________________________________
+// ____________________________________________________________________________
 
 // AppModule implements an application module for the mint module.
 type AppModule struct {
@@ -157,7 +157,7 @@ func (AppModule) EndBlock(_ sdk.Context, _ abci.RequestEndBlock) []abci.Validato
 	return []abci.ValidatorUpdate{}
 }
 
-//____________________________________________________________________________
+// ____________________________________________________________________________
 
 // AppModuleSimulation functions
 

--- a/x/params/module.go
+++ b/x/params/module.go
@@ -72,7 +72,7 @@ func (am AppModuleBasic) RegisterInterfaces(registry codectypes.InterfaceRegistr
 	proposal.RegisterInterfaces(registry)
 }
 
-//____________________________________________________________________________
+// ____________________________________________________________________________
 
 // AppModule implements an application module for the distribution module.
 type AppModule struct {

--- a/x/simulation/log.go
+++ b/x/simulation/log.go
@@ -68,7 +68,7 @@ func createLogFile() *os.File {
 	return f
 }
 
-//_____________________
+// _____________________
 // dummy log writter
 type DummyLogWriter struct{}
 

--- a/x/simulation/mock_tendermint.go
+++ b/x/simulation/mock_tendermint.go
@@ -59,7 +59,7 @@ func (vals mockValidators) getKeys() []string {
 	return keys
 }
 
-//_________________________________________________________________________________
+// _________________________________________________________________________________
 
 // randomProposer picks a random proposer from the current validator set
 func (vals mockValidators) randomProposer(r *rand.Rand) tmbytes.HexBytes {

--- a/x/simulation/operation.go
+++ b/x/simulation/operation.go
@@ -64,7 +64,7 @@ func (oe OperationEntry) MustMarshal() json.RawMessage {
 	return out
 }
 
-//_____________________________________________________________________
+// _____________________________________________________________________
 
 // OperationQueue defines an object for a queue of operations
 type OperationQueue map[int][]simulation.Operation
@@ -107,7 +107,7 @@ func queueOperations(queuedOps OperationQueue, queuedTimeOps []simulation.Future
 	}
 }
 
-//________________________________________________________________________
+// ________________________________________________________________________
 
 // WeightedOperation is an operation with associated weight.
 // This is used to bias the selection operation within the simulator.

--- a/x/simulation/simulate.go
+++ b/x/simulation/simulate.go
@@ -240,7 +240,7 @@ func SimulateFromSeed(
 	return false, exportedParams, nil
 }
 
-//______________________________________________________________________________
+// ______________________________________________________________________________
 
 type blockSimFn func(r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context,
 	accounts []simulation.Account, header tmproto.Header) (opCount int)

--- a/x/slashing/keeper/hooks.go
+++ b/x/slashing/keeper/hooks.go
@@ -42,7 +42,7 @@ func (k Keeper) AfterValidatorRemoved(ctx sdk.Context, address sdk.ConsAddress) 
 	k.deleteAddrPubkeyRelation(ctx, crypto.Address(address))
 }
 
-//_________________________________________________________________________________________
+// _________________________________________________________________________________________
 
 // Hooks wrapper struct for slashing keeper
 type Hooks struct {

--- a/x/slashing/module.go
+++ b/x/slashing/module.go
@@ -91,7 +91,7 @@ func (AppModuleBasic) GetQueryCmd() *cobra.Command {
 	return cli.GetQueryCmd()
 }
 
-//____________________________________________________________________________
+// ____________________________________________________________________________
 
 // AppModule implements an application module for the slashing module.
 type AppModule struct {
@@ -170,7 +170,7 @@ func (AppModule) EndBlock(_ sdk.Context, _ abci.RequestEndBlock) []abci.Validato
 	return []abci.ValidatorUpdate{}
 }
 
-//____________________________________________________________________________
+// ____________________________________________________________________________
 
 // AppModuleSimulation functions
 

--- a/x/slashing/simulation/operations.go
+++ b/x/slashing/simulation/operations.go
@@ -43,7 +43,6 @@ func WeightedOperations(
 }
 
 // SimulateMsgUnjail generates a MsgUnjail with random values
-// nolint: interfacer
 func SimulateMsgUnjail(ak types.AccountKeeper, bk types.BankKeeper, k keeper.Keeper, sk stakingkeeper.Keeper) simtypes.Operation {
 	return func(
 		r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context,

--- a/x/slashing/types/events.go
+++ b/x/slashing/types/events.go
@@ -1,4 +1,4 @@
-//noalias
+// noalias
 package types
 
 // Slashing module event types

--- a/x/staking/keeper/alias_functions.go
+++ b/x/staking/keeper/alias_functions.go
@@ -7,7 +7,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/staking/types"
 )
 
-//_______________________________________________________________________
+// _______________________________________________________________________
 // Validator Set
 
 // iterate through the validator set and perform the provided function
@@ -96,7 +96,7 @@ func (k Keeper) ValidatorByConsAddr(ctx sdk.Context, addr sdk.ConsAddress) types
 	return val
 }
 
-//_______________________________________________________________________
+// _______________________________________________________________________
 // Delegation Set
 
 // Returns self as it is both a validatorset and delegationset

--- a/x/staking/keeper/querier.go
+++ b/x/staking/keeper/querier.go
@@ -444,7 +444,7 @@ func queryParameters(ctx sdk.Context, k Keeper, legacyQuerierCdc *codec.LegacyAm
 	return res, nil
 }
 
-//______________________________________________________
+// ______________________________________________________
 // util
 
 func DelegationToDelegationResponse(ctx sdk.Context, k Keeper, del types.Delegation) (types.DelegationResponse, error) {

--- a/x/staking/keeper/query_utils.go
+++ b/x/staking/keeper/query_utils.go
@@ -50,7 +50,7 @@ func (k Keeper) GetDelegatorValidator(
 	return validator, nil
 }
 
-//_____________________________________________________________________________________
+// _____________________________________________________________________________________
 
 // return all delegations for a delegator
 func (k Keeper) GetAllDelegatorDelegations(ctx sdk.Context, delegator sdk.AccAddress) []types.Delegation {
@@ -59,7 +59,7 @@ func (k Keeper) GetAllDelegatorDelegations(ctx sdk.Context, delegator sdk.AccAdd
 	store := ctx.KVStore(k.storeKey)
 	delegatorPrefixKey := types.GetDelegationsKey(delegator)
 
-	iterator := sdk.KVStorePrefixIterator(store, delegatorPrefixKey) //smallest to largest
+	iterator := sdk.KVStorePrefixIterator(store, delegatorPrefixKey) // smallest to largest
 	defer iterator.Close()
 
 	i := 0

--- a/x/staking/keeper/slash_test.go
+++ b/x/staking/keeper/slash_test.go
@@ -384,7 +384,7 @@ func TestSlashWithUnbondingDelegation(t *testing.T) {
 	require.Equal(t, validator.GetStatus(), types.Unbonding)
 }
 
-//_________________________________________________________________________________
+// _________________________________________________________________________________
 // tests Slash at a previous height with a redelegation
 func TestSlashWithRedelegation(t *testing.T) {
 	app, ctx, addrDels, addrVals := bootstrapSlashTest(t, 10)

--- a/x/staking/keeper/validator.go
+++ b/x/staking/keeper/validator.go
@@ -240,7 +240,7 @@ func (k Keeper) ValidatorsPowerStoreIterator(ctx sdk.Context) sdk.Iterator {
 	return sdk.KVStoreReversePrefixIterator(store, types.ValidatorsByPowerIndexKey)
 }
 
-//_______________________________________________________________________
+// _______________________________________________________________________
 // Last Validator Index
 
 // Load the last validator power.

--- a/x/staking/legacy/v034/types.go
+++ b/x/staking/legacy/v034/types.go
@@ -1,5 +1,4 @@
 // DONTCOVER
-// nolint
 package v034
 
 import (

--- a/x/staking/legacy/v036/migrate.go
+++ b/x/staking/legacy/v036/migrate.go
@@ -1,5 +1,4 @@
 // DONTCOVER
-// nolint
 package v036
 
 import (

--- a/x/staking/legacy/v036/types.go
+++ b/x/staking/legacy/v036/types.go
@@ -1,5 +1,4 @@
 // DONTCOVER
-// nolint
 package v036
 
 import (

--- a/x/staking/legacy/v038/migrate.go
+++ b/x/staking/legacy/v038/migrate.go
@@ -1,5 +1,4 @@
 // DONTCOVER
-// nolint
 package v038
 
 import (

--- a/x/staking/legacy/v038/types.go
+++ b/x/staking/legacy/v038/types.go
@@ -1,5 +1,4 @@
 // DONTCOVER
-// nolint
 package v038
 
 import (

--- a/x/staking/module.go
+++ b/x/staking/module.go
@@ -168,7 +168,7 @@ func (am AppModule) EndBlock(ctx sdk.Context, _ abci.RequestEndBlock) []abci.Val
 	return EndBlocker(ctx, am.keeper)
 }
 
-//____________________________________________________________________________
+// ____________________________________________________________________________
 
 // AppModuleSimulation functions
 

--- a/x/staking/simulation/operations.go
+++ b/x/staking/simulation/operations.go
@@ -92,7 +92,6 @@ func WeightedOperations(
 }
 
 // SimulateMsgCreateValidator generates a MsgCreateValidator with random values
-// nolint: interfacer
 func SimulateMsgCreateValidator(ak types.AccountKeeper, bk types.BankKeeper, k keeper.Keeper) simtypes.Operation {
 	return func(
 		r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, accs []simtypes.Account, chainID string,
@@ -178,7 +177,6 @@ func SimulateMsgCreateValidator(ak types.AccountKeeper, bk types.BankKeeper, k k
 }
 
 // SimulateMsgEditValidator generates a MsgEditValidator with random values
-// nolint: interfacer
 func SimulateMsgEditValidator(ak types.AccountKeeper, bk types.BankKeeper, k keeper.Keeper) simtypes.Operation {
 	return func(
 		r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, accs []simtypes.Account, chainID string,
@@ -249,7 +247,6 @@ func SimulateMsgEditValidator(ak types.AccountKeeper, bk types.BankKeeper, k kee
 }
 
 // SimulateMsgDelegate generates a MsgDelegate with random values
-// nolint: interfacer
 func SimulateMsgDelegate(ak types.AccountKeeper, bk types.BankKeeper, k keeper.Keeper) simtypes.Operation {
 	return func(
 		r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, accs []simtypes.Account, chainID string,
@@ -322,7 +319,6 @@ func SimulateMsgDelegate(ak types.AccountKeeper, bk types.BankKeeper, k keeper.K
 }
 
 // SimulateMsgUndelegate generates a MsgUndelegate with random values
-// nolint: interfacer
 func SimulateMsgUndelegate(ak types.AccountKeeper, bk types.BankKeeper, k keeper.Keeper) simtypes.Operation {
 	return func(
 		r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, accs []simtypes.Account, chainID string,
@@ -412,7 +408,6 @@ func SimulateMsgUndelegate(ak types.AccountKeeper, bk types.BankKeeper, k keeper
 }
 
 // SimulateMsgBeginRedelegate generates a MsgBeginRedelegate with random values
-// nolint: interfacer
 func SimulateMsgBeginRedelegate(ak types.AccountKeeper, bk types.BankKeeper, k keeper.Keeper) simtypes.Operation {
 	return func(
 		r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, accs []simtypes.Account, chainID string,

--- a/x/staking/types/expected_keepers.go
+++ b/x/staking/types/expected_keepers.go
@@ -83,7 +83,7 @@ type DelegationSet interface {
 		fn func(index int64, delegation DelegationI) (stop bool))
 }
 
-//_______________________________________________________________________________
+// _______________________________________________________________________________
 // Event Hooks
 // These can be utilized to communicate between a staking keeper and another
 // keeper which must take particular actions when validators/delegators change

--- a/x/staking/types/validator.go
+++ b/x/staking/types/validator.go
@@ -103,9 +103,7 @@ func (v Validators) Less(i, j int) bool {
 
 // Implements sort interface
 func (v Validators) Swap(i, j int) {
-	it := v[i]
-	v[i] = v[j]
-	v[j] = it
+	v[i], v[j] = v[j], v[i]
 }
 
 // ValidatorsByVotingPower implements sort.Interface for []Validator based on


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

Fix linting on 0.42 branch

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [x] provided a link to the relevant issue or specification
- [x] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules)
- [x] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)