### PR TITLE
fix: improve baseapp event emission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (x/consensus) [#12905](https://github.com/cosmos/cosmos-sdk/pull/12905) Create a new `x/consensus` module that is now responsible for maintaining Tendermint consensus parameters instead of `x/param`. Legacy types remain in order to facilitate parameter migration from the deprecated `x/params`. App developers should ensure that they execute `baseapp.MigrateParams` during their chain upgrade. These legacy types will be removed in a future release.
 * (client/tx) [#13670](https://github.com/cosmos/cosmos-sdk/pull/13670) Add validation in `BuildUnsignedTx` to prevent simple inclusion of valid mnemonics
 * [#13473](https://github.com/cosmos/cosmos-sdk/pull/13473) ADR-038: Go plugin system proposal
-* [#14356](https://github.com/cosmos/cosmos-sdk/pull/14356) Add `events.GetAttribute` and `event.GetAttribute` methods to simplify the retrieval of an attribute from an event.
+* [#14356](https://github.com/cosmos/cosmos-sdk/pull/14356) Add `events.GetAttributes` and `event.GetAttribute` methods to simplify the retrieval of an attribute from event(s).
 
 ### Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,8 +56,10 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (x/consensus) [#12905](https://github.com/cosmos/cosmos-sdk/pull/12905) Create a new `x/consensus` module that is now responsible for maintaining Tendermint consensus parameters instead of `x/param`. Legacy types remain in order to facilitate parameter migration from the deprecated `x/params`. App developers should ensure that they execute `baseapp.MigrateParams` during their chain upgrade. These legacy types will be removed in a future release.
 * (client/tx) [#13670](https://github.com/cosmos/cosmos-sdk/pull/13670) Add validation in `BuildUnsignedTx` to prevent simple inclusion of valid mnemonics
 * [#13473](https://github.com/cosmos/cosmos-sdk/pull/13473) ADR-038: Go plugin system proposal
+* [#14356](https://github.com/cosmos/cosmos-sdk/pull/14356) Add `events.GetAttribute` and `event.GetAttribute` methods to simplify the retrieval of an attribute from an event.
 
 ### Improvements
+
 * (types) [#14354](https://github.com/cosmos/cosmos-sdk/pull/14354) - improve performance on Context.KVStore and Context.TransientStore by 40%
 * (crypto/keyring) [#14151](https://github.com/cosmos/cosmos-sdk/pull/14151) Move keys presentation from `crypto/keyring` to `client/keys`
 * (types) [#14163](https://github.com/cosmos/cosmos-sdk/pull/14163) Refactor `(coins Coins) Validate()` to avoid unnecessary map.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -111,6 +111,10 @@ ctx.EventManager().EmitEvent(
 )
 ```
 
+The module name is assumed by `baseapp` to be the second element of the message route: `"cosmos.bank.v1beta1.MsgSend" -> "bank"`.
+In case a module does not follow the standard message path, (e.g. IBC), it is adviced to keep emit the module name event.
+`Baseapp` only emits that event if the module have not already done so.
+
 #### `x/gov`
 
 ##### Minimum Proposal Deposit At Time of Submission

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -112,7 +112,7 @@ ctx.EventManager().EmitEvent(
 ```
 
 The module name is assumed by `baseapp` to be the second element of the message route: `"cosmos.bank.v1beta1.MsgSend" -> "bank"`.
-In case a module does not follow the standard message path, (e.g. IBC), it is adviced to keep emit the module name event.
+In case a module does not follow the standard message path, (e.g. IBC), it is advised to keep emitting the module name event.
 `Baseapp` only emits that event if the module have not already done so.
 
 #### `x/gov`

--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -847,7 +847,7 @@ func createEvents(events sdk.Events, msg sdk.Msg) sdk.Events {
 		msgEvent = msgEvent.AppendAttributes(sdk.NewAttribute(sdk.AttributeKeySender, msg.GetSigners()[0].String()))
 	}
 
-	// we verify the no module name events have been emitted
+	// we verify the the events have no module attribute
 	hasModuleEvent := false
 	for _, event := range events {
 		if event.Type != sdk.EventTypeMessage {

--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -796,7 +796,7 @@ func (app *BaseApp) runMsgs(ctx sdk.Context, msgs []sdk.Msg, mode runTxMode) (*s
 		}
 
 		// create message events
-		msgEvents := createEvents(msg).AppendEvents(msgResult.GetEvents())
+		msgEvents := createEvents(msgResult.GetEvents(), msg)
 
 		// append message events, data and logs
 		//
@@ -838,7 +838,7 @@ func makeABCIData(msgResponses []*codectypes.Any) ([]byte, error) {
 	return proto.Marshal(&sdk.TxMsgData{MsgResponses: msgResponses})
 }
 
-func createEvents(msg sdk.Msg) sdk.Events {
+func createEvents(events sdk.Events, msg sdk.Msg) sdk.Events {
 	eventMsgName := sdk.MsgTypeURL(msg)
 	msgEvent := sdk.NewEvent(sdk.EventTypeMessage, sdk.NewAttribute(sdk.AttributeKeyAction, eventMsgName))
 
@@ -847,14 +847,30 @@ func createEvents(msg sdk.Msg) sdk.Events {
 		msgEvent = msgEvent.AppendAttributes(sdk.NewAttribute(sdk.AttributeKeySender, msg.GetSigners()[0].String()))
 	}
 
-	// here we assume that routes module name is the second element of the route
-	// e.g. "cosmos.bank.v1beta1.MsgSend" => "bank"
-	moduleName := strings.Split(eventMsgName, ".")
-	if len(moduleName) > 1 {
-		msgEvent = msgEvent.AppendAttributes(sdk.NewAttribute(sdk.AttributeKeyModule, moduleName[1]))
+	// we verify the no module name events have been emitted
+	hasModuleEvent := false
+	for _, event := range events {
+		if event.Type != sdk.EventTypeMessage {
+			continue
+		}
+
+		for _, attr := range event.Attributes {
+			if attr.Key == sdk.AttributeKeyModule {
+				hasModuleEvent = true
+			}
+		}
 	}
 
-	return sdk.Events{msgEvent}
+	if !hasModuleEvent {
+		// here we assume that routes module name is the second element of the route
+		// e.g. "cosmos.bank.v1beta1.MsgSend" => "bank"
+		moduleName := strings.Split(eventMsgName, ".")
+		if len(moduleName) > 1 {
+			msgEvent = msgEvent.AppendAttributes(sdk.NewAttribute(sdk.AttributeKeyModule, moduleName[1]))
+		}
+	}
+
+	return sdk.Events{msgEvent}.AppendEvents(events)
 }
 
 // DefaultPrepareProposal returns the default implementation for processing an

--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -847,21 +847,8 @@ func createEvents(events sdk.Events, msg sdk.Msg) sdk.Events {
 		msgEvent = msgEvent.AppendAttributes(sdk.NewAttribute(sdk.AttributeKeySender, msg.GetSigners()[0].String()))
 	}
 
-	// we verify the the events have no module attribute
-	hasModuleNameEvent := false
-	for _, event := range events {
-		if event.Type != sdk.EventTypeMessage {
-			continue
-		}
-
-		for _, attr := range event.Attributes {
-			if attr.Key == sdk.AttributeKeyModule {
-				hasModuleNameEvent = true
-			}
-		}
-	}
-
-	if !hasModuleNameEvent {
+	// verify that events have no module attribute set
+	if _, found := events.GetAttributes(sdk.AttributeKeyModule); !found {
 		// here we assume that routes module name is the second element of the route
 		// e.g. "cosmos.bank.v1beta1.MsgSend" => "bank"
 		moduleName := strings.Split(eventMsgName, ".")

--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -848,7 +848,7 @@ func createEvents(events sdk.Events, msg sdk.Msg) sdk.Events {
 	}
 
 	// we verify the the events have no module attribute
-	hasModuleEvent := false
+	hasModuleNameEvent := false
 	for _, event := range events {
 		if event.Type != sdk.EventTypeMessage {
 			continue
@@ -856,12 +856,12 @@ func createEvents(events sdk.Events, msg sdk.Msg) sdk.Events {
 
 		for _, attr := range event.Attributes {
 			if attr.Key == sdk.AttributeKeyModule {
-				hasModuleEvent = true
+				hasModuleNameEvent = true
 			}
 		}
 	}
 
-	if !hasModuleEvent {
+	if !hasModuleNameEvent {
 		// here we assume that routes module name is the second element of the route
 		// e.g. "cosmos.bank.v1beta1.MsgSend" => "bank"
 		moduleName := strings.Split(eventMsgName, ".")

--- a/types/events.go
+++ b/types/events.go
@@ -197,6 +197,17 @@ func (e Event) AppendAttributes(attrs ...Attribute) Event {
 	return e
 }
 
+// GetAttribute returns an attribute for a given key present in an event.
+// If the key is not found, the boolean value will be false.
+func (e Event) GetAttribute(key string) (Attribute, bool) {
+	for _, attr := range e.Attributes {
+		if attr.Key == key {
+			return Attribute{Key: attr.Key, Value: attr.Value}, true
+		}
+	}
+	return Attribute{}, false
+}
+
 // AppendEvent adds an Event to a slice of events.
 func (e Events) AppendEvent(event Event) Events {
 	return append(e, event)
@@ -216,6 +227,19 @@ func (e Events) ToABCIEvents() []abci.Event {
 	}
 
 	return res
+}
+
+// GetAttributes returns all attributes matching a given key present in events.
+// If the key is not found, the boolean value will be false.
+func (e Events) GetAttributes(key string) ([]Attribute, bool) {
+	attrs := make([]Attribute, 0)
+	for _, event := range e {
+		if attr, found := event.GetAttribute(key); found {
+			attrs = append(attrs, attr)
+		}
+	}
+
+	return attrs, len(attrs) > 0
 }
 
 // Common event types and attribute keys

--- a/types/events_test.go
+++ b/types/events_test.go
@@ -39,6 +39,21 @@ func (s *eventsTestSuite) TestAppendAttributes() {
 	s.Require().Equal(e, sdk.NewEvent("transfer", sdk.NewAttribute("sender", "foo"), sdk.NewAttribute("recipient", "bar")))
 }
 
+func (s *eventsTestSuite) TestGetAttributes() {
+	e := sdk.NewEvent("transfer", sdk.NewAttribute("sender", "foo"))
+	e = e.AppendAttributes(sdk.NewAttribute("recipient", "bar"))
+	attr, found := e.GetAttribute("recipient")
+	s.Require().True(found)
+	s.Require().Equal(attr, sdk.NewAttribute("recipient", "bar"))
+
+	events := sdk.Events{e}.AppendEvent(sdk.NewEvent("message", sdk.NewAttribute("sender", "bar")))
+	attrs, found := events.GetAttributes("sender")
+	s.Require().True(found)
+	s.Require().Len(attrs, 2)
+	s.Require().Equal(attrs[0], sdk.NewAttribute("sender", "foo"))
+	s.Require().Equal(attrs[1], sdk.NewAttribute("sender", "bar"))
+}
+
 func (s *eventsTestSuite) TestEmptyEvents() {
 	s.Require().Equal(sdk.EmptyEvents(), sdk.Events{})
 }

--- a/types/events_test.go
+++ b/types/events_test.go
@@ -45,6 +45,8 @@ func (s *eventsTestSuite) TestGetAttributes() {
 	attr, found := e.GetAttribute("recipient")
 	s.Require().True(found)
 	s.Require().Equal(attr, sdk.NewAttribute("recipient", "bar"))
+	_, found = e.GetAttribute("foo")
+	s.Require().False(found)
 
 	events := sdk.Events{e}.AppendEvent(sdk.NewEvent("message", sdk.NewAttribute("sender", "bar")))
 	attrs, found := events.GetAttributes("sender")
@@ -52,6 +54,8 @@ func (s *eventsTestSuite) TestGetAttributes() {
 	s.Require().Len(attrs, 2)
 	s.Require().Equal(attrs[0], sdk.NewAttribute("sender", "foo"))
 	s.Require().Equal(attrs[1], sdk.NewAttribute("sender", "bar"))
+	_, found = events.GetAttributes("foo")
+	s.Require().False(found)
 }
 
 func (s *eventsTestSuite) TestEmptyEvents() {


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

Closes: #14295

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
