### PR TITLE
fix: x/bank/044 migrateDenomMetadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
     * `SaveOfflineKey`
   * Take `keyring.Record` instead of `Info` as first argument in:
     * `MkConsKeyOutput`
-    * `MkValKeyOutput` 
+    * `MkValKeyOutput`
     * `MkAccKeyOutput`
 * [\#10077](https://github.com/cosmos/cosmos-sdk/pull/10077) Remove telemetry on `GasKV` and `CacheKV` store Get/Set operations, significantly improving their performance.
 * [\#10022](https://github.com/cosmos/cosmos-sdk/pull/10022) `AuthKeeper` interface in `x/auth` now includes a function `HasAccount`.
@@ -137,6 +137,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (server) [#10016](https://github.com/cosmos/cosmos-sdk/issues/10016) Fix marshaling of index-events into server config file.
 * (x/feegrant) [\#10049](https://github.com/cosmos/cosmos-sdk/issues/10049) Fixed the error message when `period` or `period-limit` flag is not set on a feegrant grant transaction.
 * [\#10184](https://github.com/cosmos/cosmos-sdk/pull/10184) Fixed CLI tx commands to no longer explicitly require the chain-id flag as this value can come from a user config.
+* [\#10239](https://github.com/cosmos/cosmos-sdk/pull/10239) Fixed x/bank/044 migrateDenomMetadata.
 
 
 ### State Machine Breaking

--- a/x/bank/migrations/v044/keys.go
+++ b/x/bank/migrations/v044/keys.go
@@ -5,6 +5,9 @@ var (
 )
 
 func CreateAddressDenomPrefix(denom string) []byte {
-	key := append(DenomAddressPrefix, []byte(denom)...)
-	return append(key, 0)
+	key := make([]byte, len(DenomAddressPrefix)+len(denom)+1)
+	copy(key, DenomAddressPrefix)
+	copy(key[len(DenomAddressPrefix):], denom)
+	// key[last] = 0 - not needed, because this is the default
+	return key
 }

--- a/x/bank/migrations/v044/keys.go
+++ b/x/bank/migrations/v044/keys.go
@@ -4,10 +4,13 @@ var (
 	DenomAddressPrefix = []byte{0x03}
 )
 
-func CreateAddressDenomPrefix(denom string) []byte {
+// CreateDenomAddressPrefix creates a prefix for a reverse index of denomination
+// to account balance for that denomination.
+func CreateDenomAddressPrefix(denom string) []byte {
+	// we add a "zero" byte at the end - null byte terminator, to allow prefix denom prefix
+	// scan. Setting it is not needed (key[last] = 0) - because this is the default.
 	key := make([]byte, len(DenomAddressPrefix)+len(denom)+1)
 	copy(key, DenomAddressPrefix)
 	copy(key[len(DenomAddressPrefix):], denom)
-	// key[last] = 0 - not needed, because this is the default
 	return key
 }

--- a/x/bank/migrations/v044/store.go
+++ b/x/bank/migrations/v044/store.go
@@ -79,11 +79,14 @@ func migrateDenomMetadata(store sdk.KVStore) error {
 
 	for ; oldDenomMetaDataIter.Valid(); oldDenomMetaDataIter.Next() {
 		oldKey := oldDenomMetaDataIter.Key()
-		// old key: prefix_bytes | denom_bytes | denom_bytes
-		newKey := append(types.DenomMetadataPrefix, oldKey[:len(oldKey)/2+1]...)
+		l := len(oldKey)/2 + 1
 
+		var newKey = make([]byte, len(types.DenomMetadataPrefix)+l)
+		copy(newKey, types.DenomMetadataPrefix)
+		// old key: prefix_bytes | denom_bytes | denom_bytes
+		newKey = append(newKey, oldKey[:l]...)
 		store.Set(newKey, oldDenomMetaDataIter.Value())
-		oldDenomMetaDataStore.Delete(oldDenomMetaDataIter.Key())
+		oldDenomMetaDataStore.Delete(oldKey)
 	}
 
 	return nil

--- a/x/bank/migrations/v044/store.go
+++ b/x/bank/migrations/v044/store.go
@@ -59,7 +59,7 @@ func addDenomReverseIndex(store sdk.KVStore, cdc codec.BinaryCodec) error {
 
 		denomPrefixStore, ok := denomPrefixStores[balance.Denom]
 		if !ok {
-			denomPrefixStore = prefix.NewStore(store, CreateAddressDenomPrefix(balance.Denom))
+			denomPrefixStore = prefix.NewStore(store, CreateDenomAddressPrefix(balance.Denom))
 			denomPrefixStores[balance.Denom] = denomPrefixStore
 		}
 
@@ -82,9 +82,9 @@ func migrateDenomMetadata(store sdk.KVStore) error {
 		l := len(oldKey)/2 + 1
 
 		var newKey = make([]byte, len(types.DenomMetadataPrefix)+l)
-		copy(newKey, types.DenomMetadataPrefix)
 		// old key: prefix_bytes | denom_bytes | denom_bytes
-		newKey = append(newKey, oldKey[:l]...)
+		copy(newKey, types.DenomMetadataPrefix)
+		copy(newKey[len(types.DenomMetadataPrefix):], oldKey[:l])
 		store.Set(newKey, oldDenomMetaDataIter.Value())
 		oldDenomMetaDataStore.Delete(oldKey)
 	}

--- a/x/bank/migrations/v044/store_test.go
+++ b/x/bank/migrations/v044/store_test.go
@@ -47,7 +47,7 @@ func TestMigrateStore(t *testing.T) {
 	}
 
 	for _, b := range balances {
-		denomPrefixStore := prefix.NewStore(store, v044.CreateAddressDenomPrefix(b.Denom))
+		denomPrefixStore := prefix.NewStore(store, v044.CreateDenomAddressPrefix(b.Denom))
 		bz := denomPrefixStore.Get(address.MustLengthPrefix(addr))
 		require.NotNil(t, bz)
 	}
@@ -88,6 +88,7 @@ func TestMigrateDenomMetaData(t *testing.T) {
 
 	for i := range []int{0, 1} {
 		key := append(v043.DenomMetadataPrefix, []byte(metaData[i].Base)...)
+		// keys before 0.44 had denom two times in the key
 		key = append(key, []byte(metaData[i].Base)...)
 		bz, err := encCfg.Codec.Marshal(&metaData[i])
 		require.NoError(t, err)
@@ -108,7 +109,7 @@ func TestMigrateDenomMetaData(t *testing.T) {
 		bz := denomMetadataStore.Get(oldKey)
 		require.Nil(t, bz)
 
-		require.Equal(t, string(newKey)[1:], metaData[i].Base)
+		require.Equal(t, string(newKey)[1:], metaData[i].Base, "idx: %d", i)
 		bz = denomMetadataStore.Get(denomMetadataIter.Key())
 		require.NotNil(t, bz)
 		err := encCfg.Codec.Unmarshal(bz, &result)

--- a/x/bank/types/key.go
+++ b/x/bank/types/key.go
@@ -60,9 +60,10 @@ func CreateAccountBalancesPrefix(addr []byte) []byte {
 // CreateDenomAddressPrefix creates a prefix for a reverse index of denomination
 // to account balance for that denomination.
 func CreateDenomAddressPrefix(denom string) []byte {
+	// we add a "zero" byte at the end - null byte terminator, to allow prefix denom prefix
+	// scan. Setting it is not needed (key[last] = 0) - because this is the default.
 	key := make([]byte, len(DenomAddressPrefix)+len(denom)+1)
 	copy(key, DenomAddressPrefix)
 	copy(key[len(DenomAddressPrefix):], denom)
-	// key[last] = 0 - not needed, because this is the default
 	return key
 }

--- a/x/bank/types/key.go
+++ b/x/bank/types/key.go
@@ -60,6 +60,9 @@ func CreateAccountBalancesPrefix(addr []byte) []byte {
 // CreateDenomAddressPrefix creates a prefix for a reverse index of denomination
 // to account balance for that denomination.
 func CreateDenomAddressPrefix(denom string) []byte {
-	key := append(DenomAddressPrefix, []byte(denom)...)
-	return append(key, 0)
+	key := make([]byte, len(DenomAddressPrefix)+len(denom)+1)
+	copy(key, DenomAddressPrefix)
+	copy(key[len(DenomAddressPrefix):], denom)
+	// key[last] = 0 - not needed, because this is the default
+	return key
 }

--- a/x/bank/types/key_test.go
+++ b/x/bank/types/key_test.go
@@ -56,3 +56,15 @@ func TestAddressFromBalancesStore(t *testing.T) {
 		})
 	}
 }
+
+func TestCreateDenomAddressPrefix(t *testing.T) {
+	require := require.New(t)
+
+	key := types.CreateDenomAddressPrefix("")
+	require.Len(key, len(types.DenomAddressPrefix)+1)
+	require.Equal(append(types.DenomAddressPrefix, 0), key)
+
+	key = types.CreateDenomAddressPrefix("abc")
+	require.Len(key, len(types.DenomAddressPrefix)+4)
+	require.Equal(append(types.DenomAddressPrefix, 'a', 'b', 'c', 0), key)
+}


### PR DESCRIPTION
## Description

Ref: https://github.com/cosmos/cosmos-sdk/pull/10060

Fixing x/bank/migrations/v44.migrateDenomMetadata - we could potentially put a wrong data in a new key if the old keys have variable length.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [x] provided a link to the relevant issue or specification
- [x] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules)
- [x] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [x] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [x] updated the relevant documentation or specification
- [x] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)