### PR TITLE
fix(container)!: fix issue providing a module-scoped dep from a module

### DIFF
--- a/container/container.go
+++ b/container/container.go
@@ -133,6 +133,8 @@ func (c *container) getResolver(typ reflect.Type) (resolver, error) {
 	return c.resolvers[typ], nil
 }
 
+var stringType = reflect.TypeOf("")
+
 func (c *container) addNode(provider *ProviderDescriptor, key *moduleKey) (interface{}, error) {
 	providerGraphNode, err := c.locationGraphNode(provider.Location, key)
 	if err != nil {
@@ -140,10 +142,15 @@ func (c *container) addNode(provider *ProviderDescriptor, key *moduleKey) (inter
 	}
 
 	hasModuleKeyParam := false
+	hasOwnModuleKeyParam := false
 	for _, in := range provider.Inputs {
 		typ := in.Type
 		if typ == moduleKeyType {
 			hasModuleKeyParam = true
+		}
+
+		if typ == ownModuleKeyType {
+			hasOwnModuleKeyParam = true
 		}
 
 		if isAutoGroupType(typ) {
@@ -170,7 +177,7 @@ func (c *container) addNode(provider *ProviderDescriptor, key *moduleKey) (inter
 		c.addGraphEdge(typeGraphNode, providerGraphNode)
 	}
 
-	if key != nil || !hasModuleKeyParam {
+	if !hasModuleKeyParam {
 		c.logf("Registering %s", provider.Location.String())
 		c.indentLogger()
 		defer c.dedentLogger()
@@ -226,6 +233,11 @@ func (c *container) addNode(provider *ProviderDescriptor, key *moduleKey) (inter
 
 		return sp, nil
 	} else {
+		if hasOwnModuleKeyParam {
+			return nil, errors.Errorf("%T and %T must not be declared as dependencies on the same provided",
+				ModuleKey{}, OwnModuleKey{})
+		}
+
 		c.logf("Registering module-scoped provider: %s", provider.Location.String())
 		c.indentLogger()
 		defer c.dedentLogger()
@@ -311,6 +323,15 @@ func (c *container) resolve(in ProviderInput, moduleKey *moduleKey, caller Locat
 		c.logf("Providing ModuleKey %s", moduleKey.name)
 		markGraphNodeAsUsed(typeGraphNode)
 		return reflect.ValueOf(ModuleKey{moduleKey}), nil
+	}
+
+	if in.Type == ownModuleKeyType {
+		if moduleKey == nil {
+			return reflect.Value{}, errors.Errorf("trying to resolve %T for %s but not inside of any module's scope", moduleKey, caller)
+		}
+		c.logf("Providing OwnModuleKey %s", moduleKey.name)
+		markGraphNodeAsUsed(typeGraphNode)
+		return reflect.ValueOf(OwnModuleKey{moduleKey}), nil
 	}
 
 	vr, err := c.getResolver(in.Type)

--- a/container/module_key.go
+++ b/container/module_key.go
@@ -6,14 +6,17 @@ import (
 
 // ModuleKey is a special type used to scope a provider to a "module".
 //
-// Special module-scoped providers can be used with Provide by declaring a
-// provider with an input parameter of type ModuleKey. These providers
-// may construct a unique value of a dependency for each module and will
-// be called at most once per module.
+// Special module-scoped providers can be used with Provide and ProvideInModule
+// by declaring a provider with an input parameter of type ModuleKey. These
+// providers may construct a unique value of a dependency for each module and
+// will be called at most once per module.
 //
-// Providers passed to ProvideInModule can also declare an input parameter
-// of type ModuleKey to retrieve their module key but these providers will be
-// called at most once.
+// When being used with ProvideInModule, the provider will not receive its
+// own ModuleKey but rather the key of the module requesting the dependency
+// so that modules can provide module-scoped dependencies to other modules.
+//
+// In order for a module to retrieve their own module key they can define
+// a provider which requires the OwnModuleKey type and DOES NOT require ModuleKey.
 type ModuleKey struct {
 	*moduleKey
 }
@@ -28,4 +31,8 @@ func (k ModuleKey) Name() string {
 
 var moduleKeyType = reflect.TypeOf(ModuleKey{})
 
-var stringType = reflect.TypeOf("")
+// OwnModuleKey is a type which can be used in a module to retrieve its own
+// ModuleKey. It MUST NOT be used together with a ModuleKey dependency.
+type OwnModuleKey ModuleKey
+
+var ownModuleKeyType = reflect.TypeOf((*OwnModuleKey)(nil)).Elem()


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

Uncovered in #11900.

Also adds the new type `OwnModuleKey` for a module to retrieve its own module key rather than providing a module-scoped dependency to other modules.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
