### PR TITLE
docs: fix broken link in simulator.md

### DIFF
--- a/docs/building-modules/simulator.md
+++ b/docs/building-modules/simulator.md
@@ -6,7 +6,7 @@ order: 14
 
 ## Prerequisites
 
-* [Cosmos Blockchain Simulator](./../using-the-sdk/simulation.md)
+* [Cosmos Blockchain Simulator](./../core/simulation.md)
 
 ## Synopsis
 


### PR DESCRIPTION
A simple PR for fixing a broken link that existed in the documentation of [simulator.md](https://github.com/cosmos/cosmos-sdk/blob/main/docs/building-modules/simulator.md)