### PR TITLE
feat(x/auth): Add auth sim decoder case for AccountNumberStoreKeyPrefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * [#12455](https://github.com/cosmos/cosmos-sdk/pull/12455) Show attempts count in error for signing. 
 * [#12886](https://github.com/cosmos/cosmos-sdk/pull/12886) Amortize cost of processing cache KV store
 * [#12953](https://github.com/cosmos/cosmos-sdk/pull/12953) Change the default priority mechanism to be based on gas price.
+* [#13048](https://github.com/cosmos/cosmos-sdk/pull/13048) Add handling of AccountNumberStoreKeyPrefix to the x/auth simulation decoder.
 
 ### State Machine Breaking
 

--- a/x/auth/simulation/decoder.go
+++ b/x/auth/simulation/decoder.go
@@ -7,6 +7,7 @@ import (
 	gogotypes "github.com/gogo/protobuf/types"
 
 	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/kv"
 	"github.com/cosmos/cosmos-sdk/x/auth/types"
 )
@@ -40,6 +41,20 @@ func NewDecodeStore(ak AuthUnmarshaler) func(kvA, kvB kv.Pair) string {
 			ak.GetCodec().MustUnmarshal(kvB.Value, &globalAccNumberB)
 
 			return fmt.Sprintf("GlobalAccNumberA: %d\nGlobalAccNumberB: %d", globalAccNumberA, globalAccNumberB)
+
+		case bytes.HasPrefix(kvA.Key, types.AccountNumberStoreKeyPrefix):
+			var accNumA, accNumB sdk.AccAddress
+			err := accNumA.Unmarshal(kvA.Value)
+			if err != nil {
+				panic(err)
+			}
+
+			err = accNumB.Unmarshal(kvB.Value)
+			if err != nil {
+				panic(err)
+			}
+
+			return fmt.Sprintf("AccNumA: %s\nAccNumB: %s", accNumA, accNumB)
 
 		default:
 			panic(fmt.Sprintf("unexpected %s key %X (%s)", types.ModuleName, kvA.Key, kvA.Key))

--- a/x/auth/simulation/decoder_test.go
+++ b/x/auth/simulation/decoder_test.go
@@ -52,6 +52,10 @@ func TestDecodeStore(t *testing.T) {
 				Value: cdc.MustMarshal(&globalAccNumber),
 			},
 			{
+				Key:   types.AccountNumberStoreKey(5),
+				Value: acc.GetAddress().Bytes(),
+			},
+			{
 				Key:   []byte{0x99},
 				Value: []byte{0x99},
 			},
@@ -63,6 +67,7 @@ func TestDecodeStore(t *testing.T) {
 	}{
 		{"Account", fmt.Sprintf("%v\n%v", acc, acc)},
 		{"GlobalAccNumber", fmt.Sprintf("GlobalAccNumberA: %d\nGlobalAccNumberB: %d", globalAccNumber, globalAccNumber)},
+		{"AccNum", fmt.Sprintf("AccNumA: %s\nAccNumB: %s", acc.GetAddress(), acc.GetAddress())},
 		{"other", ""},
 	}
 


### PR DESCRIPTION
## Description

Closes: #13028

This PR adds handling for the `AccountNumberStoreKeyPrefix` in the simulation decoder for the `x/auth` module.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] ~~added `!` to the type prefix if API or client breaking change~~ _N/A_
- [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
- [x] provided a link to the relevant issue or specification
- [x] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/building-modules)
- [x] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
- [x] added a changelog entry to `CHANGELOG.md`
- [x] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] ~~updated the relevant documentation or specification~~ _N/A_
- [x] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
