### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -7,6 +7,9 @@ on:
     paths: 
     - "docs/**"
 
+permissions:
+  contents: read
+
 jobs:
   check-docs-build:
     if: ${{ github.event.label.name == 'docs' }}

--- a/.github/workflows/cosmovisor-release.yml
+++ b/.github/workflows/cosmovisor-release.yml
@@ -4,8 +4,13 @@ on:
   push:
     tags:
       - "cosmovisor/v*.*.*"
+permissions:
+  contents: read
+
 jobs:
   goreleaser:
+    permissions:
+      contents: write  # for goreleaser/goreleaser-action to create a GitHub release
     runs-on: buildjet-4vcpu-ubuntu-2004
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -9,8 +9,13 @@ on:
       - "docs/**"
       - "x/**/*.md"
 
+permissions:
+  contents: read
+
 jobs:
   build-and-deploy:
+    permissions:
+      contents: write  # for JamesIves/github-pages-deploy-action to push changes in repo
     runs-on: ubuntu-latest
     container:
       image: tendermintdev/docker-website-deployment

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -2,8 +2,14 @@ name: "Pull Request Labeler"
 on:
   - pull_request_target
 
+permissions:
+  contents: read
+
 jobs:
   labeler:
+    permissions:
+      contents: read  # for actions/labeler to determine modified files
+      pull-requests: write  # for actions/labeler to add labels to PRs
     runs-on: ubuntu-latest
     steps:
       - uses: actions/labeler@main

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -7,8 +7,14 @@ on:
       - edited
       - synchronize
 
+permissions:
+  contents: read
+
 jobs:
   main:
+    permissions:
+      pull-requests: read  # for amannn/action-semantic-pull-request to analyze PRs
+      statuses: write  # for amannn/action-semantic-pull-request to mark status of analyzed PR
     runs-on: ubuntu-latest
     steps:
       - uses: amannn/action-semantic-pull-request@v4.5.0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,8 +7,13 @@ on:
   push:
     branches:
       - main
+permissions:
+  contents: read
+
 jobs:
   golangci:
+    permissions:
+      pull-requests: read  # for technote-space/get-diff-action to get git reference
     name: golangci-lint
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/proto.yml
+++ b/.github/workflows/proto.yml
@@ -6,6 +6,9 @@ on:
     paths:
       - "proto/**"
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-sims.yml
+++ b/.github/workflows/release-sims.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - "rc**"
 
+permissions:
+  contents: read
+
 jobs:
   test-sim-multi-seed-long:
     runs-on: buildjet-4vcpu-ubuntu-2004

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,8 +7,13 @@ on:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+" # Push events to matching v*, i.e. v1.0, v20.15.10
 
+permissions:
+  contents: read
+
 jobs:
   release:
+    permissions:
+      contents: write  # for goreleaser/goreleaser-action to create a GitHub release
     runs-on: buildjet-4vcpu-ubuntu-2004
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/sims-045.yml
+++ b/.github/workflows/sims-045.yml
@@ -9,6 +9,9 @@ on:
 
 jobs:
   cleanup-runs:
+    permissions:
+      actions: write  # for rokroskar/workflow-run-cleanup-action to obtain workflow name & cancel it
+      contents: read  # for rokroskar/workflow-run-cleanup-action to obtain branch
     runs-on: buildjet-4vcpu-ubuntu-2004
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@master
@@ -28,6 +31,8 @@ jobs:
       - run: make build
 
   install-runsim:
+    permissions:
+      contents: none
     runs-on: buildjet-4vcpu-ubuntu-2004
     needs: build
     steps:
@@ -132,6 +137,8 @@ jobs:
           SLACK_FOOTER: ""
 
   sims-notify-failure:
+    permissions:
+      contents: none
     needs:
       [test-sim-multi-seed-short, test-sim-after-import, test-sim-import-export]
     runs-on: ubuntu-latest

--- a/.github/workflows/sims-046.yml
+++ b/.github/workflows/sims-046.yml
@@ -9,6 +9,9 @@ on:
 
 jobs:
   cleanup-runs:
+    permissions:
+      actions: write  # for rokroskar/workflow-run-cleanup-action to obtain workflow name & cancel it
+      contents: read  # for rokroskar/workflow-run-cleanup-action to obtain branch
     runs-on: buildjet-4vcpu-ubuntu-2004
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@master
@@ -28,6 +31,8 @@ jobs:
       - run: make build
 
   install-runsim:
+    permissions:
+      contents: none
     runs-on: buildjet-4vcpu-ubuntu-2004
     needs: build
     steps:
@@ -132,6 +137,8 @@ jobs:
           SLACK_FOOTER: ""
 
   sims-notify-failure:
+    permissions:
+      contents: none
     needs:
       [test-sim-multi-seed-short, test-sim-after-import, test-sim-import-export]
     runs-on: ubuntu-latest

--- a/.github/workflows/sims.yml
+++ b/.github/workflows/sims.yml
@@ -9,6 +9,9 @@ on:
 
 jobs:
   cleanup-runs:
+    permissions:
+      actions: write  # for rokroskar/workflow-run-cleanup-action to obtain workflow name & cancel it
+      contents: read  # for rokroskar/workflow-run-cleanup-action to obtain branch
     runs-on: buildjet-4vcpu-ubuntu-2004
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@master
@@ -17,6 +20,9 @@ jobs:
     if: "!startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/main'"
 
   build:
+    permissions:
+      contents: read  # for actions/checkout to fetch code
+      pull-requests: read  # for technote-space/get-diff-action to get git reference
     runs-on: buildjet-4vcpu-ubuntu-2004
     if: "!contains(github.event.head_commit.message, 'skip-sims')"
     steps:
@@ -130,6 +136,8 @@ jobs:
           SLACK_FOOTER: ""
 
   sims-notify-failure:
+    permissions:
+      contents: none
     needs:
       [test-sim-multi-seed-short, test-sim-after-import, test-sim-import-export]
     runs-on: ubuntu-latest

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -3,8 +3,14 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   stale:
+    permissions:
+      issues: write  # for actions/stale to close stale issues
+      pull-requests: write  # for actions/stale to close stale PRs
     runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@v5


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: nathannaveen <42319948+nathannaveen@users.noreply.github.com>
