### PR TITLE
chore: finish TODO of removing defunct sortJSON

### DIFF
--- a/codec/proto_codec.go
+++ b/codec/proto_codec.go
@@ -2,7 +2,6 @@ package codec
 
 import (
 	"encoding/binary"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -194,27 +193,7 @@ func (pc *ProtoCodec) MarshalAminoJSON(msg gogoproto.Message) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	jsonBytes, err := encoder.Marshal(protoMsg)
-	if err != nil {
-		return nil, err
-	}
-	// TODO: remove this sort once https://github.com/cosmos/cosmos-sdk/issues/2350#issuecomment-1542715157 lands
-	// the encoder should be rendering in lexical order
-	return sortJSON(jsonBytes)
-}
-
-// sortJSON sorts the JSON keys of the given JSON encoded byte slice.
-func sortJSON(toSortJSON []byte) ([]byte, error) {
-	var c interface{}
-	err := json.Unmarshal(toSortJSON, &c)
-	if err != nil {
-		return nil, err
-	}
-	js, err := json.Marshal(c)
-	if err != nil {
-		return nil, err
-	}
-	return js, nil
+	return encoder.Marshal(protoMsg)
 }
 
 // UnmarshalJSON implements JSONCodec.UnmarshalJSON method,

--- a/x/tx/signing/aminojson/aminojson.go
+++ b/x/tx/signing/aminojson/aminojson.go
@@ -2,7 +2,6 @@ package aminojson
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	"google.golang.org/protobuf/reflect/protoregistry"
@@ -111,27 +110,7 @@ func (h SignModeHandler) GetSignBytes(_ context.Context, signerData signing.Sign
 		Tip:           tip,
 	}
 
-	bz, err := h.encoder.Marshal(signDoc)
-	if err != nil {
-		return nil, err
-	}
-	// TODO: remove this sort once https://github.com/cosmos/cosmos-sdk/issues/2350#issuecomment-1542715157 lands
-	// the encoder should be rendering fields in lexical order
-	return sortJSON(bz)
-}
-
-// sortJSON sorts the JSON keys of the given JSON encoded byte slice.
-func sortJSON(toSortJSON []byte) ([]byte, error) {
-	var c interface{}
-	err := json.Unmarshal(toSortJSON, &c)
-	if err != nil {
-		return nil, err
-	}
-	js, err := json.Marshal(c)
-	if err != nil {
-		return nil, err
-	}
-	return js, nil
+	return h.encoder.Marshal(signDoc)
 }
 
 var _ signing.SignModeHandler = (*SignModeHandler)(nil)


### PR DESCRIPTION
Completes PR #16062 by removing sortJSON now that aminojson.Encoder sorts fields by default. sortJSON was left as a TODO

Updates #2350
Updates #16254