### PR TITLE
fix: x/tx/signing/aminojson: revert json.NewEncoder that added newlines

### DIFF
--- a/x/tx/signing/aminojson/json_marshal.go
+++ b/x/tx/signing/aminojson/json_marshal.go
@@ -305,7 +305,12 @@ func (enc Encoder) marshalMessage(msg protoreflect.Message, writer io.Writer) er
 }
 
 func jsonMarshal(w io.Writer, v interface{}) error {
-	return json.NewEncoder(w).Encode(v)
+	blob, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+	_, err = w.Write(blob)
+	return err
 }
 
 func (enc Encoder) marshalList(list protoreflect.List, writer io.Writer) error {


### PR DESCRIPTION
Reverts a change that added json.NewEncoder which unfortunately adds newlines to JSON output, and that was failing tests.