### PR TITLE
feat!: connect app version with consensus params in end block

### DIFF
--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -1,6 +1,7 @@
 package baseapp
 
 import (
+	"context"
 	"crypto/sha256"
 	"errors"
 	"fmt"
@@ -135,7 +136,7 @@ func (app *BaseApp) Info(req abci.RequestInfo) abci.ResponseInfo {
 	return abci.ResponseInfo{
 		Data:             app.name,
 		Version:          app.version,
-		AppVersion:       app.appVersion,
+		AppVersion:       app.AppVersion(context.Background()),
 		LastBlockHeight:  lastCommitID.Version,
 		LastBlockAppHash: lastCommitID.Hash,
 	}

--- a/baseapp/abci_test.go
+++ b/baseapp/abci_test.go
@@ -2,6 +2,7 @@ package baseapp_test
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -41,7 +42,7 @@ func TestABCI_Info(t *testing.T) {
 	require.Equal(t, t.Name(), res.GetData())
 	require.Equal(t, int64(0), res.LastBlockHeight)
 	require.Equal(t, []uint8(nil), res.LastBlockAppHash)
-	require.Equal(t, suite.baseApp.AppVersion(), res.AppVersion)
+	require.Equal(t, suite.baseApp.AppVersion(context.Background()), res.AppVersion)
 }
 
 func TestABCI_InitChain(t *testing.T) {

--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -1,6 +1,7 @@
 package baseapp
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"strconv"
@@ -126,10 +127,6 @@ type BaseApp struct {
 	// application's version string
 	version string
 
-	// application's protocol version that increments on every upgrade
-	// if BaseApp is passed to the upgrade keeper's NewKeeper method.
-	appVersion uint64
-
 	// recovery handler for app.runTx method
 	runTxRecoveryMiddleware recoveryMiddleware
 
@@ -199,8 +196,19 @@ func (app *BaseApp) Name() string {
 }
 
 // AppVersion returns the application's protocol version.
-func (app *BaseApp) AppVersion() uint64 {
-	return app.appVersion
+func (app *BaseApp) AppVersion(ctx context.Context) uint64 {
+	if app.paramStore == nil {
+		return 0
+	}
+
+	cp, err := app.paramStore.Get(ctx)
+	if err != nil {
+		panic(err)
+	}
+	if cp.Version == nil {
+		return 0
+	}
+	return cp.Version.App
 }
 
 // Version returns the application's version string.

--- a/baseapp/options.go
+++ b/baseapp/options.go
@@ -1,6 +1,8 @@
 package baseapp
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"io"
 
@@ -122,9 +124,22 @@ func (app *BaseApp) SetVersion(v string) {
 	app.version = v
 }
 
-// SetProtocolVersion sets the application's protocol version
-func (app *BaseApp) SetProtocolVersion(v uint64) {
-	app.appVersion = v
+// SetAppVersion sets the application's version this is used as part of the
+// header in blocks and is returned to the consensus engine in EndBlock.
+func (app *BaseApp) SetAppVersion(ctx context.Context, v uint64) error {
+	if app.paramStore == nil {
+		return errors.New("param store must be set to set app version")
+	}
+
+	cp, err := app.paramStore.Get(ctx)
+	if err != nil {
+		return err
+	}
+	cp.Version.App = v
+	if err := app.paramStore.Set(ctx, cp); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (app *BaseApp) SetDB(db dbm.DB) {

--- a/simapp/app_test.go
+++ b/simapp/app_test.go
@@ -269,8 +269,6 @@ func TestUpgradeStateOnGenesis(t *testing.T) {
 			require.Equal(t, vm[v], i.ConsensusVersion())
 		}
 	}
-
-	require.NotNil(t, app.UpgradeKeeper.GetVersionSetter())
 }
 
 // TestMergedRegistry tests that fetching the gogo/protov2 merged registry

--- a/x/upgrade/abci_test.go
+++ b/x/upgrade/abci_test.go
@@ -53,8 +53,7 @@ func setupTest(t *testing.T, height int64, skip map[int64]bool) *TestSuite {
 		s.encCfg.TxConfig.TxDecoder(),
 	)
 
-	s.keeper = keeper.NewKeeper(skip, key, s.encCfg.Codec, t.TempDir(), nil, authtypes.NewModuleAddress(govtypes.ModuleName).String())
-	s.keeper.SetVersionSetter(s.baseApp)
+	s.keeper = keeper.NewKeeper(skip, key, s.encCfg.Codec, t.TempDir(), s.baseApp, authtypes.NewModuleAddress(govtypes.ModuleName).String())
 
 	s.ctx = testCtx.Ctx.WithBlockHeader(cmtproto.Header{Time: time.Now(), Height: height})
 

--- a/x/upgrade/exported/exported.go
+++ b/x/upgrade/exported/exported.go
@@ -1,7 +1,12 @@
 package exported
 
-// ProtocolVersionSetter defines the interface fulfilled by BaseApp
-// which allows setting it's appVersion field.
-type ProtocolVersionSetter interface {
-	SetProtocolVersion(uint64)
+import "context"
+
+// AppVersionModifier defines the interface fulfilled by BaseApp
+// which allows getting and setting it's appVersion field. This
+// in turn updates the consensus params that are sent to the
+// consensus engine in EndBlock
+type AppVersionModifier interface {
+	SetAppVersion(context.Context, uint64) error
+	AppVersion(context.Context) uint64
 }

--- a/x/upgrade/types/keys.go
+++ b/x/upgrade/types/keys.go
@@ -23,8 +23,7 @@ const (
 	// VersionMapByte is a prefix to look up module names (key) and versions (value)
 	VersionMapByte = 0x2
 
-	// ProtocolVersionByte is a prefix to look up Protocol Version
-	ProtocolVersionByte = 0x3
+	// 0x3 is reserved. It was previously used to set and get the app version
 
 	// KeyUpgradedIBCState is the key under which upgraded ibc state is stored in the upgrade store
 	KeyUpgradedIBCState = "upgradedIBCState"


### PR DESCRIPTION
## Description

Closes: #16243

This PR wires up the upgrade module to the app version delivered through the `ConsensusParams` in `EndBlock` (thus removing the previous `appVersion` field in BaseApp). `x/upgrade` no longer keeps its own copy of the app version but uses the baseapp's canonical app version

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] added `!` to the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules)
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] updated the relevant documentation or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] confirmed all author checklist items have been addressed 
* [ ] reviewed state machine logic
* [ ] reviewed API design and naming
* [ ] reviewed documentation is accurate
* [ ] reviewed tests and test coverage
* [ ] manually tested (if applicable)
