### PR TITLE
fix: Use fixed length hex for pointer at FwdCapabilityKey (backport #11737)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (x/mint) [#12384](https://github.com/cosmos/cosmos-sdk/pull/12384) Ensure `GoalBonded` must be positive when performing `x/mint` parameter validation.
 * (simapp) [#12437](https://github.com/cosmos/cosmos-sdk/pull/12437) fix the non-determinstic behavior in simulations caused by `GenTx` and check 
 empty coins slice before it is used to create `banktype.MsgSend`.
+* (x/capability) []() Use fixed length hex for pointer at FwdCapabilityKey.
 
 ## [v0.45.6](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.45.6) - 2022-06-28
 

--- a/x/capability/types/keys.go
+++ b/x/capability/types/keys.go
@@ -39,7 +39,9 @@ func RevCapabilityKey(module, name string) []byte {
 // FwdCapabilityKey returns a forward lookup key for a given module and capability
 // reference.
 func FwdCapabilityKey(module string, cap *Capability) []byte {
-	// truncate the key to fixed length, keep backward compatible on common architectures.
+	// encode the key to a fixed length to avoid breaking consensus state machine
+	// it's a hacky backport of https://github.com/cosmos/cosmos-sdk/pull/11737
+	// the length 10 is picked so it's backward compatible on common architectures.
 	key := fmt.Sprintf("%#010p", cap)
 	if len(key) > 10 {
 		key = key[len(key)-10:]

--- a/x/capability/types/keys.go
+++ b/x/capability/types/keys.go
@@ -39,7 +39,12 @@ func RevCapabilityKey(module, name string) []byte {
 // FwdCapabilityKey returns a forward lookup key for a given module and capability
 // reference.
 func FwdCapabilityKey(module string, cap *Capability) []byte {
-	return []byte(fmt.Sprintf("%s/fwd/%p", module, cap))
+	// truncate the key to fixed length, keep backward compatible on common architectures.
+	key := fmt.Sprintf("%#010p", cap)
+	if len(key) > 10 {
+		key = key[len(key)-10:]
+	}
+	return []byte(fmt.Sprintf("%s/fwd/0x%s", module, key))
 }
 
 // IndexToKey returns bytes to be used as a key for a given capability index.

--- a/x/capability/types/keys_test.go
+++ b/x/capability/types/keys_test.go
@@ -2,6 +2,7 @@ package types_test
 
 import (
 	"fmt"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -31,4 +32,22 @@ func TestIndexToKey(t *testing.T) {
 
 func TestIndexFromKey(t *testing.T) {
 	require.Equal(t, uint64(3162), types.IndexFromKey([]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xc, 0x5a}))
+}
+
+// to test the backward compatibiltiy of the new function
+func legacyFwdCapabilityKey(module string, cap *types.Capability) []byte {
+	return []byte(fmt.Sprintf("%s/fwd/%p", module, cap))
+}
+
+func TestFwdCapabilityKeyCompatibility(t *testing.T) {
+	cap := types.NewCapability(24)
+	new := types.FwdCapabilityKey("bank", cap)
+	old := legacyFwdCapabilityKey("bank", cap)
+	if runtime.GOOS == "darwin" && runtime.GOARCH == "arm" {
+		// the legacy version has 1 more byte on mac m1
+		require.Equal(t, len(old), len(new)+1)
+	} else {
+		// otherwise, the new version is identical
+		require.Equal(t, new, old)
+	}
 }

--- a/x/capability/types/keys_test.go
+++ b/x/capability/types/keys_test.go
@@ -16,7 +16,12 @@ func TestRevCapabilityKey(t *testing.T) {
 
 func TestFwdCapabilityKey(t *testing.T) {
 	cap := types.NewCapability(23)
-	expected := []byte(fmt.Sprintf("bank/fwd/%p", cap))
+	key := fmt.Sprintf("%#010p", cap)
+	if len(key) > 10 {
+		key = key[len(key)-10:]
+	}
+	require.Equal(t, 10, len(key))
+	expected := []byte(fmt.Sprintf("bank/fwd/0x%s", key))
 	require.Equal(t, expected, types.FwdCapabilityKey("bank", cap))
 }
 


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

ref: #11726

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
