### PR TITLE
fix: revert \#10169 (amino multisig key unmarshalling)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,6 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### Client Breaking Changes
 
 * [\#9879](https://github.com/cosmos/cosmos-sdk/pull/9879) Modify ABCI Queries to use `abci.QueryRequest` Height field if it is non-zero, otherwise continue using context height.
-* [\#10061](https://github.com/cosmos/cosmos-sdk/pull/10061) Ensure that `LegacyAminoPubKey` struct correctly unmarshals from JSON
 
 ## [v0.44.0](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.44.0) - 2021-09-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,12 +48,12 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 * [\#9969](https://github.com/cosmos/cosmos-sdk/pull/9969) fix: use keyring in config for add-genesis-account cmd.
 * (x/genutil) [#10104](https://github.com/cosmos/cosmos-sdk/pull/10104) Ensure the `init` command reads the `--home` flag value correctly.
-* [\#10061](https://github.com/cosmos/cosmos-sdk/pull/10061) Ensure that `LegacyAminoPubKey` struct correctly unmarshals from JSON
 * (x/feegrant) [\#10049](https://github.com/cosmos/cosmos-sdk/issues/10049) Fixed the error message when `period` or `period-limit` flag is not set on a feegrant grant transaction.
 
 ### Client Breaking Changes
 
 * [\#9879](https://github.com/cosmos/cosmos-sdk/pull/9879) Modify ABCI Queries to use `abci.QueryRequest` Height field if it is non-zero, otherwise continue using context height.
+* [\#10061](https://github.com/cosmos/cosmos-sdk/pull/10061) Ensure that `LegacyAminoPubKey` struct correctly unmarshals from JSON
 
 ## [v0.44.0](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.44.0) - 2021-09-01
 

--- a/crypto/keys/multisig/amino.go
+++ b/crypto/keys/multisig/amino.go
@@ -78,9 +78,7 @@ func (m *LegacyAminoPubKey) UnmarshalAminoJSON(tmPk tmMultisig) error {
 	// Instead of just doing `*m = *protoPk`, we prefer to modify in-place the
 	// existing Anys inside `m` (instead of allocating new Anys), as so not to
 	// break the `.compat` fields in the existing Anys.
-	m.PubKeys = make([]*types.Any, len(protoPk.PubKeys))
 	for i := range m.PubKeys {
-		m.PubKeys[i] = &types.Any{}
 		m.PubKeys[i].TypeUrl = protoPk.PubKeys[i].TypeUrl
 		m.PubKeys[i].Value = protoPk.PubKeys[i].Value
 	}

--- a/crypto/keys/multisig/multisig_test.go
+++ b/crypto/keys/multisig/multisig_test.go
@@ -428,14 +428,6 @@ func TestAminoUnmarshalJSON(t *testing.T) {
 	require.NoError(t, err)
 	lpk := pk.(*kmultisig.LegacyAminoPubKey)
 	require.Equal(t, uint32(3), lpk.Threshold)
-	require.Equal(t, 5, len(pk.(*kmultisig.LegacyAminoPubKey).PubKeys))
-
-	for _, key := range pk.(*kmultisig.LegacyAminoPubKey).PubKeys {
-		require.NotNil(t, key)
-		pk := secp256k1.PubKey{}
-		err := pk.Unmarshal(key.Value)
-		require.NoError(t, err)
-	}
 }
 
 func TestProtoMarshalJSON(t *testing.T) {


### PR DESCRIPTION
## Description

Reverting https://github.com/cosmos/cosmos-sdk/pull/10169 because we are not sure if this correctly solves the issue and we don't want to block v0.44.1 release.
