### PR TITLE
docs(depinject): replace non-exported provider functions

### DIFF
--- a/depinject/README.md
+++ b/depinject/README.md
@@ -45,17 +45,20 @@ import (
 
 type AnotherInt int
 
+func GetInt() int               { return 1 }
+func GetAnotherInt() AnotherInt { return 2 }
+
 func main() {
 	var (
-	  x int
-	  y AnotherInt
+		x int
+		y AnotherInt
 	)
 
 	fmt.Printf("Before (%v, %v)\n", x, y)
 	depinject.Inject(
 		depinject.Provide(
-			func() int { return 1 },
-			func() AnotherInt { return AnotherInt(2) },
+			GetInt,
+			GetAnotherInt,
 		),
 		&x,
 		&y,
@@ -66,7 +69,7 @@ func main() {
 
 In this example, `depinject.Provide` registers two provider functions that return `int` and `AnotherInt` values. The `depinject.Inject` function is then used to inject these values into the variables `x` and `y`.
 
-Provider functions serve as the basis for the dependency tree. They are analysed to identify their inputs as dependencies and their outputs as dependents. These dependents can either be used by another provider function or be stored outside the DI container (e.g., `&x` and `&y` in the example above).
+Provider functions serve as the basis for the dependency tree. They are analysed to identify their inputs as dependencies and their outputs as dependents. These dependents can either be used by another provider function or be stored outside the DI container (e.g., `&x` and `&y` in the example above). Provider functions must be exported.
 
 ### Interface type resolution
 
@@ -98,6 +101,22 @@ type Pond struct {
 }
 ```
 
+And the following provider functions:
+
+```go
+func GetMallard() duck.Mallard {
+	return Mallard{}
+}
+
+func GetPond(duck Duck) Pond {
+	return Pond{Duck: duck}
+}
+
+func GetCanvasback() Canvasback {
+	return Canvasback{}
+}
+```
+
 In this example, there's a `Pond` struct that has a `Duck` field of type `AlsoDuck`. The `depinject` framework can automatically resolve the appropriate implementation when there's only one available, as shown below:
 
 ```go
@@ -105,10 +124,9 @@ var pond Pond
 
 depinject.Inject(
   depinject.Provide(
-    func() Mallard { return Mallard{} },
-    func(duck Duck) Pond {
-      return Pond{Duck: duck}
-    }),
+ 		GetMallard,
+ 		GetPond,
+ 	),
    &pond)
 ```
 
@@ -120,13 +138,12 @@ However, if there are multiple implementations of the `Duck` interface, as in th
 var pond Pond
 
 depinject.Inject(
-  depinject.Provide(
-    func() Mallard { return Mallard{} },
-    func() Canvasback { return Canvasback{} },
-    func(duck Duck) Pond {
-      return Pond{Duck: duck}
-    }),
-   &pond)
+	depinject.Provide(
+		GetMallard,
+		GetCanvasback,
+		GetPond,
+	),
+	&pond)
 ```
 
 A specific binding preference for `Duck` is required.
@@ -137,17 +154,18 @@ In the above situation registering a binding for a given interface binding may l
 
 ```go
 depinject.Inject(
-  depinject.Configs(
-    depinject.BindInterface(
-      "duck.Duck",
-      "duck.Mallard"),
-     depinject.Provide(
-       func() Mallard { return Mallard{} },
-       func() Canvasback { return Canvasback{} },
-       func(duck Duck) APond {
-         return Pond{Duck: duck}
-      })),
-   &pond)
+	depinject.Configs(
+		depinject.BindInterface(
+			"duck/duck.Duck",
+			"duck/duck.Mallard",
+		),
+		depinject.Provide(
+			GetMallard,
+			GetCanvasback,
+			GetPond,
+		),
+	),
+	&pond)
 ```
 
 Now `depinject` has enough information to provide `Mallard` as an input to `APond`. 


### PR DESCRIPTION

<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

Closes: #17743 

Since #12797, it's no longer possible to use non-exported functions as providers. The README used to contain examples with function literals as provider, so this change replaces them with exported functions.

An additional change updates the `BindInterface` arguments, which wasn't working on my side when running this code in go module called "duck".

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] added `!` to the type prefix if API or client breaking change
* [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [x] provided a link to the relevant issue or specification
* [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/build/building-modules/01-intro.md)
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] updated the relevant documentation or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] run `make lint` and `make test`
* [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] confirmed all author checklist items have been addressed 
* [ ] reviewed state machine logic
* [ ] reviewed API design and naming
* [ ] reviewed documentation is accurate
* [ ] reviewed tests and test coverage
* [ ] manually tested (if applicable)
