### PR TITLE
feat(x/group): add vote_paths to MsgVoteRequest

### DIFF
--- a/proto/cosmos/group/v1beta1/tx.proto
+++ b/proto/cosmos/group/v1beta1/tx.proto
@@ -271,7 +271,9 @@ message MsgVoteRequest {
   // vote_paths allows individuals to vote on proposals in groups which they
   // are part of through some nested group memberships. Multiple vote paths can
   // be provided in a single vote operation to handle cases where a single voter
-  // is a member of the parent group through multiple nested groups.
+  // is a member of the parent group through multiple nested groups. Currently
+  // nested voting is tabulated using a winner take all method rather than
+  // proportionally. However, proportional voting may be supported in the future.
   repeated VotePath vote_paths  = 6;
 
   // VotePath is the path of a voter from the group they are directly a member

--- a/proto/cosmos/group/v1beta1/tx.proto
+++ b/proto/cosmos/group/v1beta1/tx.proto
@@ -250,7 +250,12 @@ message MsgVoteRequest {
 
   // proposal is the unique ID of the proposal.
   uint64 proposal_id = 1;
-  // voter is the voter account address.
+
+  // voter is the voter account address. If voter is the address of a group
+  // account, this operation will fail because nested voting is not handled with
+  // "vote proposals" but rather through vote_paths. In order for a group to
+  // vote on a proposal in a group they are a member of, each of its members
+  // must vote on the proposal using a vote_paths.
   string voter = 2 [(cosmos_proto.scalar) = "cosmos.AddressString"];
 
   // choice is the voter's choice on the proposal.
@@ -262,6 +267,25 @@ message MsgVoteRequest {
   // exec defines whether the proposal should be executed
   // immediately after voting or not.
   Exec exec = 5;
+
+  // vote_paths allows individuals to vote on proposals in groups which they
+  // are part of through some nested group memberships. Multiple vote paths can
+  // be provided in a single vote operation to handle cases where a single voter
+  // is a member of the parent group through multiple nested groups.
+  repeated VotePath vote_paths  = 6;
+
+  // VotePath is the path of a voter from the group they are directly a member
+  // of to the group account which the proposal is in.
+  message VotePath {
+    // nested_group_path is the list of groups that the voter is in which are
+    // transitively part of the group account which the proposal is in. These
+    // group accounts should be ordered starting with the group that the voter
+    // is directly in up to the group which is directly a member of the group
+    // which has the proposal. For example if voter A is in group B, the B is in
+    // group C, C is in group D and A wants to vote on a proposal in D, then
+    // nested_group_path should be the list ["B", "C"].
+    repeated string nested_group_path = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+  }
 }
 
 // MsgVoteResponse is the Msg/Vote response type.


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

ref #9922

This approach allows voting on proposals in group which a voter is a member of them through some set of nested groups. Multiple nested voting paths can be specified in a single operation.

This approach assumes winner take all block voting, which I think is the most obviously correct default.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)