### PR TITLE
perf: Speedup cachekv iterator on large deletions & IBC v2 upgrade logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,6 +149,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * [\#10468](https://github.com/cosmos/cosmos-sdk/pull/10468) Allow futureOps to queue additional operations in simulations
 * [\#10625](https://github.com/cosmos/cosmos-sdk/pull/10625) Add `--fee-payer` CLI flag
 * (cli) [\#10683](https://github.com/cosmos/cosmos-sdk/pull/10683) In CLI, allow 1 SIGN_MODE_DIRECT signer in transactions with multiple signers.
+* (store) [\#10741](https://github.com/cosmos/cosmos-sdk/pull/10741) Significantly speedup iterator creation after delete heavy workloads. Significantly improves IBC migration times.
 
 ### Bug Fixes
 

--- a/store/cachekv/memiterator.go
+++ b/store/cachekv/memiterator.go
@@ -29,15 +29,10 @@ func newMemIterator(start, end []byte, items *dbm.MemDB, deleted map[string]stru
 		panic(err)
 	}
 
-	newDeleted := make(map[string]struct{})
-	for k, v := range deleted {
-		newDeleted[k] = v
-	}
-
 	return &memIterator{
 		Iterator: iter,
 
-		deleted: newDeleted,
+		deleted: deleted,
 	}
 }
 

--- a/store/cachekv/memiterator.go
+++ b/store/cachekv/memiterator.go
@@ -1,6 +1,8 @@
 package cachekv
 
 import (
+	"bytes"
+
 	dbm "github.com/tendermint/tm-db"
 
 	"github.com/cosmos/cosmos-sdk/store/types"
@@ -12,6 +14,7 @@ import (
 type memIterator struct {
 	types.Iterator
 
+	lastKey []byte
 	deleted map[string]struct{}
 }
 
@@ -32,14 +35,22 @@ func newMemIterator(start, end []byte, items *dbm.MemDB, deleted map[string]stru
 	return &memIterator{
 		Iterator: iter,
 
+		lastKey: nil,
 		deleted: deleted,
 	}
 }
 
 func (mi *memIterator) Value() []byte {
 	key := mi.Iterator.Key()
-	if _, ok := mi.deleted[string(key)]; ok {
+	// We need to handle the case where deleted is modified and includes our current key
+	// We handle this by maintaining a lastKey object in the iterator.
+	// If the current key is the same as the last key (and last key is not nil / the start)
+	// then we are calling value on the same thing as last time.
+	// Therefore we don't check the mi.deleted to see if this key is included in there.
+	reCallingOnOldLastKey := (mi.lastKey != nil) && bytes.Equal(key, mi.lastKey)
+	if _, ok := mi.deleted[string(key)]; ok && !reCallingOnOldLastKey {
 		return nil
 	}
+	mi.lastKey = key
 	return mi.Iterator.Value()
 }

--- a/store/cachekv/store_bench_test.go
+++ b/store/cachekv/store_bench_test.go
@@ -101,11 +101,16 @@ func benchmarkIteratorOnParentWithManyDeletes(b *testing.B, numDeletes int) {
 	// and take next D keys sequentially after.
 	startKey := randSlice(32)
 	keys := generateSequentialKeys(startKey, numDeletes)
+	// setup parent db with D keys.
 	for _, k := range keys {
 		mem.Set(k, value)
 	}
 	kvstore := cachekv.NewStore(mem)
-	// Has to be 1: due to a bug in the CacheKVStore
+	// Delete all keys from the cache KV store.
+	// The keys[1:] is to keep at least one entry in parent, due to a bug in the SDK iterator design.
+	// Essentially the iterator will never be valid, in that it should never run.
+	// However, this is incompatible with the for loop structure the SDK uses, hence
+	// causes a panic. Thus we do keys[1:].
 	for _, k := range keys[1:] {
 		kvstore.Delete(k)
 	}

--- a/store/cachekv/store_bench_test.go
+++ b/store/cachekv/store_bench_test.go
@@ -105,7 +105,7 @@ func benchmarkIteratorOnParentWithManyDeletes(b *testing.B, numDeletes int) {
 		mem.Set(k, value)
 	}
 	kvstore := cachekv.NewStore(mem)
-	// Has to be 1: in this commit due to a bug in the CacheKVStore
+	// Has to be 1: due to a bug in the CacheKVStore
 	for _, k := range keys[1:] {
 		kvstore.Delete(k)
 	}


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

This PR provides extreme speedups to the iterator creation pattern used in upgrades from IBC v1 to v2. On Osmosis, executing an upgrade from a state export was taking us over 2 hours due to this bug. (We never let it finish) After this fix, it takes under 8 minutes. (There is then ~20-30 min time overhead for IAVL commit, but thats orthogonal)

Essentially the CacheKVStore previously would iterate over every deleted item in cache when constructing an iterator. In the upgrade logic, bank first migrates the entire store, rewriting everything. (And thus adding 100k + deletes, other upgrades added far more deletes as well. Guestimmated that Osmosis had around 500k deletes) Then in IBC's upgrade, you do at least two iterator constructions per IBC client, which on Osmosis there are ~2000.  This adds up to the at least two hours we were experiencing.

This PR adds a benchmark to highlight the speed improvement, RAM improvement, and fixes this. 
```
<Benchmark name> <num benchmark iterations> <time taken> <Heap I/O> <New Memory allocated>
Before:
BenchmarkIteratorOnParentWith1MDeletes-16              1        1112540940 ns/op        101743776 B/op     38196 allocs/op
After:
BenchmarkIteratorOnParentWith1MDeletes-16         154346              7570 ns/op             331 B/op          3 allocs/op
```

Thus this fix really does solve the problem

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [x] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules)
- [x] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [x] added a changelog entry to `CHANGELOG.md`
- [x] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [x] updated the relevant documentation or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)