### PR TITLE
fix: re-add third_party protos and pin their versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ vagrant
 
 # Graphviz
 dependency-graph.png
+debug_container.dot
 
 # Latex
 *.aux
@@ -57,5 +58,3 @@ dependency-graph.png
 *.synctex.gz
 /x/genutil/config/priv_validator_key.json
 /x/genutil/data/priv_validator_state.json
-
-debug_container.dot

--- a/Makefile
+++ b/Makefile
@@ -430,9 +430,9 @@ proto-check-breaking:
 
 
 TM_URL              = https://raw.githubusercontent.com/tendermint/tendermint/v0.34.21/proto/tendermint
-GOGO_PROTO_URL      = https://raw.githubusercontent.com/regen-network/protobuf/cosmos
-COSMOS_PROTO_URL    = https://raw.githubusercontent.com/regen-network/cosmos-proto/master
-CONFIO_URL          = https://raw.githubusercontent.com/confio/ics23/v0.7.0
+GOGO_PROTO_URL      = https://raw.githubusercontent.com/regen-network/protobuf/v1.3.3-alpha.regen.1
+COSMOS_PROTO_URL    = https://raw.githubusercontent.com/regen-network/cosmos-proto/v0.3.1
+CONFIO_URL          = https://raw.githubusercontent.com/confio/ics23/go/v0.7.0
 
 TM_CRYPTO_TYPES     = third_party/proto/tendermint/crypto
 TM_ABCI_TYPES       = third_party/proto/tendermint/abci

--- a/third_party/proto/confio/proofs.proto
+++ b/third_party/proto/confio/proofs.proto
@@ -1,0 +1,235 @@
+syntax = "proto3";
+
+package ics23;
+option go_package = "github.com/confio/ics23/go";
+
+enum HashOp {
+    // NO_HASH is the default if no data passed. Note this is an illegal argument some places.
+    NO_HASH = 0;
+    SHA256 = 1;
+    SHA512 = 2;
+    KECCAK = 3;
+    RIPEMD160 = 4;
+    BITCOIN = 5;  // ripemd160(sha256(x))
+    SHA512_256 = 6;
+}
+
+/**
+LengthOp defines how to process the key and value of the LeafOp
+to include length information. After encoding the length with the given
+algorithm, the length will be prepended to the key and value bytes.
+(Each one with it's own encoded length)
+*/
+enum LengthOp {
+    // NO_PREFIX don't include any length info
+    NO_PREFIX = 0; 
+    // VAR_PROTO uses protobuf (and go-amino) varint encoding of the length
+    VAR_PROTO = 1; 
+    // VAR_RLP uses rlp int encoding of the length
+    VAR_RLP = 2; 
+    // FIXED32_BIG uses big-endian encoding of the length as a 32 bit integer
+    FIXED32_BIG = 3; 
+    // FIXED32_LITTLE uses little-endian encoding of the length as a 32 bit integer
+    FIXED32_LITTLE = 4; 
+    // FIXED64_BIG uses big-endian encoding of the length as a 64 bit integer
+    FIXED64_BIG = 5;
+    // FIXED64_LITTLE uses little-endian encoding of the length as a 64 bit integer
+    FIXED64_LITTLE = 6;
+    // REQUIRE_32_BYTES is like NONE, but will fail if the input is not exactly 32 bytes (sha256 output)
+    REQUIRE_32_BYTES = 7;
+    // REQUIRE_64_BYTES is like NONE, but will fail if the input is not exactly 64 bytes (sha512 output)
+    REQUIRE_64_BYTES = 8;
+}
+
+/**
+ExistenceProof takes a key and a value and a set of steps to perform on it.
+The result of peforming all these steps will provide a "root hash", which can
+be compared to the value in a header.
+
+Since it is computationally infeasible to produce a hash collission for any of the used
+cryptographic hash functions, if someone can provide a series of operations to transform
+a given key and value into a root hash that matches some trusted root, these key and values
+must be in the referenced merkle tree.
+
+The only possible issue is maliablity in LeafOp, such as providing extra prefix data,
+which should be controlled by a spec. Eg. with lengthOp as NONE,
+  prefix = FOO, key = BAR, value = CHOICE
+and
+  prefix = F, key = OOBAR, value = CHOICE
+would produce the same value.
+
+With LengthOp this is tricker but not impossible. Which is why the "leafPrefixEqual" field
+in the ProofSpec is valuable to prevent this mutability. And why all trees should
+length-prefix the data before hashing it.
+*/
+message ExistenceProof {
+    bytes key = 1;
+    bytes value = 2;
+    LeafOp leaf = 3;
+    repeated InnerOp path = 4;    
+}
+
+/*
+NonExistenceProof takes a proof of two neighbors, one left of the desired key,
+one right of the desired key. If both proofs are valid AND they are neighbors,
+then there is no valid proof for the given key.
+*/
+message NonExistenceProof {
+    bytes key = 1; // TODO: remove this as unnecessary??? we prove a range
+    ExistenceProof left = 2;
+    ExistenceProof right = 3;
+}
+
+/*
+CommitmentProof is either an ExistenceProof or a NonExistenceProof, or a Batch of such messages
+*/
+message CommitmentProof {
+    oneof proof {
+        ExistenceProof exist = 1;
+        NonExistenceProof nonexist = 2;
+        BatchProof batch = 3;
+        CompressedBatchProof compressed = 4;
+    }
+}
+
+/**
+LeafOp represents the raw key-value data we wish to prove, and
+must be flexible to represent the internal transformation from
+the original key-value pairs into the basis hash, for many existing
+merkle trees.
+
+key and value are passed in. So that the signature of this operation is:
+  leafOp(key, value) -> output
+
+To process this, first prehash the keys and values if needed (ANY means no hash in this case):
+  hkey = prehashKey(key)
+  hvalue = prehashValue(value)
+
+Then combine the bytes, and hash it
+  output = hash(prefix || length(hkey) || hkey || length(hvalue) || hvalue)
+*/
+message LeafOp {
+    HashOp hash = 1;
+    HashOp prehash_key = 2;
+    HashOp prehash_value = 3;
+    LengthOp length = 4;
+    // prefix is a fixed bytes that may optionally be included at the beginning to differentiate
+    // a leaf node from an inner node.
+    bytes prefix = 5;
+}
+
+/**
+InnerOp represents a merkle-proof step that is not a leaf.
+It represents concatenating two children and hashing them to provide the next result.
+
+The result of the previous step is passed in, so the signature of this op is:
+  innerOp(child) -> output
+
+The result of applying InnerOp should be:
+  output = op.hash(op.prefix || child || op.suffix)
+
+  where the || operator is concatenation of binary data,
+and child is the result of hashing all the tree below this step.
+
+Any special data, like prepending child with the length, or prepending the entire operation with
+some value to differentiate from leaf nodes, should be included in prefix and suffix.
+If either of prefix or suffix is empty, we just treat it as an empty string
+*/
+message InnerOp {
+    HashOp hash = 1;
+    bytes prefix = 2;
+    bytes suffix = 3;
+}
+
+
+/**
+ProofSpec defines what the expected parameters are for a given proof type.
+This can be stored in the client and used to validate any incoming proofs.
+
+  verify(ProofSpec, Proof) -> Proof | Error
+
+As demonstrated in tests, if we don't fix the algorithm used to calculate the
+LeafHash for a given tree, there are many possible key-value pairs that can
+generate a given hash (by interpretting the preimage differently).
+We need this for proper security, requires client knows a priori what
+tree format server uses. But not in code, rather a configuration object.
+*/
+message ProofSpec {
+  // any field in the ExistenceProof must be the same as in this spec.
+  // except Prefix, which is just the first bytes of prefix (spec can be longer) 
+  LeafOp leaf_spec = 1;
+  InnerSpec inner_spec = 2;
+  // max_depth (if > 0) is the maximum number of InnerOps allowed (mainly for fixed-depth tries)
+  int32 max_depth = 3;
+  // min_depth (if > 0) is the minimum number of InnerOps allowed (mainly for fixed-depth tries)
+  int32 min_depth = 4;
+}
+
+/*
+InnerSpec contains all store-specific structure info to determine if two proofs from a
+given store are neighbors.
+
+This enables:
+
+  isLeftMost(spec: InnerSpec, op: InnerOp)
+  isRightMost(spec: InnerSpec, op: InnerOp)
+  isLeftNeighbor(spec: InnerSpec, left: InnerOp, right: InnerOp)
+*/
+message InnerSpec {
+    // Child order is the ordering of the children node, must count from 0
+    // iavl tree is [0, 1] (left then right)
+    // merk is [0, 2, 1] (left, right, here)
+    repeated int32 child_order = 1;
+    int32 child_size = 2;
+    int32 min_prefix_length = 3;
+    int32 max_prefix_length = 4;
+    // empty child is the prehash image that is used when one child is nil (eg. 20 bytes of 0)
+    bytes empty_child = 5;
+    // hash is the algorithm that must be used for each InnerOp
+    HashOp hash = 6;
+}
+
+/*
+BatchProof is a group of multiple proof types than can be compressed
+*/
+message BatchProof {
+  repeated BatchEntry entries = 1;
+}
+
+// Use BatchEntry not CommitmentProof, to avoid recursion
+message BatchEntry {
+  oneof proof {
+    ExistenceProof exist = 1;
+    NonExistenceProof nonexist = 2;
+  }
+}
+
+
+/****** all items here are compressed forms *******/
+
+message CompressedBatchProof {
+  repeated CompressedBatchEntry entries = 1;
+  repeated InnerOp lookup_inners = 2;
+}
+
+// Use BatchEntry not CommitmentProof, to avoid recursion
+message CompressedBatchEntry {
+  oneof proof {
+    CompressedExistenceProof exist = 1;
+    CompressedNonExistenceProof nonexist = 2;
+  }
+}
+
+message CompressedExistenceProof {
+  bytes key = 1;
+  bytes value = 2;
+  LeafOp leaf = 3;
+  // these are indexes into the lookup_inners table in CompressedBatchProof
+  repeated int32 path = 4;    
+}
+
+message CompressedNonExistenceProof {
+  bytes key = 1; // TODO: remove this as unnecessary??? we prove a range
+  CompressedExistenceProof left = 2;
+  CompressedExistenceProof right = 3;
+}

--- a/third_party/proto/cosmos_proto/cosmos.proto
+++ b/third_party/proto/cosmos_proto/cosmos.proto
@@ -1,0 +1,16 @@
+syntax = "proto3";
+package cosmos_proto;
+
+import "google/protobuf/descriptor.proto";
+
+option go_package = "github.com/regen-network/cosmos-proto";
+
+extend google.protobuf.MessageOptions {
+    string interface_type = 93001;
+
+    string implements_interface = 93002;
+}
+
+extend google.protobuf.FieldOptions {
+    string accepts_interface = 93001;
+}

--- a/third_party/proto/gogoproto/gogo.proto
+++ b/third_party/proto/gogoproto/gogo.proto
@@ -1,0 +1,145 @@
+// Protocol Buffers for Go with Gadgets
+//
+// Copyright (c) 2013, The GoGo Authors. All rights reserved.
+// http://github.com/gogo/protobuf
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+syntax = "proto2";
+package gogoproto;
+
+import "google/protobuf/descriptor.proto";
+
+option java_package = "com.google.protobuf";
+option java_outer_classname = "GoGoProtos";
+option go_package = "github.com/gogo/protobuf/gogoproto";
+
+extend google.protobuf.EnumOptions {
+	optional bool goproto_enum_prefix = 62001;
+	optional bool goproto_enum_stringer = 62021;
+	optional bool enum_stringer = 62022;
+	optional string enum_customname = 62023;
+	optional bool enumdecl = 62024;
+}
+
+extend google.protobuf.EnumValueOptions {
+	optional string enumvalue_customname = 66001;
+}
+
+extend google.protobuf.FileOptions {
+	optional bool goproto_getters_all = 63001;
+	optional bool goproto_enum_prefix_all = 63002;
+	optional bool goproto_stringer_all = 63003;
+	optional bool verbose_equal_all = 63004;
+	optional bool face_all = 63005;
+	optional bool gostring_all = 63006;
+	optional bool populate_all = 63007;
+	optional bool stringer_all = 63008;
+	optional bool onlyone_all = 63009;
+
+	optional bool equal_all = 63013;
+	optional bool description_all = 63014;
+	optional bool testgen_all = 63015;
+	optional bool benchgen_all = 63016;
+	optional bool marshaler_all = 63017;
+	optional bool unmarshaler_all = 63018;
+	optional bool stable_marshaler_all = 63019;
+
+	optional bool sizer_all = 63020;
+
+	optional bool goproto_enum_stringer_all = 63021;
+	optional bool enum_stringer_all = 63022;
+
+	optional bool unsafe_marshaler_all = 63023;
+	optional bool unsafe_unmarshaler_all = 63024;
+
+	optional bool goproto_extensions_map_all = 63025;
+	optional bool goproto_unrecognized_all = 63026;
+	optional bool gogoproto_import = 63027;
+	optional bool protosizer_all = 63028;
+	optional bool compare_all = 63029;
+    optional bool typedecl_all = 63030;
+    optional bool enumdecl_all = 63031;
+
+	optional bool goproto_registration = 63032;
+	optional bool messagename_all = 63033;
+
+	optional bool goproto_sizecache_all = 63034;
+	optional bool goproto_unkeyed_all = 63035;
+}
+
+extend google.protobuf.MessageOptions {
+	optional bool goproto_getters = 64001;
+	optional bool goproto_stringer = 64003;
+	optional bool verbose_equal = 64004;
+	optional bool face = 64005;
+	optional bool gostring = 64006;
+	optional bool populate = 64007;
+	optional bool stringer = 67008;
+	optional bool onlyone = 64009;
+
+	optional bool equal = 64013;
+	optional bool description = 64014;
+	optional bool testgen = 64015;
+	optional bool benchgen = 64016;
+	optional bool marshaler = 64017;
+	optional bool unmarshaler = 64018;
+	optional bool stable_marshaler = 64019;
+
+	optional bool sizer = 64020;
+
+	optional bool unsafe_marshaler = 64023;
+	optional bool unsafe_unmarshaler = 64024;
+
+	optional bool goproto_extensions_map = 64025;
+	optional bool goproto_unrecognized = 64026;
+
+	optional bool protosizer = 64028;
+	optional bool compare = 64029;
+
+	optional bool typedecl = 64030;
+
+	optional bool messagename = 64033;
+
+	optional bool goproto_sizecache = 64034;
+	optional bool goproto_unkeyed = 64035;
+}
+
+extend google.protobuf.FieldOptions {
+	optional bool nullable = 65001;
+	optional bool embed = 65002;
+	optional string customtype = 65003;
+	optional string customname = 65004;
+	optional string jsontag = 65005;
+	optional string moretags = 65006;
+	optional string casttype = 65007;
+	optional string castkey = 65008;
+	optional string castvalue = 65009;
+
+	optional bool stdtime = 65010;
+	optional bool stdduration = 65011;
+	optional bool wktpointer = 65012;
+
+	optional string castrepeated = 65013;
+}

--- a/third_party/proto/tendermint/abci/types.proto
+++ b/third_party/proto/tendermint/abci/types.proto
@@ -1,0 +1,413 @@
+syntax = "proto3";
+package tendermint.abci;
+
+option go_package = "github.com/tendermint/tendermint/abci/types";
+
+// For more information on gogo.proto, see:
+// https://github.com/gogo/protobuf/blob/master/extensions.md
+import "tendermint/crypto/proof.proto";
+import "tendermint/types/types.proto";
+import "tendermint/crypto/keys.proto";
+import "tendermint/types/params.proto";
+import "google/protobuf/timestamp.proto";
+import "gogoproto/gogo.proto";
+
+// This file is copied from http://github.com/tendermint/abci
+// NOTE: When using custom types, mind the warnings.
+// https://github.com/gogo/protobuf/blob/master/custom_types.md#warnings-and-issues
+
+//----------------------------------------
+// Request types
+
+message Request {
+  oneof value {
+    RequestEcho               echo                 = 1;
+    RequestFlush              flush                = 2;
+    RequestInfo               info                 = 3;
+    RequestSetOption          set_option           = 4;
+    RequestInitChain          init_chain           = 5;
+    RequestQuery              query                = 6;
+    RequestBeginBlock         begin_block          = 7;
+    RequestCheckTx            check_tx             = 8;
+    RequestDeliverTx          deliver_tx           = 9;
+    RequestEndBlock           end_block            = 10;
+    RequestCommit             commit               = 11;
+    RequestListSnapshots      list_snapshots       = 12;
+    RequestOfferSnapshot      offer_snapshot       = 13;
+    RequestLoadSnapshotChunk  load_snapshot_chunk  = 14;
+    RequestApplySnapshotChunk apply_snapshot_chunk = 15;
+  }
+}
+
+message RequestEcho {
+  string message = 1;
+}
+
+message RequestFlush {}
+
+message RequestInfo {
+  string version       = 1;
+  uint64 block_version = 2;
+  uint64 p2p_version   = 3;
+}
+
+// nondeterministic
+message RequestSetOption {
+  string key   = 1;
+  string value = 2;
+}
+
+message RequestInitChain {
+  google.protobuf.Timestamp time = 1
+      [(gogoproto.nullable) = false, (gogoproto.stdtime) = true];
+  string                   chain_id         = 2;
+  ConsensusParams          consensus_params = 3;
+  repeated ValidatorUpdate validators       = 4 [(gogoproto.nullable) = false];
+  bytes                    app_state_bytes  = 5;
+  int64                    initial_height   = 6;
+}
+
+message RequestQuery {
+  bytes  data   = 1;
+  string path   = 2;
+  int64  height = 3;
+  bool   prove  = 4;
+}
+
+message RequestBeginBlock {
+  bytes                   hash                 = 1;
+  tendermint.types.Header header               = 2 [(gogoproto.nullable) = false];
+  LastCommitInfo          last_commit_info     = 3 [(gogoproto.nullable) = false];
+  repeated Evidence       byzantine_validators = 4 [(gogoproto.nullable) = false];
+}
+
+enum CheckTxType {
+  NEW     = 0 [(gogoproto.enumvalue_customname) = "New"];
+  RECHECK = 1 [(gogoproto.enumvalue_customname) = "Recheck"];
+}
+
+message RequestCheckTx {
+  bytes       tx   = 1;
+  CheckTxType type = 2;
+}
+
+message RequestDeliverTx {
+  bytes tx = 1;
+}
+
+message RequestEndBlock {
+  int64 height = 1;
+}
+
+message RequestCommit {}
+
+// lists available snapshots
+message RequestListSnapshots {}
+
+// offers a snapshot to the application
+message RequestOfferSnapshot {
+  Snapshot snapshot = 1;  // snapshot offered by peers
+  bytes    app_hash = 2;  // light client-verified app hash for snapshot height
+}
+
+// loads a snapshot chunk
+message RequestLoadSnapshotChunk {
+  uint64 height = 1;
+  uint32 format = 2;
+  uint32 chunk  = 3;
+}
+
+// Applies a snapshot chunk
+message RequestApplySnapshotChunk {
+  uint32 index  = 1;
+  bytes  chunk  = 2;
+  string sender = 3;
+}
+
+//----------------------------------------
+// Response types
+
+message Response {
+  oneof value {
+    ResponseException          exception            = 1;
+    ResponseEcho               echo                 = 2;
+    ResponseFlush              flush                = 3;
+    ResponseInfo               info                 = 4;
+    ResponseSetOption          set_option           = 5;
+    ResponseInitChain          init_chain           = 6;
+    ResponseQuery              query                = 7;
+    ResponseBeginBlock         begin_block          = 8;
+    ResponseCheckTx            check_tx             = 9;
+    ResponseDeliverTx          deliver_tx           = 10;
+    ResponseEndBlock           end_block            = 11;
+    ResponseCommit             commit               = 12;
+    ResponseListSnapshots      list_snapshots       = 13;
+    ResponseOfferSnapshot      offer_snapshot       = 14;
+    ResponseLoadSnapshotChunk  load_snapshot_chunk  = 15;
+    ResponseApplySnapshotChunk apply_snapshot_chunk = 16;
+  }
+}
+
+// nondeterministic
+message ResponseException {
+  string error = 1;
+}
+
+message ResponseEcho {
+  string message = 1;
+}
+
+message ResponseFlush {}
+
+message ResponseInfo {
+  string data = 1;
+
+  string version     = 2;
+  uint64 app_version = 3;
+
+  int64 last_block_height   = 4;
+  bytes last_block_app_hash = 5;
+}
+
+// nondeterministic
+message ResponseSetOption {
+  uint32 code = 1;
+  // bytes data = 2;
+  string log  = 3;
+  string info = 4;
+}
+
+message ResponseInitChain {
+  ConsensusParams          consensus_params = 1;
+  repeated ValidatorUpdate validators       = 2 [(gogoproto.nullable) = false];
+  bytes                    app_hash         = 3;
+}
+
+message ResponseQuery {
+  uint32 code = 1;
+  // bytes data = 2; // use "value" instead.
+  string                     log       = 3;  // nondeterministic
+  string                     info      = 4;  // nondeterministic
+  int64                      index     = 5;
+  bytes                      key       = 6;
+  bytes                      value     = 7;
+  tendermint.crypto.ProofOps proof_ops = 8;
+  int64                      height    = 9;
+  string                     codespace = 10;
+}
+
+message ResponseBeginBlock {
+  repeated Event events = 1
+      [(gogoproto.nullable) = false, (gogoproto.jsontag) = "events,omitempty"];
+}
+
+message ResponseCheckTx {
+  uint32         code       = 1;
+  bytes          data       = 2;
+  string         log        = 3;  // nondeterministic
+  string         info       = 4;  // nondeterministic
+  int64          gas_wanted = 5 [json_name = "gas_wanted"];
+  int64          gas_used   = 6 [json_name = "gas_used"];
+  repeated Event events     = 7
+      [(gogoproto.nullable) = false, (gogoproto.jsontag) = "events,omitempty"];
+  string codespace = 8;
+  string sender    = 9;
+  int64  priority  = 10;
+
+  // mempool_error is set by Tendermint.
+  // ABCI applictions creating a ResponseCheckTX should not set mempool_error.
+  string mempool_error = 11;
+}
+
+message ResponseDeliverTx {
+  uint32         code       = 1;
+  bytes          data       = 2;
+  string         log        = 3;  // nondeterministic
+  string         info       = 4;  // nondeterministic
+  int64          gas_wanted = 5 [json_name = "gas_wanted"];
+  int64          gas_used   = 6 [json_name = "gas_used"];
+  repeated Event events     = 7 [
+    (gogoproto.nullable) = false,
+    (gogoproto.jsontag)  = "events,omitempty"
+  ];  // nondeterministic
+  string codespace = 8;
+}
+
+message ResponseEndBlock {
+  repeated ValidatorUpdate validator_updates       = 1 [(gogoproto.nullable) = false];
+  ConsensusParams          consensus_param_updates = 2;
+  repeated Event           events                  = 3
+      [(gogoproto.nullable) = false, (gogoproto.jsontag) = "events,omitempty"];
+}
+
+message ResponseCommit {
+  // reserve 1
+  bytes data          = 2;
+  int64 retain_height = 3;
+}
+
+message ResponseListSnapshots {
+  repeated Snapshot snapshots = 1;
+}
+
+message ResponseOfferSnapshot {
+  Result result = 1;
+
+  enum Result {
+    UNKNOWN       = 0;  // Unknown result, abort all snapshot restoration
+    ACCEPT        = 1;  // Snapshot accepted, apply chunks
+    ABORT         = 2;  // Abort all snapshot restoration
+    REJECT        = 3;  // Reject this specific snapshot, try others
+    REJECT_FORMAT = 4;  // Reject all snapshots of this format, try others
+    REJECT_SENDER = 5;  // Reject all snapshots from the sender(s), try others
+  }
+}
+
+message ResponseLoadSnapshotChunk {
+  bytes chunk = 1;
+}
+
+message ResponseApplySnapshotChunk {
+  Result          result         = 1;
+  repeated uint32 refetch_chunks = 2;  // Chunks to refetch and reapply
+  repeated string reject_senders = 3;  // Chunk senders to reject and ban
+
+  enum Result {
+    UNKNOWN         = 0;  // Unknown result, abort all snapshot restoration
+    ACCEPT          = 1;  // Chunk successfully accepted
+    ABORT           = 2;  // Abort all snapshot restoration
+    RETRY           = 3;  // Retry chunk (combine with refetch and reject)
+    RETRY_SNAPSHOT  = 4;  // Retry snapshot (combine with refetch and reject)
+    REJECT_SNAPSHOT = 5;  // Reject this snapshot, try others
+  }
+}
+
+//----------------------------------------
+// Misc.
+
+// ConsensusParams contains all consensus-relevant parameters
+// that can be adjusted by the abci app
+message ConsensusParams {
+  BlockParams                      block     = 1;
+  tendermint.types.EvidenceParams  evidence  = 2;
+  tendermint.types.ValidatorParams validator = 3;
+  tendermint.types.VersionParams   version   = 4;
+}
+
+// BlockParams contains limits on the block size.
+message BlockParams {
+  // Note: must be greater than 0
+  int64 max_bytes = 1;
+  // Note: must be greater or equal to -1
+  int64 max_gas = 2;
+}
+
+message LastCommitInfo {
+  int32             round = 1;
+  repeated VoteInfo votes = 2 [(gogoproto.nullable) = false];
+}
+
+// Event allows application developers to attach additional information to
+// ResponseBeginBlock, ResponseEndBlock, ResponseCheckTx and ResponseDeliverTx.
+// Later, transactions may be queried using these events.
+message Event {
+  string                  type       = 1;
+  repeated EventAttribute attributes = 2 [
+    (gogoproto.nullable) = false,
+    (gogoproto.jsontag)  = "attributes,omitempty"
+  ];
+}
+
+// EventAttribute is a single key-value pair, associated with an event.
+message EventAttribute {
+  bytes key   = 1;
+  bytes value = 2;
+  bool  index = 3;  // nondeterministic
+}
+
+// TxResult contains results of executing the transaction.
+//
+// One usage is indexing transaction results.
+message TxResult {
+  int64             height = 1;
+  uint32            index  = 2;
+  bytes             tx     = 3;
+  ResponseDeliverTx result = 4 [(gogoproto.nullable) = false];
+}
+
+//----------------------------------------
+// Blockchain Types
+
+// Validator
+message Validator {
+  bytes address = 1;  // The first 20 bytes of SHA256(public key)
+  // PubKey pub_key = 2 [(gogoproto.nullable)=false];
+  int64 power = 3;  // The voting power
+}
+
+// ValidatorUpdate
+message ValidatorUpdate {
+  tendermint.crypto.PublicKey pub_key = 1 [(gogoproto.nullable) = false];
+  int64                       power   = 2;
+}
+
+// VoteInfo
+message VoteInfo {
+  Validator validator         = 1 [(gogoproto.nullable) = false];
+  bool      signed_last_block = 2;
+}
+
+enum EvidenceType {
+  UNKNOWN             = 0;
+  DUPLICATE_VOTE      = 1;
+  LIGHT_CLIENT_ATTACK = 2;
+}
+
+message Evidence {
+  EvidenceType type = 1;
+  // The offending validator
+  Validator validator = 2 [(gogoproto.nullable) = false];
+  // The height when the offense occurred
+  int64 height = 3;
+  // The corresponding time where the offense occurred
+  google.protobuf.Timestamp time = 4
+      [(gogoproto.nullable) = false, (gogoproto.stdtime) = true];
+  // Total voting power of the validator set in case the ABCI application does
+  // not store historical validators.
+  // https://github.com/tendermint/tendermint/issues/4581
+  int64 total_voting_power = 5;
+}
+
+//----------------------------------------
+// State Sync Types
+
+message Snapshot {
+  uint64 height   = 1;  // The height at which the snapshot was taken
+  uint32 format   = 2;  // The application-specific snapshot format
+  uint32 chunks   = 3;  // Number of chunks in the snapshot
+  bytes  hash     = 4;  // Arbitrary snapshot hash, equal only if identical
+  bytes  metadata = 5;  // Arbitrary application metadata
+}
+
+//----------------------------------------
+// Service Definition
+
+service ABCIApplication {
+  rpc Echo(RequestEcho) returns (ResponseEcho);
+  rpc Flush(RequestFlush) returns (ResponseFlush);
+  rpc Info(RequestInfo) returns (ResponseInfo);
+  rpc SetOption(RequestSetOption) returns (ResponseSetOption);
+  rpc DeliverTx(RequestDeliverTx) returns (ResponseDeliverTx);
+  rpc CheckTx(RequestCheckTx) returns (ResponseCheckTx);
+  rpc Query(RequestQuery) returns (ResponseQuery);
+  rpc Commit(RequestCommit) returns (ResponseCommit);
+  rpc InitChain(RequestInitChain) returns (ResponseInitChain);
+  rpc BeginBlock(RequestBeginBlock) returns (ResponseBeginBlock);
+  rpc EndBlock(RequestEndBlock) returns (ResponseEndBlock);
+  rpc ListSnapshots(RequestListSnapshots) returns (ResponseListSnapshots);
+  rpc OfferSnapshot(RequestOfferSnapshot) returns (ResponseOfferSnapshot);
+  rpc LoadSnapshotChunk(RequestLoadSnapshotChunk)
+      returns (ResponseLoadSnapshotChunk);
+  rpc ApplySnapshotChunk(RequestApplySnapshotChunk)
+      returns (ResponseApplySnapshotChunk);
+}

--- a/third_party/proto/tendermint/crypto/keys.proto
+++ b/third_party/proto/tendermint/crypto/keys.proto
@@ -1,0 +1,17 @@
+syntax = "proto3";
+package tendermint.crypto;
+
+option go_package = "github.com/tendermint/tendermint/proto/tendermint/crypto";
+
+import "gogoproto/gogo.proto";
+
+// PublicKey defines the keys available for use with Tendermint Validators
+message PublicKey {
+  option (gogoproto.compare) = true;
+  option (gogoproto.equal)   = true;
+
+  oneof sum {
+    bytes ed25519   = 1;
+    bytes secp256k1 = 2;
+  }
+}

--- a/third_party/proto/tendermint/crypto/proof.proto
+++ b/third_party/proto/tendermint/crypto/proof.proto
@@ -1,0 +1,41 @@
+syntax = "proto3";
+package tendermint.crypto;
+
+option go_package = "github.com/tendermint/tendermint/proto/tendermint/crypto";
+
+import "gogoproto/gogo.proto";
+
+message Proof {
+  int64          total     = 1;
+  int64          index     = 2;
+  bytes          leaf_hash = 3;
+  repeated bytes aunts     = 4;
+}
+
+message ValueOp {
+  // Encoded in ProofOp.Key.
+  bytes key = 1;
+
+  // To encode in ProofOp.Data
+  Proof proof = 2;
+}
+
+message DominoOp {
+  string key    = 1;
+  string input  = 2;
+  string output = 3;
+}
+
+// ProofOp defines an operation used for calculating Merkle root
+// The data could be arbitrary format, providing nessecary data
+// for example neighbouring node hash
+message ProofOp {
+  string type = 1;
+  bytes  key  = 2;
+  bytes  data = 3;
+}
+
+// ProofOps is Merkle proof defined by the list of ProofOps
+message ProofOps {
+  repeated ProofOp ops = 1 [(gogoproto.nullable) = false];
+}

--- a/third_party/proto/tendermint/libs/bits/types.proto
+++ b/third_party/proto/tendermint/libs/bits/types.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+package tendermint.libs.bits;
+
+option go_package = "github.com/tendermint/tendermint/proto/tendermint/libs/bits";
+
+message BitArray {
+  int64           bits  = 1;
+  repeated uint64 elems = 2;
+}

--- a/third_party/proto/tendermint/p2p/types.proto
+++ b/third_party/proto/tendermint/p2p/types.proto
@@ -1,0 +1,34 @@
+syntax = "proto3";
+package tendermint.p2p;
+
+option go_package = "github.com/tendermint/tendermint/proto/tendermint/p2p";
+
+import "gogoproto/gogo.proto";
+
+message NetAddress {
+  string id   = 1 [(gogoproto.customname) = "ID"];
+  string ip   = 2 [(gogoproto.customname) = "IP"];
+  uint32 port = 3;
+}
+
+message ProtocolVersion {
+  uint64 p2p   = 1 [(gogoproto.customname) = "P2P"];
+  uint64 block = 2;
+  uint64 app   = 3;
+}
+
+message DefaultNodeInfo {
+  ProtocolVersion      protocol_version = 1 [(gogoproto.nullable) = false];
+  string               default_node_id  = 2 [(gogoproto.customname) = "DefaultNodeID"];
+  string               listen_addr      = 3;
+  string               network          = 4;
+  string               version          = 5;
+  bytes                channels         = 6;
+  string               moniker          = 7;
+  DefaultNodeInfoOther other            = 8 [(gogoproto.nullable) = false];
+}
+
+message DefaultNodeInfoOther {
+  string tx_index    = 1;
+  string rpc_address = 2 [(gogoproto.customname) = "RPCAddress"];
+}

--- a/third_party/proto/tendermint/types/block.proto
+++ b/third_party/proto/tendermint/types/block.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+package tendermint.types;
+
+option go_package = "github.com/tendermint/tendermint/proto/tendermint/types";
+
+import "gogoproto/gogo.proto";
+import "tendermint/types/types.proto";
+import "tendermint/types/evidence.proto";
+
+message Block {
+  Header                        header      = 1 [(gogoproto.nullable) = false];
+  Data                          data        = 2 [(gogoproto.nullable) = false];
+  tendermint.types.EvidenceList evidence    = 3 [(gogoproto.nullable) = false];
+  Commit                        last_commit = 4;
+}

--- a/third_party/proto/tendermint/types/evidence.proto
+++ b/third_party/proto/tendermint/types/evidence.proto
@@ -1,0 +1,38 @@
+syntax = "proto3";
+package tendermint.types;
+
+option go_package = "github.com/tendermint/tendermint/proto/tendermint/types";
+
+import "gogoproto/gogo.proto";
+import "google/protobuf/timestamp.proto";
+import "tendermint/types/types.proto";
+import "tendermint/types/validator.proto";
+
+message Evidence {
+  oneof sum {
+    DuplicateVoteEvidence     duplicate_vote_evidence      = 1;
+    LightClientAttackEvidence light_client_attack_evidence = 2;
+  }
+}
+
+// DuplicateVoteEvidence contains evidence of a validator signed two conflicting votes.
+message DuplicateVoteEvidence {
+  tendermint.types.Vote     vote_a             = 1;
+  tendermint.types.Vote     vote_b             = 2;
+  int64                     total_voting_power = 3;
+  int64                     validator_power    = 4;
+  google.protobuf.Timestamp timestamp          = 5 [(gogoproto.nullable) = false, (gogoproto.stdtime) = true];
+}
+
+// LightClientAttackEvidence contains evidence of a set of validators attempting to mislead a light client.
+message LightClientAttackEvidence {
+  tendermint.types.LightBlock conflicting_block            = 1;
+  int64                       common_height                = 2;
+  repeated tendermint.types.Validator byzantine_validators = 3;
+  int64                               total_voting_power   = 4;
+  google.protobuf.Timestamp           timestamp            = 5 [(gogoproto.nullable) = false, (gogoproto.stdtime) = true];
+}
+
+message EvidenceList {
+  repeated Evidence evidence = 1 [(gogoproto.nullable) = false];
+}

--- a/third_party/proto/tendermint/types/params.proto
+++ b/third_party/proto/tendermint/types/params.proto
@@ -1,0 +1,80 @@
+syntax = "proto3";
+package tendermint.types;
+
+option go_package = "github.com/tendermint/tendermint/proto/tendermint/types";
+
+import "gogoproto/gogo.proto";
+import "google/protobuf/duration.proto";
+
+option (gogoproto.equal_all) = true;
+
+// ConsensusParams contains consensus critical parameters that determine the
+// validity of blocks.
+message ConsensusParams {
+  BlockParams     block     = 1 [(gogoproto.nullable) = false];
+  EvidenceParams  evidence  = 2 [(gogoproto.nullable) = false];
+  ValidatorParams validator = 3 [(gogoproto.nullable) = false];
+  VersionParams   version   = 4 [(gogoproto.nullable) = false];
+}
+
+// BlockParams contains limits on the block size.
+message BlockParams {
+  // Max block size, in bytes.
+  // Note: must be greater than 0
+  int64 max_bytes = 1;
+  // Max gas per block.
+  // Note: must be greater or equal to -1
+  int64 max_gas = 2;
+  // Minimum time increment between consecutive blocks (in milliseconds) If the
+  // block header timestamp is ahead of the system clock, decrease this value.
+  //
+  // Not exposed to the application.
+  int64 time_iota_ms = 3;
+}
+
+// EvidenceParams determine how we handle evidence of malfeasance.
+message EvidenceParams {
+  // Max age of evidence, in blocks.
+  //
+  // The basic formula for calculating this is: MaxAgeDuration / {average block
+  // time}.
+  int64 max_age_num_blocks = 1;
+
+  // Max age of evidence, in time.
+  //
+  // It should correspond with an app's "unbonding period" or other similar
+  // mechanism for handling [Nothing-At-Stake
+  // attacks](https://github.com/ethereum/wiki/wiki/Proof-of-Stake-FAQ#what-is-the-nothing-at-stake-problem-and-how-can-it-be-fixed).
+  google.protobuf.Duration max_age_duration = 2
+      [(gogoproto.nullable) = false, (gogoproto.stdduration) = true];
+
+  // This sets the maximum size of total evidence in bytes that can be committed in a single block.
+  // and should fall comfortably under the max block bytes.
+  // Default is 1048576 or 1MB
+  int64 max_bytes = 3;
+}
+
+// ValidatorParams restrict the public key types validators can use.
+// NOTE: uses ABCI pubkey naming, not Amino names.
+message ValidatorParams {
+  option (gogoproto.populate) = true;
+  option (gogoproto.equal)    = true;
+
+  repeated string pub_key_types = 1;
+}
+
+// VersionParams contains the ABCI application version.
+message VersionParams {
+  option (gogoproto.populate) = true;
+  option (gogoproto.equal)    = true;
+
+  uint64 app_version = 1;
+}
+
+// HashedParams is a subset of ConsensusParams.
+//
+// It is hashed into the Header.ConsensusHash.
+message HashedParams {
+  int64 block_max_bytes = 1;
+  int64 block_max_gas   = 2;
+}

--- a/third_party/proto/tendermint/types/types.proto
+++ b/third_party/proto/tendermint/types/types.proto
@@ -1,0 +1,157 @@
+syntax = "proto3";
+package tendermint.types;
+
+option go_package = "github.com/tendermint/tendermint/proto/tendermint/types";
+
+import "gogoproto/gogo.proto";
+import "google/protobuf/timestamp.proto";
+import "tendermint/crypto/proof.proto";
+import "tendermint/version/types.proto";
+import "tendermint/types/validator.proto";
+
+// BlockIdFlag indicates which BlcokID the signature is for
+enum BlockIDFlag {
+  option (gogoproto.goproto_enum_stringer) = true;
+  option (gogoproto.goproto_enum_prefix)   = false;
+
+  BLOCK_ID_FLAG_UNKNOWN = 0 [(gogoproto.enumvalue_customname) = "BlockIDFlagUnknown"];
+  BLOCK_ID_FLAG_ABSENT  = 1 [(gogoproto.enumvalue_customname) = "BlockIDFlagAbsent"];
+  BLOCK_ID_FLAG_COMMIT  = 2 [(gogoproto.enumvalue_customname) = "BlockIDFlagCommit"];
+  BLOCK_ID_FLAG_NIL     = 3 [(gogoproto.enumvalue_customname) = "BlockIDFlagNil"];
+}
+
+// SignedMsgType is a type of signed message in the consensus.
+enum SignedMsgType {
+  option (gogoproto.goproto_enum_stringer) = true;
+  option (gogoproto.goproto_enum_prefix)   = false;
+
+  SIGNED_MSG_TYPE_UNKNOWN = 0 [(gogoproto.enumvalue_customname) = "UnknownType"];
+  // Votes
+  SIGNED_MSG_TYPE_PREVOTE   = 1 [(gogoproto.enumvalue_customname) = "PrevoteType"];
+  SIGNED_MSG_TYPE_PRECOMMIT = 2 [(gogoproto.enumvalue_customname) = "PrecommitType"];
+
+  // Proposals
+  SIGNED_MSG_TYPE_PROPOSAL = 32 [(gogoproto.enumvalue_customname) = "ProposalType"];
+}
+
+// PartsetHeader
+message PartSetHeader {
+  uint32 total = 1;
+  bytes  hash  = 2;
+}
+
+message Part {
+  uint32                  index = 1;
+  bytes                   bytes = 2;
+  tendermint.crypto.Proof proof = 3 [(gogoproto.nullable) = false];
+}
+
+// BlockID
+message BlockID {
+  bytes         hash            = 1;
+  PartSetHeader part_set_header = 2 [(gogoproto.nullable) = false];
+}
+
+// --------------------------------
+
+// Header defines the structure of a Tendermint block header.
+message Header {
+  // basic block info
+  tendermint.version.Consensus version  = 1 [(gogoproto.nullable) = false];
+  string                       chain_id = 2 [(gogoproto.customname) = "ChainID"];
+  int64                        height   = 3;
+  google.protobuf.Timestamp    time     = 4 [(gogoproto.nullable) = false, (gogoproto.stdtime) = true];
+
+  // prev block info
+  BlockID last_block_id = 5 [(gogoproto.nullable) = false];
+
+  // hashes of block data
+  bytes last_commit_hash = 6;  // commit from validators from the last block
+  bytes data_hash        = 7;  // transactions
+
+  // hashes from the app output from the prev block
+  bytes validators_hash      = 8;   // validators for the current block
+  bytes next_validators_hash = 9;   // validators for the next block
+  bytes consensus_hash       = 10;  // consensus params for current block
+  bytes app_hash             = 11;  // state after txs from the previous block
+  bytes last_results_hash    = 12;  // root hash of all results from the txs from the previous block
+
+  // consensus info
+  bytes evidence_hash    = 13;  // evidence included in the block
+  bytes proposer_address = 14;  // original proposer of the block
+}
+
+// Data contains the set of transactions included in the block
+message Data {
+  // Txs that will be applied by state @ block.Height+1.
+  // NOTE: not all txs here are valid.  We're just agreeing on the order first.
+  // This means that block.AppHash does not include these txs.
+  repeated bytes txs = 1;
+}
+
+// Vote represents a prevote, precommit, or commit vote from validators for
+// consensus.
+message Vote {
+  SignedMsgType type     = 1;
+  int64         height   = 2;
+  int32         round    = 3;
+  BlockID       block_id = 4
+      [(gogoproto.nullable) = false, (gogoproto.customname) = "BlockID"];  // zero if vote is nil.
+  google.protobuf.Timestamp timestamp = 5
+      [(gogoproto.nullable) = false, (gogoproto.stdtime) = true];
+  bytes validator_address = 6;
+  int32 validator_index   = 7;
+  bytes signature         = 8;
+}
+
+// Commit contains the evidence that a block was committed by a set of validators.
+message Commit {
+  int64              height     = 1;
+  int32              round      = 2;
+  BlockID            block_id   = 3 [(gogoproto.nullable) = false, (gogoproto.customname) = "BlockID"];
+  repeated CommitSig signatures = 4 [(gogoproto.nullable) = false];
+}
+
+// CommitSig is a part of the Vote included in a Commit.
+message CommitSig {
+  BlockIDFlag               block_id_flag     = 1;
+  bytes                     validator_address = 2;
+  google.protobuf.Timestamp timestamp         = 3
+      [(gogoproto.nullable) = false, (gogoproto.stdtime) = true];
+  bytes signature = 4;
+}
+
+message Proposal {
+  SignedMsgType             type      = 1;
+  int64                     height    = 2;
+  int32                     round     = 3;
+  int32                     pol_round = 4;
+  BlockID                   block_id  = 5 [(gogoproto.customname) = "BlockID", (gogoproto.nullable) = false];
+  google.protobuf.Timestamp timestamp = 6
+      [(gogoproto.nullable) = false, (gogoproto.stdtime) = true];
+  bytes signature = 7;
+}
+
+message SignedHeader {
+  Header header = 1;
+  Commit commit = 2;
+}
+
+message LightBlock {
+  SignedHeader                  signed_header = 1;
+  tendermint.types.ValidatorSet validator_set = 2;
+}
+
+message BlockMeta {
+  BlockID block_id   = 1 [(gogoproto.customname) = "BlockID", (gogoproto.nullable) = false];
+  int64   block_size = 2;
+  Header  header     = 3 [(gogoproto.nullable) = false];
+  int64   num_txs    = 4;
+}
+
+// TxProof represents a Merkle proof of the presence of a transaction in the Merkle tree.
+message TxProof {
+  bytes                   root_hash = 1;
+  bytes                   data      = 2;
+  tendermint.crypto.Proof proof     = 3;
+}

--- a/third_party/proto/tendermint/types/validator.proto
+++ b/third_party/proto/tendermint/types/validator.proto
@@ -1,0 +1,25 @@
+syntax = "proto3";
+package tendermint.types;
+
+option go_package = "github.com/tendermint/tendermint/proto/tendermint/types";
+
+import "gogoproto/gogo.proto";
+import "tendermint/crypto/keys.proto";
+
+message ValidatorSet {
+  repeated Validator validators         = 1;
+  Validator          proposer           = 2;
+  int64              total_voting_power = 3;
+}
+
+message Validator {
+  bytes                       address           = 1;
+  tendermint.crypto.PublicKey pub_key           = 2 [(gogoproto.nullable) = false];
+  int64                       voting_power      = 3;
+  int64                       proposer_priority = 4;
+}
+
+message SimpleValidator {
+  tendermint.crypto.PublicKey pub_key      = 1;
+  int64                       voting_power = 2;
+}

--- a/third_party/proto/tendermint/version/types.proto
+++ b/third_party/proto/tendermint/version/types.proto
@@ -1,0 +1,24 @@
+syntax = "proto3";
+package tendermint.version;
+
+option go_package = "github.com/tendermint/tendermint/proto/tendermint/version";
+
+import "gogoproto/gogo.proto";
+
+// App includes the protocol and software version for the application.
+// This information is included in ResponseInfo. The App.Protocol can be
+// updated in ResponseEndBlock.
+message App {
+  uint64 protocol = 1;
+  string software = 2;
+}
+
+// Consensus captures the consensus rules for processing a block in the blockchain,
+// including all blockchain data structures and the rules of the application's
+// state transition machine.
+message Consensus {
+  option (gogoproto.equal) = true;
+
+  uint64 block = 1;
+  uint64 app   = 2;
+}


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

Closes: #12991

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
