### PR TITLE
chore(runtime): audit

### DIFF
--- a/runtime/builder.go
+++ b/runtime/builder.go
@@ -38,6 +38,7 @@ func (a *AppBuilder) Build(db dbm.DB, traceStore io.Writer, baseAppOptions ...fu
 
 	a.app.BaseApp = bApp
 	a.app.configurator = module.NewConfigurator(a.app.cdc, a.app.MsgServiceRouter(), a.app.GRPCQueryRouter())
+
 	if err := a.app.ModuleManager.RegisterServices(a.app.configurator); err != nil {
 		panic(err)
 	}

--- a/runtime/events.go
+++ b/runtime/events.go
@@ -33,12 +33,12 @@ func NewEventManager(ctx context.Context) event.Manager {
 }
 
 // Emit emits an typed event that is defined in the protobuf file.
-// In the future these events will be added to consensus
+// In the future these events will be added to consensus.
 func (e Events) Emit(ctx context.Context, event protoiface.MessageV1) error {
 	return e.EventManagerI.EmitTypedEvent(event)
 }
 
-// EmitKV emits a key value pair event
+// EmitKV emits a key value pair event.
 func (e Events) EmitKV(ctx context.Context, eventType string, attrs ...event.Attribute) error {
 	attributes := make([]sdk.Attribute, 0, len(attrs))
 
@@ -46,15 +46,12 @@ func (e Events) EmitKV(ctx context.Context, eventType string, attrs ...event.Att
 		attributes = append(attributes, sdk.NewAttribute(attr.Key, attr.Value))
 	}
 
-	events := sdk.Events{
-		sdk.NewEvent(eventType, attributes...),
-	}
-	e.EventManagerI.EmitEvents(events)
+	e.EventManagerI.EmitEvents(sdk.Events{sdk.NewEvent(eventType, attributes...)})
 	return nil
 }
 
 // Emit emits an typed event that is defined in the protobuf file.
-// In the future these events will be added to consensus
+// In the future these events will be added to consensus.
 func (e Events) EmitNonConsensus(ctx context.Context, event protoiface.MessageV1) error {
 	return e.EventManagerI.EmitTypedEvent(event)
 }

--- a/runtime/module.go
+++ b/runtime/module.go
@@ -94,7 +94,7 @@ func ProvideApp(interfaceRegistry codectypes.InterfaceRegistry) (
 
 	// At startup, check that all proto annotations are correct.
 	if err := msgservice.ValidateProtoAnnotations(protoFiles); err != nil {
-		// Once we switch to using protoreflect-based antehandlers, we might
+		// Once we switch to using protoreflect-based ante handlers, we might
 		// want to panic here instead of logging a warning.
 		_, _ = fmt.Fprintln(os.Stderr, err.Error())
 	}
@@ -178,10 +178,12 @@ func ProvideInterfaceRegistry(customGetSigners []signing.CustomGetSigner) (codec
 	if err != nil {
 		return nil, err
 	}
+
 	err = interfaceRegistry.SigningContext().Validate()
 	if err != nil {
 		return nil, err
 	}
+
 	return interfaceRegistry, nil
 }
 

--- a/runtime/services/autocli.go
+++ b/runtime/services/autocli.go
@@ -32,6 +32,7 @@ func NewAutoCLIQueryService(appModules map[string]interface{}) *AutoCLIQueryServ
 }
 
 // ExtractAutoCLIOptions extracts autocli ModuleOptions from the provided app modules.
+//
 // Example Usage:
 //
 //	ExtractAutoCLIOptions(ModuleManager.Modules)

--- a/runtime/types.go
+++ b/runtime/types.go
@@ -18,7 +18,7 @@ type AppI interface {
 	Name() string
 
 	// The application types codec.
-	// NOTE: This shoult be sealed before being returned.
+	// NOTE: This should NOT be sealed before being returned.
 	LegacyAmino() *codec.LegacyAmino
 
 	// Application updates every begin block.


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

ref: #16858

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] added `!` to the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules)
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] updated the relevant documentation or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] confirmed all author checklist items have been addressed 
* [ ] reviewed state machine logic
* [ ] reviewed API design and naming
* [ ] reviewed documentation is accurate
* [ ] reviewed tests and test coverage
* [ ] manually tested (if applicable)
