### PR TITLE
fix(x/group/internal/orm): use proper map type to string not interface{}

### DIFF
--- a/x/group/internal/orm/indexer.go
+++ b/x/group/internal/orm/indexer.go
@@ -176,7 +176,7 @@ func multiKeyAddFunc(store storetypes.KVStore, secondaryIndexKey interface{}, ro
 
 // difference returns the list of elements that are in a but not in b.
 func difference(a, b []interface{}) ([]interface{}, error) {
-	set := make(map[interface{}]struct{}, len(b))
+	set := make(map[string]struct{}, len(b))
 	for _, v := range b {
 		bt, err := keyPartBytes(v, true)
 		if err != nil {


### PR DESCRIPTION
This change uses a proper map type: map[string] not map[interface{}] and this trivially improves performance but even more makes the code much clearer/readable, avoiding the string->interface{} conversion. In micro benchmarks, just that simple change improved performance

```shell
$ benchstat before.txt after.txt
name    old time/op    new time/op    delta
Diff-8    4.73µs ± 1%    3.75µs ±14%  -20.75%  (p=0.000 n=9+10)

name    old alloc/op   new alloc/op   delta
Diff-8      568B ± 0%      376B ± 0%  -33.80%  (p=0.000 n=10+10)

name    old allocs/op  new allocs/op  delta
Diff-8      42.0 ± 0%      30.0 ± 0%  -28.57%  (p=0.000 n=10+10)
```

Fixes #18287

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->


### Summary by CodeRabbit

- Refactor: Updated internal data handling in the application. This change is part of our ongoing efforts to improve the efficiency and reliability of our software. While this update is not directly visible to users, it contributes to the overall performance and stability of the system. Please note that this change should not affect the functionality of the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->