### PR TITLE
fix(cli): home flag gets ignored when running help

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -211,6 +211,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### Bug Fixes
 
 * [\#11693](https://github.com/cosmos/cosmos-sdk/pull/11693) Add validation for gentx cmd.
+* [\#11645](https://github.com/cosmos/cosmos-sdk/pull/11645) Fix `--home` flag ignored when running help.
 * [\#11558](https://github.com/cosmos/cosmos-sdk/pull/11558) Fix `--dry-run` not working when using tx command.
 * [\#11354](https://github.com/cosmos/cosmos-sdk/pull/11355) Added missing pagination flag for `bank q total` query.
 * [\#11197](https://github.com/cosmos/cosmos-sdk/pull/11197) Signing with multisig now works with multisig address which is not in the keyring.

--- a/client/cmd.go
+++ b/client/cmd.go
@@ -93,6 +93,12 @@ func ReadPersistentCommandFlags(clientCtx Context, flagSet *pflag.FlagSet) (Cont
 		clientCtx = clientCtx.WithOutputFormat(output)
 	}
 
+	fmt.Println("-------------------------")
+	fmt.Println(clientCtx.HomeDir)
+	fmt.Println(flagSet.Changed(flags.FlagHome))
+	fmt.Println(flagSet.GetString(flags.FlagHome))
+	fmt.Println("-------------------------")
+
 	if clientCtx.HomeDir == "" || flagSet.Changed(flags.FlagHome) {
 		homeDir, _ := flagSet.GetString(flags.FlagHome)
 		clientCtx = clientCtx.WithHomeDir(homeDir)

--- a/client/cmd.go
+++ b/client/cmd.go
@@ -93,12 +93,6 @@ func ReadPersistentCommandFlags(clientCtx Context, flagSet *pflag.FlagSet) (Cont
 		clientCtx = clientCtx.WithOutputFormat(output)
 	}
 
-	fmt.Println("-------------------------")
-	fmt.Println(clientCtx.HomeDir)
-	fmt.Println(flagSet.Changed(flags.FlagHome))
-	fmt.Println(flagSet.GetString(flags.FlagHome))
-	fmt.Println("-------------------------")
-
 	if clientCtx.HomeDir == "" || flagSet.Changed(flags.FlagHome) {
 		homeDir, _ := flagSet.GetString(flags.FlagHome)
 		clientCtx = clientCtx.WithHomeDir(homeDir)
@@ -125,6 +119,8 @@ func ReadPersistentCommandFlags(clientCtx Context, flagSet *pflag.FlagSet) (Cont
 		chainID, _ := flagSet.GetString(flags.FlagChainID)
 		clientCtx = clientCtx.WithChainID(chainID)
 	}
+
+	fmt.Println(clientCtx.ChainID)
 
 	if clientCtx.Keyring == nil || flagSet.Changed(flags.FlagKeyringBackend) {
 		keyringBackend, _ := flagSet.GetString(flags.FlagKeyringBackend)

--- a/client/cmd.go
+++ b/client/cmd.go
@@ -120,8 +120,6 @@ func ReadPersistentCommandFlags(clientCtx Context, flagSet *pflag.FlagSet) (Cont
 		clientCtx = clientCtx.WithChainID(chainID)
 	}
 
-	fmt.Println(clientCtx.ChainID)
-
 	if clientCtx.Keyring == nil || flagSet.Changed(flags.FlagKeyringBackend) {
 		keyringBackend, _ := flagSet.GetString(flags.FlagKeyringBackend)
 

--- a/client/cmd_test.go
+++ b/client/cmd_test.go
@@ -70,6 +70,7 @@ func TestSetCmdClientContextHandler(t *testing.T) {
 		}
 
 		c.Flags().String(flags.FlagChainID, "", "network chain ID")
+		c.Flags().String(flags.FlagHome, "", "home dir")
 
 		return c
 	}
@@ -89,6 +90,14 @@ func TestSetCmdClientContextHandler(t *testing.T) {
 			initClientCtx.WithChainID("new-chain-id"),
 			[]string{
 				fmt.Sprintf("--%s=new-chain-id", flags.FlagChainID),
+			},
+		},
+		{
+			"flags set with space",
+			initClientCtx.WithHomeDir("/tmp/dir"),
+			[]string{
+				fmt.Sprintf("--%s", flags.FlagHome),
+				"/tmp/dir",
 			},
 		},
 	}

--- a/simapp/simd/cmd/cmd_test.go
+++ b/simapp/simd/cmd/cmd_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/cosmos/cosmos-sdk/client/flags"
 	svrcmd "github.com/cosmos/cosmos-sdk/server/cmd"
 	"github.com/cosmos/cosmos-sdk/simapp"
 	"github.com/cosmos/cosmos-sdk/simapp/simd/cmd"
@@ -21,4 +22,21 @@ func TestInitCmd(t *testing.T) {
 	})
 
 	require.NoError(t, svrcmd.Execute(rootCmd, "", simapp.DefaultNodeHome))
+}
+
+func TestHomeFlagRegistration(t *testing.T) {
+	homeDir := "/tmp/foo"
+
+	rootCmd, _ := cmd.NewRootCmd()
+
+	rootCmd.SetArgs([]string{
+		"query",
+		fmt.Sprintf("--home %s", homeDir),
+	})
+
+	require.NoError(t, svrcmd.Execute(rootCmd, "", simapp.DefaultNodeHome))
+
+	result, err := rootCmd.Flags().GetString(flags.FlagHome)
+	require.NoError(t, err)
+	require.Equal(t, result, homeDir)
 }

--- a/simapp/simd/cmd/cmd_test.go
+++ b/simapp/simd/cmd/cmd_test.go
@@ -31,7 +31,8 @@ func TestHomeFlagRegistration(t *testing.T) {
 
 	rootCmd.SetArgs([]string{
 		"query",
-		fmt.Sprintf("--home %s", homeDir),
+		fmt.Sprintf("--%s", flags.FlagHome),
+		homeDir,
 	})
 
 	require.NoError(t, svrcmd.Execute(rootCmd, "", simapp.DefaultNodeHome))

--- a/simapp/simd/cmd/root.go
+++ b/simapp/simd/cmd/root.go
@@ -192,7 +192,7 @@ func queryCommand() *cobra.Command {
 		Use:                        "query",
 		Aliases:                    []string{"q"},
 		Short:                      "Querying subcommands",
-		DisableFlagParsing:         true,
+		DisableFlagParsing:         false,
 		SuggestionsMinimumDistance: 2,
 		RunE:                       client.ValidateCmd,
 	}
@@ -215,7 +215,7 @@ func txCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:                        "tx",
 		Short:                      "Transactions subcommands",
-		DisableFlagParsing:         true,
+		DisableFlagParsing:         false,
 		SuggestionsMinimumDistance: 2,
 		RunE:                       client.ValidateCmd,
 	}


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

Closes: #11508

- [x] Consider `--home` flag when running help for transaction and queries
- [ ] Do not create a folder when making queries, but ensure an environment variable / configuration folder / `--node` flag exists. (**WIP** tbd if done here or in follow-up)

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [x] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules)
- [x] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [x] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [x] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)