### PR TITLE
fix: x/gov/client/cli: update & tighten Prompt.Parse tests

### DIFF
--- a/x/gov/client/cli/prompt.go
+++ b/x/gov/client/cli/prompt.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"reflect"
+	"reflect" // #nosec
 	"sort"
 	"strconv"
 	"strings"
@@ -94,7 +94,7 @@ func Prompt[T any](data T, namePrefix string) (T, error) {
 		case reflect.String:
 			v.Field(i).SetString(result)
 		case reflect.Int:
-			resultInt, err := strconv.Atoi(result)
+			resultInt, err := strconv.ParseInt(result, 10, 0)
 			if err != nil {
 				return data, fmt.Errorf("invalid value for int: %w", err)
 			}
@@ -104,7 +104,7 @@ func Prompt[T any](data T, namePrefix string) (T, error) {
 			//      [minInt64, maxInt64]
 			// of which on 64-bit machines, which are most common,
 			// int==int64
-			v.Field(i).SetInt(int64(resultInt))
+			v.Field(i).SetInt(resultInt)
 		default:
 			// skip other types
 			// possibly in the future we can add more types (like slices)

--- a/x/gov/client/cli/prompt_test.go
+++ b/x/gov/client/cli/prompt_test.go
@@ -82,7 +82,7 @@ func TestPromptParseInteger(t *testing.T) {
 
 			v, err := cli.Prompt(st{}, "")
 			assert.Nil(t, err, "expected a nil error")
-			assert.Equal(t, tc.want, v.I, "expected a value of zero")
+			assert.Equal(t, tc.want, v.I, "expected %d = %d", tc.want, v.I)
 		})
 	}
 }


### PR DESCRIPTION
Adds more rigorous checks to ensure that the output is as expected with range failures. While here also added control tests to ensure that we can parse integers within range of int.

Updates #13346
