### PR TITLE
feat: api server flags to start command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -171,6 +171,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Improvements
 
+* [\#11511](https://github.com/cosmos/cosmos-sdk/pull/11511) Add api server flags to start command.
 * [\#11484](https://github.com/cosmos/cosmos-sdk/pull/11484) Implement getter for keyring backend option.
 * [\#11449](https://github.com/cosmos/cosmos-sdk/pull/11449) Improved error messages when node isn't synced.
 * [\#11349](https://github.com/cosmos/cosmos-sdk/pull/11349) Add `RegisterAminoMsg` function that checks that a msg name is <40 chars (else this would break ledger nano signing) then registers the concrete msg type with amino, it should be used for registering `sdk.Msg`s with amino instead of `cdc.RegisterConcrete`.

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -15,6 +15,9 @@ import (
 const (
 	defaultMinGasPrices = ""
 
+	// DefaultAPIAddress defines the default address to bind the API server to.
+	DefaultAPIAddress = "tcp://0.0.0.0:1317"
+
 	// DefaultGRPCAddress defines the default address to bind the gRPC server to.
 	DefaultGRPCAddress = "0.0.0.0:9090"
 
@@ -223,7 +226,7 @@ func DefaultConfig() *Config {
 		API: APIConfig{
 			Enable:             false,
 			Swagger:            false,
-			Address:            "tcp://0.0.0.0:1317",
+			Address:            DefaultAPIAddress,
 			MaxOpenConnections: 1000,
 			RPCReadTimeout:     10,
 			RPCMaxBodyBytes:    1000000,

--- a/server/start.go
+++ b/server/start.go
@@ -59,6 +59,16 @@ const (
 	FlagStateSyncSnapshotInterval   = "state-sync.snapshot-interval"
 	FlagStateSyncSnapshotKeepRecent = "state-sync.snapshot-keep-recent"
 
+	// api-related flags
+	flagAPIEnable             = "api.enable"
+	flagAPISwagger            = "api.swagger"
+	flagAPIAddress            = "api.address"
+	flagAPIMaxOpenConnections = "api.max-open-connections"
+	flagRPCReadTimeout        = "api.rpc-read-timeout"
+	flagRPCWriteTimeout       = "api.rpc-write-timeout"
+	flagRPCMaxBodyBytes       = "api.rpc-max-body-bytes"
+	flagAPIEnableUnsafeCORS   = "api.enabled-unsafe-cors"
+
 	// gRPC-related flags
 	flagGRPCOnly       = "grpc-only"
 	flagGRPCEnable     = "grpc.enable"
@@ -152,6 +162,15 @@ is performed. Note, when enabled, gRPC will also be automatically enabled.
 	cmd.Flags().Uint64(FlagPruningInterval, 0, "Height interval at which pruned heights are removed from disk (ignored if pruning is not 'custom')")
 	cmd.Flags().Uint(FlagInvCheckPeriod, 0, "Assert registered invariants every N blocks")
 	cmd.Flags().Uint64(FlagMinRetainBlocks, 0, "Minimum block height offset during ABCI commit to prune Tendermint blocks")
+
+	cmd.Flags().Bool(flagAPIEnable, false, "Define if the API server should be enabled")
+	cmd.Flags().Bool(flagAPISwagger, false, "Define if swagger documentation should automatically be registered (Note: api must also be enabled.)")
+	cmd.Flags().String(flagAPIAddress, config.DefaultAPIAddress, "the API server address to listen on")
+	cmd.Flags().Uint(flagAPIMaxOpenConnections, 1000, "Define the number of maximum open connections")
+	cmd.Flags().Uint(flagRPCReadTimeout, 10, "Define the Tendermint RPC read timeout (in seconds)")
+	cmd.Flags().Uint(flagRPCWriteTimeout, 0, "Define the Tendermint RPC write timeout (in seconds)")
+	cmd.Flags().Uint(flagRPCMaxBodyBytes, 1000000, "Define the Tendermint maximum response body (in bytes)")
+	cmd.Flags().Bool(flagAPIEnableUnsafeCORS, false, "Define if CORS should be enabled (unsafe - use it at your own risk)")
 
 	cmd.Flags().Bool(flagGRPCOnly, false, "Start the node in gRPC query only mode (no Tendermint process is started)")
 	cmd.Flags().Bool(flagGRPCEnable, true, "Define if the gRPC server should be enabled")

--- a/server/start.go
+++ b/server/start.go
@@ -60,14 +60,14 @@ const (
 	FlagStateSyncSnapshotKeepRecent = "state-sync.snapshot-keep-recent"
 
 	// api-related flags
-	flagAPIEnable             = "api.enable"
-	flagAPISwagger            = "api.swagger"
-	flagAPIAddress            = "api.address"
-	flagAPIMaxOpenConnections = "api.max-open-connections"
-	flagRPCReadTimeout        = "api.rpc-read-timeout"
-	flagRPCWriteTimeout       = "api.rpc-write-timeout"
-	flagRPCMaxBodyBytes       = "api.rpc-max-body-bytes"
-	flagAPIEnableUnsafeCORS   = "api.enabled-unsafe-cors"
+	FlagAPIEnable             = "api.enable"
+	FlagAPISwagger            = "api.swagger"
+	FlagAPIAddress            = "api.address"
+	FlagAPIMaxOpenConnections = "api.max-open-connections"
+	FlagRPCReadTimeout        = "api.rpc-read-timeout"
+	FlagRPCWriteTimeout       = "api.rpc-write-timeout"
+	FlagRPCMaxBodyBytes       = "api.rpc-max-body-bytes"
+	FlagAPIEnableUnsafeCORS   = "api.enabled-unsafe-cors"
 
 	// gRPC-related flags
 	flagGRPCOnly       = "grpc-only"
@@ -163,14 +163,14 @@ is performed. Note, when enabled, gRPC will also be automatically enabled.
 	cmd.Flags().Uint(FlagInvCheckPeriod, 0, "Assert registered invariants every N blocks")
 	cmd.Flags().Uint64(FlagMinRetainBlocks, 0, "Minimum block height offset during ABCI commit to prune Tendermint blocks")
 
-	cmd.Flags().Bool(flagAPIEnable, false, "Define if the API server should be enabled")
-	cmd.Flags().Bool(flagAPISwagger, false, "Define if swagger documentation should automatically be registered (Note: api must also be enabled.)")
-	cmd.Flags().String(flagAPIAddress, config.DefaultAPIAddress, "the API server address to listen on")
-	cmd.Flags().Uint(flagAPIMaxOpenConnections, 1000, "Define the number of maximum open connections")
-	cmd.Flags().Uint(flagRPCReadTimeout, 10, "Define the Tendermint RPC read timeout (in seconds)")
-	cmd.Flags().Uint(flagRPCWriteTimeout, 0, "Define the Tendermint RPC write timeout (in seconds)")
-	cmd.Flags().Uint(flagRPCMaxBodyBytes, 1000000, "Define the Tendermint maximum response body (in bytes)")
-	cmd.Flags().Bool(flagAPIEnableUnsafeCORS, false, "Define if CORS should be enabled (unsafe - use it at your own risk)")
+	cmd.Flags().Bool(FlagAPIEnable, false, "Define if the API server should be enabled")
+	cmd.Flags().Bool(FlagAPISwagger, false, "Define if swagger documentation should automatically be registered (Note: api must also be enabled.)")
+	cmd.Flags().String(FlagAPIAddress, config.DefaultAPIAddress, "the API server address to listen on")
+	cmd.Flags().Uint(FlagAPIMaxOpenConnections, 1000, "Define the number of maximum open connections")
+	cmd.Flags().Uint(FlagRPCReadTimeout, 10, "Define the Tendermint RPC read timeout (in seconds)")
+	cmd.Flags().Uint(FlagRPCWriteTimeout, 0, "Define the Tendermint RPC write timeout (in seconds)")
+	cmd.Flags().Uint(FlagRPCMaxBodyBytes, 1000000, "Define the Tendermint maximum response body (in bytes)")
+	cmd.Flags().Bool(FlagAPIEnableUnsafeCORS, false, "Define if CORS should be enabled (unsafe - use it at your own risk)")
 
 	cmd.Flags().Bool(flagGRPCOnly, false, "Start the node in gRPC query only mode (no Tendermint process is started)")
 	cmd.Flags().Bool(flagGRPCEnable, true, "Define if the gRPC server should be enabled")


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

This PR will add api server flags to start command so we can enable api directly from command instead of modifying app.toml.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [x] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)