### PR TITLE
fix: crypto/keys/secp246k1/*: add +build cgo guard to avoid failure with CGO_ENABLED=0

### DIFF
--- a/crypto/keys/secp256k1/internal/secp256k1/secp256_test.go
+++ b/crypto/keys/secp256k1/internal/secp256k1/secp256_test.go
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
 
+//go:build !gofuzz && cgo
+// +build !gofuzz,cgo
+
 package secp256k1
 
 import (


### PR DESCRIPTION
Fixes an oversight that hadn't been considered when the build guards were added to the other files in the same directory, that this test requires linking with code that hooks into cgo. This change adds the build guard

    +build cgo

Fixes #13266