### PR TITLE
feat: add pbtime util package

### DIFF
--- a/pbtime/README.md
+++ b/pbtime/README.md
@@ -1,0 +1,3 @@
+# pbtime
+
+pbtime is a Go package, part of the core Cosmos SDK module with helper methods for [protobuf timestamp](https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#timestamp).

--- a/pbtime/cmp.go
+++ b/pbtime/cmp.go
@@ -3,9 +3,11 @@ package pbtime
 import (
 	"time"
 
+	durpb "google.golang.org/protobuf/types/known/durationpb"
 	tspb "google.golang.org/protobuf/types/known/timestamppb"
 )
 
+// IsZero returns true when t is nil or is zero unix timestamp (1970-01-01)
 func IsZero(t *tspb.Timestamp) bool {
 	return t == nil || t.Nanos == 0 && t.Seconds == 0
 }
@@ -22,9 +24,9 @@ func Compare(t1, t2 *tspb.Timestamp) int {
 	return 1
 }
 
-// Returns a new timestamp with value t + d.
+// AddStd returns a new timestamp with value t + d, where d is stdlib Duration
 // If t is nil then nil is returned
-func Add(t *tspb.Timestamp, d time.Duration) *tspb.Timestamp {
+func AddStd(t *tspb.Timestamp, d time.Duration) *tspb.Timestamp {
 	if t == nil {
 		return nil
 	}
@@ -34,4 +36,27 @@ func Add(t *tspb.Timestamp, d time.Duration) *tspb.Timestamp {
 	}
 	t2 := t.AsTime()
 	return tspb.New(t2.Add(d))
+}
+
+const second = int32(time.Second)
+
+// Add returns a new timestamp with value t + d, where d is protobuf Duration
+// If t is nil then nil is returned. Panics on overflow.
+func Add(t *tspb.Timestamp, d durpb.Duration) *tspb.Timestamp {
+	if t == nil {
+		return nil
+	}
+	if d.Seconds == 0 && d.Nanos == 0 {
+		t2 := *t
+		return &t2
+	}
+	t2 := tspb.Timestamp{
+		Seconds: t.Seconds + d.Seconds,
+		Nanos:   t.Nanos + d.Nanos,
+	}
+	if t2.Nanos >= second {
+		t2.Nanos -= second
+		t2.Seconds++
+	}
+	return &t2
 }

--- a/pbtime/cmp.go
+++ b/pbtime/cmp.go
@@ -1,0 +1,32 @@
+package pbtime
+
+import (
+	"time"
+
+	tspb "google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func IsZero(t *tspb.Timestamp) bool {
+	return t == nil || t.Nanos == 0 && t.Seconds == 0
+}
+
+// Commpare t1 and t2 and returns -1 when t1 < t2, 0 when t1 == t2 and 1 otherwise.
+// Panics if t1 or t2 is nil
+func Compare(t1, t2 *tspb.Timestamp) int {
+	if t1.Seconds == t2.Seconds && t1.Nanos == t2.Nanos {
+		return 0
+	}
+	if t1.Seconds < t2.Seconds || t1.Seconds == t2.Seconds && t1.Nanos < t2.Nanos {
+		return -1
+	}
+	return 1
+}
+
+func Add(t *tspb.Timestamp, d time.Duration) *tspb.Timestamp {
+	if d == 0 {
+		t2 := *t
+		return &t2
+	}
+	t2 := t.AsTime()
+	return tspb.New(t2.Add(d))
+}

--- a/pbtime/cmp.go
+++ b/pbtime/cmp.go
@@ -1,6 +1,7 @@
 package pbtime
 
 import (
+	"fmt"
 	"time"
 
 	durpb "google.golang.org/protobuf/types/known/durationpb"
@@ -13,8 +14,11 @@ func IsZero(t *tspb.Timestamp) bool {
 }
 
 // Commpare t1 and t2 and returns -1 when t1 < t2, 0 when t1 == t2 and 1 otherwise.
-// Panics if t1 or t2 is nil
+// Returns false if t1 or t2 is nil
 func Compare(t1, t2 *tspb.Timestamp) int {
+	if t1 == nil || t2 == nil {
+		panic(fmt.Sprint("Can't compare nil time, t1=", t1, "t2=", t2))
+	}
 	if t1.Seconds == t2.Seconds && t1.Nanos == t2.Nanos {
 		return 0
 	}

--- a/pbtime/cmp.go
+++ b/pbtime/cmp.go
@@ -22,7 +22,12 @@ func Compare(t1, t2 *tspb.Timestamp) int {
 	return 1
 }
 
+// Returns a new timestamp with value t + d.
+// If t is nil then nil is returned
 func Add(t *tspb.Timestamp, d time.Duration) *tspb.Timestamp {
+	if t == nil {
+		return nil
+	}
 	if d == 0 {
 		t2 := *t
 		return &t2

--- a/pbtime/cmp_test.go
+++ b/pbtime/cmp_test.go
@@ -76,4 +76,6 @@ func TestAddFuzzy(t *testing.T) {
 	check(0, 0, 0)
 	check(1, 2, 0)
 	check(-1, -1, 1)
+
+	requier.Equal(nil, Add(nil, time.Second), "works with nil values")
 }

--- a/pbtime/cmp_test.go
+++ b/pbtime/cmp_test.go
@@ -1,7 +1,6 @@
 package pbtime
 
 import (
-	"fmt"
 	"math/rand"
 	"testing"
 	"time"
@@ -53,10 +52,23 @@ func TestCompare(t *testing.T) {
 		{new(1, -1), new(1, -2), 1},
 	}
 	for i, tc := range tcs {
-		t.Run(fmt.Sprint("test ", i), func(t *testing.T) {
-			r := Compare(tc.t1, tc.t2)
-			require.Equal(t, tc.expected, r)
-		})
+		r := Compare(tc.t1, tc.t2)
+		require.Equal(t, tc.expected, r, "test %d", i)
+	}
+
+	// test panics
+	tcs2 := []struct {
+		t1 *tspb.Timestamp
+		t2 *tspb.Timestamp
+	}{
+		{nil, new(1, 1)},
+		{new(1, 1), nil},
+		{nil, nil},
+	}
+	for i, tc := range tcs2 {
+		require.Panics(t, func() {
+			Compare(tc.t1, tc.t2)
+		}, "test-panics %d", i)
 	}
 }
 

--- a/pbtime/cmp_test.go
+++ b/pbtime/cmp_test.go
@@ -1,0 +1,79 @@
+package pbtime
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"math/rand"
+
+	"github.com/stretchr/testify/require"
+	tspb "google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func new(s int64, n int32) *tspb.Timestamp {
+	return &tspb.Timestamp{Seconds: s, Nanos: n}
+}
+
+func TestIsZero(t *testing.T) {
+	tcs := []struct {
+		t        *tspb.Timestamp
+		expected bool
+	}{
+		{&tspb.Timestamp{}, true},
+		{new(0, 0), true},
+
+		{new(1, 0), true},
+		{new(0, 1), false},
+		{tspb.New(time.Time{}), false},
+	}
+
+	for i, tc := range tcs {
+		require.Equal(t, tc.expected, IsZero(tc.t), "test_id %d", i)
+	}
+}
+
+func TestCmpare(t *testing.T) {
+	tcs := []struct {
+		t1       *tspb.Timestamp
+		t2       *tspb.Timestamp
+		expected int
+	}{
+		{&tspb.Timestamp{}, &tspb.Timestamp{}, 0},
+		{new(1, 1), new(1, 1), 0},
+		{new(-1, 1), new(-1, 1), 0},
+		{new(231, -5), new(231, -5), 0},
+
+		{new(1, -1), new(1, 0), -1},
+		{new(1, -1), new(12, -1), -1},
+		{new(-11, -1), new(-1, -1), -1},
+
+		{new(1, -1), new(0, -1), 1},
+		{new(1, -1), new(1, -2), 1},
+	}
+	for i, tc := range tcs {
+		t.Run(fmt.Sprint("test ", i), func(t *testing.T) {
+			r := Compare(tc.t1, tc.t2)
+			require.Equal(t, tc.expected, r)
+		})
+	}
+}
+
+func TestAddFuzzy(t *testing.T) {
+	requier := require.New(t)
+	check := func(s, n int64, d time.Duration) {
+		t := time.Unix(s, n)
+		t_expected := t.Add(d)
+		tb := tspb.New(t)
+		tb = Add(tb, d)
+		requier.Equal(*tspb.New(t_expected), *tb)
+	}
+
+	for i := 0; i < 2000; i++ {
+		s, n, d := rand.Int63(), rand.Int63(), time.Duration(rand.Int63())
+		check(s, n, d)
+	}
+	check(0, 0, 0)
+	check(1, 2, 0)
+	check(-1, -1, 1)
+}

--- a/pbtime/cmp_test.go
+++ b/pbtime/cmp_test.go
@@ -33,7 +33,7 @@ func TestIsZero(t *testing.T) {
 	}
 }
 
-func TestCmpare(t *testing.T) {
+func TestCompare(t *testing.T) {
 	tcs := []struct {
 		t1       *tspb.Timestamp
 		t2       *tspb.Timestamp


### PR DESCRIPTION
## Description

Adding pbtime package bring more higher level functionality to protobuf.Timestamp (notably comparison).
With new proto directions we are going away from go stdlib time.Time.

Note, I put it into root, but maybe there is a better place?
---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)