### PR TITLE
fix(sim): set FlagSigverifyTxValue to newApp for TestAppSimulationAfterImport

### DIFF
--- a/simapp/sim_test.go
+++ b/simapp/sim_test.go
@@ -294,6 +294,9 @@ func TestAppSimulationAfterImport(t *testing.T) {
 	}()
 
 	newApp := NewSimApp(log.NewNopLogger(), newDB, nil, true, appOptions, fauxMerkleModeOpt, baseapp.SetChainID(SimAppChainID))
+	if !simcli.FlagSigverifyTxValue {
+		newApp.SetNotSigverifyTx()
+	}
 	require.Equal(t, "SimApp", newApp.Name())
 
 	_, err = newApp.InitChain(&abci.RequestInitChain{


### PR DESCRIPTION
## Description
In https://github.com/cosmos/cosmos-sdk/pull/17911, I added a new **SigverifyTx** flag whether to verify the signature of the transaction. But I forgot that **TestAppSimulationAfterImport** passed this flag to the newApp of this test. Now just add the relevant logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->


### Summary by CodeRabbit

- Test Improvement: Enhanced the `TestAppSimulationAfterImport` function to handle a new scenario. This update allows the simulation test to bypass transaction signature verification when the `FlagSigverifyTxValue` flag is set to false. This change improves the flexibility of our testing environment and ensures more robust application testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->