### PR TITLE
style!: rename direct_aux package to directaux

### DIFF
--- a/x/tx/CHANGELOG.md
+++ b/x/tx/CHANGELOG.md
@@ -35,6 +35,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 * [#15581](https://github.com/cosmos/cosmos-sdk/pull/15581) `GetSignersOptions` and `directaux.SignModeHandlerOptions` now
 require a `signing.ProtoFileResolver` interface instead of `protodesc.Resolver`.
+* [#15742](https://github.com/cosmos/cosmos-sdk/pull/15742) The `direct_aux` package has been renamed to `directaux` in line with Go conventions. No other types were changed during the package rename.
 
 ### Bug Fixes
 

--- a/x/tx/signing/directaux/direct_aux.go
+++ b/x/tx/signing/directaux/direct_aux.go
@@ -1,4 +1,4 @@
-package direct_aux
+package directaux
 
 import (
 	"context"

--- a/x/tx/signing/directaux/direct_aux_test.go
+++ b/x/tx/signing/directaux/direct_aux_test.go
@@ -1,4 +1,4 @@
-package direct_aux_test
+package directaux_test
 
 import (
 	"context"
@@ -16,7 +16,7 @@ import (
 	signingv1beta1 "cosmossdk.io/api/cosmos/tx/signing/v1beta1"
 	txv1beta1 "cosmossdk.io/api/cosmos/tx/v1beta1"
 	"cosmossdk.io/x/tx/signing"
-	"cosmossdk.io/x/tx/signing/direct_aux"
+	"cosmossdk.io/x/tx/signing/directaux"
 )
 
 func TestDirectAuxHandler(t *testing.T) {
@@ -83,7 +83,7 @@ func TestDirectAuxHandler(t *testing.T) {
 		AuthInfoBytes: authInfoBz,
 		BodyBytes:     bodyBz,
 	}
-	modeHandler, err := direct_aux.NewSignModeHandler(direct_aux.SignModeHandlerOptions{})
+	modeHandler, err := directaux.NewSignModeHandler(directaux.SignModeHandlerOptions{})
 	require.NoError(t, err)
 
 	t.Log("verify fee payer cannot use SIGN_MODE_DIRECT_AUX")

--- a/x/tx/signing/std/handler_map.go
+++ b/x/tx/signing/std/handler_map.go
@@ -4,7 +4,7 @@ import (
 	"cosmossdk.io/x/tx/signing"
 	"cosmossdk.io/x/tx/signing/aminojson"
 	"cosmossdk.io/x/tx/signing/direct"
-	"cosmossdk.io/x/tx/signing/direct_aux"
+	"cosmossdk.io/x/tx/signing/directaux"
 	"cosmossdk.io/x/tx/signing/textual"
 )
 
@@ -13,7 +13,7 @@ type SignModeOptions struct {
 	// Textual are options for SIGN_MODE_TEXTUAL
 	Textual textual.SignModeOptions
 	// DirectAux are options for SIGN_MODE_DIRECT_AUX
-	DirectAux direct_aux.SignModeHandlerOptions
+	DirectAux directaux.SignModeHandlerOptions
 	// AminoJSON are options for SIGN_MODE_LEGACY_AMINO_JSON
 	AminoJSON aminojson.SignModeHandlerOptions
 }
@@ -26,7 +26,7 @@ func (s SignModeOptions) HandlerMap() (*signing.HandlerMap, error) {
 		return nil, err
 	}
 
-	directAux, err := direct_aux.NewSignModeHandler(s.DirectAux)
+	directAux, err := directaux.NewSignModeHandler(s.DirectAux)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION

## Description

The package name was failing revive linting, and also the official package naming doc at https://go.dev/blog/package-names says not to use underscores in package names.

Doing the package name as a standalone PR to keep the scope narrow during a rename. There are other linter issues that need to be fixed in a followup PR.


<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
- [x] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
- [ ] confirmed that this PR does not change production code
