### PR TITLE
chore: deprecate unused messages instead of removing them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 * [#14017](https://github.com/cosmos/cosmos-sdk/pull/14017) Simplify ADR-028 and `address.Module`.
     * This updates the [ADR-028](https://docs.cosmos.network/main/architecture/adr-028-public-key-addresses) and enhance the `address.Module` API to support module addresses and sub-module addresses in a backward compatible way.
+* (snapshots) [#14608](https://github.com/cosmos/cosmos-sdk/pull/14608/) Deprecate unused structs `SnapshotKVItem` and `SnapshotSchema`.
 
 ## State Machine Breaking
 

--- a/api/cosmos/base/snapshots/v1beta1/snapshot.pulsar.go
+++ b/api/cosmos/base/snapshots/v1beta1/snapshot.pulsar.go
@@ -1144,6 +1144,8 @@ var (
 	fd_SnapshotItem_iavl              protoreflect.FieldDescriptor
 	fd_SnapshotItem_extension         protoreflect.FieldDescriptor
 	fd_SnapshotItem_extension_payload protoreflect.FieldDescriptor
+	fd_SnapshotItem_kv                protoreflect.FieldDescriptor
+	fd_SnapshotItem_schema            protoreflect.FieldDescriptor
 )
 
 func init() {
@@ -1153,6 +1155,8 @@ func init() {
 	fd_SnapshotItem_iavl = md_SnapshotItem.Fields().ByName("iavl")
 	fd_SnapshotItem_extension = md_SnapshotItem.Fields().ByName("extension")
 	fd_SnapshotItem_extension_payload = md_SnapshotItem.Fields().ByName("extension_payload")
+	fd_SnapshotItem_kv = md_SnapshotItem.Fields().ByName("kv")
+	fd_SnapshotItem_schema = md_SnapshotItem.Fields().ByName("schema")
 }
 
 var _ protoreflect.Message = (*fastReflection_SnapshotItem)(nil)
@@ -1246,6 +1250,18 @@ func (x *fastReflection_SnapshotItem) Range(f func(protoreflect.FieldDescriptor,
 			if !f(fd_SnapshotItem_extension_payload, value) {
 				return
 			}
+		case *SnapshotItem_Kv:
+			v := o.Kv
+			value := protoreflect.ValueOfMessage(v.ProtoReflect())
+			if !f(fd_SnapshotItem_kv, value) {
+				return
+			}
+		case *SnapshotItem_Schema:
+			v := o.Schema
+			value := protoreflect.ValueOfMessage(v.ProtoReflect())
+			if !f(fd_SnapshotItem_schema, value) {
+				return
+			}
 		}
 	}
 }
@@ -1295,6 +1311,22 @@ func (x *fastReflection_SnapshotItem) Has(fd protoreflect.FieldDescriptor) bool 
 		} else {
 			return false
 		}
+	case "cosmos.base.snapshots.v1beta1.SnapshotItem.kv":
+		if x.Item == nil {
+			return false
+		} else if _, ok := x.Item.(*SnapshotItem_Kv); ok {
+			return true
+		} else {
+			return false
+		}
+	case "cosmos.base.snapshots.v1beta1.SnapshotItem.schema":
+		if x.Item == nil {
+			return false
+		} else if _, ok := x.Item.(*SnapshotItem_Schema); ok {
+			return true
+		} else {
+			return false
+		}
 	default:
 		if fd.IsExtension() {
 			panic(fmt.Errorf("proto3 declared messages do not support extensions: cosmos.base.snapshots.v1beta1.SnapshotItem"))
@@ -1318,6 +1350,10 @@ func (x *fastReflection_SnapshotItem) Clear(fd protoreflect.FieldDescriptor) {
 	case "cosmos.base.snapshots.v1beta1.SnapshotItem.extension":
 		x.Item = nil
 	case "cosmos.base.snapshots.v1beta1.SnapshotItem.extension_payload":
+		x.Item = nil
+	case "cosmos.base.snapshots.v1beta1.SnapshotItem.kv":
+		x.Item = nil
+	case "cosmos.base.snapshots.v1beta1.SnapshotItem.schema":
 		x.Item = nil
 	default:
 		if fd.IsExtension() {
@@ -1367,6 +1403,22 @@ func (x *fastReflection_SnapshotItem) Get(descriptor protoreflect.FieldDescripto
 		} else {
 			return protoreflect.ValueOfMessage((*SnapshotExtensionPayload)(nil).ProtoReflect())
 		}
+	case "cosmos.base.snapshots.v1beta1.SnapshotItem.kv":
+		if x.Item == nil {
+			return protoreflect.ValueOfMessage((*SnapshotKVItem)(nil).ProtoReflect())
+		} else if v, ok := x.Item.(*SnapshotItem_Kv); ok {
+			return protoreflect.ValueOfMessage(v.Kv.ProtoReflect())
+		} else {
+			return protoreflect.ValueOfMessage((*SnapshotKVItem)(nil).ProtoReflect())
+		}
+	case "cosmos.base.snapshots.v1beta1.SnapshotItem.schema":
+		if x.Item == nil {
+			return protoreflect.ValueOfMessage((*SnapshotSchema)(nil).ProtoReflect())
+		} else if v, ok := x.Item.(*SnapshotItem_Schema); ok {
+			return protoreflect.ValueOfMessage(v.Schema.ProtoReflect())
+		} else {
+			return protoreflect.ValueOfMessage((*SnapshotSchema)(nil).ProtoReflect())
+		}
 	default:
 		if descriptor.IsExtension() {
 			panic(fmt.Errorf("proto3 declared messages do not support extensions: cosmos.base.snapshots.v1beta1.SnapshotItem"))
@@ -1399,6 +1451,12 @@ func (x *fastReflection_SnapshotItem) Set(fd protoreflect.FieldDescriptor, value
 	case "cosmos.base.snapshots.v1beta1.SnapshotItem.extension_payload":
 		cv := value.Message().Interface().(*SnapshotExtensionPayload)
 		x.Item = &SnapshotItem_ExtensionPayload{ExtensionPayload: cv}
+	case "cosmos.base.snapshots.v1beta1.SnapshotItem.kv":
+		cv := value.Message().Interface().(*SnapshotKVItem)
+		x.Item = &SnapshotItem_Kv{Kv: cv}
+	case "cosmos.base.snapshots.v1beta1.SnapshotItem.schema":
+		cv := value.Message().Interface().(*SnapshotSchema)
+		x.Item = &SnapshotItem_Schema{Schema: cv}
 	default:
 		if fd.IsExtension() {
 			panic(fmt.Errorf("proto3 declared messages do not support extensions: cosmos.base.snapshots.v1beta1.SnapshotItem"))
@@ -1483,6 +1541,38 @@ func (x *fastReflection_SnapshotItem) Mutable(fd protoreflect.FieldDescriptor) p
 			x.Item = oneofValue
 			return protoreflect.ValueOfMessage(value.ProtoReflect())
 		}
+	case "cosmos.base.snapshots.v1beta1.SnapshotItem.kv":
+		if x.Item == nil {
+			value := &SnapshotKVItem{}
+			oneofValue := &SnapshotItem_Kv{Kv: value}
+			x.Item = oneofValue
+			return protoreflect.ValueOfMessage(value.ProtoReflect())
+		}
+		switch m := x.Item.(type) {
+		case *SnapshotItem_Kv:
+			return protoreflect.ValueOfMessage(m.Kv.ProtoReflect())
+		default:
+			value := &SnapshotKVItem{}
+			oneofValue := &SnapshotItem_Kv{Kv: value}
+			x.Item = oneofValue
+			return protoreflect.ValueOfMessage(value.ProtoReflect())
+		}
+	case "cosmos.base.snapshots.v1beta1.SnapshotItem.schema":
+		if x.Item == nil {
+			value := &SnapshotSchema{}
+			oneofValue := &SnapshotItem_Schema{Schema: value}
+			x.Item = oneofValue
+			return protoreflect.ValueOfMessage(value.ProtoReflect())
+		}
+		switch m := x.Item.(type) {
+		case *SnapshotItem_Schema:
+			return protoreflect.ValueOfMessage(m.Schema.ProtoReflect())
+		default:
+			value := &SnapshotSchema{}
+			oneofValue := &SnapshotItem_Schema{Schema: value}
+			x.Item = oneofValue
+			return protoreflect.ValueOfMessage(value.ProtoReflect())
+		}
 	default:
 		if fd.IsExtension() {
 			panic(fmt.Errorf("proto3 declared messages do not support extensions: cosmos.base.snapshots.v1beta1.SnapshotItem"))
@@ -1507,6 +1597,12 @@ func (x *fastReflection_SnapshotItem) NewField(fd protoreflect.FieldDescriptor) 
 		return protoreflect.ValueOfMessage(value.ProtoReflect())
 	case "cosmos.base.snapshots.v1beta1.SnapshotItem.extension_payload":
 		value := &SnapshotExtensionPayload{}
+		return protoreflect.ValueOfMessage(value.ProtoReflect())
+	case "cosmos.base.snapshots.v1beta1.SnapshotItem.kv":
+		value := &SnapshotKVItem{}
+		return protoreflect.ValueOfMessage(value.ProtoReflect())
+	case "cosmos.base.snapshots.v1beta1.SnapshotItem.schema":
+		value := &SnapshotSchema{}
 		return protoreflect.ValueOfMessage(value.ProtoReflect())
 	default:
 		if fd.IsExtension() {
@@ -1534,6 +1630,10 @@ func (x *fastReflection_SnapshotItem) WhichOneof(d protoreflect.OneofDescriptor)
 			return x.Descriptor().Fields().ByName("extension")
 		case *SnapshotItem_ExtensionPayload:
 			return x.Descriptor().Fields().ByName("extension_payload")
+		case *SnapshotItem_Kv:
+			return x.Descriptor().Fields().ByName("kv")
+		case *SnapshotItem_Schema:
+			return x.Descriptor().Fields().ByName("schema")
 		}
 	default:
 		panic(fmt.Errorf("%s is not a oneof field in cosmos.base.snapshots.v1beta1.SnapshotItem", d.FullName()))
@@ -1615,6 +1715,18 @@ func (x *fastReflection_SnapshotItem) ProtoMethods() *protoiface.Methods {
 				break
 			}
 			l = options.Size(x.ExtensionPayload)
+			n += 1 + l + runtime.Sov(uint64(l))
+		case *SnapshotItem_Kv:
+			if x == nil {
+				break
+			}
+			l = options.Size(x.Kv)
+			n += 1 + l + runtime.Sov(uint64(l))
+		case *SnapshotItem_Schema:
+			if x == nil {
+				break
+			}
+			l = options.Size(x.Schema)
 			n += 1 + l + runtime.Sov(uint64(l))
 		}
 		if x.unknownFields != nil {
@@ -1699,6 +1811,32 @@ func (x *fastReflection_SnapshotItem) ProtoMethods() *protoiface.Methods {
 			i = runtime.EncodeVarint(dAtA, i, uint64(len(encoded)))
 			i--
 			dAtA[i] = 0x22
+		case *SnapshotItem_Kv:
+			encoded, err := options.Marshal(x.Kv)
+			if err != nil {
+				return protoiface.MarshalOutput{
+					NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+					Buf:               input.Buf,
+				}, err
+			}
+			i -= len(encoded)
+			copy(dAtA[i:], encoded)
+			i = runtime.EncodeVarint(dAtA, i, uint64(len(encoded)))
+			i--
+			dAtA[i] = 0x2a
+		case *SnapshotItem_Schema:
+			encoded, err := options.Marshal(x.Schema)
+			if err != nil {
+				return protoiface.MarshalOutput{
+					NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+					Buf:               input.Buf,
+				}, err
+			}
+			i -= len(encoded)
+			copy(dAtA[i:], encoded)
+			i = runtime.EncodeVarint(dAtA, i, uint64(len(encoded)))
+			i--
+			dAtA[i] = 0x32
 		}
 		if input.Buf != nil {
 			input.Buf = append(input.Buf, dAtA...)
@@ -1888,6 +2026,76 @@ func (x *fastReflection_SnapshotItem) ProtoMethods() *protoiface.Methods {
 					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
 				}
 				x.Item = &SnapshotItem_ExtensionPayload{v}
+				iNdEx = postIndex
+			case 5:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field Kv", wireType)
+				}
+				var msglen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					msglen |= int(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if msglen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + msglen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				v := &SnapshotKVItem{}
+				if err := options.Unmarshal(dAtA[iNdEx:postIndex], v); err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				x.Item = &SnapshotItem_Kv{v}
+				iNdEx = postIndex
+			case 6:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field Schema", wireType)
+				}
+				var msglen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					msglen |= int(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if msglen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + msglen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				v := &SnapshotSchema{}
+				if err := options.Unmarshal(dAtA[iNdEx:postIndex], v); err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				x.Item = &SnapshotItem_Schema{v}
 				iNdEx = postIndex
 			default:
 				iNdEx = preIndex
@@ -3818,6 +4026,974 @@ func (x *fastReflection_SnapshotExtensionPayload) ProtoMethods() *protoiface.Met
 	}
 }
 
+var (
+	md_SnapshotKVItem       protoreflect.MessageDescriptor
+	fd_SnapshotKVItem_key   protoreflect.FieldDescriptor
+	fd_SnapshotKVItem_value protoreflect.FieldDescriptor
+)
+
+func init() {
+	file_cosmos_base_snapshots_v1beta1_snapshot_proto_init()
+	md_SnapshotKVItem = File_cosmos_base_snapshots_v1beta1_snapshot_proto.Messages().ByName("SnapshotKVItem")
+	fd_SnapshotKVItem_key = md_SnapshotKVItem.Fields().ByName("key")
+	fd_SnapshotKVItem_value = md_SnapshotKVItem.Fields().ByName("value")
+}
+
+var _ protoreflect.Message = (*fastReflection_SnapshotKVItem)(nil)
+
+type fastReflection_SnapshotKVItem SnapshotKVItem
+
+func (x *SnapshotKVItem) ProtoReflect() protoreflect.Message {
+	return (*fastReflection_SnapshotKVItem)(x)
+}
+
+func (x *SnapshotKVItem) slowProtoReflect() protoreflect.Message {
+	mi := &file_cosmos_base_snapshots_v1beta1_snapshot_proto_msgTypes[7]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+var _fastReflection_SnapshotKVItem_messageType fastReflection_SnapshotKVItem_messageType
+var _ protoreflect.MessageType = fastReflection_SnapshotKVItem_messageType{}
+
+type fastReflection_SnapshotKVItem_messageType struct{}
+
+func (x fastReflection_SnapshotKVItem_messageType) Zero() protoreflect.Message {
+	return (*fastReflection_SnapshotKVItem)(nil)
+}
+func (x fastReflection_SnapshotKVItem_messageType) New() protoreflect.Message {
+	return new(fastReflection_SnapshotKVItem)
+}
+func (x fastReflection_SnapshotKVItem_messageType) Descriptor() protoreflect.MessageDescriptor {
+	return md_SnapshotKVItem
+}
+
+// Descriptor returns message descriptor, which contains only the protobuf
+// type information for the message.
+func (x *fastReflection_SnapshotKVItem) Descriptor() protoreflect.MessageDescriptor {
+	return md_SnapshotKVItem
+}
+
+// Type returns the message type, which encapsulates both Go and protobuf
+// type information. If the Go type information is not needed,
+// it is recommended that the message descriptor be used instead.
+func (x *fastReflection_SnapshotKVItem) Type() protoreflect.MessageType {
+	return _fastReflection_SnapshotKVItem_messageType
+}
+
+// New returns a newly allocated and mutable empty message.
+func (x *fastReflection_SnapshotKVItem) New() protoreflect.Message {
+	return new(fastReflection_SnapshotKVItem)
+}
+
+// Interface unwraps the message reflection interface and
+// returns the underlying ProtoMessage interface.
+func (x *fastReflection_SnapshotKVItem) Interface() protoreflect.ProtoMessage {
+	return (*SnapshotKVItem)(x)
+}
+
+// Range iterates over every populated field in an undefined order,
+// calling f for each field descriptor and value encountered.
+// Range returns immediately if f returns false.
+// While iterating, mutating operations may only be performed
+// on the current field descriptor.
+func (x *fastReflection_SnapshotKVItem) Range(f func(protoreflect.FieldDescriptor, protoreflect.Value) bool) {
+	if len(x.Key) != 0 {
+		value := protoreflect.ValueOfBytes(x.Key)
+		if !f(fd_SnapshotKVItem_key, value) {
+			return
+		}
+	}
+	if len(x.Value) != 0 {
+		value := protoreflect.ValueOfBytes(x.Value)
+		if !f(fd_SnapshotKVItem_value, value) {
+			return
+		}
+	}
+}
+
+// Has reports whether a field is populated.
+//
+// Some fields have the property of nullability where it is possible to
+// distinguish between the default value of a field and whether the field
+// was explicitly populated with the default value. Singular message fields,
+// member fields of a oneof, and proto2 scalar fields are nullable. Such
+// fields are populated only if explicitly set.
+//
+// In other cases (aside from the nullable cases above),
+// a proto3 scalar field is populated if it contains a non-zero value, and
+// a repeated field is populated if it is non-empty.
+func (x *fastReflection_SnapshotKVItem) Has(fd protoreflect.FieldDescriptor) bool {
+	switch fd.FullName() {
+	case "cosmos.base.snapshots.v1beta1.SnapshotKVItem.key":
+		return len(x.Key) != 0
+	case "cosmos.base.snapshots.v1beta1.SnapshotKVItem.value":
+		return len(x.Value) != 0
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: cosmos.base.snapshots.v1beta1.SnapshotKVItem"))
+		}
+		panic(fmt.Errorf("message cosmos.base.snapshots.v1beta1.SnapshotKVItem does not contain field %s", fd.FullName()))
+	}
+}
+
+// Clear clears the field such that a subsequent Has call reports false.
+//
+// Clearing an extension field clears both the extension type and value
+// associated with the given field number.
+//
+// Clear is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_SnapshotKVItem) Clear(fd protoreflect.FieldDescriptor) {
+	switch fd.FullName() {
+	case "cosmos.base.snapshots.v1beta1.SnapshotKVItem.key":
+		x.Key = nil
+	case "cosmos.base.snapshots.v1beta1.SnapshotKVItem.value":
+		x.Value = nil
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: cosmos.base.snapshots.v1beta1.SnapshotKVItem"))
+		}
+		panic(fmt.Errorf("message cosmos.base.snapshots.v1beta1.SnapshotKVItem does not contain field %s", fd.FullName()))
+	}
+}
+
+// Get retrieves the value for a field.
+//
+// For unpopulated scalars, it returns the default value, where
+// the default value of a bytes scalar is guaranteed to be a copy.
+// For unpopulated composite types, it returns an empty, read-only view
+// of the value; to obtain a mutable reference, use Mutable.
+func (x *fastReflection_SnapshotKVItem) Get(descriptor protoreflect.FieldDescriptor) protoreflect.Value {
+	switch descriptor.FullName() {
+	case "cosmos.base.snapshots.v1beta1.SnapshotKVItem.key":
+		value := x.Key
+		return protoreflect.ValueOfBytes(value)
+	case "cosmos.base.snapshots.v1beta1.SnapshotKVItem.value":
+		value := x.Value
+		return protoreflect.ValueOfBytes(value)
+	default:
+		if descriptor.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: cosmos.base.snapshots.v1beta1.SnapshotKVItem"))
+		}
+		panic(fmt.Errorf("message cosmos.base.snapshots.v1beta1.SnapshotKVItem does not contain field %s", descriptor.FullName()))
+	}
+}
+
+// Set stores the value for a field.
+//
+// For a field belonging to a oneof, it implicitly clears any other field
+// that may be currently set within the same oneof.
+// For extension fields, it implicitly stores the provided ExtensionType.
+// When setting a composite type, it is unspecified whether the stored value
+// aliases the source's memory in any way. If the composite value is an
+// empty, read-only value, then it panics.
+//
+// Set is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_SnapshotKVItem) Set(fd protoreflect.FieldDescriptor, value protoreflect.Value) {
+	switch fd.FullName() {
+	case "cosmos.base.snapshots.v1beta1.SnapshotKVItem.key":
+		x.Key = value.Bytes()
+	case "cosmos.base.snapshots.v1beta1.SnapshotKVItem.value":
+		x.Value = value.Bytes()
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: cosmos.base.snapshots.v1beta1.SnapshotKVItem"))
+		}
+		panic(fmt.Errorf("message cosmos.base.snapshots.v1beta1.SnapshotKVItem does not contain field %s", fd.FullName()))
+	}
+}
+
+// Mutable returns a mutable reference to a composite type.
+//
+// If the field is unpopulated, it may allocate a composite value.
+// For a field belonging to a oneof, it implicitly clears any other field
+// that may be currently set within the same oneof.
+// For extension fields, it implicitly stores the provided ExtensionType
+// if not already stored.
+// It panics if the field does not contain a composite type.
+//
+// Mutable is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_SnapshotKVItem) Mutable(fd protoreflect.FieldDescriptor) protoreflect.Value {
+	switch fd.FullName() {
+	case "cosmos.base.snapshots.v1beta1.SnapshotKVItem.key":
+		panic(fmt.Errorf("field key of message cosmos.base.snapshots.v1beta1.SnapshotKVItem is not mutable"))
+	case "cosmos.base.snapshots.v1beta1.SnapshotKVItem.value":
+		panic(fmt.Errorf("field value of message cosmos.base.snapshots.v1beta1.SnapshotKVItem is not mutable"))
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: cosmos.base.snapshots.v1beta1.SnapshotKVItem"))
+		}
+		panic(fmt.Errorf("message cosmos.base.snapshots.v1beta1.SnapshotKVItem does not contain field %s", fd.FullName()))
+	}
+}
+
+// NewField returns a new value that is assignable to the field
+// for the given descriptor. For scalars, this returns the default value.
+// For lists, maps, and messages, this returns a new, empty, mutable value.
+func (x *fastReflection_SnapshotKVItem) NewField(fd protoreflect.FieldDescriptor) protoreflect.Value {
+	switch fd.FullName() {
+	case "cosmos.base.snapshots.v1beta1.SnapshotKVItem.key":
+		return protoreflect.ValueOfBytes(nil)
+	case "cosmos.base.snapshots.v1beta1.SnapshotKVItem.value":
+		return protoreflect.ValueOfBytes(nil)
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: cosmos.base.snapshots.v1beta1.SnapshotKVItem"))
+		}
+		panic(fmt.Errorf("message cosmos.base.snapshots.v1beta1.SnapshotKVItem does not contain field %s", fd.FullName()))
+	}
+}
+
+// WhichOneof reports which field within the oneof is populated,
+// returning nil if none are populated.
+// It panics if the oneof descriptor does not belong to this message.
+func (x *fastReflection_SnapshotKVItem) WhichOneof(d protoreflect.OneofDescriptor) protoreflect.FieldDescriptor {
+	switch d.FullName() {
+	default:
+		panic(fmt.Errorf("%s is not a oneof field in cosmos.base.snapshots.v1beta1.SnapshotKVItem", d.FullName()))
+	}
+	panic("unreachable")
+}
+
+// GetUnknown retrieves the entire list of unknown fields.
+// The caller may only mutate the contents of the RawFields
+// if the mutated bytes are stored back into the message with SetUnknown.
+func (x *fastReflection_SnapshotKVItem) GetUnknown() protoreflect.RawFields {
+	return x.unknownFields
+}
+
+// SetUnknown stores an entire list of unknown fields.
+// The raw fields must be syntactically valid according to the wire format.
+// An implementation may panic if this is not the case.
+// Once stored, the caller must not mutate the content of the RawFields.
+// An empty RawFields may be passed to clear the fields.
+//
+// SetUnknown is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_SnapshotKVItem) SetUnknown(fields protoreflect.RawFields) {
+	x.unknownFields = fields
+}
+
+// IsValid reports whether the message is valid.
+//
+// An invalid message is an empty, read-only value.
+//
+// An invalid message often corresponds to a nil pointer of the concrete
+// message type, but the details are implementation dependent.
+// Validity is not part of the protobuf data model, and may not
+// be preserved in marshaling or other operations.
+func (x *fastReflection_SnapshotKVItem) IsValid() bool {
+	return x != nil
+}
+
+// ProtoMethods returns optional fastReflectionFeature-path implementations of various operations.
+// This method may return nil.
+//
+// The returned methods type is identical to
+// "google.golang.org/protobuf/runtime/protoiface".Methods.
+// Consult the protoiface package documentation for details.
+func (x *fastReflection_SnapshotKVItem) ProtoMethods() *protoiface.Methods {
+	size := func(input protoiface.SizeInput) protoiface.SizeOutput {
+		x := input.Message.Interface().(*SnapshotKVItem)
+		if x == nil {
+			return protoiface.SizeOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Size:              0,
+			}
+		}
+		options := runtime.SizeInputToOptions(input)
+		_ = options
+		var n int
+		var l int
+		_ = l
+		l = len(x.Key)
+		if l > 0 {
+			n += 1 + l + runtime.Sov(uint64(l))
+		}
+		l = len(x.Value)
+		if l > 0 {
+			n += 1 + l + runtime.Sov(uint64(l))
+		}
+		if x.unknownFields != nil {
+			n += len(x.unknownFields)
+		}
+		return protoiface.SizeOutput{
+			NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+			Size:              n,
+		}
+	}
+
+	marshal := func(input protoiface.MarshalInput) (protoiface.MarshalOutput, error) {
+		x := input.Message.Interface().(*SnapshotKVItem)
+		if x == nil {
+			return protoiface.MarshalOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Buf:               input.Buf,
+			}, nil
+		}
+		options := runtime.MarshalInputToOptions(input)
+		_ = options
+		size := options.Size(x)
+		dAtA := make([]byte, size)
+		i := len(dAtA)
+		_ = i
+		var l int
+		_ = l
+		if x.unknownFields != nil {
+			i -= len(x.unknownFields)
+			copy(dAtA[i:], x.unknownFields)
+		}
+		if len(x.Value) > 0 {
+			i -= len(x.Value)
+			copy(dAtA[i:], x.Value)
+			i = runtime.EncodeVarint(dAtA, i, uint64(len(x.Value)))
+			i--
+			dAtA[i] = 0x12
+		}
+		if len(x.Key) > 0 {
+			i -= len(x.Key)
+			copy(dAtA[i:], x.Key)
+			i = runtime.EncodeVarint(dAtA, i, uint64(len(x.Key)))
+			i--
+			dAtA[i] = 0xa
+		}
+		if input.Buf != nil {
+			input.Buf = append(input.Buf, dAtA...)
+		} else {
+			input.Buf = dAtA
+		}
+		return protoiface.MarshalOutput{
+			NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+			Buf:               input.Buf,
+		}, nil
+	}
+	unmarshal := func(input protoiface.UnmarshalInput) (protoiface.UnmarshalOutput, error) {
+		x := input.Message.Interface().(*SnapshotKVItem)
+		if x == nil {
+			return protoiface.UnmarshalOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Flags:             input.Flags,
+			}, nil
+		}
+		options := runtime.UnmarshalInputToOptions(input)
+		_ = options
+		dAtA := input.Buf
+		l := len(dAtA)
+		iNdEx := 0
+		for iNdEx < l {
+			preIndex := iNdEx
+			var wire uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				wire |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			fieldNum := int32(wire >> 3)
+			wireType := int(wire & 0x7)
+			if wireType == 4 {
+				return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: SnapshotKVItem: wiretype end group for non-group")
+			}
+			if fieldNum <= 0 {
+				return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: SnapshotKVItem: illegal tag %d (wire type %d)", fieldNum, wire)
+			}
+			switch fieldNum {
+			case 1:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field Key", wireType)
+				}
+				var byteLen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					byteLen |= int(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if byteLen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + byteLen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				x.Key = append(x.Key[:0], dAtA[iNdEx:postIndex]...)
+				if x.Key == nil {
+					x.Key = []byte{}
+				}
+				iNdEx = postIndex
+			case 2:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field Value", wireType)
+				}
+				var byteLen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					byteLen |= int(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if byteLen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + byteLen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				x.Value = append(x.Value[:0], dAtA[iNdEx:postIndex]...)
+				if x.Value == nil {
+					x.Value = []byte{}
+				}
+				iNdEx = postIndex
+			default:
+				iNdEx = preIndex
+				skippy, err := runtime.Skip(dAtA[iNdEx:])
+				if err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				if (skippy < 0) || (iNdEx+skippy) < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if (iNdEx + skippy) > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				if !options.DiscardUnknown {
+					x.unknownFields = append(x.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+				}
+				iNdEx += skippy
+			}
+		}
+
+		if iNdEx > l {
+			return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+		}
+		return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, nil
+	}
+	return &protoiface.Methods{
+		NoUnkeyedLiterals: struct{}{},
+		Flags:             protoiface.SupportMarshalDeterministic | protoiface.SupportUnmarshalDiscardUnknown,
+		Size:              size,
+		Marshal:           marshal,
+		Unmarshal:         unmarshal,
+		Merge:             nil,
+		CheckInitialized:  nil,
+	}
+}
+
+var _ protoreflect.List = (*_SnapshotSchema_1_list)(nil)
+
+type _SnapshotSchema_1_list struct {
+	list *[][]byte
+}
+
+func (x *_SnapshotSchema_1_list) Len() int {
+	if x.list == nil {
+		return 0
+	}
+	return len(*x.list)
+}
+
+func (x *_SnapshotSchema_1_list) Get(i int) protoreflect.Value {
+	return protoreflect.ValueOfBytes((*x.list)[i])
+}
+
+func (x *_SnapshotSchema_1_list) Set(i int, value protoreflect.Value) {
+	valueUnwrapped := value.Bytes()
+	concreteValue := valueUnwrapped
+	(*x.list)[i] = concreteValue
+}
+
+func (x *_SnapshotSchema_1_list) Append(value protoreflect.Value) {
+	valueUnwrapped := value.Bytes()
+	concreteValue := valueUnwrapped
+	*x.list = append(*x.list, concreteValue)
+}
+
+func (x *_SnapshotSchema_1_list) AppendMutable() protoreflect.Value {
+	panic(fmt.Errorf("AppendMutable can not be called on message SnapshotSchema at list field Keys as it is not of Message kind"))
+}
+
+func (x *_SnapshotSchema_1_list) Truncate(n int) {
+	*x.list = (*x.list)[:n]
+}
+
+func (x *_SnapshotSchema_1_list) NewElement() protoreflect.Value {
+	var v []byte
+	return protoreflect.ValueOfBytes(v)
+}
+
+func (x *_SnapshotSchema_1_list) IsValid() bool {
+	return x.list != nil
+}
+
+var (
+	md_SnapshotSchema      protoreflect.MessageDescriptor
+	fd_SnapshotSchema_keys protoreflect.FieldDescriptor
+)
+
+func init() {
+	file_cosmos_base_snapshots_v1beta1_snapshot_proto_init()
+	md_SnapshotSchema = File_cosmos_base_snapshots_v1beta1_snapshot_proto.Messages().ByName("SnapshotSchema")
+	fd_SnapshotSchema_keys = md_SnapshotSchema.Fields().ByName("keys")
+}
+
+var _ protoreflect.Message = (*fastReflection_SnapshotSchema)(nil)
+
+type fastReflection_SnapshotSchema SnapshotSchema
+
+func (x *SnapshotSchema) ProtoReflect() protoreflect.Message {
+	return (*fastReflection_SnapshotSchema)(x)
+}
+
+func (x *SnapshotSchema) slowProtoReflect() protoreflect.Message {
+	mi := &file_cosmos_base_snapshots_v1beta1_snapshot_proto_msgTypes[8]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+var _fastReflection_SnapshotSchema_messageType fastReflection_SnapshotSchema_messageType
+var _ protoreflect.MessageType = fastReflection_SnapshotSchema_messageType{}
+
+type fastReflection_SnapshotSchema_messageType struct{}
+
+func (x fastReflection_SnapshotSchema_messageType) Zero() protoreflect.Message {
+	return (*fastReflection_SnapshotSchema)(nil)
+}
+func (x fastReflection_SnapshotSchema_messageType) New() protoreflect.Message {
+	return new(fastReflection_SnapshotSchema)
+}
+func (x fastReflection_SnapshotSchema_messageType) Descriptor() protoreflect.MessageDescriptor {
+	return md_SnapshotSchema
+}
+
+// Descriptor returns message descriptor, which contains only the protobuf
+// type information for the message.
+func (x *fastReflection_SnapshotSchema) Descriptor() protoreflect.MessageDescriptor {
+	return md_SnapshotSchema
+}
+
+// Type returns the message type, which encapsulates both Go and protobuf
+// type information. If the Go type information is not needed,
+// it is recommended that the message descriptor be used instead.
+func (x *fastReflection_SnapshotSchema) Type() protoreflect.MessageType {
+	return _fastReflection_SnapshotSchema_messageType
+}
+
+// New returns a newly allocated and mutable empty message.
+func (x *fastReflection_SnapshotSchema) New() protoreflect.Message {
+	return new(fastReflection_SnapshotSchema)
+}
+
+// Interface unwraps the message reflection interface and
+// returns the underlying ProtoMessage interface.
+func (x *fastReflection_SnapshotSchema) Interface() protoreflect.ProtoMessage {
+	return (*SnapshotSchema)(x)
+}
+
+// Range iterates over every populated field in an undefined order,
+// calling f for each field descriptor and value encountered.
+// Range returns immediately if f returns false.
+// While iterating, mutating operations may only be performed
+// on the current field descriptor.
+func (x *fastReflection_SnapshotSchema) Range(f func(protoreflect.FieldDescriptor, protoreflect.Value) bool) {
+	if len(x.Keys) != 0 {
+		value := protoreflect.ValueOfList(&_SnapshotSchema_1_list{list: &x.Keys})
+		if !f(fd_SnapshotSchema_keys, value) {
+			return
+		}
+	}
+}
+
+// Has reports whether a field is populated.
+//
+// Some fields have the property of nullability where it is possible to
+// distinguish between the default value of a field and whether the field
+// was explicitly populated with the default value. Singular message fields,
+// member fields of a oneof, and proto2 scalar fields are nullable. Such
+// fields are populated only if explicitly set.
+//
+// In other cases (aside from the nullable cases above),
+// a proto3 scalar field is populated if it contains a non-zero value, and
+// a repeated field is populated if it is non-empty.
+func (x *fastReflection_SnapshotSchema) Has(fd protoreflect.FieldDescriptor) bool {
+	switch fd.FullName() {
+	case "cosmos.base.snapshots.v1beta1.SnapshotSchema.keys":
+		return len(x.Keys) != 0
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: cosmos.base.snapshots.v1beta1.SnapshotSchema"))
+		}
+		panic(fmt.Errorf("message cosmos.base.snapshots.v1beta1.SnapshotSchema does not contain field %s", fd.FullName()))
+	}
+}
+
+// Clear clears the field such that a subsequent Has call reports false.
+//
+// Clearing an extension field clears both the extension type and value
+// associated with the given field number.
+//
+// Clear is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_SnapshotSchema) Clear(fd protoreflect.FieldDescriptor) {
+	switch fd.FullName() {
+	case "cosmos.base.snapshots.v1beta1.SnapshotSchema.keys":
+		x.Keys = nil
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: cosmos.base.snapshots.v1beta1.SnapshotSchema"))
+		}
+		panic(fmt.Errorf("message cosmos.base.snapshots.v1beta1.SnapshotSchema does not contain field %s", fd.FullName()))
+	}
+}
+
+// Get retrieves the value for a field.
+//
+// For unpopulated scalars, it returns the default value, where
+// the default value of a bytes scalar is guaranteed to be a copy.
+// For unpopulated composite types, it returns an empty, read-only view
+// of the value; to obtain a mutable reference, use Mutable.
+func (x *fastReflection_SnapshotSchema) Get(descriptor protoreflect.FieldDescriptor) protoreflect.Value {
+	switch descriptor.FullName() {
+	case "cosmos.base.snapshots.v1beta1.SnapshotSchema.keys":
+		if len(x.Keys) == 0 {
+			return protoreflect.ValueOfList(&_SnapshotSchema_1_list{})
+		}
+		listValue := &_SnapshotSchema_1_list{list: &x.Keys}
+		return protoreflect.ValueOfList(listValue)
+	default:
+		if descriptor.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: cosmos.base.snapshots.v1beta1.SnapshotSchema"))
+		}
+		panic(fmt.Errorf("message cosmos.base.snapshots.v1beta1.SnapshotSchema does not contain field %s", descriptor.FullName()))
+	}
+}
+
+// Set stores the value for a field.
+//
+// For a field belonging to a oneof, it implicitly clears any other field
+// that may be currently set within the same oneof.
+// For extension fields, it implicitly stores the provided ExtensionType.
+// When setting a composite type, it is unspecified whether the stored value
+// aliases the source's memory in any way. If the composite value is an
+// empty, read-only value, then it panics.
+//
+// Set is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_SnapshotSchema) Set(fd protoreflect.FieldDescriptor, value protoreflect.Value) {
+	switch fd.FullName() {
+	case "cosmos.base.snapshots.v1beta1.SnapshotSchema.keys":
+		lv := value.List()
+		clv := lv.(*_SnapshotSchema_1_list)
+		x.Keys = *clv.list
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: cosmos.base.snapshots.v1beta1.SnapshotSchema"))
+		}
+		panic(fmt.Errorf("message cosmos.base.snapshots.v1beta1.SnapshotSchema does not contain field %s", fd.FullName()))
+	}
+}
+
+// Mutable returns a mutable reference to a composite type.
+//
+// If the field is unpopulated, it may allocate a composite value.
+// For a field belonging to a oneof, it implicitly clears any other field
+// that may be currently set within the same oneof.
+// For extension fields, it implicitly stores the provided ExtensionType
+// if not already stored.
+// It panics if the field does not contain a composite type.
+//
+// Mutable is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_SnapshotSchema) Mutable(fd protoreflect.FieldDescriptor) protoreflect.Value {
+	switch fd.FullName() {
+	case "cosmos.base.snapshots.v1beta1.SnapshotSchema.keys":
+		if x.Keys == nil {
+			x.Keys = [][]byte{}
+		}
+		value := &_SnapshotSchema_1_list{list: &x.Keys}
+		return protoreflect.ValueOfList(value)
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: cosmos.base.snapshots.v1beta1.SnapshotSchema"))
+		}
+		panic(fmt.Errorf("message cosmos.base.snapshots.v1beta1.SnapshotSchema does not contain field %s", fd.FullName()))
+	}
+}
+
+// NewField returns a new value that is assignable to the field
+// for the given descriptor. For scalars, this returns the default value.
+// For lists, maps, and messages, this returns a new, empty, mutable value.
+func (x *fastReflection_SnapshotSchema) NewField(fd protoreflect.FieldDescriptor) protoreflect.Value {
+	switch fd.FullName() {
+	case "cosmos.base.snapshots.v1beta1.SnapshotSchema.keys":
+		list := [][]byte{}
+		return protoreflect.ValueOfList(&_SnapshotSchema_1_list{list: &list})
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: cosmos.base.snapshots.v1beta1.SnapshotSchema"))
+		}
+		panic(fmt.Errorf("message cosmos.base.snapshots.v1beta1.SnapshotSchema does not contain field %s", fd.FullName()))
+	}
+}
+
+// WhichOneof reports which field within the oneof is populated,
+// returning nil if none are populated.
+// It panics if the oneof descriptor does not belong to this message.
+func (x *fastReflection_SnapshotSchema) WhichOneof(d protoreflect.OneofDescriptor) protoreflect.FieldDescriptor {
+	switch d.FullName() {
+	default:
+		panic(fmt.Errorf("%s is not a oneof field in cosmos.base.snapshots.v1beta1.SnapshotSchema", d.FullName()))
+	}
+	panic("unreachable")
+}
+
+// GetUnknown retrieves the entire list of unknown fields.
+// The caller may only mutate the contents of the RawFields
+// if the mutated bytes are stored back into the message with SetUnknown.
+func (x *fastReflection_SnapshotSchema) GetUnknown() protoreflect.RawFields {
+	return x.unknownFields
+}
+
+// SetUnknown stores an entire list of unknown fields.
+// The raw fields must be syntactically valid according to the wire format.
+// An implementation may panic if this is not the case.
+// Once stored, the caller must not mutate the content of the RawFields.
+// An empty RawFields may be passed to clear the fields.
+//
+// SetUnknown is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_SnapshotSchema) SetUnknown(fields protoreflect.RawFields) {
+	x.unknownFields = fields
+}
+
+// IsValid reports whether the message is valid.
+//
+// An invalid message is an empty, read-only value.
+//
+// An invalid message often corresponds to a nil pointer of the concrete
+// message type, but the details are implementation dependent.
+// Validity is not part of the protobuf data model, and may not
+// be preserved in marshaling or other operations.
+func (x *fastReflection_SnapshotSchema) IsValid() bool {
+	return x != nil
+}
+
+// ProtoMethods returns optional fastReflectionFeature-path implementations of various operations.
+// This method may return nil.
+//
+// The returned methods type is identical to
+// "google.golang.org/protobuf/runtime/protoiface".Methods.
+// Consult the protoiface package documentation for details.
+func (x *fastReflection_SnapshotSchema) ProtoMethods() *protoiface.Methods {
+	size := func(input protoiface.SizeInput) protoiface.SizeOutput {
+		x := input.Message.Interface().(*SnapshotSchema)
+		if x == nil {
+			return protoiface.SizeOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Size:              0,
+			}
+		}
+		options := runtime.SizeInputToOptions(input)
+		_ = options
+		var n int
+		var l int
+		_ = l
+		if len(x.Keys) > 0 {
+			for _, b := range x.Keys {
+				l = len(b)
+				n += 1 + l + runtime.Sov(uint64(l))
+			}
+		}
+		if x.unknownFields != nil {
+			n += len(x.unknownFields)
+		}
+		return protoiface.SizeOutput{
+			NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+			Size:              n,
+		}
+	}
+
+	marshal := func(input protoiface.MarshalInput) (protoiface.MarshalOutput, error) {
+		x := input.Message.Interface().(*SnapshotSchema)
+		if x == nil {
+			return protoiface.MarshalOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Buf:               input.Buf,
+			}, nil
+		}
+		options := runtime.MarshalInputToOptions(input)
+		_ = options
+		size := options.Size(x)
+		dAtA := make([]byte, size)
+		i := len(dAtA)
+		_ = i
+		var l int
+		_ = l
+		if x.unknownFields != nil {
+			i -= len(x.unknownFields)
+			copy(dAtA[i:], x.unknownFields)
+		}
+		if len(x.Keys) > 0 {
+			for iNdEx := len(x.Keys) - 1; iNdEx >= 0; iNdEx-- {
+				i -= len(x.Keys[iNdEx])
+				copy(dAtA[i:], x.Keys[iNdEx])
+				i = runtime.EncodeVarint(dAtA, i, uint64(len(x.Keys[iNdEx])))
+				i--
+				dAtA[i] = 0xa
+			}
+		}
+		if input.Buf != nil {
+			input.Buf = append(input.Buf, dAtA...)
+		} else {
+			input.Buf = dAtA
+		}
+		return protoiface.MarshalOutput{
+			NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+			Buf:               input.Buf,
+		}, nil
+	}
+	unmarshal := func(input protoiface.UnmarshalInput) (protoiface.UnmarshalOutput, error) {
+		x := input.Message.Interface().(*SnapshotSchema)
+		if x == nil {
+			return protoiface.UnmarshalOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Flags:             input.Flags,
+			}, nil
+		}
+		options := runtime.UnmarshalInputToOptions(input)
+		_ = options
+		dAtA := input.Buf
+		l := len(dAtA)
+		iNdEx := 0
+		for iNdEx < l {
+			preIndex := iNdEx
+			var wire uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				wire |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			fieldNum := int32(wire >> 3)
+			wireType := int(wire & 0x7)
+			if wireType == 4 {
+				return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: SnapshotSchema: wiretype end group for non-group")
+			}
+			if fieldNum <= 0 {
+				return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: SnapshotSchema: illegal tag %d (wire type %d)", fieldNum, wire)
+			}
+			switch fieldNum {
+			case 1:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field Keys", wireType)
+				}
+				var byteLen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					byteLen |= int(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if byteLen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + byteLen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				x.Keys = append(x.Keys, make([]byte, postIndex-iNdEx))
+				copy(x.Keys[len(x.Keys)-1], dAtA[iNdEx:postIndex])
+				iNdEx = postIndex
+			default:
+				iNdEx = preIndex
+				skippy, err := runtime.Skip(dAtA[iNdEx:])
+				if err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				if (skippy < 0) || (iNdEx+skippy) < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if (iNdEx + skippy) > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				if !options.DiscardUnknown {
+					x.unknownFields = append(x.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+				}
+				iNdEx += skippy
+			}
+		}
+
+		if iNdEx > l {
+			return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+		}
+		return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, nil
+	}
+	return &protoiface.Methods{
+		NoUnkeyedLiterals: struct{}{},
+		Flags:             protoiface.SupportMarshalDeterministic | protoiface.SupportUnmarshalDiscardUnknown,
+		Size:              size,
+		Marshal:           marshal,
+		Unmarshal:         unmarshal,
+		Merge:             nil,
+		CheckInitialized:  nil,
+	}
+}
+
 // Code generated by protoc-gen-go. DO NOT EDIT.
 // versions:
 // 	protoc-gen-go v1.27.0
@@ -3951,6 +5127,8 @@ type SnapshotItem struct {
 	//	*SnapshotItem_Iavl
 	//	*SnapshotItem_Extension
 	//	*SnapshotItem_ExtensionPayload
+	//	*SnapshotItem_Kv
+	//	*SnapshotItem_Schema
 	Item isSnapshotItem_Item `protobuf_oneof:"item"`
 }
 
@@ -4009,6 +5187,22 @@ func (x *SnapshotItem) GetExtensionPayload() *SnapshotExtensionPayload {
 	return nil
 }
 
+// Deprecated: Do not use.
+func (x *SnapshotItem) GetKv() *SnapshotKVItem {
+	if x, ok := x.GetItem().(*SnapshotItem_Kv); ok {
+		return x.Kv
+	}
+	return nil
+}
+
+// Deprecated: Do not use.
+func (x *SnapshotItem) GetSchema() *SnapshotSchema {
+	if x, ok := x.GetItem().(*SnapshotItem_Schema); ok {
+		return x.Schema
+	}
+	return nil
+}
+
 type isSnapshotItem_Item interface {
 	isSnapshotItem_Item()
 }
@@ -4029,6 +5223,16 @@ type SnapshotItem_ExtensionPayload struct {
 	ExtensionPayload *SnapshotExtensionPayload `protobuf:"bytes,4,opt,name=extension_payload,json=extensionPayload,proto3,oneof"`
 }
 
+type SnapshotItem_Kv struct {
+	// Deprecated: Do not use.
+	Kv *SnapshotKVItem `protobuf:"bytes,5,opt,name=kv,proto3,oneof"`
+}
+
+type SnapshotItem_Schema struct {
+	// Deprecated: Do not use.
+	Schema *SnapshotSchema `protobuf:"bytes,6,opt,name=schema,proto3,oneof"`
+}
+
 func (*SnapshotItem_Store) isSnapshotItem_Item() {}
 
 func (*SnapshotItem_Iavl) isSnapshotItem_Item() {}
@@ -4036,6 +5240,10 @@ func (*SnapshotItem_Iavl) isSnapshotItem_Item() {}
 func (*SnapshotItem_Extension) isSnapshotItem_Item() {}
 
 func (*SnapshotItem_ExtensionPayload) isSnapshotItem_Item() {}
+
+func (*SnapshotItem_Kv) isSnapshotItem_Item() {}
+
+func (*SnapshotItem_Schema) isSnapshotItem_Item() {}
 
 // SnapshotStoreItem contains metadata about a snapshotted store.
 //
@@ -4223,6 +5431,96 @@ func (x *SnapshotExtensionPayload) GetPayload() []byte {
 	return nil
 }
 
+// SnapshotKVItem is an exported Key/Value Pair
+//
+// Since: cosmos-sdk 0.46
+// Deprecated: This message was part of store/v2alpha1 which has been deleted from v0.47.
+//
+// Deprecated: Do not use.
+type SnapshotKVItem struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	Key   []byte `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
+	Value []byte `protobuf:"bytes,2,opt,name=value,proto3" json:"value,omitempty"`
+}
+
+func (x *SnapshotKVItem) Reset() {
+	*x = SnapshotKVItem{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_cosmos_base_snapshots_v1beta1_snapshot_proto_msgTypes[7]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *SnapshotKVItem) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SnapshotKVItem) ProtoMessage() {}
+
+// Deprecated: Use SnapshotKVItem.ProtoReflect.Descriptor instead.
+func (*SnapshotKVItem) Descriptor() ([]byte, []int) {
+	return file_cosmos_base_snapshots_v1beta1_snapshot_proto_rawDescGZIP(), []int{7}
+}
+
+func (x *SnapshotKVItem) GetKey() []byte {
+	if x != nil {
+		return x.Key
+	}
+	return nil
+}
+
+func (x *SnapshotKVItem) GetValue() []byte {
+	if x != nil {
+		return x.Value
+	}
+	return nil
+}
+
+// SnapshotSchema is an exported schema of smt store
+//
+// Since: cosmos-sdk 0.46
+// Deprecated: This message was part of store/v2alpha1 which has been deleted from v0.47.
+//
+// Deprecated: Do not use.
+type SnapshotSchema struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	Keys [][]byte `protobuf:"bytes,1,rep,name=keys,proto3" json:"keys,omitempty"`
+}
+
+func (x *SnapshotSchema) Reset() {
+	*x = SnapshotSchema{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_cosmos_base_snapshots_v1beta1_snapshot_proto_msgTypes[8]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *SnapshotSchema) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SnapshotSchema) ProtoMessage() {}
+
+// Deprecated: Use SnapshotSchema.ProtoReflect.Descriptor instead.
+func (*SnapshotSchema) Descriptor() ([]byte, []int) {
+	return file_cosmos_base_snapshots_v1beta1_snapshot_proto_rawDescGZIP(), []int{8}
+}
+
+func (x *SnapshotSchema) GetKeys() [][]byte {
+	if x != nil {
+		return x.Keys
+	}
+	return nil
+}
+
 var File_cosmos_base_snapshots_v1beta1_snapshot_proto protoreflect.FileDescriptor
 
 var file_cosmos_base_snapshots_v1beta1_snapshot_proto_rawDesc = []byte{
@@ -4246,7 +5544,7 @@ var file_cosmos_base_snapshots_v1beta1_snapshot_proto_rawDesc = []byte{
 	0x65, 0x74, 0x61, 0x64, 0x61, 0x74, 0x61, 0x22, 0x2d, 0x0a, 0x08, 0x4d, 0x65, 0x74, 0x61, 0x64,
 	0x61, 0x74, 0x61, 0x12, 0x21, 0x0a, 0x0c, 0x63, 0x68, 0x75, 0x6e, 0x6b, 0x5f, 0x68, 0x61, 0x73,
 	0x68, 0x65, 0x73, 0x18, 0x01, 0x20, 0x03, 0x28, 0x0c, 0x52, 0x0b, 0x63, 0x68, 0x75, 0x6e, 0x6b,
-	0x48, 0x61, 0x73, 0x68, 0x65, 0x73, 0x22, 0xef, 0x02, 0x0a, 0x0c, 0x53, 0x6e, 0x61, 0x70, 0x73,
+	0x48, 0x61, 0x73, 0x68, 0x65, 0x73, 0x22, 0x87, 0x04, 0x0a, 0x0c, 0x53, 0x6e, 0x61, 0x70, 0x73,
 	0x68, 0x6f, 0x74, 0x49, 0x74, 0x65, 0x6d, 0x12, 0x48, 0x0a, 0x05, 0x73, 0x74, 0x6f, 0x72, 0x65,
 	0x18, 0x01, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x30, 0x2e, 0x63, 0x6f, 0x73, 0x6d, 0x6f, 0x73, 0x2e,
 	0x62, 0x61, 0x73, 0x65, 0x2e, 0x73, 0x6e, 0x61, 0x70, 0x73, 0x68, 0x6f, 0x74, 0x73, 0x2e, 0x76,
@@ -4269,24 +5567,40 @@ var file_cosmos_base_snapshots_v1beta1_snapshot_proto_rawDesc = []byte{
 	0x74, 0x61, 0x31, 0x2e, 0x53, 0x6e, 0x61, 0x70, 0x73, 0x68, 0x6f, 0x74, 0x45, 0x78, 0x74, 0x65,
 	0x6e, 0x73, 0x69, 0x6f, 0x6e, 0x50, 0x61, 0x79, 0x6c, 0x6f, 0x61, 0x64, 0x48, 0x00, 0x52, 0x10,
 	0x65, 0x78, 0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f, 0x6e, 0x50, 0x61, 0x79, 0x6c, 0x6f, 0x61, 0x64,
-	0x42, 0x06, 0x0a, 0x04, 0x69, 0x74, 0x65, 0x6d, 0x22, 0x27, 0x0a, 0x11, 0x53, 0x6e, 0x61, 0x70,
-	0x73, 0x68, 0x6f, 0x74, 0x53, 0x74, 0x6f, 0x72, 0x65, 0x49, 0x74, 0x65, 0x6d, 0x12, 0x12, 0x0a,
-	0x04, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x6e, 0x61, 0x6d,
-	0x65, 0x22, 0x6c, 0x0a, 0x10, 0x53, 0x6e, 0x61, 0x70, 0x73, 0x68, 0x6f, 0x74, 0x49, 0x41, 0x56,
-	0x4c, 0x49, 0x74, 0x65, 0x6d, 0x12, 0x10, 0x0a, 0x03, 0x6b, 0x65, 0x79, 0x18, 0x01, 0x20, 0x01,
-	0x28, 0x0c, 0x52, 0x03, 0x6b, 0x65, 0x79, 0x12, 0x14, 0x0a, 0x05, 0x76, 0x61, 0x6c, 0x75, 0x65,
-	0x18, 0x02, 0x20, 0x01, 0x28, 0x0c, 0x52, 0x05, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x12, 0x18, 0x0a,
-	0x07, 0x76, 0x65, 0x72, 0x73, 0x69, 0x6f, 0x6e, 0x18, 0x03, 0x20, 0x01, 0x28, 0x03, 0x52, 0x07,
-	0x76, 0x65, 0x72, 0x73, 0x69, 0x6f, 0x6e, 0x12, 0x16, 0x0a, 0x06, 0x68, 0x65, 0x69, 0x67, 0x68,
-	0x74, 0x18, 0x04, 0x20, 0x01, 0x28, 0x05, 0x52, 0x06, 0x68, 0x65, 0x69, 0x67, 0x68, 0x74, 0x22,
-	0x43, 0x0a, 0x15, 0x53, 0x6e, 0x61, 0x70, 0x73, 0x68, 0x6f, 0x74, 0x45, 0x78, 0x74, 0x65, 0x6e,
-	0x73, 0x69, 0x6f, 0x6e, 0x4d, 0x65, 0x74, 0x61, 0x12, 0x12, 0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65,
-	0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12, 0x16, 0x0a, 0x06,
-	0x66, 0x6f, 0x72, 0x6d, 0x61, 0x74, 0x18, 0x02, 0x20, 0x01, 0x28, 0x0d, 0x52, 0x06, 0x66, 0x6f,
-	0x72, 0x6d, 0x61, 0x74, 0x22, 0x34, 0x0a, 0x18, 0x53, 0x6e, 0x61, 0x70, 0x73, 0x68, 0x6f, 0x74,
-	0x45, 0x78, 0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f, 0x6e, 0x50, 0x61, 0x79, 0x6c, 0x6f, 0x61, 0x64,
-	0x12, 0x18, 0x0a, 0x07, 0x70, 0x61, 0x79, 0x6c, 0x6f, 0x61, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28,
-	0x0c, 0x52, 0x07, 0x70, 0x61, 0x79, 0x6c, 0x6f, 0x61, 0x64, 0x42, 0x8a, 0x02, 0x0a, 0x21, 0x63,
+	0x12, 0x49, 0x0a, 0x02, 0x6b, 0x76, 0x18, 0x05, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x2d, 0x2e, 0x63,
+	0x6f, 0x73, 0x6d, 0x6f, 0x73, 0x2e, 0x62, 0x61, 0x73, 0x65, 0x2e, 0x73, 0x6e, 0x61, 0x70, 0x73,
+	0x68, 0x6f, 0x74, 0x73, 0x2e, 0x76, 0x31, 0x62, 0x65, 0x74, 0x61, 0x31, 0x2e, 0x53, 0x6e, 0x61,
+	0x70, 0x73, 0x68, 0x6f, 0x74, 0x4b, 0x56, 0x49, 0x74, 0x65, 0x6d, 0x42, 0x08, 0x18, 0x01, 0xe2,
+	0xde, 0x1f, 0x02, 0x4b, 0x56, 0x48, 0x00, 0x52, 0x02, 0x6b, 0x76, 0x12, 0x4b, 0x0a, 0x06, 0x73,
+	0x63, 0x68, 0x65, 0x6d, 0x61, 0x18, 0x06, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x2d, 0x2e, 0x63, 0x6f,
+	0x73, 0x6d, 0x6f, 0x73, 0x2e, 0x62, 0x61, 0x73, 0x65, 0x2e, 0x73, 0x6e, 0x61, 0x70, 0x73, 0x68,
+	0x6f, 0x74, 0x73, 0x2e, 0x76, 0x31, 0x62, 0x65, 0x74, 0x61, 0x31, 0x2e, 0x53, 0x6e, 0x61, 0x70,
+	0x73, 0x68, 0x6f, 0x74, 0x53, 0x63, 0x68, 0x65, 0x6d, 0x61, 0x42, 0x02, 0x18, 0x01, 0x48, 0x00,
+	0x52, 0x06, 0x73, 0x63, 0x68, 0x65, 0x6d, 0x61, 0x42, 0x06, 0x0a, 0x04, 0x69, 0x74, 0x65, 0x6d,
+	0x22, 0x27, 0x0a, 0x11, 0x53, 0x6e, 0x61, 0x70, 0x73, 0x68, 0x6f, 0x74, 0x53, 0x74, 0x6f, 0x72,
+	0x65, 0x49, 0x74, 0x65, 0x6d, 0x12, 0x12, 0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x01, 0x20,
+	0x01, 0x28, 0x09, 0x52, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x22, 0x6c, 0x0a, 0x10, 0x53, 0x6e, 0x61,
+	0x70, 0x73, 0x68, 0x6f, 0x74, 0x49, 0x41, 0x56, 0x4c, 0x49, 0x74, 0x65, 0x6d, 0x12, 0x10, 0x0a,
+	0x03, 0x6b, 0x65, 0x79, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0c, 0x52, 0x03, 0x6b, 0x65, 0x79, 0x12,
+	0x14, 0x0a, 0x05, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x0c, 0x52, 0x05,
+	0x76, 0x61, 0x6c, 0x75, 0x65, 0x12, 0x18, 0x0a, 0x07, 0x76, 0x65, 0x72, 0x73, 0x69, 0x6f, 0x6e,
+	0x18, 0x03, 0x20, 0x01, 0x28, 0x03, 0x52, 0x07, 0x76, 0x65, 0x72, 0x73, 0x69, 0x6f, 0x6e, 0x12,
+	0x16, 0x0a, 0x06, 0x68, 0x65, 0x69, 0x67, 0x68, 0x74, 0x18, 0x04, 0x20, 0x01, 0x28, 0x05, 0x52,
+	0x06, 0x68, 0x65, 0x69, 0x67, 0x68, 0x74, 0x22, 0x43, 0x0a, 0x15, 0x53, 0x6e, 0x61, 0x70, 0x73,
+	0x68, 0x6f, 0x74, 0x45, 0x78, 0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f, 0x6e, 0x4d, 0x65, 0x74, 0x61,
+	0x12, 0x12, 0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04,
+	0x6e, 0x61, 0x6d, 0x65, 0x12, 0x16, 0x0a, 0x06, 0x66, 0x6f, 0x72, 0x6d, 0x61, 0x74, 0x18, 0x02,
+	0x20, 0x01, 0x28, 0x0d, 0x52, 0x06, 0x66, 0x6f, 0x72, 0x6d, 0x61, 0x74, 0x22, 0x34, 0x0a, 0x18,
+	0x53, 0x6e, 0x61, 0x70, 0x73, 0x68, 0x6f, 0x74, 0x45, 0x78, 0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f,
+	0x6e, 0x50, 0x61, 0x79, 0x6c, 0x6f, 0x61, 0x64, 0x12, 0x18, 0x0a, 0x07, 0x70, 0x61, 0x79, 0x6c,
+	0x6f, 0x61, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0c, 0x52, 0x07, 0x70, 0x61, 0x79, 0x6c, 0x6f,
+	0x61, 0x64, 0x22, 0x3c, 0x0a, 0x0e, 0x53, 0x6e, 0x61, 0x70, 0x73, 0x68, 0x6f, 0x74, 0x4b, 0x56,
+	0x49, 0x74, 0x65, 0x6d, 0x12, 0x10, 0x0a, 0x03, 0x6b, 0x65, 0x79, 0x18, 0x01, 0x20, 0x01, 0x28,
+	0x0c, 0x52, 0x03, 0x6b, 0x65, 0x79, 0x12, 0x14, 0x0a, 0x05, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x18,
+	0x02, 0x20, 0x01, 0x28, 0x0c, 0x52, 0x05, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x3a, 0x02, 0x18, 0x01,
+	0x22, 0x28, 0x0a, 0x0e, 0x53, 0x6e, 0x61, 0x70, 0x73, 0x68, 0x6f, 0x74, 0x53, 0x63, 0x68, 0x65,
+	0x6d, 0x61, 0x12, 0x12, 0x0a, 0x04, 0x6b, 0x65, 0x79, 0x73, 0x18, 0x01, 0x20, 0x03, 0x28, 0x0c,
+	0x52, 0x04, 0x6b, 0x65, 0x79, 0x73, 0x3a, 0x02, 0x18, 0x01, 0x42, 0x8a, 0x02, 0x0a, 0x21, 0x63,
 	0x6f, 0x6d, 0x2e, 0x63, 0x6f, 0x73, 0x6d, 0x6f, 0x73, 0x2e, 0x62, 0x61, 0x73, 0x65, 0x2e, 0x73,
 	0x6e, 0x61, 0x70, 0x73, 0x68, 0x6f, 0x74, 0x73, 0x2e, 0x76, 0x31, 0x62, 0x65, 0x74, 0x61, 0x31,
 	0x42, 0x0d, 0x53, 0x6e, 0x61, 0x70, 0x73, 0x68, 0x6f, 0x74, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x50,
@@ -4318,7 +5632,7 @@ func file_cosmos_base_snapshots_v1beta1_snapshot_proto_rawDescGZIP() []byte {
 	return file_cosmos_base_snapshots_v1beta1_snapshot_proto_rawDescData
 }
 
-var file_cosmos_base_snapshots_v1beta1_snapshot_proto_msgTypes = make([]protoimpl.MessageInfo, 7)
+var file_cosmos_base_snapshots_v1beta1_snapshot_proto_msgTypes = make([]protoimpl.MessageInfo, 9)
 var file_cosmos_base_snapshots_v1beta1_snapshot_proto_goTypes = []interface{}{
 	(*Snapshot)(nil),                 // 0: cosmos.base.snapshots.v1beta1.Snapshot
 	(*Metadata)(nil),                 // 1: cosmos.base.snapshots.v1beta1.Metadata
@@ -4327,6 +5641,8 @@ var file_cosmos_base_snapshots_v1beta1_snapshot_proto_goTypes = []interface{}{
 	(*SnapshotIAVLItem)(nil),         // 4: cosmos.base.snapshots.v1beta1.SnapshotIAVLItem
 	(*SnapshotExtensionMeta)(nil),    // 5: cosmos.base.snapshots.v1beta1.SnapshotExtensionMeta
 	(*SnapshotExtensionPayload)(nil), // 6: cosmos.base.snapshots.v1beta1.SnapshotExtensionPayload
+	(*SnapshotKVItem)(nil),           // 7: cosmos.base.snapshots.v1beta1.SnapshotKVItem
+	(*SnapshotSchema)(nil),           // 8: cosmos.base.snapshots.v1beta1.SnapshotSchema
 }
 var file_cosmos_base_snapshots_v1beta1_snapshot_proto_depIdxs = []int32{
 	1, // 0: cosmos.base.snapshots.v1beta1.Snapshot.metadata:type_name -> cosmos.base.snapshots.v1beta1.Metadata
@@ -4334,11 +5650,13 @@ var file_cosmos_base_snapshots_v1beta1_snapshot_proto_depIdxs = []int32{
 	4, // 2: cosmos.base.snapshots.v1beta1.SnapshotItem.iavl:type_name -> cosmos.base.snapshots.v1beta1.SnapshotIAVLItem
 	5, // 3: cosmos.base.snapshots.v1beta1.SnapshotItem.extension:type_name -> cosmos.base.snapshots.v1beta1.SnapshotExtensionMeta
 	6, // 4: cosmos.base.snapshots.v1beta1.SnapshotItem.extension_payload:type_name -> cosmos.base.snapshots.v1beta1.SnapshotExtensionPayload
-	5, // [5:5] is the sub-list for method output_type
-	5, // [5:5] is the sub-list for method input_type
-	5, // [5:5] is the sub-list for extension type_name
-	5, // [5:5] is the sub-list for extension extendee
-	0, // [0:5] is the sub-list for field type_name
+	7, // 5: cosmos.base.snapshots.v1beta1.SnapshotItem.kv:type_name -> cosmos.base.snapshots.v1beta1.SnapshotKVItem
+	8, // 6: cosmos.base.snapshots.v1beta1.SnapshotItem.schema:type_name -> cosmos.base.snapshots.v1beta1.SnapshotSchema
+	7, // [7:7] is the sub-list for method output_type
+	7, // [7:7] is the sub-list for method input_type
+	7, // [7:7] is the sub-list for extension type_name
+	7, // [7:7] is the sub-list for extension extendee
+	0, // [0:7] is the sub-list for field type_name
 }
 
 func init() { file_cosmos_base_snapshots_v1beta1_snapshot_proto_init() }
@@ -4431,12 +5749,38 @@ func file_cosmos_base_snapshots_v1beta1_snapshot_proto_init() {
 				return nil
 			}
 		}
+		file_cosmos_base_snapshots_v1beta1_snapshot_proto_msgTypes[7].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*SnapshotKVItem); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_cosmos_base_snapshots_v1beta1_snapshot_proto_msgTypes[8].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*SnapshotSchema); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
 	}
 	file_cosmos_base_snapshots_v1beta1_snapshot_proto_msgTypes[2].OneofWrappers = []interface{}{
 		(*SnapshotItem_Store)(nil),
 		(*SnapshotItem_Iavl)(nil),
 		(*SnapshotItem_Extension)(nil),
 		(*SnapshotItem_ExtensionPayload)(nil),
+		(*SnapshotItem_Kv)(nil),
+		(*SnapshotItem_Schema)(nil),
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
@@ -4444,7 +5788,7 @@ func file_cosmos_base_snapshots_v1beta1_snapshot_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: file_cosmos_base_snapshots_v1beta1_snapshot_proto_rawDesc,
 			NumEnums:      0,
-			NumMessages:   7,
+			NumMessages:   9,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/proto/cosmos/base/snapshots/v1beta1/snapshot.proto
+++ b/proto/cosmos/base/snapshots/v1beta1/snapshot.proto
@@ -29,6 +29,8 @@ message SnapshotItem {
     SnapshotIAVLItem         iavl              = 2 [(gogoproto.customname) = "IAVL"];
     SnapshotExtensionMeta    extension         = 3;
     SnapshotExtensionPayload extension_payload = 4;
+    SnapshotKVItem           kv                = 5 [deprecated = true, (gogoproto.customname) = "KV"];
+    SnapshotSchema           schema            = 6 [deprecated = true];
   }
 }
 
@@ -64,4 +66,25 @@ message SnapshotExtensionMeta {
 // Since: cosmos-sdk 0.46
 message SnapshotExtensionPayload {
   bytes payload = 1;
+}
+
+// SnapshotKVItem is an exported Key/Value Pair
+//
+// Since: cosmos-sdk 0.46
+// Deprecated: This message was part of store/v2alpha1 which has been deleted from v0.47.
+message SnapshotKVItem {
+  option deprecated = true;
+
+  bytes key   = 1;
+  bytes value = 2;
+}
+
+// SnapshotSchema is an exported schema of smt store
+//
+// Since: cosmos-sdk 0.46
+// Deprecated: This message was part of store/v2alpha1 which has been deleted from v0.47.
+message SnapshotSchema {
+  option deprecated = true;
+
+  repeated bytes keys = 1;
 }

--- a/snapshots/types/snapshot.pb.go
+++ b/snapshots/types/snapshot.pb.go
@@ -157,6 +157,8 @@ type SnapshotItem struct {
 	//	*SnapshotItem_IAVL
 	//	*SnapshotItem_Extension
 	//	*SnapshotItem_ExtensionPayload
+	//	*SnapshotItem_KV
+	//	*SnapshotItem_Schema
 	Item isSnapshotItem_Item `protobuf_oneof:"item"`
 }
 
@@ -211,11 +213,19 @@ type SnapshotItem_Extension struct {
 type SnapshotItem_ExtensionPayload struct {
 	ExtensionPayload *SnapshotExtensionPayload `protobuf:"bytes,4,opt,name=extension_payload,json=extensionPayload,proto3,oneof" json:"extension_payload,omitempty"`
 }
+type SnapshotItem_KV struct {
+	KV *SnapshotKVItem `protobuf:"bytes,5,opt,name=kv,proto3,oneof" json:"kv,omitempty"`
+}
+type SnapshotItem_Schema struct {
+	Schema *SnapshotSchema `protobuf:"bytes,6,opt,name=schema,proto3,oneof" json:"schema,omitempty"`
+}
 
 func (*SnapshotItem_Store) isSnapshotItem_Item()            {}
 func (*SnapshotItem_IAVL) isSnapshotItem_Item()             {}
 func (*SnapshotItem_Extension) isSnapshotItem_Item()        {}
 func (*SnapshotItem_ExtensionPayload) isSnapshotItem_Item() {}
+func (*SnapshotItem_KV) isSnapshotItem_Item()               {}
+func (*SnapshotItem_Schema) isSnapshotItem_Item()           {}
 
 func (m *SnapshotItem) GetItem() isSnapshotItem_Item {
 	if m != nil {
@@ -252,6 +262,22 @@ func (m *SnapshotItem) GetExtensionPayload() *SnapshotExtensionPayload {
 	return nil
 }
 
+// Deprecated: Do not use.
+func (m *SnapshotItem) GetKV() *SnapshotKVItem {
+	if x, ok := m.GetItem().(*SnapshotItem_KV); ok {
+		return x.KV
+	}
+	return nil
+}
+
+// Deprecated: Do not use.
+func (m *SnapshotItem) GetSchema() *SnapshotSchema {
+	if x, ok := m.GetItem().(*SnapshotItem_Schema); ok {
+		return x.Schema
+	}
+	return nil
+}
+
 // XXX_OneofWrappers is for the internal use of the proto package.
 func (*SnapshotItem) XXX_OneofWrappers() []interface{} {
 	return []interface{}{
@@ -259,6 +285,8 @@ func (*SnapshotItem) XXX_OneofWrappers() []interface{} {
 		(*SnapshotItem_IAVL)(nil),
 		(*SnapshotItem_Extension)(nil),
 		(*SnapshotItem_ExtensionPayload)(nil),
+		(*SnapshotItem_KV)(nil),
+		(*SnapshotItem_Schema)(nil),
 	}
 }
 
@@ -484,6 +512,114 @@ func (m *SnapshotExtensionPayload) GetPayload() []byte {
 	return nil
 }
 
+// SnapshotKVItem is an exported Key/Value Pair
+//
+// Since: cosmos-sdk 0.46
+// Deprecated: This message was part of store/v2alpha1 which has been deleted from v0.47.
+//
+// Deprecated: Do not use.
+type SnapshotKVItem struct {
+	Key   []byte `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
+	Value []byte `protobuf:"bytes,2,opt,name=value,proto3" json:"value,omitempty"`
+}
+
+func (m *SnapshotKVItem) Reset()         { *m = SnapshotKVItem{} }
+func (m *SnapshotKVItem) String() string { return proto.CompactTextString(m) }
+func (*SnapshotKVItem) ProtoMessage()    {}
+func (*SnapshotKVItem) Descriptor() ([]byte, []int) {
+	return fileDescriptor_dd7a3c9b0a19e1ee, []int{7}
+}
+func (m *SnapshotKVItem) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *SnapshotKVItem) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_SnapshotKVItem.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *SnapshotKVItem) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SnapshotKVItem.Merge(m, src)
+}
+func (m *SnapshotKVItem) XXX_Size() int {
+	return m.Size()
+}
+func (m *SnapshotKVItem) XXX_DiscardUnknown() {
+	xxx_messageInfo_SnapshotKVItem.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_SnapshotKVItem proto.InternalMessageInfo
+
+func (m *SnapshotKVItem) GetKey() []byte {
+	if m != nil {
+		return m.Key
+	}
+	return nil
+}
+
+func (m *SnapshotKVItem) GetValue() []byte {
+	if m != nil {
+		return m.Value
+	}
+	return nil
+}
+
+// SnapshotSchema is an exported schema of smt store
+//
+// Since: cosmos-sdk 0.46
+// Deprecated: This message was part of store/v2alpha1 which has been deleted from v0.47.
+//
+// Deprecated: Do not use.
+type SnapshotSchema struct {
+	Keys [][]byte `protobuf:"bytes,1,rep,name=keys,proto3" json:"keys,omitempty"`
+}
+
+func (m *SnapshotSchema) Reset()         { *m = SnapshotSchema{} }
+func (m *SnapshotSchema) String() string { return proto.CompactTextString(m) }
+func (*SnapshotSchema) ProtoMessage()    {}
+func (*SnapshotSchema) Descriptor() ([]byte, []int) {
+	return fileDescriptor_dd7a3c9b0a19e1ee, []int{8}
+}
+func (m *SnapshotSchema) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *SnapshotSchema) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_SnapshotSchema.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *SnapshotSchema) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SnapshotSchema.Merge(m, src)
+}
+func (m *SnapshotSchema) XXX_Size() int {
+	return m.Size()
+}
+func (m *SnapshotSchema) XXX_DiscardUnknown() {
+	xxx_messageInfo_SnapshotSchema.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_SnapshotSchema proto.InternalMessageInfo
+
+func (m *SnapshotSchema) GetKeys() [][]byte {
+	if m != nil {
+		return m.Keys
+	}
+	return nil
+}
+
 func init() {
 	proto.RegisterType((*Snapshot)(nil), "cosmos.base.snapshots.v1beta1.Snapshot")
 	proto.RegisterType((*Metadata)(nil), "cosmos.base.snapshots.v1beta1.Metadata")
@@ -492,6 +628,8 @@ func init() {
 	proto.RegisterType((*SnapshotIAVLItem)(nil), "cosmos.base.snapshots.v1beta1.SnapshotIAVLItem")
 	proto.RegisterType((*SnapshotExtensionMeta)(nil), "cosmos.base.snapshots.v1beta1.SnapshotExtensionMeta")
 	proto.RegisterType((*SnapshotExtensionPayload)(nil), "cosmos.base.snapshots.v1beta1.SnapshotExtensionPayload")
+	proto.RegisterType((*SnapshotKVItem)(nil), "cosmos.base.snapshots.v1beta1.SnapshotKVItem")
+	proto.RegisterType((*SnapshotSchema)(nil), "cosmos.base.snapshots.v1beta1.SnapshotSchema")
 }
 
 func init() {
@@ -499,40 +637,44 @@ func init() {
 }
 
 var fileDescriptor_dd7a3c9b0a19e1ee = []byte{
-	// 513 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x94, 0x53, 0xd1, 0x6e, 0xd3, 0x30,
-	0x14, 0x8d, 0xd7, 0xb4, 0x74, 0x37, 0x41, 0xea, 0xac, 0x81, 0x22, 0x24, 0xb2, 0x92, 0x97, 0xf5,
-	0x61, 0x4b, 0x58, 0x99, 0xc4, 0x33, 0x45, 0xa0, 0x54, 0x02, 0x81, 0x3c, 0xc4, 0x03, 0x2f, 0x93,
-	0xdb, 0x7a, 0x4d, 0xd4, 0x26, 0xae, 0x6a, 0xb7, 0xa2, 0x7f, 0xc1, 0xaf, 0xf0, 0x17, 0x7b, 0xdc,
-	0x23, 0x4f, 0x13, 0x6a, 0x3f, 0x80, 0x5f, 0x40, 0xb6, 0x93, 0x30, 0x8d, 0x0d, 0xb6, 0xa7, 0xde,
-	0x73, 0x7a, 0xee, 0xf1, 0xf5, 0xc9, 0x35, 0x1c, 0x0c, 0xb9, 0xc8, 0xb8, 0x88, 0x06, 0x54, 0xb0,
-	0x48, 0xe4, 0x74, 0x26, 0x12, 0x2e, 0x45, 0xb4, 0x3c, 0x1a, 0x30, 0x49, 0x8f, 0x2a, 0x26, 0x9c,
-	0xcd, 0xb9, 0xe4, 0xf8, 0xa9, 0x51, 0x87, 0x4a, 0x1d, 0x56, 0xea, 0xb0, 0x50, 0x3f, 0xd9, 0x1d,
-	0xf3, 0x31, 0xd7, 0xca, 0x48, 0x55, 0xa6, 0x29, 0xf8, 0x8e, 0xa0, 0x79, 0x52, 0x68, 0xf1, 0x63,
-	0x68, 0x24, 0x2c, 0x1d, 0x27, 0xd2, 0x43, 0x6d, 0xd4, 0xb1, 0x49, 0x81, 0x14, 0x7f, 0xc6, 0xe7,
-	0x19, 0x95, 0xde, 0x56, 0x1b, 0x75, 0x1e, 0x92, 0x02, 0x29, 0x7e, 0x98, 0x2c, 0xf2, 0x89, 0xf0,
-	0x6a, 0x86, 0x37, 0x08, 0x63, 0xb0, 0x13, 0x2a, 0x12, 0xcf, 0x6e, 0xa3, 0x8e, 0x4b, 0x74, 0x8d,
-	0xfb, 0xd0, 0xcc, 0x98, 0xa4, 0x23, 0x2a, 0xa9, 0x57, 0x6f, 0xa3, 0x8e, 0xd3, 0xdd, 0x0f, 0xff,
-	0x39, 0x70, 0xf8, 0xbe, 0x90, 0xf7, 0xec, 0xf3, 0xcb, 0x3d, 0x8b, 0x54, 0xed, 0xc1, 0x21, 0x34,
-	0xcb, 0xff, 0xf0, 0x33, 0x70, 0xf5, 0xa1, 0xa7, 0xea, 0x10, 0x26, 0x3c, 0xd4, 0xae, 0x75, 0x5c,
-	0xe2, 0x68, 0x2e, 0xd6, 0x54, 0xf0, 0x6b, 0x0b, 0xdc, 0xf2, 0x8a, 0x7d, 0xc9, 0x32, 0x1c, 0x43,
-	0x5d, 0x48, 0x3e, 0x67, 0xfa, 0x96, 0x4e, 0xf7, 0xf9, 0x7f, 0xe6, 0x28, 0x7b, 0x4f, 0x54, 0x8f,
-	0x32, 0x88, 0x2d, 0x62, 0x0c, 0xf0, 0x07, 0xb0, 0x53, 0xba, 0x9c, 0xea, 0x58, 0x9c, 0x6e, 0x74,
-	0x47, 0xa3, 0xfe, 0xab, 0xcf, 0xef, 0x94, 0x4f, 0xaf, 0xb9, 0xbe, 0xdc, 0xb3, 0x15, 0x8a, 0x2d,
-	0xa2, 0x8d, 0xf0, 0x27, 0xd8, 0x66, 0x5f, 0x25, 0xcb, 0x45, 0xca, 0x73, 0x1d, 0xaa, 0xd3, 0x3d,
-	0xbe, 0xa3, 0xeb, 0x9b, 0xb2, 0x4f, 0x65, 0x13, 0x5b, 0xe4, 0x8f, 0x11, 0x3e, 0x83, 0x9d, 0x0a,
-	0x9c, 0xce, 0xe8, 0x6a, 0xca, 0xe9, 0x48, 0x7f, 0x1c, 0xa7, 0xfb, 0xf2, 0xbe, 0xee, 0x1f, 0x4d,
-	0x7b, 0x6c, 0x91, 0x16, 0xbb, 0xc6, 0xf5, 0x1a, 0x60, 0xa7, 0x92, 0x65, 0xc1, 0x3e, 0xec, 0xfc,
-	0x15, 0x9a, 0x5a, 0x8a, 0x9c, 0x66, 0x26, 0xf4, 0x6d, 0xa2, 0xeb, 0x60, 0x0a, 0xad, 0xeb, 0xa1,
-	0xe0, 0x16, 0xd4, 0x26, 0x6c, 0xa5, 0x65, 0x2e, 0x51, 0x25, 0xde, 0x85, 0xfa, 0x92, 0x4e, 0x17,
-	0x4c, 0xc7, 0xec, 0x12, 0x03, 0xb0, 0x07, 0x0f, 0x96, 0x6c, 0x5e, 0x05, 0x55, 0x23, 0x25, 0xbc,
-	0xb2, 0xc6, 0xea, 0x8e, 0xf5, 0x72, 0x8d, 0x83, 0xd7, 0xf0, 0xe8, 0xc6, 0xb0, 0x6e, 0x1a, 0xed,
-	0xb6, 0x9d, 0x0f, 0x8e, 0xc1, 0xbb, 0x2d, 0x13, 0x35, 0x52, 0x99, 0xae, 0x19, 0xbf, 0x84, 0xbd,
-	0xb7, 0xe7, 0x6b, 0x1f, 0x5d, 0xac, 0x7d, 0xf4, 0x73, 0xed, 0xa3, 0x6f, 0x1b, 0xdf, 0xba, 0xd8,
-	0xf8, 0xd6, 0x8f, 0x8d, 0x6f, 0x7d, 0x39, 0x18, 0xa7, 0x32, 0x59, 0x0c, 0xc2, 0x21, 0xcf, 0xa2,
-	0xe2, 0xb9, 0x9b, 0x9f, 0x43, 0x31, 0x9a, 0x5c, 0x79, 0xf4, 0x72, 0x35, 0x63, 0x62, 0xd0, 0xd0,
-	0xaf, 0xf6, 0xc5, 0xef, 0x00, 0x00, 0x00, 0xff, 0xff, 0x6c, 0x90, 0xf8, 0x1f, 0x1a, 0x04, 0x00,
-	0x00,
+	// 586 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x94, 0x54, 0xcd, 0x6e, 0xd3, 0x40,
+	0x10, 0xf6, 0x3a, 0x4e, 0x48, 0xd7, 0x06, 0xb5, 0xab, 0x82, 0x2c, 0x24, 0xdc, 0xe0, 0x4b, 0x7d,
+	0x68, 0x6d, 0x1a, 0x2a, 0x21, 0x21, 0x2e, 0x04, 0x81, 0x1c, 0x05, 0x04, 0xda, 0xa0, 0x1c, 0xb8,
+	0x54, 0x9b, 0x64, 0x1b, 0x47, 0x8e, 0xb3, 0x51, 0x76, 0x63, 0x91, 0x27, 0xe0, 0xca, 0xab, 0xf0,
+	0x16, 0x3d, 0xf6, 0xc8, 0xa9, 0x42, 0xc9, 0x8b, 0xa0, 0x5d, 0xff, 0xb4, 0x94, 0x16, 0xd2, 0x53,
+	0x66, 0x26, 0xdf, 0xf7, 0x79, 0x76, 0xbe, 0x9d, 0x85, 0x07, 0x03, 0xc6, 0x13, 0xc6, 0x83, 0x3e,
+	0xe1, 0x34, 0xe0, 0x53, 0x32, 0xe3, 0x11, 0x13, 0x3c, 0x48, 0x8f, 0xfa, 0x54, 0x90, 0xa3, 0xb2,
+	0xe2, 0xcf, 0xe6, 0x4c, 0x30, 0xf4, 0x24, 0x43, 0xfb, 0x12, 0xed, 0x97, 0x68, 0x3f, 0x47, 0x3f,
+	0xde, 0x1d, 0xb1, 0x11, 0x53, 0xc8, 0x40, 0x46, 0x19, 0xc9, 0xfd, 0x01, 0x60, 0xbd, 0x9b, 0x63,
+	0xd1, 0x23, 0x58, 0x8b, 0xe8, 0x78, 0x14, 0x09, 0x1b, 0x34, 0x80, 0x67, 0xe0, 0x3c, 0x93, 0xf5,
+	0x53, 0x36, 0x4f, 0x88, 0xb0, 0xf5, 0x06, 0xf0, 0xee, 0xe3, 0x3c, 0x93, 0xf5, 0x41, 0xb4, 0x98,
+	0xc6, 0xdc, 0xae, 0x64, 0xf5, 0x2c, 0x43, 0x08, 0x1a, 0x11, 0xe1, 0x91, 0x6d, 0x34, 0x80, 0x67,
+	0x61, 0x15, 0xa3, 0x36, 0xac, 0x27, 0x54, 0x90, 0x21, 0x11, 0xc4, 0xae, 0x36, 0x80, 0x67, 0x36,
+	0xf7, 0xfd, 0x7f, 0x36, 0xec, 0x7f, 0xc8, 0xe1, 0x2d, 0xe3, 0xec, 0x62, 0x4f, 0xc3, 0x25, 0xdd,
+	0x3d, 0x84, 0xf5, 0xe2, 0x3f, 0xf4, 0x14, 0x5a, 0xea, 0xa3, 0x27, 0xf2, 0x23, 0x94, 0xdb, 0xa0,
+	0x51, 0xf1, 0x2c, 0x6c, 0xaa, 0x5a, 0xa8, 0x4a, 0xee, 0x37, 0x03, 0x5a, 0xc5, 0x11, 0xdb, 0x82,
+	0x26, 0x28, 0x84, 0x55, 0x2e, 0xd8, 0x9c, 0xaa, 0x53, 0x9a, 0xcd, 0x67, 0xff, 0xe9, 0xa3, 0xe0,
+	0x76, 0x25, 0x47, 0x0a, 0x84, 0x1a, 0xce, 0x04, 0xd0, 0x47, 0x68, 0x8c, 0x49, 0x3a, 0x51, 0x63,
+	0x31, 0x9b, 0xc1, 0x86, 0x42, 0xed, 0xd7, 0xbd, 0xf7, 0x52, 0xa7, 0x55, 0x5f, 0x5d, 0xec, 0x19,
+	0x32, 0x0b, 0x35, 0xac, 0x84, 0xd0, 0x67, 0xb8, 0x45, 0xbf, 0x0a, 0x3a, 0xe5, 0x63, 0x36, 0x55,
+	0x43, 0x35, 0x9b, 0xc7, 0x1b, 0xaa, 0xbe, 0x2d, 0x78, 0x72, 0x36, 0xa1, 0x86, 0x2f, 0x85, 0xd0,
+	0x29, 0xdc, 0x29, 0x93, 0x93, 0x19, 0x59, 0x4e, 0x18, 0x19, 0x2a, 0x73, 0xcc, 0xe6, 0x8b, 0xbb,
+	0xaa, 0x7f, 0xca, 0xe8, 0xa1, 0x86, 0xb7, 0xe9, 0xb5, 0x1a, 0x6a, 0x43, 0x3d, 0x4e, 0x73, 0x77,
+	0x0f, 0x37, 0x14, 0xee, 0xf4, 0xca, 0x51, 0xe8, 0x9d, 0x9e, 0x0d, 0x42, 0x0d, 0xeb, 0x71, 0x8a,
+	0x3a, 0xb0, 0xc6, 0x07, 0x11, 0x4d, 0x88, 0x5d, 0xbb, 0x93, 0x5c, 0x57, 0x91, 0x5a, 0xba, 0x12,
+	0xca, 0x25, 0x5a, 0x35, 0x68, 0x8c, 0x05, 0x4d, 0xdc, 0x7d, 0xb8, 0xf3, 0x97, 0x99, 0xf2, 0xb2,
+	0x4e, 0x49, 0x92, 0x5d, 0x86, 0x2d, 0xac, 0x62, 0x77, 0x02, 0xb7, 0xaf, 0x9b, 0x85, 0xb6, 0x61,
+	0x25, 0xa6, 0x4b, 0x05, 0xb3, 0xb0, 0x0c, 0xd1, 0x2e, 0xac, 0xa6, 0x64, 0xb2, 0xa0, 0xca, 0x7e,
+	0x0b, 0x67, 0x09, 0xb2, 0xe1, 0xbd, 0x94, 0xce, 0x4b, 0x03, 0x2b, 0xb8, 0x48, 0xaf, 0xac, 0x97,
+	0x9c, 0x7d, 0xb5, 0x58, 0x2f, 0xf7, 0x0d, 0x7c, 0x78, 0xa3, 0x89, 0x37, 0xb5, 0x76, 0xdb, 0x2e,
+	0xba, 0xc7, 0xd0, 0xbe, 0xcd, 0x2b, 0xd9, 0x52, 0xe1, 0x7a, 0xd6, 0x7e, 0x91, 0xba, 0xaf, 0xe0,
+	0x83, 0x3f, 0x8d, 0xd8, 0xf4, 0x98, 0x2f, 0x75, 0x1b, 0xb8, 0xde, 0x25, 0x3b, 0x9b, 0xbb, 0xec,
+	0x38, 0xa6, 0xcb, 0x62, 0x0d, 0x55, 0x2c, 0x91, 0xad, 0x77, 0x67, 0x2b, 0x07, 0x9c, 0xaf, 0x1c,
+	0xf0, 0x6b, 0xe5, 0x80, 0xef, 0x6b, 0x47, 0x3b, 0x5f, 0x3b, 0xda, 0xcf, 0xb5, 0xa3, 0x7d, 0x39,
+	0x18, 0x8d, 0x45, 0xb4, 0xe8, 0xfb, 0x03, 0x96, 0x04, 0xf9, 0x73, 0x97, 0xfd, 0x1c, 0xf2, 0x61,
+	0x7c, 0xe5, 0xd1, 0x13, 0xcb, 0x19, 0xe5, 0xfd, 0x9a, 0x7a, 0xb5, 0x9e, 0xff, 0x0e, 0x00, 0x00,
+	0xff, 0xff, 0xe5, 0xb5, 0xd9, 0x60, 0x1a, 0x05, 0x00, 0x00,
 }
 
 func (m *Snapshot) Marshal() (dAtA []byte, err error) {
@@ -738,6 +880,48 @@ func (m *SnapshotItem_ExtensionPayload) MarshalToSizedBuffer(dAtA []byte) (int, 
 	}
 	return len(dAtA) - i, nil
 }
+func (m *SnapshotItem_KV) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *SnapshotItem_KV) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	if m.KV != nil {
+		{
+			size, err := m.KV.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintSnapshot(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0x2a
+	}
+	return len(dAtA) - i, nil
+}
+func (m *SnapshotItem_Schema) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *SnapshotItem_Schema) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	if m.Schema != nil {
+		{
+			size, err := m.Schema.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintSnapshot(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0x32
+	}
+	return len(dAtA) - i, nil
+}
 func (m *SnapshotStoreItem) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
@@ -880,6 +1064,75 @@ func (m *SnapshotExtensionPayload) MarshalToSizedBuffer(dAtA []byte) (int, error
 	return len(dAtA) - i, nil
 }
 
+func (m *SnapshotKVItem) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *SnapshotKVItem) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *SnapshotKVItem) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.Value) > 0 {
+		i -= len(m.Value)
+		copy(dAtA[i:], m.Value)
+		i = encodeVarintSnapshot(dAtA, i, uint64(len(m.Value)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.Key) > 0 {
+		i -= len(m.Key)
+		copy(dAtA[i:], m.Key)
+		i = encodeVarintSnapshot(dAtA, i, uint64(len(m.Key)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *SnapshotSchema) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *SnapshotSchema) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *SnapshotSchema) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.Keys) > 0 {
+		for iNdEx := len(m.Keys) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.Keys[iNdEx])
+			copy(dAtA[i:], m.Keys[iNdEx])
+			i = encodeVarintSnapshot(dAtA, i, uint64(len(m.Keys[iNdEx])))
+			i--
+			dAtA[i] = 0xa
+		}
+	}
+	return len(dAtA) - i, nil
+}
+
 func encodeVarintSnapshot(dAtA []byte, offset int, v uint64) int {
 	offset -= sovSnapshot(v)
 	base := offset
@@ -990,6 +1243,30 @@ func (m *SnapshotItem_ExtensionPayload) Size() (n int) {
 	}
 	return n
 }
+func (m *SnapshotItem_KV) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.KV != nil {
+		l = m.KV.Size()
+		n += 1 + l + sovSnapshot(uint64(l))
+	}
+	return n
+}
+func (m *SnapshotItem_Schema) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.Schema != nil {
+		l = m.Schema.Size()
+		n += 1 + l + sovSnapshot(uint64(l))
+	}
+	return n
+}
 func (m *SnapshotStoreItem) Size() (n int) {
 	if m == nil {
 		return 0
@@ -1051,6 +1328,38 @@ func (m *SnapshotExtensionPayload) Size() (n int) {
 	l = len(m.Payload)
 	if l > 0 {
 		n += 1 + l + sovSnapshot(uint64(l))
+	}
+	return n
+}
+
+func (m *SnapshotKVItem) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Key)
+	if l > 0 {
+		n += 1 + l + sovSnapshot(uint64(l))
+	}
+	l = len(m.Value)
+	if l > 0 {
+		n += 1 + l + sovSnapshot(uint64(l))
+	}
+	return n
+}
+
+func (m *SnapshotSchema) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if len(m.Keys) > 0 {
+		for _, b := range m.Keys {
+			l = len(b)
+			n += 1 + l + sovSnapshot(uint64(l))
+		}
 	}
 	return n
 }
@@ -1486,6 +1795,76 @@ func (m *SnapshotItem) Unmarshal(dAtA []byte) error {
 			}
 			m.Item = &SnapshotItem_ExtensionPayload{v}
 			iNdEx = postIndex
+		case 5:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field KV", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowSnapshot
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthSnapshot
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthSnapshot
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			v := &SnapshotKVItem{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			m.Item = &SnapshotItem_KV{v}
+			iNdEx = postIndex
+		case 6:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Schema", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowSnapshot
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthSnapshot
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthSnapshot
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			v := &SnapshotSchema{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			m.Item = &SnapshotItem_Schema{v}
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := skipSnapshot(dAtA[iNdEx:])
@@ -1908,6 +2287,206 @@ func (m *SnapshotExtensionPayload) Unmarshal(dAtA []byte) error {
 			if m.Payload == nil {
 				m.Payload = []byte{}
 			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipSnapshot(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthSnapshot
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *SnapshotKVItem) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowSnapshot
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: SnapshotKVItem: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: SnapshotKVItem: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Key", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowSnapshot
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				byteLen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if byteLen < 0 {
+				return ErrInvalidLengthSnapshot
+			}
+			postIndex := iNdEx + byteLen
+			if postIndex < 0 {
+				return ErrInvalidLengthSnapshot
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Key = append(m.Key[:0], dAtA[iNdEx:postIndex]...)
+			if m.Key == nil {
+				m.Key = []byte{}
+			}
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Value", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowSnapshot
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				byteLen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if byteLen < 0 {
+				return ErrInvalidLengthSnapshot
+			}
+			postIndex := iNdEx + byteLen
+			if postIndex < 0 {
+				return ErrInvalidLengthSnapshot
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Value = append(m.Value[:0], dAtA[iNdEx:postIndex]...)
+			if m.Value == nil {
+				m.Value = []byte{}
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipSnapshot(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthSnapshot
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *SnapshotSchema) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowSnapshot
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: SnapshotSchema: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: SnapshotSchema: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Keys", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowSnapshot
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				byteLen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if byteLen < 0 {
+				return ErrInvalidLengthSnapshot
+			}
+			postIndex := iNdEx + byteLen
+			if postIndex < 0 {
+				return ErrInvalidLengthSnapshot
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Keys = append(m.Keys, make([]byte, postIndex-iNdEx))
+			copy(m.Keys[len(m.Keys)-1], dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

-> PR against main https://github.com/cosmos/cosmos-sdk/pull/14597 

See https://github.com/cosmos/cosmos-sdk/pull/14591#discussion_r1068044503
It is not clear for me what is the consensus. If we want to re-add it, here is a PR for it.
Otherwise, we can just leave it as it.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
