### PR TITLE
perf: convert to string once in setCacheValue

### DIFF
--- a/store/cachekv/store.go
+++ b/store/cachekv/store.go
@@ -238,12 +238,13 @@ func (store *Store) dirtyItems(start, end []byte) {
 
 // Only entrypoint to mutate store.cache.
 func (store *Store) setCacheValue(key, value []byte, deleted bool, dirty bool) {
-	store.cache[conv.UnsafeBytesToStr(key)] = &cValue{
+	keyStr := conv.UnsafeBytesToStr(key)
+	store.cache[keyStr] = &cValue{
 		value:   value,
 		deleted: deleted,
 		dirty:   dirty,
 	}
 	if dirty {
-		store.unsortedCache[conv.UnsafeBytesToStr(key)] = struct{}{}
+		store.unsortedCache[keyStr] = struct{}{}
 	}
 }


### PR DESCRIPTION
## Description

So we don't burn un-necessary CPU in case of dirty store/delete.

```
name                          old time/op    new time/op    delta
CacheKVStoreIterator500-8       23.3µs ± 2%    23.4µs ± 1%    ~     (p=0.151 n=5+5)
CacheKVStoreIterator1000-8      47.0µs ± 2%    46.3µs ± 0%  -1.50%  (p=0.008 n=5+5)
CacheKVStoreIterator10000-8      462µs ± 3%     458µs ± 1%    ~     (p=0.690 n=5+5)
CacheKVStoreIterator50000-8     2.63ms ± 5%    2.51ms ± 2%  -4.63%  (p=0.032 n=5+5)
CacheKVStoreIterator100000-8    8.09ms ±21%    6.98ms ± 4%    ~     (p=0.151 n=5+5)
CacheKVStoreGetNoKeyFound-8      393ns ± 2%     397ns ± 2%    ~     (p=0.421 n=5+5)
CacheKVStoreGetKeyFound-8        269ns ± 5%     268ns ± 3%    ~     (p=1.000 n=5+5)
```

Fixes #9991

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [x] provided a link to the relevant issue or specification
- [x] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)