### PR TITLE
refactor: Use FormatUint instead of converting to int.

### DIFF
--- a/x/gov/keeper/msg_server.go
+++ b/x/gov/keeper/msg_server.go
@@ -119,7 +119,7 @@ func (k msgServer) Vote(goCtx context.Context, msg *v1.MsgVote) (*v1.MsgVoteResp
 		[]string{govtypes.ModuleName, "vote"},
 		1,
 		[]metrics.Label{
-			telemetry.NewLabel("proposal_id", strconv.Itoa(int(msg.ProposalId))),
+			telemetry.NewLabel("proposal_id", strconv.FormatUint(msg.ProposalId, 10)),
 		},
 	)
 
@@ -141,7 +141,7 @@ func (k msgServer) VoteWeighted(goCtx context.Context, msg *v1.MsgVoteWeighted) 
 		[]string{govtypes.ModuleName, "vote"},
 		1,
 		[]metrics.Label{
-			telemetry.NewLabel("proposal_id", strconv.Itoa(int(msg.ProposalId))),
+			telemetry.NewLabel("proposal_id", strconv.FormatUint(msg.ProposalId, 10)),
 		},
 	)
 
@@ -163,7 +163,7 @@ func (k msgServer) Deposit(goCtx context.Context, msg *v1.MsgDeposit) (*v1.MsgDe
 		[]string{govtypes.ModuleName, "deposit"},
 		1,
 		[]metrics.Label{
-			telemetry.NewLabel("proposal_id", strconv.Itoa(int(msg.ProposalId))),
+			telemetry.NewLabel("proposal_id", strconv.FormatUint(msg.ProposalId, 10)),
 		},
 	)
 


### PR DESCRIPTION
## Description

There is a warning when casting a `uint` to an `int`. For instance, [here](https://github.com/cosmos/cosmos-sdk/pull/13532/files#diff-50a11739adeec5335e446d4444326785c040c57da2c65abe9b9713aec18183ffR122). When it is just for a format, it does not make sense since `strconv` exposes a function for `uint`. This is the point of this PR.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [x] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [x] reviewed tests and test coverage
  - Had fails for `github.com/cosmos/cosmos-sdk/store/tools/ics23/iavl`, which seems unrelated.
- [ ] manually tested (if applicable)
