### PR TITLE
docs: fix module spec ordering

### DIFF
--- a/x/README.md
+++ b/x/README.md
@@ -1,6 +1,5 @@
 <!--
-parent:
-  order: false
+order: 0
 -->
 
 # List of Modules
@@ -14,6 +13,7 @@ Here are some production-grade modules that can be used in Cosmos SDK applicatio
 - [Crisis](crisis/spec/README.md) - Halting the blockchain under certain circumstances (e.g. if an invariant is broken).
 - [Distribution](distribution/spec/README.md) - Fee distribution, and staking token provision distribution.
 - [Evidence](evidence/spec/README.md) - Evidence handling for double signing, misbehaviour, etc.
+- [Feegrant](feegrant/spec/README.md) - Grant fee allowances for executing transactions.
 - [Governance](gov/spec/README.md) - On-chain proposals and voting.
 - [Mint](mint/spec/README.md) - Creation of new units of staking token.
 - [Params](params/spec/README.md) - Globally available parameter store.

--- a/x/auth/spec/04_keepers.md
+++ b/x/auth/spec/04_keepers.md
@@ -1,5 +1,5 @@
 <!--
-order: 5
+order: 4
 -->
 
 # Keepers

--- a/x/auth/spec/05_vesting.md
+++ b/x/auth/spec/05_vesting.md
@@ -1,5 +1,5 @@
 <!--
-order: 6
+order: 5
 -->
 
 # Vesting

--- a/x/auth/spec/06_params.md
+++ b/x/auth/spec/06_params.md
@@ -1,5 +1,5 @@
 <!--
-order: 7
+order: 6
 -->
 
 # Parameters

--- a/x/mint/spec/01_concepts.md
+++ b/x/mint/spec/01_concepts.md
@@ -1,5 +1,5 @@
 <!--
-order: 0
+order: 1
 -->
 
 # Concepts

--- a/x/slashing/spec/README.md
+++ b/x/slashing/spec/README.md
@@ -1,5 +1,5 @@
 <!--
-order: 20
+order: 0
 title: Slashing Overview
 parent:
   title: "slashing"

--- a/x/staking/spec/05_end_block.md
+++ b/x/staking/spec/05_end_block.md
@@ -1,5 +1,5 @@
 <!--
-order: 4
+order: 5
 -->
 
 # End-Block

--- a/x/staking/spec/06_hooks.md
+++ b/x/staking/spec/06_hooks.md
@@ -1,5 +1,5 @@
 <!--
-order: 5
+order: 6
 -->
 
 # Hooks

--- a/x/staking/spec/07_events.md
+++ b/x/staking/spec/07_events.md
@@ -1,5 +1,5 @@
 <!--
-order: 6
+order: 7
 -->
 
 # Events


### PR DESCRIPTION
## Description

Closes: #9858 

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

This pull request fixes the ordering of module spec documents.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct `docs:` prefix in the PR title
- [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [x] provided a link to the relevant issue or specification
- [x] followed the [documentation writing guidelines](https://github.com/cosmos/cosmos-sdk/blob/master/docs/DOC_WRITING_GUIDELINES.md)
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct `docs:` prefix in the PR title
- [ ] confirmed all author checklist items have been addressed 
- [ ] confirmed that this PR only changes documentation
- [ ] reviewed content for consistency
- [ ] reviewed content for thoroughness
- [ ] reviewed content for spelling and grammar
- [ ] tested instructions (if applicable)
