### PR TITLE
feat: implement backendDB options into SDK as a cli flag

### DIFF
--- a/client/flags/flags.go
+++ b/client/flags/flags.go
@@ -81,6 +81,9 @@ const (
 	// Tendermint logging flags
 	FlagLogLevel  = "log_level"
 	FlagLogFormat = "log_format"
+
+	// backendDbOptions
+	FlagDbMaxfileOpen = "maxopenfiles"
 )
 
 // LineBreak can be included in a command list to provide a blank line

--- a/go.mod
+++ b/go.mod
@@ -166,6 +166,9 @@ replace (
 	// TODO Remove it: https://github.com/cosmos/cosmos-sdk/issues/10409
 	github.com/gin-gonic/gin => github.com/gin-gonic/gin v1.8.1
 	github.com/gogo/gateway => github.com/notional-labs/gateway v1.1.1-0.20220417180718-8e60e17a098d
+
+	// TODO: remove this when https://github.com/tendermint/tm-db/pull/296 got merged
+	github.com/tendermint/tm-db => github.com/jayt106/tm-db v0.6.8-0.20220927191458-92388a1391a9
 )
 
 retract v0.43.0

--- a/go.sum
+++ b/go.sum
@@ -495,6 +495,8 @@ github.com/improbable-eng/grpc-web v0.15.0/go.mod h1:1sy9HKV4Jt9aEs9JSnkWlRJPuPt
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
+github.com/jayt106/tm-db v0.6.8-0.20220927191458-92388a1391a9 h1:BI0uw/g36zFMilbx6XEfJ9lar4/zsKxdOrV2Huinr2U=
+github.com/jayt106/tm-db v0.6.8-0.20220927191458-92388a1391a9/go.mod h1:zX419mTtVKnvR8KQnD9yNKd6XmiJhY7jiAU5JOeaI1w=
 github.com/jessevdk/go-flags v0.0.0-20141203071132-1679536dcc89/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jhump/gopoet v0.0.0-20190322174617-17282ff210b3/go.mod h1:me9yfT6IJSlOL3FCfrg+L6yzUEZ+5jW6WHt4Sk+UPUI=
 github.com/jhump/gopoet v0.1.0/go.mod h1:me9yfT6IJSlOL3FCfrg+L6yzUEZ+5jW6WHt4Sk+UPUI=
@@ -791,8 +793,6 @@ github.com/tendermint/go-amino v0.16.0 h1:GyhmgQKvqF82e2oZeuMSp9JTN0N09emoSZlb2l
 github.com/tendermint/go-amino v0.16.0/go.mod h1:TQU0M1i/ImAo+tYpZi73AU3V/dKeCoMC9Sphe2ZwGME=
 github.com/tendermint/tendermint v0.37.0-alpha.2 h1:G82quAWZUDYMTc9G7b/tntFATfm7nm6PrsvjsuMZDPI=
 github.com/tendermint/tendermint v0.37.0-alpha.2/go.mod h1:DSnBfCufF48DhIpmU2inmVo8YiEGus6uInwf46Iu01k=
-github.com/tendermint/tm-db v0.6.7 h1:fE00Cbl0jayAoqlExN6oyQJ7fR/ZtoVOmvPJ//+shu8=
-github.com/tendermint/tm-db v0.6.7/go.mod h1:byQDzFkZV1syXr/ReXS808NxA2xvyuuVgXOJ/088L6I=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/ugorji/go v1.2.7 h1:qYhyWUUd6WbiM+C6JZAUkIJt/1WrjzNHY9+KCIjVqTo=

--- a/server/constructors_test.go
+++ b/server/constructors_test.go
@@ -11,7 +11,7 @@ import (
 
 func Test_openDB(t *testing.T) {
 	t.Parallel()
-	_, err := openDB(t.TempDir(), dbm.GoLevelDBBackend)
+	_, err := openDBwithOptions(t.TempDir(), dbm.GoLevelDBBackend, nil)
 	require.NoError(t, err)
 }
 

--- a/server/export.go
+++ b/server/export.go
@@ -37,7 +37,8 @@ func ExportCmd(appExporter types.AppExporter, defaultNodeHome string) *cobra.Com
 				return err
 			}
 
-			db, err := openDB(config.RootDir, GetAppDBBackend(serverCtx.Viper))
+			opts := createDbOptionsFromFlag(serverCtx)
+			db, err := openDBwithOptions(config.RootDir, GetAppDBBackend(serverCtx.Viper), opts)
 			if err != nil {
 				return err
 			}
@@ -113,6 +114,7 @@ func ExportCmd(appExporter types.AppExporter, defaultNodeHome string) *cobra.Com
 	cmd.Flags().Int64(FlagHeight, -1, "Export state from a particular height (-1 means latest height)")
 	cmd.Flags().Bool(FlagForZeroHeight, false, "Export state to start at height zero (perform preproccessing)")
 	cmd.Flags().StringSlice(FlagJailAllowedAddrs, []string{}, "Comma-separated list of operator addresses of jailed validators to unjail")
+	cmd.Flags().Uint64(flags.FlagDbMaxfileOpen, 0, "max open files allowed in the backend DB (0 means default settings in the backend DB)")
 
 	return cmd
 }

--- a/server/rollback.go
+++ b/server/rollback.go
@@ -26,7 +26,9 @@ application.
 			ctx := GetServerContextFromCmd(cmd)
 			cfg := ctx.Config
 			home := cfg.RootDir
-			db, err := openDB(home, GetAppDBBackend(ctx.Viper))
+
+			opts := createDbOptionsFromFlag(ctx)
+			db, err := openDBwithOptions(home, GetAppDBBackend(ctx.Viper), opts)
 			if err != nil {
 				return err
 			}
@@ -48,5 +50,6 @@ application.
 	}
 
 	cmd.Flags().String(flags.FlagHome, defaultNodeHome, "The application home directory")
+	cmd.Flags().Uint64(flags.FlagDbMaxfileOpen, 0, "max open files allowed in the backend DB(0 means default settings in the backend DB)")
 	return cmd
 }

--- a/server/start.go
+++ b/server/start.go
@@ -78,6 +78,9 @@ const (
 	flagGRPCAddress    = "grpc.address"
 	flagGRPCWebEnable  = "grpc-web.enable"
 	flagGRPCWebAddress = "grpc-web.address"
+
+	// DBBackend options
+	FlagDbMaxfileOpen = "maxopenfiles"
 )
 
 // StartCmd runs the service passed in, either stand-alone or in-process with
@@ -187,6 +190,8 @@ is performed. Note, when enabled, gRPC will also be automatically enabled.
 	cmd.Flags().Uint64(FlagStateSyncSnapshotInterval, 0, "State sync snapshot interval")
 	cmd.Flags().Uint32(FlagStateSyncSnapshotKeepRecent, 2, "State sync snapshot to keep")
 
+	cmd.Flags().Uint64(FlagDbMaxfileOpen, 0, "max open files allowed in the backend DB(0 means default settings in the backend DB)")
+
 	// add support for all Tendermint-specific command line options
 	tcmd.AddNodeFlags(cmd)
 	return cmd
@@ -197,7 +202,8 @@ func startStandAlone(ctx *Context, appCreator types.AppCreator) error {
 	transport := ctx.Viper.GetString(flagTransport)
 	home := ctx.Viper.GetString(flags.FlagHome)
 
-	db, err := openDB(home, GetAppDBBackend(ctx.Viper))
+	opts := createDbOptionsFromFlag(ctx)
+	db, err := openDBwithOptions(home, GetAppDBBackend(ctx.Viper), opts)
 	if err != nil {
 		return err
 	}
@@ -269,7 +275,8 @@ func startInProcess(ctx *Context, clientCtx client.Context, appCreator types.App
 		}
 	}
 
-	db, err := openDB(home, GetAppDBBackend(ctx.Viper))
+	opts := createDbOptionsFromFlag(ctx)
+	db, err := openDBwithOptions(home, GetAppDBBackend(ctx.Viper), opts)
 	if err != nil {
 		return err
 	}

--- a/server/util.go
+++ b/server/util.go
@@ -393,9 +393,9 @@ func addrToIP(addr net.Addr) net.IP {
 	return ip
 }
 
-func openDB(rootDir string, backendType dbm.BackendType) (dbm.DB, error) {
+func openDBwithOptions(rootDir string, backendType dbm.BackendType, opts dbm.Options) (dbm.DB, error) {
 	dataDir := filepath.Join(rootDir, "data")
-	return dbm.NewDB("application", backendType, dataDir)
+	return dbm.NewDBwithOptions("application", backendType, dataDir, opts)
 }
 
 func openTraceWriter(traceWriterFile string) (w io.Writer, err error) {
@@ -407,4 +407,19 @@ func openTraceWriter(traceWriterFile string) (w io.Writer, err error) {
 		os.O_WRONLY|os.O_APPEND|os.O_CREATE,
 		0o666,
 	)
+}
+
+func createDbOptionsFromFlag(ctx *Context) dbm.Options {
+	opts := make(dbm.OptionsMap, 0)
+	if ctx == nil {
+		return opts
+	}
+
+	maxFileOpen := ctx.Viper.GetUint(flags.FlagDbMaxfileOpen)
+	if maxFileOpen > 0 {
+		opts[flags.FlagDbMaxfileOpen] = maxFileOpen
+	}
+
+	ctx.Logger.Info("starting with DB option", "option", opts)
+	return opts
 }

--- a/simapp/go.mod
+++ b/simapp/go.mod
@@ -159,4 +159,7 @@ replace (
 	// TODO Remove it: https://github.com/cosmos/cosmos-sdk/issues/10409
 	github.com/gin-gonic/gin => github.com/gin-gonic/gin v1.8.1
 	github.com/gogo/gateway => github.com/notional-labs/gateway v1.1.1-0.20220417180718-8e60e17a098d
+
+	// TODO: remove this when https://github.com/tendermint/tm-db/pull/296 got merged
+	github.com/tendermint/tm-db => github.com/jayt106/tm-db v0.6.8-0.20220927191458-92388a1391a9
 )

--- a/simapp/go.sum
+++ b/simapp/go.sum
@@ -490,6 +490,8 @@ github.com/improbable-eng/grpc-web v0.15.0/go.mod h1:1sy9HKV4Jt9aEs9JSnkWlRJPuPt
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
+github.com/jayt106/tm-db v0.6.8-0.20220927191458-92388a1391a9 h1:BI0uw/g36zFMilbx6XEfJ9lar4/zsKxdOrV2Huinr2U=
+github.com/jayt106/tm-db v0.6.8-0.20220927191458-92388a1391a9/go.mod h1:zX419mTtVKnvR8KQnD9yNKd6XmiJhY7jiAU5JOeaI1w=
 github.com/jessevdk/go-flags v0.0.0-20141203071132-1679536dcc89/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jhump/protoreflect v1.12.1-0.20220721211354-060cc04fc18b h1:izTof8BKh/nE1wrKOrloNA5q4odOarjf+Xpe+4qow98=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
@@ -779,8 +781,6 @@ github.com/tendermint/go-amino v0.16.0 h1:GyhmgQKvqF82e2oZeuMSp9JTN0N09emoSZlb2l
 github.com/tendermint/go-amino v0.16.0/go.mod h1:TQU0M1i/ImAo+tYpZi73AU3V/dKeCoMC9Sphe2ZwGME=
 github.com/tendermint/tendermint v0.37.0-alpha.2 h1:G82quAWZUDYMTc9G7b/tntFATfm7nm6PrsvjsuMZDPI=
 github.com/tendermint/tendermint v0.37.0-alpha.2/go.mod h1:DSnBfCufF48DhIpmU2inmVo8YiEGus6uInwf46Iu01k=
-github.com/tendermint/tm-db v0.6.7 h1:fE00Cbl0jayAoqlExN6oyQJ7fR/ZtoVOmvPJ//+shu8=
-github.com/tendermint/tm-db v0.6.7/go.mod h1:byQDzFkZV1syXr/ReXS808NxA2xvyuuVgXOJ/088L6I=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/ugorji/go v1.2.7 h1:qYhyWUUd6WbiM+C6JZAUkIJt/1WrjzNHY9+KCIjVqTo=

--- a/simapp/simd/cmd/root.go
+++ b/simapp/simd/cmd/root.go
@@ -277,8 +277,14 @@ func newApp(
 		panic(err)
 	}
 
+	opts := make(dbm.OptionsMap, 0)
+	maxFileOpen := cast.ToUint64(appOpts.Get(server.FlagDbMaxfileOpen))
+	if maxFileOpen > 0 {
+		opts[flags.FlagDbMaxfileOpen] = maxFileOpen
+	}
+
 	snapshotDir := filepath.Join(cast.ToString(appOpts.Get(flags.FlagHome)), "data", "snapshots")
-	snapshotDB, err := dbm.NewDB("metadata", server.GetAppDBBackend(appOpts), snapshotDir)
+	snapshotDB, err := dbm.NewDBwithOptions("metadata", server.GetAppDBBackend(appOpts), snapshotDir, opts)
 	if err != nil {
 		panic(err)
 	}

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -164,4 +164,7 @@ replace (
 	// TODO Remove it: https://github.com/cosmos/cosmos-sdk/issues/10409
 	github.com/gin-gonic/gin => github.com/gin-gonic/gin v1.8.1
 	github.com/gogo/gateway => github.com/notional-labs/gateway v1.1.1-0.20220417180718-8e60e17a098d
+
+	// TODO: remove this when https://github.com/tendermint/tm-db/pull/296 got merged
+	github.com/tendermint/tm-db => github.com/jayt106/tm-db v0.6.8-0.20220927191458-92388a1391a9
 )

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -492,6 +492,8 @@ github.com/improbable-eng/grpc-web v0.15.0/go.mod h1:1sy9HKV4Jt9aEs9JSnkWlRJPuPt
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
+github.com/jayt106/tm-db v0.6.8-0.20220927191458-92388a1391a9 h1:BI0uw/g36zFMilbx6XEfJ9lar4/zsKxdOrV2Huinr2U=
+github.com/jayt106/tm-db v0.6.8-0.20220927191458-92388a1391a9/go.mod h1:zX419mTtVKnvR8KQnD9yNKd6XmiJhY7jiAU5JOeaI1w=
 github.com/jessevdk/go-flags v0.0.0-20141203071132-1679536dcc89/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jhump/protoreflect v1.12.1-0.20220721211354-060cc04fc18b h1:izTof8BKh/nE1wrKOrloNA5q4odOarjf+Xpe+4qow98=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
@@ -781,8 +783,6 @@ github.com/tendermint/go-amino v0.16.0 h1:GyhmgQKvqF82e2oZeuMSp9JTN0N09emoSZlb2l
 github.com/tendermint/go-amino v0.16.0/go.mod h1:TQU0M1i/ImAo+tYpZi73AU3V/dKeCoMC9Sphe2ZwGME=
 github.com/tendermint/tendermint v0.37.0-alpha.2 h1:G82quAWZUDYMTc9G7b/tntFATfm7nm6PrsvjsuMZDPI=
 github.com/tendermint/tendermint v0.37.0-alpha.2/go.mod h1:DSnBfCufF48DhIpmU2inmVo8YiEGus6uInwf46Iu01k=
-github.com/tendermint/tm-db v0.6.7 h1:fE00Cbl0jayAoqlExN6oyQJ7fR/ZtoVOmvPJ//+shu8=
-github.com/tendermint/tm-db v0.6.7/go.mod h1:byQDzFkZV1syXr/ReXS808NxA2xvyuuVgXOJ/088L6I=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/ugorji/go v1.2.7 h1:qYhyWUUd6WbiM+C6JZAUkIJt/1WrjzNHY9+KCIjVqTo=


### PR DESCRIPTION
## Description

Adding a new flag maxopenfiles for setting up the backend DB max open files.
The current rocksdb (in tm-db v0.6.7) is using 4096 as the default value, it affects the backend DB in the application and the snapshot folder

Note: for saving the memory usage, we might set this flag to 1000 (the default value in tm-db v0.6.6)
i.e.

```
./simd start --maxopenfiles 1000
./simd export --maxopenfiles 1000
```

Closes: https://github.com/cosmos/cosmos-sdk/issues/10212


---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
- [x] provided a link to the relevant issue or specification
- [x] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [x] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [x] updated the relevant documentation or specification
- [x] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
