### PR TITLE
docs(v0.46): change CosmWasm link in the readme.

### DIFF
--- a/docs/CosmWasm/README.md
+++ b/docs/CosmWasm/README.md
@@ -10,4 +10,4 @@ parent:
 
 >CosmWasm is written as a module that can plug into the Cosmos SDK. This means that anyone currently building a blockchain using the Cosmos SDK can quickly and easily add CosmWasm smart contracting support to their chain, without adjusting existing logic.
 
-Read more about writing smart contracts with CosmWasm at their [documentation site](https://docs.cosmwasm.com/docs/1.0/), or visit [the repository](https://github.com/CosmWasm/cosmwasm).
+Read more about writing smart contracts with CosmWasm by reading the [CosmWasm Book]([https://docs.cosmwasm.com/docs/1.0/](https://book.cosmwasm.com/)), or visit [the repository](https://github.com/CosmWasm/cosmwasm).

--- a/docs/CosmWasm/README.md
+++ b/docs/CosmWasm/README.md
@@ -10,4 +10,4 @@ parent:
 
 >CosmWasm is written as a module that can plug into the Cosmos SDK. This means that anyone currently building a blockchain using the Cosmos SDK can quickly and easily add CosmWasm smart contracting support to their chain, without adjusting existing logic.
 
-Read more about writing smart contracts with CosmWasm by reading the [CosmWasm Book]([https://docs.cosmwasm.com/docs/1.0/](https://book.cosmwasm.com/)), or visit [the repository](https://github.com/CosmWasm/cosmwasm).
+Read more about writing smart contracts with CosmWasm by reading the [CosmWasm Book](https://book.cosmwasm.com/), or visit [the repository](https://github.com/CosmWasm/cosmwasm).


### PR DESCRIPTION
Change of the documentation link RE CosmWasm to the new CosmWasm Book.
