### PR TITLE
fix: properly handle deletes in ss stores

### DIFF
--- a/store/storage/pebbledb/db.go
+++ b/store/storage/pebbledb/db.go
@@ -18,6 +18,7 @@ const (
 
 	StorePrefixTpl   = "s/k:%s/"   // s/k:<storeKey>
 	latestVersionKey = "s/_latest" // NB: latestVersionKey key must be lexically smaller than StorePrefixTpl
+	tombstoneVal     = "TOMBSTONE"
 )
 
 var (
@@ -78,20 +79,16 @@ func (db *Database) GetLatestVersion() (uint64, error) {
 }
 
 func (db *Database) Has(storeKey string, version uint64, key []byte) (bool, error) {
-	_, err := getMVCCSlice(db.storage, storeKey, key, version)
+	val, err := db.Get(storeKey, version, key)
 	if err != nil {
-		if errors.Is(err, store.ErrRecordNotFound) {
-			return false, nil
-		}
-
-		return false, fmt.Errorf("failed to perform PebbleDB read: %w", err)
+		return false, err
 	}
 
-	return true, nil
+	return val != nil, nil
 }
 
-func (db *Database) Get(storeKey string, version uint64, key []byte) ([]byte, error) {
-	bz, err := getMVCCSlice(db.storage, storeKey, key, version)
+func (db *Database) Get(storeKey string, targetVersion uint64, key []byte) ([]byte, error) {
+	prefixedVal, err := getMVCCSlice(db.storage, storeKey, key, targetVersion)
 	if err != nil {
 		if errors.Is(err, store.ErrRecordNotFound) {
 			return nil, nil
@@ -100,47 +97,62 @@ func (db *Database) Get(storeKey string, version uint64, key []byte) ([]byte, er
 		return nil, fmt.Errorf("failed to perform PebbleDB read: %w", err)
 	}
 
-	return bz, nil
+	valBz, tombBz, ok := SplitMVCCKey(prefixedVal)
+	if !ok {
+		return nil, fmt.Errorf("invalid PebbleDB MVCC value: %s", prefixedVal)
+	}
+
+	// A tombstone of zero or a target version that is less than the tombstone
+	// version means the key is not deleted at the target version.
+	if len(tombBz) == 0 {
+		return valBz, nil
+	}
+
+	tombstone, err := decodeUint64Ascending(tombBz)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode value tombstone: %w", err)
+	}
+	if tombstone > targetVersion {
+		return nil, fmt.Errorf("value tombstone too large: %d", tombstone)
+	}
+
+	// A tombstone of zero or a target version that is less than the tombstone
+	// version means the key is not deleted at the target version.
+	if targetVersion < tombstone {
+		return valBz, nil
+	}
+
+	// the value is considered deleted
+	return nil, nil
 }
 
 func (db *Database) Set(storeKey string, version uint64, key, value []byte) error {
-	var versionBz [VersionSize]byte
-	binary.LittleEndian.PutUint64(versionBz[:], version)
-
-	batch := db.storage.NewBatch()
-
-	if err := batch.Set([]byte(latestVersionKey), versionBz[:], nil); err != nil {
-		return fmt.Errorf("failed to write PebbleDB batch: %w", err)
-	}
-	if err := batch.Set(MVCCEncode(prependStoreKey(storeKey, key), version), value, nil); err != nil {
-		return fmt.Errorf("failed to write PebbleDB batch: %w", err)
+	b, err := db.NewBatch(version)
+	if err != nil {
+		return err
 	}
 
-	if err := batch.Commit(defaultWriteOpts); err != nil {
-		return fmt.Errorf("failed to commit PebbleDB batch: %w", err)
+	if err := b.Set(storeKey, key, value); err != nil {
+		return err
 	}
 
-	return nil
+	return b.Write()
 }
 
+// Delete marks the key as deleted. The key will not be retrievable at or before
+// the provided version. However, the key is still persisted in the underlying
+// database engine as it's value is marked with a non-zero tombestone.
 func (db *Database) Delete(storeKey string, version uint64, key []byte) error {
-	var versionBz [VersionSize]byte
-	binary.LittleEndian.PutUint64(versionBz[:], version)
-
-	batch := db.storage.NewBatch()
-
-	if err := batch.Set([]byte(latestVersionKey), versionBz[:], nil); err != nil {
-		return fmt.Errorf("failed to write PebbleDB batch: %w", err)
-	}
-	if err := batch.Delete(MVCCEncode(prependStoreKey(storeKey, key), version), nil); err != nil {
-		return fmt.Errorf("failed to write PebbleDB batch: %w", err)
+	b, err := db.NewBatch(version)
+	if err != nil {
+		return err
 	}
 
-	if err := batch.Commit(defaultWriteOpts); err != nil {
-		return fmt.Errorf("failed to commit PebbleDB batch: %w", err)
+	if err := b.Delete(storeKey, key); err != nil {
+		return err
 	}
 
-	return nil
+	return b.Write()
 }
 
 func (db *Database) NewBatch(version uint64) (store.Batch, error) {
@@ -206,7 +218,7 @@ func getMVCCSlice(db *pebble.DB, storeKey string, key []byte, version uint64) ([
 
 	_, vBz, ok := SplitMVCCKey(itr.Key())
 	if !ok {
-		return nil, fmt.Errorf("unexpected key format: %s", itr.Key())
+		return nil, fmt.Errorf("invalid PebbleDB MVCC key: %s", itr.Key())
 	}
 
 	keyVersion, err := decodeUint64Ascending(vBz)

--- a/store/storage/rocksdb/db.go
+++ b/store/storage/rocksdb/db.go
@@ -179,7 +179,6 @@ func (db *Database) NewReverseIterator(storeKey string, version uint64, start, e
 }
 
 // newTSReadOptions returns ReadOptions used in the RocksDB column family read.
-// Note, a zero version indicates a maximum version.
 func newTSReadOptions(version uint64) *grocksdb.ReadOptions {
 	var ts [TimestampSize]byte
 	binary.LittleEndian.PutUint64(ts[:], version)

--- a/store/storage/rocksdb/db.go
+++ b/store/storage/rocksdb/db.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
-	"math"
 
 	"cosmossdk.io/store/v2"
 	"cosmossdk.io/store/v2/storage/util"
@@ -182,15 +181,8 @@ func (db *Database) NewReverseIterator(storeKey string, version uint64, start, e
 // newTSReadOptions returns ReadOptions used in the RocksDB column family read.
 // Note, a zero version indicates a maximum version.
 func newTSReadOptions(version uint64) *grocksdb.ReadOptions {
-	var ver uint64
-	if version == 0 {
-		ver = math.MaxUint64
-	} else {
-		ver = version
-	}
-
 	var ts [TimestampSize]byte
-	binary.LittleEndian.PutUint64(ts[:], ver)
+	binary.LittleEndian.PutUint64(ts[:], version)
 
 	readOpts := grocksdb.NewDefaultReadOptions()
 	readOpts.SetTimestamp(ts[:])

--- a/store/storage/sqlite/batch.go
+++ b/store/storage/sqlite/batch.go
@@ -79,7 +79,7 @@ func (b *Batch) Write() error {
 			}
 
 		case batchActionDel:
-			_, err := b.tx.Exec(delStmt, op.storeKey, op.key, b.version)
+			_, err := b.tx.Exec(delStmt, b.version, op.storeKey, op.key, b.version)
 			if err != nil {
 				return fmt.Errorf("failed to exec SQL statement: %w", err)
 			}

--- a/store/storage/sqlite/db.go
+++ b/store/storage/sqlite/db.go
@@ -190,7 +190,7 @@ func (db *Database) NewReverseIterator(storeKey string, version uint64, start, e
 	panic("not implemented!")
 }
 
-func (db *Database) printRowsDebug() {
+func (db *Database) PrintRowsDebug() {
 	stmt, err := db.storage.Prepare("SELECT store_key, key, value, version, tombstone FROM state_storage")
 	if err != nil {
 		panic(fmt.Errorf("failed to prepare SQL statement: %w", err))

--- a/store/storage/sqlite/db.go
+++ b/store/storage/sqlite/db.go
@@ -31,7 +31,12 @@ const (
   ON CONFLICT(store_key, key, version) DO UPDATE SET
     value = ?;
 	`
-	delStmt = "DELETE FROM state_storage WHERE store_key = ? AND key = ? AND version = ?;"
+	delStmt = `
+	UPDATE state_storage SET tombstone = ?
+	WHERE id = (
+		SELECT id FROM state_storage WHERE store_key = ? AND key = ? AND version <= ? ORDER BY version DESC LIMIT 1
+	) AND tombstone = 0;
+	`
 )
 
 var _ store.VersionedDatabase = (*Database)(nil)
@@ -53,6 +58,7 @@ func New(dataDir string) (*Database, error) {
 		key varchar not null,
 		value varchar not null,
 		version integer unsigned not null,
+		tombstone integer unsigned default 0,
 		unique (store_key, key, version)
 	);
 
@@ -104,29 +110,17 @@ func (db *Database) SetLatestVersion(version uint64) error {
 }
 
 func (db *Database) Has(storeKey string, version uint64, key []byte) (bool, error) {
-	stmt, err := db.storage.Prepare(`
-	SELECT EXISTS(
-		SELECT 1 FROM state_storage WHERE store_key = ? AND key = ? AND version <= ?
-		ORDER BY version DESC LIMIT 1
-	);
-	`)
+	val, err := db.Get(storeKey, version, key)
 	if err != nil {
-		return false, fmt.Errorf("failed to prepare SQL statement: %w", err)
+		return false, err
 	}
 
-	defer stmt.Close()
-
-	var exists bool
-	if err := stmt.QueryRow(storeKey, key, version).Scan(&exists); err != nil {
-		return false, fmt.Errorf("failed to query row: %w", err)
-	}
-
-	return exists, nil
+	return val != nil, nil
 }
 
-func (db *Database) Get(storeKey string, version uint64, key []byte) ([]byte, error) {
+func (db *Database) Get(storeKey string, targetVersion uint64, key []byte) ([]byte, error) {
 	stmt, err := db.storage.Prepare(`
-	SELECT value FROM state_storage
+	SELECT value, tombstone FROM state_storage
 	WHERE store_key = ? AND key = ? AND version <= ?
 	ORDER BY version DESC LIMIT 1;
 	`)
@@ -136,8 +130,11 @@ func (db *Database) Get(storeKey string, version uint64, key []byte) ([]byte, er
 
 	defer stmt.Close()
 
-	var value []byte
-	if err := stmt.QueryRow(storeKey, key, version).Scan(&value); err != nil {
+	var (
+		value []byte
+		tomb  uint64
+	)
+	if err := stmt.QueryRow(storeKey, key, targetVersion).Scan(&value, &tomb); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, nil
 		}
@@ -145,7 +142,14 @@ func (db *Database) Get(storeKey string, version uint64, key []byte) ([]byte, er
 		return nil, fmt.Errorf("failed to query row: %w", err)
 	}
 
-	return value, nil
+	// A tombstone of zero or a target version that is less than the tombstone
+	// version means the key is not deleted at the target version.
+	if tomb == 0 || targetVersion < tomb {
+		return value, nil
+	}
+
+	// the value is considered deleted
+	return nil, nil
 }
 
 func (db *Database) Set(storeKey string, version uint64, key, value []byte) error {
@@ -158,7 +162,7 @@ func (db *Database) Set(storeKey string, version uint64, key, value []byte) erro
 }
 
 func (db *Database) Delete(storeKey string, version uint64, key []byte) error {
-	_, err := db.storage.Exec(delStmt, storeKey, key, version)
+	_, err := db.storage.Exec(delStmt, version, storeKey, key, version)
 	if err != nil {
 		return fmt.Errorf("failed to exec SQL statement: %w", err)
 	}
@@ -187,7 +191,7 @@ func (db *Database) NewReverseIterator(storeKey string, version uint64, start, e
 }
 
 func (db *Database) printRowsDebug() {
-	stmt, err := db.storage.Prepare("SELECT store_key, key, value, version FROM state_storage")
+	stmt, err := db.storage.Prepare("SELECT store_key, key, value, version, tombstone FROM state_storage")
 	if err != nil {
 		panic(fmt.Errorf("failed to prepare SQL statement: %w", err))
 	}
@@ -206,16 +210,17 @@ func (db *Database) printRowsDebug() {
 			key      []byte
 			value    []byte
 			version  uint64
+			tomb     uint64
 		)
-		if err := rows.Scan(&storeKey, &key, &value, &version); err != nil {
+		if err := rows.Scan(&storeKey, &key, &value, &version, &tomb); err != nil {
 			panic(fmt.Sprintf("failed to scan row: %s", err))
 		}
 
-		sb.WriteString(fmt.Sprintf("STORE_KEY: %s, KEY: %s, VALUE: %s, VERSION: %d\n", storeKey, key, value, version))
+		sb.WriteString(fmt.Sprintf("STORE_KEY: %s, KEY: %s, VALUE: %s, VERSION: %d, TOMBSTONE: %d\n", storeKey, key, value, version, tomb))
 	}
 	if err := rows.Err(); err != nil {
 		panic(fmt.Errorf("received unexpected error: %w", err))
 	}
 
-	fmt.Println(sb.String())
+	fmt.Println(strings.TrimSpace(sb.String()))
 }

--- a/store/storage/storage_test_suite.go
+++ b/store/storage/storage_test_suite.go
@@ -306,52 +306,88 @@ func (s *StorageTestSuite) TestDatabase_Iterator() {
 	err = batch.Write()
 	s.Require().NoError(err)
 
-	// iterator without an end key
-	itr, err := db.NewIterator(storeKey1, 1, []byte("key000"), nil)
-	s.Require().NoError(err)
+	// iterator without an end key over multiple versions
+	for v := uint64(1); v < 5; v++ {
+		itr, err := db.NewIterator(storeKey1, v, []byte("key000"), nil)
+		s.Require().NoError(err)
 
-	defer itr.Close()
+		defer itr.Close()
 
-	var i, count int
-	for ; itr.Valid(); itr.Next() {
-		s.Require().Equal([]byte(fmt.Sprintf("key%03d", i)), itr.Key(), string(itr.Key()))
-		s.Require().Equal([]byte(fmt.Sprintf("val%03d", i)), itr.Value())
+		var i, count int
+		for ; itr.Valid(); itr.Next() {
+			s.Require().Equal([]byte(fmt.Sprintf("key%03d", i)), itr.Key(), string(itr.Key()))
+			s.Require().Equal([]byte(fmt.Sprintf("val%03d", i)), itr.Value())
 
-		i++
-		count++
+			i++
+			count++
+		}
+		s.Require().Equal(100, count)
+		s.Require().NoError(itr.Error())
+
+		// seek past domain, which should make the iterator invalid and produce an error
+		s.Require().False(itr.Next())
+		s.Require().False(itr.Valid())
 	}
-	s.Require().Equal(100, count)
-	s.Require().NoError(itr.Error())
 
-	// seek past domain, which should make the iterator invalid and produce an error
-	s.Require().False(itr.Next())
-	s.Require().False(itr.Valid())
+	// iterator with with a start and end domain over multiple versions
+	for v := uint64(1); v < 5; v++ {
+		itr2, err := db.NewIterator(storeKey1, v, []byte("key010"), []byte("key019"))
+		s.Require().NoError(err)
 
-	// iterator with with a start and end domain
-	itr2, err := db.NewIterator(storeKey1, 1, []byte("key010"), []byte("key019"))
-	s.Require().NoError(err)
+		defer itr2.Close()
 
-	defer itr2.Close()
+		i, count := 10, 0
+		for ; itr2.Valid(); itr2.Next() {
+			s.Require().Equal([]byte(fmt.Sprintf("key%03d", i)), itr2.Key())
+			s.Require().Equal([]byte(fmt.Sprintf("val%03d", i)), itr2.Value())
 
-	i, count = 10, 0
-	for ; itr2.Valid(); itr2.Next() {
-		s.Require().Equal([]byte(fmt.Sprintf("key%03d", i)), itr2.Key())
-		s.Require().Equal([]byte(fmt.Sprintf("val%03d", i)), itr2.Value())
+			i++
+			count++
+		}
+		s.Require().Equal(9, count)
+		s.Require().NoError(itr2.Error())
 
-		i++
-		count++
+		// seek past domain, which should make the iterator invalid and produce an error
+		s.Require().False(itr2.Next())
+		s.Require().False(itr2.Valid())
 	}
-	s.Require().Equal(9, count)
-	s.Require().NoError(itr2.Error())
-
-	// seek past domain, which should make the iterator invalid and produce an error
-	s.Require().False(itr2.Next())
-	s.Require().False(itr2.Valid())
 
 	// start must be <= end
 	iter3, err := db.NewIterator(storeKey1, 1, []byte("key020"), []byte("key019"))
 	s.Require().Error(err)
 	s.Require().Nil(iter3)
+}
+
+func (s *StorageTestSuite) TestDatabase_Iterator_RangedDeletes() {
+	db, err := s.NewDB(s.T().TempDir())
+	s.Require().NoError(err)
+	defer db.Close()
+
+	err = db.Set(storeKey1, 1, []byte("key001"), []byte("value001"))
+	s.Require().NoError(err)
+
+	err = db.Set(storeKey1, 1, []byte("key002"), []byte("value001"))
+	s.Require().NoError(err)
+
+	err = db.Set(storeKey1, 5, []byte("key002"), []byte("value002"))
+	s.Require().NoError(err)
+
+	err = db.Delete(storeKey1, 10, []byte("key002"))
+	s.Require().NoError(err)
+
+	itr, err := db.NewIterator(storeKey1, 11, []byte("key001"), nil)
+	s.Require().NoError(err)
+
+	defer itr.Close()
+
+	// there should only be one valid key in the iterator -- key001
+	var count int
+	for ; itr.Valid(); itr.Next() {
+		s.Require().Equal([]byte("key001"), itr.Key())
+		count++
+	}
+	s.Require().Equal(1, count)
+	s.Require().NoError(itr.Error())
 }
 
 func (s *StorageTestSuite) TestDatabase_IteratorMultiVersion() {

--- a/store/storage/util/bytes.go
+++ b/store/storage/util/bytes.go
@@ -1,0 +1,13 @@
+package util
+
+// CopyBytes copies a byte slice. It returns <nil> if the argument is <nil>.
+func CopyBytes(bz []byte) []byte {
+	if bz == nil {
+		return nil
+	}
+
+	ret := make([]byte, len(bz))
+	_ = copy(ret, bz)
+
+	return ret
+}


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

The PebbleDB and SQLite SS backends did not handle range deletes correctly as illustrated by #17505. This PR addresses handling deletes correctly for those aforementioned backends.

## Changelog

* For SQLite, we handle this via a new tombstone column where the value indicates the version it's being deleted at (if not already tombstoned). This allows us to query and iterate correctly.
* For PebbleDB, we essentially do the exact same thing we do for SQLite, except we modify the value to contain the tombstone as a suffix.
* Fix iteration lower bound bug for PebbleDB
* Add more test coverage

ref: #17505
credit: @yihuang for the test updates

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] added `!` to the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules)
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] updated the relevant documentation or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] run `make lint` and `make test`
* [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] confirmed all author checklist items have been addressed 
* [ ] reviewed state machine logic
* [ ] reviewed API design and naming
* [ ] reviewed documentation is accurate
* [ ] reviewed tests and test coverage
* [ ] manually tested (if applicable)
