### PR TITLE
feat: Add exhaustivestruct linter to error on uninitialized struct fields

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -27,6 +27,7 @@ linters:
     - revive
     - staticcheck
     - structcheck
+    - exhaustivestruct
     - stylecheck
     - typecheck
     - unconvert

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,6 +11,7 @@ linters:
     - depguard
     - dogsled
     # - errcheck
+    - exhaustivestruct
     - exportloopref
     - goconst
     - gocritic
@@ -27,7 +28,6 @@ linters:
     - revive
     - staticcheck
     - structcheck
-    - exhaustivestruct
     - stylecheck
     - typecheck
     - unconvert

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Features
 
+* [\#11250](https://github.com/cosmos/cosmos-sdk/pull/11250) Add exhaustivestruct linter to error on uninitialized struct fields.
 * (x/upgrade) [\#11116](https://github.com/cosmos/cosmos-sdk/pull/11116) `MsgSoftwareUpgrade` and  has been added to support v1beta2 msgs-based gov proposals.
 * [\#11308](https://github.com/cosmos/cosmos-sdk/pull/11308) Added a mandatory metadata field to Vote in x/gov v1beta2.
 * [\#10977](https://github.com/cosmos/cosmos-sdk/pull/10977) Now every cosmos message protobuf definition must be extended with a ``cosmos.msg.v1.signer`` option to signal the signer fields in a language agnostic way.

--- a/baseapp/grpcrouter.go
+++ b/baseapp/grpcrouter.go
@@ -30,7 +30,7 @@ type serviceData struct {
 	handler     interface{}
 }
 
-var _ gogogrpc.Server = &GRPCQueryRouter{}
+var _ gogogrpc.Server = &GRPCQueryRouter{} // nolint: exhaustivestruct
 
 // NewGRPCQueryRouter creates a new GRPCQueryRouter
 func NewGRPCQueryRouter() *GRPCQueryRouter {

--- a/baseapp/grpcrouter_helpers.go
+++ b/baseapp/grpcrouter_helpers.go
@@ -21,6 +21,7 @@ type QueryServiceTestHelper struct {
 	Ctx sdk.Context
 }
 
+// nolint: exhaustivestruct
 var (
 	_ gogogrpc.Server     = &QueryServiceTestHelper{}
 	_ gogogrpc.ClientConn = &QueryServiceTestHelper{}

--- a/client/config/cmd.go
+++ b/client/config/cmd.go
@@ -16,7 +16,7 @@ import (
 // Cmd returns a CLI command to interactively create an application CLI
 // config file.
 func Cmd() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "config <key> [value]",
 		Short: "Create or query an application CLI configuration file",
 		RunE:  runConfigCmd,

--- a/client/debug/main.go
+++ b/client/debug/main.go
@@ -26,7 +26,7 @@ var (
 
 // Cmd creates a main CLI command
 func Cmd() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "debug",
 		Short: "Tool for helping with debugging your application",
 		RunE:  client.ValidateCmd,
@@ -48,7 +48,7 @@ func getPubKeyFromString(ctx client.Context, pkstr string) (cryptotypes.PubKey, 
 }
 
 func PubkeyCmd() *cobra.Command {
-	return &cobra.Command{
+	return &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "pubkey [pubkey]",
 		Short: "Decode a pubkey from proto JSON",
 		Long: fmt.Sprintf(`Decode a pubkey from proto JSON and display it's address.
@@ -123,7 +123,7 @@ func getPubKeyFromRawString(pkstr string, keytype string) (cryptotypes.PubKey, e
 }
 
 func PubkeyRawCmd() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "pubkey-raw [pubkey] -t [{ed25519, secp256k1}]",
 		Short: "Decode a ED25519 or secp256k1 pubkey from hex, base64, or bech32",
 		Long: fmt.Sprintf(`Decode a pubkey from hex, base64, or bech32.
@@ -190,7 +190,7 @@ $ %s debug pubkey-raw cosmos1e0jnq2sun3dzjh8p2xq95kk0expwmd7shwjpfg
 }
 
 func AddrCmd() *cobra.Command {
-	return &cobra.Command{
+	return &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "addr [address]",
 		Short: "Convert an address between hex and bech32",
 		Long: fmt.Sprintf(`Convert an address between hex encoding and bech32.
@@ -231,7 +231,7 @@ $ %s debug addr cosmos1e0jnq2sun3dzjh8p2xq95kk0expwmd7shwjpfg
 }
 
 func RawBytesCmd() *cobra.Command {
-	return &cobra.Command{
+	return &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "raw-bytes [raw-bytes]",
 		Short: "Convert raw bytes output (eg. [10 21 13 255]) to hex",
 		Long: fmt.Sprintf(`Convert raw-bytes to hex.

--- a/client/flags/flags.go
+++ b/client/flags/flags.go
@@ -85,7 +85,7 @@ const (
 
 // LineBreak can be included in a command list to provide a blank line
 // to help with readability
-var LineBreak = &cobra.Command{Run: func(*cobra.Command, []string) {}}
+var LineBreak = &cobra.Command{Run: func(*cobra.Command, []string) {}} // nolint: exhaustivestruct
 
 // AddQueryFlagsToCmd adds common flags to a module query command.
 func AddQueryFlagsToCmd(cmd *cobra.Command) {

--- a/client/grpc/tmservice/service.go
+++ b/client/grpc/tmservice/service.go
@@ -22,8 +22,8 @@ type queryServer struct {
 	interfaceRegistry codectypes.InterfaceRegistry
 }
 
-var _ ServiceServer = queryServer{}
-var _ codectypes.UnpackInterfacesMessage = &GetLatestValidatorSetResponse{}
+var _ ServiceServer = queryServer{}                                         // nolint: exhaustivestruct
+var _ codectypes.UnpackInterfacesMessage = &GetLatestValidatorSetResponse{} // nolint: exhaustivestruct
 
 // NewQueryServer creates a new tendermint query server.
 func NewQueryServer(clientCtx client.Context, interfaceRegistry codectypes.InterfaceRegistry) ServiceServer {

--- a/client/grpc_query.go
+++ b/client/grpc_query.go
@@ -4,11 +4,13 @@ import (
 	gocontext "context"
 	"errors"
 	"fmt"
-	"github.com/cosmos/cosmos-sdk/codec"
-	proto "github.com/gogo/protobuf/proto"
-	"google.golang.org/grpc/encoding"
 	"reflect"
 	"strconv"
+
+	proto "github.com/gogo/protobuf/proto"
+	"google.golang.org/grpc/encoding"
+
+	"github.com/cosmos/cosmos-sdk/codec"
 
 	gogogrpc "github.com/gogo/protobuf/grpc"
 	abci "github.com/tendermint/tendermint/abci/types"
@@ -21,7 +23,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/tx"
 )
 
-var _ gogogrpc.ClientConn = Context{}
+var _ gogogrpc.ClientConn = Context{} // nolint: exhaustivestruct
 
 // fallBackCodec is used by Context in case Codec is not set.
 // it can process every gRPC type, except the ones which contain

--- a/client/keys/add.go
+++ b/client/keys/add.go
@@ -37,7 +37,7 @@ const (
 
 // AddKeyCommand defines a keys command to add a generated or recovered private key to keybase.
 func AddKeyCommand() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "add <name>",
 		Short: "Add an encrypted private key (either newly generated or recovered), encrypt it, and save to <name> file",
 		Long: `Derive a new private key and encrypt to disk.

--- a/client/keys/delete.go
+++ b/client/keys/delete.go
@@ -17,7 +17,7 @@ const (
 
 // DeleteKeyCommand deletes a key from the key store.
 func DeleteKeyCommand() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "delete <name>...",
 		Short: "Delete the given keys",
 		Long: `Delete keys from the Keybase backend.

--- a/client/keys/export.go
+++ b/client/keys/export.go
@@ -18,7 +18,7 @@ const (
 
 // ExportKeyCommand exports private keys from the key store.
 func ExportKeyCommand() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "export <name>",
 		Short: "Export private keys",
 		Long: `Export a private key from the local keyring in ASCII-armored encrypted format.

--- a/client/keys/import.go
+++ b/client/keys/import.go
@@ -12,7 +12,7 @@ import (
 
 // ImportKeyCommand imports private keys from a keyfile.
 func ImportKeyCommand() *cobra.Command {
-	return &cobra.Command{
+	return &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "import <name> <keyfile>",
 		Short: "Import private keys into the local keybase",
 		Long:  "Import a ASCII armored private key into the local keybase.",

--- a/client/keys/list.go
+++ b/client/keys/list.go
@@ -10,7 +10,7 @@ const flagListNames = "list-names"
 
 // ListKeysCmd lists all keys in the key store.
 func ListKeysCmd() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "list",
 		Short: "List all keys",
 		Long: `Return a list of all public keys stored by this key manager

--- a/client/keys/migrate.go
+++ b/client/keys/migrate.go
@@ -8,7 +8,7 @@ import (
 
 // MigrateCommand migrates key information from legacy keybase to OS secret store.
 func MigrateCommand() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "migrate",
 		Short: "Migrate keys from amino to proto serialization format",
 		Long: `Migrate keys from Amino to Protocol Buffers records.

--- a/client/keys/mnemonic.go
+++ b/client/keys/mnemonic.go
@@ -19,7 +19,7 @@ const (
 
 // MnemonicKeyCommand computes the bip39 memonic for input entropy.
 func MnemonicKeyCommand() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "mnemonic",
 		Short: "Compute the bip39 mnemonic for some input entropy",
 		Long:  "Create a bip39 mnemonic, sometimes called a seed phrase, by reading from the system entropy. To pass your own entropy, use --unsafe-entropy",

--- a/client/keys/parse.go
+++ b/client/keys/parse.go
@@ -71,7 +71,7 @@ func (bo bech32Output) String() string {
 
 // ParseKeyStringCommand parses an address from hex to bech32 and vice versa.
 func ParseKeyStringCommand() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "parse <hex-or-bech32-address>",
 		Short: "Parse address from hex to bech32 and vice versa",
 		Long: `Convert and print to stdout key addresses and fingerprints from

--- a/client/keys/rename.go
+++ b/client/keys/rename.go
@@ -13,7 +13,7 @@ import (
 
 // RenameKeyCommand renames a key from the key store.
 func RenameKeyCommand() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "rename <old_name> <new_name>",
 		Short: "Rename an existing key",
 		Long: `Rename a key from the Keybase backend.

--- a/client/keys/root.go
+++ b/client/keys/root.go
@@ -10,7 +10,7 @@ import (
 // Commands registers a sub-tree of commands to interact with
 // local private key storage.
 func Commands(defaultNodeHome string) *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "keys",
 		Short: "Manage your application's keys",
 		Long: `Keyring management commands. These keys may be in any format supported by the

--- a/client/keys/show.go
+++ b/client/keys/show.go
@@ -31,7 +31,7 @@ const (
 
 // ShowKeysCmd shows key information for a given key name.
 func ShowKeysCmd() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "show [name_or_address [name_or_address...]]",
 		Short: "Retrieve key information by name or address",
 		Long: `Display keys details. If multiple names or addresses are provided,

--- a/client/rpc/block.go
+++ b/client/rpc/block.go
@@ -14,7 +14,7 @@ import (
 
 // BlockCommand returns the verified block data for a given heights
 func BlockCommand() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "block [height]",
 		Short: "Get verified data for the block at given height",
 		Args:  cobra.MaximumNArgs(1),

--- a/client/rpc/status.go
+++ b/client/rpc/status.go
@@ -33,7 +33,7 @@ type resultStatus struct {
 
 // StatusCommand returns the command to return the status of the network.
 func StatusCommand() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "status",
 		Short: "Query remote node for status",
 		RunE: func(cmd *cobra.Command, _ []string) error {

--- a/client/rpc/validators.go
+++ b/client/rpc/validators.go
@@ -22,7 +22,7 @@ import (
 
 // ValidatorCommand returns the validator set for a given height
 func ValidatorCommand() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "tendermint-validator-set [height]",
 		Short: "Get the full tendermint validator set at given height",
 		Args:  cobra.MaximumNArgs(1),

--- a/client/test_helpers.go
+++ b/client/test_helpers.go
@@ -7,6 +7,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
+// nolint: exhaustivestruct
 var (
 	_ AccountRetriever = TestAccountRetriever{}
 	_ Account          = TestAccount{}

--- a/client/tx/legacy.go
+++ b/client/tx/legacy.go
@@ -26,7 +26,7 @@ func ConvertTxToStdTx(codec *codec.LegacyAmino, tx signing.Tx) (legacytx.StdTx, 
 
 	stdTx, ok := builder.GetTx().(legacytx.StdTx)
 	if !ok {
-		return legacytx.StdTx{}, fmt.Errorf("expected %T, got %+v", legacytx.StdTx{}, builder.GetTx())
+		return legacytx.StdTx{}, fmt.Errorf("expected %T, got %+v", legacytx.StdTx{}, builder.GetTx()) // nolint: exhaustivestruct
 	}
 
 	return stdTx, nil

--- a/codec/amino.go
+++ b/codec/amino.go
@@ -29,6 +29,7 @@ func NewLegacyAmino() *LegacyAmino {
 
 // RegisterEvidences registers Tendermint evidence types with the provided Amino
 // codec.
+// nolint: exhaustivestruct
 func RegisterEvidences(cdc *LegacyAmino) {
 	cdc.Amino.RegisterInterface((*tmtypes.Evidence)(nil), nil)
 	cdc.Amino.RegisterConcrete(&tmtypes.DuplicateVoteEvidence{}, "tendermint/DuplicateVoteEvidence", nil)

--- a/codec/amino_codec.go
+++ b/codec/amino_codec.go
@@ -10,7 +10,7 @@ type AminoCodec struct {
 	*LegacyAmino
 }
 
-var _ Codec = &AminoCodec{}
+var _ Codec = &AminoCodec{} // nolint: exhaustivestruct
 
 // NewAminoCodec returns a reference to a new AminoCodec
 func NewAminoCodec(codec *LegacyAmino) *AminoCodec {

--- a/codec/proto_codec.go
+++ b/codec/proto_codec.go
@@ -29,8 +29,8 @@ type ProtoCodec struct {
 	interfaceRegistry types.InterfaceRegistry
 }
 
-var _ Codec = &ProtoCodec{}
-var _ ProtoCodecMarshaler = &ProtoCodec{}
+var _ Codec = &ProtoCodec{}               // nolint: exhaustivestruct
+var _ ProtoCodecMarshaler = &ProtoCodec{} // nolint: exhaustivestruct
 
 // NewProtoCodec returns a reference to a new ProtoCodec
 func NewProtoCodec(interfaceRegistry types.InterfaceRegistry) *ProtoCodec {

--- a/codec/types/compat.go
+++ b/codec/types/compat.go
@@ -72,7 +72,7 @@ type AminoUnpacker struct {
 	Cdc *amino.Codec
 }
 
-var _ AnyUnpacker = AminoUnpacker{}
+var _ AnyUnpacker = AminoUnpacker{} // nolint: exhaustivestruct
 
 func (a AminoUnpacker) UnpackAny(any *Any, iface interface{}) error {
 	ac := any.compat
@@ -109,7 +109,7 @@ type AminoPacker struct {
 	Cdc *amino.Codec
 }
 
-var _ AnyUnpacker = AminoPacker{}
+var _ AnyUnpacker = AminoPacker{} // nolint: exhaustivestruct
 
 func (a AminoPacker) UnpackAny(any *Any, _ interface{}) error {
 	err := UnpackInterfaces(any.cachedValue, a)
@@ -130,7 +130,7 @@ type AminoJSONUnpacker struct {
 	Cdc *amino.Codec
 }
 
-var _ AnyUnpacker = AminoJSONUnpacker{}
+var _ AnyUnpacker = AminoJSONUnpacker{} // nolint: exhaustivestruct
 
 func (a AminoJSONUnpacker) UnpackAny(any *Any, iface interface{}) error {
 	ac := any.compat
@@ -167,7 +167,7 @@ type AminoJSONPacker struct {
 	Cdc *amino.Codec
 }
 
-var _ AnyUnpacker = AminoJSONPacker{}
+var _ AnyUnpacker = AminoJSONPacker{} // nolint: exhaustivestruct
 
 func (a AminoJSONPacker) UnpackAny(any *Any, _ interface{}) error {
 	err := UnpackInterfaces(any.cachedValue, a)
@@ -187,7 +187,7 @@ type ProtoJSONPacker struct {
 	JSONPBMarshaler *jsonpb.Marshaler
 }
 
-var _ AnyUnpacker = ProtoJSONPacker{}
+var _ AnyUnpacker = ProtoJSONPacker{} // nolint: exhaustivestruct
 
 func (a ProtoJSONPacker) UnpackAny(any *Any, _ interface{}) error {
 	if any == nil {

--- a/codec/types/types_test.go
+++ b/codec/types/types_test.go
@@ -35,6 +35,7 @@ type TestI interface {
 // concrete type.
 type FakeDog struct{}
 
+// nolint: exhaustivestruct
 var (
 	_ proto.Message   = &FakeDog{}
 	_ testdata.Animal = &FakeDog{}

--- a/crypto/codec/amino.go
+++ b/crypto/codec/amino.go
@@ -1,3 +1,4 @@
+// nolint: exhaustivestruct
 package codec
 
 import (

--- a/crypto/codec/proto.go
+++ b/crypto/codec/proto.go
@@ -1,3 +1,4 @@
+// nolint: exhaustivestruct
 package codec
 
 import (

--- a/crypto/keyring/codec.go
+++ b/crypto/keyring/codec.go
@@ -1,3 +1,4 @@
+// nolint: exhaustivestruct
 package keyring
 
 import (

--- a/crypto/keyring/keyring.go
+++ b/crypto/keyring/keyring.go
@@ -15,6 +15,8 @@ import (
 	"github.com/tendermint/crypto/bcrypt"
 	tmcrypto "github.com/tendermint/tendermint/crypto"
 
+	"github.com/cosmos/go-bip39"
+
 	"github.com/cosmos/cosmos-sdk/client/input"
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/crypto"
@@ -23,7 +25,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/crypto/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-	"github.com/cosmos/go-bip39"
 )
 
 // Backend options for Keyring
@@ -46,7 +47,7 @@ const (
 )
 
 var (
-	_                          Keyring = &keystore{}
+	_                          Keyring = &keystore{} // nolint: exhaustivestruct
 	maxPassphraseEntryAttempts         = 3
 )
 

--- a/crypto/keyring/legacy_info.go
+++ b/crypto/keyring/legacy_info.go
@@ -27,6 +27,7 @@ type LegacyInfo interface {
 	GetAlgo() hd.PubKeyType
 }
 
+// nolint: exhaustivestruct
 var (
 	_ LegacyInfo = &legacyLocalInfo{}
 	_ LegacyInfo = &legacyLedgerInfo{}

--- a/crypto/keys/ed25519/ed25519.go
+++ b/crypto/keys/ed25519/ed25519.go
@@ -34,8 +34,8 @@ const (
 	keyType = "ed25519"
 )
 
-var _ cryptotypes.PrivKey = &PrivKey{}
-var _ codec.AminoMarshaler = &PrivKey{}
+var _ cryptotypes.PrivKey = &PrivKey{}  // nolint: exhaustivestruct
+var _ codec.AminoMarshaler = &PrivKey{} // nolint: exhaustivestruct
 
 // Bytes returns the privkey byte format.
 func (privKey *PrivKey) Bytes() []byte {
@@ -150,8 +150,8 @@ func GenPrivKeyFromSecret(secret []byte) *PrivKey {
 
 //-------------------------------------
 
-var _ cryptotypes.PubKey = &PubKey{}
-var _ codec.AminoMarshaler = &PubKey{}
+var _ cryptotypes.PubKey = &PubKey{}   // nolint: exhaustivestruct
+var _ codec.AminoMarshaler = &PubKey{} // nolint: exhaustivestruct
 
 // Address is the SHA256-20 of the raw pubkey bytes.
 // It doesn't implement ADR-28 addresses and it must not be used

--- a/crypto/keys/multisig/codec.go
+++ b/crypto/keys/multisig/codec.go
@@ -1,3 +1,4 @@
+// nolint: exhaustivestruct
 package multisig
 
 import (

--- a/crypto/keys/multisig/multisig.go
+++ b/crypto/keys/multisig/multisig.go
@@ -11,8 +11,8 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/tx/signing"
 )
 
-var _ multisigtypes.PubKey = &LegacyAminoPubKey{}
-var _ types.UnpackInterfacesMessage = &LegacyAminoPubKey{}
+var _ multisigtypes.PubKey = &LegacyAminoPubKey{}          // nolint: exhaustivestruct
+var _ types.UnpackInterfacesMessage = &LegacyAminoPubKey{} // nolint: exhaustivestruct
 
 // NewLegacyAminoPubKey returns a new LegacyAminoPubKey.
 // Multisig can be constructed with multiple same keys - it will increase the power of

--- a/crypto/keys/secp256k1/secp256k1.go
+++ b/crypto/keys/secp256k1/secp256k1.go
@@ -17,8 +17,8 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/errors"
 )
 
-var _ cryptotypes.PrivKey = &PrivKey{}
-var _ codec.AminoMarshaler = &PrivKey{}
+var _ cryptotypes.PrivKey = &PrivKey{}  // nolint: exhaustivestruct
+var _ codec.AminoMarshaler = &PrivKey{} // nolint: exhaustivestruct
 
 const (
 	PrivKeySize = 32
@@ -138,8 +138,8 @@ func GenPrivKeyFromSecret(secret []byte) *PrivKey {
 
 //-------------------------------------
 
-var _ cryptotypes.PubKey = &PubKey{}
-var _ codec.AminoMarshaler = &PubKey{}
+var _ cryptotypes.PubKey = &PubKey{}   // nolint: exhaustivestruct
+var _ codec.AminoMarshaler = &PubKey{} // nolint: exhaustivestruct
 
 // PubKeySize is comprised of 32 bytes for one field element
 // (the x-coordinate), plus one byte for the parity of the y-coordinate.

--- a/crypto/keys/secp256r1/privkey_internal_test.go
+++ b/crypto/keys/secp256r1/privkey_internal_test.go
@@ -12,7 +12,7 @@ import (
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 )
 
-var _ cryptotypes.PrivKey = &PrivKey{}
+var _ cryptotypes.PrivKey = &PrivKey{} // nolint: exhaustivestruct
 
 func TestSKSuite(t *testing.T) {
 	suite.Run(t, new(SKSuite))

--- a/crypto/ledger/amino.go
+++ b/crypto/ledger/amino.go
@@ -1,3 +1,4 @@
+// nolint: exhaustivestruct
 package ledger
 
 import (

--- a/orm/encoding/ormkv/entry.go
+++ b/orm/encoding/ormkv/entry.go
@@ -136,4 +136,4 @@ func (s *SeqEntry) String() string {
 	return fmt.Sprintf("SEQ %s %d", s.TableName, s.Value)
 }
 
-var _, _, _ Entry = &PrimaryKeyEntry{}, &IndexKeyEntry{}, &SeqEntry{}
+var _, _, _ Entry = &PrimaryKeyEntry{}, &IndexKeyEntry{}, &SeqEntry{} // nolint: exhaustivestruct

--- a/orm/encoding/ormkv/index_key.go
+++ b/orm/encoding/ormkv/index_key.go
@@ -15,7 +15,7 @@ type IndexKeyCodec struct {
 	pkFieldOrder []int
 }
 
-var _ IndexCodec = &IndexKeyCodec{}
+var _ IndexCodec = &IndexKeyCodec{} // nolint: exhaustivestruct
 
 // NewIndexKeyCodec creates a new IndexKeyCodec with an optional prefix for the
 // provided message descriptor, index and primary key fields.

--- a/orm/encoding/ormkv/primary_key.go
+++ b/orm/encoding/ormkv/primary_key.go
@@ -17,7 +17,7 @@ type PrimaryKeyCodec struct {
 	unmarshalOptions proto.UnmarshalOptions
 }
 
-var _ IndexCodec = &PrimaryKeyCodec{}
+var _ IndexCodec = &PrimaryKeyCodec{} // nolint: exhaustivestruct
 
 // NewPrimaryKeyCodec creates a new PrimaryKeyCodec for the provided msg and
 // fields, with an optional prefix and unmarshal options.
@@ -33,7 +33,7 @@ func NewPrimaryKeyCodec(prefix []byte, msgType protoreflect.MessageType, fieldNa
 	}, nil
 }
 
-var _ IndexCodec = PrimaryKeyCodec{}
+var _ IndexCodec = PrimaryKeyCodec{} // nolint: exhaustivestruct
 
 func (p PrimaryKeyCodec) DecodeIndexKey(k, _ []byte) (indexFields, primaryKey []protoreflect.Value, err error) {
 	indexFields, err = p.DecodeKey(bytes.NewReader(k))

--- a/orm/encoding/ormkv/seq.go
+++ b/orm/encoding/ormkv/seq.go
@@ -20,7 +20,7 @@ func NewSeqCodec(messageType protoreflect.MessageType, prefix []byte) *SeqCodec 
 	return &SeqCodec{messageType: messageType.Descriptor().FullName(), prefix: prefix}
 }
 
-var _ EntryCodec = &SeqCodec{}
+var _ EntryCodec = &SeqCodec{} // nolint: exhaustivestruct
 
 func (s SeqCodec) DecodeEntry(k, v []byte) (Entry, error) {
 	if !bytes.Equal(k, s.prefix) {

--- a/orm/encoding/ormkv/unique_key.go
+++ b/orm/encoding/ormkv/unique_key.go
@@ -19,7 +19,7 @@ type UniqueKeyCodec struct {
 	valueCodec *KeyCodec
 }
 
-var _ IndexCodec = &UniqueKeyCodec{}
+var _ IndexCodec = &UniqueKeyCodec{} // nolint: exhaustivestruct
 
 // NewUniqueKeyCodec creates a new UniqueKeyCodec with an optional prefix for the
 // provided message descriptor, index and primary key fields.

--- a/orm/internal/testkv/debug.go
+++ b/orm/internal/testkv/debug.go
@@ -138,7 +138,7 @@ func (t debugStore) Delete(key []byte) error {
 	return nil
 }
 
-var _ kv.Store = &debugStore{}
+var _ kv.Store = &debugStore{} // nolint: exhaustivestruct
 
 type debugIterator struct {
 	iterator  kv.Iterator
@@ -186,7 +186,7 @@ func (d debugIterator) Close() error {
 	return d.iterator.Close()
 }
 
-var _ kv.Iterator = &debugIterator{}
+var _ kv.Iterator = &debugIterator{} // nolint: exhaustivestruct
 
 // EntryCodecDebugger is a Debugger instance that uses an EntryCodec and Print
 // function for debugging.

--- a/orm/model/ormdb/file.go
+++ b/orm/model/ormdb/file.go
@@ -119,4 +119,4 @@ func (f fileDescriptorDB) EncodeEntry(entry ormkv.Entry) (k, v []byte, err error
 	return table.EncodeEntry(entry)
 }
 
-var _ ormkv.EntryCodec = fileDescriptorDB{}
+var _ ormkv.EntryCodec = fileDescriptorDB{} // nolint: exhaustivestruct

--- a/orm/model/ormtable/auto_increment.go
+++ b/orm/model/ormtable/auto_increment.go
@@ -236,4 +236,4 @@ func (t *autoIncrementTable) GetTable(message proto.Message) Table {
 	return nil
 }
 
-var _ AutoIncrementTable = &autoIncrementTable{}
+var _ AutoIncrementTable = &autoIncrementTable{} // nolint: exhaustivestruct

--- a/orm/model/ormtable/batch.go
+++ b/orm/model/ormtable/batch.go
@@ -126,4 +126,4 @@ func (b *batchStoreWriter) append(entry *batchWriterEntry) {
 	b.curBuf = append(b.curBuf, entry)
 }
 
-var _ Backend = &batchIndexCommitmentWriter{}
+var _ Backend = &batchIndexCommitmentWriter{} // nolint: exhaustivestruct

--- a/orm/model/ormtable/index_impl.go
+++ b/orm/model/ormtable/index_impl.go
@@ -61,8 +61,8 @@ func (i indexKeyIndex) ListRange(ctx context.Context, from, to []interface{}, op
 	return rangeIterator(backend.IndexStoreReader(), backend, i, i.KeyCodec, from, to, options)
 }
 
-var _ indexer = &indexKeyIndex{}
-var _ Index = &indexKeyIndex{}
+var _ indexer = &indexKeyIndex{} // nolint: exhaustivestruct
+var _ Index = &indexKeyIndex{}   // nolint: exhaustivestruct
 
 func (i indexKeyIndex) doNotImplement() {}
 

--- a/orm/model/ormtable/iterator.go
+++ b/orm/model/ormtable/iterator.go
@@ -262,4 +262,4 @@ func (i indexIterator) Close() {
 
 func (indexIterator) doNotImplement() {}
 
-var _ Iterator = &indexIterator{}
+var _ Iterator = &indexIterator{} // nolint: exhaustivestruct

--- a/orm/model/ormtable/primary_key.go
+++ b/orm/model/ormtable/primary_key.go
@@ -241,4 +241,4 @@ func (p primaryKeyIndex) deleteByIterator(ctx context.Context, it Iterator) erro
 	return writer.Write()
 }
 
-var _ UniqueIndex = &primaryKeyIndex{}
+var _ UniqueIndex = &primaryKeyIndex{} // nolint: exhaustivestruct

--- a/orm/model/ormtable/table_impl.go
+++ b/orm/model/ormtable/table_impl.go
@@ -414,8 +414,8 @@ func (t tableImpl) Get(ctx context.Context, message proto.Message) (found bool, 
 	return t.primaryKeyIndex.get(backend, message, keyValues)
 }
 
-var _ Table = &tableImpl{}
-var _ Schema = &tableImpl{}
+var _ Table = &tableImpl{}  // nolint: exhaustivestruct
+var _ Schema = &tableImpl{} // nolint: exhaustivestruct
 
 type saveMode int
 

--- a/orm/model/ormtable/table_test.go
+++ b/orm/model/ormtable/table_test.go
@@ -682,7 +682,7 @@ func (m *IndexModel) Swap(i, j int) {
 	m.data[j] = x
 }
 
-var _ sort.Interface = &IndexModel{}
+var _ sort.Interface = &IndexModel{} // nolint: exhaustivestruct
 
 func TestJSONExportImport(t *testing.T) {
 	table, err := ormtable.Build(ormtable.Options{

--- a/orm/model/ormtable/unique.go
+++ b/orm/model/ormtable/unique.go
@@ -190,8 +190,8 @@ func (u uniqueKeyIndex) Fields() string {
 	return u.fields.String()
 }
 
-var _ indexer = &uniqueKeyIndex{}
-var _ UniqueIndex = &uniqueKeyIndex{}
+var _ indexer = &uniqueKeyIndex{}     // nolint: exhaustivestruct
+var _ UniqueIndex = &uniqueKeyIndex{} // nolint: exhaustivestruct
 
 // isNonTrivialUniqueKey checks if unique key fields are non-trivial, meaning that they
 // don't contain the full primary key. If they contain the full primary key, then

--- a/orm/types/ormjson/raw.go
+++ b/orm/types/ormjson/raw.go
@@ -39,7 +39,7 @@ type readCloserWrapper struct {
 
 func (r readCloserWrapper) Close() error { return nil }
 
-var _ ReadSource = rawMessageSource{}
+var _ ReadSource = rawMessageSource{} // nolint: exhaustivestruct
 
 // RawMessageTarget is a WriteTarget wrapping a raw JSON map.
 type RawMessageTarget struct {
@@ -76,4 +76,4 @@ func (r rawWriter) Close() error {
 	return nil
 }
 
-var _ WriteTarget = &RawMessageTarget{}
+var _ WriteTarget = &RawMessageTarget{} // nolint: exhaustivestruct

--- a/server/export.go
+++ b/server/export.go
@@ -23,7 +23,7 @@ const (
 
 // ExportCmd dumps app state to JSON.
 func ExportCmd(appExporter types.AppExporter, defaultNodeHome string) *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "export",
 		Short: "Export state to JSON",
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/server/mock/tx.go
+++ b/server/mock/tx.go
@@ -25,9 +25,9 @@ func (msg *kvstoreTx) Reset()         {}
 func (msg *kvstoreTx) String() string { return "TODO" }
 func (msg *kvstoreTx) ProtoMessage()  {}
 
-var _ sdk.Tx = &kvstoreTx{}
-var _ sdk.Msg = &kvstoreTx{}
-var _ middleware.GasTx = &kvstoreTx{}
+var _ sdk.Tx = &kvstoreTx{}           // nolint: exhaustivestruct
+var _ sdk.Msg = &kvstoreTx{}          // nolint: exhaustivestruct
+var _ middleware.GasTx = &kvstoreTx{} // nolint: exhaustivestruct
 
 func NewTx(key, value string) kvstoreTx {
 	bytes := fmt.Sprintf("%s=%s", key, value)

--- a/server/rollback.go
+++ b/server/rollback.go
@@ -3,15 +3,16 @@ package server
 import (
 	"fmt"
 
-	"github.com/cosmos/cosmos-sdk/client/flags"
-	"github.com/cosmos/cosmos-sdk/store/rootmulti"
 	"github.com/spf13/cobra"
 	tmcmd "github.com/tendermint/tendermint/cmd/tendermint/commands"
+
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/cosmos/cosmos-sdk/store/rootmulti"
 )
 
 // NewRollbackCmd creates a command to rollback tendermint and multistore state by one height.
 func NewRollbackCmd(defaultNodeHome string) *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "rollback",
 		Short: "rollback cosmos-sdk and tendermint state by one height",
 		Long: `

--- a/server/rosetta.go
+++ b/server/rosetta.go
@@ -13,7 +13,7 @@ import (
 // RosettaCommand builds the rosetta root command given
 // a protocol buffers serializer/deserializer
 func RosettaCommand(ir codectypes.InterfaceRegistry, cdc codec.Codec) *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "rosetta",
 		Short: "spin up a rosetta server",
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/server/rosetta/client_online.go
+++ b/server/rosetta/client_online.go
@@ -177,7 +177,7 @@ func (c *Client) BlockByHash(ctx context.Context, hash string) (crgtypes.BlockRe
 
 	block, err := c.tmRPC.BlockByHash(ctx, bHash)
 	if err != nil {
-		return crgtypes.BlockResponse{}, crgerrs.WrapError(crgerrs.ErrBadGateway, err.Error())
+		return crgtypes.BlockResponse{}, crgerrs.WrapError(crgerrs.ErrBadGateway, err.Error()) // nolint: exhaustivestruct
 	}
 
 	return c.converter.ToRosetta().BlockResponse(block), nil
@@ -186,11 +186,11 @@ func (c *Client) BlockByHash(ctx context.Context, hash string) (crgtypes.BlockRe
 func (c *Client) BlockByHeight(ctx context.Context, height *int64) (crgtypes.BlockResponse, error) {
 	height, err := c.getHeight(ctx, height)
 	if err != nil {
-		return crgtypes.BlockResponse{}, crgerrs.WrapError(crgerrs.ErrBadGateway, err.Error())
+		return crgtypes.BlockResponse{}, crgerrs.WrapError(crgerrs.ErrBadGateway, err.Error()) // nolint: exhaustivestruct
 	}
 	block, err := c.tmRPC.Block(ctx, height)
 	if err != nil {
-		return crgtypes.BlockResponse{}, crgerrs.WrapError(crgerrs.ErrBadGateway, err.Error())
+		return crgtypes.BlockResponse{}, crgerrs.WrapError(crgerrs.ErrBadGateway, err.Error()) // nolint: exhaustivestruct
 	}
 
 	return c.converter.ToRosetta().BlockResponse(block), nil
@@ -209,7 +209,7 @@ func (c *Client) BlockTransactionsByHash(ctx context.Context, hash string) (crgt
 func (c *Client) BlockTransactionsByHeight(ctx context.Context, height *int64) (crgtypes.BlockTransactionsResponse, error) {
 	height, err := c.getHeight(ctx, height)
 	if err != nil {
-		return crgtypes.BlockTransactionsResponse{}, crgerrs.WrapError(crgerrs.ErrBadGateway, err.Error())
+		return crgtypes.BlockTransactionsResponse{}, crgerrs.WrapError(crgerrs.ErrBadGateway, err.Error()) // nolint: exhaustivestruct
 	}
 	blockTxResp, err := c.blockTxs(ctx, height)
 	if err != nil {

--- a/server/start.go
+++ b/server/start.go
@@ -72,7 +72,7 @@ const (
 // StartCmd runs the service passed in, either stand-alone or in-process with
 // Tendermint.
 func StartCmd(appCreator types.AppCreator, defaultNodeHome string) *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "start",
 		Short: "Run the full node",
 		Long: `Run the full node application with Tendermint in or out of process. By

--- a/server/tm_cmds.go
+++ b/server/tm_cmds.go
@@ -18,7 +18,7 @@ import (
 
 // ShowNodeIDCmd - ported from Tendermint, dump node ID to stdout
 func ShowNodeIDCmd() *cobra.Command {
-	return &cobra.Command{
+	return &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "show-node-id",
 		Short: "Show this node's ID",
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -71,7 +71,7 @@ func ShowValidatorCmd() *cobra.Command {
 
 // ShowAddressCmd - show this node's validator address
 func ShowAddressCmd() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "show-address",
 		Short: "Shows this node's tendermint validator consensus address",
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -93,7 +93,7 @@ func ShowAddressCmd() *cobra.Command {
 
 // VersionCmd prints tendermint and ABCI version numbers.
 func VersionCmd() *cobra.Command {
-	return &cobra.Command{
+	return &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "version",
 		Short: "Print tendermint libraries' version",
 		Long: `Print protocols' and libraries' version numbers
@@ -123,7 +123,7 @@ against which this app has been compiled.
 
 // UnsafeResetAllCmd - extension of the tendermint command, resets initialization
 func UnsafeResetAllCmd() *cobra.Command {
-	return &cobra.Command{
+	return &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "unsafe-reset-all",
 		Short: "Resets the blockchain database, removes address book files, and resets data/priv_validator_state.json to the genesis state",
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/server/tm_cmds.go
+++ b/server/tm_cmds.go
@@ -37,7 +37,7 @@ func ShowNodeIDCmd() *cobra.Command {
 
 // ShowValidatorCmd - ported from Tendermint, show this node's validator info
 func ShowValidatorCmd() *cobra.Command {
-	cmd := cobra.Command{
+	cmd := cobra.Command{ // nolint: exhaustivestruct
 		Use:   "show-validator",
 		Short: "Show this node's tendermint validator info",
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/server/util.go
+++ b/server/util.go
@@ -261,7 +261,7 @@ func interceptConfigs(rootViper *viper.Viper, customAppTemplate string, customCo
 
 // add server commands
 func AddCommands(rootCmd *cobra.Command, defaultNodeHome string, appCreator types.AppCreator, appExport types.AppExporter, addStartFlags types.ModuleInitFlags) {
-	tendermintCmd := &cobra.Command{
+	tendermintCmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "tendermint",
 		Short: "Tendermint subcommands",
 	}

--- a/simapp/simd/cmd/genaccounts.go
+++ b/simapp/simd/cmd/genaccounts.go
@@ -28,7 +28,7 @@ const (
 
 // AddGenesisAccountCmd returns add-genesis-account cobra Command.
 func AddGenesisAccountCmd(defaultNodeHome string) *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "add-genesis-account [address_or_key_name] [coin][,[coin]]",
 		Short: "Add a genesis account to genesis.json",
 		Long: `Add a genesis account to genesis.json. The provided account must specify

--- a/simapp/simd/cmd/root.go
+++ b/simapp/simd/cmd/root.go
@@ -49,7 +49,7 @@ func NewRootCmd() (*cobra.Command, params.EncodingConfig) {
 		WithHomeDir(simapp.DefaultNodeHome).
 		WithViper("") // In simapp, we don't use any prefix for env variables.
 
-	rootCmd := &cobra.Command{
+	rootCmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "simd",
 		Short: "simulation app",
 		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
@@ -188,7 +188,7 @@ func addModuleInitFlags(startCmd *cobra.Command) {
 }
 
 func queryCommand() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:                        "query",
 		Aliases:                    []string{"q"},
 		Short:                      "Querying subcommands",
@@ -212,7 +212,7 @@ func queryCommand() *cobra.Command {
 }
 
 func txCommand() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:                        "tx",
 		Short:                      "Transactions subcommands",
 		DisableFlagParsing:         true,

--- a/simapp/simd/cmd/testnet.go
+++ b/simapp/simd/cmd/testnet.go
@@ -86,7 +86,7 @@ func addTestnetFlagsToCmd(cmd *cobra.Command) {
 // NewTestnetCmd creates a root testnet command with subcommands to run an in-process testnet or initialize
 // validator configuration files for running a multi-validator testnet in a separate process
 func NewTestnetCmd(mbm module.BasicManager, genBalIterator banktypes.GenesisBalancesIterator) *cobra.Command {
-	testnetCmd := &cobra.Command{
+	testnetCmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:                        "testnet",
 		Short:                      "subcommands for starting or configuring local testnets",
 		DisableFlagParsing:         true,
@@ -102,7 +102,7 @@ func NewTestnetCmd(mbm module.BasicManager, genBalIterator banktypes.GenesisBala
 
 // get cmd to initialize all files for tendermint testnet and application
 func testnetInitFilesCmd(mbm module.BasicManager, genBalIterator banktypes.GenesisBalancesIterator) *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "init-files",
 		Short: "Initialize config directories & files for a multi-validator testnet running locally via separate processes (e.g. Docker Compose or similar)",
 		Long: `init-files will setup "v" number of directories and populate each with
@@ -152,7 +152,7 @@ Example:
 
 // get cmd to start multi validator in-process testnet
 func testnetStartCmd() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "start",
 		Short: "Launch an in-process multi-validator testnet",
 		Long: `testnet will launch an in-process multi-validator testnet,

--- a/store/cachemulti/store.go
+++ b/store/cachemulti/store.go
@@ -31,7 +31,7 @@ type Store struct {
 	listeners map[types.StoreKey][]types.WriteListener
 }
 
-var _ types.CacheMultiStore = Store{}
+var _ types.CacheMultiStore = Store{} // nolint: exhaustivestruct
 
 // NewFromKVStore creates a new Store object from a mapping of store keys to
 // CacheWrapper objects and a KVStore as the database. Each CacheWrapper store

--- a/store/dbadapter/store.go
+++ b/store/dbadapter/store.go
@@ -92,4 +92,4 @@ func (dsa Store) CacheWrapWithListeners(storeKey types.StoreKey, listeners []typ
 }
 
 // dbm.DB implements KVStore so we can CacheKVStore it.
-var _ types.KVStore = Store{}
+var _ types.KVStore = Store{} // nolint: exhaustivestruct

--- a/store/gaskv/store.go
+++ b/store/gaskv/store.go
@@ -6,7 +6,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/store/types"
 )
 
-var _ types.KVStore = &Store{}
+var _ types.KVStore = &Store{} // nolint: exhaustivestruct
 
 // Store applies gas tracking to an underlying KVStore. It implements the
 // KVStore interface.

--- a/store/listenkv/store.go
+++ b/store/listenkv/store.go
@@ -6,7 +6,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/store/types"
 )
 
-var _ types.KVStore = &Store{}
+var _ types.KVStore = &Store{} // nolint: exhaustivestruct
 
 // Store implements the KVStore interface with listening enabled.
 // Operations are traced on each core KVStore call and written to any of the

--- a/store/prefix/store.go
+++ b/store/prefix/store.go
@@ -11,7 +11,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/store/types"
 )
 
-var _ types.KVStore = Store{}
+var _ types.KVStore = Store{} // nolint: exhaustivestruct
 
 // Store is similar with tendermint/tendermint/libs/db/prefix_db
 // both gives access only to the limited subset of the store

--- a/store/streaming/file/service.go
+++ b/store/streaming/file/service.go
@@ -17,7 +17,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
-var _ baseapp.StreamingService = &StreamingService{}
+var _ baseapp.StreamingService = &StreamingService{} // nolint: exhaustivestruct
 
 // StreamingService is a concrete implementation of StreamingService that writes state changes out to files
 type StreamingService struct {

--- a/store/types/proof.go
+++ b/store/types/proof.go
@@ -31,7 +31,7 @@ type CommitmentOp struct {
 	Proof *ics23.CommitmentProof
 }
 
-var _ merkle.ProofOperator = CommitmentOp{}
+var _ merkle.ProofOperator = CommitmentOp{} // nolint: exhaustivestruct
 
 func NewIavlCommitmentOp(key []byte, proof *ics23.CommitmentProof) CommitmentOp {
 	return CommitmentOp{

--- a/store/v2alpha1/dbadapter/store.go
+++ b/store/v2alpha1/dbadapter/store.go
@@ -11,7 +11,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/store/types"
 )
 
-var _ types.KVStore = Store{}
+var _ types.KVStore = Store{} // nolint: exhaustivestruct
 
 // Wrapper type for dbm.Db with implementation of KVStore
 type Store struct {

--- a/store/v2alpha1/smt/store.go
+++ b/store/v2alpha1/smt/store.go
@@ -13,6 +13,7 @@ import (
 	tmcrypto "github.com/tendermint/tendermint/proto/tendermint/crypto"
 )
 
+// nolint: exhaustivestruct
 var (
 	_ types.BasicKVStore = (*Store)(nil)
 	_ smt.MapStore       = (dbMapStore{})

--- a/testutil/mock/privval.go
+++ b/testutil/mock/privval.go
@@ -12,7 +12,7 @@ import (
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 )
 
-var _ tmtypes.PrivValidator = PV{}
+var _ tmtypes.PrivValidator = PV{} // nolint: exhaustivestruct
 
 // MockPV implements PrivValidator without any safety or persistence.
 // Only use it for testing.

--- a/testutil/testdata/animal.go
+++ b/testutil/testdata/animal.go
@@ -25,7 +25,7 @@ func (d Dog) Greet() string {
 	return fmt.Sprintf("Roof, my name is %s", d.Name)
 }
 
-var _ types.UnpackInterfacesMessage = HasAnimal{}
+var _ types.UnpackInterfacesMessage = HasAnimal{} // nolint: exhaustivestruct
 
 func (m HasAnimal) UnpackInterfaces(unpacker types.AnyUnpacker) error {
 	var animal Animal
@@ -36,7 +36,7 @@ type HasAnimalI interface {
 	TheAnimal() Animal
 }
 
-var _ HasAnimalI = &HasAnimal{}
+var _ HasAnimalI = &HasAnimal{} // nolint: exhaustivestruct
 
 func (m HasAnimal) TheAnimal() Animal {
 	return m.Animal.GetCachedValue().(Animal)
@@ -46,13 +46,13 @@ type HasHasAnimalI interface {
 	TheHasAnimal() HasAnimalI
 }
 
-var _ HasHasAnimalI = &HasHasAnimal{}
+var _ HasHasAnimalI = &HasHasAnimal{} // nolint: exhaustivestruct
 
 func (m HasHasAnimal) TheHasAnimal() HasAnimalI {
 	return m.HasAnimal.GetCachedValue().(HasAnimalI)
 }
 
-var _ types.UnpackInterfacesMessage = HasHasAnimal{}
+var _ types.UnpackInterfacesMessage = HasHasAnimal{} // nolint: exhaustivestruct
 
 func (m HasHasAnimal) UnpackInterfaces(unpacker types.AnyUnpacker) error {
 	var animal HasAnimalI
@@ -63,13 +63,13 @@ type HasHasHasAnimalI interface {
 	TheHasHasAnimal() HasHasAnimalI
 }
 
-var _ HasHasAnimalI = &HasHasAnimal{}
+var _ HasHasAnimalI = &HasHasAnimal{} // nolint: exhaustivestruct
 
 func (m HasHasHasAnimal) TheHasHasAnimal() HasHasAnimalI {
 	return m.HasHasAnimal.GetCachedValue().(HasHasAnimalI)
 }
 
-var _ types.UnpackInterfacesMessage = HasHasHasAnimal{}
+var _ types.UnpackInterfacesMessage = HasHasHasAnimal{} // nolint: exhaustivestruct
 
 func (m HasHasHasAnimal) UnpackInterfaces(unpacker types.AnyUnpacker) error {
 	var animal HasHasAnimalI

--- a/testutil/testdata/codec.go
+++ b/testutil/testdata/codec.go
@@ -1,3 +1,4 @@
+// nolint: exhaustivestruct
 package testdata
 
 import (

--- a/testutil/testdata/grpc_query.go
+++ b/testutil/testdata/grpc_query.go
@@ -11,7 +11,7 @@ import (
 
 type QueryImpl struct{}
 
-var _ QueryServer = QueryImpl{}
+var _ QueryServer = QueryImpl{} // nolint: exhaustivestruct
 
 func (e QueryImpl) TestAny(_ context.Context, request *TestAnyRequest) (*TestAnyResponse, error) {
 	animal, ok := request.AnyAnimal.GetCachedValue().(Animal)
@@ -39,14 +39,14 @@ func (e QueryImpl) SayHello(_ context.Context, request *SayHelloRequest) (*SayHe
 	return &SayHelloResponse{Greeting: greeting}, nil
 }
 
-var _ types.UnpackInterfacesMessage = &TestAnyRequest{}
+var _ types.UnpackInterfacesMessage = &TestAnyRequest{} // nolint: exhaustivestruct
 
 func (m *TestAnyRequest) UnpackInterfaces(unpacker types.AnyUnpacker) error {
 	var animal Animal
 	return unpacker.UnpackAny(m.AnyAnimal, &animal)
 }
 
-var _ types.UnpackInterfacesMessage = &TestAnyResponse{}
+var _ types.UnpackInterfacesMessage = &TestAnyResponse{} // nolint: exhaustivestruct
 
 func (m *TestAnyResponse) UnpackInterfaces(unpacker types.AnyUnpacker) error {
 	return m.HasAnimal.UnpackInterfaces(unpacker)

--- a/testutil/testdata/msg_server.go
+++ b/testutil/testdata/msg_server.go
@@ -6,7 +6,7 @@ import (
 
 type MsgServerImpl struct{}
 
-var _ MsgServer = MsgServerImpl{}
+var _ MsgServer = MsgServerImpl{} // nolint: exhaustivestruct
 
 // CreateDog implements the MsgServer interface.
 func (m MsgServerImpl) CreateDog(_ context.Context, msg *MsgCreateDog) (*MsgCreateDogResponse, error) {

--- a/testutil/testdata/tx.go
+++ b/testutil/testdata/tx.go
@@ -80,7 +80,7 @@ func (msg *TestMsg) ValidateBasic() error {
 	return nil
 }
 
-var _ sdk.Msg = &MsgCreateDog{}
+var _ sdk.Msg = &MsgCreateDog{} // nolint: exhaustivestruct
 
 func (msg *MsgCreateDog) GetSigners() []sdk.AccAddress { return []sdk.AccAddress{} }
 func (msg *MsgCreateDog) ValidateBasic() error         { return nil }

--- a/testutil/testdata_pulsar/query.go
+++ b/testutil/testdata_pulsar/query.go
@@ -1,3 +1,4 @@
+// nolint: exhaustivestruct
 package testdata_pulsar
 
 import (
@@ -25,4 +26,4 @@ func (q QueryImpl) TestAny(_ context.Context, request *TestAnyRequest) (*TestAny
 	}}, nil
 }
 
-var _ QueryServer = QueryImpl{} // nolint: exhaustivestruct
+var _ QueryServer = QueryImpl{}

--- a/testutil/testdata_pulsar/query.go
+++ b/testutil/testdata_pulsar/query.go
@@ -25,4 +25,4 @@ func (q QueryImpl) TestAny(_ context.Context, request *TestAnyRequest) (*TestAny
 	}}, nil
 }
 
-var _ QueryServer = QueryImpl{}
+var _ QueryServer = QueryImpl{} // nolint: exhaustivestruct

--- a/types/context.go
+++ b/types/context.go
@@ -267,7 +267,7 @@ func (c Context) CacheContext() (cc Context, writeCache func()) {
 	return cc, cms.Write
 }
 
-var _ context.Context = Context{}
+var _ context.Context = Context{} // nolint: exhaustivestruct
 
 // ContextKey defines a type alias for a stdlib Context key.
 type ContextKey string

--- a/types/module/configurator.go
+++ b/types/module/configurator.go
@@ -55,7 +55,7 @@ func NewConfigurator(cdc codec.Codec, msgServer grpc.Server, queryServer grpc.Se
 	}
 }
 
-var _ Configurator = configurator{}
+var _ Configurator = configurator{} // nolint: exhaustivestruct
 
 // MsgServer implements the Configurator.MsgServer method
 func (c configurator) MsgServer() grpc.Server {

--- a/types/result.go
+++ b/types/result.go
@@ -197,7 +197,7 @@ func ParseABCILogs(logs string) (res ABCIMessageLogs, err error) {
 	return res, err
 }
 
-var _, _ codectypes.UnpackInterfacesMessage = SearchTxsResult{}, TxResponse{}
+var _, _ codectypes.UnpackInterfacesMessage = SearchTxsResult{}, TxResponse{} // nolint: exhaustivestruct
 
 // UnpackInterfaces implements UnpackInterfacesMessage.UnpackInterfaces
 //

--- a/types/simulation/account.go
+++ b/types/simulation/account.go
@@ -60,7 +60,7 @@ func FindAccount(accs []Account, address sdk.Address) (Account, bool) {
 		}
 	}
 
-	return Account{}, false
+	return Account{}, false // nolint: exhaustivestruct
 }
 
 // RandomFees returns a random fee by selecting a random coin denomination and

--- a/types/tx/signing/signature.go
+++ b/types/tx/signing/signature.go
@@ -86,7 +86,7 @@ func SignatureDataFromProto(descData *SignatureDescriptor_Data) SignatureData {
 	}
 }
 
-var _, _ codectypes.UnpackInterfacesMessage = &SignatureDescriptors{}, &SignatureDescriptor{}
+var _, _ codectypes.UnpackInterfacesMessage = &SignatureDescriptors{}, &SignatureDescriptor{} // nolint: exhaustivestruct
 
 // UnpackInterfaces implements the UnpackInterfaceMessages.UnpackInterfaces method
 func (sds *SignatureDescriptors) UnpackInterfaces(unpacker codectypes.AnyUnpacker) error {

--- a/types/tx/signing/signature_data.go
+++ b/types/tx/signing/signature_data.go
@@ -30,7 +30,7 @@ type MultiSignatureData struct {
 	Signatures []SignatureData
 }
 
-var _, _ SignatureData = &SingleSignatureData{}, &MultiSignatureData{}
+var _, _ SignatureData = &SingleSignatureData{}, &MultiSignatureData{} // nolint: exhaustivestruct
 
 func (m *SingleSignatureData) isSignatureData() {}
 func (m *MultiSignatureData) isSignatureData()  {}

--- a/types/tx/types.go
+++ b/types/tx/types.go
@@ -13,8 +13,8 @@ import (
 const MaxGasWanted = uint64((1 << 63) - 1)
 
 // Interface implementation checks.
-var _, _, _, _ codectypes.UnpackInterfacesMessage = &Tx{}, &TxBody{}, &AuthInfo{}, &SignerInfo{}
-var _ sdk.Tx = &Tx{}
+var _, _, _, _ codectypes.UnpackInterfacesMessage = &Tx{}, &TxBody{}, &AuthInfo{}, &SignerInfo{} // nolint: exhaustivestruct
+var _ sdk.Tx = &Tx{}                                                                             // nolint: exhaustivestruct
 
 // GetMsgs implements the GetMsgs method on sdk.Tx.
 func (t *Tx) GetMsgs() []sdk.Msg {

--- a/version/command.go
+++ b/version/command.go
@@ -13,7 +13,7 @@ const flagLong = "long"
 
 // NewVersionCommand returns a CLI command to interactively print the application binary version information.
 func NewVersionCommand() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "version",
 		Short: "Print the application binary version information",
 		RunE: func(cmd *cobra.Command, _ []string) error {

--- a/x/auth/client/cli/broadcast.go
+++ b/x/auth/client/cli/broadcast.go
@@ -13,7 +13,7 @@ import (
 
 // GetBroadcastCommand returns the tx broadcast command.
 func GetBroadcastCommand() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "broadcast [file_path]",
 		Short: "Broadcast transactions generated offline",
 		Long: strings.TrimSpace(`Broadcast transactions created with the --generate-only

--- a/x/auth/client/cli/decode.go
+++ b/x/auth/client/cli/decode.go
@@ -15,7 +15,7 @@ const flagHex = "hex"
 // GetDecodeCommand returns the decode command to take serialized bytes and turn
 // it into a JSON-encoded transaction.
 func GetDecodeCommand() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "decode [protobuf-byte-string]",
 		Short: "Decode a binary encoded transaction string",
 		Args:  cobra.ExactArgs(1),

--- a/x/auth/client/cli/encode.go
+++ b/x/auth/client/cli/encode.go
@@ -13,7 +13,7 @@ import (
 // GetEncodeCommand returns the encode command to take a JSONified transaction and turn it into
 // Amino-serialized bytes
 func GetEncodeCommand() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "encode [file]",
 		Short: "Encode transactions generated offline",
 		Long: `Encode transactions created with the --generate-only flag and signed with the sign command.

--- a/x/auth/client/cli/query.go
+++ b/x/auth/client/cli/query.go
@@ -31,7 +31,7 @@ const (
 
 // GetQueryCmd returns the transaction commands for this module
 func GetQueryCmd() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:                        types.ModuleName,
 		Short:                      "Querying commands for the auth module",
 		DisableFlagParsing:         true,
@@ -51,7 +51,7 @@ func GetQueryCmd() *cobra.Command {
 
 // QueryParamsCmd returns the command handler for evidence parameter querying.
 func QueryParamsCmd() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "params",
 		Short: "Query the current auth parameters",
 		Args:  cobra.NoArgs,
@@ -83,7 +83,7 @@ $ <appd> query auth params
 // GetAccountCmd returns a query account that will display the state of the
 // account at a given address.
 func GetAccountCmd() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "account [address]",
 		Short: "Query for account by address",
 		Args:  cobra.ExactArgs(1),
@@ -114,7 +114,7 @@ func GetAccountCmd() *cobra.Command {
 
 // GetAccountsCmd returns a query command that will display a list of accounts
 func GetAccountsCmd() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "accounts",
 		Short: "Query all the accounts",
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -146,7 +146,7 @@ func GetAccountsCmd() *cobra.Command {
 
 // QueryAllModuleAccountsCmd returns a list of all the existing module accounts with their account information and permissions
 func QueryModuleAccountsCmd() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "module-accounts",
 		Short: "Query all module accounts",
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -173,7 +173,7 @@ func QueryModuleAccountsCmd() *cobra.Command {
 
 // QueryTxsByEventsCmd returns a command to search through transactions by events.
 func QueryTxsByEventsCmd() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "txs",
 		Short: "Query for paginated transactions that match a set of events",
 		Long: strings.TrimSpace(
@@ -244,7 +244,7 @@ $ %s query txs --%s 'message.sender=cosmos1...&message.action=withdraw_delegator
 
 // QueryTxCmd implements the default command for a tx query.
 func QueryTxCmd() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "tx --type=[hash|acc_seq|signature] [hash|acc_seq|signature]",
 		Short: "Query for a transaction by hash, \"<addr>/<seq>\" combination or comma-separated signatures in a committed block",
 		Long: strings.TrimSpace(fmt.Sprintf(`

--- a/x/auth/client/cli/tips.go
+++ b/x/auth/client/cli/tips.go
@@ -15,7 +15,7 @@ import (
 )
 
 func GetAuxToFeeCommand() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "aux-to-fee <aux_signed_tx.json>",
 		Short: "includes the aux signer data in the tx, broadcast the tx, and sends the tip amount to the broadcaster",
 		Args:  cobra.ExactArgs(1),

--- a/x/auth/client/cli/tx_multisign.go
+++ b/x/auth/client/cli/tx_multisign.go
@@ -31,7 +31,7 @@ type BroadcastReq struct {
 
 // GetSignCommand returns the sign command
 func GetMultiSignCommand() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "multisign [file] [name] [[signature]...]",
 		Short: "Generate multisig signatures for transactions generated offline",
 		Long: strings.TrimSpace(
@@ -210,7 +210,7 @@ func makeMultiSignCmd() func(cmd *cobra.Command, args []string) (err error) {
 }
 
 func GetMultiSignBatchCmd() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "multisign-batch [file] [name] [[signature-file]...]",
 		Short: "Assemble multisig transactions in batch from batch signatures",
 		Long: strings.TrimSpace(

--- a/x/auth/client/cli/tx_sign.go
+++ b/x/auth/client/cli/tx_sign.go
@@ -23,7 +23,7 @@ const (
 
 // GetSignBatchCommand returns the transaction sign-batch command.
 func GetSignBatchCommand() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "sign-batch [file]",
 		Short: "Sign transaction batch files",
 		Long: `Sign batch files of transactions generated with --generate-only.
@@ -164,7 +164,7 @@ func setOutputFile(cmd *cobra.Command) (func(), error) {
 
 // GetSignCommand returns the transaction sign command.
 func GetSignCommand() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "sign [file]",
 		Short: "Sign a transaction generated offline",
 		Long: `Sign a transaction created with the --generate-only flag.

--- a/x/auth/client/cli/validate_sigs.go
+++ b/x/auth/client/cli/validate_sigs.go
@@ -14,7 +14,7 @@ import (
 )
 
 func GetValidateSignaturesCommand() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "validate-signatures [file]",
 		Short: "validate transactions signatures",
 		Long: `Print the addresses that must sign the transaction, those who have already

--- a/x/auth/client/testutil/suite.go
+++ b/x/auth/client/testutil/suite.go
@@ -46,7 +46,7 @@ type IntegrationTestSuite struct {
 }
 
 func NewIntegrationTestSuite(cfg network.Config) *IntegrationTestSuite {
-	return &IntegrationTestSuite{cfg: cfg}
+	return &IntegrationTestSuite{cfg: cfg} // nolint: exhaustivestruct
 }
 
 func (s *IntegrationTestSuite) SetupSuite() {
@@ -427,7 +427,7 @@ func (s *IntegrationTestSuite) TestCLIQueryTxCmdByHash() {
 			"happy case",
 			[]string{txRes.TxHash, fmt.Sprintf("--%s=json", tmcli.OutputFlag)},
 			false,
-			sdk.MsgTypeURL(&banktypes.MsgSend{}),
+			sdk.MsgTypeURL(&banktypes.MsgSend{}), // nolint: exhaustivestruct
 		},
 	}
 

--- a/x/auth/client/testutil/suite.go
+++ b/x/auth/client/testutil/suite.go
@@ -402,6 +402,7 @@ func (s *IntegrationTestSuite) TestCLIQueryTxCmdByHash() {
 	s.Require().NoError(val.ClientCtx.Codec.UnmarshalJSON(out.Bytes(), &txRes))
 	s.Require().NoError(s.network.WaitForNextBlock())
 
+	// nolint: exhaustivestruct
 	testCases := []struct {
 		name           string
 		args           []string
@@ -427,7 +428,7 @@ func (s *IntegrationTestSuite) TestCLIQueryTxCmdByHash() {
 			"happy case",
 			[]string{txRes.TxHash, fmt.Sprintf("--%s=json", tmcli.OutputFlag)},
 			false,
-			sdk.MsgTypeURL(&banktypes.MsgSend{}), // nolint: exhaustivestruct
+			sdk.MsgTypeURL(&banktypes.MsgSend{}),
 		},
 	}
 
@@ -1297,7 +1298,7 @@ func (s *IntegrationTestSuite) TestGetAccountsCmd() {
 }
 
 func TestGetBroadcastCommandOfflineFlag(t *testing.T) {
-	clientCtx := client.Context{}.WithOffline(true)
+	clientCtx := client.Context{}.WithOffline(true) // nolint: exhaustivestruct
 	clientCtx = clientCtx.WithTxConfig(simapp.MakeTestEncodingConfig().TxConfig)
 
 	cmd := authcli.GetBroadcastCommand()
@@ -1308,7 +1309,7 @@ func TestGetBroadcastCommandOfflineFlag(t *testing.T) {
 }
 
 func TestGetBroadcastCommandWithoutOfflineFlag(t *testing.T) {
-	clientCtx := client.Context{}
+	clientCtx := client.Context{} // nolint: exhaustivestruct
 	txCfg := simapp.MakeTestEncodingConfig().TxConfig
 	clientCtx = clientCtx.WithTxConfig(txCfg)
 

--- a/x/auth/keeper/bech32_codec.go
+++ b/x/auth/keeper/bech32_codec.go
@@ -11,7 +11,7 @@ type bech32Codec struct {
 	bech32Prefix string
 }
 
-var _ address.Codec = &bech32Codec{}
+var _ address.Codec = &bech32Codec{} // nolint: exhaustivestruct
 
 func newBech32Codec(prefix string) bech32Codec {
 	return bech32Codec{prefix}

--- a/x/auth/keeper/grpc_query.go
+++ b/x/auth/keeper/grpc_query.go
@@ -16,7 +16,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/auth/types"
 )
 
-var _ types.QueryServer = AccountKeeper{}
+var _ types.QueryServer = AccountKeeper{} // nolint: exhaustivestruct
 
 func (ak AccountKeeper) Accounts(c context.Context, req *types.QueryAccountsRequest) (*types.QueryAccountsResponse, error) {
 	if req == nil {

--- a/x/auth/keeper/keeper.go
+++ b/x/auth/keeper/keeper.go
@@ -64,7 +64,7 @@ type AccountKeeper struct {
 	addressCdc address.Codec
 }
 
-var _ AccountKeeperI = &AccountKeeper{}
+var _ AccountKeeperI = &AccountKeeper{} // nolint: exhaustivestruct
 
 // NewAccountKeeper returns a new AccountKeeperI that uses go-amino to
 // (binary) encode and decode concrete sdk.Accounts.

--- a/x/auth/middleware/basic.go
+++ b/x/auth/middleware/basic.go
@@ -3,6 +3,8 @@ package middleware
 import (
 	"context"
 
+	abci "github.com/tendermint/tendermint/abci/types"
+
 	"github.com/cosmos/cosmos-sdk/codec/legacy"
 	"github.com/cosmos/cosmos-sdk/crypto/keys/multisig"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
@@ -12,7 +14,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/tx/signing"
 	"github.com/cosmos/cosmos-sdk/x/auth/migrations/legacytx"
 	authsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
-	abci "github.com/tendermint/tendermint/abci/types"
 )
 
 type validateBasicTxHandler struct {
@@ -30,7 +31,7 @@ func ValidateBasicMiddleware(txh tx.Handler) tx.Handler {
 	}
 }
 
-var _ tx.Handler = validateBasicTxHandler{}
+var _ tx.Handler = validateBasicTxHandler{} // nolint: exhaustivestruct
 
 // validateBasicTxMsgs executes basic validator calls for messages.
 func validateBasicTxMsgs(msgs []sdk.Msg) error {
@@ -92,7 +93,7 @@ func (txh validateBasicTxHandler) SimulateTx(ctx context.Context, req tx.Request
 	return txh.next.SimulateTx(ctx, req)
 }
 
-var _ tx.Handler = txTimeoutHeightTxHandler{}
+var _ tx.Handler = txTimeoutHeightTxHandler{} // nolint: exhaustivestruct
 
 type txTimeoutHeightTxHandler struct {
 	next tx.Handler
@@ -167,7 +168,7 @@ func ValidateMemoMiddleware(ak AccountKeeper) tx.Middleware {
 	}
 }
 
-var _ tx.Handler = validateMemoTxHandler{}
+var _ tx.Handler = validateMemoTxHandler{} // nolint: exhaustivestruct
 
 func (vmm validateMemoTxHandler) checkForValidMemo(ctx context.Context, tx sdk.Tx) error {
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
@@ -216,7 +217,7 @@ func (vmm validateMemoTxHandler) SimulateTx(ctx context.Context, req tx.Request)
 	return vmm.next.SimulateTx(ctx, req)
 }
 
-var _ tx.Handler = consumeTxSizeGasTxHandler{}
+var _ tx.Handler = consumeTxSizeGasTxHandler{} // nolint: exhaustivestruct
 
 type consumeTxSizeGasTxHandler struct {
 	ak   AccountKeeper

--- a/x/auth/middleware/block_gas.go
+++ b/x/auth/middleware/block_gas.go
@@ -17,7 +17,7 @@ func ConsumeBlockGasMiddleware(txh tx.Handler) tx.Handler {
 	return consumeBlockGasHandler{next: txh}
 }
 
-var _ tx.Handler = consumeBlockGasHandler{}
+var _ tx.Handler = consumeBlockGasHandler{} // nolint: exhaustivestruct
 
 // CheckTx implements tx.Handler.CheckTx method.
 func (cbgh consumeBlockGasHandler) CheckTx(ctx context.Context, req tx.Request, checkReq tx.RequestCheckTx) (res tx.Response, resCheckTx tx.ResponseCheckTx, err error) {

--- a/x/auth/middleware/ext.go
+++ b/x/auth/middleware/ext.go
@@ -29,7 +29,7 @@ func RejectExtensionOptionsMiddleware(txh tx.Handler) tx.Handler {
 	}
 }
 
-var _ tx.Handler = rejectExtensionOptionsTxHandler{}
+var _ tx.Handler = rejectExtensionOptionsTxHandler{} // nolint: exhaustivestruct
 
 func checkExtOpts(tx sdk.Tx) error {
 	if hasExtOptsTx, ok := tx.(HasExtensionOptionsTx); ok {

--- a/x/auth/middleware/fee.go
+++ b/x/auth/middleware/fee.go
@@ -10,7 +10,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/auth/types"
 )
 
-var _ tx.Handler = mempoolFeeTxHandler{}
+var _ tx.Handler = mempoolFeeTxHandler{} // nolint: exhaustivestruct
 
 type mempoolFeeTxHandler struct {
 	next tx.Handler
@@ -78,7 +78,7 @@ func (txh mempoolFeeTxHandler) SimulateTx(ctx context.Context, req tx.Request) (
 	return txh.next.SimulateTx(ctx, req)
 }
 
-var _ tx.Handler = deductFeeTxHandler{}
+var _ tx.Handler = deductFeeTxHandler{} // nolint: exhaustivestruct
 
 type deductFeeTxHandler struct {
 	accountKeeper  AccountKeeper

--- a/x/auth/middleware/gas.go
+++ b/x/auth/middleware/gas.go
@@ -25,7 +25,7 @@ func GasTxMiddleware(txh tx.Handler) tx.Handler {
 	return gasTxHandler{next: txh}
 }
 
-var _ tx.Handler = gasTxHandler{}
+var _ tx.Handler = gasTxHandler{} // nolint: exhaustivestruct
 
 // CheckTx implements tx.Handler.CheckTx.
 func (txh gasTxHandler) CheckTx(ctx context.Context, req tx.Request, checkReq tx.RequestCheckTx) (tx.Response, tx.ResponseCheckTx, error) {

--- a/x/auth/middleware/gas_test.go
+++ b/x/auth/middleware/gas_test.go
@@ -94,7 +94,7 @@ type customTxHandler struct {
 	fn func(context.Context, tx.Request) (tx.Response, error)
 }
 
-var _ tx.Handler = customTxHandler{}
+var _ tx.Handler = customTxHandler{} // nolint: exhaustivestruct
 
 func (h customTxHandler) DeliverTx(ctx context.Context, req tx.Request) (tx.Response, error) {
 	return h.fn(ctx, req)

--- a/x/auth/middleware/index_events.go
+++ b/x/auth/middleware/index_events.go
@@ -25,7 +25,7 @@ func NewIndexEventsTxMiddleware(indexEvents map[string]struct{}) tx.Middleware {
 	}
 }
 
-var _ tx.Handler = indexEventsTxHandler{}
+var _ tx.Handler = indexEventsTxHandler{} // nolint: exhaustivestruct
 
 // CheckTx implements tx.Handler.CheckTx method.
 func (txh indexEventsTxHandler) CheckTx(ctx context.Context, req tx.Request, checkReq tx.RequestCheckTx) (tx.Response, tx.ResponseCheckTx, error) {

--- a/x/auth/middleware/msg_service_router.go
+++ b/x/auth/middleware/msg_service_router.go
@@ -19,7 +19,7 @@ type MsgServiceRouter struct {
 	routes            map[string]MsgServiceHandler
 }
 
-var _ gogogrpc.Server = &MsgServiceRouter{}
+var _ gogogrpc.Server = &MsgServiceRouter{} // nolint: exhaustivestruct
 
 // NewMsgServiceRouter creates a new MsgServiceRouter.
 func NewMsgServiceRouter(registry codectypes.InterfaceRegistry) *MsgServiceRouter {

--- a/x/auth/middleware/priority.go
+++ b/x/auth/middleware/priority.go
@@ -8,7 +8,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/tx"
 )
 
-var _ tx.Handler = txPriorityHandler{}
+var _ tx.Handler = txPriorityHandler{} // nolint: exhaustivestruct
 
 type txPriorityHandler struct {
 	next tx.Handler

--- a/x/auth/middleware/recovery.go
+++ b/x/auth/middleware/recovery.go
@@ -21,7 +21,7 @@ func RecoveryTxMiddleware(txh tx.Handler) tx.Handler {
 	return recoveryTxHandler{next: txh}
 }
 
-var _ tx.Handler = recoveryTxHandler{}
+var _ tx.Handler = recoveryTxHandler{} // nolint: exhaustivestruct
 
 // CheckTx implements tx.Handler.CheckTx method.
 func (txh recoveryTxHandler) CheckTx(ctx context.Context, req tx.Request, checkReq tx.RequestCheckTx) (res tx.Response, resCheckTx tx.ResponseCheckTx, err error) {

--- a/x/auth/middleware/run_msgs.go
+++ b/x/auth/middleware/run_msgs.go
@@ -23,7 +23,7 @@ func NewRunMsgsTxHandler(msr *MsgServiceRouter, legacyRouter sdk.Router) tx.Hand
 	}
 }
 
-var _ tx.Handler = runMsgsTxHandler{}
+var _ tx.Handler = runMsgsTxHandler{} // nolint: exhaustivestruct
 
 // CheckTx implements tx.Handler.CheckTx method.
 func (txh runMsgsTxHandler) CheckTx(ctx context.Context, req tx.Request, checkReq tx.RequestCheckTx) (tx.Response, tx.ResponseCheckTx, error) {

--- a/x/auth/middleware/sigverify.go
+++ b/x/auth/middleware/sigverify.go
@@ -6,6 +6,8 @@ import (
 	"encoding/base64"
 	"fmt"
 
+	abci "github.com/tendermint/tendermint/abci/types"
+
 	"github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
 	kmultisig "github.com/cosmos/cosmos-sdk/crypto/keys/multisig"
 	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
@@ -18,7 +20,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/tx/signing"
 	authsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
 	"github.com/cosmos/cosmos-sdk/x/auth/types"
-	abci "github.com/tendermint/tendermint/abci/types"
 )
 
 var (
@@ -33,7 +34,7 @@ var (
 // This is where apps can define their own PubKey
 type SignatureVerificationGasConsumer = func(meter sdk.GasMeter, sig signing.SignatureV2, params types.Params) error
 
-var _ tx.Handler = setPubKeyTxHandler{}
+var _ tx.Handler = setPubKeyTxHandler{} // nolint: exhaustivestruct
 
 type setPubKeyTxHandler struct {
 	ak   AccountKeeper
@@ -150,7 +151,7 @@ func (spkm setPubKeyTxHandler) SimulateTx(ctx context.Context, req tx.Request) (
 	return spkm.next.SimulateTx(ctx, req)
 }
 
-var _ tx.Handler = validateSigCountTxHandler{}
+var _ tx.Handler = validateSigCountTxHandler{} // nolint: exhaustivestruct
 
 type validateSigCountTxHandler struct {
 	ak   AccountKeeper
@@ -286,7 +287,7 @@ func ConsumeMultisignatureVerificationGas(
 	return nil
 }
 
-var _ tx.Handler = sigGasConsumeTxHandler{}
+var _ tx.Handler = sigGasConsumeTxHandler{} // nolint: exhaustivestruct
 
 type sigGasConsumeTxHandler struct {
 	ak             AccountKeeper
@@ -385,7 +386,7 @@ func (sgcm sigGasConsumeTxHandler) SimulateTx(ctx context.Context, req tx.Reques
 	return sgcm.next.SimulateTx(ctx, req)
 }
 
-var _ tx.Handler = sigVerificationTxHandler{}
+var _ tx.Handler = sigVerificationTxHandler{} // nolint: exhaustivestruct
 
 type sigVerificationTxHandler struct {
 	ak              AccountKeeper
@@ -537,7 +538,7 @@ func (svd sigVerificationTxHandler) SimulateTx(ctx context.Context, req tx.Reque
 	return svd.next.SimulateTx(ctx, req)
 }
 
-var _ tx.Handler = incrementSequenceTxHandler{}
+var _ tx.Handler = incrementSequenceTxHandler{} // nolint: exhaustivestruct
 
 type incrementSequenceTxHandler struct {
 	ak   AccountKeeper

--- a/x/auth/middleware/tips.go
+++ b/x/auth/middleware/tips.go
@@ -21,7 +21,7 @@ func NewTipMiddleware(bankKeeper types.BankKeeper) tx.Middleware {
 	}
 }
 
-var _ tx.Handler = tipsTxHandler{}
+var _ tx.Handler = tipsTxHandler{} // nolint: exhaustivestruct
 
 // CheckTx implements tx.Handler.CheckTx.
 func (txh tipsTxHandler) CheckTx(ctx context.Context, req tx.Request, checkTx tx.RequestCheckTx) (tx.Response, tx.ResponseCheckTx, error) {

--- a/x/auth/migrations/legacytx/codec.go
+++ b/x/auth/migrations/legacytx/codec.go
@@ -1,3 +1,4 @@
+// nolint: exhaustivestruct
 package legacytx
 
 import (

--- a/x/auth/migrations/legacytx/stdsignmsg.go
+++ b/x/auth/migrations/legacytx/stdsignmsg.go
@@ -5,7 +5,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
-var _ types.UnpackInterfacesMessage = StdSignMsg{}
+var _ types.UnpackInterfacesMessage = StdSignMsg{} // nolint: exhaustivestruct
 
 // StdSignMsg is a convenience structure for passing along a Msg with the other
 // requirements for a StdSignDoc before it is signed. For use in the CLI.

--- a/x/auth/migrations/legacytx/stdtx_builder.go
+++ b/x/auth/migrations/legacytx/stdtx_builder.go
@@ -21,7 +21,7 @@ type StdTxBuilder struct {
 }
 
 // ensure interface implementation
-var _ client.TxBuilder = &StdTxBuilder{}
+var _ client.TxBuilder = &StdTxBuilder{} // nolint: exhaustivestruct
 
 // GetTx implements TxBuilder.GetTx
 func (s *StdTxBuilder) GetTx() authsigning.Tx {
@@ -87,7 +87,7 @@ type StdTxConfig struct {
 	Cdc *codec.LegacyAmino
 }
 
-var _ client.TxConfig = StdTxConfig{}
+var _ client.TxConfig = StdTxConfig{} // nolint: exhaustivestruct
 
 // NewTxBuilder implements TxConfig.NewTxBuilder
 func (s StdTxConfig) NewTxBuilder() client.TxBuilder {

--- a/x/auth/migrations/v038/types.go
+++ b/x/auth/migrations/v038/types.go
@@ -521,6 +521,7 @@ func ValidateGenAccounts(genAccounts GenesisAccounts) error {
 	return nil
 }
 
+// nolint: exhaustivestruct
 func RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
 	cryptocodec.RegisterCrypto(cdc)
 	cdc.RegisterInterface((*GenesisAccount)(nil), nil)

--- a/x/auth/migrations/v039/types.go
+++ b/x/auth/migrations/v039/types.go
@@ -415,6 +415,7 @@ func (ma *ModuleAccount) UnmarshalJSON(bz []byte) error {
 	return nil
 }
 
+// nolint: exhaustivestruct
 func RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
 	cryptocodec.RegisterCrypto(cdc)
 	cdc.RegisterInterface((*v038auth.GenesisAccount)(nil), nil)

--- a/x/auth/module.go
+++ b/x/auth/module.go
@@ -24,10 +24,11 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/auth/types"
 )
 
+// nolint: exhaustivestruct
 var (
-	_ module.AppModule           = AppModule{}      // nolint: exhaustivestruct
-	_ module.AppModuleBasic      = AppModuleBasic{} // nolint: exhaustivestruct
-	_ module.AppModuleSimulation = AppModule{}      // nolint: exhaustivestruct
+	_ module.AppModule           = AppModule{}
+	_ module.AppModuleBasic      = AppModuleBasic{}
+	_ module.AppModuleSimulation = AppModule{}
 )
 
 // AppModuleBasic defines the basic application module used by the auth module.

--- a/x/auth/module.go
+++ b/x/auth/module.go
@@ -25,9 +25,9 @@ import (
 )
 
 var (
-	_ module.AppModule           = AppModule{}
-	_ module.AppModuleBasic      = AppModuleBasic{}
-	_ module.AppModuleSimulation = AppModule{}
+	_ module.AppModule           = AppModule{}      // nolint: exhaustivestruct
+	_ module.AppModuleBasic      = AppModuleBasic{} // nolint: exhaustivestruct
+	_ module.AppModuleSimulation = AppModule{}      // nolint: exhaustivestruct
 )
 
 // AppModuleBasic defines the basic application module used by the auth module.

--- a/x/auth/signing/handler_map.go
+++ b/x/auth/signing/handler_map.go
@@ -16,7 +16,7 @@ type SignModeHandlerMap struct {
 	signModeHandlers map[signing.SignMode]SignModeHandler
 }
 
-var _ SignModeHandler = SignModeHandlerMap{}
+var _ SignModeHandler = SignModeHandlerMap{} // nolint: exhaustivestruct
 
 // NewSignModeHandlerMap returns a new SignModeHandlerMap with the provided defaultMode and handlers
 func NewSignModeHandlerMap(defaultMode signing.SignMode, handlers []SignModeHandler) SignModeHandlerMap {

--- a/x/auth/tx/builder.go
+++ b/x/auth/tx/builder.go
@@ -33,6 +33,7 @@ type wrapper struct {
 	txBodyHasUnknownNonCriticals bool
 }
 
+// nolint: exhaustivestruct
 var (
 	_ authsigning.Tx                   = &wrapper{}
 	_ client.TxBuilder                 = &wrapper{}

--- a/x/auth/tx/direct.go
+++ b/x/auth/tx/direct.go
@@ -13,7 +13,7 @@ import (
 // signModeDirectHandler defines the SIGN_MODE_DIRECT SignModeHandler
 type signModeDirectHandler struct{}
 
-var _ signing.SignModeHandler = signModeDirectHandler{}
+var _ signing.SignModeHandler = signModeDirectHandler{} // nolint: exhaustivestruct
 
 // DefaultMode implements SignModeHandler.DefaultMode
 func (signModeDirectHandler) DefaultMode() signingtypes.SignMode {

--- a/x/auth/tx/direct.go
+++ b/x/auth/tx/direct.go
@@ -13,7 +13,7 @@ import (
 // signModeDirectHandler defines the SIGN_MODE_DIRECT SignModeHandler
 type signModeDirectHandler struct{}
 
-var _ signing.SignModeHandler = signModeDirectHandler{} // nolint: exhaustivestruct
+var _ signing.SignModeHandler = signModeDirectHandler{}
 
 // DefaultMode implements SignModeHandler.DefaultMode
 func (signModeDirectHandler) DefaultMode() signingtypes.SignMode {

--- a/x/auth/tx/service.go
+++ b/x/auth/tx/service.go
@@ -3,9 +3,10 @@ package tx
 import (
 	"context"
 	"fmt"
+	"strings"
+
 	"github.com/cosmos/cosmos-sdk/client/grpc/tmservice"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-	"strings"
 
 	gogogrpc "github.com/gogo/protobuf/grpc"
 	"github.com/golang/protobuf/proto" // nolint: staticcheck
@@ -39,7 +40,7 @@ func NewTxServer(clientCtx client.Context, simulate baseAppSimulateFn, interface
 	}
 }
 
-var _ txtypes.ServiceServer = txServer{}
+var _ txtypes.ServiceServer = txServer{} // nolint: exhaustivestruct
 
 const (
 	eventFormat = "{eventType}.{eventAttribute}={value}"

--- a/x/auth/types/codec.go
+++ b/x/auth/types/codec.go
@@ -1,3 +1,4 @@
+// nolint: exhaustivestruct
 package types
 
 import (

--- a/x/auth/types/genesis.go
+++ b/x/auth/types/genesis.go
@@ -12,7 +12,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/module"
 )
 
-var _ types.UnpackInterfacesMessage = GenesisState{}
+var _ types.UnpackInterfacesMessage = GenesisState{} // nolint: exhaustivestruct
 
 // RandomGenesisAccountsFn defines the function required to generate custom account types
 type RandomGenesisAccountsFn func(simState *module.SimulationState) GenesisAccounts

--- a/x/auth/types/params.go
+++ b/x/auth/types/params.go
@@ -43,7 +43,7 @@ func NewParams(
 
 // ParamKeyTable for auth module
 func ParamKeyTable() paramtypes.KeyTable {
-	return paramtypes.NewKeyTable().RegisterParamSet(&Params{})
+	return paramtypes.NewKeyTable().RegisterParamSet(&Params{}) // nolint: exhaustivestruct
 }
 
 // ParamSetPairs implements the ParamSet interface and returns all the key/value pairs

--- a/x/auth/types/params.go
+++ b/x/auth/types/params.go
@@ -26,7 +26,7 @@ var (
 	KeySigVerifyCostSecp256k1 = []byte("SigVerifyCostSecp256k1")
 )
 
-var _ paramtypes.ParamSet = &Params{}
+var _ paramtypes.ParamSet = &Params{} // nolint: exhaustivestruct
 
 // NewParams creates a new Params object
 func NewParams(

--- a/x/auth/types/query.go
+++ b/x/auth/types/query.go
@@ -7,4 +7,4 @@ func (m *QueryAccountResponse) UnpackInterfaces(unpacker codectypes.AnyUnpacker)
 	return unpacker.UnpackAny(m.Account, &account)
 }
 
-var _ codectypes.UnpackInterfacesMessage = &QueryAccountResponse{}
+var _ codectypes.UnpackInterfacesMessage = &QueryAccountResponse{} // nolint: exhaustivestruct

--- a/x/auth/vesting/client/cli/tx.go
+++ b/x/auth/vesting/client/cli/tx.go
@@ -22,7 +22,7 @@ const (
 
 // GetTxCmd returns vesting module's transaction commands.
 func GetTxCmd() *cobra.Command {
-	txCmd := &cobra.Command{
+	txCmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:                        types.ModuleName,
 		Short:                      "Vesting transaction subcommands",
 		DisableFlagParsing:         true,
@@ -42,7 +42,7 @@ func GetTxCmd() *cobra.Command {
 // NewMsgCreateVestingAccountCmd returns a CLI command handler for creating a
 // MsgCreateVestingAccount transaction.
 func NewMsgCreateVestingAccountCmd() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "create-vesting-account [to_address] [amount] [end_time]",
 		Short: "Create a new vesting account funded with an allocation of tokens.",
 		Long: `Create a new vesting account funded with an allocation of tokens. The
@@ -88,7 +88,7 @@ timestamp.`,
 // NewMsgCreatePermanentLockedAccountCmd returns a CLI command handler for creating a
 // MsgCreatePermanentLockedAccount transaction.
 func NewMsgCreatePermanentLockedAccountCmd() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "create-permanent-locked-account [to_address] [amount]",
 		Short: "Create a new permanently locked account funded with an allocation of tokens.",
 		Long: `Create a new account funded with an allocation of permanently locked tokens. These
@@ -134,7 +134,7 @@ type InputPeriod struct {
 // NewMsgCreatePeriodicVestingAccountCmd returns a CLI command handler for creating a
 // MsgCreatePeriodicVestingAccountCmd transaction.
 func NewMsgCreatePeriodicVestingAccountCmd() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "create-periodic-vesting-account [to_address] [periods_json_file]",
 		Short: "Create a new vesting account funded with an allocation of tokens.",
 		Long: `A sequence of coins and period length in seconds. Periods are sequential, in that the duration of of a period only starts at the end of the previous period. The duration of the first period starts upon account creation. For instance, the following periods.json file shows 20 "test" coins vesting 30 days apart from each other.

--- a/x/auth/vesting/client/testutil/suite.go
+++ b/x/auth/vesting/client/testutil/suite.go
@@ -21,7 +21,7 @@ type IntegrationTestSuite struct {
 }
 
 func NewIntegrationTestSuite(cfg network.Config) *IntegrationTestSuite {
-	return &IntegrationTestSuite{cfg: cfg}
+	return &IntegrationTestSuite{cfg: cfg} // nolint: exhaustivestruct
 }
 
 func (s *IntegrationTestSuite) SetupSuite() {

--- a/x/auth/vesting/client/testutil/suite.go
+++ b/x/auth/vesting/client/testutil/suite.go
@@ -61,7 +61,7 @@ func (s *IntegrationTestSuite) TestNewMsgCreateVestingAccountCmd() {
 			},
 			expectErr:    false,
 			expectedCode: 0,
-			respType:     &sdk.TxResponse{},
+			respType:     &sdk.TxResponse{}, // nolint: exhaustivestruct
 		},
 		"create a delayed vesting account": {
 			args: []string{
@@ -76,7 +76,7 @@ func (s *IntegrationTestSuite) TestNewMsgCreateVestingAccountCmd() {
 			},
 			expectErr:    false,
 			expectedCode: 0,
-			respType:     &sdk.TxResponse{},
+			respType:     &sdk.TxResponse{}, // nolint: exhaustivestruct
 		},
 		"invalid address": {
 			args: []string{
@@ -87,7 +87,7 @@ func (s *IntegrationTestSuite) TestNewMsgCreateVestingAccountCmd() {
 			},
 			expectErr:    true,
 			expectedCode: 0,
-			respType:     &sdk.TxResponse{},
+			respType:     &sdk.TxResponse{}, // nolint: exhaustivestruct
 		},
 		"invalid coins": {
 			args: []string{
@@ -98,7 +98,7 @@ func (s *IntegrationTestSuite) TestNewMsgCreateVestingAccountCmd() {
 			},
 			expectErr:    true,
 			expectedCode: 0,
-			respType:     &sdk.TxResponse{},
+			respType:     &sdk.TxResponse{}, // nolint: exhaustivestruct
 		},
 		"invalid end time": {
 			args: []string{
@@ -109,7 +109,7 @@ func (s *IntegrationTestSuite) TestNewMsgCreateVestingAccountCmd() {
 			},
 			expectErr:    true,
 			expectedCode: 0,
-			respType:     &sdk.TxResponse{},
+			respType:     &sdk.TxResponse{}, // nolint: exhaustivestruct
 		},
 	}
 
@@ -167,7 +167,7 @@ func (s *IntegrationTestSuite) TestNewMsgCreatePermanentLockedAccountCmd() {
 			},
 			expectErr:    false,
 			expectedCode: 0,
-			respType:     &sdk.TxResponse{},
+			respType:     &sdk.TxResponse{}, // nolint: exhaustivestruct
 		},
 		"invalid address": {
 			args: []string{
@@ -178,7 +178,7 @@ func (s *IntegrationTestSuite) TestNewMsgCreatePermanentLockedAccountCmd() {
 			},
 			expectErr:    true,
 			expectedCode: 0,
-			respType:     &sdk.TxResponse{},
+			respType:     &sdk.TxResponse{}, // nolint: exhaustivestruct
 		},
 		"invalid coins": {
 			args: []string{
@@ -189,7 +189,7 @@ func (s *IntegrationTestSuite) TestNewMsgCreatePermanentLockedAccountCmd() {
 			},
 			expectErr:    true,
 			expectedCode: 0,
-			respType:     &sdk.TxResponse{},
+			respType:     &sdk.TxResponse{}, // nolint: exhaustivestruct
 		},
 	}
 

--- a/x/auth/vesting/client/testutil/suite.go
+++ b/x/auth/vesting/client/testutil/suite.go
@@ -43,6 +43,7 @@ func (s *IntegrationTestSuite) TearDownSuite() {
 func (s *IntegrationTestSuite) TestNewMsgCreateVestingAccountCmd() {
 	val := s.network.Validators[0]
 
+	// nolint: exhaustivestruct
 	testCases := map[string]struct {
 		args         []string
 		expectErr    bool
@@ -61,7 +62,7 @@ func (s *IntegrationTestSuite) TestNewMsgCreateVestingAccountCmd() {
 			},
 			expectErr:    false,
 			expectedCode: 0,
-			respType:     &sdk.TxResponse{}, // nolint: exhaustivestruct
+			respType:     &sdk.TxResponse{},
 		},
 		"create a delayed vesting account": {
 			args: []string{
@@ -76,7 +77,7 @@ func (s *IntegrationTestSuite) TestNewMsgCreateVestingAccountCmd() {
 			},
 			expectErr:    false,
 			expectedCode: 0,
-			respType:     &sdk.TxResponse{}, // nolint: exhaustivestruct
+			respType:     &sdk.TxResponse{},
 		},
 		"invalid address": {
 			args: []string{
@@ -87,7 +88,7 @@ func (s *IntegrationTestSuite) TestNewMsgCreateVestingAccountCmd() {
 			},
 			expectErr:    true,
 			expectedCode: 0,
-			respType:     &sdk.TxResponse{}, // nolint: exhaustivestruct
+			respType:     &sdk.TxResponse{},
 		},
 		"invalid coins": {
 			args: []string{
@@ -98,7 +99,7 @@ func (s *IntegrationTestSuite) TestNewMsgCreateVestingAccountCmd() {
 			},
 			expectErr:    true,
 			expectedCode: 0,
-			respType:     &sdk.TxResponse{}, // nolint: exhaustivestruct
+			respType:     &sdk.TxResponse{},
 		},
 		"invalid end time": {
 			args: []string{
@@ -109,7 +110,7 @@ func (s *IntegrationTestSuite) TestNewMsgCreateVestingAccountCmd() {
 			},
 			expectErr:    true,
 			expectedCode: 0,
-			respType:     &sdk.TxResponse{}, // nolint: exhaustivestruct
+			respType:     &sdk.TxResponse{},
 		},
 	}
 
@@ -150,6 +151,7 @@ func (s *IntegrationTestSuite) TestNewMsgCreateVestingAccountCmd() {
 func (s *IntegrationTestSuite) TestNewMsgCreatePermanentLockedAccountCmd() {
 	val := s.network.Validators[0]
 
+	// nolint: exhaustivestruct
 	testCases := map[string]struct {
 		args         []string
 		expectErr    bool
@@ -167,7 +169,7 @@ func (s *IntegrationTestSuite) TestNewMsgCreatePermanentLockedAccountCmd() {
 			},
 			expectErr:    false,
 			expectedCode: 0,
-			respType:     &sdk.TxResponse{}, // nolint: exhaustivestruct
+			respType:     &sdk.TxResponse{},
 		},
 		"invalid address": {
 			args: []string{
@@ -178,7 +180,7 @@ func (s *IntegrationTestSuite) TestNewMsgCreatePermanentLockedAccountCmd() {
 			},
 			expectErr:    true,
 			expectedCode: 0,
-			respType:     &sdk.TxResponse{}, // nolint: exhaustivestruct
+			respType:     &sdk.TxResponse{},
 		},
 		"invalid coins": {
 			args: []string{
@@ -189,7 +191,7 @@ func (s *IntegrationTestSuite) TestNewMsgCreatePermanentLockedAccountCmd() {
 			},
 			expectErr:    true,
 			expectedCode: 0,
-			respType:     &sdk.TxResponse{}, // nolint: exhaustivestruct
+			respType:     &sdk.TxResponse{},
 		},
 	}
 

--- a/x/auth/vesting/module.go
+++ b/x/auth/vesting/module.go
@@ -18,9 +18,10 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
 )
 
+// nolint: exhaustivestruct
 var (
-	_ module.AppModule      = AppModule{}      // nolint: exhaustivestruct
-	_ module.AppModuleBasic = AppModuleBasic{} // nolint: exhaustivestruct
+	_ module.AppModule      = AppModule{}
+	_ module.AppModuleBasic = AppModuleBasic{}
 )
 
 // AppModuleBasic defines the basic application module used by the sub-vesting

--- a/x/auth/vesting/module.go
+++ b/x/auth/vesting/module.go
@@ -19,8 +19,8 @@ import (
 )
 
 var (
-	_ module.AppModule      = AppModule{}
-	_ module.AppModuleBasic = AppModuleBasic{}
+	_ module.AppModule      = AppModule{}      // nolint: exhaustivestruct
+	_ module.AppModuleBasic = AppModuleBasic{} // nolint: exhaustivestruct
 )
 
 // AppModuleBasic defines the basic application module used by the sub-vesting

--- a/x/auth/vesting/msg_server.go
+++ b/x/auth/vesting/msg_server.go
@@ -25,7 +25,7 @@ func NewMsgServerImpl(k keeper.AccountKeeper, bk types.BankKeeper) types.MsgServ
 	return &msgServer{AccountKeeper: k, BankKeeper: bk}
 }
 
-var _ types.MsgServer = msgServer{}
+var _ types.MsgServer = msgServer{} // nolint: exhaustivestruct
 
 func (s msgServer) CreateVestingAccount(goCtx context.Context, msg *types.MsgCreateVestingAccount) (*types.MsgCreateVestingAccountResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)

--- a/x/auth/vesting/types/codec.go
+++ b/x/auth/vesting/types/codec.go
@@ -1,3 +1,4 @@
+// nolint: exhaustivestruct
 package types
 
 import (

--- a/x/auth/vesting/types/msgs.go
+++ b/x/auth/vesting/types/msgs.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"fmt"
+
 	"github.com/cosmos/cosmos-sdk/codec/legacy"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -17,11 +18,11 @@ const TypeMsgCreatePermanentLockedAccount = "msg_create_permanent_locked_account
 // TypeMsgCreatePeriodicVestingAccount defines the type value for a MsgCreateVestingAccount.
 const TypeMsgCreatePeriodicVestingAccount = "msg_create_periodic_vesting_account"
 
-var _ sdk.Msg = &MsgCreateVestingAccount{}
+var _ sdk.Msg = &MsgCreateVestingAccount{} // nolint: exhaustivestruct
 
-var _ sdk.Msg = &MsgCreatePermanentLockedAccount{}
+var _ sdk.Msg = &MsgCreatePermanentLockedAccount{} // nolint: exhaustivestruct
 
-var _ sdk.Msg = &MsgCreatePeriodicVestingAccount{}
+var _ sdk.Msg = &MsgCreatePeriodicVestingAccount{} // nolint: exhaustivestruct
 
 // NewMsgCreateVestingAccount returns a reference to a new MsgCreateVestingAccount.
 //nolint:interfacer

--- a/x/authz/authorization_grant.go
+++ b/x/authz/authorization_grant.go
@@ -32,6 +32,7 @@ func NewGrant(blockTime time.Time, a Authorization, expiration time.Time) (Grant
 	return g, nil
 }
 
+// nolint: exhaustivestruct
 var (
 	_ cdctypes.UnpackInterfacesMessage = &Grant{}
 )

--- a/x/authz/client/cli/query.go
+++ b/x/authz/client/cli/query.go
@@ -16,7 +16,7 @@ import (
 
 // GetQueryCmd returns the cli query commands for this module
 func GetQueryCmd() *cobra.Command {
-	authorizationQueryCmd := &cobra.Command{
+	authorizationQueryCmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:                        authz.ModuleName,
 		Short:                      "Querying commands for the authz module",
 		Long:                       "",
@@ -36,7 +36,7 @@ func GetQueryCmd() *cobra.Command {
 
 // GetCmdQueryGrants implements the query authorization command.
 func GetCmdQueryGrants() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "grants [granter-addr] [grantee-addr] [msg-type-url]?",
 		Args:  cobra.RangeArgs(2, 3),
 		Short: "query grants for a granter-grantee pair and optionally a msg-type-url",
@@ -95,7 +95,7 @@ $ %s query %s grants cosmos1skjw.. cosmos1skjwj.. %s
 }
 
 func GetQueryGranterGrants() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "granter-grants [granter-addr]",
 		Args:  cobra.ExactArgs(1),
 		Short: "query authorization grants granted by granter",
@@ -143,7 +143,7 @@ $ %s q %s granter-grants cosmos1skj..
 }
 
 func GetQueryGranteeGrants() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "grantee-grants [grantee-addr]",
 		Args:  cobra.ExactArgs(1),
 		Short: "query authorization grants granted to a grantee",

--- a/x/authz/client/cli/query.go
+++ b/x/authz/client/cli/query.go
@@ -48,7 +48,7 @@ $ %s query %s grants cosmos1skj.. cosmos1skjwj..
 $ %s query %s grants cosmos1skjw.. cosmos1skjwj.. %s
 `,
 				version.AppName, authz.ModuleName,
-				version.AppName, authz.ModuleName, bank.SendAuthorization{}.MsgTypeURL()),
+				version.AppName, authz.ModuleName, bank.SendAuthorization{}.MsgTypeURL()), // nolint: exhaustivestruct
 		),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clientCtx, err := client.GetClientQueryContext(cmd)

--- a/x/authz/client/cli/tx.go
+++ b/x/authz/client/cli/tx.go
@@ -33,7 +33,7 @@ const (
 
 // GetTxCmd returns the transaction commands for this module
 func GetTxCmd() *cobra.Command {
-	AuthorizationTxCmd := &cobra.Command{
+	AuthorizationTxCmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:                        authz.ModuleName,
 		Short:                      "Authorization transactions subcommands",
 		Long:                       "Authorize and revoke access to execute transactions on behalf of your address",
@@ -52,7 +52,7 @@ func GetTxCmd() *cobra.Command {
 }
 
 func NewCmdGrantAuthorization() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "grant <grantee> <authorization_type=\"send\"|\"generic\"|\"delegate\"|\"unbond\"|\"redelegate\"> --from <granter>",
 		Short: "Grant authorization to an address",
 		Long: strings.TrimSpace(
@@ -178,7 +178,7 @@ Examples:
 }
 
 func NewCmdRevokeAuthorization() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "revoke [grantee] [msg-type-url] --from=[granter]",
 		Short: "revoke authorization",
 		Long: strings.TrimSpace(
@@ -211,7 +211,7 @@ Example:
 }
 
 func NewCmdExecAuthorization() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "exec [tx-json-file] --from [grantee]",
 		Short: "execute tx on behalf of granter account",
 		Long: strings.TrimSpace(

--- a/x/authz/client/cli/tx.go
+++ b/x/authz/client/cli/tx.go
@@ -61,7 +61,7 @@ func NewCmdGrantAuthorization() *cobra.Command {
 Examples:
  $ %s tx %s grant cosmos1skjw.. send %s --spend-limit=1000stake --from=cosmos1skl..
  $ %s tx %s grant cosmos1skjw.. generic --msg-type=/cosmos.gov.v1.MsgVote --from=cosmos1sk..
-	`, version.AppName, authz.ModuleName, bank.SendAuthorization{}.MsgTypeURL(), version.AppName, authz.ModuleName),
+	`, version.AppName, authz.ModuleName, bank.SendAuthorization{}.MsgTypeURL(), version.AppName, authz.ModuleName), // nolint: exhaustivestruct
 		),
 		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -185,7 +185,7 @@ func NewCmdRevokeAuthorization() *cobra.Command {
 			fmt.Sprintf(`revoke authorization from a granter to a grantee:
 Example:
  $ %s tx %s revoke cosmos1skj.. %s --from=cosmos1skj..
-			`, version.AppName, authz.ModuleName, bank.SendAuthorization{}.MsgTypeURL()),
+			`, version.AppName, authz.ModuleName, bank.SendAuthorization{}.MsgTypeURL()), // nolint: exhaustivestruct
 		),
 		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/x/authz/client/testutil/grpc.go
+++ b/x/authz/client/testutil/grpc.go
@@ -74,7 +74,7 @@ func (s *IntegrationTestSuite) TestQueryGrantGRPC() {
 				g.Grants[0].UnpackInterfaces(val.ClientCtx.InterfaceRegistry)
 				auth, err := g.Grants[0].GetAuthorization()
 				require.NoError(err)
-				require.Equal(auth.MsgTypeURL(), banktypes.SendAuthorization{}.MsgTypeURL())
+				require.Equal(auth.MsgTypeURL(), banktypes.SendAuthorization{}.MsgTypeURL()) // nolint: exhaustivestruct
 			}
 		})
 	}

--- a/x/authz/client/testutil/tx.go
+++ b/x/authz/client/testutil/tx.go
@@ -139,7 +139,7 @@ func (s *IntegrationTestSuite) TearDownSuite() {
 	s.network.Cleanup()
 }
 
-var typeMsgSend = bank.SendAuthorization{}.MsgTypeURL()
+var typeMsgSend = bank.SendAuthorization{}.MsgTypeURL()                // nolint: exhaustivestruct
 var typeMsgVote = sdk.MsgTypeURL(&govv1.MsgVote{})                     // nolint: exhaustivestruct
 var typeMsgSubmitProposal = sdk.MsgTypeURL(&govv1.MsgSubmitProposal{}) // nolint: exhaustivestruct
 

--- a/x/authz/client/testutil/tx.go
+++ b/x/authz/client/testutil/tx.go
@@ -419,6 +419,7 @@ func (s *IntegrationTestSuite) TestCmdRevokeAuthorizations() {
 	)
 	s.Require().NoError(err)
 
+	// nolint: exhaustivestruct
 	testCases := []struct {
 		name         string
 		args         []string
@@ -460,7 +461,7 @@ func (s *IntegrationTestSuite) TestCmdRevokeAuthorizations() {
 				fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
 				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(10))).String()),
 			},
-			&sdk.TxResponse{}, 0, // nolint: exhaustivestruct
+			&sdk.TxResponse{}, 0,
 			false,
 		},
 		{
@@ -473,7 +474,7 @@ func (s *IntegrationTestSuite) TestCmdRevokeAuthorizations() {
 				fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
 				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(10))).String()),
 			},
-			&sdk.TxResponse{}, 0, // nolint: exhaustivestruct
+			&sdk.TxResponse{}, 0,
 			false,
 		},
 		{
@@ -487,7 +488,7 @@ func (s *IntegrationTestSuite) TestCmdRevokeAuthorizations() {
 				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(10))).String()),
 				fmt.Sprintf("--%s=%s", flags.FlagSignMode, flags.SignModeLegacyAminoJSON),
 			},
-			&sdk.TxResponse{}, 0, // nolint: exhaustivestruct
+			&sdk.TxResponse{}, 0,
 			false,
 		},
 	}
@@ -575,6 +576,7 @@ func (s *IntegrationTestSuite) TestNewExecGenericAuthorized() {
 	voteTx := fmt.Sprintf(`{"body":{"messages":[{"@type":"/cosmos.gov.v1.MsgVote","proposal_id":"1","voter":"%s","option":"VOTE_OPTION_YES"}],"memo":"","timeout_height":"0","extension_options":[],"non_critical_extension_options":[]},"auth_info":{"signer_infos":[],"fee":{"amount":[],"gas_limit":"200000","payer":"","granter":""}},"signatures":[]}`, val.Address.String())
 	execMsg := testutil.WriteToNewTempFile(s.T(), voteTx)
 
+	// nolint: exhaustivestruct
 	testCases := []struct {
 		name         string
 		args         []string
@@ -614,7 +616,7 @@ func (s *IntegrationTestSuite) TestNewExecGenericAuthorized() {
 				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(10))).String()),
 				fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
 			},
-			&sdk.TxResponse{}, // nolint: exhaustivestruct
+			&sdk.TxResponse{},
 			0,
 			false,
 		},
@@ -628,7 +630,7 @@ func (s *IntegrationTestSuite) TestNewExecGenericAuthorized() {
 				fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
 				fmt.Sprintf("--%s=%s", flags.FlagSignMode, flags.SignModeLegacyAminoJSON),
 			},
-			&sdk.TxResponse{}, 0, // nolint: exhaustivestruct
+			&sdk.TxResponse{}, 0,
 			false,
 		},
 	}

--- a/x/authz/client/testutil/tx.go
+++ b/x/authz/client/testutil/tx.go
@@ -460,7 +460,7 @@ func (s *IntegrationTestSuite) TestCmdRevokeAuthorizations() {
 				fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
 				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(10))).String()),
 			},
-			&sdk.TxResponse{}, 0,
+			&sdk.TxResponse{}, 0, // nolint: exhaustivestruct
 			false,
 		},
 		{
@@ -473,7 +473,7 @@ func (s *IntegrationTestSuite) TestCmdRevokeAuthorizations() {
 				fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
 				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(10))).String()),
 			},
-			&sdk.TxResponse{}, 0,
+			&sdk.TxResponse{}, 0, // nolint: exhaustivestruct
 			false,
 		},
 		{
@@ -487,7 +487,7 @@ func (s *IntegrationTestSuite) TestCmdRevokeAuthorizations() {
 				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(10))).String()),
 				fmt.Sprintf("--%s=%s", flags.FlagSignMode, flags.SignModeLegacyAminoJSON),
 			},
-			&sdk.TxResponse{}, 0,
+			&sdk.TxResponse{}, 0, // nolint: exhaustivestruct
 			false,
 		},
 	}
@@ -614,7 +614,7 @@ func (s *IntegrationTestSuite) TestNewExecGenericAuthorized() {
 				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(10))).String()),
 				fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
 			},
-			&sdk.TxResponse{},
+			&sdk.TxResponse{}, // nolint: exhaustivestruct
 			0,
 			false,
 		},
@@ -628,7 +628,7 @@ func (s *IntegrationTestSuite) TestNewExecGenericAuthorized() {
 				fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
 				fmt.Sprintf("--%s=%s", flags.FlagSignMode, flags.SignModeLegacyAminoJSON),
 			},
-			&sdk.TxResponse{}, 0,
+			&sdk.TxResponse{}, 0, // nolint: exhaustivestruct
 			false,
 		},
 	}

--- a/x/authz/client/testutil/tx.go
+++ b/x/authz/client/testutil/tx.go
@@ -33,7 +33,7 @@ type IntegrationTestSuite struct {
 }
 
 func NewIntegrationTestSuite(cfg network.Config) *IntegrationTestSuite {
-	return &IntegrationTestSuite{cfg: cfg}
+	return &IntegrationTestSuite{cfg: cfg} // nolint: exhaustivestruct
 }
 
 func (s *IntegrationTestSuite) SetupSuite() {
@@ -140,8 +140,8 @@ func (s *IntegrationTestSuite) TearDownSuite() {
 }
 
 var typeMsgSend = bank.SendAuthorization{}.MsgTypeURL()
-var typeMsgVote = sdk.MsgTypeURL(&govv1.MsgVote{})
-var typeMsgSubmitProposal = sdk.MsgTypeURL(&govv1.MsgSubmitProposal{})
+var typeMsgVote = sdk.MsgTypeURL(&govv1.MsgVote{})                     // nolint: exhaustivestruct
+var typeMsgSubmitProposal = sdk.MsgTypeURL(&govv1.MsgSubmitProposal{}) // nolint: exhaustivestruct
 
 func (s *IntegrationTestSuite) TestCLITxGrantAuthorization() {
 	val := s.network.Validators[0]

--- a/x/authz/codec.go
+++ b/x/authz/codec.go
@@ -1,3 +1,4 @@
+// nolint: exhaustivestruct
 package authz
 
 import (

--- a/x/authz/generic_authorization.go
+++ b/x/authz/generic_authorization.go
@@ -4,6 +4,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
+// nolint: exhaustivestruct
 var (
 	_ Authorization = &GenericAuthorization{}
 )

--- a/x/authz/genesis.go
+++ b/x/authz/genesis.go
@@ -21,7 +21,7 @@ func DefaultGenesisState() *GenesisState {
 	return &GenesisState{}
 }
 
-var _ cdctypes.UnpackInterfacesMessage = GenesisState{}
+var _ cdctypes.UnpackInterfacesMessage = GenesisState{} // nolint: exhaustivestruct
 
 // UnpackInterfaces implements UnpackInterfacesMessage.UnpackInterfaces
 func (data GenesisState) UnpackInterfaces(unpacker cdctypes.AnyUnpacker) error {

--- a/x/authz/keeper/grpc_query.go
+++ b/x/authz/keeper/grpc_query.go
@@ -17,7 +17,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/authz"
 )
 
-var _ authz.QueryServer = Keeper{}
+var _ authz.QueryServer = Keeper{} // nolint: exhaustivestruct
 
 // Authorizations implements the Query/Grants gRPC method.
 func (k Keeper) Grants(c context.Context, req *authz.QueryGrantsRequest) (*authz.QueryGrantsResponse, error) {
@@ -56,6 +56,7 @@ func (k Keeper) Grants(c context.Context, req *authz.QueryGrantsRequest) (*authz
 				Authorization: authorizationAny,
 				Expiration:    grant.Expiration,
 			}},
+			Pagination: nil,
 		}, nil
 	}
 

--- a/x/authz/keeper/grpc_query.go
+++ b/x/authz/keeper/grpc_query.go
@@ -56,7 +56,6 @@ func (k Keeper) Grants(c context.Context, req *authz.QueryGrantsRequest) (*authz
 				Authorization: authorizationAny,
 				Expiration:    grant.Expiration,
 			}},
-			Pagination: nil,
 		}, nil
 	}
 

--- a/x/authz/keeper/msg_server.go
+++ b/x/authz/keeper/msg_server.go
@@ -8,7 +8,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/authz"
 )
 
-var _ authz.MsgServer = Keeper{}
+var _ authz.MsgServer = Keeper{} // nolint: exhaustivestruct
 
 // GrantAuthorization implements the MsgServer.Grant method to create a new grant.
 func (k Keeper) Grant(goCtx context.Context, msg *authz.MsgGrant) (*authz.MsgGrantResponse, error) {

--- a/x/authz/module/module.go
+++ b/x/authz/module/module.go
@@ -24,9 +24,9 @@ import (
 )
 
 var (
-	_ module.AppModule           = AppModule{}
-	_ module.AppModuleBasic      = AppModuleBasic{}
-	_ module.AppModuleSimulation = AppModule{}
+	_ module.AppModule           = AppModule{}      // nolint: exhaustivestruct
+	_ module.AppModuleBasic      = AppModuleBasic{} // nolint: exhaustivestruct
+	_ module.AppModuleSimulation = AppModule{}      // nolint: exhaustivestruct
 )
 
 // AppModuleBasic defines the basic application module used by the authz module.

--- a/x/authz/module/module.go
+++ b/x/authz/module/module.go
@@ -23,10 +23,11 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/authz/simulation"
 )
 
+// nolint: exhaustivestruct
 var (
-	_ module.AppModule           = AppModule{}      // nolint: exhaustivestruct
-	_ module.AppModuleBasic      = AppModuleBasic{} // nolint: exhaustivestruct
-	_ module.AppModuleSimulation = AppModule{}      // nolint: exhaustivestruct
+	_ module.AppModule           = AppModule{}
+	_ module.AppModuleBasic      = AppModuleBasic{}
+	_ module.AppModuleSimulation = AppModule{}
 )
 
 // AppModuleBasic defines the basic application module used by the authz module.

--- a/x/authz/msgs.go
+++ b/x/authz/msgs.go
@@ -1,8 +1,9 @@
 package authz
 
 import (
-	"github.com/cosmos/cosmos-sdk/codec/legacy"
 	"time"
+
+	"github.com/cosmos/cosmos-sdk/codec/legacy"
 
 	"github.com/gogo/protobuf/proto"
 
@@ -12,6 +13,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/auth/migrations/legacytx"
 )
 
+// nolint: exhaustivestruct
 var (
 	_ sdk.Msg = &MsgGrant{}
 	_ sdk.Msg = &MsgRevoke{}

--- a/x/authz/simulation/genesis.go
+++ b/x/authz/simulation/genesis.go
@@ -33,7 +33,7 @@ func genGrant(r *rand.Rand, accounts []simtypes.Account, genT time.Time) []authz
 func generateRandomGrant(r *rand.Rand) *codectypes.Any {
 	authorizations := make([]*codectypes.Any, 2)
 	authorizations[0] = newAnyAuthorization(banktypes.NewSendAuthorization(sdk.NewCoins(sdk.NewCoin("stake", sdk.NewInt(1000)))))
-	authorizations[1] = newAnyAuthorization(authz.NewGenericAuthorization(sdk.MsgTypeURL(&v1.MsgSubmitProposal{})))
+	authorizations[1] = newAnyAuthorization(authz.NewGenericAuthorization(sdk.MsgTypeURL(&v1.MsgSubmitProposal{}))) // nolint: exhaustivestruct
 
 	return authorizations[r.Intn(len(authorizations))]
 }

--- a/x/authz/simulation/operations.go
+++ b/x/authz/simulation/operations.go
@@ -21,9 +21,9 @@ import (
 
 // authz message types
 var (
-	TypeMsgGrant  = sdk.MsgTypeURL(&authz.MsgGrant{})
-	TypeMsgRevoke = sdk.MsgTypeURL(&authz.MsgRevoke{})
-	TypeMsgExec   = sdk.MsgTypeURL(&authz.MsgExec{})
+	TypeMsgGrant  = sdk.MsgTypeURL(&authz.MsgGrant{})  // nolint: exhaustivestruct
+	TypeMsgRevoke = sdk.MsgTypeURL(&authz.MsgRevoke{}) // nolint: exhaustivestruct
+	TypeMsgExec   = sdk.MsgTypeURL(&authz.MsgExec{})   // nolint: exhaustivestruct
 )
 
 // Simulation operation weights constants
@@ -142,7 +142,7 @@ func SimulateMsgGrant(ak authz.AccountKeeper, bk authz.BankKeeper, _ keeper.Keep
 func generateRandomAuthorization(r *rand.Rand, spendLimit sdk.Coins) authz.Authorization {
 	authorizations := make([]authz.Authorization, 2)
 	authorizations[0] = banktype.NewSendAuthorization(spendLimit)
-	authorizations[1] = authz.NewGenericAuthorization(sdk.MsgTypeURL(&banktype.MsgSend{}))
+	authorizations[1] = authz.NewGenericAuthorization(sdk.MsgTypeURL(&banktype.MsgSend{})) // nolint: exhaustivestruct
 
 	return authorizations[r.Intn(len(authorizations))]
 }

--- a/x/authz/simulation/operations.go
+++ b/x/authz/simulation/operations.go
@@ -20,10 +20,11 @@ import (
 )
 
 // authz message types
+// nolint: exhaustivestruct
 var (
-	TypeMsgGrant  = sdk.MsgTypeURL(&authz.MsgGrant{})  // nolint: exhaustivestruct
-	TypeMsgRevoke = sdk.MsgTypeURL(&authz.MsgRevoke{}) // nolint: exhaustivestruct
-	TypeMsgExec   = sdk.MsgTypeURL(&authz.MsgExec{})   // nolint: exhaustivestruct
+	TypeMsgGrant  = sdk.MsgTypeURL(&authz.MsgGrant{})
+	TypeMsgRevoke = sdk.MsgTypeURL(&authz.MsgRevoke{})
+	TypeMsgExec   = sdk.MsgTypeURL(&authz.MsgExec{})
 )
 
 // Simulation operation weights constants

--- a/x/bank/client/cli/query.go
+++ b/x/bank/client/cli/query.go
@@ -21,7 +21,7 @@ const (
 // provided clientCtx should have, at a minimum, a verifier, Tendermint RPC client,
 // and marshaler set.
 func GetQueryCmd() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:                        types.ModuleName,
 		Short:                      "Querying commands for the bank module",
 		DisableFlagParsing:         true,
@@ -39,7 +39,7 @@ func GetQueryCmd() *cobra.Command {
 }
 
 func GetBalancesCmd() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "balances [address]",
 		Short: "Query for account balances by address",
 		Long: strings.TrimSpace(
@@ -103,7 +103,7 @@ Example:
 
 // GetCmdDenomsMetadata defines the cobra command to query client denomination metadata.
 func GetCmdDenomsMetadata() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "denom-metadata",
 		Short: "Query the client metadata for coin denominations",
 		Long: strings.TrimSpace(
@@ -156,7 +156,7 @@ To query for the client metadata of a specific coin denomination use:
 }
 
 func GetCmdQueryTotalSupply() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "total",
 		Short: "Query the total supply of coins of the chain",
 		Args:  cobra.NoArgs,

--- a/x/bank/client/cli/tx.go
+++ b/x/bank/client/cli/tx.go
@@ -12,7 +12,7 @@ import (
 
 // NewTxCmd returns a root CLI command handler for all x/bank transaction commands.
 func NewTxCmd() *cobra.Command {
-	txCmd := &cobra.Command{
+	txCmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:                        types.ModuleName,
 		Short:                      "Bank transaction subcommands",
 		DisableFlagParsing:         true,
@@ -27,7 +27,7 @@ func NewTxCmd() *cobra.Command {
 
 // NewSendTxCmd returns a CLI command handler for creating a MsgSend transaction.
 func NewSendTxCmd() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use: "send [from_key_or_address] [to_address] [amount]",
 		Short: `Send funds from one account to another. Note, the'--from' flag is
 ignored as it is implied from [from_key_or_address].`,

--- a/x/bank/client/testutil/grpc.go
+++ b/x/bank/client/testutil/grpc.go
@@ -17,6 +17,7 @@ func (s *IntegrationTestSuite) TestTotalSupplyGRPCHandler() {
 	val := s.network.Validators[0]
 	baseURL := val.APIAddress
 
+	// nolint: exhaustivestruct
 	testCases := []struct {
 		name     string
 		url      string
@@ -103,6 +104,7 @@ func (s *IntegrationTestSuite) TestDenomMetadataGRPCHandler() {
 	val := s.network.Validators[0]
 	baseURL := val.APIAddress
 
+	// nolint: exhaustivestruct
 	testCases := []struct {
 		name     string
 		url      string
@@ -228,6 +230,7 @@ func (s *IntegrationTestSuite) TestBalancesGRPCHandler() {
 	val := s.network.Validators[0]
 	baseURL := val.APIAddress
 
+	// nolint: exhaustivestruct
 	testCases := []struct {
 		name     string
 		url      string

--- a/x/bank/client/testutil/suite.go
+++ b/x/bank/client/testutil/suite.go
@@ -25,7 +25,7 @@ type IntegrationTestSuite struct {
 }
 
 func NewIntegrationTestSuite(cfg network.Config) *IntegrationTestSuite {
-	return &IntegrationTestSuite{cfg: cfg}
+	return &IntegrationTestSuite{cfg: cfg} // nolint: exhaustivestruct
 }
 
 func (s *IntegrationTestSuite) SetupSuite() {

--- a/x/bank/client/testutil/suite.go
+++ b/x/bank/client/testutil/suite.go
@@ -95,6 +95,7 @@ func (s *IntegrationTestSuite) TearDownSuite() {
 func (s *IntegrationTestSuite) TestGetBalancesCmd() {
 	val := s.network.Validators[0]
 
+	// nolint: exhaustivestruct
 	testCases := []struct {
 		name      string
 		args      []string
@@ -166,6 +167,7 @@ func (s *IntegrationTestSuite) TestGetBalancesCmd() {
 func (s *IntegrationTestSuite) TestGetCmdQueryTotalSupply() {
 	val := s.network.Validators[0]
 
+	// nolint: exhaustivestruct
 	testCases := []struct {
 		name      string
 		args      []string
@@ -238,6 +240,7 @@ func (s *IntegrationTestSuite) TestGetCmdQueryTotalSupply() {
 func (s *IntegrationTestSuite) TestGetCmdQueryDenomsMetadata() {
 	val := s.network.Validators[0]
 
+	// nolint: exhaustivestruct
 	testCases := []struct {
 		name      string
 		args      []string
@@ -390,6 +393,7 @@ func (s *IntegrationTestSuite) TestNewSendTxCmdGenOnly() {
 func (s *IntegrationTestSuite) TestNewSendTxCmd() {
 	val := s.network.Validators[0]
 
+	// nolint: exhaustivestruct
 	testCases := []struct {
 		name         string
 		from, to     sdk.AccAddress
@@ -412,7 +416,7 @@ func (s *IntegrationTestSuite) TestNewSendTxCmd() {
 				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastSync),
 				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(10))).String()),
 			},
-			false, 0, &sdk.TxResponse{}, // nolint: exhaustivestruct
+			false, 0, &sdk.TxResponse{},
 		},
 		{
 			"chain-id shouldn't be used with offline and generate-only flags",
@@ -429,7 +433,7 @@ func (s *IntegrationTestSuite) TestNewSendTxCmd() {
 				fmt.Sprintf("--%s=true", flags.FlagOffline),
 				fmt.Sprintf("--%s=true", flags.FlagGenerateOnly),
 			},
-			true, 0, &sdk.TxResponse{}, // nolint: exhaustivestruct
+			true, 0, &sdk.TxResponse{},
 		},
 		{
 			"not enough fees",
@@ -446,7 +450,7 @@ func (s *IntegrationTestSuite) TestNewSendTxCmd() {
 			},
 			false,
 			sdkerrors.ErrInsufficientFee.ABCICode(),
-			&sdk.TxResponse{}, // nolint: exhaustivestruct
+			&sdk.TxResponse{},
 		},
 		{
 			"not enough gas",
@@ -464,7 +468,7 @@ func (s *IntegrationTestSuite) TestNewSendTxCmd() {
 			},
 			false,
 			sdkerrors.ErrOutOfGas.ABCICode(),
-			&sdk.TxResponse{}, // nolint: exhaustivestruct
+			&sdk.TxResponse{},
 		},
 	}
 

--- a/x/bank/client/testutil/suite.go
+++ b/x/bank/client/testutil/suite.go
@@ -412,7 +412,7 @@ func (s *IntegrationTestSuite) TestNewSendTxCmd() {
 				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastSync),
 				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(10))).String()),
 			},
-			false, 0, &sdk.TxResponse{},
+			false, 0, &sdk.TxResponse{}, // nolint: exhaustivestruct
 		},
 		{
 			"chain-id shouldn't be used with offline and generate-only flags",
@@ -429,7 +429,7 @@ func (s *IntegrationTestSuite) TestNewSendTxCmd() {
 				fmt.Sprintf("--%s=true", flags.FlagOffline),
 				fmt.Sprintf("--%s=true", flags.FlagGenerateOnly),
 			},
-			true, 0, &sdk.TxResponse{},
+			true, 0, &sdk.TxResponse{}, // nolint: exhaustivestruct
 		},
 		{
 			"not enough fees",
@@ -446,7 +446,7 @@ func (s *IntegrationTestSuite) TestNewSendTxCmd() {
 			},
 			false,
 			sdkerrors.ErrInsufficientFee.ABCICode(),
-			&sdk.TxResponse{},
+			&sdk.TxResponse{}, // nolint: exhaustivestruct
 		},
 		{
 			"not enough gas",
@@ -464,7 +464,7 @@ func (s *IntegrationTestSuite) TestNewSendTxCmd() {
 			},
 			false,
 			sdkerrors.ErrOutOfGas.ABCICode(),
-			&sdk.TxResponse{},
+			&sdk.TxResponse{}, // nolint: exhaustivestruct
 		},
 	}
 

--- a/x/bank/keeper/grpc_query.go
+++ b/x/bank/keeper/grpc_query.go
@@ -12,7 +12,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/bank/types"
 )
 
-var _ types.QueryServer = BaseKeeper{}
+var _ types.QueryServer = BaseKeeper{} // nolint: exhaustivestruct
 
 // Balance implements the Query/Balance gRPC method
 func (k BaseKeeper) Balance(ctx context.Context, req *types.QueryBalanceRequest) (*types.QueryBalanceResponse, error) {

--- a/x/bank/keeper/keeper.go
+++ b/x/bank/keeper/keeper.go
@@ -256,7 +256,7 @@ func (k BaseKeeper) GetDenomMetaData(ctx sdk.Context, denom string) (types.Metad
 
 	bz := store.Get(conv.UnsafeStrToBytes(denom))
 	if bz == nil {
-		return types.Metadata{}, false
+		return types.Metadata{}, false // nolint: exhaustivestruct
 	}
 
 	var metadata types.Metadata

--- a/x/bank/keeper/msg_server.go
+++ b/x/bank/keeper/msg_server.go
@@ -21,7 +21,7 @@ func NewMsgServerImpl(keeper Keeper) types.MsgServer {
 	return &msgServer{Keeper: keeper}
 }
 
-var _ types.MsgServer = msgServer{}
+var _ types.MsgServer = msgServer{} // nolint: exhaustivestruct
 
 func (k msgServer) Send(goCtx context.Context, msg *types.MsgSend) (*types.MsgSendResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)

--- a/x/bank/module.go
+++ b/x/bank/module.go
@@ -26,10 +26,11 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/bank/types"
 )
 
+// nolint: exhaustivestruct
 var (
-	_ module.AppModule           = AppModule{}      // nolint: exhaustivestruct
-	_ module.AppModuleBasic      = AppModuleBasic{} // nolint: exhaustivestruct
-	_ module.AppModuleSimulation = AppModule{}      // nolint: exhaustivestruct
+	_ module.AppModule           = AppModule{}
+	_ module.AppModuleBasic      = AppModuleBasic{}
+	_ module.AppModuleSimulation = AppModule{}
 )
 
 // AppModuleBasic defines the basic application module used by the bank module.

--- a/x/bank/module.go
+++ b/x/bank/module.go
@@ -27,9 +27,9 @@ import (
 )
 
 var (
-	_ module.AppModule           = AppModule{}
-	_ module.AppModuleBasic      = AppModuleBasic{}
-	_ module.AppModuleSimulation = AppModule{}
+	_ module.AppModule           = AppModule{}      // nolint: exhaustivestruct
+	_ module.AppModuleBasic      = AppModuleBasic{} // nolint: exhaustivestruct
+	_ module.AppModuleSimulation = AppModule{}      // nolint: exhaustivestruct
 )
 
 // AppModuleBasic defines the basic application module used by the bank module.

--- a/x/bank/types/codec.go
+++ b/x/bank/types/codec.go
@@ -1,3 +1,4 @@
+// nolint: exhaustivestruct
 package types
 
 import (

--- a/x/bank/types/msgs.go
+++ b/x/bank/types/msgs.go
@@ -12,7 +12,7 @@ const (
 	TypeMsgMultiSend = "multisend"
 )
 
-var _ sdk.Msg = &MsgSend{}
+var _ sdk.Msg = &MsgSend{} // nolint: exhaustivestruct
 
 // NewMsgSend - construct a msg to send coins from one account to another.
 //nolint:interfacer
@@ -58,7 +58,7 @@ func (msg MsgSend) GetSigners() []sdk.AccAddress {
 	return []sdk.AccAddress{fromAddress}
 }
 
-var _ sdk.Msg = &MsgMultiSend{}
+var _ sdk.Msg = &MsgMultiSend{} // nolint: exhaustivestruct
 
 // NewMsgMultiSend - construct arbitrary multi-in, multi-out send msg.
 func NewMsgMultiSend(in []Input, out []Output) *MsgMultiSend {

--- a/x/bank/types/params.go
+++ b/x/bank/types/params.go
@@ -24,7 +24,7 @@ var (
 
 // ParamKeyTable for bank module.
 func ParamKeyTable() paramtypes.KeyTable {
-	return paramtypes.NewKeyTable().RegisterParamSet(&Params{})
+	return paramtypes.NewKeyTable().RegisterParamSet(&Params{}) // nolint: exhaustivestruct
 }
 
 // NewParams creates a new parameter configuration for the bank module

--- a/x/bank/types/send_authorization.go
+++ b/x/bank/types/send_authorization.go
@@ -19,7 +19,7 @@ func NewSendAuthorization(spendLimit sdk.Coins) *SendAuthorization {
 
 // MsgTypeURL implements Authorization.MsgTypeURL.
 func (a SendAuthorization) MsgTypeURL() string {
-	return sdk.MsgTypeURL(&MsgSend{})
+	return sdk.MsgTypeURL(&MsgSend{}) // nolint: exhaustivestruct
 }
 
 // Accept implements Authorization.Accept.

--- a/x/bank/types/send_authorization.go
+++ b/x/bank/types/send_authorization.go
@@ -6,6 +6,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/authz"
 )
 
+// nolint: exhaustivestruct
 var (
 	_ authz.Authorization = &SendAuthorization{}
 )

--- a/x/capability/keeper/keeper.go
+++ b/x/capability/keeper/keeper.go
@@ -186,7 +186,7 @@ func (k Keeper) GetOwners(ctx sdk.Context, index uint64) (types.CapabilityOwners
 	// get owners for index from persistent store
 	ownerBytes := prefixStore.Get(indexKey)
 	if ownerBytes == nil {
-		return types.CapabilityOwners{}, false
+		return types.CapabilityOwners{}, false // nolint: exhaustivestruct
 	}
 	var owners types.CapabilityOwners
 	k.cdc.MustUnmarshal(ownerBytes, &owners)

--- a/x/capability/module.go
+++ b/x/capability/module.go
@@ -24,10 +24,11 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/capability/types"
 )
 
+// nolint: exhaustivestruct
 var (
-	_ module.AppModule           = AppModule{}      // nolint: exhaustivestruct
-	_ module.AppModuleBasic      = AppModuleBasic{} // nolint: exhaustivestruct
-	_ module.AppModuleSimulation = AppModule{}      // nolint: exhaustivestruct
+	_ module.AppModule           = AppModule{}
+	_ module.AppModuleBasic      = AppModuleBasic{}
+	_ module.AppModuleSimulation = AppModule{}
 )
 
 // ----------------------------------------------------------------------------

--- a/x/capability/module.go
+++ b/x/capability/module.go
@@ -25,9 +25,9 @@ import (
 )
 
 var (
-	_ module.AppModule           = AppModule{}
-	_ module.AppModuleBasic      = AppModuleBasic{}
-	_ module.AppModuleSimulation = AppModule{}
+	_ module.AppModule           = AppModule{}      // nolint: exhaustivestruct
+	_ module.AppModuleBasic      = AppModuleBasic{} // nolint: exhaustivestruct
+	_ module.AppModuleSimulation = AppModule{}      // nolint: exhaustivestruct
 )
 
 // ----------------------------------------------------------------------------

--- a/x/crisis/client/cli/tx.go
+++ b/x/crisis/client/cli/tx.go
@@ -13,7 +13,7 @@ import (
 
 // NewTxCmd returns a root CLI command handler for all x/crisis transaction commands.
 func NewTxCmd() *cobra.Command {
-	txCmd := &cobra.Command{
+	txCmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:                        types.ModuleName,
 		Short:                      "Crisis transactions subcommands",
 		DisableFlagParsing:         true,
@@ -29,7 +29,7 @@ func NewTxCmd() *cobra.Command {
 // NewMsgVerifyInvariantTxCmd returns a CLI command handler for creating a
 // MsgVerifyInvariant transaction.
 func NewMsgVerifyInvariantTxCmd() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "invariant-broken [module-name] [invariant-route]",
 		Short: "Submit proof that an invariant broken to halt the chain",
 		Args:  cobra.ExactArgs(2),

--- a/x/crisis/client/testsuite/suite.go
+++ b/x/crisis/client/testsuite/suite.go
@@ -43,6 +43,7 @@ func (s *IntegrationTestSuite) TearDownSuite() {
 func (s *IntegrationTestSuite) TestNewMsgVerifyInvariantTxCmd() {
 	val := s.network.Validators[0]
 
+	// nolint: exhaustivestruct
 	testCases := []struct {
 		name         string
 		args         []string
@@ -81,7 +82,7 @@ func (s *IntegrationTestSuite) TestNewMsgVerifyInvariantTxCmd() {
 				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
 				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(10))).String()),
 			},
-			false, 0, &sdk.TxResponse{}, // nolint: exhaustivestruct
+			false, 0, &sdk.TxResponse{},
 		},
 	}
 

--- a/x/crisis/client/testsuite/suite.go
+++ b/x/crisis/client/testsuite/suite.go
@@ -21,7 +21,7 @@ type IntegrationTestSuite struct {
 }
 
 func NewIntegrationTestSuite(cfg network.Config) *IntegrationTestSuite {
-	return &IntegrationTestSuite{cfg: cfg}
+	return &IntegrationTestSuite{cfg: cfg} // nolint: exhaustivestruct
 }
 
 func (s *IntegrationTestSuite) SetupSuite() {

--- a/x/crisis/client/testsuite/suite.go
+++ b/x/crisis/client/testsuite/suite.go
@@ -81,7 +81,7 @@ func (s *IntegrationTestSuite) TestNewMsgVerifyInvariantTxCmd() {
 				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
 				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(10))).String()),
 			},
-			false, 0, &sdk.TxResponse{},
+			false, 0, &sdk.TxResponse{}, // nolint: exhaustivestruct
 		},
 	}
 

--- a/x/crisis/keeper/msg_server.go
+++ b/x/crisis/keeper/msg_server.go
@@ -7,7 +7,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/crisis/types"
 )
 
-var _ types.MsgServer = Keeper{}
+var _ types.MsgServer = Keeper{} // nolint: exhaustivestruct
 
 func (k Keeper) VerifyInvariant(goCtx context.Context, msg *types.MsgVerifyInvariant) (*types.MsgVerifyInvariantResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)

--- a/x/crisis/module.go
+++ b/x/crisis/module.go
@@ -21,9 +21,10 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/crisis/types"
 )
 
+// nolint: exhaustivestruct
 var (
-	_ module.AppModule      = AppModule{}      // nolint: exhaustivestruct
-	_ module.AppModuleBasic = AppModuleBasic{} // nolint: exhaustivestruct
+	_ module.AppModule      = AppModule{}
+	_ module.AppModuleBasic = AppModuleBasic{}
 )
 
 // Module init related flags

--- a/x/crisis/module.go
+++ b/x/crisis/module.go
@@ -22,8 +22,8 @@ import (
 )
 
 var (
-	_ module.AppModule      = AppModule{}
-	_ module.AppModuleBasic = AppModuleBasic{}
+	_ module.AppModule      = AppModule{}      // nolint: exhaustivestruct
+	_ module.AppModuleBasic = AppModuleBasic{} // nolint: exhaustivestruct
 )
 
 // Module init related flags

--- a/x/crisis/types/codec.go
+++ b/x/crisis/types/codec.go
@@ -1,3 +1,4 @@
+// nolint: exhaustivestruct
 package types
 
 import (

--- a/x/crisis/types/msgs.go
+++ b/x/crisis/types/msgs.go
@@ -7,7 +7,7 @@ import (
 )
 
 // ensure Msg interface compliance at compile time
-var _ sdk.Msg = &MsgVerifyInvariant{}
+var _ sdk.Msg = &MsgVerifyInvariant{} // nolint: exhaustivestruct
 
 // NewMsgVerifyInvariant creates a new MsgVerifyInvariant object
 //nolint:interfacer

--- a/x/crisis/types/params.go
+++ b/x/crisis/types/params.go
@@ -14,6 +14,7 @@ var (
 
 // type declaration for parameters
 func ParamKeyTable() paramtypes.KeyTable {
+	// nolint: exhaustivestruct
 	return paramtypes.NewKeyTable(
 		paramtypes.NewParamSetPair(ParamStoreKeyConstantFee, sdk.Coin{}, validateConstantFee),
 	)

--- a/x/distribution/client/cli/query.go
+++ b/x/distribution/client/cli/query.go
@@ -16,7 +16,7 @@ import (
 
 // GetQueryCmd returns the cli query commands for this module
 func GetQueryCmd() *cobra.Command {
-	distQueryCmd := &cobra.Command{
+	distQueryCmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:                        types.ModuleName,
 		Short:                      "Querying commands for the distribution module",
 		DisableFlagParsing:         true,
@@ -38,7 +38,7 @@ func GetQueryCmd() *cobra.Command {
 
 // GetCmdQueryParams implements the query params command.
 func GetCmdQueryParams() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "params",
 		Args:  cobra.NoArgs,
 		Short: "Query distribution params",
@@ -67,7 +67,7 @@ func GetCmdQueryParams() *cobra.Command {
 func GetCmdQueryValidatorOutstandingRewards() *cobra.Command {
 	bech32PrefixValAddr := sdk.GetConfig().GetBech32ValidatorAddrPrefix()
 
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "validator-outstanding-rewards [validator]",
 		Args:  cobra.ExactArgs(1),
 		Short: "Query distribution outstanding (un-withdrawn) rewards for a validator and all their delegations",
@@ -112,7 +112,7 @@ $ %s query distribution validator-outstanding-rewards %s1lwjmdnks33xwnmfayc64ycp
 func GetCmdQueryValidatorCommission() *cobra.Command {
 	bech32PrefixValAddr := sdk.GetConfig().GetBech32ValidatorAddrPrefix()
 
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "commission [validator]",
 		Args:  cobra.ExactArgs(1),
 		Short: "Query distribution validator commission",
@@ -157,7 +157,7 @@ $ %s query distribution commission %s1gghjut3ccd8ay0zduzj64hwre2fxs9ldmqhffj
 func GetCmdQueryValidatorSlashes() *cobra.Command {
 	bech32PrefixValAddr := sdk.GetConfig().GetBech32ValidatorAddrPrefix()
 
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "slashes [validator] [start-height] [end-height]",
 		Args:  cobra.ExactArgs(3),
 		Short: "Query distribution validator slashes",
@@ -224,7 +224,7 @@ func GetCmdQueryDelegatorRewards() *cobra.Command {
 	bech32PrefixAccAddr := sdk.GetConfig().GetBech32AccountAddrPrefix()
 	bech32PrefixValAddr := sdk.GetConfig().GetBech32ValidatorAddrPrefix()
 
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "rewards [delegator-addr] [validator-addr]",
 		Args:  cobra.RangeArgs(1, 2),
 		Short: "Query all distribution delegator rewards or rewards from a particular validator",
@@ -287,7 +287,7 @@ $ %s query distribution rewards %s1gghjut3ccd8ay0zduzj64hwre2fxs9ld75ru9p %s1ggh
 
 // GetCmdQueryCommunityPool returns the command for fetching community pool info.
 func GetCmdQueryCommunityPool() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "community-pool",
 		Args:  cobra.NoArgs,
 		Short: "Query the amount of coins in the community pool",

--- a/x/distribution/client/cli/tx.go
+++ b/x/distribution/client/cli/tx.go
@@ -28,7 +28,7 @@ const (
 
 // NewTxCmd returns a root CLI command handler for all x/distribution transaction commands.
 func NewTxCmd() *cobra.Command {
-	distTxCmd := &cobra.Command{
+	distTxCmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:                        types.ModuleName,
 		Short:                      "Distribution transactions subcommands",
 		DisableFlagParsing:         true,
@@ -78,7 +78,7 @@ func newSplitAndApply(
 func NewWithdrawRewardsCmd() *cobra.Command {
 	bech32PrefixValAddr := sdk.GetConfig().GetBech32ValidatorAddrPrefix()
 
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "withdraw-rewards [validator-addr]",
 		Short: "Withdraw rewards from a given delegation address, and optionally withdraw validator commission if the delegation address given is a validator operator",
 		Long: strings.TrimSpace(
@@ -121,7 +121,7 @@ $ %s tx distribution withdraw-rewards %s1gghjut3ccd8ay0zduzj64hwre2fxs9ldmqhffj 
 }
 
 func NewWithdrawAllRewardsCmd() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "withdraw-all-rewards",
 		Short: "withdraw all delegations rewards for a delegator",
 		Long: strings.TrimSpace(
@@ -186,7 +186,7 @@ $ %[1]s tx distribution withdraw-all-rewards --from mykey
 func NewSetWithdrawAddrCmd() *cobra.Command {
 	bech32PrefixAccAddr := sdk.GetConfig().GetBech32AccountAddrPrefix()
 
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "set-withdraw-addr [withdraw-addr]",
 		Short: "change the default withdraw address for rewards associated with an address",
 		Long: strings.TrimSpace(
@@ -222,7 +222,7 @@ $ %s tx distribution set-withdraw-addr %s1gghjut3ccd8ay0zduzj64hwre2fxs9ld75ru9p
 }
 
 func NewFundCommunityPoolCmd() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "fund-community-pool [amount]",
 		Args:  cobra.ExactArgs(1),
 		Short: "Funds the community pool with the specified amount",
@@ -261,7 +261,7 @@ $ %s tx distribution fund-community-pool 100uatom --from mykey
 func GetCmdSubmitProposal() *cobra.Command {
 	bech32PrefixAccAddr := sdk.GetConfig().GetBech32AccountAddrPrefix()
 
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "community-pool-spend [proposal-file]",
 		Args:  cobra.ExactArgs(1),
 		Short: "Submit a community pool spend proposal",

--- a/x/distribution/client/testutil/grpc_query_suite.go
+++ b/x/distribution/client/testutil/grpc_query_suite.go
@@ -47,6 +47,7 @@ func (s *GRPCQueryTestSuite) TestQueryParamsGRPC() {
 	val := s.network.Validators[0]
 	baseURL := val.APIAddress
 
+	// nolint: exhaustivestruct
 	testCases := []struct {
 		name     string
 		url      string
@@ -81,6 +82,7 @@ func (s *GRPCQueryTestSuite) TestQueryOutstandingRewardsGRPC() {
 	rewards, err := sdk.ParseDecCoins("19.6stake")
 	s.Require().NoError(err)
 
+	// nolint: exhaustivestruct
 	testCases := []struct {
 		name     string
 		url      string
@@ -135,6 +137,7 @@ func (s *GRPCQueryTestSuite) TestQueryValidatorCommissionGRPC() {
 	commission, err := sdk.ParseDecCoins("9.8stake")
 	s.Require().NoError(err)
 
+	// nolint: exhaustivestruct
 	testCases := []struct {
 		name     string
 		url      string
@@ -186,6 +189,7 @@ func (s *GRPCQueryTestSuite) TestQuerySlashesGRPC() {
 	val := s.network.Validators[0]
 	baseURL := val.APIAddress
 
+	// nolint: exhaustivestruct
 	testCases := []struct {
 		name     string
 		url      string
@@ -248,6 +252,7 @@ func (s *GRPCQueryTestSuite) TestQueryDelegatorRewardsGRPC() {
 	rewards, err := sdk.ParseDecCoins("9.8stake")
 	s.Require().NoError(err)
 
+	// nolint: exhaustivestruct
 	testCases := []struct {
 		name     string
 		url      string
@@ -321,6 +326,7 @@ func (s *GRPCQueryTestSuite) TestQueryDelegatorValidatorsGRPC() {
 	val := s.network.Validators[0]
 	baseURL := val.APIAddress
 
+	// nolint: exhaustivestruct
 	testCases := []struct {
 		name     string
 		url      string
@@ -373,6 +379,7 @@ func (s *GRPCQueryTestSuite) TestQueryWithdrawAddressGRPC() {
 	val := s.network.Validators[0]
 	baseURL := val.APIAddress
 
+	// nolint: exhaustivestruct
 	testCases := []struct {
 		name     string
 		url      string
@@ -428,6 +435,7 @@ func (s *GRPCQueryTestSuite) TestQueryValidatorCommunityPoolGRPC() {
 	communityPool, err := sdk.ParseDecCoins("0.4stake")
 	s.Require().NoError(err)
 
+	// nolint: exhaustivestruct
 	testCases := []struct {
 		name     string
 		url      string

--- a/x/distribution/client/testutil/suite.go
+++ b/x/distribution/client/testutil/suite.go
@@ -452,6 +452,7 @@ func (s *IntegrationTestSuite) TestGetCmdQueryCommunityPool() {
 func (s *IntegrationTestSuite) TestNewWithdrawRewardsCmd() {
 	val := s.network.Validators[0]
 
+	// nolint: exhaustivestruct
 	testCases := []struct {
 		name         string
 		valAddr      fmt.Stringer
@@ -480,7 +481,7 @@ func (s *IntegrationTestSuite) TestNewWithdrawRewardsCmd() {
 				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
 				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(10))).String()),
 			},
-			false, 0, &sdk.TxResponse{}, // nolint: exhaustivestruct
+			false, 0, &sdk.TxResponse{},
 		},
 		{
 			"valid transaction (with commission)",
@@ -492,7 +493,7 @@ func (s *IntegrationTestSuite) TestNewWithdrawRewardsCmd() {
 				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
 				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(10))).String()),
 			},
-			false, 0, &sdk.TxResponse{}, // nolint: exhaustivestruct
+			false, 0, &sdk.TxResponse{},
 		},
 	}
 
@@ -519,6 +520,7 @@ func (s *IntegrationTestSuite) TestNewWithdrawRewardsCmd() {
 func (s *IntegrationTestSuite) TestNewWithdrawAllRewardsCmd() {
 	val := s.network.Validators[0]
 
+	// nolint: exhaustivestruct
 	testCases := []struct {
 		name         string
 		args         []string
@@ -544,7 +546,7 @@ func (s *IntegrationTestSuite) TestNewWithdrawAllRewardsCmd() {
 				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
 				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(10))).String()),
 			},
-			false, 0, &sdk.TxResponse{}, // nolint: exhaustivestruct
+			false, 0, &sdk.TxResponse{},
 		},
 	}
 
@@ -572,6 +574,7 @@ func (s *IntegrationTestSuite) TestNewWithdrawAllRewardsCmd() {
 func (s *IntegrationTestSuite) TestNewSetWithdrawAddrCmd() {
 	val := s.network.Validators[0]
 
+	// nolint: exhaustivestruct
 	testCases := []struct {
 		name         string
 		args         []string
@@ -599,7 +602,7 @@ func (s *IntegrationTestSuite) TestNewSetWithdrawAddrCmd() {
 				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
 				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(10))).String()),
 			},
-			false, 0, &sdk.TxResponse{}, // nolint: exhaustivestruct
+			false, 0, &sdk.TxResponse{},
 		},
 	}
 
@@ -627,6 +630,7 @@ func (s *IntegrationTestSuite) TestNewSetWithdrawAddrCmd() {
 func (s *IntegrationTestSuite) TestNewFundCommunityPoolCmd() {
 	val := s.network.Validators[0]
 
+	// nolint: exhaustivestruct
 	testCases := []struct {
 		name         string
 		args         []string
@@ -654,7 +658,7 @@ func (s *IntegrationTestSuite) TestNewFundCommunityPoolCmd() {
 				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
 				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(10))).String()),
 			},
-			false, 0, &sdk.TxResponse{}, // nolint: exhaustivestruct
+			false, 0, &sdk.TxResponse{},
 		},
 	}
 
@@ -714,6 +718,8 @@ func (s *IntegrationTestSuite) TestGetCmdSubmitProposal() {
 }`, val.Address.String(), sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(5431)), sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(5431)))
 
 	validPropFile := testutil.WriteToNewTempFile(s.T(), validProp)
+
+	// nolint: exhaustivestruct
 	testCases := []struct {
 		name         string
 		args         []string
@@ -741,7 +747,7 @@ func (s *IntegrationTestSuite) TestGetCmdSubmitProposal() {
 				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
 				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(10))).String()),
 			},
-			false, 0, &sdk.TxResponse{}, // nolint: exhaustivestruct
+			false, 0, &sdk.TxResponse{},
 		},
 	}
 

--- a/x/distribution/client/testutil/suite.go
+++ b/x/distribution/client/testutil/suite.go
@@ -26,7 +26,7 @@ type IntegrationTestSuite struct {
 }
 
 func NewIntegrationTestSuite(cfg network.Config) *IntegrationTestSuite {
-	return &IntegrationTestSuite{cfg: cfg}
+	return &IntegrationTestSuite{cfg: cfg} // nolint: exhaustivestruct
 }
 
 // SetupSuite creates a new network for _each_ integration test. We create a new

--- a/x/distribution/client/testutil/suite.go
+++ b/x/distribution/client/testutil/suite.go
@@ -480,7 +480,7 @@ func (s *IntegrationTestSuite) TestNewWithdrawRewardsCmd() {
 				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
 				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(10))).String()),
 			},
-			false, 0, &sdk.TxResponse{},
+			false, 0, &sdk.TxResponse{}, // nolint: exhaustivestruct
 		},
 		{
 			"valid transaction (with commission)",
@@ -492,7 +492,7 @@ func (s *IntegrationTestSuite) TestNewWithdrawRewardsCmd() {
 				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
 				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(10))).String()),
 			},
-			false, 0, &sdk.TxResponse{},
+			false, 0, &sdk.TxResponse{}, // nolint: exhaustivestruct
 		},
 	}
 
@@ -544,7 +544,7 @@ func (s *IntegrationTestSuite) TestNewWithdrawAllRewardsCmd() {
 				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
 				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(10))).String()),
 			},
-			false, 0, &sdk.TxResponse{},
+			false, 0, &sdk.TxResponse{}, // nolint: exhaustivestruct
 		},
 	}
 
@@ -599,7 +599,7 @@ func (s *IntegrationTestSuite) TestNewSetWithdrawAddrCmd() {
 				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
 				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(10))).String()),
 			},
-			false, 0, &sdk.TxResponse{},
+			false, 0, &sdk.TxResponse{}, // nolint: exhaustivestruct
 		},
 	}
 
@@ -654,7 +654,7 @@ func (s *IntegrationTestSuite) TestNewFundCommunityPoolCmd() {
 				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
 				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(10))).String()),
 			},
-			false, 0, &sdk.TxResponse{},
+			false, 0, &sdk.TxResponse{}, // nolint: exhaustivestruct
 		},
 	}
 
@@ -741,7 +741,7 @@ func (s *IntegrationTestSuite) TestGetCmdSubmitProposal() {
 				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
 				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(10))).String()),
 			},
-			false, 0, &sdk.TxResponse{},
+			false, 0, &sdk.TxResponse{}, // nolint: exhaustivestruct
 		},
 	}
 

--- a/x/distribution/keeper/grpc_query.go
+++ b/x/distribution/keeper/grpc_query.go
@@ -14,7 +14,7 @@ import (
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 )
 
-var _ types.QueryServer = Keeper{}
+var _ types.QueryServer = Keeper{} // nolint: exhaustivestruct
 
 // Params queries params of distribution module
 func (k Keeper) Params(c context.Context, req *types.QueryParamsRequest) (*types.QueryParamsResponse, error) {

--- a/x/distribution/keeper/hooks.go
+++ b/x/distribution/keeper/hooks.go
@@ -11,7 +11,7 @@ type Hooks struct {
 	k Keeper
 }
 
-var _ stakingtypes.StakingHooks = Hooks{}
+var _ stakingtypes.StakingHooks = Hooks{} // nolint: exhaustivestruct
 
 // Create new distribution hooks
 func (k Keeper) Hooks() Hooks { return Hooks{k} }

--- a/x/distribution/keeper/msg_server.go
+++ b/x/distribution/keeper/msg_server.go
@@ -20,7 +20,7 @@ func NewMsgServerImpl(keeper Keeper) types.MsgServer {
 	return &msgServer{Keeper: keeper}
 }
 
-var _ types.MsgServer = msgServer{}
+var _ types.MsgServer = msgServer{} // nolint: exhaustivestruct
 
 func (k msgServer) SetWithdrawAddress(goCtx context.Context, msg *types.MsgSetWithdrawAddress) (*types.MsgSetWithdrawAddressResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)

--- a/x/distribution/keeper/store.go
+++ b/x/distribution/keeper/store.go
@@ -316,7 +316,7 @@ func (k Keeper) GetValidatorSlashEvent(ctx sdk.Context, val sdk.ValAddress, heig
 	store := ctx.KVStore(k.storeKey)
 	b := store.Get(types.GetValidatorSlashEventKey(val, height, period))
 	if b == nil {
-		return types.ValidatorSlashEvent{}, false
+		return types.ValidatorSlashEvent{}, false // nolint: exhaustivestruct
 	}
 	k.cdc.MustUnmarshal(b, &event)
 	return event, true

--- a/x/distribution/migrations/v036/types.go
+++ b/x/distribution/migrations/v036/types.go
@@ -131,6 +131,7 @@ func (csp CommunityPoolSpendProposal) String() string {
 	return b.String()
 }
 
+// nolint: exhaustivestruct
 func RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
 	cdc.RegisterConcrete(CommunityPoolSpendProposal{}, "cosmos-sdk/CommunityPoolSpendProposal", nil)
 }

--- a/x/distribution/migrations/v036/types.go
+++ b/x/distribution/migrations/v036/types.go
@@ -89,7 +89,7 @@ func NewGenesisState(
 	}
 }
 
-var _ v036gov.Content = CommunityPoolSpendProposal{}
+var _ v036gov.Content = CommunityPoolSpendProposal{} // nolint: exhaustivestruct
 
 // GetTitle returns the title of a community pool spend proposal.
 func (csp CommunityPoolSpendProposal) GetTitle() string { return csp.Title }

--- a/x/distribution/module.go
+++ b/x/distribution/module.go
@@ -24,10 +24,11 @@ import (
 	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
 )
 
+// nolint: exhaustivestruct
 var (
-	_ module.AppModule           = AppModule{}      // nolint: exhaustivestruct
-	_ module.AppModuleBasic      = AppModuleBasic{} // nolint: exhaustivestruct
-	_ module.AppModuleSimulation = AppModule{}      // nolint: exhaustivestruct
+	_ module.AppModule           = AppModule{}
+	_ module.AppModuleBasic      = AppModuleBasic{}
+	_ module.AppModuleSimulation = AppModule{}
 )
 
 // AppModuleBasic defines the basic application module used by the distribution module.

--- a/x/distribution/module.go
+++ b/x/distribution/module.go
@@ -25,9 +25,9 @@ import (
 )
 
 var (
-	_ module.AppModule           = AppModule{}
-	_ module.AppModuleBasic      = AppModuleBasic{}
-	_ module.AppModuleSimulation = AppModule{}
+	_ module.AppModule           = AppModule{}      // nolint: exhaustivestruct
+	_ module.AppModuleBasic      = AppModuleBasic{} // nolint: exhaustivestruct
+	_ module.AppModuleSimulation = AppModule{}      // nolint: exhaustivestruct
 )
 
 // AppModuleBasic defines the basic application module used by the distribution module.

--- a/x/distribution/types/codec.go
+++ b/x/distribution/types/codec.go
@@ -1,3 +1,4 @@
+// nolint: exhaustivestruct
 package types
 
 import (

--- a/x/distribution/types/msg.go
+++ b/x/distribution/types/msg.go
@@ -15,7 +15,7 @@ const (
 )
 
 // Verify interface at compile time
-var _, _, _ sdk.Msg = &MsgSetWithdrawAddress{}, &MsgWithdrawDelegatorReward{}, &MsgWithdrawValidatorCommission{}
+var _, _, _ sdk.Msg = &MsgSetWithdrawAddress{}, &MsgWithdrawDelegatorReward{}, &MsgWithdrawValidatorCommission{} // nolint: exhaustivestruct
 
 func NewMsgSetWithdrawAddress(delAddr, withdrawAddr sdk.AccAddress) *MsgSetWithdrawAddress {
 	return &MsgSetWithdrawAddress{

--- a/x/distribution/types/params.go
+++ b/x/distribution/types/params.go
@@ -19,7 +19,7 @@ var (
 
 // ParamKeyTable returns the parameter key table.
 func ParamKeyTable() paramtypes.KeyTable {
-	return paramtypes.NewKeyTable().RegisterParamSet(&Params{})
+	return paramtypes.NewKeyTable().RegisterParamSet(&Params{}) // nolint: exhaustivestruct
 }
 
 // DefaultParams returns default distribution parameters

--- a/x/distribution/types/proposal.go
+++ b/x/distribution/types/proposal.go
@@ -14,7 +14,7 @@ const (
 )
 
 // Assert CommunityPoolSpendProposal implements govtypes.Content at compile-time
-var _ govtypes.Content = &CommunityPoolSpendProposal{}
+var _ govtypes.Content = &CommunityPoolSpendProposal{} // nolint: exhaustivestruct
 
 func init() {
 	govtypes.RegisterProposalType(ProposalTypeCommunityPoolSpend)

--- a/x/evidence/client/cli/query.go
+++ b/x/evidence/client/cli/query.go
@@ -18,7 +18,7 @@ import (
 // GetQueryCmd returns the CLI command with all evidence module query commands
 // mounted.
 func GetQueryCmd() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   types.ModuleName,
 		Short: "Query for evidence by hash or for all (paginated) submitted evidence",
 		Long: strings.TrimSpace(

--- a/x/evidence/client/cli/tx.go
+++ b/x/evidence/client/cli/tx.go
@@ -13,7 +13,7 @@ import (
 // Evidence types and Handlers while having the ability to create and sign txs
 // containing them all from a single root command.
 func GetTxCmd(childCmds []*cobra.Command) *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:                        types.ModuleName,
 		Short:                      "Evidence transaction subcommands",
 		DisableFlagParsing:         true,
@@ -35,7 +35,7 @@ func GetTxCmd(childCmds []*cobra.Command) *cobra.Command {
 // All concrete evidence submission child command handlers should be registered
 // under this command.
 func SubmitEvidenceCmd() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "submit",
 		Short: "Submit arbitrary evidence of misbehavior",
 	}

--- a/x/evidence/client/testutil/suite.go
+++ b/x/evidence/client/testutil/suite.go
@@ -18,7 +18,7 @@ type IntegrationTestSuite struct {
 }
 
 func NewIntegrationTestSuite(cfg network.Config) *IntegrationTestSuite {
-	return &IntegrationTestSuite{cfg: cfg}
+	return &IntegrationTestSuite{cfg: cfg} // nolint: exhaustivestruct
 }
 
 func (s *IntegrationTestSuite) SetupSuite() {

--- a/x/evidence/keeper/grpc_query.go
+++ b/x/evidence/keeper/grpc_query.go
@@ -16,7 +16,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/evidence/types"
 )
 
-var _ types.QueryServer = Keeper{}
+var _ types.QueryServer = Keeper{} // nolint: exhaustivestruct
 
 // Evidence implements the Query/Evidence gRPC method
 func (k Keeper) Evidence(c context.Context, req *types.QueryEvidenceRequest) (*types.QueryEvidenceResponse, error) {

--- a/x/evidence/keeper/msg_server.go
+++ b/x/evidence/keeper/msg_server.go
@@ -17,7 +17,7 @@ func NewMsgServerImpl(keeper Keeper) types.MsgServer {
 	return &msgServer{Keeper: keeper}
 }
 
-var _ types.MsgServer = msgServer{}
+var _ types.MsgServer = msgServer{} // nolint: exhaustivestruct
 
 // SubmitEvidence implements the MsgServer.SubmitEvidence method.
 func (ms msgServer) SubmitEvidence(goCtx context.Context, msg *types.MsgSubmitEvidence) (*types.MsgSubmitEvidenceResponse, error) {

--- a/x/evidence/migrations/v038/types.go
+++ b/x/evidence/migrations/v038/types.go
@@ -65,7 +65,7 @@ type GenesisState struct {
 }
 
 // Assert interface implementation.
-var _ Evidence = Equivocation{}
+var _ Evidence = Equivocation{} // nolint: exhaustivestruct
 
 // Equivocation implements the Evidence interface and defines evidence of double
 // signing misbehavior.

--- a/x/evidence/module.go
+++ b/x/evidence/module.go
@@ -24,10 +24,11 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/evidence/types"
 )
 
+// nolint: exhaustivestruct
 var (
-	_ module.AppModule           = AppModule{}      // nolint: exhaustivestruct
-	_ module.AppModuleBasic      = AppModuleBasic{} // nolint: exhaustivestruct
-	_ module.AppModuleSimulation = AppModule{}      // nolint: exhaustivestruct
+	_ module.AppModule           = AppModule{}
+	_ module.AppModuleBasic      = AppModuleBasic{}
+	_ module.AppModuleSimulation = AppModule{}
 )
 
 // ----------------------------------------------------------------------------

--- a/x/evidence/module.go
+++ b/x/evidence/module.go
@@ -25,9 +25,9 @@ import (
 )
 
 var (
-	_ module.AppModule           = AppModule{}
-	_ module.AppModuleBasic      = AppModuleBasic{}
-	_ module.AppModuleSimulation = AppModule{}
+	_ module.AppModule           = AppModule{}      // nolint: exhaustivestruct
+	_ module.AppModuleBasic      = AppModuleBasic{} // nolint: exhaustivestruct
+	_ module.AppModuleSimulation = AppModule{}      // nolint: exhaustivestruct
 )
 
 // ----------------------------------------------------------------------------

--- a/x/evidence/types/codec.go
+++ b/x/evidence/types/codec.go
@@ -1,3 +1,4 @@
+// nolint: exhaustivestruct
 package types
 
 import (

--- a/x/evidence/types/evidence.go
+++ b/x/evidence/types/evidence.go
@@ -19,7 +19,7 @@ const (
 	TypeEquivocation  = "equivocation"
 )
 
-var _ exported.Evidence = &Equivocation{}
+var _ exported.Evidence = &Equivocation{} // nolint: exhaustivestruct
 
 // Route returns the Evidence Handler route for an Equivocation type.
 func (e *Equivocation) Route() string { return RouteEquivocation }

--- a/x/evidence/types/genesis.go
+++ b/x/evidence/types/genesis.go
@@ -9,7 +9,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/evidence/exported"
 )
 
-var _ types.UnpackInterfacesMessage = GenesisState{}
+var _ types.UnpackInterfacesMessage = GenesisState{} // nolint: exhaustivestruct
 
 // NewGenesisState creates a new genesis state for the evidence module.
 func NewGenesisState(e []exported.Evidence) *GenesisState {

--- a/x/evidence/types/msgs.go
+++ b/x/evidence/types/msgs.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"fmt"
+
 	"github.com/cosmos/cosmos-sdk/codec/legacy"
 
 	"github.com/gogo/protobuf/proto"
@@ -17,6 +18,7 @@ const (
 	TypeMsgSubmitEvidence = "submit_evidence"
 )
 
+// nolint: exhaustivestruct
 var (
 	_ sdk.Msg                       = &MsgSubmitEvidence{}
 	_ types.UnpackInterfacesMessage = MsgSubmitEvidence{}

--- a/x/feegrant/client/cli/query.go
+++ b/x/feegrant/client/cli/query.go
@@ -15,7 +15,7 @@ import (
 
 // GetQueryCmd returns the cli query commands for this module
 func GetQueryCmd() *cobra.Command {
-	feegrantQueryCmd := &cobra.Command{
+	feegrantQueryCmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:                        feegrant.ModuleName,
 		Short:                      "Querying commands for the feegrant module",
 		DisableFlagParsing:         true,
@@ -34,7 +34,7 @@ func GetQueryCmd() *cobra.Command {
 
 // GetCmdQueryFeeGrant returns cmd to query for a grant between granter and grantee.
 func GetCmdQueryFeeGrant() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "grant [granter] [grantee]",
 		Args:  cobra.ExactArgs(2),
 		Short: "Query details of a single grant",
@@ -83,7 +83,7 @@ $ %s query feegrant grant [granter] [grantee]
 
 // GetCmdQueryFeeGrantsByGrantee returns cmd to query for all grants for a grantee.
 func GetCmdQueryFeeGrantsByGrantee() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "grants [grantee]",
 		Args:  cobra.ExactArgs(1),
 		Short: "Query all grants of a grantee",
@@ -132,7 +132,7 @@ $ %s query feegrant grants [grantee]
 
 // GetCmdQueryFeeGrantsByGranter returns cmd to query for all grants by a granter.
 func GetCmdQueryFeeGrantsByGranter() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "grants [granter]",
 		Args:  cobra.ExactArgs(1),
 		Short: "Query all grants by a granter",

--- a/x/feegrant/client/cli/tx.go
+++ b/x/feegrant/client/cli/tx.go
@@ -26,7 +26,7 @@ const (
 
 // GetTxCmd returns the transaction commands for this module
 func GetTxCmd() *cobra.Command {
-	feegrantTxCmd := &cobra.Command{
+	feegrantTxCmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:                        feegrant.ModuleName,
 		Short:                      "Feegrant transactions subcommands",
 		Long:                       "Grant and revoke fee allowance for a grantee by a granter",
@@ -45,7 +45,7 @@ func GetTxCmd() *cobra.Command {
 
 // NewCmdFeeGrant returns a CLI command handler for creating a MsgGrantAllowance transaction.
 func NewCmdFeeGrant() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "grant [granter_key_or_address] [grantee]",
 		Short: "Grant Fee allowance to an address",
 		Long: strings.TrimSpace(
@@ -182,7 +182,7 @@ Examples:
 
 // NewCmdRevokeFeegrant returns a CLI command handler for creating a MsgRevokeAllowance transaction.
 func NewCmdRevokeFeegrant() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "revoke [granter] [grantee]",
 		Short: "revoke fee-grant",
 		Long: strings.TrimSpace(

--- a/x/feegrant/client/testutil/suite.go
+++ b/x/feegrant/client/testutil/suite.go
@@ -42,7 +42,7 @@ type IntegrationTestSuite struct {
 }
 
 func NewIntegrationTestSuite(cfg network.Config) *IntegrationTestSuite {
-	return &IntegrationTestSuite{cfg: cfg}
+	return &IntegrationTestSuite{cfg: cfg} // nolint: exhaustivestruct
 }
 
 func (s *IntegrationTestSuite) SetupSuite() {
@@ -782,7 +782,7 @@ func (s *IntegrationTestSuite) TestFilteredFeeAllowance() {
 	}
 	spendLimit := sdk.NewCoin("stake", sdk.NewInt(1000))
 
-	allowMsgs := strings.Join([]string{sdk.MsgTypeURL(&govv1beta1.MsgSubmitProposal{}), sdk.MsgTypeURL(&govv1.MsgVoteWeighted{})}, ",")
+	allowMsgs := strings.Join([]string{sdk.MsgTypeURL(&govv1beta1.MsgSubmitProposal{}), sdk.MsgTypeURL(&govv1.MsgVoteWeighted{})}, ",") // nolint: exhaustivestruct
 
 	testCases := []struct {
 		name         string

--- a/x/feegrant/client/testutil/suite.go
+++ b/x/feegrant/client/testutil/suite.go
@@ -65,7 +65,7 @@ func (s *IntegrationTestSuite) SetupSuite() {
 
 	s.createGrant(granter, grantee)
 
-	grant, err := feegrant.NewGrant(granter, grantee, &feegrant.BasicAllowance{
+	grant, err := feegrant.NewGrant(granter, grantee, &feegrant.BasicAllowance{ // nolint: exhaustivestruct
 		SpendLimit: sdk.NewCoins(sdk.NewCoin("stake", sdk.NewInt(100))),
 	})
 	s.Require().NoError(err)
@@ -118,6 +118,7 @@ func (s *IntegrationTestSuite) TestCmdGetFeeGrant() {
 	grantee := s.addedGrantee
 	clientCtx := val.ClientCtx
 
+	// nolint: exhaustivestruct
 	testCases := []struct {
 		name         string
 		args         []string
@@ -203,6 +204,7 @@ func (s *IntegrationTestSuite) TestCmdGetFeeGrantsByGrantee() {
 	grantee := s.addedGrantee
 	clientCtx := val.ClientCtx
 
+	// nolint: exhaustivestruct
 	testCases := []struct {
 		name         string
 		args         []string
@@ -259,6 +261,7 @@ func (s *IntegrationTestSuite) TestCmdGetFeeGrantsByGranter() {
 	granter := s.addedGranter
 	clientCtx := val.ClientCtx
 
+	// nolint: exhaustivestruct
 	testCases := []struct {
 		name         string
 		args         []string
@@ -326,6 +329,7 @@ func (s *IntegrationTestSuite) TestNewCmdFeeGrant() {
 		fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(10))).String()),
 	}
 
+	// nolint: exhaustivestruct
 	testCases := []struct {
 		name         string
 		args         []string
@@ -383,7 +387,7 @@ func (s *IntegrationTestSuite) TestNewCmdFeeGrant() {
 				},
 				commonFlags...,
 			),
-			false, 0, &sdk.TxResponse{}, // nolint: exhaustivestruct
+			false, 0, &sdk.TxResponse{},
 		},
 		{
 			"valid basic fee grant with granter key name",
@@ -396,7 +400,7 @@ func (s *IntegrationTestSuite) TestNewCmdFeeGrant() {
 				},
 				commonFlags...,
 			),
-			false, 0, &sdk.TxResponse{}, // nolint: exhaustivestruct
+			false, 0, &sdk.TxResponse{},
 		},
 		{
 			"valid basic fee grant with amino",
@@ -410,7 +414,7 @@ func (s *IntegrationTestSuite) TestNewCmdFeeGrant() {
 				},
 				commonFlags...,
 			),
-			false, 0, &sdk.TxResponse{}, // nolint: exhaustivestruct
+			false, 0, &sdk.TxResponse{},
 		},
 		{
 			"valid basic fee grant without spend limit",
@@ -422,7 +426,7 @@ func (s *IntegrationTestSuite) TestNewCmdFeeGrant() {
 				},
 				commonFlags...,
 			),
-			false, 0, &sdk.TxResponse{}, // nolint: exhaustivestruct
+			false, 0, &sdk.TxResponse{},
 		},
 		{
 			"valid basic fee grant without expiration",
@@ -435,7 +439,7 @@ func (s *IntegrationTestSuite) TestNewCmdFeeGrant() {
 				},
 				commonFlags...,
 			),
-			false, 0, &sdk.TxResponse{}, // nolint: exhaustivestruct
+			false, 0, &sdk.TxResponse{},
 		},
 		{
 			"valid basic fee grant without spend-limit and expiration",
@@ -447,7 +451,7 @@ func (s *IntegrationTestSuite) TestNewCmdFeeGrant() {
 				},
 				commonFlags...,
 			),
-			false, 0, &sdk.TxResponse{}, // nolint: exhaustivestruct
+			false, 0, &sdk.TxResponse{},
 		},
 		{
 			"try to add existed grant",
@@ -460,7 +464,7 @@ func (s *IntegrationTestSuite) TestNewCmdFeeGrant() {
 				},
 				commonFlags...,
 			),
-			false, 18, &sdk.TxResponse{}, // nolint: exhaustivestruct
+			false, 18, &sdk.TxResponse{},
 		},
 		{
 			"invalid number of args(periodic fee grant)",
@@ -522,7 +526,7 @@ func (s *IntegrationTestSuite) TestNewCmdFeeGrant() {
 				},
 				commonFlags...,
 			),
-			false, 0, &sdk.TxResponse{}, // nolint: exhaustivestruct
+			false, 0, &sdk.TxResponse{},
 		},
 		{
 			"valid periodic fee grant without spend-limit",
@@ -537,7 +541,7 @@ func (s *IntegrationTestSuite) TestNewCmdFeeGrant() {
 				},
 				commonFlags...,
 			),
-			false, 0, &sdk.TxResponse{}, // nolint: exhaustivestruct
+			false, 0, &sdk.TxResponse{},
 		},
 		{
 			"valid periodic fee grant without expiration",
@@ -552,7 +556,7 @@ func (s *IntegrationTestSuite) TestNewCmdFeeGrant() {
 				},
 				commonFlags...,
 			),
-			false, 0, &sdk.TxResponse{}, // nolint: exhaustivestruct
+			false, 0, &sdk.TxResponse{},
 		},
 		{
 			"valid periodic fee grant without spend-limit and expiration",
@@ -566,7 +570,7 @@ func (s *IntegrationTestSuite) TestNewCmdFeeGrant() {
 				},
 				commonFlags...,
 			),
-			false, 0, &sdk.TxResponse{}, // nolint: exhaustivestruct
+			false, 0, &sdk.TxResponse{},
 		},
 		{
 			"invalid expiration",
@@ -622,6 +626,7 @@ func (s *IntegrationTestSuite) TestNewCmdRevokeFeegrant() {
 	s.Require().NoError(err)
 	s.createGrant(granter, aminoGrantee)
 
+	// nolint: exhaustivestruct
 	testCases := []struct {
 		name         string
 		args         []string
@@ -663,7 +668,7 @@ func (s *IntegrationTestSuite) TestNewCmdRevokeFeegrant() {
 				},
 				commonFlags...,
 			),
-			false, 4, &sdk.TxResponse{}, // nolint: exhaustivestruct
+			false, 4, &sdk.TxResponse{},
 		},
 		{
 			"Valid revoke",
@@ -675,7 +680,7 @@ func (s *IntegrationTestSuite) TestNewCmdRevokeFeegrant() {
 				},
 				commonFlags...,
 			),
-			false, 0, &sdk.TxResponse{}, // nolint: exhaustivestruct
+			false, 0, &sdk.TxResponse{},
 		},
 		{
 			"Valid revoke with amino",
@@ -688,7 +693,7 @@ func (s *IntegrationTestSuite) TestNewCmdRevokeFeegrant() {
 				},
 				commonFlags...,
 			),
-			false, 0, &sdk.TxResponse{}, // nolint: exhaustivestruct
+			false, 0, &sdk.TxResponse{},
 		},
 	}
 
@@ -784,6 +789,7 @@ func (s *IntegrationTestSuite) TestFilteredFeeAllowance() {
 
 	allowMsgs := strings.Join([]string{sdk.MsgTypeURL(&govv1beta1.MsgSubmitProposal{}), sdk.MsgTypeURL(&govv1.MsgVoteWeighted{})}, ",") // nolint: exhaustivestruct
 
+	// nolint: exhaustivestruct
 	testCases := []struct {
 		name         string
 		args         []string
@@ -803,7 +809,7 @@ func (s *IntegrationTestSuite) TestFilteredFeeAllowance() {
 				},
 				commonFlags...,
 			),
-			true, &sdk.TxResponse{}, 0, // nolint: exhaustivestruct
+			true, &sdk.TxResponse{}, 0,
 		},
 		{
 			"invalid grantee address",
@@ -817,7 +823,7 @@ func (s *IntegrationTestSuite) TestFilteredFeeAllowance() {
 				},
 				commonFlags...,
 			),
-			true, &sdk.TxResponse{}, 0, // nolint: exhaustivestruct
+			true, &sdk.TxResponse{}, 0,
 		},
 		{
 			"valid filter fee grant",
@@ -831,7 +837,7 @@ func (s *IntegrationTestSuite) TestFilteredFeeAllowance() {
 				},
 				commonFlags...,
 			),
-			false, &sdk.TxResponse{}, 0, // nolint: exhaustivestruct
+			false, &sdk.TxResponse{}, 0,
 		},
 	}
 
@@ -865,7 +871,7 @@ func (s *IntegrationTestSuite) TestFilteredFeeAllowance() {
 	out, err := clitestutil.ExecTestCLICmd(clientCtx, cmd, args)
 	s.Require().NoError(err)
 
-	resp := &feegrant.Grant{}
+	resp := &feegrant.Grant{} // nolint: exhaustivestruct
 
 	s.Require().NoError(clientCtx.Codec.UnmarshalJSON(out.Bytes(), resp), out.String())
 	s.Require().Equal(resp.Grantee, resp.Grantee)
@@ -883,6 +889,7 @@ func (s *IntegrationTestSuite) TestFilteredFeeAllowance() {
 	)
 
 	// exec filtered fee allowance
+	// nolint: exhaustivestruct
 	cases := []struct {
 		name         string
 		malleate     func() (testutil.BufferWriter, error)
@@ -898,7 +905,7 @@ func (s *IntegrationTestSuite) TestFilteredFeeAllowance() {
 					fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(100))).String()),
 				)
 			},
-			&sdk.TxResponse{}, // nolint: exhaustivestruct
+			&sdk.TxResponse{},
 			0,
 		},
 		{
@@ -909,7 +916,7 @@ func (s *IntegrationTestSuite) TestFilteredFeeAllowance() {
 					fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(100))).String()),
 				)
 			},
-			&sdk.TxResponse{}, // nolint: exhaustivestruct
+			&sdk.TxResponse{},
 			2,
 		},
 		{
@@ -927,7 +934,7 @@ func (s *IntegrationTestSuite) TestFilteredFeeAllowance() {
 				cmd := cli.NewCmdFeeGrant()
 				return clitestutil.ExecTestCLICmd(clientCtx, cmd, args)
 			},
-			&sdk.TxResponse{}, // nolint: exhaustivestruct
+			&sdk.TxResponse{},
 			7,
 		},
 	}

--- a/x/feegrant/client/testutil/suite.go
+++ b/x/feegrant/client/testutil/suite.go
@@ -383,7 +383,7 @@ func (s *IntegrationTestSuite) TestNewCmdFeeGrant() {
 				},
 				commonFlags...,
 			),
-			false, 0, &sdk.TxResponse{},
+			false, 0, &sdk.TxResponse{}, // nolint: exhaustivestruct
 		},
 		{
 			"valid basic fee grant with granter key name",
@@ -396,7 +396,7 @@ func (s *IntegrationTestSuite) TestNewCmdFeeGrant() {
 				},
 				commonFlags...,
 			),
-			false, 0, &sdk.TxResponse{},
+			false, 0, &sdk.TxResponse{}, // nolint: exhaustivestruct
 		},
 		{
 			"valid basic fee grant with amino",
@@ -410,7 +410,7 @@ func (s *IntegrationTestSuite) TestNewCmdFeeGrant() {
 				},
 				commonFlags...,
 			),
-			false, 0, &sdk.TxResponse{},
+			false, 0, &sdk.TxResponse{}, // nolint: exhaustivestruct
 		},
 		{
 			"valid basic fee grant without spend limit",
@@ -422,7 +422,7 @@ func (s *IntegrationTestSuite) TestNewCmdFeeGrant() {
 				},
 				commonFlags...,
 			),
-			false, 0, &sdk.TxResponse{},
+			false, 0, &sdk.TxResponse{}, // nolint: exhaustivestruct
 		},
 		{
 			"valid basic fee grant without expiration",
@@ -435,7 +435,7 @@ func (s *IntegrationTestSuite) TestNewCmdFeeGrant() {
 				},
 				commonFlags...,
 			),
-			false, 0, &sdk.TxResponse{},
+			false, 0, &sdk.TxResponse{}, // nolint: exhaustivestruct
 		},
 		{
 			"valid basic fee grant without spend-limit and expiration",
@@ -447,7 +447,7 @@ func (s *IntegrationTestSuite) TestNewCmdFeeGrant() {
 				},
 				commonFlags...,
 			),
-			false, 0, &sdk.TxResponse{},
+			false, 0, &sdk.TxResponse{}, // nolint: exhaustivestruct
 		},
 		{
 			"try to add existed grant",
@@ -460,7 +460,7 @@ func (s *IntegrationTestSuite) TestNewCmdFeeGrant() {
 				},
 				commonFlags...,
 			),
-			false, 18, &sdk.TxResponse{},
+			false, 18, &sdk.TxResponse{}, // nolint: exhaustivestruct
 		},
 		{
 			"invalid number of args(periodic fee grant)",
@@ -522,7 +522,7 @@ func (s *IntegrationTestSuite) TestNewCmdFeeGrant() {
 				},
 				commonFlags...,
 			),
-			false, 0, &sdk.TxResponse{},
+			false, 0, &sdk.TxResponse{}, // nolint: exhaustivestruct
 		},
 		{
 			"valid periodic fee grant without spend-limit",
@@ -537,7 +537,7 @@ func (s *IntegrationTestSuite) TestNewCmdFeeGrant() {
 				},
 				commonFlags...,
 			),
-			false, 0, &sdk.TxResponse{},
+			false, 0, &sdk.TxResponse{}, // nolint: exhaustivestruct
 		},
 		{
 			"valid periodic fee grant without expiration",
@@ -552,7 +552,7 @@ func (s *IntegrationTestSuite) TestNewCmdFeeGrant() {
 				},
 				commonFlags...,
 			),
-			false, 0, &sdk.TxResponse{},
+			false, 0, &sdk.TxResponse{}, // nolint: exhaustivestruct
 		},
 		{
 			"valid periodic fee grant without spend-limit and expiration",
@@ -566,7 +566,7 @@ func (s *IntegrationTestSuite) TestNewCmdFeeGrant() {
 				},
 				commonFlags...,
 			),
-			false, 0, &sdk.TxResponse{},
+			false, 0, &sdk.TxResponse{}, // nolint: exhaustivestruct
 		},
 		{
 			"invalid expiration",
@@ -663,7 +663,7 @@ func (s *IntegrationTestSuite) TestNewCmdRevokeFeegrant() {
 				},
 				commonFlags...,
 			),
-			false, 4, &sdk.TxResponse{},
+			false, 4, &sdk.TxResponse{}, // nolint: exhaustivestruct
 		},
 		{
 			"Valid revoke",
@@ -675,7 +675,7 @@ func (s *IntegrationTestSuite) TestNewCmdRevokeFeegrant() {
 				},
 				commonFlags...,
 			),
-			false, 0, &sdk.TxResponse{},
+			false, 0, &sdk.TxResponse{}, // nolint: exhaustivestruct
 		},
 		{
 			"Valid revoke with amino",
@@ -688,7 +688,7 @@ func (s *IntegrationTestSuite) TestNewCmdRevokeFeegrant() {
 				},
 				commonFlags...,
 			),
-			false, 0, &sdk.TxResponse{},
+			false, 0, &sdk.TxResponse{}, // nolint: exhaustivestruct
 		},
 	}
 
@@ -803,7 +803,7 @@ func (s *IntegrationTestSuite) TestFilteredFeeAllowance() {
 				},
 				commonFlags...,
 			),
-			true, &sdk.TxResponse{}, 0,
+			true, &sdk.TxResponse{}, 0, // nolint: exhaustivestruct
 		},
 		{
 			"invalid grantee address",
@@ -817,7 +817,7 @@ func (s *IntegrationTestSuite) TestFilteredFeeAllowance() {
 				},
 				commonFlags...,
 			),
-			true, &sdk.TxResponse{}, 0,
+			true, &sdk.TxResponse{}, 0, // nolint: exhaustivestruct
 		},
 		{
 			"valid filter fee grant",
@@ -831,7 +831,7 @@ func (s *IntegrationTestSuite) TestFilteredFeeAllowance() {
 				},
 				commonFlags...,
 			),
-			false, &sdk.TxResponse{}, 0,
+			false, &sdk.TxResponse{}, 0, // nolint: exhaustivestruct
 		},
 	}
 
@@ -898,7 +898,7 @@ func (s *IntegrationTestSuite) TestFilteredFeeAllowance() {
 					fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(100))).String()),
 				)
 			},
-			&sdk.TxResponse{},
+			&sdk.TxResponse{}, // nolint: exhaustivestruct
 			0,
 		},
 		{
@@ -909,7 +909,7 @@ func (s *IntegrationTestSuite) TestFilteredFeeAllowance() {
 					fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(100))).String()),
 				)
 			},
-			&sdk.TxResponse{},
+			&sdk.TxResponse{}, // nolint: exhaustivestruct
 			2,
 		},
 		{
@@ -927,7 +927,7 @@ func (s *IntegrationTestSuite) TestFilteredFeeAllowance() {
 				cmd := cli.NewCmdFeeGrant()
 				return clitestutil.ExecTestCLICmd(clientCtx, cmd, args)
 			},
-			&sdk.TxResponse{},
+			&sdk.TxResponse{}, // nolint: exhaustivestruct
 			7,
 		},
 	}

--- a/x/feegrant/codec.go
+++ b/x/feegrant/codec.go
@@ -1,3 +1,4 @@
+// nolint: exhaustivestruct
 package feegrant
 
 import (

--- a/x/feegrant/genesis.go
+++ b/x/feegrant/genesis.go
@@ -4,7 +4,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec/types"
 )
 
-var _ types.UnpackInterfacesMessage = GenesisState{}
+var _ types.UnpackInterfacesMessage = GenesisState{} // nolint: exhaustivestruct
 
 // NewGenesisState creates new GenesisState object
 func NewGenesisState(entries []Grant) *GenesisState {

--- a/x/feegrant/grant.go
+++ b/x/feegrant/grant.go
@@ -8,6 +8,7 @@ import (
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
 
+// nolint: exhaustivestruct
 var (
 	_ types.UnpackInterfacesMessage = &Grant{}
 )

--- a/x/feegrant/keeper/grpc_query.go
+++ b/x/feegrant/keeper/grpc_query.go
@@ -14,7 +14,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/feegrant"
 )
 
-var _ feegrant.QueryServer = Keeper{}
+var _ feegrant.QueryServer = Keeper{} // nolint: exhaustivestruct
 
 // Allowance returns fee granted to the grantee by the granter.
 func (q Keeper) Allowance(c context.Context, req *feegrant.QueryAllowanceRequest) (*feegrant.QueryAllowanceResponse, error) {

--- a/x/feegrant/keeper/keeper.go
+++ b/x/feegrant/keeper/keeper.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"time"
 
-	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	"github.com/tendermint/tendermint/libs/log"
+
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -22,7 +23,7 @@ type Keeper struct {
 	authKeeper feegrant.AccountKeeper
 }
 
-var _ middleware.FeegrantKeeper = &Keeper{}
+var _ middleware.FeegrantKeeper = &Keeper{} // nolint: exhaustivestruct
 
 // NewKeeper creates a fee grant Keeper
 func NewKeeper(cdc codec.BinaryCodec, storeKey storetypes.StoreKey, ak feegrant.AccountKeeper) Keeper {

--- a/x/feegrant/keeper/msg_server.go
+++ b/x/feegrant/keeper/msg_server.go
@@ -21,7 +21,7 @@ func NewMsgServerImpl(k Keeper) feegrant.MsgServer {
 	}
 }
 
-var _ feegrant.MsgServer = msgServer{}
+var _ feegrant.MsgServer = msgServer{} // nolint: exhaustivestruct
 
 // GrantAllowance grants an allowance from the granter's funds to be used by the grantee.
 func (k msgServer) GrantAllowance(goCtx context.Context, msg *feegrant.MsgGrantAllowance) (*feegrant.MsgGrantAllowanceResponse, error) {

--- a/x/feegrant/module/module.go
+++ b/x/feegrant/module/module.go
@@ -24,9 +24,9 @@ import (
 )
 
 var (
-	_ module.AppModule           = AppModule{}
-	_ module.AppModuleBasic      = AppModuleBasic{}
-	_ module.AppModuleSimulation = AppModule{}
+	_ module.AppModule           = AppModule{}      // nolint: exhaustivestruct
+	_ module.AppModuleBasic      = AppModuleBasic{} // nolint: exhaustivestruct
+	_ module.AppModuleSimulation = AppModule{}      // nolint: exhaustivestruct
 )
 
 // ----------------------------------------------------------------------------

--- a/x/feegrant/module/module.go
+++ b/x/feegrant/module/module.go
@@ -23,10 +23,11 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/feegrant/simulation"
 )
 
+// nolint: exhaustivestruct
 var (
-	_ module.AppModule           = AppModule{}      // nolint: exhaustivestruct
-	_ module.AppModuleBasic      = AppModuleBasic{} // nolint: exhaustivestruct
-	_ module.AppModuleSimulation = AppModule{}      // nolint: exhaustivestruct
+	_ module.AppModule           = AppModule{}
+	_ module.AppModuleBasic      = AppModuleBasic{}
+	_ module.AppModuleSimulation = AppModule{}
 )
 
 // ----------------------------------------------------------------------------

--- a/x/feegrant/msgs.go
+++ b/x/feegrant/msgs.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/auth/migrations/legacytx"
 )
 
+// nolint: exhaustivestruct
 var (
 	_, _ sdk.Msg            = &MsgGrantAllowance{}, &MsgRevokeAllowance{}
 	_, _ legacytx.LegacyMsg = &MsgGrantAllowance{}, &MsgRevokeAllowance{} // For amino support.

--- a/x/feegrant/simulation/operations.go
+++ b/x/feegrant/simulation/operations.go
@@ -20,8 +20,8 @@ const (
 )
 
 var (
-	TypeMsgGrantAllowance  = sdk.MsgTypeURL(&feegrant.MsgGrantAllowance{})
-	TypeMsgRevokeAllowance = sdk.MsgTypeURL(&feegrant.MsgRevokeAllowance{})
+	TypeMsgGrantAllowance  = sdk.MsgTypeURL(&feegrant.MsgGrantAllowance{})  // nolint: exhaustivestruct
+	TypeMsgRevokeAllowance = sdk.MsgTypeURL(&feegrant.MsgRevokeAllowance{}) // nolint: exhaustivestruct
 )
 
 func WeightedOperations(

--- a/x/feegrant/simulation/operations.go
+++ b/x/feegrant/simulation/operations.go
@@ -19,9 +19,10 @@ const (
 	OpWeightMsgRevokeAllowance = "op_weight_msg_grant_revoke_allowance"
 )
 
+// nolint: exhaustivestruct
 var (
-	TypeMsgGrantAllowance  = sdk.MsgTypeURL(&feegrant.MsgGrantAllowance{})  // nolint: exhaustivestruct
-	TypeMsgRevokeAllowance = sdk.MsgTypeURL(&feegrant.MsgRevokeAllowance{}) // nolint: exhaustivestruct
+	TypeMsgGrantAllowance  = sdk.MsgTypeURL(&feegrant.MsgGrantAllowance{})
+	TypeMsgRevokeAllowance = sdk.MsgTypeURL(&feegrant.MsgRevokeAllowance{})
 )
 
 func WeightedOperations(

--- a/x/genutil/client/cli/collect.go
+++ b/x/genutil/client/cli/collect.go
@@ -19,7 +19,7 @@ const flagGenTxDir = "gentx-dir"
 
 // CollectGenTxsCmd - return the cobra command to collect genesis transactions
 func CollectGenTxsCmd(genBalIterator types.GenesisBalancesIterator, defaultNodeHome string) *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "collect-gentxs",
 		Short: "Collect genesis txs and output a genesis.json file",
 		RunE: func(cmd *cobra.Command, _ []string) error {

--- a/x/genutil/client/cli/gentx.go
+++ b/x/genutil/client/cli/gentx.go
@@ -33,7 +33,7 @@ func GenTxCmd(mbm module.BasicManager, txEncCfg client.TxEncodingConfig, genBalI
 	ipDefault, _ := server.ExternalIP()
 	fsCreateValidator, defaultsDesc := cli.CreateValidatorMsgFlagSet(ipDefault)
 
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "gentx [key_name] [amount]",
 		Short: "Generate a genesis tx carrying a self delegation",
 		Args:  cobra.ExactArgs(2),

--- a/x/genutil/client/cli/init.go
+++ b/x/genutil/client/cli/init.go
@@ -68,7 +68,7 @@ func displayInfo(info printInfo) error {
 // InitCmd returns a command that initializes all files needed for Tendermint
 // and the respective application.
 func InitCmd(mbm module.BasicManager, defaultNodeHome string) *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "init [moniker]",
 		Short: "Initialize private validator, p2p, genesis, and application configuration files",
 		Long:  `Initialize validators's and node's configuration files.`,

--- a/x/genutil/client/cli/migrate.go
+++ b/x/genutil/client/cli/migrate.go
@@ -54,7 +54,7 @@ func GetMigrationVersions() []string {
 
 // MigrateGenesisCmd returns a command to execute genesis state migration.
 func MigrateGenesisCmd() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "migrate [target-version] [genesis-file]",
 		Short: "Migrate genesis to a specified target version",
 		Long: fmt.Sprintf(`Migrate the source genesis into the target version and print to STDOUT.

--- a/x/genutil/client/cli/validate_genesis.go
+++ b/x/genutil/client/cli/validate_genesis.go
@@ -16,7 +16,7 @@ const chainUpgradeGuide = "https://docs.cosmos.network/master/migrations/chain-u
 
 // ValidateGenesisCmd takes a genesis file, and makes sure that it is valid.
 func ValidateGenesisCmd(mbm module.BasicManager) *cobra.Command {
-	return &cobra.Command{
+	return &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "validate-genesis [file]",
 		Args:  cobra.RangeArgs(0, 1),
 		Short: "validates the genesis file at the default location or at the location passed as an arg",

--- a/x/genutil/client/testutil/suite.go
+++ b/x/genutil/client/testutil/suite.go
@@ -29,7 +29,7 @@ type IntegrationTestSuite struct {
 }
 
 func NewIntegrationTestSuite(cfg network.Config) *IntegrationTestSuite {
-	return &IntegrationTestSuite{cfg: cfg}
+	return &IntegrationTestSuite{cfg: cfg} // nolint: exhaustivestruct
 }
 
 func (s *IntegrationTestSuite) SetupSuite() {
@@ -87,7 +87,7 @@ func (s *IntegrationTestSuite) TestGenTxCmd() {
 	msgs := tx.GetMsgs()
 	s.Require().Len(msgs, 1)
 
-	s.Require().Equal(sdk.MsgTypeURL(&types.MsgCreateValidator{}), sdk.MsgTypeURL(msgs[0]))
+	s.Require().Equal(sdk.MsgTypeURL(&types.MsgCreateValidator{}), sdk.MsgTypeURL(msgs[0])) // nolint: exhaustivestruct
 	s.Require().True(val.Address.Equals(msgs[0].GetSigners()[0]))
 	s.Require().Equal(amount, msgs[0].(*types.MsgCreateValidator).Value)
 	s.Require().NoError(tx.ValidateBasic())

--- a/x/genutil/module.go
+++ b/x/genutil/module.go
@@ -19,8 +19,8 @@ import (
 )
 
 var (
-	_ module.AppModuleGenesis = AppModule{}
-	_ module.AppModuleBasic   = AppModuleBasic{}
+	_ module.AppModuleGenesis = AppModule{}      // nolint: exhaustivestruct
+	_ module.AppModuleBasic   = AppModuleBasic{} // nolint: exhaustivestruct
 )
 
 // AppModuleBasic defines the basic application module used by the genutil module.

--- a/x/genutil/module.go
+++ b/x/genutil/module.go
@@ -18,9 +18,10 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/genutil/types"
 )
 
+// nolint: exhaustivestruct
 var (
-	_ module.AppModuleGenesis = AppModule{}      // nolint: exhaustivestruct
-	_ module.AppModuleBasic   = AppModuleBasic{} // nolint: exhaustivestruct
+	_ module.AppModuleGenesis = AppModule{}
+	_ module.AppModuleBasic   = AppModuleBasic{}
 )
 
 // AppModuleBasic defines the basic application module used by the genutil module.

--- a/x/gov/client/cli/query.go
+++ b/x/gov/client/cli/query.go
@@ -19,7 +19,7 @@ import (
 // GetQueryCmd returns the cli query commands for this module
 func GetQueryCmd() *cobra.Command {
 	// Group gov queries under a subcommand
-	govQueryCmd := &cobra.Command{
+	govQueryCmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:                        types.ModuleName,
 		Short:                      "Querying commands for the governance module",
 		DisableFlagParsing:         true,
@@ -45,7 +45,7 @@ func GetQueryCmd() *cobra.Command {
 
 // GetCmdQueryProposal implements the query proposal command.
 func GetCmdQueryProposal() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "proposal [proposal-id]",
 		Args:  cobra.ExactArgs(1),
 		Short: "Query details of a single proposal",
@@ -93,7 +93,7 @@ $ %s query gov proposal 1
 // GetCmdQueryProposals implements a query proposals command. Command to Get a
 // Proposal Information.
 func GetCmdQueryProposals() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "proposals",
 		Short: "Query proposals with optional filters",
 		Long: strings.TrimSpace(
@@ -181,7 +181,7 @@ $ %s query gov proposals --page=2 --limit=100
 // GetCmdQueryVote implements the query proposal vote command. Command to Get a
 // Proposal Information.
 func GetCmdQueryVote() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "vote [proposal-id] [voter-addr]",
 		Args:  cobra.ExactArgs(2),
 		Short: "Query details of a single vote",
@@ -255,7 +255,7 @@ $ %s query gov vote 1 cosmos1skjwj5whet0lpe65qaq4rpq03hjxlwd9nf39lk
 
 // GetCmdQueryVotes implements the command to query for proposal votes.
 func GetCmdQueryVotes() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "votes [proposal-id]",
 		Args:  cobra.ExactArgs(1),
 		Short: "Query votes on a proposal",
@@ -339,7 +339,7 @@ $ %[1]s query gov votes 1 --page=2 --limit=100
 // GetCmdQueryDeposit implements the query proposal deposit command. Command to
 // get a specific Deposit Information
 func GetCmdQueryDeposit() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "deposit [proposal-id] [depositer-addr]",
 		Args:  cobra.ExactArgs(2),
 		Short: "Query details of a deposit",
@@ -394,7 +394,7 @@ $ %s query gov deposit 1 cosmos1skjwj5whet0lpe65qaq4rpq03hjxlwd9nf39lk
 
 // GetCmdQueryDeposits implements the command to query for proposal deposits.
 func GetCmdQueryDeposits() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "deposits [proposal-id]",
 		Args:  cobra.ExactArgs(1),
 		Short: "Query deposits on a proposal",
@@ -457,7 +457,7 @@ $ %s query gov deposits 1
 
 // GetCmdQueryTally implements the command to query for proposal tally result.
 func GetCmdQueryTally() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "tally [proposal-id]",
 		Args:  cobra.ExactArgs(1),
 		Short: "Get the tally of a proposal vote",
@@ -514,7 +514,7 @@ $ %s query gov tally 1
 
 // GetCmdQueryParams implements the query params command.
 func GetCmdQueryParams() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "params",
 		Short: "Query the parameters of the governance process",
 		Long: strings.TrimSpace(
@@ -577,7 +577,7 @@ $ %s query gov params
 
 // GetCmdQueryParam implements the query param command.
 func GetCmdQueryParam() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "param [param-type]",
 		Args:  cobra.ExactArgs(1),
 		Short: "Query the parameters (voting|tallying|deposit) of the governance process",
@@ -631,7 +631,7 @@ $ %s query gov param deposit
 
 // GetCmdQueryProposer implements the query proposer command.
 func GetCmdQueryProposer() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "proposer [proposal-id]",
 		Args:  cobra.ExactArgs(1),
 		Short: "Query the proposer of a governance proposal",

--- a/x/gov/client/cli/tx.go
+++ b/x/gov/client/cli/tx.go
@@ -51,7 +51,7 @@ var ProposalFlags = []string{
 // to proposal type handlers that are implemented in other modules but are mounted
 // under the governance CLI (eg. parameter change proposals).
 func NewTxCmd(legacyPropCmds []*cobra.Command) *cobra.Command {
-	govTxCmd := &cobra.Command{
+	govTxCmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:                        types.ModuleName,
 		Short:                      "Governance transactions subcommands",
 		DisableFlagParsing:         true,
@@ -80,7 +80,7 @@ func NewTxCmd(legacyPropCmds []*cobra.Command) *cobra.Command {
 
 // NewCmdSubmitProposal implements submitting a proposal transaction command.
 func NewCmdSubmitProposal() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "submit-proposal",
 		Short: "Submit a proposal along with some messages and metadata",
 		Args:  cobra.ExactArgs(1),
@@ -138,7 +138,7 @@ Where proposal.json contains:
 // NewCmdSubmitLegacyProposal implements submitting a proposal transaction command.
 // Deprecated: please use NewCmdSubmitProposal instead.
 func NewCmdSubmitLegacyProposal() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "submit-legacy-proposal",
 		Short: "Submit a legacy proposal along with an initial deposit",
 		Long: strings.TrimSpace(
@@ -202,7 +202,7 @@ $ %s tx gov submit-legacy-proposal --title="Test Proposal" --description="My awe
 
 // NewCmdDeposit implements depositing tokens for an active proposal.
 func NewCmdDeposit() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "deposit [proposal-id] [deposit]",
 		Args:  cobra.ExactArgs(2),
 		Short: "Deposit tokens for an active proposal",
@@ -250,7 +250,7 @@ $ %s tx gov deposit 1 10stake --from mykey
 
 // NewCmdVote implements creating a new vote command.
 func NewCmdVote() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "vote [proposal-id] [option]",
 		Args:  cobra.ExactArgs(2),
 		Short: "Vote for an active proposal, options: yes/no/no_with_veto/abstain",
@@ -304,7 +304,7 @@ $ %s tx gov vote 1 yes --from mykey
 
 // NewCmdWeightedVote implements creating a new weighted vote command.
 func NewCmdWeightedVote() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "weighted-vote [proposal-id] [weighted-options]",
 		Args:  cobra.ExactArgs(2),
 		Short: "Vote for an active proposal, options: yes/no/no_with_veto/abstain",

--- a/x/gov/client/testutil/grpc.go
+++ b/x/gov/client/testutil/grpc.go
@@ -361,6 +361,7 @@ func (s *IntegrationTestSuite) TestGetParamsGRPC() {
 	vp := v1.DefaultVotingParams()
 	tp := v1.DefaultTallyParams()
 
+	// nolint: exhaustivestruct
 	testCases := []struct {
 		name       string
 		url        string

--- a/x/gov/client/testutil/suite.go
+++ b/x/gov/client/testutil/suite.go
@@ -31,7 +31,7 @@ type IntegrationTestSuite struct {
 }
 
 func NewIntegrationTestSuite(cfg network.Config) *IntegrationTestSuite {
-	return &IntegrationTestSuite{cfg: cfg}
+	return &IntegrationTestSuite{cfg: cfg} // nolint: exhaustivestruct
 }
 
 func (s *IntegrationTestSuite) SetupSuite() {

--- a/x/gov/client/testutil/suite.go
+++ b/x/gov/client/testutil/suite.go
@@ -337,7 +337,7 @@ func (s *IntegrationTestSuite) TestNewCmdSubmitProposal() {
 				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
 				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(10))).String()),
 			},
-			false, 0, &sdk.TxResponse{},
+			false, 0, &sdk.TxResponse{}, // nolint: exhaustivestruct
 		},
 	}
 
@@ -415,7 +415,7 @@ func (s *IntegrationTestSuite) TestNewCmdSubmitLegacyProposal() {
 				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
 				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(10))).String()),
 			},
-			false, 0, &sdk.TxResponse{},
+			false, 0, &sdk.TxResponse{}, // nolint: exhaustivestruct
 		},
 		{
 			"valid transaction",
@@ -429,7 +429,7 @@ func (s *IntegrationTestSuite) TestNewCmdSubmitLegacyProposal() {
 				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
 				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(10))).String()),
 			},
-			false, 0, &sdk.TxResponse{},
+			false, 0, &sdk.TxResponse{}, // nolint: exhaustivestruct
 		},
 	}
 

--- a/x/gov/client/testutil/suite.go
+++ b/x/gov/client/testutil/suite.go
@@ -226,6 +226,7 @@ func (s *IntegrationTestSuite) TestCmdProposer() {
 func (s *IntegrationTestSuite) TestCmdTally() {
 	val := s.network.Validators[0]
 
+	// nolint: exhaustivestruct
 	testCases := []struct {
 		name           string
 		args           []string
@@ -312,6 +313,7 @@ func (s *IntegrationTestSuite) TestNewCmdSubmitProposal() {
 }`, authtypes.NewModuleAddress(types.ModuleName), base64.StdEncoding.EncodeToString(propMetadata), sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(5431)))
 	validPropFile := testutil.WriteToNewTempFile(s.T(), validProp)
 
+	// nolint: exhaustivestruct
 	testCases := []struct {
 		name         string
 		args         []string
@@ -337,7 +339,7 @@ func (s *IntegrationTestSuite) TestNewCmdSubmitProposal() {
 				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
 				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(10))).String()),
 			},
-			false, 0, &sdk.TxResponse{}, // nolint: exhaustivestruct
+			false, 0, &sdk.TxResponse{},
 		},
 	}
 
@@ -377,6 +379,8 @@ func (s *IntegrationTestSuite) TestNewCmdSubmitLegacyProposal() {
   "deposit": "%s"
 }`, sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(5431)))
 	validPropFile := testutil.WriteToNewTempFile(s.T(), validProp)
+
+	// nolint: exhaustivestruct
 	testCases := []struct {
 		name         string
 		args         []string
@@ -415,7 +419,7 @@ func (s *IntegrationTestSuite) TestNewCmdSubmitLegacyProposal() {
 				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
 				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(10))).String()),
 			},
-			false, 0, &sdk.TxResponse{}, // nolint: exhaustivestruct
+			false, 0, &sdk.TxResponse{},
 		},
 		{
 			"valid transaction",
@@ -429,7 +433,7 @@ func (s *IntegrationTestSuite) TestNewCmdSubmitLegacyProposal() {
 				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
 				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(10))).String()),
 			},
-			false, 0, &sdk.TxResponse{}, // nolint: exhaustivestruct
+			false, 0, &sdk.TxResponse{},
 		},
 	}
 

--- a/x/gov/client/utils/query.go
+++ b/x/gov/client/utils/query.go
@@ -61,12 +61,12 @@ func QueryDepositsByTxQuery(clientCtx client.Context, params v1.QueryProposalPar
 		},
 		// Query proto Msgs event action v1beta1
 		[]string{
-			fmt.Sprintf("%s.%s='%s'", sdk.EventTypeMessage, sdk.AttributeKeyAction, sdk.MsgTypeURL(&v1beta1.MsgDeposit{})),
+			fmt.Sprintf("%s.%s='%s'", sdk.EventTypeMessage, sdk.AttributeKeyAction, sdk.MsgTypeURL(&v1beta1.MsgDeposit{})), // nolint: exhaustivestruct
 			fmt.Sprintf("%s.%s='%d'", types.EventTypeProposalDeposit, types.AttributeKeyProposalID, params.ProposalID),
 		},
 		// Query proto Msgs event action v1
 		[]string{
-			fmt.Sprintf("%s.%s='%s'", sdk.EventTypeMessage, sdk.AttributeKeyAction, sdk.MsgTypeURL(&v1.MsgDeposit{})),
+			fmt.Sprintf("%s.%s='%s'", sdk.EventTypeMessage, sdk.AttributeKeyAction, sdk.MsgTypeURL(&v1.MsgDeposit{})), // nolint: exhaustivestruct
 			fmt.Sprintf("%s.%s='%d'", types.EventTypeProposalDeposit, types.AttributeKeyProposalID, params.ProposalID),
 		},
 	)
@@ -124,12 +124,12 @@ func QueryVotesByTxQuery(clientCtx client.Context, params v1.QueryProposalVotesP
 			},
 			// Query Vote proto Msgs v1beta1
 			[]string{
-				fmt.Sprintf("%s.%s='%s'", sdk.EventTypeMessage, sdk.AttributeKeyAction, sdk.MsgTypeURL(&v1beta1.MsgVote{})),
+				fmt.Sprintf("%s.%s='%s'", sdk.EventTypeMessage, sdk.AttributeKeyAction, sdk.MsgTypeURL(&v1beta1.MsgVote{})), // nolint: exhaustivestruct
 				fmt.Sprintf("%s.%s='%d'", types.EventTypeProposalVote, types.AttributeKeyProposalID, params.ProposalID),
 			},
 			// Query Vote proto Msgs v1
 			[]string{
-				fmt.Sprintf("%s.%s='%s'", sdk.EventTypeMessage, sdk.AttributeKeyAction, sdk.MsgTypeURL(&v1.MsgVote{})),
+				fmt.Sprintf("%s.%s='%s'", sdk.EventTypeMessage, sdk.AttributeKeyAction, sdk.MsgTypeURL(&v1.MsgVote{})), // nolint: exhaustivestruct
 				fmt.Sprintf("%s.%s='%d'", types.EventTypeProposalVote, types.AttributeKeyProposalID, params.ProposalID),
 			},
 			// Query legacy VoteWeighted Msgs
@@ -139,12 +139,12 @@ func QueryVotesByTxQuery(clientCtx client.Context, params v1.QueryProposalVotesP
 			},
 			// Query VoteWeighted proto Msgs v1beta1
 			[]string{
-				fmt.Sprintf("%s.%s='%s'", sdk.EventTypeMessage, sdk.AttributeKeyAction, sdk.MsgTypeURL(&v1beta1.MsgVoteWeighted{})),
+				fmt.Sprintf("%s.%s='%s'", sdk.EventTypeMessage, sdk.AttributeKeyAction, sdk.MsgTypeURL(&v1beta1.MsgVoteWeighted{})), // nolint: exhaustivestruct
 				fmt.Sprintf("%s.%s='%d'", types.EventTypeProposalVote, types.AttributeKeyProposalID, params.ProposalID),
 			},
 			// Query VoteWeighted proto Msgs v1
 			[]string{
-				fmt.Sprintf("%s.%s='%s'", sdk.EventTypeMessage, sdk.AttributeKeyAction, sdk.MsgTypeURL(&v1.MsgVoteWeighted{})),
+				fmt.Sprintf("%s.%s='%s'", sdk.EventTypeMessage, sdk.AttributeKeyAction, sdk.MsgTypeURL(&v1.MsgVoteWeighted{})), // nolint: exhaustivestruct
 				fmt.Sprintf("%s.%s='%d'", types.EventTypeProposalVote, types.AttributeKeyProposalID, params.ProposalID),
 			},
 		)
@@ -216,13 +216,13 @@ func QueryVoteByTxQuery(clientCtx client.Context, params v1.QueryVoteParams) ([]
 		},
 		// Query Vote proto Msgs v1beta1
 		[]string{
-			fmt.Sprintf("%s.%s='%s'", sdk.EventTypeMessage, sdk.AttributeKeyAction, sdk.MsgTypeURL(&v1beta1.MsgVote{})),
+			fmt.Sprintf("%s.%s='%s'", sdk.EventTypeMessage, sdk.AttributeKeyAction, sdk.MsgTypeURL(&v1beta1.MsgVote{})), // nolint: exhaustivestruct
 			fmt.Sprintf("%s.%s='%d'", types.EventTypeProposalVote, types.AttributeKeyProposalID, params.ProposalID),
 			fmt.Sprintf("%s.%s='%s'", sdk.EventTypeMessage, sdk.AttributeKeySender, params.Voter.String()),
 		},
 		// Query Vote proto Msgs v1
 		[]string{
-			fmt.Sprintf("%s.%s='%s'", sdk.EventTypeMessage, sdk.AttributeKeyAction, sdk.MsgTypeURL(&v1.MsgVote{})),
+			fmt.Sprintf("%s.%s='%s'", sdk.EventTypeMessage, sdk.AttributeKeyAction, sdk.MsgTypeURL(&v1.MsgVote{})), // nolint: exhaustivestruct
 			fmt.Sprintf("%s.%s='%d'", types.EventTypeProposalVote, types.AttributeKeyProposalID, params.ProposalID),
 			fmt.Sprintf("%s.%s='%s'", sdk.EventTypeMessage, sdk.AttributeKeySender, params.Voter.String()),
 		},
@@ -234,13 +234,13 @@ func QueryVoteByTxQuery(clientCtx client.Context, params v1.QueryVoteParams) ([]
 		},
 		// Query VoteWeighted proto Msgs v1beta1
 		[]string{
-			fmt.Sprintf("%s.%s='%s'", sdk.EventTypeMessage, sdk.AttributeKeyAction, sdk.MsgTypeURL(&v1beta1.MsgVoteWeighted{})),
+			fmt.Sprintf("%s.%s='%s'", sdk.EventTypeMessage, sdk.AttributeKeyAction, sdk.MsgTypeURL(&v1beta1.MsgVoteWeighted{})), // nolint: exhaustivestruct
 			fmt.Sprintf("%s.%s='%d'", types.EventTypeProposalVote, types.AttributeKeyProposalID, params.ProposalID),
 			fmt.Sprintf("%s.%s='%s'", sdk.EventTypeMessage, sdk.AttributeKeySender, params.Voter),
 		},
 		// Query VoteWeighted proto Msgs v1
 		[]string{
-			fmt.Sprintf("%s.%s='%s'", sdk.EventTypeMessage, sdk.AttributeKeyAction, sdk.MsgTypeURL(&v1.MsgVoteWeighted{})),
+			fmt.Sprintf("%s.%s='%s'", sdk.EventTypeMessage, sdk.AttributeKeyAction, sdk.MsgTypeURL(&v1.MsgVoteWeighted{})), // nolint: exhaustivestruct
 			fmt.Sprintf("%s.%s='%d'", types.EventTypeProposalVote, types.AttributeKeyProposalID, params.ProposalID),
 			fmt.Sprintf("%s.%s='%s'", sdk.EventTypeMessage, sdk.AttributeKeySender, params.Voter),
 		},
@@ -324,13 +324,13 @@ func QueryDepositByTxQuery(clientCtx client.Context, params v1.QueryDepositParam
 		},
 		// Query proto Msgs event action v1beta1
 		[]string{
-			fmt.Sprintf("%s.%s='%s'", sdk.EventTypeMessage, sdk.AttributeKeyAction, sdk.MsgTypeURL(&v1beta1.MsgDeposit{})),
+			fmt.Sprintf("%s.%s='%s'", sdk.EventTypeMessage, sdk.AttributeKeyAction, sdk.MsgTypeURL(&v1beta1.MsgDeposit{})), // nolint: exhaustivestruct
 			fmt.Sprintf("%s.%s='%d'", types.EventTypeProposalDeposit, types.AttributeKeyProposalID, params.ProposalID),
 			fmt.Sprintf("%s.%s='%s'", sdk.EventTypeMessage, sdk.AttributeKeySender, params.Depositor.String()),
 		},
 		// Query proto Msgs event action v1
 		[]string{
-			fmt.Sprintf("%s.%s='%s'", sdk.EventTypeMessage, sdk.AttributeKeyAction, sdk.MsgTypeURL(&v1.MsgDeposit{})),
+			fmt.Sprintf("%s.%s='%s'", sdk.EventTypeMessage, sdk.AttributeKeyAction, sdk.MsgTypeURL(&v1.MsgDeposit{})), // nolint: exhaustivestruct
 			fmt.Sprintf("%s.%s='%d'", types.EventTypeProposalDeposit, types.AttributeKeyProposalID, params.ProposalID),
 			fmt.Sprintf("%s.%s='%s'", sdk.EventTypeMessage, sdk.AttributeKeySender, params.Depositor.String()),
 		},
@@ -390,12 +390,12 @@ func QueryProposerByTxQuery(clientCtx client.Context, proposalID uint64) (Propos
 		},
 		// Query proto Msgs event action v1beta1
 		[]string{
-			fmt.Sprintf("%s.%s='%s'", sdk.EventTypeMessage, sdk.AttributeKeyAction, sdk.MsgTypeURL(&v1beta1.MsgSubmitProposal{})),
+			fmt.Sprintf("%s.%s='%s'", sdk.EventTypeMessage, sdk.AttributeKeyAction, sdk.MsgTypeURL(&v1beta1.MsgSubmitProposal{})), // nolint: exhaustivestruct
 			fmt.Sprintf("%s.%s='%d'", types.EventTypeSubmitProposal, types.AttributeKeyProposalID, proposalID),
 		},
 		// Query proto Msgs event action v1
 		[]string{
-			fmt.Sprintf("%s.%s='%s'", sdk.EventTypeMessage, sdk.AttributeKeyAction, sdk.MsgTypeURL(&v1.MsgSubmitProposal{})),
+			fmt.Sprintf("%s.%s='%s'", sdk.EventTypeMessage, sdk.AttributeKeyAction, sdk.MsgTypeURL(&v1.MsgSubmitProposal{})), // nolint: exhaustivestruct
 			fmt.Sprintf("%s.%s='%d'", types.EventTypeSubmitProposal, types.AttributeKeyProposalID, proposalID),
 		},
 	)
@@ -468,12 +468,12 @@ func queryInitialDepositByTxQuery(clientCtx client.Context, proposalID uint64) (
 		},
 		// Query proto Msgs event action v1beta1
 		[]string{
-			fmt.Sprintf("%s.%s='%s'", sdk.EventTypeMessage, sdk.AttributeKeyAction, sdk.MsgTypeURL(&v1beta1.MsgSubmitProposal{})),
+			fmt.Sprintf("%s.%s='%s'", sdk.EventTypeMessage, sdk.AttributeKeyAction, sdk.MsgTypeURL(&v1beta1.MsgSubmitProposal{})), // nolint: exhaustivestruct
 			fmt.Sprintf("%s.%s='%d'", types.EventTypeSubmitProposal, types.AttributeKeyProposalID, proposalID),
 		},
 		// Query proto Msgs event action v1
 		[]string{
-			fmt.Sprintf("%s.%s='%s'", sdk.EventTypeMessage, sdk.AttributeKeyAction, sdk.MsgTypeURL(&v1.MsgSubmitProposal{})),
+			fmt.Sprintf("%s.%s='%s'", sdk.EventTypeMessage, sdk.AttributeKeyAction, sdk.MsgTypeURL(&v1.MsgSubmitProposal{})), // nolint: exhaustivestruct
 			fmt.Sprintf("%s.%s='%d'", types.EventTypeSubmitProposal, types.AttributeKeyProposalID, proposalID),
 		},
 	)

--- a/x/gov/keeper/grpc_query.go
+++ b/x/gov/keeper/grpc_query.go
@@ -15,7 +15,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/gov/types/v1beta1"
 )
 
-var _ v1.QueryServer = Keeper{}
+var _ v1.QueryServer = Keeper{} // nolint: exhaustivestruct
 
 // Proposal returns proposal details based on ProposalID
 func (q Keeper) Proposal(c context.Context, req *v1.QueryProposalRequest) (*v1.QueryProposalResponse, error) {
@@ -280,7 +280,7 @@ func (q Keeper) TallyResult(c context.Context, req *v1.QueryTallyResultRequest) 
 	return &v1.QueryTallyResultResponse{Tally: &tallyResult}, nil
 }
 
-var _ v1beta1.QueryServer = legacyQueryServer{}
+var _ v1beta1.QueryServer = legacyQueryServer{} // nolint: exhaustivestruct
 
 type legacyQueryServer struct {
 	keeper Keeper

--- a/x/gov/keeper/hooks.go
+++ b/x/gov/keeper/hooks.go
@@ -6,7 +6,7 @@ import (
 )
 
 // Implements GovHooks interface
-var _ types.GovHooks = Keeper{}
+var _ types.GovHooks = Keeper{} // nolint: exhaustivestruct
 
 // AfterProposalSubmission - call hook if registered
 func (keeper Keeper) AfterProposalSubmission(ctx sdk.Context, proposalID uint64) {

--- a/x/gov/keeper/hooks_test.go
+++ b/x/gov/keeper/hooks_test.go
@@ -15,7 +15,7 @@ import (
 	v1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 )
 
-var _ types.GovHooks = &MockGovHooksReceiver{}
+var _ types.GovHooks = &MockGovHooksReceiver{} // nolint: exhaustivestruct
 
 // GovHooks event hooks for governance proposal object (noalias)
 type MockGovHooksReceiver struct {

--- a/x/gov/keeper/msg_server.go
+++ b/x/gov/keeper/msg_server.go
@@ -12,8 +12,8 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/cosmos-sdk/x/gov/types"
+	v1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 	"github.com/cosmos/cosmos-sdk/x/gov/types/v1beta1"
-	"github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 )
 
 type msgServer struct {
@@ -26,7 +26,7 @@ func NewMsgServerImpl(keeper Keeper) v1.MsgServer {
 	return &msgServer{Keeper: keeper}
 }
 
-var _ v1.MsgServer = msgServer{}
+var _ v1.MsgServer = msgServer{} // nolint: exhaustivestruct
 
 func (k msgServer) SubmitProposal(goCtx context.Context, msg *v1.MsgSubmitProposal) (*v1.MsgSubmitProposalResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
@@ -218,7 +218,7 @@ func NewLegacyMsgServerImpl(govAcct string, v1Server v1.MsgServer) v1beta1.MsgSe
 	return &legacyMsgServer{govAcct: govAcct, server: v1Server}
 }
 
-var _ v1beta1.MsgServer = legacyMsgServer{}
+var _ v1beta1.MsgServer = legacyMsgServer{} // nolint: exhaustivestruct
 
 func (k legacyMsgServer) SubmitProposal(goCtx context.Context, msg *v1beta1.MsgSubmitProposal) (*v1beta1.MsgSubmitProposalResponse, error) {
 	contentMsg, err := v1.NewLegacyContent(msg.GetContent(), k.govAcct)

--- a/x/gov/keeper/proposal.go
+++ b/x/gov/keeper/proposal.go
@@ -32,7 +32,7 @@ func (keeper Keeper) SubmitProposal(ctx sdk.Context, messages []sdk.Msg, metadat
 
 		signers := msg.GetSigners()
 		if len(signers) != 1 {
-			return v1.Proposal{}, types.ErrInvalidSigner
+			return v1.Proposal{}, types.ErrInvalidSigner // nolint: exhaustivestruct
 		}
 
 		// assert that the governance module account is the only signer of the messages

--- a/x/gov/keeper/proposal.go
+++ b/x/gov/keeper/proposal.go
@@ -98,7 +98,7 @@ func (keeper Keeper) GetProposal(ctx sdk.Context, proposalID uint64) (v1.Proposa
 
 	bz := store.Get(types.ProposalKey(proposalID))
 	if bz == nil {
-		return v1.Proposal{}, false
+		return v1.Proposal{}, false // nolint: exhaustivestruct
 	}
 
 	var proposal v1.Proposal

--- a/x/gov/migrations/v034/types.go
+++ b/x/gov/migrations/v034/types.go
@@ -13,6 +13,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
+// nolint: exhaustivestruct
 var (
 	_ ProposalContent = TextProposal{}
 )
@@ -328,6 +329,7 @@ func (pt ProposalKind) String() string {
 	}
 }
 
+// nolint: exhaustivestruct
 func RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
 	cdc.RegisterInterface((*ProposalContent)(nil), nil)
 	cdc.RegisterConcrete(TextProposal{}, "gov/TextProposal", nil)

--- a/x/gov/migrations/v036/types.go
+++ b/x/gov/migrations/v036/types.go
@@ -24,6 +24,7 @@ const (
 	MaxTitleLength       int = 140
 )
 
+// nolint: exhaustivestruct
 var (
 	_ Content = TextProposal{}
 )
@@ -129,6 +130,7 @@ func ValidateAbstract(c Content) error {
 	return nil
 }
 
+// nolint: exhaustivestruct
 func RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
 	cdc.RegisterInterface((*Content)(nil), nil)
 	cdc.RegisterConcrete(TextProposal{}, "cosmos-sdk/TextProposal", nil)

--- a/x/gov/module.go
+++ b/x/gov/module.go
@@ -28,10 +28,11 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/gov/types/v1beta1"
 )
 
+// nolint: exhaustivestruct
 var (
-	_ module.AppModule           = AppModule{}      // nolint: exhaustivestruct
-	_ module.AppModuleBasic      = AppModuleBasic{} // nolint: exhaustivestruct
-	_ module.AppModuleSimulation = AppModule{}      // nolint: exhaustivestruct
+	_ module.AppModule           = AppModule{}
+	_ module.AppModuleBasic      = AppModuleBasic{}
+	_ module.AppModuleSimulation = AppModule{}
 )
 
 // AppModuleBasic defines the basic application module used by the gov module.

--- a/x/gov/module.go
+++ b/x/gov/module.go
@@ -29,9 +29,9 @@ import (
 )
 
 var (
-	_ module.AppModule           = AppModule{}
-	_ module.AppModuleBasic      = AppModuleBasic{}
-	_ module.AppModuleSimulation = AppModule{}
+	_ module.AppModule           = AppModule{}      // nolint: exhaustivestruct
+	_ module.AppModuleBasic      = AppModuleBasic{} // nolint: exhaustivestruct
+	_ module.AppModuleSimulation = AppModule{}      // nolint: exhaustivestruct
 )
 
 // AppModuleBasic defines the basic application module used by the gov module.

--- a/x/gov/simulation/operations.go
+++ b/x/gov/simulation/operations.go
@@ -20,6 +20,7 @@ import (
 var initialProposalID = uint64(100000000000000)
 
 // Governance message types and routes
+// nolint: exhaustivestruct
 var (
 	TypeMsgDeposit        = sdk.MsgTypeURL(&v1.MsgDeposit{})
 	TypeMsgVote           = sdk.MsgTypeURL(&v1.MsgVote{})

--- a/x/gov/simulation/operations_test.go
+++ b/x/gov/simulation/operations_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cosmos/cosmos-sdk/codec/legacy"
-
 	"github.com/stretchr/testify/require"
 	abci "github.com/tendermint/tendermint/abci/types"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"

--- a/x/gov/simulation/operations_test.go
+++ b/x/gov/simulation/operations_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cosmos/cosmos-sdk/codec/legacy"
+
 	"github.com/stretchr/testify/require"
 	abci "github.com/tendermint/tendermint/abci/types"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
@@ -45,7 +47,7 @@ func (m MockWeightedProposalContent) ContentSimulatorFn() simtypes.ContentSimula
 }
 
 // make sure the MockWeightedProposalContent satisfied the WeightedProposalContent interface
-var _ simtypes.WeightedProposalContent = MockWeightedProposalContent{}
+var _ simtypes.WeightedProposalContent = MockWeightedProposalContent{} // nolint: exhaustivestruct
 
 func mockWeightedProposalContent(n int) []simtypes.WeightedProposalContent {
 	wpc := make([]simtypes.WeightedProposalContent, n)

--- a/x/gov/types/v1/codec.go
+++ b/x/gov/types/v1/codec.go
@@ -1,3 +1,4 @@
+// nolint: exhaustivestruct
 package v1
 
 import (

--- a/x/gov/types/v1/genesis.go
+++ b/x/gov/types/v1/genesis.go
@@ -56,7 +56,7 @@ func ValidateGenesis(data *GenesisState) error {
 	return nil
 }
 
-var _ types.UnpackInterfacesMessage = GenesisState{}
+var _ types.UnpackInterfacesMessage = GenesisState{} // nolint: exhaustivestruct
 
 // UnpackInterfaces implements UnpackInterfacesMessage.UnpackInterfaces
 func (data GenesisState) UnpackInterfaces(unpacker types.AnyUnpacker) error {

--- a/x/gov/types/v1/msgs.go
+++ b/x/gov/types/v1/msgs.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/gov/types/v1beta1"
 )
 
+// nolint: exhaustivestruct
 var (
 	_, _, _, _, _ sdk.Msg                            = &MsgSubmitProposal{}, &MsgDeposit{}, &MsgVote{}, &MsgVoteWeighted{}, &MsgExecLegacyContent{}
 	_, _          codectypes.UnpackInterfacesMessage = &MsgSubmitProposal{}, &MsgExecLegacyContent{}

--- a/x/gov/types/v1/params.go
+++ b/x/gov/types/v1/params.go
@@ -31,6 +31,7 @@ var (
 
 // ParamKeyTable - Key declaration for parameters
 func ParamKeyTable() paramtypes.KeyTable {
+	// nolint: exhaustivestruct
 	return paramtypes.NewKeyTable(
 		paramtypes.NewParamSetPair(ParamStoreKeyDepositParams, DepositParams{}, validateDepositParams),
 		paramtypes.NewParamSetPair(ParamStoreKeyVotingParams, VotingParams{}, validateVotingParams),

--- a/x/gov/types/v1beta1/codec.go
+++ b/x/gov/types/v1beta1/codec.go
@@ -1,3 +1,4 @@
+// nolint: exhaustivestruct
 package v1beta1
 
 import (

--- a/x/gov/types/v1beta1/genesis.go
+++ b/x/gov/types/v1beta1/genesis.go
@@ -64,7 +64,7 @@ func ValidateGenesis(data *GenesisState) error {
 	return nil
 }
 
-var _ types.UnpackInterfacesMessage = GenesisState{}
+var _ types.UnpackInterfacesMessage = GenesisState{} // nolint: exhaustivestruct
 
 // UnpackInterfaces implements UnpackInterfacesMessage.UnpackInterfaces
 func (data GenesisState) UnpackInterfaces(unpacker types.AnyUnpacker) error {

--- a/x/gov/types/v1beta1/msgs.go
+++ b/x/gov/types/v1beta1/msgs.go
@@ -2,6 +2,7 @@ package v1beta1
 
 import (
 	"fmt"
+
 	"github.com/cosmos/cosmos-sdk/codec/legacy"
 
 	"github.com/gogo/protobuf/proto"
@@ -21,6 +22,7 @@ const (
 	TypeMsgSubmitProposal = "submit_proposal"
 )
 
+// nolint: exhaustivestruct
 var (
 	_, _, _, _ sdk.Msg                            = &MsgSubmitProposal{}, &MsgDeposit{}, &MsgVote{}, &MsgVoteWeighted{}
 	_          codectypes.UnpackInterfacesMessage = &MsgSubmitProposal{}

--- a/x/gov/types/v1beta1/proposal.go
+++ b/x/gov/types/v1beta1/proposal.go
@@ -170,7 +170,7 @@ const (
 )
 
 // Implements Content Interface
-var _ Content = &TextProposal{}
+var _ Content = &TextProposal{} // nolint: exhaustivestruct
 
 // NewTextProposal creates a text proposal Content
 func NewTextProposal(title, description string) Content {

--- a/x/group/client/cli/query.go
+++ b/x/group/client/cli/query.go
@@ -437,7 +437,7 @@ func QueryVotesByProposalCmd() *cobra.Command {
 
 // QueryVotesByProposalCmd creates a CLI command for Query/TallyResult.
 func QueryTallyResultCmd() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "tally-result [proposal-id]",
 		Short: "Query tally result of proposal",
 		Args:  cobra.ExactArgs(1),

--- a/x/group/client/cli/query.go
+++ b/x/group/client/cli/query.go
@@ -3,15 +3,16 @@ package cli
 import (
 	"strconv"
 
+	"github.com/spf13/cobra"
+
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/x/group"
-	"github.com/spf13/cobra"
 )
 
 // QueryCmd returns the cli query commands for the group module.
 func QueryCmd(name string) *cobra.Command {
-	queryCmd := &cobra.Command{
+	queryCmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:                        name,
 		Short:                      "Querying commands for the group module",
 		DisableFlagParsing:         true,
@@ -40,7 +41,7 @@ func QueryCmd(name string) *cobra.Command {
 
 // QueryGroupsByMemberCmd creates a CLI command for Query/GroupsByMember.
 func QueryGroupsByMemberCmd() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "groups-by-member [address]",
 		Short: "Query for groups by member address with pagination flags",
 		Args:  cobra.ExactArgs(1),
@@ -69,7 +70,7 @@ func QueryGroupsByMemberCmd() *cobra.Command {
 
 // QueryGroupInfoCmd creates a CLI command for Query/GroupInfo.
 func QueryGroupInfoCmd() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "group-info [id]",
 		Short: "Query for group info by group id",
 		Args:  cobra.ExactArgs(1),
@@ -104,7 +105,7 @@ func QueryGroupInfoCmd() *cobra.Command {
 
 // QueryGroupPolicyInfoCmd creates a CLI command for Query/GroupPolicyInfo.
 func QueryGroupPolicyInfoCmd() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "group-policy-info [group-policy-account]",
 		Short: "Query for group policy info by account address of group policy",
 		Args:  cobra.ExactArgs(1),
@@ -134,7 +135,7 @@ func QueryGroupPolicyInfoCmd() *cobra.Command {
 
 // QueryGroupMembersCmd creates a CLI command for Query/GroupMembers.
 func QueryGroupMembersCmd() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "group-members [id]",
 		Short: "Query for group members by group id with pagination flags",
 		Args:  cobra.ExactArgs(1),
@@ -175,7 +176,7 @@ func QueryGroupMembersCmd() *cobra.Command {
 
 // QueryGroupsByAdminCmd creates a CLI command for Query/GroupsByAdmin.
 func QueryGroupsByAdminCmd() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "groups-by-admin [admin]",
 		Short: "Query for groups by admin account address with pagination flags",
 		Args:  cobra.ExactArgs(1),
@@ -211,7 +212,7 @@ func QueryGroupsByAdminCmd() *cobra.Command {
 
 // QueryGroupPoliciesByGroupCmd creates a CLI command for Query/GroupPoliciesByGroup.
 func QueryGroupPoliciesByGroupCmd() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "group-policies-by-group [group-id]",
 		Short: "Query for group policies by group id with pagination flags",
 		Args:  cobra.ExactArgs(1),
@@ -252,7 +253,7 @@ func QueryGroupPoliciesByGroupCmd() *cobra.Command {
 
 // QueryGroupPoliciesByAdminCmd creates a CLI command for Query/GroupPoliciesByAdmin.
 func QueryGroupPoliciesByAdminCmd() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "group-policies-by-admin [admin]",
 		Short: "Query for group policies by admin account address with pagination flags",
 		Args:  cobra.ExactArgs(1),
@@ -288,7 +289,7 @@ func QueryGroupPoliciesByAdminCmd() *cobra.Command {
 
 // QueryProposalCmd creates a CLI command for Query/Proposal.
 func QueryProposalCmd() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "proposal [id]",
 		Short: "Query for proposal by id",
 		Args:  cobra.ExactArgs(1),
@@ -323,7 +324,7 @@ func QueryProposalCmd() *cobra.Command {
 
 // QueryProposalsByGroupPolicyCmd creates a CLI command for Query/ProposalsByGroupPolicy.
 func QueryProposalsByGroupPolicyCmd() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "proposals-by-group-policy [group-policy-account]",
 		Short: "Query for proposals by account address of group policy with pagination flags",
 		Args:  cobra.ExactArgs(1),
@@ -359,7 +360,7 @@ func QueryProposalsByGroupPolicyCmd() *cobra.Command {
 
 // QueryVoteByProposalVoterCmd creates a CLI command for Query/VoteByProposalVoter.
 func QueryVoteByProposalVoterCmd() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "vote [proposal-id] [voter]",
 		Short: "Query for vote by proposal id and voter account address",
 		Args:  cobra.ExactArgs(2),
@@ -395,7 +396,7 @@ func QueryVoteByProposalVoterCmd() *cobra.Command {
 
 // QueryVotesByProposalCmd creates a CLI command for Query/VotesByProposal.
 func QueryVotesByProposalCmd() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "votes-by-proposal [proposal-id]",
 		Short: "Query for votes by proposal id with pagination flags",
 		Args:  cobra.ExactArgs(1),
@@ -471,7 +472,7 @@ func QueryTallyResultCmd() *cobra.Command {
 
 // QueryVotesByVoterCmd creates a CLI command for Query/VotesByVoter.
 func QueryVotesByVoterCmd() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "votes-by-voter [voter]",
 		Short: "Query for votes by voter account address with pagination flags",
 		Args:  cobra.ExactArgs(1),

--- a/x/group/client/cli/tx.go
+++ b/x/group/client/cli/tx.go
@@ -784,7 +784,7 @@ func MsgExecCmd() *cobra.Command {
 
 // MsgLeaveGroupCmd creates a CLI command for Msg/LeaveGroup.
 func MsgLeaveGroupCmd() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "leave-group [member-address] [group-id]",
 		Short: "remove member from the group",
 		Long: ` remove member from the group

--- a/x/group/client/cli/tx.go
+++ b/x/group/client/cli/tx.go
@@ -23,7 +23,7 @@ const (
 
 // TxCmd returns a root CLI command handler for all x/group transaction commands.
 func TxCmd(name string) *cobra.Command {
-	txCmd := &cobra.Command{
+	txCmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:                        name,
 		Short:                      "Group transaction subcommands",
 		DisableFlagParsing:         true,
@@ -52,7 +52,7 @@ func TxCmd(name string) *cobra.Command {
 
 // MsgCreateGroupCmd creates a CLI command for Msg/CreateGroup.
 func MsgCreateGroupCmd() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use: "create-group [admin] [metadata] [members-json-file]",
 		Short: "Create a group which is an aggregation " +
 			"of member accounts with associated weights and " +
@@ -123,7 +123,7 @@ Where members.json contains:
 
 // MsgUpdateGroupMembersCmd creates a CLI command for Msg/UpdateGroupMembers.
 func MsgUpdateGroupMembersCmd() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "update-group-members [admin] [group-id] [members-json-file]",
 		Short: "Update a group's members. Set a member's weight to \"0\" to delete it.",
 		Long: strings.TrimSpace(
@@ -196,7 +196,7 @@ Set a member's weight to "0" to delete it.
 
 // MsgUpdateGroupAdminCmd creates a CLI command for Msg/UpdateGroupAdmin.
 func MsgUpdateGroupAdminCmd() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "update-group-admin [admin] [group-id] [new-admin]",
 		Short: "Update a group's admin",
 		Args:  cobra.ExactArgs(3),
@@ -236,7 +236,7 @@ func MsgUpdateGroupAdminCmd() *cobra.Command {
 
 // MsgUpdateGroupMetadataCmd creates a CLI command for Msg/UpdateGroupMetadata.
 func MsgUpdateGroupMetadataCmd() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "update-group-metadata [admin] [group-id] [metadata]",
 		Short: "Update a group's metadata",
 		Args:  cobra.ExactArgs(3),
@@ -276,7 +276,7 @@ func MsgUpdateGroupMetadataCmd() *cobra.Command {
 
 // MsgCreateGroupWithPolicyCmd creates a CLI command for Msg/CreateGroupWithPolicy.
 func MsgCreateGroupWithPolicyCmd() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use: "create-group-with-policy [admin] [group-metadata] [group-policy-metadata] [members-json-file] [decision-policy]",
 		Short: "Create a group with policy which is an aggregation " +
 			"of member accounts with associated weights, " +
@@ -366,7 +366,7 @@ where members.json contains:
 
 // MsgCreateGroupPolicyCmd creates a CLI command for Msg/CreateGroupPolicy.
 func MsgCreateGroupPolicyCmd() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use: "create-group-policy [admin] [group-id] [metadata] [decision-policy]",
 		Short: "Create a group policy which is an account " +
 			"associated with a group and a decision policy. " +
@@ -432,7 +432,7 @@ Ex: '{"@type":"/cosmos.group.v1.PercentageDecisionPolicy", "percentage":"0.5", "
 
 // MsgUpdateGroupPolicyAdminCmd creates a CLI command for Msg/UpdateGroupPolicyAdmin.
 func MsgUpdateGroupPolicyAdminCmd() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "update-group-policy-admin [admin] [group-policy-account] [new-admin]",
 		Short: "Update a group policy admin",
 		Args:  cobra.ExactArgs(3),
@@ -467,7 +467,7 @@ func MsgUpdateGroupPolicyAdminCmd() *cobra.Command {
 
 // MsgUpdateGroupPolicyDecisionPolicyCmd creates a CLI command for Msg/UpdateGroupPolicyDecisionPolicy.
 func MsgUpdateGroupPolicyDecisionPolicyCmd() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "update-group-policy-decision-policy [admin] [group-policy-account] [decision-policy]",
 		Short: "Update a group policy's decision policy",
 		Args:  cobra.ExactArgs(3),
@@ -516,7 +516,7 @@ func MsgUpdateGroupPolicyDecisionPolicyCmd() *cobra.Command {
 
 // MsgUpdateGroupPolicyMetadataCmd creates a CLI command for Msg/MsgUpdateGroupPolicyMetadata.
 func MsgUpdateGroupPolicyMetadataCmd() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "update-group-policy-metadata [admin] [group-policy-account] [new-metadata]",
 		Short: "Update a group policy metadata",
 		Args:  cobra.ExactArgs(3),
@@ -551,7 +551,7 @@ func MsgUpdateGroupPolicyMetadataCmd() *cobra.Command {
 
 // MsgSubmitProposalCmd creates a CLI command for Msg/SubmitProposal.
 func MsgSubmitProposalCmd() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "submit-proposal [proposal_json_file]",
 		Short: "Submit a new proposal",
 		Long: fmt.Sprintf(`Submit a new proposal.
@@ -628,7 +628,7 @@ Example:
 
 // MsgWithdrawProposalCmd creates a CLI command for Msg/WithdrawProposal.
 func MsgWithdrawProposalCmd() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "withdraw-proposal [proposal-id] [group-policy-admin-or-proposer]",
 		Short: "Withdraw a submitted proposal",
 		Long: `Withdraw a submitted proposal.
@@ -679,7 +679,7 @@ Parameters:
 
 // MsgVoteCmd creates a CLI command for Msg/Vote.
 func MsgVoteCmd() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "vote [proposal-id] [voter] [vote-option] [metadata]",
 		Short: "Vote on a proposal",
 		Long: `Vote on a proposal.
@@ -746,7 +746,7 @@ Parameters:
 
 // MsgExecCmd creates a CLI command for Msg/MsgExec.
 func MsgExecCmd() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "exec [proposal-id]",
 		Short: "Execute a proposal",
 		Args:  cobra.ExactArgs(1),

--- a/x/group/client/testutil/query.go
+++ b/x/group/client/testutil/query.go
@@ -153,6 +153,7 @@ func (s *IntegrationTestSuite) TestQueryGroupMembers() {
 	val := s.network.Validators[0]
 	clientCtx := val.ClientCtx
 
+	// nolint: exhaustivestruct
 	testCases := []struct {
 		name          string
 		args          []string

--- a/x/group/client/testutil/tx.go
+++ b/x/group/client/testutil/tx.go
@@ -106,7 +106,7 @@ func (s *IntegrationTestSuite) SetupSuite() {
 	)
 
 	s.Require().NoError(err, out.String())
-	var txResp = sdk.TxResponse{}
+	var txResp = sdk.TxResponse{} // nolint: exhaustivestruct
 	s.Require().NoError(val.ClientCtx.Codec.UnmarshalJSON(out.Bytes(), &txResp), out.String())
 	s.Require().Equal(uint32(0), txResp.Code, out.String())
 
@@ -275,7 +275,7 @@ func (s *IntegrationTestSuite) TestTxCreateGroup() {
 			),
 			false,
 			"",
-			&sdk.TxResponse{},
+			&sdk.TxResponse{}, // nolint: exhaustivestruct
 			0,
 		},
 		{
@@ -291,7 +291,7 @@ func (s *IntegrationTestSuite) TestTxCreateGroup() {
 			),
 			false,
 			"",
-			&sdk.TxResponse{},
+			&sdk.TxResponse{}, // nolint: exhaustivestruct
 			0,
 		},
 		{
@@ -432,7 +432,7 @@ func (s *IntegrationTestSuite) TestTxUpdateGroupAdmin() {
 			),
 			false,
 			"",
-			&sdk.TxResponse{},
+			&sdk.TxResponse{}, // nolint: exhaustivestruct
 			0,
 		},
 		{
@@ -448,7 +448,7 @@ func (s *IntegrationTestSuite) TestTxUpdateGroupAdmin() {
 			),
 			false,
 			"",
-			&sdk.TxResponse{},
+			&sdk.TxResponse{}, // nolint: exhaustivestruct
 			0,
 		},
 		{
@@ -533,7 +533,7 @@ func (s *IntegrationTestSuite) TestTxUpdateGroupMetadata() {
 			),
 			false,
 			"",
-			&sdk.TxResponse{},
+			&sdk.TxResponse{}, // nolint: exhaustivestruct
 			0,
 		},
 		{
@@ -549,7 +549,7 @@ func (s *IntegrationTestSuite) TestTxUpdateGroupMetadata() {
 			),
 			false,
 			"",
-			&sdk.TxResponse{},
+			&sdk.TxResponse{}, // nolint: exhaustivestruct
 			0,
 		},
 		{
@@ -636,7 +636,7 @@ func (s *IntegrationTestSuite) TestTxUpdateGroupMembers() {
 			),
 			false,
 			"",
-			&sdk.TxResponse{},
+			&sdk.TxResponse{}, // nolint: exhaustivestruct
 			0,
 		},
 		{
@@ -656,7 +656,7 @@ func (s *IntegrationTestSuite) TestTxUpdateGroupMembers() {
 			),
 			false,
 			"",
-			&sdk.TxResponse{},
+			&sdk.TxResponse{}, // nolint: exhaustivestruct
 			0,
 		},
 		{
@@ -770,7 +770,7 @@ func (s *IntegrationTestSuite) TestTxCreateGroupWithPolicy() {
 			),
 			false,
 			"",
-			&sdk.TxResponse{},
+			&sdk.TxResponse{}, // nolint: exhaustivestruct
 			0,
 		},
 		{
@@ -788,7 +788,7 @@ func (s *IntegrationTestSuite) TestTxCreateGroupWithPolicy() {
 			),
 			false,
 			"",
-			&sdk.TxResponse{},
+			&sdk.TxResponse{}, // nolint: exhaustivestruct
 			0,
 		},
 		{
@@ -807,7 +807,7 @@ func (s *IntegrationTestSuite) TestTxCreateGroupWithPolicy() {
 			),
 			false,
 			"",
-			&sdk.TxResponse{},
+			&sdk.TxResponse{}, // nolint: exhaustivestruct
 			0,
 		},
 		{
@@ -955,7 +955,7 @@ func (s *IntegrationTestSuite) TestTxCreateGroupPolicy() {
 			),
 			false,
 			"",
-			&sdk.TxResponse{},
+			&sdk.TxResponse{}, // nolint: exhaustivestruct
 			0,
 		},
 		{
@@ -971,7 +971,7 @@ func (s *IntegrationTestSuite) TestTxCreateGroupPolicy() {
 			),
 			false,
 			"",
-			&sdk.TxResponse{},
+			&sdk.TxResponse{}, // nolint: exhaustivestruct
 			0,
 		},
 		{
@@ -988,7 +988,7 @@ func (s *IntegrationTestSuite) TestTxCreateGroupPolicy() {
 			),
 			false,
 			"",
-			&sdk.TxResponse{},
+			&sdk.TxResponse{}, // nolint: exhaustivestruct
 			0,
 		},
 		{
@@ -1004,7 +1004,7 @@ func (s *IntegrationTestSuite) TestTxCreateGroupPolicy() {
 			),
 			true,
 			"key not found",
-			&sdk.TxResponse{},
+			&sdk.TxResponse{}, // nolint: exhaustivestruct
 			0,
 		},
 		{
@@ -1020,7 +1020,7 @@ func (s *IntegrationTestSuite) TestTxCreateGroupPolicy() {
 			),
 			true,
 			"group policy metadata: limit exceeded",
-			&sdk.TxResponse{},
+			&sdk.TxResponse{}, // nolint: exhaustivestruct
 			0,
 		},
 		{
@@ -1036,7 +1036,7 @@ func (s *IntegrationTestSuite) TestTxCreateGroupPolicy() {
 			),
 			true,
 			"not found",
-			&sdk.TxResponse{},
+			&sdk.TxResponse{}, // nolint: exhaustivestruct
 			0,
 		},
 		{
@@ -1052,7 +1052,7 @@ func (s *IntegrationTestSuite) TestTxCreateGroupPolicy() {
 			),
 			true,
 			"expected a positive decimal",
-			&sdk.TxResponse{},
+			&sdk.TxResponse{}, // nolint: exhaustivestruct
 			0,
 		},
 		{
@@ -1068,7 +1068,7 @@ func (s *IntegrationTestSuite) TestTxCreateGroupPolicy() {
 			),
 			true,
 			"percentage must be > 0 and <= 1",
-			&sdk.TxResponse{},
+			&sdk.TxResponse{}, // nolint: exhaustivestruct
 			0,
 		},
 	}
@@ -1125,7 +1125,7 @@ func (s *IntegrationTestSuite) TestTxUpdateGroupPolicyAdmin() {
 			),
 			false,
 			"",
-			&sdk.TxResponse{},
+			&sdk.TxResponse{}, // nolint: exhaustivestruct
 			0,
 		},
 		{
@@ -1141,7 +1141,7 @@ func (s *IntegrationTestSuite) TestTxUpdateGroupPolicyAdmin() {
 			),
 			false,
 			"",
-			&sdk.TxResponse{},
+			&sdk.TxResponse{}, // nolint: exhaustivestruct
 			0,
 		},
 		{
@@ -1156,7 +1156,7 @@ func (s *IntegrationTestSuite) TestTxUpdateGroupPolicyAdmin() {
 			),
 			true,
 			"key not found",
-			&sdk.TxResponse{},
+			&sdk.TxResponse{}, // nolint: exhaustivestruct
 			0,
 		},
 		{
@@ -1171,7 +1171,7 @@ func (s *IntegrationTestSuite) TestTxUpdateGroupPolicyAdmin() {
 			),
 			true,
 			"load group policy: not found",
-			&sdk.TxResponse{},
+			&sdk.TxResponse{}, // nolint: exhaustivestruct
 			0,
 		},
 	}
@@ -1228,7 +1228,7 @@ func (s *IntegrationTestSuite) TestTxUpdateGroupPolicyDecisionPolicy() {
 			),
 			false,
 			"",
-			&sdk.TxResponse{},
+			&sdk.TxResponse{}, // nolint: exhaustivestruct
 			0,
 		},
 		{
@@ -1243,7 +1243,7 @@ func (s *IntegrationTestSuite) TestTxUpdateGroupPolicyDecisionPolicy() {
 			),
 			false,
 			"",
-			&sdk.TxResponse{},
+			&sdk.TxResponse{}, // nolint: exhaustivestruct
 			0,
 		},
 		{
@@ -1259,7 +1259,7 @@ func (s *IntegrationTestSuite) TestTxUpdateGroupPolicyDecisionPolicy() {
 			),
 			false,
 			"",
-			&sdk.TxResponse{},
+			&sdk.TxResponse{}, // nolint: exhaustivestruct
 			0,
 		},
 		{
@@ -1274,7 +1274,7 @@ func (s *IntegrationTestSuite) TestTxUpdateGroupPolicyDecisionPolicy() {
 			),
 			true,
 			"key not found",
-			&sdk.TxResponse{},
+			&sdk.TxResponse{}, // nolint: exhaustivestruct
 			0,
 		},
 		{
@@ -1289,7 +1289,7 @@ func (s *IntegrationTestSuite) TestTxUpdateGroupPolicyDecisionPolicy() {
 			),
 			true,
 			"load group policy: not found",
-			&sdk.TxResponse{},
+			&sdk.TxResponse{}, // nolint: exhaustivestruct
 			0,
 		},
 		{
@@ -1304,7 +1304,7 @@ func (s *IntegrationTestSuite) TestTxUpdateGroupPolicyDecisionPolicy() {
 			),
 			true,
 			"expected a positive decimal",
-			&sdk.TxResponse{},
+			&sdk.TxResponse{}, // nolint: exhaustivestruct
 			0,
 		},
 		{
@@ -1319,7 +1319,7 @@ func (s *IntegrationTestSuite) TestTxUpdateGroupPolicyDecisionPolicy() {
 			),
 			true,
 			"percentage must be > 0 and <= 1",
-			&sdk.TxResponse{},
+			&sdk.TxResponse{}, // nolint: exhaustivestruct
 			0,
 		},
 	}
@@ -1376,7 +1376,7 @@ func (s *IntegrationTestSuite) TestTxUpdateGroupPolicyMetadata() {
 			),
 			false,
 			"",
-			&sdk.TxResponse{},
+			&sdk.TxResponse{}, // nolint: exhaustivestruct
 			0,
 		},
 		{
@@ -1392,7 +1392,7 @@ func (s *IntegrationTestSuite) TestTxUpdateGroupPolicyMetadata() {
 			),
 			false,
 			"",
-			&sdk.TxResponse{},
+			&sdk.TxResponse{}, // nolint: exhaustivestruct
 			0,
 		},
 		{
@@ -1407,7 +1407,7 @@ func (s *IntegrationTestSuite) TestTxUpdateGroupPolicyMetadata() {
 			),
 			true,
 			"group policy metadata: limit exceeded",
-			&sdk.TxResponse{},
+			&sdk.TxResponse{}, // nolint: exhaustivestruct
 			0,
 		},
 		{
@@ -1422,7 +1422,7 @@ func (s *IntegrationTestSuite) TestTxUpdateGroupPolicyMetadata() {
 			),
 			true,
 			"key not found",
-			&sdk.TxResponse{},
+			&sdk.TxResponse{}, // nolint: exhaustivestruct
 			0,
 		},
 		{
@@ -1437,7 +1437,7 @@ func (s *IntegrationTestSuite) TestTxUpdateGroupPolicyMetadata() {
 			),
 			true,
 			"load group policy: not found",
-			&sdk.TxResponse{},
+			&sdk.TxResponse{}, // nolint: exhaustivestruct
 			0,
 		},
 	}
@@ -1494,7 +1494,7 @@ func (s *IntegrationTestSuite) TestTxSubmitProposal() {
 			),
 			false,
 			"",
-			&sdk.TxResponse{},
+			&sdk.TxResponse{}, // nolint: exhaustivestruct
 			0,
 		},
 		{
@@ -1512,7 +1512,7 @@ func (s *IntegrationTestSuite) TestTxSubmitProposal() {
 			),
 			false,
 			"",
-			&sdk.TxResponse{},
+			&sdk.TxResponse{}, // nolint: exhaustivestruct
 			0,
 		},
 		{
@@ -1529,7 +1529,7 @@ func (s *IntegrationTestSuite) TestTxSubmitProposal() {
 			),
 			false,
 			"",
-			&sdk.TxResponse{},
+			&sdk.TxResponse{}, // nolint: exhaustivestruct
 			0,
 		},
 		{
@@ -1547,7 +1547,7 @@ func (s *IntegrationTestSuite) TestTxSubmitProposal() {
 			),
 			false,
 			"",
-			&sdk.TxResponse{},
+			&sdk.TxResponse{}, // nolint: exhaustivestruct
 			0,
 		},
 		{
@@ -1709,7 +1709,7 @@ func (s *IntegrationTestSuite) TestTxVote() {
 			),
 			false,
 			"",
-			&sdk.TxResponse{},
+			&sdk.TxResponse{}, // nolint: exhaustivestruct
 			0,
 		},
 		{
@@ -1726,7 +1726,7 @@ func (s *IntegrationTestSuite) TestTxVote() {
 			),
 			false,
 			"",
-			&sdk.TxResponse{},
+			&sdk.TxResponse{}, // nolint: exhaustivestruct
 			0,
 		},
 		{
@@ -1743,7 +1743,7 @@ func (s *IntegrationTestSuite) TestTxVote() {
 			),
 			false,
 			"",
-			&sdk.TxResponse{},
+			&sdk.TxResponse{}, // nolint: exhaustivestruct
 			0,
 		},
 		{
@@ -1760,7 +1760,7 @@ func (s *IntegrationTestSuite) TestTxVote() {
 			),
 			false,
 			"",
-			&sdk.TxResponse{},
+			&sdk.TxResponse{}, // nolint: exhaustivestruct
 			0,
 		},
 		{
@@ -1900,7 +1900,7 @@ func (s *IntegrationTestSuite) TestTxWithdrawProposal() {
 			),
 			false,
 			"",
-			&sdk.TxResponse{},
+			&sdk.TxResponse{}, // nolint: exhaustivestruct
 			0,
 		},
 		{
@@ -1914,7 +1914,7 @@ func (s *IntegrationTestSuite) TestTxWithdrawProposal() {
 			),
 			true,
 			"cannot withdraw a proposal with the status of PROPOSAL_STATUS_WITHDRAWN",
-			&sdk.TxResponse{},
+			&sdk.TxResponse{}, // nolint: exhaustivestruct
 			0,
 		},
 		{
@@ -1928,7 +1928,7 @@ func (s *IntegrationTestSuite) TestTxWithdrawProposal() {
 			),
 			true,
 			"not found",
-			&sdk.TxResponse{},
+			&sdk.TxResponse{}, // nolint: exhaustivestruct
 			0,
 		},
 		{
@@ -1942,7 +1942,7 @@ func (s *IntegrationTestSuite) TestTxWithdrawProposal() {
 			),
 			true,
 			"invalid syntax",
-			&sdk.TxResponse{},
+			&sdk.TxResponse{}, // nolint: exhaustivestruct
 			0,
 		},
 		{
@@ -1956,7 +1956,7 @@ func (s *IntegrationTestSuite) TestTxWithdrawProposal() {
 			),
 			true,
 			"key not found",
-			&sdk.TxResponse{},
+			&sdk.TxResponse{}, // nolint: exhaustivestruct
 			0,
 		},
 	}
@@ -2078,7 +2078,7 @@ func (s *IntegrationTestSuite) TestTxExec() {
 			),
 			false,
 			"",
-			&sdk.TxResponse{},
+			&sdk.TxResponse{}, // nolint: exhaustivestruct
 			0,
 		},
 		{

--- a/x/group/client/testutil/tx.go
+++ b/x/group/client/testutil/tx.go
@@ -42,7 +42,7 @@ const validMetadata = "metadata"
 var tooLongMetadata = strings.Repeat("A", 256)
 
 func NewIntegrationTestSuite(cfg network.Config) *IntegrationTestSuite {
-	return &IntegrationTestSuite{cfg: cfg}
+	return &IntegrationTestSuite{cfg: cfg} // nolint: exhaustivestruct
 }
 
 func (s *IntegrationTestSuite) SetupSuite() {

--- a/x/group/client/testutil/tx.go
+++ b/x/group/client/testutil/tx.go
@@ -110,7 +110,7 @@ func (s *IntegrationTestSuite) SetupSuite() {
 	s.Require().NoError(val.ClientCtx.Codec.UnmarshalJSON(out.Bytes(), &txResp), out.String())
 	s.Require().Equal(uint32(0), txResp.Code, out.String())
 
-	s.group = &group.GroupInfo{Id: 1, Admin: val.Address.String(), Metadata: validMetadata, TotalWeight: "3", Version: 1}
+	s.group = &group.GroupInfo{Id: 1, Admin: val.Address.String(), Metadata: validMetadata, TotalWeight: "3", Version: 1} // nolint: exhaustivestruct
 
 	// create 5 group policies
 	for i := 0; i < 5; i++ {
@@ -255,6 +255,7 @@ func (s *IntegrationTestSuite) TestTxCreateGroup() {
 	}]}`, val.Address.String(), tooLongMetadata)
 	invalidMembersMetadataFile := testutil.WriteToNewTempFile(s.T(), invalidMembersMetadata)
 
+	// nolint: exhaustivestruct
 	testCases := []struct {
 		name         string
 		args         []string
@@ -275,7 +276,7 @@ func (s *IntegrationTestSuite) TestTxCreateGroup() {
 			),
 			false,
 			"",
-			&sdk.TxResponse{}, // nolint: exhaustivestruct
+			&sdk.TxResponse{},
 			0,
 		},
 		{
@@ -291,7 +292,7 @@ func (s *IntegrationTestSuite) TestTxCreateGroup() {
 			),
 			false,
 			"",
-			&sdk.TxResponse{}, // nolint: exhaustivestruct
+			&sdk.TxResponse{},
 			0,
 		},
 		{
@@ -412,6 +413,7 @@ func (s *IntegrationTestSuite) TestTxUpdateGroupAdmin() {
 		groupIDs[i] = s.getGroupIdFromTxResponse(txResp)
 	}
 
+	// nolint: exhaustivestruct
 	testCases := []struct {
 		name         string
 		args         []string
@@ -432,7 +434,7 @@ func (s *IntegrationTestSuite) TestTxUpdateGroupAdmin() {
 			),
 			false,
 			"",
-			&sdk.TxResponse{}, // nolint: exhaustivestruct
+			&sdk.TxResponse{},
 			0,
 		},
 		{
@@ -448,7 +450,7 @@ func (s *IntegrationTestSuite) TestTxUpdateGroupAdmin() {
 			),
 			false,
 			"",
-			&sdk.TxResponse{}, // nolint: exhaustivestruct
+			&sdk.TxResponse{},
 			0,
 		},
 		{
@@ -513,6 +515,7 @@ func (s *IntegrationTestSuite) TestTxUpdateGroupMetadata() {
 		fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(10))).String()),
 	}
 
+	// nolint: exhaustivestruct
 	testCases := []struct {
 		name         string
 		args         []string
@@ -533,7 +536,7 @@ func (s *IntegrationTestSuite) TestTxUpdateGroupMetadata() {
 			),
 			false,
 			"",
-			&sdk.TxResponse{}, // nolint: exhaustivestruct
+			&sdk.TxResponse{},
 			0,
 		},
 		{
@@ -549,7 +552,7 @@ func (s *IntegrationTestSuite) TestTxUpdateGroupMetadata() {
 			),
 			false,
 			"",
-			&sdk.TxResponse{}, // nolint: exhaustivestruct
+			&sdk.TxResponse{},
 			0,
 		},
 		{
@@ -616,6 +619,7 @@ func (s *IntegrationTestSuite) TestTxUpdateGroupMembers() {
 	}]}`, val.Address.String(), tooLongMetadata)
 	invalidMembersMetadataFileName := testutil.WriteToNewTempFile(s.T(), invalidMembersMetadata).Name()
 
+	// nolint: exhaustivestruct
 	testCases := []struct {
 		name         string
 		args         []string
@@ -636,7 +640,7 @@ func (s *IntegrationTestSuite) TestTxUpdateGroupMembers() {
 			),
 			false,
 			"",
-			&sdk.TxResponse{}, // nolint: exhaustivestruct
+			&sdk.TxResponse{},
 			0,
 		},
 		{
@@ -656,7 +660,7 @@ func (s *IntegrationTestSuite) TestTxUpdateGroupMembers() {
 			),
 			false,
 			"",
-			&sdk.TxResponse{}, // nolint: exhaustivestruct
+			&sdk.TxResponse{},
 			0,
 		},
 		{
@@ -747,6 +751,7 @@ func (s *IntegrationTestSuite) TestTxCreateGroupWithPolicy() {
 	}]}`, val.Address.String(), tooLongMetadata)
 	invalidMembersMetadataFile := testutil.WriteToNewTempFile(s.T(), invalidMembersMetadata)
 
+	// nolint: exhaustivestruct
 	testCases := []struct {
 		name         string
 		args         []string
@@ -770,7 +775,7 @@ func (s *IntegrationTestSuite) TestTxCreateGroupWithPolicy() {
 			),
 			false,
 			"",
-			&sdk.TxResponse{}, // nolint: exhaustivestruct
+			&sdk.TxResponse{},
 			0,
 		},
 		{
@@ -788,7 +793,7 @@ func (s *IntegrationTestSuite) TestTxCreateGroupWithPolicy() {
 			),
 			false,
 			"",
-			&sdk.TxResponse{}, // nolint: exhaustivestruct
+			&sdk.TxResponse{},
 			0,
 		},
 		{
@@ -807,7 +812,7 @@ func (s *IntegrationTestSuite) TestTxCreateGroupWithPolicy() {
 			),
 			false,
 			"",
-			&sdk.TxResponse{}, // nolint: exhaustivestruct
+			&sdk.TxResponse{},
 			0,
 		},
 		{
@@ -934,6 +939,7 @@ func (s *IntegrationTestSuite) TestTxCreateGroupPolicy() {
 
 	groupID := s.group.Id
 
+	// nolint: exhaustivestruct
 	testCases := []struct {
 		name         string
 		args         []string
@@ -955,7 +961,7 @@ func (s *IntegrationTestSuite) TestTxCreateGroupPolicy() {
 			),
 			false,
 			"",
-			&sdk.TxResponse{}, // nolint: exhaustivestruct
+			&sdk.TxResponse{},
 			0,
 		},
 		{
@@ -971,7 +977,7 @@ func (s *IntegrationTestSuite) TestTxCreateGroupPolicy() {
 			),
 			false,
 			"",
-			&sdk.TxResponse{}, // nolint: exhaustivestruct
+			&sdk.TxResponse{},
 			0,
 		},
 		{
@@ -988,7 +994,7 @@ func (s *IntegrationTestSuite) TestTxCreateGroupPolicy() {
 			),
 			false,
 			"",
-			&sdk.TxResponse{}, // nolint: exhaustivestruct
+			&sdk.TxResponse{},
 			0,
 		},
 		{
@@ -1004,7 +1010,7 @@ func (s *IntegrationTestSuite) TestTxCreateGroupPolicy() {
 			),
 			true,
 			"key not found",
-			&sdk.TxResponse{}, // nolint: exhaustivestruct
+			&sdk.TxResponse{},
 			0,
 		},
 		{
@@ -1020,7 +1026,7 @@ func (s *IntegrationTestSuite) TestTxCreateGroupPolicy() {
 			),
 			true,
 			"group policy metadata: limit exceeded",
-			&sdk.TxResponse{}, // nolint: exhaustivestruct
+			&sdk.TxResponse{},
 			0,
 		},
 		{
@@ -1036,7 +1042,7 @@ func (s *IntegrationTestSuite) TestTxCreateGroupPolicy() {
 			),
 			true,
 			"not found",
-			&sdk.TxResponse{}, // nolint: exhaustivestruct
+			&sdk.TxResponse{},
 			0,
 		},
 		{
@@ -1052,7 +1058,7 @@ func (s *IntegrationTestSuite) TestTxCreateGroupPolicy() {
 			),
 			true,
 			"expected a positive decimal",
-			&sdk.TxResponse{}, // nolint: exhaustivestruct
+			&sdk.TxResponse{},
 			0,
 		},
 		{
@@ -1068,7 +1074,7 @@ func (s *IntegrationTestSuite) TestTxCreateGroupPolicy() {
 			),
 			true,
 			"percentage must be > 0 and <= 1",
-			&sdk.TxResponse{}, // nolint: exhaustivestruct
+			&sdk.TxResponse{},
 			0,
 		},
 	}
@@ -1105,6 +1111,7 @@ func (s *IntegrationTestSuite) TestTxUpdateGroupPolicyAdmin() {
 		fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(10))).String()),
 	}
 
+	// nolint: exhaustivestruct
 	testCases := []struct {
 		name         string
 		args         []string
@@ -1125,7 +1132,7 @@ func (s *IntegrationTestSuite) TestTxUpdateGroupPolicyAdmin() {
 			),
 			false,
 			"",
-			&sdk.TxResponse{}, // nolint: exhaustivestruct
+			&sdk.TxResponse{},
 			0,
 		},
 		{
@@ -1141,7 +1148,7 @@ func (s *IntegrationTestSuite) TestTxUpdateGroupPolicyAdmin() {
 			),
 			false,
 			"",
-			&sdk.TxResponse{}, // nolint: exhaustivestruct
+			&sdk.TxResponse{},
 			0,
 		},
 		{
@@ -1156,7 +1163,7 @@ func (s *IntegrationTestSuite) TestTxUpdateGroupPolicyAdmin() {
 			),
 			true,
 			"key not found",
-			&sdk.TxResponse{}, // nolint: exhaustivestruct
+			&sdk.TxResponse{},
 			0,
 		},
 		{
@@ -1171,7 +1178,7 @@ func (s *IntegrationTestSuite) TestTxUpdateGroupPolicyAdmin() {
 			),
 			true,
 			"load group policy: not found",
-			&sdk.TxResponse{}, // nolint: exhaustivestruct
+			&sdk.TxResponse{},
 			0,
 		},
 	}
@@ -1208,6 +1215,7 @@ func (s *IntegrationTestSuite) TestTxUpdateGroupPolicyDecisionPolicy() {
 		fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(10))).String()),
 	}
 
+	// nolint: exhaustivestruct
 	testCases := []struct {
 		name         string
 		args         []string
@@ -1228,7 +1236,7 @@ func (s *IntegrationTestSuite) TestTxUpdateGroupPolicyDecisionPolicy() {
 			),
 			false,
 			"",
-			&sdk.TxResponse{}, // nolint: exhaustivestruct
+			&sdk.TxResponse{},
 			0,
 		},
 		{
@@ -1243,7 +1251,7 @@ func (s *IntegrationTestSuite) TestTxUpdateGroupPolicyDecisionPolicy() {
 			),
 			false,
 			"",
-			&sdk.TxResponse{}, // nolint: exhaustivestruct
+			&sdk.TxResponse{},
 			0,
 		},
 		{
@@ -1259,7 +1267,7 @@ func (s *IntegrationTestSuite) TestTxUpdateGroupPolicyDecisionPolicy() {
 			),
 			false,
 			"",
-			&sdk.TxResponse{}, // nolint: exhaustivestruct
+			&sdk.TxResponse{},
 			0,
 		},
 		{
@@ -1274,7 +1282,7 @@ func (s *IntegrationTestSuite) TestTxUpdateGroupPolicyDecisionPolicy() {
 			),
 			true,
 			"key not found",
-			&sdk.TxResponse{}, // nolint: exhaustivestruct
+			&sdk.TxResponse{},
 			0,
 		},
 		{
@@ -1289,7 +1297,7 @@ func (s *IntegrationTestSuite) TestTxUpdateGroupPolicyDecisionPolicy() {
 			),
 			true,
 			"load group policy: not found",
-			&sdk.TxResponse{}, // nolint: exhaustivestruct
+			&sdk.TxResponse{},
 			0,
 		},
 		{
@@ -1304,7 +1312,7 @@ func (s *IntegrationTestSuite) TestTxUpdateGroupPolicyDecisionPolicy() {
 			),
 			true,
 			"expected a positive decimal",
-			&sdk.TxResponse{}, // nolint: exhaustivestruct
+			&sdk.TxResponse{},
 			0,
 		},
 		{
@@ -1319,7 +1327,7 @@ func (s *IntegrationTestSuite) TestTxUpdateGroupPolicyDecisionPolicy() {
 			),
 			true,
 			"percentage must be > 0 and <= 1",
-			&sdk.TxResponse{}, // nolint: exhaustivestruct
+			&sdk.TxResponse{},
 			0,
 		},
 	}
@@ -1356,6 +1364,7 @@ func (s *IntegrationTestSuite) TestTxUpdateGroupPolicyMetadata() {
 		fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(10))).String()),
 	}
 
+	// nolint: exhaustivestruct
 	testCases := []struct {
 		name         string
 		args         []string
@@ -1376,7 +1385,7 @@ func (s *IntegrationTestSuite) TestTxUpdateGroupPolicyMetadata() {
 			),
 			false,
 			"",
-			&sdk.TxResponse{}, // nolint: exhaustivestruct
+			&sdk.TxResponse{},
 			0,
 		},
 		{
@@ -1392,7 +1401,7 @@ func (s *IntegrationTestSuite) TestTxUpdateGroupPolicyMetadata() {
 			),
 			false,
 			"",
-			&sdk.TxResponse{}, // nolint: exhaustivestruct
+			&sdk.TxResponse{},
 			0,
 		},
 		{
@@ -1407,7 +1416,7 @@ func (s *IntegrationTestSuite) TestTxUpdateGroupPolicyMetadata() {
 			),
 			true,
 			"group policy metadata: limit exceeded",
-			&sdk.TxResponse{}, // nolint: exhaustivestruct
+			&sdk.TxResponse{},
 			0,
 		},
 		{
@@ -1422,7 +1431,7 @@ func (s *IntegrationTestSuite) TestTxUpdateGroupPolicyMetadata() {
 			),
 			true,
 			"key not found",
-			&sdk.TxResponse{}, // nolint: exhaustivestruct
+			&sdk.TxResponse{},
 			0,
 		},
 		{
@@ -1437,7 +1446,7 @@ func (s *IntegrationTestSuite) TestTxUpdateGroupPolicyMetadata() {
 			),
 			true,
 			"load group policy: not found",
-			&sdk.TxResponse{}, // nolint: exhaustivestruct
+			&sdk.TxResponse{},
 			0,
 		},
 	}
@@ -1472,6 +1481,7 @@ func (s *IntegrationTestSuite) TestTxSubmitProposal() {
 		fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(10))).String()),
 	}
 
+	// nolint: exhaustivestruct
 	testCases := []struct {
 		name         string
 		args         []string
@@ -1494,7 +1504,7 @@ func (s *IntegrationTestSuite) TestTxSubmitProposal() {
 			),
 			false,
 			"",
-			&sdk.TxResponse{}, // nolint: exhaustivestruct
+			&sdk.TxResponse{},
 			0,
 		},
 		{
@@ -1512,7 +1522,7 @@ func (s *IntegrationTestSuite) TestTxSubmitProposal() {
 			),
 			false,
 			"",
-			&sdk.TxResponse{}, // nolint: exhaustivestruct
+			&sdk.TxResponse{},
 			0,
 		},
 		{
@@ -1529,7 +1539,7 @@ func (s *IntegrationTestSuite) TestTxSubmitProposal() {
 			),
 			false,
 			"",
-			&sdk.TxResponse{}, // nolint: exhaustivestruct
+			&sdk.TxResponse{},
 			0,
 		},
 		{
@@ -1547,7 +1557,7 @@ func (s *IntegrationTestSuite) TestTxSubmitProposal() {
 			),
 			false,
 			"",
-			&sdk.TxResponse{}, // nolint: exhaustivestruct
+			&sdk.TxResponse{},
 			0,
 		},
 		{
@@ -1688,6 +1698,7 @@ func (s *IntegrationTestSuite) TestTxVote() {
 		ids[i] = s.getProposalIdFromTxResponse(txResp)
 	}
 
+	// nolint: exhaustivestruct
 	testCases := []struct {
 		name         string
 		args         []string
@@ -1709,7 +1720,7 @@ func (s *IntegrationTestSuite) TestTxVote() {
 			),
 			false,
 			"",
-			&sdk.TxResponse{}, // nolint: exhaustivestruct
+			&sdk.TxResponse{},
 			0,
 		},
 		{
@@ -1726,7 +1737,7 @@ func (s *IntegrationTestSuite) TestTxVote() {
 			),
 			false,
 			"",
-			&sdk.TxResponse{}, // nolint: exhaustivestruct
+			&sdk.TxResponse{},
 			0,
 		},
 		{
@@ -1743,7 +1754,7 @@ func (s *IntegrationTestSuite) TestTxVote() {
 			),
 			false,
 			"",
-			&sdk.TxResponse{}, // nolint: exhaustivestruct
+			&sdk.TxResponse{},
 			0,
 		},
 		{
@@ -1760,7 +1771,7 @@ func (s *IntegrationTestSuite) TestTxVote() {
 			),
 			false,
 			"",
-			&sdk.TxResponse{}, // nolint: exhaustivestruct
+			&sdk.TxResponse{},
 			0,
 		},
 		{
@@ -1881,6 +1892,7 @@ func (s *IntegrationTestSuite) TestTxWithdrawProposal() {
 		ids[i] = s.getProposalIdFromTxResponse(txResp)
 	}
 
+	// nolint: exhaustivestruct
 	testCases := []struct {
 		name         string
 		args         []string
@@ -1900,7 +1912,7 @@ func (s *IntegrationTestSuite) TestTxWithdrawProposal() {
 			),
 			false,
 			"",
-			&sdk.TxResponse{}, // nolint: exhaustivestruct
+			&sdk.TxResponse{},
 			0,
 		},
 		{
@@ -1914,7 +1926,7 @@ func (s *IntegrationTestSuite) TestTxWithdrawProposal() {
 			),
 			true,
 			"cannot withdraw a proposal with the status of PROPOSAL_STATUS_WITHDRAWN",
-			&sdk.TxResponse{}, // nolint: exhaustivestruct
+			&sdk.TxResponse{},
 			0,
 		},
 		{
@@ -1928,7 +1940,7 @@ func (s *IntegrationTestSuite) TestTxWithdrawProposal() {
 			),
 			true,
 			"not found",
-			&sdk.TxResponse{}, // nolint: exhaustivestruct
+			&sdk.TxResponse{},
 			0,
 		},
 		{
@@ -1942,7 +1954,7 @@ func (s *IntegrationTestSuite) TestTxWithdrawProposal() {
 			),
 			true,
 			"invalid syntax",
-			&sdk.TxResponse{}, // nolint: exhaustivestruct
+			&sdk.TxResponse{},
 			0,
 		},
 		{
@@ -1956,7 +1968,7 @@ func (s *IntegrationTestSuite) TestTxWithdrawProposal() {
 			),
 			true,
 			"key not found",
-			&sdk.TxResponse{}, // nolint: exhaustivestruct
+			&sdk.TxResponse{},
 			0,
 		},
 	}
@@ -1985,7 +1997,7 @@ func (s *IntegrationTestSuite) getProposalIdFromTxResponse(txResp sdk.TxResponse
 	s.Require().Greater(len(txResp.Logs), 0)
 	s.Require().NotNil(txResp.Logs[0].Events)
 	events := txResp.Logs[0].Events
-	createProposalEvent, _ := sdk.TypedEventToEvent(&group.EventSubmitProposal{})
+	createProposalEvent, _ := sdk.TypedEventToEvent(&group.EventSubmitProposal{}) // nolint: exhaustivestruct
 
 	for _, e := range events {
 		if e.Type == createProposalEvent.Type {
@@ -2044,6 +2056,7 @@ func (s *IntegrationTestSuite) TestTxExec() {
 		require.NoError(err, out.String())
 	}
 
+	// nolint: exhaustivestruct
 	testCases := []struct {
 		name         string
 		args         []string
@@ -2078,7 +2091,7 @@ func (s *IntegrationTestSuite) TestTxExec() {
 			),
 			false,
 			"",
-			&sdk.TxResponse{}, // nolint: exhaustivestruct
+			&sdk.TxResponse{},
 			0,
 		},
 		{

--- a/x/group/codec.go
+++ b/x/group/codec.go
@@ -1,3 +1,4 @@
+// nolint: exhaustivestruct
 package group
 
 import (

--- a/x/group/internal/orm/auto_uint64.go
+++ b/x/group/internal/orm/auto_uint64.go
@@ -6,6 +6,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/errors"
 )
 
+// nolint: exhaustivestruct
 var (
 	_ Indexable       = &AutoUInt64Table{}
 	_ TableExportable = &AutoUInt64Table{}

--- a/x/group/internal/orm/index.go
+++ b/x/group/internal/orm/index.go
@@ -19,7 +19,7 @@ type indexer interface {
 	OnUpdate(store sdk.KVStore, rowID RowID, newValue, oldValue interface{}) error
 }
 
-var _ Index = &MultiKeyIndex{}
+var _ Index = &MultiKeyIndex{} // nolint: exhaustivestruct
 
 // MultiKeyIndex is an index where multiple entries can point to the same underlying object as opposite to a unique index
 // where only one entry is allowed.

--- a/x/group/internal/orm/primary_key.go
+++ b/x/group/internal/orm/primary_key.go
@@ -5,6 +5,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
+// nolint: exhaustivestruct
 var (
 	_ Indexable       = &PrimaryKeyTable{}
 	_ TableExportable = &PrimaryKeyTable{}

--- a/x/group/internal/orm/table.go
+++ b/x/group/internal/orm/table.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/group/errors"
 )
 
+// nolint: exhaustivestruct
 var (
 	_ Indexable       = &table{}
 	_ TableExportable = &table{}

--- a/x/group/keeper/grpc_query.go
+++ b/x/group/keeper/grpc_query.go
@@ -14,7 +14,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/group/internal/orm"
 )
 
-var _ group.QueryServer = Keeper{}
+var _ group.QueryServer = Keeper{} // nolint: exhaustivestruct
 
 func (q Keeper) GroupInfo(goCtx context.Context, request *group.QueryGroupInfoRequest) (*group.QueryGroupInfoResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)

--- a/x/group/keeper/msg_server.go
+++ b/x/group/keeper/msg_server.go
@@ -18,7 +18,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/group/internal/orm"
 )
 
-var _ group.MsgServer = Keeper{}
+var _ group.MsgServer = Keeper{} // nolint: exhaustivestruct
 
 // TODO: Revisit this once we have propoer gas fee framework.
 // Tracking issues https://github.com/cosmos/cosmos-sdk/issues/9054, https://github.com/cosmos/cosmos-sdk/discussions/9072

--- a/x/group/module/module.go
+++ b/x/group/module/module.go
@@ -24,9 +24,9 @@ import (
 )
 
 var (
-	_ module.AppModule           = AppModule{}
-	_ module.AppModuleBasic      = AppModuleBasic{}
-	_ module.AppModuleSimulation = AppModule{}
+	_ module.AppModule           = AppModule{}      // nolint: exhaustivestruct
+	_ module.AppModuleBasic      = AppModuleBasic{} // nolint: exhaustivestruct
+	_ module.AppModuleSimulation = AppModule{}      // nolint: exhaustivestruct
 )
 
 type AppModule struct {

--- a/x/group/module/module.go
+++ b/x/group/module/module.go
@@ -23,10 +23,11 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/group/simulation"
 )
 
+// nolint: exhaustivestruct
 var (
-	_ module.AppModule           = AppModule{}      // nolint: exhaustivestruct
-	_ module.AppModuleBasic      = AppModuleBasic{} // nolint: exhaustivestruct
-	_ module.AppModuleSimulation = AppModule{}      // nolint: exhaustivestruct
+	_ module.AppModule           = AppModule{}
+	_ module.AppModuleBasic      = AppModuleBasic{}
+	_ module.AppModuleSimulation = AppModule{}
 )
 
 type AppModule struct {

--- a/x/group/msgs.go
+++ b/x/group/msgs.go
@@ -15,7 +15,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/group/internal/math"
 )
 
-var _ sdk.Msg = &MsgCreateGroup{}
+var _ sdk.Msg = &MsgCreateGroup{} // nolint: exhaustivestruct
 
 // Route Implements Msg.
 func (m MsgCreateGroup) Route() string { return sdk.MsgTypeURL(&m) }
@@ -69,7 +69,7 @@ func (m Member) ValidateBasic() error {
 	return nil
 }
 
-var _ sdk.Msg = &MsgUpdateGroupAdmin{}
+var _ sdk.Msg = &MsgUpdateGroupAdmin{} // nolint: exhaustivestruct
 
 // Route Implements Msg.
 func (m MsgUpdateGroupAdmin) Route() string {
@@ -119,7 +119,7 @@ func (m *MsgUpdateGroupAdmin) GetGroupID() uint64 {
 	return m.GroupId
 }
 
-var _ sdk.Msg = &MsgUpdateGroupMetadata{}
+var _ sdk.Msg = &MsgUpdateGroupMetadata{} // nolint: exhaustivestruct
 
 // Route Implements Msg.
 func (m MsgUpdateGroupMetadata) Route() string {
@@ -161,7 +161,7 @@ func (m *MsgUpdateGroupMetadata) GetGroupID() uint64 {
 	return m.GroupId
 }
 
-var _ sdk.Msg = &MsgUpdateGroupMembers{}
+var _ sdk.Msg = &MsgUpdateGroupMembers{} // nolint: exhaustivestruct
 
 // Route Implements Msg.
 func (m MsgUpdateGroupMembers) Route() string {
@@ -176,7 +176,7 @@ func (m MsgUpdateGroupMembers) GetSignBytes() []byte {
 	return sdk.MustSortJSON(legacy.Cdc.MustMarshalJSON(&m))
 }
 
-var _ sdk.Msg = &MsgUpdateGroupMembers{}
+var _ sdk.Msg = &MsgUpdateGroupMembers{} // nolint: exhaustivestruct
 
 // GetSigners returns the expected signers for a MsgUpdateGroupMembers.
 func (m MsgUpdateGroupMembers) GetSigners() []sdk.AccAddress {
@@ -212,8 +212,8 @@ func (m *MsgUpdateGroupMembers) GetGroupID() uint64 {
 	return m.GroupId
 }
 
-var _ sdk.Msg = &MsgCreateGroupWithPolicy{}
-var _ types.UnpackInterfacesMessage = MsgCreateGroupWithPolicy{}
+var _ sdk.Msg = &MsgCreateGroupWithPolicy{}                      // nolint: exhaustivestruct
+var _ types.UnpackInterfacesMessage = MsgCreateGroupWithPolicy{} // nolint: exhaustivestruct
 
 // NewMsgCreateGroupWithPolicy creates a new MsgCreateGroupWithPolicy.
 func NewMsgCreateGroupWithPolicy(admin string, members []Member, group_metadata string, group_policy_metadata string, groupPolicyAsAdmin bool, decisionPolicy DecisionPolicy) (*MsgCreateGroupWithPolicy, error) {
@@ -308,7 +308,7 @@ func (m MsgCreateGroupWithPolicy) validateMembers() error {
 	return nil
 }
 
-var _ sdk.Msg = &MsgCreateGroupPolicy{}
+var _ sdk.Msg = &MsgCreateGroupPolicy{} // nolint: exhaustivestruct
 
 // Route Implements Msg.
 func (m MsgCreateGroupPolicy) Route() string {
@@ -353,7 +353,7 @@ func (m MsgCreateGroupPolicy) ValidateBasic() error {
 	return nil
 }
 
-var _ sdk.Msg = &MsgUpdateGroupPolicyAdmin{}
+var _ sdk.Msg = &MsgUpdateGroupPolicyAdmin{} // nolint: exhaustivestruct
 
 // Route Implements Msg.
 func (m MsgUpdateGroupPolicyAdmin) Route() string {
@@ -400,8 +400,8 @@ func (m MsgUpdateGroupPolicyAdmin) ValidateBasic() error {
 	return nil
 }
 
-var _ sdk.Msg = &MsgUpdateGroupPolicyDecisionPolicy{}
-var _ types.UnpackInterfacesMessage = MsgUpdateGroupPolicyDecisionPolicy{}
+var _ sdk.Msg = &MsgUpdateGroupPolicyDecisionPolicy{}                      // nolint: exhaustivestruct
+var _ types.UnpackInterfacesMessage = MsgUpdateGroupPolicyDecisionPolicy{} // nolint: exhaustivestruct
 
 func NewMsgUpdateGroupPolicyDecisionPolicyRequest(admin sdk.AccAddress, address sdk.AccAddress, decisionPolicy DecisionPolicy) (*MsgUpdateGroupPolicyDecisionPolicy, error) {
 	m := &MsgUpdateGroupPolicyDecisionPolicy{
@@ -490,7 +490,7 @@ func (m MsgUpdateGroupPolicyDecisionPolicy) UnpackInterfaces(unpacker types.AnyU
 	return unpacker.UnpackAny(m.DecisionPolicy, &decisionPolicy)
 }
 
-var _ sdk.Msg = &MsgUpdateGroupPolicyMetadata{}
+var _ sdk.Msg = &MsgUpdateGroupPolicyMetadata{} // nolint: exhaustivestruct
 
 // Route Implements Msg.
 func (m MsgUpdateGroupPolicyMetadata) Route() string {
@@ -529,8 +529,8 @@ func (m MsgUpdateGroupPolicyMetadata) ValidateBasic() error {
 	return nil
 }
 
-var _ sdk.Msg = &MsgCreateGroupPolicy{}
-var _ types.UnpackInterfacesMessage = MsgCreateGroupPolicy{}
+var _ sdk.Msg = &MsgCreateGroupPolicy{}                      // nolint: exhaustivestruct
+var _ types.UnpackInterfacesMessage = MsgCreateGroupPolicy{} // nolint: exhaustivestruct
 
 // NewMsgCreateGroupPolicy creates a new MsgCreateGroupPolicy.
 func NewMsgCreateGroupPolicy(admin sdk.AccAddress, group uint64, metadata string, decisionPolicy DecisionPolicy) (*MsgCreateGroupPolicy, error) {
@@ -585,7 +585,7 @@ func (m MsgCreateGroupPolicy) UnpackInterfaces(unpacker types.AnyUnpacker) error
 	return unpacker.UnpackAny(m.DecisionPolicy, &decisionPolicy)
 }
 
-var _ sdk.Msg = &MsgSubmitProposal{}
+var _ sdk.Msg = &MsgSubmitProposal{} // nolint: exhaustivestruct
 
 // NewMsgSubmitProposalRequest creates a new MsgSubmitProposal.
 func NewMsgSubmitProposalRequest(address string, proposers []string, msgs []sdk.Msg, metadata string, exec Exec) (*MsgSubmitProposal, error) {
@@ -683,7 +683,7 @@ func (m MsgSubmitProposal) UnpackInterfaces(unpacker types.AnyUnpacker) error {
 	return tx.UnpackInterfaces(unpacker, m.Messages)
 }
 
-var _ sdk.Msg = &MsgWithdrawProposal{}
+var _ sdk.Msg = &MsgWithdrawProposal{} // nolint: exhaustivestruct
 
 // Route Implements Msg.
 func (m MsgWithdrawProposal) Route() string { return sdk.MsgTypeURL(&m) }
@@ -719,7 +719,7 @@ func (m MsgWithdrawProposal) ValidateBasic() error {
 	return nil
 }
 
-var _ sdk.Msg = &MsgVote{}
+var _ sdk.Msg = &MsgVote{} // nolint: exhaustivestruct
 
 // Route Implements Msg.
 func (m MsgVote) Route() string {
@@ -761,7 +761,7 @@ func (m MsgVote) ValidateBasic() error {
 	return nil
 }
 
-var _ sdk.Msg = &MsgExec{}
+var _ sdk.Msg = &MsgExec{} // nolint: exhaustivestruct
 
 // Route Implements Msg.
 func (m MsgExec) Route() string {

--- a/x/group/simulation/operations.go
+++ b/x/group/simulation/operations.go
@@ -598,10 +598,7 @@ func SimulateMsgUpdateGroupMembers(ak group.AccountKeeper,
 
 		members := genGroupMembers(r, accounts)
 		ctx := sdk.UnwrapSDKContext(sdkCtx)
-		res, err := k.GroupMembers(ctx, &group.QueryGroupMembersRequest{
-			GroupId:    groupID,
-			Pagination: nil,
-		})
+		res, err := k.GroupMembers(ctx, &group.QueryGroupMembersRequest{GroupId: groupID})
 		if err != nil {
 			return simtypes.NoOpMsg(group.ModuleName, TypeMsgUpdateGroupMembers, "group members"), nil, err
 		}
@@ -1229,10 +1226,7 @@ func randomGroupPolicy(r *rand.Rand, k keeper.Keeper, ak group.AccountKeeper,
 	}
 	groupID := groupInfo.Id
 
-	result, err := k.GroupPoliciesByGroup(sdk.WrapSDKContext(ctx), &group.QueryGroupPoliciesByGroupRequest{
-		GroupId:    groupID,
-		Pagination: nil,
-	})
+	result, err := k.GroupPoliciesByGroup(sdk.WrapSDKContext(ctx), &group.QueryGroupPoliciesByGroupRequest{GroupId: groupID})
 	if err != nil {
 		return groupInfo, nil, simtypes.Account{}, nil, err
 	}
@@ -1254,10 +1248,7 @@ func randomGroupPolicy(r *rand.Rand, k keeper.Keeper, ak group.AccountKeeper,
 
 func randomMember(r *rand.Rand, k keeper.Keeper, ak group.AccountKeeper,
 	ctx context.Context, accounts []simtypes.Account, groupID uint64) (acc simtypes.Account, account authtypes.AccountI, err error) {
-	res, err := k.GroupMembers(ctx, &group.QueryGroupMembersRequest{
-		GroupId:    groupID,
-		Pagination: nil,
-	})
+	res, err := k.GroupMembers(ctx, &group.QueryGroupMembersRequest{GroupId: groupID})
 	if err != nil {
 		return simtypes.Account{}, nil, err
 	}

--- a/x/group/simulation/operations.go
+++ b/x/group/simulation/operations.go
@@ -24,6 +24,7 @@ import (
 var initialGroupID = uint64(100000000000000)
 
 // group message types
+// nolint: exhaustivestruct
 var (
 	TypeMsgCreateGroup                     = sdk.MsgTypeURL(&group.MsgCreateGroup{})
 	TypeMsgUpdateGroupMembers              = sdk.MsgTypeURL(&group.MsgUpdateGroupMembers{})
@@ -597,7 +598,10 @@ func SimulateMsgUpdateGroupMembers(ak group.AccountKeeper,
 
 		members := genGroupMembers(r, accounts)
 		ctx := sdk.UnwrapSDKContext(sdkCtx)
-		res, err := k.GroupMembers(ctx, &group.QueryGroupMembersRequest{GroupId: groupID})
+		res, err := k.GroupMembers(ctx, &group.QueryGroupMembersRequest{
+			GroupId:    groupID,
+			Pagination: nil,
+		})
 		if err != nil {
 			return simtypes.NoOpMsg(group.ModuleName, TypeMsgUpdateGroupMembers, "group members"), nil, err
 		}
@@ -1225,7 +1229,10 @@ func randomGroupPolicy(r *rand.Rand, k keeper.Keeper, ak group.AccountKeeper,
 	}
 	groupID := groupInfo.Id
 
-	result, err := k.GroupPoliciesByGroup(sdk.WrapSDKContext(ctx), &group.QueryGroupPoliciesByGroupRequest{GroupId: groupID})
+	result, err := k.GroupPoliciesByGroup(sdk.WrapSDKContext(ctx), &group.QueryGroupPoliciesByGroupRequest{
+		GroupId:    groupID,
+		Pagination: nil,
+	})
 	if err != nil {
 		return groupInfo, nil, simtypes.Account{}, nil, err
 	}
@@ -1248,7 +1255,8 @@ func randomGroupPolicy(r *rand.Rand, k keeper.Keeper, ak group.AccountKeeper,
 func randomMember(r *rand.Rand, k keeper.Keeper, ak group.AccountKeeper,
 	ctx context.Context, accounts []simtypes.Account, groupID uint64) (acc simtypes.Account, account authtypes.AccountI, err error) {
 	res, err := k.GroupMembers(ctx, &group.QueryGroupMembersRequest{
-		GroupId: groupID,
+		GroupId:    groupID,
+		Pagination: nil,
 	})
 	if err != nil {
 		return simtypes.Account{}, nil, err

--- a/x/group/simulation/operations.go
+++ b/x/group/simulation/operations.go
@@ -1248,7 +1248,9 @@ func randomGroupPolicy(r *rand.Rand, k keeper.Keeper, ak group.AccountKeeper,
 
 func randomMember(r *rand.Rand, k keeper.Keeper, ak group.AccountKeeper,
 	ctx context.Context, accounts []simtypes.Account, groupID uint64) (acc simtypes.Account, account authtypes.AccountI, err error) {
-	res, err := k.GroupMembers(ctx, &group.QueryGroupMembersRequest{GroupId: groupID})
+	res, err := k.GroupMembers(ctx, &group.QueryGroupMembersRequest{
+		GroupId: groupID,
+	})
 	if err != nil {
 		return simtypes.Account{}, nil, err
 	}

--- a/x/group/types.go
+++ b/x/group/types.go
@@ -37,7 +37,7 @@ type DecisionPolicy interface {
 }
 
 // Implements DecisionPolicy Interface
-var _ DecisionPolicy = &ThresholdDecisionPolicy{}
+var _ DecisionPolicy = &ThresholdDecisionPolicy{} // nolint: exhaustivestruct
 
 // NewThresholdDecisionPolicy creates a threshold DecisionPolicy
 func NewThresholdDecisionPolicy(threshold string, votingPeriod time.Duration, minExecutionPeriod time.Duration) DecisionPolicy {
@@ -139,7 +139,7 @@ func (p *ThresholdDecisionPolicy) Validate(g GroupInfo, config Config) error {
 }
 
 // Implements DecisionPolicy Interface
-var _ DecisionPolicy = &PercentageDecisionPolicy{}
+var _ DecisionPolicy = &PercentageDecisionPolicy{} // nolint: exhaustivestruct
 
 // NewPercentageDecisionPolicy creates a new percentage DecisionPolicy
 func NewPercentageDecisionPolicy(percentage string, votingPeriod time.Duration, executionPeriod time.Duration) DecisionPolicy {
@@ -223,7 +223,7 @@ func (p PercentageDecisionPolicy) Allow(tally TallyResult, totalPower string, si
 	return DecisionPolicyResult{Allow: false, Final: false}, nil
 }
 
-var _ orm.Validateable = GroupPolicyInfo{}
+var _ orm.Validateable = GroupPolicyInfo{} // nolint: exhaustivestruct
 
 // NewGroupPolicyInfo creates a new GroupPolicyInfo instance
 func NewGroupPolicyInfo(address sdk.AccAddress, group uint64, admin sdk.AccAddress, metadata string,
@@ -396,7 +396,7 @@ func (v Vote) PrimaryKeyFields() []interface{} {
 	return []interface{}{v.ProposalId, addr.Bytes()}
 }
 
-var _ orm.Validateable = Vote{}
+var _ orm.Validateable = Vote{} // nolint: exhaustivestruct
 
 func (v Vote) ValidateBasic() error {
 

--- a/x/mint/client/cli/query.go
+++ b/x/mint/client/cli/query.go
@@ -12,7 +12,7 @@ import (
 
 // GetQueryCmd returns the cli query commands for the minting module.
 func GetQueryCmd() *cobra.Command {
-	mintingQueryCmd := &cobra.Command{
+	mintingQueryCmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:                        types.ModuleName,
 		Short:                      "Querying commands for the minting module",
 		DisableFlagParsing:         true,
@@ -32,7 +32,7 @@ func GetQueryCmd() *cobra.Command {
 // GetCmdQueryParams implements a command to return the current minting
 // parameters.
 func GetCmdQueryParams() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "params",
 		Short: "Query the current minting parameters",
 		Args:  cobra.NoArgs,
@@ -62,7 +62,7 @@ func GetCmdQueryParams() *cobra.Command {
 // GetCmdQueryInflation implements a command to return the current minting
 // inflation value.
 func GetCmdQueryInflation() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "inflation",
 		Short: "Query the current minting inflation value",
 		Args:  cobra.NoArgs,
@@ -92,7 +92,7 @@ func GetCmdQueryInflation() *cobra.Command {
 // GetCmdQueryAnnualProvisions implements a command to return the current minting
 // annual provisions value.
 func GetCmdQueryAnnualProvisions() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "annual-provisions",
 		Short: "Query the current minting annual provisions value",
 		Args:  cobra.NoArgs,

--- a/x/mint/client/testutil/grpc.go
+++ b/x/mint/client/testutil/grpc.go
@@ -15,6 +15,8 @@ import (
 func (s *IntegrationTestSuite) TestQueryGRPC() {
 	val := s.network.Validators[0]
 	baseURL := val.APIAddress
+
+	// nolint: exhaustivestruct
 	testCases := []struct {
 		name     string
 		url      string

--- a/x/mint/client/testutil/suite.go
+++ b/x/mint/client/testutil/suite.go
@@ -23,7 +23,7 @@ type IntegrationTestSuite struct {
 }
 
 func NewIntegrationTestSuite(cfg network.Config) *IntegrationTestSuite {
-	return &IntegrationTestSuite{cfg: cfg}
+	return &IntegrationTestSuite{cfg: cfg} // nolint: exhaustivestruct
 }
 
 func (s *IntegrationTestSuite) SetupSuite() {

--- a/x/mint/keeper/grpc_query.go
+++ b/x/mint/keeper/grpc_query.go
@@ -7,7 +7,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/mint/types"
 )
 
-var _ types.QueryServer = Keeper{}
+var _ types.QueryServer = Keeper{} // nolint: exhaustivestruct
 
 // Params returns params of the mint module.
 func (k Keeper) Params(c context.Context, _ *types.QueryParamsRequest) (*types.QueryParamsResponse, error) {

--- a/x/mint/module.go
+++ b/x/mint/module.go
@@ -24,9 +24,9 @@ import (
 )
 
 var (
-	_ module.AppModule           = AppModule{}
-	_ module.AppModuleBasic      = AppModuleBasic{}
-	_ module.AppModuleSimulation = AppModule{}
+	_ module.AppModule           = AppModule{}      // nolint: exhaustivestruct
+	_ module.AppModuleBasic      = AppModuleBasic{} // nolint: exhaustivestruct
+	_ module.AppModuleSimulation = AppModule{}      // nolint: exhaustivestruct
 )
 
 // AppModuleBasic defines the basic application module used by the mint module.

--- a/x/mint/module.go
+++ b/x/mint/module.go
@@ -23,10 +23,11 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/mint/types"
 )
 
+// nolint: exhaustivestruct
 var (
-	_ module.AppModule           = AppModule{}      // nolint: exhaustivestruct
-	_ module.AppModuleBasic      = AppModuleBasic{} // nolint: exhaustivestruct
-	_ module.AppModuleSimulation = AppModule{}      // nolint: exhaustivestruct
+	_ module.AppModule           = AppModule{}
+	_ module.AppModuleBasic      = AppModuleBasic{}
+	_ module.AppModuleSimulation = AppModule{}
 )
 
 // AppModuleBasic defines the basic application module used by the mint module.

--- a/x/mint/module.go
+++ b/x/mint/module.go
@@ -34,7 +34,7 @@ type AppModuleBasic struct {
 	cdc codec.Codec
 }
 
-var _ module.AppModuleBasic = AppModuleBasic{}
+var _ module.AppModuleBasic = AppModuleBasic{} // nolint: exhaustivestruct
 
 // Name returns the mint module's name.
 func (AppModuleBasic) Name() string {

--- a/x/mint/types/params.go
+++ b/x/mint/types/params.go
@@ -23,7 +23,7 @@ var (
 
 // ParamTable for minting module.
 func ParamKeyTable() paramtypes.KeyTable {
-	return paramtypes.NewKeyTable().RegisterParamSet(&Params{})
+	return paramtypes.NewKeyTable().RegisterParamSet(&Params{}) // nolint: exhaustivestruct
 }
 
 func NewParams(

--- a/x/nft/client/cli/query.go
+++ b/x/nft/client/cli/query.go
@@ -22,7 +22,7 @@ const (
 
 // GetQueryCmd returns the cli query commands for this module
 func GetQueryCmd() *cobra.Command {
-	nftQueryCmd := &cobra.Command{
+	nftQueryCmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:                        nft.ModuleName,
 		Short:                      "Querying commands for the nft module",
 		Long:                       "",
@@ -45,7 +45,7 @@ func GetQueryCmd() *cobra.Command {
 
 // GetCmdQueryClass implements the query class command.
 func GetCmdQueryClass() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:     "class [class-id]",
 		Args:    cobra.ExactArgs(1),
 		Short:   "query an NFT class based on its id",
@@ -71,7 +71,7 @@ func GetCmdQueryClass() *cobra.Command {
 
 // GetCmdQueryClasses implements the query classes command.
 func GetCmdQueryClasses() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:     "classes",
 		Short:   "query all NFT classes",
 		Example: fmt.Sprintf(`$ %s query %s classes`, version.AppName, nft.ModuleName),
@@ -101,7 +101,7 @@ func GetCmdQueryClasses() *cobra.Command {
 
 // GetCmdQueryNFT implements the query nft command.
 func GetCmdQueryNFT() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:     "nft [class-id] [nft-id]",
 		Args:    cobra.ExactArgs(2),
 		Short:   "query an NFT based on its class and id.",
@@ -128,7 +128,7 @@ func GetCmdQueryNFT() *cobra.Command {
 
 // GetCmdQueryNFTs implements the query nft command.
 func GetCmdQueryNFTs() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "nfts",
 		Short: "query all NFTs of a given class or owner address.",
 		Long: strings.TrimSpace(
@@ -197,7 +197,7 @@ $ %s query %s nfts <class-id> --owner=<owner>
 
 // GetCmdQueryOwner implements the query owner command.
 func GetCmdQueryOwner() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:     "owner [class-id] [nft-id]",
 		Args:    cobra.ExactArgs(2),
 		Short:   "query the owner of the NFT based on its class and id.",
@@ -224,7 +224,7 @@ func GetCmdQueryOwner() *cobra.Command {
 
 // GetCmdQueryBalance implements the query balance command.
 func GetCmdQueryBalance() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:     "balance [owner] [class-id]",
 		Args:    cobra.ExactArgs(2),
 		Short:   "query the number of NFTs of a given class owned by the owner.",
@@ -251,7 +251,7 @@ func GetCmdQueryBalance() *cobra.Command {
 
 // GetCmdQuerySupply implements the query supply command.
 func GetCmdQuerySupply() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:     "supply [class-id]",
 		Args:    cobra.ExactArgs(1),
 		Short:   "query the number of nft based on the class.",

--- a/x/nft/client/cli/tx.go
+++ b/x/nft/client/cli/tx.go
@@ -15,7 +15,7 @@ import (
 
 // GetTxCmd returns the transaction commands for this module
 func GetTxCmd() *cobra.Command {
-	nftTxCmd := &cobra.Command{
+	nftTxCmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:                        nft.ModuleName,
 		Short:                      "nft transactions subcommands",
 		Long:                       "Provides the most common nft logic for upper-level applications, compatible with Ethereum's erc721 contract",
@@ -32,7 +32,7 @@ func GetTxCmd() *cobra.Command {
 }
 
 func NewCmdSend() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "send [class-id] [nft-id] [receiver] --from [sender]",
 		Args:  cobra.ExactArgs(3),
 		Short: "transfer ownership of nft",

--- a/x/nft/client/testutil/tx.go
+++ b/x/nft/client/testutil/tx.go
@@ -60,7 +60,7 @@ type IntegrationTestSuite struct {
 }
 
 func NewIntegrationTestSuite(cfg network.Config) *IntegrationTestSuite {
-	return &IntegrationTestSuite{cfg: cfg}
+	return &IntegrationTestSuite{cfg: cfg} // nolint: exhaustivestruct
 }
 
 func (s *IntegrationTestSuite) SetupSuite() {

--- a/x/nft/codec.go
+++ b/x/nft/codec.go
@@ -1,3 +1,4 @@
+// nolint: exhaustivestruct
 package nft
 
 import (

--- a/x/nft/keeper/grpc_query.go
+++ b/x/nft/keeper/grpc_query.go
@@ -10,7 +10,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/nft"
 )
 
-var _ nft.QueryServer = Keeper{}
+var _ nft.QueryServer = Keeper{} // nolint: exhaustivestruct
 
 // Balance return the number of NFTs of a given class owned by the owner, same as balanceOf in ERC721
 func (k Keeper) Balance(goCtx context.Context, r *nft.QueryBalanceRequest) (*nft.QueryBalanceResponse, error) {

--- a/x/nft/keeper/msg_server.go
+++ b/x/nft/keeper/msg_server.go
@@ -8,7 +8,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/nft"
 )
 
-var _ nft.MsgServer = Keeper{}
+var _ nft.MsgServer = Keeper{} // nolint: exhaustivestruct
 
 // Send implement Send method of the types.MsgServer.
 func (k Keeper) Send(goCtx context.Context, msg *nft.MsgSend) (*nft.MsgSendResponse, error) {

--- a/x/nft/keeper/nft.go
+++ b/x/nft/keeper/nft.go
@@ -82,7 +82,7 @@ func (k Keeper) GetNFT(ctx sdk.Context, classID, nftID string) (nft.NFT, bool) {
 	store := k.getNFTStore(ctx, classID)
 	bz := store.Get([]byte(nftID))
 	if len(bz) == 0 {
-		return nft.NFT{}, false
+		return nft.NFT{}, false // nolint: exhaustivestruct
 	}
 	var nft nft.NFT
 	k.cdc.MustUnmarshal(bz, &nft)

--- a/x/nft/module/module.go
+++ b/x/nft/module/module.go
@@ -24,10 +24,11 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/nft/simulation"
 )
 
+// nolint: exhaustivestruct
 var (
-	_ module.AppModule           = AppModule{}      // nolint: exhaustivestruct
-	_ module.AppModuleBasic      = AppModuleBasic{} // nolint: exhaustivestruct
-	_ module.AppModuleSimulation = AppModule{}      // nolint: exhaustivestruct
+	_ module.AppModule           = AppModule{}
+	_ module.AppModuleBasic      = AppModuleBasic{}
+	_ module.AppModuleSimulation = AppModule{}
 )
 
 // AppModuleBasic defines the basic application module used by the nft module.

--- a/x/nft/module/module.go
+++ b/x/nft/module/module.go
@@ -25,9 +25,9 @@ import (
 )
 
 var (
-	_ module.AppModule           = AppModule{}
-	_ module.AppModuleBasic      = AppModuleBasic{}
-	_ module.AppModuleSimulation = AppModule{}
+	_ module.AppModule           = AppModule{}      // nolint: exhaustivestruct
+	_ module.AppModuleBasic      = AppModuleBasic{} // nolint: exhaustivestruct
+	_ module.AppModuleSimulation = AppModule{}      // nolint: exhaustivestruct
 )
 
 // AppModuleBasic defines the basic application module used by the nft module.

--- a/x/nft/msgs.go
+++ b/x/nft/msgs.go
@@ -10,6 +10,7 @@ const (
 	TypeMsgSend = "send"
 )
 
+// nolint: exhaustivestruct
 var (
 	_ sdk.Msg = &MsgSend{}
 )

--- a/x/nft/simulation/operations.go
+++ b/x/nft/simulation/operations.go
@@ -28,7 +28,7 @@ const (
 )
 
 var (
-	TypeMsgSend = sdk.MsgTypeURL(&nft.MsgSend{})
+	TypeMsgSend = sdk.MsgTypeURL(&nft.MsgSend{}) // nolint: exhaustivestruct
 )
 
 // WeightedOperations returns all the operations from the module with their respective weights

--- a/x/params/client/cli/query.go
+++ b/x/params/client/cli/query.go
@@ -11,7 +11,7 @@ import (
 
 // NewQueryCmd returns a root CLI command handler for all x/params query commands.
 func NewQueryCmd() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:                        types.ModuleName,
 		Short:                      "Querying commands for the params module",
 		DisableFlagParsing:         true,
@@ -27,7 +27,7 @@ func NewQueryCmd() *cobra.Command {
 // NewQuerySubspaceParamsCmd returns a CLI command handler for querying subspace
 // parameters managed by the x/params module.
 func NewQuerySubspaceParamsCmd() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "subspace [subspace] [key]",
 		Short: "Query for raw parameters by subspace and key",
 		Args:  cobra.ExactArgs(2),

--- a/x/params/client/cli/tx.go
+++ b/x/params/client/cli/tx.go
@@ -18,7 +18,7 @@ import (
 // NewSubmitParamChangeProposalTxCmd returns a CLI command handler for creating
 // a parameter change proposal governance transaction.
 func NewSubmitParamChangeProposalTxCmd() *cobra.Command {
-	return &cobra.Command{
+	return &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "param-change [proposal-file]",
 		Args:  cobra.ExactArgs(1),
 		Short: "Submit a parameter change proposal",

--- a/x/params/client/testutil/grpc.go
+++ b/x/params/client/testutil/grpc.go
@@ -13,6 +13,7 @@ func (s *IntegrationTestSuite) TestQueryParamsGRPC() {
 	val := s.network.Validators[0]
 	baseURL := val.APIAddress
 
+	// nolint: exhaustivestruct
 	testCases := []struct {
 		name     string
 		url      string

--- a/x/params/client/testutil/suite.go
+++ b/x/params/client/testutil/suite.go
@@ -20,7 +20,7 @@ type IntegrationTestSuite struct {
 }
 
 func NewIntegrationTestSuite(cfg network.Config) *IntegrationTestSuite {
-	return &IntegrationTestSuite{cfg: cfg}
+	return &IntegrationTestSuite{cfg: cfg} // nolint: exhaustivestruct
 }
 
 func (s *IntegrationTestSuite) SetupSuite() {

--- a/x/params/doc.go
+++ b/x/params/doc.go
@@ -61,7 +61,7 @@ Basic Usage:
 	}
 
 	func ParamKeyTable() params.KeyTable {
-		return params.NewKeyTable().RegisterParamSet(&MyParams{})
+		return params.NewKeyTable().RegisterParamSet(&MyParams{}) // nolint: exhaustivestruct
 	}
 
 4. Have the module accept a Subspace in the constructor and set the KeyTable (if necessary):

--- a/x/params/keeper/grpc_query.go
+++ b/x/params/keeper/grpc_query.go
@@ -11,7 +11,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/params/types/proposal"
 )
 
-var _ proposal.QueryServer = Keeper{}
+var _ proposal.QueryServer = Keeper{} // nolint: exhaustivestruct
 
 // Params returns subspace params
 func (k Keeper) Params(c context.Context, req *proposal.QueryParamsRequest) (*proposal.QueryParamsResponse, error) {

--- a/x/params/migrations/v036/types.go
+++ b/x/params/migrations/v036/types.go
@@ -170,6 +170,7 @@ func ErrEmptyValue(codespace string) error {
 	return fmt.Errorf("parameter value is empty")
 }
 
+// nolint: exhaustivestruct
 func RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
 	cdc.RegisterConcrete(ParameterChangeProposal{}, "cosmos-sdk/ParameterChangeProposal", nil)
 }

--- a/x/params/migrations/v036/types.go
+++ b/x/params/migrations/v036/types.go
@@ -34,7 +34,7 @@ const (
 )
 
 // Assert ParameterChangeProposal implements v036gov.Content at compile-time
-var _ v036gov.Content = ParameterChangeProposal{}
+var _ v036gov.Content = ParameterChangeProposal{} // nolint: exhaustivestruct
 
 // ParameterChangeProposal defines a proposal which contains multiple parameter
 // changes.

--- a/x/params/module.go
+++ b/x/params/module.go
@@ -24,9 +24,9 @@ import (
 )
 
 var (
-	_ module.AppModule           = AppModule{}
-	_ module.AppModuleBasic      = AppModuleBasic{}
-	_ module.AppModuleSimulation = AppModule{}
+	_ module.AppModule           = AppModule{}      // nolint: exhaustivestruct
+	_ module.AppModuleBasic      = AppModuleBasic{} // nolint: exhaustivestruct
+	_ module.AppModuleSimulation = AppModule{}      // nolint: exhaustivestruct
 )
 
 // AppModuleBasic defines the basic application module used by the params module.

--- a/x/params/module.go
+++ b/x/params/module.go
@@ -23,10 +23,11 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/params/types/proposal"
 )
 
+// nolint: exhaustivestruct
 var (
-	_ module.AppModule           = AppModule{}      // nolint: exhaustivestruct
-	_ module.AppModuleBasic      = AppModuleBasic{} // nolint: exhaustivestruct
-	_ module.AppModuleSimulation = AppModule{}      // nolint: exhaustivestruct
+	_ module.AppModule           = AppModule{}
+	_ module.AppModuleBasic      = AppModuleBasic{}
+	_ module.AppModuleSimulation = AppModule{}
 )
 
 // AppModuleBasic defines the basic application module used by the params module.

--- a/x/params/simulation/operations_test.go
+++ b/x/params/simulation/operations_test.go
@@ -37,7 +37,7 @@ func (pc MockParamChange) SimValue() simtypes.SimValFn {
 }
 
 // make sure that the MockParamChange satisfied the ParamChange interface
-var _ simtypes.ParamChange = MockParamChange{}
+var _ simtypes.ParamChange = MockParamChange{} // nolint: exhaustivestruct
 
 func TestSimulateParamChangeProposalContent(t *testing.T) {
 	s := rand.NewSource(1)

--- a/x/params/types/consensus_params.go
+++ b/x/params/types/consensus_params.go
@@ -12,6 +12,7 @@ import (
 // or provider their own when the existing validation functions do not suite their
 // needs.
 func ConsensusParamsKeyTable() KeyTable {
+	// nolint: exhaustivestruct
 	return NewKeyTable(
 		NewParamSetPair(
 			baseapp.ParamStoreKeyBlockParams, tmproto.BlockParams{}, baseapp.ValidateBlockParams,

--- a/x/params/types/proposal/codec.go
+++ b/x/params/types/proposal/codec.go
@@ -1,3 +1,4 @@
+// nolint: exhaustivestruct
 package proposal
 
 import (

--- a/x/params/types/proposal/proposal.go
+++ b/x/params/types/proposal/proposal.go
@@ -15,7 +15,7 @@ const (
 )
 
 // Assert ParameterChangeProposal implements govtypes.Content at compile-time
-var _ govtypes.Content = &ParameterChangeProposal{}
+var _ govtypes.Content = &ParameterChangeProposal{} // nolint: exhaustivestruct
 
 func init() {
 	govtypes.RegisterProposalType(ProposalTypeChange)

--- a/x/slashing/client/cli/query.go
+++ b/x/slashing/client/cli/query.go
@@ -15,7 +15,7 @@ import (
 // GetQueryCmd returns the cli query commands for this module
 func GetQueryCmd() *cobra.Command {
 	// Group slashing queries under a subcommand
-	slashingQueryCmd := &cobra.Command{
+	slashingQueryCmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:                        types.ModuleName,
 		Short:                      "Querying commands for the slashing module",
 		DisableFlagParsing:         true,
@@ -35,7 +35,7 @@ func GetQueryCmd() *cobra.Command {
 
 // GetCmdQuerySigningInfo implements the command to query signing info.
 func GetCmdQuerySigningInfo() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "signing-info [validator-conspub]",
 		Short: "Query a validator's signing information",
 		Long: strings.TrimSpace(`Use a validators' consensus public key to find the signing-info for that validator:
@@ -73,7 +73,7 @@ $ <appd> query slashing signing-info '{"@type":"/cosmos.crypto.ed25519.PubKey","
 
 // GetCmdQuerySigningInfos implements the command to query signing infos.
 func GetCmdQuerySigningInfos() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "signing-infos",
 		Short: "Query signing information of all validators",
 		Long: strings.TrimSpace(`signing infos of validators:
@@ -111,7 +111,7 @@ $ <appd> query slashing signing-infos
 
 // GetCmdQueryParams implements a command to fetch slashing parameters.
 func GetCmdQueryParams() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "params",
 		Short: "Query the current slashing parameters",
 		Args:  cobra.NoArgs,

--- a/x/slashing/client/cli/tx.go
+++ b/x/slashing/client/cli/tx.go
@@ -12,7 +12,7 @@ import (
 
 // NewTxCmd returns a root CLI command handler for all x/slashing transaction commands.
 func NewTxCmd() *cobra.Command {
-	slashingTxCmd := &cobra.Command{
+	slashingTxCmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:                        types.ModuleName,
 		Short:                      "Slashing transaction subcommands",
 		DisableFlagParsing:         true,
@@ -25,7 +25,7 @@ func NewTxCmd() *cobra.Command {
 }
 
 func NewUnjailTxCmd() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "unjail",
 		Args:  cobra.NoArgs,
 		Short: "unjail validator previously jailed for downtime",

--- a/x/slashing/client/testutil/grpc.go
+++ b/x/slashing/client/testutil/grpc.go
@@ -19,6 +19,7 @@ func (s *IntegrationTestSuite) TestGRPCQueries() {
 
 	consAddr := sdk.ConsAddress(val.PubKey.Address()).String()
 
+	// nolint: exhaustivestruct
 	testCases := []struct {
 		name     string
 		url      string

--- a/x/slashing/client/testutil/suite.go
+++ b/x/slashing/client/testutil/suite.go
@@ -159,7 +159,7 @@ func (s *IntegrationTestSuite) TestNewUnjailTxCmd() {
 				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastSync), // sync mode as there are no funds yet
 				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(10))).String()),
 			},
-			false, 0, &sdk.TxResponse{},
+			false, 0, &sdk.TxResponse{}, // nolint: exhaustivestruct
 		},
 	}
 

--- a/x/slashing/client/testutil/suite.go
+++ b/x/slashing/client/testutil/suite.go
@@ -144,6 +144,8 @@ slash_fraction_downtime: "0.010000000000000000"`,
 
 func (s *IntegrationTestSuite) TestNewUnjailTxCmd() {
 	val := s.network.Validators[0]
+
+	// nolint: exhaustivestruct
 	testCases := []struct {
 		name         string
 		args         []string
@@ -159,7 +161,7 @@ func (s *IntegrationTestSuite) TestNewUnjailTxCmd() {
 				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastSync), // sync mode as there are no funds yet
 				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(10))).String()),
 			},
-			false, 0, &sdk.TxResponse{}, // nolint: exhaustivestruct
+			false, 0, &sdk.TxResponse{},
 		},
 	}
 

--- a/x/slashing/client/testutil/suite.go
+++ b/x/slashing/client/testutil/suite.go
@@ -23,7 +23,7 @@ type IntegrationTestSuite struct {
 }
 
 func NewIntegrationTestSuite(cfg network.Config) *IntegrationTestSuite {
-	return &IntegrationTestSuite{cfg: cfg}
+	return &IntegrationTestSuite{cfg: cfg} // nolint: exhaustivestruct
 }
 
 // SetupSuite executes bootstrapping logic before all the tests, i.e. once before

--- a/x/slashing/keeper/grpc_query.go
+++ b/x/slashing/keeper/grpc_query.go
@@ -12,7 +12,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/slashing/types"
 )
 
-var _ types.QueryServer = Keeper{}
+var _ types.QueryServer = Keeper{} // nolint: exhaustivestruct
 
 func (k Keeper) Params(c context.Context, req *types.QueryParamsRequest) (*types.QueryParamsResponse, error) {
 	if req == nil {

--- a/x/slashing/keeper/hooks.go
+++ b/x/slashing/keeper/hooks.go
@@ -49,7 +49,7 @@ type Hooks struct {
 	k Keeper
 }
 
-var _ types.StakingHooks = Hooks{}
+var _ types.StakingHooks = Hooks{} // nolint: exhaustivestruct
 
 // Return the wrapper struct
 func (k Keeper) Hooks() Hooks {

--- a/x/slashing/keeper/msg_server.go
+++ b/x/slashing/keeper/msg_server.go
@@ -17,7 +17,7 @@ func NewMsgServerImpl(keeper Keeper) types.MsgServer {
 	return &msgServer{Keeper: keeper}
 }
 
-var _ types.MsgServer = msgServer{}
+var _ types.MsgServer = msgServer{} // nolint: exhaustivestruct
 
 // Unjail implements MsgServer.Unjail method.
 // Validators must submit a transaction to unjail itself after

--- a/x/slashing/module.go
+++ b/x/slashing/module.go
@@ -24,10 +24,11 @@ import (
 	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
 )
 
+// nolint: exhaustivestruct
 var (
-	_ module.AppModule           = AppModule{}      // nolint: exhaustivestruct
-	_ module.AppModuleBasic      = AppModuleBasic{} // nolint: exhaustivestruct
-	_ module.AppModuleSimulation = AppModule{}      // nolint: exhaustivestruct
+	_ module.AppModule           = AppModule{}
+	_ module.AppModuleBasic      = AppModuleBasic{}
+	_ module.AppModuleSimulation = AppModule{}
 )
 
 // AppModuleBasic defines the basic application module used by the slashing module.

--- a/x/slashing/module.go
+++ b/x/slashing/module.go
@@ -25,9 +25,9 @@ import (
 )
 
 var (
-	_ module.AppModule           = AppModule{}
-	_ module.AppModuleBasic      = AppModuleBasic{}
-	_ module.AppModuleSimulation = AppModule{}
+	_ module.AppModule           = AppModule{}      // nolint: exhaustivestruct
+	_ module.AppModuleBasic      = AppModuleBasic{} // nolint: exhaustivestruct
+	_ module.AppModuleSimulation = AppModule{}      // nolint: exhaustivestruct
 )
 
 // AppModuleBasic defines the basic application module used by the slashing module.

--- a/x/slashing/module.go
+++ b/x/slashing/module.go
@@ -35,7 +35,7 @@ type AppModuleBasic struct {
 	cdc codec.Codec
 }
 
-var _ module.AppModuleBasic = AppModuleBasic{}
+var _ module.AppModuleBasic = AppModuleBasic{} // nolint: exhaustivestruct
 
 // Name returns the slashing module's name.
 func (AppModuleBasic) Name() string {

--- a/x/slashing/types/codec.go
+++ b/x/slashing/types/codec.go
@@ -1,3 +1,4 @@
+// nolint: exhaustivestruct
 package types
 
 import (

--- a/x/slashing/types/msg.go
+++ b/x/slashing/types/msg.go
@@ -12,7 +12,7 @@ const (
 )
 
 // verify interface at compile time
-var _ sdk.Msg = &MsgUnjail{}
+var _ sdk.Msg = &MsgUnjail{} // nolint: exhaustivestruct
 
 // NewMsgUnjail creates a new MsgUnjail instance
 //nolint:interfacer

--- a/x/slashing/types/params.go
+++ b/x/slashing/types/params.go
@@ -31,7 +31,7 @@ var (
 
 // ParamKeyTable for slashing module
 func ParamKeyTable() paramtypes.KeyTable {
-	return paramtypes.NewKeyTable().RegisterParamSet(&Params{})
+	return paramtypes.NewKeyTable().RegisterParamSet(&Params{}) // nolint: exhaustivestruct
 }
 
 // NewParams creates a new Params object

--- a/x/staking/client/cli/query.go
+++ b/x/staking/client/cli/query.go
@@ -16,7 +16,7 @@ import (
 
 // GetQueryCmd returns the cli query commands for this module
 func GetQueryCmd() *cobra.Command {
-	stakingQueryCmd := &cobra.Command{
+	stakingQueryCmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:                        types.ModuleName,
 		Short:                      "Querying commands for the staking module",
 		DisableFlagParsing:         true,
@@ -48,7 +48,7 @@ func GetQueryCmd() *cobra.Command {
 func GetCmdQueryValidator() *cobra.Command {
 	bech32PrefixValAddr := sdk.GetConfig().GetBech32ValidatorAddrPrefix()
 
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "validator [validator-addr]",
 		Short: "Query a validator",
 		Long: strings.TrimSpace(
@@ -90,7 +90,7 @@ $ %s query staking validator %s1gghjut3ccd8ay0zduzj64hwre2fxs9ldmqhffj
 
 // GetCmdQueryValidators implements the query all validators command.
 func GetCmdQueryValidators() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "validators",
 		Short: "Query for all validators",
 		Args:  cobra.NoArgs,
@@ -136,7 +136,7 @@ $ %s query staking validators
 func GetCmdQueryValidatorUnbondingDelegations() *cobra.Command {
 	bech32PrefixValAddr := sdk.GetConfig().GetBech32ValidatorAddrPrefix()
 
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "unbonding-delegations-from [validator-addr]",
 		Short: "Query all unbonding delegatations from a validator",
 		Long: strings.TrimSpace(
@@ -191,7 +191,7 @@ $ %s query staking unbonding-delegations-from %s1gghjut3ccd8ay0zduzj64hwre2fxs9l
 func GetCmdQueryValidatorRedelegations() *cobra.Command {
 	bech32PrefixValAddr := sdk.GetConfig().GetBech32ValidatorAddrPrefix()
 
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "redelegations-from [validator-addr]",
 		Short: "Query all outgoing redelegatations from a validator",
 		Long: strings.TrimSpace(
@@ -246,7 +246,7 @@ func GetCmdQueryDelegation() *cobra.Command {
 	bech32PrefixAccAddr := sdk.GetConfig().GetBech32AccountAddrPrefix()
 	bech32PrefixValAddr := sdk.GetConfig().GetBech32ValidatorAddrPrefix()
 
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "delegation [delegator-addr] [validator-addr]",
 		Short: "Query a delegation based on address and validator address",
 		Long: strings.TrimSpace(
@@ -300,7 +300,7 @@ $ %s query staking delegation %s1gghjut3ccd8ay0zduzj64hwre2fxs9ld75ru9p %s1gghju
 func GetCmdQueryDelegations() *cobra.Command {
 	bech32PrefixAccAddr := sdk.GetConfig().GetBech32AccountAddrPrefix()
 
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "delegations [delegator-addr]",
 		Short: "Query all delegations made by one delegator",
 		Long: strings.TrimSpace(
@@ -355,7 +355,7 @@ $ %s query staking delegations %s1gghjut3ccd8ay0zduzj64hwre2fxs9ld75ru9p
 func GetCmdQueryValidatorDelegations() *cobra.Command {
 	bech32PrefixValAddr := sdk.GetConfig().GetBech32ValidatorAddrPrefix()
 
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "delegations-to [validator-addr]",
 		Short: "Query all delegations made to one validator",
 		Long: strings.TrimSpace(
@@ -411,7 +411,7 @@ func GetCmdQueryUnbondingDelegation() *cobra.Command {
 	bech32PrefixAccAddr := sdk.GetConfig().GetBech32AccountAddrPrefix()
 	bech32PrefixValAddr := sdk.GetConfig().GetBech32ValidatorAddrPrefix()
 
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "unbonding-delegation [delegator-addr] [validator-addr]",
 		Short: "Query an unbonding-delegation record based on delegator and validator address",
 		Long: strings.TrimSpace(
@@ -465,7 +465,7 @@ $ %s query staking unbonding-delegation %s1gghjut3ccd8ay0zduzj64hwre2fxs9ld75ru9
 func GetCmdQueryUnbondingDelegations() *cobra.Command {
 	bech32PrefixAccAddr := sdk.GetConfig().GetBech32AccountAddrPrefix()
 
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "unbonding-delegations [delegator-addr]",
 		Short: "Query all unbonding-delegations records for one delegator",
 		Long: strings.TrimSpace(
@@ -521,7 +521,7 @@ func GetCmdQueryRedelegation() *cobra.Command {
 	bech32PrefixAccAddr := sdk.GetConfig().GetBech32AccountAddrPrefix()
 	bech32PrefixValAddr := sdk.GetConfig().GetBech32ValidatorAddrPrefix()
 
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "redelegation [delegator-addr] [src-validator-addr] [dst-validator-addr]",
 		Short: "Query a redelegation record based on delegator and a source and destination validator address",
 		Long: strings.TrimSpace(
@@ -581,7 +581,7 @@ $ %s query staking redelegation %s1gghjut3ccd8ay0zduzj64hwre2fxs9ld75ru9p %s1l2r
 func GetCmdQueryRedelegations() *cobra.Command {
 	bech32PrefixAccAddr := sdk.GetConfig().GetBech32AccountAddrPrefix()
 
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "redelegations [delegator-addr]",
 		Args:  cobra.ExactArgs(1),
 		Short: "Query all redelegations records for one delegator",
@@ -633,7 +633,7 @@ $ %s query staking redelegation %s1gghjut3ccd8ay0zduzj64hwre2fxs9ld75ru9p
 
 // GetCmdQueryHistoricalInfo implements the historical info query command
 func GetCmdQueryHistoricalInfo() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "historical-info [height]",
 		Args:  cobra.ExactArgs(1),
 		Short: "Query historical info at given height",
@@ -675,7 +675,7 @@ $ %s query staking historical-info 5
 
 // GetCmdQueryPool implements the pool query command.
 func GetCmdQueryPool() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "pool",
 		Args:  cobra.NoArgs,
 		Short: "Query the current staking pool values",
@@ -711,7 +711,7 @@ $ %s query staking pool
 
 // GetCmdQueryParams implements the params query command.
 func GetCmdQueryParams() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "params",
 		Args:  cobra.NoArgs,
 		Short: "Query the current staking parameters information",

--- a/x/staking/client/cli/tx.go
+++ b/x/staking/client/cli/tx.go
@@ -30,7 +30,7 @@ var (
 
 // NewTxCmd returns a root CLI command handler for all x/staking transaction commands.
 func NewTxCmd() *cobra.Command {
-	stakingTxCmd := &cobra.Command{
+	stakingTxCmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:                        types.ModuleName,
 		Short:                      "Staking transaction subcommands",
 		DisableFlagParsing:         true,
@@ -50,7 +50,7 @@ func NewTxCmd() *cobra.Command {
 }
 
 func NewCreateValidatorCmd() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "create-validator",
 		Short: "create new validator initialized with a self-delegation to it",
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -89,7 +89,7 @@ func NewCreateValidatorCmd() *cobra.Command {
 }
 
 func NewEditValidatorCmd() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "edit-validator",
 		Short: "edit an existing validator account",
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -146,7 +146,7 @@ func NewEditValidatorCmd() *cobra.Command {
 func NewDelegateCmd() *cobra.Command {
 	bech32PrefixValAddr := sdk.GetConfig().GetBech32ValidatorAddrPrefix()
 
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "delegate [validator-addr] [amount]",
 		Args:  cobra.ExactArgs(2),
 		Short: "Delegate liquid tokens to a validator",
@@ -189,7 +189,7 @@ $ %s tx staking delegate %s1l2rsakp388kuv9k8qzq6lrm9taddae7fpx59wm 1000stake --f
 func NewRedelegateCmd() *cobra.Command {
 	bech32PrefixValAddr := sdk.GetConfig().GetBech32ValidatorAddrPrefix()
 
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "redelegate [src-validator-addr] [dst-validator-addr] [amount]",
 		Short: "Redelegate illiquid tokens from one validator to another",
 		Args:  cobra.ExactArgs(3),
@@ -237,7 +237,7 @@ $ %s tx staking redelegate %s1gghjut3ccd8ay0zduzj64hwre2fxs9ldmqhffj %s1l2rsakp3
 func NewUnbondCmd() *cobra.Command {
 	bech32PrefixValAddr := sdk.GetConfig().GetBech32ValidatorAddrPrefix()
 
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "unbond [validator-addr] [amount]",
 		Short: "Unbond shares from a validator",
 		Args:  cobra.ExactArgs(2),

--- a/x/staking/client/testutil/grpc.go
+++ b/x/staking/client/testutil/grpc.go
@@ -114,6 +114,7 @@ func (s *IntegrationTestSuite) TestGRPCQueryValidatorDelegations() {
 	val := s.network.Validators[0]
 	baseURL := val.APIAddress
 
+	// nolint: exhaustivestruct
 	testCases := []struct {
 		name         string
 		url          string
@@ -225,6 +226,7 @@ func (s *IntegrationTestSuite) TestGRPCQueryDelegation() {
 	val2 := s.network.Validators[1]
 	baseURL := val.APIAddress
 
+	// nolint: exhaustivestruct
 	testCases := []struct {
 		name         string
 		url          string
@@ -364,6 +366,7 @@ func (s *IntegrationTestSuite) TestGRPCQueryDelegatorDelegations() {
 	newAddr, err := k.GetAddress()
 	s.Require().NoError(err)
 
+	// nolint: exhaustivestruct
 	testCases := []struct {
 		name         string
 		url          string
@@ -704,6 +707,7 @@ func (s *IntegrationTestSuite) TestGRPCQueryParams() {
 	val := s.network.Validators[0]
 	baseURL := val.APIAddress
 
+	// nolint: exhaustivestruct
 	testCases := []struct {
 		name     string
 		url      string
@@ -735,6 +739,7 @@ func (s *IntegrationTestSuite) TestGRPCQueryPool() {
 	val := s.network.Validators[0]
 	baseURL := val.APIAddress
 
+	// nolint: exhaustivestruct
 	testCases := []struct {
 		name     string
 		url      string

--- a/x/staking/client/testutil/suite.go
+++ b/x/staking/client/testutil/suite.go
@@ -110,6 +110,7 @@ func (s *IntegrationTestSuite) TestNewCreateValidatorCmd() {
 	)
 	require.NoError(err)
 
+	// nolint: exhaustivestruct
 	testCases := []struct {
 		name         string
 		args         []string
@@ -193,7 +194,7 @@ func (s *IntegrationTestSuite) TestNewCreateValidatorCmd() {
 				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
 				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(10))).String()),
 			},
-			false, 0, &sdk.TxResponse{}, // nolint: exhaustivestruct
+			false, 0, &sdk.TxResponse{},
 		},
 	}
 
@@ -314,6 +315,7 @@ func (s *IntegrationTestSuite) TestGetCmdQueryDelegation() {
 	val := s.network.Validators[0]
 	val2 := s.network.Validators[1]
 
+	// nolint: exhaustivestruct
 	testCases := []struct {
 		name     string
 		args     []string
@@ -380,6 +382,7 @@ func (s *IntegrationTestSuite) TestGetCmdQueryDelegation() {
 func (s *IntegrationTestSuite) TestGetCmdQueryDelegations() {
 	val := s.network.Validators[0]
 
+	// nolint: exhaustivestruct
 	testCases := []struct {
 		name     string
 		args     []string
@@ -436,6 +439,7 @@ func (s *IntegrationTestSuite) TestGetCmdQueryDelegations() {
 func (s *IntegrationTestSuite) TestGetCmdQueryValidatorDelegations() {
 	val := s.network.Validators[0]
 
+	// nolint: exhaustivestruct
 	testCases := []struct {
 		name     string
 		args     []string
@@ -951,6 +955,7 @@ func (s *IntegrationTestSuite) TestNewEditValidatorCmd() {
 	securityContact := "test contact"
 	website := "https://test.com"
 
+	// nolint: exhaustivestruct
 	testCases := []struct {
 		name         string
 		args         []string
@@ -976,7 +981,7 @@ func (s *IntegrationTestSuite) TestNewEditValidatorCmd() {
 				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
 				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(10))).String()),
 			},
-			false, 0, &sdk.TxResponse{}, // nolint: exhaustivestruct
+			false, 0, &sdk.TxResponse{},
 		},
 		{
 			"edit validator details",
@@ -987,7 +992,7 @@ func (s *IntegrationTestSuite) TestNewEditValidatorCmd() {
 				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
 				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(10))).String()),
 			},
-			false, 0, &sdk.TxResponse{}, // nolint: exhaustivestruct
+			false, 0, &sdk.TxResponse{},
 		},
 		{
 			"edit validator identity",
@@ -998,7 +1003,7 @@ func (s *IntegrationTestSuite) TestNewEditValidatorCmd() {
 				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
 				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(10))).String()),
 			},
-			false, 0, &sdk.TxResponse{}, // nolint: exhaustivestruct
+			false, 0, &sdk.TxResponse{},
 		},
 		{
 			"edit validator security-contact",
@@ -1009,7 +1014,7 @@ func (s *IntegrationTestSuite) TestNewEditValidatorCmd() {
 				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
 				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(10))).String()),
 			},
-			false, 0, &sdk.TxResponse{}, // nolint: exhaustivestruct
+			false, 0, &sdk.TxResponse{},
 		},
 		{
 			"edit validator website",
@@ -1020,7 +1025,7 @@ func (s *IntegrationTestSuite) TestNewEditValidatorCmd() {
 				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
 				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(10))).String()),
 			},
-			false, 0, &sdk.TxResponse{}, // nolint: exhaustivestruct
+			false, 0, &sdk.TxResponse{},
 		},
 		{
 			"with all edit flags",
@@ -1034,7 +1039,7 @@ func (s *IntegrationTestSuite) TestNewEditValidatorCmd() {
 				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
 				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(10))).String()),
 			},
-			false, 0, &sdk.TxResponse{}, // nolint: exhaustivestruct
+			false, 0, &sdk.TxResponse{},
 		},
 	}
 
@@ -1080,6 +1085,7 @@ func (s *IntegrationTestSuite) TestNewDelegateCmd() {
 	)
 	s.Require().NoError(err)
 
+	// nolint: exhaustivestruct
 	testCases := []struct {
 		name         string
 		args         []string
@@ -1119,7 +1125,7 @@ func (s *IntegrationTestSuite) TestNewDelegateCmd() {
 				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
 				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(10))).String()),
 			},
-			false, 0, &sdk.TxResponse{}, // nolint: exhaustivestruct
+			false, 0, &sdk.TxResponse{},
 		},
 	}
 
@@ -1148,6 +1154,7 @@ func (s *IntegrationTestSuite) TestNewRedelegateCmd() {
 	val := s.network.Validators[0]
 	val2 := s.network.Validators[1]
 
+	// nolint: exhaustivestruct
 	testCases := []struct {
 		name         string
 		args         []string
@@ -1178,7 +1185,7 @@ func (s *IntegrationTestSuite) TestNewRedelegateCmd() {
 				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
 				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(10))).String()),
 			},
-			false, 3, &sdk.TxResponse{}, // nolint: exhaustivestruct
+			false, 3, &sdk.TxResponse{},
 		},
 		{
 			"with wrong destination validator address",
@@ -1191,7 +1198,7 @@ func (s *IntegrationTestSuite) TestNewRedelegateCmd() {
 				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
 				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(10))).String()),
 			},
-			false, 31, &sdk.TxResponse{}, // nolint: exhaustivestruct
+			false, 31, &sdk.TxResponse{},
 		},
 		{
 			"valid transaction of delegate",
@@ -1205,7 +1212,7 @@ func (s *IntegrationTestSuite) TestNewRedelegateCmd() {
 				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
 				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(10))).String()),
 			},
-			false, 0, &sdk.TxResponse{}, // nolint: exhaustivestruct
+			false, 0, &sdk.TxResponse{},
 		},
 	}
 
@@ -1233,6 +1240,7 @@ func (s *IntegrationTestSuite) TestNewRedelegateCmd() {
 func (s *IntegrationTestSuite) TestNewUnbondCmd() {
 	val := s.network.Validators[0]
 
+	// nolint: exhaustivestruct
 	testCases := []struct {
 		name         string
 		args         []string
@@ -1272,7 +1280,7 @@ func (s *IntegrationTestSuite) TestNewUnbondCmd() {
 				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
 				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(10))).String()),
 			},
-			false, 0, &sdk.TxResponse{}, // nolint: exhaustivestruct
+			false, 0, &sdk.TxResponse{},
 		},
 	}
 

--- a/x/staking/client/testutil/suite.go
+++ b/x/staking/client/testutil/suite.go
@@ -193,7 +193,7 @@ func (s *IntegrationTestSuite) TestNewCreateValidatorCmd() {
 				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
 				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(10))).String()),
 			},
-			false, 0, &sdk.TxResponse{},
+			false, 0, &sdk.TxResponse{}, // nolint: exhaustivestruct
 		},
 	}
 
@@ -976,7 +976,7 @@ func (s *IntegrationTestSuite) TestNewEditValidatorCmd() {
 				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
 				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(10))).String()),
 			},
-			false, 0, &sdk.TxResponse{},
+			false, 0, &sdk.TxResponse{}, // nolint: exhaustivestruct
 		},
 		{
 			"edit validator details",
@@ -987,7 +987,7 @@ func (s *IntegrationTestSuite) TestNewEditValidatorCmd() {
 				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
 				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(10))).String()),
 			},
-			false, 0, &sdk.TxResponse{},
+			false, 0, &sdk.TxResponse{}, // nolint: exhaustivestruct
 		},
 		{
 			"edit validator identity",
@@ -998,7 +998,7 @@ func (s *IntegrationTestSuite) TestNewEditValidatorCmd() {
 				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
 				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(10))).String()),
 			},
-			false, 0, &sdk.TxResponse{},
+			false, 0, &sdk.TxResponse{}, // nolint: exhaustivestruct
 		},
 		{
 			"edit validator security-contact",
@@ -1009,7 +1009,7 @@ func (s *IntegrationTestSuite) TestNewEditValidatorCmd() {
 				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
 				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(10))).String()),
 			},
-			false, 0, &sdk.TxResponse{},
+			false, 0, &sdk.TxResponse{}, // nolint: exhaustivestruct
 		},
 		{
 			"edit validator website",
@@ -1020,7 +1020,7 @@ func (s *IntegrationTestSuite) TestNewEditValidatorCmd() {
 				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
 				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(10))).String()),
 			},
-			false, 0, &sdk.TxResponse{},
+			false, 0, &sdk.TxResponse{}, // nolint: exhaustivestruct
 		},
 		{
 			"with all edit flags",
@@ -1034,7 +1034,7 @@ func (s *IntegrationTestSuite) TestNewEditValidatorCmd() {
 				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
 				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(10))).String()),
 			},
-			false, 0, &sdk.TxResponse{},
+			false, 0, &sdk.TxResponse{}, // nolint: exhaustivestruct
 		},
 	}
 
@@ -1119,7 +1119,7 @@ func (s *IntegrationTestSuite) TestNewDelegateCmd() {
 				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
 				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(10))).String()),
 			},
-			false, 0, &sdk.TxResponse{},
+			false, 0, &sdk.TxResponse{}, // nolint: exhaustivestruct
 		},
 	}
 
@@ -1178,7 +1178,7 @@ func (s *IntegrationTestSuite) TestNewRedelegateCmd() {
 				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
 				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(10))).String()),
 			},
-			false, 3, &sdk.TxResponse{},
+			false, 3, &sdk.TxResponse{}, // nolint: exhaustivestruct
 		},
 		{
 			"with wrong destination validator address",
@@ -1191,7 +1191,7 @@ func (s *IntegrationTestSuite) TestNewRedelegateCmd() {
 				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
 				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(10))).String()),
 			},
-			false, 31, &sdk.TxResponse{},
+			false, 31, &sdk.TxResponse{}, // nolint: exhaustivestruct
 		},
 		{
 			"valid transaction of delegate",
@@ -1205,7 +1205,7 @@ func (s *IntegrationTestSuite) TestNewRedelegateCmd() {
 				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
 				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(10))).String()),
 			},
-			false, 0, &sdk.TxResponse{},
+			false, 0, &sdk.TxResponse{}, // nolint: exhaustivestruct
 		},
 	}
 
@@ -1272,7 +1272,7 @@ func (s *IntegrationTestSuite) TestNewUnbondCmd() {
 				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
 				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(10))).String()),
 			},
-			false, 0, &sdk.TxResponse{},
+			false, 0, &sdk.TxResponse{}, // nolint: exhaustivestruct
 		},
 	}
 

--- a/x/staking/client/testutil/suite.go
+++ b/x/staking/client/testutil/suite.go
@@ -33,7 +33,7 @@ type IntegrationTestSuite struct {
 }
 
 func NewIntegrationTestSuite(cfg network.Config) *IntegrationTestSuite {
-	return &IntegrationTestSuite{cfg: cfg}
+	return &IntegrationTestSuite{cfg: cfg} // nolint: exhaustivestruct
 }
 
 func (s *IntegrationTestSuite) SetupSuite() {

--- a/x/staking/keeper/grpc_query.go
+++ b/x/staking/keeper/grpc_query.go
@@ -18,7 +18,7 @@ type Querier struct {
 	Keeper
 }
 
-var _ types.QueryServer = Querier{}
+var _ types.QueryServer = Querier{} // nolint: exhaustivestruct
 
 // Validators queries all validators that match the given status
 func (k Querier) Validators(c context.Context, req *types.QueryValidatorsRequest) (*types.QueryValidatorsResponse, error) {

--- a/x/staking/keeper/historical_info.go
+++ b/x/staking/keeper/historical_info.go
@@ -12,7 +12,7 @@ func (k Keeper) GetHistoricalInfo(ctx sdk.Context, height int64) (types.Historic
 
 	value := store.Get(key)
 	if value == nil {
-		return types.HistoricalInfo{}, false
+		return types.HistoricalInfo{}, false // nolint: exhaustivestruct
 	}
 
 	return types.MustUnmarshalHistoricalInfo(k.cdc, value), true

--- a/x/staking/keeper/hooks.go
+++ b/x/staking/keeper/hooks.go
@@ -6,7 +6,7 @@ import (
 )
 
 // Implements StakingHooks interface
-var _ types.StakingHooks = Keeper{}
+var _ types.StakingHooks = Keeper{} // nolint: exhaustivestruct
 
 // AfterValidatorCreated - call hook if registered
 func (k Keeper) AfterValidatorCreated(ctx sdk.Context, valAddr sdk.ValAddress) error {

--- a/x/staking/keeper/keeper.go
+++ b/x/staking/keeper/keeper.go
@@ -3,8 +3,9 @@ package keeper
 import (
 	"fmt"
 
-	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	"github.com/tendermint/tendermint/libs/log"
+
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -13,10 +14,10 @@ import (
 )
 
 // Implements ValidatorSet interface
-var _ types.ValidatorSet = Keeper{}
+var _ types.ValidatorSet = Keeper{} // nolint: exhaustivestruct
 
 // Implements DelegationSet interface
-var _ types.DelegationSet = Keeper{}
+var _ types.DelegationSet = Keeper{} // nolint: exhaustivestruct
 
 // keeper of the staking store
 type Keeper struct {

--- a/x/staking/keeper/msg_server.go
+++ b/x/staking/keeper/msg_server.go
@@ -24,7 +24,7 @@ func NewMsgServerImpl(keeper Keeper) types.MsgServer {
 	return &msgServer{Keeper: keeper}
 }
 
-var _ types.MsgServer = msgServer{}
+var _ types.MsgServer = msgServer{} // nolint: exhaustivestruct
 
 // CreateValidator defines a method for creating a new validator
 func (k msgServer) CreateValidator(goCtx context.Context, msg *types.MsgCreateValidator) (*types.MsgCreateValidatorResponse, error) {

--- a/x/staking/keeper/test_common.go
+++ b/x/staking/keeper/test_common.go
@@ -60,7 +60,7 @@ func TestingUpdateValidator(keeper Keeper, ctx sdk.Context, validator types.Vali
 func RandomValidator(r *rand.Rand, keeper Keeper, ctx sdk.Context) (val types.Validator, ok bool) {
 	vals := keeper.GetAllValidators(ctx)
 	if len(vals) == 0 {
-		return types.Validator{}, false
+		return types.Validator{}, false // nolint: exhaustivestruct
 	}
 
 	i := r.Intn(len(vals))

--- a/x/staking/migrations/v034/types.go
+++ b/x/staking/migrations/v034/types.go
@@ -164,7 +164,7 @@ func (v Validator) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON unmarshals the validator from JSON using Bech32
 func (v *Validator) UnmarshalJSON(data []byte) error {
-	bv := &bechValidator{}
+	bv := &bechValidator{} // nolint: exhaustivestruct
 	if err := legacy.Cdc.UnmarshalJSON(data, bv); err != nil {
 		return err
 	}

--- a/x/staking/migrations/v036/types.go
+++ b/x/staking/migrations/v036/types.go
@@ -112,7 +112,7 @@ func (v Validator) MarshalJSON() ([]byte, error) {
 }
 
 func (v *Validator) UnmarshalJSON(data []byte) error {
-	bv := &bechValidator{}
+	bv := &bechValidator{} // nolint: exhaustivestruct
 	if err := legacy.Cdc.UnmarshalJSON(data, bv); err != nil {
 		return err
 	}

--- a/x/staking/migrations/v038/types.go
+++ b/x/staking/migrations/v038/types.go
@@ -138,7 +138,7 @@ func (v Validator) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON unmarshals the validator from JSON using Bech32
 func (v *Validator) UnmarshalJSON(data []byte) error {
-	bv := &bechValidator{}
+	bv := &bechValidator{} // nolint: exhaustivestruct
 	if err := legacy.Cdc.UnmarshalJSON(data, bv); err != nil {
 		return err
 	}

--- a/x/staking/module.go
+++ b/x/staking/module.go
@@ -27,10 +27,11 @@ const (
 	consensusVersion uint64 = 3
 )
 
+// nolint: exhaustivestruct
 var (
-	_ module.AppModule           = AppModule{}      // nolint: exhaustivestruct
-	_ module.AppModuleBasic      = AppModuleBasic{} // nolint: exhaustivestruct
-	_ module.AppModuleSimulation = AppModule{}      // nolint: exhaustivestruct
+	_ module.AppModule           = AppModule{}
+	_ module.AppModuleBasic      = AppModuleBasic{}
+	_ module.AppModuleSimulation = AppModule{}
 )
 
 // AppModuleBasic defines the basic application module used by the staking module.

--- a/x/staking/module.go
+++ b/x/staking/module.go
@@ -28,9 +28,9 @@ const (
 )
 
 var (
-	_ module.AppModule           = AppModule{}
-	_ module.AppModuleBasic      = AppModuleBasic{}
-	_ module.AppModuleSimulation = AppModule{}
+	_ module.AppModule           = AppModule{}      // nolint: exhaustivestruct
+	_ module.AppModuleBasic      = AppModuleBasic{} // nolint: exhaustivestruct
+	_ module.AppModuleSimulation = AppModule{}      // nolint: exhaustivestruct
 )
 
 // AppModuleBasic defines the basic application module used by the staking module.

--- a/x/staking/module.go
+++ b/x/staking/module.go
@@ -38,7 +38,7 @@ type AppModuleBasic struct {
 	cdc codec.Codec
 }
 
-var _ module.AppModuleBasic = AppModuleBasic{}
+var _ module.AppModuleBasic = AppModuleBasic{} // nolint: exhaustivestruct
 
 // Name returns the staking module's name.
 func (AppModuleBasic) Name() string {

--- a/x/staking/types/authz.go
+++ b/x/staking/types/authz.go
@@ -139,11 +139,11 @@ func validateAndBech32fy(allowed []sdk.ValAddress, denied []sdk.ValAddress) ([]s
 func normalizeAuthzType(authzType AuthorizationType) (string, error) {
 	switch authzType {
 	case AuthorizationType_AUTHORIZATION_TYPE_DELEGATE:
-		return sdk.MsgTypeURL(&MsgDelegate{}), nil
+		return sdk.MsgTypeURL(&MsgDelegate{}), nil // nolint: exhaustivestruct
 	case AuthorizationType_AUTHORIZATION_TYPE_UNDELEGATE:
-		return sdk.MsgTypeURL(&MsgUndelegate{}), nil
+		return sdk.MsgTypeURL(&MsgUndelegate{}), nil // nolint: exhaustivestruct
 	case AuthorizationType_AUTHORIZATION_TYPE_REDELEGATE:
-		return sdk.MsgTypeURL(&MsgBeginRedelegate{}), nil
+		return sdk.MsgTypeURL(&MsgBeginRedelegate{}), nil // nolint: exhaustivestruct
 	default:
 		return "", sdkerrors.ErrInvalidType.Wrapf("unknown authorization type %T", authzType)
 	}

--- a/x/staking/types/authz.go
+++ b/x/staking/types/authz.go
@@ -11,6 +11,7 @@ import (
 const gasCostPerIteration = uint64(10)
 
 // Normalized Msg type URLs
+// nolint: exhaustivestruct
 var (
 	_ authz.Authorization = &StakeAuthorization{}
 )

--- a/x/staking/types/codec.go
+++ b/x/staking/types/codec.go
@@ -1,3 +1,4 @@
+// nolint: exhaustivestruct
 package types
 
 import (

--- a/x/staking/types/delegation.go
+++ b/x/staking/types/delegation.go
@@ -13,7 +13,7 @@ import (
 )
 
 // Implements Delegation interface
-var _ DelegationI = Delegation{}
+var _ DelegationI = Delegation{} // nolint: exhaustivestruct
 
 // String implements the Stringer interface for a DVPair object.
 func (dv DVPair) String() string {

--- a/x/staking/types/hooks.go
+++ b/x/staking/types/hooks.go
@@ -5,7 +5,7 @@ import (
 )
 
 // combine multiple staking hooks, all hook functions are run in array sequence
-var _ StakingHooks = &MultiStakingHooks{}
+var _ StakingHooks = &MultiStakingHooks{} // nolint: exhaustivestruct
 
 type MultiStakingHooks []StakingHooks
 

--- a/x/staking/types/hooks.go
+++ b/x/staking/types/hooks.go
@@ -5,7 +5,7 @@ import (
 )
 
 // combine multiple staking hooks, all hook functions are run in array sequence
-var _ StakingHooks = &MultiStakingHooks{} // nolint: exhaustivestruct
+var _ StakingHooks = &MultiStakingHooks{}
 
 type MultiStakingHooks []StakingHooks
 

--- a/x/staking/types/msg.go
+++ b/x/staking/types/msg.go
@@ -17,6 +17,7 @@ const (
 	TypeMsgBeginRedelegate = "begin_redelegate"
 )
 
+// nolint: exhaustivestruct
 var (
 	_ sdk.Msg                            = &MsgCreateValidator{}
 	_ codectypes.UnpackInterfacesMessage = (*MsgCreateValidator)(nil)

--- a/x/staking/types/params.go
+++ b/x/staking/types/params.go
@@ -50,7 +50,7 @@ var _ paramtypes.ParamSet = (*Params)(nil)
 
 // ParamTable for staking module
 func ParamKeyTable() paramtypes.KeyTable {
-	return paramtypes.NewKeyTable().RegisterParamSet(&Params{})
+	return paramtypes.NewKeyTable().RegisterParamSet(&Params{}) // nolint: exhaustivestruct
 }
 
 // NewParams creates a new Params instance

--- a/x/staking/types/validator.go
+++ b/x/staking/types/validator.go
@@ -35,7 +35,7 @@ var (
 	BondStatusBonded      = BondStatus_name[int32(Bonded)]
 )
 
-var _ ValidatorI = Validator{}
+var _ ValidatorI = Validator{} // nolint: exhaustivestruct
 
 // NewValidator constructs a new Validator
 //nolint:interfacer

--- a/x/upgrade/client/cli/query.go
+++ b/x/upgrade/client/cli/query.go
@@ -13,7 +13,7 @@ import (
 
 // GetQueryCmd returns the parent command for all x/upgrade CLi query commands.
 func GetQueryCmd() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   types.ModuleName,
 		Short: "Querying commands for the upgrade module",
 	}
@@ -29,7 +29,7 @@ func GetQueryCmd() *cobra.Command {
 
 // GetCurrentPlanCmd returns the query upgrade plan command.
 func GetCurrentPlanCmd() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "plan",
 		Short: "get upgrade plan (if one exists)",
 		Long:  "Gets the currently scheduled upgrade plan, if one exists",
@@ -63,7 +63,7 @@ func GetCurrentPlanCmd() *cobra.Command {
 // GetAppliedPlanCmd returns information about the block at which a completed
 // upgrade was applied.
 func GetAppliedPlanCmd() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "applied [upgrade-name]",
 		Short: "block header for height at which a completed upgrade was applied",
 		Long: "If upgrade-name was previously executed on the chain, this returns the header for the block at which it was applied.\n" +
@@ -115,7 +115,7 @@ func GetAppliedPlanCmd() *cobra.Command {
 
 // GetModuleVersionsCmd returns the module version list from state
 func GetModuleVersionsCmd() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "module_versions [optional module_name]",
 		Short: "get the list of module versions",
 		Long: "Gets a list of module names and their respective consensus versions.\n" +

--- a/x/upgrade/client/cli/tx.go
+++ b/x/upgrade/client/cli/tx.go
@@ -26,7 +26,7 @@ const (
 
 // GetTxCmd returns the transaction commands for this module
 func GetTxCmd() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   types.ModuleName,
 		Short: "Upgrade transaction subcommands",
 	}
@@ -37,7 +37,7 @@ func GetTxCmd() *cobra.Command {
 // NewCmdSubmitLegacyUpgradeProposal implements a command handler for submitting a software upgrade proposal transaction.
 // Deprecated: please use NewCmdSubmitUpgradeProposal instead.
 func NewCmdSubmitLegacyUpgradeProposal() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "legacy-software-upgrade [name] (--upgrade-height [height]) (--upgrade-info [info]) [flags]",
 		Args:  cobra.ExactArgs(1),
 		Short: "Submit a software upgrade proposal",
@@ -107,7 +107,7 @@ func NewCmdSubmitLegacyUpgradeProposal() *cobra.Command {
 // NewCmdSubmitLegacyCancelUpgradeProposal implements a command handler for submitting a software upgrade cancel proposal transaction.
 // Deprecated: please use NewCmdSubmitCancelUpgradeProposal instead.
 func NewCmdSubmitLegacyCancelUpgradeProposal() *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := &cobra.Command{ // nolint: exhaustivestruct
 		Use:   "legacy-cancel-software-upgrade [flags]",
 		Args:  cobra.ExactArgs(0),
 		Short: "Cancel the current software upgrade proposal",

--- a/x/upgrade/client/testutil/suite.go
+++ b/x/upgrade/client/testutil/suite.go
@@ -15,7 +15,7 @@ import (
 )
 
 func NewIntegrationTestSuite(cfg network.Config) *IntegrationTestSuite {
-	return &IntegrationTestSuite{cfg: cfg}
+	return &IntegrationTestSuite{cfg: cfg} // nolint: exhaustivestruct
 }
 
 type IntegrationTestSuite struct {

--- a/x/upgrade/keeper/grpc_query.go
+++ b/x/upgrade/keeper/grpc_query.go
@@ -8,7 +8,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/upgrade/types"
 )
 
-var _ types.QueryServer = Keeper{}
+var _ types.QueryServer = Keeper{} // nolint: exhaustivestruct
 
 // CurrentPlan implements the Query/CurrentPlan gRPC method
 func (k Keeper) CurrentPlan(c context.Context, req *types.QueryCurrentPlanRequest) (*types.QueryCurrentPlanResponse, error) {

--- a/x/upgrade/migrations/v038/types.go
+++ b/x/upgrade/migrations/v038/types.go
@@ -164,6 +164,7 @@ func (sup CancelSoftwareUpgradeProposal) String() string {
 `, sup.Title, sup.Description)
 }
 
+// nolint: exhaustivestruct
 func RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
 	cdc.RegisterConcrete(SoftwareUpgradeProposal{}, "cosmos-sdk/SoftwareUpgradeProposal", nil)
 	cdc.RegisterConcrete(CancelSoftwareUpgradeProposal{}, "cosmos-sdk/CancelSoftwareUpgradeProposal", nil)

--- a/x/upgrade/migrations/v038/types.go
+++ b/x/upgrade/migrations/v038/types.go
@@ -114,7 +114,7 @@ func NewSoftwareUpgradeProposal(title, description string, plan Plan) v036gov.Co
 }
 
 // Implements Proposal Interface
-var _ v036gov.Content = SoftwareUpgradeProposal{}
+var _ v036gov.Content = SoftwareUpgradeProposal{} // nolint: exhaustivestruct
 
 func (sup SoftwareUpgradeProposal) GetTitle() string       { return sup.Title }
 func (sup SoftwareUpgradeProposal) GetDescription() string { return sup.Description }
@@ -145,7 +145,7 @@ func NewCancelSoftwareUpgradeProposal(title, description string) v036gov.Content
 }
 
 // Implements Proposal Interface
-var _ v036gov.Content = CancelSoftwareUpgradeProposal{}
+var _ v036gov.Content = CancelSoftwareUpgradeProposal{} // nolint: exhaustivestruct
 
 func (sup CancelSoftwareUpgradeProposal) GetTitle() string       { return sup.Title }
 func (sup CancelSoftwareUpgradeProposal) GetDescription() string { return sup.Description }

--- a/x/upgrade/module.go
+++ b/x/upgrade/module.go
@@ -23,9 +23,10 @@ func init() {
 	types.RegisterLegacyAminoCodec(codec.NewLegacyAmino())
 }
 
+// nolint: exhaustivestruct
 var (
-	_ module.AppModule      = AppModule{}      // nolint: exhaustivestruct
-	_ module.AppModuleBasic = AppModuleBasic{} // nolint: exhaustivestruct
+	_ module.AppModule      = AppModule{}
+	_ module.AppModuleBasic = AppModuleBasic{}
 )
 
 // AppModuleBasic implements the sdk.AppModuleBasic interface

--- a/x/upgrade/module.go
+++ b/x/upgrade/module.go
@@ -24,8 +24,8 @@ func init() {
 }
 
 var (
-	_ module.AppModule      = AppModule{}
-	_ module.AppModuleBasic = AppModuleBasic{}
+	_ module.AppModule      = AppModule{}      // nolint: exhaustivestruct
+	_ module.AppModuleBasic = AppModuleBasic{} // nolint: exhaustivestruct
 )
 
 // AppModuleBasic implements the sdk.AppModuleBasic interface

--- a/x/upgrade/types/codec.go
+++ b/x/upgrade/types/codec.go
@@ -1,3 +1,4 @@
+// nolint: exhaustivestruct
 package types
 
 import (

--- a/x/upgrade/types/proposal.go
+++ b/x/upgrade/types/proposal.go
@@ -16,7 +16,7 @@ func NewSoftwareUpgradeProposal(title, description string, plan Plan) gov.Conten
 }
 
 // Implements Proposal Interface
-var _ gov.Content = &SoftwareUpgradeProposal{}
+var _ gov.Content = &SoftwareUpgradeProposal{} // nolint: exhaustivestruct
 
 func init() {
 	gov.RegisterProposalType(ProposalTypeSoftwareUpgrade)
@@ -46,7 +46,7 @@ func NewCancelSoftwareUpgradeProposal(title, description string) gov.Content {
 }
 
 // Implements Proposal Interface
-var _ gov.Content = &CancelSoftwareUpgradeProposal{}
+var _ gov.Content = &CancelSoftwareUpgradeProposal{} // nolint: exhaustivestruct
 
 func (csup *CancelSoftwareUpgradeProposal) GetTitle() string       { return csup.Title }
 func (csup *CancelSoftwareUpgradeProposal) GetDescription() string { return csup.Description }


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

Closes: #11215

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

Adds the [exhaustivestruct](https://golangci-lint.run/usage/linters/#exhaustivestruct) `golangci-lint` linter to error on uninitialized struct fields. 

There are 1461 exhaustivestruct errors on master right now. This PR adds ignore comments to bring that number down to about 496. Since this PR is so large I wanted to make this only include ignore comments.

----

The linter is actually smart enough to not error when we return an empty struct along with an `err`. Although I found a couple of instances where it was confused and errored still.

Types of ignore comments added:
 * [interface type assertions](https://github.com/cosmos/cosmos-sdk/pull/11250/commits/06c10049f37609d7a1a79e33f4951abdeecf8cd1): There is a [PR](https://github.com/mbilski/exhaustivestruct/pull/18) to allow us to remove these actually
 * [Various](https://github.com/cosmos/cosmos-sdk/blob/e6af51f80fc75d10f17075eee02d3a9d5c935578/x/authz/simulation/operations.go#L23-L28) [type](https://github.com/cosmos/cosmos-sdk/pull/11250/commits/849ad7fe0eb119df50b4507c5fdead0a8af02ba0) registering code
 * [Cobra command](https://github.com/cosmos/cosmos-sdk/pull/11250/commits/d6d999fb2dfeacb9e24c091ccec1fd30eba8d3ce)  usages. Also, if [this PR](https://github.com/mbilski/exhaustivestruct/pull/17/files) was merged, we could simply exclude Cobra command struct from the config and remove these ignores as well.
---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [x] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [x] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [x] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)