### PR TITLE
Proof-of-Concept: Add alt options to `PrepareProposal`

### DIFF
--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -335,7 +335,7 @@ func (app *BaseApp) PrepareProposalOption1(req abci.RequestPrepareProposal) abci
 }
 
 // Option2:
-// * Introduce `Validate` func on the app-side mempool that returns error if the aggregated txs are valid.
+// * Introduce `Validate` func on the app-side mempool that returns error if the aggregated txs are not valid.
 func (app *BaseApp) PrepareProposalOption2(req abci.RequestPrepareProposal) abci.ResponsePrepareProposal {
 	var (
 		txs       []sdk.Tx // TODO: probably better perf wise to init w `make` if we can return the expected size in `Select`

--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -359,7 +359,7 @@ func (app *BaseApp) PrepareProposalOption2(req abci.RequestPrepareProposal) abci
 		txSize := int64(len(bz))
 
 		_, _, _, _, err = app.runTx(runTxPrepareProposal, bz)
-		if err != nil { // skip tx.
+		if err != nil { // tolearte skipping tx, but we ask the app mempool later for confirmation.
 			iterator = iterator.Next()
 			continue
 		} else if byteCount += txSize; byteCount <= req.MaxTxBytes {

--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -255,7 +255,7 @@ func (app *BaseApp) PrepareProposal(req abci.RequestPrepareProposal) abci.Respon
 	)
 
 	ctx := app.getContextForTx(runTxPrepareProposal, []byte{})
-	iterator := app.mempool.Select(ctx, req.Txs, req.MaxTxBytes)
+	iterator := app.mempool.Select(ctx, req.Txs)
 
 	for iterator != nil {
 		memTx := iterator.Tx()
@@ -271,14 +271,10 @@ func (app *BaseApp) PrepareProposal(req abci.RequestPrepareProposal) abci.Respon
 		// should be valid. But some mempool implementations may insert invalid txs, so we check again.
 		_, _, _, _, err = app.runTx(runTxPrepareProposal, bz)
 		if err != nil {
-			// This doesn't quite separate out the concerns between `PrepareProposal` and app-side mempool.
-			// App-side mempool should be completely controlled by the application itself, but removing
-			// tx here seems to indicate that the ABCI methods like `PrepareProposal` can affect the app-side mempool.
 			err := app.mempool.Remove(memTx)
 			if err != nil && !errors.Is(err, mempool.ErrTxNotFound) {
 				panic(err)
 			}
-			// This feels like "silently ignore tx returned by the app-mempool", which feels like swallowing an error.
 			iterator = iterator.Next()
 			continue
 		} else if byteCount += txSize; byteCount <= req.MaxTxBytes {
@@ -288,93 +284,6 @@ func (app *BaseApp) PrepareProposal(req abci.RequestPrepareProposal) abci.Respon
 		}
 
 		iterator = iterator.Next()
-	}
-
-	return abci.ResponsePrepareProposal{Txs: txsBytes}
-}
-
-// Option1:
-// * Assume that app-side mempool will return valid set of txs. If it doesn't return a valid set then, it's considered a bug, so panic.
-// * `PrepareProposal` should perform lightweight validations only.
-func (app *BaseApp) PrepareProposalOption1(req abci.RequestPrepareProposal) abci.ResponsePrepareProposal {
-	var (
-		txsBytes  [][]byte
-		byteCount int64
-	)
-
-	ctx := app.getContextForTx(runTxPrepareProposal, []byte{})
-
-	// `Select` doesn't necessarily have to return an iterator. It can be a slice.
-	iterator := app.mempool.Select(ctx, req.Txs, req.MaxTxBytes)
-
-	for iterator != nil {
-		memTx := iterator.Tx()
-
-		bz, err := app.txEncoder(memTx)
-		if err != nil {
-			panic(err)
-		}
-
-		txSize := int64(len(bz))
-
-		_, _, _, _, err = app.runTx(runTxPrepareProposal, bz)
-		if err != nil {
-			// Don't remove tx from app.mempool for the reason mentioned above.
-			panic(err)
-		}
-
-		byteCount += txSize
-
-		if byteCount > req.MaxTxBytes {
-			panic(fmt.Errorf("app-side mempool returned more bytes than max tx bytes (%d)", req.MaxTxBytes))
-		}
-		iterator = iterator.Next()
-	}
-
-	return abci.ResponsePrepareProposal{Txs: txsBytes}
-}
-
-// Option2:
-// * Introduce `Validate` func on the app-side mempool that returns error if the aggregated txs are valid.
-func (app *BaseApp) PrepareProposalOption2(req abci.RequestPrepareProposal) abci.ResponsePrepareProposal {
-	var (
-		txs       []sdk.Tx // TODO: probably better perf wise to init w `make` if we can return the expected size in `Select`
-		txsBytes  [][]byte
-		byteCount int64
-	)
-
-	ctx := app.getContextForTx(runTxPrepareProposal, []byte{})
-
-	// `Select` doesn't necessarily have to return an iterator. It can be a slice.
-	iterator := app.mempool.Select(ctx, req.Txs, req.MaxTxBytes)
-
-	for iterator != nil {
-		memTx := iterator.Tx()
-
-		bz, err := app.txEncoder(memTx)
-		if err != nil {
-			panic(err)
-		}
-
-		txSize := int64(len(bz))
-
-		_, _, _, _, err = app.runTx(runTxPrepareProposal, bz)
-		if err != nil { // skip tx.
-			iterator = iterator.Next()
-			continue
-		} else if byteCount += txSize; byteCount <= req.MaxTxBytes {
-			txsBytes = append(txsBytes, bz)
-			txs = append(txs, memTx)
-		} else { // aggregated max bytes, skip the rest.
-			break
-		}
-
-		iterator = iterator.Next()
-	}
-
-	// After aggregating txs, ask app-side mempool if the txs are valid or not.
-	if err := app.mempool.Validate(ctx, req.Txs, req.MaxTxBytes, txs); err != nil {
-		panic(err)
 	}
 
 	return abci.ResponsePrepareProposal{Txs: txsBytes}

--- a/types/mempool/mempool.go
+++ b/types/mempool/mempool.go
@@ -13,7 +13,11 @@ type Mempool interface {
 
 	// Select returns an Iterator over the app-side mempool.  If txs are specified, then they shall be incorporated
 	// into the Iterator.  The Iterator must be closed by the caller.
-	Select(sdk.Context, [][]byte) Iterator
+	Select(sdk.Context, [][]byte, int64) Iterator
+
+	// Validate returns nil if the slice of txs specified are valid txs to reply in `ResponsePrepareProposal`.
+	// Otherwise, returns error.
+	Validate(sdk.Context, [][]byte, int64, []sdk.Tx) error
 
 	// CountTx returns the number of transactions currently in the mempool.
 	CountTx() int

--- a/types/mempool/mempool.go
+++ b/types/mempool/mempool.go
@@ -13,11 +13,7 @@ type Mempool interface {
 
 	// Select returns an Iterator over the app-side mempool.  If txs are specified, then they shall be incorporated
 	// into the Iterator.  The Iterator must be closed by the caller.
-	Select(sdk.Context, [][]byte, int64) Iterator
-
-	// Validate returns nil if the slice of txs specified are valid txs to reply in `ResponsePrepareProposal`.
-	// Otherwise, returns error.
-	Validate(sdk.Context, [][]byte, int64, []sdk.Tx) error
+	Select(sdk.Context, [][]byte) Iterator
 
 	// CountTx returns the number of transactions currently in the mempool.
 	CountTx() int


### PR DESCRIPTION
Idea/Problem:
* [Original PR comment](https://github.com/cosmos/cosmos-sdk/pull/13453#discussion_r1018316817)
* Currently, once the app mempool returns a list of txs to `PrepareProposal` via `Select`, the app does not know for sure if all txs will be included in the `ResponsePrepareProposal`.
* This matters to apps because the txs returned in `Select` were crafted in a specific way (i.e. the txs ordering or types of txs included). Ignoring or only including a subset of the returned txs would be undesirable from the app's perspective.

Options:
1.  `PrepareProposal` assumes that app-side mempool will return valid set of txs. If it doesn't return a valid set then, it's considered a bug, so panic.
2. `PrepareProposal` asks app-side mempool: "hey, these are the final txs that will be included in ResponsePrepareProposal , do these txs look okay to you still?"

I think there are better options out there, but drafting this PR to communicate the high-level thought