### PR TITLE
Fix: unmarshalling issue with multisig keys in v0.42.x

### DIFF
--- a/crypto/keys/multisig/amino.go
+++ b/crypto/keys/multisig/amino.go
@@ -78,7 +78,10 @@ func (m *LegacyAminoPubKey) UnmarshalAminoJSON(tmPk tmMultisig) error {
 	// Instead of just doing `*m = *protoPk`, we prefer to modify in-place the
 	// existing Anys inside `m` (instead of allocating new Anys), as so not to
 	// break the `.compat` fields in the existing Anys.
+
+	m.PubKeys = make ([]*types.Any, len(protoPk.PubKeys))
 	for i := range m.PubKeys {
+		m.PubKeys[i] = &types.Any{}
 		m.PubKeys[i].TypeUrl = protoPk.PubKeys[i].TypeUrl
 		m.PubKeys[i].Value = protoPk.PubKeys[i].Value
 	}

--- a/crypto/keys/multisig/multisig_test.go
+++ b/crypto/keys/multisig/multisig_test.go
@@ -32,6 +32,7 @@ func TestEquals(t *testing.T) {
 	multisigKey := kmultisig.NewLegacyAminoPubKey(1, []cryptotypes.PubKey{pubKey1, pubKey2})
 	otherMultisigKey := kmultisig.NewLegacyAminoPubKey(1, []cryptotypes.PubKey{pubKey1, multisigKey})
 
+
 	testCases := []struct {
 		msg      string
 		other    cryptotypes.PubKey
@@ -380,4 +381,5 @@ func TestAminoUnmarshalJSON(t *testing.T) {
 	err := cdc.UnmarshalJSON([]byte(pkJSON), &pk)
 	require.NoError(t, err)
 	require.Equal(t, uint32(3), pk.(*kmultisig.LegacyAminoPubKey).Threshold)
+	require.Equal(t, 5, len(pk.(*kmultisig.LegacyAminoPubKey).PubKeys))
 }


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

Closes: #10042

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

This fixes the issue outlined in #10042: The `LegacyAminoPubKey` struct fails to correctly unmarshal from JSON.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [X] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [X] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [X] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules)
- [X] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [X] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)