### PR TITLE
fix: Make module queries deterministic

### DIFF
--- a/x/auth/keeper/grpc_query.go
+++ b/x/auth/keeper/grpc_query.go
@@ -95,7 +95,7 @@ func (ak AccountKeeper) ModuleAccounts(c context.Context, req *types.QueryModule
 
 	ctx := sdk.UnwrapSDKContext(c)
 
-	// For deterministic output, sort the permAddrs by permission name.
+	// For deterministic output, sort the permAddrs by module name.
 	var sortedPermAddrs []string
 	for moduleName := range ak.permAddrs {
 		sortedPermAddrs = append(sortedPermAddrs, moduleName)

--- a/x/auth/keeper/grpc_query.go
+++ b/x/auth/keeper/grpc_query.go
@@ -96,7 +96,7 @@ func (ak AccountKeeper) ModuleAccounts(c context.Context, req *types.QueryModule
 	ctx := sdk.UnwrapSDKContext(c)
 
 	// For deterministic output, sort the permAddrs by module name.
-	var sortedPermAddrs []string
+	sortedPermAddrs := make([]string, 0, len(ak.permAddrs))
 	for moduleName := range ak.permAddrs {
 		sortedPermAddrs = append(sortedPermAddrs, moduleName)
 	}

--- a/x/auth/keeper/grpc_query.go
+++ b/x/auth/keeper/grpc_query.go
@@ -3,6 +3,7 @@ package keeper
 import (
 	"context"
 	"errors"
+	"sort"
 	"strings"
 
 	"github.com/cosmos/cosmos-sdk/store/prefix"
@@ -94,9 +95,16 @@ func (ak AccountKeeper) ModuleAccounts(c context.Context, req *types.QueryModule
 
 	ctx := sdk.UnwrapSDKContext(c)
 
+	// For deterministic output, sort the permAddrs by permission name.
+	var sortedPermAddrs []string
+	for moduleName := range ak.permAddrs {
+		sortedPermAddrs = append(sortedPermAddrs, moduleName)
+	}
+	sort.Strings(sortedPermAddrs)
+
 	modAccounts := make([]*codectypes.Any, 0, len(ak.permAddrs))
 
-	for moduleName := range ak.permAddrs {
+	for _, moduleName := range sortedPermAddrs {
 		account := ak.GetModuleAccount(ctx, moduleName)
 		if account == nil {
 			return nil, status.Errorf(codes.NotFound, "account %s not found", moduleName)

--- a/x/auth/keeper/grpc_query_test.go
+++ b/x/auth/keeper/grpc_query_test.go
@@ -1,9 +1,10 @@
 package keeper_test
 
 import (
-	"fmt"
-	"context"
 	"bytes"
+	"context"
+	"fmt"
+	"sort"
 
 	"github.com/cosmos/cosmos-sdk/testutil/testdata"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -11,6 +12,7 @@ import (
 )
 
 const addrStr = "cosmos13c3d4wq2t22dl0dstraf8jc3f902e3fsy9n3wv"
+
 var addrBytes = []byte{0x8e, 0x22, 0xda, 0xb8, 0xa, 0x5a, 0x94, 0xdf, 0xbd, 0xb0, 0x58, 0xfa, 0x93, 0xcb, 0x11, 0x49, 0x5e, 0xac, 0xc5, 0x30}
 
 func (suite *KeeperTestSuite) TestGRPCQueryAccounts() {
@@ -268,6 +270,17 @@ func (suite *KeeperTestSuite) TestGRPCQueryModuleAccounts() {
 			if tc.expPass {
 				suite.Require().NoError(err)
 				suite.Require().NotNil(res)
+				// Make sure output is sorted alphabetically.
+				var moduleNames []string
+				for _, any := range res.Accounts {
+					var account types.AccountI
+					err := suite.app.InterfaceRegistry().UnpackAny(any, &account)
+					suite.Require().NoError(err)
+					moduleAccount, ok := account.(types.ModuleAccountI)
+					suite.Require().True(ok)
+					moduleNames = append(moduleNames, moduleAccount.GetName())
+				}
+				suite.Require().True(sort.StringsAreSorted(moduleNames))
 			} else {
 				suite.Require().Error(err)
 				suite.Require().Nil(res)
@@ -289,9 +302,9 @@ func (suite *KeeperTestSuite) TestBech32Prefix() {
 
 func (suite *KeeperTestSuite) TestAddressBytesToString() {
 	testCases := []struct {
-		msg       string
-		req       *types.AddressBytesToStringRequest
-		expPass   bool
+		msg     string
+		req     *types.AddressBytesToStringRequest
+		expPass bool
 	}{
 		{
 			"success",
@@ -331,9 +344,9 @@ func (suite *KeeperTestSuite) TestAddressBytesToString() {
 
 func (suite *KeeperTestSuite) TestAddressStringToBytes() {
 	testCases := []struct {
-		msg       string
-		req       *types.AddressStringToBytesRequest
-		expPass   bool
+		msg     string
+		req     *types.AddressStringToBytesRequest
+		expPass bool
 	}{
 		{
 			"success",
@@ -352,10 +365,9 @@ func (suite *KeeperTestSuite) TestAddressStringToBytes() {
 		},
 		{
 			"address prefix is incorrect",
-			&types.AddressStringToBytesRequest{AddressString: "regen13c3d4wq2t22dl0dstraf8jc3f902e3fsy9n3wv" },
+			&types.AddressStringToBytesRequest{AddressString: "regen13c3d4wq2t22dl0dstraf8jc3f902e3fsy9n3wv"},
 			false,
 		},
-
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

The Juno halt was caused by a smart contract calling a SDK's gRPC query that was not deterministic (at least that's my understanding).

As such, a fix was proposed on cosmwasm to whitelist only the gRPC queries that are deterministic. For example, gRPC queries that return node-specific config would not be whitelisted.

In my opinion, all module queries MUST be deterministic, since they can be part of the state machine. This PR will also help adr-033.

i made a quick audit of all `x/*` grpc_query.go, to make sure all of them were deterministic. The only non-determinism I found was in auth's ModuleAccount, but it's introduced in v0.46 and not released yet.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)