### PR TITLE
fix(sim): make testutil/network genesis state deterministic

### DIFF
--- a/testutil/network/util.go
+++ b/testutil/network/util.go
@@ -122,7 +122,10 @@ func startInProcess(cfg Config, val *Validator) error {
 }
 
 func collectGenFiles(cfg Config, vals []*Validator, outputDir string) error {
-	genTime := cmttime.Now()
+	genTime := cfg.GenesisTime
+	if genTime.IsZero() {
+		genTime = cmttime.Now()
+	}
 
 	for i := 0; i < cfg.NumValidators; i++ {
 		cmtCfg := vals[i].Ctx.Config


### PR DESCRIPTION
This change fixes two sources of nondeterminism:

- Genesis time was always time.Now; it's now configurable
- The configured mnemonics were not used consistently

CC @odeke-em @alexanderbez 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->


### Summary by CodeRabbit

- New Feature: Introduced a customizable 'Genesis Time' setting, enhancing the flexibility of node initialization and key generation. This allows users to specify the genesis time for their validator nodes, providing more control over the network setup process.
- Improvement: Updated the node initialization process to ensure each validator node uses a unique mnemonic for key generation, enhancing the security and uniqueness of each node within the network.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->