### PR TITLE
chore(proto): deprecated IntProto and DecProto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,10 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (cli) [#16856](https://github.com/cosmos/cosmos-sdk/pull/16856) Improve `simd prune` UX by using the app default home directory and set pruning method as first variable argument (defaults to default).
 * (x/authz) [#16869](https://github.com/cosmos/cosmos-sdk/pull/16869) Improve error message when grant not found.
 
+### Deprecated 
+
+* (types) [#16980](https://github.com/cosmos/cosmos-sdk/pull/16980) Deprecate `IntProto` and `DecProto`. Instead, `math.Int` and `math.LegacyDec` should be used respectively. Both types support `Marshal` and `Unmarshal` for binary serialization.
+
 ### Bug Fixes
 
 * (x/bank) [#16841](https://github.com/cosmos/cosmos-sdk/pull/16841) Correctly process legacy `DenomAddressIndex` values.
@@ -61,7 +65,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (types/math) [#16040](https://github.com/cosmos/cosmos-sdk/pull/16798) Remove aliases in `types/math.go` (part 2).
 * (x/staking) [#16795](https://github.com/cosmos/cosmos-sdk/pull/16795) `DelegationToDelegationResponse`, `DelegationsToDelegationResponses`, `RedelegationsToRedelegationResponses` are no longer exported.
 
-## CLI Breaking Changes
+### CLI Breaking Changes
 
 * (x/bank) [#16899](https://github.com/cosmos/cosmos-sdk/pull/16899) With the migration to AutoCLI some bank commands have been split in two: 
     * Use `denoms-metadata` for querying all denom metadata and `denom-metadata` for querying a specific denom metadata.

--- a/api/cosmos/base/v1beta1/coin.pulsar.go
+++ b/api/cosmos/base/v1beta1/coin.pulsar.go
@@ -1931,6 +1931,7 @@ func (x *DecCoin) GetAmount() string {
 }
 
 // IntProto defines a Protobuf wrapper around an Int object.
+// Deprecated: Prefer to use math.Int directly. It supports binary Marshal and Unmarshal.
 type IntProto struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -1967,6 +1968,7 @@ func (x *IntProto) GetInt() string {
 }
 
 // DecProto defines a Protobuf wrapper around a Dec object.
+// Deprecated: Prefer to use math.LegacyDec directly. It supports binary Marshal and Unmarshal.
 type DecProto struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache

--- a/proto/cosmos/base/v1beta1/coin.proto
+++ b/proto/cosmos/base/v1beta1/coin.proto
@@ -33,16 +33,29 @@ message DecCoin {
   option (gogoproto.equal) = true;
 
   string denom  = 1;
-  string amount = 2
-      [(cosmos_proto.scalar) = "cosmos.Dec", (gogoproto.customtype) = "cosmossdk.io/math.LegacyDec", (gogoproto.nullable) = false];
+  string amount = 2 [
+    (cosmos_proto.scalar)  = "cosmos.Dec",
+    (gogoproto.customtype) = "cosmossdk.io/math.LegacyDec",
+    (gogoproto.nullable)   = false
+  ];
 }
 
 // IntProto defines a Protobuf wrapper around an Int object.
+// Deprecated: Prefer to use math.Int directly. It supports binary Marshal and Unmarshal.
 message IntProto {
-  string int = 1 [(cosmos_proto.scalar) = "cosmos.Int", (gogoproto.customtype) = "cosmossdk.io/math.Int", (gogoproto.nullable) = false];
+  string int = 1 [
+    (cosmos_proto.scalar)  = "cosmos.Int",
+    (gogoproto.customtype) = "cosmossdk.io/math.Int",
+    (gogoproto.nullable)   = false
+  ];
 }
 
 // DecProto defines a Protobuf wrapper around a Dec object.
+// Deprecated: Prefer to use math.LegacyDec directly. It supports binary Marshal and Unmarshal.
 message DecProto {
-  string dec = 1 [(cosmos_proto.scalar) = "cosmos.Dec", (gogoproto.customtype) = "cosmossdk.io/math.LegacyDec", (gogoproto.nullable) = false];
+  string dec = 1 [
+    (cosmos_proto.scalar)  = "cosmos.Dec",
+    (gogoproto.customtype) = "cosmossdk.io/math.LegacyDec",
+    (gogoproto.nullable)   = false
+  ];
 }

--- a/types/coin.pb.go
+++ b/types/coin.pb.go
@@ -123,6 +123,7 @@ func (m *DecCoin) GetDenom() string {
 }
 
 // IntProto defines a Protobuf wrapper around an Int object.
+// Deprecated: Prefer to use math.Int directly. It supports binary Marshal and Unmarshal.
 type IntProto struct {
 	Int cosmossdk_io_math.Int `protobuf:"bytes,1,opt,name=int,proto3,customtype=cosmossdk.io/math.Int" json:"int"`
 }
@@ -160,6 +161,7 @@ func (m *IntProto) XXX_DiscardUnknown() {
 var xxx_messageInfo_IntProto proto.InternalMessageInfo
 
 // DecProto defines a Protobuf wrapper around a Dec object.
+// Deprecated: Prefer to use math.LegacyDec directly. It supports binary Marshal and Unmarshal.
 type DecProto struct {
 	Dec cosmossdk_io_math.LegacyDec `protobuf:"bytes,1,opt,name=dec,proto3,customtype=cosmossdk.io/math.LegacyDec" json:"dec"`
 }

--- a/x/tx/signing/aminojson/internal/buf.lock
+++ b/x/tx/signing/aminojson/internal/buf.lock
@@ -9,8 +9,8 @@ deps:
   - remote: buf.build
     owner: cosmos
     repository: cosmos-sdk
-    commit: af6851b183cb49b8aefe32b93d7f8a7f
-    digest: shake256:3bec7abf765271dce9b6ec8a6750c399568f600e5d54b0ee6a0c3adc6c28a75cd9a9aab8c81fd28b20d1f8edb41ea0251e38e358bb3753aa33b76bb50d9dfa6d
+    commit: a0f17dcd1d6b4a03ab50d377b36da149
+    digest: shake256:fc36c3c09df4a908270170125aeb559af8424df3efa1179f09b51738b0e95df5c5f31f590e2a6ab8c31af497a0e15056efeddde7ba1e3297383d01badc68d3b3
   - remote: buf.build
     owner: cosmos
     repository: gogo-proto


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

Related to: https://github.com/cosmos/cosmos-sdk/pull/16918

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] added `!` to the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules)
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] updated the relevant documentation or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] confirmed all author checklist items have been addressed 
* [ ] reviewed state machine logic
* [ ] reviewed API design and naming
* [ ] reviewed documentation is accurate
* [ ] reviewed tests and test coverage
* [ ] manually tested (if applicable)
