### PR TITLE
fix(server): v0.45.x Populate the PruningKeepEvery config entry in GetConfig.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 * [#13588](https://github.com/cosmos/cosmos-sdk/pull/13588) Fix regression in distrubtion.WithdrawDelegationRewards when rewards are zero
 * [#13564](https://github.com/cosmos/cosmos-sdk/pull/13564) - Fix `make proto-gen`.
-* TODO(link) Use the pruning-keep-every field again.
+* (server) [#13610](https://github.com/cosmos/cosmos-sdk/pull/13610) Read the pruning-keep-every field again.
 
 ## v0.45.9 - 2022-10-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 * [#13588](https://github.com/cosmos/cosmos-sdk/pull/13588) Fix regression in distrubtion.WithdrawDelegationRewards when rewards are zero
 * [#13564](https://github.com/cosmos/cosmos-sdk/pull/13564) - Fix `make proto-gen`.
+* TODO(link) Use the pruning-keep-every field again.
 
 ## v0.45.9 - 2022-10-14
 

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -277,6 +277,7 @@ func GetConfig(v *viper.Viper) (Config, error) {
 			InterBlockCache:     v.GetBool("inter-block-cache"),
 			Pruning:             v.GetString("pruning"),
 			PruningKeepRecent:   v.GetString("pruning-keep-recent"),
+			PruningKeepEvery:    v.GetString("pruning-keep-every"),
 			PruningInterval:     v.GetString("pruning-interval"),
 			HaltHeight:          v.GetUint64("halt-height"),
 			HaltTime:            v.GetUint64("halt-time"),


### PR DESCRIPTION
## Description

This PR adds back in, the setting of the `PruningKeepEvery` config field in `GetConfig`.

When #13321 was backported to v0.45.x (#13338), it accidentally carried with it a change to the server config's `GetConfig` function that removed the setting of the `PruningKeepEvery` field. That field has been removed in `main` and `release/v0.46.x`, but still exists in `release/v0.45.x`.

This PR is targeting `release/v0.45.x` because it is only applicable there.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
