### PR TITLE
chore: update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,7 +18,7 @@ updates:
     interval: daily
   open-pull-requests-limit: 10
   labels:
-  - automerge
+  - "A:automerge"
   - dependencies
 - package-ecosystem: gomod
   directory: "/db"
@@ -26,7 +26,7 @@ updates:
     interval: daily
   open-pull-requests-limit: 10
   labels:
-  - automerge
+  - "A:automerge"
   - dependencies
 - package-ecosystem: gomod
   directory: "/api"
@@ -34,7 +34,7 @@ updates:
     interval: daily
   open-pull-requests-limit: 10
   labels:
-  - automerge
+  - "A:automerge"
   - dependencies
 - package-ecosystem: gomod
   directory: "/orm"
@@ -42,7 +42,7 @@ updates:
     interval: daily
   open-pull-requests-limit: 10
   labels:
-  - automerge
+  - "A:automerge"
   - dependencies
 - package-ecosystem: gomod
   directory: "/container"
@@ -50,7 +50,7 @@ updates:
     interval: daily
   open-pull-requests-limit: 10
   labels:
-  - automerge
+  - "A:automerge"
   - dependencies
 - package-ecosystem: gomod
   directory: "/cosmovisor"
@@ -58,5 +58,5 @@ updates:
     interval: daily
   open-pull-requests-limit: 10
   labels:
-  - automerge
+  - "A:automerge"
   - dependencies


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

Fix automerge label

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
