### PR TITLE
feat(depinject): send logging to file instead of stderr

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,9 +48,10 @@ vagrant
 .dir-locals.el
 .vscode
 
-# Graphviz
+# Depinject & Graphviz
 dependency-graph.png
 debug_container.dot
+debug_container.log
 
 # Latex
 *.aux

--- a/depinject/debug.go
+++ b/depinject/debug.go
@@ -29,6 +29,30 @@ func StderrLogger() DebugOption {
 	})
 }
 
+// FileLogger is a debug option which routes logging output to a file.
+func FileLogger(filename string) DebugOption {
+	var f *os.File
+	return Logger(func(s string) {
+		var err error
+		if f == nil {
+			f, err = os.Create(filename)
+			if err != nil {
+				panic(err)
+			}
+		}
+
+		_, err = f.Write([]byte(s))
+		if err != nil {
+			panic(err)
+		}
+
+		_, err = f.Write([]byte("\n"))
+		if err != nil {
+			panic(err)
+		}
+	})
+}
+
 // Visualizer creates an option which provides a visualizer function which
 // will receive a rendering of the container in the Graphiz DOT format
 // whenever the container finishes building or fails due to an error. The
@@ -79,14 +103,17 @@ func Logger(logger func(string)) DebugOption {
 	})
 }
 
-const debugContainerDot = "debug_container.dot"
+const (
+	debugContainerDot = "debug_container.dot"
+	debugContainerLog = "debug_container.log"
+)
 
 // Debug is a default debug option which sends log output to stderr, dumps
 // the container in the graphviz DOT and SVG formats to debug_container.dot
 // and debug_container.svg respectively.
 func Debug() DebugOption {
 	return DebugOptions(
-		StderrLogger(),
+		FileLogger(debugContainerLog),
 		FileVisualizer(debugContainerDot),
 	)
 }
@@ -139,6 +166,7 @@ func AutoDebug() DebugOption {
 		OnError(Debug()),
 		OnSuccess(DebugCleanup(func() {
 			deleteIfExists(debugContainerDot)
+			deleteIfExists(debugContainerLog)
 		})),
 	)
 }


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

Closes: #12575

This should make working with depinject a bit nicer.

Needs to be tested manually.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
