### PR TITLE
refactor:  add error to store interface

### DIFF
--- a/core/store/store.go
+++ b/core/store/store.go
@@ -4,16 +4,16 @@ import dbm "github.com/cosmos/cosmos-db"
 
 // KVStore describes the basic interface for interacting with key-value stores.
 type KVStore interface {
-	// Get returns nil iff key doesn't exist. Panics on nil key.
+	// Get returns nil iff key doesn't exist. Errors on nil key.
 	Get(key []byte) ([]byte, error)
 
-	// Has checks if a key exists. Panics on nil key.
+	// Has checks if a key exists. Errors on nil key.
 	Has(key []byte) (bool, error)
 
-	// Set sets the key. Panics on nil key or value.
+	// Set sets the key. Errors on nil key or value.
 	Set(key, value []byte) error
 
-	// Delete deletes the key. Panics on nil key.
+	// Delete deletes the key. Errors on nil key.
 	Delete(key []byte) error
 
 	// Iterator iterates over a domain of keys in ascending order. End is exclusive.
@@ -22,14 +22,14 @@ type KVStore interface {
 	// To iterate over entire domain, use store.Iterator(nil, nil)
 	// CONTRACT: No writes may happen within a domain while an iterator exists over it.
 	// Exceptionally allowed for cachekv.Store, safe to write in the modules.
-	Iterator(start, end []byte) (Iterator, error)
+	Iterator(start, end []byte) Iterator
 
 	// ReverseIterator iterates over a domain of keys in descending order. End is exclusive.
 	// Start must be less than end, or the Iterator is invalid.
 	// Iterator must be closed by caller.
 	// CONTRACT: No writes may happen within a domain while an iterator exists over it.
 	// Exceptionally allowed for cachekv.Store, safe to write in the modules.
-	ReverseIterator(start, end []byte) (Iterator, error)
+	ReverseIterator(start, end []byte) Iterator
 }
 
 // Iterator is an alias db's Iterator for convenience.

--- a/core/store/store.go
+++ b/core/store/store.go
@@ -5,16 +5,16 @@ import dbm "github.com/cosmos/cosmos-db"
 // KVStore describes the basic interface for interacting with key-value stores.
 type KVStore interface {
 	// Get returns nil iff key doesn't exist. Panics on nil key.
-	Get(key []byte) []byte
+	Get(key []byte) ([]byte, error)
 
 	// Has checks if a key exists. Panics on nil key.
-	Has(key []byte) bool
+	Has(key []byte) (bool, error)
 
 	// Set sets the key. Panics on nil key or value.
-	Set(key, value []byte)
+	Set(key, value []byte) error
 
 	// Delete deletes the key. Panics on nil key.
-	Delete(key []byte)
+	Delete(key []byte) error
 
 	// Iterator iterates over a domain of keys in ascending order. End is exclusive.
 	// Start must be less than end, or the Iterator is invalid.
@@ -22,14 +22,14 @@ type KVStore interface {
 	// To iterate over entire domain, use store.Iterator(nil, nil)
 	// CONTRACT: No writes may happen within a domain while an iterator exists over it.
 	// Exceptionally allowed for cachekv.Store, safe to write in the modules.
-	Iterator(start, end []byte) Iterator
+	Iterator(start, end []byte) (Iterator, error)
 
 	// ReverseIterator iterates over a domain of keys in descending order. End is exclusive.
 	// Start must be less than end, or the Iterator is invalid.
 	// Iterator must be closed by caller.
 	// CONTRACT: No writes may happen within a domain while an iterator exists over it.
 	// Exceptionally allowed for cachekv.Store, safe to write in the modules.
-	ReverseIterator(start, end []byte) Iterator
+	ReverseIterator(start, end []byte) (Iterator, error)
 }
 
 // Iterator is an alias db's Iterator for convenience.


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

return error on store interface instead of panic 

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
