### PR TITLE
perf: math: precompute & use square of precisionReuse instead of 2 repeated computations

### DIFF
--- a/math/dec.go
+++ b/math/dec.go
@@ -342,11 +342,12 @@ func (d LegacyDec) Quo(d2 LegacyDec) LegacyDec {
 	return d.ImmutOp(LegacyDec.QuoMut, d2)
 }
 
+var squaredPrecisionReuse = new(big.Int).Mul(precisionReuse, precisionReuse)
+
 // mutable quotient
 func (d LegacyDec) QuoMut(d2 LegacyDec) LegacyDec {
-	// multiply precision twice
-	d.i.Mul(d.i, precisionReuse)
-	d.i.Mul(d.i, precisionReuse)
+	// multiply by precision twice
+	d.i.Mul(d.i, squaredPrecisionReuse)
 	d.i.Quo(d.i, d2.i)
 
 	chopPrecisionAndRound(d.i)
@@ -364,8 +365,7 @@ func (d LegacyDec) QuoTruncate(d2 LegacyDec) LegacyDec {
 // mutable quotient truncate
 func (d LegacyDec) QuoTruncateMut(d2 LegacyDec) LegacyDec {
 	// multiply precision twice
-	d.i.Mul(d.i, precisionReuse)
-	d.i.Mul(d.i, precisionReuse)
+	d.i.Mul(d.i, squaredPrecisionReuse)
 	d.i.Quo(d.i, d2.i)
 
 	chopPrecisionAndTruncate(d.i)
@@ -383,8 +383,7 @@ func (d LegacyDec) QuoRoundUp(d2 LegacyDec) LegacyDec {
 // mutable quotient, round up
 func (d LegacyDec) QuoRoundupMut(d2 LegacyDec) LegacyDec {
 	// multiply precision twice
-	d.i.Mul(d.i, precisionReuse)
-	d.i.Mul(d.i, precisionReuse)
+	d.i.Mul(d.i, squaredPrecisionReuse)
 	d.i.Quo(d.i, d2.i)
 
 	chopPrecisionAndRoundUp(d.i)

--- a/math/dec_test.go
+++ b/math/dec_test.go
@@ -619,3 +619,50 @@ func BenchmarkMarshalTo(b *testing.B) {
 		}
 	}
 }
+
+var sink interface{}
+
+func BenchmarkLegacyQuoMut(b *testing.B) {
+	b1 := math.LegacyNewDec(17e2 + 8371)
+	b2 := math.LegacyNewDec(4371)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+            sink = b1.QuoMut(b2)
+	}
+
+	if sink == nil {
+		b.Fatal("Benchmark did not run")
+	}
+	sink = (interface{})(nil)
+}
+
+func BenchmarkLegacyQuoTruncateMut(b *testing.B) {
+	b1 := math.LegacyNewDec(17e2 + 8371)
+	b2 := math.LegacyNewDec(4371)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+            sink = b1.QuoTruncateMut(b2)
+	}
+
+	if sink == nil {
+		b.Fatal("Benchmark did not run")
+	}
+	sink = (interface{})(nil)
+}
+
+func BenchmarkLegacyQuoRoundupMut(b *testing.B) {
+	b1 := math.LegacyNewDec(17e2 + 8371)
+	b2 := math.LegacyNewDec(4371)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+            sink = b1.QuoRoundupMut(b2)
+	}
+
+	if sink == nil {
+		b.Fatal("Benchmark did not run")
+	}
+	sink = (interface{})(nil)
+}


### PR DESCRIPTION
Noticed in an audit of Quicksilver's code while examining the Quo* code, that there were
2 invocations of a multiplication with precisionReuse of the simplified form:

```go
a *= b
a *= b
```
but those can be folded into

```go
a *= (b * b)
```

of which b is computed at init time, thus (b * b) can also be computed
at init time, so the final form becomes

```go
a *= b_squared
```

While here, added benchmarks for the change.

The results of this change yield performance improvements
```shell
$ benchstat before.txt after.txt
name                    old time/op    new time/op    delta
LegacyQuo-8               43.1ns ± 1%    37.1ns ± 3%  -14.00%  (p=0.000 n=14+15)
LegacyQuoTruncateMut-8    35.2ns ± 1%    28.8ns ± 3%  -18.27%  (p=0.000 n=15+15)
LegacyQuoRoundupMut-8      287ns ± 2%     283ns ± 3%     ~     (p=0.057 n=15+15)

name                    old alloc/op   new alloc/op   delta
LegacyQuo-8                0.00B          0.00B          ~     (all equal)
LegacyQuoTruncateMut-8     0.00B          0.00B          ~     (all equal)
LegacyQuoRoundupMut-8      72.0B ± 0%     72.0B ± 0%     ~     (all equal)

name                    old allocs/op  new allocs/op  delta
LegacyQuo-8                 0.00           0.00          ~     (all equal)
LegacyQuoTruncateMut-8      0.00           0.00          ~     (all equal)
LegacyQuoRoundupMut-8       2.00 ± 0%      2.00 ± 0%     ~     (all equal)
```

Fixes #12793