### PR TITLE
doc: clarify software upgrade proposals are legacy

### DIFF
--- a/x/upgrade/types/proposal.go
+++ b/x/upgrade/types/proposal.go
@@ -9,7 +9,9 @@ const (
 	ProposalTypeCancelSoftwareUpgrade string = "CancelSoftwareUpgrade"
 )
 
-// NewSoftwareUpgradeProposal creates a new SoftwareUpgradeProposal instance
+// NewSoftwareUpgradeProposal creates a new SoftwareUpgradeProposal instance.
+// Deprecated: this proposal is considered legacy and is deprecated in favor of
+// Msg-based gov proposals. See MsgSoftwareUpgrade.
 func NewSoftwareUpgradeProposal(title, description string, plan Plan) gov.Content {
 	return &SoftwareUpgradeProposal{title, description, plan}
 }
@@ -42,7 +44,9 @@ func (sup *SoftwareUpgradeProposal) ValidateBasic() error {
 	return gov.ValidateAbstract(sup)
 }
 
-// NewCancelSoftwareUpgradeProposal creates a new CancelSoftwareUpgradeProposal instance
+// NewCancelSoftwareUpgradeProposal creates a new CancelSoftwareUpgradeProposal
+// instance. Deprecated: this proposal is considered legacy and is deprecated in
+// favor of Msg-based gov proposals. See MsgCancelUpgrade.
 func NewCancelSoftwareUpgradeProposal(title, description string) gov.Content {
 	return &CancelSoftwareUpgradeProposal{title, description}
 }


### PR DESCRIPTION
Motivation: https://github.com/cosmos/cosmos-sdk/issues/16929#issuecomment-1631960278

Inspiration for comments is from [here](https://github.com/rootulp/cosmos-sdk/blob/c75903d71c951efd3f5e3d7c000b39ce9b3654f2/proto/cosmos/upgrade/v1beta1/upgrade.proto#L46-L49) and [here](https://github.com/rootulp/cosmos-sdk/blob/c75903d71c951efd3f5e3d7c000b39ce9b3654f2/proto/cosmos/upgrade/v1beta1/upgrade.proto#L66-L69).