### PR TITLE
chore: add dependabot to all go mod locations

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,17 +5,6 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
-- package-ecosystem: gomod
-  directory: "/"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
-  reviewers:
-  - alexanderbez
-  - fedekunze
-  labels:
-  - automerge
-  - dependencies
 - package-ecosystem: npm
   directory: "/docs"
   schedule:
@@ -24,7 +13,58 @@ updates:
   reviewers:
   - fadeev
 - package-ecosystem: gomod
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10
+  labels:
+  - automerge
+  - dependencies
+- package-ecosystem: gomod
   directory: "/db"
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+  labels:
+  - automerge
+  - dependencies
+- package-ecosystem: gomod
+  directory: "api"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10
+  labels:
+  - automerge
+  - dependencies
+- package-ecosystem: gomod
+  directory: "orm"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10
+  labels:
+  - automerge
+  - dependencies
+- package-ecosystem: gomod
+  directory: "container"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10
+  labels:
+  - automerge
+  - dependencies
+- package-ecosystem: gomod
+  directory: "cosmovisor"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10
+  labels:
+  - automerge
+  - dependencies
+- package-ecosystem: gomod
+  directory: "x/group"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10
+  labels:
+  - automerge
+  - dependencies

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,7 +29,7 @@ updates:
   - automerge
   - dependencies
 - package-ecosystem: gomod
-  directory: "api"
+  directory: "/api"
   schedule:
     interval: daily
   open-pull-requests-limit: 10
@@ -37,7 +37,7 @@ updates:
   - automerge
   - dependencies
 - package-ecosystem: gomod
-  directory: "orm"
+  directory: "/orm"
   schedule:
     interval: daily
   open-pull-requests-limit: 10
@@ -45,7 +45,7 @@ updates:
   - automerge
   - dependencies
 - package-ecosystem: gomod
-  directory: "container"
+  directory: "/container"
   schedule:
     interval: daily
   open-pull-requests-limit: 10
@@ -53,7 +53,7 @@ updates:
   - automerge
   - dependencies
 - package-ecosystem: gomod
-  directory: "cosmovisor"
+  directory: "/cosmovisor"
   schedule:
     interval: daily
   open-pull-requests-limit: 10
@@ -61,7 +61,7 @@ updates:
   - automerge
   - dependencies
 - package-ecosystem: gomod
-  directory: "x/group"
+  directory: "/x/group"
   schedule:
     interval: daily
   open-pull-requests-limit: 10


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

Closes: #10554

add dependabot to all go.mod locations

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)