### PR TITLE
feat: overwrite default denom in `init` cmd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,6 +153,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### CLI Breaking Changes
 
+* (x/genutil) [#13535](https://github.com/cosmos/cosmos-sdk/pull/13535) Replace in `simd init`, the `--staking-bond-denom` flag with `--default-denom` which is used for all default denomination in the genesis, instead of only staking.
 * (tx) [#12659](https://github.com/cosmos/cosmos-sdk/pull/12659) Remove broadcast mode `block`.
 
 ### Bug Fixes

--- a/types/staking.go
+++ b/types/staking.go
@@ -1,24 +1,24 @@
 package types
 
-const (
-	// Delay, in blocks, between when validator updates are returned to the
-	// consensus-engine and when they are applied. For example, if
-	// ValidatorUpdateDelay is set to X, and if a validator set update is
-	// returned with new validators at the end of block 10, then the new
-	// validators are expected to sign blocks beginning at block 11+X.
-	//
-	// This value is constant as this should not change without a hard fork.
-	// For Tendermint this should be set to 1 block, for more details see:
-	// https://tendermint.com/docs/spec/abci/apps.html#endblock
-	ValidatorUpdateDelay int64 = 1
+// Delay, in blocks, between when validator updates are returned to the
+// consensus-engine and when they are applied. For example, if
+// ValidatorUpdateDelay is set to X, and if a validator set update is
+// returned with new validators at the end of block 10, then the new
+// validators are expected to sign blocks beginning at block 11+X.
+//
+// This value is constant as this should not change without a hard fork.
+// For Tendermint this should be set to 1 block, for more details see:
+// https://tendermint.com/docs/spec/abci/apps.html#endblock
+const ValidatorUpdateDelay int64 = 1
+
+var (
+	// DefaultBondDenom is the default bondable coin denomination (defaults to stake)
+	// Overwriting this value has the side effect of changing the default denomination in genesis
+	DefaultBondDenom = "stake"
+
+	// DefaultPowerReduction is the default amount of staking tokens required for 1 unit of consensus-engine power
+	DefaultPowerReduction = NewIntFromUint64(1000000)
 )
-
-// DefaultBondDenom is the default bondable coin denomination (defaults to stake)
-// Overwriting this value has the side effect of changing the default denomination in genesis
-var DefaultBondDenom = "stake"
-
-// DefaultPowerReduction is the default amount of staking tokens required for 1 unit of consensus-engine power
-var DefaultPowerReduction = NewIntFromUint64(1000000)
 
 // TokensToConsensusPower - convert input tokens to potential consensus-engine power
 func TokensToConsensusPower(tokens Int, powerReduction Int) int64 {

--- a/types/staking.go
+++ b/types/staking.go
@@ -13,8 +13,8 @@ const (
 	ValidatorUpdateDelay int64 = 1
 )
 
-// DefaultBondDenom is the default bondable coin denomination (stake)
-// Overwriting this value has the side effect of changing the default genesis denomination
+// DefaultBondDenom is the default bondable coin denomination (defaults to stake)
+// Overwriting this value has the side effect of changing the default denomination in genesis
 var DefaultBondDenom = "stake"
 
 // DefaultPowerReduction is the default amount of staking tokens required for 1 unit of consensus-engine power

--- a/types/staking.go
+++ b/types/staking.go
@@ -1,11 +1,6 @@
 package types
 
-// staking constants
 const (
-
-	// default bond denomination
-	DefaultBondDenom = "stake"
-
 	// Delay, in blocks, between when validator updates are returned to the
 	// consensus-engine and when they are applied. For example, if
 	// ValidatorUpdateDelay is set to X, and if a validator set update is
@@ -17,6 +12,9 @@ const (
 	// https://tendermint.com/docs/spec/abci/apps.html#endblock
 	ValidatorUpdateDelay int64 = 1
 )
+
+// DefaultBondDenom is the default bondable coin denomination (stake)
+var DefaultBondDenom = "stake"
 
 // DefaultPowerReduction is the default amount of staking tokens required for 1 unit of consensus-engine power
 var DefaultPowerReduction = NewIntFromUint64(1000000)

--- a/types/staking.go
+++ b/types/staking.go
@@ -14,6 +14,7 @@ const (
 )
 
 // DefaultBondDenom is the default bondable coin denomination (stake)
+// Overwriting this value has the side effect of changing the default genesis denomination
 var DefaultBondDenom = "stake"
 
 // DefaultPowerReduction is the default amount of staking tokens required for 1 unit of consensus-engine power

--- a/x/genutil/client/cli/init.go
+++ b/x/genutil/client/cli/init.go
@@ -22,7 +22,6 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	"github.com/cosmos/cosmos-sdk/x/genutil"
-	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 )
 
 const (
@@ -32,8 +31,8 @@ const (
 	// FlagSeed defines a flag to initialize the private validator key from a specific seed.
 	FlagRecover = "recover"
 
-	// FlagStakingBondDenom defines a flag to specify the staking token in the genesis file.
-	FlagStakingBondDenom = "staking-bond-denom"
+	// FlagDefaultBondDenom defines the default denom to use in the genesis file.
+	FlagDefaultBondDenom = "default-denom"
 )
 
 type printInfo struct {
@@ -115,7 +114,7 @@ func InitCmd(mbm module.BasicManager, defaultNodeHome string) *cobra.Command {
 
 			genFile := config.GenesisFile()
 			overwrite, _ := cmd.Flags().GetBool(FlagOverwrite)
-			stakingBondDenom, _ := cmd.Flags().GetString(FlagStakingBondDenom)
+			defaultDenom, _ := cmd.Flags().GetString(FlagDefaultBondDenom)
 
 			// use os.Stat to check if the file exists
 			_, err = os.Stat(genFile)
@@ -123,25 +122,14 @@ func InitCmd(mbm module.BasicManager, defaultNodeHome string) *cobra.Command {
 				return fmt.Errorf("genesis.json file already exists: %v", genFile)
 			}
 
-			appGenState := mbm.DefaultGenesis(cdc)
-
-			if stakingBondDenom != "" {
-				var stakingGenesis stakingtypes.GenesisState
-
-				stakingRaw := appGenState[stakingtypes.ModuleName]
-				err := clientCtx.Codec.UnmarshalJSON(stakingRaw, &stakingGenesis)
-				if err != nil {
-					return err
-				}
-
-				stakingGenesis.Params.BondDenom = stakingBondDenom
-				modifiedStakingStr, err := clientCtx.Codec.MarshalJSON(&stakingGenesis)
-				if err != nil {
-					return err
-				}
-
-				appGenState[stakingtypes.ModuleName] = modifiedStakingStr
+			// We overwrite the SDK default for side-effects, namely:
+			// - setting the default bond denom in the app state
+			// Note, that is should not be done at any other place.
+			// This can break tests.
+			if defaultDenom != "" {
+				sdk.DefaultBondDenom = defaultDenom
 			}
+			appGenState := mbm.DefaultGenesis(cdc)
 
 			appState, err := json.MarshalIndent(appGenState, "", " ")
 			if err != nil {
@@ -179,7 +167,7 @@ func InitCmd(mbm module.BasicManager, defaultNodeHome string) *cobra.Command {
 	cmd.Flags().BoolP(FlagOverwrite, "o", false, "overwrite the genesis.json file")
 	cmd.Flags().Bool(FlagRecover, false, "provide seed phrase to recover existing key instead of creating")
 	cmd.Flags().String(flags.FlagChainID, "", "genesis file chain-id, if left blank will be randomly created")
-	cmd.Flags().String(FlagStakingBondDenom, "", "genesis file staking bond denomination, if left blank default value is 'stake'")
+	cmd.Flags().String(FlagDefaultBondDenom, "", "genesis file default denomination, if left blank default value is 'stake'")
 
 	return cmd
 }

--- a/x/genutil/client/cli/init.go
+++ b/x/genutil/client/cli/init.go
@@ -122,10 +122,7 @@ func InitCmd(mbm module.BasicManager, defaultNodeHome string) *cobra.Command {
 				return fmt.Errorf("genesis.json file already exists: %v", genFile)
 			}
 
-			// We overwrite the SDK default for side-effects, namely:
-			// - setting the default bond denom in the app state
-			// Note, that is should not be done at any other place.
-			// This can break tests.
+			// Overwrites the SDK default denom for side-effects
 			if defaultDenom != "" {
 				sdk.DefaultBondDenom = defaultDenom
 			}

--- a/x/genutil/client/cli/init_test.go
+++ b/x/genutil/client/cli/init_test.go
@@ -120,7 +120,7 @@ func TestInitRecover(t *testing.T) {
 	require.NoError(t, cmd.ExecuteContext(ctx))
 }
 
-func TestInitStakingBondDenom(t *testing.T) {
+func TestInitDefaultBondDenom(t *testing.T) {
 	home := t.TempDir()
 	logger := log.NewNopLogger()
 	cfg, err := genutiltest.CreateDefaultTendermintConfig(home)
@@ -143,7 +143,7 @@ func TestInitStakingBondDenom(t *testing.T) {
 	cmd.SetArgs([]string{
 		"appnode-test",
 		fmt.Sprintf("--%s=%s", cli.HomeFlag, home),
-		fmt.Sprintf("--%s=testtoken", genutilcli.FlagStakingBondDenom),
+		fmt.Sprintf("--%s=testtoken", genutilcli.FlagDefaultBondDenom),
 	})
 	require.NoError(t, cmd.ExecuteContext(ctx))
 }


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

https://github.com/cosmos/cosmos-sdk/pull/9776 is not so useful, as it changes only the default denomination for the staking module.
More modules use `sdk.DefaultBondDenom`, such as `gov`, leading to a mix of `stake` and the chosen denomination.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
