### PR TITLE
fix: Make a denom of --min-self-delegation CLI flag required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,6 +156,7 @@ if input key is empty, or input data contains empty key.
 * (x/slashing) [\#8427](https://github.com/cosmos/cosmos-sdk/pull/8427) Fix query signing infos command
 * (x/bank) [\#9229](https://github.com/cosmos/cosmos-sdk/pull/9229) Now zero coin balances cannot be added to balances & supply stores. If any denom becomes zero corresponding key gets deleted from store.
 * (types) [\#9511](https://github.com/cosmos/cosmos-sdk/pull/9511) Change `maxBitLen` of `sdk.Int` and `sdk.Dec`  to handle max ERC20 value.
+* (cli) [\#9548](https://github.com/cosmos/cosmos-sdk/pull/9548) Make a denom of `--min-self-delegation` CLI flag required
 
 ### Deprecated
 

--- a/x/staking/client/cli/tx_test.go
+++ b/x/staking/client/cli/tx_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"testing"
 
 	"github.com/spf13/pflag"
@@ -42,38 +43,38 @@ func TestPrepareConfigForTxCreateValidator(t *testing.T) {
 			fsModify: func(fs *pflag.FlagSet) {
 				return
 			},
-			expectedCfg: mkTxValCfg(defaultAmount, "0.1", "0.2", "0.01", "1"),
+			expectedCfg: mkTxValCfg(defaultAmount, "0.1", "0.2", "0.01", "1stake"),
 		}, {
 			name: "Custom amount",
 			fsModify: func(fs *pflag.FlagSet) {
 				fs.Set(FlagAmount, "2000stake")
 			},
-			expectedCfg: mkTxValCfg("2000stake", "0.1", "0.2", "0.01", "1"),
+			expectedCfg: mkTxValCfg("2000stake", "0.1", "0.2", "0.01", "1stake"),
 		}, {
 			name: "Custom commission rate",
 			fsModify: func(fs *pflag.FlagSet) {
 				fs.Set(FlagCommissionRate, "0.54")
 			},
-			expectedCfg: mkTxValCfg(defaultAmount, "0.54", "0.2", "0.01", "1"),
+			expectedCfg: mkTxValCfg(defaultAmount, "0.54", "0.2", "0.01", "1stake"),
 		}, {
 			name: "Custom commission max rate",
 			fsModify: func(fs *pflag.FlagSet) {
 				fs.Set(FlagCommissionMaxRate, "0.89")
 			},
-			expectedCfg: mkTxValCfg(defaultAmount, "0.1", "0.89", "0.01", "1"),
+			expectedCfg: mkTxValCfg(defaultAmount, "0.1", "0.89", "0.01", "1stake"),
 		}, {
 			name: "Custom commission max change rate",
 			fsModify: func(fs *pflag.FlagSet) {
 				fs.Set(FlagCommissionMaxChangeRate, "0.55")
 			},
-			expectedCfg: mkTxValCfg(defaultAmount, "0.1", "0.2", "0.55", "1"),
+			expectedCfg: mkTxValCfg(defaultAmount, "0.1", "0.2", "0.55", "1stake"),
 		},
 		{
 			name: "Custom min self delegations",
 			fsModify: func(fs *pflag.FlagSet) {
-				fs.Set(FlagMinSelfDelegation, "0.33")
+				fs.Set(FlagMinSelfDelegation, "0.33stake")
 			},
-			expectedCfg: mkTxValCfg(defaultAmount, "0.1", "0.2", "0.01", "0.33"),
+			expectedCfg: mkTxValCfg(defaultAmount, "0.1", "0.2", "0.01", "0.33stake"),
 		},
 	}
 
@@ -91,4 +92,30 @@ func TestPrepareConfigForTxCreateValidator(t *testing.T) {
 			require.Equal(t, tc.expectedCfg, cvCfg)
 		})
 	}
+}
+
+func TestParseMinSelfDelegation(t *testing.T) {
+	coin, err := parseMinSelfDelegation("1stake", "stake")
+	require.NoError(t, err)
+	require.Equal(t, sdk.NewInt64Coin("stake", int64(1)), *coin)
+
+	coin, err = parseMinSelfDelegation("1stake", "")
+	require.NoError(t, err)
+	require.Equal(t, sdk.NewInt64Coin("stake", int64(1)), *coin)
+
+	coin, err = parseMinSelfDelegation("1stake", "uatom")
+	require.Error(t, err)
+	require.Nil(t, coin)
+
+	coin, err = parseMinSelfDelegation("1", "stake")
+	require.Error(t, err)
+	require.Nil(t, coin)
+
+	coin, err = parseMinSelfDelegation("0stake", "stake")
+	require.Error(t, err)
+	require.Nil(t, coin)
+
+	coin, err = parseMinSelfDelegation("-1stake", "stake")
+	require.Error(t, err)
+	require.Nil(t, coin)
 }

--- a/x/staking/client/cli/tx_test.go
+++ b/x/staking/client/cli/tx_test.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	"testing"
 
 	"github.com/spf13/pflag"
@@ -92,30 +91,4 @@ func TestPrepareConfigForTxCreateValidator(t *testing.T) {
 			require.Equal(t, tc.expectedCfg, cvCfg)
 		})
 	}
-}
-
-func TestParseMinSelfDelegation(t *testing.T) {
-	coin, err := parseMinSelfDelegation("1stake", "stake")
-	require.NoError(t, err)
-	require.Equal(t, sdk.NewInt64Coin("stake", int64(1)), *coin)
-
-	coin, err = parseMinSelfDelegation("1stake", "")
-	require.NoError(t, err)
-	require.Equal(t, sdk.NewInt64Coin("stake", int64(1)), *coin)
-
-	coin, err = parseMinSelfDelegation("1stake", "uatom")
-	require.Error(t, err)
-	require.Nil(t, coin)
-
-	coin, err = parseMinSelfDelegation("1", "stake")
-	require.Error(t, err)
-	require.Nil(t, coin)
-
-	coin, err = parseMinSelfDelegation("0stake", "stake")
-	require.Error(t, err)
-	require.Nil(t, coin)
-
-	coin, err = parseMinSelfDelegation("-1stake", "stake")
-	require.Error(t, err)
-	require.Nil(t, coin)
 }


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

Closes: #9386 

As we discussed, I've put a denom to the `--min-self-delegation` CLI flag.
But, I didn't change the msg types (`MsgCreateValidator` and so on) which contain `MinSelfDelegation` as `sdk.Int` in order not to break the API backward compatibility. If you think that msg types also need to be changed, please let me know :)

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [X] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [X] added `!` to the type prefix if API or client breaking change
- [X] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [X] provided a link to the relevant issue or specification
- [X] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules)
- [X] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [X] added a changelog entry to `CHANGELOG.md`
- [X] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [X] updated the relevant documentation or specification
- [X] reviewed "Files changed" and left comments if necessary
- [X] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)