### PR TITLE
perf(x/bank): 👉🥺👈 (reduce logging verbosity)

### DIFF
--- a/x/bank/keeper/keeper.go
+++ b/x/bank/keeper/keeper.go
@@ -426,7 +426,7 @@ func (k BaseKeeper) MintCoins(ctx sdk.Context, moduleName string, amounts sdk.Co
 	}
 
 	logger := k.Logger(ctx)
-	logger.Info("minted coins from module account", "amount", amounts.String(), "from", moduleName)
+	logger.Debug("minted coins from module account", "amount", amounts.String(), "from", moduleName)
 
 	// emit mint event
 	ctx.EventManager().EmitEvent(
@@ -460,7 +460,7 @@ func (k BaseKeeper) BurnCoins(ctx sdk.Context, moduleName string, amounts sdk.Co
 	}
 
 	logger := k.Logger(ctx)
-	logger.Info("burned tokens from module account", "amount", amounts.String(), "from", moduleName)
+	logger.Debug("burned tokens from module account", "amount", amounts.String(), "from", moduleName)
 
 	// emit burn event
 	ctx.EventManager().EmitEvent(


### PR DESCRIPTION
@julienrbrt 

(can get really spammy when we run our evm's estimate gas)

![image](https://user-images.githubusercontent.com/93690142/222948645-dd55e96a-d675-43e7-9eda-6a92efecb665.png)

