### PR TITLE
docs(core): add documentation in error message

### DIFF
--- a/core/appconfig/config.go
+++ b/core/appconfig/config.go
@@ -84,7 +84,7 @@ func Compose(appConfig *appv1alpha1.Config) depinject.Config {
 					module.Config.TypeUrl, appv1alpha1.E_Module.TypeDescriptor().FullName(), dumpRegisteredModules(modules)))
 			}
 
-			return depinject.Error(fmt.Errorf("no module registered for type URL %s, did you forget to import %s\n\n%s",
+			return depinject.Error(fmt.Errorf("no module registered for type URL %s, did you forget to import %s: find more information on how to configure app wiring for a module here: https://docs.cosmos.network/main/building-modules/depinject\n\n%s",
 				module.Config.TypeUrl, modDesc.GoImport, dumpRegisteredModules(modules)))
 		}
 

--- a/core/appconfig/config.go
+++ b/core/appconfig/config.go
@@ -84,7 +84,7 @@ func Compose(appConfig *appv1alpha1.Config) depinject.Config {
 					module.Config.TypeUrl, appv1alpha1.E_Module.TypeDescriptor().FullName(), dumpRegisteredModules(modules)))
 			}
 
-			return depinject.Error(fmt.Errorf("no module registered for type URL %s, did you forget to import %s: find more information on how to configure app wiring for a module here: https://docs.cosmos.network/main/building-modules/depinject\n\n%s",
+			return depinject.Error(fmt.Errorf("no module registered for type URL %s, did you forget to import %s: find more information on how to make a module ready for app wiring: https://docs.cosmos.network/main/building-modules/depinject\n\n%s",
 				module.Config.TypeUrl, modDesc.GoImport, dumpRegisteredModules(modules)))
 		}
 


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

Closes: #XXXX

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] added `!` to the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules)
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] updated the relevant documentation or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] confirmed all author checklist items have been addressed 
* [ ] reviewed state machine logic
* [ ] reviewed API design and naming
* [ ] reviewed documentation is accurate
* [ ] reviewed tests and test coverage
* [ ] manually tested (if applicable)
