### PR TITLE
fix(baseapp): fix race condition in state

### DIFF
--- a/baseapp/state.go
+++ b/baseapp/state.go
@@ -28,7 +28,7 @@ func (st *state) Context() sdk.Context {
 
 // WithContext update context of the state
 func (st *state) WithContext(ctx sdk.Context) {
-	defer st.lock.Unlock()
 	st.lock.Lock()
+	defer st.lock.Unlock()
 	st.ctx = ctx
 }

--- a/baseapp/state.go
+++ b/baseapp/state.go
@@ -1,12 +1,15 @@
 package baseapp
 
 import (
+	"sync"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 type state struct {
-	ms  sdk.CacheMultiStore
-	ctx sdk.Context
+	lock sync.RWMutex
+	ms   sdk.CacheMultiStore
+	ctx  sdk.Context
 }
 
 // CacheMultiStore calls and returns a CacheMultiStore on the state's underling
@@ -17,5 +20,15 @@ func (st *state) CacheMultiStore() sdk.CacheMultiStore {
 
 // Context returns the Context of the state.
 func (st *state) Context() sdk.Context {
+	defer st.lock.RUnlock()
+	st.lock.RLock()
+
 	return st.ctx
+}
+
+// WithContext update context of the state
+func (st *state) WithContext(ctx sdk.Context) {
+	defer st.lock.Unlock()
+	st.lock.Lock()
+	st.ctx = ctx
 }


### PR DESCRIPTION
as the state is not threadsafe when rpc and grpc are both active
race condition occurs

```
WARNING: DATA RACE
Write at 0x00c002a6cb50 by goroutine 125:
  github.com/cosmos/cosmos-sdk/baseapp.(*BaseApp).BeginBlock()
      /Users/amr/go/src/github.com/ovrclk/akash/vendor/github.com/cosmos/cosmos-sdk/baseapp/abci.go:187 +0x9b4
  github.com/ovrclk/akash/app.(*AkashApp).BeginBlock()
      <autogenerated>:1 +0x90
  github.com/tendermint/tendermint/abci/client.(*localClient).BeginBlockSync()
      /Users/amr/go/src/github.com/ovrclk/akash/vendor/github.com/tendermint/tendermint/abci/client/local_client.go:280 +0x120
  github.com/tendermint/tendermint/proxy.(*appConnConsensus).BeginBlockSync()
      /Users/amr/go/src/github.com/ovrclk/akash/vendor/github.com/tendermint/tendermint/proxy/app_conn.go:81 +0x8c
  github.com/tendermint/tendermint/state.execBlockOnProxyApp()
      /Users/amr/go/src/github.com/ovrclk/akash/vendor/github.com/tendermint/tendermint/state/execution.go:307 +0x480
  github.com/tendermint/tendermint/state.(*BlockExecutor).ApplyBlock()
      /Users/amr/go/src/github.com/ovrclk/akash/vendor/github.com/tendermint/tendermint/state/execution.go:140 +0x180
  github.com/tendermint/tendermint/consensus.(*State).finalizeCommit()
      /Users/amr/go/src/github.com/ovrclk/akash/vendor/github.com/tendermint/tendermint/consensus/state.go:1635 +0xda8
  github.com/tendermint/tendermint/consensus.(*State).tryFinalizeCommit()
      /Users/amr/go/src/github.com/ovrclk/akash/vendor/github.com/tendermint/tendermint/consensus/state.go:1546 +0x468
  github.com/tendermint/tendermint/consensus.(*State).enterCommit.func1()
      /Users/amr/go/src/github.com/ovrclk/akash/vendor/github.com/tendermint/tendermint/consensus/state.go:1481 +0x11c
  github.com/tendermint/tendermint/consensus.(*State).enterCommit()
      /Users/amr/go/src/github.com/ovrclk/akash/vendor/github.com/tendermint/tendermint/consensus/state.go:1519 +0x1264
  github.com/tendermint/tendermint/consensus.(*State).addVote()
      /Users/amr/go/src/github.com/ovrclk/akash/vendor/github.com/tendermint/tendermint/consensus/state.go:2132 +0x11fc
  github.com/tendermint/tendermint/consensus.(*State).tryAddVote()
      /Users/amr/go/src/github.com/ovrclk/akash/vendor/github.com/tendermint/tendermint/consensus/state.go:1930 +0x48
  github.com/tendermint/tendermint/consensus.(*State).handleMsg()
      /Users/amr/go/src/github.com/ovrclk/akash/vendor/github.com/tendermint/tendermint/consensus/state.go:838 +0x51c
  github.com/tendermint/tendermint/consensus.(*State).receiveRoutine()
      /Users/amr/go/src/github.com/ovrclk/akash/vendor/github.com/tendermint/tendermint/consensus/state.go:782 +0x5a0

Previous read at 0x00c002a6cb50 by goroutine 145:
  github.com/cosmos/cosmos-sdk/baseapp.(*BaseApp).createQueryContext()
      /Users/amr/go/src/github.com/ovrclk/akash/vendor/github.com/cosmos/cosmos-sdk/baseapp/abci.go:648 +0x3c4
  github.com/cosmos/cosmos-sdk/baseapp.(*BaseApp).RegisterGRPCServer.func1()
      /Users/amr/go/src/github.com/ovrclk/akash/vendor/github.com/cosmos/cosmos-sdk/baseapp/grpcserver.go:50 +0x2c0
  github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1.1.1()
      /Users/amr/go/src/github.com/ovrclk/akash/vendor/github.com/grpc-ecosystem/go-grpc-middleware/chain.go:25 +0x78
  github.com/grpc-ecosystem/go-grpc-middleware/recovery.UnaryServerInterceptor.func1()
      /Users/amr/go/src/github.com/ovrclk/akash/vendor/github.com/grpc-ecosystem/go-grpc-middleware/recovery/interceptors.go:33 +0xb8
  github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1.1.1()
      /Users/amr/go/src/github.com/ovrclk/akash/vendor/github.com/grpc-ecosystem/go-grpc-middleware/chain.go:25 +0x78
  github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1()
      /Users/amr/go/src/github.com/ovrclk/akash/vendor/github.com/grpc-ecosystem/go-grpc-middleware/chain.go:34 +0xf4
  github.com/cosmos/cosmos-sdk/x/bank/types._Query_AllBalances_Handler()
      /Users/amr/go/src/github.com/ovrclk/akash/vendor/github.com/cosmos/cosmos-sdk/x/bank/types/query.pb.go:943 +0x1bc
  github.com/cosmos/cosmos-sdk/baseapp.(*BaseApp).RegisterGRPCServer.func2()
      /Users/amr/go/src/github.com/ovrclk/akash/vendor/github.com/cosmos/cosmos-sdk/baseapp/grpcserver.go:80 +0x124
  google.golang.org/grpc.(*Server).processUnaryRPC()
      /Users/amr/go/src/github.com/ovrclk/akash/vendor/google.golang.org/grpc/server.go:1210 +0x11b4
  google.golang.org/grpc.(*Server).handleStream()
      /Users/amr/go/src/github.com/ovrclk/akash/vendor/google.golang.org/grpc/server.go:1533 +0xed8
  google.golang.org/grpc.(*Server).serveStreams.func1.2()
      /Users/amr/go/src/github.com/ovrclk/akash/vendor/google.golang.org/grpc/server.go:871 +0xa4
```

Signed-off-by: Artur Troian <troian.ap@gmail.com>