### PR TITLE
revert: "support custom mnemonics in in-process testing network"

### DIFF
--- a/server/init.go
+++ b/server/init.go
@@ -12,27 +12,16 @@ import (
 // phrase to recover the private key.
 func GenerateCoinKey(algo keyring.SignatureAlgo) (sdk.AccAddress, string, error) {
 	// generate a private key, with recovery phrase
-	info, secret, err := keyring.NewInMemory().NewMnemonic(
-		"name",
-		keyring.English,
-		sdk.GetConfig().GetFullBIP44Path(),
-		keyring.DefaultBIP39Passphrase,
-		algo)
+	info, secret, err := keyring.NewInMemory().NewMnemonic("name", keyring.English, sdk.GetConfig().GetFullBIP44Path(), keyring.DefaultBIP39Passphrase, algo)
 	if err != nil {
-		return sdk.AccAddress{}, "", err
+		return sdk.AccAddress([]byte{}), "", err
 	}
-
 	return sdk.AccAddress(info.GetPubKey().Address()), secret, nil
 }
 
 // GenerateSaveCoinKey returns the address of a public key, along with the secret
 // phrase to recover the private key.
-func GenerateSaveCoinKey(
-	keybase keyring.Keyring,
-	keyName, mnemonic string,
-	overwrite bool,
-	algo keyring.SignatureAlgo,
-) (sdk.AccAddress, string, error) {
+func GenerateSaveCoinKey(keybase keyring.Keyring, keyName string, overwrite bool, algo keyring.SignatureAlgo) (sdk.AccAddress, string, error) {
 	exists := false
 	_, err := keybase.Key(keyName)
 	if err == nil {
@@ -41,41 +30,22 @@ func GenerateSaveCoinKey(
 
 	// ensure no overwrite
 	if !overwrite && exists {
-		return sdk.AccAddress{}, "", fmt.Errorf("key already exists, overwrite is disabled")
+		return sdk.AccAddress([]byte{}), "", fmt.Errorf(
+			"key already exists, overwrite is disabled")
 	}
 
-	// remove the old key by name if it exists
+	// generate a private key, with recovery phrase
 	if exists {
-		if err := keybase.Delete(keyName); err != nil {
-			return sdk.AccAddress{}, "", fmt.Errorf("failed to overwrite key")
+		err = keybase.Delete(keyName)
+		if err != nil {
+			return sdk.AccAddress([]byte{}), "", fmt.Errorf(
+				"failed to overwrite key")
 		}
 	}
 
-	var (
-		info   keyring.Info
-		secret string
-	)
-
-	if mnemonic != "" {
-		secret = mnemonic
-		info, err = keybase.NewAccount(
-			keyName,
-			mnemonic,
-			keyring.DefaultBIP39Passphrase,
-			sdk.GetConfig().GetFullBIP44Path(),
-			algo,
-		)
-	} else {
-		info, secret, err = keybase.NewMnemonic(
-			keyName,
-			keyring.English,
-			sdk.GetConfig().GetFullBIP44Path(),
-			keyring.DefaultBIP39Passphrase,
-			algo,
-		)
-	}
+	info, secret, err := keybase.NewMnemonic(keyName, keyring.English, sdk.GetConfig().GetFullBIP44Path(), keyring.DefaultBIP39Passphrase, algo)
 	if err != nil {
-		return sdk.AccAddress{}, "", err
+		return sdk.AccAddress([]byte{}), "", err
 	}
 
 	return sdk.AccAddress(info.GetPubKey().Address()), secret, nil

--- a/server/init_test.go
+++ b/server/init_test.go
@@ -28,7 +28,7 @@ func TestGenerateSaveCoinKey(t *testing.T) {
 	kb, err := keyring.New(t.Name(), "test", t.TempDir(), nil)
 	require.NoError(t, err)
 
-	addr, mnemonic, err := server.GenerateSaveCoinKey(kb, "keyname", "", false, hd.Secp256k1)
+	addr, mnemonic, err := server.GenerateSaveCoinKey(kb, "keyname", false, hd.Secp256k1)
 	require.NoError(t, err)
 
 	// Test key was actually saved
@@ -49,15 +49,15 @@ func TestGenerateSaveCoinKeyOverwriteFlag(t *testing.T) {
 	require.NoError(t, err)
 
 	keyname := "justakey"
-	addr1, _, err := server.GenerateSaveCoinKey(kb, keyname, "", false, hd.Secp256k1)
+	addr1, _, err := server.GenerateSaveCoinKey(kb, keyname, false, hd.Secp256k1)
 	require.NoError(t, err)
 
 	// Test overwrite with overwrite=false
-	_, _, err = server.GenerateSaveCoinKey(kb, keyname, "", false, hd.Secp256k1)
+	_, _, err = server.GenerateSaveCoinKey(kb, keyname, false, hd.Secp256k1)
 	require.Error(t, err)
 
 	// Test overwrite with overwrite=true
-	addr2, _, err := server.GenerateSaveCoinKey(kb, keyname, "", true, hd.Secp256k1)
+	addr2, _, err := server.GenerateSaveCoinKey(kb, keyname, true, hd.Secp256k1)
 	require.NoError(t, err)
 
 	require.NotEqual(t, addr1, addr2)

--- a/simapp/simd/cmd/testnet.go
+++ b/simapp/simd/cmd/testnet.go
@@ -178,7 +178,7 @@ func InitTestnet(
 			return err
 		}
 
-		addr, secret, err := server.GenerateSaveCoinKey(kb, nodeDirName, "", true, algo)
+		addr, secret, err := server.GenerateSaveCoinKey(kb, nodeDirName, true, algo)
 		if err != nil {
 			_ = os.RemoveAll(outputDir)
 			return err

--- a/testutil/network/network.go
+++ b/testutil/network/network.go
@@ -81,7 +81,6 @@ type Config struct {
 	TimeoutCommit    time.Duration              // the consensus commitment timeout
 	ChainID          string                     // the network chain-id
 	NumValidators    int                        // the total number of validators to create and bond
-	Mnemonics        []string                   // custom user-provided validator operator mnemonics
 	BondDenom        string                     // the staking bond denomination
 	MinGasPrices     string                     // the minimum gas prices each validator will accept
 	AccountTokens    sdk.Int                    // the amount of unique validator tokens (e.g. 1000node0)
@@ -266,14 +265,12 @@ func New(t *testing.T, cfg Config) *Network {
 
 		p2pAddr, _, err := server.FreeTCPAddr()
 		require.NoError(t, err)
-
 		tmCfg.P2P.ListenAddress = p2pAddr
 		tmCfg.P2P.AddrBookStrict = false
 		tmCfg.P2P.AllowDuplicateIP = true
 
 		nodeID, pubKey, err := genutil.InitializeNodeValidatorFiles(tmCfg)
 		require.NoError(t, err)
-
 		nodeIDs[i] = nodeID
 		valPubKeys[i] = pubKey
 
@@ -284,12 +281,7 @@ func New(t *testing.T, cfg Config) *Network {
 		algo, err := keyring.NewSigningAlgoFromString(cfg.SigningAlgo, keyringAlgos)
 		require.NoError(t, err)
 
-		var mnemonic string
-		if i < len(cfg.Mnemonics) {
-			mnemonic = cfg.Mnemonics[i]
-		}
-
-		addr, secret, err := server.GenerateSaveCoinKey(kb, nodeDirName, mnemonic, true, algo)
+		addr, secret, err := server.GenerateSaveCoinKey(kb, nodeDirName, true, algo)
 		require.NoError(t, err)
 
 		info := map[string]string{"secret": secret}


### PR DESCRIPTION
This reverts commit 8bb7a968cc8181cb10c8c15f10665d9f14ffe73c, because it introduced an API-beraking change.

<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)