### PR TITLE
chore: rename comet logger wrapper

### DIFF
--- a/server/api/server.go
+++ b/server/api/server.go
@@ -149,9 +149,9 @@ func (s *Server) Start(ctx context.Context, cfg config.Config) error {
 
 		if enableUnsafeCORS {
 			allowAllCORS := handlers.CORS(handlers.AllowedHeaders([]string{"Content-Type"}))
-			errCh <- tmrpcserver.Serve(s.listener, allowAllCORS(s.Router), servercmtlog.CometZeroLogWrapper{Logger: s.logger}, cmtCfg)
+			errCh <- tmrpcserver.Serve(s.listener, allowAllCORS(s.Router), servercmtlog.CometLoggerWrapper{Logger: s.logger}, cmtCfg)
 		} else {
-			errCh <- tmrpcserver.Serve(s.listener, s.Router, servercmtlog.CometZeroLogWrapper{Logger: s.logger}, cmtCfg)
+			errCh <- tmrpcserver.Serve(s.listener, s.Router, servercmtlog.CometLoggerWrapper{Logger: s.logger}, cmtCfg)
 		}
 	}(cfg.API.EnableUnsafeCORS)
 

--- a/server/log/cmt_logger.go
+++ b/server/log/cmt_logger.go
@@ -5,18 +5,18 @@ import (
 	cmtlog "github.com/cometbft/cometbft/libs/log"
 )
 
-var _ cmtlog.Logger = (*CometZeroLogWrapper)(nil)
+var _ cmtlog.Logger = (*CometLoggerWrapper)(nil)
 
-// CometZeroLogWrapper provides a wrapper around a zerolog.Logger instance.
+// CometLoggerWrapper provides a wrapper around a cosmossdk.io/log instance.
 // It implements CometBFT's Logger interface.
-type CometZeroLogWrapper struct {
+type CometLoggerWrapper struct {
 	log.Logger
 }
 
 // With returns a new wrapped logger with additional context provided by a set
 // of key/value tuples. The number of tuples must be even and the key of the
 // tuple must be a string.
-func (cmt CometZeroLogWrapper) With(keyVals ...interface{}) cmtlog.Logger {
+func (cmt CometLoggerWrapper) With(keyVals ...interface{}) cmtlog.Logger {
 	logger := cmt.Logger.With(keyVals...)
-	return CometZeroLogWrapper{logger}
+	return CometLoggerWrapper{logger}
 }

--- a/server/start.go
+++ b/server/start.go
@@ -234,7 +234,7 @@ func startStandAlone(svrCtx *Context, appCreator types.AppCreator) error {
 		return fmt.Errorf("error creating listener: %v", err)
 	}
 
-	svr.SetLogger(servercmtlog.CometZeroLogWrapper{Logger: svrCtx.Logger.With("module", "abci-server")})
+	svr.SetLogger(servercmtlog.CometLoggerWrapper{Logger: svrCtx.Logger.With("module", "abci-server")})
 
 	ctx, cancelFn := context.WithCancel(context.Background())
 	g, ctx := errgroup.WithContext(ctx)
@@ -329,7 +329,7 @@ func startInProcess(svrCtx *Context, clientCtx client.Context, appCreator types.
 			genDocProvider,
 			node.DefaultDBProvider,
 			node.DefaultMetricsProvider(cfg.Instrumentation),
-			servercmtlog.CometZeroLogWrapper{Logger: svrCtx.Logger},
+			servercmtlog.CometLoggerWrapper{Logger: svrCtx.Logger},
 		)
 		if err != nil {
 			return err

--- a/testutil/network/util.go
+++ b/testutil/network/util.go
@@ -58,7 +58,7 @@ func startInProcess(cfg Config, val *Validator) error {
 		appGenesisProvider,
 		node.DefaultDBProvider,
 		node.DefaultMetricsProvider(cmtCfg.Instrumentation),
-		servercmtlog.CometZeroLogWrapper{Logger: logger.With("module", val.Moniker)},
+		servercmtlog.CometLoggerWrapper{Logger: logger.With("module", val.Moniker)},
 	)
 	if err != nil {
 		return err

--- a/testutil/testnet/cometstarter.go
+++ b/testutil/testnet/cometstarter.go
@@ -167,7 +167,7 @@ func (s *CometStarter) Start() (n *node.Node, err error) {
 			appGenesisProvider,
 			node.DefaultDBProvider,
 			node.DefaultMetricsProvider(s.cfg.Instrumentation),
-			servercmtlog.CometZeroLogWrapper{Logger: s.logger},
+			servercmtlog.CometLoggerWrapper{Logger: s.logger},
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create comet node: %w", err)

--- a/x/genutil/client/cli/init_test.go
+++ b/x/genutil/client/cli/init_test.go
@@ -218,7 +218,7 @@ func TestStartStandAlone(t *testing.T) {
 	svr, err := abci_server.NewServer(svrAddr, "socket", app)
 	require.NoError(t, err, "error creating listener")
 
-	svr.SetLogger(servercmtlog.CometZeroLogWrapper{Logger: logger.With("module", "abci-server")})
+	svr.SetLogger(servercmtlog.CometLoggerWrapper{Logger: logger.With("module", "abci-server")})
 	err = svr.Start()
 	require.NoError(t, err)
 


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

I wanted to backport the cmt_logger file to v0.47 (and some other functions we have on), so allowing cosmossdk.io/log to be used there.
However noticed on main our wrapper as an incorrect name. It isn't only limited to zerolog.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] added `!` to the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules)
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] updated the relevant documentation or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] confirmed all author checklist items have been addressed 
* [ ] reviewed state machine logic
* [ ] reviewed API design and naming
* [ ] reviewed documentation is accurate
* [ ] reviewed tests and test coverage
* [ ] manually tested (if applicable)
