### PR TITLE
refactor: ADR - Move Rosetta to standalone repository

### DIFF
--- a/docs/architecture/adr-066-rosetta-standalone.md
+++ b/docs/architecture/adr-066-rosetta-standalone.md
@@ -1,0 +1,67 @@
+# ADR 606: Rosetta standalone
+
+## Changelog
+
+* May 31, 2023: Initial draft (@Bizk)
+
+## Status
+
+DRAFT
+
+## Abstract
+
+Rosetta implementation runs on top of Cosmos SDK. The tool should rely on stable cosmos-sdk.
+releases and not experimental features in order to ensure usability and stability.
+Having the tool inside the main cosmos-sdk repo may cause unrequired updates, and make the
+tool maintenance more complicated.
+
+## Context
+
+In the current context; Rosetta is inside cosmos-sdk project due to easier maintainability.
+This is a problem because as seen in some previous commits, it has suffered unrequired changes
+like updates due to a refactor or a new experimental feature. Causing issues like missmatch
+dependencies or unexpected behaviour that needs to be addressed down the line.
+
+Since Rosetta is a standalone tool that has been implemented using Cosmos-sdk, it should only
+rely on top of the latest releases, instead of being affected by experimental features or
+interfeering over the cosmos-sdk development.
+
+Decoupling Rosetta from the cosmos-sdk project is no only a good practice since it keeps the
+scope well defined, but also it ensures better maintainability over time.
+
+## Alternatives
+
+The 2 altnernatives are:
+- **Keep the Project inside Cosmos-sdk**: This might be easier to handle from a fully immersed position.
+  maintainer's point of view, who works on different aspects of cosmos-sdk and might want to try
+  features into Rosetta.
+- **Move the project into another repo**: This approach intends to keep the scope well defined,
+  and to ensure maintainability and stability over time.
+
+## Decision
+
+We will move Rosetta into a standalone repo in order to keep the Scope well defined, a stable
+versioning, and to ensure an easier and cleaner maintainability.
+
+We will also add and keep track of quality standards as tests and following cosmos-sdk releases.
+
+## Consequences
+
+The consequence will be a new repo that contains the rosetta tool implemented by cosmos.
+
+### Positive
+
+- Better scope.
+- Easier miantainability and testing.
+- Avoids unrequired changes.
+- Easier to fork / contribute.
+
+### Negative
+
+- Adds one more repo to keep track of.
+- More dificult to test experimental features from cosmos-sdk
+
+## Further Discussions
+
+- [Discussion on migrating Rosetta into a standalone repo](https://github.com/cosmos/cosmos-sdk/issues/16276)
+- [Zondax plugin implementation Test](https://github.com/Zondax/cosmos-sdk/pull/653)

--- a/docs/architecture/adr-066-rosetta-standalone.md
+++ b/docs/architecture/adr-066-rosetta-standalone.md
@@ -19,20 +19,20 @@ tool maintenance more complicated.
 
 In the current context; Rosetta is inside cosmos-sdk project due to easier maintainability.
 This is a problem because as seen in some previous commits, it has suffered unrequired changes
-like updates due to a refactor or a new experimental feature. Causing issues like missmatch
-dependencies or unexpected behaviour that needs to be addressed down the line.
+like updates due to a refactor or a new experimental feature. Such changes can cause mismatches 
+in dependencies, or unexpected behaviour that needs to be addressed down the line.
 
-Since Rosetta is a standalone tool that has been implemented using Cosmos-sdk, it should only
-rely on top of the latest releases, instead of being affected by experimental features or
+Since Rosetta is a standalone tool that has been implemented using Cosmos-sdk, it should 
+rely only on each release, instead of being affected by experimental features or
 interfeering over the cosmos-sdk development.
 
-Decoupling Rosetta from the cosmos-sdk project is no only a good practice since it keeps the
+Decoupling Rosetta from the cosmos-sdk project is not only a good practice since it keeps the
 scope well defined, but also it ensures better maintainability over time.
 
 ## Alternatives
 
 The 2 altnernatives are:
-- **Keep the Project inside Cosmos-sdk**: This might be easier to handle from a fully immersed position.
+- **Keep Project inside Cosmos-sdk**: This might be easier to handle from a fully immersed position.
   maintainer's point of view, who works on different aspects of cosmos-sdk and might want to try
   features into Rosetta.
 - **Move the project into another repo**: This approach intends to keep the scope well defined,
@@ -43,7 +43,7 @@ The 2 altnernatives are:
 We will move Rosetta into a standalone repo in order to keep the Scope well defined, a stable
 versioning, and to ensure an easier and cleaner maintainability.
 
-We will also add and keep track of quality standards as tests and following cosmos-sdk releases.
+We will also add and keep track of quality standards as tests and follow cosmos-sdk releases.
 
 ## Consequences
 


### PR DESCRIPTION
## Description

Closes: #16276

[Epic and Discussion](https://github.com/cosmos/cosmos-sdk/issues/16276)

The goal is to move Rosetta tool under `cosmos-sdk/tools/` folder to a separated repo, in order to have a better scope, a cleaner way to maintain the code and manage all Rosetta efforts.

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [*] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [*] added `!` to the type prefix if API or client breaking change
* [*] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [/] provided a link to the relevant issue or specification
* [*] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules)
* [/] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [*] included comments for [documenting Go code](https://blog.golang.org/godoc)
* [*] updated the relevant documentation or specification
* [*] reviewed "Files changed" and left comments if necessary
* [*] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] confirmed all author checklist items have been addressed 
* [ ] reviewed state machine logic
* [ ] reviewed API design and naming
* [ ] reviewed documentation is accurate
* [ ] reviewed tests and test coverage
* [ ] manually tested (if applicable)
