### PR TITLE
fix: make ModuleAccountInvariants pass for IS SDK changes

### DIFF
--- a/x/staking/keeper/delegation.go
+++ b/x/staking/keeper/delegation.go
@@ -432,10 +432,10 @@ func (k Keeper) SetRedelegationEntry(ctx sdk.Context,
 	red, found := k.GetRedelegation(ctx, delegatorAddr, validatorSrcAddr, validatorDstAddr)
 	id := k.IncrementUnbondingId(ctx)
 	if found {
-		red.AddEntry(creationHeight, minTime, balance, sharesDst, false, id)
+		red.AddEntry(creationHeight, minTime, balance, sharesDst, id)
 	} else {
 		red = types.NewRedelegation(delegatorAddr, validatorSrcAddr,
-			validatorDstAddr, creationHeight, minTime, balance, sharesDst, false, id)
+			validatorDstAddr, creationHeight, minTime, balance, sharesDst, id)
 	}
 
 	k.SetRedelegation(ctx, red)

--- a/x/staking/keeper/delegation.go
+++ b/x/staking/keeper/delegation.go
@@ -785,7 +785,7 @@ func (k Keeper) CompleteUnbonding(ctx sdk.Context, delAddr sdk.AccAddress, valAd
 
 	// loop through all the entries and try to complete unbonding mature entries
 	for i := 0; i < len(ubd.Entries); i++ {
-		entry := &ubd.Entries[i]
+		entry := ubd.Entries[i]
 		if entry.IsMature(ctxTime) && !entry.UnbondingOnHold {
 			// Proceed with unbonding
 			ubd.RemoveEntry(int64(i))
@@ -889,7 +889,7 @@ func (k Keeper) CompleteRedelegation(
 
 	// loop through all the entries and try to complete mature redelegation entries
 	for i := 0; i < len(red.Entries); i++ {
-		entry := &red.Entries[i]
+		entry := red.Entries[i]
 		if entry.IsMature(ctxTime) && !entry.UnbondingOnHold {
 			red.RemoveEntry(int64(i))
 			i--

--- a/x/staking/keeper/delegation_test.go
+++ b/x/staking/keeper/delegation_test.go
@@ -607,7 +607,7 @@ func TestGetRedelegationsFromSrcValidator(t *testing.T) {
 
 	rd := types.NewRedelegation(addrDels[0], addrVals[0], addrVals[1], 0,
 		time.Unix(0, 0), sdk.NewInt(5),
-		sdk.NewDec(5), false, 1)
+		sdk.NewDec(5), 1)
 
 	// set and retrieve a record
 	app.StakingKeeper.SetRedelegation(ctx, rd)
@@ -634,7 +634,7 @@ func TestRedelegation(t *testing.T) {
 
 	rd := types.NewRedelegation(addrDels[0], addrVals[0], addrVals[1], 0,
 		time.Unix(0, 0).UTC(), sdk.NewInt(5),
-		sdk.NewDec(5), false, 1)
+		sdk.NewDec(5), 1)
 
 	// test shouldn't have and redelegations
 	has := app.StakingKeeper.HasReceivingRedelegation(ctx, addrDels[0], addrVals[1])

--- a/x/staking/keeper/querier.go
+++ b/x/staking/keeper/querier.go
@@ -514,7 +514,6 @@ func RedelegationsToRedelegationResponses(
 				entry.SharesDst,
 				entry.InitialBalance,
 				val.TokensFromShares(entry.SharesDst).TruncateInt(),
-				entry.UnbondingOnHold,
 				entry.UnbondingId,
 			)
 		}

--- a/x/staking/keeper/slash_test.go
+++ b/x/staking/keeper/slash_test.go
@@ -131,7 +131,7 @@ func TestSlashRedelegation(t *testing.T) {
 	// set a redelegation with an expiration timestamp beyond which the
 	// redelegation shouldn't be slashed
 	rd := types.NewRedelegation(addrDels[0], addrVals[0], addrVals[1], 0,
-		time.Unix(5, 0), sdk.NewInt(10), sdk.NewDec(10), false, 1)
+		time.Unix(5, 0), sdk.NewInt(10), sdk.NewDec(10), 1)
 
 	app.StakingKeeper.SetRedelegation(ctx, rd)
 
@@ -390,7 +390,7 @@ func TestSlashWithRedelegation(t *testing.T) {
 	// set a redelegation
 	rdTokens := app.StakingKeeper.TokensFromConsensusPower(ctx, 6)
 	rd := types.NewRedelegation(addrDels[0], addrVals[0], addrVals[1], 11,
-		time.Unix(0, 0), rdTokens, rdTokens.ToDec(), false, 1)
+		time.Unix(0, 0), rdTokens, rdTokens.ToDec(), 1)
 	app.StakingKeeper.SetRedelegation(ctx, rd)
 
 	// set the associated delegation
@@ -544,7 +544,7 @@ func TestSlashBoth(t *testing.T) {
 	rdATokens := app.StakingKeeper.TokensFromConsensusPower(ctx, 6)
 	rdA := types.NewRedelegation(addrDels[0], addrVals[0], addrVals[1], 11,
 		time.Unix(0, 0), rdATokens,
-		rdATokens.ToDec(), false, 1)
+		rdATokens.ToDec(), 1)
 	app.StakingKeeper.SetRedelegation(ctx, rdA)
 
 	// set the associated delegation

--- a/x/staking/simulation/decoder_test.go
+++ b/x/staking/simulation/decoder_test.go
@@ -40,7 +40,7 @@ func TestDecodeStore(t *testing.T) {
 	require.NoError(t, err)
 	del := types.NewDelegation(delAddr1, valAddr1, sdk.OneDec())
 	ubd := types.NewUnbondingDelegation(delAddr1, valAddr1, 15, bondTime, sdk.OneInt(), 1)
-	red := types.NewRedelegation(delAddr1, valAddr1, valAddr1, 12, bondTime, sdk.OneInt(), sdk.OneDec(), false, 0)
+	red := types.NewRedelegation(delAddr1, valAddr1, valAddr1, 12, bondTime, sdk.OneInt(), sdk.OneDec(), 0)
 
 	kvPairs := kv.Pairs{
 		Pairs: []kv.Pair{

--- a/x/staking/types/delegation.go
+++ b/x/staking/types/delegation.go
@@ -94,11 +94,12 @@ func (d Delegations) String() (out string) {
 
 func NewUnbondingDelegationEntry(creationHeight int64, completionTime time.Time, balance sdk.Int, id uint64) UnbondingDelegationEntry {
 	return UnbondingDelegationEntry{
-		CreationHeight: creationHeight,
-		CompletionTime: completionTime,
-		InitialBalance: balance,
-		Balance:        balance,
-		UnbondingId:    id,
+		CreationHeight:  creationHeight,
+		CompletionTime:  completionTime,
+		InitialBalance:  balance,
+		Balance:         balance,
+		UnbondingId:     id,
+		UnbondingOnHold: false,
 	}
 }
 
@@ -209,14 +210,14 @@ func (ubds UnbondingDelegations) String() (out string) {
 	return strings.TrimSpace(out)
 }
 
-func NewRedelegationEntry(creationHeight int64, completionTime time.Time, balance sdk.Int, sharesDst sdk.Dec, onHold bool, id uint64) RedelegationEntry {
+func NewRedelegationEntry(creationHeight int64, completionTime time.Time, balance sdk.Int, sharesDst sdk.Dec, id uint64) RedelegationEntry {
 	return RedelegationEntry{
 		CreationHeight:  creationHeight,
 		CompletionTime:  completionTime,
 		InitialBalance:  balance,
 		SharesDst:       sharesDst,
-		UnbondingOnHold: onHold,
 		UnbondingId:     id,
+		UnbondingOnHold: false,
 	}
 }
 
@@ -234,21 +235,21 @@ func (e RedelegationEntry) IsMature(currentTime time.Time) bool {
 //nolint:interfacer
 func NewRedelegation(
 	delegatorAddr sdk.AccAddress, validatorSrcAddr, validatorDstAddr sdk.ValAddress,
-	creationHeight int64, minTime time.Time, balance sdk.Int, sharesDst sdk.Dec, onHold bool, unbondingId uint64,
+	creationHeight int64, minTime time.Time, balance sdk.Int, sharesDst sdk.Dec, unbondingId uint64,
 ) Redelegation {
 	return Redelegation{
 		DelegatorAddress:    delegatorAddr.String(),
 		ValidatorSrcAddress: validatorSrcAddr.String(),
 		ValidatorDstAddress: validatorDstAddr.String(),
 		Entries: []RedelegationEntry{
-			NewRedelegationEntry(creationHeight, minTime, balance, sharesDst, onHold, unbondingId),
+			NewRedelegationEntry(creationHeight, minTime, balance, sharesDst, unbondingId),
 		},
 	}
 }
 
 // AddEntry - append entry to the unbonding delegation
-func (red *Redelegation) AddEntry(creationHeight int64, minTime time.Time, balance sdk.Int, sharesDst sdk.Dec, onHold bool, unbondingId uint64) {
-	entry := NewRedelegationEntry(creationHeight, minTime, balance, sharesDst, onHold, unbondingId)
+func (red *Redelegation) AddEntry(creationHeight int64, minTime time.Time, balance sdk.Int, sharesDst sdk.Dec, unbondingId uint64) {
+	entry := NewRedelegationEntry(creationHeight, minTime, balance, sharesDst, unbondingId)
 	red.Entries = append(red.Entries, entry)
 }
 
@@ -374,9 +375,9 @@ func NewRedelegationResponse(
 
 // NewRedelegationEntryResponse creates a new RedelegationEntryResponse instance.
 func NewRedelegationEntryResponse(
-	creationHeight int64, completionTime time.Time, sharesDst sdk.Dec, initialBalance, balance sdk.Int, onHold bool, id uint64) RedelegationEntryResponse {
+	creationHeight int64, completionTime time.Time, sharesDst sdk.Dec, initialBalance, balance sdk.Int, id uint64) RedelegationEntryResponse {
 	return RedelegationEntryResponse{
-		RedelegationEntry: NewRedelegationEntry(creationHeight, completionTime, initialBalance, sharesDst, onHold, id),
+		RedelegationEntry: NewRedelegationEntry(creationHeight, completionTime, initialBalance, sharesDst, id),
 		Balance:           balance,
 	}
 }

--- a/x/staking/types/delegation_test.go
+++ b/x/staking/types/delegation_test.go
@@ -56,10 +56,10 @@ func TestUnbondingDelegationString(t *testing.T) {
 func TestRedelegationEqual(t *testing.T) {
 	r1 := types.NewRedelegation(sdk.AccAddress(valAddr1), valAddr2, valAddr3, 0,
 		time.Unix(0, 0), sdk.NewInt(0),
-		sdk.NewDec(0), false, 1)
+		sdk.NewDec(0), 1)
 	r2 := types.NewRedelegation(sdk.AccAddress(valAddr1), valAddr2, valAddr3, 0,
 		time.Unix(0, 0), sdk.NewInt(0),
-		sdk.NewDec(0), false, 2)
+		sdk.NewDec(0), 2)
 
 	ok := r1.String() == r2.String()
 	require.True(t, ok)
@@ -74,7 +74,7 @@ func TestRedelegationEqual(t *testing.T) {
 func TestRedelegationString(t *testing.T) {
 	r := types.NewRedelegation(sdk.AccAddress(valAddr1), valAddr2, valAddr3, 0,
 		time.Unix(0, 0), sdk.NewInt(0),
-		sdk.NewDec(10), false, 1)
+		sdk.NewDec(10), 1)
 
 	require.NotEmpty(t, r.String())
 }
@@ -111,8 +111,8 @@ func TestDelegationResponses(t *testing.T) {
 func TestRedelegationResponses(t *testing.T) {
 	cdc := codec.NewLegacyAmino()
 	entries := []types.RedelegationEntryResponse{
-		types.NewRedelegationEntryResponse(0, time.Unix(0, 0), sdk.NewDec(5), sdk.NewInt(5), sdk.NewInt(5), false, 0),
-		types.NewRedelegationEntryResponse(0, time.Unix(0, 0), sdk.NewDec(5), sdk.NewInt(5), sdk.NewInt(5), false, 0),
+		types.NewRedelegationEntryResponse(0, time.Unix(0, 0), sdk.NewDec(5), sdk.NewInt(5), sdk.NewInt(5), 0),
+		types.NewRedelegationEntryResponse(0, time.Unix(0, 0), sdk.NewDec(5), sdk.NewInt(5), sdk.NewInt(5), 0),
 	}
 	rdr1 := types.NewRedelegationResponse(sdk.AccAddress(valAddr1), valAddr2, valAddr3, entries)
 	rdr2 := types.NewRedelegationResponse(sdk.AccAddress(valAddr2), valAddr1, valAddr3, entries)


### PR DESCRIPTION
The changes in https://github.com/cosmos/cosmos-sdk/pull/12554 without https://github.com/cosmos/cosmos-sdk/pull/12578