### PR TITLE
refactor(cli): use clientCtx adress codecs in cli

### DIFF
--- a/x/auth/vesting/client/cli/tx.go
+++ b/x/auth/vesting/client/cli/tx.go
@@ -9,8 +9,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"cosmossdk.io/core/address"
-
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/tx"
@@ -24,7 +22,7 @@ const (
 )
 
 // GetTxCmd returns vesting module's transaction commands.
-func GetTxCmd(ac address.Codec) *cobra.Command {
+func GetTxCmd() *cobra.Command {
 	txCmd := &cobra.Command{
 		Use:                        types.ModuleName,
 		Short:                      "Vesting transaction subcommands",
@@ -34,9 +32,9 @@ func GetTxCmd(ac address.Codec) *cobra.Command {
 	}
 
 	txCmd.AddCommand(
-		NewMsgCreateVestingAccountCmd(ac),
-		NewMsgCreatePermanentLockedAccountCmd(ac),
-		NewMsgCreatePeriodicVestingAccountCmd(ac),
+		NewMsgCreateVestingAccountCmd(),
+		NewMsgCreatePermanentLockedAccountCmd(),
+		NewMsgCreatePeriodicVestingAccountCmd(),
 	)
 
 	return txCmd
@@ -44,7 +42,7 @@ func GetTxCmd(ac address.Codec) *cobra.Command {
 
 // NewMsgCreateVestingAccountCmd returns a CLI command handler for creating a
 // MsgCreateVestingAccount transaction.
-func NewMsgCreateVestingAccountCmd(ac address.Codec) *cobra.Command {
+func NewMsgCreateVestingAccountCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create-vesting-account [to_address] [amount] [end_time]",
 		Short: "Create a new vesting account funded with an allocation of tokens.",
@@ -59,7 +57,7 @@ timestamp.`,
 			if err != nil {
 				return err
 			}
-			toAddr, err := ac.StringToBytes(args[0])
+			toAddr, err := clientCtx.AddressCodec.StringToBytes(args[0])
 			if err != nil {
 				return err
 			}
@@ -93,7 +91,7 @@ timestamp.`,
 
 // NewMsgCreatePermanentLockedAccountCmd returns a CLI command handler for creating a
 // MsgCreatePermanentLockedAccount transaction.
-func NewMsgCreatePermanentLockedAccountCmd(ac address.Codec) *cobra.Command {
+func NewMsgCreatePermanentLockedAccountCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create-permanent-locked-account [to_address] [amount]",
 		Short: "Create a new permanently locked account funded with an allocation of tokens.",
@@ -106,7 +104,7 @@ tokens.`,
 			if err != nil {
 				return err
 			}
-			toAddr, err := ac.StringToBytes(args[0])
+			toAddr, err := clientCtx.AddressCodec.StringToBytes(args[0])
 			if err != nil {
 				return err
 			}
@@ -142,7 +140,7 @@ type InputPeriod struct {
 
 // NewMsgCreatePeriodicVestingAccountCmd returns a CLI command handler for creating a
 // MsgCreatePeriodicVestingAccountCmd transaction.
-func NewMsgCreatePeriodicVestingAccountCmd(ac address.Codec) *cobra.Command {
+func NewMsgCreatePeriodicVestingAccountCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create-periodic-vesting-account [to_address] [periods_json_file]",
 		Short: "Create a new vesting account funded with an allocation of tokens.",
@@ -170,7 +168,7 @@ func NewMsgCreatePeriodicVestingAccountCmd(ac address.Codec) *cobra.Command {
 				return err
 			}
 
-			toAddr, err := ac.StringToBytes(args[0])
+			toAddr, err := clientCtx.AddressCodec.StringToBytes(args[0])
 			if err != nil {
 				return err
 			}

--- a/x/auth/vesting/client/cli/tx_test.go
+++ b/x/auth/vesting/client/cli/tx_test.go
@@ -54,7 +54,7 @@ func (s *CLITestSuite) SetupSuite() {
 
 func (s *CLITestSuite) TestNewMsgCreateVestingAccountCmd() {
 	accounts := testutil.CreateKeyringAccounts(s.T(), s.kr, 1)
-	cmd := cli.NewMsgCreateVestingAccountCmd(addresscodec.NewBech32Codec("cosmos"))
+	cmd := cli.NewMsgCreateVestingAccountCmd()
 	cmd.SetOutput(io.Discard)
 
 	extraArgs := []string{
@@ -143,7 +143,7 @@ func (s *CLITestSuite) TestNewMsgCreateVestingAccountCmd() {
 
 func (s *CLITestSuite) TestNewMsgCreatePermanentLockedAccountCmd() {
 	accounts := testutil.CreateKeyringAccounts(s.T(), s.kr, 1)
-	cmd := cli.NewMsgCreatePermanentLockedAccountCmd(addresscodec.NewBech32Codec("cosmos"))
+	cmd := cli.NewMsgCreatePermanentLockedAccountCmd()
 	cmd.SetOutput(io.Discard)
 
 	extraArgs := []string{
@@ -222,7 +222,7 @@ func (s *CLITestSuite) TestNewMsgCreatePermanentLockedAccountCmd() {
 
 func (s *CLITestSuite) TestNewMsgCreatePeriodicVestingAccountCmd() {
 	accounts := testutil.CreateKeyringAccounts(s.T(), s.kr, 1)
-	cmd := cli.NewMsgCreatePeriodicVestingAccountCmd(addresscodec.NewBech32Codec("cosmos"))
+	cmd := cli.NewMsgCreatePeriodicVestingAccountCmd()
 	cmd.SetOutput(io.Discard)
 
 	extraArgs := []string{

--- a/x/auth/vesting/module.go
+++ b/x/auth/vesting/module.go
@@ -9,7 +9,6 @@ import (
 	"google.golang.org/grpc"
 
 	modulev1 "cosmossdk.io/api/cosmos/vesting/module/v1"
-	"cosmossdk.io/core/address"
 	"cosmossdk.io/core/appmodule"
 	"cosmossdk.io/depinject"
 
@@ -33,9 +32,7 @@ var (
 // AppModuleBasic defines the basic application module used by the sub-vesting
 // module. The module itself contain no special logic or state other than message
 // handling.
-type AppModuleBasic struct {
-	ac address.Codec
-}
+type AppModuleBasic struct{}
 
 // Name returns the module's name.
 func (AppModuleBasic) Name() string {
@@ -69,7 +66,7 @@ func (AppModuleBasic) RegisterGRPCGatewayRoutes(_ client.Context, _ *gwruntime.S
 
 // GetTxCmd returns the root tx command for the auth module.
 func (ab AppModuleBasic) GetTxCmd() *cobra.Command {
-	return cli.GetTxCmd(ab.ac)
+	return cli.GetTxCmd()
 }
 
 // AppModule extends the AppModuleBasic implementation by implementing the
@@ -83,7 +80,7 @@ type AppModule struct {
 
 func NewAppModule(ak keeper.AccountKeeper, bk types.BankKeeper) AppModule {
 	return AppModule{
-		AppModuleBasic: AppModuleBasic{ac: ak.AddressCodec()},
+		AppModuleBasic: AppModuleBasic{},
 		accountKeeper:  ak,
 		bankKeeper:     bk,
 	}

--- a/x/authz/module/module.go
+++ b/x/authz/module/module.go
@@ -95,7 +95,7 @@ func (AppModuleBasic) RegisterGRPCGatewayRoutes(clientCtx sdkclient.Context, mux
 
 // GetTxCmd returns the transaction commands for the authz module
 func (ab AppModuleBasic) GetTxCmd() *cobra.Command {
-	return cli.GetTxCmd(ab.ac)
+	return cli.GetTxCmd()
 }
 
 // AppModule implements the sdk.AppModule interface

--- a/x/feegrant/client/cli/tx.go
+++ b/x/feegrant/client/cli/tx.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"cosmossdk.io/core/address"
 	"cosmossdk.io/x/feegrant"
 
 	"github.com/cosmos/cosmos-sdk/client"
@@ -27,7 +26,7 @@ const (
 )
 
 // GetTxCmd returns the transaction commands for feegrant module
-func GetTxCmd(ac address.Codec) *cobra.Command {
+func GetTxCmd() *cobra.Command {
 	feegrantTxCmd := &cobra.Command{
 		Use:                        feegrant.ModuleName,
 		Short:                      "Feegrant transactions sub-commands",
@@ -38,7 +37,7 @@ func GetTxCmd(ac address.Codec) *cobra.Command {
 	}
 
 	feegrantTxCmd.AddCommand(
-		NewCmdFeeGrant(ac),
+		NewCmdFeeGrant(),
 	)
 
 	return feegrantTxCmd
@@ -46,7 +45,7 @@ func GetTxCmd(ac address.Codec) *cobra.Command {
 
 // NewCmdFeeGrant returns a CLI command handler to create a MsgGrantAllowance transaction.
 // This command is more powerful than AutoCLI generated command as it allows a better input validation.
-func NewCmdFeeGrant(ac address.Codec) *cobra.Command {
+func NewCmdFeeGrant() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "grant [granter_key_or_address] [grantee]",
 		Aliases: []string{"grant-allowance"},
@@ -75,13 +74,13 @@ Examples:
 				return err
 			}
 
-			_, err = ac.StringToBytes(args[1])
+			_, err = clientCtx.AddressCodec.StringToBytes(args[1])
 			if err != nil {
 				return err
 			}
 
 			granter := clientCtx.GetFromAddress()
-			granterStr, err := ac.BytesToString(granter)
+			granterStr, err := clientCtx.AddressCodec.BytesToString(granter)
 			if err != nil {
 				return err
 			}

--- a/x/feegrant/client/cli/tx_test.go
+++ b/x/feegrant/client/cli/tx_test.go
@@ -136,7 +136,7 @@ func (s *CLITestSuite) createGrant(granter, grantee sdk.Address) {
 		commonFlags...,
 	)
 
-	cmd := cli.NewCmdFeeGrant(addresscodec.NewBech32Codec("cosmos"))
+	cmd := cli.NewCmdFeeGrant()
 	out, err := clitestutil.ExecTestCLICmd(s.clientCtx, cmd, args)
 	s.Require().NoError(err)
 
@@ -423,7 +423,7 @@ func (s *CLITestSuite) TestNewCmdFeeGrant() {
 		tc := tc
 
 		s.Run(tc.name, func() {
-			cmd := cli.NewCmdFeeGrant(addresscodec.NewBech32Codec("cosmos"))
+			cmd := cli.NewCmdFeeGrant()
 			out, err := clitestutil.ExecTestCLICmd(clientCtx, cmd, tc.args)
 
 			if tc.expectErr {
@@ -466,7 +466,7 @@ func (s *CLITestSuite) TestTxWithFeeGrant() {
 		commonFlags...,
 	)
 
-	cmd := cli.NewCmdFeeGrant(addresscodec.NewBech32Codec("cosmos"))
+	cmd := cli.NewCmdFeeGrant()
 
 	var res sdk.TxResponse
 	out, err := clitestutil.ExecTestCLICmd(clientCtx, cmd, args)
@@ -619,7 +619,7 @@ func (s *CLITestSuite) TestFilteredFeeAllowance() {
 		tc := tc
 
 		s.Run(tc.name, func() {
-			cmd := cli.NewCmdFeeGrant(addresscodec.NewBech32Codec("cosmos"))
+			cmd := cli.NewCmdFeeGrant()
 			out, err := clitestutil.ExecTestCLICmd(clientCtx, cmd, tc.args)
 			if tc.expectErrMsg != "" {
 				s.Require().Error(err)
@@ -669,7 +669,7 @@ func (s *CLITestSuite) TestFilteredFeeAllowance() {
 					commonFlags...,
 				)
 
-				cmd := cli.NewCmdFeeGrant(addresscodec.NewBech32Codec("cosmos"))
+				cmd := cli.NewCmdFeeGrant()
 				out, err := clitestutil.ExecTestCLICmd(clientCtx, cmd, args)
 				s.Require().NoError(clientCtx.Codec.UnmarshalJSON(out.Bytes(), &sdk.TxResponse{}), out.String())
 

--- a/x/feegrant/module/module.go
+++ b/x/feegrant/module/module.go
@@ -9,7 +9,6 @@ import (
 	"github.com/spf13/cobra"
 
 	modulev1 "cosmossdk.io/api/cosmos/feegrant/module/v1"
-	"cosmossdk.io/core/address"
 	"cosmossdk.io/core/appmodule"
 	"cosmossdk.io/core/store"
 	"cosmossdk.io/depinject"
@@ -44,7 +43,6 @@ var (
 // AppModuleBasic defines the basic application module used by the feegrant module.
 type AppModuleBasic struct {
 	cdc codec.Codec
-	ac  address.Codec
 }
 
 // Name returns the feegrant module's name.
@@ -99,7 +97,7 @@ func (ab AppModuleBasic) RegisterGRPCGatewayRoutes(clientCtx sdkclient.Context, 
 
 // GetTxCmd returns the root tx command for the feegrant module.
 func (ab AppModuleBasic) GetTxCmd() *cobra.Command {
-	return cli.GetTxCmd(ab.ac)
+	return cli.GetTxCmd()
 }
 
 // ----------------------------------------------------------------------------
@@ -119,7 +117,7 @@ type AppModule struct {
 // NewAppModule creates a new AppModule object
 func NewAppModule(cdc codec.Codec, ak feegrant.AccountKeeper, bk feegrant.BankKeeper, keeper keeper.Keeper, registry cdctypes.InterfaceRegistry) AppModule {
 	return AppModule{
-		AppModuleBasic: AppModuleBasic{cdc: cdc, ac: ak.AddressCodec()},
+		AppModuleBasic: AppModuleBasic{cdc: cdc},
 		keeper:         keeper,
 		accountKeeper:  ak,
 		bankKeeper:     bk,
@@ -205,6 +203,6 @@ func (am AppModule) RegisterStoreDecoder(sdr simtypes.StoreDecoderRegistry) {
 func (am AppModule) WeightedOperations(simState module.SimulationState) []simtypes.WeightedOperation {
 	return simulation.WeightedOperations(
 		am.registry, simState.AppParams, simState.Cdc, simState.TxConfig,
-		am.accountKeeper, am.bankKeeper, am.keeper, am.ac,
+		am.accountKeeper, am.bankKeeper, am.keeper, am.accountKeeper.AddressCodec(),
 	)
 }

--- a/x/upgrade/client/cli/parse_test.go
+++ b/x/upgrade/client/cli/parse_test.go
@@ -7,12 +7,10 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"cosmossdk.io/x/upgrade/types"
-
-	addresscodec "github.com/cosmos/cosmos-sdk/codec/address"
 )
 
 func TestParsePlan(t *testing.T) {
-	fs := NewCmdSubmitUpgradeProposal(addresscodec.NewBech32Codec("cosmos")).Flags()
+	fs := NewCmdSubmitUpgradeProposal().Flags()
 
 	proposal := types.MsgSoftwareUpgrade{
 		Plan: types.Plan{

--- a/x/upgrade/client/cli/tx.go
+++ b/x/upgrade/client/cli/tx.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	addresscodec "cosmossdk.io/core/address"
 	"cosmossdk.io/x/upgrade/plan"
 	"cosmossdk.io/x/upgrade/types"
 
@@ -29,22 +28,22 @@ const (
 )
 
 // GetTxCmd returns the transaction commands for this module
-func GetTxCmd(ac addresscodec.Codec) *cobra.Command {
+func GetTxCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   types.ModuleName,
 		Short: "Upgrade transaction subcommands",
 	}
 
 	cmd.AddCommand(
-		NewCmdSubmitUpgradeProposal(ac),
-		NewCmdSubmitCancelUpgradeProposal(ac),
+		NewCmdSubmitUpgradeProposal(),
+		NewCmdSubmitCancelUpgradeProposal(),
 	)
 
 	return cmd
 }
 
 // NewCmdSubmitUpgradeProposal implements a command handler for submitting a software upgrade proposal transaction.
-func NewCmdSubmitUpgradeProposal(ac addresscodec.Codec) *cobra.Command {
+func NewCmdSubmitUpgradeProposal() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "software-upgrade [name] (--upgrade-height [height]) (--upgrade-info [info]) [flags]",
 		Args:  cobra.ExactArgs(1),
@@ -97,11 +96,11 @@ func NewCmdSubmitUpgradeProposal(ac addresscodec.Codec) *cobra.Command {
 
 			authority, _ := cmd.Flags().GetString(FlagAuthority)
 			if authority != "" {
-				if _, err = ac.StringToBytes(authority); err != nil {
+				if _, err = clientCtx.AddressCodec.StringToBytes(authority); err != nil {
 					return fmt.Errorf("invalid authority address: %w", err)
 				}
 			} else {
-				if authority, err = ac.BytesToString(address.Module("gov")); err != nil {
+				if authority, err = clientCtx.AddressCodec.BytesToString(address.Module("gov")); err != nil {
 					return fmt.Errorf("failed to convert authority address to string: %w", err)
 				}
 			}
@@ -138,7 +137,7 @@ func NewCmdSubmitUpgradeProposal(ac addresscodec.Codec) *cobra.Command {
 }
 
 // NewCmdSubmitCancelUpgradeProposal implements a command handler for submitting a software upgrade cancel proposal transaction.
-func NewCmdSubmitCancelUpgradeProposal(ac addresscodec.Codec) *cobra.Command {
+func NewCmdSubmitCancelUpgradeProposal() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "cancel-software-upgrade [flags]",
 		Args:  cobra.ExactArgs(0),
@@ -157,11 +156,11 @@ func NewCmdSubmitCancelUpgradeProposal(ac addresscodec.Codec) *cobra.Command {
 
 			authority, _ := cmd.Flags().GetString(FlagAuthority)
 			if authority != "" {
-				if _, err = ac.StringToBytes(authority); err != nil {
+				if _, err = clientCtx.AddressCodec.StringToBytes(authority); err != nil {
 					return fmt.Errorf("invalid authority address: %w", err)
 				}
 			} else {
-				if authority, err = ac.BytesToString(address.Module("gov")); err != nil {
+				if authority, err = clientCtx.AddressCodec.BytesToString(address.Module("gov")); err != nil {
 					return fmt.Errorf("failed to convert authority address to string: %w", err)
 				}
 			}

--- a/x/upgrade/module.go
+++ b/x/upgrade/module.go
@@ -47,9 +47,7 @@ var (
 )
 
 // AppModuleBasic implements the sdk.AppModuleBasic interface
-type AppModuleBasic struct {
-	ac address.Codec
-}
+type AppModuleBasic struct{}
 
 // Name returns the ModuleName
 func (AppModuleBasic) Name() string {
@@ -70,7 +68,7 @@ func (AppModuleBasic) RegisterGRPCGatewayRoutes(clientCtx client.Context, mux *g
 
 // GetTxCmd returns the CLI transaction commands for this module
 func (ab AppModuleBasic) GetTxCmd() *cobra.Command {
-	return cli.GetTxCmd(ab.ac)
+	return cli.GetTxCmd()
 }
 
 // RegisterInterfaces registers interfaces and implementations of the upgrade module.
@@ -87,7 +85,7 @@ type AppModule struct {
 // NewAppModule creates a new AppModule object
 func NewAppModule(keeper *keeper.Keeper, ac address.Codec) AppModule {
 	return AppModule{
-		AppModuleBasic: AppModuleBasic{ac: ac},
+		AppModuleBasic: AppModuleBasic{},
 		keeper:         keeper,
 	}
 }


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

Use client context address codecs instead of passing them in cli directly.
This cannot be backported as it is v0.51 specific.

Extract some changes from https://github.com/cosmos/cosmos-sdk/pull/18039/files

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] added `!` to the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/build/building-modules/01-intro.md)
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] updated the relevant documentation or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] run `make lint` and `make test`
* [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] confirmed all author checklist items have been addressed 
* [ ] reviewed state machine logic
* [ ] reviewed API design and naming
* [ ] reviewed documentation is accurate
* [ ] reviewed tests and test coverage
* [ ] manually tested (if applicable)
