### PR TITLE
docs: Update REST endpoints for group module documentation

### DIFF
--- a/x/group/spec/05_client.md
+++ b/x/group/spec/05_client.md
@@ -1037,13 +1037,13 @@ A user can query the `group` module using REST endpoints.
 The `GroupInfo` endpoint allows users to query for group info by given group id.
 
 ```bash
-/cosmos/group/v1beta1/group_info/{group_id}
+/cosmos/group/v1/group_info/{group_id}
 ```
 
 Example:
 
 ```bash
-curl localhost:1317/cosmos/group/v1beta1/group_info/1
+curl localhost:1317/cosmos/group/v1/group_info/1
 ```
 
 Example Output:
@@ -1051,7 +1051,7 @@ Example Output:
 ```bash
 {
   "info": {
-    "group_id": "1",
+    "id": "1",
     "admin": "cosmos1..",
     "metadata": "AQ==",
     "version": "1",
@@ -1065,13 +1065,13 @@ Example Output:
 The `GroupPolicyInfo` endpoint allows users to query for group policy info by account address of group policy.
 
 ```bash
-/cosmos/group/v1beta1/group_policy_info/{address}
+/cosmos/group/v1/group_policy_info/{address}
 ```
 
 Example:
 
 ```bash
-curl localhost:1317/cosmos/group/v1beta1/group_policy_info/cosmos1..
+curl localhost:1317/cosmos/group/v1/group_policy_info/cosmos1..
 ```
 
 Example Output:
@@ -1101,13 +1101,13 @@ Example Output:
 The `GroupMembers` endpoint allows users to query for group members by group id with pagination flags.
 
 ```bash
-/cosmos/group/v1beta1/group_members/{group_id}
+/cosmos/group/v1/group_members/{group_id}
 ```
 
 Example:
 
 ```bash
-curl localhost:1317/cosmos/group/v1beta1/group_members/1
+curl localhost:1317/cosmos/group/v1/group_members/1
 ```
 
 Example Output:
@@ -1143,13 +1143,13 @@ Example Output:
 The `GroupsByAdmin` endpoint allows users to query for groups by admin account address with pagination flags.
 
 ```bash
-/cosmos/group/v1beta1/groups_by_admin/{admin}
+/cosmos/group/v1/groups_by_admin/{admin}
 ```
 
 Example:
 
 ```bash
-curl localhost:1317/cosmos/group/v1beta1/groups_by_admin/cosmos1..
+curl localhost:1317/cosmos/group/v1/groups_by_admin/cosmos1..
 ```
 
 Example Output:
@@ -1158,14 +1158,14 @@ Example Output:
 {
   "groups": [
     {
-      "group_id": "1",
+      "id": "1",
       "admin": "cosmos1..",
       "metadata": "AQ==",
       "version": "1",
       "total_weight": "3"
     },
     {
-      "group_id": "2",
+      "id": "2",
       "admin": "cosmos1..",
       "metadata": "AQ==",
       "version": "1",
@@ -1184,13 +1184,13 @@ Example Output:
 The `GroupPoliciesByGroup` endpoint allows users to query for group policies by group id with pagination flags.
 
 ```bash
-/cosmos/group/v1beta1/group_policies_by_group/{group_id}
+/cosmos/group/v1/group_policies_by_group/{group_id}
 ```
 
 Example:
 
 ```bash
-curl localhost:1317/cosmos/group/v1beta1/group_policies_by_group/1
+curl localhost:1317/cosmos/group/v1/group_policies_by_group/1
 ```
 
 Example Output:
@@ -1241,13 +1241,13 @@ Example Output:
 The `GroupPoliciesByAdmin` endpoint allows users to query for group policies by admin account address with pagination flags.
 
 ```bash
-/cosmos/group/v1beta1/group_policies_by_admin/{admin}
+/cosmos/group/v1/group_policies_by_admin/{admin}
 ```
 
 Example:
 
 ```bash
-curl localhost:1317/cosmos/group/v1beta1/group_policies_by_admin/cosmos1..
+curl localhost:1317/cosmos/group/v1/group_policies_by_admin/cosmos1..
 ```
 
 Example Output:
@@ -1267,7 +1267,7 @@ Example Output:
         "windows": {
           "voting_period": "120h",
           "min_execution_period": "0s"
-      }
+      } 
       },
     },
     {
@@ -1297,13 +1297,13 @@ Example Output:
 The `Proposal` endpoint allows users to query for proposal by id.
 
 ```bash
-/cosmos/group/v1beta1/proposal/{proposal_id}
+/cosmos/group/v1/proposal/{proposal_id}
 ```
 
 Example:
 
 ```bash
-curl localhost:1317/cosmos/group/v1beta1/proposal/1
+curl localhost:1317/cosmos/group/v1/proposal/1
 ```
 
 Example Output:
@@ -1355,13 +1355,13 @@ Example Output:
 The `ProposalsByGroupPolicy` endpoint allows users to query for proposals by account address of group policy with pagination flags.
 
 ```bash
-/cosmos/group/v1beta1/proposals_by_group_policy/{address}
+/cosmos/group/v1/proposals_by_group_policy/{address}
 ```
 
 Example:
 
 ```bash
-curl localhost:1317/cosmos/group/v1beta1/proposals_by_group_policy/cosmos1..
+curl localhost:1317/cosmos/group/v1/proposals_by_group_policy/cosmos1..
 ```
 
 Example Output:
@@ -1370,13 +1370,13 @@ Example Output:
 {
   "proposals": [
     {
-      "proposal_id": "1",
-      "address": "cosmos1..",
+      "id": "1",
+      "group_policy_address": "cosmos1..",
       "metadata": "AQ==",
       "proposers": [
         "cosmos1.."
       ],
-      "submitted_at": "2021-12-17T08:03:27.099649352Z",
+      "submit_time": "2021-12-17T08:03:27.099649352Z",
       "group_version": "1",
       "group_policy_version": "1",
       "status": "STATUS_CLOSED",
@@ -1419,7 +1419,7 @@ Example Output:
 The `VoteByProposalVoter` endpoint allows users to query for vote by proposal id and voter account address.
 
 ```bash
-/cosmos/group/v1beta1/vote_by_proposal_voter/{proposal_id}/{voter}
+/cosmos/group/v1/vote_by_proposal_voter/{proposal_id}/{voter}
 ```
 
 Example:
@@ -1447,13 +1447,13 @@ Example Output:
 The `VotesByProposal` endpoint allows users to query for votes by proposal id with pagination flags.
 
 ```bash
-/cosmos/group/v1beta1/votes_by_proposal/{proposal_id}
+/cosmos/group/v1/votes_by_proposal/{proposal_id}
 ```
 
 Example:
 
 ```bash
-curl localhost:1317/cosmos/group/v1beta1/votes_by_proposal/1
+curl localhost:1317/cosmos/group/v1/votes_by_proposal/1
 ```
 
 Example Output:
@@ -1464,9 +1464,9 @@ Example Output:
     {
       "proposal_id": "1",
       "voter": "cosmos1..",
-      "choice": "CHOICE_YES",
+      "option": "CHOICE_YES",
       "metadata": "AQ==",
-      "submitted_at": "2021-12-17T08:05:02.490164009Z"
+      "submit_time": "2021-12-17T08:05:02.490164009Z"
     }
   ],
   "pagination": {
@@ -1481,13 +1481,13 @@ Example Output:
 The `VotesByVoter` endpoint allows users to query for votes by voter account address with pagination flags.
 
 ```bash
-/cosmos/group/v1beta1/votes_by_voter/{voter}
+/cosmos/group/v1/votes_by_voter/{voter}
 ```
 
 Example:
 
 ```bash
-curl localhost:1317/cosmos/group/v1beta1/votes_by_voter/cosmos1..
+curl localhost:1317/cosmos/group/v1/votes_by_voter/cosmos1..
 ```
 
 Example Output:


### PR DESCRIPTION
This PR updates the current docs for the groups module REST endpoints in v0.46. The current endpoint prefix is `/cosmos/group/v1beta1/...` which is incorrect and has been updated to `/cosmos/group/v1/...`

For example:

```
curl localhost:1317/cosmos/group/v1beta1/group_info/1

{
  "code": 12,
  "message": "Not Implemented",
  "details": [
  ]
}
```

```
curl localhost:1317/cosmos/group/v1/group_info/1

{
  "info": {
    "id": "1",
    "admin": "cosmos15e...",
    "metadata": "",
    "version": "3",
    "total_weight": "3",
    "created_at": "2022-01-01T12:12:12.999999Z"
  }
}
```

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
