### PR TITLE
feat(log): add NewTestLogger{Info,Error} constructors

### DIFF
--- a/log/testing.go
+++ b/log/testing.go
@@ -8,10 +8,37 @@ type TestingT zerolog.TestingLog
 
 // NewTestLogger returns a logger that calls t.Log to write entries.
 //
+// The returned logger emits messages at any level.
+// For active debugging of a test with verbose logs,
+// the [NewTestLoggerInfo] and [NewTestLoggerError] functions
+// only emit messages at or above the corresponding log levels.
+//
 // If the logs may help debug a test failure,
 // you may want to use NewTestLogger(t) in your test.
 // Otherwise, use NewNopLogger().
 func NewTestLogger(t TestingT) Logger {
+	return newTestLogger(t, zerolog.DebugLevel)
+}
+
+// NewTestLoggerInfo returns a test logger that filters out messages
+// below info level.
+//
+// This is primarily helpful during active debugging of a test
+// with verbose logs.
+func NewTestLoggerInfo(t TestingT) Logger {
+	return newTestLogger(t, zerolog.InfoLevel)
+}
+
+// NewTestLoggerError returns a test logger that filters out messages
+// below Error level.
+//
+// This is primarily helpful during active debugging of a test
+// with verbose logs.
+func NewTestLoggerError(t TestingT) Logger {
+	return newTestLogger(t, zerolog.ErrorLevel)
+}
+
+func newTestLogger(t TestingT, lvl zerolog.Level) Logger {
 	cw := zerolog.NewConsoleWriter()
 	cw.Out = zerolog.TestWriter{
 		T: t,
@@ -22,5 +49,5 @@ func NewTestLogger(t TestingT) Logger {
 		// but Frame=7 prints correct source locations.
 		Frame: 7,
 	}
-	return NewCustomLogger(zerolog.New(cw))
+	return NewCustomLogger(zerolog.New(cw).Level(lvl))
 }


### PR DESCRIPTION

<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

While actively debugging a failing test, sometimes the debug-level logs are too noisy to find the actual error of interest. Add helper functions to filter out messages below info or error levels, respectively.

This approach is simpler than requiring test functions to call back into logger.Impl() and cast to a zero logger.


---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [x] added `!` to the type prefix if API or client breaking change
* [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] ~~provided a link to the relevant issue or specification~~
* [ ] ~~followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules)~~
* [ ] ~~included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)~~
* [ ] ~~added a changelog entry to `CHANGELOG.md`~~
* [x] included comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] ~~updated the relevant documentation or specification~~
* [ ] ~~reviewed "Files changed" and left comments if necessary~~
* [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] confirmed all author checklist items have been addressed 
* [ ] reviewed state machine logic
* [ ] reviewed API design and naming
* [ ] reviewed documentation is accurate
* [ ] reviewed tests and test coverage
* [ ] manually tested (if applicable)
