### PR TITLE
fix: state listener observe writes at wrong time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,6 +149,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (x/gov) [#13160](https://github.com/cosmos/cosmos-sdk/pull/13160) Remove custom marshaling of proposl and voteoption. 
 * (types) [#13430](https://github.com/cosmos/cosmos-sdk/pull/13430) Remove unused code `ResponseCheckTx` and `ResponseDeliverTx`
 * (auth) [#13460](https://github.com/cosmos/cosmos-sdk/pull/13460) The `q auth address-by-id` CLI command has been renamed to `q auth address-by-acc-num` to be more explicit. However, the old `address-by-id` version is still kept as an alias, for backwards compatibility.
+* (store) [#13476](https://github.com/cosmos/cosmos-sdk/pull/13476) Move methods `ListeningEnabled` and `SetListeners` from `MultiStore` to `CacheMultiStore`, remove them from `rootmulti.Store`, add method `CacheContextWithListeners` to `sdk.Context`.
 
 ### CLI Breaking Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -171,6 +171,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (x/gov) [#13045](https://github.com/cosmos/cosmos-sdk/pull/13045) Fix gov migrations for v3(0.46).
 * (snapshot) [#13400](https://github.com/cosmos/cosmos-sdk/pull/13400) Fix snapshot checksum issue in golang 1.19.
 * (store) [#13459](https://github.com/cosmos/cosmos-sdk/pull/13459) Don't let state listener observe the uncommitted writes.
+* (store) [#13476](https://github.com/cosmos/cosmos-sdk/pull/13476) fix state listener observe writes at wrong time.
 
 ### Deprecated
 

--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -70,7 +70,14 @@ func (app *BaseApp) InitChain(req abci.RequestInitChain) (res abci.ResponseInitC
 		return
 	}
 
+	// initChainer calls DeliverTx internally, which will use `deliverState.ctx` directly,
+	// to share the cache context with it, we override `deliverState.ctx` temporary here.
+	originalDeliverCtx := app.deliverState.ctx
+	app.deliverState.ctx = cacheCtx
+
 	res = app.initChainer(cacheCtx, req)
+
+	app.deliverState.ctx = originalDeliverCtx
 	write()
 
 	// sanity check

--- a/baseapp/options.go
+++ b/baseapp/options.go
@@ -228,8 +228,9 @@ func (app *BaseApp) SetInterfaceRegistry(registry types.InterfaceRegistry) {
 // SetStreamingService is used to set a streaming service into the BaseApp hooks and load the listeners into the multistore
 func (app *BaseApp) SetStreamingService(s StreamingService) {
 	// add the listeners for each StoreKey
+	// register the listeners on app, which will be passed to cache store when necessary.
 	for key, lis := range s.Listeners() {
-		app.cms.AddListeners(key, lis)
+		app.AddListeners(key, lis)
 	}
 	// register the StreamingService within the BaseApp
 	// BaseApp will pass BeginBlock, DeliverTx, and EndBlock requests and responses to the streaming services to update their ABCI context

--- a/server/mock/store.go
+++ b/server/mock/store.go
@@ -50,7 +50,7 @@ func (ms multiStore) SetTracer(w io.Writer) sdk.MultiStore {
 	panic("not implemented")
 }
 
-func (ms multiStore) AddListeners(key storetypes.StoreKey, listeners []storetypes.WriteListener) {
+func (ms multiStore) SetListeners(listeners map[storetypes.StoreKey][]storetypes.WriteListener) storetypes.MultiStore {
 	panic("not implemented")
 }
 

--- a/store/types/store.go
+++ b/store/types/store.go
@@ -127,19 +127,18 @@ type MultiStore interface {
 	// implied that the caller should update the context when necessary between
 	// tracing operations. The modified MultiStore is returned.
 	SetTracingContext(TraceContext) MultiStore
-
-	// ListeningEnabled returns if listening is enabled for the KVStore belonging the provided StoreKey
-	ListeningEnabled(key StoreKey) bool
-
-	// AddListeners adds WriteListeners for the KVStore belonging to the provided StoreKey
-	// It appends the listeners to a current set, if one already exists
-	AddListeners(key StoreKey, listeners []WriteListener)
 }
 
 // From MultiStore.CacheMultiStore()....
 type CacheMultiStore interface {
 	MultiStore
 	Write() // Writes operations to underlying KVStore
+
+	// ListeningEnabled returns if listening is enabled for the KVStore belonging the provided StoreKey
+	ListeningEnabled(key StoreKey) bool
+
+	// SetListeners reset all the state listeners and re-wire the kv stores.
+	SetListeners(listeners map[StoreKey][]WriteListener) CacheMultiStore
 }
 
 // CommitMultiStore is an interface for a MultiStore without cache capabilities.

--- a/types/context.go
+++ b/types/context.go
@@ -271,7 +271,14 @@ func (c Context) TransientStore(key storetypes.StoreKey) KVStore {
 // is called. Note, events are automatically emitted on the parent context's
 // EventManager when the caller executes the write.
 func (c Context) CacheContext() (cc Context, writeCache func()) {
+	return c.CacheContextWithListeners(nil)
+}
+
+func (c Context) CacheContextWithListeners(listeners map[storetypes.StoreKey][]storetypes.WriteListener) (cc Context, writeCache func()) {
 	cms := c.MultiStore().CacheMultiStore()
+	if len(listeners) > 0 {
+		cms = cms.SetListeners(listeners)
+	}
 	cc = c.WithMultiStore(cms).WithEventManager(NewEventManager())
 
 	writeCache = func() {


### PR DESCRIPTION
## Description

Closes: #13457 (again)

currently state listener only observe events at commit event, it should listen to the second layer of cache store and this layer only.
This PR do some workarounds to make state listening more stable, always wrap the consensus state machine events in a secondary cache context (the first layer is the `deliverState.ctx`), and set the listeners explicitly to listen to the writes.

### Change Highlights

- remove listener from rootmulti, keep the listening ability in `CacheMultiStore` only.
- register the listeners in the application, rather than rootmulti.
- add API `context.CacheContextWithListeners(listeners)`, to explicitly enable listeners on specific cache store.
- wrap all the state modify operations in consensus state machine inside a cache store with listeners enabled.

<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->


<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
