### PR TITLE
[CORE-206] Change default commission rate to 100%

### DIFF
--- a/x/staking/client/cli/tx.go
+++ b/x/staking/client/cli/tx.go
@@ -27,7 +27,7 @@ import (
 var (
 	DefaultTokens                  = sdk.TokensFromConsensusPower(100, sdk.DefaultPowerReduction)
 	defaultAmount                  = DefaultTokens.String() + sdk.DefaultBondDenom
-	defaultCommissionRate          = "0.1"
+	defaultCommissionRate          = "1"
 	defaultCommissionMaxRate       = "0.2"
 	defaultCommissionMaxChangeRate = "0.01"
 	defaultMinSelfDelegation       = "1"


### PR DESCRIPTION
With this change, `dydxprotocol gentx` would initialize the validator commission rate to 100% by default. Validator can pass in an alternative amount as part of their gentx config. 