### PR TITLE
perf: optimize math.Int.Size for small values

### DIFF
--- a/math/CHANGELOG.md
+++ b/math/CHANGELOG.md
@@ -34,6 +34,12 @@ Ref: https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.j
 
 # Changelog
 
+## [Unreleased]
+
+### Improvements
+
+* [#17497](https://github.com/cosmos/cosmos-sdk/pull/17497) Optimize math.Int.Size for values that fit in 53 bits.
+
 ## [math/v1.1.2](https://github.com/cosmos/cosmos-sdk/releases/tag/math/v1.1.2) - 2023-08-21
 
 ### Bug Fixes

--- a/math/fuzz_test.go
+++ b/math/fuzz_test.go
@@ -22,3 +22,15 @@ func FuzzLegacyNewDecFromStr(f *testing.F) {
 		}
 	})
 }
+
+func FuzzSmallIntSize(f *testing.F) {
+	f.Add(int64(2<<53 - 1))
+	f.Add(-int64(2<<53 - 1))
+	f.Fuzz(func(t *testing.T, input int64) {
+		i := NewInt(input)
+		exp, _ := i.Marshal()
+		if i.Size() != len(exp) {
+			t.Fatalf("input %d: i.Size()=%d, len(input)=%d", input, i.Size(), len(exp))
+		}
+	})
+}

--- a/math/int_test.go
+++ b/math/int_test.go
@@ -592,14 +592,16 @@ func TestNewIntFromString(t *testing.T) {
 }
 
 func BenchmarkIntSize(b *testing.B) {
+	var tests []math.Int
+	for _, st := range sizeTests {
+		ii, _ := math.NewIntFromString(st.s)
+		tests = append(tests, ii)
+	}
+	b.ResetTimer()
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		for _, st := range sizeTests {
-			ii, _ := math.NewIntFromString(st.s)
+		for _, ii := range tests {
 			got := ii.Size()
-			if got != st.want {
-				b.Errorf("%q:: got=%d, want=%d", st.s, got, st.want)
-			}
 			sink = got
 		}
 	}


### PR DESCRIPTION
This is a simpler version of #16263 that only optimizes values that fit in 53 bits. It is possible to optimize values that fit in 64 bits by using big.Int.BitLen and math.Log2(10), but it doesn't seem worth the complexity, especially given the revert of #16263.

I didn't succeed in beating big.Int.Marshal for values that don't fit in 64 bit.

CC @odeke-em @julienrbrt 