### PR TITLE
docs: Ignore tips when TipDecorator is absent

### DIFF
--- a/client/flags/flags.go
+++ b/client/flags/flags.go
@@ -123,7 +123,7 @@ func AddTxFlagsToCmd(cmd *cobra.Command) {
 	cmd.Flags().Uint64(FlagTimeoutHeight, 0, "Set a block timeout height to prevent the tx from being committed past a certain height")
 	cmd.Flags().String(FlagFeePayer, "", "Fee payer pays fees for the transaction instead of deducting from the signer")
 	cmd.Flags().String(FlagFeeGranter, "", "Fee granter grants fees for the transaction")
-	cmd.Flags().String(FlagTip, "", "Tip is the amount that is going to be transferred to the fee payer on the target chain. This flag is only valid when used with --aux")
+	cmd.Flags().String(FlagTip, "", "Tip is the amount that is going to be transferred to the fee payer on the target chain. This flag is only valid when used with --aux, and is ignored if the target chain didn't enable the TipDecorator")
 	cmd.Flags().Bool(FlagAux, false, "Generate aux signer data instead of sending a tx")
 
 	// --gas can accept integers and "auto"

--- a/docs/core/tips.md
+++ b/docs/core/tips.md
@@ -72,10 +72,12 @@ In both cases, using `SIGN_MODE_LEGACY_AMINO_JSON` is recommended only if hardwa
 
 ## Enabling Tips on your Chain
 
-The transaction tips functionality is introduced in Cosmos SDK v0.46, so earlier versions do not have support for tips. It is however not included by default in a v0.46 app. Enabling tips on your chain is done by adding the `TipDecorator` in your posthandler chain:
+The transaction tips functionality is introduced in Cosmos SDK v0.46, so earlier versions do not have support for tips. It is however not included by default in a v0.46 app. Sending a transaction with tips to a chain which didn't enable tips will result in a no-op, i.e. the `tip` field in the transaction will be ignored.
+
+Enabling tips on a chain is done by adding the `TipDecorator` in the posthandler chain:
 
 ```go
-// HandlerOptions are the options required for constructing a default SDK PostHandler.
+// HandlerOptions are the options required for constructing a SDK PostHandler which supports tips.
 type HandlerOptions struct {
 	BankKeeper types.BankKeeper
 }

--- a/proto/cosmos/tx/v1beta1/tx.proto
+++ b/proto/cosmos/tx/v1beta1/tx.proto
@@ -87,8 +87,12 @@ message SignDocDirectAux {
   // sequence is the sequence number of the signing account.
   uint64 sequence = 5;
 
-  // Tip is the optional tip used for meta-transactions. It should be left
-  // empty if the signer is not the tipper for this transaction.
+  // Tip is the optional tip used for transactions fees paid in another denom.
+  // It should be left empty if the signer is not the tipper for this
+  // transaction.
+  //
+  // This field is ignored if the chain didn't enable tips, i.e. didn't add the
+  // `TipDecorator` in its posthandler.
   Tip tip = 6;
 }
 
@@ -138,7 +142,10 @@ message AuthInfo {
   // of the signers. This can be estimated via simulation.
   Fee fee = 2;
 
-  // Tip is the optional tip used for meta-transactions.
+  // Tip is the optional tip used for transactions fees paid in another denom.
+  //
+  // This field is ignored if the chain didn't enable tips, i.e. didn't add the
+  // `TipDecorator` in its posthandler.
   //
   // Since: cosmos-sdk 0.46
   Tip tip = 3;


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

Add some docs and client-facing comments about how tips are ignored if the TipDecorator is not added

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
