### PR TITLE
refactor: orm/encoding/encodeutil: remove impossible len overflow check

### DIFF
--- a/orm/encoding/encodeutil/util.go
+++ b/orm/encoding/encodeutil/util.go
@@ -13,13 +13,10 @@ import (
 // This is used for efficient logical decoding of keys.
 func SkipPrefix(r *bytes.Reader, prefix []byte) error {
 	n := len(prefix)
-	if n > 0 {
-		// we skip checking the prefix for performance reasons because we assume
-		// that it was checked by the caller
-		_, err := r.Seek(int64(n), io.SeekCurrent)
-		return err
-	}
-	return nil
+	// we skip checking the prefix for performance reasons because we assume
+	// that it was checked by the caller
+	_, err := r.Seek(int64(n), io.SeekCurrent)
+	return err
 }
 
 // AppendVarUInt32 creates a new key prefix, by encoding and appending a


### PR DESCRIPTION
This change removes an impossible len overflow check; the Go spec guarantees that len will always fit inside int per https://go.dev/ref/spec#Length_and_capacity and also by the time that len overflows int*, one would have run out of memory by then, given that int is guaranteed to be either 32-bits or 64-bits depending on the architecture, and even if we looked at virtual memory that is backed by virtual pages, the max memory mapped in-process will be the max of 32-bits or 64-bits.

Fixes #17616

/cc @elias-orijtech 