### PR TITLE
fix: update `StartHeight` signing info in `AfterValidatorBonded` hook when validator re-bonds

### DIFF
--- a/x/slashing/keeper/hooks.go
+++ b/x/slashing/keeper/hooks.go
@@ -11,8 +11,7 @@ import (
 
 func (k Keeper) AfterValidatorBonded(ctx sdk.Context, address sdk.ConsAddress, _ sdk.ValAddress) error {
 	// Update the signing info start height or create a new signing info
-	_, found := k.GetValidatorSigningInfo(ctx, address)
-	if !found {
+	if _, found := k.GetValidatorSigningInfo(ctx, address); !found {
 		signingInfo := types.NewValidatorSigningInfo(
 			address,
 			ctx.BlockHeight(),

--- a/x/slashing/keeper/hooks.go
+++ b/x/slashing/keeper/hooks.go
@@ -11,8 +11,11 @@ import (
 
 func (k Keeper) AfterValidatorBonded(ctx sdk.Context, address sdk.ConsAddress, _ sdk.ValAddress) error {
 	// Update the signing info start height or create a new signing info
-	if _, found := k.GetValidatorSigningInfo(ctx, address); !found {
-		signingInfo := types.NewValidatorSigningInfo(
+	signingInfo, found := k.GetValidatorSigningInfo(ctx, address)
+	if found {
+		signingInfo.StartHeight = ctx.BlockHeight()
+	} else {
+		signingInfo = types.NewValidatorSigningInfo(
 			address,
 			ctx.BlockHeight(),
 			0,
@@ -20,8 +23,9 @@ func (k Keeper) AfterValidatorBonded(ctx sdk.Context, address sdk.ConsAddress, _
 			false,
 			0,
 		)
-		k.SetValidatorSigningInfo(ctx, address, signingInfo)
 	}
+
+	k.SetValidatorSigningInfo(ctx, address, signingInfo)
 
 	return nil
 }
@@ -73,17 +77,27 @@ func (h Hooks) AfterValidatorCreated(ctx sdk.Context, valAddr sdk.ValAddress) er
 func (h Hooks) AfterValidatorBeginUnbonding(_ sdk.Context, _ sdk.ConsAddress, _ sdk.ValAddress) error {
 	return nil
 }
-func (h Hooks) BeforeValidatorModified(_ sdk.Context, _ sdk.ValAddress) error { return nil }
+
+func (h Hooks) BeforeValidatorModified(_ sdk.Context, _ sdk.ValAddress) error {
+	return nil
+}
+
 func (h Hooks) BeforeDelegationCreated(_ sdk.Context, _ sdk.AccAddress, _ sdk.ValAddress) error {
 	return nil
 }
+
 func (h Hooks) BeforeDelegationSharesModified(_ sdk.Context, _ sdk.AccAddress, _ sdk.ValAddress) error {
 	return nil
 }
+
 func (h Hooks) BeforeDelegationRemoved(_ sdk.Context, _ sdk.AccAddress, _ sdk.ValAddress) error {
 	return nil
 }
+
 func (h Hooks) AfterDelegationModified(_ sdk.Context, _ sdk.AccAddress, _ sdk.ValAddress) error {
 	return nil
 }
-func (h Hooks) BeforeValidatorSlashed(_ sdk.Context, _ sdk.ValAddress, _ sdk.Dec) error { return nil }
+
+func (h Hooks) BeforeValidatorSlashed(_ sdk.Context, _ sdk.ValAddress, _ sdk.Dec) error {
+	return nil
+}

--- a/x/slashing/keeper/keeper_test.go
+++ b/x/slashing/keeper/keeper_test.go
@@ -237,7 +237,7 @@ func TestValidatorDippingInAndOut(t *testing.T) {
 	// shouldn't be jailed/kicked yet
 	tstaking.CheckValidator(valAddr, stakingtypes.Bonded, false)
 
-	// validator misses the an additional 500 more blocks, after the cooling off period of SignedBlockWindow (here 1000 blocks).
+	// validator misses an additional 500 more blocks, after the cooling off period of SignedBlockWindow (here 1000 blocks).
 	latest := app.SlashingKeeper.SignedBlocksWindow(ctx) + height
 	for ; height < latest+app.SlashingKeeper.MinSignedPerWindow(ctx); height++ {
 		ctx = ctx.WithBlockHeight(height)

--- a/x/slashing/keeper/keeper_test.go
+++ b/x/slashing/keeper/keeper_test.go
@@ -219,11 +219,11 @@ func TestValidatorDippingInAndOut(t *testing.T) {
 	tstaking.CheckValidator(valAddr, stakingtypes.Unbonding, false)
 
 	// 600 more blocks happened
-	height = 700
+	height = height + 600
 	ctx = ctx.WithBlockHeight(height)
 
 	// validator added back in
-	tstaking.DelegateWithPower(sdk.AccAddress(pks[2].Address()), sdk.ValAddress(pks[0].Address()), 50)
+	tstaking.DelegateWithPower(sdk.AccAddress(pks[2].Address()), valAddr, 50)
 
 	validatorUpdates = staking.EndBlocker(ctx, app.StakingKeeper)
 	require.Equal(t, 2, len(validatorUpdates))
@@ -237,9 +237,9 @@ func TestValidatorDippingInAndOut(t *testing.T) {
 	// shouldn't be jailed/kicked yet
 	tstaking.CheckValidator(valAddr, stakingtypes.Bonded, false)
 
-	// validator misses 500 more blocks, 501 total
-	latest := height
-	for ; height < latest+500; height++ {
+	// validator misses the an additional 500 more blocks, after the cooling off period of SignedBlockWindow (here 1000 blocks).
+	latest := app.SlashingKeeper.SignedBlocksWindow(ctx) + height
+	for ; height < latest+app.SlashingKeeper.MinSignedPerWindow(ctx); height++ {
 		ctx = ctx.WithBlockHeight(height)
 		app.SlashingKeeper.HandleValidatorSignature(ctx, val.Address(), newPower, false)
 	}
@@ -251,15 +251,9 @@ func TestValidatorDippingInAndOut(t *testing.T) {
 	// check all the signing information
 	signInfo, found := app.SlashingKeeper.GetValidatorSigningInfo(ctx, consAddr)
 	require.True(t, found)
-	require.Equal(t, int64(0), signInfo.StartHeight)
-	require.Equal(t, int64(0), signInfo.MissedBlocksCounter)
-	require.Equal(t, int64(0), signInfo.IndexOffset)
-
-	// array should be cleared
-	for offset := int64(0); offset < app.SlashingKeeper.SignedBlocksWindow(ctx); offset++ {
-		missed := app.SlashingKeeper.GetValidatorMissedBlockBitArray(ctx, consAddr, offset)
-		require.False(t, missed)
-	}
+	require.Equal(t, int64(700), signInfo.StartHeight)
+	require.Equal(t, int64(499), signInfo.MissedBlocksCounter)
+	require.Equal(t, int64(499), signInfo.IndexOffset)
 
 	// some blocks pass
 	height = int64(5000)
@@ -267,9 +261,7 @@ func TestValidatorDippingInAndOut(t *testing.T) {
 
 	// validator rejoins and starts signing again
 	app.StakingKeeper.Unjail(ctx, consAddr)
-	staking.EndBlocker(ctx, app.StakingKeeper)
 
-	// start signing again
 	app.SlashingKeeper.HandleValidatorSignature(ctx, val.Address(), newPower, true)
 
 	// validator should not be kicked since we reset counter/array when it was jailed
@@ -279,13 +271,11 @@ func TestValidatorDippingInAndOut(t *testing.T) {
 	// check start height is correctly set
 	signInfo, found = app.SlashingKeeper.GetValidatorSigningInfo(ctx, consAddr)
 	require.True(t, found)
-	require.Equal(t, height, signInfo.StartHeight) // TODO I don't think it should fail
-	require.Equal(t, int64(0), signInfo.MissedBlocksCounter)
-	require.Equal(t, int64(0), signInfo.IndexOffset)
+	require.Equal(t, height, signInfo.StartHeight)
 
-	// validator misses 501 blocks
-	latest = height
-	for ; height < latest+501; height++ {
+	// validator misses 501 blocks after SignedBlockWindow period (1000 blocks)
+	latest = app.SlashingKeeper.SignedBlocksWindow(ctx) + height
+	for ; height < latest+app.SlashingKeeper.MinSignedPerWindow(ctx); height++ {
 		ctx = ctx.WithBlockHeight(height)
 		app.SlashingKeeper.HandleValidatorSignature(ctx, val.Address(), newPower, false)
 	}

--- a/x/slashing/spec/01_concepts.md
+++ b/x/slashing/spec/01_concepts.md
@@ -43,16 +43,14 @@ _V<sub>u</sub>_ : validator unbonded
 
 ### Single Double Sign Infraction
 
-<----------------->
-[----------C<sub>1</sub>----D<sub>1</sub>,V<sub>u</sub>-----]
+\[----------C<sub>1</sub>----D<sub>1</sub>,V<sub>u</sub>-----\]
 
 A single infraction is committed then later discovered, at which point the
 validator is unbonded and slashed at the full amount for the infraction.
 
 ### Multiple Double Sign Infractions
 
-<--------------------------->
-[----------C<sub>1</sub>--C<sub>2</sub>---C<sub>3</sub>---D<sub>1</sub>,D<sub>2</sub>,D<sub>3</sub>V<sub>u</sub>-----]
+\[----------C<sub>1</sub>--C<sub>2</sub>---C<sub>3</sub>---D<sub>1</sub>,D<sub>2</sub>,D<sub>3</sub>V<sub>u</sub>-----\]
 
 Multiple infractions are committed and then later discovered, at which point the
 validator is jailed and slashed for only one infraction. Because the validator

--- a/x/slashing/spec/05_hooks.md
+++ b/x/slashing/spec/05_hooks.md
@@ -21,6 +21,8 @@ The following hooks impact the slashing state:
 Upon successful first-time bonding of a new validator, we create a new `ValidatorSigningInfo` structure for the
 now-bonded validator, which `StartHeight` of the current block.
 
+If the validator was out of the validator set and gets bonded again, its new bonded height is set.
+
 ```go
 onValidatorBonded(address sdk.ValAddress)
 
@@ -32,7 +34,10 @@ onValidatorBonded(address sdk.ValAddress)
       JailedUntil         : time.Unix(0, 0),
       Tombstone           : false,
       MissedBloskCounter  : 0
+    } else {
+      signingInfo.StartHeight = CurrentHeight
     }
+
     setValidatorSigningInfo(signingInfo)
   }
 


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

Closes: #10312

This PR fixes the mismatch between the behavior and the comment, as discovered in the issue above.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
- [x] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [x] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
