### PR TITLE
refactor(tests): refactor group CLI tests to be independent

### DIFF
--- a/x/group/client/testutil/tx.go
+++ b/x/group/client/testutil/tx.go
@@ -1453,15 +1453,7 @@ func (s *IntegrationTestSuite) TestTxUpdateGroupPolicyMetadata() {
 	}
 }
 
-// TestTxCreateProposal tests submitting proposal.
-//
-// Please don't rename this to TestTxSubmitProposal. It will redefine the order
-// of the tests being run in this file with `go test`, and will mess up the
-// proposal ids in other tests (e.g. voting or Exec tests).
-// This is a headache, but requires a bigger refactor of all tests in this file
-// so that each one is independent.
-// https://github.com/cosmos/cosmos-sdk/issues/11168
-func (s *IntegrationTestSuite) TestTxCreateProposal() {
+func (s *IntegrationTestSuite) TestTxSubmitProposal() {
 	val := s.network.Validators[0]
 	clientCtx := val.ClientCtx
 
@@ -1998,6 +1990,7 @@ func (s *IntegrationTestSuite) getProposalIdFromTxResponse(txResp sdk.TxResponse
 func (s *IntegrationTestSuite) TestTxExec() {
 	val := s.network.Validators[0]
 	clientCtx := val.ClientCtx
+	require := s.Require()
 
 	var commonFlags = []string{
 		fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
@@ -2005,8 +1998,9 @@ func (s *IntegrationTestSuite) TestTxExec() {
 		fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(10))).String()),
 	}
 
+	var proposalIDs []string
 	// create proposals and vote
-	for i := 3; i <= 4; i++ {
+	for i := 0; i < 2; i++ {
 		out, err := cli.ExecTestCLICmd(val.ClientCtx, client.MsgSubmitProposalCmd(),
 			append(
 				[]string{
@@ -2019,8 +2013,12 @@ func (s *IntegrationTestSuite) TestTxExec() {
 				commonFlags...,
 			),
 		)
-		s.Require().NoError(err, out.String())
-		fmt.Println(out.String())
+		require.NoError(err, out.String())
+
+		var txResp sdk.TxResponse
+		require.NoError(val.ClientCtx.Codec.UnmarshalJSON(out.Bytes(), &txResp), out.String())
+		require.Equal(uint32(0), txResp.Code, out.String())
+		proposalIDs = append(proposalIDs, s.getProposalIdFromTxResponse(txResp))
 
 		out, err = cli.ExecTestCLICmd(val.ClientCtx, client.MsgVoteCmd(),
 			append(
@@ -2033,7 +2031,7 @@ func (s *IntegrationTestSuite) TestTxExec() {
 				commonFlags...,
 			),
 		)
-		s.Require().NoError(err, out.String())
+		require.NoError(err, out.String())
 	}
 
 	testCases := []struct {
@@ -2044,25 +2042,25 @@ func (s *IntegrationTestSuite) TestTxExec() {
 		respType     proto.Message
 		expectedCode uint32
 	}{
-		// {
-		// 	"correct data",
-		// 	append(
-		// 		[]string{
-		// 			"3",
-		// 			fmt.Sprintf("--%s=%s", flags.FlagFrom, val.Address.String()),
-		// 		},
-		// 		commonFlags...,
-		// 	),
-		// 	false,
-		// 	"",
-		// 	&sdk.TxResponse{},
-		// 	0,
-		// },
+		{
+			"correct data",
+			append(
+				[]string{
+					proposalIDs[0],
+					fmt.Sprintf("--%s=%s", flags.FlagFrom, val.Address.String()),
+				},
+				commonFlags...,
+			),
+			false,
+			"",
+			&sdk.TxResponse{},
+			0,
+		},
 		{
 			"with amino-json",
 			append(
 				[]string{
-					"4",
+					proposalIDs[1],
 					fmt.Sprintf("--%s=%s", flags.FlagFrom, val.Address.String()),
 					fmt.Sprintf("--%s=%s", flags.FlagSignMode, flags.SignModeLegacyAminoJSON),
 				},
@@ -2073,34 +2071,34 @@ func (s *IntegrationTestSuite) TestTxExec() {
 			&sdk.TxResponse{},
 			0,
 		},
-		// {
-		// 	"invalid proposal id",
-		// 	append(
-		// 		[]string{
-		// 			"abcd",
-		// 			fmt.Sprintf("--%s=%s", flags.FlagFrom, val.Address.String()),
-		// 		},
-		// 		commonFlags...,
-		// 	),
-		// 	true,
-		// 	"invalid syntax",
-		// 	nil,
-		// 	0,
-		// },
-		// {
-		// 	"proposal not found",
-		// 	append(
-		// 		[]string{
-		// 			"1234",
-		// 			fmt.Sprintf("--%s=%s", flags.FlagFrom, val.Address.String()),
-		// 		},
-		// 		commonFlags...,
-		// 	),
-		// 	true,
-		// 	"proposal: not found",
-		// 	nil,
-		// 	0,
-		// },
+		{
+			"invalid proposal id",
+			append(
+				[]string{
+					"abcd",
+					fmt.Sprintf("--%s=%s", flags.FlagFrom, val.Address.String()),
+				},
+				commonFlags...,
+			),
+			true,
+			"invalid syntax",
+			nil,
+			0,
+		},
+		{
+			"proposal not found",
+			append(
+				[]string{
+					"1234",
+					fmt.Sprintf("--%s=%s", flags.FlagFrom, val.Address.String()),
+				},
+				commonFlags...,
+			),
+			true,
+			"proposal: not found",
+			nil,
+			0,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -2111,13 +2109,13 @@ func (s *IntegrationTestSuite) TestTxExec() {
 
 			out, err := cli.ExecTestCLICmd(clientCtx, cmd, tc.args)
 			if tc.expectErr {
-				s.Require().Contains(out.String(), tc.expectErrMsg)
+				require.Contains(out.String(), tc.expectErrMsg)
 			} else {
-				s.Require().NoError(err, out.String())
-				s.Require().NoError(clientCtx.Codec.UnmarshalJSON(out.Bytes(), tc.respType), out.String())
+				require.NoError(err, out.String())
+				require.NoError(clientCtx.Codec.UnmarshalJSON(out.Bytes(), tc.respType), out.String())
 
 				txResp := tc.respType.(*sdk.TxResponse)
-				s.Require().Equal(tc.expectedCode, txResp.Code, out.String())
+				require.Equal(tc.expectedCode, txResp.Code, out.String())
 			}
 		})
 	}

--- a/x/group/client/testutil/tx.go
+++ b/x/group/client/testutil/tx.go
@@ -2018,12 +2018,13 @@ func (s *IntegrationTestSuite) TestTxExec() {
 		var txResp sdk.TxResponse
 		require.NoError(val.ClientCtx.Codec.UnmarshalJSON(out.Bytes(), &txResp), out.String())
 		require.Equal(uint32(0), txResp.Code, out.String())
-		proposalIDs = append(proposalIDs, s.getProposalIdFromTxResponse(txResp))
+		proposalID := s.getProposalIdFromTxResponse(txResp)
+		proposalIDs = append(proposalIDs, proposalID)
 
 		out, err = cli.ExecTestCLICmd(val.ClientCtx, client.MsgVoteCmd(),
 			append(
 				[]string{
-					fmt.Sprintf("%d", i),
+					proposalID,
 					val.Address.String(),
 					"VOTE_OPTION_YES",
 					"",


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

Closes: #11168 

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [x] provided a link to the relevant issue or specification
- [x] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)