### PR TITLE
fix: replace reflect.Typeof.Name with fmt.Sprintf("%T")

### DIFF
--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"reflect"
 
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/libs/log"
@@ -202,7 +201,7 @@ func (app *BaseApp) MountStores(keys ...storetypes.StoreKey) {
 			app.MountStore(key, storetypes.StoreTypeTransient)
 
 		default:
-			panic("Unrecognized store key type " + reflect.TypeOf(key).Name())
+			panic(fmt.Sprintf("Unrecognized store key type :%T", key))
 		}
 	}
 }


### PR DESCRIPTION
Per https://golang.org/pkg/fmt#hdr-Printing, Go's fmt "%T" specifier
prints out the underlying type hence we don't need to invoke
reflect.Typeof(key).Name() just to get it. This change was discovered
while examining Informal Systems' static analyzers that want to flag
certain packages.

Fixes #10391