### PR TITLE
feature:  filter logging

### DIFF
--- a/server/log_filter.go
+++ b/server/log_filter.go
@@ -1,0 +1,199 @@
+package server
+
+import (
+	"fmt"
+
+	tmlog "github.com/tendermint/tendermint/libs/log"
+)
+
+type level byte
+
+const (
+	levelDebug level = 1 << iota
+	levelInfo
+	levelError
+)
+
+type filter struct {
+	next             tmlog.Logger
+	allowed          level            // XOR'd levels for default case
+	initiallyAllowed level            // XOR'd levels for initial case
+	allowedKeyvals   map[keyval]level // When key-value match, use this level
+}
+
+type keyval struct {
+	key   interface{}
+	value interface{}
+}
+
+// NewFilter wraps next and implements filtering. See the commentary on the
+// Option functions for a detailed description of how to configure levels. If
+// no options are provided, all leveled log events created with Debug, Info or
+// Error helper methods are squelched.
+func NewFilter(next tmlog.Logger, options ...Option) tmlog.Logger {
+	l := &filter{
+		next:           next,
+		allowedKeyvals: make(map[keyval]level),
+	}
+	for _, option := range options {
+		option(l)
+	}
+	l.initiallyAllowed = l.allowed
+	return l
+}
+
+func (l *filter) Info(msg string, keyvals ...interface{}) {
+	levelAllowed := l.allowed&levelInfo != 0
+	if !levelAllowed {
+		return
+	}
+	l.next.Info(msg, keyvals...)
+}
+
+func (l *filter) Debug(msg string, keyvals ...interface{}) {
+	levelAllowed := l.allowed&levelDebug != 0
+	if !levelAllowed {
+		return
+	}
+	l.next.Debug(msg, keyvals...)
+}
+
+func (l *filter) Error(msg string, keyvals ...interface{}) {
+	levelAllowed := l.allowed&levelError != 0
+	if !levelAllowed {
+		return
+	}
+	l.next.Error(msg, keyvals...)
+}
+
+// With implements Logger by constructing a new filter with a keyvals appended
+// to the logger.
+//
+// If custom level was set for a keyval pair using one of the
+// Allow*With methods, it is used as the logger's level.
+//
+// Examples:
+//     logger = log.NewFilter(logger, log.AllowError(), log.AllowInfoWith("module", "crypto"))
+//		 logger.With("module", "crypto").Info("Hello") # produces "I... Hello module=crypto"
+//
+//     logger = log.NewFilter(logger, log.AllowError(),
+//				log.AllowInfoWith("module", "crypto"),
+// 				log.AllowNoneWith("user", "Sam"))
+//		 logger.With("module", "crypto", "user", "Sam").Info("Hello") # returns nil
+//
+//     logger = log.NewFilter(logger,
+// 				log.AllowError(),
+// 				log.AllowInfoWith("module", "crypto"), log.AllowNoneWith("user", "Sam"))
+//		 logger.With("user", "Sam").With("module", "crypto").Info("Hello") # produces "I... Hello module=crypto user=Sam"
+func (l *filter) With(keyvals ...interface{}) tmlog.Logger {
+	keyInAllowedKeyvals := false
+
+	for i := len(keyvals) - 2; i >= 0; i -= 2 {
+		for kv, allowed := range l.allowedKeyvals {
+			if keyvals[i] == kv.key {
+				keyInAllowedKeyvals = true
+				// Example:
+				//		logger = log.NewFilter(logger, log.AllowError(), log.AllowInfoWith("module", "crypto"))
+				//		logger.With("module", "crypto")
+				if keyvals[i+1] == kv.value {
+					return &filter{
+						next:             l.next.With(keyvals...),
+						allowed:          allowed, // set the desired level
+						allowedKeyvals:   l.allowedKeyvals,
+						initiallyAllowed: l.initiallyAllowed,
+					}
+				}
+			}
+		}
+	}
+
+	// Example:
+	//		logger = log.NewFilter(logger, log.AllowError(), log.AllowInfoWith("module", "crypto"))
+	//		logger.With("module", "main")
+	if keyInAllowedKeyvals {
+		return &filter{
+			next:             l.next.With(keyvals...),
+			allowed:          l.initiallyAllowed, // return back to initially allowed
+			allowedKeyvals:   l.allowedKeyvals,
+			initiallyAllowed: l.initiallyAllowed,
+		}
+	}
+
+	return &filter{
+		next:             l.next.With(keyvals...),
+		allowed:          l.allowed, // simply continue with the current level
+		allowedKeyvals:   l.allowedKeyvals,
+		initiallyAllowed: l.initiallyAllowed,
+	}
+}
+
+//--------------------------------------------------------------------------------
+
+// Option sets a parameter for the filter.
+type Option func(*filter)
+
+// AllowLevel returns an option for the given level or error if no option exist
+// for such level.
+func AllowLevel(lvl string) (Option, error) {
+	switch lvl {
+	case "debug":
+		return AllowDebug(), nil
+	case "info":
+		return AllowInfo(), nil
+	case "error":
+		return AllowError(), nil
+	case "none":
+		return AllowNone(), nil
+	default:
+		return nil, fmt.Errorf("expected either \"info\", \"debug\", \"error\" or \"none\" level, given %s", lvl)
+	}
+}
+
+// AllowAll is an alias for AllowDebug.
+func AllowAll() Option {
+	return AllowDebug()
+}
+
+// AllowDebug allows error, info and debug level log events to pass.
+func AllowDebug() Option {
+	return allowed(levelError | levelInfo | levelDebug)
+}
+
+// AllowInfo allows error and info level log events to pass.
+func AllowInfo() Option {
+	return allowed(levelError | levelInfo)
+}
+
+// AllowError allows only error level log events to pass.
+func AllowError() Option {
+	return allowed(levelError)
+}
+
+// AllowNone allows no leveled log events to pass.
+func AllowNone() Option {
+	return allowed(0)
+}
+
+func allowed(allowed level) Option {
+	return func(l *filter) { l.allowed = allowed }
+}
+
+// AllowDebugWith allows error, info and debug level log events to pass for a specific key value pair.
+func AllowDebugWith(key interface{}, value interface{}) Option {
+	return func(l *filter) { l.allowedKeyvals[keyval{key, value}] = levelError | levelInfo | levelDebug }
+}
+
+// AllowInfoWith allows error and info level log events to pass for a specific key value pair.
+func AllowInfoWith(key interface{}, value interface{}) Option {
+	return func(l *filter) { l.allowedKeyvals[keyval{key, value}] = levelError | levelInfo }
+}
+
+// AllowErrorWith allows only error level log events to pass for a specific key value pair.
+func AllowErrorWith(key interface{}, value interface{}) Option {
+	return func(l *filter) { l.allowedKeyvals[keyval{key, value}] = levelError }
+}
+
+// AllowNoneWith allows no leveled log events to pass for a specific key value pair.
+func AllowNoneWith(key interface{}, value interface{}) Option {
+	return func(l *filter) { l.allowedKeyvals[keyval{key, value}] = 0 }
+}

--- a/server/log_filter_test.go
+++ b/server/log_filter_test.go
@@ -1,0 +1,147 @@
+package server_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/rs/zerolog"
+
+	"github.com/cosmos/cosmos-sdk/server"
+)
+
+func TestVariousLevels(t *testing.T) {
+	testCases := []struct {
+		name    string
+		allowed server.Option
+		want    string
+	}{
+		{
+			"AllowAll",
+			server.AllowAll(),
+			strings.Join([]string{
+				`{"level":"debug","this is":"debug log","message":"here"}`,
+				`{"level":"info","this is":"info log","message":"here"}`,
+				`{"level":"error","this is":"error log","message":"here"}`,
+			}, "\n"),
+		},
+		{
+			"AllowDebug",
+			server.AllowDebug(),
+			strings.Join([]string{
+				`{"level":"debug","this is":"debug log","message":"here"}`,
+				`{"level":"info","this is":"info log","message":"here"}`,
+				`{"level":"error","this is":"error log","message":"here"}`,
+			}, "\n"),
+		},
+		{
+			"AllowInfo",
+			server.AllowInfo(),
+			strings.Join([]string{
+				`{"level":"info","this is":"info log","message":"here"}`,
+				`{"level":"error","this is":"error log","message":"here"}`,
+			}, "\n"),
+		},
+		{
+			"AllowError",
+			server.AllowError(),
+			strings.Join([]string{
+				`{"level":"error","this is":"error log","message":"here"}`,
+			}, "\n"),
+		},
+		{
+			"AllowNone",
+			server.AllowNone(),
+			``,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			logger := server.NewFilter(server.ZeroLogWrapper{
+				Logger: zerolog.New(&buf).With().Logger(),
+			}, tc.allowed)
+
+			logger.Debug("here", "this is", "debug log")
+			logger.Info("here", "this is", "info log")
+			logger.Error("here", "this is", "error log")
+
+			if want, have := tc.want, strings.TrimSpace(buf.String()); want != have {
+				t.Errorf("\nwant:\n%s\nhave:\n%s", want, have)
+			}
+		})
+	}
+}
+
+func TestLevelContext(t *testing.T) {
+	var buf bytes.Buffer
+	zeroLogger := server.ZeroLogWrapper{
+		Logger: zerolog.New(&buf).Level(zerolog.InfoLevel).With().Logger(),
+	}
+
+	logger := server.NewFilter(zeroLogger, server.AllowError())
+
+	logger.Error("foo", "bar", "baz")
+
+	want := `{"level":"error","bar":"baz","message":"foo"}`
+	have := strings.TrimSpace(buf.String())
+	if want != have {
+		t.Errorf("\nwant '%s'\nhave '%s'", want, have)
+	}
+
+	buf.Reset()
+	logger.Info("foo", "bar", "baz")
+	if want, have := ``, strings.TrimSpace(buf.String()); want != have {
+		t.Errorf("\nwant '%s'\nhave '%s'", want, have)
+	}
+}
+
+func TestVariousAllowWith(t *testing.T) {
+	var buf bytes.Buffer
+
+	logger := server.ZeroLogWrapper{
+		Logger: zerolog.New(&buf).With().Logger(),
+	}
+
+	logger1 := server.NewFilter(logger, server.AllowError(), server.AllowInfoWith("context", "value"))
+	logger1.With("context", "value").Info("foo", "bar", "baz")
+
+	want := `{"level":"info","context":"value","bar":"baz","message":"foo"}`
+	have := strings.TrimSpace(buf.String())
+	if want != have {
+		t.Errorf("\nwant '%s'\nhave '%s'", want, have)
+	}
+
+	buf.Reset()
+
+	logger2 := server.NewFilter(
+		logger,
+		server.AllowError(),
+		server.AllowInfoWith("context", "value"),
+		server.AllowNoneWith("user", "Sam"),
+	)
+
+	logger2.With("context", "value", "user", "Sam").Info("foo", "bar", "baz")
+	if want, have := ``, strings.TrimSpace(buf.String()); want != have {
+		t.Errorf("\nwant '%s'\nhave '%s'", want, have)
+	}
+
+	buf.Reset()
+
+	logger3 := server.NewFilter(
+		logger,
+		server.AllowError(),
+		server.AllowInfoWith("context", "value"),
+		server.AllowNoneWith("user", "Sam"),
+	)
+
+	logger3.With("user", "Sam").With("context", "value").Info("foo", "bar", "baz")
+
+	want = `{"level":"info","user":"Sam","context":"value","bar":"baz","message":"foo"}`
+	have = strings.TrimSpace(buf.String())
+	if want != have {
+		t.Errorf("\nwant '%s'\nhave '%s'", want, have)
+	}
+}


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

Closes: #XXXX

allow node operators to filter logs. 

Filter code is reused from tendermint 0.33. 

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
