### PR TITLE
fix(reflection): Temporary fix for FileDescriptorSet bug

### DIFF
--- a/runtime/services/reflection.go
+++ b/runtime/services/reflection.go
@@ -45,6 +45,18 @@ func NewReflectionService() (*ReflectionService, error) {
 			return nil, err
 		}
 
+		// The if check below is a temporary fix for https://github.com/cosmos/cosmos-sdk/issues/14713.
+		//
+		// It seems we're registering twice gogo.proto.
+		// See Frojdi's comments in server/grpc/gogoreflection/fix_registration.go.
+		// Skipping here `gogo.proto` and only including `gogoproto/gogo.proto`.
+		if *fd.Name == "gogo.proto" ||
+			// If we don't skip this one, we have the error:
+			// proto: file "descriptor.proto" has a name conflict over google.protobuf.FileDescriptorSet
+			*fd.Name == "descriptor.proto" {
+			continue
+		}
+
 		fds.File = append(fds.File, fd)
 		haveFileDescriptor[*fd.Name] = true
 	}


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

ref: #14713 

This is a temporary fix for the issue above. To fix it correctly, we should fix the root problem of how these 2 files register themselves.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
