### PR TITLE
fix: normalize timestamps before roundtrip

### DIFF
--- a/fuzz/tests/types_parsetimebytes_test.go
+++ b/fuzz/tests/types_parsetimebytes_test.go
@@ -12,13 +12,20 @@ import (
 
 func FuzzTypesParseTimeBytes(f *testing.F) {
 	f.Fuzz(func(t *testing.T, bin []byte) {
+		// Normalize input, reject invalid timestamps.
 		ti, err := types.ParseTimeBytes(bin)
 		if err != nil {
 			return
 		}
 		brt := types.FormatTimeBytes(ti)
-		if !bytes.Equal(brt, bin) {
-			panic(fmt.Sprintf("Roundtrip failure, got\n%s", brt))
+		// Check that roundtripping a normalized timestamp doesn't change it.
+		ti2, err := types.ParseTimeBytes(brt)
+		if err != nil {
+			panic(fmt.Errorf("failed to parse formatted time %q: %w", brt, err))
+		}
+		brt2 := types.FormatTimeBytes(ti2)
+		if !bytes.Equal(brt, brt2) {
+			panic(fmt.Sprintf("Roundtrip failure, got\n%q\nwant\n%q", brt, brt2))
 		}
 	})
 }


### PR DESCRIPTION
CC @odeke-em. This fixes the fuzzing false positives such as `0600-06-01T0:51:07.000600600` vs `0600-06-01T00:51:07.000600600` as [you diagnosed](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=33530) on the OSS-Fuzz tracker.