### PR TITLE
bug: lookup and return validators from liquid stake accounting functions

### DIFF
--- a/x/staking/keeper/liquid_stake.go
+++ b/x/staking/keeper/liquid_stake.go
@@ -138,20 +138,20 @@ func (k Keeper) DecreaseTotalLiquidStakedTokens(ctx sdk.Context, amount sdk.Int)
 // and the total liquid staked shares cannot exceed the validator bond cap
 // 1) (TotalLiquidStakedTokens / TotalStakedTokens) <= ValidatorLiquidStakingCap
 // 2) LiquidShares <= (ValidatorBondShares * ValidatorBondFactor)
-func (k Keeper) SafelyIncreaseValidatorLiquidShares(ctx sdk.Context, validator types.Validator, shares sdk.Dec) error {
+func (k Keeper) SafelyIncreaseValidatorLiquidShares(ctx sdk.Context, validator types.Validator, shares sdk.Dec) (types.Validator, error) {
 	// Confirm the validator bond factor and validator liquid staking cap will not be exceeded
 	if k.CheckExceedsValidatorBondCap(ctx, validator, shares) {
-		return types.ErrInsufficientValidatorBondShares
+		return validator, types.ErrInsufficientValidatorBondShares
 	}
 	if k.CheckExceedsValidatorLiquidStakingCap(ctx, validator, shares) {
-		return types.ErrValidatorLiquidStakingCapExceeded
+		return validator, types.ErrValidatorLiquidStakingCapExceeded
 	}
 
 	// Increment the validator's liquid shares
 	validator.LiquidShares = validator.LiquidShares.Add(shares)
 	k.SetValidator(ctx, validator)
 
-	return nil
+	return validator, nil
 }
 
 // DecreaseValidatorLiquidShares decrements the liquid shares on a validator

--- a/x/staking/keeper/liquid_stake.go
+++ b/x/staking/keeper/liquid_stake.go
@@ -193,7 +193,12 @@ func (k Keeper) IncreaseValidatorBondShares(ctx sdk.Context, valAddress sdk.ValA
 // SafelyDecreaseValidatorBond decrements the validator's self bond
 // so long as it will not cause the current delegations to exceed the threshold
 // set by validator bond factor
-func (k Keeper) SafelyDecreaseValidatorBond(ctx sdk.Context, validator types.Validator, shares sdk.Dec) error {
+func (k Keeper) SafelyDecreaseValidatorBond(ctx sdk.Context, valAddress sdk.ValAddress, shares sdk.Dec) error {
+	validator, found := k.GetValidator(ctx, valAddress)
+	if !found {
+		return types.ErrNoValidatorFound
+	}
+
 	// Check if the decreased self bond will cause the validator bond threshold to be exceeded
 	validatorBondFactor := k.ValidatorBondFactor(ctx)
 	validatorBondEnabled := !validatorBondFactor.Equal(types.ValidatorBondCapDisabled)

--- a/x/staking/keeper/liquid_stake.go
+++ b/x/staking/keeper/liquid_stake.go
@@ -166,9 +166,16 @@ func (k Keeper) DecreaseValidatorLiquidShares(ctx sdk.Context, validator types.V
 
 // Increase validator bond shares increments the validator's self bond
 // in the event that the delegation amount on a validator bond delegation is increased
-func (k Keeper) IncreaseValidatorBondShares(ctx sdk.Context, validator types.Validator, shares sdk.Dec) {
+func (k Keeper) IncreaseValidatorBondShares(ctx sdk.Context, validatorAddress sdk.ValAddress, shares sdk.Dec) error {
+	validator, found := k.GetValidator(ctx, validatorAddress)
+	if !found {
+		return types.ErrNoValidatorFound
+	}
+
 	validator.ValidatorBondShares = validator.ValidatorBondShares.Add(shares)
 	k.SetValidator(ctx, validator)
+
+	return nil
 }
 
 // SafelyDecreaseValidatorBond decrements the validator's self bond

--- a/x/staking/keeper/liquid_stake.go
+++ b/x/staking/keeper/liquid_stake.go
@@ -155,13 +155,13 @@ func (k Keeper) SafelyIncreaseValidatorLiquidShares(ctx sdk.Context, validator t
 }
 
 // DecreaseValidatorLiquidShares decrements the liquid shares on a validator
-func (k Keeper) DecreaseValidatorLiquidShares(ctx sdk.Context, validator types.Validator, shares sdk.Dec) error {
+func (k Keeper) DecreaseValidatorLiquidShares(ctx sdk.Context, validator types.Validator, shares sdk.Dec) (types.Validator, error) {
 	if shares.GT(validator.LiquidShares) {
-		return types.ErrValidatorLiquidSharesUnderflow
+		return validator, types.ErrValidatorLiquidSharesUnderflow
 	}
 	validator.LiquidShares = validator.LiquidShares.Sub(shares)
 	k.SetValidator(ctx, validator)
-	return nil
+	return validator, nil
 }
 
 // Increase validator bond shares increments the validator's self bond

--- a/x/staking/keeper/liquid_stake.go
+++ b/x/staking/keeper/liquid_stake.go
@@ -178,8 +178,8 @@ func (k Keeper) DecreaseValidatorLiquidShares(ctx sdk.Context, valAddress sdk.Va
 
 // Increase validator bond shares increments the validator's self bond
 // in the event that the delegation amount on a validator bond delegation is increased
-func (k Keeper) IncreaseValidatorBondShares(ctx sdk.Context, validatorAddress sdk.ValAddress, shares sdk.Dec) error {
-	validator, found := k.GetValidator(ctx, validatorAddress)
+func (k Keeper) IncreaseValidatorBondShares(ctx sdk.Context, valAddress sdk.ValAddress, shares sdk.Dec) error {
+	validator, found := k.GetValidator(ctx, valAddress)
 	if !found {
 		return types.ErrNoValidatorFound
 	}

--- a/x/staking/keeper/liquid_stake_test.go
+++ b/x/staking/keeper/liquid_stake_test.go
@@ -758,7 +758,7 @@ func TestSafelyDecreaseValidatorBond(t *testing.T) {
 	// from (100 * 10 = 1000) to (100 * 5 = 500)
 	// Since this is still above the initial liquid shares of 200, this will succeed
 	decreaseAmount, expectedBondShares := sdk.NewDec(5), sdk.NewDec(5)
-	err := app.StakingKeeper.SafelyDecreaseValidatorBond(ctx, initialValidator, decreaseAmount)
+	err := app.StakingKeeper.SafelyDecreaseValidatorBond(ctx, valAddress, decreaseAmount)
 	require.NoError(t, err)
 
 	actualValidator, found := app.StakingKeeper.GetValidator(ctx, valAddress)
@@ -769,7 +769,7 @@ func TestSafelyDecreaseValidatorBond(t *testing.T) {
 	// This time, the cap will be reduced to (factor * shares) = (100 * 1) = 100
 	// However, the liquid shares are currently 200, so this should fail
 	decreaseAmount, expectedBondShares = sdk.NewDec(4), sdk.NewDec(1)
-	err = app.StakingKeeper.SafelyDecreaseValidatorBond(ctx, actualValidator, decreaseAmount)
+	err = app.StakingKeeper.SafelyDecreaseValidatorBond(ctx, valAddress, decreaseAmount)
 	require.ErrorIs(t, err, types.ErrInsufficientValidatorBondShares)
 
 	// Finally, disable the cap and attempt to decrease again
@@ -777,7 +777,7 @@ func TestSafelyDecreaseValidatorBond(t *testing.T) {
 	params.ValidatorBondFactor = types.ValidatorBondCapDisabled
 	app.StakingKeeper.SetParams(ctx, params)
 
-	err = app.StakingKeeper.SafelyDecreaseValidatorBond(ctx, actualValidator, decreaseAmount)
+	err = app.StakingKeeper.SafelyDecreaseValidatorBond(ctx, valAddress, decreaseAmount)
 	require.NoError(t, err)
 
 	actualValidator, found = app.StakingKeeper.GetValidator(ctx, valAddress)

--- a/x/staking/keeper/liquid_stake_test.go
+++ b/x/staking/keeper/liquid_stake_test.go
@@ -665,7 +665,7 @@ func TestSafelyIncreaseValidatorLiquidShares(t *testing.T) {
 
 	// Attempt to increase the validator liquid shares, it should throw an
 	// error that the validator bond cap was exceeded
-	err := app.StakingKeeper.SafelyIncreaseValidatorLiquidShares(ctx, initialValidator, firstIncreaseAmount)
+	_, err := app.StakingKeeper.SafelyIncreaseValidatorLiquidShares(ctx, valAddress, firstIncreaseAmount)
 	require.ErrorIs(t, err, types.ErrInsufficientValidatorBondShares)
 	checkValidatorLiquidShares(initialLiquidShares, "shares after low bond factor")
 
@@ -675,12 +675,12 @@ func TestSafelyIncreaseValidatorLiquidShares(t *testing.T) {
 
 	// Try the increase again and check that it succeeded
 	expectedLiquidSharesAfterFirstStake := initialLiquidShares.Add(firstIncreaseAmount)
-	err = app.StakingKeeper.SafelyIncreaseValidatorLiquidShares(ctx, initialValidator, firstIncreaseAmount)
+	_, err = app.StakingKeeper.SafelyIncreaseValidatorLiquidShares(ctx, valAddress, firstIncreaseAmount)
 	require.NoError(t, err)
 	checkValidatorLiquidShares(expectedLiquidSharesAfterFirstStake, "shares with cap loose bond cap")
 
 	// Attempt another increase, it should fail from the liquid staking cap
-	err = app.StakingKeeper.SafelyIncreaseValidatorLiquidShares(ctx, initialValidator, secondIncreaseAmount)
+	_, err = app.StakingKeeper.SafelyIncreaseValidatorLiquidShares(ctx, valAddress, secondIncreaseAmount)
 	require.ErrorIs(t, err, types.ErrValidatorLiquidStakingCapExceeded)
 	checkValidatorLiquidShares(expectedLiquidSharesAfterFirstStake, "shares after liquid staking cap hit")
 
@@ -690,7 +690,7 @@ func TestSafelyIncreaseValidatorLiquidShares(t *testing.T) {
 
 	// Finally confirm that the increase succeeded this time
 	expectedLiquidSharesAfterSecondStake := initialLiquidShares.Add(secondIncreaseAmount)
-	err = app.StakingKeeper.SafelyIncreaseValidatorLiquidShares(ctx, initialValidator, secondIncreaseAmount)
+	_, err = app.StakingKeeper.SafelyIncreaseValidatorLiquidShares(ctx, valAddress, secondIncreaseAmount)
 	require.NoError(t, err, "no error expected after increasing liquid staking cap")
 	checkValidatorLiquidShares(expectedLiquidSharesAfterSecondStake, "shares after loose liquid stake cap")
 }
@@ -714,7 +714,7 @@ func TestDecreaseValidatorLiquidShares(t *testing.T) {
 	app.StakingKeeper.SetValidator(ctx, initialValidator)
 
 	// Decrease the validator liquid shares, and confirm the new share amount has been updated
-	err := app.StakingKeeper.DecreaseValidatorLiquidShares(ctx, initialValidator, decreaseAmount)
+	_, err := app.StakingKeeper.DecreaseValidatorLiquidShares(ctx, valAddress, decreaseAmount)
 	require.NoError(t, err, "no error expected when decreasing validator liquid shares")
 
 	actualValidator, found := app.StakingKeeper.GetValidator(ctx, valAddress)
@@ -722,7 +722,7 @@ func TestDecreaseValidatorLiquidShares(t *testing.T) {
 	require.Equal(t, initialLiquidShares.Sub(decreaseAmount), actualValidator.LiquidShares, "liquid shares")
 
 	// Attempt to decrease by a larger amount than it has, it should fail
-	err = app.StakingKeeper.DecreaseValidatorLiquidShares(ctx, actualValidator, initialLiquidShares)
+	_, err = app.StakingKeeper.DecreaseValidatorLiquidShares(ctx, valAddress, initialLiquidShares)
 	require.ErrorIs(t, err, types.ErrValidatorLiquidSharesUnderflow)
 }
 

--- a/x/staking/keeper/liquid_stake_test.go
+++ b/x/staking/keeper/liquid_stake_test.go
@@ -639,7 +639,7 @@ func TestSafelyIncreaseValidatorLiquidShares(t *testing.T) {
 	validatorTotalShares := sdk.NewDec(75)
 
 	firstIncreaseAmount := sdk.NewDec(20)
-	secondIncreaseAmount := sdk.NewDec(40)
+	secondIncreaseAmount := sdk.NewDec(10) // total increase of 30
 
 	initialBondFactor := sdk.NewDec(1)
 	finalBondFactor := sdk.NewDec(10)
@@ -689,7 +689,7 @@ func TestSafelyIncreaseValidatorLiquidShares(t *testing.T) {
 	app.StakingKeeper.SetParams(ctx, params)
 
 	// Finally confirm that the increase succeeded this time
-	expectedLiquidSharesAfterSecondStake := initialLiquidShares.Add(secondIncreaseAmount)
+	expectedLiquidSharesAfterSecondStake := expectedLiquidSharesAfterFirstStake.Add(secondIncreaseAmount)
 	_, err = app.StakingKeeper.SafelyIncreaseValidatorLiquidShares(ctx, valAddress, secondIncreaseAmount)
 	require.NoError(t, err, "no error expected after increasing liquid staking cap")
 	checkValidatorLiquidShares(expectedLiquidSharesAfterSecondStake, "shares after loose liquid stake cap")

--- a/x/staking/keeper/msg_server.go
+++ b/x/staking/keeper/msg_server.go
@@ -332,14 +332,9 @@ func (k msgServer) BeginRedelegate(goCtx context.Context, msg *types.MsgBeginRed
 		if _, err = k.SafelyIncreaseValidatorLiquidShares(ctx, dstValidator, dstShares); err != nil {
 			return nil, err
 		}
-		if err := k.DecreaseValidatorLiquidShares(ctx, srcValidator, srcShares); err != nil {
+		srcValidator, err = k.DecreaseValidatorLiquidShares(ctx, srcValidator, srcShares)
+		if err != nil {
 			return nil, err
-		}
-		// Note: this is required for downstream uses of each validator variable
-		// since the liquid shares were updated above
-		srcValidator, found = k.GetValidator(ctx, valSrcAddr)
-		if !found {
-			return nil, types.ErrNoValidatorFound
 		}
 	}
 
@@ -457,14 +452,9 @@ func (k msgServer) Undelegate(goCtx context.Context, msg *types.MsgUndelegate) (
 		if err := k.DecreaseTotalLiquidStakedTokens(ctx, tokens); err != nil {
 			return nil, err
 		}
-		if err := k.DecreaseValidatorLiquidShares(ctx, validator, shares); err != nil {
+		validator, err = k.DecreaseValidatorLiquidShares(ctx, validator, shares)
+		if err != nil {
 			return nil, err
-		}
-		// Note: this is required for downstream uses of the validator variable
-		// since the liquid shares were updated above
-		validator, found = k.GetValidator(ctx, addr)
-		if !found {
-			return nil, types.ErrNoValidatorFound
 		}
 	}
 
@@ -885,14 +875,9 @@ func (k msgServer) RedeemTokensForShares(goCtx context.Context, msg *types.MsgRe
 		if err := k.DecreaseTotalLiquidStakedTokens(ctx, tokens); err != nil {
 			return nil, err
 		}
-		if err := k.DecreaseValidatorLiquidShares(ctx, validator, shares); err != nil {
+		validator, err = k.DecreaseValidatorLiquidShares(ctx, validator, shares)
+		if err != nil {
 			return nil, err
-		}
-		// Note: this is required for downstream uses of the validator variable
-		// since the liquid shares were updated above
-		validator, found = k.GetValidator(ctx, valAddr)
-		if !found {
-			return nil, types.ErrNoValidatorFound
 		}
 	}
 

--- a/x/staking/keeper/msg_server.go
+++ b/x/staking/keeper/msg_server.go
@@ -238,6 +238,10 @@ func (k msgServer) Delegate(goCtx context.Context, msg *types.MsgDelegate) (*typ
 		return nil, types.ErrNoDelegation
 	}
 	if delegation.ValidatorBond {
+		validator, found = k.GetValidator(ctx, valAddr)
+		if !found {
+			return nil, types.ErrNoValidatorFound
+		}
 		k.IncreaseValidatorBondShares(ctx, validator, newShares)
 	}
 
@@ -366,6 +370,11 @@ func (k msgServer) BeginRedelegate(goCtx context.Context, msg *types.MsgBeginRed
 		return nil, types.ErrNoDelegation
 	}
 	if dstDelegation.ValidatorBond {
+		// Note: the validator must be re-read from the store since it was modified in BeginRedelegate
+		dstValidator, found := k.GetValidator(ctx, valDstAddr)
+		if !found {
+			return nil, types.ErrNoValidatorFound
+		}
 		dstShares, err := dstValidator.SharesFromTokensTruncated(msg.Amount.Amount)
 		if err != nil {
 			return nil, err
@@ -621,6 +630,11 @@ func (k msgServer) CancelUnbondingDelegation(goCtx context.Context, msg *types.M
 		return nil, types.ErrNoDelegation
 	}
 	if delegation.ValidatorBond {
+		// Note: the validator must be re-read from the store since it was modified in BeginRedelegate
+		validator, found := k.GetValidator(ctx, valAddr)
+		if !found {
+			return nil, types.ErrNoValidatorFound
+		}
 		k.IncreaseValidatorBondShares(ctx, validator, newShares)
 	}
 

--- a/x/staking/keeper/msg_server.go
+++ b/x/staking/keeper/msg_server.go
@@ -329,7 +329,7 @@ func (k msgServer) BeginRedelegate(goCtx context.Context, msg *types.MsgBeginRed
 		if err != nil {
 			return nil, err
 		}
-		if _, err = k.SafelyIncreaseValidatorLiquidShares(ctx, valDstAddr, dstShares); err != nil {
+		if _, err := k.SafelyIncreaseValidatorLiquidShares(ctx, valDstAddr, dstShares); err != nil {
 			return nil, err
 		}
 		srcValidator, err = k.DecreaseValidatorLiquidShares(ctx, valSrcAddr, srcShares)

--- a/x/staking/keeper/msg_server.go
+++ b/x/staking/keeper/msg_server.go
@@ -215,7 +215,7 @@ func (k msgServer) Delegate(goCtx context.Context, msg *types.MsgDelegate) (*typ
 		if err := k.SafelyIncreaseTotalLiquidStakedTokens(ctx, tokens, false); err != nil {
 			return nil, err
 		}
-		validator, err = k.SafelyIncreaseValidatorLiquidShares(ctx, validator, shares)
+		validator, err = k.SafelyIncreaseValidatorLiquidShares(ctx, valAddr, shares)
 		if err != nil {
 			return nil, err
 		}
@@ -329,10 +329,10 @@ func (k msgServer) BeginRedelegate(goCtx context.Context, msg *types.MsgBeginRed
 		if err != nil {
 			return nil, err
 		}
-		if _, err = k.SafelyIncreaseValidatorLiquidShares(ctx, dstValidator, dstShares); err != nil {
+		if _, err = k.SafelyIncreaseValidatorLiquidShares(ctx, valDstAddr, dstShares); err != nil {
 			return nil, err
 		}
-		srcValidator, err = k.DecreaseValidatorLiquidShares(ctx, srcValidator, srcShares)
+		srcValidator, err = k.DecreaseValidatorLiquidShares(ctx, valSrcAddr, srcShares)
 		if err != nil {
 			return nil, err
 		}
@@ -452,7 +452,7 @@ func (k msgServer) Undelegate(goCtx context.Context, msg *types.MsgUndelegate) (
 		if err := k.DecreaseTotalLiquidStakedTokens(ctx, tokens); err != nil {
 			return nil, err
 		}
-		validator, err = k.DecreaseValidatorLiquidShares(ctx, validator, shares)
+		validator, err = k.DecreaseValidatorLiquidShares(ctx, addr, shares)
 		if err != nil {
 			return nil, err
 		}
@@ -563,7 +563,7 @@ func (k msgServer) CancelUnbondingDelegation(goCtx context.Context, msg *types.M
 		if err := k.SafelyIncreaseTotalLiquidStakedTokens(ctx, tokens, false); err != nil {
 			return nil, err
 		}
-		validator, err = k.SafelyIncreaseValidatorLiquidShares(ctx, validator, shares)
+		validator, err = k.SafelyIncreaseValidatorLiquidShares(ctx, valAddr, shares)
 		if err != nil {
 			return nil, err
 		}
@@ -732,7 +732,7 @@ func (k msgServer) TokenizeShares(goCtx context.Context, msg *types.MsgTokenizeS
 		if err := k.SafelyIncreaseTotalLiquidStakedTokens(ctx, msg.Amount.Amount, true); err != nil {
 			return nil, err
 		}
-		validator, err = k.SafelyIncreaseValidatorLiquidShares(ctx, validator, shares)
+		validator, err = k.SafelyIncreaseValidatorLiquidShares(ctx, valAddr, shares)
 		if err != nil {
 			return nil, err
 		}
@@ -875,7 +875,7 @@ func (k msgServer) RedeemTokensForShares(goCtx context.Context, msg *types.MsgRe
 		if err := k.DecreaseTotalLiquidStakedTokens(ctx, tokens); err != nil {
 			return nil, err
 		}
-		validator, err = k.DecreaseValidatorLiquidShares(ctx, validator, shares)
+		validator, err = k.DecreaseValidatorLiquidShares(ctx, valAddr, shares)
 		if err != nil {
 			return nil, err
 		}

--- a/x/staking/keeper/msg_server.go
+++ b/x/staking/keeper/msg_server.go
@@ -215,14 +215,9 @@ func (k msgServer) Delegate(goCtx context.Context, msg *types.MsgDelegate) (*typ
 		if err := k.SafelyIncreaseTotalLiquidStakedTokens(ctx, tokens, false); err != nil {
 			return nil, err
 		}
-		if err := k.SafelyIncreaseValidatorLiquidShares(ctx, validator, shares); err != nil {
+		validator, err = k.SafelyIncreaseValidatorLiquidShares(ctx, validator, shares)
+		if err != nil {
 			return nil, err
-		}
-		// Note: this is required for downstream uses of the validator variable
-		// since the validator's liquid shares were updated above
-		validator, found = k.GetValidator(ctx, valAddr)
-		if !found {
-			return nil, types.ErrNoValidatorFound
 		}
 	}
 
@@ -334,7 +329,7 @@ func (k msgServer) BeginRedelegate(goCtx context.Context, msg *types.MsgBeginRed
 		if err != nil {
 			return nil, err
 		}
-		if err := k.SafelyIncreaseValidatorLiquidShares(ctx, dstValidator, dstShares); err != nil {
+		if _, err = k.SafelyIncreaseValidatorLiquidShares(ctx, dstValidator, dstShares); err != nil {
 			return nil, err
 		}
 		if err := k.DecreaseValidatorLiquidShares(ctx, srcValidator, srcShares); err != nil {
@@ -578,14 +573,9 @@ func (k msgServer) CancelUnbondingDelegation(goCtx context.Context, msg *types.M
 		if err := k.SafelyIncreaseTotalLiquidStakedTokens(ctx, tokens, false); err != nil {
 			return nil, err
 		}
-		if err := k.SafelyIncreaseValidatorLiquidShares(ctx, validator, shares); err != nil {
+		validator, err = k.SafelyIncreaseValidatorLiquidShares(ctx, validator, shares)
+		if err != nil {
 			return nil, err
-		}
-		// Note: this is required for downstream uses of the validator variable
-		// since the validator's liquid shares were updated above
-		validator, found = k.GetValidator(ctx, valAddr)
-		if !found {
-			return nil, types.ErrNoValidatorFound
 		}
 	}
 
@@ -752,14 +742,9 @@ func (k msgServer) TokenizeShares(goCtx context.Context, msg *types.MsgTokenizeS
 		if err := k.SafelyIncreaseTotalLiquidStakedTokens(ctx, msg.Amount.Amount, true); err != nil {
 			return nil, err
 		}
-		if err := k.SafelyIncreaseValidatorLiquidShares(ctx, validator, shares); err != nil {
+		validator, err = k.SafelyIncreaseValidatorLiquidShares(ctx, validator, shares)
+		if err != nil {
 			return nil, err
-		}
-		// Note: this is required for downstream uses of the validator variable
-		// since the validator's liquid shares were updated above
-		validator, found = k.GetValidator(ctx, valAddr)
-		if !found {
-			return nil, types.ErrNoValidatorFound
 		}
 	}
 


### PR DESCRIPTION
## Overview of Bug
When re-delegating to an existing validator bond delegation, upstream changes to the validator struct are accidentally overwritten, preventing a validator set update. More specifically, in `msg_server.Delegate`, `IncreaseValidatorBondShares` is called with a `validator` struct; however, at this point, the validator struct is stale relative to the underlying validator in the store, which was modified above by `k.Delegate`. Thus, the validator in the store is overwritten.

[[Relevant code](https://github.com/cosmos/cosmos-sdk/blob/feature/v0.45.x-ics-lsm/x/staking/keeper/msg_server.go#L230-L242)]

```go
validator, found := k.GetValidator(ctx, valAddress)
...

k.Delegate(..., validator,...) // updates the validator in the store but does not change the validator variable
...

if delegation.ValidatorBond {
   k.IncreaseValidatorBondShares(..., validator, ...) // stale validator passed, changes from k.Delegate overwritten
}
```

## Solution
The solution to the specific bug was to re-read the validator from the store in `IncreaseValidatorBondShares` so it doesn't accidentally overwrite earlier changes. 

To be extra cautious, the other validator liquid stake accounting functions were also modified with this same behavior. Additionally, a validator was returned from the function rather than relying on the calling function to refresh the variable with a lookup after. **This was not entirely necessary and, there are no bugs in these other functions to our knowledge,** but this should give some added protection should these functions be re-ordered in the future.

**Old:**
```go
func SomeAccountingFunction(validator types.Validator) error { // validator passed
   validator.Attribute = something
   k.SetValidator(validator)
   return nil
}

func SomeMsgServerFunction() {
   validator, found := k.GetValidator(valAddress) 
   if !found {
      return err
   }

   if err := SomeAccountingFunction(validator) {
      return err
   }

   validator, found := k.GetValidator(valAddress) // calling function must remember to look up validator again
   if !found {
      return err
   }

  k.SomeDownstreamFunction(validator) 
}
```

**New:**
```go
func SomeAccountingFunction(valAddress sdk.ValAddress) (types.Validator, error) { // val address passed instead
   validator, found := k.GetValidator(valAddress) // fresh lookup
   if !found {
      return err
   }
   validator.Attribute = something
   k.SetValidator(validator)
   return validator, nil // returns validator
}

func SomeMsgServerFunction() {
   validator, found := k.GetValidator(valAddress) 
   if !found {
      return err
   }

   validator, err = SomeAccountingFunction(validatorAddress) // no need to re-read from store after
   if err != nil {
      return err
   }

  k.SomeDownstreamFunction(validator) 
}
```

## Brief Changelog
* Modified `IncreaseValidatorBond`, `SafelyDecreaseValidatorBond`, `SafelyIncreaseValidatorLiquidShares` and `DecreaseValidatorLiquidShares` to take the val address as a parameter and do a validator lookup at the start
* Modified `SafelyIncreaseValidatorLiquidShares` and `DecreaseValidatorLiquidShares` to return the new validator from the function