### PR TITLE
fix(store/streaming): reset BlockMetadata between blocks

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -39,12 +39,16 @@ module.exports = {
     },
     versions: [
       {
-        "label": "v0.44",
-        "key": "v0.44"
-      },
-      {
         "label": "v0.45",
         "key": "v0.45"
+      },
+      {
+        "label": "v0.46",
+        "key": "v0.46"
+      },
+      {
+        "label": "v0.47",
+        "key": "v0.47"
       },
       {
         "label": "main",

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -39,16 +39,12 @@ module.exports = {
     },
     versions: [
       {
+        "label": "v0.44",
+        "key": "v0.44"
+      },
+      {
         "label": "v0.45",
         "key": "v0.45"
-      },
-      {
-        "label": "v0.46",
-        "key": "v0.46"
-      },
-      {
-        "label": "v0.47",
-        "key": "v0.47"
       },
       {
         "label": "main",

--- a/store/streaming/file/service.go
+++ b/store/streaming/file/service.go
@@ -161,6 +161,8 @@ func (fss *StreamingService) doListenCommit(ctx context.Context, res abci.Respon
 		if err := writeLengthPrefixedFile(path.Join(fss.writeDir, metaFileName), bz, fss.fsync); err != nil {
 			return err
 		}
+		// reset block metadata for next block so that deliverTx does not accumulate between blocks
+		fss.blockMetadata = types.BlockMetadata{}
 	}
 
 	var buf bytes.Buffer


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

Without this fix block meta data files emitted by the file state streaming grow forever since each successive file contains the txs of all prior blocks.  This just resets the tx list between blocks.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] added `!` to the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/build/building-modules/01-intro.md)
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] updated the relevant documentation or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] run `make lint` and `make test`
* [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] confirmed all author checklist items have been addressed 
* [ ] reviewed state machine logic
* [ ] reviewed API design and naming
* [ ] reviewed documentation is accurate
* [ ] reviewed tests and test coverage
* [ ] manually tested (if applicable)
