### PR TITLE
chore: Enforce order of store commits in root store

### DIFF
--- a/store/rootmulti/store.go
+++ b/store/rootmulti/store.go
@@ -37,8 +37,8 @@ const (
 
 const iavlDisablefastNodeDefault = false
 
-// keysForStoreKeyMap returns a slice of keys for the provided map lexically sorted by StoreKey.Name()
-func keysForStoreKeyMap[V any](m map[types.StoreKey]V) []types.StoreKey {
+// keysFromStoreKeyMap returns a slice of keys for the provided map lexically sorted by StoreKey.Name()
+func keysFromStoreKeyMap[V any](m map[types.StoreKey]V) []types.StoreKey {
 	keys := make([]types.StoreKey, 0, len(m))
 	for key := range m {
 		keys = append(keys, key)
@@ -745,7 +745,7 @@ func (rs *Store) Snapshot(height uint64, protoWriter protoio.Writer) error {
 		name string
 	}
 	stores := []namedStore{}
-	keys := keysForStoreKeyMap(rs.stores)
+	keys := keysFromStoreKeyMap(rs.stores)
 	for _, key := range keys {
 		switch store := rs.GetCommitKVStore(key).(type) {
 		case *iavl.Store:
@@ -963,7 +963,7 @@ func (rs *Store) loadCommitStoreFromParams(key types.StoreKey, id types.CommitID
 }
 
 func (rs *Store) buildCommitInfo(version int64) *types.CommitInfo {
-	keys := keysForStoreKeyMap(rs.stores)
+	keys := keysFromStoreKeyMap(rs.stores)
 	storeInfos := []types.StoreInfo{}
 	for _, key := range keys {
 		store := rs.stores[key]
@@ -1050,7 +1050,7 @@ func GetLatestVersion(db dbm.DB) int64 {
 // Commits each store and returns a new commitInfo.
 func commitStores(version int64, storeMap map[types.StoreKey]types.CommitKVStore, removalMap map[types.StoreKey]bool) *types.CommitInfo {
 	storeInfos := make([]types.StoreInfo, 0, len(storeMap))
-	storeKeys := keysForStoreKeyMap(storeMap)
+	storeKeys := keysFromStoreKeyMap(storeMap)
 	for _, key := range storeKeys {
 		store := storeMap[key]
 		last := store.LastCommitID()

--- a/store/rootmulti/store.go
+++ b/store/rootmulti/store.go
@@ -1050,11 +1050,7 @@ func GetLatestVersion(db dbm.DB) int64 {
 // Commits each store and returns a new commitInfo.
 func commitStores(version int64, storeMap map[types.StoreKey]types.CommitKVStore, removalMap map[types.StoreKey]bool) *types.CommitInfo {
 	storeInfos := make([]types.StoreInfo, 0, len(storeMap))
-<<<<<<< HEAD
 	storeKeys := keysFromStoreKeyMap(storeMap)
-=======
-	storeKeys := keysForStoreKeyMap(storeMap)
->>>>>>> accca1a68 (correct sort logic)
 	for _, key := range storeKeys {
 		store := storeMap[key]
 		last := store.LastCommitID()

--- a/store/rootmulti/store.go
+++ b/store/rootmulti/store.go
@@ -230,9 +230,6 @@ func (rs *Store) loadVersion(ver int64, upgrades *types.StoreUpgrades) error {
 	for key := range rs.storesParams {
 		storesKeys = append(storesKeys, key)
 	}
-	sort.Slice(storesKeys, func(i, j int) bool {
-		return storesKeys[i].String() < storesKeys[j].String()
-	})
 
 	if upgrades != nil {
 		// deterministic iteration order for upgrades
@@ -1053,8 +1050,9 @@ func GetLatestVersion(db dbm.DB) int64 {
 // Commits each store and returns a new commitInfo.
 func commitStores(version int64, storeMap map[types.StoreKey]types.CommitKVStore, removalMap map[types.StoreKey]bool) *types.CommitInfo {
 	storeInfos := make([]types.StoreInfo, 0, len(storeMap))
-
-	for key, store := range storeMap {
+	storeKeys := keysForStoreKeyMap(storeMap)
+	for _, key := range storeKeys {
+		store := storeMap[key]
 		last := store.LastCommitID()
 
 		// If a commit event execution is interrupted, a new iavl store's version will be larger than the rootmulti's metadata, when the block is replayed, we should avoid committing that iavl store again.

--- a/store/rootmulti/store.go
+++ b/store/rootmulti/store.go
@@ -230,6 +230,10 @@ func (rs *Store) loadVersion(ver int64, upgrades *types.StoreUpgrades) error {
 	for key := range rs.storesParams {
 		storesKeys = append(storesKeys, key)
 	}
+	sort.Slice(storesKeys, func(i, j int) bool {
+		return storesKeys[i].String() < storesKeys[j].String()
+	})
+
 	if upgrades != nil {
 		// deterministic iteration order for upgrades
 		// (as the underlying store may change and

--- a/store/rootmulti/store.go
+++ b/store/rootmulti/store.go
@@ -1050,7 +1050,11 @@ func GetLatestVersion(db dbm.DB) int64 {
 // Commits each store and returns a new commitInfo.
 func commitStores(version int64, storeMap map[types.StoreKey]types.CommitKVStore, removalMap map[types.StoreKey]bool) *types.CommitInfo {
 	storeInfos := make([]types.StoreInfo, 0, len(storeMap))
+<<<<<<< HEAD
 	storeKeys := keysFromStoreKeyMap(storeMap)
+=======
+	storeKeys := keysForStoreKeyMap(storeMap)
+>>>>>>> accca1a68 (correct sort logic)
 	for _, key := range storeKeys {
 		store := storeMap[key]
 		last := store.LastCommitID()


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description
From what I read, LSM backend used by the sdk prefer the keys to be commited in ascending order. Right now, there's no logic enforcing the order of `rootmulti.Store.stores` and so when `rootmulti.Store` commit, we can't be sure that we're commiting the module stores in ascending order. 

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
