### PR TITLE
fix(math): `FormatInt` returns error on empty string

### DIFF
--- a/math/CHANGELOG.md
+++ b/math/CHANGELOG.md
@@ -34,6 +34,12 @@ Ref: https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.j
 
 # Changelog
 
+## [Unreleased]
+
+### Bug Fixes
+
+* [#15714](https://github.com/cosmos/cosmos-sdk/pull/15714) `FormatInt` returns an error on empty string
+
 ## [math/v1.0.0](https://github.com/cosmos/cosmos-sdk/releases/tag/math/v1.0.0) - 2023-03-23
 
 ### Bug Fixes

--- a/math/int.go
+++ b/math/int.go
@@ -457,6 +457,10 @@ var stringsBuilderPool = &sync.Pool{
 // string following ADR-050. This function operates with string manipulation
 // (instead of manipulating the int or sdk.Int object).
 func FormatInt(v string) (string, error) {
+	if len(v) == 0 {
+		return "", fmt.Errorf("cannot format empty string")
+	}
+
 	sign := ""
 	if v[0] == '-' {
 		sign = "-"

--- a/math/int_test.go
+++ b/math/int_test.go
@@ -473,6 +473,11 @@ func TestFormatIntNonDigits(t *testing.T) {
 	}
 }
 
+func TestFormatIntEmptyString(t *testing.T) {
+	_, err := math.FormatInt("")
+	require.ErrorContains(t, err, "cannot format empty string")
+}
+
 func TestFormatIntCorrectness(t *testing.T) {
 	tests := []struct {
 		in   string


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

`math.FormatInt` was panicking when passing in an empty string, we should return an error instead.

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] added `!` to the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules)
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] updated the relevant documentation or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] confirmed all author checklist items have been addressed 
* [ ] reviewed state machine logic
* [ ] reviewed API design and naming
* [ ] reviewed documentation is accurate
* [ ] reviewed tests and test coverage
* [ ] manually tested (if applicable)
