### PR TITLE
fix(cli): improve `prune` command ux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Improvements
 
+* (cli) [#16856](https://github.com/cosmos/cosmos-sdk/pull/16856) Improve `simd prune` UX by using the app default home directory.
 * (all) [#16537](https://github.com/cosmos/cosmos-sdk/pull/16537) Properly propagated fmt.Errorf errors + using errors.New where appropriate.
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Improvements
 
-* (cli) [#16856](https://github.com/cosmos/cosmos-sdk/pull/16856) Improve `simd prune` UX by using the app default home directory.
+* (cli) [#16856](https://github.com/cosmos/cosmos-sdk/pull/16856) Improve `simd prune` UX by using the app default home directory and set pruning method as first variable argument (defaults to default).
 * (all) [#16537](https://github.com/cosmos/cosmos-sdk/pull/16537) Properly propagated fmt.Errorf errors + using errors.New where appropriate.
 
 ### Bug Fixes

--- a/client/pruning/main.go
+++ b/client/pruning/main.go
@@ -26,16 +26,15 @@ func Cmd(appCreator servertypes.AppCreator, defaultNodeHome string) *cobra.Comma
 		Use:   "prune [pruning-method]",
 		Short: "Prune app history states by keeping the recent heights and deleting old heights",
 		Long: `Prune app history states by keeping the recent heights and deleting old heights.
-		The pruning option is provided via the 'pruning' argument or alternatively with '--pruning-keep-recent'
-		
-		- default: the last 362880 states are kept
-		- nothing: all historic states will be saved, nothing will be deleted (i.e. archiving node)
-		- everything: 2 latest states will be kept
-		- custom: allow pruning options to be manually specified through 'pruning-keep-recent'.
+The pruning option is provided via the 'pruning' argument or alternatively with '--pruning-keep-recent'
 
-		Note: When the --app-db-backend flag is not specified, the default backend type is 'goleveldb'.
-		Supported app-db-backend types include 'goleveldb', 'rocksdb', 'pebbledb'.
-		`,
+- default: the last 362880 states are kept
+- nothing: all historic states will be saved, nothing will be deleted (i.e. archiving node)
+- everything: 2 latest states will be kept
+- custom: allow pruning options to be manually specified through 'pruning-keep-recent'
+
+Note: When the --app-db-backend flag is not specified, the default backend type is 'goleveldb'.
+Supported app-db-backend types include 'goleveldb', 'rocksdb', 'pebbledb'.`,
 		Example: "prune custom --pruning-keep-recent 100 --app-db-backend 'goleveldb'",
 		Args:    cobra.RangeArgs(0, 1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/client/pruning/main.go
+++ b/client/pruning/main.go
@@ -50,7 +50,7 @@ func Cmd(appCreator servertypes.AppCreator, defaultNodeHome string) *cobra.Comma
 			if err != nil {
 				return err
 			}
-			fmt.Printf("get pruning options from command flags, strategy: %v, keep-recent: %v\n",
+			cmd.Printf("get pruning options from command flags, strategy: %v, keep-recent: %v\n",
 				pruningOptions.Strategy,
 				pruningOptions.KeepRecent,
 			)
@@ -80,16 +80,14 @@ func Cmd(appCreator servertypes.AppCreator, defaultNodeHome string) *cobra.Comma
 			}
 
 			pruningHeight := latestHeight - int64(pruningOptions.KeepRecent)
-			fmt.Printf(
-				"pruning heights up to %v\n",
-				pruningHeight,
-			)
+			cmd.Printf("pruning heights up to %v\n", pruningHeight)
 
 			err = rootMultiStore.PruneStores(pruningHeight)
 			if err != nil {
 				return err
 			}
-			fmt.Printf("successfully pruned the application root multi stores\n")
+
+			cmd.Println("successfully pruned the application root multi stores")
 			return nil
 		},
 	}

--- a/client/pruning/main.go
+++ b/client/pruning/main.go
@@ -21,7 +21,7 @@ const FlagAppDBBackend = "app-db-backend"
 
 // Cmd prunes the sdk root multi store history versions based on the pruning options
 // specified by command flags.
-func Cmd(appCreator servertypes.AppCreator) *cobra.Command {
+func Cmd(appCreator servertypes.AppCreator, defaultNodeHome string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "prune",
 		Short: "Prune app history states by keeping the recent heights and deleting old heights",
@@ -38,7 +38,7 @@ func Cmd(appCreator servertypes.AppCreator) *cobra.Command {
 		'--home' and '--app-db-backend'.
 		valid app-db-backend type includes 'goleveldb', 'rocksdb', 'pebbledb'.
 		`,
-		Example: "prune --home './' --app-db-backend 'goleveldb' --pruning 'custom' --pruning-keep-recent 100",
+		Example: "prune --app-db-backend 'goleveldb' --pruning 'custom' --pruning-keep-recent 100",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			vp := viper.New()
 
@@ -56,6 +56,10 @@ func Cmd(appCreator servertypes.AppCreator) *cobra.Command {
 			)
 
 			home := vp.GetString(flags.FlagHome)
+			if home == "" {
+				home = defaultNodeHome
+			}
+
 			db, err := openDB(home, server.GetAppDBBackend(vp))
 			if err != nil {
 				return err
@@ -90,7 +94,7 @@ func Cmd(appCreator servertypes.AppCreator) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().String(flags.FlagHome, "", "The database home directory")
+	cmd.Flags().String(flags.FlagHome, defaultNodeHome, "The application home directory")
 	cmd.Flags().String(FlagAppDBBackend, "", "The type of database for application and snapshots databases")
 	cmd.Flags().String(server.FlagPruning, pruningtypes.PruningOptionDefault, "Pruning strategy (default|nothing|everything|custom)")
 	cmd.Flags().Uint64(server.FlagPruningKeepRecent, 0, "Number of recent heights to keep on disk (ignored if pruning is not 'custom')")

--- a/simapp/simd/cmd/root.go
+++ b/simapp/simd/cmd/root.go
@@ -197,7 +197,7 @@ func initRootCmd(rootCmd *cobra.Command, encodingConfig params.EncodingConfig, b
 		NewTestnetCmd(basicManager, banktypes.GenesisBalancesIterator{}),
 		debug.Cmd(),
 		confixcmd.ConfigCommand(),
-		pruning.Cmd(newApp),
+		pruning.Cmd(newApp, simapp.DefaultNodeHome),
 		snapshot.Cmd(newApp),
 	)
 

--- a/simapp/simd/cmd/root_v2.go
+++ b/simapp/simd/cmd/root_v2.go
@@ -213,7 +213,7 @@ func initRootCmd(
 		NewTestnetCmd(basicManager, banktypes.GenesisBalancesIterator{}),
 		debug.Cmd(),
 		confixcmd.ConfigCommand(),
-		pruning.Cmd(newApp),
+		pruning.Cmd(newApp, simapp.DefaultNodeHome),
 		snapshot.Cmd(newApp),
 	)
 


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

Closes: https://github.com/cosmos/cosmos-sdk/issues/16855

Right now, passing the home flag is mandatory otherwise it panics. It isn't a great UX, as every other SDK commands do not require to always pass a flag.

Looking as well now how to make the ux for this command better.
In the backport, I'll do it non-breaking for v0.46 and v0.47.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] added `!` to the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules)
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] updated the relevant documentation or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] confirmed all author checklist items have been addressed 
* [ ] reviewed state machine logic
* [ ] reviewed API design and naming
* [ ] reviewed documentation is accurate
* [ ] reviewed tests and test coverage
* [ ] manually tested (if applicable)
