### PR TITLE
fix(group): Better error logs for MsgExec

### DIFF
--- a/x/group/keeper/msg_server.go
+++ b/x/group/keeper/msg_server.go
@@ -752,7 +752,7 @@ func (k Keeper) Exec(goCtx context.Context, req *group.MsgExec) (*group.MsgExecR
 		_, err = k.doExecuteMsgs(ctx, k.router, proposal, addr)
 		if err != nil {
 			proposal.ExecutorResult = group.PROPOSAL_EXECUTOR_RESULT_FAILURE
-			logs = fmt.Sprintf("proposal execution failed on proposal %d, because of error %+v", id, err)
+			logs = fmt.Sprintf("proposal execution failed on proposal %d, because of error %s", id, err.Error())
 			k.Logger(ctx).Info("proposal execution failed", "cause", err, "proposalID", id)
 		} else {
 			proposal.ExecutorResult = group.PROPOSAL_EXECUTOR_RESULT_SUCCESS

--- a/x/group/keeper/proposal_executor.go
+++ b/x/group/keeper/proposal_executor.go
@@ -39,7 +39,7 @@ func (s Keeper) doExecuteMsgs(ctx sdk.Context, router *authmiddleware.MsgService
 		}
 		r, err := handler(ctx, msg)
 		if err != nil {
-			return nil, errors.Wrapf(err, "message %q at position %d", msg, i)
+			return nil, errors.Wrapf(err, "message %s at position %d", sdk.MsgTypeURL(msg), i)
 		}
 		// Handler should always return non-nil sdk.Result.
 		if r == nil {


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

ref: #10968 

Before, the event on MsgExec failure looks like:

```
{
          "key": "logs",
          "value": "\"proposal execution failed on proposal 2, because of error \\ngithub.com/cosmos/cosmos-sdk/x/bank/keeper.BaseSendKeeper.subUnlockedCoins\\n\\t/Users/amaury/Workspace/regen/cosmos-sdk/x/bank/keeper/send.go:192\\ngithub.com/cosmos/cosmos-sdk/x/bank/keeper.BaseSendKeeper.SendCoins\\n\\t/Users/amaury/Workspace/regen/cosmos-sdk/x/bank/keeper/send.go:137\\ngithub.com/cosmos/cosmos-sdk/x/bank/keeper.msgServer.Send\\n\\t/Users/amaury/Workspace/regen/cosmos-sdk/x/bank/keeper/msg_server.go:46\\ngithub.com/cosmos/cosmos-sdk/x/bank/types._Msg_Send_Handler.func1\\n\\t/Users/amaury/Workspace/regen/cosmos-sdk/x/bank/types/tx.pb.go:324\\ngithub.com/cosmos/cosmos-sdk/x/auth/middleware.(*MsgServiceRouter).RegisterService.func2.1\\n\\t/Users/amaury/Workspace/regen/cosmos-sdk/x/auth/middleware/msg_service_router.go:114\\ngithub.com/cosmos/cosmos-sdk/x/bank/types._Msg_Send_Handler\\n\\t/Users/amaury/Workspace/regen/cosmos-sdk/x/bank/types/tx.pb.go:326\\ngithub.com/cosmos/cosmos-sdk/x/auth/middleware.(*MsgServiceRouter).RegisterService.func2\\n\\t/Users/amaury/Workspace/regen/cosmos-sdk/x/auth/middleware/msg_service_router.go:118\\ngithub.com/cosmos/cosmos-sdk/x/group/keeper.Keeper.doExecuteMsgs\\n\\t/Users/amaury/Workspace/regen/cosmos-sdk/x/group/keeper/proposal_executor.go:40\\ngithub.com/cosmos/cosmos-sdk/x/group/keeper.Keeper.Exec\\n\\t/Users/amaury/Workspace/regen/cosmos-sdk/x/group/keeper/msg_server.go:752\\ngithub.com/cosmos/cosmos-sdk/x/group._Msg_Exec_Handler.func1\\n\\t/Users/amaury/Workspace/regen/cosmos-sdk/x/group/tx.pb.go:2069\\ngithub.com/cosmos/cosmos-sdk/x/auth/middleware.(*MsgServiceRouter).RegisterService.func2.1\\n\\t/Users/amaury/Workspace/regen/cosmos-sdk/x/auth/middleware/msg_service_router.go:114\\ngithub.com/cosmos/cosmos-sdk/x/group._Msg_Exec_Handler\\n\\t/Users/amaury/Workspace/regen/cosmos-sdk/x/group/tx.pb.go:2071\\ngithub.com/cosmos/cosmos-sdk/x/auth/middleware.(*MsgServiceRouter).RegisterService.func2\\n\\t/Users/amaury/Workspace/regen/cosmos-sdk/x/auth/middleware/msg_service_router.go:118\\ngithub.com/cosmos/cosmos-sdk/x/auth/middleware.runMsgsTxHandler.runMsgs\\n\\t/Users/amaury/Workspace/regen/cosmos-sdk/x/auth/middleware/run_msgs.go:67\\ngithub.com/cosmos/cosmos-sdk/x/auth/middleware.runMsgsTxHandler.DeliverTx\\n\\t/Users/amaury/Workspace/regen/cosmos-sdk/x/auth/middleware/run_msgs.go:36\\ngithub.com/cosmos/cosmos-sdk/x/auth/middleware.tipsTxHandler.DeliverTx\\n\\t/Users/amaury/Workspace/regen/cosmos-sdk/x/auth/middleware/tips.go:36\\ngithub.com/cosmos/cosmos-sdk/x/auth/middleware.consumeBlockGasHandler.DeliverTx\\n\\t/Users/amaury/Workspace/regen/cosmos-sdk/x/auth/middleware/block_gas.go:47\\ngithub.com/cosmos/cosmos-sdk/x/auth/middleware.branchAndRun\\n\\t/Users/amaury/Workspace/regen/cosmos-sdk/x/auth/middleware/branch_store.go:45\\ngithub.com/cosmos/cosmos-sdk/x/auth/middleware.branchStoreHandler.DeliverTx\\n\\t/Users/amaury/Workspace/regen/cosmos-sdk/x/auth/middleware/branch_store.go:29\\ngithub.com/cosmos/cosmos-sdk/x/auth/middleware.incrementSequenceTxHandler.DeliverTx\\n\\t/Users/amaury/Workspace/regen/cosmos-sdk/x/auth/middleware/sigverify.go:604\\ngithub.com/cosmos/cosmos-sdk/x/auth/middleware.sigVerificationTxHandler.DeliverTx\\n\\t/Users/amaury/Workspace/regen/cosmos-sdk/x/auth/middleware/sigverify.go:532\\ngithub.com/cosmos/cosmos-sdk/x/auth/middleware.sigGasConsumeTxHandler.DeliverTx\\n\\t/Users/amaury/Workspace/regen/cosmos-sdk/x/auth/middleware/sigverify.go:380\\ngithub.com/cosmos/cosmos-sdk/x/auth/middleware.validateSigCountTxHandler.DeliverTx\\n\\t/Users/amaury/Workspace/regen/cosmos-sdk/x/auth/middleware/sigverify.go:213\\ngithub.com/cosmos/cosmos-sdk/x/auth/middleware.setPubKeyTxHandler.DeliverTx\\n\\t/Users/amaury/Workspace/regen/cosmos-sdk/x/auth/middleware/sigverify.go:142\\ngithub.com/cosmos/cosmos-sdk/x/auth/middleware.deductFeeTxHandler.DeliverTx\\n\\t/Users/amaury/Workspace/regen/cosmos-sdk/x/auth/middleware/fee.go:124\\ngithub.com/cosmos/cosmos-sdk/x/auth/middleware.consumeTxSizeGasTxHandler.DeliverTx\\n\\t/Users/amaury/Workspace/regen/cosmos-sdk/x/auth/middleware/basic.go:322\\ngithub.com/cosmos/cosmos-sdk/x/auth/middleware.validateMemoTxHandler.DeliverTx\\n\\t/Users/amaury/Workspace/regen/cosmos-sdk/x/auth/middleware/basic.go:207\\ngithub.com/cosmos/cosmos-sdk/x/auth/middleware.txTimeoutHeightTxHandler.DeliverTx\\n\\t/Users/amaury/Workspace/regen/cosmos-sdk/x/auth/middleware/basic.go:141\\ngithub.com/cosmos/cosmos-sdk/x/auth/middleware.validateBasicTxHandler.DeliverTx\\n\\t/Users/amaury/Workspace/regen/cosmos-sdk/x/auth/middleware/basic.go:79\\ngithub.com/cosmos/cosmos-sdk/x/auth/middleware.rejectExtensionOptionsTxHandler.DeliverTx\\n\\t/Users/amaury/Workspace/regen/cosmos-sdk/x/auth/middleware/ext.go:76\\nmessage \\\"from_address:\\\\\\\"cosmos142498n8sya3k3s5jftp7dujuqfw3ag4tpzc2ve45ykpwx6zmng8sn2mzmw\\\\\\\" to_address:\\\\\\\"cosmos1uce9j2nwcsvr5asrpayxx57tjzkj8ctf2cm77r\\\\\\\" amount:\\u003cdenom:\\\\\\\"stake\\\\\\\" amount:\\\\\\\"10\\\\\\\" \\u003e \\\" at position 0: 0stake is smaller than 10stake: insufficient funds\"",
          "index": true
        }
```

After, it looks like:

```
 {
          "key": "logs",
          "value": "\"proposal execution failed on proposal 2, because of error message /cosmos.bank.v1beta1.MsgSend at position 0: 0stake is smaller than 10stake: insufficient funds\"",
          "index": true
        }
```

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
