### PR TITLE
feat: Additional keys added to upgrade.proto

### DIFF
--- a/proto/cosmos/upgrade/v1beta1/upgrade.proto
+++ b/proto/cosmos/upgrade/v1beta1/upgrade.proto
@@ -23,24 +23,34 @@ message Plan {
   // assumed that the software is out-of-date when the upgrade Time or Height is
   // reached and the software will exit.
   string name = 1;
+  
+  // Unequivocally set the proper version tag and commit hash to avoid upgrade confusion.
+  // The additional information will allow for checks that are queriable on chain to ensure
+  // that the admin of the node did correctly update to the proper version/hash.
+  // This will also allow others to set a task which will be able to automatically download
+  // the update from github with no question if it is the correct one or not.
+  // This will provide also provide history to the exact upgrade.
+  string github_release_tag = 2;
+
+  string github_release_commit_hash = 3;
 
   // Deprecated: Time based upgrades have been deprecated. Time based upgrade logic
   // has been removed from the SDK.
   // If this field is not empty, an error will be thrown.
-  google.protobuf.Timestamp time = 2
+  google.protobuf.Timestamp time = 4
       [deprecated = true, (gogoproto.stdtime) = true, (gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 
   // The height at which the upgrade must be performed.
-  int64 height = 3;
+  int64 height = 5;
 
   // Any application specific upgrade info to be included on-chain
   // such as a git commit that validators could automatically upgrade to
-  string info = 4;
+  string info = 6;
 
   // Deprecated: UpgradedClientState field has been deprecated. IBC upgrade logic has been
   // moved to the IBC module in the sub module 02-client.
   // If this field is not empty, an error will be thrown.
-  google.protobuf.Any upgraded_client_state = 5 [deprecated = true];
+  google.protobuf.Any upgraded_client_state = 7 [deprecated = true];
 }
 
 // SoftwareUpgradeProposal is a gov Content type for initiating a software


### PR DESCRIPTION
## Description

Currently, there is no defined place to put the release version tag and/or commit hash for Upgrade plans.

Adding this information is beneficial in a few ways.
- Provides an unequivocal field for the version tag and commit hash, eliminating any confusion or issues when using git to fetch the update
- Will provide a back history for later reference
- Will allow admins to create tools to verify upgrade versions, as well as automatically fetching them.

I have been working on an upgrade script that I plan on releasing for all to use.  One of the issues I am currently running into is parsing the information found in Upgrade Gov Props/Plans.  There is really no standard for listing the version/commit has to upgrade to.  For example, Stargaze's recent upgrade listed the upgrade version as `v11` but the tag is really `v11.0.0`.  Another issue that can arise is, when multiple versions are listed in the description, like what else the upgrade is updating to, determining the proper version tag for GitHub is not reliable.  

<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

The additional code below is what I am proposing to add upstream as well as backport to the other current supported versions, 0.45.x, 0.46.x, etc..
I placed them under the `name` string, as it seemed more appropriate to reorder them in this fashion.

coded added:
```
  string github_release_tag = 2;

  string github_release_commit_hash = 3;
```

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] added `!` to the type prefix if API or client breaking change
* [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules)
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] updated the relevant documentation or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] confirmed all author checklist items have been addressed 
* [ ] reviewed state machine logic
* [ ] reviewed API design and naming
* [ ] reviewed documentation is accurate
* [ ] reviewed tests and test coverage
* [ ] manually tested (if applicable)
