### PR TITLE
test(baseapp): use no-op logger

### DIFF
--- a/baseapp/abci_test.go
+++ b/baseapp/abci_test.go
@@ -78,7 +78,7 @@ func TestABCI_First_block_Height(t *testing.T) {
 func TestABCI_InitChain(t *testing.T) {
 	name := t.Name()
 	db := dbm.NewMemDB()
-	logger := log.NewTestLogger(t)
+	logger := log.NewNopLogger()
 	app := baseapp.NewBaseApp(name, logger, db, nil, baseapp.SetChainID("test-chain-id"))
 
 	capKey := storetypes.NewKVStoreKey("main")
@@ -180,7 +180,7 @@ func TestABCI_InitChain(t *testing.T) {
 func TestABCI_InitChain_WithInitialHeight(t *testing.T) {
 	name := t.Name()
 	db := dbm.NewMemDB()
-	app := baseapp.NewBaseApp(name, log.NewTestLogger(t), db, nil)
+	app := baseapp.NewBaseApp(name, log.NewNopLogger(), db, nil)
 
 	_, err := app.InitChain(
 		&abci.RequestInitChain{
@@ -197,7 +197,7 @@ func TestABCI_InitChain_WithInitialHeight(t *testing.T) {
 func TestABCI_FinalizeBlock_WithInitialHeight(t *testing.T) {
 	name := t.Name()
 	db := dbm.NewMemDB()
-	app := baseapp.NewBaseApp(name, log.NewTestLogger(t), db, nil)
+	app := baseapp.NewBaseApp(name, log.NewNopLogger(), db, nil)
 
 	_, err := app.InitChain(
 		&abci.RequestInitChain{
@@ -219,7 +219,7 @@ func TestABCI_FinalizeBlock_WithInitialHeight(t *testing.T) {
 func TestABCI_FinalizeBlock_WithBeginAndEndBlocker(t *testing.T) {
 	name := t.Name()
 	db := dbm.NewMemDB()
-	app := baseapp.NewBaseApp(name, log.NewTestLogger(t), db, nil)
+	app := baseapp.NewBaseApp(name, log.NewNopLogger(), db, nil)
 
 	app.SetBeginBlocker(func(ctx sdk.Context) (sdk.BeginBlock, error) {
 		return sdk.BeginBlock{
@@ -286,7 +286,7 @@ func TestABCI_FinalizeBlock_WithBeginAndEndBlocker(t *testing.T) {
 func TestABCI_ExtendVote(t *testing.T) {
 	name := t.Name()
 	db := dbm.NewMemDB()
-	app := baseapp.NewBaseApp(name, log.NewTestLogger(t), db, nil)
+	app := baseapp.NewBaseApp(name, log.NewNopLogger(), db, nil)
 
 	app.SetExtendVoteHandler(func(ctx sdk.Context, req *abci.RequestExtendVote) (*abci.ResponseExtendVote, error) {
 		voteExt := "foo" + hex.EncodeToString(req.Hash) + strconv.FormatInt(req.Height, 10)
@@ -369,7 +369,7 @@ func TestABCI_ExtendVote(t *testing.T) {
 func TestABCI_OnlyVerifyVoteExtension(t *testing.T) {
 	name := t.Name()
 	db := dbm.NewMemDB()
-	app := baseapp.NewBaseApp(name, log.NewTestLogger(t), db, nil)
+	app := baseapp.NewBaseApp(name, log.NewNopLogger(), db, nil)
 
 	app.SetVerifyVoteExtensionHandler(func(ctx sdk.Context, req *abci.RequestVerifyVoteExtension) (*abci.ResponseVerifyVoteExtension, error) {
 		// do some kind of verification here
@@ -503,7 +503,7 @@ func TestABCI_P2PQuery(t *testing.T) {
 func TestBaseApp_PrepareCheckState(t *testing.T) {
 	db := dbm.NewMemDB()
 	name := t.Name()
-	logger := log.NewTestLogger(t)
+	logger := log.NewNopLogger()
 
 	cp := &cmtproto.ConsensusParams{
 		Block: &cmtproto.BlockParams{
@@ -532,7 +532,7 @@ func TestBaseApp_PrepareCheckState(t *testing.T) {
 func TestBaseApp_Precommit(t *testing.T) {
 	db := dbm.NewMemDB()
 	name := t.Name()
-	logger := log.NewTestLogger(t)
+	logger := log.NewNopLogger()
 
 	cp := &cmtproto.ConsensusParams{
 		Block: &cmtproto.BlockParams{
@@ -1238,7 +1238,7 @@ func TestABCI_Query(t *testing.T) {
 }
 
 func TestABCI_GetBlockRetentionHeight(t *testing.T) {
-	logger := log.NewTestLogger(t)
+	logger := log.NewNopLogger()
 	db := dbm.NewMemDB()
 	name := t.Name()
 
@@ -1351,7 +1351,7 @@ func TestABCI_GetBlockRetentionHeight(t *testing.T) {
 func TestPrepareCheckStateCalledWithCheckState(t *testing.T) {
 	t.Parallel()
 
-	logger := log.NewTestLogger(t)
+	logger := log.NewNopLogger()
 	db := dbm.NewMemDB()
 	name := t.Name()
 	app := baseapp.NewBaseApp(name, logger, db, nil)
@@ -1374,7 +1374,7 @@ func TestPrepareCheckStateCalledWithCheckState(t *testing.T) {
 func TestPrecommiterCalledWithDeliverState(t *testing.T) {
 	t.Parallel()
 
-	logger := log.NewTestLogger(t)
+	logger := log.NewNopLogger()
 	db := dbm.NewMemDB()
 	name := t.Name()
 	app := baseapp.NewBaseApp(name, logger, db, nil)
@@ -2009,7 +2009,7 @@ func TestABCI_HaltChain(t *testing.T) {
 func TestBaseApp_PreFinalizeBlockHook(t *testing.T) {
 	db := dbm.NewMemDB()
 	name := t.Name()
-	logger := log.NewTestLogger(t)
+	logger := log.NewNopLogger()
 
 	app := baseapp.NewBaseApp(name, logger, db, nil)
 	_, err := app.InitChain(&abci.RequestInitChain{})

--- a/baseapp/baseapp_test.go
+++ b/baseapp/baseapp_test.go
@@ -66,7 +66,7 @@ func NewBaseAppSuite(t *testing.T, opts ...func(*baseapp.BaseApp)) *BaseAppSuite
 	txConfig := authtx.NewTxConfig(cdc, authtx.DefaultSignModes)
 	db := dbm.NewMemDB()
 
-	app := baseapp.NewBaseApp(t.Name(), log.NewTestLogger(t), db, txConfig.TxDecoder(), opts...)
+	app := baseapp.NewBaseApp(t.Name(), log.NewNopLogger(), db, txConfig.TxDecoder(), opts...)
 	require.Equal(t, t.Name(), app.Name())
 
 	app.SetInterfaceRegistry(cdc.InterfaceRegistry())
@@ -91,7 +91,7 @@ func getQueryBaseapp(t *testing.T) *baseapp.BaseApp {
 
 	db := dbm.NewMemDB()
 	name := t.Name()
-	app := baseapp.NewBaseApp(name, log.NewTestLogger(t), db, nil)
+	app := baseapp.NewBaseApp(name, log.NewNopLogger(), db, nil)
 
 	_, err := app.FinalizeBlock(&abci.RequestFinalizeBlock{Height: 1})
 	require.NoError(t, err)
@@ -192,7 +192,7 @@ func NewBaseAppSuiteWithSnapshots(t *testing.T, cfg SnapshotsConfig, opts ...fun
 }
 
 func TestLoadVersion(t *testing.T) {
-	logger := log.NewTestLogger(t)
+	logger := log.NewNopLogger()
 	pruningOpt := baseapp.SetPruning(pruningtypes.NewPruningOptions(pruningtypes.PruningNothing))
 	db := dbm.NewMemDB()
 	name := t.Name()
@@ -323,7 +323,7 @@ func TestSetLoader(t *testing.T) {
 			if tc.setLoader != nil {
 				opts = append(opts, tc.setLoader)
 			}
-			app := baseapp.NewBaseApp(t.Name(), log.NewTestLogger(t), db, nil, opts...)
+			app := baseapp.NewBaseApp(t.Name(), log.NewNopLogger(), db, nil, opts...)
 			app.MountStores(storetypes.NewKVStoreKey(tc.loadStoreKey))
 			err := app.LoadLatestVersion()
 			require.Nil(t, err)
@@ -346,7 +346,7 @@ func TestVersionSetterGetter(t *testing.T) {
 	pruningOpt := baseapp.SetPruning(pruningtypes.NewPruningOptions(pruningtypes.PruningDefault))
 	db := dbm.NewMemDB()
 	name := t.Name()
-	app := baseapp.NewBaseApp(name, log.NewTestLogger(t), db, nil, pruningOpt)
+	app := baseapp.NewBaseApp(name, log.NewNopLogger(), db, nil, pruningOpt)
 
 	require.Equal(t, "", app.Version())
 	res, err := app.Query(context.TODO(), &abci.RequestQuery{Path: "app/version"})
@@ -405,7 +405,7 @@ func TestOptionFunction(t *testing.T) {
 	}
 
 	db := dbm.NewMemDB()
-	bap := baseapp.NewBaseApp("starting name", log.NewTestLogger(t), db, nil, testChangeNameHelper("new name"))
+	bap := baseapp.NewBaseApp("starting name", log.NewNopLogger(), db, nil, testChangeNameHelper("new name"))
 	require.Equal(t, bap.Name(), "new name", "BaseApp should have had name changed via option function")
 }
 
@@ -597,7 +597,7 @@ func TestABCI_CreateQueryContext(t *testing.T) {
 
 	db := dbm.NewMemDB()
 	name := t.Name()
-	app := baseapp.NewBaseApp(name, log.NewTestLogger(t), db, nil)
+	app := baseapp.NewBaseApp(name, log.NewNopLogger(), db, nil)
 
 	_, err := app.FinalizeBlock(&abci.RequestFinalizeBlock{Height: 1})
 	require.NoError(t, err)

--- a/baseapp/grpcrouter_test.go
+++ b/baseapp/grpcrouter_test.go
@@ -59,7 +59,7 @@ func TestRegisterQueryServiceTwice(t *testing.T) {
 	err := depinject.Inject(
 		depinject.Configs(
 			makeMinimalConfig(),
-			depinject.Supply(log.NewTestLogger(t)),
+			depinject.Supply(log.NewNopLogger()),
 		),
 		&appBuilder)
 	require.NoError(t, err)

--- a/baseapp/msg_service_router_test.go
+++ b/baseapp/msg_service_router_test.go
@@ -30,7 +30,7 @@ func TestRegisterMsgService(t *testing.T) {
 	err := depinject.Inject(
 		depinject.Configs(
 			makeMinimalConfig(),
-			depinject.Supply(log.NewTestLogger(t)),
+			depinject.Supply(log.NewNopLogger()),
 		), &appBuilder, &registry)
 	require.NoError(t, err)
 	app := appBuilder.Build(dbm.NewMemDB(), nil)
@@ -62,7 +62,7 @@ func TestRegisterMsgServiceTwice(t *testing.T) {
 	err := depinject.Inject(
 		depinject.Configs(
 			makeMinimalConfig(),
-			depinject.Supply(log.NewTestLogger(t)),
+			depinject.Supply(log.NewNopLogger()),
 		), &appBuilder, &registry)
 	require.NoError(t, err)
 	db := dbm.NewMemDB()


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

Sometimes tests are failing in CI because the test logger does not work properly.
This updates it to always use a no-op logger within the baseapp tests.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] added `!` to the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules)
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] updated the relevant documentation or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] run `make lint` and `make test`
* [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] confirmed all author checklist items have been addressed 
* [ ] reviewed state machine logic
* [ ] reviewed API design and naming
* [ ] reviewed documentation is accurate
* [ ] reviewed tests and test coverage
* [ ] manually tested (if applicable)
