### PR TITLE
chore(x/genutil): cleanup CollectTxs

### DIFF
--- a/x/genutil/collect.go
+++ b/x/genutil/collect.go
@@ -76,8 +76,7 @@ func CollectTxs(cdc codec.JSONCodec, txJSONDecoder sdk.TxDecoder, moniker, genTx
 		return appGenTxs, persistentPeers, err
 	}
 
-	var fos []os.DirEntry
-	fos, err = os.ReadDir(genTxsDir)
+	fos, err := os.ReadDir(genTxsDir)
 	if err != nil {
 		return appGenTxs, persistentPeers, err
 	}
@@ -96,6 +95,9 @@ func CollectTxs(cdc codec.JSONCodec, txJSONDecoder sdk.TxDecoder, moniker, genTx
 	// addresses and IPs (and port) validator server info
 	var addressesIPs []string
 
+	// TODO (https://github.com/cosmos/cosmos-sdk/issues/17815):
+	// Examine CPU and RAM profiles to see if we can parsing
+	// and ValidateAndGetGenTx concurrent.
 	for _, fo := range fos {
 		if fo.IsDir() {
 			continue
@@ -151,7 +153,7 @@ func CollectTxs(cdc codec.JSONCodec, txJSONDecoder sdk.TxDecoder, moniker, genTx
 			return appGenTxs, persistentPeers, fmt.Errorf("account %s balance not in genesis state: %+v", valAccAddr, balancesMap)
 		}
 
-		_, valOk := balancesMap[sdk.AccAddress(valAddr).String()]
+		_, valOk := balancesMap[valAccAddr]
 		if !valOk {
 			_, file, no, ok := runtime.Caller(1)
 			if ok {


### PR DESCRIPTION
This change moves []os.DirEntry close to where it is used and also reuses the already created sdk.AccAddress.String() []byte->string (sure it is cached but unnecessary to re-invoke) as a key to the balancesMap.

Fixes #17814 

/cc @elias-orijtech 