### PR TITLE
fix: update nftOfClassByOwnerStoreKey

### DIFF
--- a/x/nft/keeper/grpc_query_test.go
+++ b/x/nft/keeper/grpc_query_test.go
@@ -57,7 +57,7 @@ func (suite *TestSuite) TestBalance() {
 				}
 			},
 			"",
-			1,
+			2,
 			func(index int, require *require.Assertions, res *nft.QueryBalanceResponse, expBalance uint64) {
 				require.Equal(res.Amount, expBalance, "the error occurred on:%d", index)
 			},

--- a/x/nft/keeper/keeper_test.go
+++ b/x/nft/keeper/keeper_test.go
@@ -158,6 +158,22 @@ func (s *TestSuite) TestMint() {
 	// test GetTotalSupply
 	supply := s.app.NFTKeeper.GetTotalSupply(s.ctx, testClassID)
 	s.Require().EqualValues(uint64(1), supply)
+
+	expNFT2 := nft.NFT{
+		ClassId: testClassID,
+		Id:      testID + "2",
+		Uri:     testURI + "2",
+	}
+	err = s.app.NFTKeeper.Mint(s.ctx, expNFT2, s.addrs[0])
+	s.Require().NoError(err)
+
+	// test GetNFTsOfClassByOwner
+	actNFTs = s.app.NFTKeeper.GetNFTsOfClassByOwner(s.ctx, testClassID, s.addrs[0])
+	s.Require().EqualValues([]nft.NFT{expNFT,expNFT2}, actNFTs)
+
+	// test GetBalance
+	balance = s.app.NFTKeeper.GetBalance(s.ctx, testClassID, s.addrs[0])
+	s.Require().EqualValues(uint64(2), balance)
 }
 
 func (s *TestSuite) TestBurn() {

--- a/x/nft/keeper/keys.go
+++ b/x/nft/keeper/keys.go
@@ -53,7 +53,7 @@ func nftOfClassByOwnerStoreKey(owner sdk.AccAddress, classID string) []byte {
 	owner = address.MustLengthPrefix(owner)
 	classIDBz := conv.UnsafeStrToBytes(classID)
 
-	var key = make([]byte, len(NFTOfClassByOwnerKey)+len(owner)+len(Delimiter))
+	var key = make([]byte, len(NFTOfClassByOwnerKey)+len(owner)+len(classIDBz)+len(Delimiter))
 	copy(key, NFTOfClassByOwnerKey)
 	copy(key[len(NFTOfClassByOwnerKey):], owner)
 	copy(key[len(NFTOfClassByOwnerKey)+len(owner):], classIDBz)


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## The length of `nftOfClassByOwnerStoreKey` is incorrect, and` len(classIDBz)` is not included. As a result, when querying nft according to `owner` and `classID`, the nft that does not belong to the classID will be returned.

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)