### PR TITLE
chore: make configurator.Config.ModuleConfigs public

### DIFF
--- a/testutil/configurator/configurator.go
+++ b/testutil/configurator/configurator.go
@@ -93,7 +93,7 @@ var initGenesisOrder = []string{
 
 // Config should never need to be instantiated manually and is solely used for ModuleOption.
 type Config struct {
-	moduleConfigs  map[string]*appv1alpha1.ModuleConfig
+	ModuleConfigs  map[string]*appv1alpha1.ModuleConfig
 	setInitGenesis bool
 }
 
@@ -101,7 +101,7 @@ type ModuleOption func(config *Config)
 
 func BankModule() ModuleOption {
 	return func(config *Config) {
-		config.moduleConfigs["bank"] = &appv1alpha1.ModuleConfig{
+		config.ModuleConfigs["bank"] = &appv1alpha1.ModuleConfig{
 			Name:   "bank",
 			Config: appconfig.WrapAny(&bankmodulev1.Module{}),
 		}
@@ -110,7 +110,7 @@ func BankModule() ModuleOption {
 
 func AuthModule() ModuleOption {
 	return func(config *Config) {
-		config.moduleConfigs["auth"] = &appv1alpha1.ModuleConfig{
+		config.ModuleConfigs["auth"] = &appv1alpha1.ModuleConfig{
 			Name: "auth",
 			Config: appconfig.WrapAny(&authmodulev1.Module{
 				Bech32Prefix: "cosmos",
@@ -130,7 +130,7 @@ func AuthModule() ModuleOption {
 
 func ParamsModule() ModuleOption {
 	return func(config *Config) {
-		config.moduleConfigs["params"] = &appv1alpha1.ModuleConfig{
+		config.ModuleConfigs["params"] = &appv1alpha1.ModuleConfig{
 			Name:   "params",
 			Config: appconfig.WrapAny(&paramsmodulev1.Module{}),
 		}
@@ -139,7 +139,7 @@ func ParamsModule() ModuleOption {
 
 func TxModule() ModuleOption {
 	return func(config *Config) {
-		config.moduleConfigs["tx"] = &appv1alpha1.ModuleConfig{
+		config.ModuleConfigs["tx"] = &appv1alpha1.ModuleConfig{
 			Name:   "tx",
 			Config: appconfig.WrapAny(&txconfigv1.Config{}),
 		}
@@ -148,7 +148,7 @@ func TxModule() ModuleOption {
 
 func StakingModule() ModuleOption {
 	return func(config *Config) {
-		config.moduleConfigs["staking"] = &appv1alpha1.ModuleConfig{
+		config.ModuleConfigs["staking"] = &appv1alpha1.ModuleConfig{
 			Name:   "staking",
 			Config: appconfig.WrapAny(&stakingmodulev1.Module{}),
 		}
@@ -157,7 +157,7 @@ func StakingModule() ModuleOption {
 
 func SlashingModule() ModuleOption {
 	return func(config *Config) {
-		config.moduleConfigs["slashing"] = &appv1alpha1.ModuleConfig{
+		config.ModuleConfigs["slashing"] = &appv1alpha1.ModuleConfig{
 			Name:   "slashing",
 			Config: appconfig.WrapAny(&slashingmodulev1.Module{}),
 		}
@@ -166,7 +166,7 @@ func SlashingModule() ModuleOption {
 
 func GenutilModule() ModuleOption {
 	return func(config *Config) {
-		config.moduleConfigs["genutil"] = &appv1alpha1.ModuleConfig{
+		config.ModuleConfigs["genutil"] = &appv1alpha1.ModuleConfig{
 			Name:   "genutil",
 			Config: appconfig.WrapAny(&genutilmodulev1.Module{}),
 		}
@@ -175,7 +175,7 @@ func GenutilModule() ModuleOption {
 
 func DistributionModule() ModuleOption {
 	return func(config *Config) {
-		config.moduleConfigs["distribution"] = &appv1alpha1.ModuleConfig{
+		config.ModuleConfigs["distribution"] = &appv1alpha1.ModuleConfig{
 			Name:   "distribution",
 			Config: appconfig.WrapAny(&distrmodulev1.Module{}),
 		}
@@ -184,7 +184,7 @@ func DistributionModule() ModuleOption {
 
 func FeegrantModule() ModuleOption {
 	return func(config *Config) {
-		config.moduleConfigs["feegrant"] = &appv1alpha1.ModuleConfig{
+		config.ModuleConfigs["feegrant"] = &appv1alpha1.ModuleConfig{
 			Name:   "feegrant",
 			Config: appconfig.WrapAny(&feegrantmodulev1.Module{}),
 		}
@@ -193,7 +193,7 @@ func FeegrantModule() ModuleOption {
 
 func VestingModule() ModuleOption {
 	return func(config *Config) {
-		config.moduleConfigs["vesting"] = &appv1alpha1.ModuleConfig{
+		config.ModuleConfigs["vesting"] = &appv1alpha1.ModuleConfig{
 			Name:   "vesting",
 			Config: appconfig.WrapAny(&vestingmodulev1.Module{}),
 		}
@@ -202,7 +202,7 @@ func VestingModule() ModuleOption {
 
 func GovModule() ModuleOption {
 	return func(config *Config) {
-		config.moduleConfigs["gov"] = &appv1alpha1.ModuleConfig{
+		config.ModuleConfigs["gov"] = &appv1alpha1.ModuleConfig{
 			Name:   "gov",
 			Config: appconfig.WrapAny(&govmodulev1.Module{}),
 		}
@@ -211,7 +211,7 @@ func GovModule() ModuleOption {
 
 func ConsensusModule() ModuleOption {
 	return func(config *Config) {
-		config.moduleConfigs["consensus"] = &appv1alpha1.ModuleConfig{
+		config.ModuleConfigs["consensus"] = &appv1alpha1.ModuleConfig{
 			Name:   "consensus",
 			Config: appconfig.WrapAny(&consensusmodulev1.Module{}),
 		}
@@ -220,7 +220,7 @@ func ConsensusModule() ModuleOption {
 
 func MintModule() ModuleOption {
 	return func(config *Config) {
-		config.moduleConfigs["mint"] = &appv1alpha1.ModuleConfig{
+		config.ModuleConfigs["mint"] = &appv1alpha1.ModuleConfig{
 			Name:   "mint",
 			Config: appconfig.WrapAny(&mintmodulev1.Module{}),
 			GolangBindings: []*appv1alpha1.GolangBinding{
@@ -235,7 +235,7 @@ func MintModule() ModuleOption {
 
 func EvidenceModule() ModuleOption {
 	return func(config *Config) {
-		config.moduleConfigs["evidence"] = &appv1alpha1.ModuleConfig{
+		config.ModuleConfigs["evidence"] = &appv1alpha1.ModuleConfig{
 			Name:   "evidence",
 			Config: appconfig.WrapAny(&evidencemodulev1.Module{}),
 		}
@@ -244,7 +244,7 @@ func EvidenceModule() ModuleOption {
 
 func AuthzModule() ModuleOption {
 	return func(config *Config) {
-		config.moduleConfigs["authz"] = &appv1alpha1.ModuleConfig{
+		config.ModuleConfigs["authz"] = &appv1alpha1.ModuleConfig{
 			Name:   "authz",
 			Config: appconfig.WrapAny(&authzmodulev1.Module{}),
 		}
@@ -253,7 +253,7 @@ func AuthzModule() ModuleOption {
 
 func GroupModule() ModuleOption {
 	return func(config *Config) {
-		config.moduleConfigs["group"] = &appv1alpha1.ModuleConfig{
+		config.ModuleConfigs["group"] = &appv1alpha1.ModuleConfig{
 			Name:   "group",
 			Config: appconfig.WrapAny(&groupmodulev1.Module{}),
 		}
@@ -262,7 +262,7 @@ func GroupModule() ModuleOption {
 
 func NFTModule() ModuleOption {
 	return func(config *Config) {
-		config.moduleConfigs["nft"] = &appv1alpha1.ModuleConfig{
+		config.ModuleConfigs["nft"] = &appv1alpha1.ModuleConfig{
 			Name:   "nft",
 			Config: appconfig.WrapAny(&nftmodulev1.Module{}),
 		}
@@ -271,7 +271,7 @@ func NFTModule() ModuleOption {
 
 func CircuitModule() ModuleOption {
 	return func(config *Config) {
-		config.moduleConfigs["circuit"] = &appv1alpha1.ModuleConfig{
+		config.ModuleConfigs["circuit"] = &appv1alpha1.ModuleConfig{
 			Name:   "circuit",
 			Config: appconfig.WrapAny(&circuitmodulev1.Module{}),
 		}
@@ -286,7 +286,7 @@ func OmitInitGenesis() ModuleOption {
 
 func NewAppConfig(opts ...ModuleOption) depinject.Config {
 	cfg := &Config{
-		moduleConfigs:  make(map[string]*appv1alpha1.ModuleConfig),
+		ModuleConfigs:  make(map[string]*appv1alpha1.ModuleConfig),
 		setInitGenesis: true,
 	}
 	for _, opt := range opts {
@@ -299,24 +299,24 @@ func NewAppConfig(opts ...ModuleOption) depinject.Config {
 	overrides := make([]*runtimev1alpha1.StoreKeyConfig, 0)
 
 	for _, s := range beginBlockOrder {
-		if _, ok := cfg.moduleConfigs[s]; ok {
+		if _, ok := cfg.ModuleConfigs[s]; ok {
 			beginBlockers = append(beginBlockers, s)
 		}
 	}
 
 	for _, s := range endBlockersOrder {
-		if _, ok := cfg.moduleConfigs[s]; ok {
+		if _, ok := cfg.ModuleConfigs[s]; ok {
 			endBlockers = append(endBlockers, s)
 		}
 	}
 
 	for _, s := range initGenesisOrder {
-		if _, ok := cfg.moduleConfigs[s]; ok {
+		if _, ok := cfg.ModuleConfigs[s]; ok {
 			initGenesis = append(initGenesis, s)
 		}
 	}
 
-	if _, ok := cfg.moduleConfigs["auth"]; ok {
+	if _, ok := cfg.ModuleConfigs["auth"]; ok {
 		overrides = append(overrides, &runtimev1alpha1.StoreKeyConfig{ModuleName: "auth", KvStoreKey: "acc"})
 	}
 
@@ -335,7 +335,7 @@ func NewAppConfig(opts ...ModuleOption) depinject.Config {
 		Config: appconfig.WrapAny(runtimeConfig),
 	}}
 
-	for _, m := range cfg.moduleConfigs {
+	for _, m := range cfg.ModuleConfigs {
 		modules = append(modules, m)
 	}
 


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

follow-up of #16624 because I forgot to make the field public, so I still cannot use it.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] added `!` to the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules)
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] updated the relevant documentation or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] confirmed all author checklist items have been addressed 
* [ ] reviewed state machine logic
* [ ] reviewed API design and naming
* [ ] reviewed documentation is accurate
* [ ] reviewed tests and test coverage
* [ ] manually tested (if applicable)
