### PR TITLE
perf: avoid unnecessary byteslice->string before fmt %s verb

### DIFF
--- a/client/keys/add_ledger_test.go
+++ b/client/keys/add_ledger_test.go
@@ -54,7 +54,7 @@ func Test_runAddCmdLedgerWithCustomCoinType(t *testing.T) {
 		fmt.Sprintf("--%s=0", flagIndex),
 		fmt.Sprintf("--%s=330", flagCoinType),
 		fmt.Sprintf("--%s=%s", cli.OutputFlag, OutputFormatText),
-		fmt.Sprintf("--%s=%s", flags.FlagKeyAlgorithm, string(hd.Secp256k1Type)),
+		fmt.Sprintf("--%s=%s", flags.FlagKeyAlgorithm, hd.Secp256k1Type),
 		fmt.Sprintf("--%s=%s", flags.FlagKeyringBackend, keyring.BackendTest),
 	})
 
@@ -104,7 +104,7 @@ func Test_runAddCmdLedger(t *testing.T) {
 		"keyname1",
 		fmt.Sprintf("--%s=true", flags.FlagUseLedger),
 		fmt.Sprintf("--%s=%s", cli.OutputFlag, OutputFormatText),
-		fmt.Sprintf("--%s=%s", flags.FlagKeyAlgorithm, string(hd.Secp256k1Type)),
+		fmt.Sprintf("--%s=%s", flags.FlagKeyAlgorithm, hd.Secp256k1Type),
 		fmt.Sprintf("--%s=%d", flagCoinType, sdk.CoinType),
 		fmt.Sprintf("--%s=%s", flags.FlagKeyringBackend, keyring.BackendTest),
 	})

--- a/client/keys/add_test.go
+++ b/client/keys/add_test.go
@@ -45,7 +45,7 @@ func Test_runAddCmdBasic(t *testing.T) {
 		"keyname1",
 		fmt.Sprintf("--%s=%s", flags.FlagHome, kbHome),
 		fmt.Sprintf("--%s=%s", cli.OutputFlag, OutputFormatText),
-		fmt.Sprintf("--%s=%s", flags.FlagKeyAlgorithm, string(hd.Secp256k1Type)),
+		fmt.Sprintf("--%s=%s", flags.FlagKeyAlgorithm, hd.Secp256k1Type),
 		fmt.Sprintf("--%s=%s", flags.FlagKeyringBackend, keyring.BackendTest),
 	})
 	mockIn.Reset("y\n")
@@ -58,7 +58,7 @@ func Test_runAddCmdBasic(t *testing.T) {
 		"keyname2",
 		fmt.Sprintf("--%s=%s", flags.FlagHome, kbHome),
 		fmt.Sprintf("--%s=%s", cli.OutputFlag, OutputFormatText),
-		fmt.Sprintf("--%s=%s", flags.FlagKeyAlgorithm, string(hd.Secp256k1Type)),
+		fmt.Sprintf("--%s=%s", flags.FlagKeyAlgorithm, hd.Secp256k1Type),
 		fmt.Sprintf("--%s=%s", flags.FlagKeyringBackend, keyring.BackendTest),
 	})
 
@@ -72,7 +72,7 @@ func Test_runAddCmdBasic(t *testing.T) {
 		"keyname4",
 		fmt.Sprintf("--%s=%s", flags.FlagHome, kbHome),
 		fmt.Sprintf("--%s=%s", cli.OutputFlag, OutputFormatText),
-		fmt.Sprintf("--%s=%s", flags.FlagKeyAlgorithm, string(hd.Secp256k1Type)),
+		fmt.Sprintf("--%s=%s", flags.FlagKeyAlgorithm, hd.Secp256k1Type),
 		fmt.Sprintf("--%s=%s", flags.FlagKeyringBackend, keyring.BackendTest),
 	})
 
@@ -84,7 +84,7 @@ func Test_runAddCmdBasic(t *testing.T) {
 		fmt.Sprintf("--%s=%s", flags.FlagHome, kbHome),
 		fmt.Sprintf("--%s=true", flags.FlagDryRun),
 		fmt.Sprintf("--%s=%s", cli.OutputFlag, OutputFormatText),
-		fmt.Sprintf("--%s=%s", flags.FlagKeyAlgorithm, string(hd.Secp256k1Type)),
+		fmt.Sprintf("--%s=%s", flags.FlagKeyAlgorithm, hd.Secp256k1Type),
 	})
 
 	require.NoError(t, cmd.ExecuteContext(ctx))
@@ -247,7 +247,7 @@ func TestAddRecoverFileBackend(t *testing.T) {
 		"keyname1",
 		fmt.Sprintf("--%s=%s", flags.FlagHome, kbHome),
 		fmt.Sprintf("--%s=%s", cli.OutputFlag, OutputFormatText),
-		fmt.Sprintf("--%s=%s", flags.FlagKeyAlgorithm, string(hd.Secp256k1Type)),
+		fmt.Sprintf("--%s=%s", flags.FlagKeyAlgorithm, hd.Secp256k1Type),
 		fmt.Sprintf("--%s=%s", flags.FlagKeyringBackend, keyring.BackendFile),
 		fmt.Sprintf("--%s", flagRecover),
 	})

--- a/crypto/keyring/signing_algorithms_test.go
+++ b/crypto/keyring/signing_algorithms_test.go
@@ -56,7 +56,7 @@ func TestAltSigningAlgoList_Contains(t *testing.T) {
 
 func TestAltSigningAlgoList_String(t *testing.T) {
 	list := SigningAlgoList{hd.Secp256k1, notSupportedAlgo{}}
-	require.Equal(t, fmt.Sprintf("%s,notSupported", string(hd.Secp256k1Type)), list.String())
+	require.Equal(t, fmt.Sprintf("%s,notSupported", hd.Secp256k1Type), list.String())
 }
 
 type notSupportedAlgo struct {

--- a/x/capability/simulation/decoder.go
+++ b/x/capability/simulation/decoder.go
@@ -27,7 +27,7 @@ func NewDecodeStore(cdc codec.Codec) func(kvA, kvB kv.Pair) string {
 			return fmt.Sprintf("CapabilityOwners A: %v\nCapabilityOwners B: %v\n", capOwnersA, capOwnersB)
 
 		default:
-			panic(fmt.Sprintf("invalid %s key prefix %X (%s)", types.ModuleName, kvA.Key, string(kvA.Key)))
+			panic(fmt.Sprintf("invalid %s key prefix %X (%s)", types.ModuleName, kvA.Key, kvA.Key))
 		}
 	}
 }

--- a/x/genutil/client/cli/init.go
+++ b/x/genutil/client/cli/init.go
@@ -61,7 +61,7 @@ func displayInfo(info printInfo) error {
 		return err
 	}
 
-	_, err = fmt.Fprintf(os.Stderr, "%s\n", string(sdk.MustSortJSON(out)))
+	_, err = fmt.Fprintf(os.Stderr, "%s\n", sdk.MustSortJSON(out))
 
 	return err
 }

--- a/x/params/types/subspace.go
+++ b/x/params/types/subspace.go
@@ -88,7 +88,7 @@ func (s Subspace) transientStore(ctx sdk.Context) sdk.KVStore {
 func (s Subspace) Validate(ctx sdk.Context, key []byte, value interface{}) error {
 	attr, ok := s.table.m[string(key)]
 	if !ok {
-		return fmt.Errorf("parameter %s not registered", string(key))
+		return fmt.Errorf("parameter %s not registered", key)
 	}
 
 	if err := attr.vfn(value); err != nil {
@@ -167,7 +167,7 @@ func (s Subspace) Modified(ctx sdk.Context, key []byte) bool {
 func (s Subspace) checkType(key []byte, value interface{}) {
 	attr, ok := s.table.m[string(key)]
 	if !ok {
-		panic(fmt.Sprintf("parameter %s not registered", string(key)))
+		panic(fmt.Sprintf("parameter %s not registered", key))
 	}
 
 	ty := attr.ty
@@ -209,7 +209,7 @@ func (s Subspace) Set(ctx sdk.Context, key []byte, value interface{}) {
 func (s Subspace) Update(ctx sdk.Context, key, value []byte) error {
 	attr, ok := s.table.m[string(key)]
 	if !ok {
-		panic(fmt.Sprintf("parameter %s not registered", string(key)))
+		panic(fmt.Sprintf("parameter %s not registered", key))
 	}
 
 	ty := attr.ty

--- a/x/upgrade/client/cli/query.go
+++ b/x/upgrade/client/cli/query.go
@@ -104,7 +104,7 @@ func GetAppliedPlanCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return clientCtx.PrintString(fmt.Sprintf("%s\n", string(bz)))
+			return clientCtx.PrintString(fmt.Sprintf("%s\n", bz))
 		},
 	}
 


### PR DESCRIPTION
fmt.Printf or fmt.Sprintf already know how to convert a
byteslice into a string when building the output; we shouldn't
incur the unnecessary string(byteslice) conversion.
Using Bencher, we can see improvements such as
https://dashboard.github.orijtech.com/benchmark/3245b8e4bbbd44a597480319aaa4b9fe
which in independent experiments show:

* time/op (ns/op)
FormatIt-8	1.2µs ± 2%	1.1µs ± 10%	-11.77%	(p=0.000 n=10+9)

* speed (MB/s)
FormatIt-8	0.71GB/s ± 2%	0.80GB/s ± 9%	+13.59%	(p=0.000 n=10+9)

* allocs/op (B/op)
FormatIt-8	2.0kB ± 0%	1.1kB ± 0%	-45.62%	(p=0.000 n=10+10)

* allocs/op (count/op)
FormatIt-8	11 ± 0%	        9.0 ± 0%	-18.18%	(p=0.000 n=10+10)

Fixes #10363