### PR TITLE
fix(log): add fallback to `Stringer` when type do not implement `json.Marshaler` interface

### DIFF
--- a/log/CHANGELOG.md
+++ b/log/CHANGELOG.md
@@ -39,7 +39,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Bug Fixes
 
-* [#17205](https://github.com/cosmos/cosmos-sdk/pull/17205) Fix marshaling cometbft `log.Lazy` struct.
+* [#17205](https://github.com/cosmos/cosmos-sdk/pull/17205) Fix types that do not implement the `json.Marshaler` interface.
 
 ## [v1.1.0](https://github.com/cosmos/cosmos-sdk/releases/tag/log/v1.1.0) - 2023-04-27
 

--- a/log/CHANGELOG.md
+++ b/log/CHANGELOG.md
@@ -37,6 +37,10 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 * [#17194](https://github.com/cosmos/cosmos-sdk/pull/17194) Avoid repeating parse log level in filterFunc.
 
+### Bug Fixes
+
+* [#17205](https://github.com/cosmos/cosmos-sdk/pull/17205) Fix marshaling cometbft `log.Lazy` struct.
+
 ## [v1.1.0](https://github.com/cosmos/cosmos-sdk/releases/tag/log/v1.1.0) - 2023-04-27
 
 * [#15956](https://github.com/cosmos/cosmos-sdk/pull/15956) Introduce options to configure logger (enable/disable colored output, customize log timestamps).

--- a/log/logger.go
+++ b/log/logger.go
@@ -1,6 +1,7 @@
 package log
 
 import (
+	"encoding"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -13,6 +14,10 @@ import (
 func init() {
 	zerolog.InterfaceMarshalFunc = func(i interface{}) ([]byte, error) {
 		switch v := i.(type) {
+		case json.Marshaler:
+			return json.Marshal(i)
+		case encoding.TextMarshaler:
+			return json.Marshal(i)
 		case fmt.Stringer:
 			return fmt.Appendf([]byte("\""), "%s%s", v.String(), "\""), nil
 		default:

--- a/log/logger.go
+++ b/log/logger.go
@@ -1,12 +1,25 @@
 package log
 
 import (
+	"encoding/json"
+	"fmt"
 	"io"
 
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/pkgerrors"
 )
+
+func init() {
+	zerolog.InterfaceMarshalFunc = func(i interface{}) ([]byte, error) {
+		switch v := i.(type) {
+		case fmt.Stringer:
+			return fmt.Appendf([]byte("\""), "%s%s", v.String(), "\""), nil
+		default:
+			return json.Marshal(i)
+		}
+	}
+}
 
 // ModuleKey defines a module logging key.
 const ModuleKey = "module"


### PR DESCRIPTION
## Description

* Fix marshal [lazy](https://github.com/cometbft/cometbft/blob/main/libs/log/lazy.go) in `zerolog`

before

```
3:57PM INF starting node with ABCI CometBFT in-process module=server
3:57PM INF service start impl=multiAppConn module=proxy msg={}
3:57PM INF service start connection=query impl=localClient module=abci-client msg={}
3:57PM INF service start connection=snapshot impl=localClient module=abci-client msg={}
3:57PM INF service start connection=mempool impl=localClient module=abci-client msg={}
3:57PM INF service start connection=consensus impl=localClient module=abci-client msg={}
3:57PM INF service start impl=EventBus module=events msg={}
3:57PM INF service start impl=PubSub module=pubsub msg={}
3:57PM INF service start impl=IndexerService module=txindex msg={}
3:57PM INF ABCI Handshake App Info hash={} height=11 module=consensus protocol-version=0 software-version=0.46.0-beta2-2384-gd0e8ca7bd6
3:57PM INF ABCI Replay Blocks appHeight=11 module=consensus stateHeight=11 storeHeight=11
3:57PM INF Completed ABCI Handshake - CometBFT and App are synced appHash={} appHeight=11 module=consensus
3:57PM INF Version info abci=2.0.0 block=11 commit_hash= module=server p2p=8 tendermint_version=0.38.0-rc3
3:57PM INF This node is a validator addr=5974E8737C3E317BCBF550E7444C6500C35865D3 module=consensus pubKey=1N1zgFNDmvZ4YodKj4+G3ciLn6tL/8ROE1aq86Avghg=
```

after

```
3:52PM INF starting node with ABCI CometBFT in-process module=server
3:52PM INF service start impl=multiAppConn module=proxy msg="Starting multiAppConn service"
3:52PM INF service start connection=query impl=localClient module=abci-client msg="Starting localClient service"
3:52PM INF service start connection=snapshot impl=localClient module=abci-client msg="Starting localClient service"
3:52PM INF service start connection=mempool impl=localClient module=abci-client msg="Starting localClient service"
3:52PM INF service start connection=consensus impl=localClient module=abci-client msg="Starting localClient service"
3:52PM INF service start impl=EventBus module=events msg="Starting EventBus service"
3:52PM INF service start impl=PubSub module=pubsub msg="Starting PubSub service"
3:52PM INF service start impl=IndexerService module=txindex msg="Starting IndexerService service"
3:52PM INF ABCI Handshake App Info hash=BF291EFBD0F874D0CB26BAA2CEEA1F513DBDDF07DF49006A39A733E46867D6D4 height=9 module=consensus protocol-version=0 software-version=0.46.0-beta2-2383-g883264db1b
3:52PM INF ABCI Replay Blocks appHeight=9 module=consensus stateHeight=9 storeHeight=9
3:52PM INF Completed ABCI Handshake - CometBFT and App are synced appHash=BF291EFBD0F874D0CB26BAA2CEEA1F513DBDDF07DF49006A39A733E46867D6D4 appHeight=9 module=consensus
3:52PM INF Version info abci=2.0.0 block=11 commit_hash= module=server p2p=8 tendermint_version=0.38.0-rc3
3:52PM INF This node is a validator addr=5974E8737C3E317BCBF550E7444C6500C35865D3 module=consensus pubKey=PubKeyEd25519{D4DD738053439AF67862874A8F8F86DDC88B9FAB4BFFC44E1356AAF3A02F8218}
```