### PR TITLE
fix: app wiring simulation failures

### DIFF
--- a/contrib/images/simd-dlv/Dockerfile
+++ b/contrib/images/simd-dlv/Dockerfile
@@ -8,6 +8,8 @@ COPY go.mod go.sum /work/
 COPY db/go.mod db/go.sum /work/db/
 COPY errors/go.mod errors/go.sum /work/errors/
 COPY math/go.mod math/go.sum /work/math/
+COPY api/go.mod api/go.sum /work/api/
+COPY core/go.mod core/go.sum /work/core/
 
 RUN go mod download
 COPY ./ /work

--- a/contrib/images/simd-env/Dockerfile
+++ b/contrib/images/simd-env/Dockerfile
@@ -7,6 +7,8 @@ COPY go.mod go.sum /work/
 COPY db/go.mod db/go.sum /work/db/
 COPY errors/go.mod errors/go.sum /work/errors/
 COPY math/go.mod math/go.sum /work/math/
+COPY api/go.mod api/go.sum /work/api/
+COPY core/go.mod core/go.sum /work/core/
 
 RUN go mod download
 COPY ./ /work

--- a/go.mod
+++ b/go.mod
@@ -62,7 +62,10 @@ require (
 	sigs.k8s.io/yaml v1.3.0
 )
 
-require github.com/cosmos/cosmos-sdk/container v1.0.0-alpha.4
+require (
+	github.com/cosmos/cosmos-sdk/container v1.0.0-alpha.4
+	golang.org/x/exp v0.0.0-20220428152302-39d4317da171
+)
 
 require (
 	cloud.google.com/go v0.100.2 // indirect
@@ -138,7 +141,6 @@ require (
 	github.com/zondax/hid v0.9.1-0.20220302062450-5552068d2266 // indirect
 	go.etcd.io/bbolt v1.3.6 // indirect
 	go.opencensus.io v0.23.0 // indirect
-	golang.org/x/exp v0.0.0-20220428152302-39d4317da171 // indirect
 	golang.org/x/net v0.0.0-20220412020605-290c469a71a5 // indirect
 	golang.org/x/oauth2 v0.0.0-20220411215720-9780585627b5 // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/confio/ics23/go v0.7.0
 	github.com/cosmos/btcutil v1.0.4
 	github.com/cosmos/cosmos-proto v1.0.0-alpha7
+	github.com/cosmos/cosmos-sdk/container v1.0.0-alpha.4
 	github.com/cosmos/cosmos-sdk/db v1.0.0-beta.1
 	github.com/cosmos/go-bip39 v1.0.0
 	github.com/cosmos/iavl v0.18.0
@@ -55,16 +56,12 @@ require (
 	github.com/tendermint/tendermint v0.35.4
 	github.com/tendermint/tm-db v0.6.6
 	golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4
+	golang.org/x/exp v0.0.0-20220428152302-39d4317da171
 	google.golang.org/genproto v0.0.0-20220407144326-9054f6ed7bac
 	google.golang.org/grpc v1.46.2
 	google.golang.org/protobuf v1.28.0
 	pgregory.net/rapid v0.4.7
 	sigs.k8s.io/yaml v1.3.0
-)
-
-require (
-	github.com/cosmos/cosmos-sdk/container v1.0.0-alpha.4
-	golang.org/x/exp v0.0.0-20220428152302-39d4317da171
 )
 
 require (

--- a/runtime/app.go
+++ b/runtime/app.go
@@ -156,7 +156,7 @@ func (a *App) RegisterTendermintService(clientCtx client.Context) {
 	)
 }
 
-// FindStoreKey fetches a registered StoreKey from the App in linear time.
+// UnsafeFindStoreKey FindStoreKey fetches a registered StoreKey from the App in linear time.
 //
 // NOTE: This should only be used in testing.
 func (a *App) UnsafeFindStoreKey(storeKey string) storetypes.StoreKey {

--- a/runtime/app.go
+++ b/runtime/app.go
@@ -159,7 +159,7 @@ func (a *App) RegisterTendermintService(clientCtx client.Context) {
 // FindStoreKey fetches a registered StoreKey from the App in linear time.
 //
 // NOTE: This should only be used in testing.
-func (a *App) FindStoreKey(storeKey string) storetypes.StoreKey {
+func (a *App) UnsafeFindStoreKey(storeKey string) storetypes.StoreKey {
 	i := slices.IndexFunc(a.storeKeys, func(s storetypes.StoreKey) bool { return s.Name() == storeKey })
 	if i == -1 {
 		return nil

--- a/runtime/app.go
+++ b/runtime/app.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/gogo/protobuf/grpc"
 	abci "github.com/tendermint/tendermint/abci/types"
+	"golang.org/x/exp/slices"
 
 	runtimev1alpha1 "cosmossdk.io/api/cosmos/app/runtime/v1alpha1"
 
@@ -153,6 +154,18 @@ func (a *App) RegisterTendermintService(clientCtx client.Context) {
 		a.interfaceRegistry,
 		a.Query,
 	)
+}
+
+// FindStoreKey fetches a registered StoreKey from the App in linear time.
+//
+// NOTE: This should only be used in testing.
+func (a *App) FindStoreKey(storeKey string) storetypes.StoreKey {
+	i := slices.IndexFunc(a.storeKeys, func(s storetypes.StoreKey) bool { return s.Name() == storeKey })
+	if i == -1 {
+		return nil
+	}
+
+	return a.storeKeys[i]
 }
 
 var _ servertypes.Application = &App{}

--- a/simapp/app.go
+++ b/simapp/app.go
@@ -325,7 +325,7 @@ func NewSimApp(
 
 	app.GovKeeper = *govKeeper.SetHooks(
 		govtypes.NewMultiGovHooks(
-		// register the governance hooks
+			// register the governance hooks
 		),
 	)
 	// set the governance module account as the authority for conducting upgrades
@@ -545,7 +545,17 @@ func (app *SimApp) InterfaceRegistry() codectypes.InterfaceRegistry {
 //
 // NOTE: This is solely to be used for testing purposes.
 func (app *SimApp) GetKey(storeKey string) *storetypes.KVStoreKey {
-	return app.keys[storeKey]
+	kvsk := app.keys[storeKey]
+	if kvsk != nil {
+		return kvsk
+	}
+
+	sk := app.FindStoreKey(storeKey)
+	kvStoreKey, ok := sk.(*storetypes.KVStoreKey)
+	if !ok {
+		return nil
+	}
+	return kvStoreKey
 }
 
 // GetTKey returns the TransientStoreKey for the provided store key.

--- a/simapp/app.go
+++ b/simapp/app.go
@@ -325,7 +325,7 @@ func NewSimApp(
 
 	app.GovKeeper = *govKeeper.SetHooks(
 		govtypes.NewMultiGovHooks(
-			// register the governance hooks
+		// register the governance hooks
 		),
 	)
 	// set the governance module account as the authority for conducting upgrades
@@ -416,6 +416,7 @@ func NewSimApp(
 		staking.NewAppModule(appCodec, app.StakingKeeper, app.AccountKeeper, app.BankKeeper),
 		distr.NewAppModule(appCodec, app.DistrKeeper, app.AccountKeeper, app.BankKeeper, app.StakingKeeper),
 		slashing.NewAppModule(appCodec, app.SlashingKeeper, app.AccountKeeper, app.BankKeeper, app.StakingKeeper),
+		params.NewAppModule(app.ParamsKeeper),
 		evidence.NewAppModule(app.EvidenceKeeper),
 		authzmodule.NewAppModule(appCodec, app.AuthzKeeper, app.AccountKeeper, app.BankKeeper, app.interfaceRegistry),
 		groupmodule.NewAppModule(appCodec, app.GroupKeeper, app.AccountKeeper, app.BankKeeper, app.interfaceRegistry),

--- a/simapp/app.go
+++ b/simapp/app.go
@@ -550,7 +550,7 @@ func (app *SimApp) GetKey(storeKey string) *storetypes.KVStoreKey {
 		return kvsk
 	}
 
-	sk := app.FindStoreKey(storeKey)
+	sk := app.UnsafeFindStoreKey(storeKey)
 	kvStoreKey, ok := sk.(*storetypes.KVStoreKey)
 	if !ok {
 		return nil

--- a/simapp/sim_test.go
+++ b/simapp/sim_test.go
@@ -175,23 +175,23 @@ func TestAppImportExport(t *testing.T) {
 	fmt.Printf("comparing stores...\n")
 
 	storeKeysPrefixes := []StoreKeysPrefixes{
-		{app.keys[authtypes.StoreKey], newApp.keys[authtypes.StoreKey], [][]byte{}},
+		{app.GetKey(authtypes.StoreKey), newApp.GetKey(authtypes.StoreKey), [][]byte{}},
 		{
-			app.keys[stakingtypes.StoreKey], newApp.keys[stakingtypes.StoreKey],
+			app.GetKey(stakingtypes.StoreKey), newApp.GetKey(stakingtypes.StoreKey),
 			[][]byte{
 				stakingtypes.UnbondingQueueKey, stakingtypes.RedelegationQueueKey, stakingtypes.ValidatorQueueKey,
 				stakingtypes.HistoricalInfoKey,
 			},
 		}, // ordering may change but it doesn't matter
-		{app.keys[slashingtypes.StoreKey], newApp.keys[slashingtypes.StoreKey], [][]byte{}},
-		{app.keys[minttypes.StoreKey], newApp.keys[minttypes.StoreKey], [][]byte{}},
-		{app.keys[distrtypes.StoreKey], newApp.keys[distrtypes.StoreKey], [][]byte{}},
-		{app.keys[banktypes.StoreKey], newApp.keys[banktypes.StoreKey], [][]byte{banktypes.BalancesPrefix}},
-		{app.keys[paramtypes.StoreKey], newApp.keys[paramtypes.StoreKey], [][]byte{}},
-		{app.keys[govtypes.StoreKey], newApp.keys[govtypes.StoreKey], [][]byte{}},
-		{app.keys[evidencetypes.StoreKey], newApp.keys[evidencetypes.StoreKey], [][]byte{}},
-		{app.keys[capabilitytypes.StoreKey], newApp.keys[capabilitytypes.StoreKey], [][]byte{}},
-		{app.keys[authzkeeper.StoreKey], newApp.keys[authzkeeper.StoreKey], [][]byte{authzkeeper.GrantKey, authzkeeper.GrantQueuePrefix}},
+		{app.GetKey(slashingtypes.StoreKey), newApp.GetKey(slashingtypes.StoreKey), [][]byte{}},
+		{app.GetKey(minttypes.StoreKey), newApp.GetKey(minttypes.StoreKey), [][]byte{}},
+		{app.GetKey(distrtypes.StoreKey), newApp.GetKey(distrtypes.StoreKey), [][]byte{}},
+		{app.GetKey(banktypes.StoreKey), newApp.GetKey(banktypes.StoreKey), [][]byte{banktypes.BalancesPrefix}},
+		{app.GetKey(paramtypes.StoreKey), newApp.GetKey(paramtypes.StoreKey), [][]byte{}},
+		{app.GetKey(govtypes.StoreKey), newApp.GetKey(govtypes.StoreKey), [][]byte{}},
+		{app.GetKey(evidencetypes.StoreKey), newApp.GetKey(evidencetypes.StoreKey), [][]byte{}},
+		{app.GetKey(capabilitytypes.StoreKey), newApp.GetKey(capabilitytypes.StoreKey), [][]byte{}},
+		{app.GetKey(authzkeeper.StoreKey), newApp.GetKey(authzkeeper.StoreKey), [][]byte{authzkeeper.GrantKey, authzkeeper.GrantQueuePrefix}},
 	}
 
 	for _, skp := range storeKeysPrefixes {


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

Resolves simulation test failures introduced in #11924.

### x/staking failure

Symptom of this failure is the descriptive log message

```
Simulating... block 5/50, operation 500/753. Logs to writing to /home/mkoco/.simapp/simulations/2022-05-25_16:39:13.log
    simulate.go:302: error on block  5/50, operation (534/753) from x/staking:
        failed to execute message; message index: 0: amount is greater than the unbonding delegation entry balance: invalid request [/home/mkoco/go/pkg/mod/cosmossdk.io/errors@v1.0.0-beta.6/errors.go:187]
        Comment: unable to deliver tx
```

originating in [x/staking/keeper/msg_server.CancelUnbondingDelegation](https://github.com/cosmos/cosmos-sdk/blob/16badb17be9ad98ec7143d6d45f6643a3c04a71f/x/staking/keeper/msg_server.go#L453).  I was not able to find a concrete fix other than re-adding a new instance of the `params` module back to `SimApp`'s call to `module.NewSimulationManager` which evidently has a side-effect I do not understand.

### store test failure

error log:

```
compared 0 different key/value pairs between KVStoreKey{0xc0010c5e00, acc} and KVStoreKey{0xc000b44560, acc}
compared 0 different key/value pairs between KVStoreKey{0xc0010c5e20, staking} and KVStoreKey{0xc000b44580, staking}
compared 0 different key/value pairs between KVStoreKey{0xc0010c5e50, slashing} and KVStoreKey{0xc000b445b0, slashing}
compared 0 different key/value pairs between KVStoreKey{0xc0010c5e30, mint} and KVStoreKey{0xc000b44590, mint}
compared 0 different key/value pairs between KVStoreKey{0xc0010c5e40, distribution} and KVStoreKey{0xc000b445a0, distribution}
compared 0 different key/value pairs between KVStoreKey{0xc0010c5e10, bank} and KVStoreKey{0xc000b44570, bank}
--- FAIL: TestAppImportExport (17.93s)
panic: kv store with key <nil> has not been registered in stores [recovered]
```

originating in [sim_test.go](https://github.com/cosmos/cosmos-sdk/blob/16badb17be9ad98ec7143d6d45f6643a3c04a71f/simapp/sim_test.go#L198).   The root cause here seems to be test code which either fetches from `SimApp.keys` directly or uses `SimApp.GetKey` to fetch a `StoreKey` instance in order to build a keeper for various testing functions.  Use of this pattern is ubiquitous:

![image](https://user-images.githubusercontent.com/1236532/170525115-c5f079b2-36d7-4f81-bafa-b0aaeb450978.png)

To this end a store key fetching function was added to `runtime/app`.  As more keepers are moved over to the runtime they should *just work* in test as `SimApp.GetKey` now falls back to `App.FindStoreKey` on not found.  I am not a huge fan of this approach since it's exposing `runtime` internals, alternative approaches include:

- maintain a duplicate list of storeKeys derived from `runtime` in `SimApp`
- refactor all testing code (37 usages) to build/fetch keepers in a different way so this dependency can be removed (not sure how possible this without reviewing each usage)
- as per @aaronc use an *unsafe* flag to disable `FindStoreKey` by deafult

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
