### PR TITLE
fix(ve-validation): account for BlockID flag in vote-extensions

### DIFF
--- a/baseapp/abci_utils.go
+++ b/baseapp/abci_utils.go
@@ -64,6 +64,12 @@ func ValidateVoteExtensions(
 
 	sumVP := math.NewInt(0)
 	for _, vote := range extCommit.Votes {
+		// only check + include power if the vote is a commit vote. There must be super-majority otherwise the prev. block (block vote is for)
+		// could not have been committed
+		if vote.BlockIdFlag != cmtproto.BlockIDFlagCommit {
+			continue
+		}
+
 		if !extsEnabled {
 			if len(vote.VoteExtension) > 0 {
 				return fmt.Errorf("vote extensions disabled; received non-empty vote extension at height %d", currentHeight)

--- a/baseapp/abci_utils_test.go
+++ b/baseapp/abci_utils_test.go
@@ -1,20 +1,21 @@
 package baseapp_test
 
 import (
-	"testing"
-	"github.com/stretchr/testify/suite"
-	"github.com/cosmos/gogoproto/proto"
-	protoio "github.com/cosmos/gogoproto/io"
 	"bytes"
-	"github.com/cosmos/cosmos-sdk/baseapp/testutil/mock"
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	cmtprotocrypto "github.com/cometbft/cometbft/proto/tendermint/crypto"
-	"github.com/cometbft/cometbft/crypto/secp256k1"
-	"github.com/golang/mock/gomock"
 	"cosmossdk.io/math"
-	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
+	"testing"
+
 	abci "github.com/cometbft/cometbft/abci/types"
+	"github.com/cometbft/cometbft/crypto/secp256k1"
+	cmtprotocrypto "github.com/cometbft/cometbft/proto/tendermint/crypto"
+	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
+	protoio "github.com/cosmos/gogoproto/io"
+	"github.com/cosmos/gogoproto/proto"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/suite"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/baseapp"
+	"github.com/cosmos/cosmos-sdk/baseapp/testutil/mock"
 )
 
 const (
@@ -23,8 +24,8 @@ const (
 
 type testValidator struct {
 	consAddr sdk.ConsAddress
-	tmPk cmtprotocrypto.PublicKey
-	privKey secp256k1.PrivKey
+	tmPk     cmtprotocrypto.PublicKey
+	privKey  secp256k1.PrivKey
 }
 
 func newTestValidator() testValidator {
@@ -38,15 +39,15 @@ func newTestValidator() testValidator {
 
 	return testValidator{
 		consAddr: sdk.ConsAddress(pubkey.Address()),
-		tmPk: tmPk,
-		privKey: privkey,
+		tmPk:     tmPk,
+		privKey:  privkey,
 	}
 }
 
 func (t testValidator) toValidator() abci.Validator {
 	return abci.Validator{
 		Address: t.consAddr.Bytes(),
-		Power: 0, // ignored for now
+		Power:   0, // ignored for now
 	}
 }
 
@@ -54,8 +55,8 @@ type ABCIUtilsTestSuite struct {
 	suite.Suite
 
 	valStore *mock.MockValidatorStore
-	vals    [3]testValidator
-	ctx    sdk.Context
+	vals     [3]testValidator
+	ctx      sdk.Context
 }
 
 func NewABCIUtilsTestSuite(t *testing.T) *ABCIUtilsTestSuite {
@@ -97,9 +98,9 @@ func (s *ABCIUtilsTestSuite) TestValidateVoteExtensionsHappyPath() {
 	ext := []byte("vote-extension")
 	cve := cmtproto.CanonicalVoteExtension{
 		Extension: ext,
-		Height: 2,
-		Round: int64(0),
-		ChainId: chainID,
+		Height:    2,
+		Round:     int64(0),
+		ChainId:   chainID,
 	}
 
 	bz, err := marshalDelimitedFn(&cve)
@@ -118,36 +119,37 @@ func (s *ABCIUtilsTestSuite) TestValidateVoteExtensionsHappyPath() {
 		Round: 0,
 		Votes: []abci.ExtendedVoteInfo{
 			{
-				Validator: s.vals[0].toValidator(),
-				VoteExtension: ext,
+				Validator:          s.vals[0].toValidator(),
+				VoteExtension:      ext,
 				ExtensionSignature: extSig0,
-				BlockIdFlag: cmtproto.BlockIDFlagCommit,
+				BlockIdFlag:        cmtproto.BlockIDFlagCommit,
 			},
 			{
-				Validator: s.vals[1].toValidator(),
-				VoteExtension: ext,
+				Validator:          s.vals[1].toValidator(),
+				VoteExtension:      ext,
 				ExtensionSignature: extSig1,
-				BlockIdFlag: cmtproto.BlockIDFlagCommit,
+				BlockIdFlag:        cmtproto.BlockIDFlagCommit,
 			},
 			{
-				Validator: s.vals[2].toValidator(),
-				VoteExtension: ext,
+				Validator:          s.vals[2].toValidator(),
+				VoteExtension:      ext,
 				ExtensionSignature: extSig2,
-				BlockIdFlag: cmtproto.BlockIDFlagCommit,
+				BlockIdFlag:        cmtproto.BlockIDFlagCommit,
 			},
 		},
 	}
 	// expect-pass (votes of height 2 are included in next block)
 	s.Require().NoError(baseapp.ValidateVoteExtensions(s.ctx, s.valStore, 3, chainID, llc))
 }
+
 // check ValidateVoteExtensions works when a single node has submitted a BlockID_Absent
 func (s *ABCIUtilsTestSuite) TestValidateVoteExtensionsSingleVoteAbsent() {
 	ext := []byte("vote-extension")
 	cve := cmtproto.CanonicalVoteExtension{
 		Extension: ext,
-		Height: 2,
-		Round: int64(0),
-		ChainId: chainID,
+		Height:    2,
+		Round:     int64(0),
+		ChainId:   chainID,
 	}
 
 	bz, err := marshalDelimitedFn(&cve)
@@ -163,35 +165,36 @@ func (s *ABCIUtilsTestSuite) TestValidateVoteExtensionsSingleVoteAbsent() {
 		Round: 0,
 		Votes: []abci.ExtendedVoteInfo{
 			{
-				Validator: s.vals[0].toValidator(),
-				VoteExtension: ext,
+				Validator:          s.vals[0].toValidator(),
+				VoteExtension:      ext,
 				ExtensionSignature: extSig0,
-				BlockIdFlag: cmtproto.BlockIDFlagCommit,
+				BlockIdFlag:        cmtproto.BlockIDFlagCommit,
 			},
 			// validator of power >1/3 is missing, so commit-info shld still be valid
 			{
-				Validator: s.vals[1].toValidator(),
+				Validator:   s.vals[1].toValidator(),
 				BlockIdFlag: cmtproto.BlockIDFlagAbsent,
 			},
 			{
-				Validator: s.vals[2].toValidator(),
-				VoteExtension: ext,
+				Validator:          s.vals[2].toValidator(),
+				VoteExtension:      ext,
 				ExtensionSignature: extSig2,
-				BlockIdFlag: cmtproto.BlockIDFlagCommit,
+				BlockIdFlag:        cmtproto.BlockIDFlagCommit,
 			},
 		},
 	}
 	// expect-pass (votes of height 2 are included in next block)
 	s.Require().NoError(baseapp.ValidateVoteExtensions(s.ctx, s.valStore, 3, chainID, llc))
 }
+
 // check ValidateVoteExtensions works when a single node has submitted a BlockID_Nil
 func (s *ABCIUtilsTestSuite) TestValidateVoteExtensionsSingleVoteNil() {
 	ext := []byte("vote-extension")
 	cve := cmtproto.CanonicalVoteExtension{
 		Extension: ext,
-		Height: 2,
-		Round: int64(0),
-		ChainId: chainID,
+		Height:    2,
+		Round:     int64(0),
+		ChainId:   chainID,
 	}
 
 	bz, err := marshalDelimitedFn(&cve)
@@ -207,21 +210,21 @@ func (s *ABCIUtilsTestSuite) TestValidateVoteExtensionsSingleVoteNil() {
 		Round: 0,
 		Votes: []abci.ExtendedVoteInfo{
 			{
-				Validator: s.vals[0].toValidator(),
-				VoteExtension: ext,
+				Validator:          s.vals[0].toValidator(),
+				VoteExtension:      ext,
 				ExtensionSignature: extSig0,
-				BlockIdFlag: cmtproto.BlockIDFlagCommit,
+				BlockIdFlag:        cmtproto.BlockIDFlagCommit,
 			},
 			// validator of power <1/3 is missing, so commit-info shld still be valid
 			{
-				Validator: s.vals[1].toValidator(),
+				Validator:   s.vals[1].toValidator(),
 				BlockIdFlag: cmtproto.BlockIDFlagNil,
 			},
 			{
-				Validator: s.vals[2].toValidator(),
-				VoteExtension: ext,
+				Validator:          s.vals[2].toValidator(),
+				VoteExtension:      ext,
 				ExtensionSignature: extSig2,
-				BlockIdFlag: cmtproto.BlockIDFlagCommit,
+				BlockIdFlag:        cmtproto.BlockIDFlagCommit,
 			},
 		},
 	}
@@ -234,9 +237,9 @@ func (s *ABCIUtilsTestSuite) TestValidateVoteExtensionsTwoVotesNilAbsent() {
 	ext := []byte("vote-extension")
 	cve := cmtproto.CanonicalVoteExtension{
 		Extension: ext,
-		Height: 2,
-		Round: int64(0),
-		ChainId: chainID,
+		Height:    2,
+		Round:     int64(0),
+		ChainId:   chainID,
 	}
 
 	bz, err := marshalDelimitedFn(&cve)
@@ -250,18 +253,18 @@ func (s *ABCIUtilsTestSuite) TestValidateVoteExtensionsTwoVotesNilAbsent() {
 		Votes: []abci.ExtendedVoteInfo{
 			// validator of power >2/3 is missing, so commit-info shld still be valid
 			{
-				Validator: s.vals[0].toValidator(),
+				Validator:   s.vals[0].toValidator(),
 				BlockIdFlag: cmtproto.BlockIDFlagCommit,
 			},
 			{
-				Validator: s.vals[1].toValidator(),
+				Validator:   s.vals[1].toValidator(),
 				BlockIdFlag: cmtproto.BlockIDFlagNil,
 			},
 			{
-				Validator: s.vals[2].toValidator(),
-				VoteExtension: ext,
+				Validator:          s.vals[2].toValidator(),
+				VoteExtension:      ext,
 				ExtensionSignature: extSig2,
-				BlockIdFlag: cmtproto.BlockIDFlagAbsent,
+				BlockIdFlag:        cmtproto.BlockIDFlagAbsent,
 			},
 		},
 	}
@@ -269,8 +272,6 @@ func (s *ABCIUtilsTestSuite) TestValidateVoteExtensionsTwoVotesNilAbsent() {
 	// expect-pass (votes of height 2 are included in next block)
 	s.Require().Error(baseapp.ValidateVoteExtensions(s.ctx, s.valStore, 3, chainID, llc))
 }
-
-
 func marshalDelimitedFn(msg proto.Message) ([]byte, error) {
 	var buf bytes.Buffer
 	if err := protoio.NewDelimitedWriter(&buf).WriteMsg(msg); err != nil {

--- a/baseapp/abci_utils_test.go
+++ b/baseapp/abci_utils_test.go
@@ -1,0 +1,281 @@
+package baseapp_test
+
+import (
+	"testing"
+	"github.com/stretchr/testify/suite"
+	"github.com/cosmos/gogoproto/proto"
+	protoio "github.com/cosmos/gogoproto/io"
+	"bytes"
+	"github.com/cosmos/cosmos-sdk/baseapp/testutil/mock"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	cmtprotocrypto "github.com/cometbft/cometbft/proto/tendermint/crypto"
+	"github.com/cometbft/cometbft/crypto/secp256k1"
+	"github.com/golang/mock/gomock"
+	"cosmossdk.io/math"
+	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
+	abci "github.com/cometbft/cometbft/abci/types"
+	"github.com/cosmos/cosmos-sdk/baseapp"
+)
+
+const (
+	chainID = "chain-id"
+)
+
+type testValidator struct {
+	consAddr sdk.ConsAddress
+	tmPk cmtprotocrypto.PublicKey
+	privKey secp256k1.PrivKey
+}
+
+func newTestValidator() testValidator {
+	privkey := secp256k1.GenPrivKey()
+	pubkey := privkey.PubKey()
+	tmPk := cmtprotocrypto.PublicKey{
+		Sum: &cmtprotocrypto.PublicKey_Secp256K1{
+			Secp256K1: pubkey.Bytes(),
+		},
+	}
+
+	return testValidator{
+		consAddr: sdk.ConsAddress(pubkey.Address()),
+		tmPk: tmPk,
+		privKey: privkey,
+	}
+}
+
+func (t testValidator) toValidator() abci.Validator {
+	return abci.Validator{
+		Address: t.consAddr.Bytes(),
+		Power: 0, // ignored for now
+	}
+}
+
+type ABCIUtilsTestSuite struct {
+	suite.Suite
+
+	valStore *mock.MockValidatorStore
+	vals    [3]testValidator
+	ctx    sdk.Context
+}
+
+func NewABCIUtilsTestSuite(t *testing.T) *ABCIUtilsTestSuite {
+	// create 3 validators
+	s := &ABCIUtilsTestSuite{
+		vals: [3]testValidator{
+			newTestValidator(),
+			newTestValidator(),
+			newTestValidator(),
+		},
+	}
+
+	// create mock
+	ctrl := gomock.NewController(t)
+	valStore := mock.NewMockValidatorStore(ctrl)
+	s.valStore = valStore
+
+	// set up mock
+	s.valStore.EXPECT().BondedTokensAndPubKeyByConsAddr(gomock.Any(), s.vals[0].consAddr.Bytes()).Return(math.NewInt(333), s.vals[0].tmPk, nil).AnyTimes()
+	s.valStore.EXPECT().BondedTokensAndPubKeyByConsAddr(gomock.Any(), s.vals[1].consAddr.Bytes()).Return(math.NewInt(333), s.vals[1].tmPk, nil).AnyTimes()
+	s.valStore.EXPECT().BondedTokensAndPubKeyByConsAddr(gomock.Any(), s.vals[2].consAddr.Bytes()).Return(math.NewInt(334), s.vals[2].tmPk, nil).AnyTimes()
+	s.valStore.EXPECT().TotalBondedTokens(gomock.Any()).Return(math.NewInt(1000), nil).AnyTimes()
+
+	// create context
+	s.ctx = sdk.Context{}.WithConsensusParams(cmtproto.ConsensusParams{
+		Abci: &cmtproto.ABCIParams{
+			VoteExtensionsEnableHeight: 2,
+		},
+	})
+	return s
+}
+
+func TestACITUtilsTestSuite(t *testing.T) {
+	suite.Run(t, NewABCIUtilsTestSuite(t))
+}
+
+// check ValidateVoteExtensions works when all nodes have CommitBlockID votes
+func (s *ABCIUtilsTestSuite) TestValidateVoteExtensionsHappyPath() {
+	ext := []byte("vote-extension")
+	cve := cmtproto.CanonicalVoteExtension{
+		Extension: ext,
+		Height: 2,
+		Round: int64(0),
+		ChainId: chainID,
+	}
+
+	bz, err := marshalDelimitedFn(&cve)
+	s.Require().NoError(err)
+
+	extSig0, err := s.vals[0].privKey.Sign(bz)
+	s.Require().NoError(err)
+
+	extSig1, err := s.vals[1].privKey.Sign(bz)
+	s.Require().NoError(err)
+
+	extSig2, err := s.vals[2].privKey.Sign(bz)
+	s.Require().NoError(err)
+
+	llc := abci.ExtendedCommitInfo{
+		Round: 0,
+		Votes: []abci.ExtendedVoteInfo{
+			{
+				Validator: s.vals[0].toValidator(),
+				VoteExtension: ext,
+				ExtensionSignature: extSig0,
+				BlockIdFlag: cmtproto.BlockIDFlagCommit,
+			},
+			{
+				Validator: s.vals[1].toValidator(),
+				VoteExtension: ext,
+				ExtensionSignature: extSig1,
+				BlockIdFlag: cmtproto.BlockIDFlagCommit,
+			},
+			{
+				Validator: s.vals[2].toValidator(),
+				VoteExtension: ext,
+				ExtensionSignature: extSig2,
+				BlockIdFlag: cmtproto.BlockIDFlagCommit,
+			},
+		},
+	}
+	// expect-pass (votes of height 2 are included in next block)
+	s.Require().NoError(baseapp.ValidateVoteExtensions(s.ctx, s.valStore, 3, chainID, llc))
+}
+// check ValidateVoteExtensions works when a single node has submitted a BlockID_Absent
+func (s *ABCIUtilsTestSuite) TestValidateVoteExtensionsSingleVoteAbsent() {
+	ext := []byte("vote-extension")
+	cve := cmtproto.CanonicalVoteExtension{
+		Extension: ext,
+		Height: 2,
+		Round: int64(0),
+		ChainId: chainID,
+	}
+
+	bz, err := marshalDelimitedFn(&cve)
+	s.Require().NoError(err)
+
+	extSig0, err := s.vals[0].privKey.Sign(bz)
+	s.Require().NoError(err)
+
+	extSig2, err := s.vals[2].privKey.Sign(bz)
+	s.Require().NoError(err)
+
+	llc := abci.ExtendedCommitInfo{
+		Round: 0,
+		Votes: []abci.ExtendedVoteInfo{
+			{
+				Validator: s.vals[0].toValidator(),
+				VoteExtension: ext,
+				ExtensionSignature: extSig0,
+				BlockIdFlag: cmtproto.BlockIDFlagCommit,
+			},
+			// validator of power >1/3 is missing, so commit-info shld still be valid
+			{
+				Validator: s.vals[1].toValidator(),
+				BlockIdFlag: cmtproto.BlockIDFlagAbsent,
+			},
+			{
+				Validator: s.vals[2].toValidator(),
+				VoteExtension: ext,
+				ExtensionSignature: extSig2,
+				BlockIdFlag: cmtproto.BlockIDFlagCommit,
+			},
+		},
+	}
+	// expect-pass (votes of height 2 are included in next block)
+	s.Require().NoError(baseapp.ValidateVoteExtensions(s.ctx, s.valStore, 3, chainID, llc))
+}
+// check ValidateVoteExtensions works when a single node has submitted a BlockID_Nil
+func (s *ABCIUtilsTestSuite) TestValidateVoteExtensionsSingleVoteNil() {
+	ext := []byte("vote-extension")
+	cve := cmtproto.CanonicalVoteExtension{
+		Extension: ext,
+		Height: 2,
+		Round: int64(0),
+		ChainId: chainID,
+	}
+
+	bz, err := marshalDelimitedFn(&cve)
+	s.Require().NoError(err)
+
+	extSig0, err := s.vals[0].privKey.Sign(bz)
+	s.Require().NoError(err)
+
+	extSig2, err := s.vals[2].privKey.Sign(bz)
+	s.Require().NoError(err)
+
+	llc := abci.ExtendedCommitInfo{
+		Round: 0,
+		Votes: []abci.ExtendedVoteInfo{
+			{
+				Validator: s.vals[0].toValidator(),
+				VoteExtension: ext,
+				ExtensionSignature: extSig0,
+				BlockIdFlag: cmtproto.BlockIDFlagCommit,
+			},
+			// validator of power <1/3 is missing, so commit-info shld still be valid
+			{
+				Validator: s.vals[1].toValidator(),
+				BlockIdFlag: cmtproto.BlockIDFlagNil,
+			},
+			{
+				Validator: s.vals[2].toValidator(),
+				VoteExtension: ext,
+				ExtensionSignature: extSig2,
+				BlockIdFlag: cmtproto.BlockIDFlagCommit,
+			},
+		},
+	}
+	// expect-pass (votes of height 2 are included in next block)
+	s.Require().NoError(baseapp.ValidateVoteExtensions(s.ctx, s.valStore, 3, chainID, llc))
+}
+
+// check ValidateVoteExtensions works when two nodes have submitted a BlockID_Nil / BlockID_Absent
+func (s *ABCIUtilsTestSuite) TestValidateVoteExtensionsTwoVotesNilAbsent() {
+	ext := []byte("vote-extension")
+	cve := cmtproto.CanonicalVoteExtension{
+		Extension: ext,
+		Height: 2,
+		Round: int64(0),
+		ChainId: chainID,
+	}
+
+	bz, err := marshalDelimitedFn(&cve)
+	s.Require().NoError(err)
+
+	extSig2, err := s.vals[2].privKey.Sign(bz)
+	s.Require().NoError(err)
+
+	llc := abci.ExtendedCommitInfo{
+		Round: 0,
+		Votes: []abci.ExtendedVoteInfo{
+			// validator of power >2/3 is missing, so commit-info shld still be valid
+			{
+				Validator: s.vals[0].toValidator(),
+				BlockIdFlag: cmtproto.BlockIDFlagCommit,
+			},
+			{
+				Validator: s.vals[1].toValidator(),
+				BlockIdFlag: cmtproto.BlockIDFlagNil,
+			},
+			{
+				Validator: s.vals[2].toValidator(),
+				VoteExtension: ext,
+				ExtensionSignature: extSig2,
+				BlockIdFlag: cmtproto.BlockIDFlagAbsent,
+			},
+		},
+	}
+
+	// expect-pass (votes of height 2 are included in next block)
+	s.Require().Error(baseapp.ValidateVoteExtensions(s.ctx, s.valStore, 3, chainID, llc))
+}
+
+
+func marshalDelimitedFn(msg proto.Message) ([]byte, error) {
+	var buf bytes.Buffer
+	if err := protoio.NewDelimitedWriter(&buf).WriteMsg(msg); err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}


### PR DESCRIPTION
## Description

Closes: #17393

# In This PR
 - I check that the only votes validated in `ValidateVoteExtensions` are votes that have `BlockIDCommit`, in other words, vote-extensions that accompanied pre-commits for the previous block. In this case, the block must have come w/ > super-majority of such votes
 - I also add an extensive test-suite of the `ValidateVoteExtensions` method, covering the cases leading to the above issue.

## Files Changed
 - `baseapp/abci_utils.go` (changed)
 - `baseapp/abci_utils_test.go` (added)
### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [NA ] added `!` to the type prefix if API or client breaking change
* [ x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [x ] provided a link to the relevant issue or specification
* [ x] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules)
* [x ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [x ] added a changelog entry to `CHANGELOG.md`
* [x ] included comments for [documenting Go code](https://blog.golang.org/godoc)
* [x ] updated the relevant documentation or specification
* [ x] reviewed "Files changed" and left comments if necessary
* [x ] run `make lint` and `make test`
* [ x] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] confirmed all author checklist items have been addressed 
* [ ] reviewed state machine logic
* [ ] reviewed API design and naming
* [ ] reviewed documentation is accurate
* [ ] reviewed tests and test coverage
* [ ] manually tested (if applicable)
