### PR TITLE
ci: don't spend too much time on absurd long HD derivation paths

### DIFF
--- a/fuzz/tests/crypto_hd_deriveprivatekeyforpath_test.go
+++ b/fuzz/tests/crypto_hd_deriveprivatekeyforpath_test.go
@@ -21,6 +21,12 @@ func FuzzCryptoHDDerivePrivateKeyForPath(f *testing.F) {
 			return
 		}
 		mnemonic, path := splits[0], splits[1]
+		if len(path) > 1e5 {
+			// Deriving a private key takes non-trivial time proportional
+			// to the path length. Skip the longer ones that trigger timeouts
+			// on fuzzing infrastructure.
+			return
+		}
 		seed := mnemonicToSeed(string(mnemonic))
 		master, ch := hd.ComputeMastersFromSeed(seed)
 		hd.DerivePrivateKeyForPath(master, ch, string(path))


### PR DESCRIPTION
Very long (~1e6) paths trigger timeouts on the OSS-Fuzz infrastructure
and is not worth spending time on.

CC @odeke-em 