### PR TITLE
feat(log): add stacktrace display option

### DIFF
--- a/log/CHANGELOG.md
+++ b/log/CHANGELOG.md
@@ -31,9 +31,13 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
-### Features
+## [v1.2.0](https://github.com/cosmos/cosmos-sdk/releases/tag/log/v1.2.0) - 2023-07-04
 
-* [#15956](https://github.com/cosmos/cosmos-sdk/pull/15956) Introduce extra options to configure logger.
+* [#15956](https://github.com/cosmos/cosmos-sdk/pull/15956) Introduce extra options for enabling error stack trace.
+
+## [v1.1.0](https://github.com/cosmos/cosmos-sdk/releases/tag/log/v1.1.0) - 2023-04-27
+
+* [#15956](https://github.com/cosmos/cosmos-sdk/pull/15956) Introduce extra options to configure logger (enable/disable colored output, customize log timestamps).
 
 ## [v1.0.0](https://github.com/cosmos/cosmos-sdk/releases/tag/log/v1.0.0) - 2023-03-30
 

--- a/log/CHANGELOG.md
+++ b/log/CHANGELOG.md
@@ -31,13 +31,11 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
-## [v1.2.0](https://github.com/cosmos/cosmos-sdk/releases/tag/log/v1.2.0) - 2023-07-04
-
-* [#15956](https://github.com/cosmos/cosmos-sdk/pull/15956) Introduce extra options for enabling error stack trace.
+* [#15956](https://github.com/cosmos/cosmos-sdk/pull/15956) Introduce an option for enabling error stack trace.
 
 ## [v1.1.0](https://github.com/cosmos/cosmos-sdk/releases/tag/log/v1.1.0) - 2023-04-27
 
-* [#15956](https://github.com/cosmos/cosmos-sdk/pull/15956) Introduce extra options to configure logger (enable/disable colored output, customize log timestamps).
+* [#15956](https://github.com/cosmos/cosmos-sdk/pull/15956) Introduce options to configure logger (enable/disable colored output, customize log timestamps).
 
 ## [v1.0.0](https://github.com/cosmos/cosmos-sdk/releases/tag/log/v1.0.0) - 2023-03-30
 

--- a/log/go.mod
+++ b/log/go.mod
@@ -3,6 +3,7 @@ module cosmossdk.io/log
 go 1.20
 
 require (
+	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.29.1
 	gotest.tools/v3 v3.5.0
 )

--- a/log/go.sum
+++ b/log/go.sum
@@ -9,6 +9,7 @@ github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27k
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-isatty v0.0.19 h1:JITubQf0MOLdlGRuRq+jtsDlekdYPia9ZFsB8h/APPA=
 github.com/mattn/go-isatty v0.0.19/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/rs/xid v1.4.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/rs/zerolog v1.29.1 h1:cO+d60CHkknCbvzEWxP0S9K6KqyTjrCNUy1LdQLCGPc=

--- a/log/logger.go
+++ b/log/logger.go
@@ -3,7 +3,9 @@ package log
 import (
 	"io"
 
+	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/pkgerrors"
 )
 
 // ModuleKey defines a module logging key.
@@ -66,6 +68,12 @@ func NewLogger(dst io.Writer, options ...Option) Logger {
 
 	if logCfg.Filter != nil {
 		output = NewFilterWriter(output, logCfg.Filter)
+	}
+
+	if logCfg.StackTrace {
+		zerolog.ErrorStackMarshaler = func(err error) interface{} {
+			return pkgerrors.MarshalStack(errors.WithStack(err))
+		}
 	}
 
 	logger := zerolog.New(output)

--- a/log/logger.go
+++ b/log/logger.go
@@ -70,13 +70,15 @@ func NewLogger(dst io.Writer, options ...Option) Logger {
 		output = NewFilterWriter(output, logCfg.Filter)
 	}
 
+	logger := zerolog.New(output)
 	if logCfg.StackTrace {
 		zerolog.ErrorStackMarshaler = func(err error) interface{} {
 			return pkgerrors.MarshalStack(errors.WithStack(err))
 		}
+
+		logger = logger.With().Stack().Logger()
 	}
 
-	logger := zerolog.New(output)
 	if logCfg.TimeFormat != "" {
 		logger = logger.With().Timestamp().Logger()
 	}

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -1,0 +1,30 @@
+package log_test
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"cosmossdk.io/log"
+)
+
+func TestLoggerOptionStackTrace(t *testing.T) {
+	buf := new(bytes.Buffer)
+	logger := log.NewLogger(buf, log.TraceOption(true), log.ColorOption(false))
+	logger.Error("this log should be displayed", "error", inner())
+	if strings.Count(buf.String(), "logger_test.go") != 1 {
+		t.Fatalf("stack trace not found, got: %s", buf.String())
+	}
+	buf.Reset()
+
+	logger = log.NewLogger(buf, log.TraceOption(false), log.ColorOption(false))
+	logger.Error("this log should be displayed", "error", inner())
+	if strings.Count(buf.String(), "logger_test.go") > 0 {
+		t.Fatalf("stack trace found, got: %s", buf.String())
+	}
+}
+
+func inner() error {
+	return errors.New("seems we have an error here")
+}

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestLoggerOptionStackTrace(t *testing.T) {
+	t.Skip() // todo(@julienrbrt) unskip when https://github.com/rs/zerolog/pull/560 merged
+
 	buf := new(bytes.Buffer)
 	logger := log.NewLogger(buf, log.TraceOption(true), log.ColorOption(false))
 	logger.Error("this log should be displayed", "error", inner())

--- a/log/options.go
+++ b/log/options.go
@@ -12,6 +12,7 @@ var defaultConfig = Config{
 	Filter:     nil,
 	OutputJSON: false,
 	Color:      true,
+	StackTrace: false,
 	TimeFormat: time.Kitchen,
 }
 
@@ -21,6 +22,7 @@ type Config struct {
 	Filter     FilterFunc
 	OutputJSON bool
 	Color      bool
+	StackTrace bool
 	TimeFormat string
 }
 
@@ -76,5 +78,12 @@ func ColorOption(val bool) Option {
 func TimeFormatOption(format string) Option {
 	return func(cfg *Config) {
 		cfg.TimeFormat = format
+	}
+}
+
+// TraceOption add option to enable/disable print of stacktrace on error log
+func TraceOption(val bool) Option {
+	return func(cfg *Config) {
+		cfg.StackTrace = val
 	}
 }


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

In the SDK implementation of `cosmossdk.io/log` there is a confusion between the `trace` level (like error,info,debug,...) and displaying the stack trace of an error. The logger currently does not support the latter, while the `--trace` flag is for that. This PR adds the functionality to the logger lib.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] added `!` to the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules)
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] updated the relevant documentation or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] confirmed all author checklist items have been addressed 
* [ ] reviewed state machine logic
* [ ] reviewed API design and naming
* [ ] reviewed documentation is accurate
* [ ] reviewed tests and test coverage
* [ ] manually tested (if applicable)
