### PR TITLE
fix: add cosmos_proto implements

### DIFF
--- a/proto/cosmos/distribution/v1beta1/distribution.proto
+++ b/proto/cosmos/distribution/v1beta1/distribution.proto
@@ -102,6 +102,7 @@ message CommunityPoolSpendProposal {
   option (gogoproto.equal)            = false;
   option (gogoproto.goproto_getters)  = false;
   option (gogoproto.goproto_stringer) = false;
+  option (cosmos_proto.implements_interface) = "cosmos.gov.v1beta1.Content";
 
   string   title                           = 1;
   string   description                     = 2;
@@ -143,6 +144,7 @@ message DelegationDelegatorReward {
 message CommunityPoolSpendProposalWithDeposit {
   option (gogoproto.goproto_getters)  = false;
   option (gogoproto.goproto_stringer) = true;
+  option (cosmos_proto.implements_interface) = "cosmos.gov.v1beta1.Content";
 
   string title       = 1;
   string description = 2;

--- a/proto/cosmos/params/v1beta1/params.proto
+++ b/proto/cosmos/params/v1beta1/params.proto
@@ -5,11 +5,13 @@ option go_package            = "github.com/cosmos/cosmos-sdk/x/params/types/prop
 option (gogoproto.equal_all) = true;
 
 import "gogoproto/gogo.proto";
+import "cosmos_proto/cosmos.proto";
 
 // ParameterChangeProposal defines a proposal to change one or more parameters.
 message ParameterChangeProposal {
   option (gogoproto.goproto_getters)  = false;
   option (gogoproto.goproto_stringer) = false;
+  option (cosmos_proto.implements_interface) = "cosmos.gov.v1beta1.Content";
 
   string               title       = 1;
   string               description = 2;

--- a/proto/cosmos/upgrade/v1beta1/upgrade.proto
+++ b/proto/cosmos/upgrade/v1beta1/upgrade.proto
@@ -4,6 +4,7 @@ package cosmos.upgrade.v1beta1;
 import "google/protobuf/any.proto";
 import "gogoproto/gogo.proto";
 import "google/protobuf/timestamp.proto";
+import "cosmos_proto/cosmos.proto";
 
 option go_package                      = "github.com/cosmos/cosmos-sdk/x/upgrade/types";
 option (gogoproto.goproto_getters_all) = false;
@@ -47,6 +48,7 @@ message Plan {
 // proposals, see MsgSoftwareUpgrade.
 message SoftwareUpgradeProposal {
   option deprecated                   = true;
+  option (cosmos_proto.implements_interface) = "cosmos.gov.v1beta1.Content";
   option (gogoproto.equal)            = true;
   option (gogoproto.goproto_stringer) = false;
 
@@ -61,6 +63,7 @@ message SoftwareUpgradeProposal {
 // proposals, see MsgCancelUpgrade.
 message CancelSoftwareUpgradeProposal {
   option deprecated                   = true;
+  option (cosmos_proto.implements_interface) = "cosmos.gov.v1beta1.Content";
   option (gogoproto.equal)            = true;
   option (gogoproto.goproto_stringer) = false;
 


### PR DESCRIPTION
It seems that we're missing the `cosmos_proto.implements_interface` on many proposal messages/structs

this is a draft to discuss adding options in protos for better codegen tooling. It seems that the following messages/structs are meant to implement `Content`:

```
option (cosmos_proto.implements_interface) = "cosmos.gov.v1beta1.Content"
```

Would this be a breaking change? Happy to improve/amend this so it's mergeable.
