### PR TITLE
chore: optimize get last completed upgrade

### DIFF
--- a/x/upgrade/keeper/keeper.go
+++ b/x/upgrade/keeper/keeper.go
@@ -243,24 +243,18 @@ func (k Keeper) GetLastCompletedUpgrade(ctx sdk.Context) (string, int64) {
 	iter := sdk.KVStoreReversePrefixIterator(ctx.KVStore(k.storeKey), []byte{types.DoneByte})
 	defer iter.Close()
 
-	var upgrades []upgrade
+	var latest upgrade
+	var found bool
 	for ; iter.Valid(); iter.Next() {
-		name := parseDoneKey(iter.Key())
 		value := int64(sdk.BigEndianToUint64(iter.Value()))
-
-		upgrades = append(upgrades, upgrade{Name: name, BlockHeight: value})
+		if !found || value >= latest.BlockHeight {
+			found = true
+			name := parseDoneKey(iter.Key())
+			latest = upgrade{Name: name, BlockHeight: value}
+		}
 	}
 
-	// sort upgrades in descending order by block height
-	sort.SliceStable(upgrades, func(i, j int) bool {
-		return upgrades[i].BlockHeight > upgrades[j].BlockHeight
-	})
-
-	if len(upgrades) > 0 {
-		return upgrades[0].Name, upgrades[0].BlockHeight
-	}
-
-	return "", 0
+	return latest.Name, latest.BlockHeight
 }
 
 // parseDoneKey - split upgrade name from the done key

--- a/x/upgrade/keeper/keeper.go
+++ b/x/upgrade/keeper/keeper.go
@@ -246,11 +246,11 @@ func (k Keeper) GetLastCompletedUpgrade(ctx sdk.Context) (string, int64) {
 	var latest upgrade
 	var found bool
 	for ; iter.Valid(); iter.Next() {
-		value := int64(sdk.BigEndianToUint64(iter.Value()))
-		if !found || value >= latest.BlockHeight {
+		upgradeHeight := int64(sdk.BigEndianToUint64(iter.Value()))
+		if !found || upgradeHeight >= latest.BlockHeight {
 			found = true
 			name := parseDoneKey(iter.Key())
-			latest = upgrade{Name: name, BlockHeight: value}
+			latest = upgrade{Name: name, BlockHeight: upgradeHeight}
 		}
 	}
 

--- a/x/upgrade/keeper/keeper.go
+++ b/x/upgrade/keeper/keeper.go
@@ -243,8 +243,10 @@ func (k Keeper) GetLastCompletedUpgrade(ctx sdk.Context) (string, int64) {
 	iter := sdk.KVStoreReversePrefixIterator(ctx.KVStore(k.storeKey), []byte{types.DoneByte})
 	defer iter.Close()
 
-	var latest upgrade
-	var found bool
+	var (
+		latest upgrade
+		found  bool
+	)
 	for ; iter.Valid(); iter.Next() {
 		upgradeHeight := int64(sdk.BigEndianToUint64(iter.Value()))
 		if !found || upgradeHeight >= latest.BlockHeight {


### PR DESCRIPTION
## Description

Followup on https://github.com/cosmos/cosmos-sdk/pull/12264
Removes sort and finds latest upgrade in place rather than adding additional sorting.

PS: not sure if this should be ported to other branches.



---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
