### PR TITLE
refactor: create TxConfig directly in simulations

### DIFF
--- a/types/module/testutil/codec.go
+++ b/types/module/testutil/codec.go
@@ -41,3 +41,9 @@ func MakeTestEncodingConfig(modules ...module.AppModuleBasic) TestEncodingConfig
 
 	return encCfg
 }
+
+func MakeTestTxConfig() client.TxConfig {
+	interfaceRegistry := types.NewInterfaceRegistry()
+	cdc := codec.NewProtoCodec(interfaceRegistry)
+	return tx.NewTxConfig(cdc, tx.DefaultSignModes)
+}

--- a/x/bank/app_test.go
+++ b/x/bank/app_test.go
@@ -156,7 +156,7 @@ func TestSendNotEnoughBalance(t *testing.T) {
 
 	sendMsg := types.NewMsgSend(addr1, addr2, sdk.Coins{sdk.NewInt64Coin("foocoin", 100)})
 	header := cmtproto.Header{Height: baseApp.LastBlockHeight() + 1}
-	txConfig := moduletestutil.MakeTestEncodingConfig().TxConfig
+	txConfig := moduletestutil.MakeTestTxConfig()
 	_, _, err := simtestutil.SignCheckDeliver(t, txConfig, baseApp, header, []sdk.Msg{sendMsg}, "", []uint64{origAccNum}, []uint64{origSeq}, false, false, priv1)
 	require.Error(t, err)
 
@@ -233,7 +233,7 @@ func TestMsgMultiSendWithAccounts(t *testing.T) {
 
 	for _, tc := range testCases {
 		header := cmtproto.Header{Height: baseApp.LastBlockHeight() + 1}
-		txConfig := moduletestutil.MakeTestEncodingConfig().TxConfig
+		txConfig := moduletestutil.MakeTestTxConfig()
 		_, _, err := simtestutil.SignCheckDeliver(t, txConfig, baseApp, header, tc.msgs, "", tc.accNums, tc.accSeqs, tc.expSimPass, tc.expPass, tc.privKeys...)
 		if tc.expPass {
 			require.NoError(t, err)
@@ -284,7 +284,7 @@ func TestMsgMultiSendMultipleOut(t *testing.T) {
 
 	for _, tc := range testCases {
 		header := cmtproto.Header{Height: baseApp.LastBlockHeight() + 1}
-		txConfig := moduletestutil.MakeTestEncodingConfig().TxConfig
+		txConfig := moduletestutil.MakeTestTxConfig()
 		_, _, err := simtestutil.SignCheckDeliver(t, txConfig, baseApp, header, tc.msgs, "", tc.accNums, tc.accSeqs, tc.expSimPass, tc.expPass, tc.privKeys...)
 		require.NoError(t, err)
 
@@ -337,7 +337,7 @@ func TestMsgMultiSendDependent(t *testing.T) {
 
 	for _, tc := range testCases {
 		header := cmtproto.Header{Height: baseApp.LastBlockHeight() + 1}
-		txConfig := moduletestutil.MakeTestEncodingConfig().TxConfig
+		txConfig := moduletestutil.MakeTestTxConfig()
 		_, _, err := simtestutil.SignCheckDeliver(t, txConfig, baseApp, header, tc.msgs, "", tc.accNums, tc.accSeqs, tc.expSimPass, tc.expPass, tc.privKeys...)
 		require.NoError(t, err)
 
@@ -441,7 +441,7 @@ func TestMsgSetSendEnabled(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(tt *testing.T) {
 			header := cmtproto.Header{Height: s.App.LastBlockHeight() + 1}
-			txGen := moduletestutil.MakeTestEncodingConfig().TxConfig
+			txGen := moduletestutil.MakeTestTxConfig()
 			_, _, err = simtestutil.SignCheckDeliver(tt, txGen, s.App.BaseApp, header, tc.msgs, "", []uint64{0}, tc.accSeqs, tc.expSimPass, tc.expPass, priv1)
 			if len(tc.expInError) > 0 {
 				require.Error(tt, err)

--- a/x/bank/bench_test.go
+++ b/x/bank/bench_test.go
@@ -76,7 +76,7 @@ func BenchmarkOneBankSendTxPerBlock(b *testing.B) {
 	require.NoError(b, testutil.FundAccount(s.BankKeeper, ctx, addr1, sdk.NewCoins(sdk.NewInt64Coin("foocoin", 100000000000))))
 
 	baseApp.Commit()
-	txGen := moduletestutil.MakeTestEncodingConfig().TxConfig
+	txGen := moduletestutil.MakeTestTxConfig()
 
 	// Precompute all txs
 	txs, err := genSequenceOfTxs(txGen, []sdk.Msg{sendMsg1}, []uint64{0}, []uint64{uint64(0)}, b.N, priv1)
@@ -121,7 +121,7 @@ func BenchmarkOneBankMultiSendTxPerBlock(b *testing.B) {
 	require.NoError(b, testutil.FundAccount(s.BankKeeper, ctx, addr1, sdk.NewCoins(sdk.NewInt64Coin("foocoin", 100000000000))))
 
 	baseApp.Commit()
-	txGen := moduletestutil.MakeTestEncodingConfig().TxConfig
+	txGen := moduletestutil.MakeTestTxConfig()
 
 	// Precompute all txs
 	txs, err := genSequenceOfTxs(txGen, []sdk.Msg{multiSendMsg1}, []uint64{0}, []uint64{uint64(0)}, b.N, priv1)

--- a/x/bank/simulation/operations.go
+++ b/x/bank/simulation/operations.go
@@ -147,7 +147,7 @@ func sendMsgSend(
 			return err
 		}
 	}
-	txGen := moduletestutil.MakeTestEncodingConfig().TxConfig
+	txGen := moduletestutil.MakeTestTxConfig()
 	tx, err := simtestutil.GenSignedMockTx(
 		r,
 		txGen,
@@ -350,7 +350,7 @@ func sendMsgMultiSend(
 			return err
 		}
 	}
-	txGen := moduletestutil.MakeTestEncodingConfig().TxConfig
+	txGen := moduletestutil.MakeTestTxConfig()
 	tx, err := simtestutil.GenSignedMockTx(
 		r,
 		txGen,

--- a/x/gov/simulation/operations.go
+++ b/x/gov/simulation/operations.go
@@ -226,7 +226,7 @@ func simulateMsgSubmitProposal(ak types.AccountKeeper, bk types.BankKeeper, k *k
 		}
 
 		account := ak.GetAccount(ctx, simAccount.Address)
-		txGen := moduletestutil.MakeTestEncodingConfig().TxConfig
+		txGen := moduletestutil.MakeTestTxConfig()
 		tx, err := simtestutil.GenSignedMockTx(
 			r,
 			txGen,
@@ -317,7 +317,7 @@ func SimulateMsgDeposit(ak types.AccountKeeper, bk types.BankKeeper, k *keeper.K
 		txCtx := simulation.OperationInput{
 			R:             r,
 			App:           app,
-			TxGen:         moduletestutil.MakeTestEncodingConfig().TxConfig,
+			TxGen:         moduletestutil.MakeTestTxConfig(),
 			Cdc:           nil,
 			Msg:           msg,
 			Context:       ctx,
@@ -366,7 +366,7 @@ func operationSimulateMsgVote(ak types.AccountKeeper, bk types.BankKeeper, k *ke
 		txCtx := simulation.OperationInput{
 			R:               r,
 			App:             app,
-			TxGen:           moduletestutil.MakeTestEncodingConfig().TxConfig,
+			TxGen:           moduletestutil.MakeTestTxConfig(),
 			Cdc:             nil,
 			Msg:             msg,
 			Context:         ctx,
@@ -417,7 +417,7 @@ func operationSimulateMsgVoteWeighted(ak types.AccountKeeper, bk types.BankKeepe
 		txCtx := simulation.OperationInput{
 			R:               r,
 			App:             app,
-			TxGen:           moduletestutil.MakeTestEncodingConfig().TxConfig,
+			TxGen:           moduletestutil.MakeTestTxConfig(),
 			Cdc:             nil,
 			Msg:             msg,
 			Context:         ctx,
@@ -460,7 +460,7 @@ func SimulateMsgCancelProposal(ak types.AccountKeeper, bk types.BankKeeper, k *k
 		txCtx := simulation.OperationInput{
 			R:               r,
 			App:             app,
-			TxGen:           moduletestutil.MakeTestEncodingConfig().TxConfig,
+			TxGen:           moduletestutil.MakeTestTxConfig(),
 			Cdc:             nil,
 			Msg:             msg,
 			Context:         ctx,

--- a/x/slashing/app_test.go
+++ b/x/slashing/app_test.go
@@ -77,7 +77,7 @@ func TestSlashingMsgs(t *testing.T) {
 	require.NoError(t, err)
 
 	header := cmtproto.Header{Height: app.LastBlockHeight() + 1}
-	txConfig := moduletestutil.MakeTestEncodingConfig().TxConfig
+	txConfig := moduletestutil.MakeTestTxConfig()
 	_, _, err = sims.SignCheckDeliver(t, txConfig, app.BaseApp, header, []sdk.Msg{createValidatorMsg}, "", []uint64{0}, []uint64{0}, true, true, priv1)
 	require.NoError(t, err)
 	require.True(t, sdk.Coins{genCoin.Sub(bondCoin)}.Equal(bankKeeper.GetAllBalances(ctxCheck, addr1)))

--- a/x/staking/app_test.go
+++ b/x/staking/app_test.go
@@ -68,7 +68,7 @@ func TestStakingMsgs(t *testing.T) {
 	require.NoError(t, err)
 
 	header := cmtproto.Header{Height: app.LastBlockHeight() + 1}
-	txConfig := moduletestutil.MakeTestEncodingConfig().TxConfig
+	txConfig := moduletestutil.MakeTestTxConfig()
 	_, _, err = simtestutil.SignCheckDeliver(t, txConfig, app.BaseApp, header, []sdk.Msg{createValidatorMsg}, "", []uint64{0}, []uint64{0}, true, true, priv1)
 	require.NoError(t, err)
 	require.True(t, sdk.Coins{genCoin.Sub(bondCoin)}.Equal(bankKeeper.GetAllBalances(ctxCheck, addr1)))

--- a/x/staking/simulation/operations.go
+++ b/x/staking/simulation/operations.go
@@ -177,7 +177,7 @@ func SimulateMsgCreateValidator(ak types.AccountKeeper, bk types.BankKeeper, k *
 		txCtx := simulation.OperationInput{
 			R:             r,
 			App:           app,
-			TxGen:         moduletestutil.MakeTestEncodingConfig().TxConfig,
+			TxGen:         moduletestutil.MakeTestTxConfig(),
 			Cdc:           nil,
 			Msg:           msg,
 			Context:       ctx,
@@ -235,7 +235,7 @@ func SimulateMsgEditValidator(ak types.AccountKeeper, bk types.BankKeeper, k *ke
 		txCtx := simulation.OperationInput{
 			R:               r,
 			App:             app,
-			TxGen:           moduletestutil.MakeTestEncodingConfig().TxConfig,
+			TxGen:           moduletestutil.MakeTestTxConfig(),
 			Cdc:             nil,
 			Msg:             msg,
 			Context:         ctx,
@@ -302,7 +302,7 @@ func SimulateMsgDelegate(ak types.AccountKeeper, bk types.BankKeeper, k *keeper.
 		txCtx := simulation.OperationInput{
 			R:             r,
 			App:           app,
-			TxGen:         moduletestutil.MakeTestEncodingConfig().TxConfig,
+			TxGen:         moduletestutil.MakeTestTxConfig(),
 			Cdc:           nil,
 			Msg:           msg,
 			Context:       ctx,
@@ -379,7 +379,7 @@ func SimulateMsgUndelegate(ak types.AccountKeeper, bk types.BankKeeper, k *keepe
 		txCtx := simulation.OperationInput{
 			R:               r,
 			App:             app,
-			TxGen:           moduletestutil.MakeTestEncodingConfig().TxConfig,
+			TxGen:           moduletestutil.MakeTestTxConfig(),
 			Cdc:             nil,
 			Msg:             msg,
 			Context:         ctx,
@@ -460,7 +460,7 @@ func SimulateMsgCancelUnbondingDelegate(ak types.AccountKeeper, bk types.BankKee
 		txCtx := simulation.OperationInput{
 			R:               r,
 			App:             app,
-			TxGen:           moduletestutil.MakeTestEncodingConfig().TxConfig,
+			TxGen:           moduletestutil.MakeTestTxConfig(),
 			Cdc:             nil,
 			Msg:             msg,
 			Context:         ctx,
@@ -563,7 +563,7 @@ func SimulateMsgBeginRedelegate(ak types.AccountKeeper, bk types.BankKeeper, k *
 		txCtx := simulation.OperationInput{
 			R:               r,
 			App:             app,
-			TxGen:           moduletestutil.MakeTestEncodingConfig().TxConfig,
+			TxGen:           moduletestutil.MakeTestTxConfig(),
 			Cdc:             nil,
 			Msg:             msg,
 			Context:         ctx,


### PR DESCRIPTION


<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

While running a memory profile on the test-sim-nondeterminism tests, I saw that there was a non-negligible amount of allocations occurring in moduletestutil.MakeTestEncodingConfig. Many of those calls were only retrieving the TxConfig field from the returned value, so I extracted a smaller method that only produces a TxConfig, and used that where possible.

I don't have numbers to quantify the difference in allocations, as different runs use different seeds. Clearly the new implementation does less work for the same effect.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [x] added `!` to the type prefix if API or client breaking change
* [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [x] provided a link to the relevant issue or specification
* [x] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules)
* [x] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [x] added a changelog entry to `CHANGELOG.md`
* [x] included comments for [documenting Go code](https://blog.golang.org/godoc)
* [x] updated the relevant documentation or specification
* [x] reviewed "Files changed" and left comments if necessary
* [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] confirmed all author checklist items have been addressed 
* [ ] reviewed state machine logic
* [ ] reviewed API design and naming
* [ ] reviewed documentation is accurate
* [ ] reviewed tests and test coverage
* [ ] manually tested (if applicable)
