### PR TITLE
build: fix build environment for the liveness test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -228,7 +228,7 @@ jobs:
 
   liveness-test:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2.1.4

--- a/Makefile
+++ b/Makefile
@@ -498,13 +498,8 @@ proto-update-deps:
 # Run a 4-node testnet locally via docker compose
 localnet-start: build-linux localnet-stop
 	$(if $(shell $(DOCKER) inspect -f '{{ .Id }}' cosmossdk/simd-env 2>/dev/null),$(info found image cosmossdk/simd-env),$(MAKE) -C contrib/images simd-env)
-	if ! test -f build/node0/simd/config/genesis.json; then $(DOCKER) run --rm \
-		--user $(shell id -u):$(shell id -g) \
-		-v $(BUILDDIR):/simd:Z \
-		-v /etc/group:/etc/group:ro \
-		-v /etc/passwd:/etc/passwd:ro \
-		-v /etc/shadow:/etc/shadow:ro \
-		cosmossdk/simd-env testnet init-files --v 4 -o . --starting-ip-address 192.168.10.2 --keyring-backend=test ; fi
+	$(DOCKER) run --rm -v $(CURDIR)/localnet:/data cosmossdk/simd-env \
+		testnet init-files --v 4 -o /data --starting-ip-address 192.168.10.2 --keyring-backend=test
 	docker-compose up -d
 
 localnet-stop:

--- a/contrib/images/Makefile
+++ b/contrib/images/Makefile
@@ -1,6 +1,7 @@
 all: simd-env
 
 simd-env:
-	docker build --build-arg UID=$(shell id -u) --build-arg GID=$(shell id -g) --tag cosmossdk/simd-env simd-env
+	docker build --tag cosmossdk/simd-env -f simd-env/Dockerfile \
+		$(shell git rev-parse --show-toplevel)
 
 .PHONY: all simd-env

--- a/contrib/images/simd-env/Dockerfile
+++ b/contrib/images/simd-env/Dockerfile
@@ -1,18 +1,21 @@
-FROM ubuntu:18.04
+FROM golang:1.17-alpine AS build
+RUN apk add build-base git linux-headers
+WORKDIR /work
+COPY go.mod go.sum /work/
+COPY db/go.mod db/go.sum /work/db/
+RUN go mod download
+COPY ./ /work
+RUN LEDGER_ENABLED=false make clean build
 
-RUN apt-get update && \
-  apt-get -y upgrade && \
-  apt-get -y install curl jq file
+FROM alpine:3.14 AS run
+RUN apk add bash curl jq
+COPY contrib/images/simd-env/wrapper.sh /usr/bin/wrapper.sh
 
-ARG UID=1000
-ARG GID=1000
-
-USER ${UID}:${GID}
-VOLUME [ "/simd" ]
+VOLUME /simd
+COPY --from=build /work/build/simd /simd/
 WORKDIR /simd
+
 EXPOSE 26656 26657
 ENTRYPOINT ["/usr/bin/wrapper.sh"]
 CMD ["start", "--log_format", "plain"]
 STOPSIGNAL SIGTERM
-
-COPY wrapper.sh /usr/bin/wrapper.sh

--- a/contrib/images/simd-env/wrapper.sh
+++ b/contrib/images/simd-env/wrapper.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env sh
+set -euo pipefail
+set -x
 
 BINARY=/simd/${BINARY:-simd}
 ID=${ID:-0}
@@ -9,14 +11,7 @@ if ! [ -f "${BINARY}" ]; then
 	exit 1
 fi
 
-BINARY_CHECK="$(file "$BINARY" | grep 'ELF 64-bit LSB executable, x86-64')"
-
-if [ -z "${BINARY_CHECK}" ]; then
-	echo "Binary needs to be OS linux, ARCH amd64"
-	exit 1
-fi
-
-export SIMDHOME="/simd/node${ID}/simd"
+export SIMDHOME="/data/node${ID}/simd"
 
 if [ -d "$(dirname "${SIMDHOME}"/"${LOG}")" ]; then
   "${BINARY}" --home "${SIMDHOME}" "$@" | tee "${SIMDHOME}/${LOG}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - ID=0
       - LOG=${LOG:-simd.log}
     volumes:
-      - ./build:/simd:Z
+      - ./localnet:/data:Z
     networks:
       localnet:
         ipv4_address: 192.168.10.2
@@ -28,7 +28,7 @@ services:
       - ID=1
       - LOG=${LOG:-simd.log}
     volumes:
-      - ./build:/simd:Z
+      - ./localnet:/data:Z
     networks:
       localnet:
         ipv4_address: 192.168.10.3
@@ -44,7 +44,7 @@ services:
       - "1319:1317"
       - "9092:9090"
     volumes:
-      - ./build:/simd:Z
+      - ./localnet:/data:Z
     networks:
       localnet:
         ipv4_address: 192.168.10.4
@@ -60,7 +60,7 @@ services:
       - "1320:1317"
       - "9093:9090"
     volumes:
-      - ./build:/simd:Z
+      - ./localnet:/data:Z
     networks:
       localnet:
         ipv4_address: 192.168.10.5

--- a/gratuitous.go
+++ b/gratuitous.go
@@ -1,0 +1,2 @@
+// Package gratuitous is a no-op Go change to trigger CI actions.
+package gratuitous

--- a/gratuitous.go
+++ b/gratuitous.go
@@ -1,2 +1,0 @@
-// Package gratuitous is a no-op Go change to trigger CI actions.
-package gratuitous


### PR DESCRIPTION
Extracted from #10210.

Make the test more reproducible, so that it does not require coordination
between the build container and the run container.

- Use layers to more advantage.
- Include bash in the run container.
- Put writable output onto a volume.

**Note to reviewers:** I included a stub Go file to trigger the CI. That should be dropped before merging this change.