### PR TITLE
docs: Update account.go comments

### DIFF
--- a/x/auth/types/account.go
+++ b/x/auth/types/account.go
@@ -142,7 +142,7 @@ func (acc BaseAccount) UnpackInterfaces(unpacker codectypes.AnyUnpacker) error {
 	return unpacker.UnpackAny(acc.PubKey, &pubKey)
 }
 
-// NewModuleAddressOrAddress gets an input string and returns an AccAddress.
+// NewModuleAddressOrBech32Address gets an input string and returns an AccAddress.
 // If the input is a valid address, it returns the address.
 // If the input is a module name, it returns the module address.
 func NewModuleAddressOrBech32Address(input string) sdk.AccAddress {


### PR DESCRIPTION

## Description

The description for NewModuleAddressOrBech32Address function in account.go file is not correct. I updated the comments with the correct function name.
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Summary by CodeRabbit

- Refactor: The function `NewModuleAddressOrAddress` has been renamed to `NewModuleAddressOrBech32Address`. This change is part of our ongoing efforts to improve the clarity and consistency of our codebase. Please note that this update does not introduce any new features or changes in functionality. It is purely a naming adjustment to enhance the readability and maintainability of our code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->