### PR TITLE
fix(simulation): Fix all problems `make test-sim-custom-genesis-fast` for simulation test.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### Bug Fixes
 
 * (x/gov) [#17873](https://github.com/cosmos/cosmos-sdk/pull/17873) Fail any inactive and active proposals whose messages cannot be decoded.
-* (simulation) [#17910](https://github.com/cosmos/cosmos-sdk/pull/17910) Fix all problems with executing command `make test-sim-custom-genesis-fast` for simulation test.
+* (simulation) [#17911](https://github.com/cosmos/cosmos-sdk/pull/17911) Fix all problems with executing command `make test-sim-custom-genesis-fast` for simulation test.
 
 ### API Breaking Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### Bug Fixes
 
 * (x/gov) [#17873](https://github.com/cosmos/cosmos-sdk/pull/17873) Fail any inactive and active proposals whose messages cannot be decoded.
+* (simulation) [#17910](https://github.com/cosmos/cosmos-sdk/pull/17910) Fix all problems with executing command `make test-sim-custom-genesis-fast` for simulation test.
 
 ### API Breaking Changes
 

--- a/Makefile
+++ b/Makefile
@@ -270,8 +270,8 @@ test-sim-nondeterminism-streaming:
 
 test-sim-custom-genesis-fast:
 	@echo "Running custom genesis simulation..."
-	@echo "By default, ${HOME}/.gaiad/config/genesis.json will be used."
-	@cd ${CURRENT_DIR}/simapp && go test -mod=readonly -run TestFullAppSimulation -Genesis=${HOME}/.gaiad/config/genesis.json \
+	@echo "By default, ${HOME}/.simapp/config/genesis.json will be used."
+	@cd ${CURRENT_DIR}/simapp && go test -mod=readonly -run TestFullAppSimulation -Genesis=${HOME}/.simapp/config/genesis.json \
 		-Enabled=true -NumBlocks=100 -BlockSize=200 -Commit=true -Seed=99 -Period=5 -v -timeout 24h
 
 test-sim-import-export: runsim
@@ -284,8 +284,8 @@ test-sim-after-import: runsim
 
 test-sim-custom-genesis-multi-seed: runsim
 	@echo "Running multi-seed custom genesis simulation..."
-	@echo "By default, ${HOME}/.gaiad/config/genesis.json will be used."
-	@cd ${CURRENT_DIR}/simapp && $(BINDIR)/runsim -Genesis=${HOME}/.gaiad/config/genesis.json -SimAppPkg=. -ExitOnFail 400 5 TestFullAppSimulation
+	@echo "By default, ${HOME}/.simapp/config/genesis.json will be used."
+	@cd ${CURRENT_DIR}/simapp && $(BINDIR)/runsim -Genesis=${HOME}/.simapp/config/genesis.json -SimAppPkg=. -ExitOnFail 400 5 TestFullAppSimulation
 
 test-sim-multi-seed-long: runsim
 	@echo "Running long multi-seed application simulation. This may take awhile!"

--- a/Makefile
+++ b/Makefile
@@ -272,7 +272,7 @@ test-sim-custom-genesis-fast:
 	@echo "Running custom genesis simulation..."
 	@echo "By default, ${HOME}/.simapp/config/genesis.json will be used."
 	@cd ${CURRENT_DIR}/simapp && go test -mod=readonly -run TestFullAppSimulation -Genesis=${HOME}/.simapp/config/genesis.json \
-		-Enabled=true -NumBlocks=100 -BlockSize=200 -Commit=true -Seed=99 -Period=5 -v -timeout 24h
+		-Enabled=true -NumBlocks=100 -BlockSize=200 -Commit=true -Seed=99 -Period=5 -SigverifyTx=false -v -timeout 24h
 
 test-sim-import-export: runsim
 	@echo "Running application import/export simulation. This may take several minutes..."
@@ -285,7 +285,7 @@ test-sim-after-import: runsim
 test-sim-custom-genesis-multi-seed: runsim
 	@echo "Running multi-seed custom genesis simulation..."
 	@echo "By default, ${HOME}/.simapp/config/genesis.json will be used."
-	@cd ${CURRENT_DIR}/simapp && $(BINDIR)/runsim -Genesis=${HOME}/.simapp/config/genesis.json -SimAppPkg=. -ExitOnFail 400 5 TestFullAppSimulation
+	@cd ${CURRENT_DIR}/simapp && $(BINDIR)/runsim -Genesis=${HOME}/.simapp/config/genesis.json -SigverifyTx=false -SimAppPkg=. -ExitOnFail 400 5 TestFullAppSimulation
 
 test-sim-multi-seed-long: runsim
 	@echo "Running long multi-seed application simulation. This may take awhile!"

--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -89,7 +89,7 @@ type BaseApp struct {
 	addrPeerFilter sdk.PeerFilter // filter peers by address and port
 	idPeerFilter   sdk.PeerFilter // filter peers by node ID
 	fauxMerkleMode bool           // if true, IAVL MountStores uses MountStoresDB for simulation speed.
-	sigverifyTx    bool           // whether to sigverify check for transaction
+	sigverifyTx    bool           // in the simulation test, since the account does not have a private key, we have to ignore the tx sigverify.
 
 	// manages snapshots, i.e. dumps of app state at certain intervals
 	snapshotManager *snapshots.Manager

--- a/baseapp/options.go
+++ b/baseapp/options.go
@@ -264,6 +264,11 @@ func (app *BaseApp) SetFauxMerkleMode() {
 	app.fauxMerkleMode = true
 }
 
+// SetNotSigverify during simulation testing, transaction signature verification needs to be ignored.
+func (app *BaseApp) SetNotSigverifyTx() {
+	app.sigverifyTx = false
+}
+
 // SetCommitMultiStoreTracer sets the store tracer on the BaseApp's underlying
 // CommitMultiStore.
 func (app *BaseApp) SetCommitMultiStoreTracer(w io.Writer) {

--- a/baseapp/test_helpers.go
+++ b/baseapp/test_helpers.go
@@ -1,9 +1,8 @@
 package baseapp
 
 import (
-	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
-
 	errorsmod "cosmossdk.io/errors"
+	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
@@ -35,7 +34,8 @@ func (app *BaseApp) SimDeliver(txEncoder sdk.TxEncoder, tx sdk.Tx) (sdk.GasInfo,
 	if err != nil {
 		return sdk.GasInfo{}, nil, errorsmod.Wrapf(sdkerrors.ErrInvalidRequest, "%s", err)
 	}
-	gasInfo, result, _, err := app.runTx(execModeSimulationFinalize, bz)
+
+	gasInfo, result, _, err := app.runTx(execModeFinalize, bz)
 	return gasInfo, result, err
 }
 
@@ -46,7 +46,7 @@ func (app *BaseApp) SimTxFinalizeBlock(txEncoder sdk.TxEncoder, tx sdk.Tx) (sdk.
 		return sdk.GasInfo{}, nil, errorsmod.Wrapf(sdkerrors.ErrInvalidRequest, "%s", err)
 	}
 
-	gasInfo, result, _, err := app.runTx(execModeSimulationFinalize, bz)
+	gasInfo, result, _, err := app.runTx(execModeFinalize, bz)
 	return gasInfo, result, err
 }
 

--- a/baseapp/test_helpers.go
+++ b/baseapp/test_helpers.go
@@ -35,7 +35,7 @@ func (app *BaseApp) SimDeliver(txEncoder sdk.TxEncoder, tx sdk.Tx) (sdk.GasInfo,
 	if err != nil {
 		return sdk.GasInfo{}, nil, errorsmod.Wrapf(sdkerrors.ErrInvalidRequest, "%s", err)
 	}
-	gasInfo, result, _, err := app.runTx(execModeFinalize, bz)
+	gasInfo, result, _, err := app.runTx(execModeSimulationFinalize, bz)
 	return gasInfo, result, err
 }
 
@@ -46,7 +46,7 @@ func (app *BaseApp) SimTxFinalizeBlock(txEncoder sdk.TxEncoder, tx sdk.Tx) (sdk.
 		return sdk.GasInfo{}, nil, errorsmod.Wrapf(sdkerrors.ErrInvalidRequest, "%s", err)
 	}
 
-	gasInfo, result, _, err := app.runTx(execModeFinalize, bz)
+	gasInfo, result, _, err := app.runTx(execModeSimulationFinalize, bz)
 	return gasInfo, result, err
 }
 

--- a/baseapp/test_helpers.go
+++ b/baseapp/test_helpers.go
@@ -1,8 +1,9 @@
 package baseapp
 
 import (
-	errorsmod "cosmossdk.io/errors"
 	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
+
+	errorsmod "cosmossdk.io/errors"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"

--- a/simapp/sim_test.go
+++ b/simapp/sim_test.go
@@ -76,6 +76,9 @@ func TestFullAppSimulation(t *testing.T) {
 	appOptions[server.FlagInvCheckPeriod] = simcli.FlagPeriodValue
 
 	app := NewSimApp(logger, db, nil, true, appOptions, fauxMerkleModeOpt, baseapp.SetChainID(SimAppChainID))
+	if !simcli.FlagSigverifyTxValue {
+		app.SetNotSigverifyTx()
+	}
 	require.Equal(t, "SimApp", app.Name())
 
 	// run randomized simulation
@@ -121,6 +124,9 @@ func TestAppImportExport(t *testing.T) {
 	appOptions[server.FlagInvCheckPeriod] = simcli.FlagPeriodValue
 
 	app := NewSimApp(logger, db, nil, true, appOptions, fauxMerkleModeOpt, baseapp.SetChainID(SimAppChainID))
+	if !simcli.FlagSigverifyTxValue {
+		app.SetNotSigverifyTx()
+	}
 	require.Equal(t, "SimApp", app.Name())
 
 	// Run randomized simulation
@@ -240,6 +246,9 @@ func TestAppSimulationAfterImport(t *testing.T) {
 	appOptions[server.FlagInvCheckPeriod] = simcli.FlagPeriodValue
 
 	app := NewSimApp(logger, db, nil, true, appOptions, fauxMerkleModeOpt, baseapp.SetChainID(SimAppChainID))
+	if !simcli.FlagSigverifyTxValue {
+		app.SetNotSigverifyTx()
+	}
 	require.Equal(t, "SimApp", app.Name())
 
 	// Run randomized simulation
@@ -362,6 +371,9 @@ func TestAppStateDeterminism(t *testing.T) {
 
 			db := dbm.NewMemDB()
 			app := NewSimApp(logger, db, nil, true, appOptions, interBlockCacheOpt(), baseapp.SetChainID(SimAppChainID))
+			if !simcli.FlagSigverifyTxValue {
+				app.SetNotSigverifyTx()
+			}
 
 			fmt.Printf(
 				"running non-determinism simulation; seed %d: %d/%d, attempt: %d/%d\n",

--- a/testutil/sims/state_helpers.go
+++ b/testutil/sims/state_helpers.go
@@ -3,6 +3,7 @@ package sims
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
 	"io"
 	"math/rand"
 	"os"
@@ -288,7 +289,7 @@ func AppStateFromGenesisFileFn(r io.Reader, cdc codec.JSONCodec, genesisFile str
 		}
 
 		// create simulator accounts
-		simAcc := simtypes.Account{PrivKey: privKey, PubKey: privKey.PubKey(), Address: a.GetAddress()}
+		simAcc := simtypes.Account{PrivKey: privKey, PubKey: privKey.PubKey(), Address: a.GetAddress(), ConsKey: ed25519.GenPrivKeyFromSecret(privkeySeed)}
 		newAccs[i] = simAcc
 	}
 

--- a/testutil/sims/state_helpers.go
+++ b/testutil/sims/state_helpers.go
@@ -10,8 +10,6 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
-
 	"github.com/cosmos/gogoproto/proto"
 
 	"cosmossdk.io/math"

--- a/testutil/sims/state_helpers.go
+++ b/testutil/sims/state_helpers.go
@@ -4,18 +4,20 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
-	"github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
 	"io"
 	"math/rand"
 	"os"
 	"path/filepath"
 	"time"
 
+	"github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
+
 	"github.com/cosmos/gogoproto/proto"
 
 	"cosmossdk.io/math"
 
 	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
 	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"

--- a/types/context.go
+++ b/types/context.go
@@ -50,6 +50,7 @@ type Context struct {
 	blockGasMeter        storetypes.GasMeter
 	checkTx              bool
 	recheckTx            bool // if recheckTx == true, then checkTx must also be true
+	sigverifyTx          bool // when run simulation, because the private key corresponding to the account in the genesis.json randomly generated, we must skip the sigverify.
 	execMode             ExecMode
 	minGasPrice          DecCoins
 	consParams           cmtproto.ConsensusParams
@@ -78,6 +79,7 @@ func (c Context) GasMeter() storetypes.GasMeter                 { return c.gasMe
 func (c Context) BlockGasMeter() storetypes.GasMeter            { return c.blockGasMeter }
 func (c Context) IsCheckTx() bool                               { return c.checkTx }
 func (c Context) IsReCheckTx() bool                             { return c.recheckTx }
+func (c Context) IsSigverifyTx() bool                           { return c.sigverifyTx }
 func (c Context) ExecMode() ExecMode                            { return c.execMode }
 func (c Context) MinGasPrices() DecCoins                        { return c.minGasPrice }
 func (c Context) EventManager() EventManagerI                   { return c.eventManager }
@@ -127,6 +129,7 @@ func NewContext(ms storetypes.MultiStore, isCheckTx bool, logger log.Logger) Con
 		header:               h,
 		chainID:              h.ChainID,
 		checkTx:              isCheckTx,
+		sigverifyTx:          true,
 		logger:               logger,
 		gasMeter:             storetypes.NewInfiniteGasMeter(),
 		minGasPrice:          DecCoins{},
@@ -251,6 +254,13 @@ func (c Context) WithIsReCheckTx(isRecheckTx bool) Context {
 	}
 	c.recheckTx = isRecheckTx
 	c.execMode = ExecModeReCheck
+	return c
+}
+
+// WithIsSigverifyTx called with true will sigverify in auth module
+// If the transaction is executed in execModeSimulationFinalize mode, the sigverify check will be skipped.
+func (c Context) WithIsSigverifyTx(isSigverifyTx bool) Context {
+	c.sigverifyTx = isSigverifyTx
 	return c
 }
 

--- a/types/context.go
+++ b/types/context.go
@@ -258,7 +258,6 @@ func (c Context) WithIsReCheckTx(isRecheckTx bool) Context {
 }
 
 // WithIsSigverifyTx called with true will sigverify in auth module
-// If the transaction is executed in execModeSimulationFinalize mode, the sigverify check will be skipped.
 func (c Context) WithIsSigverifyTx(isSigverifyTx bool) Context {
 	c.sigverifyTx = isSigverifyTx
 	return c

--- a/x/auth/ante/sigverify.go
+++ b/x/auth/ante/sigverify.go
@@ -90,7 +90,7 @@ func (spkd SetPubKeyDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate b
 			pk = simSecp256k1Pubkey
 		}
 		// Only make check if simulate=false
-		if !simulate && !bytes.Equal(pk.Address(), signers[i]) {
+		if !simulate && !bytes.Equal(pk.Address(), signers[i]) && ctx.IsSigverifyTx() {
 			return ctx, errorsmod.Wrapf(sdkerrors.ErrInvalidPubKey,
 				"pubKey does not match signer address %s with signer index: %d", signerStrs[i], i)
 		}
@@ -302,7 +302,7 @@ func (svd SigVerificationDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simul
 		}
 
 		// no need to verify signatures on recheck tx
-		if !simulate && !ctx.IsReCheckTx() {
+		if !simulate && !ctx.IsReCheckTx() && ctx.IsSigverifyTx() {
 			anyPk, _ := codectypes.NewAnyWithValue(pubKey)
 
 			signerData := txsigning.SignerData{

--- a/x/group/simulation/operations.go
+++ b/x/group/simulation/operations.go
@@ -1229,13 +1229,19 @@ func randomGroup(r *rand.Rand, k keeper.Keeper, ak group.AccountKeeper,
 
 	switch {
 	case groupID > initialGroupID:
-		// select a random ID between [initialGroupID, groupID]
-		groupID = uint64(simtypes.RandIntBetween(r, int(initialGroupID), int(groupID)))
+		// select a random ID between (initialGroupID, groupID]
+		// if there is at least one group information, then the groupID at this time must be greater than or equal to 1
+		groupID = uint64(simtypes.RandIntBetween(r, int(initialGroupID+1), int(groupID+1)))
 
 	default:
 		// This is called on the first call to this function
 		// in order to update the global variable
 		initialGroupID = groupID
+	}
+
+	// when groupID is 0, it proves that SimulateMsgCreateGroup has never been called. that is, no group exists in the chain
+	if groupID == 0 {
+		return nil, simtypes.Account{}, nil, nil
 	}
 
 	res, err := k.GroupInfo(ctx, &group.QueryGroupInfoRequest{GroupId: groupID})

--- a/x/simulation/client/cli/flags.go
+++ b/x/simulation/client/cli/flags.go
@@ -30,6 +30,7 @@ var (
 	FlagVerboseValue     bool
 	FlagPeriodValue      uint
 	FlagGenesisTimeValue int64
+	FlagSigverifyTxValue bool
 )
 
 // GetSimulatorFlags gets the values of all the available simulation flags
@@ -56,6 +57,7 @@ func GetSimulatorFlags() {
 	flag.BoolVar(&FlagVerboseValue, "Verbose", false, "verbose log output")
 	flag.UintVar(&FlagPeriodValue, "Period", 0, "run slow invariants only once every period assertions")
 	flag.Int64Var(&FlagGenesisTimeValue, "GenesisTime", 0, "override genesis UNIX time instead of using a random UNIX time")
+	flag.BoolVar(&FlagSigverifyTxValue, "SigverifyTx", true, "whether to sigverify check for transaction ")
 }
 
 // NewConfigFromFlags creates a simulation from the retrieved values of the flags.

--- a/x/simulation/simulate.go
+++ b/x/simulation/simulate.go
@@ -84,8 +84,10 @@ func SimulateFromSeed(
 	// Second variable to keep pending validator set (delayed one block since
 	// TM 0.24) Initially this is the same as the initial validator set
 	validators, blockTime, accs, chainID := initChain(r, params, accs, app, appStateFn, config, cdc)
-	if len(accs) == 0 {
-		return true, params, fmt.Errorf("must have greater than zero genesis accounts")
+	// At least 2 accounts must be added here, otherwise when executing SimulateMsgSend
+	// two accounts will be selected to meet the conditions from != to and it will fall into an infinite loop.
+	if len(accs) <= 1 {
+		return true, params, fmt.Errorf("At least two genesis accounts are required")
 	}
 
 	config.ChainID = chainID

--- a/x/simulation/simulate.go
+++ b/x/simulation/simulate.go
@@ -87,7 +87,7 @@ func SimulateFromSeed(
 	// At least 2 accounts must be added here, otherwise when executing SimulateMsgSend
 	// two accounts will be selected to meet the conditions from != to and it will fall into an infinite loop.
 	if len(accs) <= 1 {
-		return true, params, fmt.Errorf("At least two genesis accounts are required")
+		return true, params, fmt.Errorf("at least two genesis accounts are required")
 	}
 
 	config.ChainID = chainID


### PR DESCRIPTION
cosmos sdk provides a powerful simulation testing capability, and one of the simulation modes `TestFullAppSimulation` allows for simulation testing using data from `genesis.json`. The original implementation can be found at [https://github.com/cosmos/cosmos-sdk/pull/3428](https://github.com/cosmos/cosmos-sdk/pull/3428). However, with the release of v0.40.0, there have been significant changes to the code and `TestFullAppSimulation` is no longer being maintained.

The following are my steps:

To begin, the chain-related data can be initialized using the following command, at least 2 accounts must be added for genesis account, otherwise when executing SimulateMsgSend, two accounts will be selected to meet the conditions from != to and it will fall into an infinite loop.

```bash
simd init cosmos --chain-id simulation-app

simd keys add my_validator --keyring-backend test

MY_VALIDATOR_ADDRESS=$(simd keys show my_validator -a --keyring-backend test)

simd genesis add-genesis-account $MY_VALIDATOR_ADDRESS 100000000000stake
simd genesis add-genesis-account cosmos1gfg9ucc7rrzc207y9qfmf58erftzf8z8ww5lr7 100000000000stake
simd genesis add-genesis-account cosmos1lh6pmahlkytz7lmrs25a42j6kxlmztyt204kyq 100000000000stake
simd genesis add-genesis-account cosmos18v3mjs2pmssd03v0qz80fr0u2j5p7lxw8nchxg 100000000000stake

simd genesis gentx my_validator 100000000stake --chain-id simulation-app --keyring-backend test

simd genesis collect-gentxs

```

Then, in the latest `main` branch, execute the command `make test-sim-custom-genesis-fast` (note: you need to modify `-Genesis=${HOME}/.gaiad/config/genesis.json` to `-Genesis=${HOME}/.simapp/config/genesis.json` in the Makefile first). You may encounter the following error:

```bash
Running custom genesis simulation...
By default, /Users/lcq/.gaiad/config/genesis.json will be used.
=== RUN   TestFullAppSimulation
Starting SimulateFromSeed with randomness created with seed 99
Randomized simulation params: 
{}
Selected randomly generated consensus parameters:
{
 "block": {
  "max_bytes": 21456269,
  "max_gas": -1
 },
 "evidence": {
  "max_age_num_blocks": 302400,
  "max_age_duration": 1814400000000000
 },
 "validator": {
  "pub_key_types": [
   "ed25519"
  ]
 }
}
Starting the simulation from time Wed Sep 27 15:49:06 UTC 2023 (unixtime 1695829746)
Simulating... block 1/100, operation 0/269. Logs to writing to /Users/lcq/.simapp/simulations/2023-09-28_00:18:10.log
    simulate.go:347: error on block  1/100, operation (1/269) from x/group:
        group: not found [cosmos/cosmos-sdk/x/group/keeper/grpc_query.go:27]
        Comment: 
--- FAIL: TestFullAppSimulation (0.12s)
FAIL

```

Based on the errors encountered during each execution of `make test-sim-custom-genesis-fast`, I have identified and attempted to resolve three potential issues:

Issue 1: Fix the problem where the account randomly generated by `AppStateFromGenesisFileFn` does not have a `ConsKey`, causing `SimulateMsgCreateValidator` to fail.
This issue primarily arises when executing `SimulateMsgCreateValidator`. The accounts generated by `AppStateFromGenesisFileFn` do not have the `ConsKey` field specified, leading to a null pointer exception when calling `simAccount.ConsKey.PubKey()`.

Issue 2: Fix the problem of operating on a group, such as `SimulateMsgCreateGroupPolicy`, when the group does not exist in the chain during simulation testing.
The problem is encountered when executing the simulation test of the group module. It occurs when there is no group created, meaning there is no group in the chain. Some operations are performed on an empty group, such as executing `SimulateMsgCreateGroupPolicy`.

Issue 3: Add the **SigverifyTx** flag in the simulation test  whether to check the transaction signature.
During the execution of `AppStateFromGenesisFileFn`, the private keys corresponding to addresses are generated randomly. Therefore, when executing transactions, we need to skip the signature verification check.
Of course, if the genesis data is also randomly generated, such as the simulation test executed by the  `make test-sim-nondeterminism` command, the private key corresponding to the address generated at this time is correct, and the signature needs to be verified at this time. 
Or when we also read the data initialization chain from the genesis.json file. If the private keys corresponding to all addresses are passed in, we can also verify the signature at this time.
So I added a **`SigverifyTx`** flag that leaves it up to the user to decide whether signature verification of the transaction is required. For example, if I want to skip signature verification when executing simulation, then I can run `go test -mod=readonly -run TestFullAppSimulation -Genesis=genesis.json -SigverifyTx=false`