### PR TITLE
chore: prepare v0.45.16 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,15 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 # Changelog
 
-## [Unreleased]
+Since **v0.45.15**, the v0.45.x line of the Cosmos SDK has reached end-of-life.
+Any release after **v0.45.15** is a security release that contains security fixes.
+It is strongly recommended to upgrade to these releases as well.
+
+## [v0.45.16](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.45.16) - 2023-05-11
+
+## Security Bug Fixes
+
+* (x/feegrant) [#16097](https://github.com/cosmos/cosmos-sdk/pull/16097) Fix infinite feegrant allowance bug.
 
 ## [v0.45.15](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.45.15) - 2023-03-22
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,21 +1,12 @@
-# Cosmos SDK v0.45.15 Release Notes
+# Cosmos SDK v0.45.16 Release Notes
 
-This release includes the migration to [CometBFT v0.34.27](https://github.com/cometbft/cometbft/blob/v0.34.27/CHANGELOG.md#v03427).
-This migration should be minimally breaking for chains.
-From `v0.45.15`+, the following replace is *mandatory* in the `go.mod` of your application:
+The Cosmos SDK v0.45.x line has reached end-of-life since v0.45.15. This is an exceptional security release according to our [release policy](https://github.com/cosmos/cosmos-sdk/blob/2262199/RELEASE_PROCESS.md#major-release-maintenance).
 
-```go
-// use cometbft
-replace github.com/tendermint/tendermint => github.com/cometbft/cometbft v0.34.27
-```
-
-Additionally, the SDK sets its minimum version to Go 1.19. This is not because the SDK uses new Go 1.19 functionalities, but to signal that we recommend chains to upgrade to Go 1.19 — Go 1.18 is not supported by the Go Team anymore.
-Note, that SDK recommends chains to use the same Go version across all of their network.
-We recommend, as well, chains to perform a **coordinated upgrade** when migrating from Go 1.18 to Go 1.19.
+It fixes an issue in the `x/feegrant` module on version <= v0.45.15. Cosmos SDK v0.46.x+ is not affected.
 
 Please see the [CHANGELOG](https://github.com/cosmos/cosmos-sdk/blob/release/v0.45.x/CHANGELOG.md) for an exhaustive list of changes.
 
-**Full Commit History**: https://github.com/cosmos/cosmos-sdk/compare/v0.45.14...v0.45.15
+**Full Commit History**: https://github.com/cosmos/cosmos-sdk/compare/v0.45.15...v0.45.16
 
 ## End-of-Life Notice
 
@@ -25,23 +16,3 @@ The SDK team maintains the two latest major versions of the SDK. This means no f
 We encourage all chains to upgrade to the latest release of the SDK, or the `v0.46.x` line.
 
 Refer to the [upgrading guide](https://github.com/cosmos/cosmos-sdk/blob/main/UPGRADING.md) for how to upgrade a chain to the latest release.
-
-## FAQ Migration to CometBFT v0.34.27
-
-### I use `tm-db` but I get an import error with `cometbft-db`
-
-For preventing API breaking changes, the SDK team has kept using `tm-db` for `v0.45.x` and `v0.46.x`.
-However, the CometBFT team kept using `cometbft-db` for their `v0.34.x` line.
-This means if your app directly interact with CometBFT (e.g. for a force pruning command), you will need to use `cometbft-db` there.
-When not interacting with CometBFT directly, you can use `tm-db` as usual.
-
-### I get import errors with `btcd`
-
-If you are using an old version of `btcd`, you will need to upgrade to the latest version.
-The previous versions had vulnerabilities so the SDK and CometBFT have upgraded to the latest version.
-In the latest version `btcsuite/btcd` and `btcsuite/btcd/btcec` are two separate go modules.
-
-### I encounter state sync issues
-
-Please ensure you have built the binary with the same Go version as the network.
-You can easily verify that by querying `/cosmos/base/tendermint/v1beta1/node_info` of a node in the network, and checking the `go_version` field.


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

Prepare v0.45.16 release notes

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] added `!` to the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules)
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] updated the relevant documentation or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] confirmed all author checklist items have been addressed 
* [ ] reviewed state machine logic
* [ ] reviewed API design and naming
* [ ] reviewed documentation is accurate
* [ ] reviewed tests and test coverage
* [ ] manually tested (if applicable)
