### PR TITLE
fix: small fix in x/nft CLI tests

### DIFF
--- a/x/nft/client/cli/tx_test.go
+++ b/x/nft/client/cli/tx_test.go
@@ -24,8 +24,9 @@ import (
 	"github.com/cosmos/cosmos-sdk/testutil/network"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	testutilmod "github.com/cosmos/cosmos-sdk/types/module/testutil"
-	"github.com/cosmos/cosmos-sdk/x/genutil"
 	"github.com/cosmos/cosmos-sdk/x/nft"
+	nftmodule "github.com/cosmos/cosmos-sdk/x/nft/module"
+
 	"github.com/cosmos/cosmos-sdk/x/nft/client/cli"
 	nfttestutil "github.com/cosmos/cosmos-sdk/x/nft/testutil"
 )
@@ -109,7 +110,7 @@ func TestCLITestSuite(t *testing.T) {
 }
 
 func (s *CLITestSuite) SetupSuite() {
-	s.encCfg = testutilmod.MakeTestEncodingConfig(genutil.AppModuleBasic{})
+	s.encCfg = testutilmod.MakeTestEncodingConfig(nftmodule.AppModuleBasic{})
 	s.kr = keyring.NewInMemory(s.encCfg.Codec)
 	s.baseCtx = client.Context{}.
 		WithKeyring(s.kr).


### PR DESCRIPTION
This PR fixes the wrong config returned in x/nft CLI tests
