### PR TITLE
cli: fix` --dry-run` not working when using tx command

### DIFF
--- a/client/cmd.go
+++ b/client/cmd.go
@@ -248,7 +248,7 @@ func readTxCommandFlags(clientCtx Context, flagSet *pflag.FlagSet) (Context, err
 
 	if clientCtx.From == "" || flagSet.Changed(flags.FlagFrom) {
 		from, _ := flagSet.GetString(flags.FlagFrom)
-		fromAddr, fromName, keyType, err := GetFromFields(clientCtx.Keyring, from, clientCtx.GenerateOnly)
+		fromAddr, fromName, keyType, err := GetFromFields(clientCtx.Keyring, from, clientCtx.Simulate)
 		if err != nil {
 			return clientCtx, err
 		}

--- a/client/context_test.go
+++ b/client/context_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/codec/types"
+	"github.com/cosmos/cosmos-sdk/crypto/hd"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	"github.com/cosmos/cosmos-sdk/testutil/network"
 	"github.com/cosmos/cosmos-sdk/testutil/testdata"
@@ -113,4 +114,79 @@ func TestCLIQueryConn(t *testing.T) {
 	res, err := testClient.Echo(context.Background(), &testdata.EchoRequest{Message: "hello"})
 	require.NoError(t, err)
 	require.Equal(t, "hello", res.Message)
+}
+
+func TestGetFromFields(t *testing.T) {
+	cfg := network.DefaultConfig()
+	path := hd.CreateHDPath(118, 0, 0).String()
+
+	testCases := []struct {
+		keyring     func() keyring.Keyring
+		from        string
+		expectedErr string
+		simulate    bool
+	}{
+		{
+			keyring: func() keyring.Keyring {
+				kb := keyring.NewInMemory(cfg.Codec)
+
+				_, _, err := kb.NewMnemonic("alice", keyring.English, path, keyring.DefaultBIP39Passphrase, hd.Secp256k1)
+				require.NoError(t, err)
+
+				return kb
+			},
+			from: "alice",
+		},
+		{
+			keyring: func() keyring.Keyring {
+				return keyring.NewInMemory(cfg.Codec)
+			},
+			from:        "cosmos139f7kncmglres2nf3h4hc4tade85ekfr8sulz5",
+			expectedErr: "key with address cosmos139f7kncmglres2nf3h4hc4tade85ekfr8sulz5 not found: key not found",
+		},
+		{
+			keyring: func() keyring.Keyring {
+				kb, err := keyring.New(t.Name(), keyring.BackendTest, t.TempDir(), nil, cfg.Codec)
+				require.NoError(t, err)
+
+				_, _, err = kb.NewMnemonic("bob", keyring.English, path, keyring.DefaultBIP39Passphrase, hd.Secp256k1)
+				require.NoError(t, err)
+
+				return kb
+			},
+			from: "bob",
+		},
+		{
+			keyring: func() keyring.Keyring {
+				kb, err := keyring.New(t.Name(), keyring.BackendTest, t.TempDir(), nil, cfg.Codec)
+				require.NoError(t, err)
+				return kb
+			},
+			from:        "bob",
+			expectedErr: "bob.info: key not found",
+		},
+		{
+			keyring: func() keyring.Keyring {
+				return keyring.NewInMemory(cfg.Codec)
+			},
+			from:     "alice",
+			simulate: true,
+		},
+		{
+			keyring: func() keyring.Keyring {
+				return keyring.NewInMemory(cfg.Codec)
+			},
+			from:     "cosmos139f7kncmglres2nf3h4hc4tade85ekfr8sulz5",
+			simulate: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		_, _, _, err := client.GetFromFields(tc.keyring(), tc.from, tc.simulate)
+		if tc.expectedErr == "" {
+			require.NoError(t, err)
+		} else {
+			require.Equal(t, tc.expectedErr, err.Error())
+		}
+	}
 }

--- a/x/auth/client/cli/tx_sign.go
+++ b/x/auth/client/cli/tx_sign.go
@@ -106,7 +106,7 @@ func makeSignBatchCmd() func(cmd *cobra.Command, args []string) error {
 			}
 			if ms == "" {
 				from, _ := cmd.Flags().GetString(flags.FlagFrom)
-				_, fromName, _, err := client.GetFromFields(txFactory.Keybase(), from, clientCtx.GenerateOnly)
+				_, fromName, _, err := client.GetFromFields(txFactory.Keybase(), from, clientCtx.Simulate)
 				if err != nil {
 					return fmt.Errorf("error getting account from keybase: %w", err)
 				}
@@ -115,7 +115,7 @@ func makeSignBatchCmd() func(cmd *cobra.Command, args []string) error {
 					return err
 				}
 			} else {
-				multisigAddr, _, _, err := client.GetFromFields(txFactory.Keybase(), ms, clientCtx.GenerateOnly)
+				multisigAddr, _, _, err := client.GetFromFields(txFactory.Keybase(), ms, clientCtx.Simulate)
 				if err != nil {
 					return fmt.Errorf("error getting account from keybase: %w", err)
 				}
@@ -235,7 +235,7 @@ func makeSignCmd() func(cmd *cobra.Command, args []string) error {
 			return err
 		}
 		from, _ := cmd.Flags().GetString(flags.FlagFrom)
-		_, fromName, _, err := client.GetFromFields(txF.Keybase(), from, clientCtx.GenerateOnly)
+		_, fromName, _, err := client.GetFromFields(txF.Keybase(), from, clientCtx.Simulate)
 		if err != nil {
 			return fmt.Errorf("error getting account from keybase: %w", err)
 		}
@@ -245,7 +245,7 @@ func makeSignCmd() func(cmd *cobra.Command, args []string) error {
 			multisigAddr, err := sdk.AccAddressFromBech32(multisig)
 			if err != nil {
 				// Bech32 decode error, maybe it's a name, we try to fetch from keyring
-				multisigAddr, _, _, err = client.GetFromFields(txFactory.Keybase(), multisig, clientCtx.GenerateOnly)
+				multisigAddr, _, _, err = client.GetFromFields(txFactory.Keybase(), multisig, clientCtx.Simulate)
 				if err != nil {
 					return fmt.Errorf("error getting account from keybase: %w", err)
 				}

--- a/x/bank/client/cli/tx.go
+++ b/x/bank/client/cli/tx.go
@@ -38,6 +38,7 @@ ignored as it is implied from [from_key_or_address].`,
 			if err != nil {
 				return err
 			}
+
 			toAddr, err := sdk.AccAddressFromBech32(args[1])
 			if err != nil {
 				return err

--- a/x/feegrant/client/testutil/suite.go
+++ b/x/feegrant/client/testutil/suite.go
@@ -316,7 +316,7 @@ func (s *IntegrationTestSuite) TestNewCmdFeeGrant() {
 	alreadyExistedGrantee := s.addedGrantee
 	clientCtx := val.ClientCtx
 
-	fromAddr, fromName, _, err := client.GetFromFields(clientCtx.Keyring, granter.String(), clientCtx.GenerateOnly)
+	fromAddr, fromName, _, err := client.GetFromFields(clientCtx.Keyring, granter.String(), clientCtx.Simulate)
 	s.Require().Equal(fromAddr, granter)
 	s.Require().NoError(err)
 


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

Closes: #11149

Automatically generate keys when using `--dry-run`.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [x] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [x] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)