### PR TITLE
fix(simulation): fix the problem of `validator set is empty after InitGenesis` in simulation test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (x/slashing) [#18016](https://github.com/cosmos/cosmos-sdk/pull/18016) Fixed builder function for missed blocks key (`validatorMissedBlockBitArrayPrefixKey`) in slashing/migration/v4
 * (x/gov) [#17873](https://github.com/cosmos/cosmos-sdk/pull/17873) Fail any inactive and active proposals whose messages cannot be decoded.
 * (simulation) [#17911](https://github.com/cosmos/cosmos-sdk/pull/17911) Fix all problems with executing command `make test-sim-custom-genesis-fast` for simulation test.
+* (simulation) [#18196](https://github.com/cosmos/cosmos-sdk/pull/18196) Fix the problem of `validator set is empty after InitGenesis` in simulation test.
 
 ### API Breaking Changes
 

--- a/testutil/sims/state_helpers.go
+++ b/testutil/sims/state_helpers.go
@@ -208,11 +208,11 @@ func AppStateRandomizedFn(
 	)
 	appParams.GetOrGenerate(
 		StakePerAccount, &initialStake, r,
-		func(r *rand.Rand) { initialStake = math.NewInt(r.Int63n(1e12)) },
+		func(r *rand.Rand) { initialStake = sdk.DefaultPowerReduction.AddRaw(r.Int63n(1e12)) },
 	)
 	appParams.GetOrGenerate(
 		InitiallyBondedValidators, &numInitiallyBonded, r,
-		func(r *rand.Rand) { numInitiallyBonded = int64(r.Intn(300)) },
+		func(r *rand.Rand) { numInitiallyBonded = int64(r.Intn(299) + 1) },
 	)
 
 	if numInitiallyBonded > numAccs {


### PR DESCRIPTION

<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

When I execute `make test-sim-nondeterminism` for simulation testing, there is a certain probability that **validator set is empty after InitGenesis, please ensure at least one validator is initialized with a delegation greater than or equal to the Problem with DefaultPowerReduction ({1374391948096})**. The place for `panic` is:

https://github.com/cosmos/cosmos-sdk/blob/2fbc547ce9/x/simulation/simulate.go#L50

The actual error occurs at:

https://github.com/cosmos/cosmos-sdk/blob/2fbc547/types/module/module.go#L517

After analysis, there are two reasons that trigger this error.

Reason 1: When `AppStateRandomizedFn` is a random parameter, when `initialStake < DefaultPowerReduction`, the `ConsensusPower` of each validator is equal to 0, resulting in no validator.

Reason 2: When `AppStateRandomizedFn` is a random parameter, when `numInitiallyBonded` is 0, there is no validator.

So we must ensure that `initialStake >= DefaultPowerReduction` and `numInitiallyBonded >= 1` when using `AppStateRandomizedFn` random parameters


Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] added `!` to the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/build/building-modules/01-intro.md)
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] updated the relevant documentation or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] run `make lint` and `make test`
* [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] confirmed all author checklist items have been addressed 
* [ ] reviewed state machine logic
* [ ] reviewed API design and naming
* [ ] reviewed documentation is accurate
* [ ] reviewed tests and test coverage
* [ ] manually tested (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Summary by CodeRabbit

- Bug Fix: Addressed an issue in the simulation test where the validator set was empty after InitGenesis. This fix enhances the reliability of our testing environment, ensuring more accurate results.
- New Feature: Updated the `AppStateRandomizedFn` function to generate random values for `initialStake` and `numInitiallyBonded` parameters. This change introduces an element of randomness to our simulations, making them more robust and representative of real-world scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->