### PR TITLE
fix: slack channel

### DIFF
--- a/.github/workflows/sims-045.yml
+++ b/.github/workflows/sims-045.yml
@@ -113,7 +113,7 @@ jobs:
         uses: rtCamp/action-slack-notify@v2.2.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_CHANNEL: cosmos-sdk-sims
+          SLACK_CHANNEL: sdk-sims
           SLACK_USERNAME: Sim Tests release/0.45.x
           SLACK_ICON_EMOJI: ":white_check_mark:"
           SLACK_COLOR: good
@@ -132,7 +132,7 @@ jobs:
         uses: rtCamp/action-slack-notify@v2.2.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_CHANNEL: cosmos-sdk-sims
+          SLACK_CHANNEL: sdk-sims
           SLACK_USERNAME: Sim Tests release/0.45.x
           SLACK_ICON_EMOJI: ":skull:"
           SLACK_COLOR: danger

--- a/.github/workflows/sims-046.yml
+++ b/.github/workflows/sims-046.yml
@@ -113,7 +113,7 @@ jobs:
         uses: rtCamp/action-slack-notify@v2.2.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_CHANNEL: cosmos-sdk-sims
+          SLACK_CHANNEL: sdk-sims
           SLACK_USERNAME: Sim Tests release/0.46.x
           SLACK_ICON_EMOJI: ":white_check_mark:"
           SLACK_COLOR: good
@@ -132,7 +132,7 @@ jobs:
         uses: rtCamp/action-slack-notify@v2.2.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_CHANNEL: cosmos-sdk-sims
+          SLACK_CHANNEL: sdk-sims
           SLACK_USERNAME: Sim Tests release/0.46.x
           SLACK_ICON_EMOJI: ":skull:"
           SLACK_COLOR: danger

--- a/.github/workflows/sims-047.yml
+++ b/.github/workflows/sims-047.yml
@@ -113,7 +113,7 @@ jobs:
         uses: rtCamp/action-slack-notify@v2.2.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_CHANNEL: cosmos-sdk-sims
+          SLACK_CHANNEL: sdk-sims
           SLACK_USERNAME: Sim Tests release/0.47.x
           SLACK_ICON_EMOJI: ":white_check_mark:"
           SLACK_COLOR: good
@@ -132,7 +132,7 @@ jobs:
         uses: rtCamp/action-slack-notify@v2.2.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_CHANNEL: cosmos-sdk-sims
+          SLACK_CHANNEL: sdk-sims
           SLACK_USERNAME: Sim Tests release/0.47.x
           SLACK_ICON_EMOJI: ":skull:"
           SLACK_COLOR: danger

--- a/.github/workflows/sims-nightly.yml
+++ b/.github/workflows/sims-nightly.yml
@@ -63,7 +63,7 @@ jobs:
         uses: rtCamp/action-slack-notify@v2.2.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_CHANNEL: cosmos-sdk-sims
+          SLACK_CHANNEL: sdk-sims
           SLACK_USERNAME: Sim Tests
           SLACK_ICON_EMOJI: ":white_check_mark:"
           SLACK_COLOR: good
@@ -81,7 +81,7 @@ jobs:
         uses: rtCamp/action-slack-notify@v2.2.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_CHANNEL: cosmos-sdk-sims
+          SLACK_CHANNEL: sdk-sims
           SLACK_USERNAME: Sim Tests
           SLACK_ICON_EMOJI: ":skull:"
           SLACK_COLOR: danger

--- a/.github/workflows/sims.yml
+++ b/.github/workflows/sims.yml
@@ -99,7 +99,7 @@ jobs:
         uses: rtCamp/action-slack-notify@v2.2.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_CHANNEL: cosmos-sdk-sims
+          SLACK_CHANNEL: sdk-sims
           SLACK_USERNAME: Sim Tests
           SLACK_ICON_EMOJI: ":white_check_mark:"
           SLACK_COLOR: good
@@ -118,7 +118,7 @@ jobs:
         uses: rtCamp/action-slack-notify@v2.2.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_CHANNEL: cosmos-sdk-sims
+          SLACK_CHANNEL: sdk-sims
           SLACK_USERNAME: Sim Tests
           SLACK_ICON_EMOJI: ":skull:"
           SLACK_COLOR: danger


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

Closes: #15790 

change channel the bot is suppose to post too 

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] added `!` to the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules)
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] updated the relevant documentation or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] confirmed all author checklist items have been addressed 
* [ ] reviewed state machine logic
* [ ] reviewed API design and naming
* [ ] reviewed documentation is accurate
* [ ] reviewed tests and test coverage
* [ ] manually tested (if applicable)
