### PR TITLE
perf(x/staking/keeper): make Slash return early iff zero tokens to burn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Improvements
 
+* (x/staking/keeper) [#]18049(https://github.com/cosmos/cosmos-sdk/pull/18049) return early if Slash encounters zero tokens to burn.
 * (x/staking/keeper) [#18035](https://github.com/cosmos/cosmos-sdk/pull/18035) Hoisted out of the redelegation loop, the non-changing validator and delegator addresses parsing.
 * (keyring) [#17913](https://github.com/cosmos/cosmos-sdk/pull/17913) Add `NewAutoCLIKeyring` for creating an AutoCLI keyring from a SDK keyring.
 * (codec) [#17913](https://github.com/cosmos/cosmos-sdk/pull/17913) `codectypes.NewAnyWithValue` supports proto v2 messages.


### PR DESCRIPTION
This change makes Keeper.Slash return early if there are no tokens to burn! This change also skips invoking the
.Hooks().BeforeValidatorSlashed hook because literally there is no slashing that can happen if there are no tokens to burn.

Given that the result of burning zero tokens SHOULD be a no-operation (noop) but we go through the whole routine, assuming no zero tokens would be burnt, one could argue on a protocol implementation/conformation that with zero tokens to burn, invoking Keeper.RemoveValidatorTokens which invokes:

  Keeper.DeleteValidatorByPowerIndex
    -> (Keeper.DeleteValidatorByPowerIndex)
    -> validator.RemoveTokens
    -> Keeper.SetValidator
    -> Keeper.SetValidatorByPowerIndex

was causing a potential self inflicted Byzantine risk because that operation is non-atomic (it ran through a series of operations that could fail on their own yet could not be rolled back and not idempotent), will rely on network operations yet the actual result will have the operations back to the original: more investigation is needed to examine the risk/impact of previously letting zero tokens be burnt and run through that process.

Fixes #18034