### PR TITLE
fix: rosetta bech32 err

### DIFF
--- a/tools/rosetta/config.go
+++ b/tools/rosetta/config.go
@@ -143,7 +143,7 @@ func (c *Config) validate() error {
 		return fmt.Errorf("cometbft rpc not provided")
 	}
 	if !strings.HasPrefix(c.TendermintRPC, "tcp://") {
-		c.TendermintRPC = fmt.Sprintf("tcp://%s", c.TendermintRPC)
+		fmt.Println("[Rosetta]- No 'tcp://' prefix for the tendermint rpc url.")
 	}
 
 	return nil

--- a/tools/rosetta/converter.go
+++ b/tools/rosetta/converter.go
@@ -3,6 +3,7 @@ package rosetta
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -344,7 +345,11 @@ func sdkEventToBalanceOperations(status string, event abci.Event) (operations []
 	default:
 		return nil, false
 	case banktypes.EventTypeCoinSpent:
-		spender := sdk.MustAccAddressFromBech32(event.Attributes[0].Value)
+		addr, err := base64.StdEncoding.DecodeString(event.Attributes[0].Value)
+		if err != nil {
+			panic(err)
+		}
+		spender := sdk.MustAccAddressFromBech32(string(addr))
 		coins, err := sdk.ParseCoinsNormalized(event.Attributes[1].Value)
 		if err != nil {
 			panic(err)


### PR DESCRIPTION


## Description

Closes: #XXXX

Fix the error for bech32 on rosetta standalone so it can correctly parse for addresses in transaction.
