### PR TITLE
chore(ci): rename statediff CI workflow to consensuswarn

### DIFF
--- a/.github/workflows/consensuswarn.yml
+++ b/.github/workflows/consensuswarn.yml
@@ -14,6 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: orijtech/statediff@main
+      - uses: orijtech/consensuswarn@main
         with:
           roots: 'github.com/cosmos/cosmos-sdk/baseapp.BaseApp.DeliverTx,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.BeginBlock,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.EndBlock,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.Commit'


### PR DESCRIPTION
The tool is renamed as per https://github.com/orijtech/statediff/issues/6.

CC @odeke-em 