### PR TITLE
docs: prepare cosmovisor 1.3.0 release

### DIFF
--- a/cosmovisor/CHANGELOG.md
+++ b/cosmovisor/CHANGELOG.md
@@ -36,9 +36,16 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
-* [#13221](https://github.com/cosmos/cosmos-sdk/pull/13221) Fix `go install`.
+## v1.3.0 2022-09-11
+
+### Improvements
+
 * [#12921](https://github.com/cosmos/cosmos-sdk/pull/12918) Add documentation about expected plan path name.
 * [#12918](https://github.com/cosmos/cosmos-sdk/pull/12918) Automatically set version using module version.
+
+### Bug Fixes
+
+* [#13221](https://github.com/cosmos/cosmos-sdk/pull/13221) Fix `go install`.
 
 ## v1.2.0 2022-07-26
 
@@ -49,7 +56,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * [\#11823](https://github.com/cosmos/cosmos-sdk/pull/11823) Refactor `cosmovisor` CLI to use `cobra`.
 * [\#11731](https://github.com/cosmos/cosmos-sdk/pull/11731) `cosmovisor version -o json` returns the cosmovisor version and the result of `simd --output json --long` in one JSON object.
 
-### Bugfix
+### Bug Fixes
 
 * [\#12005](https://github.com/cosmos/cosmos-sdk/pull/12005) Fix cosmovisor binary usage for pre-upgrade
 

--- a/cosmovisor/README.md
+++ b/cosmovisor/README.md
@@ -35,13 +35,13 @@ Cosmovisor is designed to be used as a wrapper for a `Cosmos SDK` app:
 
 Cosmovisor is part of the Cosmos SDK monorepo, but it's a separate module with it's own release schedule.
 
-Release branches have the following format `release/cosmovisor/vA.B.x`, where A and B are a number (e.g. `release/cosmovisor/v1.2.x`). Releases are tagged using the following format: `cosmovisor/vA.B.C`.
+Release branches have the following format `release/cosmovisor/vA.B.x`, where A and B are a number (e.g. `release/cosmovisor/v1.3.x`). Releases are tagged using the following format: `cosmovisor/vA.B.C`.
 
 ## Setup
 
 ### Installation
 
-You can download Cosmovisor from the [Github releases](https://github.com/cosmos/cosmos-sdk/releases/tag/cosmovisor%2Fv1.2.1).
+You can download Cosmovisor from the [GitHub releases](https://github.com/cosmos/cosmos-sdk/releases/tag/cosmovisor%2Fv1.3.0).
 
 To install the latest version of `cosmovisor`, run the following command:
 

--- a/cosmovisor/RELEASE_NOTES.md
+++ b/cosmovisor/RELEASE_NOTES.md
@@ -1,6 +1,4 @@
-# Cosmovisor v1.2.1 Release Notes
-
-### Bug Fixes
+# Cosmovisor v1.3.0 Release Notes
 
 * Fix failure when installing cosmovisor via `go install`.
 


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

Closes: #11305
Prepares for tagging Cosmovisor 1.3.0

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
