### PR TITLE
fix(server/grpc): Fix unnecessary wait in `StartGRPCServer`

### DIFF
--- a/server/grpc/server.go
+++ b/server/grpc/server.go
@@ -68,17 +68,16 @@ func StartGRPCServer(clientCtx client.Context, app types.Application, cfg config
 	errCh := make(chan error)
 	go func() {
 		err = grpcSrv.Serve(listener)
-		if err != nil {
-			errCh <- fmt.Errorf("failed to serve: %w", err)
-		}
+		errCh <- err
 	}()
 
 	select {
 	case err := <-errCh:
-		return nil, err
-
-	case <-time.After(types.ServerStartTime):
+		if err != nil {
+			return nil, fmt.Errorf("failed to serve: %w", err)
+		}
+	case <-time.After(types.ServerStartTime): // TODO: ideally this would respect a ctx.Err
 		// assume server started successfully
-		return grpcSrv, nil
 	}
+	return grpcSrv, nil
 }


### PR DESCRIPTION
Removes unnecessary wait inside of `StartGRPCServer` by performing error check outside routine.

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
- [x] provided a link to the relevant issue or specification
- [x] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
