### PR TITLE
chore: fix migration paths

### DIFF
--- a/x/auth/keeper/migrations.go
+++ b/x/auth/keeper/migrations.go
@@ -3,14 +3,12 @@ package keeper
 import (
 	"github.com/gogo/protobuf/grpc"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/auth/exported"
 	v043 "github.com/cosmos/cosmos-sdk/x/auth/migrations/v043"
 	v046 "github.com/cosmos/cosmos-sdk/x/auth/migrations/v046"
-
-	"github.com/cosmos/cosmos-sdk/x/auth/exported"
+	v4 "github.com/cosmos/cosmos-sdk/x/auth/migrations/v4"
 	"github.com/cosmos/cosmos-sdk/x/auth/types"
-
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	v2 "github.com/cosmos/cosmos-sdk/x/auth/migrations/v2"
 )
 
 // Migrator is a struct for handling in-place store migrations.
@@ -58,7 +56,7 @@ func (m Migrator) Migrate2to3(ctx sdk.Context) error {
 // and managed by the x/params modules and stores them directly into the x/auth
 // module state.
 func (m Migrator) Migrate3to4(ctx sdk.Context) error {
-	return v2.Migrate(ctx, ctx.KVStore(m.keeper.storeKey), m.legacySubspace, m.keeper.cdc)
+	return v4.Migrate(ctx, ctx.KVStore(m.keeper.storeKey), m.legacySubspace, m.keeper.cdc)
 }
 
 // V45_SetAccount implements V45_SetAccount

--- a/x/auth/migrations/v043/store_test.go
+++ b/x/auth/migrations/v043/store_test.go
@@ -8,8 +8,6 @@ import (
 	"github.com/stretchr/testify/require"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 
-	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
-
 	"github.com/cosmos/cosmos-sdk/testutil"
 	simtestutil "github.com/cosmos/cosmos-sdk/testutil/sims"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -17,11 +15,12 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/auth"
 	authexported "github.com/cosmos/cosmos-sdk/x/auth/exported"
 	"github.com/cosmos/cosmos-sdk/x/auth/keeper"
-	v2 "github.com/cosmos/cosmos-sdk/x/auth/migrations/v2"
+	v4 "github.com/cosmos/cosmos-sdk/x/auth/migrations/v4"
 	authtestutil "github.com/cosmos/cosmos-sdk/x/auth/testutil"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	"github.com/cosmos/cosmos-sdk/x/auth/vesting/exported"
 	"github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
+	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
 	"github.com/cosmos/cosmos-sdk/x/staking"
 	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
@@ -43,7 +42,7 @@ func TestMigrateVestingAccounts(t *testing.T) {
 	encCfg := moduletestutil.MakeTestEncodingConfig(auth.AppModuleBasic{})
 	cdc := encCfg.Codec
 
-	storeKey := sdk.NewKVStoreKey(v2.ModuleName)
+	storeKey := sdk.NewKVStoreKey(v4.ModuleName)
 	tKey := sdk.NewTransientStoreKey("transient_test")
 	ctx := testutil.DefaultContext(storeKey, tKey)
 	store := ctx.KVStore(storeKey)
@@ -62,7 +61,7 @@ func TestMigrateVestingAccounts(t *testing.T) {
 	require.NoError(t, err)
 
 	legacySubspace := newMockSubspace(authtypes.DefaultParams())
-	require.NoError(t, v2.Migrate(ctx, store, legacySubspace, cdc))
+	require.NoError(t, v4.Migrate(ctx, store, legacySubspace, cdc))
 
 	ctx = app.BaseApp.NewContext(false, tmproto.Header{Time: time.Now()})
 	stakingKeeper.SetParams(ctx, stakingtypes.DefaultParams())

--- a/x/auth/migrations/v046/store_test.go
+++ b/x/auth/migrations/v046/store_test.go
@@ -5,20 +5,20 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
+
 	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
 	"github.com/cosmos/cosmos-sdk/testutil"
 	simtestutil "github.com/cosmos/cosmos-sdk/testutil/sims"
-	"github.com/cosmos/cosmos-sdk/x/auth"
-	"github.com/cosmos/cosmos-sdk/x/auth/keeper"
-	v2 "github.com/cosmos/cosmos-sdk/x/auth/migrations/v2"
-	authtestutil "github.com/cosmos/cosmos-sdk/x/auth/testutil"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
+	"github.com/cosmos/cosmos-sdk/x/auth"
 	authexported "github.com/cosmos/cosmos-sdk/x/auth/exported"
-	"github.com/stretchr/testify/require"
-	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
+	"github.com/cosmos/cosmos-sdk/x/auth/keeper"
+	v4 "github.com/cosmos/cosmos-sdk/x/auth/migrations/v4"
+	authtestutil "github.com/cosmos/cosmos-sdk/x/auth/testutil"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 )
 
 type mockSubspace struct {
@@ -38,7 +38,7 @@ func TestMigrateMapAccAddressToAccNumberKey(t *testing.T) {
 	encCfg := moduletestutil.MakeTestEncodingConfig(auth.AppModuleBasic{})
 	cdc := encCfg.Codec
 
-	storeKey := sdk.NewKVStoreKey(v2.ModuleName)
+	storeKey := sdk.NewKVStoreKey(v4.ModuleName)
 	tKey := sdk.NewTransientStoreKey("transient_test")
 	ctx := testutil.DefaultContext(storeKey, tKey)
 	store := ctx.KVStore(storeKey)
@@ -54,7 +54,7 @@ func TestMigrateMapAccAddressToAccNumberKey(t *testing.T) {
 	require.NoError(t, err)
 
 	legacySubspace := newMockSubspace(authtypes.DefaultParams())
-	require.NoError(t, v2.Migrate(ctx, store, legacySubspace, cdc))
+	require.NoError(t, v4.Migrate(ctx, store, legacySubspace, cdc))
 
 	// new base account
 	senderPrivKey := secp256k1.GenPrivKey()

--- a/x/auth/migrations/v4/migrate.go
+++ b/x/auth/migrations/v4/migrate.go
@@ -1,4 +1,4 @@
-package v2
+package v4
 
 import (
 	"github.com/cosmos/cosmos-sdk/codec"

--- a/x/auth/migrations/v4/migrator_test.go
+++ b/x/auth/migrations/v4/migrator_test.go
@@ -1,4 +1,4 @@
-package v2_test
+package v4_test
 
 import (
 	"testing"
@@ -7,11 +7,10 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/testutil"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-
 	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
 	"github.com/cosmos/cosmos-sdk/x/auth"
 	"github.com/cosmos/cosmos-sdk/x/auth/exported"
-	v2 "github.com/cosmos/cosmos-sdk/x/auth/migrations/v2"
+	v4 "github.com/cosmos/cosmos-sdk/x/auth/migrations/v4"
 	"github.com/cosmos/cosmos-sdk/x/auth/types"
 )
 
@@ -31,16 +30,16 @@ func TestMigrate(t *testing.T) {
 	encCfg := moduletestutil.MakeTestEncodingConfig(auth.AppModuleBasic{})
 	cdc := encCfg.Codec
 
-	storeKey := sdk.NewKVStoreKey(v2.ModuleName)
+	storeKey := sdk.NewKVStoreKey(v4.ModuleName)
 	tKey := sdk.NewTransientStoreKey("transient_test")
 	ctx := testutil.DefaultContext(storeKey, tKey)
 	store := ctx.KVStore(storeKey)
 
 	legacySubspace := newMockSubspace(types.DefaultParams())
-	require.NoError(t, v2.Migrate(ctx, store, legacySubspace, cdc))
+	require.NoError(t, v4.Migrate(ctx, store, legacySubspace, cdc))
 
 	var res types.Params
-	bz := store.Get(v2.ParamsKey)
+	bz := store.Get(v4.ParamsKey)
 	require.NoError(t, cdc.Unmarshal(bz, &res))
 	require.Equal(t, legacySubspace.ps, res)
 }

--- a/x/auth/module.go
+++ b/x/auth/module.go
@@ -6,21 +6,18 @@ import (
 	"fmt"
 	"math/rand"
 
-	"cosmossdk.io/depinject"
-
-	gwruntime "github.com/grpc-ecosystem/grpc-gateway/runtime"
-
-	"github.com/spf13/cobra"
-	abci "github.com/tendermint/tendermint/abci/types"
-
 	modulev1 "cosmossdk.io/api/cosmos/auth/module/v1"
 	"cosmossdk.io/core/appmodule"
-	"github.com/cosmos/cosmos-sdk/runtime"
-	store "github.com/cosmos/cosmos-sdk/store/types"
+	"cosmossdk.io/depinject"
+	gwruntime "github.com/grpc-ecosystem/grpc-gateway/runtime"
+	"github.com/spf13/cobra"
+	abci "github.com/tendermint/tendermint/abci/types"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/codec"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	"github.com/cosmos/cosmos-sdk/runtime"
+	store "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"

--- a/x/crisis/keeper/migrator.go
+++ b/x/crisis/keeper/migrator.go
@@ -3,7 +3,7 @@ package keeper
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/crisis/exported"
-	v046 "github.com/cosmos/cosmos-sdk/x/crisis/migrations/v046"
+	v2 "github.com/cosmos/cosmos-sdk/x/crisis/migrations/v2"
 )
 
 // Migrator is a struct for handling in-place state migrations.
@@ -24,5 +24,5 @@ func NewMigrator(k *Keeper, ss exported.Subspace) Migrator {
 // and managed by the x/params modules and stores them directly into the x/mint
 // module state.
 func (m Migrator) Migrate1to2(ctx sdk.Context) error {
-	return v046.MigrateStore(ctx, m.keeper.storeKey, m.legacySubspace, m.keeper.cdc)
+	return v2.MigrateStore(ctx, m.keeper.storeKey, m.legacySubspace, m.keeper.cdc)
 }

--- a/x/crisis/migrations/v2/migrate.go
+++ b/x/crisis/migrations/v2/migrate.go
@@ -1,4 +1,4 @@
-package v046
+package v2
 
 import (
 	"github.com/cosmos/cosmos-sdk/codec"

--- a/x/crisis/migrations/v2/migrate_test.go
+++ b/x/crisis/migrations/v2/migrate_test.go
@@ -1,15 +1,16 @@
-package v046_test
+package v2_test
 
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/cosmos/cosmos-sdk/testutil"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
-	v046 "github.com/cosmos/cosmos-sdk/x/crisis/migrations/v046"
+	v2 "github.com/cosmos/cosmos-sdk/x/crisis/migrations/v2"
 	"github.com/cosmos/cosmos-sdk/x/crisis/types"
 	"github.com/cosmos/cosmos-sdk/x/distribution"
-	"github.com/stretchr/testify/require"
 )
 
 type mockSubspace struct {
@@ -28,16 +29,16 @@ func TestMigrate(t *testing.T) {
 	encCfg := moduletestutil.MakeTestEncodingConfig(distribution.AppModuleBasic{})
 	cdc := encCfg.Codec
 
-	storeKey := sdk.NewKVStoreKey(v046.ModuleName)
+	storeKey := sdk.NewKVStoreKey(v2.ModuleName)
 	tKey := sdk.NewTransientStoreKey("transient_test")
 	ctx := testutil.DefaultContext(storeKey, tKey)
 	store := ctx.KVStore(storeKey)
 
 	legacySubspace := newMockSubspace(types.DefaultGenesisState().ConstantFee)
-	require.NoError(t, v046.MigrateStore(ctx, storeKey, legacySubspace, cdc))
+	require.NoError(t, v2.MigrateStore(ctx, storeKey, legacySubspace, cdc))
 
 	var res sdk.Coin
-	bz := store.Get(v046.ConstantFeeKey)
+	bz := store.Get(v2.ConstantFeeKey)
 	require.NoError(t, cdc.Unmarshal(bz, &res))
 	require.NotNil(t, res)
 	require.Equal(t, legacySubspace.constantFee, res)

--- a/x/crisis/module.go
+++ b/x/crisis/module.go
@@ -5,14 +5,14 @@ import (
 	"fmt"
 	"time"
 
+	modulev1 "cosmossdk.io/api/cosmos/crisis/module/v1"
 	"cosmossdk.io/core/appmodule"
+	"cosmossdk.io/depinject"
 	gwruntime "github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/spf13/cast"
 	"github.com/spf13/cobra"
 	abci "github.com/tendermint/tendermint/abci/types"
 
-	modulev1 "cosmossdk.io/api/cosmos/crisis/module/v1"
-	"cosmossdk.io/depinject"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/codec"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"

--- a/x/distribution/keeper/migrations.go
+++ b/x/distribution/keeper/migrations.go
@@ -4,7 +4,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/distribution/exported"
 	v043 "github.com/cosmos/cosmos-sdk/x/distribution/migrations/v043"
-	v046 "github.com/cosmos/cosmos-sdk/x/distribution/migrations/v046"
+	v3 "github.com/cosmos/cosmos-sdk/x/distribution/migrations/v3"
 )
 
 // Migrator is a struct for handling in-place store migrations.
@@ -28,5 +28,5 @@ func (m Migrator) Migrate1to2(ctx sdk.Context) error {
 // and managed by the x/params module and stores them directly into the x/distribution
 // module state.
 func (m Migrator) Migrate2to3(ctx sdk.Context) error {
-	return v046.MigrateStore(ctx, m.keeper.storeKey, m.legacySubspace, m.keeper.cdc)
+	return v3.MigrateStore(ctx, m.keeper.storeKey, m.legacySubspace, m.keeper.cdc)
 }

--- a/x/distribution/migrations/v3/migrate.go
+++ b/x/distribution/migrations/v3/migrate.go
@@ -1,4 +1,4 @@
-package v046
+package v3
 
 import (
 	"github.com/cosmos/cosmos-sdk/codec"

--- a/x/distribution/migrations/v3/migrate_test.go
+++ b/x/distribution/migrations/v3/migrate_test.go
@@ -1,16 +1,17 @@
-package v046_test
+package v3_test
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/cosmos/cosmos-sdk/testutil"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
 	"github.com/cosmos/cosmos-sdk/x/distribution"
 	"github.com/cosmos/cosmos-sdk/x/distribution/exported"
-	v046 "github.com/cosmos/cosmos-sdk/x/distribution/migrations/v046"
+	v3 "github.com/cosmos/cosmos-sdk/x/distribution/migrations/v3"
 	"github.com/cosmos/cosmos-sdk/x/distribution/types"
-	"github.com/stretchr/testify/require"
 )
 
 type mockSubspace struct {
@@ -29,16 +30,16 @@ func TestMigrate(t *testing.T) {
 	encCfg := moduletestutil.MakeTestEncodingConfig(distribution.AppModuleBasic{})
 	cdc := encCfg.Codec
 
-	storeKey := sdk.NewKVStoreKey(v046.ModuleName)
+	storeKey := sdk.NewKVStoreKey(v3.ModuleName)
 	tKey := sdk.NewTransientStoreKey("transient_test")
 	ctx := testutil.DefaultContext(storeKey, tKey)
 	store := ctx.KVStore(storeKey)
 
 	legacySubspace := newMockSubspace(types.DefaultParams())
-	require.NoError(t, v046.MigrateStore(ctx, storeKey, legacySubspace, cdc))
+	require.NoError(t, v3.MigrateStore(ctx, storeKey, legacySubspace, cdc))
 
 	var res types.Params
-	bz := store.Get(v046.ParamsKey)
+	bz := store.Get(v3.ParamsKey)
 	require.NoError(t, cdc.Unmarshal(bz, &res))
 	require.Equal(t, legacySubspace.ps, res)
 }

--- a/x/distribution/module.go
+++ b/x/distribution/module.go
@@ -6,13 +6,13 @@ import (
 	"fmt"
 	"math/rand"
 
+	modulev1 "cosmossdk.io/api/cosmos/distribution/module/v1"
+	"cosmossdk.io/core/appmodule"
+	"cosmossdk.io/depinject"
 	gwruntime "github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/spf13/cobra"
 	abci "github.com/tendermint/tendermint/abci/types"
 
-	modulev1 "cosmossdk.io/api/cosmos/distribution/module/v1"
-	"cosmossdk.io/core/appmodule"
-	"cosmossdk.io/depinject"
 	sdkclient "github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/codec"
 	cdctypes "github.com/cosmos/cosmos-sdk/codec/types"

--- a/x/slashing/keeper/migrations.go
+++ b/x/slashing/keeper/migrations.go
@@ -4,7 +4,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/slashing/exported"
 	v043 "github.com/cosmos/cosmos-sdk/x/slashing/migrations/v043"
-	v2 "github.com/cosmos/cosmos-sdk/x/slashing/migrations/v2"
+	v3 "github.com/cosmos/cosmos-sdk/x/slashing/migrations/v3"
 )
 
 // Migrator is a struct for handling in-place store migrations.
@@ -28,5 +28,5 @@ func (m Migrator) Migrate1to2(ctx sdk.Context) error {
 // and managed by the x/params modules and stores them directly into the x/slashing
 // module state.
 func (m Migrator) Migrate2to3(ctx sdk.Context) error {
-	return v2.Migrate(ctx, ctx.KVStore(m.keeper.storeKey), m.legacySubspace, m.keeper.cdc)
+	return v3.Migrate(ctx, ctx.KVStore(m.keeper.storeKey), m.legacySubspace, m.keeper.cdc)
 }

--- a/x/slashing/migrations/v3/migrate.go
+++ b/x/slashing/migrations/v3/migrate.go
@@ -1,4 +1,4 @@
-package v2
+package v3
 
 import (
 	"github.com/cosmos/cosmos-sdk/codec"

--- a/x/slashing/migrations/v3/migrator_test.go
+++ b/x/slashing/migrations/v3/migrator_test.go
@@ -1,4 +1,4 @@
-package v2_test
+package v3_test
 
 import (
 	"testing"
@@ -7,11 +7,10 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/testutil"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-
 	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
 	"github.com/cosmos/cosmos-sdk/x/slashing"
 	"github.com/cosmos/cosmos-sdk/x/slashing/exported"
-	v2 "github.com/cosmos/cosmos-sdk/x/slashing/migrations/v2"
+	v3 "github.com/cosmos/cosmos-sdk/x/slashing/migrations/v3"
 	"github.com/cosmos/cosmos-sdk/x/slashing/types"
 )
 
@@ -31,16 +30,16 @@ func TestMigrate(t *testing.T) {
 	encCfg := moduletestutil.MakeTestEncodingConfig(slashing.AppModuleBasic{})
 	cdc := encCfg.Codec
 
-	storeKey := sdk.NewKVStoreKey(v2.ModuleName)
+	storeKey := sdk.NewKVStoreKey(v3.ModuleName)
 	tKey := sdk.NewTransientStoreKey("transient_test")
 	ctx := testutil.DefaultContext(storeKey, tKey)
 	store := ctx.KVStore(storeKey)
 
 	legacySubspace := newMockSubspace(types.DefaultParams())
-	require.NoError(t, v2.Migrate(ctx, store, legacySubspace, cdc))
+	require.NoError(t, v3.Migrate(ctx, store, legacySubspace, cdc))
 
 	var res types.Params
-	bz := store.Get(v2.ParamsKey)
+	bz := store.Get(v3.ParamsKey)
 	require.NoError(t, cdc.Unmarshal(bz, &res))
 	require.Equal(t, legacySubspace.ps, res)
 }

--- a/x/slashing/module.go
+++ b/x/slashing/module.go
@@ -8,29 +8,27 @@ import (
 
 	modulev1 "cosmossdk.io/api/cosmos/slashing/module/v1"
 	"cosmossdk.io/core/appmodule"
-	staking "github.com/cosmos/cosmos-sdk/x/staking/types"
-
+	"cosmossdk.io/depinject"
 	gwruntime "github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/spf13/cobra"
 	abci "github.com/tendermint/tendermint/abci/types"
 
-	"cosmossdk.io/depinject"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/codec"
 	cdctypes "github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/cosmos/cosmos-sdk/runtime"
 	store "github.com/cosmos/cosmos-sdk/store/types"
-	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	"github.com/cosmos/cosmos-sdk/x/slashing/client/cli"
 	"github.com/cosmos/cosmos-sdk/x/slashing/exported"
 	"github.com/cosmos/cosmos-sdk/x/slashing/keeper"
 	"github.com/cosmos/cosmos-sdk/x/slashing/simulation"
 	"github.com/cosmos/cosmos-sdk/x/slashing/types"
+	staking "github.com/cosmos/cosmos-sdk/x/staking/types"
 )
 
 // ConsensusVersion defines the current x/slashing module consensus version.


### PR DESCRIPTION
The PRs that are migrating away from `x/params`, I realized folks are defining the migration path incorrectly -- it's supposed to be the **_consensus_** version.