### PR TITLE
refactor(log): elide keyval translation to map

### DIFF
--- a/log/CHANGELOG.md
+++ b/log/CHANGELOG.md
@@ -30,3 +30,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 # Changelog
 
 ## [Unreleased]
+
+### Improvements
+
+* [#15158](https://github.com/cosmos/cosmos-sdk/pull/15158) Ensure zero allocations during logging calls to Debug(), Info(), Error()

--- a/log/bench_test.go
+++ b/log/bench_test.go
@@ -1,0 +1,124 @@
+package log_test
+
+import (
+	"bytes"
+	"io"
+	"testing"
+	"time"
+
+	"cosmossdk.io/log"
+	"github.com/rs/zerolog"
+)
+
+func BenchmarkLoggers(b *testing.B) {
+	b.ReportAllocs()
+
+	type benchCase struct {
+		name    string
+		keyVals []any
+	}
+
+	// Just test two simple cases for the nop logger benchmarks.
+	nopCases := []benchCase{
+		{name: "empty key vals"},
+		{name: "single string", keyVals: []any{"foo", "bar"}},
+	}
+
+	benchCases := append(nopCases, []benchCase{
+		{
+			name:    "single small int",
+			keyVals: []any{"foo", 1},
+		},
+		{
+			// Small numbers may be optimized, so check if an unusual/larger number performs different.
+			name:    "single largeish int",
+			keyVals: []any{"foo", 123456789},
+		},
+		{
+			name:    "single float",
+			keyVals: []any{"foo", 2.71828182},
+		},
+		{
+			name:    "single byte slice",
+			keyVals: []any{"foo", []byte{0xde, 0xad, 0xbe, 0xef}},
+		},
+		{
+			name:    "single duration",
+			keyVals: []any{"foo", 10 * time.Second},
+		},
+
+		{
+			name:    "two values",
+			keyVals: []any{"foo", "foo", "bar", "bar"},
+		},
+		{
+			name:    "four values",
+			keyVals: []any{"foo", "foo", "bar", "bar", "baz", "baz", "quux", "quux"},
+		},
+		{
+			name:    "eight values",
+			keyVals: []any{"one", 1, "two", 2, "three", 3, "four", 4, "five", 5, "six", 6, "seven", 7, "eight", 8},
+		},
+	}...)
+
+	const message = "test message"
+
+	// If running with "go test -v", print out the log messages as a sanity check.
+	if testing.Verbose() {
+		checkBuf := new(bytes.Buffer)
+		for _, bc := range benchCases {
+			checkBuf.Reset()
+			logger := log.ZeroLogWrapper{Logger: zerolog.New(checkBuf)}
+			logger.Info(message, bc.keyVals...)
+
+			b.Logf("zero logger output for %s: %s", bc.name, checkBuf.String())
+		}
+	}
+
+	// The real logger exposed by this package,
+	// writing to an io.Discard writer,
+	// so that real write time is negligible.
+	b.Run("zerolog", func(b *testing.B) {
+		for _, bc := range benchCases {
+			bc := bc
+			b.Run(bc.name, func(b *testing.B) {
+				logger := log.ZeroLogWrapper{Logger: zerolog.New(io.Discard)}
+
+				for i := 0; i < b.N; i++ {
+					logger.Info(message, bc.keyVals...)
+				}
+			})
+		}
+	})
+
+	// zerolog offers a no-op writer.
+	// It appears to be slower than our custom NopLogger,
+	// so include it in the nop benchmarks as a point of reference.
+	b.Run("zerolog nop", func(b *testing.B) {
+		for _, bc := range nopCases {
+			bc := bc
+			b.Run(bc.name, func(b *testing.B) {
+				logger := log.ZeroLogWrapper{Logger: zerolog.Nop()}
+
+				for i := 0; i < b.N; i++ {
+					logger.Info(message, bc.keyVals...)
+				}
+			})
+		}
+	})
+
+	// The nop logger we use in tests,
+	// also useful as a reference for how expensive zerolog is.
+	b.Run("nop logger", func(b *testing.B) {
+		for _, bc := range nopCases {
+			bc := bc
+			b.Run(bc.name, func(b *testing.B) {
+				logger := log.NewNopLogger()
+
+				for i := 0; i < b.N; i++ {
+					logger.Info(message, bc.keyVals...)
+				}
+			})
+		}
+	})
+}

--- a/log/zerolog.go
+++ b/log/zerolog.go
@@ -35,39 +35,26 @@ type ZeroLogWrapper struct {
 // of key/value tuples may be provided to add context to the log. The number of
 // tuples must be even and the key of the tuple must be a string.
 func (z ZeroLogWrapper) Info(msg string, keyVals ...interface{}) {
-	z.Logger.Info().Fields(getLogFields(keyVals...)).Msg(msg)
+	z.Logger.Info().Fields(keyVals).Msg(msg)
 }
 
 // Error implements Tendermint's Logger interface and logs with level ERR. A set
 // of key/value tuples may be provided to add context to the log. The number of
 // tuples must be even and the key of the tuple must be a string.
 func (z ZeroLogWrapper) Error(msg string, keyVals ...interface{}) {
-	z.Logger.Error().Fields(getLogFields(keyVals...)).Msg(msg)
+	z.Logger.Error().Fields(keyVals).Msg(msg)
 }
 
 // Debug implements Tendermint's Logger interface and logs with level DEBUG. A set
 // of key/value tuples may be provided to add context to the log. The number of
 // tuples must be even and the key of the tuple must be a string.
 func (z ZeroLogWrapper) Debug(msg string, keyVals ...interface{}) {
-	z.Logger.Debug().Fields(getLogFields(keyVals...)).Msg(msg)
+	z.Logger.Debug().Fields(keyVals).Msg(msg)
 }
 
 // With returns a new wrapped logger with additional context provided by a set
 // of key/value tuples. The number of tuples must be even and the key of the
 // tuple must be a string.
 func (z ZeroLogWrapper) With(keyVals ...interface{}) cmtlog.Logger {
-	return ZeroLogWrapper{z.Logger.With().Fields(getLogFields(keyVals...)).Logger()}
-}
-
-func getLogFields(keyVals ...interface{}) map[string]interface{} {
-	if len(keyVals)%2 != 0 {
-		return nil
-	}
-
-	fields := make(map[string]interface{})
-	for i := 0; i < len(keyVals); i += 2 {
-		fields[keyVals[i].(string)] = keyVals[i+1]
-	}
-
-	return fields
+	return ZeroLogWrapper{z.Logger.With().Fields(keyVals).Logger()}
 }


### PR DESCRIPTION
## Description

The zerolog Fields method accepts a `[]any` in the same format we use in the Logger interface's methods, so translating the slice to a map is unnecessary.

Include microbenchmark to prove this difference.

Before omitting getLogFields:

```
BenchmarkLoggers/zerolog/empty_key_vals-10         	11605411	        90.57 ns/op	      24 B/op	       1 allocs/op
BenchmarkLoggers/zerolog/single_string-10          	 6691237	       179.2 ns/op	      56 B/op	       3 allocs/op
BenchmarkLoggers/zerolog/single_small_int-10       	 6597535	       182.6 ns/op	      56 B/op	       3 allocs/op
BenchmarkLoggers/zerolog/single_largeish_int-10    	 6357801	       189.6 ns/op	      56 B/op	       3 allocs/op
BenchmarkLoggers/zerolog/single_float-10           	 5022015	       240.0 ns/op	      56 B/op	       3 allocs/op
BenchmarkLoggers/zerolog/single_byte_slice-10      	 6291516	       189.9 ns/op	      56 B/op	       3 allocs/op
BenchmarkLoggers/zerolog/single_duration-10        	 5478682	       218.1 ns/op	      56 B/op	       3 allocs/op
BenchmarkLoggers/zerolog/two_values-10             	 4692778	       254.7 ns/op	      88 B/op	       4 allocs/op
BenchmarkLoggers/zerolog/four_values-10            	 2798709	       416.5 ns/op	     152 B/op	       6 allocs/op
BenchmarkLoggers/zerolog/eight_values-10           	 1460266	       822.2 ns/op	     280 B/op	      10 allocs/op
```

After omitting getLogFields:

```
BenchmarkLoggers/zerolog/empty_key_vals-10         	21484472	        55.89 ns/op	       0 B/op	       0 allocs/op
BenchmarkLoggers/zerolog/single_string-10          	15827601	        74.40 ns/op	       0 B/op	       0 allocs/op
BenchmarkLoggers/zerolog/single_small_int-10       	15395997	        77.92 ns/op	       0 B/op	       0 allocs/op
BenchmarkLoggers/zerolog/single_largeish_int-10    	14214717	        84.11 ns/op	       0 B/op	       0 allocs/op
BenchmarkLoggers/zerolog/single_float-10           	 9016212	       133.1 ns/op	       0 B/op	       0 allocs/op
BenchmarkLoggers/zerolog/single_byte_slice-10      	13968756	        85.88 ns/op	       0 B/op	       0 allocs/op
BenchmarkLoggers/zerolog/single_duration-10        	10588659	       113.4 ns/op	       0 B/op	       0 allocs/op
BenchmarkLoggers/zerolog/two_values-10             	12969648	        93.72 ns/op	       0 B/op	       0 allocs/op
BenchmarkLoggers/zerolog/four_values-10            	 9006982	       136.3 ns/op	       0 B/op	       0 allocs/op
BenchmarkLoggers/zerolog/eight_values-10           	 4979397	       239.5 ns/op	       0 B/op	       0 allocs/op
```
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->


---

### Author Checklist


I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] ~~provided a link to the relevant issue or specification~~
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules)
- [x] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
- [x] added a changelog entry to `CHANGELOG.md`
- [x] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] ~~updated the relevant documentation or specification~~
- [ ] ~~reviewed "Files changed" and left comments if necessary~~
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
