### PR TITLE
fix(client/v2): fix duplicate modules addition and add logger

### DIFF
--- a/client/v2/autocli/app.go
+++ b/client/v2/autocli/app.go
@@ -12,6 +12,7 @@ import (
 	"cosmossdk.io/core/address"
 	"cosmossdk.io/core/appmodule"
 	"cosmossdk.io/depinject"
+	"cosmossdk.io/log"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
@@ -28,6 +29,9 @@ import (
 // One method for extracting autocli options is via the github.com/cosmos/cosmos-sdk/runtime/services.ExtractAutoCLIOptions function.
 type AppOptions struct {
 	depinject.In
+
+	// Logger is the logger to use for client/v2.
+	Logger log.Logger
 
 	// Modules are the AppModule implementations for the modules in the app.
 	Modules map[string]appmodule.AppModule
@@ -64,6 +68,7 @@ type AppOptions struct {
 //	err = autoCliOpts.EnhanceRootCommand(rootCmd)
 func (appOptions AppOptions) EnhanceRootCommand(rootCmd *cobra.Command) error {
 	builder := &Builder{
+		Logger: appOptions.Logger,
 		Builder: flag.Builder{
 			TypeResolver:          protoregistry.GlobalTypes,
 			FileResolver:          proto.HybridResolver,

--- a/client/v2/autocli/builder.go
+++ b/client/v2/autocli/builder.go
@@ -8,6 +8,7 @@ import (
 
 	"cosmossdk.io/client/v2/autocli/flag"
 	"cosmossdk.io/client/v2/autocli/keyring"
+	"cosmossdk.io/log"
 )
 
 // Builder manages options for building CLI commands.
@@ -15,16 +16,23 @@ type Builder struct {
 	// flag.Builder embeds the flag builder and its options.
 	flag.Builder
 
+	// Logger is the logger used by the builder.
+	Logger log.Logger
+
 	// GetClientConn specifies how CLI commands will resolve a grpc.ClientConnInterface
 	// from a given context.
 	GetClientConn func(*cobra.Command) (grpc.ClientConnInterface, error)
 
+	// AddQueryConnFlags and AddTxConnFlags are functions that add flags to query and transaction commands
 	AddQueryConnFlags func(*cobra.Command)
-
-	AddTxConnFlags func(*cobra.Command)
+	AddTxConnFlags    func(*cobra.Command)
 }
 
 func (b *Builder) Validate() error {
+	if b.Logger == nil {
+		b.Logger = log.NewNopLogger()
+	}
+
 	if b.AddressCodec == nil {
 		return errors.New("address codec is required in builder")
 	}

--- a/client/v2/autocli/common.go
+++ b/client/v2/autocli/common.go
@@ -84,13 +84,15 @@ func (b *Builder) enhanceCommandCommon(
 	customCmds map[string]*cobra.Command,
 ) error {
 	moduleOptions := appOptions.ModuleOptions
-	if moduleOptions == nil {
+	if len(moduleOptions) == 0 {
 		moduleOptions = make(map[string]*autocliv1.ModuleOptions)
 	}
 	for name, module := range appOptions.Modules {
 		if _, ok := moduleOptions[name]; !ok {
 			if module, ok := module.(HasAutoCLIConfig); ok {
 				moduleOptions[name] = module.AutoCLIOptions()
+			} else {
+				moduleOptions[name] = nil
 			}
 		}
 	}

--- a/client/v2/autocli/common.go
+++ b/client/v2/autocli/common.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-	"golang.org/x/exp/maps"
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"sigs.k8s.io/yaml"
 
@@ -43,7 +42,7 @@ func (b *Builder) buildMethodCommandCommon(descriptor protoreflect.MethodDescrip
 	}
 
 	cmd := &cobra.Command{
-		SilenceUsage: true,
+		SilenceUsage: false,
 		Use:          use,
 		Long:         long,
 		Short:        options.Short,
@@ -85,22 +84,23 @@ func (b *Builder) enhanceCommandCommon(
 	customCmds map[string]*cobra.Command,
 ) error {
 	moduleOptions := appOptions.ModuleOptions
-	if len(moduleOptions) == 0 {
-		moduleOptions = map[string]*autocliv1.ModuleOptions{}
-		for name, module := range appOptions.Modules {
+	if moduleOptions == nil {
+		moduleOptions = make(map[string]*autocliv1.ModuleOptions)
+	}
+	for name, module := range appOptions.Modules {
+		if _, ok := moduleOptions[name]; !ok {
 			if module, ok := module.(HasAutoCLIConfig); ok {
 				moduleOptions[name] = module.AutoCLIOptions()
 			}
 		}
 	}
 
-	modules := append(maps.Keys(appOptions.Modules), maps.Keys(moduleOptions)...)
-	for _, moduleName := range modules {
-		modOpts, hasModuleOptions := moduleOptions[moduleName]
+	for moduleName, modOpts := range moduleOptions {
+		hasModuleOptions := modOpts != nil
 
 		// if we have an existing command skip adding one here
 		if subCmd := findSubCommand(cmd, moduleName); subCmd != nil {
-			if hasModuleOptions {
+			if hasModuleOptions { // check if we need to enhance the existing command
 				if err := enhanceCustomCmd(b, subCmd, cmdType, modOpts); err != nil {
 					return err
 				}
@@ -111,7 +111,7 @@ func (b *Builder) enhanceCommandCommon(
 
 		// if we have a custom command use that instead of generating one
 		if custom, ok := customCmds[moduleName]; ok {
-			if hasModuleOptions {
+			if hasModuleOptions { // check if we need to enhance the existing command
 				if err := enhanceCustomCmd(b, custom, cmdType, modOpts); err != nil {
 					return err
 				}

--- a/client/v2/autocli/query.go
+++ b/client/v2/autocli/query.go
@@ -31,9 +31,12 @@ func (b *Builder) BuildQueryCommand(appOptions AppOptions, customCmds map[string
 // order to add auto-generated commands to an existing command.
 func (b *Builder) AddQueryServiceCommands(cmd *cobra.Command, cmdDescriptor *autocliv1.ServiceCommandDescriptor) error {
 	for cmdName, subCmdDesc := range cmdDescriptor.SubCommands {
-		subCmd := topLevelCmd(cmdName, fmt.Sprintf("Querying commands for the %s service", subCmdDesc.Service))
-		err := b.AddQueryServiceCommands(subCmd, subCmdDesc)
-		if err != nil {
+		subCmd := findSubCommand(cmd, cmdName)
+		if subCmd == nil {
+			subCmd = topLevelCmd(cmdName, fmt.Sprintf("Querying commands for the %s service", subCmdDesc.Service))
+		}
+
+		if err := b.AddQueryServiceCommands(subCmd, subCmdDesc); err != nil {
 			return err
 		}
 
@@ -63,8 +66,7 @@ func (b *Builder) AddQueryServiceCommands(cmd *cobra.Command, cmdDescriptor *aut
 		}
 	}
 
-	n := methods.Len()
-	for i := 0; i < n; i++ {
+	for i := 0; i < methods.Len(); i++ {
 		methodDescriptor := methods.Get(i)
 		methodOpts, ok := rpcOptMap[methodDescriptor.Name()]
 		if !ok {
@@ -82,7 +84,7 @@ func (b *Builder) AddQueryServiceCommands(cmd *cobra.Command, cmdDescriptor *aut
 
 		if findSubCommand(cmd, methodCmd.Name()) != nil {
 			// do not overwrite existing commands
-			// @julienrbrt: should we display a warning?
+			// we do not display a warning because you may want to overwrite an autocli command
 			continue
 		}
 

--- a/client/v2/go.mod
+++ b/client/v2/go.mod
@@ -6,13 +6,13 @@ require (
 	cosmossdk.io/api v0.7.0
 	cosmossdk.io/core v0.9.0
 	cosmossdk.io/depinject v1.0.0-alpha.4
+	cosmossdk.io/log v1.2.0
 	github.com/cockroachdb/errors v1.10.0
 	github.com/cosmos/cosmos-proto v1.0.0-beta.3
 	github.com/cosmos/cosmos-sdk v0.46.0-beta2.0.20230718211500-1d74652f6021
 	github.com/cosmos/gogoproto v1.4.10
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/pflag v1.0.5
-	golang.org/x/exp v0.0.0-20230711153332-06a737ee72cb
 	google.golang.org/grpc v1.57.0
 	google.golang.org/protobuf v1.31.0
 	gotest.tools/v3 v3.5.0
@@ -22,7 +22,6 @@ require (
 require (
 	cosmossdk.io/collections v0.3.0 // indirect
 	cosmossdk.io/errors v1.0.0 // indirect
-	cosmossdk.io/log v1.2.0 // indirect
 	cosmossdk.io/math v1.0.1 // indirect
 	cosmossdk.io/store v1.0.0-alpha.1 // indirect
 	cosmossdk.io/x/tx v0.9.1 // indirect
@@ -136,6 +135,7 @@ require (
 	github.com/zondax/ledger-go v0.14.1 // indirect
 	go.etcd.io/bbolt v1.3.7 // indirect
 	golang.org/x/crypto v0.12.0 // indirect
+	golang.org/x/exp v0.0.0-20230711153332-06a737ee72cb // indirect
 	golang.org/x/net v0.12.0 // indirect
 	golang.org/x/sync v0.3.0 // indirect
 	golang.org/x/sys v0.11.0 // indirect

--- a/x/crisis/autocli.go
+++ b/x/crisis/autocli.go
@@ -18,9 +18,6 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					PositionalArgs: []*autocliv1.PositionalArgDescriptor{{ProtoField: "invariant_module_name"}, {ProtoField: "invariant_route"}},
 				},
 			},
-			SubCommands: map[string]*autocliv1.ServiceCommandDescriptor{
-				"v1beta1": {Service: crisisv1beta1.Msg_ServiceDesc.ServiceName},
-			},
 		},
 	}
 }

--- a/x/gov/autocli.go
+++ b/x/gov/autocli.go
@@ -93,7 +93,9 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 			},
 			// map v1beta1 as a sub-command
 			SubCommands: map[string]*autocliv1.ServiceCommandDescriptor{
-				"v1beta1": {Service: govv1beta1.Query_ServiceDesc.ServiceName},
+				"v1beta1": {
+					Service: govv1beta1.Query_ServiceDesc.ServiceName,
+				},
 			},
 			EnhanceCustomCommand: true, // We still have manual commands in gov that we want to keep
 		},
@@ -101,7 +103,9 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 			Service: govv1.Msg_ServiceDesc.ServiceName,
 			// map v1beta1 as a sub-command
 			SubCommands: map[string]*autocliv1.ServiceCommandDescriptor{
-				"v1beta1": {Service: govv1beta1.Msg_ServiceDesc.ServiceName},
+				"v1beta1": {
+					Service: govv1beta1.Msg_ServiceDesc.ServiceName,
+				},
 			},
 		},
 	}


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

Add a logger to client/v2. Note, by default the logging is disabled in client/v2 if no logger is provided.
In root_v2 we supply a no-op logger so it is as well disabled by default.

While playing with it, it surfaced a bug where it could happen that some subcommands could be added due to duplicate module keys.

Additionally, duplicate subcommands would not be correctly enhanced. This is fixed here as well.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] added `!` to the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules)
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] updated the relevant documentation or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] run `make lint` and `make test`
* [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] confirmed all author checklist items have been addressed 
* [ ] reviewed state machine logic
* [ ] reviewed API design and naming
* [ ] reviewed documentation is accurate
* [ ] reviewed tests and test coverage
* [ ] manually tested (if applicable)
