### PR TITLE
refactor: remove suite from chaindecorator handler test

### DIFF
--- a/types/handler_test.go
+++ b/types/handler_test.go
@@ -4,34 +4,22 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
-	"github.com/stretchr/testify/suite"
+	"github.com/stretchr/testify/require"
 
 	"github.com/cosmos/cosmos-sdk/testutil/mock"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
-type handlerTestSuite struct {
-	suite.Suite
-}
-
-func TestHandlerTestSuite(t *testing.T) {
-	suite.Run(t, new(handlerTestSuite))
-}
-
-func (s *handlerTestSuite) SetupSuite() {
-	s.T().Parallel()
-}
-
-func (s *handlerTestSuite) TestChainAnteDecorators() {
+func TestChainAnteDecorators(t *testing.T) {
 	// test panic
-	s.Require().Nil(sdk.ChainAnteDecorators([]sdk.AnteDecorator{}...))
+	require.Nil(t, sdk.ChainAnteDecorators([]sdk.AnteDecorator{}...))
 
 	ctx, tx := sdk.Context{}, sdk.Tx(nil)
-	mockCtrl := gomock.NewController(s.T())
+	mockCtrl := gomock.NewController(t)
 	mockAnteDecorator1 := mock.NewMockAnteDecorator(mockCtrl)
 	mockAnteDecorator1.EXPECT().AnteHandle(gomock.Eq(ctx), gomock.Eq(tx), true, gomock.Any()).Times(1)
 	_, err := sdk.ChainAnteDecorators(mockAnteDecorator1)(ctx, tx, true)
-	s.Require().NoError(err)
+	require.NoError(t, err)
 
 	mockAnteDecorator2 := mock.NewMockAnteDecorator(mockCtrl)
 	// NOTE: we can't check that mockAnteDecorator2 is passed as the last argument because
@@ -43,5 +31,5 @@ func (s *handlerTestSuite) TestChainAnteDecorators() {
 	_, err = sdk.ChainAnteDecorators(
 		mockAnteDecorator1,
 		mockAnteDecorator2)(ctx, tx, true)
-	s.Require().NoError(err)
+	require.NoError(t, err)
 }


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

remove unnecessary test suite for a single test 

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
