### PR TITLE
fix: make sure the math.Int.Size fast path is equivalent to the slow path

### DIFF
--- a/math/int.go
+++ b/math/int.go
@@ -431,7 +431,7 @@ func (i *Int) Unmarshal(data []byte) error {
 // Size implements the gogo proto custom type interface.
 func (i *Int) Size() int {
 	if i.i == nil {
-		return 1
+		i.i = new(big.Int)
 	}
 	// A float64 can store 52 bits exactly, which allows us to use
 	// math.Log10 to compute the size fast and garbage free.


### PR DESCRIPTION
Revert PR #17736 indicates that the math.Int.Size optimization for small integers introduced a state break.

However, I failed to reproduce any difference between the fast and slow path for a large interval of integers around 2<<51, 2<<52, 2<<53 as well as 0, indicating that the fast path is not to blame.

Another possibility is that the slow path has a side-effect, namely initializing the `i` field by calling Marshal:

```go
 func (i Int) Marshal() ([]byte, error) {
 	if i.i == nil {
 		i.i = new(big.Int)
 	}
 	return i.i.MarshalText()
 }
```

This change implements the same side-effect, regardless of which path is taken by Int.Size.

Possibly supersedes #17736.

