### PR TITLE
docs: add documentation for nft module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,8 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Improvements
 
-* [13789](https://github.com/cosmos/cosmos-sdk/pull/13789) Add tx `encode` and `decode` endpoints to tx service.
+* (x/nft) [#13836](https://github.com/cosmos/cosmos-sdk/pull/13836) Remove the validation for `classID` and `nftID` from the NFT module.
+* [#13789](https://github.com/cosmos/cosmos-sdk/pull/13789) Add tx `encode` and `decode` endpoints to tx service.
   > Note: This endpoint will only encode proto messages, Amino encoding is not supported.
 * [#13826](https://github.com/cosmos/cosmos-sdk/pull/13826) Support custom `GasConfig` configuration for applications.
 * [#13619](https://github.com/cosmos/cosmos-sdk/pull/13619) Add new function called LogDeferred to report errors in defers. Use the function in x/bank files.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -4,6 +4,8 @@ This guide provides instructions for upgrading to specific versions of Cosmos SD
 
 ## [Unreleased]
 
+## [v0.47.x](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.47.0)
+
 ### Simulation
 
 Remove `RandomizedParams` from `AppModuleSimulation` interface. Previously, it used to generate random parameter changes during simulations, however, it does so through ParamChangeProposal which is now legacy. Since all modules were migrated, we can now safely remove this from `AppModuleSimulation` interface.
@@ -36,6 +38,7 @@ SimApp's `app.go` is now using [App Wiring](https://docs.cosmos.network/main/bui
 This means that modules are injected directly into SimApp thanks to a [configuration file](https://github.com/cosmos/cosmos-sdk/blob/main/simapp/app_config.go).
 The old behavior is preserved and can still be used, without the dependency injection framework, as shows [`app_legacy.go`](https://github.com/cosmos/cosmos-sdk/blob/main/simapp/app_legacy.go).
 If you are using a legacy `app.go` without dependency injection, add the following lines to your `app.go` in order to provide newer gRPC services:
+
 ```go
 autocliv1.RegisterQueryServer(app.GRPCQueryRouter(), runtimeservices.NewAutoCLIQueryService(app.ModuleManager.Modules))
 
@@ -156,6 +159,11 @@ After:
 app.ConsensusParamsKeeper = consensusparamkeeper.NewKeeper(appCodec, keys[upgradetypes.StoreKey], authtypes.NewModuleAddress(govtypes.ModuleName).String())
 bApp.SetParamStore(&app.ConsensusParamsKeeper)
 ```
+
+#### `x/nft`
+
+The SDK does not validate anymore the `classID` and `nftID` of an NFT, for extra flexibility in your NFT implementation.
+This means chain developers need to validate the `classID` and `nftID` of an NFT.
 
 ### Ledger
 

--- a/tests/e2e/nft/grpc.go
+++ b/tests/e2e/nft/grpc.go
@@ -322,6 +322,18 @@ func (s *IntegrationTestSuite) TestQueryNFTGRPC() {
 			},
 			expectErr: false,
 		},
+		{
+			name: "class id does not exist",
+			args: struct {
+				ClassID string
+				ID      string
+			}{
+				ClassID: "class",
+				ID:      ExpNFT.Id,
+			},
+			expectErr: true,
+			errorMsg:  "not found nft",
+		},
 	}
 	nftURL := val.APIAddress + "/cosmos/nft/v1beta1/nfts/%s/%s"
 	for _, tc := range testCases {

--- a/x/nft/README.md
+++ b/x/nft/README.md
@@ -67,7 +67,12 @@ TotalSupply is responsible for tracking the number of all nfts under a certain c
 
 ## Messages
 
-In this section we describe the processing of messages for the nft module.
+In this section we describe the processing of messages for the NFT module.
+
+:::warning
+The validation of `ClassID` and `NftID` is left to the app developer.  
+The SDK does not provide any validation for these fields.
+:::
 
 ### MsgSend
 
@@ -75,9 +80,9 @@ You can use the `MsgSend` message to transfer the ownership of nft. This is a fu
 
 The message handling should fail if:
 
-* provided `ClassID` is not exist.
-* provided `Id` is not exist.
-* provided `Sender` is not the owner of nft.
+* provided `ClassID` does not exist.
+* provided `Id` does not exist.
+* provided `Sender` does not the owner of nft.
 
 ## Events
 


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

Follow-up of #13836 for docs.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
