### PR TITLE
refactor: use len check instead of nil check in multisignature

### DIFF
--- a/crypto/types/multisig/multisignature.go
+++ b/crypto/types/multisig/multisignature.go
@@ -1,6 +1,7 @@
 package multisig
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -73,7 +74,7 @@ func AddSignatureFromPubKey(mSig *signing.MultiSignatureData, sig signing.Signat
 	}
 
 	if len(keys) == 0 {
-		return fmt.Errorf("keys can't be empty or nil %v", keys)
+		return errors.New("keys can't be empty")
 	}
 
 	index := getIndex(pubkey, keys)

--- a/crypto/types/multisig/multisignature.go
+++ b/crypto/types/multisig/multisignature.go
@@ -63,13 +63,19 @@ func AddSignatureFromPubKey(mSig *signing.MultiSignatureData, sig signing.Signat
 	if mSig == nil {
 		return fmt.Errorf("value of mSig is nil %v", mSig)
 	}
+
 	if sig == nil {
 		return fmt.Errorf("value of sig is nil %v", sig)
 	}
 
-	if pubkey == nil || keys == nil {
-		return fmt.Errorf("pubkey or keys can't be nil %v %v", pubkey, keys)
+	if pubkey == nil {
+		return fmt.Errorf("pubkey can't be nil %v", pubkey)
 	}
+
+	if len(keys) == 0 {
+		return fmt.Errorf("keys can't be empty or nil %v", keys)
+	}
+
 	index := getIndex(pubkey, keys)
 	if index == -1 {
 		keysStr := make([]string, len(keys))


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

Closes: #8027

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
