### PR TITLE
refactor: CircuitBreaker IsAllowed now uses context.Context and returns error

### DIFF
--- a/baseapp/circuit.go
+++ b/baseapp/circuit.go
@@ -1,10 +1,8 @@
 package baseapp
 
-import (
-	sdk "github.com/cosmos/cosmos-sdk/types"
-)
+import "context"
 
 // CircuitBreaker is an interface that defines the methods for a circuit breaker.
 type CircuitBreaker interface {
-	IsAllowed(ctx sdk.Context, typeURL string) bool
+	IsAllowed(ctx context.Context, typeURL string) (bool, error)
 }

--- a/baseapp/msg_service_router.go
+++ b/baseapp/msg_service_router.go
@@ -135,7 +135,12 @@ func (msr *MsgServiceRouter) RegisterService(sd *grpc.ServiceDesc, handler inter
 
 			if msr.circuitBreaker != nil {
 				msgURL := sdk.MsgTypeURL(msg)
-				if !msr.circuitBreaker.IsAllowed(ctx, msgURL) {
+				isAllowed, err := msr.circuitBreaker.IsAllowed(ctx, msgURL)
+				if err != nil {
+					return nil, err
+				}
+
+				if !isAllowed {
 					return nil, fmt.Errorf("circuit breaker disables execution of this message: %s", msgURL)
 				}
 			}

--- a/x/circuit/ante/circuit.go
+++ b/x/circuit/ante/circuit.go
@@ -1,13 +1,16 @@
 package ante
 
 import (
+	"context"
+
 	"github.com/cockroachdb/errors"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 // CircuitBreaker is an interface that defines the methods for a circuit breaker.
 type CircuitBreaker interface {
-	IsAllowed(ctx sdk.Context, typeURL string) bool
+	IsAllowed(ctx context.Context, typeURL string) (bool, error)
 }
 
 // CircuitBreakerDecorator is an AnteDecorator that checks if the transaction type is allowed to enter the mempool or be executed
@@ -24,7 +27,12 @@ func NewCircuitBreakerDecorator(ck CircuitBreaker) CircuitBreakerDecorator {
 func (cbd CircuitBreakerDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (sdk.Context, error) {
 	// loop through all the messages and check if the message type is allowed
 	for _, msg := range tx.GetMsgs() {
-		if !cbd.circuitKeeper.IsAllowed(ctx, sdk.MsgTypeURL(msg)) {
+		isAllowed, err := cbd.circuitKeeper.IsAllowed(ctx, sdk.MsgTypeURL(msg))
+		if err != nil {
+			return ctx, err
+		}
+
+		if !isAllowed {
 			return ctx, errors.New("tx type not allowed")
 		}
 	}

--- a/x/circuit/ante/circuit_test.go
+++ b/x/circuit/ante/circuit_test.go
@@ -1,6 +1,7 @@
 package ante_test
 
 import (
+	"context"
 	"testing"
 
 	storetypes "cosmossdk.io/store/types"
@@ -32,8 +33,8 @@ type MockCircuitBreaker struct {
 	isAllowed bool
 }
 
-func (m MockCircuitBreaker) IsAllowed(ctx sdk.Context, typeURL string) bool {
-	return typeURL == "/cosmos.circuit.v1.MsgAuthorizeCircuitBreaker"
+func (m MockCircuitBreaker) IsAllowed(ctx context.Context, typeURL string) (bool, error) {
+	return typeURL == "/cosmos.circuit.v1.MsgAuthorizeCircuitBreaker", nil
 }
 
 func initFixture(t *testing.T) *fixture {

--- a/x/circuit/keeper/keeper.go
+++ b/x/circuit/keeper/keeper.go
@@ -1,11 +1,14 @@
 package keeper
 
 import (
+	context "context"
+
 	proto "github.com/cosmos/gogoproto/proto"
 
 	"cosmossdk.io/core/address"
 	storetypes "cosmossdk.io/store/types"
 	"cosmossdk.io/x/circuit/types"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -64,9 +67,10 @@ func (k *Keeper) SetPermissions(ctx sdk.Context, address []byte, perms *types.Pe
 	return nil
 }
 
-func (k *Keeper) IsAllowed(ctx sdk.Context, msgURL string) bool {
-	store := ctx.KVStore(k.storekey)
-	return !store.Has(types.CreateDisableMsgPrefix(msgURL))
+func (k *Keeper) IsAllowed(ctx context.Context, msgURL string) (bool, error) {
+	sdkCtx := sdk.UnwrapSDKContext(ctx)
+	store := sdkCtx.KVStore(k.storekey)
+	return !store.Has(types.CreateDisableMsgPrefix(msgURL)), nil
 }
 
 func (k *Keeper) DisableMsg(ctx sdk.Context, msgURL string) {

--- a/x/circuit/keeper/msg_server_test.go
+++ b/x/circuit/keeper/msg_server_test.go
@@ -99,7 +99,8 @@ func Test_TripCircuitBreaker(t *testing.T) {
 	_, err := srv.TripCircuitBreaker(ft.Ctx, admintrip)
 	require.NoError(t, err)
 
-	allowed := ft.Keeper.IsAllowed(ft.Ctx, url)
+	allowed, err := ft.Keeper.IsAllowed(ft.Ctx, url)
+	require.NoError(t, err)
 	require.False(t, allowed, "circuit breaker should be tripped")
 
 	// user with all messages trips circuit breaker
@@ -115,7 +116,8 @@ func Test_TripCircuitBreaker(t *testing.T) {
 	_, err = srv.TripCircuitBreaker(ft.Ctx, superTrip)
 	require.NoError(t, err)
 
-	allowed = ft.Keeper.IsAllowed(ft.Ctx, url2)
+	allowed, err = ft.Keeper.IsAllowed(ft.Ctx, url2)
+	require.NoError(t, err)
 	require.False(t, allowed, "circuit breaker should be tripped")
 
 	// user with no permission attempts to trips circuit breaker
@@ -156,14 +158,16 @@ func Test_ResetCircuitBreaker(t *testing.T) {
 	_, err := srv.TripCircuitBreaker(ft.Ctx, admintrip)
 	require.NoError(t, err)
 
-	allowed := ft.Keeper.IsAllowed(ft.Ctx, url)
+	allowed, err := ft.Keeper.IsAllowed(ft.Ctx, url)
+	require.NoError(t, err)
 	require.False(t, allowed, "circuit breaker should be tripped")
 
 	adminReset := &types.MsgResetCircuitBreaker{Authority: addresses[0], MsgTypeUrls: []string{url}}
 	_, err = srv.ResetCircuitBreaker(ft.Ctx, adminReset)
 	require.NoError(t, err)
 
-	allowed = ft.Keeper.IsAllowed(ft.Ctx, url)
+	allowed, err = ft.Keeper.IsAllowed(ft.Ctx, url)
+	require.NoError(t, err)
 	require.True(t, allowed, "circuit breaker should be reset")
 
 	// user has no  permission to reset circuit breaker
@@ -171,14 +175,16 @@ func Test_ResetCircuitBreaker(t *testing.T) {
 	_, err = srv.TripCircuitBreaker(ft.Ctx, admintrip)
 	require.NoError(t, err)
 
-	allowed = ft.Keeper.IsAllowed(ft.Ctx, url)
+	allowed, err = ft.Keeper.IsAllowed(ft.Ctx, url)
+	require.NoError(t, err)
 	require.False(t, allowed, "circuit breaker should be tripped")
 
 	unknownUserReset := &types.MsgResetCircuitBreaker{Authority: addresses[1], MsgTypeUrls: []string{url}}
 	_, err = srv.ResetCircuitBreaker(ft.Ctx, unknownUserReset)
 	require.Error(t, err)
 
-	allowed = ft.Keeper.IsAllowed(ft.Ctx, url)
+	allowed, err = ft.Keeper.IsAllowed(ft.Ctx, url)
+	require.NoError(t, err)
 	require.False(t, allowed, "circuit breaker should be reset")
 
 	// user with all messages resets circuit breaker


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] added `!` to the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules)
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] updated the relevant documentation or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] confirmed all author checklist items have been addressed 
* [ ] reviewed state machine logic
* [ ] reviewed API design and naming
* [ ] reviewed documentation is accurate
* [ ] reviewed tests and test coverage
* [ ] manually tested (if applicable)
