### PR TITLE
feat!: remove Must*(Un)Marshal methods from Codec interface

### DIFF
--- a/codec/codec.go
+++ b/codec/codec.go
@@ -23,27 +23,16 @@ type (
 	BinaryCodec interface {
 		// Marshal returns binary encoding of v.
 		Marshal(o ProtoMarshaler) ([]byte, error)
-		// MustMarshal calls Marshal and panics if error is returned.
-		MustMarshal(o ProtoMarshaler) []byte
-
 		// MarshalLengthPrefixed returns binary encoding of v with bytes length prefix.
 		MarshalLengthPrefixed(o ProtoMarshaler) ([]byte, error)
-		// MustMarshalLengthPrefixed calls MarshalLengthPrefixed and panics if
-		// error is returned.
-		MustMarshalLengthPrefixed(o ProtoMarshaler) []byte
 
 		// Unmarshal parses the data encoded with Marshal method and stores the result
 		// in the value pointed to by v.
 		Unmarshal(bz []byte, ptr ProtoMarshaler) error
-		// MustUnmarshal calls Unmarshal and panics if error is returned.
-		MustUnmarshal(bz []byte, ptr ProtoMarshaler)
 
 		// Unmarshal parses the data encoded with UnmarshalLengthPrefixed method and stores
 		// the result in the value pointed to by v.
 		UnmarshalLengthPrefixed(bz []byte, ptr ProtoMarshaler) error
-		// MustUnmarshalLengthPrefixed calls UnmarshalLengthPrefixed and panics if error
-		// is returned.
-		MustUnmarshalLengthPrefixed(bz []byte, ptr ProtoMarshaler)
 
 		// MarshalInterface is a helper method which will wrap `i` into `Any` for correct
 		// binary interface (de)serialization.
@@ -59,8 +48,6 @@ type (
 	JSONCodec interface {
 		// MarshalJSON returns JSON encoding of v.
 		MarshalJSON(o proto.Message) ([]byte, error)
-		// MustMarshalJSON calls MarshalJSON and panics if error is returned.
-		MustMarshalJSON(o proto.Message) []byte
 		// MarshalInterfaceJSON is a helper method which will wrap `i` into `Any` for correct
 		// JSON interface (de)serialization.
 		MarshalInterfaceJSON(i proto.Message) ([]byte, error)
@@ -72,8 +59,6 @@ type (
 		// UnmarshalJSON parses the data encoded with MarshalJSON method and stores the result
 		// in the value pointed to by v.
 		UnmarshalJSON(bz []byte, ptr proto.Message) error
-		// MustUnmarshalJSON calls Unmarshal and panics if error is returned.
-		MustUnmarshalJSON(bz []byte, ptr proto.Message)
 	}
 
 	// ProtoMarshaler defines an interface a type must implement to serialize itself


### PR DESCRIPTION
Must* methods are definitely abused in Cosmos SDK. It's harder to make good tests, and the API doesn't allow to have a good error flow.

`panic` should be rather limited to a bad use of our API. Not to the processing errors. `panic` should not happen in the runtime if a user is using our API correctly.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)