### PR TITLE
refactor: remove unused context argument from types/simulation.RandomFees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### API Breaking Changes
 
+* (types/simulation) [#17737](https://github.com/cosmos/cosmos-sdk/pull/17737) Remove unused parameter from `RandomFees`
 * (x/staking) [#17486](https://github.com/cosmos/cosmos-sdk/pull/17486) Use collections for `RedelegationQueueKey`:
     * remove from `types`: `GetRedelegationTimeKey`
     * remove from `Keeper`: `RedelegationQueueIterator`

--- a/types/simulation/account.go
+++ b/types/simulation/account.go
@@ -65,7 +65,7 @@ func FindAccount(accs []Account, address sdk.Address) (Account, bool) {
 // RandomFees returns a random fee by selecting a random coin denomination and
 // amount from the account's available balance. If the user doesn't have enough
 // funds for paying fees, it returns empty coins.
-func RandomFees(r *rand.Rand, ctx sdk.Context, spendableCoins sdk.Coins) (sdk.Coins, error) {
+func RandomFees(r *rand.Rand, spendableCoins sdk.Coins) (sdk.Coins, error) {
 	if spendableCoins.Empty() {
 		return nil, nil
 	}

--- a/types/simulation/account_test.go
+++ b/types/simulation/account_test.go
@@ -68,7 +68,7 @@ func TestRandomFees(t *testing.T) {
 		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := simulation.RandomFees(r, sdk.Context{}, tt.spendableCoins)
+			got, err := simulation.RandomFees(r, tt.spendableCoins)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("RandomFees() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/x/authz/simulation/operations.go
+++ b/x/authz/simulation/operations.go
@@ -105,7 +105,7 @@ func SimulateMsgGrant(
 
 		granterAcc := ak.GetAccount(ctx, granter.Address)
 		spendableCoins := bk.SpendableCoins(ctx, granter.Address)
-		fees, err := simtypes.RandomFees(r, ctx, spendableCoins)
+		fees, err := simtypes.RandomFees(r, spendableCoins)
 		if err != nil {
 			return simtypes.NoOpMsg(authz.ModuleName, TypeMsgGrant, err.Error()), nil, err
 		}
@@ -191,7 +191,7 @@ func SimulateMsgRevoke(
 		}
 
 		spendableCoins := bk.SpendableCoins(ctx, granterAddr)
-		fees, err := simtypes.RandomFees(r, ctx, spendableCoins)
+		fees, err := simtypes.RandomFees(r, spendableCoins)
 		if err != nil {
 			return simtypes.NoOpMsg(authz.ModuleName, TypeMsgRevoke, "fee error"), nil, err
 		}
@@ -297,7 +297,7 @@ func SimulateMsgExec(
 
 		msgExec := authz.NewMsgExec(granteeAddr, msg)
 		granteeSpendableCoins := bk.SpendableCoins(ctx, granteeAddr)
-		fees, err := simtypes.RandomFees(r, ctx, granteeSpendableCoins)
+		fees, err := simtypes.RandomFees(r, granteeSpendableCoins)
 		if err != nil {
 			return simtypes.NoOpMsg(authz.ModuleName, TypeMsgExec, "fee error"), nil, err
 		}

--- a/x/bank/simulation/operations.go
+++ b/x/bank/simulation/operations.go
@@ -154,7 +154,7 @@ func sendMsgSend(
 
 	coins, hasNeg := spendable.SafeSub(msg.Amount...)
 	if !hasNeg {
-		fees, err = simtypes.RandomFees(r, ctx, coins)
+		fees, err = simtypes.RandomFees(r, coins)
 		if err != nil {
 			return err
 		}
@@ -371,7 +371,7 @@ func sendMsgMultiSend(
 	spendable := bk.SpendableCoins(ctx, feePayer.GetAddress())
 	coins, hasNeg := spendable.SafeSub(msg.Inputs[0].Coins...)
 	if !hasNeg {
-		fees, err = simtypes.RandomFees(r, ctx, coins)
+		fees, err = simtypes.RandomFees(r, coins)
 		if err != nil {
 			return err
 		}

--- a/x/distribution/simulation/operations.go
+++ b/x/distribution/simulation/operations.go
@@ -255,7 +255,7 @@ func SimulateMsgFundCommunityPool(txConfig client.TxConfig, ak types.AccountKeep
 
 		coins, hasNeg := spendable.SafeSub(fundAmount...)
 		if !hasNeg {
-			fees, err = simtypes.RandomFees(r, ctx, coins)
+			fees, err = simtypes.RandomFees(r, coins)
 			if err != nil {
 				return simtypes.NoOpMsg(types.ModuleName, sdk.MsgTypeURL(&types.MsgFundCommunityPool{}), "unable to generate fees"), nil, err
 			}

--- a/x/gov/simulation/operations.go
+++ b/x/gov/simulation/operations.go
@@ -338,7 +338,7 @@ func SimulateMsgDeposit(
 		var fees sdk.Coins
 		coins, hasNeg := spendable.SafeSub(deposit...)
 		if !hasNeg {
-			fees, err = simtypes.RandomFees(r, ctx, coins)
+			fees, err = simtypes.RandomFees(r, coins)
 			if err != nil {
 				return simtypes.NoOpMsg(types.ModuleName, sdk.MsgTypeURL(msg), "unable to generate fees"), nil, err
 			}

--- a/x/group/simulation/operations.go
+++ b/x/group/simulation/operations.go
@@ -230,7 +230,7 @@ func SimulateMsgCreateGroup(
 		accAddr := acc.Address.String()
 
 		spendableCoins := bk.SpendableCoins(ctx, account.GetAddress())
-		fees, err := simtypes.RandomFees(r, ctx, spendableCoins)
+		fees, err := simtypes.RandomFees(r, spendableCoins)
 		if err != nil {
 			return simtypes.NoOpMsg(group.ModuleName, TypeMsgCreateGroup, "fee error"), nil, err
 		}
@@ -277,7 +277,7 @@ func SimulateMsgCreateGroupWithPolicy(
 		accAddr := acc.Address.String()
 
 		spendableCoins := bk.SpendableCoins(ctx, account.GetAddress())
-		fees, err := simtypes.RandomFees(r, ctx, spendableCoins)
+		fees, err := simtypes.RandomFees(r, spendableCoins)
 		if err != nil {
 			return simtypes.NoOpMsg(group.ModuleName, TypeMsgCreateGroup, "fee error"), nil, err
 		}
@@ -347,7 +347,7 @@ func SimulateMsgCreateGroupPolicy(
 		groupID := groupInfo.Id
 
 		spendableCoins := bk.SpendableCoins(sdkCtx, account.GetAddress())
-		fees, err := simtypes.RandomFees(r, sdkCtx, spendableCoins)
+		fees, err := simtypes.RandomFees(r, spendableCoins)
 		if err != nil {
 			return simtypes.NoOpMsg(group.ModuleName, TypeMsgCreateGroupPolicy, "fee error"), nil, err
 		}
@@ -436,7 +436,7 @@ func SimulateMsgSubmitProposal(
 		}
 
 		spendableCoins := bk.SpendableCoins(sdkCtx, account.GetAddress())
-		fees, err := simtypes.RandomFees(r, sdkCtx, spendableCoins)
+		fees, err := simtypes.RandomFees(r, spendableCoins)
 		if err != nil {
 			return simtypes.NoOpMsg(group.ModuleName, TypeMsgSubmitProposal, "fee error"), nil, err
 		}
@@ -494,7 +494,7 @@ func SimulateMsgUpdateGroupAdmin(
 		groupID := groupInfo.Id
 
 		spendableCoins := bk.SpendableCoins(sdkCtx, account.GetAddress())
-		fees, err := simtypes.RandomFees(r, sdkCtx, spendableCoins)
+		fees, err := simtypes.RandomFees(r, spendableCoins)
 		if err != nil {
 			return simtypes.NoOpMsg(group.ModuleName, TypeMsgUpdateGroupAdmin, "fee error"), nil, err
 		}
@@ -559,7 +559,7 @@ func SimulateMsgUpdateGroupMetadata(
 		groupID := groupInfo.Id
 
 		spendableCoins := bk.SpendableCoins(sdkCtx, account.GetAddress())
-		fees, err := simtypes.RandomFees(r, sdkCtx, spendableCoins)
+		fees, err := simtypes.RandomFees(r, spendableCoins)
 		if err != nil {
 			return simtypes.NoOpMsg(group.ModuleName, TypeMsgUpdateGroupMetadata, "fee error"), nil, err
 		}
@@ -615,7 +615,7 @@ func SimulateMsgUpdateGroupMembers(
 		groupID := groupInfo.Id
 
 		spendableCoins := bk.SpendableCoins(sdkCtx, account.GetAddress())
-		fees, err := simtypes.RandomFees(r, sdkCtx, spendableCoins)
+		fees, err := simtypes.RandomFees(r, spendableCoins)
 		if err != nil {
 			return simtypes.NoOpMsg(group.ModuleName, TypeMsgUpdateGroupMembers, "fee error"), nil, err
 		}
@@ -698,7 +698,7 @@ func SimulateMsgUpdateGroupPolicyAdmin(
 		groupPolicyAddr := groupPolicy.Address
 
 		spendableCoins := bk.SpendableCoins(sdkCtx, account.GetAddress())
-		fees, err := simtypes.RandomFees(r, sdkCtx, spendableCoins)
+		fees, err := simtypes.RandomFees(r, spendableCoins)
 		if err != nil {
 			return simtypes.NoOpMsg(group.ModuleName, TypeMsgUpdateGroupPolicyAdmin, "fee error"), nil, err
 		}
@@ -763,7 +763,7 @@ func SimulateMsgUpdateGroupPolicyDecisionPolicy(
 		groupPolicyAddr := groupPolicy.Address
 
 		spendableCoins := bk.SpendableCoins(sdkCtx, account.GetAddress())
-		fees, err := simtypes.RandomFees(r, sdkCtx, spendableCoins)
+		fees, err := simtypes.RandomFees(r, spendableCoins)
 		if err != nil {
 			return simtypes.NoOpMsg(group.ModuleName, TypeMsgUpdateGroupPolicyDecisionPolicy, "fee error"), nil, err
 		}
@@ -827,7 +827,7 @@ func SimulateMsgUpdateGroupPolicyMetadata(
 		groupPolicyAddr := groupPolicy.Address
 
 		spendableCoins := bk.SpendableCoins(sdkCtx, account.GetAddress())
-		fees, err := simtypes.RandomFees(r, sdkCtx, spendableCoins)
+		fees, err := simtypes.RandomFees(r, spendableCoins)
 		if err != nil {
 			return simtypes.NoOpMsg(group.ModuleName, TypeMsgUpdateGroupPolicyMetadata, "fee error"), nil, err
 		}
@@ -932,7 +932,7 @@ func SimulateMsgWithdrawProposal(
 		proposerAcc := ak.GetAccount(sdkCtx, proposer.Address)
 
 		spendableCoins := bk.SpendableCoins(sdkCtx, proposer.Address)
-		fees, err := simtypes.RandomFees(r, sdkCtx, spendableCoins)
+		fees, err := simtypes.RandomFees(r, spendableCoins)
 		if err != nil {
 			return simtypes.NoOpMsg(group.ModuleName, TypeMsgWithdrawProposal, "fee error"), nil, err
 		}
@@ -1003,7 +1003,7 @@ func SimulateMsgVote(
 		}
 
 		spendableCoins := bk.SpendableCoins(sdkCtx, account.GetAddress())
-		fees, err := simtypes.RandomFees(r, sdkCtx, spendableCoins)
+		fees, err := simtypes.RandomFees(r, spendableCoins)
 		if err != nil {
 			return simtypes.NoOpMsg(group.ModuleName, TypeMsgVote, "fee error"), nil, err
 		}
@@ -1099,7 +1099,7 @@ func SimulateMsgExec(
 		groupPolicyAddr := groupPolicy.Address
 
 		spendableCoins := bk.SpendableCoins(sdkCtx, account.GetAddress())
-		fees, err := simtypes.RandomFees(r, sdkCtx, spendableCoins)
+		fees, err := simtypes.RandomFees(r, spendableCoins)
 		if err != nil {
 			return simtypes.NoOpMsg(group.ModuleName, TypeMsgExec, "fee error"), nil, err
 		}
@@ -1188,7 +1188,7 @@ func SimulateMsgLeaveGroup(
 		}
 
 		spendableCoins := bk.SpendableCoins(sdkCtx, acc.Address)
-		fees, err := simtypes.RandomFees(r, sdkCtx, spendableCoins)
+		fees, err := simtypes.RandomFees(r, spendableCoins)
 		if err != nil {
 			return simtypes.NoOpMsg(group.ModuleName, TypeMsgLeaveGroup, "fee error"), nil, err
 		}

--- a/x/nft/simulation/operations.go
+++ b/x/nft/simulation/operations.go
@@ -72,7 +72,7 @@ func SimulateMsgSend(
 
 		senderAcc := ak.GetAccount(ctx, sender.Address)
 		spendableCoins := bk.SpendableCoins(ctx, sender.Address)
-		fees, err := simtypes.RandomFees(r, ctx, spendableCoins)
+		fees, err := simtypes.RandomFees(r, spendableCoins)
 		if err != nil {
 			return simtypes.NoOpMsg(nft.ModuleName, TypeMsgSend, err.Error()), nil, err
 		}

--- a/x/simulation/util.go
+++ b/x/simulation/util.go
@@ -90,7 +90,7 @@ func GenAndDeliverTxWithRandFees(txCtx OperationInput) (simtypes.OperationMsg, [
 		return simtypes.NoOpMsg(txCtx.ModuleName, sdk.MsgTypeURL(txCtx.Msg), "message doesn't leave room for fees"), nil, err
 	}
 
-	fees, err = simtypes.RandomFees(txCtx.R, txCtx.Context, coins)
+	fees, err = simtypes.RandomFees(txCtx.R, coins)
 	if err != nil {
 		return simtypes.NoOpMsg(txCtx.ModuleName, sdk.MsgTypeURL(txCtx.Msg), "unable to generate fees"), nil, err
 	}

--- a/x/slashing/simulation/operations.go
+++ b/x/slashing/simulation/operations.go
@@ -109,7 +109,7 @@ func SimulateMsgUnjail(
 		account := ak.GetAccount(ctx, sdk.AccAddress(bz))
 		spendable := bk.SpendableCoins(ctx, account.GetAddress())
 
-		fees, err := simtypes.RandomFees(r, ctx, spendable)
+		fees, err := simtypes.RandomFees(r, spendable)
 		if err != nil {
 			return simtypes.NoOpMsg(types.ModuleName, msgType, "unable to generate fees"), nil, err
 		}

--- a/x/staking/simulation/operations.go
+++ b/x/staking/simulation/operations.go
@@ -150,7 +150,7 @@ func SimulateMsgCreateValidator(
 
 		coins, hasNeg := spendable.SafeSub(selfDelegation)
 		if !hasNeg {
-			fees, err = simtypes.RandomFees(r, ctx, coins)
+			fees, err = simtypes.RandomFees(r, coins)
 			if err != nil {
 				return simtypes.NoOpMsg(types.ModuleName, msgType, "unable to generate fees"), nil, err
 			}
@@ -321,7 +321,7 @@ func SimulateMsgDelegate(
 
 		coins, hasNeg := spendable.SafeSub(bondAmt)
 		if !hasNeg {
-			fees, err = simtypes.RandomFees(r, ctx, coins)
+			fees, err = simtypes.RandomFees(r, coins)
 			if err != nil {
 				return simtypes.NoOpMsg(types.ModuleName, msgType, "unable to generate fees"), nil, err
 			}


### PR DESCRIPTION
As part of the simulator rewrite, this change makes RandomFees useful where a sdk.Context is not available.

CC @odeke-em 