### PR TITLE
refactor(math)!: remove aliases in math

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -184,6 +184,8 @@ Ref: https://keepachangelog.com/en/1.0.0/
     * The signature of `VerifySignature` has been changed to accept a `x/tx/signing.HandlerMap` and other structs from `x/tx` as arguments.
     * The signature of `NewTxConfigWithTextual` has been deprecated and its signature changed to accept a `SignModeOptions`.
 * (x/genutil) [#15999](https://github.com/cosmos/cosmos-sdk/pull/15999) Genutil now takes the `GenesisTxHanlder` interface instead of deliverTx. The interface is implemented on baseapp
+* (types/math) [#16040](https://github.com/cosmos/cosmos-sdk/pull/16040) Remove unused aliases in math.go
+    * Remove aliases Uint, ZeroDec, OneDec, SmallestDec, NewDec, NewDecWithPrec, NewDecFromBigInt, NewDecFromInt, NewDecFromIntWithPrec, NewDecFromStr, MustNewDecFromStr, MaxSortableDec, ValidSortableDec, SortableDecBytes, DecsEqual, MinDec, MaxDec, DecEq, DecApproxEq, Precision, DecimalPrecisionsBits, NewIntFromBigInt, OneInt, NewInt, ZeroInt, IntEq, NewIntFromString, NewUint, NewIntFromUint64, MaxInt, MinInt, Uint        
 
 ### Client Breaking Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -185,7 +185,6 @@ Ref: https://keepachangelog.com/en/1.0.0/
     * The signature of `NewTxConfigWithTextual` has been deprecated and its signature changed to accept a `SignModeOptions`.
 * (x/genutil) [#15999](https://github.com/cosmos/cosmos-sdk/pull/15999) Genutil now takes the `GenesisTxHanlder` interface instead of deliverTx. The interface is implemented on baseapp
 * (types/math) [#16040](https://github.com/cosmos/cosmos-sdk/pull/16040) Remove unused aliases in math.go
-    * Remove aliases Uint, ZeroDec, OneDec, SmallestDec, NewDec, NewDecWithPrec, NewDecFromBigInt, NewDecFromInt, NewDecFromIntWithPrec, NewDecFromStr, MustNewDecFromStr, MaxSortableDec, ValidSortableDec, SortableDecBytes, DecsEqual, MinDec, MaxDec, DecEq, DecApproxEq, Precision, DecimalPrecisionsBits, NewIntFromBigInt, OneInt, NewInt, ZeroInt, IntEq, NewIntFromString, NewUint, NewIntFromUint64, MaxInt, MinInt, Uint        
 
 ### Client Breaking Changes
 

--- a/tests/e2e/gov/tx.go
+++ b/tests/e2e/gov/tx.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"fmt"
 
+	"cosmossdk.io/math"
 	"github.com/cosmos/cosmos-sdk/testutil"
 
 	"github.com/cosmos/gogoproto/proto"
@@ -373,7 +374,7 @@ func (s *E2ETestSuite) TestNewCmdCancelProposal() {
 					s.Require().NoError(err)
 					remainingAmount := v1.DefaultMinDepositTokens.Mul(
 						v1.DefaultProposalCancelRatio.Mul(sdk.MustNewDecFromStr("100")).TruncateInt(),
-					).Quo(sdk.NewIntFromUint64(100))
+					).Quo(math.NewIntFromUint64(100))
 
 					// new balance = old balance + remaining amount from proposal deposit - txFee (cancel proposal)
 					txFee := sdk.NewInt(10)

--- a/tests/integration/aminojson/aminojson_test.go
+++ b/tests/integration/aminojson/aminojson_test.go
@@ -30,6 +30,7 @@ import (
 	stakingapi "cosmossdk.io/api/cosmos/staking/v1beta1"
 	txv1beta1 "cosmossdk.io/api/cosmos/tx/v1beta1"
 	vestingapi "cosmossdk.io/api/cosmos/vesting/v1beta1"
+	"cosmossdk.io/math"
 	"cosmossdk.io/x/evidence"
 	feegrantmodule "cosmossdk.io/x/feegrant/module"
 	"cosmossdk.io/x/tx/signing/aminojson"
@@ -200,7 +201,7 @@ func TestAminoJSON_LegacyParity(t *testing.T) {
 	genericAuthPulsar := newAny(t, &authzapi.GenericAuthorization{Msg: "foo"})
 	pubkeyAny, _ := codectypes.NewAnyWithValue(&secp256k1types.PubKey{Key: []byte("foo")})
 	pubkeyAnyPulsar := newAny(t, &secp256k1.PubKey{Key: []byte("foo")})
-	dec10bz, _ := types.NewDec(10).Marshal()
+	dec10bz, _ := math.LegacyNewDec(10).Marshal()
 	int123bz, _ := types.NewInt(123).Marshal()
 
 	cases := map[string]struct {
@@ -251,7 +252,7 @@ func TestAminoJSON_LegacyParity(t *testing.T) {
 			pulsar: &distapi.DelegatorStartingInfo{},
 		},
 		"distribution/delegator_starting_info/non_zero_dec": {
-			gogo:                &disttypes.DelegatorStartingInfo{Stake: types.NewDec(10)},
+			gogo:                &disttypes.DelegatorStartingInfo{Stake: math.LegacyNewDec(10)},
 			pulsar:              &distapi.DelegatorStartingInfo{Stake: "10.000000000000000000"},
 			protoUnmarshalFails: true,
 		},
@@ -331,7 +332,7 @@ func TestAminoJSON_LegacyParity(t *testing.T) {
 		"slashing/params/dec": {
 			gogo: &slashingtypes.Params{
 				DowntimeJailDuration: 1e9 + 7,
-				MinSignedPerWindow:   types.NewDec(10),
+				MinSignedPerWindow:   math.LegacyNewDec(10),
 			},
 			pulsar: &slashingapi.Params{
 				DowntimeJailDuration: &durationpb.Duration{Seconds: 1, Nanos: 7},

--- a/tests/integration/distribution/keeper/grpc_query_test.go
+++ b/tests/integration/distribution/keeper/grpc_query_test.go
@@ -46,8 +46,8 @@ func TestGRPCParams(t *testing.T) {
 			malleate: func() {
 				params = types.Params{
 					CommunityTax:        sdk.NewDecWithPrec(3, 1),
-					BaseProposerReward:  sdk.ZeroDec(),
-					BonusProposerReward: sdk.ZeroDec(),
+					BaseProposerReward:  math.LegacyZeroDec(),
+					BonusProposerReward: math.LegacyZeroDec(),
 					WithdrawAddrEnabled: true,
 				}
 

--- a/tests/integration/distribution/keeper/msg_server_test.go
+++ b/tests/integration/distribution/keeper/msg_server_test.go
@@ -656,8 +656,8 @@ func TestMsgUpdateParams(t *testing.T) {
 				Params: distrtypes.Params{
 					CommunityTax:        sdk.NewDecWithPrec(2, 0),
 					WithdrawAddrEnabled: withdrawAddrEnabled,
-					BaseProposerReward:  sdk.ZeroDec(),
-					BonusProposerReward: sdk.ZeroDec(),
+					BaseProposerReward:  math.LegacyZeroDec(),
+					BonusProposerReward: math.LegacyZeroDec(),
 				},
 			},
 			expErr:    true,
@@ -670,8 +670,8 @@ func TestMsgUpdateParams(t *testing.T) {
 				Params: distrtypes.Params{
 					CommunityTax:        sdk.NewDecWithPrec(2, 0),
 					WithdrawAddrEnabled: withdrawAddrEnabled,
-					BaseProposerReward:  sdk.ZeroDec(),
-					BonusProposerReward: sdk.ZeroDec(),
+					BaseProposerReward:  math.LegacyZeroDec(),
+					BonusProposerReward: math.LegacyZeroDec(),
 				},
 			},
 			expErr:    true,
@@ -684,8 +684,8 @@ func TestMsgUpdateParams(t *testing.T) {
 				Params: distrtypes.Params{
 					CommunityTax:        sdk.NewDecWithPrec(-2, 1),
 					WithdrawAddrEnabled: withdrawAddrEnabled,
-					BaseProposerReward:  sdk.ZeroDec(),
-					BonusProposerReward: sdk.ZeroDec(),
+					BaseProposerReward:  math.LegacyZeroDec(),
+					BonusProposerReward: math.LegacyZeroDec(),
 				},
 			},
 			expErr:    true,
@@ -698,7 +698,7 @@ func TestMsgUpdateParams(t *testing.T) {
 				Params: distrtypes.Params{
 					CommunityTax:        communityTax,
 					BaseProposerReward:  sdk.NewDecWithPrec(1, 2),
-					BonusProposerReward: sdk.ZeroDec(),
+					BonusProposerReward: math.LegacyZeroDec(),
 					WithdrawAddrEnabled: withdrawAddrEnabled,
 				},
 			},
@@ -711,7 +711,7 @@ func TestMsgUpdateParams(t *testing.T) {
 				Authority: f.distrKeeper.GetAuthority(),
 				Params: distrtypes.Params{
 					CommunityTax:        communityTax,
-					BaseProposerReward:  sdk.ZeroDec(),
+					BaseProposerReward:  math.LegacyZeroDec(),
 					BonusProposerReward: sdk.NewDecWithPrec(1, 2),
 					WithdrawAddrEnabled: withdrawAddrEnabled,
 				},
@@ -725,8 +725,8 @@ func TestMsgUpdateParams(t *testing.T) {
 				Authority: f.distrKeeper.GetAuthority(),
 				Params: distrtypes.Params{
 					CommunityTax:        communityTax,
-					BaseProposerReward:  sdk.ZeroDec(),
-					BonusProposerReward: sdk.ZeroDec(),
+					BaseProposerReward:  math.LegacyZeroDec(),
+					BonusProposerReward: math.LegacyZeroDec(),
 					WithdrawAddrEnabled: withdrawAddrEnabled,
 				},
 			},

--- a/tests/integration/gov/keeper/grpc_query_test.go
+++ b/tests/integration/gov/keeper/grpc_query_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	"cosmossdk.io/math"
 	"gotest.tools/v3/assert"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -255,10 +256,10 @@ func TestLegacyGRPCQueryTally(t *testing.T) {
 }
 
 func v1TallyToV1Beta1Tally(t v1.TallyResult) v1beta1.TallyResult {
-	yes, _ := sdk.NewIntFromString(t.YesCount)
-	no, _ := sdk.NewIntFromString(t.NoCount)
-	noWithVeto, _ := sdk.NewIntFromString(t.NoWithVetoCount)
-	abstain, _ := sdk.NewIntFromString(t.AbstainCount)
+	yes, _ := math.NewIntFromString(t.YesCount)
+	no, _ := math.NewIntFromString(t.NoCount)
+	noWithVeto, _ := math.NewIntFromString(t.NoWithVetoCount)
+	abstain, _ := math.NewIntFromString(t.AbstainCount)
 	return v1beta1.TallyResult{
 		Yes:        yes,
 		No:         no,

--- a/tests/integration/staking/keeper/common_test.go
+++ b/tests/integration/staking/keeper/common_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"cosmossdk.io/log"
+	"cosmossdk.io/math"
 	storetypes "cosmossdk.io/store/types"
 	"gotest.tools/v3/assert"
 
@@ -45,7 +46,7 @@ type fixture struct {
 }
 
 func init() {
-	sdk.DefaultPowerReduction = sdk.NewIntFromBigInt(new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil))
+	sdk.DefaultPowerReduction = math.NewIntFromBigInt(new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil))
 }
 
 // intended to be used with require/assert:  require.True(ValEq(...))

--- a/tests/integration/staking/keeper/unbonding_test.go
+++ b/tests/integration/staking/keeper/unbonding_test.go
@@ -97,7 +97,7 @@ func doUnbondingDelegation(
 	notBondedAmt1 := bankKeeper.GetBalance(ctx, stakingKeeper.GetNotBondedPool(ctx).GetAddress(), bondDenom).Amount
 
 	var err error
-	undelegateAmount := sdk.NewDec(1)
+	undelegateAmount := math.LegacyNewDec(1)
 	completionTime, undelegatedAmount, err := stakingKeeper.Undelegate(ctx, addrDels[0], addrVals[0], undelegateAmount)
 	assert.NilError(t, err)
 	assert.Assert(t, undelegateAmount.Equal(math.LegacyNewDecFromInt(undelegatedAmount)))
@@ -128,13 +128,13 @@ func doRedelegation(
 	hookCalled *bool,
 ) (completionTime time.Time) {
 	var err error
-	completionTime, err = stakingKeeper.BeginRedelegation(ctx, addrDels[0], addrVals[0], addrVals[1], sdk.NewDec(1))
+	completionTime, err = stakingKeeper.BeginRedelegation(ctx, addrDels[0], addrVals[0], addrVals[1], math.LegacyNewDec(1))
 	assert.NilError(t, err)
 
 	// Check that the redelegation happened- we look up the entry and see that it has the correct number of shares
 	redelegations := stakingKeeper.GetRedelegationsFromSrcValidator(ctx, addrVals[0])
 	assert.Equal(t, 1, len(redelegations))
-	assert.DeepEqual(t, sdk.NewDec(1), redelegations[0].Entries[0].SharesDst)
+	assert.DeepEqual(t, math.LegacyNewDec(1), redelegations[0].Entries[0].SharesDst)
 
 	// check that our hook was called
 	assert.Assert(t, *hookCalled)

--- a/tests/integration/staking/keeper/validator_bench_test.go
+++ b/tests/integration/staking/keeper/validator_bench_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"cosmossdk.io/math"
 	storetypes "cosmossdk.io/store/types"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -58,7 +59,7 @@ func BenchmarkGetValidatorDelegations(b *testing.B) {
 			delegator := sdk.AccAddress(fmt.Sprintf("address%d", i))
 			banktestutil.FundAccount(f.sdkCtx, f.bankKeeper, delegator,
 				sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(int64(i)))))
-			NewDel := types.NewDelegation(delegator, val, sdk.NewDec(int64(i)))
+			NewDel := types.NewDelegation(delegator, val, math.LegacyNewDec(int64(i)))
 			f.stakingKeeper.SetDelegation(f.sdkCtx, NewDel)
 		}
 	}
@@ -91,7 +92,7 @@ func BenchmarkGetValidatorDelegationsLegacy(b *testing.B) {
 			delegator := sdk.AccAddress(fmt.Sprintf("address%d", i))
 			banktestutil.FundAccount(f.sdkCtx, f.bankKeeper, delegator,
 				sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(int64(i)))))
-			NewDel := types.NewDelegation(delegator, val, sdk.NewDec(int64(i)))
+			NewDel := types.NewDelegation(delegator, val, math.LegacyNewDec(int64(i)))
 			f.stakingKeeper.SetDelegation(f.sdkCtx, NewDel)
 		}
 	}

--- a/tests/integration/staking/keeper/validator_test.go
+++ b/tests/integration/staking/keeper/validator_test.go
@@ -151,7 +151,7 @@ func TestGetValidatorSortingUnmixed(t *testing.T) {
 
 	// initialize some validators into the state
 	amts := []math.Int{
-		sdk.NewIntFromUint64(0),
+		math.NewIntFromUint64(0),
 		f.stakingKeeper.PowerReduction(f.sdkCtx).MulRaw(100),
 		f.stakingKeeper.PowerReduction(f.sdkCtx),
 		f.stakingKeeper.PowerReduction(f.sdkCtx).MulRaw(400),
@@ -245,7 +245,7 @@ func TestGetValidatorSortingMixed(t *testing.T) {
 
 	// initialize some validators into the state
 	amts := []math.Int{
-		sdk.NewIntFromUint64(0),
+		math.NewIntFromUint64(0),
 		f.stakingKeeper.PowerReduction(f.sdkCtx).MulRaw(100),
 		f.stakingKeeper.PowerReduction(f.sdkCtx),
 		f.stakingKeeper.PowerReduction(f.sdkCtx).MulRaw(400),

--- a/testutil/testnet/genesis.go
+++ b/testutil/testnet/genesis.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"time"
 
+	"cosmossdk.io/math"
 	cmttypes "github.com/cometbft/cometbft/types"
 
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -107,7 +108,7 @@ func (b *GenesisBuilder) GenTx(privVal secp256k1.PrivKey, val cmttypes.GenesisVa
 			MaxRate:       sdk.MustNewDecFromStr("0.2"),
 			MaxChangeRate: sdk.MustNewDecFromStr("0.01"),
 		},
-		sdk.OneInt(),
+		math.OneInt(),
 	)
 	if err != nil {
 		panic(err)

--- a/types/dec_coin.go
+++ b/types/dec_coin.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"cosmossdk.io/errors"
+	"cosmossdk.io/math"
 )
 
 // ----------------------------------------------------------------------------
@@ -328,7 +329,7 @@ func (coins DecCoins) Intersect(coinsB DecCoins) DecCoins {
 	for i, coin := range coins {
 		minCoin := DecCoin{
 			Denom:  coin.Denom,
-			Amount: MinDec(coin.Amount, coinsB.AmountOf(coin.Denom)),
+			Amount: math.LegacyMinDec(coin.Amount, coinsB.AmountOf(coin.Denom)),
 		}
 		res[i] = minCoin
 	}
@@ -456,14 +457,14 @@ func (coins DecCoins) AmountOf(denom string) Dec {
 
 	switch len(coins) {
 	case 0:
-		return ZeroDec()
+		return math.LegacyZeroDec()
 
 	case 1:
 		coin := coins[0]
 		if coin.Denom == denom {
 			return coin.Amount
 		}
-		return ZeroDec()
+		return math.LegacyZeroDec()
 
 	default:
 		midIdx := len(coins) / 2 // 2:1, 3:1, 4:2

--- a/types/dec_coin_test.go
+++ b/types/dec_coin_test.go
@@ -377,34 +377,34 @@ func (s *decCoinTestSuite) TestParseDecCoins() {
 		{"", nil, false},
 		{"4stake", sdk.DecCoins{sdk.NewDecCoinFromDec("stake", sdk.NewDecFromInt(math.NewInt(4)))}, false},
 		{"5.5atom,4stake", sdk.DecCoins{
-			sdk.NewDecCoinFromDec("atom", sdk.NewDecWithPrec(5500000000000000000, sdk.Precision)),
+			sdk.NewDecCoinFromDec("atom", sdk.NewDecWithPrec(5500000000000000000, math.LegacyPrecision)),
 			sdk.NewDecCoinFromDec("stake", math.LegacyNewDec(4)),
 		}, false},
 		{"0.0stake", sdk.DecCoins{}, false}, // remove zero coins
 		{"10.0btc,1.0atom,20.0btc", nil, true},
 		{
 			"0.004STAKE",
-			sdk.DecCoins{sdk.NewDecCoinFromDec("STAKE", sdk.NewDecWithPrec(4000000000000000, sdk.Precision))},
+			sdk.DecCoins{sdk.NewDecCoinFromDec("STAKE", sdk.NewDecWithPrec(4000000000000000, math.LegacyPrecision))},
 			false,
 		},
 		{
 			"0.004stake",
-			sdk.DecCoins{sdk.NewDecCoinFromDec("stake", sdk.NewDecWithPrec(4000000000000000, sdk.Precision))},
+			sdk.DecCoins{sdk.NewDecCoinFromDec("stake", sdk.NewDecWithPrec(4000000000000000, math.LegacyPrecision))},
 			false,
 		},
 		{
 			"5.04atom,0.004stake",
 			sdk.DecCoins{
-				sdk.NewDecCoinFromDec("atom", sdk.NewDecWithPrec(5040000000000000000, sdk.Precision)),
-				sdk.NewDecCoinFromDec("stake", sdk.NewDecWithPrec(4000000000000000, sdk.Precision)),
+				sdk.NewDecCoinFromDec("atom", sdk.NewDecWithPrec(5040000000000000000, math.LegacyPrecision)),
+				sdk.NewDecCoinFromDec("stake", sdk.NewDecWithPrec(4000000000000000, math.LegacyPrecision)),
 			},
 			false,
 		},
 		{
 			"0.0stake,0.004stake,5.04atom", // remove zero coins
 			sdk.DecCoins{
-				sdk.NewDecCoinFromDec("atom", sdk.NewDecWithPrec(5040000000000000000, sdk.Precision)),
-				sdk.NewDecCoinFromDec("stake", sdk.NewDecWithPrec(4000000000000000, sdk.Precision)),
+				sdk.NewDecCoinFromDec("atom", sdk.NewDecWithPrec(5040000000000000000, math.LegacyPrecision)),
+				sdk.NewDecCoinFromDec("stake", sdk.NewDecWithPrec(4000000000000000, math.LegacyPrecision)),
 			},
 			false,
 		},
@@ -429,8 +429,8 @@ func (s *decCoinTestSuite) TestDecCoinsString() {
 		{sdk.DecCoins{}, ""},
 		{
 			sdk.DecCoins{
-				sdk.NewDecCoinFromDec("atom", sdk.NewDecWithPrec(5040000000000000000, sdk.Precision)),
-				sdk.NewDecCoinFromDec("stake", sdk.NewDecWithPrec(4000000000000000, sdk.Precision)),
+				sdk.NewDecCoinFromDec("atom", sdk.NewDecWithPrec(5040000000000000000, math.LegacyPrecision)),
+				sdk.NewDecCoinFromDec("stake", sdk.NewDecWithPrec(4000000000000000, math.LegacyPrecision)),
 			},
 			"5.040000000000000000atom,0.004000000000000000stake",
 		},

--- a/types/denom.go
+++ b/types/denom.go
@@ -2,6 +2,8 @@ package types
 
 import (
 	"fmt"
+
+	"cosmossdk.io/math"
 )
 
 // denomUnits contains a mapping of denomination mapped to their respective unit
@@ -34,12 +36,12 @@ func RegisterDenom(denom string, unit Dec) error {
 // is returned if the denomination is registered.
 func GetDenomUnit(denom string) (Dec, bool) {
 	if err := ValidateDenom(denom); err != nil {
-		return ZeroDec(), false
+		return math.LegacyZeroDec(), false
 	}
 
 	unit, ok := denomUnits[denom]
 	if !ok {
-		return ZeroDec(), false
+		return math.LegacyZeroDec(), false
 	}
 
 	return unit, true

--- a/types/denom_internal_test.go
+++ b/types/denom_internal_test.go
@@ -3,6 +3,7 @@ package types
 import (
 	"testing"
 
+	"cosmossdk.io/math"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -22,7 +23,7 @@ func TestInternalDenomTestSuite(t *testing.T) {
 }
 
 func (s *internalDenomTestSuite) TestRegisterDenom() {
-	atomUnit := OneDec() // 1 (base denom unit)
+	atomUnit := math.LegacyOneDec() // 1 (base denom unit)
 
 	s.Require().NoError(RegisterDenom(atom, atomUnit))
 	s.Require().Error(RegisterDenom(atom, atomUnit))
@@ -33,7 +34,7 @@ func (s *internalDenomTestSuite) TestRegisterDenom() {
 
 	res, ok = GetDenomUnit(matom)
 	s.Require().False(ok)
-	s.Require().Equal(ZeroDec(), res)
+	s.Require().Equal(math.LegacyZeroDec(), res)
 
 	// reset registration
 	baseDenom = ""
@@ -41,7 +42,7 @@ func (s *internalDenomTestSuite) TestRegisterDenom() {
 }
 
 func (s *internalDenomTestSuite) TestConvertCoins() {
-	atomUnit := OneDec() // 1 (base denom unit)
+	atomUnit := math.LegacyOneDec() // 1 (base denom unit)
 	s.Require().NoError(RegisterDenom(atom, atomUnit))
 
 	matomUnit := NewDecWithPrec(1, 3) // 10^-3 (milli)
@@ -108,7 +109,7 @@ func (s *internalDenomTestSuite) TestConvertCoins() {
 }
 
 func (s *internalDenomTestSuite) TestConvertDecCoins() {
-	atomUnit := OneDec() // 1 (base denom unit)
+	atomUnit := math.LegacyOneDec() // 1 (base denom unit)
 	s.Require().NoError(RegisterDenom(atom, atomUnit))
 
 	matomUnit := NewDecWithPrec(1, 3) // 10^-3 (milli)

--- a/types/math.go
+++ b/types/math.go
@@ -11,25 +11,12 @@ import (
 //
 // Please use the above module instead of this package.
 type (
-	Int  = sdkmath.Int
-	Uint = sdkmath.Uint
+	Int = sdkmath.Int
 )
 
 var (
-	NewIntFromBigInt = sdkmath.NewIntFromBigInt
-	OneInt           = sdkmath.OneInt
-	NewInt           = sdkmath.NewInt
-	ZeroInt          = sdkmath.ZeroInt
-	IntEq            = sdkmath.IntEq
-	NewIntFromString = sdkmath.NewIntFromString
-	NewUint          = sdkmath.NewUint
-	NewIntFromUint64 = sdkmath.NewIntFromUint64
-	MaxInt           = sdkmath.MaxInt
-	MinInt           = sdkmath.MinInt
-)
-
-const (
-	MaxBitLen = sdkmath.MaxBitLen
+	NewInt  = sdkmath.NewInt
+	ZeroInt = sdkmath.ZeroInt
 )
 
 func (ip IntProto) String() string {
@@ -40,31 +27,11 @@ type (
 	Dec = sdkmath.LegacyDec
 )
 
-const (
-	Precision            = sdkmath.LegacyPrecision
-	DecimalPrecisionBits = sdkmath.LegacyDecimalPrecisionBits
-)
-
 var (
-	ZeroDec                  = sdkmath.LegacyZeroDec
-	OneDec                   = sdkmath.LegacyOneDec
-	SmallestDec              = sdkmath.LegacySmallestDec
-	NewDec                   = sdkmath.LegacyNewDec
-	NewDecWithPrec           = sdkmath.LegacyNewDecWithPrec
-	NewDecFromBigInt         = sdkmath.LegacyNewDecFromBigInt
-	NewDecFromBigIntWithPrec = sdkmath.LegacyNewDecFromBigIntWithPrec
-	NewDecFromInt            = sdkmath.LegacyNewDecFromInt
-	NewDecFromIntWithPrec    = sdkmath.LegacyNewDecFromIntWithPrec
-	NewDecFromStr            = sdkmath.LegacyNewDecFromStr
-	MustNewDecFromStr        = sdkmath.LegacyMustNewDecFromStr
-	MaxSortableDec           = sdkmath.LegacyMaxSortableDec
-	ValidSortableDec         = sdkmath.LegacyValidSortableDec
-	SortableDecBytes         = sdkmath.LegacySortableDecBytes
-	DecsEqual                = sdkmath.LegacyDecsEqual
-	MinDec                   = sdkmath.LegacyMinDec
-	MaxDec                   = sdkmath.LegacyMaxDec
-	DecEq                    = sdkmath.LegacyDecEq
-	DecApproxEq              = sdkmath.LegacyDecApproxEq
+	NewDecWithPrec    = sdkmath.LegacyNewDecWithPrec
+	NewDecFromInt     = sdkmath.LegacyNewDecFromInt
+	NewDecFromStr     = sdkmath.LegacyNewDecFromStr
+	MustNewDecFromStr = sdkmath.LegacyMustNewDecFromStr
 )
 
 var _ CustomProtobufType = (*Dec)(nil)

--- a/x/auth/tx/aux_test.go
+++ b/x/auth/tx/aux_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"cosmossdk.io/math"
 	"github.com/stretchr/testify/require"
 
 	clienttx "github.com/cosmos/cosmos-sdk/client/tx"
@@ -25,7 +26,7 @@ var (
 
 	msg     = testdata.NewTestMsg(tipperAddr, aux2Addr)
 	memo    = "test-memo"
-	tip     = &txtypes.Tip{Tipper: tipperAddr.String(), Amount: sdk.NewCoins(sdk.NewCoin("tip-denom", sdk.NewIntFromUint64(123)))}
+	tip     = &txtypes.Tip{Tipper: tipperAddr.String(), Amount: sdk.NewCoins(sdk.NewCoin("tip-denom", math.NewIntFromUint64(123)))}
 	chainID = "test-chain"
 	gas     = testdata.NewTestGasLimit()
 	fee     = testdata.NewTestFeeAmount()

--- a/x/auth/vesting/types/vesting_account.go
+++ b/x/auth/vesting/types/vesting_account.go
@@ -68,7 +68,7 @@ func (bva *BaseVestingAccount) TrackDelegation(balance, vestingCoins, amount sdk
 		// compute x and y per the specification, where:
 		// X := min(max(V - DV, 0), D)
 		// Y := D - X
-		x := sdk.MinInt(sdk.MaxInt(vestingAmt.Sub(delVestingAmt), math.ZeroInt()), coin.Amount)
+		x := sdk.MinInt(math.MaxInt(vestingAmt.Sub(delVestingAmt), math.ZeroInt()), coin.Amount)
 		y := coin.Amount.Sub(x)
 
 		if !x.IsZero() {

--- a/x/auth/vesting/types/vesting_account.go
+++ b/x/auth/vesting/types/vesting_account.go
@@ -68,7 +68,7 @@ func (bva *BaseVestingAccount) TrackDelegation(balance, vestingCoins, amount sdk
 		// compute x and y per the specification, where:
 		// X := min(max(V - DV, 0), D)
 		// Y := D - X
-		x := sdk.MinInt(math.MaxInt(vestingAmt.Sub(delVestingAmt), math.ZeroInt()), coin.Amount)
+		x := math.MinInt(math.MaxInt(vestingAmt.Sub(delVestingAmt), math.ZeroInt()), coin.Amount)
 		y := coin.Amount.Sub(x)
 
 		if !x.IsZero() {
@@ -105,8 +105,8 @@ func (bva *BaseVestingAccount) TrackUndelegation(amount sdk.Coins) {
 		// compute x and y per the specification, where:
 		// X := min(DF, D)
 		// Y := min(DV, D - X)
-		x := sdk.MinInt(delegatedFree, coin.Amount)
-		y := sdk.MinInt(delegatedVesting, coin.Amount.Sub(x))
+		x := math.MinInt(delegatedFree, coin.Amount)
+		y := math.MinInt(delegatedVesting, coin.Amount.Sub(x))
 
 		if !x.IsZero() {
 			xCoin := sdk.NewCoin(coin.Denom, x)

--- a/x/distribution/keeper/delegation.go
+++ b/x/distribution/keeper/delegation.go
@@ -144,7 +144,7 @@ func (k Keeper) CalculateDelegationRewards(ctx context.Context, val stakingtypes
 		// A small amount of this error is tolerated and corrected for,
 		// however any greater amount should be considered a breach in expected
 		// behavior.
-		marginOfErr := sdk.SmallestDec().MulInt64(3)
+		marginOfErr := math.LegacySmallestDec().MulInt64(3)
 		if stake.LTE(currentStake.Add(marginOfErr)) {
 			stake = currentStake
 		} else {

--- a/x/gov/keeper/msg_server_test.go
+++ b/x/gov/keeper/msg_server_test.go
@@ -1645,7 +1645,7 @@ func (suite *KeeperTestSuite) TestMsgUpdateParams() {
 
 func (suite *KeeperTestSuite) TestSubmitProposal_InitialDeposit() {
 	const meetsDepositValue = baseDepositTestAmount * baseDepositTestPercent / 100
-	baseDepositRatioDec := sdk.NewDec(baseDepositTestPercent).Quo(sdk.NewDec(100))
+	baseDepositRatioDec := sdkmath.LegacyNewDec(baseDepositTestPercent).Quo(sdkmath.LegacyNewDec(100))
 
 	testcases := map[string]struct {
 		minDeposit             sdk.Coins

--- a/x/gov/migrations/v3/convert.go
+++ b/x/gov/migrations/v3/convert.go
@@ -3,6 +3,7 @@ package v3
 import (
 	"fmt"
 
+	sdkmath "cosmossdk.io/math"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
@@ -70,19 +71,19 @@ func ConvertToLegacyProposal(proposal v1.Proposal) (v1beta1.Proposal, error) {
 }
 
 func ConvertToLegacyTallyResult(tally *v1.TallyResult) (v1beta1.TallyResult, error) {
-	yes, ok := types.NewIntFromString(tally.YesCount)
+	yes, ok := sdkmath.NewIntFromString(tally.YesCount)
 	if !ok {
 		return v1beta1.TallyResult{}, fmt.Errorf("unable to convert yes tally string (%s) to int", tally.YesCount)
 	}
-	no, ok := types.NewIntFromString(tally.NoCount)
+	no, ok := sdkmath.NewIntFromString(tally.NoCount)
 	if !ok {
 		return v1beta1.TallyResult{}, fmt.Errorf("unable to convert no tally string (%s) to int", tally.NoCount)
 	}
-	veto, ok := types.NewIntFromString(tally.NoWithVetoCount)
+	veto, ok := sdkmath.NewIntFromString(tally.NoWithVetoCount)
 	if !ok {
 		return v1beta1.TallyResult{}, fmt.Errorf("unable to convert no with veto tally string (%s) to int", tally.NoWithVetoCount)
 	}
-	abstain, ok := types.NewIntFromString(tally.AbstainCount)
+	abstain, ok := sdkmath.NewIntFromString(tally.AbstainCount)
 	if !ok {
 		return v1beta1.TallyResult{}, fmt.Errorf("unable to convert abstain tally string (%s) to int", tally.AbstainCount)
 	}

--- a/x/gov/migrations/v4/store_test.go
+++ b/x/gov/migrations/v4/store_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"cosmossdk.io/math"
-	sdkmath "cosmossdk.io/math"
 	storetypes "cosmossdk.io/store/types"
 
 	"github.com/cosmos/cosmos-sdk/runtime"
@@ -133,7 +132,7 @@ func getTestProposal() []sdk.Msg {
 	}
 
 	return []sdk.Msg{
-		banktypes.NewMsgSend(govAcct, addr, sdk.NewCoins(sdk.NewCoin("stake", sdkmath.NewInt(1000)))),
+		banktypes.NewMsgSend(govAcct, addr, sdk.NewCoins(sdk.NewCoin("stake", math.NewInt(1000)))),
 		legacyProposalMsg,
 	}
 }

--- a/x/gov/migrations/v4/store_test.go
+++ b/x/gov/migrations/v4/store_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"cosmossdk.io/math"
 	sdkmath "cosmossdk.io/math"
 	storetypes "cosmossdk.io/store/types"
 
@@ -107,7 +108,7 @@ func TestMigrateStore(t *testing.T) {
 	require.Equal(t, legacySubspace.tp.Quorum, params.Quorum)
 	require.Equal(t, legacySubspace.tp.Threshold, params.Threshold)
 	require.Equal(t, legacySubspace.tp.VetoThreshold, params.VetoThreshold)
-	require.Equal(t, sdk.ZeroDec().String(), params.MinInitialDepositRatio)
+	require.Equal(t, math.LegacyZeroDec().String(), params.MinInitialDepositRatio)
 
 	// Check proposals' status
 	var migratedProp1 v1.Proposal

--- a/x/mint/keeper/keeper_test.go
+++ b/x/mint/keeper/keeper_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"cosmossdk.io/math"
-	sdkmath "cosmossdk.io/math"
 	storetypes "cosmossdk.io/store/types"
 
 	"github.com/cosmos/cosmos-sdk/testutil"
@@ -81,10 +80,10 @@ func (s *IntegrationTestSuite) TestParams() {
 			name: "set invalid params (⚠️ not validated in keeper)",
 			input: types.Params{
 				MintDenom:           sdk.DefaultBondDenom,
-				InflationRateChange: sdkmath.LegacyNewDecWithPrec(-13, 2),
-				InflationMax:        sdkmath.LegacyNewDecWithPrec(20, 2),
-				InflationMin:        sdkmath.LegacyNewDecWithPrec(7, 2),
-				GoalBonded:          sdkmath.LegacyNewDecWithPrec(67, 2),
+				InflationRateChange: math.LegacyNewDecWithPrec(-13, 2),
+				InflationMax:        math.LegacyNewDecWithPrec(20, 2),
+				InflationMin:        math.LegacyNewDecWithPrec(7, 2),
+				GoalBonded:          math.LegacyNewDecWithPrec(67, 2),
 				BlocksPerYear:       uint64(60 * 60 * 8766 / 5),
 			},
 			expectErr: false,
@@ -93,10 +92,10 @@ func (s *IntegrationTestSuite) TestParams() {
 			name: "set full valid params",
 			input: types.Params{
 				MintDenom:           sdk.DefaultBondDenom,
-				InflationRateChange: sdkmath.LegacyNewDecWithPrec(8, 2),
-				InflationMax:        sdkmath.LegacyNewDecWithPrec(20, 2),
-				InflationMin:        sdkmath.LegacyNewDecWithPrec(2, 2),
-				GoalBonded:          sdkmath.LegacyNewDecWithPrec(37, 2),
+				InflationRateChange: math.LegacyNewDecWithPrec(8, 2),
+				InflationMax:        math.LegacyNewDecWithPrec(20, 2),
+				InflationMin:        math.LegacyNewDecWithPrec(2, 2),
+				GoalBonded:          math.LegacyNewDecWithPrec(37, 2),
 				BlocksPerYear:       uint64(60 * 60 * 8766 / 5),
 			},
 			expectErr: false,
@@ -127,16 +126,16 @@ func (s *IntegrationTestSuite) TestAliasFunctions() {
 	s.stakingKeeper.EXPECT().StakingTokenSupply(s.ctx).Return(stakingTokenSupply)
 	s.Require().Equal(s.mintKeeper.StakingTokenSupply(s.ctx), stakingTokenSupply)
 
-	bondedRatio := sdkmath.LegacyNewDecWithPrec(15, 2)
+	bondedRatio := math.LegacyNewDecWithPrec(15, 2)
 	s.stakingKeeper.EXPECT().BondedRatio(s.ctx).Return(bondedRatio)
 	s.Require().Equal(s.mintKeeper.BondedRatio(s.ctx), bondedRatio)
 
-	coins := sdk.NewCoins(sdk.NewCoin("stake", sdkmath.NewInt(1000000)))
+	coins := sdk.NewCoins(sdk.NewCoin("stake", math.NewInt(1000000)))
 	s.bankKeeper.EXPECT().MintCoins(s.ctx, types.ModuleName, coins).Return(nil)
 	s.Require().Equal(s.mintKeeper.MintCoins(s.ctx, sdk.NewCoins()), nil)
 	s.Require().Nil(s.mintKeeper.MintCoins(s.ctx, coins))
 
-	fees := sdk.NewCoins(sdk.NewCoin("stake", sdkmath.NewInt(1000)))
+	fees := sdk.NewCoins(sdk.NewCoin("stake", math.NewInt(1000)))
 	s.bankKeeper.EXPECT().SendCoinsFromModuleToModule(s.ctx, types.ModuleName, authtypes.FeeCollectorName, fees).Return(nil)
 	s.Require().Nil(s.mintKeeper.AddCollectedFees(s.ctx, fees))
 }

--- a/x/mint/keeper/keeper_test.go
+++ b/x/mint/keeper/keeper_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/suite"
 
+	"cosmossdk.io/math"
 	sdkmath "cosmossdk.io/math"
 	storetypes "cosmossdk.io/store/types"
 
@@ -122,7 +123,7 @@ func (s *IntegrationTestSuite) TestParams() {
 }
 
 func (s *IntegrationTestSuite) TestAliasFunctions() {
-	stakingTokenSupply := sdk.NewIntFromUint64(100000000000)
+	stakingTokenSupply := math.NewIntFromUint64(100000000000)
 	s.stakingKeeper.EXPECT().StakingTokenSupply(s.ctx).Return(stakingTokenSupply)
 	s.Require().Equal(s.mintKeeper.StakingTokenSupply(s.ctx), stakingTokenSupply)
 

--- a/x/staking/keeper/msg_server_test.go
+++ b/x/staking/keeper/msg_server_test.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"cosmossdk.io/math"
-	sdkmath "cosmossdk.io/math"
 
 	"github.com/golang/mock/gomock"
 
@@ -253,7 +252,7 @@ func (s *KeeperTestSuite) TestMsgEditValidator() {
 	require.NotNil(pk)
 
 	comm := stakingtypes.NewCommissionRates(math.LegacyNewDec(0), math.LegacyNewDec(0), math.LegacyNewDec(0))
-	msg, err := stakingtypes.NewMsgCreateValidator(ValAddr, pk, sdk.NewCoin("stake", sdk.NewInt(10)), stakingtypes.Description{Moniker: "NewVal"}, comm, sdkmath.OneInt())
+	msg, err := stakingtypes.NewMsgCreateValidator(ValAddr, pk, sdk.NewCoin("stake", sdk.NewInt(10)), stakingtypes.Description{Moniker: "NewVal"}, comm, math.OneInt())
 	require.NoError(err)
 
 	res, err := msgServer.CreateValidator(ctx, msg)
@@ -261,7 +260,7 @@ func (s *KeeperTestSuite) TestMsgEditValidator() {
 	require.NotNil(res)
 
 	newRate := math.LegacyZeroDec()
-	invalidRate := sdkmath.LegacyNewDec(2)
+	invalidRate := math.LegacyNewDec(2)
 
 	lowSelfDel := math.OneInt()
 	highSelfDel := math.NewInt(100)
@@ -427,7 +426,7 @@ func (s *KeeperTestSuite) TestMsgDelegate() {
 
 	comm := stakingtypes.NewCommissionRates(math.LegacyNewDec(0), math.LegacyNewDec(0), math.LegacyNewDec(0))
 
-	msg, err := stakingtypes.NewMsgCreateValidator(ValAddr, pk, sdk.NewCoin("stake", sdk.NewInt(10)), stakingtypes.Description{Moniker: "NewVal"}, comm, sdkmath.OneInt())
+	msg, err := stakingtypes.NewMsgCreateValidator(ValAddr, pk, sdk.NewCoin("stake", sdk.NewInt(10)), stakingtypes.Description{Moniker: "NewVal"}, comm, math.OneInt())
 	require.NoError(err)
 
 	res, err := msgServer.CreateValidator(ctx, msg)
@@ -552,7 +551,7 @@ func (s *KeeperTestSuite) TestMsgBeginRedelegate() {
 	comm := stakingtypes.NewCommissionRates(math.LegacyNewDec(0), math.LegacyNewDec(0), math.LegacyNewDec(0))
 	amt := sdk.Coin{Denom: sdk.DefaultBondDenom, Amount: keeper.TokensFromConsensusPower(s.ctx, int64(100))}
 
-	msg, err := stakingtypes.NewMsgCreateValidator(srcValAddr, pk, amt, stakingtypes.Description{Moniker: "NewVal"}, comm, sdkmath.OneInt())
+	msg, err := stakingtypes.NewMsgCreateValidator(srcValAddr, pk, amt, stakingtypes.Description{Moniker: "NewVal"}, comm, math.OneInt())
 	require.NoError(err)
 	res, err := msgServer.CreateValidator(ctx, msg)
 	require.NoError(err)
@@ -562,7 +561,7 @@ func (s *KeeperTestSuite) TestMsgBeginRedelegate() {
 	s.accountKeeper.EXPECT().BytesToString(addr2).Return(addr2.String(), nil).AnyTimes()
 	s.bankKeeper.EXPECT().DelegateCoinsFromAccountToModule(gomock.Any(), addr2, stakingtypes.NotBondedPoolName, gomock.Any()).AnyTimes()
 
-	msg, err = stakingtypes.NewMsgCreateValidator(dstValAddr, dstPk, amt, stakingtypes.Description{Moniker: "NewVal"}, comm, sdkmath.OneInt())
+	msg, err = stakingtypes.NewMsgCreateValidator(dstValAddr, dstPk, amt, stakingtypes.Description{Moniker: "NewVal"}, comm, math.OneInt())
 	require.NoError(err)
 
 	res, err = msgServer.CreateValidator(ctx, msg)
@@ -717,7 +716,7 @@ func (s *KeeperTestSuite) TestMsgUndelegate() {
 	comm := stakingtypes.NewCommissionRates(math.LegacyNewDec(0), math.LegacyNewDec(0), math.LegacyNewDec(0))
 	amt := sdk.Coin{Denom: sdk.DefaultBondDenom, Amount: keeper.TokensFromConsensusPower(s.ctx, int64(100))}
 
-	msg, err := stakingtypes.NewMsgCreateValidator(ValAddr, pk, amt, stakingtypes.Description{Moniker: "NewVal"}, comm, sdkmath.OneInt())
+	msg, err := stakingtypes.NewMsgCreateValidator(ValAddr, pk, amt, stakingtypes.Description{Moniker: "NewVal"}, comm, math.OneInt())
 	require.NoError(err)
 	res, err := msgServer.CreateValidator(ctx, msg)
 	require.NoError(err)
@@ -845,7 +844,7 @@ func (s *KeeperTestSuite) TestMsgCancelUnbondingDelegation() {
 
 	s.bankKeeper.EXPECT().DelegateCoinsFromAccountToModule(gomock.Any(), Addr, stakingtypes.NotBondedPoolName, gomock.Any()).AnyTimes()
 
-	msg, err := stakingtypes.NewMsgCreateValidator(ValAddr, pk, amt, stakingtypes.Description{Moniker: "NewVal"}, comm, sdkmath.OneInt())
+	msg, err := stakingtypes.NewMsgCreateValidator(ValAddr, pk, amt, stakingtypes.Description{Moniker: "NewVal"}, comm, math.OneInt())
 	require.NoError(err)
 	res, err := msgServer.CreateValidator(ctx, msg)
 	require.NoError(err)

--- a/x/staking/keeper/msg_server_test.go
+++ b/x/staking/keeper/msg_server_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"cosmossdk.io/math"
+	sdkmath "cosmossdk.io/math"
 
 	"github.com/golang/mock/gomock"
 
@@ -252,7 +253,7 @@ func (s *KeeperTestSuite) TestMsgEditValidator() {
 	require.NotNil(pk)
 
 	comm := stakingtypes.NewCommissionRates(math.LegacyNewDec(0), math.LegacyNewDec(0), math.LegacyNewDec(0))
-	msg, err := stakingtypes.NewMsgCreateValidator(ValAddr, pk, sdk.NewCoin("stake", sdk.NewInt(10)), stakingtypes.Description{Moniker: "NewVal"}, comm, sdk.OneInt())
+	msg, err := stakingtypes.NewMsgCreateValidator(ValAddr, pk, sdk.NewCoin("stake", sdk.NewInt(10)), stakingtypes.Description{Moniker: "NewVal"}, comm, sdkmath.OneInt())
 	require.NoError(err)
 
 	res, err := msgServer.CreateValidator(ctx, msg)
@@ -260,7 +261,7 @@ func (s *KeeperTestSuite) TestMsgEditValidator() {
 	require.NotNil(res)
 
 	newRate := math.LegacyZeroDec()
-	invalidRate := sdk.NewDec(2)
+	invalidRate := sdkmath.LegacyNewDec(2)
 
 	lowSelfDel := math.OneInt()
 	highSelfDel := math.NewInt(100)
@@ -426,7 +427,7 @@ func (s *KeeperTestSuite) TestMsgDelegate() {
 
 	comm := stakingtypes.NewCommissionRates(math.LegacyNewDec(0), math.LegacyNewDec(0), math.LegacyNewDec(0))
 
-	msg, err := stakingtypes.NewMsgCreateValidator(ValAddr, pk, sdk.NewCoin("stake", sdk.NewInt(10)), stakingtypes.Description{Moniker: "NewVal"}, comm, sdk.OneInt())
+	msg, err := stakingtypes.NewMsgCreateValidator(ValAddr, pk, sdk.NewCoin("stake", sdk.NewInt(10)), stakingtypes.Description{Moniker: "NewVal"}, comm, sdkmath.OneInt())
 	require.NoError(err)
 
 	res, err := msgServer.CreateValidator(ctx, msg)
@@ -551,7 +552,7 @@ func (s *KeeperTestSuite) TestMsgBeginRedelegate() {
 	comm := stakingtypes.NewCommissionRates(math.LegacyNewDec(0), math.LegacyNewDec(0), math.LegacyNewDec(0))
 	amt := sdk.Coin{Denom: sdk.DefaultBondDenom, Amount: keeper.TokensFromConsensusPower(s.ctx, int64(100))}
 
-	msg, err := stakingtypes.NewMsgCreateValidator(srcValAddr, pk, amt, stakingtypes.Description{Moniker: "NewVal"}, comm, sdk.OneInt())
+	msg, err := stakingtypes.NewMsgCreateValidator(srcValAddr, pk, amt, stakingtypes.Description{Moniker: "NewVal"}, comm, sdkmath.OneInt())
 	require.NoError(err)
 	res, err := msgServer.CreateValidator(ctx, msg)
 	require.NoError(err)
@@ -561,7 +562,7 @@ func (s *KeeperTestSuite) TestMsgBeginRedelegate() {
 	s.accountKeeper.EXPECT().BytesToString(addr2).Return(addr2.String(), nil).AnyTimes()
 	s.bankKeeper.EXPECT().DelegateCoinsFromAccountToModule(gomock.Any(), addr2, stakingtypes.NotBondedPoolName, gomock.Any()).AnyTimes()
 
-	msg, err = stakingtypes.NewMsgCreateValidator(dstValAddr, dstPk, amt, stakingtypes.Description{Moniker: "NewVal"}, comm, sdk.OneInt())
+	msg, err = stakingtypes.NewMsgCreateValidator(dstValAddr, dstPk, amt, stakingtypes.Description{Moniker: "NewVal"}, comm, sdkmath.OneInt())
 	require.NoError(err)
 
 	res, err = msgServer.CreateValidator(ctx, msg)
@@ -716,7 +717,7 @@ func (s *KeeperTestSuite) TestMsgUndelegate() {
 	comm := stakingtypes.NewCommissionRates(math.LegacyNewDec(0), math.LegacyNewDec(0), math.LegacyNewDec(0))
 	amt := sdk.Coin{Denom: sdk.DefaultBondDenom, Amount: keeper.TokensFromConsensusPower(s.ctx, int64(100))}
 
-	msg, err := stakingtypes.NewMsgCreateValidator(ValAddr, pk, amt, stakingtypes.Description{Moniker: "NewVal"}, comm, sdk.OneInt())
+	msg, err := stakingtypes.NewMsgCreateValidator(ValAddr, pk, amt, stakingtypes.Description{Moniker: "NewVal"}, comm, sdkmath.OneInt())
 	require.NoError(err)
 	res, err := msgServer.CreateValidator(ctx, msg)
 	require.NoError(err)
@@ -844,7 +845,7 @@ func (s *KeeperTestSuite) TestMsgCancelUnbondingDelegation() {
 
 	s.bankKeeper.EXPECT().DelegateCoinsFromAccountToModule(gomock.Any(), Addr, stakingtypes.NotBondedPoolName, gomock.Any()).AnyTimes()
 
-	msg, err := stakingtypes.NewMsgCreateValidator(ValAddr, pk, amt, stakingtypes.Description{Moniker: "NewVal"}, comm, sdk.OneInt())
+	msg, err := stakingtypes.NewMsgCreateValidator(ValAddr, pk, amt, stakingtypes.Description{Moniker: "NewVal"}, comm, sdkmath.OneInt())
 	require.NoError(err)
 	res, err := msgServer.CreateValidator(ctx, msg)
 	require.NoError(err)

--- a/x/staking/migrations/v5/migrations_test.go
+++ b/x/staking/migrations/v5/migrations_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	sdkmath "cosmossdk.io/math"
 	storetypes "cosmossdk.io/store/types"
 	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -87,7 +88,7 @@ func TestDelegationsByValidatorMigrations(t *testing.T) {
 	var addedDels []stakingtypes.Delegation
 
 	for i := 1; i < 11; i++ {
-		del1 := stakingtypes.NewDelegation(accAddrs[i], valAddrs[0], sdk.NewDec(100))
+		del1 := stakingtypes.NewDelegation(accAddrs[i], valAddrs[0], sdkmath.LegacyNewDec(100))
 		store.Set(stakingtypes.GetDelegationKey(accAddrs[i], valAddrs[0]), stakingtypes.MustMarshalDelegation(cdc, del1))
 		addedDels = append(addedDels, del1)
 	}


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

ref #14405

removes some unused aliases from math.go


---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] added `!` to the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules)
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] updated the relevant documentation or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] confirmed all author checklist items have been addressed 
* [ ] reviewed state machine logic
* [ ] reviewed API design and naming
* [ ] reviewed documentation is accurate
* [ ] reviewed tests and test coverage
* [ ] manually tested (if applicable)
