### PR TITLE
fix: Don't error on startup if min-gas-price is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,7 +132,6 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * [\#8628](https://github.com/cosmos/cosmos-sdk/issues/8628) Commands no longer print outputs using `stderr` by default
 * [\#9134](https://github.com/cosmos/cosmos-sdk/pull/9134) Renamed the CLI flag `--memo` to `--note`.
 * [\#9291](https://github.com/cosmos/cosmos-sdk/pull/9291) Migration scripts prior to v0.38 have been removed from the CLI `migrate` command. The oldest supported migration is v0.39->v0.42.
-* [\#9371](https://github.com/cosmos/cosmos-sdk/pull/9371) Non-zero default fees/Server will error if there's an empty value for min-gas-price in app.toml
 
 
 ### Improvements

--- a/server/start.go
+++ b/server/start.go
@@ -247,8 +247,8 @@ func startInProcess(ctx *Context, clientCtx client.Context, appCreator types.App
 
 	config := config.GetConfig(ctx.Viper)
 	if err := config.ValidateBasic(); err != nil {
-		ctx.Logger.Info("WARNING: The minimum-gas-prices config in app.toml is set to the empty string. "+
-			"This defaults to 0 in the current version, but will error in the next version "+
+		ctx.Logger.Error("WARNING: The minimum-gas-prices config in app.toml is set to the empty string. " +
+			"This defaults to 0 in the current version, but will error in the next version " +
 			"(SDK v0.44). Please explicitly put the desired minimum-gas-prices in your app.toml.")
 	}
 

--- a/server/start.go
+++ b/server/start.go
@@ -249,7 +249,7 @@ func startInProcess(ctx *Context, clientCtx client.Context, appCreator types.App
 	if err := config.ValidateBasic(); err != nil {
 		ctx.Logger.Info("The minimum-gas-prices config in app.toml is set to the empty string. "+
 			"This defaults to 0 in the current version, but will error in the next version "+
-			"(SDK v0.44). Please explicitly put the desired minimum-gas-prices in your app.toml.", "config")
+			"(SDK v0.44). Please explicitly put the desired minimum-gas-prices in your app.toml.")
 	}
 
 	app := appCreator(ctx.Logger, db, traceWriter, ctx.Viper)

--- a/server/start.go
+++ b/server/start.go
@@ -247,7 +247,7 @@ func startInProcess(ctx *Context, clientCtx client.Context, appCreator types.App
 
 	config := config.GetConfig(ctx.Viper)
 	if err := config.ValidateBasic(); err != nil {
-		ctx.Logger.Info("The minimum-gas-prices config in app.toml is set to the empty string. "+
+		ctx.Logger.Info("WARNING: The minimum-gas-prices config in app.toml is set to the empty string. "+
 			"This defaults to 0 in the current version, but will error in the next version "+
 			"(SDK v0.44). Please explicitly put the desired minimum-gas-prices in your app.toml.")
 	}

--- a/server/start.go
+++ b/server/start.go
@@ -247,7 +247,9 @@ func startInProcess(ctx *Context, clientCtx client.Context, appCreator types.App
 
 	config := config.GetConfig(ctx.Viper)
 	if err := config.ValidateBasic(); err != nil {
-		return err
+		ctx.Logger.Info("The minimum-gas-prices config in app.toml is set to the empty string. "+
+			"This defaults to 0 in the current version, but will error in the next version "+
+			"(SDK v0.44). Please explicitly put the desired minimum-gas-prices in your app.toml.", "config")
 	}
 
 	app := appCreator(ctx.Logger, db, traceWriter, ctx.Viper)

--- a/server/util_test.go
+++ b/server/util_test.go
@@ -11,15 +11,9 @@ import (
 	"testing"
 
 	"github.com/spf13/cobra"
-	"github.com/stretchr/testify/require"
 
-	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/server"
-	"github.com/cosmos/cosmos-sdk/server/config"
-	"github.com/cosmos/cosmos-sdk/simapp"
-	genutilcli "github.com/cosmos/cosmos-sdk/x/genutil/client/cli"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
 
 var cancelledInPreRun = errors.New("Cancelled in prerun")
@@ -405,35 +399,4 @@ func TestInterceptConfigsWithBadPermissions(t *testing.T) {
 	if err := cmd.ExecuteContext(ctx); !os.IsPermission(err) {
 		t.Fatalf("Failed to catch permissions error, got: [%T] %v", err, err)
 	}
-}
-
-func TestEmptyMinGasPrices(t *testing.T) {
-	tempDir := t.TempDir()
-	err := os.Mkdir(filepath.Join(tempDir, "config"), os.ModePerm)
-	require.NoError(t, err)
-	encCfg := simapp.MakeTestEncodingConfig()
-
-	// Run InitCmd to create necessary config files.
-	clientCtx := client.Context{}.WithHomeDir(tempDir).WithJSONCodec(encCfg.Marshaler)
-	serverCtx := server.NewDefaultContext()
-	ctx := context.WithValue(context.Background(), server.ServerContextKey, serverCtx)
-	ctx = context.WithValue(ctx, client.ClientContextKey, &clientCtx)
-	cmd := genutilcli.InitCmd(simapp.ModuleBasics, tempDir)
-	cmd.SetArgs([]string{"appnode-test"})
-	err = cmd.ExecuteContext(ctx)
-	require.NoError(t, err)
-
-	// Modify app.toml.
-	appCfgTempFilePath := filepath.Join(tempDir, "config", "app.toml")
-	appConf := config.DefaultConfig()
-	appConf.BaseConfig.MinGasPrices = ""
-	config.WriteConfigFile(appCfgTempFilePath, appConf)
-
-	// Run StartCmd.
-	cmd = server.StartCmd(nil, tempDir)
-	cmd.PreRunE = func(cmd *cobra.Command, _ []string) error {
-		return server.InterceptConfigsPreRunHandler(cmd, "", nil)
-	}
-	err = cmd.ExecuteContext(ctx)
-	require.Errorf(t, err, sdkerrors.ErrAppConfig.Error())
 }


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

We introduced throwing an error when min-gas-price was empty in #9371 in 0.43. It seems like it may be too big of a CLI breaking change too soon. Internally at Regen we discussed of showing a warning in 0.43, and throwing the error in 0.44

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [x] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)