### PR TITLE
fix: runtime: fix (*App).RegisterMoodules inconsistency in checking/memoizing appModule

### DIFF
--- a/runtime/app.go
+++ b/runtime/app.go
@@ -59,12 +59,12 @@ func (a *App) RegisterModules(modules ...module.AppModule) error {
 		if _, ok := a.ModuleManager.Modules[name]; ok {
 			return fmt.Errorf("AppModule named %q already exists", name)
 		}
-		a.ModuleManager.Modules[name] = appModule
 
 		if _, ok := a.basicManager[name]; ok {
 			return fmt.Errorf("AppModuleBasic named %q already exists", name)
 		}
 
+		a.ModuleManager.Modules[name] = appModule
 		a.basicManager[name] = appModule
 		appModule.RegisterInterfaces(a.interfaceRegistry)
 		appModule.RegisterLegacyAminoCodec(a.amino)


### PR DESCRIPTION
Fixes an inconsistency in checking for duplicates in ModuleManager's Modules[name] then also basicManager[name] in which memoization could happen for .Module[name] but fail after a duplicate check in basicManager[name]. This change instead only memoizes the AppModule after the duplicate checks have all cleared.

Fixes #14006