### PR TITLE
refactor: hide `--output` flags that don't work

### DIFF
--- a/x/auth/client/cli/decode.go
+++ b/x/auth/client/cli/decode.go
@@ -48,7 +48,7 @@ func GetDecodeCommand() *cobra.Command {
 
 	cmd.Flags().BoolP(flagHex, "x", false, "Treat input as hexadecimal instead of base64")
 	flags.AddTxFlagsToCmd(cmd)
-	_ = cmd.Flags().MarkHidden(flags.FlagOutput) //decoding makes sense to output only json
+	_ = cmd.Flags().MarkHidden(flags.FlagOutput) // decoding makes sense to output only json
 
 	return cmd
 }

--- a/x/auth/client/cli/decode.go
+++ b/x/auth/client/cli/decode.go
@@ -48,6 +48,7 @@ func GetDecodeCommand() *cobra.Command {
 
 	cmd.Flags().BoolP(flagHex, "x", false, "Treat input as hexadecimal instead of base64")
 	flags.AddTxFlagsToCmd(cmd)
+	_ = cmd.Flags().MarkHidden(flags.FlagOutput) //decoding makes sense to output only json
 
 	return cmd
 }

--- a/x/auth/client/cli/encode.go
+++ b/x/auth/client/cli/encode.go
@@ -42,6 +42,7 @@ If you supply a dash (-) argument in place of an input filename, the command rea
 	}
 
 	flags.AddTxFlagsToCmd(cmd)
+	_ = cmd.Flags().MarkHidden(flags.FlagOutput) // encoding makes sense to output only json
 
 	return cmd
 }

--- a/x/auth/client/cli/tx_multisign.go
+++ b/x/auth/client/cli/tx_multisign.go
@@ -61,6 +61,7 @@ The SIGN_MODE_DIRECT sign mode is not supported.'
 	cmd.Flags().Bool(flagSigOnly, false, "Print only the generated signature, then exit")
 	cmd.Flags().String(flags.FlagOutputDocument, "", "The document is written to the given file instead of STDOUT")
 	flags.AddTxFlagsToCmd(cmd)
+	_ = cmd.Flags().MarkHidden(flags.FlagOutput)
 
 	return cmd
 }
@@ -182,8 +183,7 @@ func makeMultiSignCmd() func(cmd *cobra.Command, args []string) (err error) {
 
 		outputDoc, _ := cmd.Flags().GetString(flags.FlagOutputDocument)
 		if outputDoc == "" {
-			cmd.Printf("%s\n", json)
-			return nil
+			return clientCtx.PrintString(fmt.Sprintf("%s\n", json))
 		}
 
 		fp, err := os.OpenFile(outputDoc, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o644)
@@ -198,9 +198,7 @@ func makeMultiSignCmd() func(cmd *cobra.Command, args []string) (err error) {
 			}
 		}()
 
-		err = clientCtx.PrintBytes(json)
-
-		return err
+		return clientCtx.PrintBytes(json)
 	}
 }
 
@@ -235,6 +233,7 @@ The SIGN_MODE_DIRECT sign mode is not supported.'
 	)
 	cmd.Flags().String(flags.FlagOutputDocument, "", "The document is written to the given file instead of STDOUT")
 	flags.AddTxFlagsToCmd(cmd)
+	_ = cmd.Flags().MarkHidden(flags.FlagOutput) // signing makes sense to output only json
 
 	return cmd
 }

--- a/x/auth/client/cli/tx_multisign.go
+++ b/x/auth/client/cli/tx_multisign.go
@@ -181,24 +181,15 @@ func makeMultiSignCmd() func(cmd *cobra.Command, args []string) (err error) {
 			return err
 		}
 
-		outputDoc, _ := cmd.Flags().GetString(flags.FlagOutputDocument)
-		if outputDoc == "" {
-			return clientCtx.PrintString(fmt.Sprintf("%s\n", json))
-		}
-
-		fp, err := os.OpenFile(outputDoc, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o644)
+		closeFunc, err := setOutputFile(cmd)
 		if err != nil {
 			return err
 		}
 
-		defer func() {
-			err2 := fp.Close()
-			if err == nil {
-				err = err2
-			}
-		}()
+		defer closeFunc()
 
-		return clientCtx.PrintBytes(json)
+		cmd.Printf("%s\n", json)
+		return nil
 	}
 }
 

--- a/x/genutil/client/cli/gentx.go
+++ b/x/genutil/client/cli/gentx.go
@@ -216,6 +216,7 @@ $ %s gentx my-key-name 1000000stake --home=/path/to/home/dir --keyring-backend=o
 	cmd.Flags().String(flags.FlagOutputDocument, "", "Write the genesis transaction JSON document to the given file instead of the default location")
 	cmd.Flags().AddFlagSet(fsCreateValidator)
 	flags.AddTxFlagsToCmd(cmd)
+	_ = cmd.Flags().MarkHidden(flags.FlagOutput) // signing makes sense to output only json
 
 	return cmd
 }


### PR DESCRIPTION
## Description

follow-up #17183 
