### PR TITLE
feat: Add `GetParamSetIfExists` to prevent panic on breaking param changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Improvements
 
+* (x/params) [#12615](https://github.com/cosmos/cosmos-sdk/pull/12615) Add `GetParamSetIfExists` function to params `Subspace` to prevent panics on breaking changes.
 * [#12668](https://github.com/cosmos/cosmos-sdk/pull/12668) Add `authz_msg_index` event attribute to message events emitted when executing via `MsgExec` through `x/authz`.
 * [#12697](https://github.com/cosmos/cosmos-sdk/pull/12697) Upgrade IAVL to v0.19.0 with fast index and error propagation. NOTE: first start will take a while to propagate into new model.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Improvements
 
-* (x/params) [#12615](https://github.com/cosmos/cosmos-sdk/pull/12615) Add `GetParamSetIfExists` function to params `Subspace` to prevent panics on breaking changes.
+* (x/params) [#12724](https://github.com/cosmos/cosmos-sdk/pull/12724) Add `GetParamSetIfExists` function to params `Subspace` to prevent panics on breaking changes.
 * [#12668](https://github.com/cosmos/cosmos-sdk/pull/12668) Add `authz_msg_index` event attribute to message events emitted when executing via `MsgExec` through `x/authz`.
 * [#12697](https://github.com/cosmos/cosmos-sdk/pull/12697) Upgrade IAVL to v0.19.0 with fast index and error propagation. NOTE: first start will take a while to propagate into new model.
 

--- a/x/params/types/common_test.go
+++ b/x/params/types/common_test.go
@@ -10,9 +10,10 @@ import (
 )
 
 var (
-	keyUnbondingTime = []byte("UnbondingTime")
-	keyMaxValidators = []byte("MaxValidators")
-	keyBondDenom     = []byte("BondDenom")
+	keyUnbondingTime          = []byte("UnbondingTime")
+	keyMaxValidators          = []byte("MaxValidators")
+	keyBondDenom              = []byte("BondDenom")
+	keyMaxRedelegationEntries = []byte("MaxRedelegationEntries")
 
 	key  = sdk.NewKVStoreKey("storekey")
 	tkey = sdk.NewTransientStoreKey("transientstorekey")
@@ -22,6 +23,13 @@ type params struct {
 	UnbondingTime time.Duration `json:"unbonding_time" yaml:"unbonding_time"`
 	MaxValidators uint16        `json:"max_validators" yaml:"max_validators"`
 	BondDenom     string        `json:"bond_denom" yaml:"bond_denom"`
+}
+
+type paramsV2 struct {
+	UnbondingTime          time.Duration `json:"unbonding_time" yaml:"unbonding_time"`
+	MaxValidators          uint16        `json:"max_validators" yaml:"max_validators"`
+	BondDenom              string        `json:"bond_denom" yaml:"bond_denom"`
+	MaxRedelegationEntries uint32        `json:"max_redelegation_entries" yaml:"max_redelegation_entries"`
 }
 
 func validateUnbondingTime(i interface{}) error {
@@ -59,11 +67,29 @@ func validateBondDenom(i interface{}) error {
 	return nil
 }
 
+func validateMaxRedelegationEntries(i interface{}) error {
+	_, ok := i.(uint32)
+	if !ok {
+		return fmt.Errorf("invalid parameter type: %T", i)
+	}
+
+	return nil
+}
+
 func (p *params) ParamSetPairs() types.ParamSetPairs {
 	return types.ParamSetPairs{
 		{keyUnbondingTime, &p.UnbondingTime, validateUnbondingTime},
 		{keyMaxValidators, &p.MaxValidators, validateMaxValidators},
 		{keyBondDenom, &p.BondDenom, validateBondDenom},
+	}
+}
+
+func (p *paramsV2) ParamSetPairs() types.ParamSetPairs {
+	return types.ParamSetPairs{
+		{keyUnbondingTime, &p.UnbondingTime, validateUnbondingTime},
+		{keyMaxValidators, &p.MaxValidators, validateMaxValidators},
+		{keyBondDenom, &p.BondDenom, validateBondDenom},
+		{keyMaxRedelegationEntries, &p.MaxRedelegationEntries, validateMaxRedelegationEntries},
 	}
 }
 

--- a/x/params/types/subspace.go
+++ b/x/params/types/subspace.go
@@ -223,6 +223,15 @@ func (s Subspace) GetParamSet(ctx sdk.Context, ps ParamSet) {
 	}
 }
 
+// GetParamSetIfExists iterates through each ParamSetPair where for each pair, it will
+// retrieve the value and set it to the corresponding value pointer provided
+// in the ParamSetPair by calling Subspace#GetIfExists.
+func (s Subspace) GetParamSetIfExists(ctx sdk.Context, ps ParamSet) {
+	for _, pair := range ps.ParamSetPairs() {
+		s.GetIfExists(ctx, pair.Key, pair.Value)
+	}
+}
+
 // SetParamSet iterates through each ParamSetPair and sets the value with the
 // corresponding parameter key in the Subspace's KVStore.
 func (s Subspace) SetParamSet(ctx sdk.Context, ps ParamSet) {

--- a/x/params/types/subspace_test.go
+++ b/x/params/types/subspace_test.go
@@ -182,6 +182,7 @@ func (suite *SubspaceTestSuite) TestGetParamSetIfExists() {
 	suite.Require().Equal(a.MaxValidators, b.MaxValidators)
 	suite.Require().Equal(a.BondDenom, b.BondDenom)
 	suite.Require().Zero(b.MaxRedelegationEntries)
+	suite.Require().False(suite.ss.Has(suite.ctx, keyMaxRedelegationEntries), "key from the new param version should not yet exist")
 }
 
 func (suite *SubspaceTestSuite) TestSetParamSet() {

--- a/x/params/types/subspace_test.go
+++ b/x/params/types/subspace_test.go
@@ -162,6 +162,28 @@ func (suite *SubspaceTestSuite) TestGetParamSet() {
 	suite.Require().Equal(a.BondDenom, b.BondDenom)
 }
 
+func (suite *SubspaceTestSuite) TestGetParamSetIfExists() {
+	a := params{
+		UnbondingTime: time.Hour * 48,
+		MaxValidators: 100,
+		BondDenom:     "stake",
+	}
+	suite.Require().NotPanics(func() {
+		suite.ss.Set(suite.ctx, keyUnbondingTime, a.UnbondingTime)
+		suite.ss.Set(suite.ctx, keyMaxValidators, a.MaxValidators)
+		suite.ss.Set(suite.ctx, keyBondDenom, a.BondDenom)
+	})
+
+	b := paramsV2{}
+	suite.Require().NotPanics(func() {
+		suite.ss.GetParamSetIfExists(suite.ctx, &b)
+	})
+	suite.Require().Equal(a.UnbondingTime, b.UnbondingTime)
+	suite.Require().Equal(a.MaxValidators, b.MaxValidators)
+	suite.Require().Equal(a.BondDenom, b.BondDenom)
+	suite.Require().Zero(b.MaxRedelegationEntries)
+}
+
 func (suite *SubspaceTestSuite) TestSetParamSet() {
 	testCases := []struct {
 		name string


### PR DESCRIPTION
- imp(params): Add GetParamSetIfExists to prevent panic on breaking param changes
- test
- imp(params): Add GetParamSetIfExists to prevent panic on breaking param changes

<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
