### PR TITLE
fix(server): use CometBFT fallback for `db_backend`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (baseapp) [#17159](https://github.com/cosmos/cosmos-sdk/pull/17159) Validators can propose blocks that exceed the gas limit.
 * (x/group) [#17146](https://github.com/cosmos/cosmos-sdk/pull/17146) Rename x/group legacy ORM package's error codespace from "orm" to "legacy_orm", preventing collisions with ORM's error codespace "orm".
 * (x/bank) [#17170](https://github.com/cosmos/cosmos-sdk/pull/17170) Avoid empty spendable error message on send coins.
+* (db_backend) [#17181](https://github.com/cosmos/cosmos-sdk/pull/17181) Fix `db_backend` lookup fallback from `config.toml`
 
 ### API Breaking Changes
 

--- a/server/config/toml.go
+++ b/server/config/toml.go
@@ -79,8 +79,7 @@ iavl-disable-fastnode = {{ .BaseConfig.IAVLDisableFastNode }}
 
 # AppDBBackend defines the database backend type to use for the application and snapshots DBs.
 # An empty string indicates that a fallback will be used.
-# First fallback is the deprecated compile-time types.DBBackend value.
-# Second fallback (if the types.DBBackend also isn't set), is the db-backend value set in CometBFT's config.toml.
+# The fallback is the db_backend value set in CometBFT's config.toml.
 app-db-backend = "{{ .BaseConfig.AppDBBackend }}"
 
 ###############################################################################

--- a/server/util.go
+++ b/server/util.go
@@ -403,7 +403,7 @@ func ListenForQuitSignals(g *errgroup.Group, block bool, cancelFn context.Cancel
 func GetAppDBBackend(opts types.AppOptions) dbm.BackendType {
 	rv := cast.ToString(opts.Get("app-db-backend"))
 	if len(rv) == 0 {
-		rv = cast.ToString(opts.Get("db-backend"))
+		rv = cast.ToString(opts.Get("db_backend"))
 	}
 
 	// Cosmos SDK has migrated to cosmos-db which does not support all the backends which tm-db supported


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

Our team uses rocksdb as the underlying database, but the application still wrote LevelDB files under `data/application.db`. Our `config.toml` file had `db_backend = "rocksdb"` and the documentation in `app.toml` says the following:

```toml
# AppDBBackend defines the database backend type to use for the application and snapshots DBs.
# An empty string indicates that a fallback will be used.
# First fallback is the deprecated compile-time types.DBBackend value.
# Second fallback (if the types.DBBackend also isn't set), is the db-backend value set in Tendermint's config.toml.
app-db-backend = ""
```

There are two things wrong with this comment:

1. We set the legacy `-X github.com/cosmos/cosmos-sdk/types.DBBackend=rocksdb` linker flag at build time, but it had no effect. Just searching the `cosmos-sdk/types` directory shows no `DBBackend` variable anymore, so it was removed. The TOML comment is thus outdated, and this PR removes that misleading comment.

2. The CosmosSDK application doesn't actually use the `db_backend` value from `config.toml`, due to a typo in the lookup key. When running the startup code through a debugger, we saw that the Viper config contains a `db_backend` field, but the code is looking for a `db-backend` field (note the underscore and hyphen mismatch). Please see the screenshot below. This PR fixes the lookup and fixes the typo in the TOML comment.

<img width="1343" alt="Screenshot 2023-07-28 at 4 22 08 PM" src="https://github.com/cosmos/cosmos-sdk/assets/5478483/640e780a-3fdd-4973-a5f9-66df3884aadc">

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] added `!` to the type prefix if API or client breaking change
* [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules)
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [x] added a changelog entry to `CHANGELOG.md`
* [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] updated the relevant documentation or specification
* [x] reviewed "Files changed" and left comments if necessary
* [x] run `make lint` and `make test`
* [x] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] confirmed all author checklist items have been addressed 
* [ ] reviewed state machine logic
* [ ] reviewed API design and naming
* [ ] reviewed documentation is accurate
* [ ] reviewed tests and test coverage
* [ ] manually tested (if applicable)
