### PR TITLE
fix: db/dbtest/util

### DIFF
--- a/db/dbtest/util.go
+++ b/db/dbtest/util.go
@@ -23,8 +23,8 @@ func AssertDomain(t *testing.T, itr dbm.Iterator, start, end []byte) {
 
 func AssertItem(t *testing.T, itr dbm.Iterator, key, value []byte) {
 	t.Helper()
-	assert.Exactly(t, itr.Key(), k)
-	assert.Exactly(t, itr.Value(), v)
+	assert.Exactly(t, key, itr.Key())
+	assert.Exactly(t, value, itr.Value())
 }
 
 func AssertInvalid(t *testing.T, itr dbm.Iterator) {


### PR DESCRIPTION
## Description

Closes: #XXXX

See https://dashboard.github.orijtech.com/benchmark/c29ef717d40744458619a51d565e7471

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)