### PR TITLE
fix: keep behavior from v0.47 in PrepareProposal panic recovery

### DIFF
--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -453,7 +453,7 @@ func (app *BaseApp) PrepareProposal(req *abci.RequestPrepareProposal) (resp *abc
 				"panic", err,
 			)
 
-			resp = &abci.ResponsePrepareProposal{}
+			resp = &abci.ResponsePrepareProposal{Txs: req.Txs}
 		}
 	}()
 

--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -460,7 +460,7 @@ func (app *BaseApp) PrepareProposal(req *abci.RequestPrepareProposal) (resp *abc
 	resp, err = app.prepareProposal(app.prepareProposalState.ctx, req)
 	if err != nil {
 		app.logger.Error("failed to prepare proposal", "height", req.Height, "time", req.Time, "err", err)
-		return &abci.ResponsePrepareProposal{}, nil
+		return &abci.ResponsePrepareProposal{Txs: req.Txs}, nil
 	}
 
 	return resp, nil

--- a/baseapp/abci_test.go
+++ b/baseapp/abci_test.go
@@ -2331,7 +2331,6 @@ func TestABCI_PrepareProposal_Panic(t *testing.T) {
 	resPrepareProposal, err = suite.baseApp.PrepareProposal(&reqPrepareProposal)
 	require.NoError(t, err)
 	require.Equal(t, 3, len(resPrepareProposal.Txs))
-
 }
 
 func TestOptimisticExecution(t *testing.T) {

--- a/baseapp/abci_test.go
+++ b/baseapp/abci_test.go
@@ -2296,6 +2296,44 @@ func TestBaseApp_VoteExtensions(t *testing.T) {
 	require.Equal(t, avgPrice, committedAvgPrice)
 }
 
+func TestABCI_PrepareProposal_Panic(t *testing.T) {
+	prepareOpt := func(bapp *baseapp.BaseApp) {
+		bapp.SetPrepareProposal(func(ctx sdk.Context, req *abci.RequestPrepareProposal) (*abci.ResponsePrepareProposal, error) {
+			if len(req.Txs) == 3 {
+				panic("i don't like number 3, panic")
+			}
+			// return empty if no panic
+			return &abci.ResponsePrepareProposal{}, nil
+		})
+	}
+
+	suite := NewBaseAppSuite(t, prepareOpt)
+
+	_, err := suite.baseApp.InitChain(&abci.RequestInitChain{
+		InitialHeight:   1,
+		ConsensusParams: &cmtproto.ConsensusParams{},
+	})
+	require.NoError(t, err)
+
+	txs := [][]byte{{1}, {2}}
+	reqPrepareProposal := abci.RequestPrepareProposal{
+		MaxTxBytes: 1000,
+		Height:     1, // this value can't be 0
+		Txs:        txs,
+	}
+	resPrepareProposal, err := suite.baseApp.PrepareProposal(&reqPrepareProposal)
+	require.NoError(t, err)
+	require.Equal(t, 0, len(resPrepareProposal.Txs))
+
+	// make it panic, and check if it returns 3 txs (because of panic recovery)
+	txs = [][]byte{{1}, {2}, {3}}
+	reqPrepareProposal.Txs = txs
+	resPrepareProposal, err = suite.baseApp.PrepareProposal(&reqPrepareProposal)
+	require.NoError(t, err)
+	require.Equal(t, 3, len(resPrepareProposal.Txs))
+
+}
+
 func TestOptimisticExecution(t *testing.T) {
 	suite := NewBaseAppSuite(t, baseapp.SetOptimisticExecution())
 


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

In v0.47.x when recovering from a panic during PrepareProposal we return a proposal that includes all the transactions that it got from RequestPrepareProposal. This was later modified (without a clear reason afaik, maybe just by mistake).

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] added `!` to the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/build/building-modules/01-intro.md)
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] updated the relevant documentation or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] run `make lint` and `make test`
* [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] confirmed all author checklist items have been addressed 
* [ ] reviewed state machine logic
* [ ] reviewed API design and naming
* [ ] reviewed documentation is accurate
* [ ] reviewed tests and test coverage
* [ ] manually tested (if applicable)
