### PR TITLE
test: add test on `StringifyEvents`

### DIFF
--- a/types/events.go
+++ b/types/events.go
@@ -211,7 +211,7 @@ func (e Events) ToABCIEvents() []abci.Event {
 }
 
 // Common event types and attribute keys
-var (
+const (
 	EventTypeTx = "tx"
 
 	AttributeKeyAccountSequence = "acc_seq"

--- a/types/events_test.go
+++ b/types/events_test.go
@@ -122,7 +122,7 @@ func (s *eventsTestSuite) TestStringifyEvents() {
 			name: "multiple events with same attributes",
 			events: sdk.Events{
 				sdk.NewEvent(
-					sdk.EventTypeMessage,
+					"message",
 					sdk.NewAttribute(sdk.AttributeKeyModule, "staking"),
 					sdk.NewAttribute(sdk.AttributeKeySender, "cosmos1foo"),
 				),

--- a/types/events_test.go
+++ b/types/events_test.go
@@ -103,20 +103,43 @@ func (s *eventsTestSuite) TestEventManagerTypedEvents() {
 }
 
 func (s *eventsTestSuite) TestStringifyEvents() {
-	e := sdk.Events{
-		sdk.NewEvent("message", sdk.NewAttribute("sender", "foo")),
-		sdk.NewEvent("message", sdk.NewAttribute("module", "bank")),
+	cases := []struct {
+		name       string
+		events     sdk.Events
+		expTxtStr  string
+		expJSONStr string
+	}{
+		{
+			name: "default",
+			events: sdk.Events{
+				sdk.NewEvent("message", sdk.NewAttribute(sdk.AttributeKeySender, "foo")),
+				sdk.NewEvent("message", sdk.NewAttribute(sdk.AttributeKeyModule, "bank")),
+			},
+			expTxtStr:  "\t\t- message\n\t\t\t- sender: foo\n\t\t\t- module: bank",
+			expJSONStr: "[{\"type\":\"message\",\"attributes\":[{\"key\":\"sender\",\"value\":\"foo\"},{\"key\":\"module\",\"value\":\"bank\"}]}]",
+		},
+		{
+			name: "multiple events with same attributes",
+			events: sdk.Events{
+				sdk.NewEvent(
+					sdk.EventTypeMessage,
+					sdk.NewAttribute(sdk.AttributeKeyModule, "staking"),
+					sdk.NewAttribute(sdk.AttributeKeySender, "cosmos1foo"),
+				),
+				sdk.NewEvent("message", sdk.NewAttribute(sdk.AttributeKeySender, "foo")),
+			},
+			expTxtStr:  "\t\t- message\n\t\t\t- module: staking\n\t\t\t- sender: cosmos1foo\n\t\t\t- sender: foo",
+			expJSONStr: `[{"type":"message","attributes":[{"key":"module","value":"staking"},{"key":"sender","value":"cosmos1foo"},{"key":"sender","value":"foo"}]}]`,
+		},
 	}
-	se := sdk.StringifyEvents(e.ToABCIEvents())
 
-	expectedTxtStr := "\t\t- message\n\t\t\t- sender: foo\n\t\t\t- module: bank"
-	s.Require().Equal(expectedTxtStr, se.String())
-
-	bz, err := json.Marshal(se)
-	s.Require().NoError(err)
-
-	expectedJSONStr := "[{\"type\":\"message\",\"attributes\":[{\"key\":\"sender\",\"value\":\"foo\"},{\"key\":\"module\",\"value\":\"bank\"}]}]"
-	s.Require().Equal(expectedJSONStr, string(bz))
+	for _, test := range cases {
+		se := sdk.StringifyEvents(test.events.ToABCIEvents())
+		s.Require().Equal(test.expTxtStr, se.String())
+		bz, err := json.Marshal(se)
+		s.Require().NoError(err)
+		s.Require().Equal(test.expJSONStr, string(bz))
+	}
 }
 
 func (s *eventsTestSuite) TestMarkEventsToIndex() {

--- a/x/bank/types/events.go
+++ b/x/bank/types/events.go
@@ -9,7 +9,7 @@ const (
 	EventTypeTransfer = "transfer"
 
 	AttributeKeyRecipient = "recipient"
-	AttributeKeySender    = "sender"
+	AttributeKeySender    = sdk.AttributeKeySender
 
 	AttributeValueCategory = ModuleName
 


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

Add test on `StringifyEvents` (makes the behavior more clear for someone not familiar with the code)

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
- [x] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [x] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
