### PR TITLE
refactor: More cleanup of server/start.go

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (store) [#16067](https://github.com/cosmos/cosmos-sdk/pull/16067) Add local snapshots management commands.
 * (server) [#16142](https://github.com/cosmos/cosmos-sdk/pull/16142) Remove JSON Indentation from the GRPC to REST gateway's responses. (Saving bandwidth)
 * (baseapp) [#16193](https://github.com/cosmos/cosmos-sdk/pull/16193) Add `Close` method to `BaseApp` for custom app to cleanup resource in graceful shutdown.
+* (server) [#16238](https://github.com/cosmos/cosmos-sdk/pull/16238) Don't setup p2p node keys if starting a node in GRPC only mode.
 
 ### State Machine Breaking
 

--- a/server/start.go
+++ b/server/start.go
@@ -354,18 +354,19 @@ func startInProcess(svrCtx *Context, svrCfg serverconfig.Config, clientCtx clien
 }
 
 func startApp(svrCtx *Context, appCreator types.AppCreator, opts StartCmdOptions) (app types.Application, cleanupFn func(), err error) {
-	traceWriter, cleanupFn, err := setupTraceWriter(svrCtx)
+	traceWriter, traceCleanupFn, err := setupTraceWriter(svrCtx)
 	if err != nil {
-		return app, cleanupFn, err
+		return app, traceCleanupFn, err
 	}
 
 	home := svrCtx.Config.RootDir
 	db, err := opts.DBOpener(home, GetAppDBBackend(svrCtx.Viper))
 	if err != nil {
-		return app, cleanupFn, err
+		return app, traceCleanupFn, err
 	}
 
 	app = appCreator(svrCtx.Logger, db, traceWriter, svrCtx.Viper)
+	cleanupFn = func() { traceCleanupFn(); app.Close() }
 	return app, cleanupFn, nil
 }
 

--- a/server/start.go
+++ b/server/start.go
@@ -235,10 +235,10 @@ func startStandAlone(svrCtx *Context, appCreator types.AppCreator, opts StartCmd
 	transport := svrCtx.Viper.GetString(flagTransport)
 
 	app, appCleanupFn, err := startApp(svrCtx, appCreator, opts)
+	defer appCleanupFn()
 	if err != nil {
 		return err
 	}
-	defer appCleanupFn()
 
 	svrCfg, err := getAndValidateConfig(svrCtx)
 	if err != nil {
@@ -388,13 +388,13 @@ func startInProcess(svrCtx *Context, clientCtx client.Context, appCreator types.
 func startApp(svrCtx *Context, appCreator types.AppCreator, opts StartCmdOptions) (app types.Application, cleanupFn func(), err error) {
 	traceWriter, traceWriterCleanup, err := setupTraceWriter(svrCtx)
 	if err != nil {
-		return app, cleanupFn, err
+		return app, traceWriterCleanup, err
 	}
 
 	home := svrCtx.Config.RootDir
 	db, err := opts.DBOpener(home, GetAppDBBackend(svrCtx.Viper))
 	if err != nil {
-		return app, cleanupFn, err
+		return app, traceWriterCleanup, err
 	}
 
 	app = appCreator(svrCtx.Logger, db, traceWriter, svrCtx.Viper)

--- a/server/start.go
+++ b/server/start.go
@@ -282,7 +282,8 @@ func startStandAlone(svrCtx *Context, app types.Application, opts StartCmdOption
 }
 
 func startInProcess(svrCtx *Context, svrCfg serverconfig.Config, clientCtx client.Context, app types.Application,
-	metrics *telemetry.Metrics, opts StartCmdOptions) error {
+	metrics *telemetry.Metrics, opts StartCmdOptions,
+) error {
 	cmtCfg := svrCtx.Config
 	home := cmtCfg.RootDir
 

--- a/server/start.go
+++ b/server/start.go
@@ -235,10 +235,10 @@ func startStandAlone(svrCtx *Context, appCreator types.AppCreator, opts StartCmd
 	transport := svrCtx.Viper.GetString(flagTransport)
 
 	app, appCleanupFn, err := startApp(svrCtx, appCreator, opts)
-	defer appCleanupFn()
 	if err != nil {
 		return err
 	}
+	defer appCleanupFn()
 
 	svrCfg, err := getAndValidateConfig(svrCtx)
 	if err != nil {
@@ -386,19 +386,19 @@ func startInProcess(svrCtx *Context, clientCtx client.Context, appCreator types.
 }
 
 func startApp(svrCtx *Context, appCreator types.AppCreator, opts StartCmdOptions) (app types.Application, cleanupFn func(), err error) {
-	traceWriter, traceWriterCleanup, err := setupTraceWriter(svrCtx)
+	traceWriter, cleanupFn, err := setupTraceWriter(svrCtx)
 	if err != nil {
-		return app, traceWriterCleanup, err
+		return app, cleanupFn, err
 	}
 
 	home := svrCtx.Config.RootDir
 	db, err := opts.DBOpener(home, GetAppDBBackend(svrCtx.Viper))
 	if err != nil {
-		return app, traceWriterCleanup, err
+		return app, cleanupFn, err
 	}
 
 	app = appCreator(svrCtx.Logger, db, traceWriter, svrCtx.Viper)
-	return app, traceWriterCleanup, nil
+	return app, cleanupFn, nil
 }
 
 func startCmtNode(cfg *cmtcfg.Config, app types.Application, svrCtx *Context) (tmNode *node.Node, err error) {

--- a/server/start.go
+++ b/server/start.go
@@ -366,7 +366,12 @@ func startApp(svrCtx *Context, appCreator types.AppCreator, opts StartCmdOptions
 	}
 
 	app = appCreator(svrCtx.Logger, db, traceWriter, svrCtx.Viper)
-	cleanupFn = func() { traceCleanupFn(); app.Close() }
+	cleanupFn = func() {
+		traceCleanupFn()
+		if localErr := app.Close(); localErr != nil {
+			svrCtx.Logger.Error(localErr.Error())
+		}
+	}
 	return app, cleanupFn, nil
 }
 

--- a/server/types/app.go
+++ b/server/types/app.go
@@ -60,6 +60,7 @@ type (
 		SnapshotManager() *snapshots.Manager
 
 		// Close is called in start cmd to gracefully cleanup resources.
+		// Must be safe to be called multiple times.
 		Close() error
 	}
 


### PR DESCRIPTION
## Description

Address some TODO's I left in server/start.go from #15041 

This PR has five changes, beyond some line count / complexity reduction. Namely:
- Get and validate config before doing any store work
- Start the trace server before opening the database
- Actually close the trace server 
- Don't create a p2p node key when you are in grpc only mode
- Extract common starting logic between startStandAlone and startInProcess

These weren't done in #15041 in order for that PR to be changing no functionality.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [x] added `!` to the type prefix if API or client breaking change
* [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [x] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules)
* [x] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [x] added a changelog entry to `CHANGELOG.md`
* [x] included comments for [documenting Go code](https://blog.golang.org/godoc)
* [x] updated the relevant documentation or specification
* [x] reviewed "Files changed" and left comments if necessary
* [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] confirmed all author checklist items have been addressed 
* [ ] reviewed state machine logic
* [ ] reviewed API design and naming
* [ ] reviewed documentation is accurate
* [ ] reviewed tests and test coverage
* [ ] manually tested (if applicable)
