### PR TITLE
feat: Add convenience method for constructing key to access account's balance for a given denom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -307,6 +307,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (deps) Downgrade to Tendermint [v0.34.20-rc0](https://github.com/tendermint/tendermint/releases/tag/v0.34.20-rc0).
 * [#12089](https://github.com/cosmos/cosmos-sdk/pull/12089) Mark the `TipDecorator` as beta, don't include it in simapp by default.
 * [#12153](https://github.com/cosmos/cosmos-sdk/pull/12153) Add a new `NewSimulationManagerFromAppModules` constructor, to simplify simulation wiring.
+* (x/bank) [#12674](https://github.com/cosmos/cosmos-sdk/pull/12674) Add convenience function `CreatePrefixedAccountStoreKey()` to construct key to access account's balance for a given denom.
 
 ### Bug Fixes
 

--- a/x/bank/migrations/v2/store.go
+++ b/x/bank/migrations/v2/store.go
@@ -63,7 +63,7 @@ func migrateBalanceKeys(store sdk.KVStore) {
 	for ; oldStoreIter.Valid(); oldStoreIter.Next() {
 		addr := v1.AddressFromBalancesStore(oldStoreIter.Key())
 		denom := oldStoreIter.Key()[v042auth.AddrLen:]
-		newStoreKey := append(CreateAccountBalancesPrefix(addr), denom...)
+		newStoreKey := types.CreatePrefixedAccountStoreKey(addr, denom)
 
 		// Set new key on store. Values don't change.
 		store.Set(newStoreKey, oldStoreIter.Value())

--- a/x/bank/migrations/v2/store_test.go
+++ b/x/bank/migrations/v2/store_test.go
@@ -93,13 +93,13 @@ func TestBalanceKeysMigration(t *testing.T) {
 	err = v2bank.MigrateStore(ctx, bankKey, encCfg.Codec)
 	require.NoError(t, err)
 
-	newKey := append(types.CreateAccountBalancesPrefix(addr), []byte(fooCoin.Denom)...)
+	newKey := types.CreatePrefixedAccountStoreKey(addr, []byte(fooCoin.Denom))
 	// -7 because we replaced "balances" with 0x02,
 	// +1 because we added length-prefix to address.
 	require.Equal(t, len(oldFooKey)-7+1, len(newKey))
 	require.Nil(t, store.Get(oldFooKey))
 	require.Equal(t, fooBz, store.Get(newKey))
 
-	newKeyFooBar := append(types.CreateAccountBalancesPrefix(addr), []byte(fooBarCoin.Denom)...)
+	newKeyFooBar := types.CreatePrefixedAccountStoreKey(addr, []byte(fooBarCoin.Denom))
 	require.Nil(t, store.Get(newKeyFooBar)) // after migration zero balances pruned from store.
 }

--- a/x/bank/types/keys.go
+++ b/x/bank/types/keys.go
@@ -70,8 +70,8 @@ func AddressAndDenomFromBalancesStore(key []byte) (sdk.AccAddress, string, error
 
 // CreatePrefixedAccountStoreKey returns the key for the given account and denomination.
 // This method can be used when performing an ABCI query for the balance of an account.
-func CreatePrefixedAccountStoreKey(addr []byte, denom string) []byte {
-	return append(CreateAccountBalancesPrefix(addr), []byte(denom)...)
+func CreatePrefixedAccountStoreKey(addr []byte, denom []byte) []byte {
+	return append(CreateAccountBalancesPrefix(addr), denom...)
 }
 
 // CreateAccountBalancesPrefix creates the prefix for an account's balances.

--- a/x/bank/types/keys.go
+++ b/x/bank/types/keys.go
@@ -68,6 +68,12 @@ func AddressAndDenomFromBalancesStore(key []byte) (sdk.AccAddress, string, error
 	return key[1 : addrBound+1], string(key[addrBound+1:]), nil
 }
 
+// CreatePrefixedAccountStoreKey returns the key for the given account and denomination.
+// This method can be used when performing an ABCI query for the balance of an account.
+func CreatePrefixedAccountStoreKey(addr []byte, denom string) []byte {
+	return append(CreateAccountBalancesPrefix(addr), []byte(denom)...)
+}
+
 // CreateAccountBalancesPrefix creates the prefix for an account's balances.
 func CreateAccountBalancesPrefix(addr []byte) []byte {
 	return append(BalancesPrefix, address.MustLengthPrefix(addr)...)


### PR DESCRIPTION
This PR adds a convenience method for constructing the key necessary to query for the account's balance of a given denom. 

I ran into this issue since we are using ABCI query now to perform balance requests because we are also requesting merkle proofs for the returned balance [here](https://github.com/celestiaorg/celestia-node/pull/911/files#diff-0ee31f5a7bd88e9f758e6bebdf3ee36365519e55a451098d9638c39afe5eac42R144).

It would be nice to have a definitive convenience method for constructing the key.

[Ref.](github.com/celestiaorg/celestia-node/pull/911)