### PR TITLE
chore: set circuitbreaker in app.go as example

### DIFF
--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -491,6 +491,9 @@ func (app *BaseApp) GetFinalizeBlockStateCtx() sdk.Context {
 // SetCircuitBreaker sets the circuit breaker for the BaseApp.
 // The circuit breaker is checked on every message execution to verify if a transaction should be executed or not.
 func (app *BaseApp) SetCircuitBreaker(cb CircuitBreaker) {
+	if app.msgServiceRouter == nil {
+		panic("cannot set circuit breaker with no msg service router set")
+	}
 	app.msgServiceRouter.SetCircuit(cb)
 }
 

--- a/simapp/app.go
+++ b/simapp/app.go
@@ -302,6 +302,7 @@ func NewSimApp(
 	)
 
 	app.CircuitKeeper = circuitkeeper.NewKeeper(keys[circuittypes.StoreKey], authtypes.NewModuleAddress(govtypes.ModuleName).String(), app.AccountKeeper.AddressCodec())
+	app.BaseApp.SetCircuitBreaker(&app.CircuitKeeper)
 
 	app.AuthzKeeper = authzkeeper.NewKeeper(runtime.NewKVStoreService(keys[authzkeeper.StoreKey]), appCodec, app.MsgServiceRouter(), app.AccountKeeper)
 

--- a/x/circuit/module.go
+++ b/x/circuit/module.go
@@ -13,9 +13,11 @@ import (
 	store "cosmossdk.io/store/types"
 	"cosmossdk.io/x/circuit/client/cli"
 	abci "github.com/cometbft/cometbft/abci/types"
+	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/codec"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	"github.com/cosmos/cosmos-sdk/runtime"
 	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
@@ -162,8 +164,9 @@ type Inputs struct {
 type Outputs struct {
 	depinject.Out
 
-	CircuitKeeper keeper.Keeper
-	Module        appmodule.AppModule
+	CircuitKeeper  keeper.Keeper
+	Module         appmodule.AppModule
+	baseappOptions runtime.BaseAppOption
 }
 
 func ProvideModule(in Inputs) Outputs {
@@ -180,5 +183,9 @@ func ProvideModule(in Inputs) Outputs {
 	)
 	m := NewAppModule(in.Cdc, circuitkeeper)
 
-	return Outputs{CircuitKeeper: circuitkeeper, Module: m}
+	baseappOpt := func(app *baseapp.BaseApp) {
+		app.SetCircuitBreaker(&circuitkeeper)
+	}
+
+	return Outputs{CircuitKeeper: circuitkeeper, Module: m, baseappOptions: baseappOpt}
 }

--- a/x/circuit/module.go
+++ b/x/circuit/module.go
@@ -151,7 +151,7 @@ func init() {
 	)
 }
 
-type Inputs struct {
+type ModuleInputs struct {
 	depinject.In
 
 	Config *modulev1.Module
@@ -161,15 +161,15 @@ type Inputs struct {
 	AddressCodec address.Codec
 }
 
-type Outputs struct {
+type ModuleOutputs struct {
 	depinject.Out
 
 	CircuitKeeper  keeper.Keeper
 	Module         appmodule.AppModule
-	baseappOptions runtime.BaseAppOption
+	BaseappOptions runtime.BaseAppOption
 }
 
-func ProvideModule(in Inputs) Outputs {
+func ProvideModule(in ModuleInputs) ModuleOutputs {
 	// default to governance authority if not provided
 	authority := authtypes.NewModuleAddress("gov")
 	if in.Config.Authority != "" {
@@ -187,5 +187,5 @@ func ProvideModule(in Inputs) Outputs {
 		app.SetCircuitBreaker(&circuitkeeper)
 	}
 
-	return Outputs{CircuitKeeper: circuitkeeper, Module: m, baseappOptions: baseappOpt}
+	return ModuleOutputs{CircuitKeeper: circuitkeeper, Module: m, BaseappOptions: baseappOpt}
 }


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

set the circuit breaker in app.go as an example of how to set it

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] added `!` to the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules)
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] updated the relevant documentation or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] confirmed all author checklist items have been addressed 
* [ ] reviewed state machine logic
* [ ] reviewed API design and naming
* [ ] reviewed documentation is accurate
* [ ] reviewed tests and test coverage
* [ ] manually tested (if applicable)
