### PR TITLE
refactor(x/upgrade): create directory when dump disk

### DIFF
--- a/x/upgrade/abci_test.go
+++ b/x/upgrade/abci_test.go
@@ -3,7 +3,6 @@ package upgrade_test
 import (
 	"context"
 	"errors"
-	"os"
 	"testing"
 	"time"
 
@@ -379,12 +378,6 @@ func TestDumpUpgradeInfoToFile(t *testing.T) {
 	t.Log("Verify upgrade height from file matches ")
 	require.Equal(upgradeInfo.Height, planHeight)
 	require.Equal(upgradeInfo.Name, plan.Name)
-
-	// clear the test file
-	upgradeInfoFilePath, err := s.keeper.GetUpgradeInfoPath()
-	require.Nil(err)
-	err = os.Remove(upgradeInfoFilePath)
-	require.Nil(err)
 }
 
 // TODO: add testcase to for `no upgrade handler is present for last applied upgrade`.


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

* homePath may be empty, and I couldn't find the reason for it, which causes the `data` directory to be created in the current directory every time`simd` is used.

https://github.com/cosmos/cosmos-sdk/blob/320eea11c217f64e89dced4c345b7b5f73f55ce9/x/upgrade/module.go#L206

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] added `!` to the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules)
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] updated the relevant documentation or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] run `make lint` and `make test`
* [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] confirmed all author checklist items have been addressed 
* [ ] reviewed state machine logic
* [ ] reviewed API design and naming
* [ ] reviewed documentation is accurate
* [ ] reviewed tests and test coverage
* [ ] manually tested (if applicable)
