### PR TITLE
fix: `x/capability` `InitMemStore` should not consume gas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -270,6 +270,7 @@ extension interfaces. `module.Manager.Modules` is now of type `map[string]interf
 
 ### Bug Fixes
 
+* (x/capability) [#15030](https://github.com/cosmos/cosmos-sdk/pull/15030) Fixed bug where `x/capability` consumed `GasMeter` gas during `InitMemStore`.
 * [#14995](https://github.com/cosmos/cosmos-sdk/pull/14995) Allow unknown fields in `ParseTypedEvent`.
 * [#14952](https://github.com/cosmos/cosmos-sdk/pull/14952) Pin version of github.com/syndtr/goleveldb `v1.0.1-0.20210819022825-2ae1ddf74ef7` to avoid issues in the store.
 * (store) [#14931](https://github.com/cosmos/cosmos-sdk/pull/14931) Exclude in-memory KVStores, i.e. `StoreTypeMemory`, from CommitInfo commitments.

--- a/x/capability/capability_test.go
+++ b/x/capability/capability_test.go
@@ -74,9 +74,9 @@ func (suite *CapabilityTestSuite) TestInitializeMemStore() {
 	prevGas := ctx.GasMeter().GasConsumed()
 	restartedModule := capability.NewAppModule(suite.cdc, *newKeeper, true)
 	restartedModule.BeginBlock(ctx, abci.RequestBeginBlock{})
+	gasUsed := ctx.GasMeter().GasConsumed()
 	suite.Require().True(newKeeper.IsInitialized(ctx), "memstore initialized flag not set")
 	blockGasUsed := ctx.BlockGasMeter().GasConsumed()
-	gasUsed := ctx.GasMeter().GasConsumed()
 
 	suite.Require().Equal(prevBlockGas, blockGasUsed, "beginblocker consumed block gas during execution")
 	suite.Require().Equal(prevGas, gasUsed, "beginblocker consumed gas during execution")

--- a/x/capability/capability_test.go
+++ b/x/capability/capability_test.go
@@ -78,8 +78,8 @@ func (suite *CapabilityTestSuite) TestInitializeMemStore() {
 	suite.Require().True(newKeeper.IsInitialized(ctx), "memstore initialized flag not set")
 	blockGasUsed := ctx.BlockGasMeter().GasConsumed()
 
-	suite.Require().Equal(prevBlockGas, blockGasUsed, "beginblocker consumed block gas during execution")
-	suite.Require().Equal(prevGas, gasUsed, "beginblocker consumed gas during execution")
+	suite.Require().Equal(prevBlockGas, blockGasUsed, "ensure beginblocker consumed no block gas during execution")
+	suite.Require().Equal(prevGas, gasUsed, "ensure beginblocker consumed no gas during execution")
 
 	// Mock the first transaction getting capability and subsequently failing
 	// by using a cached context and discarding all cached writes.

--- a/x/capability/capability_test.go
+++ b/x/capability/capability_test.go
@@ -70,12 +70,15 @@ func (suite *CapabilityTestSuite) TestInitializeMemStore() {
 
 	// Mock app beginblock and ensure that no gas has been consumed and memstore is initialized
 	ctx = suite.app.BaseApp.NewContext(false, cmtproto.Header{}).WithBlockGasMeter(storetypes.NewGasMeter(50))
-	prevGas := ctx.BlockGasMeter().GasConsumed()
+	prevBlockGas := ctx.BlockGasMeter().GasConsumed()
+	prevGas := ctx.GasMeter().GasConsumed()
 	restartedModule := capability.NewAppModule(suite.cdc, *newKeeper, true)
 	restartedModule.BeginBlock(ctx, abci.RequestBeginBlock{})
 	suite.Require().True(newKeeper.IsInitialized(ctx), "memstore initialized flag not set")
-	gasUsed := ctx.BlockGasMeter().GasConsumed()
+	blockGasUsed := ctx.BlockGasMeter().GasConsumed()
+	gasUsed := ctx.GasMeter().GasConsumed()
 
+	suite.Require().Equal(prevBlockGas, blockGasUsed, "beginblocker consumed block gas during execution")
 	suite.Require().Equal(prevGas, gasUsed, "beginblocker consumed gas during execution")
 
 	// Mock the first transaction getting capability and subsequently failing

--- a/x/capability/keeper/keeper.go
+++ b/x/capability/keeper/keeper.go
@@ -119,8 +119,9 @@ func (k *Keeper) InitMemStore(ctx sdk.Context) {
 		panic(fmt.Sprintf("invalid memory store type; got %s, expected: %s", memStoreType, storetypes.StoreTypeMemory))
 	}
 
-	// create context with no block gas meter to ensure we do not consume gas during local initialization logic.
-	noGasCtx := ctx.WithBlockGasMeter(storetypes.NewInfiniteGasMeter())
+	// Create a context with no `BlockGasMeter`, and no `GasMeter`. This ensures we do not consume gas during local
+	// initialization logic.
+	noGasCtx := ctx.WithBlockGasMeter(storetypes.NewInfiniteGasMeter()).WithGasMeter(storetypes.NewInfiniteGasMeter())
 
 	// check if memory store has not been initialized yet by checking if initialized flag is nil.
 	if !k.IsInitialized(noGasCtx) {


### PR DESCRIPTION
## Description

Closes: #15015

The `capability` module's `InitMemStore` function increments `gasMeter` non-deterministically across validators.

When a validator is restarted, [InitMemStore](https://github.com/dydxprotocol/cosmos-sdk/blob/bc3d81996dfcb6d823596a9c2dbf73dce4337dd6/x/capability/module.go#L153) is called during `BeginBlock` of the next committed block. This function performs some store operations which increment `GasUsed` on the `GasMeter` [here](https://github.com/dydxprotocol/cosmos-sdk/blob/bc3d81996dfcb6d823596a9c2dbf73dce4337dd6/x/capability/keeper/keeper.go#L125-L145).

So long as `SetGasMeter` is always called as part of the AnteHandler chain (which is the current behavior of the default AnteHandler chain [here](https://github.com/dydxprotocol/cosmos-sdk/blob/dydx-fork-v0.47.0-alpha2/x/auth/ante/setup.go#L40)), then this is not an issue as the `GasMeter` will be reset between `BeginBlock` and the first `DeliverTx` call.

However, if the application uses a custom AnteHandler chain that omits this behavior, the `GasUsed` within each transaction will vary, as the `GasMeter` will be the initial meter set during `BeginBlock` [here](https://github.com/dydxprotocol/cosmos-sdk/blob/dydx-fork-v0.47.0-alpha2/baseapp/abci.go#L165) which increments gas differently if the capability module's `MemStore` has not yet been initialized.

As a solution, this PR adds `WithGasMeter` to the `noGasCtx` [here](https://github.com/dydxprotocol/cosmos-sdk/blob/bc3d81996dfcb6d823596a9c2dbf73dce4337dd6/x/capability/keeper/keeper.go#L122) which ensures that `InitMemStore` consumes no gas from `GasMeter`.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [X] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [X] added `!` to the type prefix if API or client breaking change
- [X] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
- [X] provided a link to the relevant issue or specification
- [X] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules)
- [X] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
- [x] added a changelog entry to `CHANGELOG.md`
- [X] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [X] updated the relevant documentation or specification
- [X] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
