### PR TITLE
refactor(context): Pass `EventManager` to the context as an interface.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Improvements
 
+* (context)[#14384](https://github.com/cosmos/cosmos-sdk/pull/14384) refactor(context): Pass EventManager to the context as an interface.
 * (types) [#14354](https://github.com/cosmos/cosmos-sdk/pull/14354) - improve performance on Context.KVStore and Context.TransientStore by 40%
 * (crypto/keyring) [#14151](https://github.com/cosmos/cosmos-sdk/pull/14151) Move keys presentation from `crypto/keyring` to `client/keys`
 * (types) [#14163](https://github.com/cosmos/cosmos-sdk/pull/14163) Refactor `(coins Coins) Validate()` to avoid unnecessary map.

--- a/types/context.go
+++ b/types/context.go
@@ -37,7 +37,7 @@ type Context struct {
 	recheckTx            bool // if recheckTx == true, then checkTx must also be true
 	minGasPrice          DecCoins
 	consParams           *tmproto.ConsensusParams
-	eventManager         *EventManager
+	eventManager         EventManagerI
 	priority             int64 // The tx priority, only relevant in CheckTx
 	kvGasConfig          storetypes.GasConfig
 	transientKVGasConfig storetypes.GasConfig
@@ -60,7 +60,7 @@ func (c Context) BlockGasMeter() GasMeter                    { return c.blockGas
 func (c Context) IsCheckTx() bool                            { return c.checkTx }
 func (c Context) IsReCheckTx() bool                          { return c.recheckTx }
 func (c Context) MinGasPrices() DecCoins                     { return c.minGasPrice }
-func (c Context) EventManager() *EventManager                { return c.eventManager }
+func (c Context) EventManager() EventManagerI                { return c.eventManager }
 func (c Context) Priority() int64                            { return c.priority }
 func (c Context) KVGasConfig() storetypes.GasConfig          { return c.kvGasConfig }
 func (c Context) TransientKVGasConfig() storetypes.GasConfig { return c.transientKVGasConfig }

--- a/types/events.go
+++ b/types/events.go
@@ -22,10 +22,7 @@ type EventManagerI interface {
 	ABCIEvents() []abci.Event
 	EmitTypedEvent(tev proto.Message) error
 	EmitTypedEvents(tevs ...proto.Message) error
-
-	// Deprecated: Use EmitTypedEvent
 	EmitEvent(event Event)
-	// Deprecated: Use EmitTypedEvents
 	EmitEvents(events Events)
 }
 

--- a/types/events.go
+++ b/types/events.go
@@ -17,9 +17,23 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 )
 
+type EventManagerI interface {
+	Events() Events
+	ABCIEvents() []abci.Event
+	EmitTypedEvent(tev proto.Message) error
+	EmitTypedEvents(tevs ...proto.Message) error
+
+	// Deprecated: Use EmitTypedEvent
+	EmitEvent(event Event)
+	// Deprecated: Use EmitTypedEvents
+	EmitEvents(events Events)
+}
+
 // ----------------------------------------------------------------------------
 // Event Manager
 // ----------------------------------------------------------------------------
+
+var _ EventManagerI = (*EventManager)(nil)
 
 // EventManager implements a simple wrapper around a slice of Event objects that
 // can be emitted from.


### PR DESCRIPTION
This PR modifies the `sdk.Context` to support passing in the EventManager as an interface. This is useful for chains who want to add custom event behaviour to their application.