### PR TITLE
POC: zero copy go API

### DIFF
--- a/x/bank/types/zerocopy/coin.go
+++ b/x/bank/types/zerocopy/coin.go
@@ -1,0 +1,42 @@
+package zerocopy
+
+const (
+	coinDenomOffset  = 0
+	coinAmountOffset = coinDenomOffset + 4
+	coinSize         = coinAmountOffset + 4
+)
+
+type Coin struct {
+	ctx *BufferContext
+}
+
+func (c *Coin) Denom() string {
+	return c.ctx.ResolvePointer(coinDenomOffset).ReadString()
+}
+
+func (c *Coin) Amount() string {
+	return c.ctx.ResolvePointer(coinAmountOffset).ReadString()
+}
+
+func (c *Coin) SetDenom(x string) *Coin {
+	c.ctx.SetString(coinDenomOffset, x)
+	return c
+}
+
+func (c *Coin) SetAmount(x string) *Coin {
+	c.ctx.SetString(coinAmountOffset, x)
+	return c
+}
+
+func (c *Coin) WithBufferContext(ctx *BufferContext) *Coin {
+	c.ctx = ctx
+	return c
+}
+
+func (c *Coin) BufferContext() *BufferContext {
+	return c.ctx
+}
+
+func (c *Coin) Size() uint32 {
+	return coinSize
+}

--- a/x/bank/types/zerocopy/msgsend.go
+++ b/x/bank/types/zerocopy/msgsend.go
@@ -1,0 +1,72 @@
+package zerocopy
+
+const (
+	msgSendFromAddressOffset = 0
+	msgSendToAddressOffset   = msgSendFromAddressOffset + 4
+	msgSendCoinsOffset       = msgSendToAddressOffset + 4
+	msgSendSize              = msgSendCoinsOffset + 4
+)
+
+type MsgSend struct {
+	ctx *BufferContext
+}
+
+func (m *MsgSend) FromAddress() string {
+	if m.ctx == nil {
+		return ""
+	}
+	return m.ctx.ResolvePointer(msgSendFromAddressOffset).ReadString()
+}
+
+func (m *MsgSend) ToAddress() string {
+	if m.ctx == nil {
+		return ""
+	}
+	return m.ctx.ResolvePointer(msgSendToAddressOffset).ReadString()
+}
+
+func (m *MsgSend) init() {
+	if m.ctx == nil {
+		_, m.ctx = (&Buffer{}).Alloc(msgSendSize)
+	}
+}
+
+func (m *MsgSend) SetFromAddress(x string) *MsgSend {
+	m.init()
+	m.ctx.SetString(msgSendFromAddressOffset, x)
+	return m
+}
+
+func (m *MsgSend) SetToAddress(x string) *MsgSend {
+	m.init()
+	m.ctx.SetString(msgSendToAddressOffset, x)
+	return m
+}
+
+func (m *MsgSend) Coins() Array[*Coin] {
+	m.init()
+	return ReadArray[Coin](m.ctx, msgSendCoinsOffset)
+}
+
+func (m *MsgSend) InitCoins(size int) Array[*Coin] {
+	m.init()
+	return InitArray[Coin](m.ctx, msgSendCoinsOffset, size)
+}
+
+func (m *MsgSend) WithContext(ctx *BufferContext) *MsgSend {
+	m.ctx = ctx
+	return m
+}
+
+func (c *MsgSend) WithBufferContext(ctx *BufferContext) *MsgSend {
+	c.ctx = ctx
+	return c
+}
+
+func (c *MsgSend) BufferContext() *BufferContext {
+	return c.ctx
+}
+
+func (c *MsgSend) Size() uint32 {
+	return msgSendSize
+}

--- a/x/bank/types/zerocopy/msgsend.go
+++ b/x/bank/types/zerocopy/msgsend.go
@@ -58,15 +58,15 @@ func (m *MsgSend) WithContext(ctx *BufferContext) *MsgSend {
 	return m
 }
 
-func (c *MsgSend) WithBufferContext(ctx *BufferContext) *MsgSend {
-	c.ctx = ctx
-	return c
+func (m *MsgSend) WithBufferContext(ctx *BufferContext) *MsgSend {
+	m.ctx = ctx
+	return m
 }
 
-func (c *MsgSend) BufferContext() *BufferContext {
-	return c.ctx
+func (m *MsgSend) BufferContext() *BufferContext {
+	return m.ctx
 }
 
-func (c *MsgSend) Size() uint32 {
+func (m *MsgSend) Size() uint32 {
 	return msgSendSize
 }

--- a/x/bank/types/zerocopy/zerocopy.go
+++ b/x/bank/types/zerocopy/zerocopy.go
@@ -1,0 +1,120 @@
+package zerocopy
+
+import "encoding/binary"
+
+type Context struct {
+	buf []byte
+}
+
+func (c Context) ReadUint32(offset uint64) uint32 {
+	return binary.LittleEndian.Uint32(c.buf[offset : offset+8])
+}
+
+func (c Context) SetUint32(offset uint64, value uint32) {
+	binary.LittleEndian.PutUint32(c.buf[offset:offset+8], value)
+}
+
+func (c Context) ReadUint64(offset uint64) uint64 {
+	return binary.LittleEndian.Uint64(c.buf[offset : offset+8])
+}
+
+func (c Context) SetUint64(offset uint64, value uint64) {
+	binary.LittleEndian.PutUint64(c.buf[offset:offset+8], value)
+}
+
+func (c Context) ResolvePointer(offset uint64) Context {
+	ptrOffset := c.ReadUint64(offset)
+	return Context{c.buf[ptrOffset:]}
+}
+
+func (c Context) ReadString() string {
+	n := c.ReadUint32(0)
+	return string(c.buf[4 : 4+n])
+}
+
+func (c Context) SetString(x string) {
+	n := len(x)
+	binary.LittleEndian.AppendUint32(c.buf, uint32(n))
+	// TODO deal with making sure there's enough space in array
+	copy(c.buf[4:4+n], x)
+}
+
+type MsgSend struct {
+	ctx Context
+}
+
+func (m MsgSend) FromAddress() string {
+	return m.ctx.ResolvePointer(0).ReadString()
+}
+
+func (m MsgSend) ToAddress() string {
+	return m.ctx.ResolvePointer(4).ReadString()
+}
+
+func (m MsgSend) SetFromAddress(x string) MsgSend {
+	m.ctx.ResolvePointer(0).SetString(x)
+	return m
+}
+
+func (m MsgSend) SetToAddress(x string) MsgSend {
+	m.ctx.ResolvePointer(4).SetString(x)
+	return m
+}
+
+func (m MsgSend) Coins() Array[Coin] {
+	return Array[Coin]{m.ctx.ResolvePointer(8)}
+}
+
+func (m MsgSend) WithContext(ctx Context) MsgSend {
+	m.ctx = ctx
+	return m
+}
+
+type Coin struct {
+	ctx Context
+}
+
+func (c Coin) Denom() string {
+	return c.ctx.ResolvePointer(0).ReadString()
+}
+
+func (c Coin) Amount() string {
+	return c.ctx.ResolvePointer(4).ReadString()
+}
+
+func (c Coin) SetDenom(x string) Coin {
+	c.ctx.ResolvePointer(0).SetString(x)
+	return c
+}
+
+func (c Coin) SetAmount(x string) Coin {
+	c.ctx.ResolvePointer(4).SetString(x)
+	return c
+}
+
+func (c Coin) WithContext(ctx Context) Coin {
+	c.ctx = ctx
+	return c
+}
+
+type Array[T WithContext[T]] struct {
+	ctx Context
+}
+
+func Get[T WithContext[T]](array Array[T], i int) T {
+	var x T
+	array.ctx.ResolvePointer(uint64((i + 1) * 4))
+	return x.WithContext(array.ctx)
+}
+
+func Length[T any](array Array[T]) int {
+	return int(array.ctx.ReadUint64(0))
+}
+
+func Append[T any](array Array[T]) T {
+	panic("TODO")
+}
+
+type WithContext[T any] interface {
+	WithContext(Context) T
+}

--- a/x/bank/types/zerocopy/zerocopy.go
+++ b/x/bank/types/zerocopy/zerocopy.go
@@ -141,6 +141,7 @@ func InitArray[T any, PT interface {
 	return Array[*T]{array: array}
 }
 
+// Array is a fixed length array. Its elements, however, should be assumed to be mutable.
 type Array[T any] struct {
 	array []T
 }

--- a/x/bank/types/zerocopy/zerocopy_test.go
+++ b/x/bank/types/zerocopy/zerocopy_test.go
@@ -1,0 +1,26 @@
+package zerocopy
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestMsgSend(t *testing.T) {
+	msgSend := &MsgSend{}
+	msgSend.SetFromAddress("cosmos1").SetToAddress("cosmos2")
+	coins := msgSend.InitCoins(2)
+	coins.Get(0).SetDenom("atom").SetAmount("100")
+	coins.Get(1).SetDenom("foo").SetAmount("200")
+
+	msgSend2 := &MsgSend{}
+	msgSend2.WithBufferContext(msgSend.BufferContext())
+	assert.Equal(t, msgSend2.FromAddress(), "cosmos1")
+	assert.Equal(t, msgSend2.ToAddress(), "cosmos2")
+	coins2 := msgSend2.Coins()
+	assert.Equal(t, coins2.Len(), 2)
+	assert.Equal(t, coins2.Get(0).Denom(), "atom")
+	assert.Equal(t, coins2.Get(0).Amount(), "100")
+	assert.Equal(t, coins2.Get(1).Denom(), "foo")
+	assert.Equal(t, coins2.Get(1).Amount(), "200")
+}


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

This proof of concept arose from team discussions on ADR 054 (#11802) around approach B and a zero-copy message passing approach.

It choose to implement an approach where all struct elements are at fixed offsets.

This has the pros that:
* in Rust it could likely be represented directly with structs without needing as many getters/setters as in go
* the performance overhead should be pretty low because offsets don't need to be computed

The big downside of this approach is that (unlike something like https://capnproto.org/encoding.html), it would be hard to add new fields to existing structs in the case where the writer has an older schema version than the reader because the reader would improperly read struct offsets which don't exist. To mitigate this, I can think of two work-arounds:
* encode the largest offset in the struct and use getters/setters in rust as opposed to struct fields
* do stateful encoding where the encoder needs to be made aware of the size of structs that readers are expecting

We could explore the Rust side of things to see what approach makes sense if we want to go in this direction.

Another downside of this approach is that it doesn't optimize for storage space so it is likely not a great on-disk or over the wire format without compression (we could look at something like https://capnproto.org/encoding.html#packing). For the time-being, I don't think this is a big issue because we're only taking about using this between modules in the same process but in separate VMs so encoded size is not a concern. But if we can do some sort of packing too, it might be nice to consider this for other use cases.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
