### PR TITLE
chore(client/v2): remove trailing whitespace in golden files

### DIFF
--- a/client/v2/autocli/testdata/help-deprecated-msg.golden
+++ b/client/v2/autocli/testdata/help-deprecated-msg.golden
@@ -5,23 +5,23 @@ Usage:
   test deprecatedmsg send [flags]
 
 Flags:
-      --a-bool                                                               
-      --a-coin cosmos.base.v1beta1.Coin                                      
-      --a-message testpb.AMessage (json)                                     
-      --a-validator-address account address or key name                      
+      --a-bool
+      --a-coin cosmos.base.v1beta1.Coin
+      --a-message testpb.AMessage (json)
+      --a-validator-address account address or key name
   -a, --account-number uint                                                  The account number of the signing account (offline mode only)
-      --an-address account address or key name                               
+      --an-address account address or key name
       --an-enum Enum (unspecified | one | two | five | neg-three)             (default unspecified)
       --aux                                                                  Generate aux signer data instead of sending a tx
       --bools bools                                                           (default [])
   -b, --broadcast-mode string                                                Transaction broadcasting mode (sync|async) (default "sync")
-      --bz binary                                                            
+      --bz binary
       --chain-id string                                                      The network chain ID
-      --deprecated-field string                                              
+      --deprecated-field string
       --dry-run                                                              ignore the --gas flag and perform a simulation of a transaction, but don't broadcast it (when enabled, the local Keybase is not accessible)
-      --duration duration                                                    
-      --durations duration (repeated)                                        
-      --enums Enum (unspecified | one | two | five | neg-three) (repeated)   
+      --duration duration
+      --durations duration (repeated)
+      --enums Enum (unspecified | one | two | five | neg-three) (repeated)
       --fee-granter string                                                   Fee granter grants fees for the transaction
       --fee-payer string                                                     Fee payer pays fees for the transaction instead of deducting from the signer
       --fees string                                                          Fees to pay along with transaction; eg: 10uatom
@@ -31,9 +31,9 @@ Flags:
       --gas-prices string                                                    Gas prices in decimal format to determine the transaction fee (e.g. 0.1uatom)
       --generate-only                                                        Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase only accessed when providing a key name)
   -h, --help                                                                 help for send
-      --hidden-bool                                                          
-      --i32 int32                                                            
-      --i64 int                                                              
+      --hidden-bool
+      --i32 int32
+      --i64 int
       --keyring-backend string                                               Select keyring's backend (os|file|kwallet|pass|test|memory) (default "os")
       --keyring-dir string                                                   The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                                                               Use a connected Ledger device
@@ -42,24 +42,24 @@ Flags:
       --note string                                                          Note to add a description to the transaction (previously --memo)
       --offline                                                              Offline mode (does not allow any online functionality)
   -o, --output string                                                        Output format (text|json) (default "json")
-      --page-count-total                                                     
-      --page-key binary                                                      
-      --page-limit uint                                                      
-      --page-offset uint                                                     
-      --page-reverse                                                         
-      --positional1 int32                                                    
-      --positional2 string                                                   
-      --positional3-varargs cosmos.base.v1beta1.Coin (repeated)              
+      --page-count-total
+      --page-key binary
+      --page-limit uint
+      --page-offset uint
+      --page-reverse
+      --positional1 int32
+      --positional2 string
+      --positional3-varargs cosmos.base.v1beta1.Coin (repeated)
   -s, --sequence uint                                                        The sequence number of the signing account (offline mode only)
-      --shorthand-deprecated-field string                                    
+      --shorthand-deprecated-field string
       --sign-mode string                                                     Choose sign mode (direct|amino-json|direct-aux), this is an advanced feature
-      --some-messages testpb.AMessage (json) (repeated)                      
-      --str string                                                           
-      --strings strings                                                      
+      --some-messages testpb.AMessage (json) (repeated)
+      --str string
+      --strings strings
       --timeout-height uint                                                  Set a block timeout height to prevent the tx from being committed past a certain height
-      --timestamp timestamp (RFC 3339)                                       
+      --timestamp timestamp (RFC 3339)
       --tip string                                                           Tip is the amount that is going to be transferred to the fee payer on the target chain. This flag is only valid when used with --aux, and is ignored if the target chain didn't enable the TipDecorator
-      --u32 uint32                                                           
-      --u64 uint                                                             
+      --u32 uint32
+      --u64 uint
       --uints uints                                                           (default [])
   -y, --yes                                                                  Skip tx broadcasting prompt confirmation

--- a/client/v2/autocli/testdata/help-deprecated.golden
+++ b/client/v2/autocli/testdata/help-deprecated.golden
@@ -3,45 +3,45 @@ Usage:
   test deprecatedecho echo [flags]
 
 Flags:
-      --a-bool                                                               
-      --a-coin cosmos.base.v1beta1.Coin                                      
-      --a-consensus-address account address or key name                      
-      --a-message testpb.AMessage (json)                                     
-      --a-validator-address account address or key name                      
-      --an-address account address or key name                               
+      --a-bool
+      --a-coin cosmos.base.v1beta1.Coin
+      --a-consensus-address account address or key name
+      --a-message testpb.AMessage (json)
+      --a-validator-address account address or key name
+      --an-address account address or key name
       --an-enum Enum (unspecified | one | two | five | neg-three)             (default unspecified)
       --bools bools                                                           (default [])
-      --bz binary                                                            
-      --deprecated-field string                                              
-      --duration duration                                                    
-      --durations duration (repeated)                                        
-      --enums Enum (unspecified | one | two | five | neg-three) (repeated)   
+      --bz binary
+      --deprecated-field string
+      --duration duration
+      --durations duration (repeated)
+      --enums Enum (unspecified | one | two | five | neg-three) (repeated)
       --grpc-addr string                                                     the gRPC endpoint to use for this chain
       --grpc-insecure                                                        allow gRPC over insecure channels, if not the server must use TLS
       --height int                                                           Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help                                                                 help for echo
-      --hidden-bool                                                          
-      --i32 int32                                                            
-      --i64 int                                                              
-      --map-string-coin map[string]cosmos.base.v1beta1.Coin                  
+      --hidden-bool
+      --i32 int32
+      --i64 int
+      --map-string-coin map[string]cosmos.base.v1beta1.Coin
       --map-string-string stringToString                                      (default [])
-      --map-string-uint32 stringToUint32                                     
+      --map-string-uint32 stringToUint32
       --no-indent                                                            Do not indent JSON output
       --node string                                                          <host>:<port> to CometBFT RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string                                                        Output format (text|json) (default "text")
-      --page-count-total                                                     
-      --page-key binary                                                      
-      --page-limit uint                                                      
-      --page-offset uint                                                     
-      --page-reverse                                                         
-      --positional1 int32                                                    
-      --positional2 string                                                   
-      --positional3-varargs cosmos.base.v1beta1.Coin (repeated)              
-      --shorthand-deprecated-field string                                    
-      --some-messages testpb.AMessage (json) (repeated)                      
-      --str string                                                           
-      --strings strings                                                      
-      --timestamp timestamp (RFC 3339)                                       
-      --u32 uint32                                                           
-      --u64 uint                                                             
+      --page-count-total
+      --page-key binary
+      --page-limit uint
+      --page-offset uint
+      --page-reverse
+      --positional1 int32
+      --positional2 string
+      --positional3-varargs cosmos.base.v1beta1.Coin (repeated)
+      --shorthand-deprecated-field string
+      --some-messages testpb.AMessage (json) (repeated)
+      --str string
+      --strings strings
+      --timestamp timestamp (RFC 3339)
+      --u32 uint32
+      --u64 uint
       --uints uints                                                           (default [])

--- a/client/v2/autocli/testdata/help-echo-msg.golden
+++ b/client/v2/autocli/testdata/help-echo-msg.golden
@@ -10,23 +10,23 @@ Examples:
 send 1 abc {}
 
 Flags:
-      --a-bool                                                               
-      --a-coin cosmos.base.v1beta1.Coin                                      
-      --a-message testpb.AMessage (json)                                     
-      --a-validator-address account address or key name                      
+      --a-bool
+      --a-coin cosmos.base.v1beta1.Coin
+      --a-message testpb.AMessage (json)
+      --a-validator-address account address or key name
   -a, --account-number uint                                                  The account number of the signing account (offline mode only)
-      --an-address account address or key name                               
+      --an-address account address or key name
       --an-enum Enum (unspecified | one | two | five | neg-three)             (default unspecified)
       --aux                                                                  Generate aux signer data instead of sending a tx
       --bools bools                                                           (default [])
   -b, --broadcast-mode string                                                Transaction broadcasting mode (sync|async) (default "sync")
-      --bz binary                                                            
+      --bz binary
       --chain-id string                                                      The network chain ID
       --deprecated-field string                                               (DEPRECATED: don't use this)
       --dry-run                                                              ignore the --gas flag and perform a simulation of a transaction, but don't broadcast it (when enabled, the local Keybase is not accessible)
-      --duration duration                                                    
-      --durations duration (repeated)                                        
-      --enums Enum (unspecified | one | two | five | neg-three) (repeated)   
+      --duration duration
+      --durations duration (repeated)
+      --enums Enum (unspecified | one | two | five | neg-three) (repeated)
       --fee-granter string                                                   Fee granter grants fees for the transaction
       --fee-payer string                                                     Fee payer pays fees for the transaction instead of deducting from the signer
       --fees string                                                          Fees to pay along with transaction; eg: 10uatom
@@ -37,7 +37,7 @@ Flags:
       --generate-only                                                        Build an unsigned transaction and write it to STDOUT (when enabled, the local Keybase only accessed when providing a key name)
   -h, --help                                                                 help for send
       --i32 int32                                                            some random int32
-      --i64 int                                                              
+      --i64 int
       --keyring-backend string                                               Select keyring's backend (os|file|kwallet|pass|test|memory) (default "os")
       --keyring-dir string                                                   The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                                                               Use a connected Ledger device
@@ -46,19 +46,19 @@ Flags:
       --note string                                                          Note to add a description to the transaction (previously --memo)
       --offline                                                              Offline mode (does not allow any online functionality)
   -o, --output string                                                        Output format (text|json) (default "json")
-      --page-count-total                                                     
-      --page-key binary                                                      
-      --page-limit uint                                                      
-      --page-offset uint                                                     
-      --page-reverse                                                         
+      --page-count-total
+      --page-key binary
+      --page-limit uint
+      --page-offset uint
+      --page-reverse
   -s, --sequence uint                                                        The sequence number of the signing account (offline mode only)
   -d, --shorthand-deprecated-field string                                     (DEPRECATED: bad idea)
       --sign-mode string                                                     Choose sign mode (direct|amino-json|direct-aux), this is an advanced feature
-      --some-messages testpb.AMessage (json) (repeated)                      
-      --str string                                                           
-      --strings strings                                                      
+      --some-messages testpb.AMessage (json) (repeated)
+      --str string
+      --strings strings
       --timeout-height uint                                                  Set a block timeout height to prevent the tx from being committed past a certain height
-      --timestamp timestamp (RFC 3339)                                       
+      --timestamp timestamp (RFC 3339)
       --tip string                                                           Tip is the amount that is going to be transferred to the fee payer on the target chain. This flag is only valid when used with --aux, and is ignored if the target chain didn't enable the TipDecorator
       --u64 uint                                                             some random uint64
   -u, --uint32 uint32                                                        some random uint32

--- a/client/v2/autocli/testdata/help-echo.golden
+++ b/client/v2/autocli/testdata/help-echo.golden
@@ -10,41 +10,41 @@ Examples:
 echo 1 abc {}
 
 Flags:
-      --a-bool                                                               
+      --a-bool
       --a-coin cosmos.base.v1beta1.Coin                                      some random coin
-      --a-consensus-address account address or key name                      
-      --a-message testpb.AMessage (json)                                     
-      --a-validator-address account address or key name                      
-      --an-address account address or key name                               
+      --a-consensus-address account address or key name
+      --a-message testpb.AMessage (json)
+      --a-validator-address account address or key name
+      --an-address account address or key name
       --an-enum Enum (unspecified | one | two | five | neg-three)             (default unspecified)
       --bools bools                                                           (default [])
       --bz binary                                                            some bytes
       --deprecated-field string                                               (DEPRECATED: don't use this)
       --duration duration                                                    some random duration
-      --durations duration (repeated)                                        
-      --enums Enum (unspecified | one | two | five | neg-three) (repeated)   
+      --durations duration (repeated)
+      --enums Enum (unspecified | one | two | five | neg-three) (repeated)
       --grpc-addr string                                                     the gRPC endpoint to use for this chain
       --grpc-insecure                                                        allow gRPC over insecure channels, if not the server must use TLS
       --height int                                                           Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help                                                                 help for echo
       --i32 int32                                                            some random int32
-      --i64 int                                                              
+      --i64 int
       --map-string-coin map[string]cosmos.base.v1beta1.Coin                  some map of string to coin
       --map-string-string stringToString                                     some map of string to string (default [])
       --map-string-uint32 stringToUint32                                     some map of string to int32
       --no-indent                                                            Do not indent JSON output
       --node string                                                          <host>:<port> to CometBFT RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string                                                        Output format (text|json) (default "text")
-      --page-count-total                                                     
-      --page-key binary                                                      
-      --page-limit uint                                                      
-      --page-offset uint                                                     
-      --page-reverse                                                         
+      --page-count-total
+      --page-key binary
+      --page-limit uint
+      --page-offset uint
+      --page-reverse
   -s, --shorthand-deprecated-field string                                     (DEPRECATED: bad idea)
-      --some-messages testpb.AMessage (json) (repeated)                      
-      --str string                                                           
-      --strings strings                                                      
-      --timestamp timestamp (RFC 3339)                                       
+      --some-messages testpb.AMessage (json) (repeated)
+      --str string
+      --strings strings
+      --timestamp timestamp (RFC 3339)
       --u64 uint                                                             some random uint64
   -u, --uint32 uint32                                                        some random uint32
       --uints uints                                                           (default [])

--- a/client/v2/autocli/testdata/help.golden
+++ b/client/v2/autocli/testdata/help.golden
@@ -10,30 +10,30 @@ Examples:
 echo 1 abc {}
 
 Flags:
-      --a-bool                                                               
-      --a-coin cosmos.base.v1beta1.Coin (json)                               
-      --a-message testpb.AMessage (json)                                     
-      --an-address bech32 account address key name                           
+      --a-bool
+      --a-coin cosmos.base.v1beta1.Coin (json)
+      --a-message testpb.AMessage (json)
+      --an-address bech32 account address key name
       --an-enum Enum (unspecified | one | two | five | neg-three)             (default unspecified)
       --bools bools                                                           (default [])
-      --bz bytesBase64                                                       
+      --bz bytesBase64
       --deprecated-field string                                               (DEPRECATED: don't use this)
-      --duration duration                                                    
-      --durations duration (repeated)                                        
-      --enums Enum (unspecified | one | two | five | neg-three) (repeated)   
+      --duration duration
+      --durations duration (repeated)
+      --enums Enum (unspecified | one | two | five | neg-three) (repeated)
   -h, --help                                                                 help for echo
       --i32 int32                                                            some random int32
-      --i64 int                                                             
-      --page-count-total                                                     
-      --page-key bytesBase64                                                 
-      --page-limit uint                                                      
-      --page-offset uint                                                     
-      --page-reverse                                                         
+      --i64 int
+      --page-count-total
+      --page-key bytesBase64
+      --page-limit uint
+      --page-offset uint
+      --page-reverse
   -s, --shorthand-deprecated-field string                                     (DEPRECATED: bad idea)
-      --some-messages testpb.AMessage (json) (repeated)                      
-      --str string                                                           
-      --strings strings                                                      
-      --timestamp timestamp (RFC 3339)                                       
+      --some-messages testpb.AMessage (json) (repeated)
+      --str string
+      --strings strings
+      --timestamp timestamp (RFC 3339)
       --u64 uint[=5]                                                         some random uint64
   -u, --uint32 uint32                                                        some random uint32
       --uints uints                                                           (default [])


### PR DESCRIPTION
Found while auditing v0.50.0-beta0 vs v0.50.0-rc0. In the future, one can verify absence by running

```shell
$ git grep '\s\+$' | cut -d":" -f1 | sort | uniq
```

Fixes #17851