### PR TITLE
fix(math): NewUintFromBigInt argument mutation

### DIFF
--- a/math/CHANGELOG.md
+++ b/math/CHANGELOG.md
@@ -42,6 +42,7 @@ Ref: https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.j
 
 ### Bug Fixes
 
+* [#18214](https://github.com/cosmos/cosmos-sdk/pull/18214) Ensure that modifying the argument to `NewUIntFromBigInt` doesn't mutate the returned value.
 * [#17725](https://github.com/cosmos/cosmos-sdk/pull/17725) Fix state break in ApproxRoot. This has been present since math/v1.0.1. It changed the rounding behavior at precision end in an intermediary division from banker's to truncation. The truncation occurs from binary right shift in the case of square roots. The change is now reverted back to banker's rounding universally for any root.
 
 ## [math/v1.1.2](https://github.com/cosmos/cosmos-sdk/releases/tag/math/v1.1.2) - 2023-08-21

--- a/math/uint.go
+++ b/math/uint.go
@@ -235,7 +235,6 @@ func checkNewUint(i *big.Int) (Uint, error) {
 	if err := UintOverflow(i); err != nil {
 		return Uint{}, err
 	}
-
 	return Uint{new(big.Int).Set(i)}, nil
 }
 

--- a/math/uint.go
+++ b/math/uint.go
@@ -235,7 +235,8 @@ func checkNewUint(i *big.Int) (Uint, error) {
 	if err := UintOverflow(i); err != nil {
 		return Uint{}, err
 	}
-	return Uint{i}, nil
+
+	return Uint{new(big.Int).Set(i)}, nil
 }
 
 // RelativePow raises x to the power of n, where x (and the result, z) are scaled by factor b

--- a/math/uint_test.go
+++ b/math/uint_test.go
@@ -261,6 +261,16 @@ func (s *uintTestSuite) TestParseUint() {
 	}
 }
 
+func (s *uintTestSuite) TestNewUintFromBigInt() {
+	r := big.NewInt(42)
+	i := sdkmath.NewUintFromBigInt(r)
+	s.Require().Equal(r, i.BigInt())
+
+	// modify r and ensure i doesn't change
+	r = r.SetInt64(100)
+	s.Require().NotEqual(r, i.BigInt())
+}
+
 func randuint() sdkmath.Uint {
 	return sdkmath.NewUint(rand.Uint64())
 }


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

same as https://github.com/cosmos/cosmos-sdk/pull/17352 but for NewUintFromBigInt

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] added `!` to the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/build/building-modules/01-intro.md)
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] updated the relevant documentation or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] run `make lint` and `make test`
* [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] confirmed all author checklist items have been addressed 
* [ ] reviewed state machine logic
* [ ] reviewed API design and naming
* [ ] reviewed documentation is accurate
* [ ] reviewed tests and test coverage
* [ ] manually tested (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Summary by CodeRabbit

- Bug Fix: Enhanced the reliability of the `NewUIntFromBigInt` function to ensure that modifying the input does not affect the returned value, providing a more stable and predictable user experience.
- Bug Fix: Updated the `RelativePow` function to return 1 when raising 0 to the power of 0, improving mathematical consistency.
- Bug Fix: Reverted the rounding behavior in the `ApproxRoot` function to use banker's rounding universally, ensuring more accurate results.
- Test: Added new test cases for the `NewUintFromBigInt` and `TestParseUint` functions, increasing the robustness of our testing suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->