### PR TITLE
fix: Marshaling of empty sdk.Int returns nil instead of 0

### DIFF
--- a/types/int.go
+++ b/types/int.go
@@ -334,7 +334,7 @@ func (i Int) String() string {
 // MarshalJSON defines custom encoding scheme
 func (i Int) MarshalJSON() ([]byte, error) {
 	if i.i == nil { // Necessary since default Uint initialization has i.i as nil
-		i.i = new(big.Int)
+		return i.i.MarshalText()
 	}
 	return marshalJSON(i.i)
 }

--- a/types/int.go
+++ b/types/int.go
@@ -334,7 +334,7 @@ func (i Int) String() string {
 // MarshalJSON defines custom encoding scheme
 func (i Int) MarshalJSON() ([]byte, error) {
 	if i.i == nil { // Necessary since default Uint initialization has i.i as nil
-		return i.i.MarshalText()
+		return i.i.MarshalJSON()
 	}
 	return marshalJSON(i.i)
 }

--- a/types/int_test.go
+++ b/types/int_test.go
@@ -305,6 +305,30 @@ func (s *intTestSuite) TestEncodingTableInt() {
 		s.Require().Nil(err, "Error unmarshaling Int. tc #%d, err %s", tcnum, err)
 		s.Require().Equal(tc.i, i, "Unmarshaled value is different from exported. tc #%d", tcnum)
 	}
+
+	// Test cases testing marshalling
+	cases2 := []struct {
+		i      sdk.Int
+		jsonBz []byte
+		rawBz  []byte
+	}{
+		{
+			sdk.Int{},
+			[]byte("<nil>"),
+			[]byte{0x30},
+		},
+	}
+
+	for tcnum, tc := range cases2 {
+		bz, err := tc.i.MarshalJSON()
+		s.Require().Nil(err, "Error marshaling Int. tc #%d, err %s", tcnum, err)
+		s.Require().Equal(tc.jsonBz, bz, "Marshaled value is different from exported. tc #%d", tcnum+len(cases))
+
+		bz, err = tc.i.Marshal()
+		s.Require().Nil(err, "Error marshaling Int. tc #%d, err %s", tcnum, err)
+		s.Require().Equal(tc.rawBz, bz, "Marshaled value is different from exported. tc #%d", tcnum+len(cases))
+	}
+
 }
 
 func (s *intTestSuite) TestEncodingTableUint() {


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

Fixes: #9629

When empty instance of `sdk.Int` is passed to `MarshalJSON` , defaults to how `big.Int` handles the marshalling which returns nil instead of `0`

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [x] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules)
- [x] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)