### PR TITLE
fix: edit validator bug from cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Bug Fixes
 
+* [\#12317](https://github.com/cosmos/cosmos-sdk/pull/12317) Rename `edit-validator` command's `--moniker` flag to `--new-moniker`
 * (x/upgrade) [#12264](https://github.com/cosmos/cosmos-sdk/pull/12264) Fix `GetLastCompleteUpgrade` to properly return the latest upgrade.
 * (x/crisis) [#12208](https://github.com/cosmos/cosmos-sdk/pull/12208) Fix progress index of crisis invariant assertion logs.
 

--- a/x/staking/client/cli/flags.go
+++ b/x/staking/client/cli/flags.go
@@ -16,6 +16,7 @@ const (
 	FlagSharesFraction      = "shares-fraction"
 
 	FlagMoniker         = "moniker"
+	FlagEditMoniker     = "new-moniker"
 	FlagIdentity        = "identity"
 	FlagWebsite         = "website"
 	FlagSecurityContact = "security-contact"
@@ -82,7 +83,7 @@ func FlagSetPublicKey() *flag.FlagSet {
 func flagSetDescriptionEdit() *flag.FlagSet {
 	fs := flag.NewFlagSet("", flag.ContinueOnError)
 
-	fs.String(FlagMoniker, types.DoNotModifyDesc, "The validator's name")
+	fs.String(FlagEditMoniker, types.DoNotModifyDesc, "The validator's name")
 	fs.String(FlagIdentity, types.DoNotModifyDesc, "The (optional) identity signature (ex. UPort or Keybase)")
 	fs.String(FlagWebsite, types.DoNotModifyDesc, "The validator's (optional) website")
 	fs.String(FlagSecurityContact, types.DoNotModifyDesc, "The validator's (optional) security contact email")

--- a/x/staking/client/cli/tx.go
+++ b/x/staking/client/cli/tx.go
@@ -98,7 +98,7 @@ func NewEditValidatorCmd() *cobra.Command {
 				return err
 			}
 			valAddr := clientCtx.GetFromAddress()
-			moniker, _ := cmd.Flags().GetString(FlagMoniker)
+			moniker, _ := cmd.Flags().GetString(FlagEditMoniker)
 			identity, _ := cmd.Flags().GetString(FlagIdentity)
 			website, _ := cmd.Flags().GetString(FlagWebsite)
 			security, _ := cmd.Flags().GetString(FlagSecurityContact)

--- a/x/staking/client/testutil/cli_test.go
+++ b/x/staking/client/testutil/cli_test.go
@@ -1,3 +1,4 @@
+//go:build norace
 // +build norace
 
 package testutil

--- a/x/staking/client/testutil/suite.go
+++ b/x/staking/client/testutil/suite.go
@@ -1353,3 +1353,51 @@ func (s *IntegrationTestSuite) TestBlockResults() {
 		s.network.WaitForNextBlock()
 	}
 }
+
+// https://github.com/cosmos/cosmos-sdk/issues/10660
+func (s *IntegrationTestSuite) TestEditValidatorMoniker() {
+	val := s.network.Validators[0]
+	require := s.Require()
+
+	txCmd := cli.NewEditValidatorCmd()
+	moniker := "testing"
+	_, err := clitestutil.ExecTestCLICmd(val.ClientCtx, txCmd, []string{
+		val.ValAddress.String(),
+		fmt.Sprintf("--%s=%s", flags.FlagFrom, val.Address.String()),
+		fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
+		fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
+		fmt.Sprintf("--%s=%s", cli.FlagEditMoniker, moniker),
+		fmt.Sprintf("--%s=https://newvalidator.io", cli.FlagWebsite),
+		fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(10))).String()),
+	})
+	require.NoError(err)
+
+	queryCmd := cli.GetCmdQueryValidator()
+	res, err := clitestutil.ExecTestCLICmd(
+		val.ClientCtx, queryCmd,
+		[]string{val.ValAddress.String(), fmt.Sprintf("--%s=json", tmcli.OutputFlag)},
+	)
+	require.NoError(err)
+	var result types.Validator
+	require.NoError(val.ClientCtx.Codec.UnmarshalJSON(res.Bytes(), &result))
+	require.Equal(result.GetMoniker(), moniker)
+
+	_, err = clitestutil.ExecTestCLICmd(val.ClientCtx, txCmd, []string{
+		val.ValAddress.String(),
+		fmt.Sprintf("--%s=%s", flags.FlagFrom, val.Address.String()),
+		fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
+		fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
+		fmt.Sprintf("--%s=https://newvalidator.io", cli.FlagWebsite),
+		fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(10))).String()),
+	})
+	require.NoError(err)
+
+	res, err = clitestutil.ExecTestCLICmd(
+		val.ClientCtx, queryCmd,
+		[]string{val.ValAddress.String(), fmt.Sprintf("--%s=json", tmcli.OutputFlag)},
+	)
+	require.NoError(err)
+
+	require.NoError(val.ClientCtx.Codec.UnmarshalJSON(res.Bytes(), &result))
+	require.Equal(result.GetMoniker(), moniker)
+}


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

Closes: #12311 

This is a backport PR of #10684 to release into v0.45

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
