### PR TITLE
refactor(simapp): add `,squash` tag

### DIFF
--- a/simapp/simd/cmd/root.go
+++ b/simapp/simd/cmd/root.go
@@ -146,7 +146,7 @@ func initAppConfig() (string, interface{}) {
 	}
 
 	type CustomAppConfig struct {
-		serverconfig.Config
+		serverconfig.Config `mapstructure:",squash"`
 
 		WASM WASMConfig `mapstructure:"wasm"`
 	}

--- a/simapp/simd/cmd/root_v2.go
+++ b/simapp/simd/cmd/root_v2.go
@@ -156,7 +156,7 @@ func initAppConfig() (string, interface{}) {
 	}
 
 	type CustomAppConfig struct {
-		serverconfig.Config
+		serverconfig.Config `mapstructure:",squash"`
 
 		WASM WASMConfig `mapstructure:"wasm"`
 	}


### PR DESCRIPTION
## Description

Avoid being unable to directly parse the data in `viper` into [CustomAppConfig](https://github.com/cosmos/cosmos-sdk/blob/54ed7dab3982dfd667bf7ad3afcd6c6fbc8f3c61/simapp/simd/cmd/root_v2.go#L158) through `viper.Unmarshal(config)`, although `CustomAppConfig` here is not used, but I think it should be demonstrated in simapp.