### PR TITLE
feat(hubl): support output flag

### DIFF
--- a/client/v2/autocli/common.go
+++ b/client/v2/autocli/common.go
@@ -3,6 +3,7 @@ package autocli
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	autocliv1 "cosmossdk.io/api/cosmos/autocli/v1"
 	"github.com/cosmos/cosmos-sdk/client/flags"
@@ -157,6 +158,6 @@ func (b *Builder) outOrStdoutFormat(cmd *cobra.Command, out []byte) error {
 		}
 	}
 
-	_, err = fmt.Fprintln(cmd.OutOrStdout(), string(out))
-	return err
+	cmd.Println(strings.TrimSpace(string(out)))
+	return nil
 }

--- a/client/v2/autocli/query.go
+++ b/client/v2/autocli/query.go
@@ -124,8 +124,7 @@ func (b *Builder) BuildQueryMethodCommand(descriptor protoreflect.MethodDescript
 			return err
 		}
 
-		err = b.outOrStdoutFormat(cmd, bz)
-		return err
+		return b.outOrStdoutFormat(cmd, bz)
 	})
 	if err != nil {
 		return nil, err

--- a/tools/hubl/internal/remote.go
+++ b/tools/hubl/internal/remote.go
@@ -13,6 +13,7 @@ import (
 	"google.golang.org/protobuf/reflect/protoregistry"
 	"google.golang.org/protobuf/types/dynamicpb"
 
+	"github.com/cosmos/cosmos-sdk/client/flags"
 	addresscodec "github.com/cosmos/cosmos-sdk/codec/address"
 
 	"cosmossdk.io/client/v2/autocli"
@@ -108,6 +109,7 @@ func RemoteCommand(config *Config, configDir string) ([]*cobra.Command, error) {
 			update   bool
 			reconfig bool
 			insecure bool
+			output   string
 		)
 
 		chainCmd := &cobra.Command{
@@ -128,6 +130,7 @@ func RemoteCommand(config *Config, configDir string) ([]*cobra.Command, error) {
 		chainCmd.Flags().BoolVar(&update, flagUpdate, false, "update the CLI commands for the selected chain (should be used after every chain upgrade)")
 		chainCmd.Flags().BoolVar(&reconfig, flagConfig, false, "re-configure the selected chain (allows choosing a new gRPC endpoint and refreshes data")
 		chainCmd.Flags().BoolVar(&insecure, flagInsecure, false, "allow re-configuring the selected chain using an insecure gRPC connection")
+		chainCmd.PersistentFlags().StringVar(&output, flags.FlagOutput, flags.OutputFormatJSON, "output format (text|json)")
 
 		if err := appOpts.EnhanceRootCommandWithBuilder(chainCmd, builder); err != nil {
 			return nil, err


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

Seen that hubl didn't support the output flag that is supported by `client/v2`.
This PR adds it. It as well removes in `client/v2` the empty line when returning a `yaml`. 

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] added `!` to the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules)
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] updated the relevant documentation or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] confirmed all author checklist items have been addressed 
* [ ] reviewed state machine logic
* [ ] reviewed API design and naming
* [ ] reviewed documentation is accurate
* [ ] reviewed tests and test coverage
* [ ] manually tested (if applicable)
