### PR TITLE
fix: x/group/internal/orm: return iterator close errors

### DIFF
--- a/x/group/internal/orm/index.go
+++ b/x/group/internal/orm/index.go
@@ -256,8 +256,7 @@ func (i indexIterator) LoadNext(dest codec.ProtoMarshaler) (RowID, error) {
 
 // Close releases the iterator and should be called at the end of iteration
 func (i indexIterator) Close() error {
-	i.it.Close()
-	return nil
+	return i.it.Close()
 }
 
 // PrefixRange turns a prefix into a (start, end) range. The start is the given prefix value and

--- a/x/group/internal/orm/table.go
+++ b/x/group/internal/orm/table.go
@@ -308,6 +308,5 @@ func (i typeSafeIterator) LoadNext(dest codec.ProtoMarshaler) (RowID, error) {
 }
 
 func (i typeSafeIterator) Close() error {
-	i.it.Close()
-	return nil
+	return i.it.Close()
 }


### PR DESCRIPTION
Instead of nakedly always returning nil, instead return the actual close errors.

Fixes https://github.com/cosmos/cosmos-sdk/security/code-scanning/6295
Fixes https://github.com/cosmos/cosmos-sdk/security/code-scanning/6296
