### PR TITLE
fix: Change proposer address cast for `sdk_block` conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -312,6 +312,7 @@ extension interfaces. `module.Manager.Modules` is now of type `map[string]interf
 * (server) [#13778](https://github.com/cosmos/cosmos-sdk/pull/13778) Set Cosmos SDK default endpoints to localhost to avoid unknown exposure of endpoints.
 * (x/auth) [#13877](https://github.com/cosmos/cosmos-sdk/pull/13877) Fix account number handling during `InitGenesis`.
 * (cli) [#14509](https://github.com/cosmos/cosmos-sdk/pull/14509) Added missing options to keyring-backend flag usage 
+* [#15243](https://github.com/cosmos/cosmos-sdk/pull/15243) `LatestBlockResponse` & `BlockByHeightResponse` types' field `sdk_block` was incorrectly cast `proposer_address` bytes to validator operator address, now to consensus address
 
 ### Deprecated
 

--- a/client/grpc/cmtservice/util.go
+++ b/client/grpc/cmtservice/util.go
@@ -21,18 +21,18 @@ func convertHeader(h cmtprototypes.Header) Header {
 		EvidenceHash:       h.EvidenceHash,
 		LastResultsHash:    h.LastResultsHash,
 		LastCommitHash:     h.LastCommitHash,
-		ProposerAddress:    sdk.ValAddress(h.ProposerAddress).String(),
+		ProposerAddress:    sdk.ConsAddress(h.ProposerAddress).String(),
 	}
 }
 
 // convertBlock converts CometBFT block to sdk block
-func convertBlock(tmblock *cmtprototypes.Block) *Block {
+func convertBlock(cmtblock *cmtprototypes.Block) *Block {
 	b := new(Block)
 
-	b.Header = convertHeader(tmblock.Header)
-	b.LastCommit = tmblock.LastCommit
-	b.Data = tmblock.Data
-	b.Evidence = tmblock.Evidence
+	b.Header = convertHeader(cmtblock.Header)
+	b.LastCommit = cmtblock.LastCommit
+	b.Data = cmtblock.Data
+	b.Evidence = cmtblock.Evidence
 
 	return b
 }

--- a/tests/e2e/client/grpc/cmtservice/service_test.go
+++ b/tests/e2e/client/grpc/cmtservice/service_test.go
@@ -92,8 +92,8 @@ func (s *E2ETestSuite) TestQueryLatestBlock() {
 	s.Require().NoError(err)
 	var blockInfoRes cmtservice.GetLatestBlockResponse
 	s.Require().NoError(val.ClientCtx.Codec.UnmarshalJSON(restRes, &blockInfoRes))
-	s.Require().Equal(types.ValAddress(blockInfoRes.Block.Header.ProposerAddress).String(), blockInfoRes.SdkBlock.Header.ProposerAddress)
-	s.Require().Contains(blockInfoRes.SdkBlock.Header.ProposerAddress, "cosmosvaloper")
+	s.Require().Equal(types.ConsAddress(blockInfoRes.Block.Header.ProposerAddress).String(), blockInfoRes.SdkBlock.Header.ProposerAddress)
+	s.Require().Contains(blockInfoRes.SdkBlock.Header.ProposerAddress, "cosmosvalcons")
 }
 
 func (s *E2ETestSuite) TestQueryBlockByHeight() {
@@ -105,7 +105,7 @@ func (s *E2ETestSuite) TestQueryBlockByHeight() {
 	s.Require().NoError(err)
 	var blockInfoRes cmtservice.GetBlockByHeightResponse
 	s.Require().NoError(val.ClientCtx.Codec.UnmarshalJSON(restRes, &blockInfoRes))
-	s.Require().Contains(blockInfoRes.SdkBlock.Header.ProposerAddress, "cosmosvaloper")
+	s.Require().Contains(blockInfoRes.SdkBlock.Header.ProposerAddress, "cosmosvalcons")
 }
 
 func (s *E2ETestSuite) TestQueryLatestValidatorSet() {


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

Closes: #14079

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->
`LatestBlockResponse` & `BlockByHeightResponse` types'  field `sdk_block` was incorrectly casted `proposer_address` bytes to `cosmosvaloper` address. But Tendermint/CometBFT return bytes of consensus address `cosmosvalcons`. 

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
- [x] provided a link to the relevant issue or specification
- [x] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules)
- [x] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
- [x] added a changelog entry to `CHANGELOG.md`
- [x] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [x] updated the relevant documentation or specification
- [x] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
