### PR TITLE
chore: bound mempool size by default

### DIFF
--- a/server/config/config.go
+++ b/server/config/config.go
@@ -289,7 +289,7 @@ func DefaultConfig() *Config {
 			},
 		},
 		Mempool: MempoolConfig{
-			MaxTxs: 0,
+			MaxTxs: 5_000,
 		},
 	}
 }

--- a/server/config/toml.go
+++ b/server/config/toml.go
@@ -226,7 +226,7 @@ fsync = "{{ .Streamers.File.Fsync }}"
 
 [mempool]
 # Setting max-txs to 0 will allow for a unbounded amount of transactions in the mempool.
-# Setting max_txs to negative 1 (-1) will disable transaction from be inserted into the mempool.
+# Setting max_txs to negative 1 (-1) will disable transaction from being inserted into the mempool.
 # Setting max_txs to a positive number  (> 0) will limit the number of transactions in the mempool, by the specified amount.
 max-txs = "{{ .Mempool.MaxTxs }}"
 

--- a/server/config/toml.go
+++ b/server/config/toml.go
@@ -219,8 +219,8 @@ prefix = "{{ .Streamers.File.Prefix }}"
 
 [mempool]
 # Setting max-txs to 0 will allow for a unbounded amount of transactions in the mempool.
-# Setting max_txs to negative (-) will disable transaction from be inserted into the mempool.
-# Setting max_txs to positive (>) will limit the number of transactions in the mempool.
+# Setting max_txs to negative 1 (-1) will disable transaction from be inserted into the mempool.
+# Setting max_txs to a positive number  (> 0) will limit the number of transactions in the mempool, by the specified amount.
 max-txs = "{{ .Mempool.MaxTxs }}"
 
 `

--- a/server/config/toml.go
+++ b/server/config/toml.go
@@ -226,7 +226,7 @@ fsync = "{{ .Streamers.File.Fsync }}"
 
 [mempool]
 # Setting max-txs to 0 will allow for a unbounded amount of transactions in the mempool.
-# Setting max_txs to negative 1 (-1) will disable transaction from being inserted into the mempool.
+# Setting max_txs to negative 1 (-1) will disable transactions from being inserted into the mempool.
 # Setting max_txs to a positive number  (> 0) will limit the number of transactions in the mempool, by the specified amount.
 max-txs = "{{ .Mempool.MaxTxs }}"
 

--- a/server/config/toml.go
+++ b/server/config/toml.go
@@ -218,6 +218,9 @@ prefix = "{{ .Streamers.File.Prefix }}"
 ###############################################################################
 
 [mempool]
+# Setting max-txs to 0 will allow for a unbounded amount of transactions in the mempool.
+# Setting max_txs to negative (-) will disable transaction from be inserted into the mempool.
+# Setting max_txs to positive (>) will limit the number of transactions in the mempool.
 max-txs = "{{ .Mempool.MaxTxs }}"
 
 `


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

default should be safer than unbound 

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
