### PR TITLE
fix: allow grpc server enabled even when api off

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -442,6 +442,7 @@ jobs:
         id: git_diff
         with:
           PATTERNS: |
+            contrib/rosetta/*
             tools/rosetta/**/*.go
             tools/rosetta/go.mod
             tools/rosetta/go.sum

--- a/contrib/rosetta/configuration/data.sh
+++ b/contrib/rosetta/configuration/data.sh
@@ -33,7 +33,7 @@ sed -i 's/127.0.0.1/0.0.0.0/g' /root/.simapp/config/config.toml
 
 # start simd
 echo starting simd...
-simd start --pruning=nothing --api.enable true &
+simd start --pruning=nothing &
 pid=$!
 echo simd started with PID $pid
 

--- a/contrib/rosetta/docker-compose.yaml
+++ b/contrib/rosetta/docker-compose.yaml
@@ -3,7 +3,7 @@ version: "3"
 services:
   cosmos:
     image: rosetta-ci:latest
-    command: ["simd", "start", "--pruning", "nothing", "--grpc.enable", "true", "--grpc.address", "0.0.0.0:9090", "--grpc-web.enable", "true", "--api.enable", "true"]
+    command: ["simd", "start", "--pruning", "nothing", "--grpc.enable", "true", "--grpc.address", "0.0.0.0:9090", "--grpc-web.enable", "true"]
     ports:
       - 9090:9090
       - 26657:26657

--- a/server/start.go
+++ b/server/start.go
@@ -441,6 +441,17 @@ func startInProcess(ctx *Context, clientCtx client.Context, appCreator types.App
 		}
 	}
 
+	// If gRPC is enabled but API is not, we need to start the gRPC server
+	// without the API server. If the API server is enabled, we've already
+	// started the grpc server.
+	if config.GRPC.Enable && !config.API.Enable {
+		grpcSrv, err = servergrpc.StartGRPCServer(clientCtx, app, config.GRPC)
+		if err != nil {
+			return err
+		}
+		defer grpcSrv.Stop()
+	}
+
 	// At this point it is safe to block the process if we're in gRPC only mode as
 	// we do not need to handle any Tendermint related processes.
 	if gRPCOnly {


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

I wondered why https://github.com/cosmos/cosmos-sdk/pull/14888 needed to enable the API server, while it was needing only the GRPC server.
Turns out this PR https://github.com/cosmos/cosmos-sdk/pull/14652 added a regression, where the gRPC server was only started when the API server is (as gRPC-Web and gRPC-Gateway are on the same port, we need a gRPC instance there).

This PR adds a condition to still start the gRPC server even when the API is disabled.
We can then revert https://github.com/cosmos/cosmos-sdk/pull/14888 as well.

No changelog required because we are on main and this was never released.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
