### PR TITLE
docs: fix broken IBC spec link, IBC page order

### DIFF
--- a/docs/ibc/integration.md
+++ b/docs/ibc/integration.md
@@ -206,7 +206,7 @@ connection handhake.
 The IBC module also has
 [`BeginBlock`](https://github.com/cosmos/ibc-go/blob/main/modules/core/02-client/abci.go) logic as
 well. This is optional as it is only required if your application uses the [localhost
-client](https://github.com/cosmos/ics/blob/master/spec/ics-009-loopback-client) to connect two
+client](https://github.com/cosmos/ibc/tree/master/spec/client/ics-009-loopback-client) to connect two
 different modules from the same chain.
 
 ::: tip

--- a/docs/ibc/overview.md
+++ b/docs/ibc/overview.md
@@ -1,4 +1,6 @@
-<!-- order: 1 -->
+<!-- 
+order: 1 
+-->
 
 # IBC Overview
 


### PR DESCRIPTION
Guessing that the IBC Overview page not rendering as the first page in the order, probably because the `order: 1` is in an inline comment
<img width="473" alt="image" src="https://user-images.githubusercontent.com/20461629/126861185-46e8b7ec-1b62-461e-960a-f7976603ba09.png">
