### PR TITLE
feat: auto-set block timestamp for historical queries

### DIFF
--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -1,6 +1,7 @@
 package baseapp
 
 import (
+	"context"
 	"crypto/sha256"
 	"errors"
 	"fmt"
@@ -10,15 +11,14 @@ import (
 	"syscall"
 	"time"
 
+	errorsmod "cosmossdk.io/errors"
+	snapshottypes "cosmossdk.io/store/snapshots/types"
+	storetypes "cosmossdk.io/store/types"
 	abci "github.com/cometbft/cometbft/abci/types"
 	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
 	"github.com/cosmos/gogoproto/proto"
 	"google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
-
-	errorsmod "cosmossdk.io/errors"
-	snapshottypes "cosmossdk.io/store/snapshots/types"
-	storetypes "cosmossdk.io/store/types"
 
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/telemetry"
@@ -806,6 +806,20 @@ func (app *BaseApp) CreateQueryContext(height int64, prove bool) (sdk.Context, e
 	ctx := sdk.NewContext(cacheMS, app.checkState.ctx.BlockHeader(), true, app.logger).
 		WithMinGasPrices(app.minGasPrices).
 		WithBlockHeight(height)
+
+	// query for and set the block timestamp at the given height
+	if height != lastBlockHeight {
+		if app.blockRetriever == nil {
+			return sdk.Context{}, errorsmod.Wrapf(sdkerrors.ErrAppConfig, "cannot query historical height %d without block retriever set", height)
+		}
+
+		block, err := app.blockRetriever(context.Background(), height)
+		if err != nil || block == nil {
+			return sdk.Context{}, errorsmod.Wrapf(err, "failed to query for historical block %d", height)
+		}
+
+		ctx = ctx.WithBlockTime(block.Header.Time)
+	}
 
 	return ctx, nil
 }

--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -57,7 +57,8 @@ type BaseApp struct { //nolint: maligned
 	qms               storetypes.MultiStore       // Optional alternative multistore for querying only.
 	storeLoader       StoreLoader                 // function to handle store loading, may be overridden with SetStoreLoader()
 	grpcQueryRouter   *GRPCQueryRouter            // router for redirecting gRPC query calls
-	msgServiceRouter  *MsgServiceRouter           // router for redirecting Msg service messages
+	blockRetriever    BlockRetriever
+	msgServiceRouter  *MsgServiceRouter // router for redirecting Msg service messages
 	interfaceRegistry codectypes.InterfaceRegistry
 	txDecoder         sdk.TxDecoder // unmarshal []byte into sdk.Tx
 	txEncoder         sdk.TxEncoder // marshal sdk.Tx into []byte

--- a/baseapp/grpcserver.go
+++ b/baseapp/grpcserver.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 
 	errorsmod "cosmossdk.io/errors"
+	cmttypes "github.com/cometbft/cometbft/proto/tendermint/types"
 	gogogrpc "github.com/cosmos/gogoproto/grpc"
 	grpcmiddleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	grpcrecovery "github.com/grpc-ecosystem/go-grpc-middleware/recovery"
@@ -17,6 +18,10 @@ import (
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	grpctypes "github.com/cosmos/cosmos-sdk/types/grpc"
 )
+
+// BlockRetriever defines the function signature for retrieving a block, typically
+// from the CometBFT RPC service.
+type BlockRetriever func(context.Context, int64) (*cmttypes.Block, error)
 
 // GRPCQueryRouter returns the GRPCQueryRouter of a BaseApp.
 func (app *BaseApp) GRPCQueryRouter() *GRPCQueryRouter { return app.grpcQueryRouter }

--- a/baseapp/options.go
+++ b/baseapp/options.go
@@ -297,3 +297,7 @@ func (app *BaseApp) SetStoreMetrics(gatherer metrics.StoreMetrics) {
 func (app *BaseApp) SetStreamingManager(manager storetypes.StreamingManager) {
 	app.streamingManager = manager
 }
+
+func (app *BaseApp) SetBlockRetriever(br BlockRetriever) {
+	app.blockRetriever = br
+}

--- a/client/grpc/cmtservice/service.go
+++ b/client/grpc/cmtservice/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	abci "github.com/cometbft/cometbft/abci/types"
+	cmttypes "github.com/cometbft/cometbft/proto/tendermint/types"
 	gogogrpc "github.com/cosmos/gogoproto/grpc"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"google.golang.org/grpc/codes"
@@ -255,8 +256,28 @@ func RegisterTendermintService(
 	RegisterServiceServer(server, NewQueryServer(clientCtx, iRegistry, queryFn))
 }
 
+// RegisterTendermintServiceWithServer registers the CometBFT queries on the
+// gRPC router with a provided ServiceServer.
+func RegisterTendermintServiceWithService(server gogogrpc.Server, ss ServiceServer) {
+	RegisterServiceServer(server, ss)
+}
+
 // RegisterGRPCGatewayRoutes mounts the CometBFT service's GRPC-gateway routes on the
 // given Mux.
 func RegisterGRPCGatewayRoutes(clientConn gogogrpc.ClientConn, mux *runtime.ServeMux) {
 	_ = RegisterServiceHandlerClient(context.Background(), mux, NewServiceClient(clientConn))
+}
+
+// BlockRetriever returns a function that retrieves the block at the given
+// height from a CometBFT RPC service using the provided gRPC ServiceServer, which
+// uses the GetBlockByHeight request.
+func BlockRetriever(ss ServiceServer) func(context.Context, int64) (*cmttypes.Block, error) {
+	return func(ctx context.Context, height int64) (*cmttypes.Block, error) {
+		b, err := ss.GetBlockByHeight(ctx, &GetBlockByHeightRequest{Height: height})
+		if err != nil {
+			return nil, err
+		}
+
+		return b.Block, nil
+	}
 }

--- a/runtime/app.go
+++ b/runtime/app.go
@@ -158,12 +158,10 @@ func (a *App) RegisterTxService(clientCtx client.Context) {
 
 // RegisterTendermintService implements the Application.RegisterTendermintService method.
 func (a *App) RegisterTendermintService(clientCtx client.Context) {
-	cmtservice.RegisterTendermintService(
-		clientCtx,
-		a.GRPCQueryRouter(),
-		a.interfaceRegistry,
-		a.Query,
-	)
+	ss := cmtservice.NewQueryServer(clientCtx, a.interfaceRegistry, a.Query)
+	cmtservice.RegisterTendermintServiceWithService(a.BaseApp.GRPCQueryRouter(), ss)
+
+	a.BaseApp.SetBlockRetriever(cmtservice.BlockRetriever(ss))
 }
 
 // RegisterNodeService registers the node gRPC service on the app gRPC router.

--- a/simapp/app.go
+++ b/simapp/app.go
@@ -431,7 +431,8 @@ func NewSimApp(
 	// NOTE: The genutils module must occur after staking so that pools are
 	// properly initialized with tokens from genesis accounts.
 	// NOTE: The genutils module must also occur after auth so that it can access the params from auth.
-	genesisModuleOrder := []string{authtypes.ModuleName, banktypes.ModuleName,
+	genesisModuleOrder := []string{
+		authtypes.ModuleName, banktypes.ModuleName,
 		distrtypes.ModuleName, stakingtypes.ModuleName, slashingtypes.ModuleName, govtypes.ModuleName,
 		minttypes.ModuleName, crisistypes.ModuleName, genutiltypes.ModuleName, evidencetypes.ModuleName, authz.ModuleName,
 		feegrant.ModuleName, nft.ModuleName, group.ModuleName, paramstypes.ModuleName, upgradetypes.ModuleName,
@@ -685,12 +686,10 @@ func (app *SimApp) RegisterTxService(clientCtx client.Context) {
 
 // RegisterTendermintService implements the Application.RegisterTendermintService method.
 func (app *SimApp) RegisterTendermintService(clientCtx client.Context) {
-	cmtservice.RegisterTendermintService(
-		clientCtx,
-		app.BaseApp.GRPCQueryRouter(),
-		app.interfaceRegistry,
-		app.Query,
-	)
+	ss := cmtservice.NewQueryServer(clientCtx, app.interfaceRegistry, app.Query)
+	cmtservice.RegisterTendermintServiceWithService(app.BaseApp.GRPCQueryRouter(), ss)
+
+	app.BaseApp.SetBlockRetriever(cmtservice.BlockRetriever(ss))
 }
 
 func (app *SimApp) RegisterNodeService(clientCtx client.Context) {

--- a/types/errors/errors.go
+++ b/types/errors/errors.go
@@ -132,7 +132,8 @@ var (
 	// Examples: not DB domain error, file writing etc...
 	ErrIO = errorsmod.Register(RootCodespace, 39, "Internal IO error")
 
-	// ErrAppConfig defines an error occurred if min-gas-prices field in BaseConfig is empty.
+	// ErrAppConfig defines an error occurred if application configuration is
+	// misconfigured.
 	ErrAppConfig = errorsmod.Register(RootCodespace, 40, "error in app.toml")
 
 	// ErrInvalidGasLimit defines an error when an invalid GasWanted value is


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

Closes: #12226

This change automatically set's the block time on the `Context` that is provided to all queries. It does this by querying for the actual block.

Re the solution:

**Pros**

* A single place where this is handled; no need for app devs to handle this
* No need to store timestamp/height mapping in memory which could grow unbounded

**Cons**

* Requires app devs to modify their `RegisterTendermintService` implementation

I can't think of any other way to achieve this. Curious to see what others think.

cc @ValarDragon @tac0turtle @julienrbrt 

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
