### PR TITLE
fix: query tx events with `>=` and `<=` operators

### DIFF
--- a/x/auth/tx/service.go
+++ b/x/auth/tx/service.go
@@ -45,7 +45,8 @@ var (
 	_ txtypes.ServiceServer = txServer{}
 
 	// EventRegex checks that an event string is formatted with {alphabetic}.{alphabetic}={value}
-	EventRegex = regexp.MustCompile(`^[a-zA-Z_]+\.[a-zA-Z_]+=\S+$`)
+	// Note: in addition to equality, the `>=` and `<=` operators are also valid.
+	EventRegex = regexp.MustCompile(`^[a-zA-Z_]+\.[a-zA-Z_]+[<>]?=\S+$`)
 )
 
 const (

--- a/x/auth/tx/service_test.go
+++ b/x/auth/tx/service_test.go
@@ -184,6 +184,16 @@ func TestEventRegex(t *testing.T) {
 			event: "tx.signature='foobar/baz123=='",
 			match: true,
 		},
+		{
+			name:  "valid: with >= operator",
+			event: "tx.height>=10'",
+			match: true,
+		},
+		{
+			name:  "valid: with <= operator",
+			event: "tx.height<=10'",
+			match: true,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Closes https://github.com/cosmos/cosmos-sdk/issues/16993