### PR TITLE
chore: math lib update and type fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Improvements
 
+* [#12791](https://github.com/cosmos/cosmos-sdk/pull/12791) Bump the math library used in the sdk and replace old usages of sdk.*
 * [#12717](https://github.com/cosmos/cosmos-sdk/pull/12717) Use injected encoding params in simapp.
 * (x/bank) [#12674](https://github.com/cosmos/cosmos-sdk/pull/12674) Add convenience function `CreatePrefixedAccountStoreKey()` to construct key to access account's balance for a given denom.
 * [#12702](https://github.com/cosmos/cosmos-sdk/pull/12702) Linting and tidiness, fixed two minor security warnings. 

--- a/api/cosmos/distribution/v1beta1/distribution.pulsar.go
+++ b/api/cosmos/distribution/v1beta1/distribution.pulsar.go
@@ -7015,7 +7015,7 @@ func (x *CommunityPoolSpendProposal) GetAmount() []*v1beta1.Coin {
 // staking token, and the creation height (to check later on if any slashes have
 // occurred). NOTE: Even though validators are slashed to whole staking tokens,
 // the delegators within the validator may be left with less than a full token,
-// thus sdk.Dec is used.
+// thus math.LegacyDec is used.
 type DelegatorStartingInfo struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache

--- a/client/tx/factory.go
+++ b/client/tx/factory.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 
+	"cosmossdk.io/math"
 	"github.com/spf13/pflag"
 
 	"github.com/cosmos/cosmos-sdk/client"
@@ -259,7 +260,7 @@ func (f Factory) BuildUnsignedTx(msgs ...sdk.Msg) (client.TxBuilder, error) {
 			return nil, errors.New("cannot provide both fees and gas prices")
 		}
 
-		glDec := sdk.NewDec(int64(f.gas))
+		glDec := math.LegacyNewDec(int64(f.gas))
 
 		// Derive the fees based on the provided gas prices, where
 		// fee = ceil(gasPrice * gasLimit).

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	cosmossdk.io/core v0.1.0
 	cosmossdk.io/depinject v1.0.0-alpha.1.0.20220726092710-f848e4300a8a
 	cosmossdk.io/errors v1.0.0-beta.7
-	cosmossdk.io/math v1.0.0-beta.3.0.20220726092710-f848e4300a8a
+	cosmossdk.io/math v1.0.0-beta.3
 	github.com/99designs/keyring v1.2.1
 	github.com/armon/go-metrics v0.4.0
 	github.com/bgentry/speakeasy v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -74,6 +74,8 @@ cosmossdk.io/depinject v1.0.0-alpha.1.0.20220726092710-f848e4300a8a h1:yXENAEjWJ
 cosmossdk.io/depinject v1.0.0-alpha.1.0.20220726092710-f848e4300a8a/go.mod h1:zEXZ6zmw52FyN3X/oH9QxBXGbBQjzFDJjWxzkCw7FJo=
 cosmossdk.io/errors v1.0.0-beta.7 h1:gypHW76pTQGVnHKo6QBkb4yFOJjC+sUGRc5Al3Odj1w=
 cosmossdk.io/errors v1.0.0-beta.7/go.mod h1:mz6FQMJRku4bY7aqS/Gwfcmr/ue91roMEKAmDUDpBfE=
+cosmossdk.io/math v1.0.0-beta.3 h1:TbZxSopz2LqjJ7aXYfn7nJSb8vNaBklW6BLpcei1qwM=
+cosmossdk.io/math v1.0.0-beta.3/go.mod h1:3LYasri3Zna4XpbrTNdKsWmD5fHHkaNAod/mNT9XdE4=
 cosmossdk.io/math v1.0.0-beta.3.0.20220726092710-f848e4300a8a h1:3lmQIAF6ScBJ8kW5ZNejcBUJpwWhE2y57qEUI+OBESU=
 cosmossdk.io/math v1.0.0-beta.3.0.20220726092710-f848e4300a8a/go.mod h1:3LYasri3Zna4XpbrTNdKsWmD5fHHkaNAod/mNT9XdE4=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=

--- a/simapp/simd/cmd/testnet.go
+++ b/simapp/simd/cmd/testnet.go
@@ -297,7 +297,7 @@ func initTestnetFiles(
 			valPubKeys[i],
 			sdk.NewCoin(sdk.DefaultBondDenom, valTokens),
 			stakingtypes.NewDescription(nodeDirName, "", "", "", ""),
-			stakingtypes.NewCommissionRates(sdk.OneDec(), sdk.OneDec(), sdk.OneDec()),
+			stakingtypes.NewCommissionRates(math.LegacyOneDec(), math.LegacyOneDec(), math.LegacyOneDec()),
 			math.OneInt(),
 		)
 		if err != nil {

--- a/testutil/network/network.go
+++ b/testutil/network/network.go
@@ -483,7 +483,7 @@ func New(l Logger, baseDir string, cfg Config) (*Network, error) {
 			valPubKeys[i],
 			sdk.NewCoin(cfg.BondDenom, cfg.BondedTokens),
 			stakingtypes.NewDescription(nodeDirName, "", "", "", ""),
-			stakingtypes.NewCommissionRates(commission, sdk.OneDec(), sdk.OneDec()),
+			stakingtypes.NewCommissionRates(commission, math.LegacyOneDec(), math.LegacyOneDec()),
 			math.OneInt(),
 		)
 		if err != nil {

--- a/testutil/sims/app_helpers.go
+++ b/testutil/sims/app_helpers.go
@@ -195,15 +195,15 @@ func GenesisStateWithValSet(codec codec.Codec, genesisState map[string]json.RawM
 			Jailed:            false,
 			Status:            stakingtypes.Bonded,
 			Tokens:            bondAmt,
-			DelegatorShares:   sdk.OneDec(),
+			DelegatorShares:   math.LegacyOneDec(),
 			Description:       stakingtypes.Description{},
 			UnbondingHeight:   int64(0),
 			UnbondingTime:     time.Unix(0, 0).UTC(),
-			Commission:        stakingtypes.NewCommission(sdk.ZeroDec(), sdk.ZeroDec(), sdk.ZeroDec()),
+			Commission:        stakingtypes.NewCommission(math.LegacyZeroDec(), math.LegacyZeroDec(), math.LegacyZeroDec()),
 			MinSelfDelegation: math.ZeroInt(),
 		}
 		validators = append(validators, validator)
-		delegations = append(delegations, stakingtypes.NewDelegation(genAccs[0].GetAddress(), val.Address.Bytes(), sdk.OneDec()))
+		delegations = append(delegations, stakingtypes.NewDelegation(genAccs[0].GetAddress(), val.Address.Bytes(), math.LegacyOneDec()))
 
 	}
 	// set validators and delegations

--- a/types/dec_coin_test.go
+++ b/types/dec_coin_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"cosmossdk.io/math"
 	"github.com/stretchr/testify/suite"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -34,16 +35,16 @@ func (s *decCoinTestSuite) TestNewDecCoin() {
 
 func (s *decCoinTestSuite) TestNewDecCoinFromDec() {
 	s.Require().NotPanics(func() {
-		sdk.NewDecCoinFromDec(testDenom1, sdk.NewDec(5))
+		sdk.NewDecCoinFromDec(testDenom1, math.LegacyNewDec(5))
 	})
 	s.Require().NotPanics(func() {
 		sdk.NewDecCoinFromDec(testDenom1, sdk.ZeroDec())
 	})
 	s.Require().NotPanics(func() {
-		sdk.NewDecCoinFromDec(strings.ToUpper(testDenom1), sdk.NewDec(5))
+		sdk.NewDecCoinFromDec(strings.ToUpper(testDenom1), math.LegacyNewDec(5))
 	})
 	s.Require().Panics(func() {
-		sdk.NewDecCoinFromDec(testDenom1, sdk.NewDec(-5))
+		sdk.NewDecCoinFromDec(testDenom1, math.LegacyNewDec(-5))
 	})
 }
 
@@ -86,9 +87,9 @@ func (s *decCoinTestSuite) TestAddDecCoin() {
 }
 
 func (s *decCoinTestSuite) TestAddDecCoins() {
-	one := sdk.NewDec(1)
-	zero := sdk.NewDec(0)
-	two := sdk.NewDec(2)
+	one := math.LegacyNewDec(1)
+	zero := math.LegacyNewDec(0)
+	two := math.LegacyNewDec(2)
 
 	cases := []struct {
 		inputOne sdk.DecCoins
@@ -117,11 +118,11 @@ func (s *decCoinTestSuite) TestFilteredZeroDecCoins() {
 		{
 			name: "all greater than zero",
 			input: sdk.DecCoins{
-				{"testa", sdk.NewDec(1)},
-				{"testb", sdk.NewDec(2)},
-				{"testc", sdk.NewDec(3)},
-				{"testd", sdk.NewDec(4)},
-				{"teste", sdk.NewDec(5)},
+				{"testa", math.LegacyNewDec(1)},
+				{"testb", math.LegacyNewDec(2)},
+				{"testc", math.LegacyNewDec(3)},
+				{"testd", math.LegacyNewDec(4)},
+				{"teste", math.LegacyNewDec(5)},
 			},
 			original: "1.000000000000000000testa,2.000000000000000000testb,3.000000000000000000testc,4.000000000000000000testd,5.000000000000000000teste",
 			expected: "1.000000000000000000testa,2.000000000000000000testb,3.000000000000000000testc,4.000000000000000000testd,5.000000000000000000teste",
@@ -130,11 +131,11 @@ func (s *decCoinTestSuite) TestFilteredZeroDecCoins() {
 		{
 			name: "zero coin in middle",
 			input: sdk.DecCoins{
-				{"testa", sdk.NewDec(1)},
-				{"testb", sdk.NewDec(2)},
-				{"testc", sdk.NewDec(0)},
-				{"testd", sdk.NewDec(4)},
-				{"teste", sdk.NewDec(5)},
+				{"testa", math.LegacyNewDec(1)},
+				{"testb", math.LegacyNewDec(2)},
+				{"testc", math.LegacyNewDec(0)},
+				{"testd", math.LegacyNewDec(4)},
+				{"teste", math.LegacyNewDec(5)},
 			},
 			original: "1.000000000000000000testa,2.000000000000000000testb,0.000000000000000000testc,4.000000000000000000testd,5.000000000000000000teste",
 			expected: "1.000000000000000000testa,2.000000000000000000testb,4.000000000000000000testd,5.000000000000000000teste",
@@ -143,11 +144,11 @@ func (s *decCoinTestSuite) TestFilteredZeroDecCoins() {
 		{
 			name: "zero coin end (unordered)",
 			input: sdk.DecCoins{
-				{"teste", sdk.NewDec(5)},
-				{"testc", sdk.NewDec(3)},
-				{"testa", sdk.NewDec(1)},
-				{"testd", sdk.NewDec(4)},
-				{"testb", sdk.NewDec(0)},
+				{"teste", math.LegacyNewDec(5)},
+				{"testc", math.LegacyNewDec(3)},
+				{"testa", math.LegacyNewDec(1)},
+				{"testd", math.LegacyNewDec(4)},
+				{"testb", math.LegacyNewDec(0)},
 			},
 			original: "5.000000000000000000teste,3.000000000000000000testc,1.000000000000000000testa,4.000000000000000000testd,0.000000000000000000testb",
 			expected: "1.000000000000000000testa,3.000000000000000000testc,4.000000000000000000testd,5.000000000000000000teste",
@@ -157,11 +158,11 @@ func (s *decCoinTestSuite) TestFilteredZeroDecCoins() {
 		{
 			name: "panic when same denoms in multiple coins",
 			input: sdk.DecCoins{
-				{"testa", sdk.NewDec(5)},
-				{"testa", sdk.NewDec(3)},
-				{"testa", sdk.NewDec(1)},
-				{"testd", sdk.NewDec(4)},
-				{"testb", sdk.NewDec(2)},
+				{"testa", math.LegacyNewDec(5)},
+				{"testa", math.LegacyNewDec(3)},
+				{"testa", math.LegacyNewDec(1)},
+				{"testd", math.LegacyNewDec(4)},
+				{"testb", math.LegacyNewDec(2)},
 			},
 			original: "5.000000000000000000teste,3.000000000000000000testc,1.000000000000000000testa,4.000000000000000000testd,0.000000000000000000testb",
 			expected: "1.000000000000000000testa,3.000000000000000000testc,4.000000000000000000testd,5.000000000000000000teste",
@@ -192,17 +193,17 @@ func (s *decCoinTestSuite) TestIsValid() {
 			"valid coins should have passed",
 		},
 		{
-			sdk.DecCoin{Denom: "BTC", Amount: sdk.NewDec(10)},
+			sdk.DecCoin{Denom: "BTC", Amount: math.LegacyNewDec(10)},
 			true,
 			"valid uppercase denom",
 		},
 		{
-			sdk.DecCoin{Denom: "Bitcoin", Amount: sdk.NewDec(10)},
+			sdk.DecCoin{Denom: "Bitcoin", Amount: math.LegacyNewDec(10)},
 			true,
 			"valid mixed case denom",
 		},
 		{
-			sdk.DecCoin{Denom: "btc", Amount: sdk.NewDec(-10)},
+			sdk.DecCoin{Denom: "btc", Amount: math.LegacyNewDec(-10)},
 			false,
 			"negative amount",
 		},
@@ -271,7 +272,7 @@ func (s *decCoinTestSuite) TestSubDecCoins() {
 			"unorted coins should panic",
 		},
 		{
-			sdk.DecCoins{sdk.DecCoin{Denom: "BTC", Amount: sdk.NewDec(10)}, sdk.NewDecCoin("eth", sdk.NewInt(15)), sdk.NewDecCoin("mytoken", sdk.NewInt(5))},
+			sdk.DecCoins{sdk.DecCoin{Denom: "BTC", Amount: math.LegacyNewDec(10)}, sdk.NewDecCoin("eth", sdk.NewInt(15)), sdk.NewDecCoin("mytoken", sdk.NewInt(5))},
 			false,
 			"invalid denoms",
 		},
@@ -345,16 +346,16 @@ func (s *decCoinTestSuite) TestDecCoinsValidate() {
 		expectedPass bool
 	}{
 		{sdk.DecCoins{}, true},
-		{sdk.DecCoins{sdk.DecCoin{testDenom1, sdk.NewDec(5)}}, true},
-		{sdk.DecCoins{sdk.DecCoin{testDenom1, sdk.NewDec(5)}, sdk.DecCoin{testDenom2, sdk.NewDec(100000)}}, true},
-		{sdk.DecCoins{sdk.DecCoin{testDenom1, sdk.NewDec(-5)}}, false},
-		{sdk.DecCoins{sdk.DecCoin{"BTC", sdk.NewDec(5)}}, true},
-		{sdk.DecCoins{sdk.DecCoin{"0BTC", sdk.NewDec(5)}}, false},
-		{sdk.DecCoins{sdk.DecCoin{testDenom1, sdk.NewDec(5)}, sdk.DecCoin{"B", sdk.NewDec(100000)}}, false},
-		{sdk.DecCoins{sdk.DecCoin{testDenom1, sdk.NewDec(5)}, sdk.DecCoin{testDenom2, sdk.NewDec(-100000)}}, false},
-		{sdk.DecCoins{sdk.DecCoin{testDenom1, sdk.NewDec(-5)}, sdk.DecCoin{testDenom2, sdk.NewDec(100000)}}, false},
-		{sdk.DecCoins{sdk.DecCoin{"BTC", sdk.NewDec(5)}, sdk.DecCoin{testDenom2, sdk.NewDec(100000)}}, true},
-		{sdk.DecCoins{sdk.DecCoin{"0BTC", sdk.NewDec(5)}, sdk.DecCoin{testDenom2, sdk.NewDec(100000)}}, false},
+		{sdk.DecCoins{sdk.DecCoin{testDenom1, math.LegacyNewDec(5)}}, true},
+		{sdk.DecCoins{sdk.DecCoin{testDenom1, math.LegacyNewDec(5)}, sdk.DecCoin{testDenom2, math.LegacyNewDec(100000)}}, true},
+		{sdk.DecCoins{sdk.DecCoin{testDenom1, math.LegacyNewDec(-5)}}, false},
+		{sdk.DecCoins{sdk.DecCoin{"BTC", math.LegacyNewDec(5)}}, true},
+		{sdk.DecCoins{sdk.DecCoin{"0BTC", math.LegacyNewDec(5)}}, false},
+		{sdk.DecCoins{sdk.DecCoin{testDenom1, math.LegacyNewDec(5)}, sdk.DecCoin{"B", math.LegacyNewDec(100000)}}, false},
+		{sdk.DecCoins{sdk.DecCoin{testDenom1, math.LegacyNewDec(5)}, sdk.DecCoin{testDenom2, math.LegacyNewDec(-100000)}}, false},
+		{sdk.DecCoins{sdk.DecCoin{testDenom1, math.LegacyNewDec(-5)}, sdk.DecCoin{testDenom2, math.LegacyNewDec(100000)}}, false},
+		{sdk.DecCoins{sdk.DecCoin{"BTC", math.LegacyNewDec(5)}, sdk.DecCoin{testDenom2, math.LegacyNewDec(100000)}}, true},
+		{sdk.DecCoins{sdk.DecCoin{"0BTC", math.LegacyNewDec(5)}, sdk.DecCoin{testDenom2, math.LegacyNewDec(100000)}}, false},
 	}
 
 	for i, tc := range testCases {
@@ -377,7 +378,7 @@ func (s *decCoinTestSuite) TestParseDecCoins() {
 		{"4stake", sdk.DecCoins{sdk.NewDecCoinFromDec("stake", sdk.NewDecFromInt(sdk.NewInt(4)))}, false},
 		{"5.5atom,4stake", sdk.DecCoins{
 			sdk.NewDecCoinFromDec("atom", sdk.NewDecWithPrec(5500000000000000000, sdk.Precision)),
-			sdk.NewDecCoinFromDec("stake", sdk.NewDec(4)),
+			sdk.NewDecCoinFromDec("stake", math.LegacyNewDec(4)),
 		}, false},
 		{"0.0stake", sdk.DecCoins{}, false}, // remove zero coins
 		{"10.0btc,1.0atom,20.0btc", nil, true},
@@ -518,7 +519,7 @@ func (s *decCoinTestSuite) TestDecCoinsQuoDecTruncate() {
 	}{
 		{sdk.DecCoins{}, sdk.ZeroDec(), sdk.DecCoins(nil), true},
 		{sdk.DecCoins{sdk.NewDecCoinFromDec("foo", x)}, y, sdk.DecCoins(nil), false},
-		{sdk.DecCoins{sdk.NewInt64DecCoin("foo", 5)}, sdk.NewDec(2), sdk.DecCoins{sdk.NewDecCoinFromDec("foo", sdk.MustNewDecFromStr("2.5"))}, false},
+		{sdk.DecCoins{sdk.NewInt64DecCoin("foo", 5)}, math.LegacyNewDec(2), sdk.DecCoins{sdk.NewDecCoinFromDec("foo", sdk.MustNewDecFromStr("2.5"))}, false},
 	}
 
 	for i, tc := range testCases {
@@ -533,8 +534,8 @@ func (s *decCoinTestSuite) TestDecCoinsQuoDecTruncate() {
 }
 
 func (s *decCoinTestSuite) TestNewDecCoinsWithIsValid() {
-	fake1 := append(sdk.NewDecCoins(sdk.NewDecCoin("mytoken", sdk.NewInt(10))), sdk.DecCoin{Denom: "10BTC", Amount: sdk.NewDec(10)})
-	fake2 := append(sdk.NewDecCoins(sdk.NewDecCoin("mytoken", sdk.NewInt(10))), sdk.DecCoin{Denom: "BTC", Amount: sdk.NewDec(-10)})
+	fake1 := append(sdk.NewDecCoins(sdk.NewDecCoin("mytoken", sdk.NewInt(10))), sdk.DecCoin{Denom: "10BTC", Amount: math.LegacyNewDec(10)})
+	fake2 := append(sdk.NewDecCoins(sdk.NewDecCoin("mytoken", sdk.NewInt(10))), sdk.DecCoin{Denom: "BTC", Amount: math.LegacyNewDec(-10)})
 
 	tests := []struct {
 		coin       sdk.DecCoins
@@ -569,7 +570,7 @@ func (s *decCoinTestSuite) TestNewDecCoinsWithIsValid() {
 }
 
 func (s *decCoinTestSuite) TestDecCoins_AddDecCoinWithIsValid() {
-	lengthTestDecCoins := sdk.NewDecCoins().Add(sdk.NewDecCoin("mytoken", sdk.NewInt(10))).Add(sdk.DecCoin{Denom: "BTC", Amount: sdk.NewDec(10)})
+	lengthTestDecCoins := sdk.NewDecCoins().Add(sdk.NewDecCoin("mytoken", sdk.NewInt(10))).Add(sdk.DecCoin{Denom: "BTC", Amount: math.LegacyNewDec(10)})
 	s.Require().Equal(2, len(lengthTestDecCoins), "should be 2")
 
 	tests := []struct {
@@ -583,12 +584,12 @@ func (s *decCoinTestSuite) TestDecCoins_AddDecCoinWithIsValid() {
 			"valid coins should have passed",
 		},
 		{
-			sdk.NewDecCoins().Add(sdk.NewDecCoin("mytoken", sdk.NewInt(10))).Add(sdk.DecCoin{Denom: "0BTC", Amount: sdk.NewDec(10)}),
+			sdk.NewDecCoins().Add(sdk.NewDecCoin("mytoken", sdk.NewInt(10))).Add(sdk.DecCoin{Denom: "0BTC", Amount: math.LegacyNewDec(10)}),
 			false,
 			"invalid denoms",
 		},
 		{
-			sdk.NewDecCoins().Add(sdk.NewDecCoin("mytoken", sdk.NewInt(10))).Add(sdk.DecCoin{Denom: "BTC", Amount: sdk.NewDec(-10)}),
+			sdk.NewDecCoins().Add(sdk.NewDecCoin("mytoken", sdk.NewInt(10))).Add(sdk.DecCoin{Denom: "BTC", Amount: math.LegacyNewDec(-10)}),
 			false,
 			"negative amount",
 		},
@@ -611,7 +612,7 @@ func (s *decCoinTestSuite) TestDecCoins_Empty() {
 		msg            string
 	}{
 		{sdk.DecCoins{}, true, "No coins as expected."},
-		{sdk.DecCoins{sdk.DecCoin{testDenom1, sdk.NewDec(5)}}, false, "DecCoins is not empty"},
+		{sdk.DecCoins{sdk.DecCoin{testDenom1, math.LegacyNewDec(5)}}, false, "DecCoins is not empty"},
 	}
 
 	for _, tc := range testCases {
@@ -638,13 +639,13 @@ func (s *decCoinTestSuite) TestDecCoins_GetDenomByIndex() {
 			"",
 			true,
 		},
-		{"When index out of bounds", sdk.DecCoins{sdk.DecCoin{testDenom1, sdk.NewDec(5)}}, 2, "", true},
-		{"When negative index", sdk.DecCoins{sdk.DecCoin{testDenom1, sdk.NewDec(5)}}, -1, "", true},
+		{"When index out of bounds", sdk.DecCoins{sdk.DecCoin{testDenom1, math.LegacyNewDec(5)}}, 2, "", true},
+		{"When negative index", sdk.DecCoins{sdk.DecCoin{testDenom1, math.LegacyNewDec(5)}}, -1, "", true},
 		{
 			"Appropriate index case",
 			sdk.DecCoins{
-				sdk.DecCoin{testDenom1, sdk.NewDec(5)},
-				sdk.DecCoin{testDenom2, sdk.NewDec(57)},
+				sdk.DecCoin{testDenom1, math.LegacyNewDec(5)},
+				sdk.DecCoin{testDenom2, math.LegacyNewDec(57)},
 			},
 			1, testDenom2, false,
 		},
@@ -671,24 +672,24 @@ func (s *decCoinTestSuite) TestDecCoins_IsAllPositive() {
 	}{
 		{"No Coins", sdk.DecCoins{}, false},
 
-		{"One Coin - Zero value", sdk.DecCoins{sdk.DecCoin{testDenom1, sdk.NewDec(0)}}, false},
+		{"One Coin - Zero value", sdk.DecCoins{sdk.DecCoin{testDenom1, math.LegacyNewDec(0)}}, false},
 
-		{"One Coin - Positive value", sdk.DecCoins{sdk.DecCoin{testDenom1, sdk.NewDec(5)}}, true},
+		{"One Coin - Positive value", sdk.DecCoins{sdk.DecCoin{testDenom1, math.LegacyNewDec(5)}}, true},
 
-		{"One Coin - Negative value", sdk.DecCoins{sdk.DecCoin{testDenom1, sdk.NewDec(-15)}}, false},
+		{"One Coin - Negative value", sdk.DecCoins{sdk.DecCoin{testDenom1, math.LegacyNewDec(-15)}}, false},
 
 		{"Multiple Coins - All positive value", sdk.DecCoins{
-			sdk.DecCoin{testDenom1, sdk.NewDec(51)},
-			sdk.DecCoin{testDenom1, sdk.NewDec(123)},
-			sdk.DecCoin{testDenom1, sdk.NewDec(50)},
-			sdk.DecCoin{testDenom1, sdk.NewDec(92233720)},
+			sdk.DecCoin{testDenom1, math.LegacyNewDec(51)},
+			sdk.DecCoin{testDenom1, math.LegacyNewDec(123)},
+			sdk.DecCoin{testDenom1, math.LegacyNewDec(50)},
+			sdk.DecCoin{testDenom1, math.LegacyNewDec(92233720)},
 		}, true},
 
 		{"Multiple Coins - Some negative value", sdk.DecCoins{
-			sdk.DecCoin{testDenom1, sdk.NewDec(51)},
-			sdk.DecCoin{testDenom1, sdk.NewDec(-123)},
-			sdk.DecCoin{testDenom1, sdk.NewDec(0)},
-			sdk.DecCoin{testDenom1, sdk.NewDec(92233720)},
+			sdk.DecCoin{testDenom1, math.LegacyNewDec(51)},
+			sdk.DecCoin{testDenom1, math.LegacyNewDec(-123)},
+			sdk.DecCoin{testDenom1, math.LegacyNewDec(0)},
+			sdk.DecCoin{testDenom1, math.LegacyNewDec(92233720)},
 		}, false},
 	}
 
@@ -712,17 +713,17 @@ func (s *decCoinTestSuite) TestDecCoin_IsLT() {
 		expectedResult bool
 		expectedPanic  bool
 	}{
-		{"Same Denom - Less than other coin", sdk.DecCoin{testDenom1, sdk.NewDec(3)}, sdk.DecCoin{testDenom1, sdk.NewDec(19)}, true, false},
+		{"Same Denom - Less than other coin", sdk.DecCoin{testDenom1, math.LegacyNewDec(3)}, sdk.DecCoin{testDenom1, math.LegacyNewDec(19)}, true, false},
 
-		{"Same Denom - Greater than other coin", sdk.DecCoin{testDenom1, sdk.NewDec(343340)}, sdk.DecCoin{testDenom1, sdk.NewDec(14)}, false, false},
+		{"Same Denom - Greater than other coin", sdk.DecCoin{testDenom1, math.LegacyNewDec(343340)}, sdk.DecCoin{testDenom1, math.LegacyNewDec(14)}, false, false},
 
-		{"Same Denom - Same as other coin", sdk.DecCoin{testDenom1, sdk.NewDec(20)}, sdk.DecCoin{testDenom1, sdk.NewDec(20)}, false, false},
+		{"Same Denom - Same as other coin", sdk.DecCoin{testDenom1, math.LegacyNewDec(20)}, sdk.DecCoin{testDenom1, math.LegacyNewDec(20)}, false, false},
 
-		{"Different Denom - Less than other coin", sdk.DecCoin{testDenom1, sdk.NewDec(3)}, sdk.DecCoin{testDenom2, sdk.NewDec(19)}, true, true},
+		{"Different Denom - Less than other coin", sdk.DecCoin{testDenom1, math.LegacyNewDec(3)}, sdk.DecCoin{testDenom2, math.LegacyNewDec(19)}, true, true},
 
-		{"Different Denom - Greater than other coin", sdk.DecCoin{testDenom1, sdk.NewDec(343340)}, sdk.DecCoin{testDenom2, sdk.NewDec(14)}, true, true},
+		{"Different Denom - Greater than other coin", sdk.DecCoin{testDenom1, math.LegacyNewDec(343340)}, sdk.DecCoin{testDenom2, math.LegacyNewDec(14)}, true, true},
 
-		{"Different Denom - Same as other coin", sdk.DecCoin{testDenom1, sdk.NewDec(20)}, sdk.DecCoin{testDenom2, sdk.NewDec(20)}, true, true},
+		{"Different Denom - Same as other coin", sdk.DecCoin{testDenom1, math.LegacyNewDec(20)}, sdk.DecCoin{testDenom2, math.LegacyNewDec(20)}, true, true},
 	}
 
 	for i, tc := range testCases {
@@ -749,17 +750,17 @@ func (s *decCoinTestSuite) TestDecCoin_IsGTE() {
 		expectedResult bool
 		expectedPanic  bool
 	}{
-		{"Same Denom - Less than other coin", sdk.DecCoin{testDenom1, sdk.NewDec(3)}, sdk.DecCoin{testDenom1, sdk.NewDec(19)}, false, false},
+		{"Same Denom - Less than other coin", sdk.DecCoin{testDenom1, math.LegacyNewDec(3)}, sdk.DecCoin{testDenom1, math.LegacyNewDec(19)}, false, false},
 
-		{"Same Denom - Greater than other coin", sdk.DecCoin{testDenom1, sdk.NewDec(343340)}, sdk.DecCoin{testDenom1, sdk.NewDec(14)}, true, false},
+		{"Same Denom - Greater than other coin", sdk.DecCoin{testDenom1, math.LegacyNewDec(343340)}, sdk.DecCoin{testDenom1, math.LegacyNewDec(14)}, true, false},
 
-		{"Same Denom - Same as other coin", sdk.DecCoin{testDenom1, sdk.NewDec(20)}, sdk.DecCoin{testDenom1, sdk.NewDec(20)}, true, false},
+		{"Same Denom - Same as other coin", sdk.DecCoin{testDenom1, math.LegacyNewDec(20)}, sdk.DecCoin{testDenom1, math.LegacyNewDec(20)}, true, false},
 
-		{"Different Denom - Less than other coin", sdk.DecCoin{testDenom1, sdk.NewDec(3)}, sdk.DecCoin{testDenom2, sdk.NewDec(19)}, true, true},
+		{"Different Denom - Less than other coin", sdk.DecCoin{testDenom1, math.LegacyNewDec(3)}, sdk.DecCoin{testDenom2, math.LegacyNewDec(19)}, true, true},
 
-		{"Different Denom - Greater than other coin", sdk.DecCoin{testDenom1, sdk.NewDec(343340)}, sdk.DecCoin{testDenom2, sdk.NewDec(14)}, true, true},
+		{"Different Denom - Greater than other coin", sdk.DecCoin{testDenom1, math.LegacyNewDec(343340)}, sdk.DecCoin{testDenom2, math.LegacyNewDec(14)}, true, true},
 
-		{"Different Denom - Same as other coin", sdk.DecCoin{testDenom1, sdk.NewDec(20)}, sdk.DecCoin{testDenom2, sdk.NewDec(20)}, true, true},
+		{"Different Denom - Same as other coin", sdk.DecCoin{testDenom1, math.LegacyNewDec(20)}, sdk.DecCoin{testDenom2, math.LegacyNewDec(20)}, true, true},
 	}
 
 	for i, tc := range testCases {
@@ -787,22 +788,22 @@ func (s *decCoinTestSuite) TestDecCoins_IsZero() {
 	}{
 		{"No Coins", sdk.DecCoins{}, true},
 
-		{"One Coin - Zero value", sdk.DecCoins{sdk.DecCoin{testDenom1, sdk.NewDec(0)}}, true},
+		{"One Coin - Zero value", sdk.DecCoins{sdk.DecCoin{testDenom1, math.LegacyNewDec(0)}}, true},
 
-		{"One Coin - Positive value", sdk.DecCoins{sdk.DecCoin{testDenom1, sdk.NewDec(5)}}, false},
+		{"One Coin - Positive value", sdk.DecCoins{sdk.DecCoin{testDenom1, math.LegacyNewDec(5)}}, false},
 
 		{"Multiple Coins - All zero value", sdk.DecCoins{
-			sdk.DecCoin{testDenom1, sdk.NewDec(0)},
-			sdk.DecCoin{testDenom1, sdk.NewDec(0)},
-			sdk.DecCoin{testDenom1, sdk.NewDec(0)},
-			sdk.DecCoin{testDenom1, sdk.NewDec(0)},
+			sdk.DecCoin{testDenom1, math.LegacyNewDec(0)},
+			sdk.DecCoin{testDenom1, math.LegacyNewDec(0)},
+			sdk.DecCoin{testDenom1, math.LegacyNewDec(0)},
+			sdk.DecCoin{testDenom1, math.LegacyNewDec(0)},
 		}, true},
 
 		{"Multiple Coins - Some positive value", sdk.DecCoins{
-			sdk.DecCoin{testDenom1, sdk.NewDec(0)},
-			sdk.DecCoin{testDenom1, sdk.NewDec(0)},
-			sdk.DecCoin{testDenom1, sdk.NewDec(0)},
-			sdk.DecCoin{testDenom1, sdk.NewDec(92233720)},
+			sdk.DecCoin{testDenom1, math.LegacyNewDec(0)},
+			sdk.DecCoin{testDenom1, math.LegacyNewDec(0)},
+			sdk.DecCoin{testDenom1, math.LegacyNewDec(0)},
+			sdk.DecCoin{testDenom1, math.LegacyNewDec(92233720)},
 		}, false},
 	}
 
@@ -825,39 +826,39 @@ func (s *decCoinTestSuite) TestDecCoins_MulDec() {
 		multiplier     sdk.Dec
 		expectedResult sdk.DecCoins
 	}{
-		{"No Coins", sdk.DecCoins{}, sdk.NewDec(1), sdk.DecCoins(nil)},
+		{"No Coins", sdk.DecCoins{}, math.LegacyNewDec(1), sdk.DecCoins(nil)},
 
 		{"Multiple coins - zero multiplier", sdk.DecCoins{
-			sdk.DecCoin{testDenom1, sdk.NewDec(10)},
-			sdk.DecCoin{testDenom1, sdk.NewDec(30)},
-		}, sdk.NewDec(0), sdk.DecCoins(nil)},
+			sdk.DecCoin{testDenom1, math.LegacyNewDec(10)},
+			sdk.DecCoin{testDenom1, math.LegacyNewDec(30)},
+		}, math.LegacyNewDec(0), sdk.DecCoins(nil)},
 
 		{"Multiple coins - positive multiplier", sdk.DecCoins{
-			sdk.DecCoin{testDenom1, sdk.NewDec(1)},
-			sdk.DecCoin{testDenom1, sdk.NewDec(2)},
-			sdk.DecCoin{testDenom1, sdk.NewDec(3)},
-			sdk.DecCoin{testDenom1, sdk.NewDec(4)},
-		}, sdk.NewDec(2), sdk.DecCoins{
-			sdk.DecCoin{testDenom1, sdk.NewDec(20)},
+			sdk.DecCoin{testDenom1, math.LegacyNewDec(1)},
+			sdk.DecCoin{testDenom1, math.LegacyNewDec(2)},
+			sdk.DecCoin{testDenom1, math.LegacyNewDec(3)},
+			sdk.DecCoin{testDenom1, math.LegacyNewDec(4)},
+		}, math.LegacyNewDec(2), sdk.DecCoins{
+			sdk.DecCoin{testDenom1, math.LegacyNewDec(20)},
 		}},
 
 		{"Multiple coins - negative multiplier", sdk.DecCoins{
-			sdk.DecCoin{testDenom1, sdk.NewDec(1)},
-			sdk.DecCoin{testDenom1, sdk.NewDec(2)},
-			sdk.DecCoin{testDenom1, sdk.NewDec(3)},
-			sdk.DecCoin{testDenom1, sdk.NewDec(4)},
-		}, sdk.NewDec(-2), sdk.DecCoins{
-			sdk.DecCoin{testDenom1, sdk.NewDec(-20)},
+			sdk.DecCoin{testDenom1, math.LegacyNewDec(1)},
+			sdk.DecCoin{testDenom1, math.LegacyNewDec(2)},
+			sdk.DecCoin{testDenom1, math.LegacyNewDec(3)},
+			sdk.DecCoin{testDenom1, math.LegacyNewDec(4)},
+		}, math.LegacyNewDec(-2), sdk.DecCoins{
+			sdk.DecCoin{testDenom1, math.LegacyNewDec(-20)},
 		}},
 
 		{"Multiple coins - Different denom", sdk.DecCoins{
-			sdk.DecCoin{testDenom1, sdk.NewDec(1)},
-			sdk.DecCoin{testDenom2, sdk.NewDec(2)},
-			sdk.DecCoin{testDenom1, sdk.NewDec(3)},
-			sdk.DecCoin{testDenom2, sdk.NewDec(4)},
-		}, sdk.NewDec(2), sdk.DecCoins{
-			sdk.DecCoin{testDenom1, sdk.NewDec(8)},
-			sdk.DecCoin{testDenom2, sdk.NewDec(12)},
+			sdk.DecCoin{testDenom1, math.LegacyNewDec(1)},
+			sdk.DecCoin{testDenom2, math.LegacyNewDec(2)},
+			sdk.DecCoin{testDenom1, math.LegacyNewDec(3)},
+			sdk.DecCoin{testDenom2, math.LegacyNewDec(4)},
+		}, math.LegacyNewDec(2), sdk.DecCoins{
+			sdk.DecCoin{testDenom1, math.LegacyNewDec(8)},
+			sdk.DecCoin{testDenom2, math.LegacyNewDec(12)},
 		}},
 	}
 
@@ -878,24 +879,24 @@ func (s *decCoinTestSuite) TestDecCoins_MulDecTruncate() {
 		expectedResult sdk.DecCoins
 		expectedPanic  bool
 	}{
-		{"No Coins", sdk.DecCoins{}, sdk.NewDec(1), sdk.DecCoins(nil), false},
+		{"No Coins", sdk.DecCoins{}, math.LegacyNewDec(1), sdk.DecCoins(nil), false},
 
 		{"Multiple coins - zero multiplier", sdk.DecCoins{
 			sdk.DecCoin{testDenom1, sdk.NewDecWithPrec(10, 3)},
 			sdk.DecCoin{testDenom1, sdk.NewDecWithPrec(30, 2)},
-		}, sdk.NewDec(0), sdk.DecCoins{}, false},
+		}, math.LegacyNewDec(0), sdk.DecCoins{}, false},
 
 		{"Multiple coins - positive multiplier", sdk.DecCoins{
 			sdk.DecCoin{testDenom1, sdk.NewDecWithPrec(15, 1)},
 			sdk.DecCoin{testDenom1, sdk.NewDecWithPrec(15, 1)},
-		}, sdk.NewDec(1), sdk.DecCoins{
+		}, math.LegacyNewDec(1), sdk.DecCoins{
 			sdk.DecCoin{testDenom1, sdk.NewDecWithPrec(3, 0)},
 		}, false},
 
 		{"Multiple coins - positive multiplier", sdk.DecCoins{
 			sdk.DecCoin{testDenom1, sdk.NewDecWithPrec(15, 1)},
 			sdk.DecCoin{testDenom1, sdk.NewDecWithPrec(15, 1)},
-		}, sdk.NewDec(-2), sdk.DecCoins{
+		}, math.LegacyNewDec(-2), sdk.DecCoins{
 			sdk.DecCoin{testDenom1, sdk.NewDecWithPrec(-6, 0)},
 		}, false},
 
@@ -904,7 +905,7 @@ func (s *decCoinTestSuite) TestDecCoins_MulDecTruncate() {
 			sdk.DecCoin{testDenom2, sdk.NewDecWithPrec(3333, 4)},
 			sdk.DecCoin{testDenom1, sdk.NewDecWithPrec(15, 1)},
 			sdk.DecCoin{testDenom2, sdk.NewDecWithPrec(333, 4)},
-		}, sdk.NewDec(10), sdk.DecCoins{
+		}, math.LegacyNewDec(10), sdk.DecCoins{
 			sdk.DecCoin{testDenom1, sdk.NewDecWithPrec(30, 0)},
 			sdk.DecCoin{testDenom2, sdk.NewDecWithPrec(3666, 3)},
 		}, false},
@@ -931,35 +932,35 @@ func (s *decCoinTestSuite) TestDecCoins_QuoDec() {
 		expectedResult sdk.DecCoins
 		panics         bool
 	}{
-		{"No Coins", sdk.DecCoins{}, sdk.NewDec(1), sdk.DecCoins(nil), false},
+		{"No Coins", sdk.DecCoins{}, math.LegacyNewDec(1), sdk.DecCoins(nil), false},
 
 		{"Multiple coins - zero input", sdk.DecCoins{
-			sdk.DecCoin{testDenom1, sdk.NewDec(10)},
-			sdk.DecCoin{testDenom1, sdk.NewDec(30)},
-		}, sdk.NewDec(0), sdk.DecCoins(nil), true},
+			sdk.DecCoin{testDenom1, math.LegacyNewDec(10)},
+			sdk.DecCoin{testDenom1, math.LegacyNewDec(30)},
+		}, math.LegacyNewDec(0), sdk.DecCoins(nil), true},
 
 		{"Multiple coins - positive input", sdk.DecCoins{
-			sdk.DecCoin{testDenom1, sdk.NewDec(3)},
-			sdk.DecCoin{testDenom1, sdk.NewDec(4)},
-		}, sdk.NewDec(2), sdk.DecCoins{
+			sdk.DecCoin{testDenom1, math.LegacyNewDec(3)},
+			sdk.DecCoin{testDenom1, math.LegacyNewDec(4)},
+		}, math.LegacyNewDec(2), sdk.DecCoins{
 			sdk.DecCoin{testDenom1, sdk.NewDecWithPrec(35, 1)},
 		}, false},
 
 		{"Multiple coins - negative input", sdk.DecCoins{
-			sdk.DecCoin{testDenom1, sdk.NewDec(3)},
-			sdk.DecCoin{testDenom1, sdk.NewDec(4)},
-		}, sdk.NewDec(-2), sdk.DecCoins{
+			sdk.DecCoin{testDenom1, math.LegacyNewDec(3)},
+			sdk.DecCoin{testDenom1, math.LegacyNewDec(4)},
+		}, math.LegacyNewDec(-2), sdk.DecCoins{
 			sdk.DecCoin{testDenom1, sdk.NewDecWithPrec(-35, 1)},
 		}, false},
 
 		{"Multiple coins - Different input", sdk.DecCoins{
-			sdk.DecCoin{testDenom1, sdk.NewDec(1)},
-			sdk.DecCoin{testDenom2, sdk.NewDec(2)},
-			sdk.DecCoin{testDenom1, sdk.NewDec(3)},
-			sdk.DecCoin{testDenom2, sdk.NewDec(4)},
-		}, sdk.NewDec(2), sdk.DecCoins{
-			sdk.DecCoin{testDenom1, sdk.NewDec(2)},
-			sdk.DecCoin{testDenom2, sdk.NewDec(3)},
+			sdk.DecCoin{testDenom1, math.LegacyNewDec(1)},
+			sdk.DecCoin{testDenom2, math.LegacyNewDec(2)},
+			sdk.DecCoin{testDenom1, math.LegacyNewDec(3)},
+			sdk.DecCoin{testDenom2, math.LegacyNewDec(4)},
+		}, math.LegacyNewDec(2), sdk.DecCoins{
+			sdk.DecCoin{testDenom1, math.LegacyNewDec(2)},
+			sdk.DecCoin{testDenom2, math.LegacyNewDec(3)},
 		}, false},
 	}
 
@@ -986,29 +987,29 @@ func (s *decCoinTestSuite) TestDecCoin_IsEqual() {
 	}{
 		{
 			"Different Denom Same Amount",
-			sdk.DecCoin{testDenom1, sdk.NewDec(20)},
-			sdk.DecCoin{testDenom2, sdk.NewDec(20)},
+			sdk.DecCoin{testDenom1, math.LegacyNewDec(20)},
+			sdk.DecCoin{testDenom2, math.LegacyNewDec(20)},
 			false, true,
 		},
 
 		{
 			"Different Denom Different Amount",
-			sdk.DecCoin{testDenom1, sdk.NewDec(20)},
-			sdk.DecCoin{testDenom2, sdk.NewDec(10)},
+			sdk.DecCoin{testDenom1, math.LegacyNewDec(20)},
+			sdk.DecCoin{testDenom2, math.LegacyNewDec(10)},
 			false, true,
 		},
 
 		{
 			"Same Denom Different Amount",
-			sdk.DecCoin{testDenom1, sdk.NewDec(20)},
-			sdk.DecCoin{testDenom1, sdk.NewDec(10)},
+			sdk.DecCoin{testDenom1, math.LegacyNewDec(20)},
+			sdk.DecCoin{testDenom1, math.LegacyNewDec(10)},
 			false, false,
 		},
 
 		{
 			"Same Denom Same Amount",
-			sdk.DecCoin{testDenom1, sdk.NewDec(20)},
-			sdk.DecCoin{testDenom1, sdk.NewDec(20)},
+			sdk.DecCoin{testDenom1, math.LegacyNewDec(20)},
+			sdk.DecCoin{testDenom1, math.LegacyNewDec(20)},
 			true, false,
 		},
 	}
@@ -1038,34 +1039,34 @@ func (s *decCoinTestSuite) TestDecCoins_IsEqual() {
 		expectedPanic  bool
 	}{
 		{"Different length sets", sdk.DecCoins{
-			sdk.DecCoin{testDenom1, sdk.NewDec(3)},
-			sdk.DecCoin{testDenom1, sdk.NewDec(4)},
+			sdk.DecCoin{testDenom1, math.LegacyNewDec(3)},
+			sdk.DecCoin{testDenom1, math.LegacyNewDec(4)},
 		}, sdk.DecCoins{
-			sdk.DecCoin{testDenom1, sdk.NewDec(35)},
+			sdk.DecCoin{testDenom1, math.LegacyNewDec(35)},
 		}, false, false},
 
 		{"Same length - different denoms", sdk.DecCoins{
-			sdk.DecCoin{testDenom1, sdk.NewDec(3)},
-			sdk.DecCoin{testDenom1, sdk.NewDec(4)},
+			sdk.DecCoin{testDenom1, math.LegacyNewDec(3)},
+			sdk.DecCoin{testDenom1, math.LegacyNewDec(4)},
 		}, sdk.DecCoins{
-			sdk.DecCoin{testDenom2, sdk.NewDec(3)},
-			sdk.DecCoin{testDenom2, sdk.NewDec(4)},
+			sdk.DecCoin{testDenom2, math.LegacyNewDec(3)},
+			sdk.DecCoin{testDenom2, math.LegacyNewDec(4)},
 		}, false, true},
 
 		{"Same length - different amounts", sdk.DecCoins{
-			sdk.DecCoin{testDenom1, sdk.NewDec(3)},
-			sdk.DecCoin{testDenom1, sdk.NewDec(4)},
+			sdk.DecCoin{testDenom1, math.LegacyNewDec(3)},
+			sdk.DecCoin{testDenom1, math.LegacyNewDec(4)},
 		}, sdk.DecCoins{
-			sdk.DecCoin{testDenom1, sdk.NewDec(41)},
-			sdk.DecCoin{testDenom1, sdk.NewDec(343)},
+			sdk.DecCoin{testDenom1, math.LegacyNewDec(41)},
+			sdk.DecCoin{testDenom1, math.LegacyNewDec(343)},
 		}, false, false},
 
 		{"Same length - same amounts", sdk.DecCoins{
-			sdk.DecCoin{testDenom1, sdk.NewDec(33)},
-			sdk.DecCoin{testDenom1, sdk.NewDec(344)},
+			sdk.DecCoin{testDenom1, math.LegacyNewDec(33)},
+			sdk.DecCoin{testDenom1, math.LegacyNewDec(344)},
 		}, sdk.DecCoins{
-			sdk.DecCoin{testDenom1, sdk.NewDec(33)},
-			sdk.DecCoin{testDenom1, sdk.NewDec(344)},
+			sdk.DecCoin{testDenom1, math.LegacyNewDec(33)},
+			sdk.DecCoin{testDenom1, math.LegacyNewDec(344)},
 		}, true, false},
 	}
 
@@ -1094,11 +1095,11 @@ func (s *decCoinTestSuite) TestDecCoin_Validate() {
 	}{
 		{"Uninitialized deccoin", empty, false},
 
-		{"Invalid denom string", sdk.DecCoin{"(){9**&})", sdk.NewDec(33)}, false},
+		{"Invalid denom string", sdk.DecCoin{"(){9**&})", math.LegacyNewDec(33)}, false},
 
-		{"Negative coin amount", sdk.DecCoin{testDenom1, sdk.NewDec(-33)}, false},
+		{"Negative coin amount", sdk.DecCoin{testDenom1, math.LegacyNewDec(-33)}, false},
 
-		{"Valid coin", sdk.DecCoin{testDenom1, sdk.NewDec(33)}, true},
+		{"Valid coin", sdk.DecCoin{testDenom1, math.LegacyNewDec(33)}, true},
 	}
 
 	for i, tc := range testCases {

--- a/types/dec_coin_test.go
+++ b/types/dec_coin_test.go
@@ -38,7 +38,7 @@ func (s *decCoinTestSuite) TestNewDecCoinFromDec() {
 		sdk.NewDecCoinFromDec(testDenom1, math.LegacyNewDec(5))
 	})
 	s.Require().NotPanics(func() {
-		sdk.NewDecCoinFromDec(testDenom1, sdk.ZeroDec())
+		sdk.NewDecCoinFromDec(testDenom1, math.LegacyZeroDec())
 	})
 	s.Require().NotPanics(func() {
 		sdk.NewDecCoinFromDec(strings.ToUpper(testDenom1), math.LegacyNewDec(5))
@@ -517,7 +517,7 @@ func (s *decCoinTestSuite) TestDecCoinsQuoDecTruncate() {
 		result sdk.DecCoins
 		panics bool
 	}{
-		{sdk.DecCoins{}, sdk.ZeroDec(), sdk.DecCoins(nil), true},
+		{sdk.DecCoins{}, math.LegacyZeroDec(), sdk.DecCoins(nil), true},
 		{sdk.DecCoins{sdk.NewDecCoinFromDec("foo", x)}, y, sdk.DecCoins(nil), false},
 		{sdk.DecCoins{sdk.NewInt64DecCoin("foo", 5)}, math.LegacyNewDec(2), sdk.DecCoins{sdk.NewDecCoinFromDec("foo", sdk.MustNewDecFromStr("2.5"))}, false},
 	}

--- a/types/simulation/rand_util.go
+++ b/types/simulation/rand_util.go
@@ -70,7 +70,7 @@ func RandomAmount(r *rand.Rand, max math.Int) math.Int {
 
 // RandomDecAmount generates a random decimal amount
 // Note: The range of RandomDecAmount includes max, and is, in fact, biased to return max as well as 0.
-func RandomDecAmount(r *rand.Rand, max sdk.Dec) sdk.Dec {
+func RandomDecAmount(r *rand.Rand, max sdk.Dec) math.LegacyDec {
 	randInt := big.NewInt(0)
 
 	switch r.Intn(10) {

--- a/x/auth/ante/ante_test.go
+++ b/x/auth/ante/ante_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"cosmossdk.io/math"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 
@@ -1480,7 +1481,7 @@ func TestAnteHandlerReCheck(t *testing.T) {
 	// create new minimum gas price so antehandler fails on recheck
 	suite.ctx = suite.ctx.WithMinGasPrices([]sdk.DecCoin{{
 		Denom:  "dnecoin", // fee does not have this denom
-		Amount: sdk.NewDec(5),
+		Amount: math.LegacyNewDec(5),
 	}})
 	_, err = suite.anteHandler(suite.ctx, tx, false)
 	require.NotNil(t, err, "antehandler on recheck did not fail when mingasPrice was changed")

--- a/x/auth/ante/fee_test.go
+++ b/x/auth/ante/fee_test.go
@@ -3,6 +3,7 @@ package ante_test
 import (
 	"testing"
 
+	"cosmossdk.io/math"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	"github.com/cosmos/cosmos-sdk/testutil/testdata"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -70,7 +71,7 @@ func TestEnsureMempoolFees(t *testing.T) {
 	require.NoError(t, err)
 
 	// Set high gas price so standard test fee fails
-	atomPrice := sdk.NewDecCoinFromDec("atom", sdk.NewDec(200).Quo(sdk.NewDec(100000)))
+	atomPrice := sdk.NewDecCoinFromDec("atom", math.LegacyNewDec(200).Quo(math.LegacyNewDec(100000)))
 	highGasPrice := []sdk.DecCoin{atomPrice}
 	s.ctx = s.ctx.WithMinGasPrices(highGasPrice)
 
@@ -96,7 +97,7 @@ func TestEnsureMempoolFees(t *testing.T) {
 	// Set IsCheckTx back to true for testing sufficient mempool fee
 	s.ctx = s.ctx.WithIsCheckTx(true)
 
-	atomPrice = sdk.NewDecCoinFromDec("atom", sdk.NewDec(0).Quo(sdk.NewDec(100000)))
+	atomPrice = sdk.NewDecCoinFromDec("atom", math.LegacyNewDec(0).Quo(math.LegacyNewDec(100000)))
 	lowGasPrice := []sdk.DecCoin{atomPrice}
 	s.ctx = s.ctx.WithMinGasPrices(lowGasPrice)
 

--- a/x/auth/ante/validator_tx_fee.go
+++ b/x/auth/ante/validator_tx_fee.go
@@ -3,6 +3,7 @@ package ante
 import (
 	"math"
 
+	sdkmath "cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
@@ -28,7 +29,7 @@ func checkTxFeeWithValidatorMinGasPrices(ctx sdk.Context, tx sdk.Tx) (sdk.Coins,
 
 			// Determine the required fees by multiplying each required minimum gas
 			// price by the gas limit, where fee = ceil(minGasPrice * gasLimit).
-			glDec := sdk.NewDec(int64(gas))
+			glDec := sdkmath.LegacyNewDec(int64(gas))
 			for i, gp := range minGasPrices {
 				fee := gp.Amount.Mul(glDec)
 				requiredFees[i] = sdk.NewCoin(gp.Denom, fee.Ceil().RoundInt())

--- a/x/auth/migrations/legacytx/stdtx.go
+++ b/x/auth/migrations/legacytx/stdtx.go
@@ -1,6 +1,7 @@
 package legacytx
 
 import (
+	"cosmossdk.io/math"
 	"github.com/cosmos/cosmos-sdk/codec/legacy"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
@@ -70,7 +71,7 @@ func (fee StdFee) Bytes() []byte {
 // originally part of the submitted transaction because the fee is computed
 // as fee = ceil(gasWanted * gasPrices).
 func (fee StdFee) GasPrices() sdk.DecCoins {
-	return sdk.NewDecCoinsFromCoins(fee.Amount...).QuoDec(sdk.NewDec(int64(fee.Gas)))
+	return sdk.NewDecCoinsFromCoins(fee.Amount...).QuoDec(math.LegacyNewDec(int64(fee.Gas)))
 }
 
 // StdTip is the tips used in a tipped transaction.

--- a/x/auth/vesting/types/vesting_account.go
+++ b/x/auth/vesting/types/vesting_account.go
@@ -238,7 +238,7 @@ func (cva ContinuousVestingAccount) GetVestedCoins(blockTime time.Time) sdk.Coin
 	// calculate the vesting scalar
 	x := blockTime.Unix() - cva.StartTime
 	y := cva.EndTime - cva.StartTime
-	s := sdk.NewDec(x).Quo(sdk.NewDec(y))
+	s := math.LegacyNewDec(x).Quo(math.LegacyNewDec(y))
 
 	for _, ovc := range cva.OriginalVesting {
 		vestedAmt := sdk.NewDecFromInt(ovc.Amount).Mul(s).RoundInt()

--- a/x/distribution/abci_test.go
+++ b/x/distribution/abci_test.go
@@ -3,6 +3,7 @@ package distribution_test
 import (
 	"testing"
 
+	"cosmossdk.io/math"
 	"github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	simtestutil "github.com/cosmos/cosmos-sdk/testutil/sims"
@@ -26,7 +27,7 @@ const (
 
 var (
 	valTokens                = sdk.TokensFromConsensusPower(50, sdk.DefaultPowerReduction)
-	validatorCommissionRates = stakingtypes.NewCommissionRates(sdk.OneDec(), sdk.OneDec(), sdk.OneDec())
+	validatorCommissionRates = stakingtypes.NewCommissionRates(math.LegacyOneDec(), math.LegacyOneDec(), math.LegacyOneDec())
 )
 
 type validator struct {

--- a/x/distribution/keeper/allocation.go
+++ b/x/distribution/keeper/allocation.go
@@ -81,7 +81,7 @@ func (k Keeper) AllocateTokens(
 
 	// calculate fraction allocated to validators
 	communityTax := k.GetCommunityTax(ctx)
-	voteMultiplier := sdk.OneDec().Sub(proposerMultiplier).Sub(communityTax)
+	voteMultiplier := math.LegacyOneDec().Sub(proposerMultiplier).Sub(communityTax)
 
 	// allocate tokens proportionally to voting power
 	// TODO consider parallelizing later, ref https://github.com/cosmos/cosmos-sdk/pull/3099#discussion_r246276376

--- a/x/distribution/keeper/allocation.go
+++ b/x/distribution/keeper/allocation.go
@@ -3,6 +3,7 @@ package keeper
 import (
 	"fmt"
 
+	"cosmossdk.io/math"
 	abci "github.com/tendermint/tendermint/abci/types"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -42,7 +43,7 @@ func (k Keeper) AllocateTokens(
 	}
 
 	// calculate fraction votes
-	previousFractionVotes := sdk.NewDec(sumPreviousPrecommitPower).Quo(sdk.NewDec(totalPreviousPower))
+	previousFractionVotes := math.LegacyNewDec(sumPreviousPrecommitPower).Quo(math.LegacyNewDec(totalPreviousPower))
 
 	// calculate previous proposer reward
 	baseProposerReward := k.GetBaseProposerReward(ctx)
@@ -89,7 +90,7 @@ func (k Keeper) AllocateTokens(
 
 		// TODO consider microslashing for missing votes.
 		// ref https://github.com/cosmos/cosmos-sdk/issues/2525#issuecomment-430838701
-		powerFraction := sdk.NewDec(vote.Validator.Power).QuoTruncate(sdk.NewDec(totalPreviousPower))
+		powerFraction := math.LegacyNewDec(vote.Validator.Power).QuoTruncate(math.LegacyNewDec(totalPreviousPower))
 		reward := feesCollected.MulDecTruncate(voteMultiplier).MulDecTruncate(powerFraction)
 		k.AllocateTokensToValidator(ctx, validator, reward)
 		remaining = remaining.Sub(reward)

--- a/x/distribution/keeper/allocation_test.go
+++ b/x/distribution/keeper/allocation_test.go
@@ -3,6 +3,7 @@ package keeper_test
 import (
 	"testing"
 
+	"cosmossdk.io/math"
 	"github.com/stretchr/testify/require"
 	abci "github.com/tendermint/tendermint/abci/types"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
@@ -42,19 +43,19 @@ func TestAllocateTokensToValidatorWithCommission(t *testing.T) {
 	tstaking := teststaking.NewHelper(t, ctx, stakingKeeper)
 
 	// create validator with 50% commission
-	tstaking.Commission = stakingtypes.NewCommissionRates(sdk.NewDecWithPrec(5, 1), sdk.NewDecWithPrec(5, 1), sdk.NewDec(0))
+	tstaking.Commission = stakingtypes.NewCommissionRates(sdk.NewDecWithPrec(5, 1), sdk.NewDecWithPrec(5, 1), math.LegacyNewDec(0))
 	tstaking.CreateValidator(sdk.ValAddress(addrs[0]), valConsPk1, sdk.NewInt(100), true)
 	val := stakingKeeper.Validator(ctx, valAddrs[0])
 
 	// allocate tokens
 	tokens := sdk.DecCoins{
-		{Denom: sdk.DefaultBondDenom, Amount: sdk.NewDec(10)},
+		{Denom: sdk.DefaultBondDenom, Amount: math.LegacyNewDec(10)},
 	}
 	distrKeeper.AllocateTokensToValidator(ctx, val, tokens)
 
 	// check commission
 	expected := sdk.DecCoins{
-		{Denom: sdk.DefaultBondDenom, Amount: sdk.NewDec(5)},
+		{Denom: sdk.DefaultBondDenom, Amount: math.LegacyNewDec(5)},
 	}
 	require.Equal(t, expected, distrKeeper.GetValidatorAccumulatedCommission(ctx, val.GetOperator()).Commission)
 
@@ -88,11 +89,11 @@ func TestAllocateTokensToManyValidators(t *testing.T) {
 	tstaking := teststaking.NewHelper(t, ctx, stakingKeeper)
 
 	// create validator with 50% commission
-	tstaking.Commission = stakingtypes.NewCommissionRates(sdk.NewDecWithPrec(5, 1), sdk.NewDecWithPrec(5, 1), sdk.NewDec(0))
+	tstaking.Commission = stakingtypes.NewCommissionRates(sdk.NewDecWithPrec(5, 1), sdk.NewDecWithPrec(5, 1), math.LegacyNewDec(0))
 	tstaking.CreateValidator(valAddrs[0], valConsPk1, sdk.NewInt(100), true)
 
 	// create second validator with 0% commission
-	tstaking.Commission = stakingtypes.NewCommissionRates(sdk.NewDec(0), sdk.NewDec(0), sdk.NewDec(0))
+	tstaking.Commission = stakingtypes.NewCommissionRates(math.LegacyNewDec(0), math.LegacyNewDec(0), math.LegacyNewDec(0))
 	tstaking.CreateValidator(valAddrs[1], valConsPk2, sdk.NewInt(100), true)
 
 	abciValA := abci.Validator{
@@ -139,7 +140,7 @@ func TestAllocateTokensToManyValidators(t *testing.T) {
 	require.Equal(t, sdk.DecCoins{{Denom: sdk.DefaultBondDenom, Amount: sdk.NewDecWithPrec(465, 1)}}, distrKeeper.GetValidatorOutstandingRewards(ctx, valAddrs[0]).Rewards)
 	require.Equal(t, sdk.DecCoins{{Denom: sdk.DefaultBondDenom, Amount: sdk.NewDecWithPrec(515, 1)}}, distrKeeper.GetValidatorOutstandingRewards(ctx, valAddrs[1]).Rewards)
 	// 2 community pool coins
-	require.Equal(t, sdk.DecCoins{{Denom: sdk.DefaultBondDenom, Amount: sdk.NewDec(2)}}, distrKeeper.GetFeePool(ctx).CommunityPool)
+	require.Equal(t, sdk.DecCoins{{Denom: sdk.DefaultBondDenom, Amount: math.LegacyNewDec(2)}}, distrKeeper.GetFeePool(ctx).CommunityPool)
 	// 50% commission for first proposer, (0.5 * 93%) * 100 / 2 = 23.25
 	require.Equal(t, sdk.DecCoins{{Denom: sdk.DefaultBondDenom, Amount: sdk.NewDecWithPrec(2325, 2)}}, distrKeeper.GetValidatorAccumulatedCommission(ctx, valAddrs[0]).Commission)
 	// zero commission for second proposer
@@ -176,15 +177,15 @@ func TestAllocateTokensTruncation(t *testing.T) {
 	tstaking := teststaking.NewHelper(t, ctx, stakingKeeper)
 
 	// create validator with 10% commission
-	tstaking.Commission = stakingtypes.NewCommissionRates(sdk.NewDecWithPrec(1, 1), sdk.NewDecWithPrec(1, 1), sdk.NewDec(0))
+	tstaking.Commission = stakingtypes.NewCommissionRates(sdk.NewDecWithPrec(1, 1), sdk.NewDecWithPrec(1, 1), math.LegacyNewDec(0))
 	tstaking.CreateValidator(valAddrs[0], valConsPk1, sdk.NewInt(110), true)
 
 	// create second validator with 10% commission
-	tstaking.Commission = stakingtypes.NewCommissionRates(sdk.NewDecWithPrec(1, 1), sdk.NewDecWithPrec(1, 1), sdk.NewDec(0))
+	tstaking.Commission = stakingtypes.NewCommissionRates(sdk.NewDecWithPrec(1, 1), sdk.NewDecWithPrec(1, 1), math.LegacyNewDec(0))
 	tstaking.CreateValidator(valAddrs[1], valConsPk2, sdk.NewInt(100), true)
 
 	// create third validator with 10% commission
-	tstaking.Commission = stakingtypes.NewCommissionRates(sdk.NewDecWithPrec(1, 1), sdk.NewDecWithPrec(1, 1), sdk.NewDec(0))
+	tstaking.Commission = stakingtypes.NewCommissionRates(sdk.NewDecWithPrec(1, 1), sdk.NewDecWithPrec(1, 1), math.LegacyNewDec(0))
 	tstaking.CreateValidator(valAddrs[2], valConsPk3, sdk.NewInt(100), true)
 
 	abciValA := abci.Validator{

--- a/x/distribution/keeper/delegation.go
+++ b/x/distribution/keeper/delegation.go
@@ -3,6 +3,7 @@ package keeper
 import (
 	"fmt"
 
+	"cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/cosmos/cosmos-sdk/x/distribution/types"
@@ -86,7 +87,7 @@ func (k Keeper) CalculateDelegationRewards(ctx sdk.Context, val stakingtypes.Val
 
 					// Note: It is necessary to truncate so we don't allow withdrawing
 					// more rewards than owed.
-					stake = stake.MulTruncate(sdk.OneDec().Sub(event.Fraction))
+					stake = stake.MulTruncate(math.LegacyOneDec().Sub(event.Fraction))
 					startingPeriod = endingPeriod
 				}
 				return false

--- a/x/distribution/keeper/delegation_test.go
+++ b/x/distribution/keeper/delegation_test.go
@@ -44,7 +44,7 @@ func TestCalculateRewardsBasic(t *testing.T) {
 	valAddrs := simtestutil.ConvertAddrsToValAddrs(addr)
 
 	// create validator with 50% commission
-	tstaking.Commission = stakingtypes.NewCommissionRates(sdk.NewDecWithPrec(5, 1), sdk.NewDecWithPrec(5, 1), sdk.NewDec(0))
+	tstaking.Commission = stakingtypes.NewCommissionRates(sdk.NewDecWithPrec(5, 1), sdk.NewDecWithPrec(5, 1), math.LegacyNewDec(0))
 	tstaking.CreateValidator(valAddrs[0], valConsPk1, sdk.NewInt(100), true)
 
 	// end block to bond validator and start new block
@@ -73,7 +73,7 @@ func TestCalculateRewardsBasic(t *testing.T) {
 
 	// allocate some rewards
 	initial := int64(10)
-	tokens := sdk.DecCoins{{Denom: sdk.DefaultBondDenom, Amount: sdk.NewDec(initial)}}
+	tokens := sdk.DecCoins{{Denom: sdk.DefaultBondDenom, Amount: math.LegacyNewDec(initial)}}
 	distrKeeper.AllocateTokensToValidator(ctx, val, tokens)
 
 	// end period
@@ -83,10 +83,10 @@ func TestCalculateRewardsBasic(t *testing.T) {
 	rewards = distrKeeper.CalculateDelegationRewards(ctx, val, del, endingPeriod)
 
 	// rewards should be half the tokens
-	require.Equal(t, sdk.DecCoins{{Denom: sdk.DefaultBondDenom, Amount: sdk.NewDec(initial / 2)}}, rewards)
+	require.Equal(t, sdk.DecCoins{{Denom: sdk.DefaultBondDenom, Amount: math.LegacyNewDec(initial / 2)}}, rewards)
 
 	// commission should be the other half
-	require.Equal(t, sdk.DecCoins{{Denom: sdk.DefaultBondDenom, Amount: sdk.NewDec(initial / 2)}}, distrKeeper.GetValidatorAccumulatedCommission(ctx, valAddrs[0]).Commission)
+	require.Equal(t, sdk.DecCoins{{Denom: sdk.DefaultBondDenom, Amount: math.LegacyNewDec(initial / 2)}}, distrKeeper.GetValidatorAccumulatedCommission(ctx, valAddrs[0]).Commission)
 }
 
 func TestCalculateRewardsAfterSlash(t *testing.T) {
@@ -110,7 +110,7 @@ func TestCalculateRewardsAfterSlash(t *testing.T) {
 	tstaking := teststaking.NewHelper(t, ctx, stakingKeeper)
 
 	// create validator with 50% commission
-	tstaking.Commission = stakingtypes.NewCommissionRates(sdk.NewDecWithPrec(5, 1), sdk.NewDecWithPrec(5, 1), sdk.NewDec(0))
+	tstaking.Commission = stakingtypes.NewCommissionRates(sdk.NewDecWithPrec(5, 1), sdk.NewDecWithPrec(5, 1), math.LegacyNewDec(0))
 	valPower := int64(100)
 	tstaking.CreateValidatorWithValPower(valAddrs[0], valConsPk1, valPower, true)
 
@@ -186,7 +186,7 @@ func TestCalculateRewardsAfterManySlashes(t *testing.T) {
 
 	// create validator with 50% commission
 	valPower := int64(100)
-	tstaking.Commission = stakingtypes.NewCommissionRates(sdk.NewDecWithPrec(5, 1), sdk.NewDecWithPrec(5, 1), sdk.NewDec(0))
+	tstaking.Commission = stakingtypes.NewCommissionRates(sdk.NewDecWithPrec(5, 1), sdk.NewDecWithPrec(5, 1), math.LegacyNewDec(0))
 	tstaking.CreateValidatorWithValPower(valAddrs[0], valConsPk1, valPower, true)
 
 	// end block to bond validator
@@ -272,7 +272,7 @@ func TestCalculateRewardsMultiDelegator(t *testing.T) {
 	valAddrs := simtestutil.ConvertAddrsToValAddrs(addr)
 
 	// create validator with 50% commission
-	tstaking.Commission = stakingtypes.NewCommissionRates(sdk.NewDecWithPrec(5, 1), sdk.NewDecWithPrec(5, 1), sdk.NewDec(0))
+	tstaking.Commission = stakingtypes.NewCommissionRates(sdk.NewDecWithPrec(5, 1), sdk.NewDecWithPrec(5, 1), math.LegacyNewDec(0))
 	tstaking.CreateValidator(valAddrs[0], valConsPk1, sdk.NewInt(100), true)
 
 	// end block to bond validator
@@ -287,7 +287,7 @@ func TestCalculateRewardsMultiDelegator(t *testing.T) {
 
 	// allocate some rewards
 	initial := int64(20)
-	tokens := sdk.DecCoins{{Denom: sdk.DefaultBondDenom, Amount: sdk.NewDec(initial)}}
+	tokens := sdk.DecCoins{{Denom: sdk.DefaultBondDenom, Amount: math.LegacyNewDec(initial)}}
 	distrKeeper.AllocateTokensToValidator(ctx, val, tokens)
 
 	// second delegation
@@ -314,16 +314,16 @@ func TestCalculateRewardsMultiDelegator(t *testing.T) {
 	rewards := distrKeeper.CalculateDelegationRewards(ctx, val, del1, endingPeriod)
 
 	// rewards for del1 should be 3/4 initial
-	require.Equal(t, sdk.DecCoins{{Denom: sdk.DefaultBondDenom, Amount: sdk.NewDec(initial * 3 / 4)}}, rewards)
+	require.Equal(t, sdk.DecCoins{{Denom: sdk.DefaultBondDenom, Amount: math.LegacyNewDec(initial * 3 / 4)}}, rewards)
 
 	// calculate delegation rewards for del2
 	rewards = distrKeeper.CalculateDelegationRewards(ctx, val, del2, endingPeriod)
 
 	// rewards for del2 should be 1/4 initial
-	require.Equal(t, sdk.DecCoins{{Denom: sdk.DefaultBondDenom, Amount: sdk.NewDec(initial * 1 / 4)}}, rewards)
+	require.Equal(t, sdk.DecCoins{{Denom: sdk.DefaultBondDenom, Amount: math.LegacyNewDec(initial * 1 / 4)}}, rewards)
 
 	// commission should be equal to initial (50% twice)
-	require.Equal(t, sdk.DecCoins{{Denom: sdk.DefaultBondDenom, Amount: sdk.NewDec(initial)}}, distrKeeper.GetValidatorAccumulatedCommission(ctx, valAddrs[0]).Commission)
+	require.Equal(t, sdk.DecCoins{{Denom: sdk.DefaultBondDenom, Amount: math.LegacyNewDec(initial)}}, distrKeeper.GetValidatorAccumulatedCommission(ctx, valAddrs[0]).Commission)
 }
 
 func TestWithdrawDelegationRewardsBasic(t *testing.T) {
@@ -359,7 +359,7 @@ func TestWithdrawDelegationRewardsBasic(t *testing.T) {
 
 	// create validator with 50% commission
 	power := int64(100)
-	tstaking.Commission = stakingtypes.NewCommissionRates(sdk.NewDecWithPrec(5, 1), sdk.NewDecWithPrec(5, 1), sdk.NewDec(0))
+	tstaking.Commission = stakingtypes.NewCommissionRates(sdk.NewDecWithPrec(5, 1), sdk.NewDecWithPrec(5, 1), math.LegacyNewDec(0))
 	valTokens := tstaking.CreateValidatorWithValPower(valAddrs[0], valConsPk1, power, true)
 
 	// assert correct initial balance
@@ -435,7 +435,7 @@ func TestCalculateRewardsAfterManySlashesInSameBlock(t *testing.T) {
 
 	// create validator with 50% commission
 	valPower := int64(100)
-	tstaking.Commission = stakingtypes.NewCommissionRates(sdk.NewDecWithPrec(5, 1), sdk.NewDecWithPrec(5, 1), sdk.NewDec(0))
+	tstaking.Commission = stakingtypes.NewCommissionRates(sdk.NewDecWithPrec(5, 1), sdk.NewDecWithPrec(5, 1), math.LegacyNewDec(0))
 	tstaking.CreateValidatorWithValPower(valAddrs[0], valConsPk1, valPower, true)
 
 	// end block to bond validator
@@ -514,7 +514,7 @@ func TestCalculateRewardsMultiDelegatorMultiSlash(t *testing.T) {
 	valAddrs := simtestutil.ConvertAddrsToValAddrs(addr)
 
 	// create validator with 50% commission
-	tstaking.Commission = stakingtypes.NewCommissionRates(sdk.NewDecWithPrec(5, 1), sdk.NewDecWithPrec(5, 1), sdk.NewDec(0))
+	tstaking.Commission = stakingtypes.NewCommissionRates(sdk.NewDecWithPrec(5, 1), sdk.NewDecWithPrec(5, 1), math.LegacyNewDec(0))
 	valPower := int64(100)
 	tstaking.CreateValidatorWithValPower(valAddrs[0], valConsPk1, valPower, true)
 
@@ -609,10 +609,10 @@ func TestCalculateRewardsMultiDelegatorMultWithdraw(t *testing.T) {
 	require.NoError(t, banktestutil.FundModuleAccount(bankKeeper, ctx, distrAcc.GetName(), sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(1000)))))
 	accountKeeper.SetModuleAccount(ctx, distrAcc)
 
-	tokens := sdk.DecCoins{sdk.NewDecCoinFromDec(sdk.DefaultBondDenom, sdk.NewDec(initial))}
+	tokens := sdk.DecCoins{sdk.NewDecCoinFromDec(sdk.DefaultBondDenom, math.LegacyNewDec(initial))}
 
 	// create validator with 50% commission
-	tstaking.Commission = stakingtypes.NewCommissionRates(sdk.NewDecWithPrec(5, 1), sdk.NewDecWithPrec(5, 1), sdk.NewDec(0))
+	tstaking.Commission = stakingtypes.NewCommissionRates(sdk.NewDecWithPrec(5, 1), sdk.NewDecWithPrec(5, 1), math.LegacyNewDec(0))
 	tstaking.CreateValidator(valAddrs[0], valConsPk1, sdk.NewInt(100), true)
 
 	// end block to bond validator
@@ -706,10 +706,10 @@ func TestCalculateRewardsMultiDelegatorMultWithdraw(t *testing.T) {
 	rewards = distrKeeper.CalculateDelegationRewards(ctx, val, del2, endingPeriod)
 
 	// rewards for del2 should be 1/4 initial
-	require.Equal(t, sdk.DecCoins{{Denom: sdk.DefaultBondDenom, Amount: sdk.NewDec(initial / 4)}}, rewards)
+	require.Equal(t, sdk.DecCoins{{Denom: sdk.DefaultBondDenom, Amount: math.LegacyNewDec(initial / 4)}}, rewards)
 
 	// commission should be half initial
-	require.Equal(t, sdk.DecCoins{{Denom: sdk.DefaultBondDenom, Amount: sdk.NewDec(initial / 2)}}, distrKeeper.GetValidatorAccumulatedCommission(ctx, valAddrs[0]).Commission)
+	require.Equal(t, sdk.DecCoins{{Denom: sdk.DefaultBondDenom, Amount: math.LegacyNewDec(initial / 2)}}, distrKeeper.GetValidatorAccumulatedCommission(ctx, valAddrs[0]).Commission)
 
 	// next block
 	ctx = ctx.WithBlockHeight(ctx.BlockHeight() + 1)
@@ -728,13 +728,13 @@ func TestCalculateRewardsMultiDelegatorMultWithdraw(t *testing.T) {
 	rewards = distrKeeper.CalculateDelegationRewards(ctx, val, del1, endingPeriod)
 
 	// rewards for del1 should be 1/4 initial
-	require.Equal(t, sdk.DecCoins{{Denom: sdk.DefaultBondDenom, Amount: sdk.NewDec(initial / 4)}}, rewards)
+	require.Equal(t, sdk.DecCoins{{Denom: sdk.DefaultBondDenom, Amount: math.LegacyNewDec(initial / 4)}}, rewards)
 
 	// calculate delegation rewards for del2
 	rewards = distrKeeper.CalculateDelegationRewards(ctx, val, del2, endingPeriod)
 
 	// rewards for del2 should be 1/2 initial
-	require.Equal(t, sdk.DecCoins{{Denom: sdk.DefaultBondDenom, Amount: sdk.NewDec(initial / 2)}}, rewards)
+	require.Equal(t, sdk.DecCoins{{Denom: sdk.DefaultBondDenom, Amount: math.LegacyNewDec(initial / 2)}}, rewards)
 
 	// commission should be zero
 	require.True(t, distrKeeper.GetValidatorAccumulatedCommission(ctx, valAddrs[0]).Commission.IsZero())
@@ -768,10 +768,10 @@ func Test100PercentCommissionReward(t *testing.T) {
 	require.NoError(t, banktestutil.FundModuleAccount(bankKeeper, ctx, distrAcc.GetName(), sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(1000)))))
 	accountKeeper.SetModuleAccount(ctx, distrAcc)
 
-	tokens := sdk.DecCoins{sdk.NewDecCoinFromDec(sdk.DefaultBondDenom, sdk.NewDec(initial))}
+	tokens := sdk.DecCoins{sdk.NewDecCoinFromDec(sdk.DefaultBondDenom, math.LegacyNewDec(initial))}
 
 	// create validator with 100% commission
-	tstaking.Commission = stakingtypes.NewCommissionRates(sdk.NewDecWithPrec(10, 1), sdk.NewDecWithPrec(10, 1), sdk.NewDec(0))
+	tstaking.Commission = stakingtypes.NewCommissionRates(sdk.NewDecWithPrec(10, 1), sdk.NewDecWithPrec(10, 1), math.LegacyNewDec(0))
 	tstaking.CreateValidator(valAddrs[0], valConsPk1, sdk.NewInt(100), true)
 	stakingKeeper.Delegation(ctx, sdk.AccAddress(valAddrs[0]), valAddrs[0])
 

--- a/x/distribution/keeper/grpc_query_test.go
+++ b/x/distribution/keeper/grpc_query_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	"cosmossdk.io/math"
 	"github.com/stretchr/testify/suite"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 
@@ -125,8 +126,8 @@ func (suite *KeeperTestSuite) TestGRPCValidatorOutstandingRewards() {
 	ctx, queryClient, valAddrs := suite.ctx, suite.queryClient, suite.valAddrs
 
 	valCommission := sdk.DecCoins{
-		sdk.NewDecCoinFromDec("mytoken", sdk.NewDec(5000)),
-		sdk.NewDecCoinFromDec("stake", sdk.NewDec(300)),
+		sdk.NewDecCoinFromDec("mytoken", math.LegacyNewDec(5000)),
+		sdk.NewDecCoinFromDec("stake", math.LegacyNewDec(300)),
 	}
 
 	// set outstanding rewards
@@ -176,7 +177,7 @@ func (suite *KeeperTestSuite) TestGRPCValidatorOutstandingRewards() {
 func (suite *KeeperTestSuite) TestGRPCValidatorCommission() {
 	ctx, queryClient, valAddrs := suite.ctx, suite.queryClient, suite.valAddrs
 
-	commission := sdk.DecCoins{{Denom: "token1", Amount: sdk.NewDec(4)}, {Denom: "token2", Amount: sdk.NewDec(2)}}
+	commission := sdk.DecCoins{{Denom: "token1", Amount: math.LegacyNewDec(4)}, {Denom: "token2", Amount: math.LegacyNewDec(2)}}
 	suite.distrKeeper.SetValidatorAccumulatedCommission(ctx, valAddrs[0], types.ValidatorAccumulatedCommission{Commission: commission})
 
 	var req *types.QueryValidatorCommissionRequest
@@ -362,7 +363,7 @@ func (suite *KeeperTestSuite) TestGRPCDelegationRewards() {
 	ctx, addrs, valAddrs := suite.ctx, suite.addrs, suite.valAddrs
 
 	tstaking := teststaking.NewHelper(suite.T(), ctx, suite.stakingKeeper)
-	tstaking.Commission = stakingtypes.NewCommissionRates(sdk.NewDecWithPrec(5, 1), sdk.NewDecWithPrec(5, 1), sdk.NewDec(0))
+	tstaking.Commission = stakingtypes.NewCommissionRates(sdk.NewDecWithPrec(5, 1), sdk.NewDecWithPrec(5, 1), math.LegacyNewDec(0))
 	tstaking.CreateValidator(valAddrs[0], valConsPk1, sdk.NewInt(100), true)
 
 	staking.EndBlocker(ctx, suite.stakingKeeper)
@@ -375,7 +376,7 @@ func (suite *KeeperTestSuite) TestGRPCDelegationRewards() {
 	val := suite.stakingKeeper.Validator(ctx, valAddrs[0])
 
 	initial := int64(10)
-	tokens := sdk.DecCoins{{Denom: sdk.DefaultBondDenom, Amount: sdk.NewDec(initial)}}
+	tokens := sdk.DecCoins{{Denom: sdk.DefaultBondDenom, Amount: math.LegacyNewDec(initial)}}
 	suite.distrKeeper.AllocateTokensToValidator(ctx, val, tokens)
 
 	// test command delegation rewards grpc
@@ -435,7 +436,7 @@ func (suite *KeeperTestSuite) TestGRPCDelegationRewards() {
 				}
 
 				expRes = &types.QueryDelegationRewardsResponse{
-					Rewards: sdk.DecCoins{{Denom: sdk.DefaultBondDenom, Amount: sdk.NewDec(initial / 2)}},
+					Rewards: sdk.DecCoins{{Denom: sdk.DefaultBondDenom, Amount: math.LegacyNewDec(initial / 2)}},
 				}
 			},
 			true,

--- a/x/distribution/keeper/keeper_test.go
+++ b/x/distribution/keeper/keeper_test.go
@@ -71,8 +71,8 @@ func TestWithdrawValidatorCommission(t *testing.T) {
 	ctx := app.BaseApp.NewContext(false, tmproto.Header{})
 
 	valCommission := sdk.DecCoins{
-		sdk.NewDecCoinFromDec("mytoken", sdk.NewDec(5).Quo(sdk.NewDec(4))),
-		sdk.NewDecCoinFromDec("stake", sdk.NewDec(3).Quo(sdk.NewDec(2))),
+		sdk.NewDecCoinFromDec("mytoken", math.LegacyNewDec(5).Quo(math.LegacyNewDec(4))),
+		sdk.NewDecCoinFromDec("stake", math.LegacyNewDec(3).Quo(math.LegacyNewDec(2))),
 	}
 
 	addr := simtestutil.AddTestAddrs(bankKeeper, stakingKeeper, ctx, 1, sdk.NewInt(1000000000))
@@ -111,8 +111,8 @@ func TestWithdrawValidatorCommission(t *testing.T) {
 	// check remainder
 	remainder := distrKeeper.GetValidatorAccumulatedCommission(ctx, valAddrs[0]).Commission
 	require.Equal(t, sdk.DecCoins{
-		sdk.NewDecCoinFromDec("mytoken", sdk.NewDec(1).Quo(sdk.NewDec(4))),
-		sdk.NewDecCoinFromDec("stake", sdk.NewDec(1).Quo(sdk.NewDec(2))),
+		sdk.NewDecCoinFromDec("mytoken", math.LegacyNewDec(1).Quo(math.LegacyNewDec(4))),
+		sdk.NewDecCoinFromDec("stake", math.LegacyNewDec(1).Quo(math.LegacyNewDec(2))),
 	}, remainder)
 
 	require.True(t, true)
@@ -135,8 +135,8 @@ func TestGetTotalRewards(t *testing.T) {
 	ctx := app.BaseApp.NewContext(false, tmproto.Header{})
 
 	valCommission := sdk.DecCoins{
-		sdk.NewDecCoinFromDec("mytoken", sdk.NewDec(5).Quo(sdk.NewDec(4))),
-		sdk.NewDecCoinFromDec("stake", sdk.NewDec(3).Quo(sdk.NewDec(2))),
+		sdk.NewDecCoinFromDec("mytoken", math.LegacyNewDec(5).Quo(math.LegacyNewDec(4))),
+		sdk.NewDecCoinFromDec("stake", math.LegacyNewDec(3).Quo(math.LegacyNewDec(2))),
 	}
 
 	addr := simtestutil.AddTestAddrs(bankKeeper, stakingKeeper, ctx, 2, sdk.NewInt(1000000000))
@@ -145,7 +145,7 @@ func TestGetTotalRewards(t *testing.T) {
 	distrKeeper.SetValidatorOutstandingRewards(ctx, valAddrs[0], types.ValidatorOutstandingRewards{Rewards: valCommission})
 	distrKeeper.SetValidatorOutstandingRewards(ctx, valAddrs[1], types.ValidatorOutstandingRewards{Rewards: valCommission})
 
-	expectedRewards := valCommission.MulDec(sdk.NewDec(2))
+	expectedRewards := valCommission.MulDec(math.LegacyNewDec(2))
 	totalRewards := distrKeeper.GetTotalRewards(ctx)
 
 	require.Equal(t, expectedRewards, totalRewards)

--- a/x/distribution/keeper/params.go
+++ b/x/distribution/keeper/params.go
@@ -1,6 +1,7 @@
 package keeper
 
 import (
+	"cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/distribution/types"
 )
@@ -34,12 +35,12 @@ func (k Keeper) SetParams(ctx sdk.Context, params types.Params) error {
 }
 
 // GetCommunityTax returns the current distribution community tax.
-func (k Keeper) GetCommunityTax(ctx sdk.Context) sdk.Dec {
+func (k Keeper) GetCommunityTax(ctx sdk.Context) math.LegacyDec {
 	return k.GetParams(ctx).CommunityTax
 }
 
 // GetBaseProposerReward returns the current distribution base proposer rate.
-func (k Keeper) GetBaseProposerReward(ctx sdk.Context) sdk.Dec {
+func (k Keeper) GetBaseProposerReward(ctx sdk.Context) math.LegacyDec {
 	return k.GetParams(ctx).BaseProposerReward
 }
 

--- a/x/distribution/keeper/validator.go
+++ b/x/distribution/keeper/validator.go
@@ -3,6 +3,7 @@ package keeper
 import (
 	"fmt"
 
+	"cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/cosmos/cosmos-sdk/x/distribution/types"
@@ -88,7 +89,7 @@ func (k Keeper) decrementReferenceCount(ctx sdk.Context, valAddr sdk.ValAddress,
 }
 
 func (k Keeper) updateValidatorSlashFraction(ctx sdk.Context, valAddr sdk.ValAddress, fraction sdk.Dec) {
-	if fraction.GT(sdk.OneDec()) || fraction.IsNegative() {
+	if fraction.GT(math.LegacyOneDec()) || fraction.IsNegative() {
 		panic(fmt.Sprintf("fraction must be >=0 and <=1, current fraction: %v", fraction))
 	}
 

--- a/x/distribution/simulation/decoder_test.go
+++ b/x/distribution/simulation/decoder_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"cosmossdk.io/depinject"
+	"cosmossdk.io/math"
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -30,15 +31,15 @@ func TestDecodeDistributionStore(t *testing.T) {
 
 	dec := simulation.NewDecodeStore(cdc)
 
-	decCoins := sdk.DecCoins{sdk.NewDecCoinFromDec(sdk.DefaultBondDenom, sdk.OneDec())}
+	decCoins := sdk.DecCoins{sdk.NewDecCoinFromDec(sdk.DefaultBondDenom, math.LegacyOneDec())}
 	feePool := types.InitialFeePool()
 	feePool.CommunityPool = decCoins
-	info := types.NewDelegatorStartingInfo(2, sdk.OneDec(), 200)
+	info := types.NewDelegatorStartingInfo(2, math.LegacyOneDec(), 200)
 	outstanding := types.ValidatorOutstandingRewards{Rewards: decCoins}
 	commission := types.ValidatorAccumulatedCommission{Commission: decCoins}
 	historicalRewards := types.NewValidatorHistoricalRewards(decCoins, 100)
 	currentRewards := types.NewValidatorCurrentRewards(decCoins, 5)
-	slashEvent := types.NewValidatorSlashEvent(10, sdk.OneDec())
+	slashEvent := types.NewValidatorSlashEvent(10, math.LegacyOneDec())
 
 	kvPairs := kv.Pairs{
 		Pairs: []kv.Pair{

--- a/x/distribution/simulation/genesis.go
+++ b/x/distribution/simulation/genesis.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"math/rand"
 
+	"cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	"github.com/cosmos/cosmos-sdk/x/distribution/types"
@@ -21,17 +22,17 @@ const (
 )
 
 // GenCommunityTax randomized CommunityTax
-func GenCommunityTax(r *rand.Rand) sdk.Dec {
+func GenCommunityTax(r *rand.Rand) math.LegacyDec {
 	return sdk.NewDecWithPrec(1, 2).Add(sdk.NewDecWithPrec(int64(r.Intn(30)), 2))
 }
 
 // GenBaseProposerReward randomized BaseProposerReward
-func GenBaseProposerReward(r *rand.Rand) sdk.Dec {
+func GenBaseProposerReward(r *rand.Rand) math.LegacyDec {
 	return sdk.NewDecWithPrec(1, 2).Add(sdk.NewDecWithPrec(int64(r.Intn(30)), 2))
 }
 
 // GenBonusProposerReward randomized BonusProposerReward
-func GenBonusProposerReward(r *rand.Rand) sdk.Dec {
+func GenBonusProposerReward(r *rand.Rand) math.LegacyDec {
 	return sdk.NewDecWithPrec(1, 2).Add(sdk.NewDecWithPrec(int64(r.Intn(30)), 2))
 }
 

--- a/x/distribution/simulation/operations_test.go
+++ b/x/distribution/simulation/operations_test.go
@@ -108,7 +108,7 @@ func (suite *SimTestSuite) TestSimulateMsgWithdrawDelegatorReward() {
 	delegator := accounts[1]
 	delegation := stakingtypes.NewDelegation(delegator.Address, validator0.GetOperator(), issuedShares)
 	suite.stakingKeeper.SetDelegation(suite.ctx, delegation)
-	suite.distrKeeper.SetDelegatorStartingInfo(suite.ctx, validator0.GetOperator(), delegator.Address, distrtypes.NewDelegatorStartingInfo(2, sdk.OneDec(), 200))
+	suite.distrKeeper.SetDelegatorStartingInfo(suite.ctx, validator0.GetOperator(), delegator.Address, distrtypes.NewDelegatorStartingInfo(2, math.LegacyOneDec(), 200))
 
 	suite.setupValidatorRewards(validator0.GetOperator())
 
@@ -270,7 +270,7 @@ func (suite *SimTestSuite) getTestingAccounts(r *rand.Rand, n int) []simtypes.Ac
 }
 
 func (suite *SimTestSuite) getTestingValidator0(accounts []simtypes.Account) stakingtypes.Validator {
-	commission0 := stakingtypes.NewCommission(sdk.ZeroDec(), sdk.OneDec(), sdk.OneDec())
+	commission0 := stakingtypes.NewCommission(math.LegacyZeroDec(), math.LegacyOneDec(), math.LegacyOneDec())
 	return suite.getTestingValidator(accounts, commission0, 0)
 }
 
@@ -293,7 +293,7 @@ func (suite *SimTestSuite) getTestingValidator(accounts []simtypes.Account, comm
 }
 
 func (suite *SimTestSuite) setupValidatorRewards(valAddress sdk.ValAddress) {
-	decCoins := sdk.DecCoins{sdk.NewDecCoinFromDec(sdk.DefaultBondDenom, sdk.OneDec())}
+	decCoins := sdk.DecCoins{sdk.NewDecCoinFromDec(sdk.DefaultBondDenom, math.LegacyOneDec())}
 	historicalRewards := distrtypes.NewValidatorHistoricalRewards(decCoins, 2)
 	suite.distrKeeper.SetValidatorHistoricalRewards(suite.ctx, valAddress, 2, historicalRewards)
 	// setup current revards

--- a/x/distribution/simulation/operations_test.go
+++ b/x/distribution/simulation/operations_test.go
@@ -4,6 +4,7 @@ import (
 	"math/rand"
 	"testing"
 
+	"cosmossdk.io/math"
 	"github.com/stretchr/testify/suite"
 	abci "github.com/tendermint/tendermint/abci/types"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
@@ -158,8 +159,8 @@ func (suite *SimTestSuite) testSimulateMsgWithdrawValidatorCommission(tokenName 
 
 	// set outstanding rewards
 	valCommission := sdk.NewDecCoins(
-		sdk.NewDecCoinFromDec(tokenName, sdk.NewDec(5).Quo(sdk.NewDec(2))),
-		sdk.NewDecCoinFromDec("stake", sdk.NewDec(1).Quo(sdk.NewDec(1))),
+		sdk.NewDecCoinFromDec(tokenName, math.LegacyNewDec(5).Quo(math.LegacyNewDec(2))),
+		sdk.NewDecCoinFromDec("stake", math.LegacyNewDec(1).Quo(math.LegacyNewDec(1))),
 	)
 
 	suite.distrKeeper.SetValidatorOutstandingRewards(suite.ctx, validator0.GetOperator(), types.ValidatorOutstandingRewards{Rewards: valCommission})
@@ -283,7 +284,7 @@ func (suite *SimTestSuite) getTestingValidator(accounts []simtypes.Account, comm
 	require.NoError(err)
 	validator, err = validator.SetInitialCommission(commission)
 	require.NoError(err)
-	validator.DelegatorShares = sdk.NewDec(100)
+	validator.DelegatorShares = math.LegacyNewDec(100)
 	validator.Tokens = sdk.NewInt(1000000)
 
 	suite.stakingKeeper.SetValidator(suite.ctx, validator)

--- a/x/distribution/types/distribution.pb.go
+++ b/x/distribution/types/distribution.pb.go
@@ -469,7 +469,7 @@ var xxx_messageInfo_CommunityPoolSpendProposal proto.InternalMessageInfo
 // staking token, and the creation height (to check later on if any slashes have
 // occurred). NOTE: Even though validators are slashed to whole staking tokens,
 // the delegators within the validator may be left with less than a full token,
-// thus sdk.Dec is used.
+// thus math.LegacyDec is used.
 type DelegatorStartingInfo struct {
 	PreviousPeriod uint64                                 `protobuf:"varint,1,opt,name=previous_period,json=previousPeriod,proto3" json:"previous_period,omitempty"`
 	Stake          github_com_cosmos_cosmos_sdk_types.Dec `protobuf:"bytes,2,opt,name=stake,proto3,customtype=github.com/cosmos/cosmos-sdk/types.Dec" json:"stake"`

--- a/x/distribution/types/fee_pool_test.go
+++ b/x/distribution/types/fee_pool_test.go
@@ -3,6 +3,7 @@ package types_test
 import (
 	"testing"
 
+	"cosmossdk.io/math"
 	"github.com/stretchr/testify/require"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -13,6 +14,6 @@ func TestValidateGenesis(t *testing.T) {
 	fp := types.InitialFeePool()
 	require.Nil(t, fp.ValidateGenesis())
 
-	fp2 := types.FeePool{CommunityPool: sdk.DecCoins{{Denom: "stake", Amount: sdk.NewDec(-1)}}}
+	fp2 := types.FeePool{CommunityPool: sdk.DecCoins{{Denom: "stake", Amount: math.LegacyNewDec(-1)}}}
 	require.NotNil(t, fp2.ValidateGenesis())
 }

--- a/x/distribution/types/params.go
+++ b/x/distribution/types/params.go
@@ -3,6 +3,7 @@ package types
 import (
 	"fmt"
 
+	"cosmossdk.io/math"
 	"sigs.k8s.io/yaml"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -25,7 +26,7 @@ func (p Params) String() string {
 
 // ValidateBasic performs basic validation on distribution parameters.
 func (p Params) ValidateBasic() error {
-	if p.CommunityTax.IsNegative() || p.CommunityTax.GT(sdk.OneDec()) {
+	if p.CommunityTax.IsNegative() || p.CommunityTax.GT(math.LegacyOneDec()) {
 		return fmt.Errorf(
 			"community tax should be non-negative and less than one: %s", p.CommunityTax,
 		)
@@ -40,7 +41,7 @@ func (p Params) ValidateBasic() error {
 			"bonus proposer reward should be positive: %s", p.BonusProposerReward,
 		)
 	}
-	if v := p.BaseProposerReward.Add(p.BonusProposerReward).Add(p.CommunityTax); v.GT(sdk.OneDec()) {
+	if v := p.BaseProposerReward.Add(p.BonusProposerReward).Add(p.CommunityTax); v.GT(math.LegacyOneDec()) {
 		return fmt.Errorf(
 			"sum of base, bonus proposer rewards, and community tax cannot be greater than one: %s", v,
 		)
@@ -61,7 +62,7 @@ func validateCommunityTax(i interface{}) error {
 	if v.IsNegative() {
 		return fmt.Errorf("community tax must be positive: %s", v)
 	}
-	if v.GT(sdk.OneDec()) {
+	if v.GT(math.LegacyOneDec()) {
 		return fmt.Errorf("community tax too large: %s", v)
 	}
 
@@ -80,7 +81,7 @@ func validateBaseProposerReward(i interface{}) error {
 	if v.IsNegative() {
 		return fmt.Errorf("base proposer reward must be positive: %s", v)
 	}
-	if v.GT(sdk.OneDec()) {
+	if v.GT(math.LegacyOneDec()) {
 		return fmt.Errorf("base proposer reward too large: %s", v)
 	}
 
@@ -99,7 +100,7 @@ func validateBonusProposerReward(i interface{}) error {
 	if v.IsNegative() {
 		return fmt.Errorf("bonus proposer reward must be positive: %s", v)
 	}
-	if v.GT(sdk.OneDec()) {
+	if v.GT(math.LegacyOneDec()) {
 		return fmt.Errorf("bonus proposer reward too large: %s", v)
 	}
 

--- a/x/distribution/types/params_internal_test.go
+++ b/x/distribution/types/params_internal_test.go
@@ -3,6 +3,7 @@ package types
 import (
 	"testing"
 
+	"cosmossdk.io/math"
 	"github.com/stretchr/testify/require"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -19,9 +20,9 @@ func Test_validateAuxFuncs(t *testing.T) {
 	}{
 		{"wrong type", args{10.5}, true},
 		{"empty sdk.Dec", args{sdk.Dec{}}, true},
-		{"negative", args{sdk.NewDec(-1)}, true},
-		{"one dec", args{sdk.NewDec(1)}, false},
-		{"two dec", args{sdk.NewDec(2)}, true},
+		{"negative", args{math.LegacyNewDec(-1)}, true},
+		{"one dec", args{math.LegacyNewDec(1)}, false},
+		{"two dec", args{math.LegacyNewDec(2)}, true},
 	}
 	for _, tt := range tests {
 		tt := tt

--- a/x/gov/common_test.go
+++ b/x/gov/common_test.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"testing"
 
+	"cosmossdk.io/math"
 	"github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -21,7 +22,7 @@ var (
 	valTokens           = sdk.TokensFromConsensusPower(42, sdk.DefaultPowerReduction)
 	TestProposal        = v1beta1.NewTextProposal("Test", "description")
 	TestDescription     = stakingtypes.NewDescription("T", "E", "S", "T", "Z")
-	TestCommissionRates = stakingtypes.NewCommissionRates(sdk.ZeroDec(), sdk.ZeroDec(), sdk.ZeroDec())
+	TestCommissionRates = stakingtypes.NewCommissionRates(math.LegacyZeroDec(), math.LegacyZeroDec(), math.LegacyZeroDec())
 )
 
 // mkTestLegacyContent creates a MsgExecLegacyContent for testing purposes.

--- a/x/gov/keeper/grpc_query_test.go
+++ b/x/gov/keeper/grpc_query_test.go
@@ -4,6 +4,7 @@ import (
 	gocontext "context"
 	"fmt"
 
+	"cosmossdk.io/math"
 	"github.com/cosmos/cosmos-sdk/simapp"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/query"
@@ -878,9 +879,9 @@ func (suite *KeeperTestSuite) TestLegacyGRPCQueryParams() {
 	)
 
 	defaultTallyParams := v1beta1.TallyParams{
-		Quorum:        sdk.NewDec(0),
-		Threshold:     sdk.NewDec(0),
-		VetoThreshold: sdk.NewDec(0),
+		Quorum:        math.LegacyNewDec(0),
+		Threshold:     math.LegacyNewDec(0),
+		VetoThreshold: math.LegacyNewDec(0),
 	}
 
 	testCases := []struct {

--- a/x/gov/keeper/tally.go
+++ b/x/gov/keeper/tally.go
@@ -1,6 +1,7 @@
 package keeper
 
 import (
+	"cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	v1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
@@ -12,12 +13,12 @@ import (
 // voters
 func (keeper Keeper) Tally(ctx sdk.Context, proposal v1.Proposal) (passes bool, burnDeposits bool, tallyResults v1.TallyResult) {
 	results := make(map[v1.VoteOption]sdk.Dec)
-	results[v1.OptionYes] = sdk.ZeroDec()
-	results[v1.OptionAbstain] = sdk.ZeroDec()
-	results[v1.OptionNo] = sdk.ZeroDec()
-	results[v1.OptionNoWithVeto] = sdk.ZeroDec()
+	results[v1.OptionYes] = math.LegacyZeroDec()
+	results[v1.OptionAbstain] = math.LegacyZeroDec()
+	results[v1.OptionNo] = math.LegacyZeroDec()
+	results[v1.OptionNoWithVeto] = math.LegacyZeroDec()
 
-	totalVotingPower := sdk.ZeroDec()
+	totalVotingPower := math.LegacyZeroDec()
 	currValidators := make(map[string]v1.ValidatorGovInfo)
 
 	// fetch all the bonded validators, insert them into currValidators
@@ -26,7 +27,7 @@ func (keeper Keeper) Tally(ctx sdk.Context, proposal v1.Proposal) (passes bool, 
 			validator.GetOperator(),
 			validator.GetBondedTokens(),
 			validator.GetDelegatorShares(),
-			sdk.ZeroDec(),
+			math.LegacyZeroDec(),
 			v1.WeightedVoteOptions{},
 		)
 
@@ -105,7 +106,7 @@ func (keeper Keeper) Tally(ctx sdk.Context, proposal v1.Proposal) (passes bool, 
 	}
 
 	// If no one votes (everyone abstains), proposal fails
-	if totalVotingPower.Sub(results[v1.OptionAbstain]).Equal(sdk.ZeroDec()) {
+	if totalVotingPower.Sub(results[v1.OptionAbstain]).Equal(math.LegacyZeroDec()) {
 		return false, false, tallyResults
 	}
 

--- a/x/gov/migrations/v2/store_test.go
+++ b/x/gov/migrations/v2/store_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"cosmossdk.io/math"
 	"github.com/stretchr/testify/require"
 
 	"github.com/cosmos/cosmos-sdk/testutil"
@@ -31,7 +32,7 @@ func TestMigrateStore(t *testing.T) {
 	// Use real values for votes, as we're testing weighted votes.
 	oldVote := v1beta1.Vote{ProposalId: 1, Voter: "foobar", Option: v1beta1.OptionNoWithVeto}
 	oldVoteValue := cdc.MustMarshal(&oldVote)
-	newVote := v1beta1.Vote{ProposalId: 1, Voter: "foobar", Options: v1beta1.WeightedVoteOptions{{Option: v1beta1.OptionNoWithVeto, Weight: sdk.NewDec(1)}}}
+	newVote := v1beta1.Vote{ProposalId: 1, Voter: "foobar", Options: v1beta1.WeightedVoteOptions{{Option: v1beta1.OptionNoWithVeto, Weight: math.LegacyNewDec(1)}}}
 	newVoteValue := cdc.MustMarshal(&newVote)
 
 	testCases := []struct {

--- a/x/gov/migrations/v3/convert_test.go
+++ b/x/gov/migrations/v3/convert_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/tx"
 	v3 "github.com/cosmos/cosmos-sdk/x/gov/migrations/v3"
@@ -154,7 +155,7 @@ func TestConvertToLegacyVote(t *testing.T) {
 				require.Equal(t, v1beta1Vote.ProposalId, vote.ProposalId)
 				require.Equal(t, v1beta1Vote.Voter, vote.Voter)
 				require.Equal(t, v1beta1Vote.Options[0].Option, v1beta1.OptionYes)
-				require.Equal(t, v1beta1Vote.Options[0].Weight, sdk.NewDec(1))
+				require.Equal(t, v1beta1Vote.Options[0].Weight, math.LegacyNewDec(1))
 			}
 		})
 	}

--- a/x/gov/simulation/genesis.go
+++ b/x/gov/simulation/genesis.go
@@ -8,6 +8,7 @@ import (
 	"math/rand"
 	"time"
 
+	"cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	"github.com/cosmos/cosmos-sdk/types/simulation"
@@ -41,17 +42,17 @@ func GenVotingParamsVotingPeriod(r *rand.Rand) time.Duration {
 }
 
 // GenTallyParamsQuorum randomized TallyParamsQuorum
-func GenTallyParamsQuorum(r *rand.Rand) sdk.Dec {
+func GenTallyParamsQuorum(r *rand.Rand) math.LegacyDec {
 	return sdk.NewDecWithPrec(int64(simulation.RandIntBetween(r, 334, 500)), 3)
 }
 
 // GenTallyParamsThreshold randomized TallyParamsThreshold
-func GenTallyParamsThreshold(r *rand.Rand) sdk.Dec {
+func GenTallyParamsThreshold(r *rand.Rand) math.LegacyDec {
 	return sdk.NewDecWithPrec(int64(simulation.RandIntBetween(r, 450, 550)), 3)
 }
 
 // GenTallyParamsVeto randomized TallyParamsVeto
-func GenTallyParamsVeto(r *rand.Rand) sdk.Dec {
+func GenTallyParamsVeto(r *rand.Rand) math.LegacyDec {
 	return sdk.NewDecWithPrec(int64(simulation.RandIntBetween(r, 250, 334)), 3)
 }
 

--- a/x/gov/types/v1/msgs.go
+++ b/x/gov/types/v1/msgs.go
@@ -3,6 +3,7 @@ package v1
 import (
 	"fmt"
 
+	"cosmossdk.io/math"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
@@ -194,7 +195,7 @@ func (msg MsgVoteWeighted) ValidateBasic() error {
 		return sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, WeightedVoteOptions(msg.Options).String())
 	}
 
-	totalWeight := sdk.NewDec(0)
+	totalWeight := math.LegacyNewDec(0)
 	usedOptions := make(map[VoteOption]bool)
 	for _, option := range msg.Options {
 		if !option.IsValid() {
@@ -211,11 +212,11 @@ func (msg MsgVoteWeighted) ValidateBasic() error {
 		usedOptions[option.Option] = true
 	}
 
-	if totalWeight.GT(sdk.NewDec(1)) {
+	if totalWeight.GT(math.LegacyNewDec(1)) {
 		return sdkerrors.Wrap(types.ErrInvalidVote, "Total weight overflow 1.00")
 	}
 
-	if totalWeight.LT(sdk.NewDec(1)) {
+	if totalWeight.LT(math.LegacyNewDec(1)) {
 		return sdkerrors.Wrap(types.ErrInvalidVote, "Total weight lower than 1.00")
 	}
 

--- a/x/gov/types/v1/msgs_test.go
+++ b/x/gov/types/v1/msgs_test.go
@@ -3,10 +3,11 @@ package v1_test
 import (
 	"testing"
 
+	"cosmossdk.io/math"
 	"github.com/stretchr/testify/require"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/cosmos/cosmos-sdk/x/gov/types/v1"
+	v1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 	"github.com/cosmos/cosmos-sdk/x/gov/types/v1beta1"
 )
 
@@ -101,18 +102,18 @@ func TestMsgVoteWeighted(t *testing.T) {
 		{0, addrs[0], v1.NewNonSplitVoteOption(v1.OptionNoWithVeto), "", true},
 		{0, addrs[0], v1.NewNonSplitVoteOption(v1.OptionAbstain), "", true},
 		{0, addrs[0], v1.WeightedVoteOptions{ // weight sum > 1
-			v1.NewWeightedVoteOption(v1.OptionYes, sdk.NewDec(1)),
-			v1.NewWeightedVoteOption(v1.OptionAbstain, sdk.NewDec(1)),
+			v1.NewWeightedVoteOption(v1.OptionYes, math.LegacyNewDec(1)),
+			v1.NewWeightedVoteOption(v1.OptionAbstain, math.LegacyNewDec(1)),
 		}, "", false},
 		{0, addrs[0], v1.WeightedVoteOptions{ // duplicate option
 			v1.NewWeightedVoteOption(v1.OptionYes, sdk.NewDecWithPrec(5, 1)),
 			v1.NewWeightedVoteOption(v1.OptionYes, sdk.NewDecWithPrec(5, 1)),
 		}, "", false},
 		{0, addrs[0], v1.WeightedVoteOptions{ // zero weight
-			v1.NewWeightedVoteOption(v1.OptionYes, sdk.NewDec(0)),
+			v1.NewWeightedVoteOption(v1.OptionYes, math.LegacyNewDec(0)),
 		}, "", false},
 		{0, addrs[0], v1.WeightedVoteOptions{ // negative weight
-			v1.NewWeightedVoteOption(v1.OptionYes, sdk.NewDec(-1)),
+			v1.NewWeightedVoteOption(v1.OptionYes, math.LegacyNewDec(-1)),
 		}, "", false},
 		{0, addrs[0], v1.WeightedVoteOptions{}, "", false},
 		{0, addrs[0], v1.NewNonSplitVoteOption(v1.VoteOption(0x13)), "", false},

--- a/x/gov/types/v1/params.go
+++ b/x/gov/types/v1/params.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -91,7 +92,7 @@ func (p Params) ValidateBasic() error {
 	if quorum.IsNegative() {
 		return fmt.Errorf("quorom cannot be negative: %s", quorum)
 	}
-	if quorum.GT(sdk.OneDec()) {
+	if quorum.GT(math.LegacyOneDec()) {
 		return fmt.Errorf("quorom too large: %s", p.Quorum)
 	}
 
@@ -102,7 +103,7 @@ func (p Params) ValidateBasic() error {
 	if !threshold.IsPositive() {
 		return fmt.Errorf("vote threshold must be positive: %s", threshold)
 	}
-	if threshold.GT(sdk.OneDec()) {
+	if threshold.GT(math.LegacyOneDec()) {
 		return fmt.Errorf("vote threshold too large: %s", threshold)
 	}
 
@@ -113,7 +114,7 @@ func (p Params) ValidateBasic() error {
 	if !vetoThreshold.IsPositive() {
 		return fmt.Errorf("veto threshold must be positive: %s", vetoThreshold)
 	}
-	if vetoThreshold.GT(sdk.OneDec()) {
+	if vetoThreshold.GT(math.LegacyOneDec()) {
 		return fmt.Errorf("veto threshold too large: %s", vetoThreshold)
 	}
 

--- a/x/gov/types/v1/params_legacy.go
+++ b/x/gov/types/v1/params_legacy.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 
+	"cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
 )
@@ -53,7 +54,7 @@ func validateTallyParams(i interface{}) error {
 	if quorum.IsNegative() {
 		return fmt.Errorf("quorom cannot be negative: %s", quorum)
 	}
-	if quorum.GT(sdk.OneDec()) {
+	if quorum.GT(math.LegacyOneDec()) {
 		return fmt.Errorf("quorom too large: %s", v)
 	}
 
@@ -64,7 +65,7 @@ func validateTallyParams(i interface{}) error {
 	if !threshold.IsPositive() {
 		return fmt.Errorf("vote threshold must be positive: %s", threshold)
 	}
-	if threshold.GT(sdk.OneDec()) {
+	if threshold.GT(math.LegacyOneDec()) {
 		return fmt.Errorf("vote threshold too large: %s", v)
 	}
 
@@ -75,7 +76,7 @@ func validateTallyParams(i interface{}) error {
 	if !vetoThreshold.IsPositive() {
 		return fmt.Errorf("veto threshold must be positive: %s", vetoThreshold)
 	}
-	if vetoThreshold.GT(sdk.OneDec()) {
+	if vetoThreshold.GT(math.LegacyOneDec()) {
 		return fmt.Errorf("veto threshold too large: %s", v)
 	}
 

--- a/x/gov/types/v1/tally.go
+++ b/x/gov/types/v1/tally.go
@@ -9,8 +9,8 @@ import (
 type ValidatorGovInfo struct {
 	Address             sdk.ValAddress      // address of the validator operator
 	BondedTokens        math.Int            // Power of a Validator
-	DelegatorShares     sdk.Dec             // Total outstanding delegator shares
-	DelegatorDeductions sdk.Dec             // Delegator deductions from validator's delegators voting independently
+	DelegatorShares     math.LegacyDec      // Total outstanding delegator shares
+	DelegatorDeductions math.LegacyDec      // Delegator deductions from validator's delegators voting independently
 	Vote                WeightedVoteOptions // Vote of the validator
 }
 

--- a/x/gov/types/v1/vote.go
+++ b/x/gov/types/v1/vote.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -66,7 +67,7 @@ func (w *WeightedVoteOption) IsValid() bool {
 		return false
 	}
 
-	if !weight.IsPositive() || weight.GT(sdk.NewDec(1)) {
+	if !weight.IsPositive() || weight.GT(math.LegacyNewDec(1)) {
 		return false
 	}
 
@@ -75,13 +76,13 @@ func (w *WeightedVoteOption) IsValid() bool {
 
 // NewNonSplitVoteOption creates a single option vote with weight 1
 func NewNonSplitVoteOption(option VoteOption) WeightedVoteOptions {
-	return WeightedVoteOptions{{option, sdk.NewDec(1).String()}}
+	return WeightedVoteOptions{{option, math.LegacyNewDec(1).String()}}
 }
 
 // ValidWeightedVoteOption returns true if the sub vote is valid and false otherwise.
 func ValidWeightedVoteOption(option WeightedVoteOption) bool {
 	weight, err := sdk.NewDecFromStr(option.Weight)
-	if err != nil || !weight.IsPositive() || weight.GT(sdk.NewDec(1)) {
+	if err != nil || !weight.IsPositive() || weight.GT(math.LegacyNewDec(1)) {
 		return false
 	}
 	return ValidVoteOption(option.Option)

--- a/x/gov/types/v1beta1/genesis.go
+++ b/x/gov/types/v1beta1/genesis.go
@@ -3,8 +3,8 @@ package v1beta1
 import (
 	"fmt"
 
+	"cosmossdk.io/math"
 	"github.com/cosmos/cosmos-sdk/codec/types"
-	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 // NewGenesisState creates a new genesis state for the governance module
@@ -45,13 +45,13 @@ func (data GenesisState) Empty() bool {
 // ValidateGenesis checks if parameters are within valid ranges
 func ValidateGenesis(data *GenesisState) error {
 	threshold := data.TallyParams.Threshold
-	if threshold.IsNegative() || threshold.GT(sdk.OneDec()) {
+	if threshold.IsNegative() || threshold.GT(math.LegacyOneDec()) {
 		return fmt.Errorf("governance vote threshold should be positive and less or equal to one, is %s",
 			threshold.String())
 	}
 
 	veto := data.TallyParams.VetoThreshold
-	if veto.IsNegative() || veto.GT(sdk.OneDec()) {
+	if veto.IsNegative() || veto.GT(math.LegacyOneDec()) {
 		return fmt.Errorf("governance vote veto threshold should be positive and less or equal to one, is %s",
 			veto.String())
 	}

--- a/x/gov/types/v1beta1/msgs.go
+++ b/x/gov/types/v1beta1/msgs.go
@@ -3,6 +3,7 @@ package v1beta1
 import (
 	"fmt"
 
+	"cosmossdk.io/math"
 	"github.com/gogo/protobuf/proto"
 	"sigs.k8s.io/yaml"
 
@@ -239,7 +240,7 @@ func (msg MsgVoteWeighted) ValidateBasic() error {
 		return sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, WeightedVoteOptions(msg.Options).String())
 	}
 
-	totalWeight := sdk.NewDec(0)
+	totalWeight := math.LegacyNewDec(0)
 	usedOptions := make(map[VoteOption]bool)
 	for _, option := range msg.Options {
 		if !ValidWeightedVoteOption(option) {
@@ -252,11 +253,11 @@ func (msg MsgVoteWeighted) ValidateBasic() error {
 		usedOptions[option.Option] = true
 	}
 
-	if totalWeight.GT(sdk.NewDec(1)) {
+	if totalWeight.GT(math.LegacyNewDec(1)) {
 		return sdkerrors.Wrap(types.ErrInvalidVote, "Total weight overflow 1.00")
 	}
 
-	if totalWeight.LT(sdk.NewDec(1)) {
+	if totalWeight.LT(math.LegacyNewDec(1)) {
 		return sdkerrors.Wrap(types.ErrInvalidVote, "Total weight lower than 1.00")
 	}
 

--- a/x/gov/types/v1beta1/msgs_test.go
+++ b/x/gov/types/v1beta1/msgs_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"cosmossdk.io/math"
 	"github.com/stretchr/testify/require"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -135,18 +136,18 @@ func TestMsgVoteWeighted(t *testing.T) {
 		{0, addrs[0], NewNonSplitVoteOption(OptionNoWithVeto), true},
 		{0, addrs[0], NewNonSplitVoteOption(OptionAbstain), true},
 		{0, addrs[0], WeightedVoteOptions{ // weight sum > 1
-			WeightedVoteOption{Option: OptionYes, Weight: sdk.NewDec(1)},
-			WeightedVoteOption{Option: OptionAbstain, Weight: sdk.NewDec(1)},
+			WeightedVoteOption{Option: OptionYes, Weight: math.LegacyNewDec(1)},
+			WeightedVoteOption{Option: OptionAbstain, Weight: math.LegacyNewDec(1)},
 		}, false},
 		{0, addrs[0], WeightedVoteOptions{ // duplicate option
 			WeightedVoteOption{Option: OptionYes, Weight: sdk.NewDecWithPrec(5, 1)},
 			WeightedVoteOption{Option: OptionYes, Weight: sdk.NewDecWithPrec(5, 1)},
 		}, false},
 		{0, addrs[0], WeightedVoteOptions{ // zero weight
-			WeightedVoteOption{Option: OptionYes, Weight: sdk.NewDec(0)},
+			WeightedVoteOption{Option: OptionYes, Weight: math.LegacyNewDec(0)},
 		}, false},
 		{0, addrs[0], WeightedVoteOptions{ // negative weight
-			WeightedVoteOption{Option: OptionYes, Weight: sdk.NewDec(-1)},
+			WeightedVoteOption{Option: OptionYes, Weight: math.LegacyNewDec(-1)},
 		}, false},
 		{0, addrs[0], WeightedVoteOptions{}, false},
 		{0, addrs[0], NewNonSplitVoteOption(VoteOption(0x13)), false},

--- a/x/gov/types/v1beta1/tally.go
+++ b/x/gov/types/v1beta1/tally.go
@@ -11,8 +11,8 @@ import (
 type ValidatorGovInfo struct {
 	Address             sdk.ValAddress      // address of the validator operator
 	BondedTokens        math.Int            // Power of a Validator
-	DelegatorShares     sdk.Dec             // Total outstanding delegator shares
-	DelegatorDeductions sdk.Dec             // Delegator deductions from validator's delegators voting independently
+	DelegatorShares     math.LegacyDec      // Total outstanding delegator shares
+	DelegatorDeductions math.LegacyDec      // Delegator deductions from validator's delegators voting independently
 	Vote                WeightedVoteOptions // Vote of the validator
 }
 

--- a/x/gov/types/v1beta1/vote.go
+++ b/x/gov/types/v1beta1/vote.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"cosmossdk.io/math"
 	"sigs.k8s.io/yaml"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -57,7 +58,7 @@ func (v Votes) String() string {
 
 // NewNonSplitVoteOption creates a single option vote with weight 1
 func NewNonSplitVoteOption(option VoteOption) WeightedVoteOptions {
-	return WeightedVoteOptions{{option, sdk.NewDec(1)}}
+	return WeightedVoteOptions{{option, math.LegacyNewDec(1)}}
 }
 
 func (v WeightedVoteOption) String() string {
@@ -78,7 +79,7 @@ func (v WeightedVoteOptions) String() (out string) {
 
 // ValidWeightedVoteOption returns true if the sub vote is valid and false otherwise.
 func ValidWeightedVoteOption(option WeightedVoteOption) bool {
-	if !option.Weight.IsPositive() || option.Weight.GT(sdk.NewDec(1)) {
+	if !option.Weight.IsPositive() || option.Weight.GT(math.LegacyNewDec(1)) {
 		return false
 	}
 	return ValidVoteOption(option.Option)

--- a/x/mint/client/testutil/grpc.go
+++ b/x/mint/client/testutil/grpc.go
@@ -3,6 +3,7 @@ package testutil
 import (
 	"fmt"
 
+	"cosmossdk.io/math"
 	"github.com/cosmos/cosmos-sdk/testutil"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	grpctypes "github.com/cosmos/cosmos-sdk/types/grpc"
@@ -29,7 +30,7 @@ func (s *IntegrationTestSuite) TestQueryGRPC() {
 			&minttypes.QueryParamsResponse{},
 			&minttypes.QueryParamsResponse{
 				Params: minttypes.NewParams("stake", sdk.NewDecWithPrec(13, 2), sdk.NewDecWithPrec(100, 2),
-					sdk.NewDec(1), sdk.NewDecWithPrec(67, 2), (60 * 60 * 8766 / 5)),
+					math.LegacyNewDec(1), sdk.NewDecWithPrec(67, 2), (60 * 60 * 8766 / 5)),
 			},
 		},
 		{
@@ -38,7 +39,7 @@ func (s *IntegrationTestSuite) TestQueryGRPC() {
 			map[string]string{},
 			&minttypes.QueryInflationResponse{},
 			&minttypes.QueryInflationResponse{
-				Inflation: sdk.NewDec(1),
+				Inflation: math.LegacyNewDec(1),
 			},
 		},
 		{
@@ -49,7 +50,7 @@ func (s *IntegrationTestSuite) TestQueryGRPC() {
 			},
 			&minttypes.QueryAnnualProvisionsResponse{},
 			&minttypes.QueryAnnualProvisionsResponse{
-				AnnualProvisions: sdk.NewDec(500000000),
+				AnnualProvisions: math.LegacyNewDec(500000000),
 			},
 		},
 	}

--- a/x/mint/keeper/keeper.go
+++ b/x/mint/keeper/keeper.go
@@ -112,7 +112,7 @@ func (k Keeper) StakingTokenSupply(ctx sdk.Context) math.Int {
 
 // BondedRatio implements an alias call to the underlying staking keeper's
 // BondedRatio to be used in BeginBlocker.
-func (k Keeper) BondedRatio(ctx sdk.Context) sdk.Dec {
+func (k Keeper) BondedRatio(ctx sdk.Context) math.LegacyDec {
 	return k.stakingKeeper.BondedRatio(ctx)
 }
 

--- a/x/mint/simulation/decoder_test.go
+++ b/x/mint/simulation/decoder_test.go
@@ -7,7 +7,6 @@ import (
 	"cosmossdk.io/math"
 	"github.com/stretchr/testify/require"
 
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/kv"
 	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
 	"github.com/cosmos/cosmos-sdk/x/mint"
@@ -20,7 +19,7 @@ func TestDecodeStore(t *testing.T) {
 
 	dec := simulation.NewDecodeStore(encCfg.Codec)
 
-	minter := types.NewMinter(sdk.OneDec(), math.LegacyNewDec(15))
+	minter := types.NewMinter(math.LegacyOneDec(), math.LegacyNewDec(15))
 
 	kvPairs := kv.Pairs{
 		Pairs: []kv.Pair{

--- a/x/mint/simulation/decoder_test.go
+++ b/x/mint/simulation/decoder_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"cosmossdk.io/math"
 	"github.com/stretchr/testify/require"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -19,7 +20,7 @@ func TestDecodeStore(t *testing.T) {
 
 	dec := simulation.NewDecodeStore(encCfg.Codec)
 
-	minter := types.NewMinter(sdk.OneDec(), sdk.NewDec(15))
+	minter := types.NewMinter(sdk.OneDec(), math.LegacyNewDec(15))
 
 	kvPairs := kv.Pairs{
 		Pairs: []kv.Pair{

--- a/x/mint/simulation/genesis.go
+++ b/x/mint/simulation/genesis.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"math/rand"
 
+	"cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	"github.com/cosmos/cosmos-sdk/x/mint/types"
@@ -22,27 +23,27 @@ const (
 )
 
 // GenInflation randomized Inflation
-func GenInflation(r *rand.Rand) sdk.Dec {
+func GenInflation(r *rand.Rand) math.LegacyDec {
 	return sdk.NewDecWithPrec(int64(r.Intn(99)), 2)
 }
 
 // GenInflationRateChange randomized InflationRateChange
-func GenInflationRateChange(r *rand.Rand) sdk.Dec {
+func GenInflationRateChange(r *rand.Rand) math.LegacyDec {
 	return sdk.NewDecWithPrec(int64(r.Intn(99)), 2)
 }
 
 // GenInflationMax randomized InflationMax
-func GenInflationMax(r *rand.Rand) sdk.Dec {
+func GenInflationMax(r *rand.Rand) math.LegacyDec {
 	return sdk.NewDecWithPrec(20, 2)
 }
 
 // GenInflationMin randomized InflationMin
-func GenInflationMin(r *rand.Rand) sdk.Dec {
+func GenInflationMin(r *rand.Rand) math.LegacyDec {
 	return sdk.NewDecWithPrec(7, 2)
 }
 
 // GenGoalBonded randomized GoalBonded
-func GenGoalBonded(r *rand.Rand) sdk.Dec {
+func GenGoalBonded(r *rand.Rand) math.LegacyDec {
 	return sdk.NewDecWithPrec(67, 2)
 }
 

--- a/x/mint/simulation/genesis_test.go
+++ b/x/mint/simulation/genesis_test.go
@@ -52,7 +52,7 @@ func TestRandomizedGenState(t *testing.T) {
 	require.Equal(t, "stake", mintGenesis.Params.MintDenom)
 	require.Equal(t, "0stake", mintGenesis.Minter.BlockProvision(mintGenesis.Params).String())
 	require.Equal(t, "0.170000000000000000", mintGenesis.Minter.NextAnnualProvisions(mintGenesis.Params, math.OneInt()).String())
-	require.Equal(t, "0.169999926644441493", mintGenesis.Minter.NextInflationRate(mintGenesis.Params, sdk.OneDec()).String())
+	require.Equal(t, "0.169999926644441493", mintGenesis.Minter.NextInflationRate(mintGenesis.Params, math.LegacyOneDec()).String())
 	require.Equal(t, "0.170000000000000000", mintGenesis.Minter.Inflation.String())
 	require.Equal(t, "0.000000000000000000", mintGenesis.Minter.AnnualProvisions.String())
 }

--- a/x/mint/types/genesis.go
+++ b/x/mint/types/genesis.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -12,7 +13,7 @@ import (
 type InflationCalculationFn func(ctx sdk.Context, minter Minter, params Params, bondedRatio sdk.Dec) sdk.Dec
 
 // DefaultInflationCalculationFn is the default function used to calculate inflation.
-func DefaultInflationCalculationFn(_ sdk.Context, minter Minter, params Params, bondedRatio sdk.Dec) sdk.Dec {
+func DefaultInflationCalculationFn(_ sdk.Context, minter Minter, params Params, bondedRatio sdk.Dec) math.LegacyDec {
 	return minter.NextInflationRate(params, bondedRatio)
 }
 

--- a/x/mint/types/minter.go
+++ b/x/mint/types/minter.go
@@ -21,7 +21,7 @@ func NewMinter(inflation, annualProvisions sdk.Dec) Minter {
 func InitialMinter(inflation sdk.Dec) Minter {
 	return NewMinter(
 		inflation,
-		sdk.NewDec(0),
+		math.LegacyNewDec(0),
 	)
 }
 
@@ -54,7 +54,7 @@ func (m Minter) NextInflationRate(params Params, bondedRatio sdk.Dec) sdk.Dec {
 	inflationRateChangePerYear := sdk.OneDec().
 		Sub(bondedRatio.Quo(params.GoalBonded)).
 		Mul(params.InflationRateChange)
-	inflationRateChange := inflationRateChangePerYear.Quo(sdk.NewDec(int64(params.BlocksPerYear)))
+	inflationRateChange := inflationRateChangePerYear.Quo(math.LegacyNewDec(int64(params.BlocksPerYear)))
 
 	// adjust the new annual inflation for this next cycle
 	inflation := m.Inflation.Add(inflationRateChange) // note inflationRateChange may be negative

--- a/x/mint/types/minter.go
+++ b/x/mint/types/minter.go
@@ -51,7 +51,7 @@ func (m Minter) NextInflationRate(params Params, bondedRatio sdk.Dec) sdk.Dec {
 	// 7% and 20%.
 
 	// (1 - bondedRatio/GoalBonded) * InflationRateChange
-	inflationRateChangePerYear := sdk.OneDec().
+	inflationRateChangePerYear := math.LegacyOneDec().
 		Sub(bondedRatio.Quo(params.GoalBonded)).
 		Mul(params.InflationRateChange)
 	inflationRateChange := inflationRateChangePerYear.Quo(math.LegacyNewDec(int64(params.BlocksPerYear)))

--- a/x/mint/types/minter.go
+++ b/x/mint/types/minter.go
@@ -43,7 +43,7 @@ func ValidateMinter(minter Minter) error {
 }
 
 // NextInflationRate returns the new inflation rate for the next hour.
-func (m Minter) NextInflationRate(params Params, bondedRatio sdk.Dec) sdk.Dec {
+func (m Minter) NextInflationRate(params Params, bondedRatio sdk.Dec) math.LegacyDec {
 	// The target annual inflation rate is recalculated for each previsions cycle. The
 	// inflation is also subject to a rate change (positive or negative) depending on
 	// the distance from the desired ratio (67%). The maximum rate change possible is
@@ -70,7 +70,7 @@ func (m Minter) NextInflationRate(params Params, bondedRatio sdk.Dec) sdk.Dec {
 
 // NextAnnualProvisions returns the annual provisions based on current total
 // supply and inflation rate.
-func (m Minter) NextAnnualProvisions(_ Params, totalSupply math.Int) sdk.Dec {
+func (m Minter) NextAnnualProvisions(_ Params, totalSupply math.Int) math.LegacyDec {
 	return m.Inflation.MulInt(totalSupply)
 }
 

--- a/x/mint/types/minter_test.go
+++ b/x/mint/types/minter_test.go
@@ -91,7 +91,7 @@ func TestBlockProvision(t *testing.T) {
 // previously using math.Int operations:
 // BenchmarkBlockProvision-4 5000000 220 ns/op
 //
-// using sdk.Dec operations: (current implementation)
+// using math.LegacyDec operations: (current implementation)
 // BenchmarkBlockProvision-4 3000000 429 ns/op
 func BenchmarkBlockProvision(b *testing.B) {
 	b.ReportAllocs()

--- a/x/mint/types/minter_test.go
+++ b/x/mint/types/minter_test.go
@@ -22,31 +22,31 @@ func TestNextInflation(t *testing.T) {
 		bondedRatio, setInflation, expChange sdk.Dec
 	}{
 		// with 0% bonded atom supply the inflation should increase by InflationRateChange
-		{sdk.ZeroDec(), sdk.NewDecWithPrec(7, 2), params.InflationRateChange.Quo(blocksPerYr)},
+		{math.LegacyZeroDec(), sdk.NewDecWithPrec(7, 2), params.InflationRateChange.Quo(blocksPerYr)},
 
 		// 100% bonded, starting at 20% inflation and being reduced
 		// (1 - (1/0.67))*(0.13/8667)
 		{
-			sdk.OneDec(), sdk.NewDecWithPrec(20, 2),
-			sdk.OneDec().Sub(sdk.OneDec().Quo(params.GoalBonded)).Mul(params.InflationRateChange).Quo(blocksPerYr),
+			math.LegacyOneDec(), sdk.NewDecWithPrec(20, 2),
+			math.LegacyOneDec().Sub(math.LegacyOneDec().Quo(params.GoalBonded)).Mul(params.InflationRateChange).Quo(blocksPerYr),
 		},
 
 		// 50% bonded, starting at 10% inflation and being increased
 		{
 			sdk.NewDecWithPrec(5, 1), sdk.NewDecWithPrec(10, 2),
-			sdk.OneDec().Sub(sdk.NewDecWithPrec(5, 1).Quo(params.GoalBonded)).Mul(params.InflationRateChange).Quo(blocksPerYr),
+			math.LegacyOneDec().Sub(sdk.NewDecWithPrec(5, 1).Quo(params.GoalBonded)).Mul(params.InflationRateChange).Quo(blocksPerYr),
 		},
 
 		// test 7% minimum stop (testing with 100% bonded)
-		{sdk.OneDec(), sdk.NewDecWithPrec(7, 2), sdk.ZeroDec()},
-		{sdk.OneDec(), sdk.NewDecWithPrec(700000001, 10), sdk.NewDecWithPrec(-1, 10)},
+		{math.LegacyOneDec(), sdk.NewDecWithPrec(7, 2), math.LegacyZeroDec()},
+		{math.LegacyOneDec(), sdk.NewDecWithPrec(700000001, 10), sdk.NewDecWithPrec(-1, 10)},
 
 		// test 20% maximum stop (testing with 0% bonded)
-		{sdk.ZeroDec(), sdk.NewDecWithPrec(20, 2), sdk.ZeroDec()},
-		{sdk.ZeroDec(), sdk.NewDecWithPrec(1999999999, 10), sdk.NewDecWithPrec(1, 10)},
+		{math.LegacyZeroDec(), sdk.NewDecWithPrec(20, 2), math.LegacyZeroDec()},
+		{math.LegacyZeroDec(), sdk.NewDecWithPrec(1999999999, 10), sdk.NewDecWithPrec(1, 10)},
 
 		// perfect balance shouldn't change inflation
-		{sdk.NewDecWithPrec(67, 2), sdk.NewDecWithPrec(15, 2), sdk.ZeroDec()},
+		{sdk.NewDecWithPrec(67, 2), sdk.NewDecWithPrec(15, 2), math.LegacyZeroDec()},
 	}
 	for i, tc := range tests {
 		minter.Inflation = tc.setInflation

--- a/x/mint/types/minter_test.go
+++ b/x/mint/types/minter_test.go
@@ -4,6 +4,7 @@ import (
 	"math/rand"
 	"testing"
 
+	"cosmossdk.io/math"
 	"github.com/stretchr/testify/require"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -12,7 +13,7 @@ import (
 func TestNextInflation(t *testing.T) {
 	minter := DefaultInitialMinter()
 	params := DefaultParams()
-	blocksPerYr := sdk.NewDec(int64(params.BlocksPerYear))
+	blocksPerYr := math.LegacyNewDec(int64(params.BlocksPerYear))
 
 	// Governing Mechanism:
 	//    inflationRateChangePerYear = (1- BondedRatio/ GoalBonded) * MaxInflationRateChange
@@ -74,7 +75,7 @@ func TestBlockProvision(t *testing.T) {
 		{(secondsPerYear / 5) / 2, 0},
 	}
 	for i, tc := range tests {
-		minter.AnnualProvisions = sdk.NewDec(tc.annualProvisions)
+		minter.AnnualProvisions = math.LegacyNewDec(tc.annualProvisions)
 		provisions := minter.BlockProvision(params)
 
 		expProvisions := sdk.NewCoin(params.MintDenom,
@@ -99,7 +100,7 @@ func BenchmarkBlockProvision(b *testing.B) {
 
 	s1 := rand.NewSource(100)
 	r1 := rand.New(s1)
-	minter.AnnualProvisions = sdk.NewDec(r1.Int63n(1000000))
+	minter.AnnualProvisions = math.LegacyNewDec(r1.Int63n(1000000))
 
 	// run the BlockProvision function b.N times
 	for n := 0; n < b.N; n++ {

--- a/x/mint/types/params.go
+++ b/x/mint/types/params.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"cosmossdk.io/math"
 	"sigs.k8s.io/yaml"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -94,7 +95,7 @@ func validateInflationRateChange(i interface{}) error {
 	if v.IsNegative() {
 		return fmt.Errorf("inflation rate change cannot be negative: %s", v)
 	}
-	if v.GT(sdk.OneDec()) {
+	if v.GT(math.LegacyOneDec()) {
 		return fmt.Errorf("inflation rate change too large: %s", v)
 	}
 
@@ -110,7 +111,7 @@ func validateInflationMax(i interface{}) error {
 	if v.IsNegative() {
 		return fmt.Errorf("max inflation cannot be negative: %s", v)
 	}
-	if v.GT(sdk.OneDec()) {
+	if v.GT(math.LegacyOneDec()) {
 		return fmt.Errorf("max inflation too large: %s", v)
 	}
 
@@ -126,7 +127,7 @@ func validateInflationMin(i interface{}) error {
 	if v.IsNegative() {
 		return fmt.Errorf("min inflation cannot be negative: %s", v)
 	}
-	if v.GT(sdk.OneDec()) {
+	if v.GT(math.LegacyOneDec()) {
 		return fmt.Errorf("min inflation too large: %s", v)
 	}
 
@@ -142,7 +143,7 @@ func validateGoalBonded(i interface{}) error {
 	if v.IsNegative() || v.IsZero() {
 		return fmt.Errorf("goal bonded must be positive: %s", v)
 	}
-	if v.GT(sdk.OneDec()) {
+	if v.GT(math.LegacyOneDec()) {
 		return fmt.Errorf("goal bonded too large: %s", v)
 	}
 

--- a/x/params/keeper/keeper_test.go
+++ b/x/params/keeper/keeper_test.go
@@ -192,7 +192,7 @@ func TestSubspace(t *testing.T) {
 		{"uint64", uint64(1), uint64(0), new(uint64)},
 		{"int", sdk.NewInt(1), *new(math.Int), new(math.Int)},
 		{"uint", sdk.NewUint(1), *new(sdk.Uint), new(sdk.Uint)},
-		{"dec", sdk.NewDec(1), *new(sdk.Dec), new(sdk.Dec)},
+		{"dec", math.LegacyNewDec(1), *new(sdk.Dec), new(sdk.Dec)},
 		{"struct", s{1}, s{0}, new(s)},
 	}
 

--- a/x/slashing/app_test.go
+++ b/x/slashing/app_test.go
@@ -63,7 +63,7 @@ func TestSlashingMsgs(t *testing.T) {
 	simapp.CheckBalance(t, app, addr1, sdk.Coins{genCoin})
 
 	description := stakingtypes.NewDescription("foo_moniker", "", "", "", "")
-	commission := stakingtypes.NewCommissionRates(sdk.ZeroDec(), sdk.ZeroDec(), sdk.ZeroDec())
+	commission := stakingtypes.NewCommissionRates(math.LegacyZeroDec(), math.LegacyZeroDec(), math.LegacyZeroDec())
 
 	createValidatorMsg, err := stakingtypes.NewMsgCreateValidator(
 		sdk.ValAddress(addr1), valKey.PubKey(), bondCoin, description, commission, math.OneInt(),

--- a/x/slashing/simulation/genesis.go
+++ b/x/slashing/simulation/genesis.go
@@ -30,7 +30,7 @@ func GenSignedBlocksWindow(r *rand.Rand) int64 {
 }
 
 // GenMinSignedPerWindow randomized MinSignedPerWindow
-func GenMinSignedPerWindow(r *rand.Rand) sdk.Dec {
+func GenMinSignedPerWindow(r *rand.Rand) math.LegacyDec {
 	return sdk.NewDecWithPrec(int64(r.Intn(10)), 1)
 }
 
@@ -40,12 +40,12 @@ func GenDowntimeJailDuration(r *rand.Rand) time.Duration {
 }
 
 // GenSlashFractionDoubleSign randomized SlashFractionDoubleSign
-func GenSlashFractionDoubleSign(r *rand.Rand) sdk.Dec {
+func GenSlashFractionDoubleSign(r *rand.Rand) math.LegacyDec {
 	return math.LegacyNewDec(1).Quo(math.LegacyNewDec(int64(r.Intn(50) + 1)))
 }
 
 // GenSlashFractionDowntime randomized SlashFractionDowntime
-func GenSlashFractionDowntime(r *rand.Rand) sdk.Dec {
+func GenSlashFractionDowntime(r *rand.Rand) math.LegacyDec {
 	return math.LegacyNewDec(1).Quo(math.LegacyNewDec(int64(r.Intn(200) + 1)))
 }
 

--- a/x/slashing/simulation/genesis.go
+++ b/x/slashing/simulation/genesis.go
@@ -8,6 +8,7 @@ import (
 	"math/rand"
 	"time"
 
+	"cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	"github.com/cosmos/cosmos-sdk/types/simulation"
@@ -40,12 +41,12 @@ func GenDowntimeJailDuration(r *rand.Rand) time.Duration {
 
 // GenSlashFractionDoubleSign randomized SlashFractionDoubleSign
 func GenSlashFractionDoubleSign(r *rand.Rand) sdk.Dec {
-	return sdk.NewDec(1).Quo(sdk.NewDec(int64(r.Intn(50) + 1)))
+	return math.LegacyNewDec(1).Quo(math.LegacyNewDec(int64(r.Intn(50) + 1)))
 }
 
 // GenSlashFractionDowntime randomized SlashFractionDowntime
 func GenSlashFractionDowntime(r *rand.Rand) sdk.Dec {
-	return sdk.NewDec(1).Quo(sdk.NewDec(int64(r.Intn(200) + 1)))
+	return math.LegacyNewDec(1).Quo(math.LegacyNewDec(int64(r.Intn(200) + 1)))
 }
 
 // RandomizedGenState generates a random GenesisState for slashing

--- a/x/slashing/simulation/operations_test.go
+++ b/x/slashing/simulation/operations_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"cosmossdk.io/math"
 	"github.com/stretchr/testify/suite"
 	abci "github.com/tendermint/tendermint/abci/types"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
@@ -202,7 +203,7 @@ func getTestingValidator(ctx sdk.Context, stakingKeeper *stakingkeeper.Keeper, a
 		return stakingtypes.Validator{}, fmt.Errorf("failed to set initial commission: %w", err)
 	}
 
-	validator.DelegatorShares = sdk.NewDec(100)
+	validator.DelegatorShares = math.LegacyNewDec(100)
 	validator.Tokens = sdk.NewInt(1000000)
 
 	stakingKeeper.SetValidator(ctx, validator)

--- a/x/slashing/simulation/operations_test.go
+++ b/x/slashing/simulation/operations_test.go
@@ -165,7 +165,7 @@ func (suite *SimTestSuite) TestSimulateMsgUnjail() {
 	suite.Require().NoError(err)
 	selfDelegation := stakingtypes.NewDelegation(val0AccAddress.Bytes(), validator0.GetOperator(), issuedShares)
 	suite.stakingKeeper.SetDelegation(ctx, selfDelegation)
-	suite.distrKeeper.SetDelegatorStartingInfo(ctx, validator0.GetOperator(), val0AccAddress.Bytes(), distrtypes.NewDelegatorStartingInfo(2, sdk.OneDec(), 200))
+	suite.distrKeeper.SetDelegatorStartingInfo(ctx, validator0.GetOperator(), val0AccAddress.Bytes(), distrtypes.NewDelegatorStartingInfo(2, math.LegacyOneDec(), 200))
 
 	// begin a new block
 	suite.app.BeginBlock(abci.RequestBeginBlock{Header: tmproto.Header{Height: suite.app.LastBlockHeight() + 1, AppHash: suite.app.LastCommitID().Hash, Time: blockTime}})
@@ -185,7 +185,7 @@ func (suite *SimTestSuite) TestSimulateMsgUnjail() {
 }
 
 func getTestingValidator0(ctx sdk.Context, stakingKeeper *stakingkeeper.Keeper, accounts []simtypes.Account) (stakingtypes.Validator, error) {
-	commission0 := stakingtypes.NewCommission(sdk.ZeroDec(), sdk.OneDec(), sdk.OneDec())
+	commission0 := stakingtypes.NewCommission(math.LegacyZeroDec(), math.LegacyOneDec(), math.LegacyOneDec())
 	return getTestingValidator(ctx, stakingKeeper, accounts, commission0, 0)
 }
 

--- a/x/slashing/types/genesis.go
+++ b/x/slashing/types/genesis.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	sdk "github.com/cosmos/cosmos-sdk/types"
+	"cosmossdk.io/math"
 )
 
 // NewGenesisState creates a new GenesisState object
@@ -38,17 +38,17 @@ func DefaultGenesisState() *GenesisState {
 // ValidateGenesis validates the slashing genesis parameters
 func ValidateGenesis(data GenesisState) error {
 	downtime := data.Params.SlashFractionDowntime
-	if downtime.IsNegative() || downtime.GT(sdk.OneDec()) {
+	if downtime.IsNegative() || downtime.GT(math.LegacyOneDec()) {
 		return fmt.Errorf("slashing fraction downtime should be less than or equal to one and greater than zero, is %s", downtime.String())
 	}
 
 	dblSign := data.Params.SlashFractionDoubleSign
-	if dblSign.IsNegative() || dblSign.GT(sdk.OneDec()) {
+	if dblSign.IsNegative() || dblSign.GT(math.LegacyOneDec()) {
 		return fmt.Errorf("slashing fraction double sign should be less than or equal to one and greater than zero, is %s", dblSign.String())
 	}
 
 	minSign := data.Params.MinSignedPerWindow
-	if minSign.IsNegative() || minSign.GT(sdk.OneDec()) {
+	if minSign.IsNegative() || minSign.GT(math.LegacyOneDec()) {
 		return fmt.Errorf("min signed per window should be less than or equal to one and greater than zero, is %s", minSign.String())
 	}
 

--- a/x/slashing/types/params.go
+++ b/x/slashing/types/params.go
@@ -87,7 +87,7 @@ func validateMinSignedPerWindow(i interface{}) error {
 	if v.IsNegative() {
 		return fmt.Errorf("min signed per window cannot be negative: %s", v)
 	}
-	if v.GT(sdk.OneDec()) {
+	if v.GT(math.LegacyOneDec()) {
 		return fmt.Errorf("min signed per window too large: %s", v)
 	}
 
@@ -116,7 +116,7 @@ func validateSlashFractionDoubleSign(i interface{}) error {
 	if v.IsNegative() {
 		return fmt.Errorf("double sign slash fraction cannot be negative: %s", v)
 	}
-	if v.GT(sdk.OneDec()) {
+	if v.GT(math.LegacyOneDec()) {
 		return fmt.Errorf("double sign slash fraction too large: %s", v)
 	}
 
@@ -132,7 +132,7 @@ func validateSlashFractionDowntime(i interface{}) error {
 	if v.IsNegative() {
 		return fmt.Errorf("downtime slash fraction cannot be negative: %s", v)
 	}
-	if v.GT(sdk.OneDec()) {
+	if v.GT(math.LegacyOneDec()) {
 		return fmt.Errorf("downtime slash fraction too large: %s", v)
 	}
 

--- a/x/slashing/types/params.go
+++ b/x/slashing/types/params.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -15,8 +16,8 @@ const (
 
 var (
 	DefaultMinSignedPerWindow      = sdk.NewDecWithPrec(5, 1)
-	DefaultSlashFractionDoubleSign = sdk.NewDec(1).Quo(sdk.NewDec(20))
-	DefaultSlashFractionDowntime   = sdk.NewDec(1).Quo(sdk.NewDec(100))
+	DefaultSlashFractionDoubleSign = math.LegacyNewDec(1).Quo(math.LegacyNewDec(20))
+	DefaultSlashFractionDowntime   = math.LegacyNewDec(1).Quo(math.LegacyNewDec(100))
 )
 
 // NewParams creates a new Params object

--- a/x/staking/bench_test.go
+++ b/x/staking/bench_test.go
@@ -3,6 +3,7 @@ package staking_test
 import (
 	"testing"
 
+	"cosmossdk.io/math"
 	"github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/staking"
@@ -32,7 +33,7 @@ func benchmarkValidateGenesis(b *testing.B, n int) {
 		validator := teststaking.NewValidator(b, addr, pubKey)
 		ni := int64(i + 1)
 		validator.Tokens = sdk.NewInt(ni)
-		validator.DelegatorShares = sdk.NewDec(ni)
+		validator.DelegatorShares = math.LegacyNewDec(ni)
 		validators = append(validators, validator)
 	}
 

--- a/x/staking/client/testutil/grpc.go
+++ b/x/staking/client/testutil/grpc.go
@@ -3,6 +3,7 @@ package testutil
 import (
 	"fmt"
 
+	"cosmossdk.io/math"
 	"github.com/gogo/protobuf/proto"
 
 	"github.com/cosmos/cosmos-sdk/crypto/hd"
@@ -270,7 +271,7 @@ func (s *IntegrationTestSuite) TestGRPCQueryDelegation() {
 					Delegation: types.Delegation{
 						DelegatorAddress: val.Address.String(),
 						ValidatorAddress: val2.ValAddress.String(),
-						Shares:           sdk.NewDec(10),
+						Shares:           math.LegacyNewDec(10),
 					},
 					Balance: sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(10)),
 				},

--- a/x/staking/client/testutil/suite.go
+++ b/x/staking/client/testutil/suite.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"cosmossdk.io/math"
 	"github.com/gogo/protobuf/proto"
 	"github.com/stretchr/testify/suite"
 	tmcli "github.com/tendermint/tendermint/libs/cli"
@@ -364,7 +365,7 @@ func (s *IntegrationTestSuite) TestGetCmdQueryDelegation() {
 				Delegation: types.Delegation{
 					DelegatorAddress: val.Address.String(),
 					ValidatorAddress: val2.ValAddress.String(),
-					Shares:           sdk.NewDec(10),
+					Shares:           math.LegacyNewDec(10),
 				},
 				Balance: sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(10)),
 			},

--- a/x/staking/common_test.go
+++ b/x/staking/common_test.go
@@ -34,7 +34,7 @@ var (
 	valKey  = ed25519.GenPrivKey()
 	valAddr = sdk.AccAddress(valKey.PubKey().Address())
 
-	commissionRates = types.NewCommissionRates(sdk.ZeroDec(), sdk.ZeroDec(), sdk.ZeroDec())
+	commissionRates = types.NewCommissionRates(math.LegacyZeroDec(), math.LegacyZeroDec(), math.LegacyZeroDec())
 
 	PKs = simtestutil.CreateTestPubKeys(500)
 )

--- a/x/staking/genesis_test.go
+++ b/x/staking/genesis_test.go
@@ -18,7 +18,7 @@ func TestValidateGenesis(t *testing.T) {
 	pk := ed25519.GenPrivKey().PubKey()
 	genValidators1[0] = teststaking.NewValidator(t, sdk.ValAddress(pk.Address()), pk)
 	genValidators1[0].Tokens = math.OneInt()
-	genValidators1[0].DelegatorShares = sdk.OneDec()
+	genValidators1[0].DelegatorShares = math.LegacyOneDec()
 
 	tests := []struct {
 		name    string
@@ -33,7 +33,7 @@ func TestValidateGenesis(t *testing.T) {
 		}, true},
 		{"no delegator shares", func(data *types.GenesisState) {
 			data.Validators = genValidators1
-			data.Validators[0].DelegatorShares = sdk.ZeroDec()
+			data.Validators[0].DelegatorShares = math.LegacyZeroDec()
 		}, true},
 		{"jailed and bonded validator", func(data *types.GenesisState) {
 			data.Validators = genValidators1

--- a/x/staking/keeper/delegation.go
+++ b/x/staking/keeper/delegation.go
@@ -210,7 +210,7 @@ func (k Keeper) IterateDelegatorUnbondingDelegations(ctx sdk.Context, delegator 
 
 // GetDelegatorBonded returs the total amount a delegator has bonded.
 func (k Keeper) GetDelegatorBonded(ctx sdk.Context, delegator sdk.AccAddress) math.Int {
-	bonded := sdk.ZeroDec()
+	bonded := math.LegacyZeroDec()
 
 	k.IterateDelegatorDelegations(ctx, delegator, func(delegation types.Delegation) bool {
 		validatorAddr, err := sdk.ValAddressFromBech32(delegation.ValidatorAddress)
@@ -619,13 +619,13 @@ func (k Keeper) Delegate(
 	// Validator loses all tokens due to slashing. In this case,
 	// make all future delegations invalid.
 	if validator.InvalidExRate() {
-		return sdk.ZeroDec(), types.ErrDelegatorShareExRateInvalid
+		return math.LegacyZeroDec(), types.ErrDelegatorShareExRateInvalid
 	}
 
 	// Get or create the delegation object
 	delegation, found := k.GetDelegation(ctx, delAddr, validator.GetOperator())
 	if !found {
-		delegation = types.NewDelegation(delAddr, validator.GetOperator(), sdk.ZeroDec())
+		delegation = types.NewDelegation(delAddr, validator.GetOperator(), math.LegacyZeroDec())
 	}
 
 	// call the appropriate hook if present
@@ -636,7 +636,7 @@ func (k Keeper) Delegate(
 	}
 
 	if err != nil {
-		return sdk.ZeroDec(), err
+		return math.LegacyZeroDec(), err
 	}
 
 	delegatorAddress := sdk.MustAccAddressFromBech32(delegation.DelegatorAddress)

--- a/x/staking/keeper/delegation_test.go
+++ b/x/staking/keeper/delegation_test.go
@@ -46,7 +46,7 @@ func TestDelegation(t *testing.T) {
 	validators[2] = keeper.TestingUpdateValidator(app.StakingKeeper, ctx, validators[2], true)
 
 	// first add a validators[0] to delegate too
-	bond1to1 := types.NewDelegation(addrDels[0], valAddrs[0], sdk.NewDec(9))
+	bond1to1 := types.NewDelegation(addrDels[0], valAddrs[0], math.LegacyNewDec(9))
 
 	// check the empty keeper first
 	_, found := app.StakingKeeper.GetDelegation(ctx, addrDels[0], valAddrs[0])
@@ -59,18 +59,18 @@ func TestDelegation(t *testing.T) {
 	require.Equal(t, bond1to1, resBond)
 
 	// modify a records, save, and retrieve
-	bond1to1.Shares = sdk.NewDec(99)
+	bond1to1.Shares = math.LegacyNewDec(99)
 	app.StakingKeeper.SetDelegation(ctx, bond1to1)
 	resBond, found = app.StakingKeeper.GetDelegation(ctx, addrDels[0], valAddrs[0])
 	require.True(t, found)
 	require.Equal(t, bond1to1, resBond)
 
 	// add some more records
-	bond1to2 := types.NewDelegation(addrDels[0], valAddrs[1], sdk.NewDec(9))
-	bond1to3 := types.NewDelegation(addrDels[0], valAddrs[2], sdk.NewDec(9))
-	bond2to1 := types.NewDelegation(addrDels[1], valAddrs[0], sdk.NewDec(9))
-	bond2to2 := types.NewDelegation(addrDels[1], valAddrs[1], sdk.NewDec(9))
-	bond2to3 := types.NewDelegation(addrDels[1], valAddrs[2], sdk.NewDec(9))
+	bond1to2 := types.NewDelegation(addrDels[0], valAddrs[1], math.LegacyNewDec(9))
+	bond1to3 := types.NewDelegation(addrDels[0], valAddrs[2], math.LegacyNewDec(9))
+	bond2to1 := types.NewDelegation(addrDels[1], valAddrs[0], math.LegacyNewDec(9))
+	bond2to2 := types.NewDelegation(addrDels[1], valAddrs[1], math.LegacyNewDec(9))
+	bond2to3 := types.NewDelegation(addrDels[1], valAddrs[2], math.LegacyNewDec(9))
 	app.StakingKeeper.SetDelegation(ctx, bond1to2)
 	app.StakingKeeper.SetDelegation(ctx, bond1to3)
 	app.StakingKeeper.SetDelegation(ctx, bond2to1)
@@ -273,7 +273,7 @@ func TestUnbondingDelegationsMaxEntries(t *testing.T) {
 	var completionTime time.Time
 	for i := uint32(0); i < maxEntries; i++ {
 		var err error
-		completionTime, err = app.StakingKeeper.Undelegate(ctx, addrDels[0], addrVals[0], sdk.NewDec(1))
+		completionTime, err = app.StakingKeeper.Undelegate(ctx, addrDels[0], addrVals[0], math.LegacyNewDec(1))
 		require.NoError(t, err)
 	}
 
@@ -286,7 +286,7 @@ func TestUnbondingDelegationsMaxEntries(t *testing.T) {
 	oldNotBonded = app.BankKeeper.GetBalance(ctx, app.StakingKeeper.GetNotBondedPool(ctx).GetAddress(), bondDenom).Amount
 
 	// an additional unbond should fail due to max entries
-	_, err := app.StakingKeeper.Undelegate(ctx, addrDels[0], addrVals[0], sdk.NewDec(1))
+	_, err := app.StakingKeeper.Undelegate(ctx, addrDels[0], addrVals[0], math.LegacyNewDec(1))
 	require.Error(t, err)
 
 	newBonded = app.BankKeeper.GetBalance(ctx, app.StakingKeeper.GetBondedPool(ctx).GetAddress(), bondDenom).Amount
@@ -308,7 +308,7 @@ func TestUnbondingDelegationsMaxEntries(t *testing.T) {
 	oldNotBonded = app.BankKeeper.GetBalance(ctx, app.StakingKeeper.GetNotBondedPool(ctx).GetAddress(), bondDenom).Amount
 
 	// unbonding  should work again
-	_, err = app.StakingKeeper.Undelegate(ctx, addrDels[0], addrVals[0], sdk.NewDec(1))
+	_, err = app.StakingKeeper.Undelegate(ctx, addrDels[0], addrVals[0], math.LegacyNewDec(1))
 	require.NoError(t, err)
 
 	newBonded = app.BankKeeper.GetBalance(ctx, app.StakingKeeper.GetBondedPool(ctx).GetAddress(), bondDenom).Amount
@@ -453,7 +453,7 @@ func TestUndelegateFromUnbondingValidator(t *testing.T) {
 	ctx = ctx.WithBlockTime(blockTime2)
 
 	// unbond some of the other delegation's shares
-	_, err = app.StakingKeeper.Undelegate(ctx, addrDels[1], addrVals[0], sdk.NewDec(6))
+	_, err = app.StakingKeeper.Undelegate(ctx, addrDels[1], addrVals[0], math.LegacyNewDec(6))
 	require.NoError(t, err)
 
 	// retrieve the unbonding delegation
@@ -627,7 +627,7 @@ func TestGetRedelegationsFromSrcValidator(t *testing.T) {
 
 	rd := types.NewRedelegation(addrDels[0], addrVals[0], addrVals[1], 0,
 		time.Unix(0, 0), sdk.NewInt(5),
-		sdk.NewDec(5))
+		math.LegacyNewDec(5))
 
 	// set and retrieve a record
 	app.StakingKeeper.SetRedelegation(ctx, rd)
@@ -654,7 +654,7 @@ func TestRedelegation(t *testing.T) {
 
 	rd := types.NewRedelegation(addrDels[0], addrVals[0], addrVals[1], 0,
 		time.Unix(0, 0).UTC(), sdk.NewInt(5),
-		sdk.NewDec(5))
+		math.LegacyNewDec(5))
 
 	// test shouldn't have and redelegations
 	has := app.StakingKeeper.HasReceivingRedelegation(ctx, addrDels[0], addrVals[1])
@@ -682,7 +682,7 @@ func TestRedelegation(t *testing.T) {
 	require.True(t, has)
 
 	// modify a records, save, and retrieve
-	rd.Entries[0].SharesDst = sdk.NewDec(21)
+	rd.Entries[0].SharesDst = math.LegacyNewDec(21)
 	app.StakingKeeper.SetRedelegation(ctx, rd)
 
 	resRed, found = app.StakingKeeper.GetRedelegation(ctx, addrDels[0], addrVals[0], addrVals[1])
@@ -734,7 +734,7 @@ func TestRedelegateToSameValidator(t *testing.T) {
 	selfDelegation := types.NewDelegation(val0AccAddr, addrVals[0], issuedShares)
 	app.StakingKeeper.SetDelegation(ctx, selfDelegation)
 
-	_, err := app.StakingKeeper.BeginRedelegation(ctx, val0AccAddr, addrVals[0], addrVals[0], sdk.NewDec(5))
+	_, err := app.StakingKeeper.BeginRedelegation(ctx, val0AccAddr, addrVals[0], addrVals[0], math.LegacyNewDec(5))
 	require.Error(t, err)
 }
 
@@ -776,12 +776,12 @@ func TestRedelegationMaxEntries(t *testing.T) {
 	var completionTime time.Time
 	for i := uint32(0); i < maxEntries; i++ {
 		var err error
-		completionTime, err = app.StakingKeeper.BeginRedelegation(ctx, val0AccAddr, addrVals[0], addrVals[1], sdk.NewDec(1))
+		completionTime, err = app.StakingKeeper.BeginRedelegation(ctx, val0AccAddr, addrVals[0], addrVals[1], math.LegacyNewDec(1))
 		require.NoError(t, err)
 	}
 
 	// an additional redelegation should fail due to max entries
-	_, err := app.StakingKeeper.BeginRedelegation(ctx, val0AccAddr, addrVals[0], addrVals[1], sdk.NewDec(1))
+	_, err := app.StakingKeeper.BeginRedelegation(ctx, val0AccAddr, addrVals[0], addrVals[1], math.LegacyNewDec(1))
 	require.Error(t, err)
 
 	// mature redelegations
@@ -790,7 +790,7 @@ func TestRedelegationMaxEntries(t *testing.T) {
 	require.NoError(t, err)
 
 	// redelegation should work again
-	_, err = app.StakingKeeper.BeginRedelegation(ctx, val0AccAddr, addrVals[0], addrVals[1], sdk.NewDec(1))
+	_, err = app.StakingKeeper.BeginRedelegation(ctx, val0AccAddr, addrVals[0], addrVals[1], math.LegacyNewDec(1))
 	require.NoError(t, err)
 }
 

--- a/x/staking/keeper/invariants.go
+++ b/x/staking/keeper/invariants.go
@@ -169,7 +169,7 @@ func DelegatorSharesInvariant(k *Keeper) sdk.Invariant {
 
 		// initialize a map: validator -> its delegation shares
 		for _, validator := range validators {
-			validatorsDelegationShares[validator.GetOperator().String()] = sdk.ZeroDec()
+			validatorsDelegationShares[validator.GetOperator().String()] = math.LegacyZeroDec()
 		}
 
 		// iterate through all the delegations to calculate the total delegation shares for each validator

--- a/x/staking/keeper/msg_server_test.go
+++ b/x/staking/keeper/msg_server_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"cosmossdk.io/math"
 	"github.com/cosmos/cosmos-sdk/simapp"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/bank/testutil"
@@ -178,7 +179,7 @@ func TestMsgUpdateParams(t *testing.T) {
 			input: &types.MsgUpdateParams{
 				Authority: app.StakingKeeper.GetAuthority(),
 				Params: types.Params{
-					MinCommissionRate: sdk.NewDec(-10),
+					MinCommissionRate: math.LegacyNewDec(-10),
 					UnbondingTime:     types.DefaultUnbondingTime,
 					MaxValidators:     types.DefaultMaxValidators,
 					MaxEntries:        types.DefaultMaxEntries,
@@ -194,7 +195,7 @@ func TestMsgUpdateParams(t *testing.T) {
 			input: &types.MsgUpdateParams{
 				Authority: app.StakingKeeper.GetAuthority(),
 				Params: types.Params{
-					MinCommissionRate: sdk.NewDec(2),
+					MinCommissionRate: math.LegacyNewDec(2),
 					UnbondingTime:     types.DefaultUnbondingTime,
 					MaxValidators:     types.DefaultMaxValidators,
 					MaxEntries:        types.DefaultMaxEntries,

--- a/x/staking/keeper/params.go
+++ b/x/staking/keeper/params.go
@@ -45,7 +45,7 @@ func (k Keeper) PowerReduction(ctx sdk.Context) math.Int {
 }
 
 // MinCommissionRate - Minimum validator commission rate
-func (k Keeper) MinCommissionRate(ctx sdk.Context) sdk.Dec {
+func (k Keeper) MinCommissionRate(ctx sdk.Context) math.LegacyDec {
 	return k.GetParams(ctx).MinCommissionRate
 }
 

--- a/x/staking/keeper/pool.go
+++ b/x/staking/keeper/pool.go
@@ -75,5 +75,5 @@ func (k Keeper) BondedRatio(ctx sdk.Context) sdk.Dec {
 		return sdk.NewDecFromInt(k.TotalBondedTokens(ctx)).QuoInt(stakeSupply)
 	}
 
-	return sdk.ZeroDec()
+	return math.LegacyZeroDec()
 }

--- a/x/staking/keeper/pool.go
+++ b/x/staking/keeper/pool.go
@@ -69,7 +69,7 @@ func (k Keeper) StakingTokenSupply(ctx sdk.Context) math.Int {
 }
 
 // BondedRatio the fraction of the staking tokens which are currently bonded
-func (k Keeper) BondedRatio(ctx sdk.Context) sdk.Dec {
+func (k Keeper) BondedRatio(ctx sdk.Context) math.LegacyDec {
 	stakeSupply := k.StakingTokenSupply(ctx)
 	if stakeSupply.IsPositive() {
 		return sdk.NewDecFromInt(k.TotalBondedTokens(ctx)).QuoInt(stakeSupply)

--- a/x/staking/keeper/slash.go
+++ b/x/staking/keeper/slash.go
@@ -112,8 +112,8 @@ func (k Keeper) Slash(ctx sdk.Context, consAddr sdk.ConsAddress, infractionHeigh
 	if validator.Tokens.IsPositive() {
 		effectiveFraction := sdk.NewDecFromInt(tokensToBurn).QuoRoundUp(sdk.NewDecFromInt(validator.Tokens))
 		// possible if power has changed
-		if effectiveFraction.GT(sdk.OneDec()) {
-			effectiveFraction = sdk.OneDec()
+		if effectiveFraction.GT(math.LegacyOneDec()) {
+			effectiveFraction = math.LegacyOneDec()
 		}
 		// call the before-slashed hook
 		k.BeforeValidatorSlashed(ctx, operatorAddress, effectiveFraction)

--- a/x/staking/keeper/slash_test.go
+++ b/x/staking/keeper/slash_test.go
@@ -133,12 +133,12 @@ func TestSlashRedelegation(t *testing.T) {
 	// set a redelegation with an expiration timestamp beyond which the
 	// redelegation shouldn't be slashed
 	rd := types.NewRedelegation(addrDels[0], addrVals[0], addrVals[1], 0,
-		time.Unix(5, 0), sdk.NewInt(10), sdk.NewDec(10))
+		time.Unix(5, 0), sdk.NewInt(10), math.LegacyNewDec(10))
 
 	app.StakingKeeper.SetRedelegation(ctx, rd)
 
 	// set the associated delegation
-	del := types.NewDelegation(addrDels[0], addrVals[1], sdk.NewDec(10))
+	del := types.NewDelegation(addrDels[0], addrVals[1], math.LegacyNewDec(10))
 	app.StakingKeeper.SetDelegation(ctx, del)
 
 	// started redelegating prior to the current height, stake didn't contribute to infraction

--- a/x/staking/keeper/slash_test.go
+++ b/x/staking/keeper/slash_test.go
@@ -446,7 +446,7 @@ func TestSlashWithRedelegation(t *testing.T) {
 	validator, found = app.StakingKeeper.GetValidatorByConsAddr(ctx, consAddr)
 	require.True(t, found)
 
-	require.NotPanics(t, func() { app.StakingKeeper.Slash(ctx, consAddr, 10, 10, sdk.OneDec()) })
+	require.NotPanics(t, func() { app.StakingKeeper.Slash(ctx, consAddr, 10, 10, math.LegacyOneDec()) })
 	burnAmount = app.StakingKeeper.TokensFromConsensusPower(ctx, 7)
 
 	// read updated pool
@@ -480,10 +480,10 @@ func TestSlashWithRedelegation(t *testing.T) {
 	validator, found = app.StakingKeeper.GetValidatorByConsAddr(ctx, consAddr)
 	require.True(t, found)
 
-	require.NotPanics(t, func() { app.StakingKeeper.Slash(ctx, consAddr, 10, 10, sdk.OneDec()) })
+	require.NotPanics(t, func() { app.StakingKeeper.Slash(ctx, consAddr, 10, 10, math.LegacyOneDec()) })
 
-	burnAmount = sdk.NewDecFromInt(app.StakingKeeper.TokensFromConsensusPower(ctx, 10)).Mul(sdk.OneDec()).TruncateInt()
-	burnAmount = burnAmount.Sub(sdk.OneDec().MulInt(rdTokens).TruncateInt())
+	burnAmount = sdk.NewDecFromInt(app.StakingKeeper.TokensFromConsensusPower(ctx, 10)).Mul(math.LegacyOneDec()).TruncateInt()
+	burnAmount = burnAmount.Sub(math.LegacyOneDec().MulInt(rdTokens).TruncateInt())
 
 	// read updated pool
 	bondedPool = app.StakingKeeper.GetBondedPool(ctx)
@@ -513,7 +513,7 @@ func TestSlashWithRedelegation(t *testing.T) {
 	validator, _ = app.StakingKeeper.GetValidatorByConsAddr(ctx, consAddr)
 	require.Equal(t, validator.GetStatus(), types.Unbonding)
 
-	require.NotPanics(t, func() { app.StakingKeeper.Slash(ctx, consAddr, 10, 10, sdk.OneDec()) })
+	require.NotPanics(t, func() { app.StakingKeeper.Slash(ctx, consAddr, 10, 10, math.LegacyOneDec()) })
 
 	// read updated pool
 	bondedPool = app.StakingKeeper.GetBondedPool(ctx)

--- a/x/staking/keeper/validator_test.go
+++ b/x/staking/keeper/validator_test.go
@@ -242,7 +242,7 @@ func TestSlashToZeroPowerRemoved(t *testing.T) {
 	require.Equal(t, valTokens, validator.Tokens, "\nvalidator %v\npool %v", validator, valTokens)
 
 	// slash the validator by 100%
-	app.StakingKeeper.Slash(ctx, sdk.ConsAddress(PKs[0].Address()), 0, 100, sdk.OneDec())
+	app.StakingKeeper.Slash(ctx, sdk.ConsAddress(PKs[0].Address()), 0, 100, math.LegacyOneDec())
 	// apply TM updates
 	applyValidatorSetUpdates(t, ctx, app.StakingKeeper, -1)
 	// validator should be unbonding
@@ -1081,7 +1081,7 @@ func TestUpdateValidatorCommission(t *testing.T) {
 		newRate     sdk.Dec
 		expectedErr bool
 	}{
-		{val1, sdk.ZeroDec(), true},
+		{val1, math.LegacyZeroDec(), true},
 		{val2, sdk.NewDecWithPrec(-1, 1), true},
 		{val2, sdk.NewDecWithPrec(4, 1), true},
 		{val2, sdk.NewDecWithPrec(3, 1), true},

--- a/x/staking/keeper/validator_test.go
+++ b/x/staking/keeper/validator_test.go
@@ -147,7 +147,7 @@ func TestUpdateValidatorByPowerIndex(t *testing.T) {
 
 	// burn half the delegator shares
 	app.StakingKeeper.DeleteValidatorByPowerIndex(ctx, validator)
-	validator, burned := validator.RemoveDelShares(delSharesCreated.Quo(sdk.NewDec(2)))
+	validator, burned := validator.RemoveDelShares(delSharesCreated.Quo(math.LegacyNewDec(2)))
 	require.Equal(t, app.StakingKeeper.TokensFromConsensusPower(ctx, 50), burned)
 	keeper.TestingUpdateValidator(app.StakingKeeper, ctx, validator, true) // update the validator, possibly kicking it out
 	require.False(t, keeper.ValidatorByPowerIndexExists(ctx, app.StakingKeeper, power))
@@ -574,8 +574,8 @@ func TestGetValidatorsEdgeCases(t *testing.T) {
 
 	// validator 3 kicked out temporarily
 	app.StakingKeeper.DeleteValidatorByPowerIndex(ctx, validators[3])
-	rmTokens := validators[3].TokensFromShares(sdk.NewDec(201)).TruncateInt()
-	validators[3], _ = validators[3].RemoveDelShares(sdk.NewDec(201))
+	rmTokens := validators[3].TokensFromShares(math.LegacyNewDec(201)).TruncateInt()
+	validators[3], _ = validators[3].RemoveDelShares(math.LegacyNewDec(201))
 
 	bondedPool := app.StakingKeeper.GetBondedPool(ctx)
 	require.NoError(t, testutil.FundModuleAccount(app.BankKeeper, ctx, bondedPool.GetName(), sdk.NewCoins(sdk.NewCoin(params.BondDenom, rmTokens))))

--- a/x/staking/simulation/decoder_test.go
+++ b/x/staking/simulation/decoder_test.go
@@ -39,9 +39,9 @@ func TestDecodeStore(t *testing.T) {
 
 	val, err := types.NewValidator(valAddr1, delPk1, types.NewDescription("test", "test", "test", "test", "test"))
 	require.NoError(t, err)
-	del := types.NewDelegation(delAddr1, valAddr1, sdk.OneDec())
+	del := types.NewDelegation(delAddr1, valAddr1, math.LegacyOneDec())
 	ubd := types.NewUnbondingDelegation(delAddr1, valAddr1, 15, bondTime, math.OneInt())
-	red := types.NewRedelegation(delAddr1, valAddr1, valAddr1, 12, bondTime, math.OneInt(), sdk.OneDec())
+	red := types.NewRedelegation(delAddr1, valAddr1, valAddr1, 12, bondTime, math.OneInt(), math.LegacyOneDec())
 
 	kvPairs := kv.Pairs{
 		Pairs: []kv.Pair{

--- a/x/staking/simulation/operations_test.go
+++ b/x/staking/simulation/operations_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"cosmossdk.io/math"
 	cryptocodec "github.com/cosmos/cosmos-sdk/crypto/codec"
 	"github.com/stretchr/testify/require"
 	abci "github.com/tendermint/tendermint/abci/types"
@@ -368,7 +369,7 @@ func getTestingValidator(t *testing.T, app *simapp.SimApp, ctx sdk.Context, acco
 	validator, err := validator.SetInitialCommission(commission)
 	require.NoError(t, err)
 
-	validator.DelegatorShares = sdk.NewDec(100)
+	validator.DelegatorShares = math.LegacyNewDec(100)
 	validator.Tokens = app.StakingKeeper.TokensFromConsensusPower(ctx, 100)
 
 	app.StakingKeeper.SetValidator(ctx, validator)

--- a/x/staking/simulation/operations_test.go
+++ b/x/staking/simulation/operations_test.go
@@ -120,7 +120,7 @@ func TestSimulateMsgCancelUnbondingDelegation(t *testing.T) {
 	delegator := accounts[1]
 	delegation := types.NewDelegation(delegator.Address, validator0.GetOperator(), issuedShares)
 	app.StakingKeeper.SetDelegation(ctx, delegation)
-	app.DistrKeeper.SetDelegatorStartingInfo(ctx, validator0.GetOperator(), delegator.Address, distrtypes.NewDelegatorStartingInfo(2, sdk.OneDec(), 200))
+	app.DistrKeeper.SetDelegatorStartingInfo(ctx, validator0.GetOperator(), delegator.Address, distrtypes.NewDelegatorStartingInfo(2, math.LegacyOneDec(), 200))
 
 	setupValidatorRewards(app, ctx, validator0.GetOperator())
 
@@ -234,7 +234,7 @@ func TestSimulateMsgUndelegate(t *testing.T) {
 	delegator := accounts[1]
 	delegation := types.NewDelegation(delegator.Address, validator0.GetOperator(), issuedShares)
 	app.StakingKeeper.SetDelegation(ctx, delegation)
-	app.DistrKeeper.SetDelegatorStartingInfo(ctx, validator0.GetOperator(), delegator.Address, distrtypes.NewDelegatorStartingInfo(2, sdk.OneDec(), 200))
+	app.DistrKeeper.SetDelegatorStartingInfo(ctx, validator0.GetOperator(), delegator.Address, distrtypes.NewDelegatorStartingInfo(2, math.LegacyOneDec(), 200))
 
 	setupValidatorRewards(app, ctx, validator0.GetOperator())
 
@@ -282,7 +282,7 @@ func TestSimulateMsgBeginRedelegate(t *testing.T) {
 	delegator := accounts[2]
 	delegation := types.NewDelegation(delegator.Address, validator1.GetOperator(), issuedShares)
 	app.StakingKeeper.SetDelegation(ctx, delegation)
-	app.DistrKeeper.SetDelegatorStartingInfo(ctx, validator1.GetOperator(), delegator.Address, distrtypes.NewDelegatorStartingInfo(2, sdk.OneDec(), 200))
+	app.DistrKeeper.SetDelegatorStartingInfo(ctx, validator1.GetOperator(), delegator.Address, distrtypes.NewDelegatorStartingInfo(2, math.LegacyOneDec(), 200))
 
 	setupValidatorRewards(app, ctx, validator0.GetOperator())
 	setupValidatorRewards(app, ctx, validator1.GetOperator())
@@ -352,12 +352,12 @@ func createTestApp(t *testing.T, isCheckTx bool, r *rand.Rand, n int) (*simapp.S
 }
 
 func getTestingValidator0(t *testing.T, app *simapp.SimApp, ctx sdk.Context, accounts []simtypes.Account) types.Validator {
-	commission0 := types.NewCommission(sdk.ZeroDec(), sdk.OneDec(), sdk.OneDec())
+	commission0 := types.NewCommission(math.LegacyZeroDec(), math.LegacyOneDec(), math.LegacyOneDec())
 	return getTestingValidator(t, app, ctx, accounts, commission0, 0)
 }
 
 func getTestingValidator1(t *testing.T, app *simapp.SimApp, ctx sdk.Context, accounts []simtypes.Account) types.Validator {
-	commission1 := types.NewCommission(sdk.ZeroDec(), sdk.ZeroDec(), sdk.ZeroDec())
+	commission1 := types.NewCommission(math.LegacyZeroDec(), math.LegacyZeroDec(), math.LegacyZeroDec())
 	return getTestingValidator(t, app, ctx, accounts, commission1, 1)
 }
 
@@ -378,7 +378,7 @@ func getTestingValidator(t *testing.T, app *simapp.SimApp, ctx sdk.Context, acco
 }
 
 func setupValidatorRewards(app *simapp.SimApp, ctx sdk.Context, valAddress sdk.ValAddress) {
-	decCoins := sdk.DecCoins{sdk.NewDecCoinFromDec(sdk.DefaultBondDenom, sdk.OneDec())}
+	decCoins := sdk.DecCoins{sdk.NewDecCoinFromDec(sdk.DefaultBondDenom, math.LegacyOneDec())}
 	historicalRewards := distrtypes.NewValidatorHistoricalRewards(decCoins, 2)
 	app.DistrKeeper.SetValidatorHistoricalRewards(ctx, valAddress, 2, historicalRewards)
 	// setup current revards

--- a/x/staking/teststaking/helper.go
+++ b/x/staking/teststaking/helper.go
@@ -141,5 +141,5 @@ func (sh *Helper) TurnBlockTimeDiff(diff time.Duration) sdk.Context {
 
 // ZeroCommission constructs a commission rates with all zeros.
 func ZeroCommission() stakingtypes.CommissionRates {
-	return stakingtypes.NewCommissionRates(sdk.ZeroDec(), sdk.ZeroDec(), sdk.ZeroDec())
+	return stakingtypes.NewCommissionRates(math.LegacyZeroDec(), math.LegacyZeroDec(), math.LegacyZeroDec())
 }

--- a/x/staking/types/commission.go
+++ b/x/staking/types/commission.go
@@ -3,6 +3,7 @@ package types
 import (
 	"time"
 
+	"cosmossdk.io/math"
 	"sigs.k8s.io/yaml"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -54,7 +55,7 @@ func (cr CommissionRates) Validate() error {
 		// max rate cannot be negative
 		return ErrCommissionNegative
 
-	case cr.MaxRate.GT(sdk.OneDec()):
+	case cr.MaxRate.GT(math.LegacyOneDec()):
 		// max rate cannot be greater than 1
 		return ErrCommissionHuge
 

--- a/x/staking/types/commission_test.go
+++ b/x/staking/types/commission_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"cosmossdk.io/math"
 	"github.com/stretchr/testify/require"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -16,19 +17,19 @@ func TestCommissionValidate(t *testing.T) {
 		expectErr bool
 	}{
 		// invalid commission; max rate < 0%
-		{types.NewCommission(sdk.ZeroDec(), sdk.MustNewDecFromStr("-1.00"), sdk.ZeroDec()), true},
+		{types.NewCommission(math.LegacyZeroDec(), sdk.MustNewDecFromStr("-1.00"), math.LegacyZeroDec()), true},
 		// invalid commission; max rate > 100%
-		{types.NewCommission(sdk.ZeroDec(), sdk.MustNewDecFromStr("2.00"), sdk.ZeroDec()), true},
+		{types.NewCommission(math.LegacyZeroDec(), sdk.MustNewDecFromStr("2.00"), math.LegacyZeroDec()), true},
 		// invalid commission; rate < 0%
-		{types.NewCommission(sdk.MustNewDecFromStr("-1.00"), sdk.ZeroDec(), sdk.ZeroDec()), true},
+		{types.NewCommission(sdk.MustNewDecFromStr("-1.00"), math.LegacyZeroDec(), math.LegacyZeroDec()), true},
 		// invalid commission; rate > max rate
-		{types.NewCommission(sdk.MustNewDecFromStr("0.75"), sdk.MustNewDecFromStr("0.50"), sdk.ZeroDec()), true},
+		{types.NewCommission(sdk.MustNewDecFromStr("0.75"), sdk.MustNewDecFromStr("0.50"), math.LegacyZeroDec()), true},
 		// invalid commission; max change rate < 0%
-		{types.NewCommission(sdk.OneDec(), sdk.OneDec(), sdk.MustNewDecFromStr("-1.00")), true},
+		{types.NewCommission(math.LegacyOneDec(), math.LegacyOneDec(), sdk.MustNewDecFromStr("-1.00")), true},
 		// invalid commission; max change rate > max rate
-		{types.NewCommission(sdk.OneDec(), sdk.MustNewDecFromStr("0.75"), sdk.MustNewDecFromStr("0.90")), true},
+		{types.NewCommission(math.LegacyOneDec(), sdk.MustNewDecFromStr("0.75"), sdk.MustNewDecFromStr("0.90")), true},
 		// valid commission
-		{types.NewCommission(sdk.MustNewDecFromStr("0.20"), sdk.OneDec(), sdk.MustNewDecFromStr("0.10")), false},
+		{types.NewCommission(sdk.MustNewDecFromStr("0.20"), math.LegacyOneDec(), sdk.MustNewDecFromStr("0.10")), false},
 	}
 
 	for i, tc := range testCases {

--- a/x/staking/types/delegation.go
+++ b/x/staking/types/delegation.go
@@ -72,7 +72,7 @@ func (d Delegation) GetValidatorAddr() sdk.ValAddress {
 	}
 	return addr
 }
-func (d Delegation) GetShares() sdk.Dec { return d.Shares }
+func (d Delegation) GetShares() math.LegacyDec { return d.Shares }
 
 // String returns a human readable string representation of a Delegation.
 func (d Delegation) String() string {

--- a/x/staking/types/delegation_test.go
+++ b/x/staking/types/delegation_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"cosmossdk.io/math"
 	"github.com/stretchr/testify/require"
 
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -13,21 +14,21 @@ import (
 )
 
 func TestDelegationEqual(t *testing.T) {
-	d1 := types.NewDelegation(sdk.AccAddress(valAddr1), valAddr2, sdk.NewDec(100))
+	d1 := types.NewDelegation(sdk.AccAddress(valAddr1), valAddr2, math.LegacyNewDec(100))
 	d2 := d1
 
 	ok := d1.String() == d2.String()
 	require.True(t, ok)
 
 	d2.ValidatorAddress = valAddr3.String()
-	d2.Shares = sdk.NewDec(200)
+	d2.Shares = math.LegacyNewDec(200)
 
 	ok = d1.String() == d2.String()
 	require.False(t, ok)
 }
 
 func TestDelegationString(t *testing.T) {
-	d := types.NewDelegation(sdk.AccAddress(valAddr1), valAddr2, sdk.NewDec(100))
+	d := types.NewDelegation(sdk.AccAddress(valAddr1), valAddr2, math.LegacyNewDec(100))
 	require.NotEmpty(t, d.String())
 }
 
@@ -56,15 +57,15 @@ func TestUnbondingDelegationString(t *testing.T) {
 func TestRedelegationEqual(t *testing.T) {
 	r1 := types.NewRedelegation(sdk.AccAddress(valAddr1), valAddr2, valAddr3, 0,
 		time.Unix(0, 0), sdk.NewInt(0),
-		sdk.NewDec(0))
+		math.LegacyNewDec(0))
 	r2 := types.NewRedelegation(sdk.AccAddress(valAddr1), valAddr2, valAddr3, 0,
 		time.Unix(0, 0), sdk.NewInt(0),
-		sdk.NewDec(0))
+		math.LegacyNewDec(0))
 
 	ok := r1.String() == r2.String()
 	require.True(t, ok)
 
-	r2.Entries[0].SharesDst = sdk.NewDec(10)
+	r2.Entries[0].SharesDst = math.LegacyNewDec(10)
 	r2.Entries[0].CompletionTime = time.Unix(20*20*2, 0)
 
 	ok = r1.String() == r2.String()
@@ -74,16 +75,16 @@ func TestRedelegationEqual(t *testing.T) {
 func TestRedelegationString(t *testing.T) {
 	r := types.NewRedelegation(sdk.AccAddress(valAddr1), valAddr2, valAddr3, 0,
 		time.Unix(0, 0), sdk.NewInt(0),
-		sdk.NewDec(10))
+		math.LegacyNewDec(10))
 
 	require.NotEmpty(t, r.String())
 }
 
 func TestDelegationResponses(t *testing.T) {
 	cdc := codec.NewLegacyAmino()
-	dr1 := types.NewDelegationResp(sdk.AccAddress(valAddr1), valAddr2, sdk.NewDec(5),
+	dr1 := types.NewDelegationResp(sdk.AccAddress(valAddr1), valAddr2, math.LegacyNewDec(5),
 		sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(5)))
-	dr2 := types.NewDelegationResp(sdk.AccAddress(valAddr1), valAddr3, sdk.NewDec(5),
+	dr2 := types.NewDelegationResp(sdk.AccAddress(valAddr1), valAddr3, math.LegacyNewDec(5),
 		sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(5)))
 	drs := types.DelegationResponses{dr1, dr2}
 
@@ -111,8 +112,8 @@ func TestDelegationResponses(t *testing.T) {
 func TestRedelegationResponses(t *testing.T) {
 	cdc := codec.NewLegacyAmino()
 	entries := []types.RedelegationEntryResponse{
-		types.NewRedelegationEntryResponse(0, time.Unix(0, 0), sdk.NewDec(5), sdk.NewInt(5), sdk.NewInt(5)),
-		types.NewRedelegationEntryResponse(0, time.Unix(0, 0), sdk.NewDec(5), sdk.NewInt(5), sdk.NewInt(5)),
+		types.NewRedelegationEntryResponse(0, time.Unix(0, 0), math.LegacyNewDec(5), sdk.NewInt(5), sdk.NewInt(5)),
+		types.NewRedelegationEntryResponse(0, time.Unix(0, 0), math.LegacyNewDec(5), sdk.NewInt(5), sdk.NewInt(5)),
 	}
 	rdr1 := types.NewRedelegationResponse(sdk.AccAddress(valAddr1), valAddr2, valAddr3, entries)
 	rdr2 := types.NewRedelegationResponse(sdk.AccAddress(valAddr2), valAddr1, valAddr3, entries)

--- a/x/staking/types/exported.go
+++ b/x/staking/types/exported.go
@@ -12,7 +12,7 @@ import (
 type DelegationI interface {
 	GetDelegatorAddr() sdk.AccAddress // delegator sdk.AccAddress for the bond
 	GetValidatorAddr() sdk.ValAddress // validator operator address
-	GetShares() sdk.Dec               // amount of validator's shares held in this delegation
+	GetShares() math.LegacyDec        // amount of validator's shares held in this delegation
 }
 
 // ValidatorI expected validator functions
@@ -30,12 +30,12 @@ type ValidatorI interface {
 	GetTokens() math.Int                                     // validation tokens
 	GetBondedTokens() math.Int                               // validator bonded tokens
 	GetConsensusPower(math.Int) int64                        // validation power in tendermint
-	GetCommission() sdk.Dec                                  // validator commission rate
+	GetCommission() math.LegacyDec                           // validator commission rate
 	GetMinSelfDelegation() math.Int                          // validator minimum self delegation
-	GetDelegatorShares() sdk.Dec                             // total outstanding delegator shares
-	TokensFromShares(sdk.Dec) sdk.Dec                        // token worth of provided delegator shares
-	TokensFromSharesTruncated(sdk.Dec) sdk.Dec               // token worth of provided delegator shares, truncated
-	TokensFromSharesRoundUp(sdk.Dec) sdk.Dec                 // token worth of provided delegator shares, rounded up
+	GetDelegatorShares() math.LegacyDec                      // total outstanding delegator shares
+	TokensFromShares(sdk.Dec) math.LegacyDec                 // token worth of provided delegator shares
+	TokensFromSharesTruncated(sdk.Dec) math.LegacyDec        // token worth of provided delegator shares, truncated
+	TokensFromSharesRoundUp(sdk.Dec) math.LegacyDec          // token worth of provided delegator shares, rounded up
 	SharesFromTokens(amt math.Int) (sdk.Dec, error)          // shares worth of delegator's bond
 	SharesFromTokensTruncated(amt math.Int) (sdk.Dec, error) // truncated shares worth of delegator's bond
 }

--- a/x/staking/types/msg.go
+++ b/x/staking/types/msg.go
@@ -187,7 +187,7 @@ func (msg MsgEditValidator) ValidateBasic() error {
 	}
 
 	if msg.CommissionRate != nil {
-		if msg.CommissionRate.GT(sdk.OneDec()) || msg.CommissionRate.IsNegative() {
+		if msg.CommissionRate.GT(math.LegacyOneDec()) || msg.CommissionRate.IsNegative() {
 			return sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "commission rate must be between 0 and 1 (inclusive)")
 		}
 	}

--- a/x/staking/types/msg_test.go
+++ b/x/staking/types/msg_test.go
@@ -59,7 +59,7 @@ func TestMsgDecode(t *testing.T) {
 // test ValidateBasic for MsgCreateValidator
 func TestMsgCreateValidator(t *testing.T) {
 	commission1 := types.NewCommissionRates(sdk.ZeroDec(), sdk.ZeroDec(), sdk.ZeroDec())
-	commission2 := types.NewCommissionRates(sdk.NewDec(5), sdk.NewDec(5), sdk.NewDec(5))
+	commission2 := types.NewCommissionRates(math.LegacyNewDec(5), math.LegacyNewDec(5), math.LegacyNewDec(5))
 
 	tests := []struct {
 		name, moniker, identity, website, securityContact, details string
@@ -285,7 +285,7 @@ func TestMsgUpdateParamsValidateBasic(t *testing.T) {
 					MaxEntries:        types.DefaultMaxEntries,
 					MaxValidators:     types.DefaultMaxValidators,
 					HistoricalEntries: types.DefaultHistoricalEntries,
-					MinCommissionRate: sdk.NewDec(-1),
+					MinCommissionRate: math.LegacyNewDec(-1),
 					BondDenom:         "denom",
 				},
 			},
@@ -301,7 +301,7 @@ func TestMsgUpdateParamsValidateBasic(t *testing.T) {
 					MaxEntries:        types.DefaultMaxEntries,
 					MaxValidators:     types.DefaultMaxValidators,
 					HistoricalEntries: types.DefaultHistoricalEntries,
-					MinCommissionRate: sdk.NewDec(2),
+					MinCommissionRate: math.LegacyNewDec(2),
 					BondDenom:         "denom",
 				},
 			},

--- a/x/staking/types/msg_test.go
+++ b/x/staking/types/msg_test.go
@@ -41,7 +41,7 @@ func TestMsgDecode(t *testing.T) {
 
 	// now let's try to serialize the whole message
 
-	commission1 := types.NewCommissionRates(sdk.ZeroDec(), sdk.ZeroDec(), sdk.ZeroDec())
+	commission1 := types.NewCommissionRates(math.LegacyZeroDec(), math.LegacyZeroDec(), math.LegacyZeroDec())
 	msg, err := types.NewMsgCreateValidator(valAddr1, pk1, coinPos, types.Description{}, commission1, math.OneInt())
 	require.NoError(t, err)
 	msgSerialized, err := cdc.MarshalInterface(msg)
@@ -58,7 +58,7 @@ func TestMsgDecode(t *testing.T) {
 
 // test ValidateBasic for MsgCreateValidator
 func TestMsgCreateValidator(t *testing.T) {
-	commission1 := types.NewCommissionRates(sdk.ZeroDec(), sdk.ZeroDec(), sdk.ZeroDec())
+	commission1 := types.NewCommissionRates(math.LegacyZeroDec(), math.LegacyZeroDec(), math.LegacyZeroDec())
 	commission2 := types.NewCommissionRates(math.LegacyNewDec(5), math.LegacyNewDec(5), math.LegacyNewDec(5))
 
 	tests := []struct {
@@ -111,7 +111,7 @@ func TestMsgEditValidator(t *testing.T) {
 
 	for _, tc := range tests {
 		description := types.NewDescription(tc.moniker, tc.identity, tc.website, tc.securityContact, tc.details)
-		newRate := sdk.ZeroDec()
+		newRate := math.LegacyZeroDec()
 
 		msg := types.NewMsgEditValidator(tc.validatorAddr, description, &newRate, &tc.minSelfDelegation)
 		if tc.expectPass {

--- a/x/staking/types/params.go
+++ b/x/staking/types/params.go
@@ -33,7 +33,7 @@ const (
 )
 
 // DefaultMinCommissionRate is set to 0%
-var DefaultMinCommissionRate = sdk.ZeroDec()
+var DefaultMinCommissionRate = math.LegacyZeroDec()
 
 // NewParams creates a new Params instance
 func NewParams(unbondingTime time.Duration, maxValidators, maxEntries, historicalEntries uint32, bondDenom string, minCommissionRate sdk.Dec) Params {
@@ -197,7 +197,7 @@ func validateMinCommissionRate(i interface{}) error {
 	if v.IsNegative() {
 		return fmt.Errorf("minimum commission rate cannot be negative: %s", v)
 	}
-	if v.GT(sdk.OneDec()) {
+	if v.GT(math.LegacyOneDec()) {
 		return fmt.Errorf("minimum commission rate cannot be greater than 100%%: %s", v)
 	}
 

--- a/x/staking/types/params_test.go
+++ b/x/staking/types/params_test.go
@@ -3,9 +3,9 @@ package types_test
 import (
 	"testing"
 
+	"cosmossdk.io/math"
 	"github.com/stretchr/testify/require"
 
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/staking/types"
 )
 
@@ -30,9 +30,9 @@ func Test_validateParams(t *testing.T) {
 	require.NoError(t, params.Validate())
 
 	// validate mincommision
-	params.MinCommissionRate = sdk.NewDec(-1)
+	params.MinCommissionRate = math.LegacyNewDec(-1)
 	require.Error(t, params.Validate())
 
-	params.MinCommissionRate = sdk.NewDec(2)
+	params.MinCommissionRate = math.LegacyNewDec(2)
 	require.Error(t, params.Validate())
 }

--- a/x/staking/types/validator.go
+++ b/x/staking/types/validator.go
@@ -52,11 +52,11 @@ func NewValidator(operator sdk.ValAddress, pubKey cryptotypes.PubKey, descriptio
 		Jailed:            false,
 		Status:            Unbonded,
 		Tokens:            math.ZeroInt(),
-		DelegatorShares:   sdk.ZeroDec(),
+		DelegatorShares:   math.LegacyZeroDec(),
 		Description:       description,
 		UnbondingHeight:   int64(0),
 		UnbondingTime:     time.Unix(0, 0).UTC(),
-		Commission:        NewCommission(sdk.ZeroDec(), sdk.ZeroDec(), sdk.ZeroDec()),
+		Commission:        NewCommission(math.LegacyZeroDec(), math.LegacyZeroDec(), math.LegacyZeroDec()),
 		MinSelfDelegation: math.OneInt(),
 	}, nil
 }
@@ -330,7 +330,7 @@ func (v Validator) TokensFromSharesRoundUp(shares sdk.Dec) sdk.Dec {
 // returns an error if the validator has no tokens.
 func (v Validator) SharesFromTokens(amt math.Int) (sdk.Dec, error) {
 	if v.Tokens.IsZero() {
-		return sdk.ZeroDec(), ErrInsufficientShares
+		return math.LegacyZeroDec(), ErrInsufficientShares
 	}
 
 	return v.GetDelegatorShares().MulInt(amt).QuoInt(v.GetTokens()), nil
@@ -340,7 +340,7 @@ func (v Validator) SharesFromTokens(amt math.Int) (sdk.Dec, error) {
 // a bond amount. It returns an error if the validator has no tokens.
 func (v Validator) SharesFromTokensTruncated(amt math.Int) (sdk.Dec, error) {
 	if v.Tokens.IsZero() {
-		return sdk.ZeroDec(), ErrInsufficientShares
+		return math.LegacyZeroDec(), ErrInsufficientShares
 	}
 
 	return v.GetDelegatorShares().MulInt(amt).QuoTruncate(sdk.NewDecFromInt(v.GetTokens())), nil

--- a/x/staking/types/validator.go
+++ b/x/staking/types/validator.go
@@ -311,18 +311,18 @@ func (v Validator) InvalidExRate() bool {
 }
 
 // calculate the token worth of provided shares
-func (v Validator) TokensFromShares(shares sdk.Dec) sdk.Dec {
+func (v Validator) TokensFromShares(shares sdk.Dec) math.LegacyDec {
 	return (shares.MulInt(v.Tokens)).Quo(v.DelegatorShares)
 }
 
 // calculate the token worth of provided shares, truncated
-func (v Validator) TokensFromSharesTruncated(shares sdk.Dec) sdk.Dec {
+func (v Validator) TokensFromSharesTruncated(shares sdk.Dec) math.LegacyDec {
 	return (shares.MulInt(v.Tokens)).QuoTruncate(v.DelegatorShares)
 }
 
 // TokensFromSharesRoundUp returns the token worth of provided shares, rounded
 // up.
-func (v Validator) TokensFromSharesRoundUp(shares sdk.Dec) sdk.Dec {
+func (v Validator) TokensFromSharesRoundUp(shares sdk.Dec) math.LegacyDec {
 	return (shares.MulInt(v.Tokens)).QuoRoundUp(v.DelegatorShares)
 }
 
@@ -516,9 +516,9 @@ func (v Validator) GetBondedTokens() math.Int { return v.BondedTokens() }
 func (v Validator) GetConsensusPower(r math.Int) int64 {
 	return v.ConsensusPower(r)
 }
-func (v Validator) GetCommission() sdk.Dec         { return v.Commission.Rate }
-func (v Validator) GetMinSelfDelegation() math.Int { return v.MinSelfDelegation }
-func (v Validator) GetDelegatorShares() sdk.Dec    { return v.DelegatorShares }
+func (v Validator) GetCommission() math.LegacyDec      { return v.Commission.Rate }
+func (v Validator) GetMinSelfDelegation() math.Int     { return v.MinSelfDelegation }
+func (v Validator) GetDelegatorShares() math.LegacyDec { return v.DelegatorShares }
 
 // UnpackInterfaces implements UnpackInterfacesMessage.UnpackInterfaces
 func (v Validator) UnpackInterfaces(unpacker codectypes.AnyUnpacker) error {

--- a/x/staking/types/validator_test.go
+++ b/x/staking/types/validator_test.go
@@ -216,13 +216,13 @@ func TestValidatorSetInitialCommission(t *testing.T) {
 		commission  types.Commission
 		expectedErr bool
 	}{
-		{val, types.NewCommission(sdk.ZeroDec(), sdk.ZeroDec(), sdk.ZeroDec()), false},
-		{val, types.NewCommission(sdk.ZeroDec(), sdk.NewDecWithPrec(-1, 1), sdk.ZeroDec()), true},
-		{val, types.NewCommission(sdk.ZeroDec(), math.LegacyNewDec(15000000000), sdk.ZeroDec()), true},
-		{val, types.NewCommission(sdk.NewDecWithPrec(-1, 1), sdk.ZeroDec(), sdk.ZeroDec()), true},
-		{val, types.NewCommission(sdk.NewDecWithPrec(2, 1), sdk.NewDecWithPrec(1, 1), sdk.ZeroDec()), true},
-		{val, types.NewCommission(sdk.ZeroDec(), sdk.ZeroDec(), sdk.NewDecWithPrec(-1, 1)), true},
-		{val, types.NewCommission(sdk.ZeroDec(), sdk.NewDecWithPrec(1, 1), sdk.NewDecWithPrec(2, 1)), true},
+		{val, types.NewCommission(math.LegacyZeroDec(), math.LegacyZeroDec(), math.LegacyZeroDec()), false},
+		{val, types.NewCommission(math.LegacyZeroDec(), sdk.NewDecWithPrec(-1, 1), math.LegacyZeroDec()), true},
+		{val, types.NewCommission(math.LegacyZeroDec(), math.LegacyNewDec(15000000000), math.LegacyZeroDec()), true},
+		{val, types.NewCommission(sdk.NewDecWithPrec(-1, 1), math.LegacyZeroDec(), math.LegacyZeroDec()), true},
+		{val, types.NewCommission(sdk.NewDecWithPrec(2, 1), sdk.NewDecWithPrec(1, 1), math.LegacyZeroDec()), true},
+		{val, types.NewCommission(math.LegacyZeroDec(), math.LegacyZeroDec(), sdk.NewDecWithPrec(-1, 1)), true},
+		{val, types.NewCommission(math.LegacyZeroDec(), sdk.NewDecWithPrec(1, 1), sdk.NewDecWithPrec(2, 1)), true},
 	}
 
 	for i, tc := range testCases {

--- a/x/staking/types/validator_test.go
+++ b/x/staking/types/validator_test.go
@@ -76,16 +76,16 @@ func TestABCIValidatorUpdateZero(t *testing.T) {
 }
 
 func TestShareTokens(t *testing.T) {
-	validator := mkValidator(100, sdk.NewDec(100))
-	assert.True(sdk.DecEq(t, sdk.NewDec(50), validator.TokensFromShares(sdk.NewDec(50))))
+	validator := mkValidator(100, math.LegacyNewDec(100))
+	assert.True(sdk.DecEq(t, math.LegacyNewDec(50), validator.TokensFromShares(math.LegacyNewDec(50))))
 
 	validator.Tokens = sdk.NewInt(50)
-	assert.True(sdk.DecEq(t, sdk.NewDec(25), validator.TokensFromShares(sdk.NewDec(50))))
-	assert.True(sdk.DecEq(t, sdk.NewDec(5), validator.TokensFromShares(sdk.NewDec(10))))
+	assert.True(sdk.DecEq(t, math.LegacyNewDec(25), validator.TokensFromShares(math.LegacyNewDec(50))))
+	assert.True(sdk.DecEq(t, math.LegacyNewDec(5), validator.TokensFromShares(math.LegacyNewDec(10))))
 }
 
 func TestRemoveTokens(t *testing.T) {
-	validator := mkValidator(100, sdk.NewDec(100))
+	validator := mkValidator(100, math.LegacyNewDec(100))
 
 	// remove tokens and test check everything
 	validator = validator.RemoveTokens(sdk.NewInt(10))
@@ -105,9 +105,9 @@ func TestAddTokensValidatorBonded(t *testing.T) {
 	validator = validator.UpdateStatus(types.Bonded)
 	validator, delShares := validator.AddTokensFromDel(sdk.NewInt(10))
 
-	assert.True(sdk.DecEq(t, sdk.NewDec(10), delShares))
+	assert.True(sdk.DecEq(t, math.LegacyNewDec(10), delShares))
 	assert.True(math.IntEq(t, sdk.NewInt(10), validator.BondedTokens()))
-	assert.True(sdk.DecEq(t, sdk.NewDec(10), validator.DelegatorShares))
+	assert.True(sdk.DecEq(t, math.LegacyNewDec(10), validator.DelegatorShares))
 }
 
 func TestAddTokensValidatorUnbonding(t *testing.T) {
@@ -115,10 +115,10 @@ func TestAddTokensValidatorUnbonding(t *testing.T) {
 	validator = validator.UpdateStatus(types.Unbonding)
 	validator, delShares := validator.AddTokensFromDel(sdk.NewInt(10))
 
-	assert.True(sdk.DecEq(t, sdk.NewDec(10), delShares))
+	assert.True(sdk.DecEq(t, math.LegacyNewDec(10), delShares))
 	assert.Equal(t, types.Unbonding, validator.Status)
 	assert.True(math.IntEq(t, sdk.NewInt(10), validator.Tokens))
-	assert.True(sdk.DecEq(t, sdk.NewDec(10), validator.DelegatorShares))
+	assert.True(sdk.DecEq(t, math.LegacyNewDec(10), validator.DelegatorShares))
 }
 
 func TestAddTokensValidatorUnbonded(t *testing.T) {
@@ -126,10 +126,10 @@ func TestAddTokensValidatorUnbonded(t *testing.T) {
 	validator = validator.UpdateStatus(types.Unbonded)
 	validator, delShares := validator.AddTokensFromDel(sdk.NewInt(10))
 
-	assert.True(sdk.DecEq(t, sdk.NewDec(10), delShares))
+	assert.True(sdk.DecEq(t, math.LegacyNewDec(10), delShares))
 	assert.Equal(t, types.Unbonded, validator.Status)
 	assert.True(math.IntEq(t, sdk.NewInt(10), validator.Tokens))
-	assert.True(sdk.DecEq(t, sdk.NewDec(10), validator.DelegatorShares))
+	assert.True(sdk.DecEq(t, math.LegacyNewDec(10), validator.DelegatorShares))
 }
 
 // TODO refactor to make simpler like the AddToken tests above
@@ -139,18 +139,18 @@ func TestRemoveDelShares(t *testing.T) {
 		ConsensusPubkey: pk1Any,
 		Status:          types.Bonded,
 		Tokens:          sdk.NewInt(100),
-		DelegatorShares: sdk.NewDec(100),
+		DelegatorShares: math.LegacyNewDec(100),
 	}
 
 	// Remove delegator shares
-	valB, coinsB := valA.RemoveDelShares(sdk.NewDec(10))
+	valB, coinsB := valA.RemoveDelShares(math.LegacyNewDec(10))
 	require.Equal(t, int64(10), coinsB.Int64())
 	require.Equal(t, int64(90), valB.DelegatorShares.RoundInt64())
 	require.Equal(t, int64(90), valB.BondedTokens().Int64())
 
 	// specific case from random tests
-	validator := mkValidator(5102, sdk.NewDec(115))
-	_, tokens := validator.RemoveDelShares(sdk.NewDec(29))
+	validator := mkValidator(5102, math.LegacyNewDec(115))
+	_, tokens := validator.RemoveDelShares(math.LegacyNewDec(29))
 
 	require.True(math.IntEq(t, sdk.NewInt(1286), tokens))
 }
@@ -159,13 +159,13 @@ func TestAddTokensFromDel(t *testing.T) {
 	validator := newValidator(t, valAddr1, pk1)
 
 	validator, shares := validator.AddTokensFromDel(sdk.NewInt(6))
-	require.True(sdk.DecEq(t, sdk.NewDec(6), shares))
-	require.True(sdk.DecEq(t, sdk.NewDec(6), validator.DelegatorShares))
+	require.True(sdk.DecEq(t, math.LegacyNewDec(6), shares))
+	require.True(sdk.DecEq(t, math.LegacyNewDec(6), validator.DelegatorShares))
 	require.True(math.IntEq(t, sdk.NewInt(6), validator.Tokens))
 
 	validator, shares = validator.AddTokensFromDel(sdk.NewInt(3))
-	require.True(sdk.DecEq(t, sdk.NewDec(3), shares))
-	require.True(sdk.DecEq(t, sdk.NewDec(9), validator.DelegatorShares))
+	require.True(sdk.DecEq(t, math.LegacyNewDec(3), shares))
+	require.True(sdk.DecEq(t, math.LegacyNewDec(9), validator.DelegatorShares))
 	require.True(math.IntEq(t, sdk.NewInt(9), validator.Tokens))
 }
 
@@ -189,7 +189,7 @@ func TestUpdateStatus(t *testing.T) {
 }
 
 func TestPossibleOverflow(t *testing.T) {
-	delShares := sdk.NewDec(391432570689183511).Quo(sdk.NewDec(40113011844664))
+	delShares := math.LegacyNewDec(391432570689183511).Quo(math.LegacyNewDec(40113011844664))
 	validator := mkValidator(2159, delShares)
 	newValidator, _ := validator.AddTokensFromDel(sdk.NewInt(71))
 
@@ -218,7 +218,7 @@ func TestValidatorSetInitialCommission(t *testing.T) {
 	}{
 		{val, types.NewCommission(sdk.ZeroDec(), sdk.ZeroDec(), sdk.ZeroDec()), false},
 		{val, types.NewCommission(sdk.ZeroDec(), sdk.NewDecWithPrec(-1, 1), sdk.ZeroDec()), true},
-		{val, types.NewCommission(sdk.ZeroDec(), sdk.NewDec(15000000000), sdk.ZeroDec()), true},
+		{val, types.NewCommission(sdk.ZeroDec(), math.LegacyNewDec(15000000000), sdk.ZeroDec()), true},
 		{val, types.NewCommission(sdk.NewDecWithPrec(-1, 1), sdk.ZeroDec(), sdk.ZeroDec()), true},
 		{val, types.NewCommission(sdk.NewDecWithPrec(2, 1), sdk.NewDecWithPrec(1, 1), sdk.ZeroDec()), true},
 		{val, types.NewCommission(sdk.ZeroDec(), sdk.ZeroDec(), sdk.NewDecWithPrec(-1, 1)), true},


### PR DESCRIPTION
## Description

Upgrades the math library in the repo root and find/replaces many usages of sdk.Dec, sdk.ZeroDec, sdk.OneDec, sdk.NewDec with their legacy-ified-math-lib replacements.

Note for review: I assume that I did not find 100% of usages

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
