### PR TITLE
feat: min and max operators on coins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -171,6 +171,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (gov) [\#10854](https://github.com/cosmos/cosmos-sdk/pull/10854) v1beta2's vote doesn't include the deprecate `option VoteOption` anymore. Instead, it only uses `WeightedVoteOption`.
 * (types) [\#11004](https://github.com/cosmos/cosmos-sdk/pull/11004) Added mutable versions of many of the sdk.Dec types operations.  This improves performance when used by avoiding reallocating a new bigint for each operation.
 * (x/auth) [\#10880](https://github.com/cosmos/cosmos-sdk/pull/10880) Added a new query to the tx query service that returns a block with transactions fully decoded.
+* (types) [\#11200](https://github.com/cosmos/cosmos-sdk/pull/11200) Added `Min()` and `Max()` operations on sdk.Coins.
 
 ### Bug Fixes
 

--- a/types/coin.go
+++ b/types/coin.go
@@ -392,7 +392,8 @@ func (coins Coins) SafeSub(coinsB Coins) (Coins, bool) {
 
 // Max returns the maximum of each denom of its inputs.
 // The inputs should be sorted. Note that the max might
-// not be equal to either of its inputs.
+// not be equal to either of its inputs. Uses multiset
+// semantics, so unmentioned denoms are implicitly zero.
 func (coins Coins) Max(coinsB Coins) Coins {
 	// coins + coinsB = min(coins, coinsB) + max(coins, coinsB)
 	return coins.Add(coinsB...).Sub(coins.Min(coinsB))
@@ -400,7 +401,8 @@ func (coins Coins) Max(coinsB Coins) Coins {
 
 // Min returns the minimum of each denom of its inputs.
 // The inputs should be sorted. Note that the min might
-// not be equal to either of its inputs.
+// not be equal to either of its inputs. Uses multiset
+// semantics, so unmentioned denoms are implicitly zero.
 func (coins Coins) Min(coinsB Coins) Coins {
 	min := make([]Coin, 0)
 	for indexA, indexB := 0, 0; indexA < len(coins) && indexB < len(coinsB); {

--- a/types/coin.go
+++ b/types/coin.go
@@ -449,6 +449,8 @@ func (coins Coins) Max(coinsB Coins) Coins {
 // {1A, 3B, 2C}.Min({4A, 2B, 2C} == {1A, 2B, 2C})
 // {2A, 3B}.Min({1B, 4C}) == {1B}
 // {1A, 2B}.Min({3C}) == empty
+//
+// See also DecCoins.Intersect().
 func (coins Coins) Min(coinsB Coins) Coins {
 	min := make([]Coin, 0)
 	for indexA, indexB := 0, 0; indexA < len(coins) && indexB < len(coinsB); {
@@ -471,15 +473,6 @@ func (coins Coins) Min(coinsB Coins) Coins {
 		}
 	}
 	return NewCoins(min...)
-}
-
-// Intersect will return a new set of coins which coinains the minimum Coin
-// for common denoms found in both `coins` and `coinsB`. Identical to Min()
-// method and provided for compatibility with DecCoins. Note that the
-// corresponding Union() alias for Max() will not be provided since it is
-// dangerously confusable with Add().
-func (coins Coins) Intersect(coinsB Coins) Coins {
-	return coins.Min(coinsB)
 }
 
 // IsAllGT returns true if for every denom in coinsB,

--- a/types/coin.go
+++ b/types/coin.go
@@ -395,7 +395,7 @@ func (coins Coins) SafeSub(coinsB Coins) (Coins, bool) {
 // not be equal to either of its inputs. Uses multiset
 // semantics, so unmentioned denoms are implicitly zero.
 func (coins Coins) Max(coinsB Coins) Coins {
-	// coins + coinsB = min(coins, coinsB) + max(coins, coinsB)
+	// coins + coinsB == min(coins, coinsB) + max(coins, coinsB)
 	return coins.Add(coinsB...).Sub(coins.Min(coinsB))
 }
 
@@ -425,6 +425,15 @@ func (coins Coins) Min(coinsB Coins) Coins {
 		}
 	}
 	return NewCoins(min...)
+}
+
+// Intersect will return a new set of coins which coinains the minimum Coin
+// for common denoms found in both `coins` and `coinsB`. Identical to Min()
+// method and provided for compatibility with DecCoins. Note that the
+// corresponding Union() alias for Max() will not be provided since it is
+// dangerously confusable with Add().
+func (coins Coins) Intersect(coinsB Coins) Coins {
+	return coins.Min(coinsB)
 }
 
 // IsAllGT returns true if for every denom in coinsB,

--- a/types/coin_test.go
+++ b/types/coin_test.go
@@ -657,6 +657,33 @@ func (s *coinTestSuite) TestCoins_Validate() {
 	}
 }
 
+func (s *coinTestSuite) TestMinMax() {
+	one := sdk.OneInt()
+	two := sdk.NewInt(2)
+
+	cases := []struct {
+		name   string
+		input1 sdk.Coins
+		input2 sdk.Coins
+		min    sdk.Coins
+		max    sdk.Coins
+	}{
+		{"zero-zero", sdk.Coins{}, sdk.Coins{}, sdk.Coins{}, sdk.Coins{}},
+		{"zero-one", sdk.Coins{}, sdk.Coins{{testDenom1, one}}, sdk.Coins{}, sdk.Coins{{testDenom1, one}}},
+		{"two-zero", sdk.Coins{{testDenom2, two}}, sdk.Coins{}, sdk.Coins{}, sdk.Coins{{testDenom2, two}}},
+		{"disjoint", sdk.Coins{{testDenom1, one}}, sdk.Coins{{testDenom2, two}}, sdk.Coins{}, sdk.Coins{{testDenom1, one}, {testDenom2, two}}},
+		{"overlap", sdk.Coins{{testDenom1, one}, {testDenom2, two}}, sdk.Coins{{testDenom1, two}, {testDenom2, one}},
+			sdk.Coins{{testDenom1, one}, {testDenom2, one}}, sdk.Coins{{testDenom1, two}, {testDenom2, two}}},
+	}
+
+	for _, tc := range cases {
+		min := tc.input1.Min(tc.input2)
+		max := tc.input1.Max(tc.input2)
+		s.Require().True(min.IsEqual(tc.min), tc.name)
+		s.Require().True(max.IsEqual(tc.max), tc.name)
+	}
+}
+
 func (s *coinTestSuite) TestCoinsGT() {
 	one := sdk.OneInt()
 	two := sdk.NewInt(2)

--- a/types/coin_test.go
+++ b/types/coin_test.go
@@ -679,8 +679,10 @@ func (s *coinTestSuite) TestMinMax() {
 	for _, tc := range cases {
 		min := tc.input1.Min(tc.input2)
 		max := tc.input1.Max(tc.input2)
+		intersect := tc.input1.Intersect(tc.input2)
 		s.Require().True(min.IsEqual(tc.min), tc.name)
 		s.Require().True(max.IsEqual(tc.max), tc.name)
+		s.Require().True(intersect.IsEqual(tc.min), tc.name)
 	}
 }
 

--- a/types/coin_test.go
+++ b/types/coin_test.go
@@ -679,10 +679,8 @@ func (s *coinTestSuite) TestMinMax() {
 	for _, tc := range cases {
 		min := tc.input1.Min(tc.input2)
 		max := tc.input1.Max(tc.input2)
-		intersect := tc.input1.Intersect(tc.input2)
 		s.Require().True(min.IsEqual(tc.min), tc.name)
 		s.Require().True(max.IsEqual(tc.max), tc.name)
-		s.Require().True(intersect.IsEqual(tc.min), tc.name)
 	}
 }
 

--- a/types/dec_coin.go
+++ b/types/dec_coin.go
@@ -319,7 +319,7 @@ func (coins DecCoins) SafeSub(coinsB DecCoins) (DecCoins, bool) {
 // Intersect will return a new set of coins which contains the minimum DecCoin
 // for common denoms found in both `coins` and `coinsB`. For denoms not common
 // to both `coins` and `coinsB` the minimum is considered to be 0, thus they
-// are not added to the final set.In other words, trim any denom amount from
+// are not added to the final set. In other words, trim any denom amount from
 // coin which exceeds that of coinB, such that (coin.Intersect(coinB)).IsLTE(coinB).
 func (coins DecCoins) Intersect(coinsB DecCoins) DecCoins {
 	res := make([]DecCoin, len(coins))
@@ -331,6 +331,22 @@ func (coins DecCoins) Intersect(coinsB DecCoins) DecCoins {
 		res[i] = minCoin
 	}
 	return removeZeroDecCoins(res)
+}
+
+// Min returns the minimum of each denom of its inputs, including
+// the implicitly-zero absent denoms. Identical to Intersect() and
+// provided for compatibility with Coins.
+func (coins DecCoins) Min(coinsB DecCoins) DecCoins {
+	return coins.Intersect(coinsB)
+}
+
+// Max returns the maximum of each denom of its inputs, including
+// the implicitly-zero absent denoms. Though this is the
+// multiset union operation, that name is dangerously confusable
+// with Add(), and will not be used.
+func (coins DecCoins) Max(coinsB DecCoins) DecCoins {
+	// coins + coinsB == min(coins, coinsB) + max(coins, coinsB)
+	return coins.Add(coinsB...).Sub(coins.Min(coinsB))
 }
 
 // GetDenomByIndex returns the Denom to make the findDup generic

--- a/types/dec_coin.go
+++ b/types/dec_coin.go
@@ -321,6 +321,7 @@ func (coins DecCoins) SafeSub(coinsB DecCoins) (DecCoins, bool) {
 // to both `coins` and `coinsB` the minimum is considered to be 0, thus they
 // are not added to the final set. In other words, trim any denom amount from
 // coin which exceeds that of coinB, such that (coin.Intersect(coinB)).IsLTE(coinB).
+// See also Coins.Min().
 func (coins DecCoins) Intersect(coinsB DecCoins) DecCoins {
 	res := make([]DecCoin, len(coins))
 	for i, coin := range coins {
@@ -331,22 +332,6 @@ func (coins DecCoins) Intersect(coinsB DecCoins) DecCoins {
 		res[i] = minCoin
 	}
 	return removeZeroDecCoins(res)
-}
-
-// Min returns the minimum of each denom of its inputs, including
-// the implicitly-zero absent denoms. Identical to Intersect() and
-// provided for compatibility with Coins.
-func (coins DecCoins) Min(coinsB DecCoins) DecCoins {
-	return coins.Intersect(coinsB)
-}
-
-// Max returns the maximum of each denom of its inputs, including
-// the implicitly-zero absent denoms. Though this is the
-// multiset union operation, that name is dangerously confusable
-// with Add(), and will not be used.
-func (coins DecCoins) Max(coinsB DecCoins) DecCoins {
-	// coins + coinsB == min(coins, coinsB) + max(coins, coinsB)
-	return coins.Add(coinsB...).Sub(coins.Min(coinsB))
 }
 
 // GetDenomByIndex returns the Denom to make the findDup generic

--- a/x/auth/vesting/types/vesting_account.go
+++ b/x/auth/vesting/types/vesting_account.go
@@ -41,20 +41,10 @@ func NewBaseVestingAccount(baseAccount *authtypes.BaseAccount, originalVesting s
 //
 // CONTRACT: Delegated vesting coins and vestingCoins must be sorted.
 func (bva BaseVestingAccount) LockedCoinsFromVesting(vestingCoins sdk.Coins) sdk.Coins {
-	lockedCoins := sdk.NewCoins()
-
-	for _, vestingCoin := range vestingCoins {
-		vestingAmt := vestingCoin.Amount
-		delVestingAmt := bva.DelegatedVesting.AmountOf(vestingCoin.Denom)
-
-		max := sdk.MaxInt(vestingAmt.Sub(delVestingAmt), sdk.ZeroInt())
-		lockedCoin := sdk.NewCoin(vestingCoin.Denom, max)
-
-		if !lockedCoin.IsZero() {
-			lockedCoins = lockedCoins.Add(lockedCoin)
-		}
+	lockedCoins := vestingCoins.Sub(vestingCoins.Min(bva.DelegatedVesting))
+	if lockedCoins == nil {
+		return sdk.Coins{}
 	}
-
 	return lockedCoins
 }
 


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

Closes: #10995

Adds `Min()` and `Max()` operations on `sdk.Coins` for per-denom minimum and maximum.

Replaced an example of manual low-level construction of `Coins` with higher-level operators.
Upcoming enhancements to vesting accounts make heavy use of this pattern.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [X] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [X] added `!` to the type prefix if API or client breaking change
- [X] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [X] provided a link to the relevant issue or specification
- [X] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules)
- [X] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [X] added a changelog entry to `CHANGELOG.md`
- [X] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [X] updated the relevant documentation or specification
- [X] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)