### PR TITLE
fix: Go badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ parent:
   <a href="https://github.com/cosmos/cosmos-sdk/blob/main/LICENSE">
     <img alt="License: Apache-2.0" src="https://img.shields.io/github/license/cosmos/cosmos-sdk.svg" />
   </a>
-  <a href="https://pkg.go.dev/github.com/cosmos/cosmos-sdk?tab=doc">
-    <img alt="GoDoc" src="https://pkg.go.dev/github.com/cosmos/cosmos-sdk?status.svg" />
+  <a href="https://pkg.go.dev/github.com/cosmos/cosmos-sdk">
+    <img src="https://pkg.go.dev/badge/github.com/cosmos/cosmos-sdk.svg" alt="Go Reference">
   </a>
   <a href="https://goreportcard.com/report/github.com/cosmos/cosmos-sdk">
     <img alt="Go report card" src="https://goreportcard.com/badge/github.com/cosmos/cosmos-sdk" />


### PR DESCRIPTION
## Description

The previous GoDoc badge never renders for me so I fixed the badge link based on the [Go badge tool]( https://pkg.go.dev/badge/?path=https%3A%2F%2Fpkg.go.dev%2Fgithub.com%2Fcosmos%2Fcosmos-sdk)

## Screenshot
Before | After
--- | ---
<img width="587" alt="go-badge-before" src="https://user-images.githubusercontent.com/3699047/184705731-08afb47f-1fd3-49ea-91bb-da2d1cd6afc1.png"> | <img width="589" alt="go-badge-after" src="https://user-images.githubusercontent.com/3699047/184705605-c4a298b9-6cd2-49af-8c91-dbe315c23e2a.png">
