### PR TITLE
chore: linting 

### DIFF
--- a/orm/encoding/ormkv/unique_key_test.go
+++ b/orm/encoding/ormkv/unique_key_test.go
@@ -46,9 +46,8 @@ func TestUniqueKeyCodec(t *testing.T) {
 		if isTrivialUniqueKey {
 			assert.ErrorContains(t, err, "no new uniqueness constraint")
 			return
-		} else {
-			assert.NilError(t, err)
 		}
+		assert.NilError(t, err)
 
 		for i := 0; i < 100; i++ {
 			a := testutil.GenA.Draw(t, fmt.Sprintf("a%d", i))

--- a/orm/internal/codegen/file.go
+++ b/orm/internal/codegen/file.go
@@ -1,4 +1,4 @@
-// nolint"unused" // ignore unused code linting
+// nolint:unused // ignore unused code linting
 package codegen
 
 import (

--- a/orm/model/ormtable/auto_increment.go
+++ b/orm/model/ormtable/auto_increment.go
@@ -140,9 +140,9 @@ func (t autoIncrementTable) ValidateJSON(reader io.Reader) error {
 
 		if t.customJSONValidator != nil {
 			return t.customJSONValidator(message)
-		} else {
-			return DefaultJSONValidator(message)
 		}
+
+		return DefaultJSONValidator(message)
 	})
 }
 
@@ -175,14 +175,14 @@ func (t autoIncrementTable) ImportJSON(ctx context.Context, reader io.Reader) er
 }
 
 func (t autoIncrementTable) decodeAutoIncJSON(backend Backend, reader io.Reader, onMsg func(message proto.Message, maxID uint64) error) error {
-	decoder, err := t.startDecodeJson(reader)
+	decoder, err := t.startDecodeJSON(reader)
 	if err != nil {
 		return err
 	}
 
 	var seq uint64
 
-	return t.doDecodeJson(decoder,
+	return t.doDecodeJSON(decoder,
 		func(message json.RawMessage) bool {
 			err = json.Unmarshal(message, &seq)
 			if err == nil {

--- a/orm/model/ormtable/batch.go
+++ b/orm/model/ormtable/batch.go
@@ -62,14 +62,15 @@ func flushWrites(store kv.Store, writer *batchStoreWriter) error {
 
 func flushBuf(store kv.Store, writes []*batchWriterEntry) error {
 	for _, write := range writes {
-		if write.hookCall != nil {
+		switch {
+		case write.hookCall != nil:
 			write.hookCall()
-		} else if !write.delete {
+		case !write.delete:
 			err := store.Set(write.key, write.value)
 			if err != nil {
 				return err
 			}
-		} else {
+		default:
 			err := store.Delete(write.key)
 			if err != nil {
 				return err

--- a/orm/model/ormtable/bench_test.go
+++ b/orm/model/ormtable/bench_test.go
@@ -70,7 +70,7 @@ func bench(b *testing.B, newBackend func(testing.TB) ormtable.Backend) {
 	})
 }
 
-func benchInsert(b *testing.B, ctx context.Context) {
+func benchInsert(b *testing.B, ctx context.Context) { //nolint:revive // ignore for benchmark
 	balanceTable := initBalanceTable(b)
 	for i := 0; i < b.N; i++ {
 		assert.NilError(b, balanceTable.Insert(ctx, &testpb.Balance{
@@ -81,7 +81,7 @@ func benchInsert(b *testing.B, ctx context.Context) {
 	}
 }
 
-func benchUpdate(b *testing.B, ctx context.Context) {
+func benchUpdate(b *testing.B, ctx context.Context) { //nolint:revive // ignore for benchmark
 	balanceTable := initBalanceTable(b)
 	for i := 0; i < b.N; i++ {
 		assert.NilError(b, balanceTable.Update(ctx, &testpb.Balance{
@@ -92,7 +92,7 @@ func benchUpdate(b *testing.B, ctx context.Context) {
 	}
 }
 
-func benchGet(b *testing.B, ctx context.Context) {
+func benchGet(b *testing.B, ctx context.Context) { //nolint:revive // ignore for benchmark
 	balanceTable := initBalanceTable(b)
 	for i := 0; i < b.N; i++ {
 		balance, err := balanceTable.Get(ctx, fmt.Sprintf("acct%d", i), "bar")
@@ -101,7 +101,7 @@ func benchGet(b *testing.B, ctx context.Context) {
 	}
 }
 
-func benchDelete(b *testing.B, ctx context.Context) {
+func benchDelete(b *testing.B, ctx context.Context) { //nolint:revive // ignore for benchmark
 	balanceTable := initBalanceTable(b)
 	for i := 0; i < b.N; i++ {
 		assert.NilError(b, balanceTable.Delete(ctx, &testpb.Balance{

--- a/orm/model/ormtable/index_impl.go
+++ b/orm/model/ormtable/index_impl.go
@@ -120,6 +120,6 @@ func (i indexKeyIndex) readValueFromIndexKey(backend ReadBackend, primaryKey []p
 	return nil
 }
 
-func (p indexKeyIndex) Fields() string {
-	return p.fields.String()
+func (i indexKeyIndex) Fields() string {
+	return i.fields.String()
 }

--- a/orm/model/ormtable/singleton.go
+++ b/orm/model/ormtable/singleton.go
@@ -37,9 +37,9 @@ func (t singleton) ValidateJSON(reader io.Reader) error {
 
 	if t.customJSONValidator != nil {
 		return t.customJSONValidator(msg)
-	} else {
-		return DefaultJSONValidator(msg)
 	}
+
+	return DefaultJSONValidator(msg)
 }
 
 func (t singleton) ImportJSON(ctx context.Context, reader io.Reader) error {

--- a/orm/model/ormtable/table_impl.go
+++ b/orm/model/ormtable/table_impl.go
@@ -24,10 +24,10 @@ type tableImpl struct {
 	indexes               []Index
 	indexesByFields       map[fieldnames.FieldNames]concreteIndex
 	uniqueIndexesByFields map[fieldnames.FieldNames]UniqueIndex
-	indexesById           map[uint32]Index
-	entryCodecsById       map[uint32]ormkv.EntryCodec
+	indexesByID           map[uint32]Index
+	entryCodecsByID       map[uint32]ormkv.EntryCodec
 	tablePrefix           []byte
-	tableId               uint32
+	tableID               uint32
 	typeResolver          TypeResolver
 	customJSONValidator   func(message proto.Message) error
 }
@@ -44,7 +44,7 @@ func (t tableImpl) PrimaryKey() UniqueIndex {
 }
 
 func (t tableImpl) GetIndexByID(id uint32) Index {
-	return t.indexesById[id]
+	return t.indexesByID[id]
 }
 
 func (t tableImpl) Save(ctx context.Context, message proto.Message) error {
@@ -187,16 +187,16 @@ func (t tableImpl) DefaultJSON() json.RawMessage {
 	return json.RawMessage("[]")
 }
 
-func (t tableImpl) decodeJson(reader io.Reader, onMsg func(message proto.Message) error) error {
-	decoder, err := t.startDecodeJson(reader)
+func (t tableImpl) decodeJSON(reader io.Reader, onMsg func(message proto.Message) error) error {
+	decoder, err := t.startDecodeJSON(reader)
 	if err != nil {
 		return err
 	}
 
-	return t.doDecodeJson(decoder, nil, onMsg)
+	return t.doDecodeJSON(decoder, nil, onMsg)
 }
 
-func (t tableImpl) startDecodeJson(reader io.Reader) (*json.Decoder, error) {
+func (t tableImpl) startDecodeJSON(reader io.Reader) (*json.Decoder, error) {
 	decoder := json.NewDecoder(reader)
 	token, err := decoder.Token()
 	if err != nil {
@@ -213,7 +213,7 @@ func (t tableImpl) startDecodeJson(reader io.Reader) (*json.Decoder, error) {
 // onFirst is called on the first RawMessage and used for auto-increment tables
 // to decode the sequence in which case it should return true.
 // onMsg is called on every decoded message
-func (t tableImpl) doDecodeJson(decoder *json.Decoder, onFirst func(message json.RawMessage) bool, onMsg func(message proto.Message) error) error {
+func (t tableImpl) doDecodeJSON(decoder *json.Decoder, onFirst func(message json.RawMessage) bool, onMsg func(message proto.Message) error) error {
 	unmarshalOptions := protojson.UnmarshalOptions{Resolver: t.typeResolver}
 
 	first := true
@@ -280,7 +280,7 @@ func DefaultJSONValidator(message proto.Message) error {
 }
 
 func (t tableImpl) ValidateJSON(reader io.Reader) error {
-	return t.decodeJson(reader, func(message proto.Message) error {
+	return t.decodeJSON(reader, func(message proto.Message) error {
 		if t.customJSONValidator != nil {
 			return t.customJSONValidator(message)
 		}
@@ -295,7 +295,7 @@ func (t tableImpl) ImportJSON(ctx context.Context, reader io.Reader) error {
 		return err
 	}
 
-	return t.decodeJson(reader, func(message proto.Message) error {
+	return t.decodeJSON(reader, func(message proto.Message) error {
 		return t.save(ctx, backend, message, saveModeDefault)
 	})
 }
@@ -366,7 +366,7 @@ func (t tableImpl) DecodeEntry(k, v []byte) (ormkv.Entry, error) {
 		return nil, ormerrors.UnexpectedDecodePrefix.Wrapf("uint32 varint id out of range %d", id)
 	}
 
-	idx, ok := t.entryCodecsById[uint32(id)]
+	idx, ok := t.entryCodecsByID[uint32(id)]
 	if !ok {
 		return nil, ormerrors.UnexpectedDecodePrefix.Wrapf("can't find field with id %d", id)
 	}
@@ -391,7 +391,7 @@ func (t tableImpl) EncodeEntry(entry ormkv.Entry) (k, v []byte, err error) {
 }
 
 func (t tableImpl) ID() uint32 {
-	return t.tableId
+	return t.tableID
 }
 
 func (t tableImpl) Has(ctx context.Context, message proto.Message) (found bool, err error) {

--- a/orm/model/ormtable/table_test.go
+++ b/orm/model/ormtable/table_test.go
@@ -797,7 +797,7 @@ func TestJSONExportImport(t *testing.T) {
 	assertTablesEqual(t, table, store, store2)
 }
 
-func assertTablesEqual(t assert.TestingT, table ormtable.Table, ctx, ctx2 context.Context) {
+func assertTablesEqual(t assert.TestingT, table ormtable.Table, ctx, ctx2 context.Context) { //nolint:revive // ignore long function name
 	it, err := table.List(ctx, nil)
 	assert.NilError(t, err)
 	it2, err := table.List(ctx2, nil)


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

this should make linting green 

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] added `!` to the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules)
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] updated the relevant documentation or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] confirmed all author checklist items have been addressed 
* [ ] reviewed state machine logic
* [ ] reviewed API design and naming
* [ ] reviewed documentation is accurate
* [ ] reviewed tests and test coverage
* [ ] manually tested (if applicable)
