### PR TITLE
feat(cosmovisor): add ability to run custom preupgrade script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,6 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Features
 
-* (tools) [#16550](https://github.com/cosmos/cosmos-sdk/pull/16550) Add COSMOVISOR_CUSTOM_PREUPGRADE to cosmovisor to execute custom pre-upgrade scripts.
 * [#15970](https://github.com/cosmos/cosmos-sdk/pull/15970) Enable SIGN_MODE_TEXTUAL.
 * (types) [#15958](https://github.com/cosmos/cosmos-sdk/pull/15958) Add `module.NewBasicManagerFromManager` for creating a basic module manager from a module manager.
 * (runtime) [#15818](https://github.com/cosmos/cosmos-sdk/pull/15818) Provide logger through `depinject` instead of appBuilder.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Features
 
+* (tools) [#16550](https://github.com/cosmos/cosmos-sdk/pull/16550) Add COSMOVISOR_CUSTOM_PREUPGRADE to cosmovisor to execute custom pre-upgrade scripts.
 * [#15970](https://github.com/cosmos/cosmos-sdk/pull/15970) Enable SIGN_MODE_TEXTUAL.
 * (types) [#15958](https://github.com/cosmos/cosmos-sdk/pull/15958) Add `module.NewBasicManagerFromManager` for creating a basic module manager from a module manager.
 * (runtime) [#15818](https://github.com/cosmos/cosmos-sdk/pull/15818) Provide logger through `depinject` instead of appBuilder.

--- a/tools/cosmovisor/CHANGELOG.md
+++ b/tools/cosmovisor/CHANGELOG.md
@@ -39,6 +39,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ## Features
 
 * [#16573](https://github.com/cosmos/cosmos-sdk/pull/16573) Extend `cosmovisor` configuration with new log format options
+* [#16550](https://github.com/cosmos/cosmos-sdk/pull/16550) Add COSMOVISOR_CUSTOM_PREUPGRADE to cosmovisor to execute custom pre-upgrade scripts (separate from daemon pre-upgrade).
 * [#15361](https://github.com/cosmos/cosmos-sdk/pull/15361) Add `cosmovisor config` command to display the configuration used by cosmovisor.
 * [#12457](https://github.com/cosmos/cosmos-sdk/issues/12457) Add `cosmovisor pre-upgrade` command to manually add an upgrade to cosmovisor.
 

--- a/tools/cosmovisor/README.md
+++ b/tools/cosmovisor/README.md
@@ -97,7 +97,7 @@ Use of `cosmovisor` without one of the action arguments is deprecated. For backw
 * `COSMOVISOR_DISABLE_LOGS` (defaults to `false`). If set to true, this will disable Cosmovisor logs (but not the underlying process) completely. This may be useful, for example, when a Cosmovisor subcommand you are executing returns a valid JSON you are then parsing, as logs added by Cosmovisor make this output not a valid JSON.
 * `COSMOVISOR_COLOR_LOGS` (defaults to `true`). If set to true, this will colorise Cosmovisor logs (but not the underlying process).
 * `COSMOVISOR_TIMEFORMAT_LOGS` (defaults to `kitchen`). If set to a value (`layout|ansic|unixdate|rubydate|rfc822|rfc822z|rfc850|rfc1123|rfc1123z|rfc3339|rfc3339nano|kitchen`), this will add timestamp prefix to Cosmovisor logs (but not the underlying process).
-* `COSMOVISOR_CUSTOM_PREUPGRADE` (defaults to ``).  If set, this will run $DAEMON_HOME/cosmovisor/$COSMOVISOR_CUSTOM_PREUPGRADE prior to upgrade with the arguments [ upgrade.Name, upgrade.Height ]
+* `COSMOVISOR_CUSTOM_PREUPGRADE` (defaults to ``).  If set, this will run $DAEMON_HOME/cosmovisor/$COSMOVISOR_CUSTOM_PREUPGRADE prior to upgrade with the arguments [ upgrade.Name, upgrade.Height ].  Executes a custom script (separate and prior to the chain daemon pre-upgrade command)
 
 ### Folder Layout
 

--- a/tools/cosmovisor/README.md
+++ b/tools/cosmovisor/README.md
@@ -97,6 +97,7 @@ Use of `cosmovisor` without one of the action arguments is deprecated. For backw
 * `COSMOVISOR_DISABLE_LOGS` (defaults to `false`). If set to true, this will disable Cosmovisor logs (but not the underlying process) completely. This may be useful, for example, when a Cosmovisor subcommand you are executing returns a valid JSON you are then parsing, as logs added by Cosmovisor make this output not a valid JSON.
 * `COSMOVISOR_COLOR_LOGS` (defaults to `true`). If set to true, this will colorise Cosmovisor logs (but not the underlying process).
 * `COSMOVISOR_TIMEFORMAT_LOGS` (defaults to `kitchen`). If set to a value (`layout|ansic|unixdate|rubydate|rfc822|rfc822z|rfc850|rfc1123|rfc1123z|rfc3339|rfc3339nano|kitchen`), this will add timestamp prefix to Cosmovisor logs (but not the underlying process).
+* `COSMOVISOR_CUSTOM_PREUPGRADE` (defaults to ``).  If set, this will run $DAEMON_HOME/cosmovisor/$COSMOVISOR_CUSTOM_PREUPGRADE prior to upgrade with the arguments [ upgrade.Name, upgrade.Height ]
 
 ### Folder Layout
 
@@ -109,10 +110,11 @@ Use of `cosmovisor` without one of the action arguments is deprecated. For backw
 │   └── bin
 │       └── $DAEMON_NAME
 └── upgrades
-    └── <name>
-        ├── bin
-        │   └── $DAEMON_NAME
-        └── upgrade-info.json
+│   └── <name>
+│       ├── bin
+│       │   └── $DAEMON_NAME
+│       └── upgrade-info.json
+└── preupgrade.sh (optional)
 ```
 
 The `cosmovisor/` directory incudes a subdirectory for each version of the application (i.e. `genesis` or `upgrades/<name>`). Within each subdirectory is the application binary (i.e. `bin/$DAEMON_NAME`) and any additional auxiliary files associated with each binary. `current` is a symbolic link to the currently active directory (i.e. `genesis` or `upgrades/<name>`). The `name` variable in `upgrades/<name>` is the lowercased URI-encoded name of the upgrade as specified in the upgrade module plan. Note that the upgrade name path are normalized to be lowercased: for instance, `MyUpgrade` is normalized to `myupgrade`, and its path is `upgrades/myupgrade`.

--- a/tools/cosmovisor/args.go
+++ b/tools/cosmovisor/args.go
@@ -34,6 +34,7 @@ const (
 	EnvDisableLogs              = "COSMOVISOR_DISABLE_LOGS"
 	EnvColorLogs                = "COSMOVISOR_COLOR_LOGS"
 	EnvTimeFormatLogs           = "COSMOVISOR_TIMEFORMAT_LOGS"
+	EnvCustomPreupgrade         = "COSMOVISOR_CUSTOM_PREUPGRADE"
 )
 
 const (
@@ -61,6 +62,8 @@ type Config struct {
 	DisableLogs              bool
 	ColorLogs                bool
 	TimeFormatLogs           string
+	CustomPreupgrade         string
+
 	// currently running upgrade
 	currentUpgrade upgradetypes.Plan
 }
@@ -148,9 +151,10 @@ func (cfg *Config) CurrentBin() (string, error) {
 func GetConfigFromEnv() (*Config, error) {
 	var errs []error
 	cfg := &Config{
-		Home:           os.Getenv(EnvHome),
-		Name:           os.Getenv(EnvName),
-		DataBackupPath: os.Getenv(EnvDataBackupPath),
+		Home:             os.Getenv(EnvHome),
+		Name:             os.Getenv(EnvName),
+		DataBackupPath:   os.Getenv(EnvDataBackupPath),
+		CustomPreupgrade: os.Getenv(EnvCustomPreupgrade),
 	}
 
 	if cfg.DataBackupPath == "" {
@@ -431,6 +435,7 @@ func (cfg Config) DetailString() string {
 		{EnvDisableLogs, fmt.Sprintf("%t", cfg.DisableLogs)},
 		{EnvColorLogs, fmt.Sprintf("%t", cfg.ColorLogs)},
 		{EnvTimeFormatLogs, cfg.TimeFormatLogs},
+		{EnvCustomPreupgrade, cfg.CustomPreupgrade},
 	}
 
 	derivedEntries := []struct{ name, value string }{

--- a/tools/cosmovisor/args_test.go
+++ b/tools/cosmovisor/args_test.go
@@ -37,6 +37,7 @@ type cosmovisorEnv struct {
 	DisableLogs              string
 	ColorLogs                string
 	TimeFormatLogs           string
+	CustomPreupgrade         string
 }
 
 type envMap struct {
@@ -60,6 +61,7 @@ func (c cosmovisorEnv) ToMap() map[string]envMap {
 		EnvDisableLogs:              {val: c.DisableLogs, allowEmpty: false},
 		EnvColorLogs:                {val: c.ColorLogs, allowEmpty: false},
 		EnvTimeFormatLogs:           {val: c.TimeFormatLogs, allowEmpty: true},
+		EnvCustomPreupgrade:         {val: c.CustomPreupgrade, allowEmpty: true},
 	}
 }
 
@@ -92,6 +94,8 @@ func (c *cosmovisorEnv) Set(envVar, envVal string) {
 		c.ColorLogs = envVal
 	case EnvTimeFormatLogs:
 		c.TimeFormatLogs = envVal
+	case EnvCustomPreupgrade:
+		c.CustomPreupgrade = envVal
 	default:
 		panic(fmt.Errorf("Unknown environment variable [%s]. Ccannot set field to [%s]. ", envVar, envVal))
 	}
@@ -451,6 +455,7 @@ func (s *argsTestSuite) TestGetConfigFromEnv() {
 		interval, preupgradeMaxRetries int,
 		disableLogs, colorLogs bool,
 		timeFormatLogs string,
+		customPreUpgrade string,
 	) *Config {
 		return &Config{
 			Home:                     home,
@@ -466,6 +471,7 @@ func (s *argsTestSuite) TestGetConfigFromEnv() {
 			DisableLogs:              disableLogs,
 			ColorLogs:                colorLogs,
 			TimeFormatLogs:           timeFormatLogs,
+			CustomPreupgrade:         customPreUpgrade,
 		}
 	}
 
@@ -495,13 +501,13 @@ func (s *argsTestSuite) TestGetConfigFromEnv() {
 		},
 		{
 			name:             "all good",
-			envVals:          cosmovisorEnv{absPath, "testname", "true", "true", "false", "600ms", "true", "", "303ms", "1", "false", "true", "kitchen"},
-			expectedCfg:      newConfig(absPath, "testname", true, true, false, 600, true, absPath, 303, 1, false, true, time.Kitchen),
+			envVals:          cosmovisorEnv{absPath, "testname", "true", "true", "false", "600ms", "true", "", "303ms", "1", "false", "true", "kitchen", "preupgrade.sh"},
+			expectedCfg:      newConfig(absPath, "testname", true, true, false, 600, true, absPath, 303, 1, false, true, time.Kitchen, "preupgrade.sh"),
 			expectedErrCount: 0,
 		},
 		{
 			name:             "nothing set",
-			envVals:          cosmovisorEnv{"", "", "", "", "", "", "", "", "", "", "false", "false", ""},
+			envVals:          cosmovisorEnv{"", "", "", "", "", "", "", "", "", "", "false", "false", "", ""},
 			expectedCfg:      nil,
 			expectedErrCount: 3,
 		},
@@ -509,224 +515,217 @@ func (s *argsTestSuite) TestGetConfigFromEnv() {
 		// timeformat tests are done in the TestTimeFormat
 		{
 			name:             "download bin bad",
-			envVals:          cosmovisorEnv{absPath, "testname", "bad", "true", "false", "600ms", "true", "", "303ms", "1", "false", "true", "kitchen"},
+			envVals:          cosmovisorEnv{absPath, "testname", "bad", "true", "false", "600ms", "true", "", "303ms", "1", "false", "true", "kitchen", ""},
 			expectedCfg:      nil,
 			expectedErrCount: 1,
 		},
 		{
-			name: "download bin not set",
-
-			envVals:          cosmovisorEnv{absPath, "testname", "", "true", "false", "600ms", "true", "", "303ms", "1", "false", "true", "kitchen"},
-			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, true, absPath, 303, 1, false, true, time.Kitchen),
+			name:             "download bin not set",
+			envVals:          cosmovisorEnv{absPath, "testname", "", "true", "false", "600ms", "true", "", "303ms", "1", "false", "true", "kitchen", ""},
+			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, true, absPath, 303, 1, false, true, time.Kitchen, ""),
 			expectedErrCount: 0,
 		},
 		{
 			name:             "download bin true",
-			envVals:          cosmovisorEnv{absPath, "testname", "true", "true", "false", "600ms", "true", "", "303ms", "1", "false", "true", "kitchen"},
-			expectedCfg:      newConfig(absPath, "testname", true, true, false, 600, true, absPath, 303, 1, false, true, time.Kitchen),
+			envVals:          cosmovisorEnv{absPath, "testname", "true", "true", "false", "600ms", "true", "", "303ms", "1", "false", "true", "kitchen", "preupgrade.sh"},
+			expectedCfg:      newConfig(absPath, "testname", true, true, false, 600, true, absPath, 303, 1, false, true, time.Kitchen, "preupgrade.sh"),
 			expectedErrCount: 0,
 		},
 		{
 			name:             "download bin false",
-			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "true", "", "303ms", "1", "false", "true", "kitchen"},
-			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, true, absPath, 303, 1, false, true, time.Kitchen),
+			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "true", "", "303ms", "1", "false", "true", "kitchen", "preupgrade.sh"},
+			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, true, absPath, 303, 1, false, true, time.Kitchen, "preupgrade.sh"),
 			expectedErrCount: 0,
 		},
 		{
 			name:             "download ensure checksum true",
-			envVals:          cosmovisorEnv{absPath, "testname", "true", "true", "false", "600ms", "true", "", "303ms", "1", "false", "true", "kitchen"},
-			expectedCfg:      newConfig(absPath, "testname", true, true, false, 600, true, absPath, 303, 1, false, true, time.Kitchen),
-			expectedErrCount: 0,
-		},
-		{
-			name:             "download ensure checksum false",
-			envVals:          cosmovisorEnv{absPath, "testname", "true", "false", "false", "600ms", "true", "", "303ms", "1", "false", "true", "kitchen"},
-			expectedCfg:      newConfig(absPath, "testname", true, false, false, 600, true, absPath, 303, 1, false, true, time.Kitchen),
+			envVals:          cosmovisorEnv{absPath, "testname", "true", "false", "false", "600ms", "true", "", "303ms", "1", "false", "true", "kitchen", "preupgrade.sh"},
+			expectedCfg:      newConfig(absPath, "testname", true, false, false, 600, true, absPath, 303, 1, false, true, time.Kitchen, "preupgrade.sh"),
 			expectedErrCount: 0,
 		},
 		{
 			name:             "restart upgrade bad",
-			envVals:          cosmovisorEnv{absPath, "testname", "true", "true", "bad", "600ms", "true", "", "303ms", "1", "false", "true", "kitchen"},
+			envVals:          cosmovisorEnv{absPath, "testname", "true", "true", "bad", "600ms", "true", "", "303ms", "1", "false", "true", "kitchen", "preupgrade.sh"},
 			expectedCfg:      nil,
 			expectedErrCount: 1,
 		},
 		{
 			name:             "restart upgrade not set",
-			envVals:          cosmovisorEnv{absPath, "testname", "true", "true", "", "600ms", "true", "", "303ms", "1", "false", "true", "kitchen"},
-			expectedCfg:      newConfig(absPath, "testname", true, true, true, 600, true, absPath, 303, 1, false, true, time.Kitchen),
+			envVals:          cosmovisorEnv{absPath, "testname", "true", "true", "", "600ms", "true", "", "303ms", "1", "false", "true", "kitchen", "preupgrade.sh"},
+			expectedCfg:      newConfig(absPath, "testname", true, true, true, 600, true, absPath, 303, 1, false, true, time.Kitchen, "preupgrade.sh"),
 			expectedErrCount: 0,
 		},
 		{
 			name:             "restart upgrade true",
-			envVals:          cosmovisorEnv{absPath, "testname", "true", "true", "true", "600ms", "true", "", "303ms", "1", "false", "true", "kitchen"},
-			expectedCfg:      newConfig(absPath, "testname", true, true, true, 600, true, absPath, 303, 1, false, true, time.Kitchen),
+			envVals:          cosmovisorEnv{absPath, "testname", "true", "true", "true", "600ms", "true", "", "303ms", "1", "false", "true", "kitchen", "preupgrade.sh"},
+			expectedCfg:      newConfig(absPath, "testname", true, true, true, 600, true, absPath, 303, 1, false, true, time.Kitchen, "preupgrade.sh"),
 			expectedErrCount: 0,
 		},
 		{
 			name:             "restart upgrade true",
-			envVals:          cosmovisorEnv{absPath, "testname", "true", "true", "false", "600ms", "true", "", "303ms", "1", "false", "true", "kitchen"},
-			expectedCfg:      newConfig(absPath, "testname", true, true, false, 600, true, absPath, 303, 1, false, true, time.Kitchen),
+			envVals:          cosmovisorEnv{absPath, "testname", "true", "true", "false", "600ms", "true", "", "303ms", "1", "false", "true", "kitchen", "preupgrade.sh"},
+			expectedCfg:      newConfig(absPath, "testname", true, true, false, 600, true, absPath, 303, 1, false, true, time.Kitchen, "preupgrade.sh"),
 			expectedErrCount: 0,
 		},
 		{
 			name:             "skip unsafe backups bad",
-			envVals:          cosmovisorEnv{absPath, "testname", "true", "true", "false", "600ms", "bad", "", "303ms", "1", "false", "true", "kitchen"},
+			envVals:          cosmovisorEnv{absPath, "testname", "true", "true", "false", "600ms", "bad", "", "303ms", "1", "false", "true", "kitchen", "preupgrade.sh"},
 			expectedCfg:      nil,
 			expectedErrCount: 1,
 		},
 		{
 			name:             "skip unsafe backups not set",
-			envVals:          cosmovisorEnv{absPath, "testname", "true", "true", "false", "600ms", "", "", "303ms", "1", "false", "true", "kitchen"},
-			expectedCfg:      newConfig(absPath, "testname", true, true, false, 600, false, absPath, 303, 1, false, true, time.Kitchen),
+			envVals:          cosmovisorEnv{absPath, "testname", "true", "true", "false", "600ms", "", "", "303ms", "1", "false", "true", "kitchen", "preupgrade.sh"},
+			expectedCfg:      newConfig(absPath, "testname", true, true, false, 600, false, absPath, 303, 1, false, true, time.Kitchen, "preupgrade.sh"),
 			expectedErrCount: 0,
 		},
 		{
 			name:             "skip unsafe backups true",
-			envVals:          cosmovisorEnv{absPath, "testname", "true", "true", "false", "600ms", "true", "", "303ms", "1", "false", "true", "kitchen"},
-			expectedCfg:      newConfig(absPath, "testname", true, true, false, 600, true, absPath, 303, 1, false, true, time.Kitchen),
+			envVals:          cosmovisorEnv{absPath, "testname", "true", "true", "false", "600ms", "true", "", "303ms", "1", "false", "true", "kitchen", "preupgrade.sh"},
+			expectedCfg:      newConfig(absPath, "testname", true, true, false, 600, true, absPath, 303, 1, false, true, time.Kitchen, "preupgrade.sh"),
 			expectedErrCount: 0,
 		},
 		{
 			name:             "skip unsafe backups false",
-			envVals:          cosmovisorEnv{absPath, "testname", "true", "true", "false", "600ms", "false", "", "303ms", "1", "false", "true", "kitchen"},
-			expectedCfg:      newConfig(absPath, "testname", true, true, false, 600, false, absPath, 303, 1, false, true, time.Kitchen),
+			envVals:          cosmovisorEnv{absPath, "testname", "true", "true", "false", "600ms", "false", "", "303ms", "1", "false", "true", "kitchen", "preupgrade.sh"},
+			expectedCfg:      newConfig(absPath, "testname", true, true, false, 600, false, absPath, 303, 1, false, true, time.Kitchen, "preupgrade.sh"),
 			expectedErrCount: 0,
 		},
 		{
 			name:             "poll interval bad",
-			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "bad", "1", "false", "true", "kitchen"},
+			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "bad", "1", "false", "true", "kitchen", "preupgrade.sh"},
 			expectedCfg:      nil,
 			expectedErrCount: 1,
 		},
 		{
 			name:             "poll interval 0",
-			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "0", "1", "false", "true", "kitchen"},
+			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "0", "1", "false", "true", "kitchen", "preupgrade.sh"},
 			expectedCfg:      nil,
 			expectedErrCount: 1,
 		},
 		{
 			name:             "poll interval not set",
-			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "", "1", "false", "false", "kitchen"},
-			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, false, absPath, 300, 1, false, false, time.Kitchen),
+			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "", "1", "false", "false", "kitchen", "preupgrade.sh"},
+			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, false, absPath, 300, 1, false, false, time.Kitchen, "preupgrade.sh"),
 			expectedErrCount: 0,
 		},
 		{
 			name:             "poll interval 600",
-			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "600", "1", "false", "true", "kitchen"},
+			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "600", "1", "false", "true", "kitchen", "preupgrade.sh"},
 			expectedCfg:      nil,
 			expectedErrCount: 1,
 		},
 		{
 			name:             "poll interval 1s",
-			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "1s", "1", "false", "false", "kitchen"},
-			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, false, absPath, 1000, 1, false, false, time.Kitchen),
+			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "1s", "1", "false", "false", "kitchen", "preupgrade.sh"},
+			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, false, absPath, 1000, 1, false, false, time.Kitchen, "preupgrade.sh"),
 			expectedErrCount: 0,
 		},
 		{
 			name:             "poll interval -3m",
-			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "-3m", "1", "false", "true", "kitchen"},
+			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "-3m", "1", "false", "true", "kitchen", "preupgrade.sh"},
 			expectedCfg:      nil,
 			expectedErrCount: 1,
 		},
 		{
 			name:             "restart delay bad",
-			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "bad", "false", "", "303ms", "1", "false", "true", "kitchen"},
+			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "bad", "false", "", "303ms", "1", "false", "true", "kitchen", "preupgrade.sh"},
 			expectedCfg:      nil,
 			expectedErrCount: 1,
 		},
 		{
 			name:             "restart delay 0",
-			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "0", "false", "", "303ms", "1", "false", "true", "kitchen"},
+			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "0", "false", "", "303ms", "1", "false", "true", "kitchen", "preupgrade.sh"},
 			expectedCfg:      nil,
 			expectedErrCount: 1,
 		},
 		{
 			name:             "restart delay not set",
-			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "", "false", "", "303ms", "1", "false", "false", "kitchen"},
-			expectedCfg:      newConfig(absPath, "testname", false, true, false, 0, false, absPath, 303, 1, false, false, time.Kitchen),
+			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "", "false", "", "303ms", "1", "false", "false", "kitchen", "preupgrade.sh"},
+			expectedCfg:      newConfig(absPath, "testname", false, true, false, 0, false, absPath, 303, 1, false, false, time.Kitchen, "preupgrade.sh"),
 			expectedErrCount: 0,
 		},
 		{
 			name:             "restart delay 600",
-			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600", "false", "", "300ms", "1", "false", "true", "kitchen"},
+			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600", "false", "", "300ms", "1", "false", "true", "kitchen", "preupgrade.sh"},
 			expectedCfg:      nil,
 			expectedErrCount: 1,
 		},
 		{
 			name:             "restart delay 1s",
-			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "1s", "false", "", "303ms", "1", "false", "false", "kitchen"},
-			expectedCfg:      newConfig(absPath, "testname", false, true, false, 1000, false, absPath, 303, 1, false, false, time.Kitchen),
+			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "1s", "false", "", "303ms", "1", "false", "false", "kitchen", "preupgrade.sh"},
+			expectedCfg:      newConfig(absPath, "testname", false, true, false, 1000, false, absPath, 303, 1, false, false, time.Kitchen, "preupgrade.sh"),
 			expectedErrCount: 0,
 		},
 		{
 			name:             "restart delay -3m",
-			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "-3m", "false", "", "303ms", "1", "false", "true", "kitchen"},
+			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "-3m", "false", "", "303ms", "1", "false", "true", "kitchen", "preupgrade.sh"},
 			expectedCfg:      nil,
 			expectedErrCount: 1,
 		},
 		{
 			name:             "prepupgrade max retries bad",
-			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "406ms", "bad", "false", "true", "kitchen"},
+			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "406ms", "bad", "false", "true", "kitchen", "preupgrade.sh"},
 			expectedCfg:      nil,
 			expectedErrCount: 1,
 		},
 		{
 			name:             "prepupgrade max retries 0",
-			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "406ms", "0", "false", "false", "kitchen"},
-			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, false, absPath, 406, 0, false, false, time.Kitchen),
+			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "406ms", "0", "false", "false", "kitchen", "preupgrade.sh"},
+			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, false, absPath, 406, 0, false, false, time.Kitchen, "preupgrade.sh"),
 			expectedErrCount: 0,
 		},
 		{
 			name:             "prepupgrade max retries not set",
-			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "406ms", "", "false", "false", "kitchen"},
-			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, false, absPath, 406, 0, false, false, time.Kitchen),
+			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "406ms", "", "false", "false", "kitchen", "preupgrade.sh"},
+			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, false, absPath, 406, 0, false, false, time.Kitchen, "preupgrade.sh"),
 			expectedErrCount: 0,
 		},
 		{
 			name:             "prepupgrade max retries 5",
-			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "406ms", "5", "false", "false", "kitchen"},
-			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, false, absPath, 406, 5, false, false, time.Kitchen),
+			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "406ms", "5", "false", "false", "kitchen", "preupgrade.sh"},
+			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, false, absPath, 406, 5, false, false, time.Kitchen, "preupgrade.sh"),
 			expectedErrCount: 0,
 		},
 		{
 			name:             "disable logs bad",
-			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "406ms", "5", "bad", "true", "kitchen"},
+			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "406ms", "5", "bad", "true", "kitchen", "preupgrade.sh"},
 			expectedCfg:      nil,
 			expectedErrCount: 1,
 		},
 		{
 			name:             "disable logs good",
-			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "406ms", "", "true", "false", "kitchen"},
-			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, false, absPath, 406, 0, true, false, time.Kitchen),
+			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "406ms", "", "true", "false", "kitchen", "preupgrade.sh"},
+			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, false, absPath, 406, 0, true, false, time.Kitchen, "preupgrade.sh"),
 			expectedErrCount: 0,
 		},
 		{
 			name:             "disable logs color bad",
-			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "406ms", "5", "true", "bad", "kitchen"},
+			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "406ms", "5", "true", "bad", "kitchen", "preupgrade.sh"},
 			expectedCfg:      nil,
 			expectedErrCount: 1,
 		},
 		{
 			name:             "disable logs color good",
-			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "406ms", "", "true", "false", "kitchen"},
-			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, false, absPath, 406, 0, true, false, time.Kitchen),
+			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "406ms", "", "true", "false", "kitchen", "preupgrade.sh"},
+			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, false, absPath, 406, 0, true, false, time.Kitchen, "preupgrade.sh"),
 			expectedErrCount: 0,
 		},
 		{
 			name:             "disable logs timestamp",
-			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "406ms", "", "true", "false", ""},
-			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, false, absPath, 406, 0, true, false, ""),
+			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "406ms", "", "true", "false", "", "preupgrade.sh"},
+			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, false, absPath, 406, 0, true, false, "", "preupgrade.sh"),
 			expectedErrCount: 0,
 		},
 		{
 			name:             "enable rf3339 logs timestamp",
-			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "406ms", "", "true", "true", "rfc3339"},
-			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, false, absPath, 406, 0, true, true, time.RFC3339),
+			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "406ms", "", "true", "true", "rfc3339", "preupgrade.sh"},
+			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, false, absPath, 406, 0, true, true, time.RFC3339, "preupgrade.sh"),
 			expectedErrCount: 0,
 		},
 		{
 			name:             "invalid logs timestamp format",
-			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "406ms", "", "true", "true", "invalid"},
+			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "406ms", "", "true", "true", "invalid", "preupgrade.sh"},
 			expectedCfg:      nil,
 			expectedErrCount: 1,
 		},

--- a/tools/cosmovisor/process.go
+++ b/tools/cosmovisor/process.go
@@ -188,8 +188,8 @@ func (l Launcher) doCustomPreUpgrade() error {
 		return err
 	}
 
-	if uInfo.Name == "" {
-		return fmt.Errorf("upgrade-info.json is empty")
+	if err = uInfo.ValidateBasic(); err != nil {
+		return fmt.Errorf("invalid upgrade plan: %w", err)
 	}
 
 	// check if preupgradeFile is executable file

--- a/tools/cosmovisor/process.go
+++ b/tools/cosmovisor/process.go
@@ -179,7 +179,7 @@ func (l Launcher) doCustomPreUpgrade() error {
 
 	// check if upgrade-info.json is not empty.
 	var uInfo upgradetypes.Plan
-	upgradeInfoFile, err := os.ReadFile(filepath.Join(l.cfg.Home, "data", "upgrade-info.json"))
+	upgradeInfoFile, err := os.ReadFile(l.cfg.UpgradeInfoFilePath())
 	if err != nil {
 		return fmt.Errorf("error while reading upgrade-info.json: %w", err)
 	}

--- a/tools/cosmovisor/process.go
+++ b/tools/cosmovisor/process.go
@@ -78,6 +78,10 @@ func (l Launcher) Run(args []string, stdout, stderr io.Writer) (bool, error) {
 			return false, err
 		}
 
+		if err := l.doCustomPreUpgrade(); err != nil {
+			return false, err
+		}
+
 		if err := UpgradeBinary(log.NewCustomLogger(*l.logger), l.cfg, l.fw.currentInfo); err != nil {
 			return false, err
 		}
@@ -164,6 +168,60 @@ func (l Launcher) doBackup() error {
 		et := time.Now()
 		l.logger.Info().Str("backup saved at", dst).Time("backup completion time", et).TimeDiff("time taken to complete backup", et, st).Msg("backup completed")
 	}
+
+	return nil
+}
+
+func (l Launcher) doCustomPreUpgrade() error {
+	if l.cfg.CustomPreupgrade == "" {
+		return nil
+	}
+
+	// check if upgrade-info.json is not empty.
+	var uInfo upgradetypes.Plan
+	upgradeInfoFile, err := os.ReadFile(filepath.Join(l.cfg.Home, "data", "upgrade-info.json"))
+	if err != nil {
+		return fmt.Errorf("error while reading upgrade-info.json: %w", err)
+	}
+
+	if err = json.Unmarshal(upgradeInfoFile, &uInfo); err != nil {
+		return err
+	}
+
+	if uInfo.Name == "" {
+		return fmt.Errorf("upgrade-info.json is empty")
+	}
+
+	// check if preupgradeFile is executable file
+	preupgradeFile := filepath.Join(l.cfg.Home, "cosmovisor", l.cfg.CustomPreupgrade)
+	l.logger.Info().Str("Looking for COSMOVISOR_CUSTOM_PREUPGRADE file ", preupgradeFile)
+	info, err := os.Stat(preupgradeFile)
+	if err != nil {
+		l.logger.Error().Msg("COSMOVISOR_CUSTOM_PREUPGRADE file missing")
+		return err
+	}
+	if !info.Mode().IsRegular() {
+		_, f := filepath.Split(preupgradeFile)
+		return fmt.Errorf("COSMOVISOR_CUSTOM_PREUPGRADE: %s is not a regular file", f)
+	}
+
+	// Set execute bit if necessary
+	oldMode := info.Mode().Perm()
+	newMode := oldMode | 0o100 // Set the three execute bits to on (a+x).
+	if oldMode != newMode {
+		if err := os.Chmod(preupgradeFile, newMode); err != nil {
+			l.logger.Info().Msg("COSMOVISOR_CUSTOM_PREUPGRADE could not add execute permission")
+			return fmt.Errorf("COSMOVISOR_CUSTOM_PREUPGRADE could not add execute permission")
+		}
+	}
+
+	// Run preupgradeFile
+	result, err := exec.Command(preupgradeFile, uInfo.Name, fmt.Sprintf("%d", uInfo.Height)).Output()
+	if err != nil {
+		return err
+	}
+
+	l.logger.Info().Str("command", preupgradeFile).Str("argv1", uInfo.Name).Str("argv2", fmt.Sprintf("%d", uInfo.Height)).Bytes("result", result).Msg("COSMOVISOR_CUSTOM_PREUPGRADE result")
 
 	return nil
 }

--- a/tools/cosmovisor/process.go
+++ b/tools/cosmovisor/process.go
@@ -205,9 +205,11 @@ func (l Launcher) doCustomPreUpgrade() error {
 		return fmt.Errorf("COSMOVISOR_CUSTOM_PREUPGRADE: %s is not a regular file", f)
 	}
 
-	// Set execute bit if necessary
+	// Set the execute bit for only the current user
+	// Given:  Current user - Group - Everyone
+	//       0o     RWX     - RWX   - RWX
 	oldMode := info.Mode().Perm()
-	newMode := oldMode | 0o100 // Set the three execute bits to on (a+x).
+	newMode := oldMode | 0o100
 	if oldMode != newMode {
 		if err := os.Chmod(preupgradeFile, newMode); err != nil {
 			l.logger.Info().Msg("COSMOVISOR_CUSTOM_PREUPGRADE could not add execute permission")

--- a/tools/cosmovisor/process.go
+++ b/tools/cosmovisor/process.go
@@ -197,7 +197,7 @@ func (l Launcher) doCustomPreUpgrade() error {
 	l.logger.Info().Str("Looking for COSMOVISOR_CUSTOM_PREUPGRADE file ", preupgradeFile)
 	info, err := os.Stat(preupgradeFile)
 	if err != nil {
-		l.logger.Error().Msg("COSMOVISOR_CUSTOM_PREUPGRADE file missing")
+		l.logger.Error().Str("file", preupgradeFile).Msg("COSMOVISOR_CUSTOM_PREUPGRADE file missing")
 		return err
 	}
 	if !info.Mode().IsRegular() {
@@ -216,7 +216,9 @@ func (l Launcher) doCustomPreUpgrade() error {
 	}
 
 	// Run preupgradeFile
-	result, err := exec.Command(preupgradeFile, uInfo.Name, fmt.Sprintf("%d", uInfo.Height)).Output()
+	cmd := exec.Command(preupgradeFile, uInfo.Name, fmt.Sprintf("%d", uInfo.Height))
+	cmd.Dir = l.cfg.Home
+	result, err := cmd.Output()
 	if err != nil {
 		return err
 	}

--- a/tools/cosmovisor/process_test.go
+++ b/tools/cosmovisor/process_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"path/filepath"
 	"sync"
 	"testing"
 	"time"
@@ -151,6 +152,103 @@ func (s *processTestSuite) TestLaunchProcessWithDownloads() {
 	currentBin, err = cfg.CurrentBin()
 	require.NoError(err)
 	require.Equal(cfg.UpgradeBin("chain3"), currentBin)
+
+	// run the last chain
+	args = []string{"end", "--halt", upgradeFilename}
+	stdout.Reset()
+	stderr.Reset()
+	doUpgrade, err = launcher.Run(args, stdout, stderr)
+	require.NoError(err)
+	require.False(doUpgrade)
+	require.Equal("", stderr.String())
+	require.Equal("Chain 3 from zipped directory\nArgs: end --halt "+upgradeFilename+"\n", stdout.String())
+
+	// and this doesn't upgrade
+	currentBin, err = cfg.CurrentBin()
+	require.NoError(err)
+	require.Equal(cfg.UpgradeBin("chain3"), currentBin)
+}
+
+// TestCustomPreupgrade will try running the script a few times and watch upgrades work properly
+// and args are passed through
+func (s *processTestSuite) TestLaunchProcessWithDownloadsAndMissingPreupgrade() {
+	// test case upgrade path (binaries from testdata/download directory):
+	// genesis -> chain2-zip_bin
+	// chain2-zip_bin -> ref_to_chain3-zip_dir.json = (json for the next download instructions) -> chain3-zip_dir
+	// chain3-zip_dir - doesn't upgrade
+	require := s.Require()
+	home := copyTestData(s.T(), "download")
+	cfg := &cosmovisor.Config{Home: home, Name: "autod", AllowDownloadBinaries: true, PollInterval: 100, UnsafeSkipBackup: true, CustomPreupgrade: "missing.sh"}
+	logger := log.NewLogger(os.Stdout).With(log.ModuleKey, "cosmovisor")
+	upgradeFilename := cfg.UpgradeInfoFilePath()
+
+	// should run the genesis binary and produce expected output
+	currentBin, err := cfg.CurrentBin()
+	require.NoError(err)
+	require.Equal(cfg.GenesisBin(), currentBin)
+	launcher, err := cosmovisor.NewLauncher(logger, cfg)
+	require.NoError(err)
+
+	// Missing Preupgrade Script
+	stdout, stderr := newBuffer(), newBuffer()
+	args := []string{"some", "args", upgradeFilename}
+	_, err = launcher.Run(args, stdout, stderr)
+
+	require.Error(err)
+}
+
+// TestCustomPreupgrade will try running the script a few times and watch upgrades work properly
+// and args are passed through
+func (s *processTestSuite) TestLaunchProcessWithDownloadsAndPreupgrade() {
+	// test case upgrade path (binaries from testdata/download directory):
+	// genesis -> chain2-zip_bin
+	// chain2-zip_bin -> ref_to_chain3-zip_dir.json = (json for the next download instructions) -> chain3-zip_dir
+	// chain3-zip_dir - doesn't upgrade
+	require := s.Require()
+	home := copyTestData(s.T(), "download")
+	cfg := &cosmovisor.Config{Home: home, Name: "autod", AllowDownloadBinaries: true, PollInterval: 100, UnsafeSkipBackup: true, CustomPreupgrade: "preupgrade.sh"}
+	logger := log.NewLogger(os.Stdout).With(log.ModuleKey, "cosmovisor")
+	upgradeFilename := cfg.UpgradeInfoFilePath()
+
+	// should run the genesis binary and produce expected output
+	currentBin, err := cfg.CurrentBin()
+	require.NoError(err)
+	require.Equal(cfg.GenesisBin(), currentBin)
+	launcher, err := cosmovisor.NewLauncher(logger, cfg)
+	require.NoError(err)
+
+	stdout, stderr := newBuffer(), newBuffer()
+	args := []string{"some", "args", upgradeFilename}
+	doUpgrade, err := launcher.Run(args, stdout, stderr)
+
+	require.NoError(err)
+	require.True(doUpgrade)
+	require.Equal("", stderr.String())
+	require.Equal("Genesis autod. Args: some args "+upgradeFilename+"\n"+`ERROR: UPGRADE "chain2" NEEDED at height: 49: zip_binary`+"\n", stdout.String())
+	currentBin, err = cfg.CurrentBin()
+	require.NoError(err)
+	require.Equal(cfg.UpgradeBin("chain2"), currentBin)
+
+	// should have preupgrade.sh results
+	require.FileExists(filepath.Join(home, "upgrade_name_chain2_height_49"))
+
+	// start chain2
+	stdout.Reset()
+	stderr.Reset()
+	args = []string{"run", "--fast", upgradeFilename}
+	doUpgrade, err = launcher.Run(args, stdout, stderr)
+	require.NoError(err)
+
+	require.Equal("", stderr.String())
+	require.Equal("Chain 2 from zipped binary\nArgs: run --fast "+upgradeFilename+"\n"+`ERROR: UPGRADE "chain3" NEEDED at height: 936: ref_to_chain3-zip_dir.json module=main`+"\n", stdout.String())
+	// ended with one more upgrade
+	require.True(doUpgrade)
+	currentBin, err = cfg.CurrentBin()
+	require.NoError(err)
+	require.Equal(cfg.UpgradeBin("chain3"), currentBin)
+
+	// should have preupgrade.sh results
+	require.FileExists(filepath.Join(home, "upgrade_name_chain3_height_936"))
 
 	// run the last chain
 	args = []string{"end", "--halt", upgradeFilename}

--- a/tools/cosmovisor/testdata/download/cosmovisor/preupgrade.sh
+++ b/tools/cosmovisor/testdata/download/cosmovisor/preupgrade.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+echo "OK" >  upgrade_name_$1_height_$2
+echo PWD=`pwd`
+echo upgrade_name_$1_height_$2


### PR DESCRIPTION
## Description

Validators/Infrastructure providers need the ability to execute custom scripts for backup, alerting, and other functions prior to upgrade.  

Set environment variable COSMOVISOR_CUSTOM_PREUPGRADE=preupgrade.sh to execute `.simapp/cosmovisor/preupgrade.sh` during upgrade.

Custom script is run with 2 arguments [ Upgrade Name, Upgrade Height ]

For example:
`.simapp/cosmovisor/preupgrade.sh v2 2000` for upgrade v2 at height 2000

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] added `!` to the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules)
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [x] added a changelog entry to `CHANGELOG.md`
* [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] updated the relevant documentation or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] confirmed all author checklist items have been addressed 
* [ ] reviewed state machine logic
* [ ] reviewed API design and naming
* [ ] reviewed documentation is accurate
* [ ] reviewed tests and test coverage
* [ ] manually tested (if applicable)
