### PR TITLE
chore: update CHANGELOG.md to correctly reference ics23 version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -198,7 +198,7 @@ All users should upgrade immediately.
 Users *must* add a replace directive in their go.mod for the new `ics23` package in the SDK:
 
 ```go
-replace github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v8.0.0
+replace github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
 ```
 
 ### Features


### PR DESCRIPTION
Changelog.md incorrectly reference ics23 v8.0.0, instead of v0.8.0.

This PR rectifies this.

No functional change.