### PR TITLE
refactor: undo sdk/types import in store. 

### DIFF
--- a/store/prefix/store_test.go
+++ b/store/prefix/store_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/store/gaskv"
 	"github.com/cosmos/cosmos-sdk/store/iavl"
 	"github.com/cosmos/cosmos-sdk/store/types"
-	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 // copied from iavl/store_test.go
@@ -248,7 +247,7 @@ func mockStoreWithStuff() types.KVStore {
 	store.Set(bz("key2"), bz("value2"))
 	store.Set(bz("key3"), bz("value3"))
 	store.Set(bz("something"), bz("else"))
-	store.Set(bz("k"), bz(sdk.PrefixValidator))
+	store.Set(bz("k"), bz("val"))
 	store.Set(bz("ke"), bz("valu"))
 	store.Set(bz("kee"), bz("valuu"))
 	return store

--- a/store/streaming/constructor_test.go
+++ b/store/streaming/constructor_test.go
@@ -3,6 +3,10 @@ package streaming_test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+	"github.com/tendermint/tendermint/libs/log"
+	dbm "github.com/tendermint/tm-db"
+
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/codec"
 	codecTypes "github.com/cosmos/cosmos-sdk/codec/types"
@@ -11,13 +15,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/store/streaming/file"
 	"github.com/cosmos/cosmos-sdk/store/types"
 	simtestutil "github.com/cosmos/cosmos-sdk/testutil/sims"
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module/testutil"
-
-	"github.com/tendermint/tendermint/libs/log"
-	dbm "github.com/tendermint/tm-db"
-
-	"github.com/stretchr/testify/require"
 )
 
 type fakeOptions struct{}
@@ -26,7 +24,7 @@ func (f *fakeOptions) Get(string) interface{} { return nil }
 
 var (
 	mockOptions       = new(fakeOptions)
-	mockKeys          = []types.StoreKey{sdk.NewKVStoreKey("mockKey1"), sdk.NewKVStoreKey("mockKey2")}
+	mockKeys          = []types.StoreKey{types.NewKVStoreKey("mockKey1"), types.NewKVStoreKey("mockKey2")}
 	interfaceRegistry = codecTypes.NewInterfaceRegistry()
 	testMarshaller    = codec.NewProtoCodec(interfaceRegistry)
 )
@@ -53,7 +51,7 @@ func TestStreamingServiceConstructor(t *testing.T) {
 func TestLoadStreamingServices(t *testing.T) {
 	db := dbm.NewMemDB()
 	encCdc := testutil.MakeTestEncodingConfig()
-	keys := sdk.NewKVStoreKeys("mockKey1", "mockKey2")
+	keys := types.NewKVStoreKeys("mockKey1", "mockKey2")
 	bApp := baseapp.NewBaseApp("appName", log.NewNopLogger(), db, nil)
 
 	testCases := map[string]struct {

--- a/store/streaming/file/service_test.go
+++ b/store/streaming/file/service_test.go
@@ -1,6 +1,7 @@
 package file
 
 import (
+	"context"
 	"encoding/binary"
 	"fmt"
 	"os"
@@ -15,7 +16,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	codecTypes "github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/cosmos/cosmos-sdk/store/types"
-	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 var (
@@ -23,7 +23,7 @@ var (
 	testMarshaller               = codec.NewProtoCodec(interfaceRegistry)
 	testStreamingService         *StreamingService
 	testListener1, testListener2 types.WriteListener
-	emptyContext                 = sdk.Context{}
+	emptyContext                 = context.TODO()
 
 	// test abci message types
 	mockHash          = []byte{1, 2, 3, 4, 5, 6, 7, 8, 9}
@@ -88,8 +88,8 @@ var (
 	}
 
 	// mock store keys
-	mockStoreKey1 = sdk.NewKVStoreKey("mockStore1")
-	mockStoreKey2 = sdk.NewKVStoreKey("mockStore2")
+	mockStoreKey1 = types.NewKVStoreKey("mockStore1")
+	mockStoreKey2 = types.NewKVStoreKey("mockStore2")
 
 	// file stuff
 	testPrefix = "testPrefix"

--- a/store/types/store.go
+++ b/store/types/store.go
@@ -370,6 +370,19 @@ func NewKVStoreKey(name string) *KVStoreKey {
 	}
 }
 
+// NewKVStoreKeys returns a map of new  pointers to KVStoreKey's.
+// The function will panic if there is a potential conflict in names (see `assertNoPrefix`
+// function for more details).
+func NewKVStoreKeys(names ...string) map[string]*KVStoreKey {
+	assertNoPrefix(names)
+	keys := make(map[string]*KVStoreKey, len(names))
+	for _, n := range names {
+		keys[n] = NewKVStoreKey(n)
+	}
+
+	return keys
+}
+
 func (key *KVStoreKey) Name() string {
 	return key.name
 }

--- a/store/types/utils.go
+++ b/store/types/utils.go
@@ -2,6 +2,9 @@ package types
 
 import (
 	"bytes"
+	fmt "fmt"
+	"sort"
+	"strings"
 
 	"github.com/cosmos/cosmos-sdk/types/kv"
 )
@@ -104,4 +107,17 @@ func PrefixEndBytes(prefix []byte) []byte {
 // range query such that the input would be included
 func InclusiveEndBytes(inclusiveBytes []byte) []byte {
 	return append(inclusiveBytes, byte(0x00))
+}
+
+// assertNoCommonPrefix will panic if there are two keys: k1 and k2 in keys, such that
+// k1 is a prefix of k2
+func assertNoPrefix(keys []string) {
+	sorted := make([]string, len(keys))
+	copy(sorted, keys)
+	sort.Strings(sorted)
+	for i := 1; i < len(sorted); i++ {
+		if strings.HasPrefix(sorted[i], sorted[i-1]) {
+			panic(fmt.Sprint("Potential key collision between KVStores:", sorted[i], " - ", sorted[i-1]))
+		}
+	}
 }

--- a/store/types/utils_test.go
+++ b/store/types/utils_test.go
@@ -9,17 +9,17 @@ import (
 	dbm "github.com/tendermint/tm-db"
 
 	"github.com/cosmos/cosmos-sdk/store/rootmulti"
-	sdk "github.com/cosmos/cosmos-sdk/store/types"
+	"github.com/cosmos/cosmos-sdk/store/types"
 )
 
-func initTestStores(t *testing.T) (sdk.KVStore, sdk.KVStore) {
+func initTestStores(t *testing.T) (types.KVStore, types.KVStore) {
 	db := dbm.NewMemDB()
 	ms := rootmulti.NewStore(db, log.NewNopLogger())
 
-	key1 := sdk.NewKVStoreKey("store1")
-	key2 := sdk.NewKVStoreKey("store2")
-	require.NotPanics(t, func() { ms.MountStoreWithDB(key1, sdk.StoreTypeIAVL, db) })
-	require.NotPanics(t, func() { ms.MountStoreWithDB(key2, sdk.StoreTypeIAVL, db) })
+	key1 := types.NewKVStoreKey("store1")
+	key2 := types.NewKVStoreKey("store2")
+	require.NotPanics(t, func() { ms.MountStoreWithDB(key1, types.StoreTypeIAVL, db) })
+	require.NotPanics(t, func() { ms.MountStoreWithDB(key2, types.StoreTypeIAVL, db) })
 	require.NoError(t, ms.LoadLatestVersion())
 	return ms.GetKVStore(key1), ms.GetKVStore(key2)
 }
@@ -32,27 +32,27 @@ func TestDiffKVStores(t *testing.T) {
 	store1.Set(k1, v1)
 	store2.Set(k1, v1)
 
-	kvAs, kvBs := sdk.DiffKVStores(store1, store2, nil)
+	kvAs, kvBs := types.DiffKVStores(store1, store2, nil)
 	require.Equal(t, 0, len(kvAs))
 	require.Equal(t, len(kvAs), len(kvBs))
 
 	// delete k1 from store2, which is now empty
 	store2.Delete(k1)
-	kvAs, kvBs = sdk.DiffKVStores(store1, store2, nil)
+	kvAs, kvBs = types.DiffKVStores(store1, store2, nil)
 	require.Equal(t, 1, len(kvAs))
 	require.Equal(t, len(kvAs), len(kvBs))
 
 	// set k1 in store2, different value than what store1 holds for k1
 	v2 := []byte("v2")
 	store2.Set(k1, v2)
-	kvAs, kvBs = sdk.DiffKVStores(store1, store2, nil)
+	kvAs, kvBs = types.DiffKVStores(store1, store2, nil)
 	require.Equal(t, 1, len(kvAs))
 	require.Equal(t, len(kvAs), len(kvBs))
 
 	// add k2 to store2
 	k2 := []byte("k2")
 	store2.Set(k2, v2)
-	kvAs, kvBs = sdk.DiffKVStores(store1, store2, nil)
+	kvAs, kvBs = types.DiffKVStores(store1, store2, nil)
 	require.Equal(t, 2, len(kvAs))
 	require.Equal(t, len(kvAs), len(kvBs))
 
@@ -66,7 +66,7 @@ func TestDiffKVStores(t *testing.T) {
 	k1Prefixed := append(prefix, k1...)
 	store1.Set(k1Prefixed, v1)
 	store2.Set(k1Prefixed, v2)
-	kvAs, kvBs = sdk.DiffKVStores(store1, store2, [][]byte{prefix})
+	kvAs, kvBs = types.DiffKVStores(store1, store2, [][]byte{prefix})
 	require.Equal(t, 0, len(kvAs))
 	require.Equal(t, len(kvAs), len(kvBs))
 }
@@ -74,16 +74,16 @@ func TestDiffKVStores(t *testing.T) {
 func TestPrefixEndBytes(t *testing.T) {
 	t.Parallel()
 	bs1 := []byte{0x23, 0xA5, 0x06}
-	require.True(t, bytes.Equal([]byte{0x23, 0xA5, 0x07}, sdk.PrefixEndBytes(bs1)))
+	require.True(t, bytes.Equal([]byte{0x23, 0xA5, 0x07}, types.PrefixEndBytes(bs1)))
 	bs2 := []byte{0x23, 0xA5, 0xFF}
-	require.True(t, bytes.Equal([]byte{0x23, 0xA6}, sdk.PrefixEndBytes(bs2)))
-	require.Nil(t, sdk.PrefixEndBytes([]byte{0xFF}))
-	require.Nil(t, sdk.PrefixEndBytes(nil))
+	require.True(t, bytes.Equal([]byte{0x23, 0xA6}, types.PrefixEndBytes(bs2)))
+	require.Nil(t, types.PrefixEndBytes([]byte{0xFF}))
+	require.Nil(t, types.PrefixEndBytes(nil))
 }
 
 func TestInclusiveEndBytes(t *testing.T) {
 	t.Parallel()
-	require.True(t, bytes.Equal([]byte{0x00}, sdk.InclusiveEndBytes(nil)))
+	require.True(t, bytes.Equal([]byte{0x00}, types.InclusiveEndBytes(nil)))
 	bs := []byte("test")
-	require.True(t, bytes.Equal(append(bs, byte(0x00)), sdk.InclusiveEndBytes(bs)))
+	require.True(t, bytes.Equal(append(bs, byte(0x00)), types.InclusiveEndBytes(bs)))
 }

--- a/types/store_test.go
+++ b/types/store_test.go
@@ -39,7 +39,7 @@ func (s *storeTestSuite) TestPrefixEndBytes() {
 	}
 
 	for _, test := range testCases {
-		end := sdk.PrefixEndBytes(test.prefix)
+		end := types.PrefixEndBytes(test.prefix)
 		s.Require().Equal(test.expected, end)
 	}
 }
@@ -120,7 +120,7 @@ func (s *storeTestSuite) initTestStores() (types.KVStore, types.KVStore) {
 }
 
 func (s *storeTestSuite) checkDiffResults(store1, store2 types.KVStore) {
-	kvAs1, kvBs1 := sdk.DiffKVStores(store1, store2, nil)
+	kvAs1, kvBs1 := types.DiffKVStores(store1, store2, nil)
 	kvAs2, kvBs2 := types.DiffKVStores(store1, store2, nil)
 	s.Require().Equal(kvAs1, kvAs2)
 	s.Require().Equal(kvBs1, kvBs2)


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

reduce reliance on sdk/types in store package. 



---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
