### PR TITLE
fix: filtered pagination NextKey off-by-one when Offset != 0 and CountTotal == true

### DIFF
--- a/types/query/filtered_pagination.go
+++ b/types/query/filtered_pagination.go
@@ -98,7 +98,9 @@ func FilteredPaginate(
 		}
 
 		if numHits == end+1 {
-			nextKey = iterator.Key()
+			if nextKey == nil {
+				nextKey = iterator.Key()
+			}
 
 			if !countTotal {
 				break


### PR DESCRIPTION


<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

Closes: [#11407](https://github.com/cosmos/cosmos-sdk/issues/11407)

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

In the original code, when CountTotal == true, the iteration goes even after the `end+1`-th hit.

The `end+1`-th hit is expected to be `NextKey`. However, if there is a no-hit after after that, `numHits == end+1` is still true, and `NextKey` will be set to key beyond the `end+1`-th hit, resulting in consecutive queries missing the `end+1`-th hit.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)