### PR TITLE
feat: add configurator config options

### DIFF
--- a/testutil/configurator/configurator.go
+++ b/testutil/configurator/configurator.go
@@ -25,79 +25,102 @@ import (
 	"cosmossdk.io/depinject"
 )
 
-var beginBlockOrder = []string{
-	"upgrade",
-	"mint",
-	"distribution",
-	"slashing",
-	"evidence",
-	"staking",
-	"auth",
-	"bank",
-	"gov",
-	"crisis",
-	"genutil",
-	"authz",
-	"feegrant",
-	"nft",
-	"group",
-	"params",
-	"consensus",
-	"vesting",
-	"circuit",
-}
-
-var endBlockersOrder = []string{
-	"crisis",
-	"gov",
-	"staking",
-	"auth",
-	"bank",
-	"distribution",
-	"slashing",
-	"mint",
-	"genutil",
-	"evidence",
-	"authz",
-	"feegrant",
-	"nft",
-	"group",
-	"params",
-	"consensus",
-	"upgrade",
-	"vesting",
-	"circuit",
-}
-
-var initGenesisOrder = []string{
-	"auth",
-	"bank",
-	"distribution",
-	"staking",
-	"slashing",
-	"gov",
-	"mint",
-	"crisis",
-	"genutil",
-	"evidence",
-	"authz",
-	"feegrant",
-	"nft",
-	"group",
-	"params",
-	"consensus",
-	"upgrade",
-	"vesting",
-	"circuit",
-}
-
 // Config should never need to be instantiated manually and is solely used for ModuleOption.
 type Config struct {
-	ModuleConfigs  map[string]*appv1alpha1.ModuleConfig
-	setInitGenesis bool
+	ModuleConfigs      map[string]*appv1alpha1.ModuleConfig
+	BeginBlockersOrder []string
+	EndBlockersOrder   []string
+	InitGenesisOrder   []string
+	setInitGenesis     bool
+}
+
+var defaultConfig = &Config{
+	ModuleConfigs: make(map[string]*appv1alpha1.ModuleConfig),
+	BeginBlockersOrder: []string{
+		"upgrade",
+		"mint",
+		"distribution",
+		"slashing",
+		"evidence",
+		"staking",
+		"auth",
+		"bank",
+		"gov",
+		"crisis",
+		"genutil",
+		"authz",
+		"feegrant",
+		"nft",
+		"group",
+		"params",
+		"consensus",
+		"vesting",
+		"circuit",
+	},
+	EndBlockersOrder: []string{
+		"crisis",
+		"gov",
+		"staking",
+		"auth",
+		"bank",
+		"distribution",
+		"slashing",
+		"mint",
+		"genutil",
+		"evidence",
+		"authz",
+		"feegrant",
+		"nft",
+		"group",
+		"params",
+		"consensus",
+		"upgrade",
+		"vesting",
+		"circuit",
+	},
+	InitGenesisOrder: []string{
+		"auth",
+		"bank",
+		"distribution",
+		"staking",
+		"slashing",
+		"gov",
+		"mint",
+		"crisis",
+		"genutil",
+		"evidence",
+		"authz",
+		"feegrant",
+		"nft",
+		"group",
+		"params",
+		"consensus",
+		"upgrade",
+		"vesting",
+		"circuit",
+	},
+	setInitGenesis: true,
 }
 
 type ModuleOption func(config *Config)
+
+func WithBeginBlockersOrderOption(beginBlockOrder []string) ModuleOption {
+	return func(config *Config) {
+		config.BeginBlockersOrder = beginBlockOrder
+	}
+}
+
+func WithEndBlockersOrderOption(endBlockersOrder []string) ModuleOption {
+	return func(config *Config) {
+		config.EndBlockersOrder = endBlockersOrder
+	}
+}
+
+func WithInitGenesisOrderOption(initGenesisOrder []string) ModuleOption {
+	return func(config *Config) {
+		config.InitGenesisOrder = initGenesisOrder
+	}
+}
 
 func BankModule() ModuleOption {
 	return func(config *Config) {
@@ -285,10 +308,7 @@ func OmitInitGenesis() ModuleOption {
 }
 
 func NewAppConfig(opts ...ModuleOption) depinject.Config {
-	cfg := &Config{
-		ModuleConfigs:  make(map[string]*appv1alpha1.ModuleConfig),
-		setInitGenesis: true,
-	}
+	cfg := defaultConfig
 	for _, opt := range opts {
 		opt(cfg)
 	}
@@ -298,19 +318,19 @@ func NewAppConfig(opts ...ModuleOption) depinject.Config {
 	initGenesis := make([]string, 0)
 	overrides := make([]*runtimev1alpha1.StoreKeyConfig, 0)
 
-	for _, s := range beginBlockOrder {
+	for _, s := range cfg.BeginBlockersOrder {
 		if _, ok := cfg.ModuleConfigs[s]; ok {
 			beginBlockers = append(beginBlockers, s)
 		}
 	}
 
-	for _, s := range endBlockersOrder {
+	for _, s := range cfg.EndBlockersOrder {
 		if _, ok := cfg.ModuleConfigs[s]; ok {
 			endBlockers = append(endBlockers, s)
 		}
 	}
 
-	for _, s := range initGenesisOrder {
+	for _, s := range cfg.InitGenesisOrder {
 		if _, ok := cfg.ModuleConfigs[s]; ok {
 			initGenesis = append(initGenesis, s)
 		}


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

The more I use the configurator, the more I need it more configurable.
Currently you cannot use it when adding external modules, this PR solves that.

```go
panic: all modules must be defined when setting SetOrderInitGenesis, missing: [example] [recovered]
	panic: all modules must be defined when setting SetOrderInitGenesis, missing: [example]
```

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] added `!` to the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules)
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] updated the relevant documentation or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] confirmed all author checklist items have been addressed 
* [ ] reviewed state machine logic
* [ ] reviewed API design and naming
* [ ] reviewed documentation is accurate
* [ ] reviewed tests and test coverage
* [ ] manually tested (if applicable)
