### PR TITLE
feat(math): add YAML marshaler to Uint

### DIFF
--- a/math/uint.go
+++ b/math/uint.go
@@ -140,6 +140,11 @@ func (u Uint) MarshalJSON() ([]byte, error) {
 	return marshalJSON(u.i)
 }
 
+// MarshalYAML returns the YAML representation.
+func (i Uint) MarshalYAML() (interface{}, error) {
+	return i.String(), nil
+}
+
 // UnmarshalJSON defines custom decoding scheme
 func (u *Uint) UnmarshalJSON(bz []byte) error {
 	if u.i == nil { // Necessary since default Uint initialization has i.i as nil

--- a/math/uint_test.go
+++ b/math/uint_test.go
@@ -1,6 +1,7 @@
 package math_test
 
 import (
+	"encoding/json"
 	"fmt"
 	"math"
 	"math/big"
@@ -10,6 +11,7 @@ import (
 
 	sdkmath "cosmossdk.io/math"
 	"github.com/stretchr/testify/suite"
+	"sigs.k8s.io/yaml"
 )
 
 type uintTestSuite struct {
@@ -22,6 +24,18 @@ func TestUnitTestSuite(t *testing.T) {
 
 func (s *uintTestSuite) SetupSuite() {
 	s.T().Parallel()
+}
+
+func (s *uintTestSuite) TestUintMarshalYAMLandJSON() {
+	u1 := sdkmath.NewUint(1235)
+	bz, err := yaml.Marshal(u1)
+	s.Require().NoError(err)
+	s.Require().Equal("\"1235\"\n", string(bz))
+
+	bz, err = json.Marshal(u1)
+	s.Require().NoError(err)
+	s.Require().Equal(`"1235"`, string(bz))
+
 }
 
 func (s *uintTestSuite) TestUintPanics() {


### PR DESCRIPTION
## Description

Text `math.Uint` serialization doesn't work because YAML marshaler is not implemented. When someone will try to run YAML marshaler, it won't print `Uint` fields.

In this PR I'm adding `MarshalYAML` method to `Uint`.

Added backports to 0.45 and 0.46

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
