### PR TITLE
fix: core/coins: skip 2 int64(uint32) casts by comparison checks and silence gosec warnings

### DIFF
--- a/core/coins/format.go
+++ b/core/coins/format.go
@@ -44,17 +44,15 @@ func formatCoin(coin *basev1beta1.Coin, metadata *bankv1beta1.Metadata) (string,
 		return vr + " " + coin.Denom, err
 	}
 
-	exponentDiff := int64(coinExp) - int64(dispExp)
-
 	dispAmount, err := math.LegacyNewDecFromStr(coin.Amount)
 	if err != nil {
 		return "", err
 	}
 
-	if exponentDiff > 0 {
-		dispAmount = dispAmount.Mul(math.LegacyNewDec(10).Power(uint64(exponentDiff)))
+	if coinExp > dispExp {
+		dispAmount = dispAmount.Mul(math.LegacyNewDec(10).Power(uint64(coinExp - dispExp)))
 	} else {
-		dispAmount = dispAmount.Quo(math.LegacyNewDec(10).Power(uint64(-exponentDiff)))
+		dispAmount = dispAmount.Quo(math.LegacyNewDec(10).Power(uint64(dispExp - coinExp)))
 	}
 
 	vr, err := math.FormatDec(dispAmount.String())


### PR DESCRIPTION
Instead of 2 unnecessary int64(uint32) casts, then a negative check, this change checks magnitudes before the respective subtractions and then converts uint64(uint32) which avoids the possible integer overflow warnings generated by gosec.

Fixes https://github.com/cosmos/cosmos-sdk/security/code-scanning/6713
Fixes https://github.com/cosmos/cosmos-sdk/security/code-scanning/6714
Fixes https://github.com/cosmos/cosmos-sdk/security/code-scanning/6715
Fixes https://github.com/cosmos/cosmos-sdk/security/code-scanning/6716