### PR TITLE
fix: bank store migration

### DIFF
--- a/x/bank/migrations/v046/store.go
+++ b/x/bank/migrations/v046/store.go
@@ -80,7 +80,7 @@ func migrateDenomMetadata(store sdk.KVStore) error {
 
 	for ; oldDenomMetaDataIter.Valid(); oldDenomMetaDataIter.Next() {
 		oldKey := oldDenomMetaDataIter.Key()
-		l := len(oldKey)/2 + 1
+		l := len(oldKey) / 2
 
 		newKey := make([]byte, len(types.DenomMetadataPrefix)+l)
 		// old key: prefix_bytes | denom_bytes | denom_bytes

--- a/x/bank/migrations/v046/store_test.go
+++ b/x/bank/migrations/v046/store_test.go
@@ -87,8 +87,9 @@ func TestMigrateDenomMetaData(t *testing.T) {
 	denomMetadataStore := prefix.NewStore(store, v043.DenomMetadataPrefix)
 
 	for i := range []int{0, 1} {
-		key := append(v043.DenomMetadataPrefix, []byte(metaData[i].Base)...)
+
 		// keys before 0.45 had denom two times in the key
+		key := append([]byte{}, []byte(metaData[i].Base)...)
 		key = append(key, []byte(metaData[i].Base)...)
 		bz, err := encCfg.Codec.Marshal(&metaData[i])
 		require.NoError(t, err)
@@ -105,11 +106,11 @@ func TestMigrateDenomMetaData(t *testing.T) {
 		newKey := denomMetadataIter.Key()
 
 		// make sure old entry is deleted
-		oldKey := append(newKey, newKey[1:]...)
+		oldKey := append(newKey, newKey[0:]...)
 		bz := denomMetadataStore.Get(oldKey)
 		require.Nil(t, bz)
 
-		require.Equal(t, string(newKey)[1:], metaData[i].Base, "idx: %d", i)
+		require.Equal(t, string(newKey), metaData[i].Base, "idx: %d", i)
 		bz = denomMetadataStore.Get(denomMetadataIter.Key())
 		require.NotNil(t, bz)
 		err := encCfg.Codec.Unmarshal(bz, &result)


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

Closes: #13797 

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

While running an upgrade handler for gaia v8 we supplement the bank metadata. In doing so we found that the metadata was not retrievable using the new KV store pattern in v0.46. Coincidentally, we were trying to retrieve the metadata before the migration had been run. Ironically, after fixing the order, it was still not retrievable because there was a bug in how the store migration was written.

The current implementation infers that the store prefix needs to be included in the key, however the prefix is already omitted as part of the prefix store used in the migration code (and subsequent test).

We iterated over the whole store to check what was the key. When we incorrectly tried to retrieve before the migration we printed out a key of `uatomuatom`. Once we switched the migrations to run before we tried retrieving the metadata we printed out the key of `uatomu`. This demonstrates the migration is applied to a key of the wrong length. The addition of one letter is from the incorrect expectation that the store prefix (`0x1`) should be accounted for.

```go
for ; oldDenomMetaDataIter.Valid(); oldDenomMetaDataIter.Next() {
		oldKey := oldDenomMetaDataIter.Key()
		l := len(oldKey)/2 + 1
```

instead of 
```go
for ; oldDenomMetaDataIter.Valid(); oldDenomMetaDataIter.Next() {
		oldKey := oldDenomMetaDataIter.Key()
		l := len(oldKey) / 2
```

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
- [x] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
