### PR TITLE
style: bump golangci-lint and lint baseapp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -374,7 +374,7 @@ benchmark:
 ###############################################################################
 
 golangci_lint_cmd=golangci-lint
-golangci_version=v1.51.2
+golangci_version=v1.52.2
 
 lint:
 	@echo "--> Running linter"

--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -129,7 +129,7 @@ func (app *BaseApp) InitChain(req abci.RequestInitChain) (res abci.ResponseInitC
 }
 
 // Info implements the ABCI interface.
-func (app *BaseApp) Info(req abci.RequestInfo) abci.ResponseInfo {
+func (app *BaseApp) Info(_ abci.RequestInfo) abci.ResponseInfo {
 	lastCommitID := app.cms.LastCommitID()
 
 	return abci.ResponseInfo{
@@ -593,7 +593,7 @@ func (app *BaseApp) Query(req abci.RequestQuery) (res abci.ResponseQuery) {
 }
 
 // ListSnapshots implements the ABCI interface. It delegates to app.snapshotManager if set.
-func (app *BaseApp) ListSnapshots(req abci.RequestListSnapshots) abci.ResponseListSnapshots {
+func (app *BaseApp) ListSnapshots(_ abci.RequestListSnapshots) abci.ResponseListSnapshots {
 	resp := abci.ResponseListSnapshots{Snapshots: []*abci.Snapshot{}}
 	if app.snapshotManager == nil {
 		return resp

--- a/baseapp/grpcrouter_test.go
+++ b/baseapp/grpcrouter_test.go
@@ -44,9 +44,9 @@ func TestGRPCQueryRouter(t *testing.T) {
 	require.Equal(t, "Hello Foo!", res2.Greeting)
 
 	spot := &testdata.Dog{Name: "Spot", Size_: "big"}
-	any, err := types.NewAnyWithValue(spot)
+	anyAnimal, err := types.NewAnyWithValue(spot)
 	require.NoError(t, err)
-	res3, err := client.TestAny(context.Background(), &testdata.TestAnyRequest{AnyAnimal: any})
+	res3, err := client.TestAny(context.Background(), &testdata.TestAnyRequest{AnyAnimal: anyAnimal})
 	require.NoError(t, err)
 	require.NotNil(t, res3)
 	require.Equal(t, spot, res3.HasAnimal.Animal.GetCachedValue())
@@ -162,9 +162,9 @@ func testQueryDataRacesSameHandler(t *testing.T, makeClientConn func(*baseapp.GR
 			require.Equal(t, "Hello Foo!", res2.Greeting)
 
 			spot := &testdata.Dog{Name: "Spot", Size_: "big"}
-			any, err := types.NewAnyWithValue(spot)
+			anyAnimal, err := types.NewAnyWithValue(spot)
 			require.NoError(t, err)
-			res3, err := client.TestAny(context.Background(), &testdata.TestAnyRequest{AnyAnimal: any})
+			res3, err := client.TestAny(context.Background(), &testdata.TestAnyRequest{AnyAnimal: anyAnimal})
 			require.NoError(t, err)
 			require.NotNil(t, res3)
 			require.Equal(t, spot, res3.HasAnimal.Animal.GetCachedValue())

--- a/baseapp/streaming_test.go
+++ b/baseapp/streaming_test.go
@@ -29,19 +29,19 @@ func NewMockABCIListener(name string) MockABCIListener {
 	}
 }
 
-func (m MockABCIListener) ListenBeginBlock(ctx context.Context, req abci.RequestBeginBlock, res abci.ResponseBeginBlock) error {
+func (m MockABCIListener) ListenBeginBlock(_ context.Context, _ abci.RequestBeginBlock, _ abci.ResponseBeginBlock) error {
 	return nil
 }
 
-func (m MockABCIListener) ListenEndBlock(ctx context.Context, req abci.RequestEndBlock, res abci.ResponseEndBlock) error {
+func (m MockABCIListener) ListenEndBlock(_ context.Context, _ abci.RequestEndBlock, _ abci.ResponseEndBlock) error {
 	return nil
 }
 
-func (m MockABCIListener) ListenDeliverTx(ctx context.Context, req abci.RequestDeliverTx, res abci.ResponseDeliverTx) error {
+func (m MockABCIListener) ListenDeliverTx(_ context.Context, _ abci.RequestDeliverTx, _ abci.ResponseDeliverTx) error {
 	return nil
 }
 
-func (m *MockABCIListener) ListenCommit(ctx context.Context, res abci.ResponseCommit, changeSet []*storetypes.StoreKVPair) error {
+func (m *MockABCIListener) ListenCommit(_ context.Context, _ abci.ResponseCommit, changeSet []*storetypes.StoreKVPair) error {
 	m.ChangeSet = changeSet
 	return nil
 }


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

This PR lints the baseapp folder in the repo root go module and bumps the version of golangci-lint referenced in the Makefile

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] added `!` to the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules)
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] updated the relevant documentation or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] confirmed all author checklist items have been addressed 
* [ ] reviewed state machine logic
* [ ] reviewed API design and naming
* [ ] reviewed documentation is accurate
* [ ] reviewed tests and test coverage
* [ ] manually tested (if applicable)
