### PR TITLE
refactor(client): Remove usage of GetSignBytes from AuxTxBuilder

### DIFF
--- a/client/tx/aux_builder.go
+++ b/client/tx/aux_builder.go
@@ -216,6 +216,21 @@ func (b *AuxTxBuilder) GetSignBytes() ([]byte, error) {
 
 	sd.BodyBytes = bodyBz
 
+	// validate basic
+	if len(bodyBz) == 0 {
+		return nil, sdkerrors.ErrInvalidRequest.Wrap("body bytes cannot be empty")
+	}
+
+	if sd.PublicKey == nil {
+		return nil, sdkerrors.ErrInvalidPubKey.Wrap("public key cannot be empty")
+	}
+
+	if sd.Tip != nil {
+		if sd.Tip.Tipper == "" {
+			return nil, sdkerrors.ErrInvalidRequest.Wrap("tipper cannot be empty")
+		}
+	}
+
 	var signBz []byte
 	switch b.auxSignerData.Mode {
 	case signingv1beta1.SignMode_SIGN_MODE_DIRECT_AUX:

--- a/client/tx/aux_builder_test.go
+++ b/client/tx/aux_builder_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	txv1beta1 "cosmossdk.io/api/cosmos/tx/v1beta1"
 	"github.com/cosmos/cosmos-sdk/client/tx"
 	"github.com/cosmos/cosmos-sdk/codec"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
@@ -233,7 +234,7 @@ func TestAuxTxBuilder(t *testing.T) {
 }
 
 // checkCorrectData that the auxSignerData's content matches the inputs we gave.
-func checkCorrectData(t *testing.T, cdc codec.Codec, auxSignerData typestx.AuxSignerData, signMode signing.SignMode) {
+func checkCorrectData(t *testing.T, cdc codec.Codec, auxSignerData txv1beta1.AuxSignerData, signMode signing.SignMode) {
 	pkAny, err := codectypes.NewAnyWithValue(pub1)
 	require.NoError(t, err)
 	msgAny, err := codectypes.NewAnyWithValue(msg1)

--- a/client/tx/aux_builder_test.go
+++ b/client/tx/aux_builder_test.go
@@ -4,7 +4,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/anypb"
 
+	basev1beta1 "cosmossdk.io/api/cosmos/base/v1beta1"
 	txv1beta1 "cosmossdk.io/api/cosmos/tx/v1beta1"
 	"github.com/cosmos/cosmos-sdk/client/tx"
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -15,6 +17,7 @@ import (
 	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
 	typestx "github.com/cosmos/cosmos-sdk/types/tx"
 	"github.com/cosmos/cosmos-sdk/types/tx/signing"
+	authsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
 	"github.com/cosmos/cosmos-sdk/x/bank"
 )
 
@@ -235,7 +238,11 @@ func TestAuxTxBuilder(t *testing.T) {
 
 // checkCorrectData that the auxSignerData's content matches the inputs we gave.
 func checkCorrectData(t *testing.T, cdc codec.Codec, auxSignerData txv1beta1.AuxSignerData, signMode signing.SignMode) {
-	pkAny, err := codectypes.NewAnyWithValue(pub1)
+	legacyPkAny, err := codectypes.NewAnyWithValue(pub1)
+	pkAny := &anypb.Any{
+		TypeUrl: legacyPkAny.TypeUrl,
+		Value:   legacyPkAny.Value,
+	}
 	require.NoError(t, err)
 	msgAny, err := codectypes.NewAnyWithValue(msg1)
 	require.NoError(t, err)
@@ -244,6 +251,19 @@ func checkCorrectData(t *testing.T, cdc codec.Codec, auxSignerData txv1beta1.Aux
 	err = cdc.Unmarshal(auxSignerData.SignDoc.BodyBytes, &body)
 	require.NoError(t, err)
 
+	tipAmount := make([]*basev1beta1.Coin, len(tip.Amount))
+	for i, coin := range tip.Amount {
+		tipAmount[i] = &basev1beta1.Coin{
+			Denom:  coin.Denom,
+			Amount: coin.Amount.String(),
+		}
+	}
+	txv1beta1Tip := &txv1beta1.Tip{
+		Amount: tipAmount,
+		Tipper: tip.Tipper,
+	}
+	apiSignMode, err := authsigning.InternalSignModeToAPI(signMode)
+
 	require.Equal(t, uint64(1), auxSignerData.SignDoc.AccountNumber)
 	require.Equal(t, uint64(2), auxSignerData.SignDoc.Sequence)
 	require.Equal(t, timeoutHeight, body.TimeoutHeight)
@@ -251,7 +271,7 @@ func checkCorrectData(t *testing.T, cdc codec.Codec, auxSignerData txv1beta1.Aux
 	require.Equal(t, chainID, auxSignerData.SignDoc.ChainId)
 	require.Equal(t, msgAny, body.GetMessages()[0])
 	require.Equal(t, pkAny, auxSignerData.SignDoc.PublicKey)
-	require.Equal(t, tip, auxSignerData.SignDoc.Tip)
-	require.Equal(t, signMode, auxSignerData.Mode)
+	require.Equal(t, txv1beta1Tip, auxSignerData.SignDoc.Tip)
+	require.Equal(t, apiSignMode, auxSignerData.Mode)
 	require.Equal(t, rawSig, auxSignerData.Sig)
 }

--- a/client/tx/tx.go
+++ b/client/tx/tx.go
@@ -11,6 +11,7 @@ import (
 	gogogrpc "github.com/cosmos/gogoproto/grpc"
 	"github.com/spf13/pflag"
 
+	txv1beta1 "cosmossdk.io/api/cosmos/tx/v1beta1"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/input"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
@@ -368,11 +369,11 @@ func (gr GasEstimateResponse) String() string {
 }
 
 // makeAuxSignerData generates an AuxSignerData from the client inputs.
-func makeAuxSignerData(clientCtx client.Context, f Factory, msgs ...sdk.Msg) (tx.AuxSignerData, error) {
+func makeAuxSignerData(clientCtx client.Context, f Factory, msgs ...sdk.Msg) (txv1beta1.AuxSignerData, error) {
 	b := NewAuxTxBuilder()
 	fromAddress, name, _, err := client.GetFromFields(clientCtx, clientCtx.Keyring, clientCtx.From)
 	if err != nil {
-		return tx.AuxSignerData{}, err
+		return txv1beta1.AuxSignerData{}, err
 	}
 
 	b.SetAddress(fromAddress.String())
@@ -382,7 +383,7 @@ func makeAuxSignerData(clientCtx client.Context, f Factory, msgs ...sdk.Msg) (tx
 	} else {
 		accNum, seq, err := clientCtx.AccountRetriever.GetAccountNumberSequence(clientCtx, fromAddress)
 		if err != nil {
-			return tx.AuxSignerData{}, err
+			return txv1beta1.AuxSignerData{}, err
 		}
 		b.SetAccountNumber(accNum)
 		b.SetSequence(seq)
@@ -390,45 +391,45 @@ func makeAuxSignerData(clientCtx client.Context, f Factory, msgs ...sdk.Msg) (tx
 
 	err = b.SetMsgs(msgs...)
 	if err != nil {
-		return tx.AuxSignerData{}, err
+		return txv1beta1.AuxSignerData{}, err
 	}
 
 	if f.tip != nil {
 		if _, err := sdk.AccAddressFromBech32(f.tip.Tipper); err != nil {
-			return tx.AuxSignerData{}, sdkerrors.ErrInvalidAddress.Wrap("tipper must be a bech32 address")
+			return txv1beta1.AuxSignerData{}, sdkerrors.ErrInvalidAddress.Wrap("tipper must be a bech32 address")
 		}
 		b.SetTip(f.tip)
 	}
 
 	err = b.SetSignMode(f.SignMode())
 	if err != nil {
-		return tx.AuxSignerData{}, err
+		return txv1beta1.AuxSignerData{}, err
 	}
 
 	key, err := clientCtx.Keyring.Key(name)
 	if err != nil {
-		return tx.AuxSignerData{}, err
+		return txv1beta1.AuxSignerData{}, err
 	}
 
 	pub, err := key.GetPubKey()
 	if err != nil {
-		return tx.AuxSignerData{}, err
+		return txv1beta1.AuxSignerData{}, err
 	}
 
 	err = b.SetPubKey(pub)
 	if err != nil {
-		return tx.AuxSignerData{}, err
+		return txv1beta1.AuxSignerData{}, err
 	}
 
 	b.SetChainID(clientCtx.ChainID)
 	signBz, err := b.GetSignBytes()
 	if err != nil {
-		return tx.AuxSignerData{}, err
+		return txv1beta1.AuxSignerData{}, err
 	}
 
 	sig, _, err := clientCtx.Keyring.Sign(name, signBz, f.signMode)
 	if err != nil {
-		return tx.AuxSignerData{}, err
+		return txv1beta1.AuxSignerData{}, err
 	}
 	b.SetSignature(sig)
 

--- a/x/auth/signing/adapter.go
+++ b/x/auth/signing/adapter.go
@@ -35,7 +35,7 @@ func GetSignBytesAdapter(
 	}
 	txData := adaptableTx.GetSigningTxData()
 
-	txSignMode, err := internalSignModeToAPI(mode)
+	txSignMode, err := InternalSignModeToAPI(mode)
 	if err != nil {
 		return nil, err
 	}

--- a/x/auth/signing/verify.go
+++ b/x/auth/signing/verify.go
@@ -40,8 +40,8 @@ func APISignModeToInternal(mode signingv1beta1.SignMode) (signing.SignMode, erro
 	}
 }
 
-// internalSignModeToAPI converts a signing.SignMode to a protobuf SignMode.
-func internalSignModeToAPI(mode signing.SignMode) (signingv1beta1.SignMode, error) {
+// InternalSignModeToAPI converts a signing.SignMode to a protobuf SignMode.
+func InternalSignModeToAPI(mode signing.SignMode) (signingv1beta1.SignMode, error) {
 	switch mode {
 	case signing.SignMode_SIGN_MODE_DIRECT:
 		return signingv1beta1.SignMode_SIGN_MODE_DIRECT, nil
@@ -68,7 +68,7 @@ func VerifySignature(
 ) error {
 	switch data := signatureData.(type) {
 	case *signing.SingleSignatureData:
-		signMode, err := internalSignModeToAPI(data.SignMode)
+		signMode, err := InternalSignModeToAPI(data.SignMode)
 		if err != nil {
 			return err
 		}
@@ -87,7 +87,7 @@ func VerifySignature(
 			return fmt.Errorf("expected %T, got %T", (multisig.PubKey)(nil), pubKey)
 		}
 		err := multiPK.VerifyMultisignature(func(mode signing.SignMode) ([]byte, error) {
-			signMode, err := internalSignModeToAPI(mode)
+			signMode, err := InternalSignModeToAPI(mode)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

Ref: #16024 

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] added `!` to the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules)
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] updated the relevant documentation or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] confirmed all author checklist items have been addressed 
* [ ] reviewed state machine logic
* [ ] reviewed API design and naming
* [ ] reviewed documentation is accurate
* [ ] reviewed tests and test coverage
* [ ] manually tested (if applicable)
