### PR TITLE
feat: update x/upgrade keeper.DumpUpgradeInfoToDisk to support Plan.Info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
+### Improvements
+* (x/upgrade) [\#10532](https://github.com/cosmos/cosmos-sdk/pull/10532)  Update x/upgrade `keeper.DumpUpgradeInfoToDisk` to save `Plan.Info`.
+
 ### Bug Fixes
 
 * [\#10414](https://github.com/cosmos/cosmos-sdk/pull/10414) Use `sdk.GetConfig().GetFullBIP44Path()` instead `sdk.FullFundraiserPath` to generate key

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ## [Unreleased]
 
 ### Improvements
-* (x/upgrade) [\#10532](https://github.com/cosmos/cosmos-sdk/pull/10532)  Update x/upgrade `keeper.DumpUpgradeInfoToDisk` to save `Plan.Info`.
+* (x/upgrade) [\#10532](https://github.com/cosmos/cosmos-sdk/pull/10532)  Add `keeper.DumpUpgradeInfoWithInfoToDisk` to include `Plan.Info` in the upgrade-info file.
 
 ### Bug Fixes
 

--- a/x/upgrade/abci.go
+++ b/x/upgrade/abci.go
@@ -42,7 +42,7 @@ func BeginBlocker(k keeper.Keeper, ctx sdk.Context, _ abci.RequestBeginBlock) {
 		if !k.HasHandler(plan.Name) {
 			// Write the upgrade info to disk. The UpgradeStoreLoader uses this info to perform or skip
 			// store migrations.
-			err := k.DumpUpgradeInfoToDisk(ctx.BlockHeight(), plan.Name)
+			err := k.DumpUpgradeInfoToDisk(ctx.BlockHeight(), plan.Name, plan.Info)
 			if err != nil {
 				panic(fmt.Errorf("unable to write upgrade info to filesystem: %s", err.Error()))
 			}

--- a/x/upgrade/abci.go
+++ b/x/upgrade/abci.go
@@ -42,7 +42,7 @@ func BeginBlocker(k keeper.Keeper, ctx sdk.Context, _ abci.RequestBeginBlock) {
 		if !k.HasHandler(plan.Name) {
 			// Write the upgrade info to disk. The UpgradeStoreLoader uses this info to perform or skip
 			// store migrations.
-			err := k.DumpUpgradeInfoToDisk(ctx.BlockHeight(), plan.Name, plan.Info)
+			err := k.DumpUpgradeInfoWithInfoToDisk(ctx.BlockHeight(), plan.Name, plan.Info)
 			if err != nil {
 				panic(fmt.Errorf("unable to write upgrade info to filesystem: %s", err.Error()))
 			}

--- a/x/upgrade/keeper/keeper.go
+++ b/x/upgrade/keeper/keeper.go
@@ -325,11 +325,19 @@ func (k Keeper) IsSkipHeight(height int64) bool {
 	return k.skipUpgradeHeights[height]
 }
 
-// DumpUpgradeInfoToDisk writes upgrade information to UpgradeInfoFileName.
+// DumpUpgradeInfoToDisk writes upgrade information to UpgradeInfoFileName. The function
+// doesn't save the `Plan.Info` data, hence it won't support auto download functionality
+// by cosmvisor.
+// NOTE: this function will be update in the next release.
+func (k Keeper) DumpUpgradeInfoToDisk(height int64, name string) error {
+	return k.DumpUpgradeInfoWithInfoToDisk(height, name, "")
+}
+
+// Deprecated: DumpUpgradeInfoWithInfoToDisk writes upgrade information to UpgradeInfoFileName.
 // `info` should be provided and contain Plan.Info data in order to support
 // auto download functionality by cosmovisor and other tools using upgarde-info.json
 // (GetUpgradeInfoPath()) file.
-func (k Keeper) DumpUpgradeInfoToDisk(height int64, name string, info ...string) error {
+func (k Keeper) DumpUpgradeInfoWithInfoToDisk(height int64, name string, info string) error {
 	upgradeInfoFilePath, err := k.GetUpgradeInfoPath()
 	if err != nil {
 		return err
@@ -338,9 +346,7 @@ func (k Keeper) DumpUpgradeInfoToDisk(height int64, name string, info ...string)
 	upgradeInfo := upgradeInfo{
 		Name:   name,
 		Height: height,
-	}
-	if len(info) != 0 {
-		upgradeInfo.Info = info[0]
+		Info:   info,
 	}
 	bz, err := json.Marshal(upgradeInfo)
 	if err != nil {

--- a/x/upgrade/keeper/keeper.go
+++ b/x/upgrade/keeper/keeper.go
@@ -327,7 +327,7 @@ func (k Keeper) IsSkipHeight(height int64) bool {
 
 // DumpUpgradeInfoToDisk writes upgrade information to UpgradeInfoFileName.
 // `info` should be provided and contain Plan.Info data in order to support
-// auto upgrade functionality by cosmovisor and other tools using upgarde-info.json
+// auto download functionality by cosmovisor and other tools using upgarde-info.json
 // (GetUpgradeInfoPath()) file.
 func (k Keeper) DumpUpgradeInfoToDisk(height int64, name string, info ...string) error {
 	upgradeInfoFilePath, err := k.GetUpgradeInfoPath()


### PR DESCRIPTION
## Description

Closes: #10531
Closes: #10428

Straw-man attempt to bring the plan.Info data in to upgrade-info.json file in a backward compatible way.


---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)