### PR TITLE
style: update receivers for linter

### DIFF
--- a/client/v2/autocli/common.go
+++ b/client/v2/autocli/common.go
@@ -119,7 +119,7 @@ func (b *Builder) outOrStdoutFormat(cmd *cobra.Command, out []byte) error {
 			return err
 		}
 	}
-	_, err = fmt.Fprintln(cmd.OutOrStdout(), string(out))
+	fmt.Fprintln(cmd.OutOrStdout(), string(out))
 
 	return nil
 }

--- a/client/v2/autocli/flag/duration.go
+++ b/client/v2/autocli/flag/duration.go
@@ -10,11 +10,11 @@ import (
 
 type durationType struct{}
 
-func (t durationType) NewValue(context.Context, *Builder) Value {
+func (d durationType) NewValue(context.Context, *Builder) Value {
 	return &durationValue{}
 }
 
-func (t durationType) DefaultValue() string {
+func (d durationType) DefaultValue() string {
 	return ""
 }
 
@@ -22,30 +22,30 @@ type durationValue struct {
 	value *durationpb.Duration
 }
 
-func (a durationValue) Get(protoreflect.Value) (protoreflect.Value, error) {
-	if a.value == nil {
+func (d durationValue) Get(protoreflect.Value) (protoreflect.Value, error) {
+	if d.value == nil {
 		return protoreflect.Value{}, nil
 	}
-	return protoreflect.ValueOfMessage(a.value.ProtoReflect()), nil
+	return protoreflect.ValueOfMessage(d.value.ProtoReflect()), nil
 }
 
-func (v durationValue) String() string {
-	if v.value == nil {
+func (d durationValue) String() string {
+	if d.value == nil {
 		return ""
 	}
-	return v.value.AsDuration().String()
+	return d.value.AsDuration().String()
 }
 
-func (v *durationValue) Set(s string) error {
+func (d *durationValue) Set(s string) error {
 	dur, err := time.ParseDuration(s)
 	if err != nil {
 		return err
 	}
 
-	v.value = durationpb.New(dur)
+	d.value = durationpb.New(dur)
 	return nil
 }
 
-func (v durationValue) Type() string {
+func (d durationValue) Type() string {
 	return "duration"
 }

--- a/client/v2/autocli/flag/timestamp.go
+++ b/client/v2/autocli/flag/timestamp.go
@@ -29,22 +29,22 @@ func (t timestampValue) Get(protoreflect.Value) (protoreflect.Value, error) {
 	return protoreflect.ValueOfMessage(t.value.ProtoReflect()), nil
 }
 
-func (v timestampValue) String() string {
-	if v.value == nil {
+func (t timestampValue) String() string {
+	if t.value == nil {
 		return ""
 	}
-	return v.value.AsTime().Format(time.RFC3339)
+	return t.value.AsTime().Format(time.RFC3339)
 }
 
-func (v *timestampValue) Set(s string) error {
-	t, err := time.Parse(time.RFC3339, s)
+func (t *timestampValue) Set(s string) error {
+	time, err := time.Parse(time.RFC3339, s)
 	if err != nil {
 		return err
 	}
-	v.value = timestamppb.New(t)
+	t.value = timestamppb.New(time)
 	return nil
 }
 
-func (v timestampValue) Type() string {
+func (t timestampValue) Type() string {
 	return "timestamp (RFC 3339)"
 }

--- a/client/v2/autocli/msg_test.go
+++ b/client/v2/autocli/msg_test.go
@@ -367,7 +367,3 @@ func TestEnhanceMessageCommand(t *testing.T) {
 	err = b.enhanceCommandCommon(cmd, options, customCommands, enhanceMsg)
 	assert.NilError(t, err)
 }
-
-type testMessageServer struct {
-	testpb.UnimplementedMsgServer
-}

--- a/x/nft/client/cli/tx_test.go
+++ b/x/nft/client/cli/tx_test.go
@@ -189,7 +189,7 @@ func (s *CLITestSuite) TestCLITxSend() {
 	for _, tc := range testCases {
 		tc := tc
 		s.Run(tc.name, func() {
-			args := append(tc.args, extraArgs...) //nolint:gocritic // false positive
+			args := append(tc.args, extraArgs...)
 			cmd := cli.NewCmdSend()
 			cmd.SetContext(s.ctx)
 			cmd.SetArgs(args)

--- a/x/nft/simulation/operations.go
+++ b/x/nft/simulation/operations.go
@@ -18,7 +18,7 @@ import (
 
 const (
 	// OpWeightMsgSend Simulation operation weights constants
-	OpWeightMsgSend = "op_weight_msg_send" //nolint:gosec
+	OpWeightMsgSend = "op_weight_msg_send"
 
 	// WeightSend nft operations weights
 	WeightSend = 100


### PR DESCRIPTION

## Description
fix for linting issue `receiver-naming: receiver name v should be consistent with previous receiver name a for durationValue (revive)`

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] added `!` to the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules)
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] updated the relevant documentation or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] confirmed all author checklist items have been addressed 
* [ ] reviewed state machine logic
* [ ] reviewed API design and naming
* [ ] reviewed documentation is accurate
* [ ] reviewed tests and test coverage
* [ ] manually tested (if applicable)
