### PR TITLE
refactor!: remove `clientCtx.PrintObjectLegacy`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### API Breaking Changes
 
+* (client) []() Remove deprecated `clientCtx.PrintObjectLegacy`. Use `clientCtx.PrintProto` or `clientCtx.PrintRaw` instead.
 * (x/distribution) [#17115](https://github.com/cosmos/cosmos-sdk/pull/17115) Use collections for `PreviousProposer` and `ValidatorSlashEvents`:
     * remove from `Keeper`: `GetPreviousProposerConsAddr`, `SetPreviousProposerConsAddr`, `GetValidatorHistoricalReferenceCount`, `GetValidatorSlashEvent`, `SetValidatorSlashEvent`.
 * (x/slashing) [17063](https://github.com/cosmos/cosmos-sdk/pull/17063) Use collections for `HistoricalInfo`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### API Breaking Changes
 
-* (client) []() Remove deprecated `clientCtx.PrintObjectLegacy`. Use `clientCtx.PrintProto` or `clientCtx.PrintRaw` instead.
+* (client) [#17259](https://github.com/cosmos/cosmos-sdk/pull/17259) Remove deprecated `clientCtx.PrintObjectLegacy`. Use `clientCtx.PrintProto` or `clientCtx.PrintRaw` instead.
 * (x/distribution) [#17115](https://github.com/cosmos/cosmos-sdk/pull/17115) Use collections for `PreviousProposer` and `ValidatorSlashEvents`:
     * remove from `Keeper`: `GetPreviousProposerConsAddr`, `SetPreviousProposerConsAddr`, `GetValidatorHistoricalReferenceCount`, `GetValidatorSlashEvent`, `SetValidatorSlashEvent`.
 * (x/slashing) [17063](https://github.com/cosmos/cosmos-sdk/pull/17063) Use collections for `HistoricalInfo`:

--- a/client/context.go
+++ b/client/context.go
@@ -321,17 +321,6 @@ func (ctx Context) PrintProto(toPrint proto.Message) error {
 	return ctx.printOutput(out)
 }
 
-// PrintObjectLegacy is a variant of PrintProto that doesn't require a proto.Message type
-// and uses amino JSON encoding.
-// Deprecated: It will be removed in the near future!
-func (ctx Context) PrintObjectLegacy(toPrint interface{}) error {
-	out, err := ctx.LegacyAmino.MarshalJSON(toPrint)
-	if err != nil {
-		return err
-	}
-	return ctx.printOutput(out)
-}
-
 // PrintRaw is a variant of PrintProto that doesn't require a proto.Message type
 // and uses a raw JSON message. No marshaling is performed.
 func (ctx Context) PrintRaw(toPrint json.RawMessage) error {

--- a/client/context_test.go
+++ b/client/context_test.go
@@ -68,52 +68,6 @@ x: "10"
 `, buf.String())
 }
 
-func TestContext_PrintObjectLegacy(t *testing.T) {
-	ctx := client.Context{}
-
-	animal := &testdata.Dog{
-		Size_: "big",
-		Name:  "Spot",
-	}
-	anyAnimal, err := types.NewAnyWithValue(animal)
-	require.NoError(t, err)
-	hasAnimal := &testdata.HasAnimal{
-		Animal: anyAnimal,
-		X:      10,
-	}
-
-	// amino
-	amino := testdata.NewTestAmino()
-	ctx = ctx.WithLegacyAmino(&codec.LegacyAmino{Amino: amino})
-
-	// json
-	buf := &bytes.Buffer{}
-	ctx = ctx.WithOutput(buf)
-	ctx.OutputFormat = flags.OutputFormatJSON
-	err = ctx.PrintObjectLegacy(hasAnimal)
-	require.NoError(t, err)
-	require.Equal(t,
-		`{"type":"testpb/HasAnimal","value":{"animal":{"type":"testpb/Dog","value":{"size":"big","name":"Spot"}},"x":"10"}}
-`, buf.String())
-
-	// yaml
-	buf = &bytes.Buffer{}
-	ctx = ctx.WithOutput(buf)
-	ctx.OutputFormat = flags.OutputFormatText
-	err = ctx.PrintObjectLegacy(hasAnimal)
-	require.NoError(t, err)
-	require.Equal(t,
-		`type: testpb/HasAnimal
-value:
-  animal:
-    type: testpb/Dog
-    value:
-      name: Spot
-      size: big
-  x: "10"
-`, buf.String())
-}
-
 func TestContext_PrintRaw(t *testing.T) {
 	ctx := client.Context{}
 	hasAnimal := json.RawMessage(`{"animal":{"@type":"/testpb.Dog","size":"big","name":"Spot"},"x":"10"}`)


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

https://github.com/cosmos/cosmos-sdk/pull/17187 removed the usage of `PrintObjectLegacy` in the codebase, which was deprecated for several versions. We can then remove this in v0.51.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] added `!` to the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules)
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] updated the relevant documentation or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] run `make lint` and `make test`
* [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] confirmed all author checklist items have been addressed 
* [ ] reviewed state machine logic
* [ ] reviewed API design and naming
* [ ] reviewed documentation is accurate
* [ ] reviewed tests and test coverage
* [ ] manually tested (if applicable)
