### PR TITLE
fix: delete VotingPeriodProposalKey when deleting proposal

### DIFF
--- a/x/gov/keeper/proposal.go
+++ b/x/gov/keeper/proposal.go
@@ -212,6 +212,7 @@ func (keeper Keeper) DeleteProposal(ctx sdk.Context, proposalID uint64) {
 	}
 	if proposal.VotingEndTime != nil {
 		keeper.RemoveFromActiveProposalQueue(ctx, proposalID, *proposal.VotingEndTime)
+		store.Delete(types.VotingPeriodProposalKey(proposalID))
 	}
 
 	store.Delete(types.ProposalKey(proposalID))

--- a/x/gov/simulation/decoder.go
+++ b/x/gov/simulation/decoder.go
@@ -58,6 +58,9 @@ func NewDecodeStore(cdc codec.Codec) func(kvA, kvB kv.Pair) string {
 			cdc.MustUnmarshal(kvB.Value, &voteB)
 			return fmt.Sprintf("%v\n%v", voteA, voteB)
 
+		case bytes.Equal(kvA.Key[:1], types.VotingPeriodProposalKeyPrefix):
+			return fmt.Sprintf("%v\n%v", kvA.Value, kvB.Value)
+
 		default:
 			panic(fmt.Sprintf("invalid governance key prefix %X", kvA.Key[:1]))
 		}

--- a/x/gov/types/keys.go
+++ b/x/gov/types/keys.go
@@ -31,6 +31,8 @@ const (
 //
 // - 0x03: nextProposalID
 //
+// - 0x04<proposalID_Bytes>: []byte{0x01} if proposalID is in the voting period
+//
 // - 0x10<proposalID_Bytes><depositorAddrLen (1 Byte)><depositorAddr_Bytes>: Deposit
 //
 // - 0x20<proposalID_Bytes><voterAddrLen (1 Byte)><voterAddr_Bytes>: Voter


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

Fixes a bug in which the VotingPeriodProposal index would remain when calling `DeleteProposal`. Previously we were doing this only when calling `SetProposal`.

This was the cause of simulations failing on main, because the proposal was being deleted but this key wasn't so when importing the state in a second app this key wasn't being re-created (because there was no proposal); so when comparing the states, this key was missing.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
