### PR TITLE
fix: x/tx/signing/textual: use standardized Timestamp+Duration comparators in tests

### DIFF
--- a/x/tx/signing/textual/duration_test.go
+++ b/x/tx/signing/textual/duration_test.go
@@ -10,7 +10,6 @@ import (
 	"cosmossdk.io/x/tx/signing/textual"
 	"github.com/stretchr/testify/require"
 
-	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
 	dpb "google.golang.org/protobuf/types/known/durationpb"
 )
@@ -54,7 +53,7 @@ func TestDurationJSON(t *testing.T) {
 			msg := val.Message().Interface()
 			require.IsType(t, &dpb.Duration{}, msg)
 			duration := msg.(*dpb.Duration)
-			require.True(t, proto.Equal(duration, tc.Proto), "%v vs %v", duration, tc.Proto)
+			require.Equal(t, duration.AsDuration(), tc.Proto.AsDuration(), "%v vs %v", duration, tc.Proto)
 		})
 	}
 }

--- a/x/tx/signing/textual/fuzz_test.go
+++ b/x/tx/signing/textual/fuzz_test.go
@@ -2,7 +2,12 @@ package textual_test
 
 import (
 	"context"
+	"encoding/json"
+	"os"
 	"testing"
+
+	"google.golang.org/protobuf/reflect/protoreflect"
+	tspb "google.golang.org/protobuf/types/known/timestamppb"
 
 	"cosmossdk.io/x/tx/signing/textual"
 )
@@ -26,5 +31,73 @@ func FuzzIntValueRendererParse(f *testing.F) {
 	ctx := context.Background()
 	f.Fuzz(func(t *testing.T, input string) {
 		_, _ = ivr.Parse(ctx, []textual.Screen{{Content: input}})
+	})
+}
+
+func FuzzTimestampValueRendererParse(f *testing.F) {
+	if testing.Short() {
+		f.Skip()
+	}
+
+	// 1. Firstly add some seed valid content.
+	f.Add("2006-01-02T15:04:05Z")
+	f.Add("1970-01-01T00:00:00.00000001Z")
+	f.Add("2022-07-14T11:22:20.983Z")
+	f.Add("1969-12-31T23:59:59Z")
+
+	// 2. Now fuzz it.
+	tvr := textual.NewTimestampValueRenderer()
+	ctx := context.Background()
+	f.Fuzz(func(t *testing.T, input string) {
+		_, _ = tvr.Parse(ctx, []textual.Screen{{Content: input}})
+	})
+}
+
+func FuzzTimestampJSONParseToParseRoundTrip(f *testing.F) {
+	// 1. Use the seeds from testdata and mutate them.
+	seed, err := os.ReadFile("./internal/testdata/timestamp.json")
+	if err != nil {
+		f.Fatal(err)
+	}
+	f.Add(seed)
+
+	f.Fuzz(func(t *testing.T, input []byte) {
+		var testCases []timestampJsonTest
+		if err := json.Unmarshal(input, &testCases); err != nil {
+			return
+		}
+
+		for _, tc := range testCases {
+			rend := textual.NewTimestampValueRenderer()
+
+			// If it successfully JSON unmarshals let's test it out.
+			var screens []textual.Screen
+			var err error
+
+			if tc.Proto != nil {
+				screens, err = rend.Format(context.Background(), protoreflect.ValueOf(tc.Proto.ProtoReflect()))
+				if err != nil {
+					continue
+				}
+			}
+
+			val, err := rend.Parse(context.Background(), screens)
+			if err != nil {
+				continue
+			}
+
+			msg := val.Message().Interface()
+			gotTs, ok := msg.(*tspb.Timestamp)
+			if !ok {
+				t.Fatalf("Wrong type for timestamp: %T", msg)
+			}
+			// Please avoid using proto.Equal to compare timestamps given they aren't
+			// in standardized form and will produce false positives for example given input:
+			//  []byte(`[{"proto":{"nanos":1000000000}}]`)
+			// Per issue: https://github.com/cosmos/cosmos-sdk/issues/15761
+			if !gotTs.AsTime().Equal(tc.Proto.AsTime()) {
+				t.Fatalf("Roundtrip mismatch\n\tGot:  %#v\n\tWant: %#v", gotTs, tc.Proto)
+			}
+		}
 	})
 }

--- a/x/tx/signing/textual/testdata/fuzz/FuzzIntValueRendererParse/5838cdfae7b16cde
+++ b/x/tx/signing/textual/testdata/fuzz/FuzzIntValueRendererParse/5838cdfae7b16cde
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("")

--- a/x/tx/signing/textual/testdata/fuzz/FuzzIntValueRendererParse/e521654378d1371f
+++ b/x/tx/signing/textual/testdata/fuzz/FuzzIntValueRendererParse/e521654378d1371f
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("\xb0\x1b\x16d@L0@'")

--- a/x/tx/signing/textual/testdata/fuzz/FuzzTimestampJSON/7fee543ff80f1279
+++ b/x/tx/signing/textual/testdata/fuzz/FuzzTimestampJSON/7fee543ff80f1279
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("[{\"proto\":{\"nAnos\":1000000000}}]")


### PR DESCRIPTION
Found by fuzzing, this change changes the tests to check that the final roundtripped result is compared using standardizes timestamppb and durationpb methods: .AsTime() and .AsDuration() respectively. The reason is that if one passes in a value of:

    timestamppb.Timestamp{Secs:0, Nanos: 1_000_000_001}

which is technically the same as:

    timestamppb.Timestamp{Secs:1, Nanos: 1}

the tests would fail spuriously yet when turned into a time.Time object they produce the exact same value.
The same applies for a Duration.

Also while here, added more fuzz tests.

Fixes #15761