### PR TITLE
chore: remove admin use from templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -27,12 +27,3 @@ through the appropriate channels won't receive any bounty.
 ## Steps to Reproduce
 
 <!-- What commands in order should someone run to reproduce your problem? -->
-
-____
-
-## For Admin Use
-
-- [ ] Not duplicate issue
-- [ ] Appropriate labels applied
-- [ ] Appropriate contributors tagged
-- [ ] Contributor assigned/self-assigned

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -25,12 +25,3 @@ Are there any disadvantages of including this feature? -->
 ## Proposal
 
 <!-- Detailed description of requirements of implementation -->
-
-____
-
-#### For Admin Use
-
-- [ ] Not duplicate issue
-- [ ] Appropriate labels applied
-- [ ] Appropriate contributors tagged
-- [ ] Contributor assigned/self-assigned


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

Closes: #12692 

remove admin use from issue templates