### PR TITLE
test(server/grpc): avoid using deprecated protoreflect function

### DIFF
--- a/server/grpc/server_test.go
+++ b/server/grpc/server_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/jhump/protoreflect/grpcreflect"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
-	rpb "google.golang.org/grpc/reflection/grpc_reflection_v1alpha"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	reflectionv1 "github.com/cosmos/cosmos-sdk/client/grpc/reflection"
@@ -110,12 +109,11 @@ func (s *IntegrationTestSuite) TestGRPCServer_Reflection() {
 	// Test server reflection
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
-	stub := rpb.NewServerReflectionClient(s.conn)
 	// NOTE(fdymylja): we use grpcreflect because it solves imports too
 	// so that we can always assert that given a reflection server it is
 	// possible to fully query all the methods, without having any context
 	// on the proto registry
-	rc := grpcreflect.NewClient(ctx, stub)
+	rc := grpcreflect.NewClientAuto(ctx, s.conn)
 
 	services, err := rc.ListServices()
 	s.Require().NoError(err)


### PR DESCRIPTION

## Description

NewClient was deprecated in favor of NewClientAuto, in jhump/protoreflect v1.14.0. Dependabot recently updated us from v1.12 to v1.15, and the linter has been complaining about the use of the deprecated function.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] ~~provided a link to the relevant issue or specification~~
- [ ] ~~reviewed "Files changed" and left comments if necessary~~
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
- [ ] confirmed that this PR does not change production code
