### PR TITLE
feat: x/tx/signing/aminojson: Marshal sort fields

### DIFF
--- a/tests/integration/aminojson/aminojson_test.go
+++ b/tests/integration/aminojson/aminojson_test.go
@@ -99,7 +99,7 @@ func TestAminoJSON_Equivalence(t *testing.T) {
 		gov.AppModuleBasic{}, groupmodule.AppModuleBasic{}, mint.AppModuleBasic{}, params.AppModuleBasic{},
 		slashing.AppModuleBasic{}, staking.AppModuleBasic{}, upgrade.AppModuleBasic{}, vesting.AppModuleBasic{})
 	legacytx.RegressionTestingAminoCodec = encCfg.Amino
-	aj := aminojson.NewEncoder(aminojson.EncoderOptions{})
+	aj := aminojson.NewEncoder(aminojson.EncoderOptions{DoNotSortFields: true})
 
 	for _, tt := range rapidgen.DefaultGeneratedTypes {
 		desc := tt.Pulsar.ProtoReflect().Descriptor()
@@ -209,7 +209,7 @@ func TestAminoJSON_LegacyParity(t *testing.T) {
 		vesting.AppModuleBasic{}, gov.AppModuleBasic{})
 	legacytx.RegressionTestingAminoCodec = encCfg.Amino
 
-	aj := aminojson.NewEncoder(aminojson.EncoderOptions{})
+	aj := aminojson.NewEncoder(aminojson.EncoderOptions{DoNotSortFields: true})
 	addr1 := types.AccAddress("addr1")
 	now := time.Now()
 

--- a/tests/integration/aminojson/repeated_test.go
+++ b/tests/integration/aminojson/repeated_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestRepeatedFields(t *testing.T) {
 	cdc := codec.NewLegacyAmino()
-	aj := aminojson.NewEncoder(aminojson.EncoderOptions{})
+	aj := aminojson.NewEncoder(aminojson.EncoderOptions{DoNotSortFields: true})
 
 	cases := map[string]struct {
 		gogo    gogoproto.Message

--- a/x/tx/CHANGELOG.md
+++ b/x/tx/CHANGELOG.md
@@ -37,6 +37,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 * [#16044](https://github.com/cosmos/cosmos-sdk/pull/16044): rename aminojson.NewAminoJSON -> aminojson.NewEncoder
 * [#16047](https://github.com/cosmos/cosmos-sdk/pull/16047): aminojson.NewEncoder now takes EncoderOptions as an argument.
+* [#16254](https://github.com/cosmos/cosmos-sdk/pull/16254): aminojson.Encoder.Marshal now sorts all fields like encoding/json.Marshal does, hence no more need for sdk.\*SortJSON.
 
 ## v0.6.2
 

--- a/x/tx/signing/aminojson/bench_test.go
+++ b/x/tx/signing/aminojson/bench_test.go
@@ -1,0 +1,66 @@
+package aminojson_test
+
+import (
+	"testing"
+
+	"cosmossdk.io/x/tx/signing/aminojson"
+	"cosmossdk.io/x/tx/signing/aminojson/internal/testpb"
+)
+
+var sink any
+
+var msg = &testpb.ABitOfEverything{
+	Message: &testpb.NestedMessage{
+		Foo: "test",
+		Bar: 0, // this is the default value and should be omitted from output
+	},
+	Enum:     testpb.AnEnum_ONE,
+	Repeated: []int32{3, -7, 2, 6, 4},
+	Str:      `abcxyz"foo"def`,
+	Bool:     true,
+	Bytes:    []byte{0, 1, 2, 3},
+	I32:      -15,
+	F32:      1001,
+	U32:      1200,
+	Si32:     -376,
+	Sf32:     -1000,
+	I64:      14578294827584932,
+	F64:      9572348124213523654,
+	U64:      4759492485,
+	Si64:     -59268425823934,
+	Sf64:     -659101379604211154,
+}
+
+func BenchmarkAminoJSONNaiveSort(b *testing.B) {
+	benchmarkAminoJSON(b, true)
+}
+
+func BenchmarkAminoJSONDefaultSort(b *testing.B) {
+	benchmarkAminoJSON(b, false)
+}
+
+func benchmarkAminoJSON(b *testing.B, addNaiveSort bool) {
+	enc := aminojson.NewEncoder(aminojson.EncoderOptions{DoNotSortFields: addNaiveSort})
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		sink = runAminoJSON(b, enc, addNaiveSort)
+	}
+	if sink == nil {
+		b.Fatal("Benchmark was not run")
+	}
+	sink = nil
+}
+
+func runAminoJSON(b *testing.B, enc aminojson.Encoder, addNaiveSort bool) []byte {
+	bz, err := enc.Marshal(msg)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	if addNaiveSort {
+		return naiveSortedJSON(b, bz)
+	}
+	return bz
+}


### PR DESCRIPTION
This change gives (aminojson.Encoder).Marshal the ability to sort field names before marshalling, mimicking the outward behavior of encoding/json.Marshal and thus eliminating a long prior roundtrip that required sdk.*SortJSON which would take the produced JSON and encoding/json.Unmarshal it to an interface firstly, then encoding/json.Marshal it out to get the field names sorted. While here, this change adds an opt-out field to aminojson.EncoderOptions called "DoNotSortFields", in case one wants to preserve legacy behavior for compatibility checks/reasons.

The performance benchmarks from before and after reveal improvements

```shell
$ benchstat before.txt after.txt
name         old time/op    new time/op    delta
AminoJSON-8    76.4µs ± 1%    61.7µs ± 2%  -19.28%  (p=0.000 n=9+10)

name         old alloc/op   new alloc/op   delta
AminoJSON-8    15.0kB ± 0%     9.4kB ± 0%  -37.28%  (p=0.000 n=10+10)

name         old allocs/op  new allocs/op  delta
AminoJSON-8       332 ± 0%       234 ± 0%  -29.52%  (p=0.000 n=10+10)
```

Fixes #2350