### PR TITLE
feat(cosmovisor): Cosmovisor upgrade plan without automatic lower case

### DIFF
--- a/tools/cosmovisor/CHANGELOG.md
+++ b/tools/cosmovisor/CHANGELOG.md
@@ -45,6 +45,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## Improvements
 
+* [#16919](https://github.com/cosmos/cosmos-sdk/pull/16919) Add COSMOVISOR_DISABLE_RECASE to cosmovisor to disable automatic case change for plan name
 * [#14881](https://github.com/cosmos/cosmos-sdk/pull/14881) Refactor Cosmovisor to use `x/upgrade` validation logic.
 * [#14881](https://github.com/cosmos/cosmos-sdk/pull/14881) Refactor Cosmovisor to depend only on the `x/upgrade` module.
 * [#15362](https://github.com/cosmos/cosmos-sdk/pull/15362) Allow disabling Cosmovisor logs

--- a/tools/cosmovisor/README.md
+++ b/tools/cosmovisor/README.md
@@ -98,6 +98,7 @@ Use of `cosmovisor` without one of the action arguments is deprecated. For backw
 * `COSMOVISOR_COLOR_LOGS` (defaults to `true`). If set to true, this will colorise Cosmovisor logs (but not the underlying process).
 * `COSMOVISOR_TIMEFORMAT_LOGS` (defaults to `kitchen`). If set to a value (`layout|ansic|unixdate|rubydate|rfc822|rfc822z|rfc850|rfc1123|rfc1123z|rfc3339|rfc3339nano|kitchen`), this will add timestamp prefix to Cosmovisor logs (but not the underlying process).
 * `COSMOVISOR_CUSTOM_PREUPGRADE` (defaults to ``).  If set, this will run $DAEMON_HOME/cosmovisor/$COSMOVISOR_CUSTOM_PREUPGRADE prior to upgrade with the arguments [ upgrade.Name, upgrade.Height ].  Executes a custom script (separate and prior to the chain daemon pre-upgrade command)
+* `COSMOVISOR_DISABLE_RECASE` (defaults to `false`).  If set to true, the upgrade directory will expected to match the upgrade plan name without any case changes
 
 ### Folder Layout
 

--- a/tools/cosmovisor/args.go
+++ b/tools/cosmovisor/args.go
@@ -33,6 +33,7 @@ const (
 	EnvColorLogs                = "COSMOVISOR_COLOR_LOGS"
 	EnvTimeFormatLogs           = "COSMOVISOR_TIMEFORMAT_LOGS"
 	EnvCustomPreupgrade         = "COSMOVISOR_CUSTOM_PREUPGRADE"
+	EnvDisableRecase            = "COSMOVISOR_DISABLE_RECASE"
 )
 
 const (
@@ -58,6 +59,7 @@ type Config struct {
 	ColorLogs                bool
 	TimeFormatLogs           string
 	CustomPreupgrade         string
+	DisableRecase            bool
 
 	// currently running upgrade
 	currentUpgrade upgradetypes.Plan
@@ -176,6 +178,9 @@ func GetConfigFromEnv() (*Config, error) {
 		errs = append(errs, err)
 	}
 	if cfg.TimeFormatLogs, err = TimeFormatOptionFromEnv(EnvTimeFormatLogs, time.Kitchen); err != nil {
+		errs = append(errs, err)
+	}
+	if cfg.DisableRecase, err = BooleanOption(EnvDisableRecase, false); err != nil {
 		errs = append(errs, err)
 	}
 

--- a/tools/cosmovisor/args_test.go
+++ b/tools/cosmovisor/args_test.go
@@ -38,6 +38,7 @@ type cosmovisorEnv struct {
 	ColorLogs                string
 	TimeFormatLogs           string
 	CustomPreupgrade         string
+	DisableRecase            string
 }
 
 type envMap struct {
@@ -62,6 +63,7 @@ func (c cosmovisorEnv) ToMap() map[string]envMap {
 		EnvColorLogs:                {val: c.ColorLogs, allowEmpty: false},
 		EnvTimeFormatLogs:           {val: c.TimeFormatLogs, allowEmpty: true},
 		EnvCustomPreupgrade:         {val: c.CustomPreupgrade, allowEmpty: true},
+		EnvDisableRecase:            {val: c.DisableRecase, allowEmpty: true},
 	}
 }
 
@@ -96,6 +98,8 @@ func (c *cosmovisorEnv) Set(envVar, envVal string) {
 		c.TimeFormatLogs = envVal
 	case EnvCustomPreupgrade:
 		c.CustomPreupgrade = envVal
+	case EnvDisableRecase:
+		c.DisableRecase = envVal
 	default:
 		panic(fmt.Errorf("Unknown environment variable [%s]. Ccannot set field to [%s]. ", envVar, envVal))
 	}
@@ -456,6 +460,7 @@ func (s *argsTestSuite) TestGetConfigFromEnv() {
 		disableLogs, colorLogs bool,
 		timeFormatLogs string,
 		customPreUpgrade string,
+		disableRecase bool,
 	) *Config {
 		return &Config{
 			Home:                     home,
@@ -472,6 +477,7 @@ func (s *argsTestSuite) TestGetConfigFromEnv() {
 			ColorLogs:                colorLogs,
 			TimeFormatLogs:           timeFormatLogs,
 			CustomPreupgrade:         customPreUpgrade,
+			DisableRecase:            disableRecase,
 		}
 	}
 
@@ -495,19 +501,21 @@ func (s *argsTestSuite) TestGetConfigFromEnv() {
 				Interval:                 "bad",
 				PreupgradeMaxRetries:     "bad",
 				TimeFormatLogs:           "bad",
+				CustomPreupgrade:         "",
+				DisableRecase:            "bad",
 			},
 			expectedCfg:      nil,
-			expectedErrCount: 11,
+			expectedErrCount: 12,
 		},
 		{
 			name:             "all good",
-			envVals:          cosmovisorEnv{absPath, "testname", "true", "true", "false", "600ms", "true", "", "303ms", "1", "false", "true", "kitchen", "preupgrade.sh"},
-			expectedCfg:      newConfig(absPath, "testname", true, true, false, 600, true, absPath, 303, 1, false, true, time.Kitchen, "preupgrade.sh"),
+			envVals:          cosmovisorEnv{absPath, "testname", "true", "true", "false", "600ms", "true", "", "303ms", "1", "false", "true", "kitchen", "preupgrade.sh", "true"},
+			expectedCfg:      newConfig(absPath, "testname", true, true, false, 600, true, absPath, 303, 1, false, true, time.Kitchen, "preupgrade.sh", true),
 			expectedErrCount: 0,
 		},
 		{
 			name:             "nothing set",
-			envVals:          cosmovisorEnv{"", "", "", "", "", "", "", "", "", "", "false", "false", "", ""},
+			envVals:          cosmovisorEnv{"", "", "", "", "", "", "", "", "", "", "false", "false", "", "", ""},
 			expectedCfg:      nil,
 			expectedErrCount: 3,
 		},
@@ -515,218 +523,229 @@ func (s *argsTestSuite) TestGetConfigFromEnv() {
 		// timeformat tests are done in the TestTimeFormat
 		{
 			name:             "download bin bad",
-			envVals:          cosmovisorEnv{absPath, "testname", "bad", "true", "false", "600ms", "true", "", "303ms", "1", "false", "true", "kitchen", ""},
+			envVals:          cosmovisorEnv{absPath, "testname", "bad", "true", "false", "600ms", "true", "", "303ms", "1", "false", "true", "kitchen", "", ""},
 			expectedCfg:      nil,
 			expectedErrCount: 1,
 		},
 		{
 			name:             "download bin not set",
-			envVals:          cosmovisorEnv{absPath, "testname", "", "true", "false", "600ms", "true", "", "303ms", "1", "false", "true", "kitchen", ""},
-			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, true, absPath, 303, 1, false, true, time.Kitchen, ""),
+			envVals:          cosmovisorEnv{absPath, "testname", "", "true", "false", "600ms", "true", "", "303ms", "1", "false", "true", "kitchen", "", ""},
+			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, true, absPath, 303, 1, false, true, time.Kitchen, "", false),
 			expectedErrCount: 0,
 		},
 		{
 			name:             "download bin true",
-			envVals:          cosmovisorEnv{absPath, "testname", "true", "true", "false", "600ms", "true", "", "303ms", "1", "false", "true", "kitchen", "preupgrade.sh"},
-			expectedCfg:      newConfig(absPath, "testname", true, true, false, 600, true, absPath, 303, 1, false, true, time.Kitchen, "preupgrade.sh"),
+			envVals:          cosmovisorEnv{absPath, "testname", "true", "true", "false", "600ms", "true", "", "303ms", "1", "false", "true", "kitchen", "preupgrade.sh", ""},
+			expectedCfg:      newConfig(absPath, "testname", true, true, false, 600, true, absPath, 303, 1, false, true, time.Kitchen, "preupgrade.sh", false),
 			expectedErrCount: 0,
 		},
 		{
 			name:             "download bin false",
-			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "true", "", "303ms", "1", "false", "true", "kitchen", "preupgrade.sh"},
-			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, true, absPath, 303, 1, false, true, time.Kitchen, "preupgrade.sh"),
+			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "true", "", "303ms", "1", "false", "true", "kitchen", "preupgrade.sh", ""},
+			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, true, absPath, 303, 1, false, true, time.Kitchen, "preupgrade.sh", false),
 			expectedErrCount: 0,
 		},
 		{
 			name:             "download ensure checksum true",
-			envVals:          cosmovisorEnv{absPath, "testname", "true", "false", "false", "600ms", "true", "", "303ms", "1", "false", "true", "kitchen", "preupgrade.sh"},
-			expectedCfg:      newConfig(absPath, "testname", true, false, false, 600, true, absPath, 303, 1, false, true, time.Kitchen, "preupgrade.sh"),
+			envVals:          cosmovisorEnv{absPath, "testname", "true", "false", "false", "600ms", "true", "", "303ms", "1", "false", "true", "kitchen", "preupgrade.sh", ""},
+			expectedCfg:      newConfig(absPath, "testname", true, false, false, 600, true, absPath, 303, 1, false, true, time.Kitchen, "preupgrade.sh", false),
 			expectedErrCount: 0,
 		},
 		{
 			name:             "restart upgrade bad",
-			envVals:          cosmovisorEnv{absPath, "testname", "true", "true", "bad", "600ms", "true", "", "303ms", "1", "false", "true", "kitchen", "preupgrade.sh"},
+			envVals:          cosmovisorEnv{absPath, "testname", "true", "true", "bad", "600ms", "true", "", "303ms", "1", "false", "true", "kitchen", "preupgrade.sh", ""},
 			expectedCfg:      nil,
 			expectedErrCount: 1,
 		},
 		{
 			name:             "restart upgrade not set",
-			envVals:          cosmovisorEnv{absPath, "testname", "true", "true", "", "600ms", "true", "", "303ms", "1", "false", "true", "kitchen", "preupgrade.sh"},
-			expectedCfg:      newConfig(absPath, "testname", true, true, true, 600, true, absPath, 303, 1, false, true, time.Kitchen, "preupgrade.sh"),
+			envVals:          cosmovisorEnv{absPath, "testname", "true", "true", "", "600ms", "true", "", "303ms", "1", "false", "true", "kitchen", "preupgrade.sh", ""},
+			expectedCfg:      newConfig(absPath, "testname", true, true, true, 600, true, absPath, 303, 1, false, true, time.Kitchen, "preupgrade.sh", false),
 			expectedErrCount: 0,
 		},
 		{
 			name:             "restart upgrade true",
-			envVals:          cosmovisorEnv{absPath, "testname", "true", "true", "true", "600ms", "true", "", "303ms", "1", "false", "true", "kitchen", "preupgrade.sh"},
-			expectedCfg:      newConfig(absPath, "testname", true, true, true, 600, true, absPath, 303, 1, false, true, time.Kitchen, "preupgrade.sh"),
+			envVals:          cosmovisorEnv{absPath, "testname", "true", "true", "true", "600ms", "true", "", "303ms", "1", "false", "true", "kitchen", "preupgrade.sh", ""},
+			expectedCfg:      newConfig(absPath, "testname", true, true, true, 600, true, absPath, 303, 1, false, true, time.Kitchen, "preupgrade.sh", false),
 			expectedErrCount: 0,
 		},
 		{
 			name:             "restart upgrade true",
-			envVals:          cosmovisorEnv{absPath, "testname", "true", "true", "false", "600ms", "true", "", "303ms", "1", "false", "true", "kitchen", "preupgrade.sh"},
-			expectedCfg:      newConfig(absPath, "testname", true, true, false, 600, true, absPath, 303, 1, false, true, time.Kitchen, "preupgrade.sh"),
+			envVals:          cosmovisorEnv{absPath, "testname", "true", "true", "false", "600ms", "true", "", "303ms", "1", "false", "true", "kitchen", "preupgrade.sh", ""},
+			expectedCfg:      newConfig(absPath, "testname", true, true, false, 600, true, absPath, 303, 1, false, true, time.Kitchen, "preupgrade.sh", false),
 			expectedErrCount: 0,
 		},
 		{
 			name:             "skip unsafe backups bad",
-			envVals:          cosmovisorEnv{absPath, "testname", "true", "true", "false", "600ms", "bad", "", "303ms", "1", "false", "true", "kitchen", "preupgrade.sh"},
+			envVals:          cosmovisorEnv{absPath, "testname", "true", "true", "false", "600ms", "bad", "", "303ms", "1", "false", "true", "kitchen", "preupgrade.sh", ""},
 			expectedCfg:      nil,
 			expectedErrCount: 1,
 		},
 		{
 			name:             "skip unsafe backups not set",
-			envVals:          cosmovisorEnv{absPath, "testname", "true", "true", "false", "600ms", "", "", "303ms", "1", "false", "true", "kitchen", "preupgrade.sh"},
-			expectedCfg:      newConfig(absPath, "testname", true, true, false, 600, false, absPath, 303, 1, false, true, time.Kitchen, "preupgrade.sh"),
+			envVals:          cosmovisorEnv{absPath, "testname", "true", "true", "false", "600ms", "", "", "303ms", "1", "false", "true", "kitchen", "preupgrade.sh", ""},
+			expectedCfg:      newConfig(absPath, "testname", true, true, false, 600, false, absPath, 303, 1, false, true, time.Kitchen, "preupgrade.sh", false),
 			expectedErrCount: 0,
 		},
 		{
 			name:             "skip unsafe backups true",
-			envVals:          cosmovisorEnv{absPath, "testname", "true", "true", "false", "600ms", "true", "", "303ms", "1", "false", "true", "kitchen", "preupgrade.sh"},
-			expectedCfg:      newConfig(absPath, "testname", true, true, false, 600, true, absPath, 303, 1, false, true, time.Kitchen, "preupgrade.sh"),
+			envVals:          cosmovisorEnv{absPath, "testname", "true", "true", "false", "600ms", "true", "", "303ms", "1", "false", "true", "kitchen", "preupgrade.sh", ""},
+			expectedCfg:      newConfig(absPath, "testname", true, true, false, 600, true, absPath, 303, 1, false, true, time.Kitchen, "preupgrade.sh", false),
 			expectedErrCount: 0,
 		},
 		{
 			name:             "skip unsafe backups false",
-			envVals:          cosmovisorEnv{absPath, "testname", "true", "true", "false", "600ms", "false", "", "303ms", "1", "false", "true", "kitchen", "preupgrade.sh"},
-			expectedCfg:      newConfig(absPath, "testname", true, true, false, 600, false, absPath, 303, 1, false, true, time.Kitchen, "preupgrade.sh"),
+			envVals:          cosmovisorEnv{absPath, "testname", "true", "true", "false", "600ms", "false", "", "303ms", "1", "false", "true", "kitchen", "preupgrade.sh", ""},
+			expectedCfg:      newConfig(absPath, "testname", true, true, false, 600, false, absPath, 303, 1, false, true, time.Kitchen, "preupgrade.sh", false),
 			expectedErrCount: 0,
 		},
 		{
 			name:             "poll interval bad",
-			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "bad", "1", "false", "true", "kitchen", "preupgrade.sh"},
+			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "bad", "1", "false", "true", "kitchen", "preupgrade.sh", ""},
 			expectedCfg:      nil,
 			expectedErrCount: 1,
 		},
 		{
 			name:             "poll interval 0",
-			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "0", "1", "false", "true", "kitchen", "preupgrade.sh"},
+			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "0", "1", "false", "true", "kitchen", "preupgrade.sh", ""},
 			expectedCfg:      nil,
 			expectedErrCount: 1,
 		},
 		{
 			name:             "poll interval not set",
-			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "", "1", "false", "false", "kitchen", "preupgrade.sh"},
-			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, false, absPath, 300, 1, false, false, time.Kitchen, "preupgrade.sh"),
+			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "", "1", "false", "false", "kitchen", "preupgrade.sh", ""},
+			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, false, absPath, 300, 1, false, false, time.Kitchen, "preupgrade.sh", false),
 			expectedErrCount: 0,
 		},
 		{
 			name:             "poll interval 600",
-			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "600", "1", "false", "true", "kitchen", "preupgrade.sh"},
+			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "600", "1", "false", "true", "kitchen", "preupgrade.sh", ""},
 			expectedCfg:      nil,
 			expectedErrCount: 1,
 		},
 		{
 			name:             "poll interval 1s",
-			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "1s", "1", "false", "false", "kitchen", "preupgrade.sh"},
-			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, false, absPath, 1000, 1, false, false, time.Kitchen, "preupgrade.sh"),
+			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "1s", "1", "false", "false", "kitchen", "preupgrade.sh", ""},
+			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, false, absPath, 1000, 1, false, false, time.Kitchen, "preupgrade.sh", false),
 			expectedErrCount: 0,
 		},
 		{
 			name:             "poll interval -3m",
-			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "-3m", "1", "false", "true", "kitchen", "preupgrade.sh"},
+			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "-3m", "1", "false", "true", "kitchen", "preupgrade.sh", ""},
 			expectedCfg:      nil,
 			expectedErrCount: 1,
 		},
 		{
 			name:             "restart delay bad",
-			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "bad", "false", "", "303ms", "1", "false", "true", "kitchen", "preupgrade.sh"},
+			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "bad", "false", "", "303ms", "1", "false", "true", "kitchen", "preupgrade.sh", ""},
 			expectedCfg:      nil,
 			expectedErrCount: 1,
 		},
 		{
 			name:             "restart delay 0",
-			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "0", "false", "", "303ms", "1", "false", "true", "kitchen", "preupgrade.sh"},
+			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "0", "false", "", "303ms", "1", "false", "true", "kitchen", "preupgrade.sh", ""},
 			expectedCfg:      nil,
 			expectedErrCount: 1,
 		},
 		{
 			name:             "restart delay not set",
-			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "", "false", "", "303ms", "1", "false", "false", "kitchen", "preupgrade.sh"},
-			expectedCfg:      newConfig(absPath, "testname", false, true, false, 0, false, absPath, 303, 1, false, false, time.Kitchen, "preupgrade.sh"),
+			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "", "false", "", "303ms", "1", "false", "false", "kitchen", "preupgrade.sh", ""},
+			expectedCfg:      newConfig(absPath, "testname", false, true, false, 0, false, absPath, 303, 1, false, false, time.Kitchen, "preupgrade.sh", false),
 			expectedErrCount: 0,
 		},
 		{
 			name:             "restart delay 600",
-			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600", "false", "", "300ms", "1", "false", "true", "kitchen", "preupgrade.sh"},
+			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600", "false", "", "300ms", "1", "false", "true", "kitchen", "preupgrade.sh", ""},
 			expectedCfg:      nil,
 			expectedErrCount: 1,
 		},
 		{
 			name:             "restart delay 1s",
-			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "1s", "false", "", "303ms", "1", "false", "false", "kitchen", "preupgrade.sh"},
-			expectedCfg:      newConfig(absPath, "testname", false, true, false, 1000, false, absPath, 303, 1, false, false, time.Kitchen, "preupgrade.sh"),
+			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "1s", "false", "", "303ms", "1", "false", "false", "kitchen", "preupgrade.sh", ""},
+			expectedCfg:      newConfig(absPath, "testname", false, true, false, 1000, false, absPath, 303, 1, false, false, time.Kitchen, "preupgrade.sh", false),
 			expectedErrCount: 0,
 		},
 		{
 			name:             "restart delay -3m",
-			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "-3m", "false", "", "303ms", "1", "false", "true", "kitchen", "preupgrade.sh"},
+			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "-3m", "false", "", "303ms", "1", "false", "true", "kitchen", "preupgrade.sh", ""},
 			expectedCfg:      nil,
 			expectedErrCount: 1,
 		},
 		{
 			name:             "prepupgrade max retries bad",
-			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "406ms", "bad", "false", "true", "kitchen", "preupgrade.sh"},
+			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "406ms", "bad", "false", "true", "kitchen", "preupgrade.sh", ""},
 			expectedCfg:      nil,
 			expectedErrCount: 1,
 		},
 		{
 			name:             "prepupgrade max retries 0",
-			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "406ms", "0", "false", "false", "kitchen", "preupgrade.sh"},
-			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, false, absPath, 406, 0, false, false, time.Kitchen, "preupgrade.sh"),
+			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "406ms", "0", "false", "false", "kitchen", "preupgrade.sh", ""},
+			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, false, absPath, 406, 0, false, false, time.Kitchen, "preupgrade.sh", false),
 			expectedErrCount: 0,
 		},
 		{
 			name:             "prepupgrade max retries not set",
-			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "406ms", "", "false", "false", "kitchen", "preupgrade.sh"},
-			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, false, absPath, 406, 0, false, false, time.Kitchen, "preupgrade.sh"),
+			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "406ms", "", "false", "false", "kitchen", "preupgrade.sh", ""},
+			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, false, absPath, 406, 0, false, false, time.Kitchen, "preupgrade.sh", false),
 			expectedErrCount: 0,
 		},
 		{
 			name:             "prepupgrade max retries 5",
-			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "406ms", "5", "false", "false", "kitchen", "preupgrade.sh"},
-			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, false, absPath, 406, 5, false, false, time.Kitchen, "preupgrade.sh"),
+			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "406ms", "5", "false", "false", "kitchen", "preupgrade.sh", ""},
+			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, false, absPath, 406, 5, false, false, time.Kitchen, "preupgrade.sh", false),
 			expectedErrCount: 0,
 		},
 		{
 			name:             "disable logs bad",
-			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "406ms", "5", "bad", "true", "kitchen", "preupgrade.sh"},
+			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "406ms", "5", "bad", "true", "kitchen", "preupgrade.sh", ""},
 			expectedCfg:      nil,
 			expectedErrCount: 1,
 		},
 		{
 			name:             "disable logs good",
-			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "406ms", "", "true", "false", "kitchen", "preupgrade.sh"},
-			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, false, absPath, 406, 0, true, false, time.Kitchen, "preupgrade.sh"),
+			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "406ms", "", "true", "false", "kitchen", "preupgrade.sh", ""},
+			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, false, absPath, 406, 0, true, false, time.Kitchen, "preupgrade.sh", false),
 			expectedErrCount: 0,
 		},
 		{
 			name:             "disable logs color bad",
-			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "406ms", "5", "true", "bad", "kitchen", "preupgrade.sh"},
+			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "406ms", "5", "true", "bad", "kitchen", "preupgrade.sh", ""},
 			expectedCfg:      nil,
 			expectedErrCount: 1,
 		},
 		{
 			name:             "disable logs color good",
-			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "406ms", "", "true", "false", "kitchen", "preupgrade.sh"},
-			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, false, absPath, 406, 0, true, false, time.Kitchen, "preupgrade.sh"),
+			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "406ms", "", "true", "false", "kitchen", "preupgrade.sh", ""},
+			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, false, absPath, 406, 0, true, false, time.Kitchen, "preupgrade.sh", false),
 			expectedErrCount: 0,
 		},
 		{
 			name:             "disable logs timestamp",
-			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "406ms", "", "true", "false", "", "preupgrade.sh"},
-			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, false, absPath, 406, 0, true, false, "", "preupgrade.sh"),
+			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "406ms", "", "true", "false", "", "preupgrade.sh", ""},
+			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, false, absPath, 406, 0, true, false, "", "preupgrade.sh", false),
 			expectedErrCount: 0,
 		},
 		{
 			name:             "enable rf3339 logs timestamp",
-			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "406ms", "", "true", "true", "rfc3339", "preupgrade.sh"},
-			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, false, absPath, 406, 0, true, true, time.RFC3339, "preupgrade.sh"),
+			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "406ms", "", "true", "true", "rfc3339", "preupgrade.sh", ""},
+			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, false, absPath, 406, 0, true, true, time.RFC3339, "preupgrade.sh", false),
 			expectedErrCount: 0,
 		},
 		{
 			name:             "invalid logs timestamp format",
-			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "406ms", "", "true", "true", "invalid", "preupgrade.sh"},
+			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "406ms", "", "true", "true", "invalid", "preupgrade.sh", ""},
 			expectedCfg:      nil,
+			expectedErrCount: 1,
+		},
+		{
+			name:             "disable recase good",
+			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "406ms", "", "true", "true", "rfc3339", "preupgrade.sh", "true"},
+			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, false, absPath, 406, 0, true, true, time.RFC3339, "preupgrade.sh", true),
+			expectedErrCount: 0,
+		},
+		{
+			name:             "disable recase bad",
+			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "406ms", "", "true", "true", "rfc3339", "preupgrade.sh", "bad"},
 			expectedErrCount: 1,
 		},
 	}

--- a/tools/cosmovisor/cmd/cosmovisor/add_upgrade.go
+++ b/tools/cosmovisor/cmd/cosmovisor/add_upgrade.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -24,7 +25,6 @@ func NewAddUpgradeCmd() *cobra.Command {
 
 	addUpgrade.Flags().Bool(cosmovisor.FlagForce, false, "overwrite existing upgrade binary / upgrade-info.json file")
 	addUpgrade.Flags().Int64(cosmovisor.FlagUpgradeHeight, 0, "define a height at which to upgrade the binary automatically (without governance proposal)")
-	addUpgrade.Flags().Bool(cosmovisor.FlagDisableRecase, false, "do not lower case plan name")
 
 	return addUpgrade
 }
@@ -39,11 +39,7 @@ func AddUpgrade(cmd *cobra.Command, args []string) error {
 	logger := cfg.Logger(os.Stdout)
 
 	upgradeName := args[0]
-	disableRecase, err := cmd.Flags().GetBool(cosmovisor.FlagDisableRecase)
-	if err != nil {
-		return fmt.Errorf("failed to get disable-recase flag: %w", err)
-	}
-	if disableRecase == false {
+	if !cfg.DisableRecase {
 		upgradeName = strings.ToLower(args[0])
 	}
 
@@ -98,7 +94,7 @@ func AddUpgrade(cmd *cobra.Command, args []string) error {
 			return err
 		}
 
-		logger.Info(fmt.Sprintf("%s/%s created, %s upgrade binary will switch at height %d", cfg.UpgradeInfoFilePath(), upgradetypes.UpgradeInfoFilename, upgradeName, upgradeHeight))
+		logger.Info(fmt.Sprintf("%s created, %s upgrade binary will switch at height %d", filepath.Join(cfg.UpgradeInfoFilePath(), upgradetypes.UpgradeInfoFilename), upgradeName, upgradeHeight))
 	}
 
 	return nil

--- a/tools/cosmovisor/cmd/cosmovisor/add_upgrade.go
+++ b/tools/cosmovisor/cmd/cosmovisor/add_upgrade.go
@@ -24,6 +24,7 @@ func NewAddUpgradeCmd() *cobra.Command {
 
 	addUpgrade.Flags().Bool(cosmovisor.FlagForce, false, "overwrite existing upgrade binary / upgrade-info.json file")
 	addUpgrade.Flags().Int64(cosmovisor.FlagUpgradeHeight, 0, "define a height at which to upgrade the binary automatically (without governance proposal)")
+	addUpgrade.Flags().Bool(cosmovisor.FlagDisableRecase, false, "do not lower case plan name")
 
 	return addUpgrade
 }
@@ -37,9 +38,13 @@ func AddUpgrade(cmd *cobra.Command, args []string) error {
 
 	logger := cfg.Logger(os.Stdout)
 
-	upgradeName := strings.ToLower(args[0])
-	if len(upgradeName) == 0 {
-		return fmt.Errorf("upgrade name cannot be empty")
+	upgradeName := args[0]
+	disableRecase, err := cmd.Flags().GetBool(cosmovisor.FlagDisableRecase)
+	if err != nil {
+		return fmt.Errorf("failed to get disable-recase flag: %w", err)
+	}
+	if disableRecase == false {
+		upgradeName = strings.ToLower(args[0])
 	}
 
 	executablePath := args[1]
@@ -93,7 +98,7 @@ func AddUpgrade(cmd *cobra.Command, args []string) error {
 			return err
 		}
 
-		logger.Info(fmt.Sprintf("%s created, %s upgrade binary will switch at height %d", upgradetypes.UpgradeInfoFilename, upgradeName, upgradeHeight))
+		logger.Info(fmt.Sprintf("%s/%s created, %s upgrade binary will switch at height %d", cfg.UpgradeInfoFilePath(), upgradetypes.UpgradeInfoFilename, upgradeName, upgradeHeight))
 	}
 
 	return nil

--- a/tools/cosmovisor/flags.go
+++ b/tools/cosmovisor/flags.go
@@ -6,4 +6,5 @@ const (
 	FlagCosmovisorOnly    = "cosmovisor-only"
 	FlagForce             = "force"
 	FlagUpgradeHeight     = "upgrade-height"
+	FlagDisableRecase     = "disable-recase"
 )

--- a/tools/cosmovisor/flags.go
+++ b/tools/cosmovisor/flags.go
@@ -6,5 +6,4 @@ const (
 	FlagCosmovisorOnly    = "cosmovisor-only"
 	FlagForce             = "force"
 	FlagUpgradeHeight     = "upgrade-height"
-	FlagDisableRecase     = "disable-recase"
 )

--- a/tools/cosmovisor/process_test.go
+++ b/tools/cosmovisor/process_test.go
@@ -74,6 +74,51 @@ func (s *processTestSuite) TestLaunchProcess() {
 	require.Equal(cfg.UpgradeBin("chain2"), currentBin)
 }
 
+// TestPlanDisableRecase will test upgrades without lower case plan names
+func (s *processTestSuite) TestPlanDisableRecase() {
+	// binaries from testdata/validate directory
+	require := s.Require()
+	home := copyTestData(s.T(), "norecase")
+	cfg := &cosmovisor.Config{Home: home, Name: "dummyd", PollInterval: 20, UnsafeSkipBackup: true, DisableRecase: true}
+	logger := log.NewTestLogger(s.T()).With(log.ModuleKey, "cosmosvisor")
+
+	// should run the genesis binary and produce expected output
+	stdout, stderr := newBuffer(), newBuffer()
+	currentBin, err := cfg.CurrentBin()
+	require.NoError(err)
+	require.Equal(cfg.GenesisBin(), currentBin)
+
+	launcher, err := cosmovisor.NewLauncher(logger, cfg)
+	require.NoError(err)
+
+	upgradeFile := cfg.UpgradeInfoFilePath()
+
+	args := []string{"foo", "bar", "1234", upgradeFile}
+	doUpgrade, err := launcher.Run(args, stdout, stderr)
+	require.NoError(err)
+	require.True(doUpgrade)
+	require.Equal("", stderr.String())
+	require.Equal(fmt.Sprintf("Genesis foo bar 1234 %s\nUPGRADE \"Chain2\" NEEDED at height: 49: {}\n", upgradeFile), stdout.String())
+
+	// ensure this is upgraded now and produces new output
+	currentBin, err = cfg.CurrentBin()
+	require.NoError(err)
+
+	require.Equal(cfg.UpgradeBin("Chain2"), currentBin)
+	args = []string{"second", "run", "--verbose"}
+	stdout.Reset()
+	stderr.Reset()
+
+	doUpgrade, err = launcher.Run(args, stdout, stderr)
+	require.NoError(err)
+	require.False(doUpgrade)
+	require.Equal("", stderr.String())
+	require.Equal("Chain 2 is live!\nArgs: second run --verbose\nFinished successfully\n", stdout.String())
+
+	// ended without other upgrade
+	require.Equal(cfg.UpgradeBin("Chain2"), currentBin)
+}
+
 func (s *processTestSuite) TestLaunchProcessWithRestartDelay() {
 	// binaries from testdata/validate directory
 	require := s.Require()

--- a/tools/cosmovisor/scanner.go
+++ b/tools/cosmovisor/scanner.go
@@ -203,7 +203,7 @@ func parseUpgradeInfoFile(filename string, disableRecase bool) (upgradetypes.Pla
 	}
 
 	// normalize name to prevent operator error in upgrade name case sensitivity errors.
-	if disableRecase == false {
+	if !disableRecase {
 		upgradePlan.Name = strings.ToLower(upgradePlan.Name)
 	}
 

--- a/tools/cosmovisor/scanner_test.go
+++ b/tools/cosmovisor/scanner_test.go
@@ -13,50 +13,66 @@ func TestParseUpgradeInfoFile(t *testing.T) {
 	cases := []struct {
 		filename      string
 		expectUpgrade upgradetypes.Plan
+		disableRecase bool
 		expectErr     bool
 	}{
 		{
 			filename:      "f1-good.json",
+			disableRecase: false,
 			expectUpgrade: upgradetypes.Plan{Name: "upgrade1", Info: "some info", Height: 123},
 			expectErr:     false,
 		},
 		{
 			filename:      "f2-normalized-name.json",
+			disableRecase: false,
 			expectUpgrade: upgradetypes.Plan{Name: "upgrade2", Info: "some info", Height: 125},
 			expectErr:     false,
 		},
 		{
+			filename:      "f2-normalized-name.json",
+			disableRecase: true,
+			expectUpgrade: upgradetypes.Plan{Name: "Upgrade2", Info: "some info", Height: 125},
+			expectErr:     false,
+		},
+		{
 			filename:      "f2-bad-type.json",
+			disableRecase: false,
 			expectUpgrade: upgradetypes.Plan{},
 			expectErr:     true,
 		},
 		{
 			filename:      "f2-bad-type-2.json",
+			disableRecase: false,
 			expectUpgrade: upgradetypes.Plan{},
 			expectErr:     true,
 		},
 		{
 			filename:      "f3-empty.json",
+			disableRecase: false,
 			expectUpgrade: upgradetypes.Plan{},
 			expectErr:     true,
 		},
 		{
 			filename:      "f4-empty-obj.json",
+			disableRecase: false,
 			expectUpgrade: upgradetypes.Plan{},
 			expectErr:     true,
 		},
 		{
 			filename:      "f5-partial-obj-1.json",
+			disableRecase: false,
 			expectUpgrade: upgradetypes.Plan{},
 			expectErr:     true,
 		},
 		{
 			filename:      "f5-partial-obj-2.json",
+			disableRecase: false,
 			expectUpgrade: upgradetypes.Plan{},
 			expectErr:     true,
 		},
 		{
 			filename:      "unknown.json",
+			disableRecase: false,
 			expectUpgrade: upgradetypes.Plan{},
 			expectErr:     true,
 		},
@@ -66,7 +82,7 @@ func TestParseUpgradeInfoFile(t *testing.T) {
 		tc := cases[i]
 		t.Run(tc.filename, func(t *testing.T) {
 			require := require.New(t)
-			ui, err := parseUpgradeInfoFile(filepath.Join(".", "testdata", "upgrade-files", tc.filename))
+			ui, err := parseUpgradeInfoFile(filepath.Join(".", "testdata", "upgrade-files", tc.filename), tc.disableRecase)
 			if tc.expectErr {
 				require.Error(err)
 			} else {

--- a/tools/cosmovisor/testdata/norecase/cosmovisor/genesis/bin/dummyd
+++ b/tools/cosmovisor/testdata/norecase/cosmovisor/genesis/bin/dummyd
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+echo Genesis $@
+sleep 1
+test -z $4 && exit 1001
+echo 'UPGRADE "Chain2" NEEDED at height: 49: {}'
+echo '{"name":"Chain2","height":49,"info":""}' > $4
+sleep 2
+echo Never should be printed!!!

--- a/tools/cosmovisor/testdata/norecase/cosmovisor/upgrades/Chain2/bin/dummyd
+++ b/tools/cosmovisor/testdata/norecase/cosmovisor/upgrades/Chain2/bin/dummyd
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+echo Chain 2 is live!
+echo Args: $@
+sleep 1
+echo Finished successfully


### PR DESCRIPTION
## Description
Follow up for:
https://github.com/cosmos/cosmos-sdk/pull/16549/files#r1245473528

Add option for cosmovisor to use upgrade plan names without automatic lower case.  

This is helpful when using original non-case changed plan names from:
* online web based chain explorers
* output of `daemond q gov proposals`
* output of `daemond q upgrade plan`

Some validators automate the configuration of daemon upgrades but do not have automatic lower case tooling 

Validators who copy and paste from explorers to avoid typos in plan names can manually edit, but that manual edit can introduce typos.

Some plan names may use characters that do not have obvious lower case rules.  For example lower case of "ΔİΞ" = "δiξ" but not all validators know how golang's internal libraries implement lower casing.


---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [X] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] added `!` to the type prefix if API or client breaking change
* [X] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules)
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [X] added a changelog entry to `CHANGELOG.md`
* [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] updated the relevant documentation or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] confirmed all author checklist items have been addressed 
* [ ] reviewed state machine logic
* [ ] reviewed API design and naming
* [ ] reviewed documentation is accurate
* [ ] reviewed tests and test coverage
* [ ] manually tested (if applicable)
