### PR TITLE
refactor: Don't break SignModeHandler API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Improvements
 
+* (signing) [#TODO](https://github.com/cosmos/cosmos-sdk/pull/) Add a new SignModeHandlerWithContext interface with a new GetSignBytesWithContext to get the sign bytes using `context.Context` as an argument to access state.
 * [13882] (https://github.com/cosmos/cosmos-sdk/pull/13882) Add tx `encode` and `decode` endpoints to amino tx service.
   > Note: These endpoints encodes and decodes only amino txs.
 * (config) [#13894](https://github.com/cosmos/cosmos-sdk/pull/13894) Support state streaming configuration in `app.toml` template and default configuration.
@@ -177,7 +178,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * [#13794](https://github.com/cosmos/cosmos-sdk/pull/13794) Most methods on `types/module.AppModule` have been moved to 
 extension interfaces. `module.Manager.Modules` is now of type `map[string]interface{}` to support in parallel the new 
 `cosmossdk.io/core/appmodule.AppModule` API.
-* (signing) [#13701](https://github.com/cosmos/cosmos-sdk/pull/) Add `context.Context` as an argument to SignModeHandler's `GetSignBytes` method and `x/auth/signing.VerifySignature`. You can pass `nil` for now, it will only be used once SIGN_MODE_TEXTUAL is live.
+* (signing) [#13701](https://github.com/cosmos/cosmos-sdk/pull/) Add `context.Context` as an argument `x/auth/signing.VerifySignature`.
 * (x/group) [#13876](https://github.com/cosmos/cosmos-sdk/pull/13876) Add `GetMinExecutionPeriod` method on DecisionPolicy interface.
 * (x/auth)[#13780](https://github.com/cosmos/cosmos-sdk/pull/13780) Querying with `id` (type of int64) in `AccountAddressByID` grpc query now throws error, use account-id(type of uint64) instead.
 * (snapshots) [14048](https://github.com/cosmos/cosmos-sdk/pull/14048) Move the Snapshot package to the store package. This is done in an effort group all storage related logic under one package. 

--- a/client/tx/tx.go
+++ b/client/tx/tx.go
@@ -158,7 +158,16 @@ func SignWithPrivKey(
 	var sigV2 signing.SignatureV2
 
 	// Generate the bytes to be signed.
-	signBytes, err := txConfig.SignModeHandler().GetSignBytes(ctx, signMode, signerData, txBuilder.GetTx())
+	var (
+		signBytes []byte
+		err       error
+	)
+	h, ok := txConfig.SignModeHandler().(authsigning.SignModeHandlerWithContext)
+	if ok {
+		signBytes, err = h.GetSignBytesWithContext(ctx, signMode, signerData, txBuilder.GetTx())
+	} else {
+		signBytes, err = txConfig.SignModeHandler().GetSignBytes(signMode, signerData, txBuilder.GetTx())
+	}
 	if err != nil {
 		return sigV2, err
 	}
@@ -300,7 +309,13 @@ func Sign(ctx context.Context, txf Factory, name string, txBuilder client.TxBuil
 	}
 
 	// Generate the bytes to be signed.
-	bytesToSign, err := txf.txConfig.SignModeHandler().GetSignBytes(ctx, signMode, signerData, txBuilder.GetTx())
+	var bytesToSign []byte
+	h, ok := txf.txConfig.SignModeHandler().(authsigning.SignModeHandlerWithContext)
+	if ok {
+		bytesToSign, err = h.GetSignBytesWithContext(ctx, signMode, signerData, txBuilder.GetTx())
+	} else {
+		bytesToSign, err = txf.txConfig.SignModeHandler().GetSignBytes(signMode, signerData, txBuilder.GetTx())
+	}
 	if err != nil {
 		return err
 	}

--- a/testutil/sims/tx_helpers.go
+++ b/testutil/sims/tx_helpers.go
@@ -1,7 +1,6 @@
 package sims
 
 import (
-	"context"
 	"math/rand"
 	"testing"
 	"time"
@@ -62,8 +61,9 @@ func GenSignedMockTx(r *rand.Rand, txConfig client.TxConfig, msgs []sdk.Msg, fee
 			Sequence:      accSeqs[i],
 			PubKey:        p.PubKey(),
 		}
-		// When Textual is wired up, the context argument should be retrieved from the client context.
-		signBytes, err := txConfig.SignModeHandler().GetSignBytes(context.TODO(), signMode, signerData, tx.GetTx())
+		// When Textual is wired up, use GetSignBytesWithContext
+		// ref: https://github.com/cosmos/cosmos-sdk/issues/13747
+		signBytes, err := txConfig.SignModeHandler().GetSignBytes(signMode, signerData, tx.GetTx())
 		if err != nil {
 			panic(err)
 		}

--- a/tools/rosetta/converter.go
+++ b/tools/rosetta/converter.go
@@ -115,7 +115,15 @@ func NewConverter(cdc *codec.ProtoCodec, ir codectypes.InterfaceRegistry, cfg sd
 		txDecode:        cfg.TxDecoder(),
 		txEncode:        cfg.TxEncoder(),
 		bytesToSign: func(tx authsigning.Tx, signerData authsigning.SignerData) (b []byte, err error) {
-			bytesToSign, err := cfg.SignModeHandler().GetSignBytes(context.TODO(), signing.SignMode_SIGN_MODE_LEGACY_AMINO_JSON, signerData, tx)
+			var bytesToSign []byte
+			h, ok := cfg.SignModeHandler().(authsigning.SignModeHandlerWithContext)
+			if ok {
+				// Replace context.TODO() with a client side context
+				// https://github.com/cosmos/cosmos-sdk/issues/13747
+				bytesToSign, err = h.GetSignBytesWithContext(context.TODO(), signing.SignMode_SIGN_MODE_LEGACY_AMINO_JSON, signerData, tx)
+			} else {
+				bytesToSign, err = cfg.SignModeHandler().GetSignBytes(signing.SignMode_SIGN_MODE_LEGACY_AMINO_JSON, signerData, tx)
+			}
 			if err != nil {
 				return nil, err
 			}

--- a/tools/rosetta/go.mod
+++ b/tools/rosetta/go.mod
@@ -111,5 +111,10 @@ require (
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
 
-// Update to rosetta-sdk-go temporarly to have `check:spec` passing. See https://github.com/coinbase/rosetta-sdk-go/issues/449
-replace github.com/coinbase/rosetta-sdk-go => github.com/coinbase/rosetta-sdk-go v0.8.2-0.20221007214527-e03849ba430a
+replace (
+	// temporary until we tag a new sdk version
+	github.com/cosmos/cosmos-sdk => ../..
+
+	// Update to rosetta-sdk-go temporarly to have `check:spec` passing. See https://github.com/coinbase/rosetta-sdk-go/issues/449
+	github.com/coinbase/rosetta-sdk-go => github.com/coinbase/rosetta-sdk-go v0.8.2-0.20221007214527-e03849ba430a
+)

--- a/x/auth/migrations/legacytx/amino_signing.go
+++ b/x/auth/migrations/legacytx/amino_signing.go
@@ -1,7 +1,6 @@
 package legacytx
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -33,7 +32,7 @@ func (stdTxSignModeHandler) Modes() []signingtypes.SignMode {
 }
 
 // DefaultMode implements SignModeHandler.GetSignBytes
-func (stdTxSignModeHandler) GetSignBytes(_ context.Context, mode signingtypes.SignMode, data signing.SignerData, tx sdk.Tx) ([]byte, error) {
+func (stdTxSignModeHandler) GetSignBytes(mode signingtypes.SignMode, data signing.SignerData, tx sdk.Tx) ([]byte, error) {
 	if mode != signingtypes.SignMode_SIGN_MODE_LEGACY_AMINO_JSON {
 		return nil, fmt.Errorf("expected %s, got %s", signingtypes.SignMode_SIGN_MODE_LEGACY_AMINO_JSON, mode)
 	}

--- a/x/auth/migrations/legacytx/amino_signing_test.go
+++ b/x/auth/migrations/legacytx/amino_signing_test.go
@@ -52,7 +52,7 @@ func TestLegacyAminoJSONHandler_GetSignBytes(t *testing.T) {
 		Sequence:      seqNum,
 		PubKey:        priv1.PubKey(),
 	}
-	signBz, err := handler.GetSignBytes(nil, signingtypes.SignMode_SIGN_MODE_LEGACY_AMINO_JSON, signingData, tx)
+	signBz, err := handler.GetSignBytes(signingtypes.SignMode_SIGN_MODE_LEGACY_AMINO_JSON, signingData, tx)
 	require.NoError(t, err)
 
 	expectedSignBz := StdSignBytes(chainId, accNum, seqNum, timeoutHeight, fee, msgs, memo, nil)
@@ -60,7 +60,7 @@ func TestLegacyAminoJSONHandler_GetSignBytes(t *testing.T) {
 	require.Equal(t, expectedSignBz, signBz)
 
 	// expect error with wrong sign mode
-	_, err = handler.GetSignBytes(nil, signingtypes.SignMode_SIGN_MODE_DIRECT, signingData, tx)
+	_, err = handler.GetSignBytes(signingtypes.SignMode_SIGN_MODE_DIRECT, signingData, tx)
 	require.Error(t, err)
 }
 

--- a/x/auth/signing/handler_map.go
+++ b/x/auth/signing/handler_map.go
@@ -51,11 +51,28 @@ func (h SignModeHandlerMap) Modes() []signing.SignMode {
 	return h.modes
 }
 
-// DefaultMode implements SignModeHandler.GetSignBytes
-func (h SignModeHandlerMap) GetSignBytes(ctx context.Context, mode signing.SignMode, data SignerData, tx sdk.Tx) ([]byte, error) {
+// GetSignBytes implements SignModeHandler.GetSignBytes
+func (h SignModeHandlerMap) GetSignBytes(mode signing.SignMode, data SignerData, tx sdk.Tx) ([]byte, error) {
 	handler, found := h.signModeHandlers[mode]
 	if !found {
 		return nil, fmt.Errorf("can't verify sign mode %s", mode.String())
 	}
-	return handler.GetSignBytes(ctx, mode, data, tx)
+	return handler.GetSignBytes(mode, data, tx)
+}
+
+// GetSignBytesWithContext implements SignModeHandler.GetSignBytesWithContext
+func (h SignModeHandlerMap) GetSignBytesWithContext(ctx context.Context, mode signing.SignMode, data SignerData, tx sdk.Tx) ([]byte, error) {
+	handler, found := h.signModeHandlers[mode]
+	if !found {
+		return nil, fmt.Errorf("can't verify sign mode %s", mode.String())
+	}
+
+	handlerWithContext, ok := handler.(SignModeHandlerWithContext)
+	if ok {
+		return handlerWithContext.GetSignBytesWithContext(ctx, mode, data, tx)
+	}
+
+	// Default to stateless GetSignBytes if the underlying handler does not
+	// implement WithContext.
+	return handlerWithContext.GetSignBytes(mode, data, tx)
 }

--- a/x/auth/signing/sign_mode_handler.go
+++ b/x/auth/signing/sign_mode_handler.go
@@ -20,7 +20,19 @@ type SignModeHandler interface {
 
 	// GetSignBytes returns the sign bytes for the provided SignMode, SignerData and Tx,
 	// or an error
-	GetSignBytes(ctx context.Context, mode signing.SignMode, data SignerData, tx sdk.Tx) ([]byte, error)
+	GetSignBytes(mode signing.SignMode, data SignerData, tx sdk.Tx) ([]byte, error)
+}
+
+// SignModeHandlerWithContext is like SignModeHandler, with a new GetSignBytes
+// method which takes an additional context.Context argument, to be used to
+// access state. Consumers should preferably type-cast to this interface and
+// pass in the context.Context arg, and default to SignModeHandler otherwise.
+type SignModeHandlerWithContext interface {
+	SignModeHandler
+
+	// GetSignBytes returns the sign bytes for the provided SignMode, SignerData and Tx,
+	// or an error
+	GetSignBytesWithContext(ctx context.Context, mode signing.SignMode, data SignerData, tx sdk.Tx) ([]byte, error)
 }
 
 // SignerData is the specific information needed to sign a transaction that generally

--- a/x/auth/tx/direct.go
+++ b/x/auth/tx/direct.go
@@ -1,7 +1,6 @@
 package tx
 
 import (
-	"context"
 	"fmt"
 
 	signingtypes "github.com/cosmos/cosmos-sdk/types/tx/signing"
@@ -27,7 +26,7 @@ func (signModeDirectHandler) Modes() []signingtypes.SignMode {
 }
 
 // GetSignBytes implements SignModeHandler.GetSignBytes
-func (signModeDirectHandler) GetSignBytes(_ context.Context, mode signingtypes.SignMode, data signing.SignerData, tx sdk.Tx) ([]byte, error) {
+func (signModeDirectHandler) GetSignBytes(mode signingtypes.SignMode, data signing.SignerData, tx sdk.Tx) ([]byte, error) {
 	if mode != signingtypes.SignMode_SIGN_MODE_DIRECT {
 		return nil, fmt.Errorf("expected %s, got %s", signingtypes.SignMode_SIGN_MODE_DIRECT, mode)
 	}

--- a/x/auth/tx/direct_aux.go
+++ b/x/auth/tx/direct_aux.go
@@ -1,7 +1,6 @@
 package tx
 
 import (
-	"context"
 	"fmt"
 
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
@@ -29,7 +28,7 @@ func (signModeDirectAuxHandler) Modes() []signingtypes.SignMode {
 
 // GetSignBytes implements SignModeHandler.GetSignBytes
 func (signModeDirectAuxHandler) GetSignBytes(
-	_ context.Context, mode signingtypes.SignMode, data signing.SignerData, tx sdk.Tx,
+	mode signingtypes.SignMode, data signing.SignerData, tx sdk.Tx,
 ) ([]byte, error) {
 	if mode != signingtypes.SignMode_SIGN_MODE_DIRECT_AUX {
 		return nil, fmt.Errorf("expected %s, got %s", signingtypes.SignMode_SIGN_MODE_DIRECT_AUX, mode)

--- a/x/auth/tx/direct_aux_test.go
+++ b/x/auth/tx/direct_aux_test.go
@@ -80,11 +80,11 @@ func TestDirectAuxHandler(t *testing.T) {
 	modeHandler := signModeDirectAuxHandler{}
 
 	t.Log("verify fee payer cannot use SIGN_MODE_DIRECT_AUX")
-	_, err = modeHandler.GetSignBytes(nil, signingtypes.SignMode_SIGN_MODE_DIRECT_AUX, feePayerSigningData, txBuilder.GetTx())
+	_, err = modeHandler.GetSignBytes(signingtypes.SignMode_SIGN_MODE_DIRECT_AUX, feePayerSigningData, txBuilder.GetTx())
 	require.EqualError(t, err, fmt.Sprintf("fee payer %s cannot sign with %s: unauthorized", feePayerAddr.String(), signingtypes.SignMode_SIGN_MODE_DIRECT_AUX))
 
 	t.Log("verify GetSignBytes with generating sign bytes by marshaling signDocDirectAux")
-	signBytes, err := modeHandler.GetSignBytes(nil, signingtypes.SignMode_SIGN_MODE_DIRECT_AUX, signingData, txBuilder.GetTx())
+	signBytes, err := modeHandler.GetSignBytes(signingtypes.SignMode_SIGN_MODE_DIRECT_AUX, signingData, txBuilder.GetTx())
 	require.NoError(t, err)
 	require.NotNil(t, signBytes)
 
@@ -121,7 +121,7 @@ func TestDirectAuxHandler(t *testing.T) {
 	require.NoError(t, err)
 	err = txBuilder.SetSignatures(sig)
 	require.NoError(t, err)
-	signBytes, err = modeHandler.GetSignBytes(nil, signingtypes.SignMode_SIGN_MODE_DIRECT_AUX, signingData, txBuilder.GetTx())
+	signBytes, err = modeHandler.GetSignBytes(signingtypes.SignMode_SIGN_MODE_DIRECT_AUX, signingData, txBuilder.GetTx())
 	require.NoError(t, err)
 	require.Equal(t, expectedSignBytes, signBytes)
 
@@ -148,7 +148,7 @@ func TestDirectAuxModeHandler_nonDIRECT_MODE(t *testing.T) {
 		t.Run(invalidMode.String(), func(t *testing.T) {
 			var dh signModeDirectAuxHandler
 			var signingData signing.SignerData
-			_, err := dh.GetSignBytes(nil, invalidMode, signingData, nil)
+			_, err := dh.GetSignBytes(invalidMode, signingData, nil)
 			require.Error(t, err)
 			wantErr := fmt.Errorf("expected %s, got %s", signingtypes.SignMode_SIGN_MODE_DIRECT_AUX, invalidMode)
 			require.Equal(t, err, wantErr)
@@ -160,7 +160,7 @@ func TestDirectAuxModeHandler_nonProtoTx(t *testing.T) {
 	var dh signModeDirectAuxHandler
 	var signingData signing.SignerData
 	tx := new(nonProtoTx)
-	_, err := dh.GetSignBytes(nil, signingtypes.SignMode_SIGN_MODE_DIRECT_AUX, signingData, tx)
+	_, err := dh.GetSignBytes(signingtypes.SignMode_SIGN_MODE_DIRECT_AUX, signingData, tx)
 	require.Error(t, err)
 	wantErr := fmt.Errorf("can only handle a protobuf Tx, got %T", tx)
 	require.Equal(t, err, wantErr)

--- a/x/auth/tx/direct_test.go
+++ b/x/auth/tx/direct_test.go
@@ -75,7 +75,7 @@ func TestDirectModeHandler(t *testing.T) {
 		PubKey:        pubkey,
 	}
 
-	signBytes, err := modeHandler.GetSignBytes(nil, signingtypes.SignMode_SIGN_MODE_DIRECT, signingData, txBuilder.GetTx())
+	signBytes, err := modeHandler.GetSignBytes(signingtypes.SignMode_SIGN_MODE_DIRECT, signingData, txBuilder.GetTx())
 
 	require.NoError(t, err)
 	require.NotNil(t, signBytes)
@@ -120,7 +120,7 @@ func TestDirectModeHandler(t *testing.T) {
 	require.NoError(t, err)
 	err = txBuilder.SetSignatures(sig)
 	require.NoError(t, err)
-	signBytes, err = modeHandler.GetSignBytes(nil, signingtypes.SignMode_SIGN_MODE_DIRECT, signingData, txBuilder.GetTx())
+	signBytes, err = modeHandler.GetSignBytes(signingtypes.SignMode_SIGN_MODE_DIRECT, signingData, txBuilder.GetTx())
 	require.NoError(t, err)
 	require.Equal(t, expectedSignBytes, signBytes)
 
@@ -141,7 +141,7 @@ func TestDirectModeHandler_nonDIRECT_MODE(t *testing.T) {
 		t.Run(invalidMode.String(), func(t *testing.T) {
 			var dh signModeDirectHandler
 			var signingData signing.SignerData
-			_, err := dh.GetSignBytes(nil, invalidMode, signingData, nil)
+			_, err := dh.GetSignBytes(invalidMode, signingData, nil)
 			require.Error(t, err)
 			wantErr := fmt.Errorf("expected %s, got %s", signingtypes.SignMode_SIGN_MODE_DIRECT, invalidMode)
 			require.Equal(t, err, wantErr)
@@ -160,7 +160,7 @@ func TestDirectModeHandler_nonProtoTx(t *testing.T) {
 	var dh signModeDirectHandler
 	var signingData signing.SignerData
 	tx := new(nonProtoTx)
-	_, err := dh.GetSignBytes(nil, signingtypes.SignMode_SIGN_MODE_DIRECT, signingData, tx)
+	_, err := dh.GetSignBytes(signingtypes.SignMode_SIGN_MODE_DIRECT, signingData, tx)
 	require.Error(t, err)
 	wantErr := fmt.Errorf("can only handle a protobuf Tx, got %T", tx)
 	require.Equal(t, err, wantErr)

--- a/x/auth/tx/encode_decode_test.go
+++ b/x/auth/tx/encode_decode_test.go
@@ -128,7 +128,7 @@ func TestUnknownFields(t *testing.T) {
 				decoder := DefaultTxDecoder(codec.NewProtoCodec(codectypes.NewInterfaceRegistry()))
 				theTx, err := decoder(txBz)
 				require.NoError(t, err)
-				_, err = handler.GetSignBytes(nil, signingtypes.SignMode_SIGN_MODE_LEGACY_AMINO_JSON, signing.SignerData{}, theTx)
+				_, err = handler.GetSignBytes(signingtypes.SignMode_SIGN_MODE_LEGACY_AMINO_JSON, signing.SignerData{}, theTx)
 				require.EqualError(t, err, tt.shouldAminoErr)
 			}
 		})

--- a/x/auth/tx/legacy_amino_json.go
+++ b/x/auth/tx/legacy_amino_json.go
@@ -1,7 +1,6 @@
 package tx
 
 import (
-	"context"
 	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -27,7 +26,7 @@ func (s signModeLegacyAminoJSONHandler) Modes() []signingtypes.SignMode {
 	return []signingtypes.SignMode{signingtypes.SignMode_SIGN_MODE_LEGACY_AMINO_JSON}
 }
 
-func (s signModeLegacyAminoJSONHandler) GetSignBytes(_ context.Context, mode signingtypes.SignMode, data signing.SignerData, tx sdk.Tx) ([]byte, error) {
+func (s signModeLegacyAminoJSONHandler) GetSignBytes(mode signingtypes.SignMode, data signing.SignerData, tx sdk.Tx) ([]byte, error) {
 	if mode != signingtypes.SignMode_SIGN_MODE_LEGACY_AMINO_JSON {
 		return nil, fmt.Errorf("expected %s, got %s", signingtypes.SignMode_SIGN_MODE_LEGACY_AMINO_JSON, mode)
 	}

--- a/x/auth/tx/legacy_amino_json_test.go
+++ b/x/auth/tx/legacy_amino_json_test.go
@@ -97,7 +97,7 @@ func TestLegacyAminoJSONHandler_GetSignBytes(t *testing.T) {
 				AccountNumber: accNum,
 				Sequence:      seqNum,
 			}
-			signBz, err := handler.GetSignBytes(nil, signingtypes.SignMode_SIGN_MODE_LEGACY_AMINO_JSON, signingData, tx)
+			signBz, err := handler.GetSignBytes(signingtypes.SignMode_SIGN_MODE_LEGACY_AMINO_JSON, signingData, tx)
 			require.NoError(t, err)
 
 			require.Equal(t, tc.expectedSignBz, signBz)
@@ -116,7 +116,7 @@ func TestLegacyAminoJSONHandler_GetSignBytes(t *testing.T) {
 	}
 
 	// expect error with wrong sign mode
-	_, err := handler.GetSignBytes(nil, signingtypes.SignMode_SIGN_MODE_DIRECT, signingData, tx)
+	_, err := handler.GetSignBytes(signingtypes.SignMode_SIGN_MODE_DIRECT, signingData, tx)
 	require.Error(t, err)
 
 	// expect error with extension options
@@ -126,7 +126,7 @@ func TestLegacyAminoJSONHandler_GetSignBytes(t *testing.T) {
 	require.NoError(t, err)
 	bldr.tx.Body.ExtensionOptions = []*cdctypes.Any{any}
 	tx = bldr.GetTx()
-	_, err = handler.GetSignBytes(nil, signingtypes.SignMode_SIGN_MODE_LEGACY_AMINO_JSON, signingData, tx)
+	_, err = handler.GetSignBytes(signingtypes.SignMode_SIGN_MODE_LEGACY_AMINO_JSON, signingData, tx)
 	require.Error(t, err)
 
 	// expect error with non-critical extension options
@@ -134,7 +134,7 @@ func TestLegacyAminoJSONHandler_GetSignBytes(t *testing.T) {
 	buildTx(t, bldr)
 	bldr.tx.Body.NonCriticalExtensionOptions = []*cdctypes.Any{any}
 	tx = bldr.GetTx()
-	_, err = handler.GetSignBytes(nil, signingtypes.SignMode_SIGN_MODE_LEGACY_AMINO_JSON, signingData, tx)
+	_, err = handler.GetSignBytes(signingtypes.SignMode_SIGN_MODE_LEGACY_AMINO_JSON, signingData, tx)
 	require.Error(t, err)
 }
 

--- a/x/auth/tx/testutil/suite.go
+++ b/x/auth/tx/testutil/suite.go
@@ -2,7 +2,6 @@ package tx
 
 import (
 	"bytes"
-	"context"
 
 	"github.com/stretchr/testify/suite"
 
@@ -135,7 +134,7 @@ func (s *TxConfigTestSuite) TestTxBuilderSetSignatures() {
 		Sequence:      seq1,
 		PubKey:        pubkey,
 	}
-	signBytes, err := signModeHandler.GetSignBytes(context.TODO(), signModeHandler.DefaultMode(), signerData, sigTx)
+	signBytes, err := signModeHandler.GetSignBytes(signModeHandler.DefaultMode(), signerData, sigTx)
 	s.Require().NoError(err)
 	sigBz, err := privKey.Sign(signBytes)
 	s.Require().NoError(err)
@@ -147,7 +146,7 @@ func (s *TxConfigTestSuite) TestTxBuilderSetSignatures() {
 		Sequence:      mseq,
 		PubKey:        multisigPk,
 	}
-	mSignBytes, err := signModeHandler.GetSignBytes(context.TODO(), signModeHandler.DefaultMode(), signerData, sigTx)
+	mSignBytes, err := signModeHandler.GetSignBytes(signModeHandler.DefaultMode(), signerData, sigTx)
 	s.Require().NoError(err)
 	mSigBz1, err := privKey.Sign(mSignBytes)
 	s.Require().NoError(err)


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

This PR reverts the API breaking changes on SignModeHandler introduced in #13646, as they break rosetta integration. It does so by introducing a new SignModeHandlerWithContext interface, and let consumers type cast to check which interface to use.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
