### PR TITLE
fix(circuit): Reset only doable by authorized account

### DIFF
--- a/x/circuit/keeper/msg_server_test.go
+++ b/x/circuit/keeper/msg_server_test.go
@@ -291,7 +291,7 @@ func TestResetCircuitBreaker(t *testing.T) {
 	require.NoError(t, err)
 
 	// user with some messages resets circuit breaker
-	someMsgsReset := &types.MsgResetCircuitBreaker{Authority: addresses[2], MsgTypeUrls: []string{url}}
+	someMsgsReset := &types.MsgResetCircuitBreaker{Authority: addresses[2], MsgTypeUrls: []string{url2}}
 	_, err = srv.ResetCircuitBreaker(ft.ctx, someMsgsReset)
 	require.NoError(t, err)
 	require.Equal(
@@ -299,14 +299,14 @@ func TestResetCircuitBreaker(t *testing.T) {
 		sdk.NewEvent(
 			"reset_circuit_breaker",
 			sdk.NewAttribute("authority", addresses[2]),
-			sdk.NewAttribute("msg_url", url),
+			sdk.NewAttribute("msg_url", url2),
 		),
 		lastEvent(ft.ctx),
 	)
 
 	// user tries to reset an already reset circuit breaker
-	admintrip = &types.MsgTripCircuitBreaker{Authority: addresses[1], MsgTypeUrls: []string{url2}}
-	_, err = srv.TripCircuitBreaker(ft.ctx, admintrip)
+	someMsgsReset = &types.MsgResetCircuitBreaker{Authority: addresses[1], MsgTypeUrls: []string{url2}}
+	_, err = srv.ResetCircuitBreaker(ft.ctx, someMsgsReset)
 	require.Error(t, err)
 }
 
@@ -315,4 +315,61 @@ func lastEvent(ctx context.Context) sdk.Event {
 	events := sdkCtx.EventManager().Events()
 
 	return events[len(events)-1]
+}
+
+func TestResetCircuitBreakerSomeMsgs(t *testing.T) {
+	ft := initFixture(t)
+	authority, err := ft.ac.BytesToString(ft.mockAddr)
+	require.NoError(t, err)
+
+	srv := keeper.NewMsgServerImpl(ft.keeper)
+
+	// admin resets circuit breaker
+	url := "cosmos.bank.v1beta1.MsgSend"
+	url2 := "the_only_message_acc2_can_trip_and_reset"
+
+	// add acc2 as an authorized account for only url2
+	authmsg := &types.MsgAuthorizeCircuitBreaker{
+		Granter: authority,
+		Grantee: addresses[2],
+		Permissions: &types.Permissions{
+			Level:         types.Permissions_LEVEL_SOME_MSGS,
+			LimitTypeUrls: []string{url2},
+		},
+	}
+	_, err = srv.AuthorizeCircuitBreaker(ft.ctx, authmsg)
+	require.NoError(t, err)
+
+	// admin trips circuit breaker
+	admintrip := &types.MsgTripCircuitBreaker{Authority: authority, MsgTypeUrls: []string{url, url2}}
+	_, err = srv.TripCircuitBreaker(ft.ctx, admintrip)
+	require.NoError(t, err)
+
+	// sanity check, both messages should be tripped
+	allowed, err := ft.keeper.IsAllowed(ft.ctx, url)
+	require.NoError(t, err)
+	require.False(t, allowed, "circuit breaker should be tripped")
+
+	allowed, err = ft.keeper.IsAllowed(ft.ctx, url2)
+	require.NoError(t, err)
+	require.False(t, allowed, "circuit breaker should be tripped")
+
+	// now let's try to reset url using acc2 (should fail)
+	acc2Reset := &types.MsgResetCircuitBreaker{Authority: addresses[2], MsgTypeUrls: []string{url}}
+	_, err = srv.ResetCircuitBreaker(ft.ctx, acc2Reset)
+	require.Error(t, err)
+
+	// now let's try to reset url2 using acc2 (should pass)
+	acc2Reset = &types.MsgResetCircuitBreaker{Authority: addresses[2], MsgTypeUrls: []string{url2}}
+	_, err = srv.ResetCircuitBreaker(ft.ctx, acc2Reset)
+	require.NoError(t, err)
+
+	// Only url2 should be reset, url should still be tripped
+	allowed, err = ft.keeper.IsAllowed(ft.ctx, url)
+	require.NoError(t, err)
+	require.False(t, allowed, "circuit breaker should be tripped")
+
+	allowed, err = ft.keeper.IsAllowed(ft.ctx, url2)
+	require.NoError(t, err)
+	require.True(t, allowed, "circuit breaker should be reset")
 }


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

There was a bug in which an account that has authorization for some msgs could reset the circuit breaker for any message, this was happening because we weren't checking for those permissions separately.

While I was at it, I refactored the code to be a bit cleaner and less repetitive (imo); if it doesn't look good we can revert to using the switch case.

Now we first check if the user has any permissions at all, if not we return early. Then we iterate through messages, and if the user is not a super_admin/all_msgs/authority we check if it has permissions over the specific message.


<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] added `!` to the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules)
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] updated the relevant documentation or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] run `make lint` and `make test`
* [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] confirmed all author checklist items have been addressed 
* [ ] reviewed state machine logic
* [ ] reviewed API design and naming
* [ ] reviewed documentation is accurate
* [ ] reviewed tests and test coverage
* [ ] manually tested (if applicable)
