### PR TITLE
fix: all: avoid map ranging whenever possible to fix non-determinism security warnings

### DIFF
--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -230,7 +230,7 @@ func (app *BaseApp) MountStores(keys ...storetypes.StoreKey) {
 // MountKVStores mounts all IAVL or DB stores to the provided keys in the
 // BaseApp multistore.
 func (app *BaseApp) MountKVStores(keys map[string]*storetypes.KVStoreKey) {
-	for _, key := range keys {
+	for _, key := range maps.Values(keys) {
 		if !app.fauxMerkleMode {
 			app.MountStore(key, storetypes.StoreTypeIAVL)
 		} else {
@@ -244,7 +244,8 @@ func (app *BaseApp) MountKVStores(keys map[string]*storetypes.KVStoreKey) {
 // MountTransientStores mounts all transient stores to the provided keys in
 // the BaseApp multistore.
 func (app *BaseApp) MountTransientStores(keys map[string]*storetypes.TransientStoreKey) {
-	for _, key := range keys {
+	keyL := maps.Values(keys)
+	for _, key := range keyL {
 		app.MountStore(key, storetypes.StoreTypeTransient)
 	}
 }

--- a/client/v2/autocli/flag/register.go
+++ b/client/v2/autocli/flag/register.go
@@ -68,7 +68,8 @@ func (b *Builder) addMessageFlags(ctx context.Context, flagSet *pflag.FlagSet, m
 	}
 
 	// validate flag options
-	for name := range commandOptions.FlagOptions {
+	names := maps.Keys(commandOptions.FlagOptions)
+	for _, name := range names {
 		if fields.ByName(protoreflect.Name(name)) == nil {
 			return nil, fmt.Errorf("can't find field %s on %s specified as a flag", name, messageType.Descriptor().FullName())
 		}

--- a/client/v2/autocli/query.go
+++ b/client/v2/autocli/query.go
@@ -2,10 +2,12 @@ package autocli
 
 import (
 	"fmt"
+	"sort"
 
 	autocliv1 "cosmossdk.io/api/cosmos/autocli/v1"
 	"github.com/iancoleman/strcase"
 	"github.com/spf13/cobra"
+	"golang.org/x/exp/maps"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/reflect/protoregistry"
@@ -19,12 +21,17 @@ import (
 func (b *Builder) BuildQueryCommand(moduleOptions map[string]*autocliv1.ModuleOptions, customCmds map[string]*cobra.Command) (*cobra.Command, error) {
 	queryCmd := topLevelCmd("query", "Querying subcommands")
 	queryCmd.Aliases = []string{"q"}
-	for moduleName, modOpts := range moduleOptions {
+
+	// Ensure that building module query commands is in a deterministic pattern.
+	moduleNames := maps.Keys(moduleOptions)
+	sort.Strings(moduleNames)
+	for _, moduleName := range moduleNames {
 		if customCmds[moduleName] != nil {
 			// custom commands get added lower down
 			continue
 		}
 
+		modOpts := moduleOptions[moduleName]
 		queryCmdDesc := modOpts.Query
 		if queryCmdDesc != nil {
 			cmd, err := b.BuildModuleQueryCommand(moduleName, queryCmdDesc)

--- a/core/internal/registry.go
+++ b/core/internal/registry.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"reflect"
 
+	"golang.org/x/exp/maps"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
 
@@ -29,7 +30,7 @@ type ModuleInitializer struct {
 func ModulesByProtoMessageName() (map[protoreflect.FullName]*ModuleInitializer, error) {
 	res := map[protoreflect.FullName]*ModuleInitializer{}
 
-	for _, initializer := range ModuleRegistry {
+	for _, initializer := range maps.Values(ModuleRegistry) {
 		descriptor := initializer.ConfigProtoMessage.ProtoReflect().Descriptor()
 		fullName := descriptor.FullName()
 		if _, ok := res[fullName]; ok {

--- a/orm/model/ormdb/module.go
+++ b/orm/model/ormdb/module.go
@@ -6,6 +6,7 @@ import (
 	"encoding/binary"
 	"math"
 
+	"golang.org/x/exp/maps"
 	"google.golang.org/protobuf/reflect/protoregistry"
 
 	ormv1alpha1 "cosmossdk.io/api/cosmos/orm/v1alpha1"
@@ -119,12 +120,12 @@ func NewModuleDB(schema *ormv1alpha1.ModuleSchemaDescriptor, options ModuleDBOpt
 		}
 
 		db.filesById[id] = fdSchema
-		for name, table := range fdSchema.tablesByName {
+		for _, name := range maps.Keys(fdSchema.tablesByName) {
 			if _, ok := db.tablesByName[name]; ok {
 				return nil, ormerrors.UnexpectedError.Wrapf("duplicate table %s", name)
 			}
 
-			db.tablesByName[name] = table
+			db.tablesByName[name] = fdSchema.tablesByName[name]
 		}
 	}
 

--- a/orm/model/ormtable/build.go
+++ b/orm/model/ormtable/build.go
@@ -9,6 +9,7 @@ import (
 
 	"google.golang.org/protobuf/reflect/protoregistry"
 
+	"golang.org/x/exp/maps"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
 
@@ -259,7 +260,7 @@ func Build(options Options) (Table, error) {
 			}
 		}
 
-		for name := range altNames {
+		for _, name := range maps.Keys(altNames) {
 			if _, ok := table.indexesByFields[name]; ok {
 				return nil, fmt.Errorf("duplicate index for fields %s", name)
 			}

--- a/runtime/module.go
+++ b/runtime/module.go
@@ -8,6 +8,7 @@ import (
 	runtimev1alpha1 "cosmossdk.io/api/cosmos/app/runtime/v1alpha1"
 	"cosmossdk.io/core/appmodule"
 	"cosmossdk.io/depinject"
+	"golang.org/x/exp/maps"
 
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -50,7 +51,9 @@ func ProvideCodecs(moduleBasics map[string]AppModuleBasicWrapper) (
 
 	// build codecs
 	basicManager := module.BasicManager{}
-	for name, wrapper := range moduleBasics {
+	names := maps.Keys(moduleBasics)
+	for _, name := range names {
+		wrapper := moduleBasics[name]
 		basicManager[name] = wrapper
 		wrapper.RegisterInterfaces(interfaceRegistry)
 		wrapper.RegisterLegacyAminoCodec(amino)

--- a/store/internal/maps/maps.go
+++ b/store/internal/maps/maps.go
@@ -6,6 +6,7 @@ import (
 	"github.com/tendermint/tendermint/crypto/merkle"
 	"github.com/tendermint/tendermint/crypto/tmhash"
 	tmcrypto "github.com/tendermint/tendermint/proto/tendermint/crypto"
+	"golang.org/x/exp/maps"
 
 	"github.com/cosmos/cosmos-sdk/types/kv"
 )
@@ -185,8 +186,9 @@ func HashFromMap(m map[string][]byte) []byte {
 // The keys are sorted before the proofs are computed.
 func ProofsFromMap(m map[string][]byte) ([]byte, map[string]*tmcrypto.Proof, []string) {
 	sm := newSimpleMap()
-	for k, v := range m {
-		sm.Set(k, v)
+	kL := maps.Keys(m)
+	for _, k := range kL {
+		sm.Set(k, m[k])
 	}
 
 	sm.Sort()

--- a/store/internal/proofs/create.go
+++ b/store/internal/proofs/create.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 
 	ics23 "github.com/confio/ics23/go"
+	"golang.org/x/exp/maps"
 
 	sdkmaps "github.com/cosmos/cosmos-sdk/store/internal/maps"
 )
@@ -84,7 +85,8 @@ func CreateNonMembershipProof(data map[string][]byte, key []byte) (*ics23.Commit
 }
 
 func createExistenceProof(data map[string][]byte, key []byte) (*ics23.ExistenceProof, error) {
-	for k := range data {
+	keys := maps.Keys(data)
+	for _, k := range keys {
 		if k == "" {
 			return nil, ErrEmptyKeyInData
 		}

--- a/tests/e2e/evidence/suite.go
+++ b/tests/e2e/evidence/suite.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/stretchr/testify/suite"
+	"golang.org/x/exp/maps"
 
 	clitestutil "github.com/cosmos/cosmos-sdk/testutil/cli"
 	"github.com/cosmos/cosmos-sdk/testutil/network"
@@ -56,8 +57,8 @@ func (s *IntegrationTestSuite) TestGetQueryCmd() {
 		},
 	}
 
-	for name, tc := range testCases {
-		tc := tc
+	for _, name := range maps.Keys(testCases) {
+		tc := testCases[name]
 
 		s.Run(name, func() {
 			cmd := cli.GetQueryCmd()

--- a/types/module/module.go
+++ b/types/module/module.go
@@ -533,7 +533,7 @@ func (m *Manager) EndBlock(ctx sdk.Context, req abci.RequestEndBlock) abci.Respo
 // GetVersionMap gets consensus version from all modules
 func (m *Manager) GetVersionMap() VersionMap {
 	vermap := make(VersionMap)
-	for _, v := range m.Modules {
+	for _, v := range maps.Values(m.Modules) {
 		version := v.ConsensusVersion()
 		name := v.Name()
 		vermap[name] = version

--- a/x/authz/migrations/v046/store.go
+++ b/x/authz/migrations/v046/store.go
@@ -1,6 +1,10 @@
 package v046
 
 import (
+	"sort"
+
+	"golang.org/x/exp/maps"
+
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/internal/conv"
 	"github.com/cosmos/cosmos-sdk/store/prefix"
@@ -58,7 +62,10 @@ func addExpiredGrantsIndex(ctx sdk.Context, store storetypes.KVStore, cdc codec.
 		}
 	}
 
-	for key, v := range queueItems {
+	keys := maps.Keys(queueItems)
+	sort.Strings(keys)
+	for _, key := range keys {
+		v := queueItems[key]
 		bz, err := cdc.Marshal(&authz.GrantQueueItem{
 			MsgTypeUrls: v,
 		})

--- a/x/gov/keeper/tally.go
+++ b/x/gov/keeper/tally.go
@@ -5,6 +5,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	v1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	"golang.org/x/exp/maps"
 )
 
 // TODO: Break into several smaller functions for clarity
@@ -73,7 +74,8 @@ func (keeper Keeper) Tally(ctx sdk.Context, proposal v1.Proposal) (passes bool, 
 	})
 
 	// iterate over the validators again to tally their voting power
-	for _, val := range currValidators {
+	valL := maps.Values(currValidators)
+	for _, val := range valL {
 		if len(val.Vote) == 0 {
 			continue
 		}

--- a/x/params/keeper/keeper.go
+++ b/x/params/keeper/keeper.go
@@ -62,12 +62,9 @@ func (k Keeper) GetSubspace(s string) (types.Subspace, bool) {
 
 // GetSubspaces returns all the registered subspaces.
 func (k Keeper) GetSubspaces() []types.Subspace {
-	spaces := make([]types.Subspace, len(k.spaces))
-	i := 0
+	spaces := make([]types.Subspace, 0, len(k.spaces))
 	for _, ss := range k.spaces {
-		spaces[i] = *ss
-		i++
+		spaces = append(spaces, *ss)
 	}
-
 	return spaces
 }

--- a/x/params/types/table.go
+++ b/x/params/types/table.go
@@ -3,6 +3,8 @@ package types
 import (
 	"reflect"
 
+	"golang.org/x/exp/maps"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -72,7 +74,7 @@ func (t KeyTable) RegisterParamSet(ps ParamSet) KeyTable {
 }
 
 func (t KeyTable) maxKeyLength() (res int) {
-	for k := range t.m {
+	for _, k := range maps.Keys(t.m) {
 		l := len(k)
 		if l > res {
 			res = l

--- a/x/staking/keeper/val_state_change.go
+++ b/x/staking/keeper/val_state_change.go
@@ -8,6 +8,7 @@ import (
 	"cosmossdk.io/math"
 	gogotypes "github.com/cosmos/gogoproto/types"
 	abci "github.com/tendermint/tendermint/abci/types"
+	"golang.org/x/exp/maps"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/staking/types"
@@ -399,7 +400,8 @@ func sortNoLongerBonded(last validatorsByAddr) ([][]byte, error) {
 	noLongerBonded := make([][]byte, len(last))
 	index := 0
 
-	for valAddrStr := range last {
+	valAddrL := maps.Keys(last)
+	for _, valAddrStr := range valAddrL {
 		valAddrBytes, err := sdk.ValAddressFromBech32(valAddrStr)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Fixes errors reported by cosmos/gosec for non-deterministic map ranging, but using golang.org/x/exp/maps.(Keys, Values) where necessary.
