### PR TITLE
fix(hubl): malformed msgName and error handling 

### DIFF
--- a/tools/hubl/internal/compat.go
+++ b/tools/hubl/internal/compat.go
@@ -266,7 +266,7 @@ func guessAutocli(files *protoregistry.Files) *autocliv1.AppOptionsResponse {
 // Removes the first character "/" from the received name
 func implMsgNameCleanup(implMessages []string) (cleanImplMessages []string) {
 	for _, implMessage := range implMessages {
-		if len(implMessage) >= 1 && implMessage[1] == '/' {
+		if len(implMessage) >= 1 && implMessage[0] == '/' {
 			cleanImplMessages = append(cleanImplMessages, implMessage[1:])
 		} else {
 			cleanImplMessages = append(cleanImplMessages, implMessage)

--- a/tools/hubl/internal/compat.go
+++ b/tools/hubl/internal/compat.go
@@ -30,7 +30,7 @@ func loadFileDescriptorsGRPCReflection(ctx context.Context, client *grpc.ClientC
 				InterfaceName: iface,
 			})
 			if err == nil {
-				interfaceImplNames = append(interfaceImplNames, implRes.ImplementationMessageNames...)
+				interfaceImplNames = append(interfaceImplNames, implRes.ImplementationMessageNames[1:]...)
 			}
 		}
 	}
@@ -56,6 +56,8 @@ func loadFileDescriptorsGRPCReflection(ctx context.Context, client *grpc.ClientC
 			}
 
 			switch res := in.MessageResponse.(type) {
+			case *grpc_reflection_v1alpha.ServerReflectionResponse_ErrorResponse:
+				panic(err)
 			case *grpc_reflection_v1alpha.ServerReflectionResponse_ListServicesResponse:
 				waitListServiceRes <- res.ListServicesResponse //nolint:staticcheck // SA1019: we want to keep using v1alpha
 			case *grpc_reflection_v1alpha.ServerReflectionResponse_FileDescriptorResponse:

--- a/tools/hubl/internal/compat.go
+++ b/tools/hubl/internal/compat.go
@@ -30,7 +30,7 @@ func loadFileDescriptorsGRPCReflection(ctx context.Context, client *grpc.ClientC
 				InterfaceName: iface,
 			})
 			if err == nil {
-				interfaceImplNames = append(interfaceImplNames, implRes.ImplementationMessageNames[1:]...)
+				interfaceImplNames = append(interfaceImplNames, implMsgNameCleanup(implRes.ImplementationMessageNames)...)
 			}
 		}
 	}
@@ -261,6 +261,19 @@ func guessAutocli(files *protoregistry.Files) *autocliv1.AppOptionsResponse {
 	})
 
 	return &autocliv1.AppOptionsResponse{ModuleOptions: res}
+}
+
+// Removes the first character "/" from the received name
+func implMsgNameCleanup(implMessages []string) (cleanImplMessages []string) {
+	for _, implMessage := range implMessages {
+		if len(implMessage) >= 1 && implMessage[1] == '/' {
+			cleanImplMessages = append(cleanImplMessages, implMessage[1:])
+		} else {
+			cleanImplMessages = append(cleanImplMessages, implMessage)
+		}
+	}
+
+	return cleanImplMessages
 }
 
 var defaultAutocliMappings = map[protoreflect.FullName]string{


### PR DESCRIPTION
## Description

Closes:  #16600

This PR corrects an unhandled error on hubl reflection over msgName types.
- Adds error handling to the server communication function
- Fixes the cause of the issue

The error have been happening because the original messages started with a `/` character, while the grpc server expects names without the `/` character.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [*] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [*] added `!` to the type prefix if API or client breaking change
* [*] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [*] provided a link to the relevant issue or specification
* [*] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules)
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [*] added a changelog entry to `CHANGELOG.md`
* [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] updated the relevant documentation or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] confirmed all author checklist items have been addressed 
* [ ] reviewed state machine logic
* [ ] reviewed API design and naming
* [ ] reviewed documentation is accurate
* [ ] reviewed tests and test coverage
* [ ] manually tested (if applicable)
