### PR TITLE
ci: Push protobufs for release tag events

### DIFF
--- a/.github/workflows/proto-registry.yml
+++ b/.github/workflows/proto-registry.yml
@@ -8,6 +8,10 @@ on:
     paths:
       - "proto/**"
 
+    # Sequence of patterns matched against refs/tags
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+" # Push events to matching v*, i.e. v1.0, v20.15.10
+
 jobs:
   push:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Push protobufs when a new release tag event is triggered.

This will help to keep protobufs in sync with the imported version specified in go.mod .

See this [comment](https://github.com/CosmWasm/wasmd/pull/757#issuecomment-1064895170) for better context understanding.

I have...

- [ ] included tags filter to push event in proto-registry GH action