### PR TITLE
fix(x/auth): allow multiple = signs in `GetTxsEvent`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (x/staking) [#12303](https://github.com/cosmos/cosmos-sdk/pull/12303) Use bytes instead of string comparison in delete validator queue
 * (testutil/sims) [#12374](https://github.com/cosmos/cosmos-sdk/pull/12374) fix the non-determinstic behavior in simulations caused by `GenSignedMockTx` and check 
 empty coins slice before it is used to create `banktype.MsgSend`.
+* (x/auth/tx) [#12474](https://github.com/cosmos/cosmos-sdk/pull/12474) Remove condition in GetTxsEvent that disallowed multiple equal signs, which would break event queries with base64 strings (i.e. query by signature).
 
 ## [v0.46.0-rc1](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.46.0-rc1) - 2022-05-23
 

--- a/x/auth/tx/service.go
+++ b/x/auth/tx/service.go
@@ -3,6 +3,7 @@ package tx
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strings"
 
 	gogogrpc "github.com/gogo/protobuf/grpc"
@@ -39,13 +40,18 @@ func NewTxServer(clientCtx client.Context, simulate baseAppSimulateFn, interface
 	}
 }
 
-var _ txtypes.ServiceServer = txServer{}
+var (
+	_ txtypes.ServiceServer = txServer{}
+
+	// EventRegex checks that an event string is formatted with {alphabetic}.{alphabetic}={value}
+	EventRegex = regexp.MustCompile(`^[a-zA-Z]+\.[a-zA-Z]+=\S+$`)
+)
 
 const (
 	eventFormat = "{eventType}.{eventAttribute}={value}"
 )
 
-// TxsByEvents implements the ServiceServer.TxsByEvents RPC method.
+// GetTxsEvent implements the ServiceServer.TxsByEvents RPC method.
 func (s txServer) GetTxsEvent(ctx context.Context, req *txtypes.GetTxsEventRequest) (*txtypes.GetTxsEventResponse, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "request cannot be nil")
@@ -69,7 +75,7 @@ func (s txServer) GetTxsEvent(ctx context.Context, req *txtypes.GetTxsEventReque
 	}
 
 	for _, event := range req.Events {
-		if !strings.Contains(event, "=") || strings.Count(event, "=") > 1 {
+		if !EventRegex.Match([]byte(event)) {
 			return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("invalid event; event %s should be of the format: %s", event, eventFormat))
 		}
 	}

--- a/x/auth/tx/service_test.go
+++ b/x/auth/tx/service_test.go
@@ -4,10 +4,12 @@ package tx_test
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/cosmos/cosmos-sdk/client"
@@ -28,6 +30,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/tx/signing"
 	authclient "github.com/cosmos/cosmos-sdk/x/auth/client"
 	authtest "github.com/cosmos/cosmos-sdk/x/auth/client/testutil"
+	authtx "github.com/cosmos/cosmos-sdk/x/auth/tx"
 	bankcli "github.com/cosmos/cosmos-sdk/x/bank/client/testutil"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 )
@@ -109,6 +112,74 @@ func (s *IntegrationTestSuite) SetupSuite() {
 func (s *IntegrationTestSuite) TearDownSuite() {
 	s.T().Log("tearing down integration test suite")
 	s.network.Cleanup()
+}
+
+func (s *IntegrationTestSuite) TestQueryBySig() {
+	// broadcast tx
+	txb := s.mkTxBuilder()
+	txbz, err := s.cfg.TxConfig.TxEncoder()(txb.GetTx())
+	s.Require().NoError(err)
+	_, err = s.queryClient.BroadcastTx(context.Background(), &tx.BroadcastTxRequest{TxBytes: txbz, Mode: tx.BroadcastMode_BROADCAST_MODE_BLOCK})
+	s.Require().NoError(err)
+
+	// get the signature out of the builder
+	sigs, err := txb.GetTx().GetSignaturesV2()
+	s.Require().NoError(err)
+	s.Require().Len(sigs, 1)
+	sig, ok := sigs[0].Data.(*signing.SingleSignatureData)
+	s.Require().True(ok)
+
+	// encode, format, query
+	b64Sig := base64.StdEncoding.EncodeToString(sig.Signature)
+	sigFormatted := fmt.Sprintf("%s.%s='%s'", sdk.EventTypeTx, sdk.AttributeKeySignature, b64Sig)
+	res, err := s.queryClient.GetTxsEvent(context.Background(), &tx.GetTxsEventRequest{
+		Events:  []string{sigFormatted},
+		OrderBy: 0,
+		Page:    0,
+		Limit:   10,
+	})
+	s.Require().NoError(err)
+	s.Require().Len(res.Txs, 1)
+	s.Require().Len(res.Txs[0].Signatures, 1)
+	s.Require().Equal(res.Txs[0].Signatures[0], sig.Signature)
+}
+
+func TestEventRegex(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name  string
+		event string
+		match bool
+	}{
+		{
+			name:  "valid: with quotes",
+			event: "tx.message='something'",
+			match: true,
+		},
+		{
+			name:  "valid: no quotes",
+			event: "tx.message=something",
+			match: true,
+		},
+		{
+			name:  "invalid: too many separators",
+			event: "tx.message.foo='bar'",
+			match: false,
+		},
+		{
+			name:  "valid: symbols ok",
+			event: "tx.signature='foobar/baz123=='",
+			match: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			match := authtx.EventRegex.Match([]byte(tc.event))
+			require.Equal(t, tc.match, match)
+		})
+	}
 }
 
 func (s IntegrationTestSuite) TestSimulateTx_GRPC() {

--- a/x/auth/tx/service_test.go
+++ b/x/auth/tx/service_test.go
@@ -142,6 +142,10 @@ func (s *IntegrationTestSuite) TestQueryBySig() {
 	s.Require().Len(res.Txs, 1)
 	s.Require().Len(res.Txs[0].Signatures, 1)
 	s.Require().Equal(res.Txs[0].Signatures[0], sig.Signature)
+
+	// bad format should error
+	_, err = s.queryClient.GetTxsEvent(context.Background(), &tx.GetTxsEventRequest{Events: []string{"tx.foo.bar='baz'"}})
+	s.Require().ErrorContains(err, "invalid event;")
 }
 
 func TestEventRegex(t *testing.T) {


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

- removes the enforcement of a single equal sign in `GetTxsEvent` which was preventing querying by base64 encoded signatures.
- switches event string check to regex.


Closes: #12471 

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
