### PR TITLE
feat: allow disabling cosmovisor logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,6 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (x/groups) [#14879](https://github.com/cosmos/cosmos-sdk/pull/14879) Add `Query/Groups` query to get all the groups.
 * (x/genutil,cli) [#15147](https://github.com/cosmos/cosmos-sdk/pull/15147) Add `--initial-height` flag to cli init cmd to provide `genesis.json` with user defined initial block height
 * (x/gov) [#15151](https://github.com/cosmos/cosmos-sdk/pull/15151) Add `burn_vote_quorum`, `burn_proposal_deposit_prevote` and `burn_vote_veto` params to allow applications to decide if they would like to burn deposits
-* (tools) [#15362](https://github.com/cosmos/cosmos-sdk/pull/15362) Allow disabling Cosmovisor logs
 
 ### Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (x/groups) [#14879](https://github.com/cosmos/cosmos-sdk/pull/14879) Add `Query/Groups` query to get all the groups.
 * (x/genutil,cli) [#15147](https://github.com/cosmos/cosmos-sdk/pull/15147) Add `--initial-height` flag to cli init cmd to provide `genesis.json` with user defined initial block height
 * (x/gov) [#15151](https://github.com/cosmos/cosmos-sdk/pull/15151) Add `burn_vote_quorum`, `burn_proposal_deposit_prevote` and `burn_vote_veto` params to allow applications to decide if they would like to burn deposits
+* (tools) [#15362](https://github.com/cosmos/cosmos-sdk/pull/15362) Allow disabling Cosmovisor logs
 
 ### Improvements
 

--- a/tools/cosmovisor/CHANGELOG.md
+++ b/tools/cosmovisor/CHANGELOG.md
@@ -44,6 +44,8 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 * [#14881](https://github.com/cosmos/cosmos-sdk/pull/14881) Refactor Cosmovisor to use `x/upgrade` validation logic.
 * [#14881](https://github.com/cosmos/cosmos-sdk/pull/14881) Refactor Cosmovisor to depend only on the `x/upgrade` module.
+* [#15362](https://github.com/cosmos/cosmos-sdk/pull/15362) Allow disabling Cosmovisor logs
+
 
 ## v1.4.0 2022-10-23
 

--- a/tools/cosmovisor/README.md
+++ b/tools/cosmovisor/README.md
@@ -99,7 +99,8 @@ All arguments passed to `cosmovisor run` will be passed to the application binar
 * `DAEMON_POLL_INTERVAL` (*optional*, default 300 milliseconds), is the interval length for polling the upgrade plan file. The value must be a duration (e.g. `1s`).
 * `DAEMON_DATA_BACKUP_DIR` option to set a custom backup directory. If not set, `DAEMON_HOME` is used.
 * `UNSAFE_SKIP_BACKUP` (defaults to `false`), if set to `true`, upgrades directly without performing a backup. Otherwise (`false`, default) backs up the data before trying the upgrade. The default value of false is useful and recommended in case of failures and when a backup needed to rollback. We recommend using the default backup option `UNSAFE_SKIP_BACKUP=false`.
-* `DAEMON_PREUPGRADE_MAX_RETRIES` (defaults to `0`). The maximum number of times to call `pre-upgrade` in the application after exit status of `31`. After the maximum number of retries, cosmovisor fails the upgrade.
+* `DAEMON_PREUPGRADE_MAX_RETRIES` (defaults to `0`). The maximum number of times to call `pre-upgrade` in the application after exit status of `31`. After the maximum number of retries, Cosmovisor fails the upgrade.
+* `COSMOVISOR_DISABLE_LOGS` (defaults to `false`). If set to true, this will disable Cosmovisor logs (but not the underlying process) completely. This may be useful, for example, when a Cosmovisor subcommand you are executing returns a valid JSON you are then parsing, as logs added by Cosmovisor make this output not a valid JSON.
 
 ### Folder Layout
 

--- a/tools/cosmovisor/args.go
+++ b/tools/cosmovisor/args.go
@@ -28,7 +28,7 @@ const (
 	EnvDataBackupPath       = "DAEMON_DATA_BACKUP_DIR"
 	EnvInterval             = "DAEMON_POLL_INTERVAL"
 	EnvPreupgradeMaxRetries = "DAEMON_PREUPGRADE_MAX_RETRIES"
-	EnvDisableLogs          = "DAEMON_DISABLE_LOGS"
+	EnvDisableLogs          = "COSMOVISOR_DISABLE_LOGS"
 )
 
 const (

--- a/tools/cosmovisor/args.go
+++ b/tools/cosmovisor/args.go
@@ -374,6 +374,7 @@ func (cfg Config) DetailString() string {
 		{EnvSkipBackup, fmt.Sprintf("%t", cfg.UnsafeSkipBackup)},
 		{EnvDataBackupPath, cfg.DataBackupPath},
 		{EnvPreupgradeMaxRetries, fmt.Sprintf("%d", cfg.PreupgradeMaxRetries)},
+		{EnvDisableLogs, fmt.Sprintf("%t", cfg.DisableLogs)},
 	}
 
 	derivedEntries := []struct{ name, value string }{

--- a/tools/cosmovisor/args.go
+++ b/tools/cosmovisor/args.go
@@ -28,6 +28,7 @@ const (
 	EnvDataBackupPath       = "DAEMON_DATA_BACKUP_DIR"
 	EnvInterval             = "DAEMON_POLL_INTERVAL"
 	EnvPreupgradeMaxRetries = "DAEMON_PREUPGRADE_MAX_RETRIES"
+	EnvDisableLogs          = "DAEMON_DISABLE_LOGS"
 )
 
 const (
@@ -51,6 +52,7 @@ type Config struct {
 	UnsafeSkipBackup      bool
 	DataBackupPath        string
 	PreupgradeMaxRetries  int
+	DisableLogs           bool
 
 	// currently running upgrade
 	currentUpgrade upgradetypes.Plan
@@ -156,6 +158,9 @@ func GetConfigFromEnv() (*Config, error) {
 		errs = append(errs, err)
 	}
 	if cfg.UnsafeSkipBackup, err = booleanOption(EnvSkipBackup, false); err != nil {
+		errs = append(errs, err)
+	}
+	if cfg.DisableLogs, err = booleanOption(EnvDisableLogs, false); err != nil {
 		errs = append(errs, err)
 	}
 

--- a/tools/cosmovisor/cmd/cosmovisor/run.go
+++ b/tools/cosmovisor/cmd/cosmovisor/run.go
@@ -3,6 +3,7 @@ package main
 import (
 	"cosmossdk.io/log"
 	"cosmossdk.io/tools/cosmovisor"
+	"github.com/rs/zerolog"
 	"github.com/spf13/cobra"
 )
 
@@ -16,17 +17,21 @@ var runCmd = &cobra.Command{
 	SilenceUsage:       true,
 	DisableFlagParsing: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		logger := cmd.Context().Value(log.ContextKey).(log.Logger)
-
-		return Run(logger, args)
+		return Run(cmd, args)
 	},
 }
 
 // Run runs the configured program with the given args and monitors it for upgrades.
-func Run(logger log.Logger, args []string, options ...RunOption) error {
+func Run(cmd *cobra.Command, args []string, options ...RunOption) error {
 	cfg, err := cosmovisor.GetConfigFromEnv()
 	if err != nil {
 		return err
+	}
+
+	logger := cmd.Context().Value(log.ContextKey).(log.Logger)
+
+	if cfg.DisableLogs {
+		logger = log.NewCustomLogger(zerolog.Nop())
 	}
 
 	runCfg := DefaultRunConfig

--- a/tools/cosmovisor/cmd/cosmovisor/version.go
+++ b/tools/cosmovisor/cmd/cosmovisor/version.go
@@ -6,8 +6,6 @@ import (
 	"runtime/debug"
 	"strings"
 
-	"cosmossdk.io/log"
-	"github.com/rs/zerolog"
 	"github.com/spf13/cobra"
 )
 
@@ -24,13 +22,11 @@ var versionCmd = &cobra.Command{
 	Short:        "Prints the version of Cosmovisor.",
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		logger := cmd.Context().Value(log.ContextKey).(log.Logger)
-
 		if val, err := cmd.Flags().GetString(OutputFlag); val == "json" && err == nil {
-			return printVersionJSON(logger, args)
+			return printVersionJSON(cmd, args)
 		}
 
-		return printVersion(logger, args)
+		return printVersion(cmd, args)
 	},
 }
 
@@ -43,25 +39,21 @@ func getVersion() string {
 	return strings.TrimSpace(version.Main.Version)
 }
 
-func printVersion(logger log.Logger, args []string) error {
+func printVersion(cmd *cobra.Command, args []string) error {
 	fmt.Printf("cosmovisor version: %s\n", getVersion())
 
-	if err := Run(logger, append([]string{"version"}, args...)); err != nil {
+	if err := Run(cmd, append([]string{"version"}, args...)); err != nil {
 		return fmt.Errorf("failed to run version command: %w", err)
 	}
 
 	return nil
 }
 
-func printVersionJSON(logger log.Logger, args []string) error {
+func printVersionJSON(cmd *cobra.Command, args []string) error {
 	buf := new(strings.Builder)
 
-	// disable logger
-	zl := logger.Impl().(*zerolog.Logger)
-	logger = log.NewCustomLogger(zl.Level(zerolog.Disabled))
-
 	if err := Run(
-		logger,
+		cmd,
 		[]string{"version", "--long", "--output", "json"},
 		StdOutRunOption(buf),
 	); err != nil {


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

Closes: #15359

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

Introduces DAEMON_DISABLE_LOGS env variable for Cosmovisor, when set to true, Cosmovisor won't write any logs into stdout. That is useful when you need to run a subcommand that returns a valid JSON but Cosmovisor's logging makes it invalid.
Additionally, I removed the logic with always disabled logging in `cosmovisor version --output json`, as this is redundant and isn't as flexible as the DAEMON_DISABLE_LOGS approach.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
- [x] provided a link to the relevant issue or specification
- [x] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
- [x] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [x] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
