### PR TITLE
feat(cli/module)!: separate the app genesis state by module into folders when export/import/validate

### DIFF
--- a/client/flags/flags.go
+++ b/client/flags/flags.go
@@ -77,6 +77,7 @@ const (
 	FlagTip              = "tip"
 	FlagAux              = "aux"
 	FlagOutput           = tmcli.OutputFlag
+	FlagGenesisFilePath  = "genesis-path"
 
 	// Tendermint logging flags
 	FlagLogLevel  = "log_level"

--- a/client/flags/flags.go
+++ b/client/flags/flags.go
@@ -77,7 +77,6 @@ const (
 	FlagTip              = "tip"
 	FlagAux              = "aux"
 	FlagOutput           = tmcli.OutputFlag
-	FlagGenesisFilePath  = "genesis-path"
 
 	// Tendermint logging flags
 	FlagLogLevel  = "log_level"

--- a/runtime/app.go
+++ b/runtime/app.go
@@ -121,6 +121,10 @@ func (a *App) EndBlocker(ctx sdk.Context, req abci.RequestEndBlock) abci.Respons
 
 // InitChainer initializes the chain.
 func (a *App) InitChainer(ctx sdk.Context, req abci.RequestInitChain) abci.ResponseInitChain {
+	if len(a.ModuleManager.GenesisPath) > 0 {
+		return a.ModuleManager.InitGenesis(ctx, a.cdc, nil)
+	}
+
 	var genesisState map[string]json.RawMessage
 	if err := json.Unmarshal(req.AppStateBytes, &genesisState); err != nil {
 		panic(err)

--- a/runtime/types.go
+++ b/runtime/types.go
@@ -32,7 +32,12 @@ type AppI interface {
 	LoadHeight(height int64) error
 
 	// Exports the state of the application for a genesis file.
-	ExportAppStateAndValidators(forZeroHeight bool, jailAllowedAddrs []string, modulesToExport []string) (types.ExportedApp, error)
+	ExportAppStateAndValidators(
+		forZeroHeight bool,
+		jailAllowedAddrs []string,
+		modulesToExport []string,
+		splitModules bool,
+	) (types.ExportedApp, error)
 
 	// Helper for the simulation framework.
 	SimulationManager() *module.SimulationManager

--- a/server/export.go
+++ b/server/export.go
@@ -5,6 +5,7 @@ package server
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/spf13/cobra"
 	tmjson "github.com/tendermint/tendermint/libs/json"
@@ -33,6 +34,11 @@ func ExportCmd(appExporter types.AppExporter, defaultNodeHome string) *cobra.Com
 
 			homeDir, _ := cmd.Flags().GetString(flags.FlagHome)
 			config.SetRoot(homeDir)
+
+			genesisExportPath, err := cmd.Flags().GetString(flags.FlagGenesisFilePath)
+			if err != nil {
+				return err
+			}
 
 			if _, err := os.Stat(config.GenesisFile()); os.IsNotExist(err) {
 				return err
@@ -96,17 +102,23 @@ func ExportCmd(appExporter types.AppExporter, defaultNodeHome string) *cobra.Com
 				},
 			}
 
-			// NOTE: Tendermint uses a custom JSON decoder for GenesisDoc
-			// (except for stuff inside AppState). Inside AppState, we're free
-			// to encode as protobuf or amino.
-			encoded, err := tmjson.Marshal(doc)
-			if err != nil {
-				return err
-			}
+			if len(genesisExportPath) > 0 {
+				if err := doc.SaveAs(filepath.Join(genesisExportPath, "genesis", "genesis.json")); err != nil {
+					return err
+				}
+			} else {
+				// NOTE: Tendermint uses a custom JSON decoder for GenesisDoc
+				// (except for stuff inside AppState). Inside AppState, we're free
+				// to encode as protobuf or amino.
+				encoded, err := tmjson.Marshal(doc)
+				if err != nil {
+					return err
+				}
 
-			cmd.SetOut(cmd.OutOrStdout())
-			cmd.SetErr(cmd.OutOrStderr())
-			cmd.Println(string(sdk.MustSortJSON(encoded)))
+				cmd.SetOut(cmd.OutOrStdout())
+				cmd.SetErr(cmd.OutOrStderr())
+				cmd.Println(string(sdk.MustSortJSON(encoded)))
+			}
 			return nil
 		},
 	}
@@ -116,6 +128,7 @@ func ExportCmd(appExporter types.AppExporter, defaultNodeHome string) *cobra.Com
 	cmd.Flags().Bool(FlagForZeroHeight, false, "Export state to start at height zero (perform preproccessing)")
 	cmd.Flags().StringSlice(FlagJailAllowedAddrs, []string{}, "Comma-separated list of operator addresses of jailed validators to unjail")
 	cmd.Flags().StringSlice(FlagModulesToExport, []string{}, "Comma-separated list of modules to export. If empty, will export all modules")
+	cmd.Flags().String(flags.FlagGenesisFilePath, "", "Export state to the designated file path")
 
 	return cmd
 }

--- a/server/types/app.go
+++ b/server/types/app.go
@@ -83,5 +83,5 @@ type (
 
 	// AppExporter is a function that dumps all app state to
 	// JSON-serializable structure and returns the current validator set.
-	AppExporter func(log.Logger, dbm.DB, io.Writer, int64, bool, []string, AppOptions, []string) (ExportedApp, error)
+	AppExporter func(log.Logger, dbm.DB, io.Writer, int64, bool, []string, AppOptions, []string, bool) (ExportedApp, error)
 )

--- a/simapp/app.go
+++ b/simapp/app.go
@@ -326,7 +326,10 @@ func (app *SimApp) Name() string { return app.BaseApp.Name() }
 func (app *SimApp) InitChainer(ctx sdk.Context, req abci.RequestInitChain) abci.ResponseInitChain {
 	jsonObj := make(map[string]json.RawMessage)
 	jsonObj["module_genesis_state"] = []byte("true")
-	loadAppStateFromFolder, _ := json.Marshal(jsonObj)
+	loadAppStateFromFolder, err := json.Marshal(jsonObj)
+	if err != nil {
+		panic(err)
+	}
 	buf := bytes.NewBuffer(nil)
 	if err := json.Compact(buf, req.AppStateBytes); err != nil {
 		panic(err)

--- a/simapp/app.go
+++ b/simapp/app.go
@@ -327,13 +327,13 @@ func (app *SimApp) InitChainer(ctx sdk.Context, req abci.RequestInitChain) abci.
 	jsonObj := make(map[string]json.RawMessage)
 	jsonObj["module_genesis_state"] = []byte("true")
 	loadAppStateFromFolder, _ := json.Marshal(jsonObj)
-	var genesisState GenesisState
-	if bytes.Equal(loadAppStateFromFolder, req.AppStateBytes) {
-		app.ModuleManager.SetGenesisPath(filepath.Join(app.homepath, "config", "genesis"))
-	} else {
-		if err := json.Unmarshal(req.AppStateBytes, &genesisState); err != nil {
-			panic(err)
-		}
+	buf := bytes.NewBuffer(nil)
+	if err := json.Compact(buf, req.AppStateBytes); err != nil {
+		panic(err)
+	}
+
+	if bytes.Equal(loadAppStateFromFolder, buf.Bytes()) {
+		app.App.ModuleManager.SetGenesisPath(filepath.Join(app.homepath, "config", "genesis"))
 	}
 
 	app.UpgradeKeeper.SetModuleVersionMap(ctx, app.ModuleManager.GetVersionMap())

--- a/simapp/app.go
+++ b/simapp/app.go
@@ -250,7 +250,6 @@ func NewSimApp(
 
 	app.App = appBuilder.Build(logger, db, traceStore, baseAppOptions...)
 	app.homepath = cast.ToString(appOpts.Get(flags.FlagHome))
-
 	ep := cast.ToString(appOpts.Get(flags.FlagGenesisFilePath))
 	if len(ep) > 0 {
 		app.exportpath = filepath.Join(ep, "genesis")

--- a/simapp/app_legacy.go
+++ b/simapp/app_legacy.go
@@ -197,11 +197,7 @@ type SimApp struct {
 	// module configurator
 	configurator module.Configurator
 
-	// the root folder of the app config and data
-	homepath string
-
-	// the path for the genesis state exporting
-	exportpath string
+	appOpts servertypes.AppOptions
 }
 
 func init() {
@@ -263,12 +259,7 @@ func NewSimApp(
 		keys:              keys,
 		tkeys:             tkeys,
 		memKeys:           memKeys,
-	}
-
-	app.homepath = cast.ToString(appOpts.Get(flags.FlagHome))
-	ep := cast.ToString(appOpts.Get(flags.FlagGenesisFilePath))
-	if len(ep) > 0 {
-		app.exportpath = filepath.Join(ep, "genesis")
+		appOpts:           appOpts,
 	}
 
 	app.ParamsKeeper = initParamsKeeper(appCodec, legacyAmino, keys[paramstypes.StoreKey], tkeys[paramstypes.TStoreKey])
@@ -571,7 +562,8 @@ func (app *SimApp) InitChainer(ctx sdk.Context, req abci.RequestInitChain) abci.
 
 	var genesisState GenesisState
 	if bytes.Equal(loadAppStateFromFolder, buf.Bytes()) {
-		app.ModuleManager.SetGenesisPath(filepath.Join(app.homepath, "config", "genesis"))
+		homepath := cast.ToString(app.appOpts.Get(flags.FlagHome))
+		app.ModuleManager.GenesisPath = filepath.Join(homepath, "config", "genesis")
 	} else {
 		if err := json.Unmarshal(req.AppStateBytes, &genesisState); err != nil {
 			panic(err)

--- a/simapp/app_test.go
+++ b/simapp/app_test.go
@@ -60,7 +60,7 @@ func TestSimAppExportAndBlockedAddrs(t *testing.T) {
 	logger2 := log.NewTMLogger(log.NewSyncWriter(os.Stdout))
 	// Making a new app object with the db, so that initchain hasn't been called
 	app2 := NewSimApp(logger2, db, nil, true, simtestutil.NewAppOptionsWithFlagHome(DefaultNodeHome))
-	_, err := app2.ExportAppStateAndValidators(false, []string{}, []string{})
+	_, err := app2.ExportAppStateAndValidators(false, []string{}, []string{}, false)
 	require.NoError(t, err, "ExportAppStateAndValidators should not have an error")
 }
 

--- a/simapp/export.go
+++ b/simapp/export.go
@@ -28,10 +28,25 @@ func (app *SimApp) ExportAppStateAndValidators(forZeroHeight bool, jailAllowedAd
 		app.prepForZeroHeightGenesis(ctx, jailAllowedAddrs)
 	}
 
-	genState := app.ModuleManager.ExportGenesisForModules(ctx, app.appCodec, modulesToExport)
-	appState, err := json.MarshalIndent(genState, "", "  ")
+	app.ModuleManager.SetGenesisPath(app.exportpath)
+	genState, err := app.ModuleManager.ExportGenesisForModules(ctx, app.appCodec, modulesToExport)
 	if err != nil {
 		return servertypes.ExportedApp{}, err
+	}
+
+	var appState []byte
+	if app.exportpath != "" {
+		jsonObj := make(map[string]json.RawMessage)
+		jsonObj["module_genesis_state"] = []byte("true")
+		appState, err = json.MarshalIndent(jsonObj, "", "  ")
+		if err != nil {
+			return servertypes.ExportedApp{}, err
+		}
+	} else {
+		appState, err = json.MarshalIndent(genState, "", "  ")
+		if err != nil {
+			return servertypes.ExportedApp{}, err
+		}
 	}
 
 	validators, err := staking.WriteValidators(ctx, app.StakingKeeper)

--- a/simapp/sim_test.go
+++ b/simapp/sim_test.go
@@ -134,7 +134,7 @@ func TestAppImportExport(t *testing.T) {
 	require.Equal(t, "SimApp", app.Name())
 
 	// Run randomized simulation and export the genesis state
-	exported := randomSimulation(t, app, config, db)
+	exported := randomSimulation(t, app, config, db, false)
 
 	fmt.Printf("importing genesis...\n")
 
@@ -218,7 +218,7 @@ func TestAppSimulationAfterImport(t *testing.T) {
 
 	fmt.Printf("exporting genesis...\n")
 
-	exported, err := app.ExportAppStateAndValidators(true, []string{}, []string{})
+	exported, err := app.ExportAppStateAndValidators(true, []string{}, []string{}, false)
 	require.NoError(t, err)
 
 	fmt.Printf("importing genesis...\n")
@@ -341,15 +341,14 @@ func TestAppImportExportWithAppStatePath(t *testing.T) {
 	tmp := t.TempDir()
 
 	appOptions := make(simtestutil.AppOptionsMap, 0)
-	appOptions[flags.FlagHome] = DefaultNodeHome
+	appOptions[flags.FlagHome] = tmp
 	appOptions[server.FlagInvCheckPeriod] = simcli.FlagPeriodValue
-	appOptions[flags.FlagGenesisFilePath] = tmp
 
 	app := NewSimApp(logger, db, nil, true, appOptions, fauxMerkleModeOpt)
 	require.Equal(t, "SimApp", app.Name())
 
 	// Run randomized simulation and export the genesis state
-	exported := randomSimulation(t, app, config, db)
+	exported := randomSimulation(t, app, config, db, true)
 
 	fmt.Printf("importing genesis...\n")
 
@@ -375,11 +374,11 @@ func TestAppImportExportWithAppStatePath(t *testing.T) {
 		}
 	}()
 
-	newApp.ModuleManager.SetGenesisPath(tmp)
+	newApp.ModuleManager.GenesisPath = tmp
 	checkStoresAfterInitGenesis(t, app, newApp, exported.ConsensusParams, nil)
 }
 
-func randomSimulation(t *testing.T, app *SimApp, config simtypes.Config, db dbm.DB) servertypes.ExportedApp {
+func randomSimulation(t *testing.T, app *SimApp, config simtypes.Config, db dbm.DB, splitModule bool) servertypes.ExportedApp {
 	_, simParams, simErr := simulation.SimulateFromSeed(
 		t,
 		os.Stdout,
@@ -403,7 +402,7 @@ func randomSimulation(t *testing.T, app *SimApp, config simtypes.Config, db dbm.
 
 	fmt.Printf("exporting genesis...\n")
 
-	exported, err := app.ExportAppStateAndValidators(false, []string{}, []string{})
+	exported, err := app.ExportAppStateAndValidators(false, []string{}, []string{}, splitModule)
 	require.NoError(t, err)
 
 	return exported

--- a/simapp/simd/cmd/root.go
+++ b/simapp/simd/cmd/root.go
@@ -176,7 +176,6 @@ func initRootCmd(rootCmd *cobra.Command, encodingConfig params.EncodingConfig) {
 		genutilcli.CollectGenTxsCmd(banktypes.GenesisBalancesIterator{}, simapp.DefaultNodeHome,
 			gentxModule.GenTxValidator),
 		genutilcli.MigrateGenesisCmd(),
-
 		genutilcli.GenTxCmd(simapp.ModuleBasics, encodingConfig.TxConfig,
 			banktypes.GenesisBalancesIterator{}, simapp.DefaultNodeHome),
 		genutilcli.ValidateGenesisCmd(simapp.ModuleBasics),

--- a/simapp/simd/cmd/root.go
+++ b/simapp/simd/cmd/root.go
@@ -319,6 +319,7 @@ func appExport(
 	jailAllowedAddrs []string,
 	appOpts servertypes.AppOptions,
 	modulesToExport []string,
+	splitModules bool,
 ) (servertypes.ExportedApp, error) {
 	var simApp *simapp.SimApp
 
@@ -348,5 +349,5 @@ func appExport(
 		simApp = simapp.NewSimApp(logger, db, traceStore, true, appOpts)
 	}
 
-	return simApp.ExportAppStateAndValidators(forZeroHeight, jailAllowedAddrs, modulesToExport)
+	return simApp.ExportAppStateAndValidators(forZeroHeight, jailAllowedAddrs, modulesToExport, splitModules)
 }

--- a/simapp/simd/cmd/root.go
+++ b/simapp/simd/cmd/root.go
@@ -176,6 +176,7 @@ func initRootCmd(rootCmd *cobra.Command, encodingConfig params.EncodingConfig) {
 		genutilcli.CollectGenTxsCmd(banktypes.GenesisBalancesIterator{}, simapp.DefaultNodeHome,
 			gentxModule.GenTxValidator),
 		genutilcli.MigrateGenesisCmd(),
+
 		genutilcli.GenTxCmd(simapp.ModuleBasics, encodingConfig.TxConfig,
 			banktypes.GenesisBalancesIterator{}, simapp.DefaultNodeHome),
 		genutilcli.ValidateGenesisCmd(simapp.ModuleBasics),

--- a/tests/e2e/server/export_test.go
+++ b/tests/e2e/server/export_test.go
@@ -157,7 +157,16 @@ func setupApp(t *testing.T, tempDir string) (*simapp.SimApp, context.Context, *t
 	app.Commit()
 
 	cmd := server.ExportCmd(
-		func(_ log.Logger, _ dbm.DB, _ io.Writer, height int64, forZeroHeight bool, jailAllowedAddrs []string, appOptions types.AppOptions, modulesToExport []string) (types.ExportedApp, error) {
+		func(
+			_ log.Logger,
+			_ dbm.DB,
+			_ io.Writer,
+			height int64,
+			forZeroHeight bool,
+			jailAllowedAddrs []string,
+			appOptions types.AppOptions,
+			modulesToExport []string,
+			splitModules bool) (types.ExportedApp, error) {
 			var simApp *simapp.SimApp
 			if height != -1 {
 				simApp = simapp.NewSimApp(logger, db, nil, false, appOptions)
@@ -169,7 +178,7 @@ func setupApp(t *testing.T, tempDir string) (*simapp.SimApp, context.Context, *t
 				simApp = simapp.NewSimApp(logger, db, nil, true, appOptions)
 			}
 
-			return simApp.ExportAppStateAndValidators(forZeroHeight, jailAllowedAddrs, modulesToExport, false)
+			return simApp.ExportAppStateAndValidators(forZeroHeight, jailAllowedAddrs, modulesToExport, splitModules)
 		}, tempDir)
 
 	ctx := context.Background()

--- a/tests/e2e/server/export_test.go
+++ b/tests/e2e/server/export_test.go
@@ -169,7 +169,7 @@ func setupApp(t *testing.T, tempDir string) (*simapp.SimApp, context.Context, *t
 				simApp = simapp.NewSimApp(logger, db, nil, true, appOptions)
 			}
 
-			return simApp.ExportAppStateAndValidators(forZeroHeight, jailAllowedAddrs, modulesToExport)
+			return simApp.ExportAppStateAndValidators(forZeroHeight, jailAllowedAddrs, modulesToExport, false)
 		}, tempDir)
 
 	ctx := context.Background()

--- a/testutil/sims/simulation_helpers.go
+++ b/testutil/sims/simulation_helpers.go
@@ -72,7 +72,7 @@ func SimulationOperations(app runtime.AppI, cdc codec.JSONCodec, config simtypes
 func CheckExportSimulation(app runtime.AppI, config simtypes.Config, params simtypes.Params) error {
 	if config.ExportStatePath != "" {
 		fmt.Println("exporting app state...")
-		exported, err := app.ExportAppStateAndValidators(false, nil, nil)
+		exported, err := app.ExportAppStateAndValidators(false, nil, nil, false)
 		if err != nil {
 			return err
 		}

--- a/types/module/module.go
+++ b/types/module/module.go
@@ -363,6 +363,8 @@ func (m *Manager) ExportGenesisForModules(ctx sdk.Context, cdc codec.JSONCodec, 
 				return nil, fmt.Errorf("ExportGenesis to file failed, module=%s err=%v", moduleName, err)
 			}
 		}
+
+		return genesisData, nil
 	}
 
 	// b.

--- a/types/module/module.go
+++ b/types/module/module.go
@@ -614,6 +614,7 @@ func DefaultMigrationsOrder(modules []string) []string {
 	return out
 }
 
+// CreateExportFile creates new file for exporting the module genesus state
 func CreateExportFile(exportPath string, moduleName string, index int) (*os.File, error) {
 	if err := os.MkdirAll(exportPath, 0o700); err != nil {
 		return nil, fmt.Errorf("failed to create directory: %w", err)
@@ -628,6 +629,7 @@ func CreateExportFile(exportPath string, moduleName string, index int) (*os.File
 	return f, nil
 }
 
+// OpenModuleStateFile opens the genesis state file given the path, module name, and file index
 func OpenModuleStateFile(importPath string, moduleName string, index int) (*os.File, error) {
 	fp := filepath.Join(importPath, fmt.Sprintf("genesis_%s_%d.bin", moduleName, index))
 	f, err := os.OpenFile(filepath.Clean(fp), os.O_RDONLY, 0o600)

--- a/types/module/module.go
+++ b/types/module/module.go
@@ -33,7 +33,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"math"
 	"os"
 	"path/filepath"
 	"sort"
@@ -656,7 +655,12 @@ func byteChunk(bz []byte, index int) []byte {
 
 // byteChunks calculates the number of chunks in the byte slice.
 func byteChunks(bz []byte) int {
-	return int(math.Ceil(float64(len(bz)) / float64(stateChunkSize)))
+	bzs := len(bz)
+	if bzs%stateChunkSize == 0 {
+		return bzs / stateChunkSize
+	}
+
+	return bzs/stateChunkSize + 1
 }
 
 // fileWrite writes the module's genesis state into files, each file containing

--- a/types/module/module.go
+++ b/types/module/module.go
@@ -32,7 +32,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -696,7 +695,7 @@ func fileWrite(modulePath, moduleName string, bz []byte) error {
 // FileRead reads the module's genesus state given the file path and the module name, returns json encoded
 // data
 func FileRead(modulePath string, moduleName string) ([]byte, error) {
-	files, err := ioutil.ReadDir(modulePath)
+	files, err := os.ReadDir(modulePath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read folder from %s: %w", modulePath, err)
 	}

--- a/types/module/module_test.go
+++ b/types/module/module_test.go
@@ -206,12 +206,12 @@ func TestManager_ExportGenesis(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, want, actual)
 
-	actual, err = mm.ExportGenesisForModules(ctx, cdc, []string{})
+	actual, err = mm.ExportGenesisForModules(ctx, cdc, []string{}, false)
 	require.NoError(t, err)
 	require.Equal(t, want, actual)
 
 	require.Panics(t, func() {
-		mm.ExportGenesisForModules(ctx, cdc, []string{"module1", "modulefoo"})
+		mm.ExportGenesisForModules(ctx, cdc, []string{"module1", "modulefoo"}, false)
 	})
 }
 
@@ -423,7 +423,7 @@ func TestManager_InitGenesisWithPath(t *testing.T) {
 	require.NoError(t, err)
 
 	// set the file import path
-	mm.SetGenesisPath(tmp)
+	mm.GenesisPath = tmp
 	var res abci.ResponseInitChain
 	require.NotPanics(t, func() {
 		res = mm.InitGenesis(ctx, cdc, nil)
@@ -462,10 +462,10 @@ func TestManager_ExportGenesisWithPath(t *testing.T) {
 	mockAppModule2.EXPECT().ExportGenesis(gomock.Eq(ctx), gomock.Eq(cdc)).Times(1).Return(appGenesisState[mod2])
 
 	// assign the export path
-	mm.SetGenesisPath(tmp)
+	mm.GenesisPath = tmp
 
 	// run actual genesis state export
-	actual, err := mm.ExportGenesis(ctx, cdc)
+	actual, err := mm.ExportGenesisForModules(ctx, cdc, []string{}, true)
 	require.NoError(t, err)
 	require.Equal(t, make(map[string]json.RawMessage), actual)
 

--- a/types/module/module_test.go
+++ b/types/module/module_test.go
@@ -198,8 +198,14 @@ func TestManager_ExportGenesis(t *testing.T) {
 		"module1": json.RawMessage(`{"key1": "value1"}`),
 		"module2": json.RawMessage(`{"key2": "value2"}`),
 	}
-	require.Equal(t, want, mm.ExportGenesis(ctx, cdc))
-	require.Equal(t, want, mm.ExportGenesisForModules(ctx, cdc, []string{}))
+
+	actual, err := mm.ExportGenesis(ctx, cdc)
+	require.NoError(t, err)
+	require.Equal(t, want, actual)
+
+	actual, err = mm.ExportGenesisForModules(ctx, cdc, []string{})
+	require.NoError(t, err)
+	require.Equal(t, want, actual)
 
 	require.Panics(t, func() {
 		mm.ExportGenesisForModules(ctx, cdc, []string{"module1", "modulefoo"})

--- a/x/authz/client/testutil/grpc.go
+++ b/x/authz/client/testutil/grpc.go
@@ -186,7 +186,7 @@ func (s *IntegrationTestSuite) TestQueryGranterGrantsGRPC() {
 		},
 		{
 			"no authorizations found",
-			fmt.Sprintf("%s/cosmos/authz/v1beta1/grants/granter/%s", val.APIAddress, grantee.String()),
+			fmt.Sprintf("%s/cosmos/authz/v1beta1/grants/granter/%s", val.APIAddress, string(grantee)),
 			false,
 			"",
 			0,
@@ -245,7 +245,7 @@ func (s *IntegrationTestSuite) TestQueryGranteeGrantsGRPC() {
 		},
 		{
 			"valid query",
-			fmt.Sprintf("%s/cosmos/authz/v1beta1/grants/grantee/%s", val.APIAddress, grantee.String()),
+			fmt.Sprintf("%s/cosmos/authz/v1beta1/grants/grantee/%s", val.APIAddress, string(grantee)),
 			false,
 			"",
 			1,

--- a/x/genutil/client/cli/validate_genesis.go
+++ b/x/genutil/client/cli/validate_genesis.go
@@ -57,13 +57,7 @@ func ValidateGenesisCmd(mbm module.BasicManager) *cobra.Command {
 				}
 
 				for _, b := range mbm {
-					f, err := module.OpenGenesisModuleFile(filepath.Join(genesisFilePath, b.Name()), b.Name())
-					if err != nil {
-						return err
-					}
-					defer f.Close()
-
-					bz, err := module.FileRead(f)
+					bz, err := module.FileRead(filepath.Join(genesisFilePath, b.Name()), b.Name())
 					if err != nil {
 						return err
 					}

--- a/x/genutil/client/cli/validate_genesis.go
+++ b/x/genutil/client/cli/validate_genesis.go
@@ -100,7 +100,7 @@ func ValidateGenesisCmd(mbm module.BasicManager) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().Bool(FlagValidateSplitModules, false, "validate the modules' genesis state in appHome/genesis folder")
+	cmd.Flags().Bool(FlagValidateSplitModules, false, "validate the modules' genesis state in current working path")
 
 	return cmd
 }


### PR DESCRIPTION
## Description

Closes: #12808

updates:
add extra arguments in ExportAppStateAndValidators (API-breaking). Since #13437 already added this new API, it should be fine if this PR is accepted and released in the same SDK version.

### Implementation
- Export
add `split-modules` flag in the cli `export`, the app will export the genesis state to the current working path and name it `genesis`. otherwise, the export cli will export the whole app genesis state into a `genesis.json` file (the current default export method)

- Validate
use `validate-split-modules` flag in the cli `validate-genesis`, to validate the exported `genesis` folder

- Import (InitChain)
 a. clean out the app data directory, i.e. `home/.simapp/data`. 
 b. copy/move the exported `genesis` folder to the app config directory, i.e. `home/.simapp/config`. 
 c. copy/move `genesis.json` in the`genesis` folder to the app config directory
 d. re-start the app


The structure in the`genesis` folder will be (the gray background meaning it's a folder):

`genesis`
> genesis.json
> `A(module)`
>> genesis_A_0.bin

If the module state is more than 100 MB (currently hard cording), it will split into several files
> `B(module)`
>> genesis_B_0.bin
>> genesis_B_1.bin
>> genesis_B_Y.bin

> `X(module)`
>> genesis_X_0.bin


- [x] document update
- [x] integrating tests

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
- [x] provided a link to the relevant issue or specification
- [x] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/building-modules)
- [x] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [x] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [x] updated the relevant documentation or specification
- [x] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
