### PR TITLE
feat!: deprecate auth/types.NewModuleAddress

### DIFF
--- a/types/address/hash.go
+++ b/types/address/hash.go
@@ -59,13 +59,18 @@ func Compose(typ string, subAddresses []Addressable) ([]byte, error) {
 }
 
 // Module is a specialized version of a composed address for modules. Each module account
-// is constructed from a module name and module account key.
+// is constructed from a module name and a key for the new account. The key must be unique
+// in the module scope, and is usually constructed from some object id. Example, let's
+// a x/dao module, and a new DAO object, it's address would be:
+//     address.Module(dao.ModuleName, newDAO.ID)
 func Module(moduleName string, key []byte) []byte {
 	mKey := append([]byte(moduleName), 0)
 	return Hash("module", append(mKey, key...))
 }
 
 // Derive derives a new address from the main `address` and a derivation `key`.
+// This function is used to create a sub accounts. To create a module accounts (on
+// module level 1), use the `Module` function.
 func Derive(address []byte, key []byte) []byte {
 	return Hash(conv.UnsafeBytesToStr(address), key)
 }

--- a/x/auth/types/account.go
+++ b/x/auth/types/account.go
@@ -170,6 +170,13 @@ func NewModuleAddress(name string) sdk.AccAddress {
 	return sdk.AccAddress(crypto.AddressHash([]byte(name)))
 }
 
+// LegacyModuleAddress creates an AccAddress using module name hash.
+// This function doesn't follow ADR-028 and should not be used.
+// `types/address.Module(newAccouuntName, modKey)` should be used instead.
+func LegacyModuleAddress(name string) sdk.AccAddress {
+	return sdk.AccAddress(crypto.AddressHash([]byte(name)))
+}
+
 // NewEmptyModuleAccount creates a empty ModuleAccount from a string
 func NewEmptyModuleAccount(name string, permissions ...string) *ModuleAccount {
 	moduleAddress := NewModuleAddress(name)

--- a/x/auth/types/account.go
+++ b/x/auth/types/account.go
@@ -159,7 +159,13 @@ func (acc BaseAccount) UnpackInterfaces(unpacker codectypes.AnyUnpacker) error {
 	return unpacker.UnpackAny(acc.PubKey, &pubKey)
 }
 
-// NewModuleAddress creates an AccAddress from the hash of the module's name
+// Deprecated: NewModuleAddress creates an AccAddress from the hash of the module's name
+// This function doesn't follow ADR-028 and will be deleted in the next release. Use
+// `types/address.Module(newAccouuntName, modKey)` instead to cerate a module account. Eg:
+//    address.Module(dao.ModuleName, newDAO.ID)
+//  Above, newDAO.ID is an ID for a new DAO created in the x/dao module, for which we want to
+//  create an account. See also the `address.Derive` function which is used to derive new
+//  sub-accounts.
 func NewModuleAddress(name string) sdk.AccAddress {
 	return sdk.AccAddress(crypto.AddressHash([]byte(name)))
 }


### PR DESCRIPTION
## Description

Closes: #10225

Implementing  the option 2:
* deprecate NewModuleAddress (and update SDK to not use it in any place) and remove in the subsequent release (1.0).

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)