### PR TITLE
fix(snapshot): grant execution permissions to the snapshot dir for the owner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (x/gov) [#17873](https://github.com/cosmos/cosmos-sdk/pull/17873) Fail any inactive and active proposals whose messages cannot be decoded.
 * (simulation) [#17911](https://github.com/cosmos/cosmos-sdk/pull/17911) Fix all problems with executing command `make test-sim-custom-genesis-fast` for simulation test.
 * (simulation) [#18196](https://github.com/cosmos/cosmos-sdk/pull/18196) Fix the problem of `validator set is empty after InitGenesis` in simulation test.
+* (snapshot) [#18292](https://github.com/cosmos/cosmos-sdk/pull/18292) Grant execution permissions to the snapshot dir for the owner.
 
 ### API Breaking Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,7 +76,6 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (x/gov) [#17873](https://github.com/cosmos/cosmos-sdk/pull/17873) Fail any inactive and active proposals whose messages cannot be decoded.
 * (simulation) [#17911](https://github.com/cosmos/cosmos-sdk/pull/17911) Fix all problems with executing command `make test-sim-custom-genesis-fast` for simulation test.
 * (simulation) [#18196](https://github.com/cosmos/cosmos-sdk/pull/18196) Fix the problem of `validator set is empty after InitGenesis` in simulation test.
-* (snapshot) [#18294](https://github.com/cosmos/cosmos-sdk/pull/18294) Grant execution permissions to the snapshot dir for the owner.
 
 ### API Breaking Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,7 +76,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (x/gov) [#17873](https://github.com/cosmos/cosmos-sdk/pull/17873) Fail any inactive and active proposals whose messages cannot be decoded.
 * (simulation) [#17911](https://github.com/cosmos/cosmos-sdk/pull/17911) Fix all problems with executing command `make test-sim-custom-genesis-fast` for simulation test.
 * (simulation) [#18196](https://github.com/cosmos/cosmos-sdk/pull/18196) Fix the problem of `validator set is empty after InitGenesis` in simulation test.
-* (snapshot) [#18292](https://github.com/cosmos/cosmos-sdk/pull/18292) Grant execution permissions to the snapshot dir for the owner.
+* (snapshot) [#18294](https://github.com/cosmos/cosmos-sdk/pull/18294) Grant execution permissions to the snapshot dir for the owner.
 
 ### API Breaking Changes
 

--- a/server/util.go
+++ b/server/util.go
@@ -537,7 +537,7 @@ func DefaultBaseappOptions(appOpts types.AppOptions) []func(*baseapp.BaseApp) {
 func GetSnapshotStore(appOpts types.AppOptions) (*snapshots.Store, error) {
 	homeDir := cast.ToString(appOpts.Get(flags.FlagHome))
 	snapshotDir := filepath.Join(homeDir, "data", "snapshots")
-	if err := os.MkdirAll(snapshotDir, 0o644); err != nil {
+	if err := os.MkdirAll(snapshotDir, 0o744); err != nil {
 		return nil, fmt.Errorf("failed to create snapshots directory: %w", err)
 	}
 


### PR DESCRIPTION


## Description

In PR https://github.com/cosmos/cosmos-sdk/pull/18206 , the permissions of snapshot dir were modified. However, in my macos sonoma 14,  when executing **simd start --home ./nodes/node0/simd** the following error occurred: **panic: failed to initialize database: stat nodes/node0/simd /data/snapshots/metadata.db: permission denied**. The main reason is lack of execute permissions for the owner.

In addition, search for the keyword **os.MkdirAll** in the project, and the owner will have executable permissions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Feature: Enhanced the snapshot feature by improving access permissions. This update allows the owner to execute commands in the snapshot directory, providing more control and flexibility. This change is aimed at improving the user experience and functionality of the snapshot feature.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->