### PR TITLE
perf: Speedup Dec.Sqrt()

### DIFF
--- a/math/CHANGELOG.md
+++ b/math/CHANGELOG.md
@@ -43,6 +43,7 @@ Ref: https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.j
 ### Improvements
 
 * [#15768](https://github.com/cosmos/cosmos-sdk/pull/15768) Removed the second call to the `init` method for the global variable `grand`.
+* [#16141](https://github.com/cosmos/cosmos-sdk/pull/16141) Speedup `LegacyDec.ApproxRoot` and `LegacyDec.ApproxSqrt`.
 
 ## [math/v1.0.0](https://github.com/cosmos/cosmos-sdk/releases/tag/math/v1.0.0) - 2023-03-23
 

--- a/math/dec.go
+++ b/math/dec.go
@@ -220,6 +220,7 @@ func (d LegacyDec) LTE(d2 LegacyDec) bool      { return (d.i).Cmp(d2.i) <= 0 }  
 func (d LegacyDec) Neg() LegacyDec             { return LegacyDec{new(big.Int).Neg(d.i)} } // reverse the decimal sign
 func (d LegacyDec) NegMut() LegacyDec          { d.i.Neg(d.i); return d }                  // reverse the decimal sign, mutable
 func (d LegacyDec) Abs() LegacyDec             { return LegacyDec{new(big.Int).Abs(d.i)} } // absolute value
+func (d LegacyDec) AbsMut() LegacyDec          { d.i.Abs(d.i); return d }                  // absolute value, mutable
 func (d LegacyDec) Set(d2 LegacyDec) LegacyDec { d.i.Set(d2.i); return d }                 // set to existing dec value
 func (d LegacyDec) Clone() LegacyDec           { return LegacyDec{new(big.Int).Set(d.i)} } // clone new dec
 
@@ -442,20 +443,28 @@ func (d LegacyDec) ApproxRoot(root uint64) (guess LegacyDec, err error) {
 		return absRoot.NegMut(), err
 	}
 
-	if root == 1 || d.IsZero() || d.Equal(LegacyOneDec()) {
+	// One decimal, that we invalidate later. Helps us save a heap allocation.
+	scratchOneDec := LegacyOneDec()
+	if root == 1 || d.IsZero() || d.Equal(scratchOneDec) {
 		return d, nil
 	}
 
 	if root == 0 {
-		return LegacyOneDec(), nil
+		return scratchOneDec, nil
 	}
 
-	guess, delta := LegacyOneDec(), LegacyOneDec()
+	guess, delta := scratchOneDec, LegacyOneDec()
+	smallestDec := LegacySmallestDec()
 
-	for iter := 0; delta.Abs().GT(LegacySmallestDec()) && iter < maxApproxRootIterations; iter++ {
-		prev := guess.Power(root - 1)
+	for iter := 0; delta.AbsMut().GT(smallestDec) && iter < maxApproxRootIterations; iter++ {
+		// Set prev = guess^{root - 1}, with an optimization for sqrt
+		// where root=2 => prev = guess. (And thus no extra heap allocations)
+		prev := guess
+		if root != 2 {
+			prev = guess.Power(root - 1)
+		}
 		if prev.IsZero() {
-			prev = LegacySmallestDec()
+			prev = smallestDec
 		}
 		delta.Set(d).QuoMut(prev)
 		delta.SubMut(guess)

--- a/math/dec.go
+++ b/math/dec.go
@@ -468,7 +468,13 @@ func (d LegacyDec) ApproxRoot(root uint64) (guess LegacyDec, err error) {
 		}
 		delta.Set(d).QuoMut(prev)
 		delta.SubMut(guess)
-		delta.QuoInt64Mut(int64(root))
+		// delta = delta / root.
+		// We optimize for sqrt, where root=2 => delta = delta >> 1
+		if root == 2 {
+			delta.i.Rsh(delta.i, 1)
+		} else {
+			delta.QuoInt64Mut(int64(root))
+		}
 
 		guess.AddMut(delta)
 	}

--- a/math/dec_test.go
+++ b/math/dec_test.go
@@ -655,7 +655,7 @@ func BenchmarkLegacyQuoTruncateMut(b *testing.B) {
 	sink = (interface{})(nil)
 }
 
-func BenchmarkLegacySqrt(b *testing.B) {
+func BenchmarkLegacySqrtOnMersennePrime(b *testing.B) {
 	b1 := math.LegacyNewDec(2).Power(127).Sub(math.LegacyOneDec())
 	b.ReportAllocs()
 	b.ResetTimer()

--- a/math/dec_test.go
+++ b/math/dec_test.go
@@ -453,12 +453,16 @@ func (s *decimalTestSuite) TestApproxSqrt() {
 		input    math.LegacyDec
 		expected math.LegacyDec
 	}{
-		{math.LegacyOneDec(), math.LegacyOneDec()},                                                     // 1.0 => 1.0
-		{math.LegacyNewDecWithPrec(25, 2), math.LegacyNewDecWithPrec(5, 1)},                            // 0.25 => 0.5
-		{math.LegacyNewDecWithPrec(4, 2), math.LegacyNewDecWithPrec(2, 1)},                             // 0.09 => 0.3
-		{math.LegacyNewDecFromInt(math.NewInt(9)), math.LegacyNewDecFromInt(math.NewInt(3))},           // 9 => 3
-		{math.LegacyNewDecFromInt(math.NewInt(-9)), math.LegacyNewDecFromInt(math.NewInt(-3))},         // -9 => -3
-		{math.LegacyNewDecFromInt(math.NewInt(2)), math.LegacyNewDecWithPrec(1414213562373095049, 18)}, // 2 => 1.414213562373095049
+		{math.LegacyOneDec(), math.LegacyOneDec()},                                 // 1.0 => 1.0
+		{math.LegacyNewDecWithPrec(25, 2), math.LegacyNewDecWithPrec(5, 1)},        // 0.25 => 0.5
+		{math.LegacyNewDecWithPrec(4, 2), math.LegacyNewDecWithPrec(2, 1)},         // 0.09 => 0.3
+		{math.LegacyNewDec(9), math.LegacyNewDecFromInt(math.NewInt(3))},           // 9 => 3
+		{math.LegacyNewDec(-9), math.LegacyNewDecFromInt(math.NewInt(-3))},         // -9 => -3
+		{math.LegacyNewDec(2), math.LegacyNewDecWithPrec(1414213562373095049, 18)}, // 2 => 1.414213562373095049
+		{ // 2^127 - 1 => 13043817825332782212.3495718062525083688 which rounds to 13043817825332782212.3495718062525083689
+			math.LegacyNewDec(2).Power(127).Sub(math.LegacyOneDec()),
+			math.LegacyMustNewDecFromStr("13043817825332782212.349571806252508369"),
+		},
 	}
 
 	for i, tc := range testCases {
@@ -643,6 +647,20 @@ func BenchmarkLegacyQuoTruncateMut(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		sink = b1.QuoTruncateMut(b2)
+	}
+
+	if sink == nil {
+		b.Fatal("Benchmark did not run")
+	}
+	sink = (interface{})(nil)
+}
+
+func BenchmarkLegacySqrt(b *testing.B) {
+	b1 := math.LegacyNewDec(2).Power(127).Sub(math.LegacyOneDec())
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		sink, _ = b1.ApproxSqrt()
 	}
 
 	if sink == nil {


### PR DESCRIPTION
## Description

Speeds up the Dec.Sqrt() routine which is in a hot loop for Osmosis AMM code.

This is done by lowering heap allocations, through better use of constant re-use, or mutative methods.

Old:
```
BenchmarkLegacySqrtOnMersennePrime-16               23086             51408 ns/op           26730 B/op	     726 allocs/op
```
New:
```
BenchmarkLegacySqrtOnMersennePrime-16    	   39177	     28938 ns/op	   11864 B/op	     214 allocs/op
```

More important than the pure raw time, is the number of allocations, as those induce system overheads in Garbage Collection at scale, that don't get represented in the micro-bench here.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [x] added `!` to the type prefix if API or client breaking change
* [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [x] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules)
* [x] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [x] added a changelog entry to `CHANGELOG.md`
* [x] included comments for [documenting Go code](https://blog.golang.org/godoc)
* [x] updated the relevant documentation or specification
* [x] reviewed "Files changed" and left comments if necessary
* [x] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] confirmed all author checklist items have been addressed 
* [ ] reviewed state machine logic
* [ ] reviewed API design and naming
* [ ] reviewed documentation is accurate
* [ ] reviewed tests and test coverage
* [ ] manually tested (if applicable)
