### PR TITLE
fix(types): fill in `Type` field when emitting pulsar type events

### DIFF
--- a/types/events.go
+++ b/types/events.go
@@ -79,12 +79,13 @@ func (em *EventManager) EmitTypedEvents(tevs ...gogoproto.Message) error {
 
 // TypedEventToEvent takes typed event and converts to Event object
 func TypedEventToEvent(tev gogoproto.Message) (Event, error) {
-	var evtType string
-	if pulsarMsg, ok := tev.(proto.Message); ok {
-		evtType = string(proto.MessageName(pulsarMsg))
-	} else {
-		evtType = gogoproto.MessageName(tev)
+	evtType := gogoproto.MessageName(tev)
+	if evtType == "" {
+		if pulsarMsg, ok := tev.(proto.Message); ok {
+			evtType = string(proto.MessageName(pulsarMsg))
+		}
 	}
+
 	evtJSON, err := codec.ProtoMarshalJSON(tev, nil)
 	if err != nil {
 		return Event{}, err

--- a/types/events.go
+++ b/types/events.go
@@ -9,9 +9,10 @@ import (
 
 	"golang.org/x/exp/maps"
 	"golang.org/x/exp/slices"
+	proto2 "google.golang.org/protobuf/proto"
 
 	"github.com/gogo/protobuf/jsonpb"
-	proto "github.com/gogo/protobuf/proto"
+	"github.com/gogo/protobuf/proto"
 	abci "github.com/tendermint/tendermint/abci/types"
 
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -78,7 +79,12 @@ func (em *EventManager) EmitTypedEvents(tevs ...proto.Message) error {
 
 // TypedEventToEvent takes typed event and converts to Event object
 func TypedEventToEvent(tev proto.Message) (Event, error) {
-	evtType := proto.MessageName(tev)
+	var evtType string
+	if pulsarMsg, ok := tev.(proto2.Message); ok {
+		evtType = string(proto2.MessageName(pulsarMsg))
+	} else {
+		evtType = proto.MessageName(tev)
+	}
 	evtJSON, err := codec.ProtoMarshalJSON(tev, nil)
 	if err != nil {
 		return Event{}, err

--- a/types/events_test.go
+++ b/types/events_test.go
@@ -257,6 +257,7 @@ func (s *eventsTestSuite) TestMarkEventsToIndex() {
 }
 
 func (s *eventsTestSuite) TestEventProtoCompat() {
+	expected := "cosmos.nft.v1beta1.EventSend"
 	pulsarEvent := nftv1beta1.EventSend{
 		ClassId:  "foo",
 		Id:       "bar",
@@ -269,7 +270,7 @@ func (s *eventsTestSuite) TestEventProtoCompat() {
 
 	events := em.Events()
 	event := events[len(events)-1]
-	s.Require().NotEmpty(event.Type)
+	s.Require().Equal(expected, event.Type)
 
 	gogoEvent := nft.EventSend{
 		ClassId:  "corge",
@@ -283,5 +284,5 @@ func (s *eventsTestSuite) TestEventProtoCompat() {
 
 	events = em.Events()
 	event = events[len(events)-1]
-	s.Require().NotEmpty(event.Type)
+	s.Require().Equal(expected, event.Type)
 }


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

Fixes a bug where passing a Pulsar type to `EmitTypedEvent` would leave the `Type` field blank in the event.

Closes: #13022 

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
