### PR TITLE
fix: RelativePow now returns 1 when 0^0

### DIFF
--- a/math/CHANGELOG.md
+++ b/math/CHANGELOG.md
@@ -42,6 +42,7 @@ Ref: https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.j
 
 ### Bug Fixes
 
+* [#18211](https://github.com/cosmos/cosmos-sdk/pull/18211) RelativePow now returns 1 when 0^0, before it was returning the scale factor.
 * [#17725](https://github.com/cosmos/cosmos-sdk/pull/17725) Fix state break in ApproxRoot. This has been present since math/v1.0.1. It changed the rounding behavior at precision end in an intermediary division from banker's to truncation. The truncation occurs from binary right shift in the case of square roots. The change is now reverted back to banker's rounding universally for any root.
 
 ## [math/v1.1.2](https://github.com/cosmos/cosmos-sdk/releases/tag/math/v1.1.2) - 2023-08-21

--- a/math/uint.go
+++ b/math/uint.go
@@ -243,7 +243,7 @@ func checkNewUint(i *big.Int) (Uint, error) {
 func RelativePow(x, n, b Uint) (z Uint) {
 	if x.IsZero() {
 		if n.IsZero() {
-			z = b // 0^0 = 1
+			z = OneUint() // 0^0 = 1
 			return z
 		}
 		z = ZeroUint() // otherwise 0^a = 0

--- a/math/uint_test.go
+++ b/math/uint_test.go
@@ -271,7 +271,7 @@ func (s *uintTestSuite) TestRelativePow() {
 		want sdkmath.Uint
 	}{
 		{[]sdkmath.Uint{sdkmath.ZeroUint(), sdkmath.ZeroUint(), sdkmath.OneUint()}, sdkmath.OneUint()},
-		{[]sdkmath.Uint{sdkmath.ZeroUint(), sdkmath.ZeroUint(), sdkmath.NewUint(10)}, sdkmath.NewUint(10)},
+		{[]sdkmath.Uint{sdkmath.ZeroUint(), sdkmath.ZeroUint(), sdkmath.NewUint(10)}, sdkmath.NewUint(1)},
 		{[]sdkmath.Uint{sdkmath.ZeroUint(), sdkmath.OneUint(), sdkmath.NewUint(10)}, sdkmath.ZeroUint()},
 		{[]sdkmath.Uint{sdkmath.NewUint(10), sdkmath.NewUint(2), sdkmath.OneUint()}, sdkmath.NewUint(100)},
 		{[]sdkmath.Uint{sdkmath.NewUint(210), sdkmath.NewUint(2), sdkmath.NewUint(100)}, sdkmath.NewUint(441)},


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

I've checked current usages and it doesn't look like there are people misusing this enough to ever get the wrong result. The issue is that when x and n are 0 then the result is whatever being passed as b, even though there's a comment stating `// 0^0 = 1`.

This is not being used in the SDK btw.

https://github.com/search?q=RelativePow+language%3AGo&type=code&l=Go

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] added `!` to the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/build/building-modules/01-intro.md)
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] updated the relevant documentation or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] run `make lint` and `make test`
* [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] confirmed all author checklist items have been addressed 
* [ ] reviewed state machine logic
* [ ] reviewed API design and naming
* [ ] reviewed documentation is accurate
* [ ] reviewed tests and test coverage
* [ ] manually tested (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Summary by CodeRabbit

- Bug Fix: Corrected the behavior of the `RelativePow` function to return 1 when raising 0 to the power of 0, enhancing the mathematical accuracy of the software.
- Bug Fix: Reverted a change in the `ApproxRoot` function's rounding behavior, ensuring consistent and expected results across all calculations. 

These changes improve the reliability of mathematical operations within the software, providing users with more accurate and predictable results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->