### PR TITLE
ci: .github/workflows: add staticmajor to catch leaking resources

### DIFF
--- a/.github/workflows/staticmajor.yml
+++ b/.github/workflows/staticmajor.yml
@@ -1,0 +1,22 @@
+name: Staticmajor static analyzer to catch leaking resources & other bad code patterns
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  run_staticmajor:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3
+      - name: Staticmajor action
+        id: staticmajor
+        uses: orijtech/staticmajor-action@main
+        with:
+            packages: ./...
+            resleak: true
+            structslop: false
+            tests: false


### PR DESCRIPTION
Brings in a static analyzer that catches leaking resources like unclosed file handles, networking handles etc that can't easily be caught except in very critical code reviews as well as a bunch of other static analyzers that Orijtech Inc produces.