### PR TITLE
chore: check for nil params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,6 +161,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (types) [#17885](https://github.com/cosmos/cosmos-sdk/pull/17885) `InitGenesis` & `ExportGenesis` now take `context.Context` instead of `sdk.Context`
 * (x/auth) [#17985](https://github.com/cosmos/cosmos-sdk/pull/17985) Remove `StdTxConfig`
     * Remove depreacted `MakeTestingEncodingParams` from `simapp/params`
+* (x/consensus) [#18041](https://github.com/cosmos/cosmos-sdk/pull/18041) `ToProtoConsensusParams()` returns an error 
 
 ### CLI Breaking Changes
 

--- a/x/consensus/keeper/keeper.go
+++ b/x/consensus/keeper/keeper.go
@@ -67,7 +67,10 @@ func (k Keeper) UpdateParams(ctx context.Context, msg *types.MsgUpdateParams) (*
 		return nil, fmt.Errorf("invalid authority; expected %s, got %s", k.GetAuthority(), msg.Authority)
 	}
 
-	consensusParams := msg.ToProtoConsensusParams()
+	consensusParams, err := msg.ToProtoConsensusParams()
+	if err != nil {
+		return nil, err
+	}
 	if err := cmttypes.ConsensusParamsFromProto(consensusParams).ValidateBasic(); err != nil {
 		return nil, err
 	}

--- a/x/consensus/keeper/keeper_test.go
+++ b/x/consensus/keeper/keeper_test.go
@@ -175,6 +175,17 @@ func (s *KeeperTestSuite) TestUpdateParams() {
 			expErr:    true,
 			expErrMsg: "invalid authority",
 		},
+		{
+			name: "invalid params",
+			input: &types.MsgUpdateParams{
+				Authority: s.consensusParamsKeeper.GetAuthority(),
+				Block:     defaultConsensusParams.Block,
+				Validator: defaultConsensusParams.Validator,
+				Evidence:  nil,
+			},
+			expErr:    true,
+			expErrMsg: "all parameters must be present",
+		},
 	}
 
 	for _, tc := range testCases {

--- a/x/consensus/keeper/keeper_test.go
+++ b/x/consensus/keeper/keeper_test.go
@@ -176,12 +176,34 @@ func (s *KeeperTestSuite) TestUpdateParams() {
 			expErrMsg: "invalid authority",
 		},
 		{
-			name: "invalid params",
+			name: "nil evidence params",
 			input: &types.MsgUpdateParams{
 				Authority: s.consensusParamsKeeper.GetAuthority(),
 				Block:     defaultConsensusParams.Block,
 				Validator: defaultConsensusParams.Validator,
 				Evidence:  nil,
+			},
+			expErr:    true,
+			expErrMsg: "all parameters must be present",
+		},
+		{
+			name: "nil block params",
+			input: &types.MsgUpdateParams{
+				Authority: s.consensusParamsKeeper.GetAuthority(),
+				Block:     nil,
+				Validator: defaultConsensusParams.Validator,
+				Evidence:  defaultConsensusParams.Evidence,
+			},
+			expErr:    true,
+			expErrMsg: "all parameters must be present",
+		},
+		{
+			name: "nil validator params",
+			input: &types.MsgUpdateParams{
+				Authority: s.consensusParamsKeeper.GetAuthority(),
+				Block:     defaultConsensusParams.Block,
+				Validator: nil,
+				Evidence:  defaultConsensusParams.Evidence,
 			},
 			expErr:    true,
 			expErrMsg: "all parameters must be present",

--- a/x/consensus/types/msgs.go
+++ b/x/consensus/types/msgs.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"errors"
+	fmt "fmt"
 
 	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
 	cmttypes "github.com/cometbft/cometbft/types"
@@ -12,9 +13,12 @@ import (
 var _ sdk.Msg = &MsgUpdateParams{}
 
 func (msg MsgUpdateParams) ToProtoConsensusParams() (cmtproto.ConsensusParams, error) {
-	if msg.Block == nil && msg.Evidence == nil && msg.Validator == nil && msg.Abci == nil {
+	if msg.Evidence == nil || msg.Block == nil || msg.Validator == nil {
 		return cmtproto.ConsensusParams{}, errors.New("all parameters must be present")
 	}
+
+	fmt.Println(msg.Evidence)
+
 	cp := cmtproto.ConsensusParams{
 		Block: &cmtproto.BlockParams{
 			MaxBytes: msg.Block.MaxBytes,

--- a/x/consensus/types/msgs.go
+++ b/x/consensus/types/msgs.go
@@ -2,7 +2,6 @@ package types
 
 import (
 	"errors"
-	fmt "fmt"
 
 	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
 	cmttypes "github.com/cometbft/cometbft/types"
@@ -16,8 +15,6 @@ func (msg MsgUpdateParams) ToProtoConsensusParams() (cmtproto.ConsensusParams, e
 	if msg.Evidence == nil || msg.Block == nil || msg.Validator == nil {
 		return cmtproto.ConsensusParams{}, errors.New("all parameters must be present")
 	}
-
-	fmt.Println(msg.Evidence)
 
 	cp := cmtproto.ConsensusParams{
 		Block: &cmtproto.BlockParams{

--- a/x/consensus/types/msgs.go
+++ b/x/consensus/types/msgs.go
@@ -1,6 +1,8 @@
 package types
 
 import (
+	"errors"
+
 	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
 	cmttypes "github.com/cometbft/cometbft/types"
 
@@ -9,7 +11,10 @@ import (
 
 var _ sdk.Msg = &MsgUpdateParams{}
 
-func (msg MsgUpdateParams) ToProtoConsensusParams() cmtproto.ConsensusParams {
+func (msg MsgUpdateParams) ToProtoConsensusParams() (cmtproto.ConsensusParams, error) {
+	if msg.Block == nil && msg.Evidence == nil && msg.Validator == nil && msg.Abci == nil {
+		return cmtproto.ConsensusParams{}, errors.New("all parameters must be present")
+	}
 	cp := cmtproto.ConsensusParams{
 		Block: &cmtproto.BlockParams{
 			MaxBytes: msg.Block.MaxBytes,
@@ -32,5 +37,5 @@ func (msg MsgUpdateParams) ToProtoConsensusParams() cmtproto.ConsensusParams {
 		}
 	}
 
-	return cp
+	return cp, nil
 }


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

A40

check for nil params

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] added `!` to the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/build/building-modules/01-intro.md)
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] updated the relevant documentation or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] run `make lint` and `make test`
* [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] confirmed all author checklist items have been addressed 
* [ ] reviewed state machine logic
* [ ] reviewed API design and naming
* [ ] reviewed documentation is accurate
* [ ] reviewed tests and test coverage
* [ ] manually tested (if applicable)
