### PR TITLE
docs: Better describe ABCI-exposed /key and /subspace store APIs

### DIFF
--- a/docs/docs/core/06-grpc_rest.md
+++ b/docs/docs/core/06-grpc_rest.md
@@ -86,7 +86,8 @@ Some CometBFT RPC endpoints are directly related to the Cosmos SDK:
     * any Protobuf fully-qualified service method, such as `/cosmos.bank.v1beta1.Query/AllBalances`. The `data` field should then include the method's request parameter(s) encoded as bytes using Protobuf.
     * `/app/simulate`: this will simulate a transaction, and return some information such as gas used.
     * `/app/version`: this will return the application's version.
-    * `/store/{path}`: this will query the store directly.
+    * `/store/{storeName}/key`: this will directly query the named store for data associated with the key represented in the `data` parameter.
+    * `/store/{storeName}/subspace`: this will directly query the named store for key/value pairs in which the key has the value of the `data` parameter as a prefix.
     * `/p2p/filter/addr/{port}`: this will return a filtered list of the node's P2P peers by address port.
     * `/p2p/filter/id/{id}`: this will return a filtered list of the node's P2P peers by ID.
 * `/broadcast_tx_{aync,async,commit}`: these 3 endpoint will broadcast a transaction to other peers. CLI, gRPC and REST expose [a way to broadcast transations](./01-transactions.md#broadcasting-the-transaction), but they all use these 3 CometBFT RPCs under the hood.

--- a/docs/docs/core/06-grpc_rest.md
+++ b/docs/docs/core/06-grpc_rest.md
@@ -78,7 +78,7 @@ The Cosmos SDK's [Swagger generation script](https://github.com/cosmos/cosmos-sd
 
 ## CometBFT RPC
 
-Independently from the Cosmos SDK, CometBFT also exposes a RPC server. This RPC server can be configured by tuning parameters under the `rpc` table in the `~/.simapp/config/config.toml`, the default listening address is `tcp://localhost:26657`. An OpenAPI specification of all CometBFT RPC endpoints is available [here](https://docs.cometbft.com/master/rpc/).
+Independently from the Cosmos SDK, CometBFT also exposes a RPC server. This RPC server can be configured by tuning parameters under the `rpc` table in the `~/.simapp/config/config.toml`, the default listening address is `tcp://localhost:26657`. An OpenAPI specification of all CometBFT RPC endpoints is available [here](https://docs.cometbft.com/main/rpc/).
 
 Some CometBFT RPC endpoints are directly related to the Cosmos SDK:
 


### PR DESCRIPTION
## Description

Clarifies the valid paths for ABCI "/store/…" requests.

### Author Checklist

I have...

- [x] included the correct `docs:` prefix in the PR title
- [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
- [x] [_not applicable_] provided a link to the relevant issue or specification
- [x] followed the [documentation writing guidelines](https://github.com/cosmos/cosmos-sdk/blob/main/docs/DOC_WRITING_GUIDELINES.md)
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct `docs:` prefix in the PR title
- [ ] confirmed all author checklist items have been addressed 
- [ ] confirmed that this PR only changes documentation
- [ ] reviewed content for consistency
- [ ] reviewed content for thoroughness
- [ ] reviewed content for spelling and grammar
- [ ] tested instructions (if applicable)
