### PR TITLE
fix: cosmovisor: isolate and return masked errors that are not non-existence errors

### DIFF
--- a/cosmovisor/upgrade.go
+++ b/cosmovisor/upgrade.go
@@ -33,8 +33,15 @@ func UpgradeBinary(logger *zerolog.Logger, cfg *Config, info upgradetypes.Plan) 
 	}
 
 	// if the dir is there already, don't download either
-	if _, err := os.Stat(cfg.UpgradeDir(info.Name)); !os.IsNotExist(err) {
+	switch fi, err := os.Stat(cfg.UpgradeDir(info.Name)); {
+	case fi != nil: // The directory exists, do not overwrite.
 		return errors.New("upgrade dir already exists, won't overwrite")
+
+	case os.IsNotExist(err): // In this case the directory doesn't exist, continue below.
+		// Do nothing and we shall download the binary down below.
+
+	default: // Otherwise an unexpected error
+		return fmt.Errorf("unhandled error: %w", err)
 	}
 
 	// If not there, then we try to download it... maybe


### PR DESCRIPTION
Enumerates and improves on the error checking for non-existance errors to clearly return unhandled errors such as access restrictions, unaccessible volumes etc, when trying to download binaries. The prior code assumed that either the file existed or the only error to be returned would be about the file not existing, yet this isn't always true.

Fixes #13469
