### PR TITLE
feat: expose module account setter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (x/bank) [#17569](https://github.com/cosmos/cosmos-sdk/pull/17569) Introduce a new message type, `MsgBurn `, to burn coins.
 * (server) [#17094](https://github.com/cosmos/cosmos-sdk/pull/17094) Add duration `shutdown-grace` for resource clean up (closing database handles) before exit.
 * (baseapp) [#18071](https://github.com/cosmos/cosmos-sdk/pull/18071) Add hybrid handlers to `MsgServiceRouter`.
+* (x/auth) [#18108](https://github.com/cosmos/cosmos-sdk/pull/18108) export a module from the keeper that set the module account and permissions
 
 ### Improvements
 

--- a/x/auth/keeper/keeper.go
+++ b/x/auth/keeper/keeper.go
@@ -253,6 +253,21 @@ func (ak AccountKeeper) GetModuleAccountAndPermissions(ctx context.Context, modu
 	return maccI, perms
 }
 
+// SetModuleAccountAndPermissions the module account from the auth account store and its
+// registered permissions
+func (ak AccountKeeper) SetModuleAccountAndPermissions(ctx sdk.Context, moduleName string, perms ...string) types.ModuleAccountI {
+	// create a new empty module account
+	macc := types.NewEmptyModuleAccount(moduleName, perms...)
+	// set the account number
+	maccI := (ak.NewAccount(ctx, macc)).(types.ModuleAccountI)
+	// Add the account to the store
+	ak.SetModuleAccount(ctx, maccI)
+	// Add the permissions for the module account
+	ak.permAddrs[moduleName] = types.NewPermissionsForAddress(maccI.GetName(), perms)
+
+	return maccI
+}
+
 // GetModuleAccount gets the module account from the auth account store, if the account does not
 // exist in the AccountKeeper, then it is created.
 func (ak AccountKeeper) GetModuleAccount(ctx context.Context, moduleName string) sdk.ModuleAccountI {


### PR DESCRIPTION
## Description

Exposes the `SetModuleAccountAndPermissions` which allows overwriting or creating a module account with its permissions. This can be useful for cases like:
- an account has been assigned to a module by mistake,
- an external account has been assigned to a module instead of a module account,
-  change the permissions of a an existent module account,
- etc...

### Author Checklist
I have...

* [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [x] added `!` to the type prefix if API or client breaking change
* [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/build/building-modules/01-intro.md)
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] updated the relevant documentation or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] run `make lint` and `make test`
* [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] confirmed all author checklist items have been addressed 
* [ ] reviewed state machine logic
* [ ] reviewed API design and naming
* [ ] reviewed documentation is accurate
* [ ] reviewed tests and test coverage
* [ ] manually tested (if applicable)
