### PR TITLE
fix: fix allow list bypassed when whole spend limit used

### DIFF
--- a/x/bank/types/send_authorization.go
+++ b/x/bank/types/send_authorization.go
@@ -33,19 +33,9 @@ func (a SendAuthorization) Accept(ctx sdk.Context, msg sdk.Msg) (authz.AcceptRes
 		return authz.AcceptResponse{}, sdkerrors.ErrInvalidType.Wrap("type mismatch")
 	}
 
-	toAddr := mSend.ToAddress
-
-	limitLeft, isNegative := a.SpendLimit.SafeSub(mSend.Amount...)
-	if isNegative {
-		return authz.AcceptResponse{}, sdkerrors.ErrInsufficientFunds.Wrapf("requested amount is more than spend limit")
-	}
-	if limitLeft.IsZero() {
-		return authz.AcceptResponse{Accept: true, Delete: true}, nil
-	}
-
 	isAddrExists := false
+	toAddr := mSend.ToAddress
 	allowedList := a.GetAllowList()
-
 	for _, addr := range allowedList {
 		ctx.GasMeter().ConsumeGas(gasCostPerIteration, "send authorization")
 		if addr == toAddr {
@@ -56,6 +46,14 @@ func (a SendAuthorization) Accept(ctx sdk.Context, msg sdk.Msg) (authz.AcceptRes
 
 	if len(allowedList) > 0 && !isAddrExists {
 		return authz.AcceptResponse{}, sdkerrors.ErrUnauthorized.Wrapf("cannot send to %s address", toAddr)
+	}
+
+	limitLeft, isNegative := a.SpendLimit.SafeSub(mSend.Amount...)
+	if isNegative {
+		return authz.AcceptResponse{}, sdkerrors.ErrInsufficientFunds.Wrapf("requested amount is more than spend limit")
+	}
+	if limitLeft.IsZero() {
+		return authz.AcceptResponse{Accept: true, Delete: true}, nil
 	}
 
 	return authz.AcceptResponse{Accept: true, Delete: false, Updated: &SendAuthorization{SpendLimit: limitLeft, AllowList: allowedList}}, nil

--- a/x/bank/types/send_authorization_test.go
+++ b/x/bank/types/send_authorization_test.go
@@ -85,4 +85,25 @@ func TestSendAuthorization(t *testing.T) {
 	require.NotNil(t, resp.Updated)
 	// coins1000-coins500 = coins500
 	require.Equal(t, types.NewSendAuthorization(coins500, allowList).String(), resp.Updated.String())
+
+	t.Log("send everything to address not in allow list")
+	authzWithAllowList = types.NewSendAuthorization(coins1000, allowList)
+	require.Equal(t, authzWithAllowList.MsgTypeURL(), "/cosmos.bank.v1beta1.MsgSend")
+	require.NoError(t, authorization.ValidateBasic())
+	send = types.NewMsgSend(fromAddr, unknownAddr, coins1000)
+	require.NoError(t, authzWithAllowList.ValidateBasic())
+	resp, err = authzWithAllowList.Accept(ctx, send)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), fmt.Sprintf("cannot send to %s address", unknownAddr))
+
+	t.Log("send everything to address in allow list")
+	authzWithAllowList = types.NewSendAuthorization(coins1000, allowList)
+	require.Equal(t, authzWithAllowList.MsgTypeURL(), "/cosmos.bank.v1beta1.MsgSend")
+	require.NoError(t, authorization.ValidateBasic())
+	send = types.NewMsgSend(fromAddr, allowList[0], coins1000)
+	require.NoError(t, authzWithAllowList.ValidateBasic())
+	resp, err = authzWithAllowList.Accept(ctx, send)
+	require.NoError(t, err)
+	require.True(t, resp.Accept)
+	require.Nil(t, resp.Updated)
 }


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

Closes: #XXXX

We don't need changelog as it was never released.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
