### PR TITLE
chore: audit server package

### DIFF
--- a/server/config/config.go
+++ b/server/config/config.go
@@ -166,7 +166,8 @@ type StateSyncConfig struct {
 	SnapshotKeepRecent uint32 `mapstructure:"snapshot-keep-recent"`
 }
 
-// MempoolConfig defines the configurations for the appside mempool
+// MempoolConfig defines the configurations for the SDK built-in app-side mempool
+// implementations.
 type MempoolConfig struct {
 	// MaxTxs defines the behavior of the mempool. A negative value indicates
 	// the mempool is disabled entirely, zero indicates that the mempool is

--- a/server/config/toml.go
+++ b/server/config/toml.go
@@ -230,7 +230,10 @@ fsync = "{{ .Streamers.File.Fsync }}"
 [mempool]
 # Setting max-txs to 0 will allow for a unbounded amount of transactions in the mempool.
 # Setting max_txs to negative 1 (-1) will disable transactions from being inserted into the mempool.
-# Setting max_txs to a positive number  (> 0) will limit the number of transactions in the mempool, by the specified amount.
+# Setting max_txs to a positive number (> 0) will limit the number of transactions in the mempool, by the specified amount.
+#
+# Note, this configuration only applies to SDK built-in app-side mempool
+# implementations.
 max-txs = "{{ .Mempool.MaxTxs }}"
 `
 

--- a/server/grpc/gogoreflection/fix_registration.go
+++ b/server/grpc/gogoreflection/fix_registration.go
@@ -14,7 +14,8 @@ import (
 	dpb "github.com/golang/protobuf/protoc-gen-go/descriptor"
 )
 
-// importsToFix lets us now that we're only fixing gogoproto/gogoproto.proto imports, we're not fixing cosmos protos.
+// importsToFix lets us now that we're only fixing gogoproto/gogoproto.proto
+// imports, we're not fixing cosmos Proto schemas.
 var importsToFix = map[string]string{
 	"gogo.proto": "gogoproto/gogo.proto",
 }
@@ -41,15 +42,15 @@ func fixRegistration(registeredAs, importedAs string) error {
 	if err != nil {
 		return fmt.Errorf("unable to compress: %w", err)
 	}
+
 	gogoproto.RegisterFile(importedAs, fixedRaw)
 	return nil
 }
 
 func init() {
-	// we need to fix the gogoproto filedesc to match the import path
-	// in theory this shouldn't be required, generally speaking
-	// proto files should be imported as their registration path
-
+	// We need to fix the gogoproto file descriptor to match the import path, in
+	// theory this shouldn't be required, generally speaking proto files should be
+	// imported as their registration path.
 	for registeredAs, importedAs := range importsToFix {
 		err := fixRegistration(registeredAs, importedAs)
 		if err != nil {
@@ -66,23 +67,27 @@ func compress(fd *dpb.FileDescriptorProto) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	buf := new(bytes.Buffer)
 	cw := gzip.NewWriter(buf)
+
 	_, err = cw.Write(fdBytes)
 	if err != nil {
 		cw.Close()
 		return nil, err
 	}
+
 	err = cw.Close()
 	if err != nil {
 		return nil, err
 	}
+
 	return buf.Bytes(), nil
 }
 
 func getFileDescriptor(filePath string) []byte {
-	// since we got well known descriptors which are not registered into gogoproto registry
-	// but are instead registered into the proto one, we need to check both
+	// Since we got well known descriptors which are not registered into gogoproto
+	// registry but are instead registered into the proto one, we need to check both.
 	fd := gogoproto.FileDescriptor(filePath)
 	if len(fd) != 0 {
 		return fd
@@ -109,7 +114,7 @@ func getExtension(extID int32, m proto.Message) *gogoproto.ExtensionDesc {
 	}
 
 	// check into proto registry
-	//nolint:staticcheck // Seems likely that we should refactor this file.
+	//nolint:staticcheck
 	for id, desc := range proto.RegisteredExtensions(m) {
 		if id == extID {
 			return &gogoproto.ExtensionDesc{
@@ -128,6 +133,7 @@ func getExtension(extID int32, m proto.Message) *gogoproto.ExtensionDesc {
 
 func getExtensionsNumbers(m proto.Message) []int32 {
 	gogoProtoExts := gogoproto.RegisteredExtensions(m)
+
 	out := make([]int32, 0, len(gogoProtoExts))
 	for id := range gogoProtoExts {
 		out = append(out, id)
@@ -141,5 +147,6 @@ func getExtensionsNumbers(m proto.Message) []int32 {
 	for id := range protoExts {
 		out = append(out, id)
 	}
+
 	return out
 }

--- a/server/grpc/grpc_web.go
+++ b/server/grpc/grpc_web.go
@@ -27,7 +27,7 @@ func StartGRPCWeb(grpcSrv *grpc.Server, config config.Config) (*http.Server, err
 	grpcWebSrv := &http.Server{
 		Addr:              config.GRPCWeb.Address,
 		Handler:           wrappedServer,
-		ReadHeaderTimeout: 500000000, // added because G112: Potential Slowloris Attack because ReadHeaderTimeout is not configured in the http.Server
+		ReadHeaderTimeout: 500000000,
 	}
 
 	errCh := make(chan error)

--- a/server/mock/helpers.go
+++ b/server/mock/helpers.go
@@ -3,15 +3,21 @@ package mock
 import (
 	"fmt"
 	"os"
+	"testing"
 
 	abci "github.com/tendermint/tendermint/abci/types"
 	tmlog "github.com/tendermint/tendermint/libs/log"
 )
 
-// SetupApp returns an application as well as a clean-up function
-// to be used to quickly setup a test case with an app.
+// SetupApp returns an application as well as a clean-up function to be used to
+// quickly setup a test case with an app.
 func SetupApp() (abci.Application, func(), error) {
-	logger := tmlog.NewTMLogger(tmlog.NewSyncWriter(os.Stdout)).With("module", "mock")
+	var logger tmlog.Logger
+	if testing.Verbose() {
+		logger = tmlog.NewTMLogger(tmlog.NewSyncWriter(os.Stdout)).With("module", "mock")
+	} else {
+		logger = tmlog.NewNopLogger()
+	}
 
 	rootDir, err := os.MkdirTemp("", "mock-sdk")
 	if err != nil {

--- a/server/util.go
+++ b/server/util.go
@@ -89,7 +89,8 @@ func bindFlags(basename string, cmd *cobra.Command, v *viper.Viper) (err error) 
 			panic(err)
 		}
 
-		// Apply the viper config value to the flag when the flag is not set and viper has a value
+		// Apply the viper config value to the flag when the flag is not set and
+		// viper has a value.
 		if !f.Changed && v.IsSet(f.Name) {
 			val := v.Get(f.Name)
 			err = cmd.Flags().Set(f.Name, fmt.Sprintf("%v", val))
@@ -117,7 +118,7 @@ func InterceptConfigsPreRunHandler(cmd *cobra.Command, customAppConfigTemplate s
 
 	// Get the executable name and configure the viper instance so that environmental
 	// variables are checked based off that name. The underscore character is used
-	// as a separator
+	// as a separator.
 	executableName, err := os.Executable()
 	if err != nil {
 		return err
@@ -125,13 +126,14 @@ func InterceptConfigsPreRunHandler(cmd *cobra.Command, customAppConfigTemplate s
 
 	basename := path.Base(executableName)
 
-	// Configure the viper instance
+	// configure the viper instance
 	if err := serverCtx.Viper.BindPFlags(cmd.Flags()); err != nil {
 		return err
 	}
 	if err := serverCtx.Viper.BindPFlags(cmd.PersistentFlags()); err != nil {
 		return err
 	}
+
 	serverCtx.Viper.SetEnvPrefix(basename)
 	serverCtx.Viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_", "-", "_"))
 	serverCtx.Viper.AutomaticEnv()
@@ -147,19 +149,20 @@ func InterceptConfigsPreRunHandler(cmd *cobra.Command, customAppConfigTemplate s
 	if err = bindFlags(basename, cmd, serverCtx.Viper); err != nil {
 		return err
 	}
+
 	logger := tmlog.NewTMLogger(tmlog.NewSyncWriter(os.Stdout))
 	logger, err = tmflags.ParseLogLevel(config.LogLevel, logger, tmcfg.DefaultLogLevel)
 	if err != nil {
 		return err
 	}
 
-	// Check if the tendermint flag for trace logging is set
-	// if it is then setup a tracing logger in this app as well
+	// Check if the tendermint flag for trace logging is set if it is then setup
+	// a tracing logger in this app as well.
 	if serverCtx.Viper.GetBool(tmcli.TraceFlag) {
 		logger = tmlog.NewTracingLogger(logger)
 	}
 
-	serverCtx.Logger = logger.With("module", "main")
+	serverCtx.Logger = logger.With("module", "server")
 
 	return SetCmdServerContext(cmd, serverCtx)
 }
@@ -362,13 +365,13 @@ func WaitForQuitSignals() ErrorCode {
 // GetAppDBBackend gets the backend type to use for the application DBs.
 func GetAppDBBackend(opts types.AppOptions) dbm.BackendType {
 	rv := cast.ToString(opts.Get("app-db-backend"))
-
 	if len(rv) == 0 {
 		rv = cast.ToString(opts.Get("db-backend"))
 	}
 	if len(rv) != 0 {
 		return dbm.BackendType(rv)
 	}
+
 	return dbm.GoLevelDBBackend
 }
 
@@ -452,7 +455,10 @@ func DefaultBaseappOptions(appOpts types.AppOptions) []func(*baseapp.BaseApp) {
 		baseapp.SetSnapshot(snapshotStore, snapshotOptions),
 		baseapp.SetIAVLCacheSize(cast.ToInt(appOpts.Get(FlagIAVLCacheSize))),
 		baseapp.SetIAVLDisableFastNode(cast.ToBool(appOpts.Get(FlagDisableIAVLFastNode))),
-		baseapp.SetMempool(mempool.NewSenderNonceMempool(
-			mempool.SenderNonceMaxTxOpt(cast.ToInt(appOpts.Get(FlagMempoolMaxTxs))))),
+		baseapp.SetMempool(
+			mempool.NewSenderNonceMempool(
+				mempool.SenderNonceMaxTxOpt(cast.ToInt(appOpts.Get(FlagMempoolMaxTxs))),
+			),
+		),
 	}
 }


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

ref: #14256



---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
