### PR TITLE
fix(crypto): secp256k1 cgo duplicate symbols

### DIFF
--- a/crypto/keys/secp256k1/internal/secp256k1/ext.h
+++ b/crypto/keys/secp256k1/internal/secp256k1/ext.h
@@ -59,7 +59,7 @@ static int secp256k1_ext_ecdsa_verify(
 	if (!cosmos_secp256k1_ec_pubkey_parse(ctx, &pubkey, pubkeydata, pubkeylen)) {
 		return 0;
 	}
-	return secp256k1_ecdsa_verify(ctx, &sig, msgdata, &pubkey);
+	return cosmos_secp256k1_ecdsa_verify(ctx, &sig, msgdata, &pubkey);
 }
 
 // secp256k1_ext_reencode_pubkey decodes then encodes a public key. It can be used to

--- a/crypto/keys/secp256k1/internal/secp256k1/ext.h
+++ b/crypto/keys/secp256k1/internal/secp256k1/ext.h
@@ -27,7 +27,7 @@ static int secp256k1_ext_ecdsa_recover(
 	if (!secp256k1_ecdsa_recoverable_signature_parse_compact(ctx, &sig, sigdata, (int)sigdata[64])) {
 		return 0;
 	}
-	if (!secp256k1_ecdsa_recover(ctx, &pubkey, &sig, msgdata)) {
+	if (!cosmos_secp256k1_ecdsa_recover(ctx, &pubkey, &sig, msgdata)) {
 		return 0;
 	}
 	size_t outputlen = 65;

--- a/crypto/keys/secp256k1/internal/secp256k1/ext.h
+++ b/crypto/keys/secp256k1/internal/secp256k1/ext.h
@@ -53,7 +53,7 @@ static int secp256k1_ext_ecdsa_verify(
 	secp256k1_ecdsa_signature sig;
 	secp256k1_pubkey pubkey;
 
-	if (!secp256k1_ecdsa_signature_parse_compact(ctx, &sig, sigdata)) {
+	if (!cosmos_secp256k1_ecdsa_signature_parse_compact(ctx, &sig, sigdata)) {
 		return 0;
 	}
 	if (!secp256k1_ec_pubkey_parse(ctx, &pubkey, pubkeydata, pubkeylen)) {

--- a/crypto/keys/secp256k1/internal/secp256k1/ext.h
+++ b/crypto/keys/secp256k1/internal/secp256k1/ext.h
@@ -4,7 +4,7 @@
 
 // secp256k1_context_create_sign_verify creates a context for signing and signature verification.
 static secp256k1_context* secp256k1_context_create_sign_verify() {
-	return secp256k1_context_create(SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY);
+	return cosmos_secp256k1_context_create(SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY);
 }
 
 // secp256k1_ext_ecdsa_recover recovers the public key of an encoded compact signature.

--- a/crypto/keys/secp256k1/internal/secp256k1/ext.h
+++ b/crypto/keys/secp256k1/internal/secp256k1/ext.h
@@ -89,7 +89,7 @@ static int secp256k1_ext_reencode_pubkey(
 	return cosmos_secp256k1_ec_pubkey_serialize(ctx, out, &outlen, &pubkey, flag);
 }
 
-// secp256k1_ext_scalar_mul multiplies a point by a scalar in constant time.
+// cosmos_secp256k1_ext_scalar_mul multiplies a point by a scalar in constant time.
 //
 // Returns: 1: multiplication was successful
 //          0: scalar was invalid (zero or overflow)
@@ -98,7 +98,7 @@ static int secp256k1_ext_reencode_pubkey(
 //  In:     point:    pointer to a 64-byte public point,
 //                    encoded as two 256bit big-endian numbers.
 //          scalar:   a 32-byte scalar with which to multiply the point
-int secp256k1_ext_scalar_mul(const secp256k1_context* ctx, unsigned char *point, const unsigned char *scalar) {
+int cosmos_secp256k1_ext_scalar_mul(const secp256k1_context* ctx, unsigned char *point, const unsigned char *scalar) {
 	int ret = 0;
 	int overflow = 0;
 	secp256k1_fe feX, feY;

--- a/crypto/keys/secp256k1/internal/secp256k1/ext.h
+++ b/crypto/keys/secp256k1/internal/secp256k1/ext.h
@@ -56,7 +56,7 @@ static int secp256k1_ext_ecdsa_verify(
 	if (!cosmos_secp256k1_ecdsa_signature_parse_compact(ctx, &sig, sigdata)) {
 		return 0;
 	}
-	if (!secp256k1_ec_pubkey_parse(ctx, &pubkey, pubkeydata, pubkeylen)) {
+	if (!cosmos_secp256k1_ec_pubkey_parse(ctx, &pubkey, pubkeydata, pubkeylen)) {
 		return 0;
 	}
 	return secp256k1_ecdsa_verify(ctx, &sig, msgdata, &pubkey);
@@ -82,7 +82,7 @@ static int secp256k1_ext_reencode_pubkey(
 ) {
 	secp256k1_pubkey pubkey;
 
-	if (!secp256k1_ec_pubkey_parse(ctx, &pubkey, pubkeydata, pubkeylen)) {
+	if (!cosmos_secp256k1_ec_pubkey_parse(ctx, &pubkey, pubkeydata, pubkeylen)) {
 		return 0;
 	}
 	unsigned int flag = (outlen == 33) ? SECP256K1_EC_COMPRESSED : SECP256K1_EC_UNCOMPRESSED;

--- a/crypto/keys/secp256k1/internal/secp256k1/ext.h
+++ b/crypto/keys/secp256k1/internal/secp256k1/ext.h
@@ -31,7 +31,7 @@ static int secp256k1_ext_ecdsa_recover(
 		return 0;
 	}
 	size_t outputlen = 65;
-	return secp256k1_ec_pubkey_serialize(ctx, pubkey_out, &outputlen, &pubkey, SECP256K1_EC_UNCOMPRESSED);
+	return cosmos_secp256k1_ec_pubkey_serialize(ctx, pubkey_out, &outputlen, &pubkey, SECP256K1_EC_UNCOMPRESSED);
 }
 
 // secp256k1_ext_ecdsa_verify verifies an encoded compact signature.
@@ -86,7 +86,7 @@ static int secp256k1_ext_reencode_pubkey(
 		return 0;
 	}
 	unsigned int flag = (outlen == 33) ? SECP256K1_EC_COMPRESSED : SECP256K1_EC_UNCOMPRESSED;
-	return secp256k1_ec_pubkey_serialize(ctx, out, &outlen, &pubkey, flag);
+	return cosmos_secp256k1_ec_pubkey_serialize(ctx, out, &outlen, &pubkey, flag);
 }
 
 // secp256k1_ext_scalar_mul multiplies a point by a scalar in constant time.

--- a/crypto/keys/secp256k1/internal/secp256k1/ext.h
+++ b/crypto/keys/secp256k1/internal/secp256k1/ext.h
@@ -24,7 +24,7 @@ static int secp256k1_ext_ecdsa_recover(
 	secp256k1_ecdsa_recoverable_signature sig;
 	secp256k1_pubkey pubkey;
 
-	if (!secp256k1_ecdsa_recoverable_signature_parse_compact(ctx, &sig, sigdata, (int)sigdata[64])) {
+	if (!cosmos_secp256k1_ecdsa_recoverable_signature_parse_compact(ctx, &sig, sigdata, (int)sigdata[64])) {
 		return 0;
 	}
 	if (!cosmos_secp256k1_ecdsa_recover(ctx, &pubkey, &sig, msgdata)) {

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/contrib/lax_der_parsing.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/contrib/lax_der_parsing.c
@@ -17,7 +17,7 @@ int ecdsa_signature_parse_der_lax(const secp256k1_context* ctx, secp256k1_ecdsa_
     int overflow = 0;
 
     /* Hack to initialize sig with a correctly-parsed but invalid signature. */
-    secp256k1_ecdsa_signature_parse_compact(ctx, sig, tmpsig);
+    cosmos_secp256k1_ecdsa_signature_parse_compact(ctx, sig, tmpsig);
 
     /* Sequence tag byte */
     if (pos == inputlen || input[pos] != 0x30) {
@@ -139,11 +139,11 @@ int ecdsa_signature_parse_der_lax(const secp256k1_context* ctx, secp256k1_ecdsa_
     }
 
     if (!overflow) {
-        overflow = !secp256k1_ecdsa_signature_parse_compact(ctx, sig, tmpsig);
+        overflow = !cosmos_secp256k1_ecdsa_signature_parse_compact(ctx, sig, tmpsig);
     }
     if (overflow) {
         memset(tmpsig, 0, 64);
-        secp256k1_ecdsa_signature_parse_compact(ctx, sig, tmpsig);
+        cosmos_secp256k1_ecdsa_signature_parse_compact(ctx, sig, tmpsig);
     }
     return 1;
 }

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/contrib/lax_der_parsing.h
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/contrib/lax_der_parsing.h
@@ -27,7 +27,7 @@
  *
  * Do not use this for new systems. Use well-defined DER or compact signatures
  * instead if you have the choice (see secp256k1_ecdsa_signature_parse_der and
- * secp256k1_ecdsa_signature_parse_compact).
+ * cosmos_secp256k1_ecdsa_signature_parse_compact).
  *
  * The supported violations are:
  * - All numbers are parsed as nonnegative integers, even though X.609-0207

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/contrib/lax_der_parsing.h
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/contrib/lax_der_parsing.h
@@ -26,7 +26,7 @@
  * certain violations are easily supported. You may need to adapt it.
  *
  * Do not use this for new systems. Use well-defined DER or compact signatures
- * instead if you have the choice (see secp256k1_ecdsa_signature_parse_der and
+ * instead if you have the choice (see cosmos_secp256k1_ecdsa_signature_parse_der and
  * cosmos_secp256k1_ecdsa_signature_parse_compact).
  *
  * The supported violations are:

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/contrib/lax_der_privatekey_parsing.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/contrib/lax_der_privatekey_parsing.c
@@ -80,7 +80,7 @@ int ec_privkey_export_der(const secp256k1_context *ctx, unsigned char *privkey, 
         memcpy(ptr, key32, 32); ptr += 32;
         memcpy(ptr, middle, sizeof(middle)); ptr += sizeof(middle);
         pubkeylen = 33;
-        secp256k1_ec_pubkey_serialize(ctx, ptr, &pubkeylen, &pubkey, SECP256K1_EC_COMPRESSED);
+        cosmos_secp256k1_ec_pubkey_serialize(ctx, ptr, &pubkeylen, &pubkey, SECP256K1_EC_COMPRESSED);
         ptr += pubkeylen;
         *privkeylen = ptr - privkey;
     } else {
@@ -105,7 +105,7 @@ int ec_privkey_export_der(const secp256k1_context *ctx, unsigned char *privkey, 
         memcpy(ptr, key32, 32); ptr += 32;
         memcpy(ptr, middle, sizeof(middle)); ptr += sizeof(middle);
         pubkeylen = 65;
-        secp256k1_ec_pubkey_serialize(ctx, ptr, &pubkeylen, &pubkey, SECP256K1_EC_UNCOMPRESSED);
+        cosmos_secp256k1_ec_pubkey_serialize(ctx, ptr, &pubkeylen, &pubkey, SECP256K1_EC_UNCOMPRESSED);
         ptr += pubkeylen;
         *privkeylen = ptr - privkey;
     }

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/contrib/lax_der_privatekey_parsing.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/contrib/lax_der_privatekey_parsing.c
@@ -46,7 +46,7 @@ int ec_privkey_import_der(const secp256k1_context* ctx, unsigned char *out32, co
         return 0;
     }
     memcpy(out32 + 32 - privkey[1], privkey + 2, privkey[1]);
-    if (!secp256k1_ec_seckey_verify(ctx, out32)) {
+    if (!cosmos_secp256k1_ec_seckey_verify(ctx, out32)) {
         memset(out32, 0, 32);
         return 0;
     }

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/contrib/lax_der_privatekey_parsing.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/contrib/lax_der_privatekey_parsing.c
@@ -56,7 +56,7 @@ int ec_privkey_import_der(const secp256k1_context* ctx, unsigned char *out32, co
 int ec_privkey_export_der(const secp256k1_context *ctx, unsigned char *privkey, size_t *privkeylen, const unsigned char *key32, int compressed) {
     secp256k1_pubkey pubkey;
     size_t pubkeylen = 0;
-    if (!secp256k1_ec_pubkey_create(ctx, &pubkey, key32)) {
+    if (!cosmos_secp256k1_ec_pubkey_create(ctx, &pubkey, key32)) {
         *privkeylen = 0;
         return 0;
     }

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/include/secp256k1.h
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/include/secp256k1.h
@@ -494,7 +494,7 @@ SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_pubkey_create(
  * In/Out:  seckey: pointer to a 32-byte private key.
  * In:      tweak:  pointer to a 32-byte tweak.
  */
-SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_privkey_tweak_add(
+SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int cosmos_secp256k1_ec_privkey_tweak_add(
     const secp256k1_context* ctx,
     unsigned char *seckey,
     const unsigned char *tweak

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/include/secp256k1.h
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/include/secp256k1.h
@@ -173,7 +173,7 @@ SECP256K1_API secp256k1_context* secp256k1_context_create(
  *  Returns: a newly created context object.
  *  Args:    ctx: an existing context to copy (cannot be NULL)
  */
-SECP256K1_API secp256k1_context* secp256k1_context_clone(
+SECP256K1_API secp256k1_context* cosmos_secp256k1_context_clone(
     const secp256k1_context* ctx
 ) SECP256K1_ARG_NONNULL(1) SECP256K1_WARN_UNUSED_RESULT;
 

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/include/secp256k1.h
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/include/secp256k1.h
@@ -348,7 +348,7 @@ SECP256K1_API int secp256k1_ecdsa_signature_serialize_der(
  *
  *  See cosmos_secp256k1_ecdsa_signature_parse_compact for details about the encoding.
  */
-SECP256K1_API int secp256k1_ecdsa_signature_serialize_compact(
+SECP256K1_API int cosmos_secp256k1_ecdsa_signature_serialize_compact(
     const secp256k1_context* ctx,
     unsigned char *output64,
     const secp256k1_ecdsa_signature* sig

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/include/secp256k1.h
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/include/secp256k1.h
@@ -537,7 +537,7 @@ SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int cosmos_secp256k1_ec_privkey_tweak
  * In/Out:  pubkey: pointer to a public key obkect.
  * In:      tweak:  pointer to a 32-byte tweak.
  */
-SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_pubkey_tweak_mul(
+SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int cosmos_secp256k1_ec_pubkey_tweak_mul(
     const secp256k1_context* ctx,
     secp256k1_pubkey *pubkey,
     const unsigned char *tweak

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/include/secp256k1.h
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/include/secp256k1.h
@@ -48,7 +48,7 @@ typedef struct secp256k1_context_struct secp256k1_context;
  *  guaranteed to be portable between different platforms or versions. It is
  *  however guaranteed to be 64 bytes in size, and can be safely copied/moved.
  *  If you need to convert to a format suitable for storage, transmission, or
- *  comparison, use secp256k1_ec_pubkey_serialize and secp256k1_ec_pubkey_parse.
+ *  comparison, use cosmos_secp256k1_ec_pubkey_serialize and secp256k1_ec_pubkey_parse.
  */
 typedef struct {
     unsigned char data[64];
@@ -155,7 +155,7 @@ typedef int (*secp256k1_nonce_function)(
 #define SECP256K1_CONTEXT_SIGN (SECP256K1_FLAGS_TYPE_CONTEXT | SECP256K1_FLAGS_BIT_CONTEXT_SIGN)
 #define SECP256K1_CONTEXT_NONE (SECP256K1_FLAGS_TYPE_CONTEXT)
 
-/** Flag to pass to secp256k1_ec_pubkey_serialize and secp256k1_ec_privkey_export. */
+/** Flag to pass to cosmos_secp256k1_ec_pubkey_serialize and secp256k1_ec_privkey_export. */
 #define SECP256K1_EC_COMPRESSED (SECP256K1_FLAGS_TYPE_COMPRESSION | SECP256K1_FLAGS_BIT_COMPRESSION)
 #define SECP256K1_EC_UNCOMPRESSED (SECP256K1_FLAGS_TYPE_COMPRESSION)
 
@@ -270,7 +270,7 @@ SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_pubkey_parse(
  *          flags:      SECP256K1_EC_COMPRESSED if serialization should be in
  *                      compressed format, otherwise SECP256K1_EC_UNCOMPRESSED.
  */
-SECP256K1_API int secp256k1_ec_pubkey_serialize(
+SECP256K1_API int cosmos_secp256k1_ec_pubkey_serialize(
     const secp256k1_context* ctx,
     unsigned char *output,
     size_t *outputlen,

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/include/secp256k1.h
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/include/secp256k1.h
@@ -293,7 +293,7 @@ SECP256K1_API int cosmos_secp256k1_ec_pubkey_serialize(
  *  S are zero, the resulting sig value is guaranteed to fail validation for any
  *  message and public key.
  */
-SECP256K1_API int secp256k1_ecdsa_signature_parse_compact(
+SECP256K1_API int cosmos_secp256k1_ecdsa_signature_parse_compact(
     const secp256k1_context* ctx,
     secp256k1_ecdsa_signature* sig,
     const unsigned char *input64
@@ -346,7 +346,7 @@ SECP256K1_API int secp256k1_ecdsa_signature_serialize_der(
  *  Out:    output64:  a pointer to a 64-byte array to store the compact serialization
  *  In:     sig:       a pointer to an initialized signature object
  *
- *  See secp256k1_ecdsa_signature_parse_compact for details about the encoding.
+ *  See cosmos_secp256k1_ecdsa_signature_parse_compact for details about the encoding.
  */
 SECP256K1_API int secp256k1_ecdsa_signature_serialize_compact(
     const secp256k1_context* ctx,

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/include/secp256k1.h
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/include/secp256k1.h
@@ -434,7 +434,7 @@ SECP256K1_API int cosmos_secp256k1_ecdsa_signature_normalize(
 SECP256K1_API extern const secp256k1_nonce_function cosmos_secp256k1_nonce_function_rfc6979;
 
 /** A default safe nonce generation function (currently equal to cosmos_secp256k1_nonce_function_rfc6979). */
-SECP256K1_API extern const secp256k1_nonce_function secp256k1_nonce_function_default;
+SECP256K1_API extern const secp256k1_nonce_function cosmos_secp256k1_nonce_function_default;
 
 /** Create an ECDSA signature.
  *
@@ -444,7 +444,7 @@ SECP256K1_API extern const secp256k1_nonce_function secp256k1_nonce_function_def
  *  Out:     sig:    pointer to an array where the signature will be placed (cannot be NULL)
  *  In:      msg32:  the 32-byte message hash being signed (cannot be NULL)
  *           seckey: pointer to a 32-byte secret key (cannot be NULL)
- *           noncefp:pointer to a nonce generation function. If NULL, secp256k1_nonce_function_default is used
+ *           noncefp:pointer to a nonce generation function. If NULL, cosmos_secp256k1_nonce_function_default is used
  *           ndata:  pointer to arbitrary data used by the nonce generation function (can be NULL)
  *
  * The created signature is always in lower-S form. See

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/include/secp256k1.h
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/include/secp256k1.h
@@ -35,7 +35,7 @@ extern "C" {
  *  A constructed context can safely be used from multiple threads
  *  simultaneously, but API call that take a non-const pointer to a context
  *  need exclusive access to it. In particular this is the case for
- *  cosmos_secp256k1_context_destroy and secp256k1_context_randomize.
+ *  cosmos_secp256k1_context_destroy and cosmos_secp256k1_context_randomize.
  *
  *  Regarding randomization, either do it once at creation time (in which case
  *  you do not need any locking for the other calls), or use a read-write lock.
@@ -549,7 +549,7 @@ SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int cosmos_secp256k1_ec_pubkey_tweak_
  *  Args:    ctx:       pointer to a context object (cannot be NULL)
  *  In:      seed32:    pointer to a 32-byte random seed (NULL resets to initial state)
  */
-SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_context_randomize(
+SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int cosmos_secp256k1_context_randomize(
     secp256k1_context* ctx,
     const unsigned char *seed32
 ) SECP256K1_ARG_NONNULL(1);

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/include/secp256k1.h
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/include/secp256k1.h
@@ -431,9 +431,9 @@ SECP256K1_API int secp256k1_ecdsa_signature_normalize(
  * If a data pointer is passed, it is assumed to be a pointer to 32 bytes of
  * extra entropy.
  */
-SECP256K1_API extern const secp256k1_nonce_function secp256k1_nonce_function_rfc6979;
+SECP256K1_API extern const secp256k1_nonce_function cosmos_secp256k1_nonce_function_rfc6979;
 
-/** A default safe nonce generation function (currently equal to secp256k1_nonce_function_rfc6979). */
+/** A default safe nonce generation function (currently equal to cosmos_secp256k1_nonce_function_rfc6979). */
 SECP256K1_API extern const secp256k1_nonce_function secp256k1_nonce_function_default;
 
 /** Create an ECDSA signature.

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/include/secp256k1.h
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/include/secp256k1.h
@@ -466,7 +466,7 @@ SECP256K1_API int cosmos_secp256k1_ecdsa_sign(
  *  Args:    ctx: pointer to a context object (cannot be NULL)
  *  In:      seckey: pointer to a 32-byte secret key (cannot be NULL)
  */
-SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_seckey_verify(
+SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int cosmos_secp256k1_ec_seckey_verify(
     const secp256k1_context* ctx,
     const unsigned char *seckey
 ) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2);

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/include/secp256k1.h
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/include/secp256k1.h
@@ -372,7 +372,7 @@ SECP256K1_API int secp256k1_ecdsa_signature_serialize_compact(
  *
  * For details, see the comments for that function.
  */
-SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_ecdsa_verify(
+SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int cosmos_secp256k1_ecdsa_verify(
     const secp256k1_context* ctx,
     const secp256k1_ecdsa_signature *sig,
     const unsigned char *msg32,
@@ -417,7 +417,7 @@ SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_ecdsa_verify(
  *  property is required for an application.
  *
  *  The cosmos_secp256k1_ecdsa_sign function will by default create signatures in the
- *  lower-S form, and secp256k1_ecdsa_verify will not accept others. In case
+ *  lower-S form, and cosmos_secp256k1_ecdsa_verify will not accept others. In case
  *  signatures come from a system that cannot enforce this property,
  *  cosmos_secp256k1_ecdsa_signature_normalize must be called before verification.
  */

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/include/secp256k1.h
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/include/secp256k1.h
@@ -416,7 +416,7 @@ SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_ecdsa_verify(
  *  accept various non-unique encodings, so care should be taken when this
  *  property is required for an application.
  *
- *  The secp256k1_ecdsa_sign function will by default create signatures in the
+ *  The cosmos_secp256k1_ecdsa_sign function will by default create signatures in the
  *  lower-S form, and secp256k1_ecdsa_verify will not accept others. In case
  *  signatures come from a system that cannot enforce this property,
  *  secp256k1_ecdsa_signature_normalize must be called before verification.
@@ -450,7 +450,7 @@ SECP256K1_API extern const secp256k1_nonce_function secp256k1_nonce_function_def
  * The created signature is always in lower-S form. See
  * secp256k1_ecdsa_signature_normalize for more details.
  */
-SECP256K1_API int secp256k1_ecdsa_sign(
+SECP256K1_API int cosmos_secp256k1_ecdsa_sign(
     const secp256k1_context* ctx,
     secp256k1_ecdsa_signature *sig,
     const unsigned char *msg32,

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/include/secp256k1.h
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/include/secp256k1.h
@@ -479,7 +479,7 @@ SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int cosmos_secp256k1_ec_seckey_verify
  *  Out:    pubkey:     pointer to the created public key (cannot be NULL)
  *  In:     seckey:     pointer to a 32-byte private key (cannot be NULL)
  */
-SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_pubkey_create(
+SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int cosmos_secp256k1_ec_pubkey_create(
     const secp256k1_context* ctx,
     secp256k1_pubkey *pubkey,
     const unsigned char *seckey

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/include/secp256k1.h
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/include/secp256k1.h
@@ -150,7 +150,7 @@ typedef int (*secp256k1_nonce_function)(
 #define SECP256K1_FLAGS_BIT_CONTEXT_SIGN (1 << 9)
 #define SECP256K1_FLAGS_BIT_COMPRESSION (1 << 8)
 
-/** Flags to pass to secp256k1_context_create. */
+/** Flags to pass to cosmos_secp256k1_context_create. */
 #define SECP256K1_CONTEXT_VERIFY (SECP256K1_FLAGS_TYPE_CONTEXT | SECP256K1_FLAGS_BIT_CONTEXT_VERIFY)
 #define SECP256K1_CONTEXT_SIGN (SECP256K1_FLAGS_TYPE_CONTEXT | SECP256K1_FLAGS_BIT_CONTEXT_SIGN)
 #define SECP256K1_CONTEXT_NONE (SECP256K1_FLAGS_TYPE_CONTEXT)
@@ -164,7 +164,7 @@ typedef int (*secp256k1_nonce_function)(
  *  Returns: a newly created context object.
  *  In:      flags: which parts of the context to initialize.
  */
-SECP256K1_API secp256k1_context* secp256k1_context_create(
+SECP256K1_API secp256k1_context* cosmos_secp256k1_context_create(
     unsigned int flags
 ) SECP256K1_WARN_UNUSED_RESULT;
 

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/include/secp256k1.h
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/include/secp256k1.h
@@ -523,7 +523,7 @@ SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_pubkey_tweak_add(
  * In/Out: seckey: pointer to a 32-byte private key.
  * In:     tweak:  pointer to a 32-byte tweak.
  */
-SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_privkey_tweak_mul(
+SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int cosmos_secp256k1_ec_privkey_tweak_mul(
     const secp256k1_context* ctx,
     unsigned char *seckey,
     const unsigned char *tweak

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/include/secp256k1.h
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/include/secp256k1.h
@@ -48,7 +48,7 @@ typedef struct secp256k1_context_struct secp256k1_context;
  *  guaranteed to be portable between different platforms or versions. It is
  *  however guaranteed to be 64 bytes in size, and can be safely copied/moved.
  *  If you need to convert to a format suitable for storage, transmission, or
- *  comparison, use cosmos_secp256k1_ec_pubkey_serialize and secp256k1_ec_pubkey_parse.
+ *  comparison, use cosmos_secp256k1_ec_pubkey_serialize and cosmos_secp256k1_ec_pubkey_parse.
  */
 typedef struct {
     unsigned char data[64];
@@ -248,7 +248,7 @@ SECP256K1_API void secp256k1_context_set_error_callback(
  *  0x03), uncompressed (65 bytes, header byte 0x04), or hybrid (65 bytes, header
  *  byte 0x06 or 0x07) format public keys.
  */
-SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_pubkey_parse(
+SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int cosmos_secp256k1_ec_pubkey_parse(
     const secp256k1_context* ctx,
     secp256k1_pubkey* pubkey,
     const unsigned char *input,

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/include/secp256k1.h
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/include/secp256k1.h
@@ -367,7 +367,7 @@ SECP256K1_API int secp256k1_ecdsa_signature_serialize_compact(
  * form are accepted.
  *
  * If you need to accept ECDSA signatures from sources that do not obey this
- * rule, apply secp256k1_ecdsa_signature_normalize to the signature prior to
+ * rule, apply cosmos_secp256k1_ecdsa_signature_normalize to the signature prior to
  * validation, but be aware that doing so results in malleable signatures.
  *
  * For details, see the comments for that function.
@@ -419,9 +419,9 @@ SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_ecdsa_verify(
  *  The cosmos_secp256k1_ecdsa_sign function will by default create signatures in the
  *  lower-S form, and secp256k1_ecdsa_verify will not accept others. In case
  *  signatures come from a system that cannot enforce this property,
- *  secp256k1_ecdsa_signature_normalize must be called before verification.
+ *  cosmos_secp256k1_ecdsa_signature_normalize must be called before verification.
  */
-SECP256K1_API int secp256k1_ecdsa_signature_normalize(
+SECP256K1_API int cosmos_secp256k1_ecdsa_signature_normalize(
     const secp256k1_context* ctx,
     secp256k1_ecdsa_signature *sigout,
     const secp256k1_ecdsa_signature *sigin
@@ -448,7 +448,7 @@ SECP256K1_API extern const secp256k1_nonce_function secp256k1_nonce_function_def
  *           ndata:  pointer to arbitrary data used by the nonce generation function (can be NULL)
  *
  * The created signature is always in lower-S form. See
- * secp256k1_ecdsa_signature_normalize for more details.
+ * cosmos_secp256k1_ecdsa_signature_normalize for more details.
  */
 SECP256K1_API int cosmos_secp256k1_ecdsa_sign(
     const secp256k1_context* ctx,

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/include/secp256k1.h
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/include/secp256k1.h
@@ -206,7 +206,7 @@ SECP256K1_API void secp256k1_context_destroy(
  *              (NULL restores a default handler that calls abort).
  *        data: the opaque pointer to pass to fun above.
  */
-SECP256K1_API void secp256k1_context_set_illegal_callback(
+SECP256K1_API void cosmos_secp256k1_context_set_illegal_callback(
     secp256k1_context* ctx,
     void (*fun)(const char* message, void* data),
     const void* data
@@ -218,7 +218,7 @@ SECP256K1_API void secp256k1_context_set_illegal_callback(
  *  This can only trigger in case of a hardware failure, miscompilation,
  *  memory corruption, serious bug in the library, or other error would can
  *  otherwise result in undefined behaviour. It will not trigger due to mere
- *  incorrect usage of the API (see secp256k1_context_set_illegal_callback
+ *  incorrect usage of the API (see cosmos_secp256k1_context_set_illegal_callback
  *  for that). After this callback returns, anything may happen, including
  *  crashing.
  *

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/include/secp256k1.h
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/include/secp256k1.h
@@ -510,7 +510,7 @@ SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_privkey_tweak_add(
  * In/Out:  pubkey: pointer to a public key object.
  * In:      tweak:  pointer to a 32-byte tweak.
  */
-SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_pubkey_tweak_add(
+SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int cosmos_secp256k1_ec_pubkey_tweak_add(
     const secp256k1_context* ctx,
     secp256k1_pubkey *pubkey,
     const unsigned char *tweak

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/include/secp256k1.h
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/include/secp256k1.h
@@ -314,7 +314,7 @@ SECP256K1_API int cosmos_secp256k1_ecdsa_signature_parse_compact(
  *  encoded numbers are out of range, signature validation with it is
  *  guaranteed to fail for every message and public key.
  */
-SECP256K1_API int secp256k1_ecdsa_signature_parse_der(
+SECP256K1_API int cosmos_secp256k1_ecdsa_signature_parse_der(
     const secp256k1_context* ctx,
     secp256k1_ecdsa_signature* sig,
     const unsigned char *input,

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/include/secp256k1.h
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/include/secp256k1.h
@@ -35,7 +35,7 @@ extern "C" {
  *  A constructed context can safely be used from multiple threads
  *  simultaneously, but API call that take a non-const pointer to a context
  *  need exclusive access to it. In particular this is the case for
- *  secp256k1_context_destroy and secp256k1_context_randomize.
+ *  cosmos_secp256k1_context_destroy and secp256k1_context_randomize.
  *
  *  Regarding randomization, either do it once at creation time (in which case
  *  you do not need any locking for the other calls), or use a read-write lock.
@@ -182,7 +182,7 @@ SECP256K1_API secp256k1_context* cosmos_secp256k1_context_clone(
  *  The context pointer may not be used afterwards.
  *  Args:   ctx: an existing context to destroy (cannot be NULL)
  */
-SECP256K1_API void secp256k1_context_destroy(
+SECP256K1_API void cosmos_secp256k1_context_destroy(
     secp256k1_context* ctx
 );
 

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/include/secp256k1.h
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/include/secp256k1.h
@@ -228,7 +228,7 @@ SECP256K1_API void cosmos_secp256k1_context_set_illegal_callback(
  *              handler that calls abort).
  *        data: the opaque pointer to pass to fun above.
  */
-SECP256K1_API void secp256k1_context_set_error_callback(
+SECP256K1_API void cosmos_secp256k1_context_set_error_callback(
     secp256k1_context* ctx,
     void (*fun)(const char* message, void* data),
     const void* data

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/include/secp256k1.h
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/include/secp256k1.h
@@ -332,7 +332,7 @@ SECP256K1_API int cosmos_secp256k1_ecdsa_signature_parse_der(
  *                     if 0 was returned).
  *  In:     sig:       a pointer to an initialized signature object
  */
-SECP256K1_API int secp256k1_ecdsa_signature_serialize_der(
+SECP256K1_API int cosmos_secp256k1_ecdsa_signature_serialize_der(
     const secp256k1_context* ctx,
     unsigned char *output,
     size_t *outputlen,

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/include/secp256k1.h
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/include/secp256k1.h
@@ -563,7 +563,7 @@ SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int cosmos_secp256k1_context_randomiz
  *  In:     ins:        pointer to array of pointers to public keys (cannot be NULL)
  *          n:          the number of public keys to add together (must be at least 1)
  */
-SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_pubkey_combine(
+SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int cosmos_secp256k1_ec_pubkey_combine(
     const secp256k1_context* ctx,
     secp256k1_pubkey *out,
     const secp256k1_pubkey * const * ins,

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/include/secp256k1_recovery.h
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/include/secp256k1_recovery.h
@@ -75,7 +75,7 @@ SECP256K1_API int cosmos_secp256k1_ecdsa_recoverable_signature_serialize_compact
  *  Out:     sig:    pointer to an array where the signature will be placed (cannot be NULL)
  *  In:      msg32:  the 32-byte message hash being signed (cannot be NULL)
  *           seckey: pointer to a 32-byte secret key (cannot be NULL)
- *           noncefp:pointer to a nonce generation function. If NULL, secp256k1_nonce_function_default is used
+ *           noncefp:pointer to a nonce generation function. If NULL, cosmos_secp256k1_nonce_function_default is used
  *           ndata:  pointer to arbitrary data used by the nonce generation function (can be NULL)
  */
 SECP256K1_API int cosmos_secp256k1_ecdsa_sign_recoverable(

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/include/secp256k1_recovery.h
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/include/secp256k1_recovery.h
@@ -33,7 +33,7 @@ typedef struct {
  *  In:   input64: a pointer to a 64-byte compact signature
  *        recid:   the recovery id (0, 1, 2 or 3)
  */
-SECP256K1_API int secp256k1_ecdsa_recoverable_signature_parse_compact(
+SECP256K1_API int cosmos_secp256k1_ecdsa_recoverable_signature_parse_compact(
     const secp256k1_context* ctx,
     secp256k1_ecdsa_recoverable_signature* sig,
     const unsigned char *input64,

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/include/secp256k1_recovery.h
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/include/secp256k1_recovery.h
@@ -46,7 +46,7 @@ SECP256K1_API int secp256k1_ecdsa_recoverable_signature_parse_compact(
  *  Out: sig:    a pointer to a normal signature (cannot be NULL).
  *  In:  sigin:  a pointer to a recoverable signature (cannot be NULL).
  */
-SECP256K1_API int secp256k1_ecdsa_recoverable_signature_convert(
+SECP256K1_API int cosmos_secp256k1_ecdsa_recoverable_signature_convert(
     const secp256k1_context* ctx,
     secp256k1_ecdsa_signature* sig,
     const secp256k1_ecdsa_recoverable_signature* sigin

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/include/secp256k1_recovery.h
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/include/secp256k1_recovery.h
@@ -60,7 +60,7 @@ SECP256K1_API int cosmos_secp256k1_ecdsa_recoverable_signature_convert(
  *        recid:    a pointer to an integer to hold the recovery id (can be NULL).
  *  In:   sig:      a pointer to an initialized signature object (cannot be NULL)
  */
-SECP256K1_API int secp256k1_ecdsa_recoverable_signature_serialize_compact(
+SECP256K1_API int cosmos_secp256k1_ecdsa_recoverable_signature_serialize_compact(
     const secp256k1_context* ctx,
     unsigned char *output64,
     int *recid,

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/include/secp256k1_recovery.h
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/include/secp256k1_recovery.h
@@ -78,7 +78,7 @@ SECP256K1_API int secp256k1_ecdsa_recoverable_signature_serialize_compact(
  *           noncefp:pointer to a nonce generation function. If NULL, secp256k1_nonce_function_default is used
  *           ndata:  pointer to arbitrary data used by the nonce generation function (can be NULL)
  */
-SECP256K1_API int secp256k1_ecdsa_sign_recoverable(
+SECP256K1_API int cosmos_secp256k1_ecdsa_sign_recoverable(
     const secp256k1_context* ctx,
     secp256k1_ecdsa_recoverable_signature *sig,
     const unsigned char *msg32,

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/include/secp256k1_recovery.h
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/include/secp256k1_recovery.h
@@ -96,7 +96,7 @@ SECP256K1_API int secp256k1_ecdsa_sign_recoverable(
  *  In:      sig:        pointer to initialized signature that supports pubkey recovery (cannot be NULL)
  *           msg32:      the 32-byte message hash assumed to be signed (cannot be NULL)
  */
-SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_ecdsa_recover(
+SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int cosmos_secp256k1_ecdsa_recover(
     const secp256k1_context* ctx,
     secp256k1_pubkey *pubkey,
     const secp256k1_ecdsa_recoverable_signature *sig,

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/bench_ecdh.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/bench_ecdh.c
@@ -29,7 +29,7 @@ static void bench_ecdh_setup(void* arg) {
     };
 
     /* create a context with no capabilities */
-    data->ctx = secp256k1_context_create(SECP256K1_FLAGS_TYPE_CONTEXT);
+    data->ctx = cosmos_secp256k1_context_create(SECP256K1_FLAGS_TYPE_CONTEXT);
     for (i = 0; i < 32; i++) {
         data->scalar[i] = i + 1;
     }

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/bench_ecdh.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/bench_ecdh.c
@@ -33,7 +33,7 @@ static void bench_ecdh_setup(void* arg) {
     for (i = 0; i < 32; i++) {
         data->scalar[i] = i + 1;
     }
-    CHECK(secp256k1_ec_pubkey_parse(data->ctx, &data->point, point, sizeof(point)) == 1);
+    CHECK(cosmos_secp256k1_ec_pubkey_parse(data->ctx, &data->point, point, sizeof(point)) == 1);
 }
 
 static void bench_ecdh(void* arg) {

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/bench_internal.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/bench_internal.c
@@ -296,7 +296,7 @@ void bench_context_verify(void* arg) {
     int i;
     (void)arg;
     for (i = 0; i < 20; i++) {
-        secp256k1_context_destroy(cosmos_secp256k1_context_create(SECP256K1_CONTEXT_VERIFY));
+        cosmos_secp256k1_context_destroy(cosmos_secp256k1_context_create(SECP256K1_CONTEXT_VERIFY));
     }
 }
 
@@ -304,7 +304,7 @@ void bench_context_sign(void* arg) {
     int i;
     (void)arg;
     for (i = 0; i < 200; i++) {
-        secp256k1_context_destroy(cosmos_secp256k1_context_create(SECP256K1_CONTEXT_SIGN));
+        cosmos_secp256k1_context_destroy(cosmos_secp256k1_context_create(SECP256K1_CONTEXT_SIGN));
     }
 }
 

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/bench_internal.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/bench_internal.c
@@ -296,7 +296,7 @@ void bench_context_verify(void* arg) {
     int i;
     (void)arg;
     for (i = 0; i < 20; i++) {
-        secp256k1_context_destroy(secp256k1_context_create(SECP256K1_CONTEXT_VERIFY));
+        secp256k1_context_destroy(cosmos_secp256k1_context_create(SECP256K1_CONTEXT_VERIFY));
     }
 }
 
@@ -304,7 +304,7 @@ void bench_context_sign(void* arg) {
     int i;
     (void)arg;
     for (i = 0; i < 200; i++) {
-        secp256k1_context_destroy(secp256k1_context_create(SECP256K1_CONTEXT_SIGN));
+        secp256k1_context_destroy(cosmos_secp256k1_context_create(SECP256K1_CONTEXT_SIGN));
     }
 }
 

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/bench_recover.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/bench_recover.c
@@ -27,7 +27,7 @@ void bench_recover(void* arg) {
         secp256k1_ecdsa_recoverable_signature sig;
         CHECK(secp256k1_ecdsa_recoverable_signature_parse_compact(data->ctx, &sig, data->sig, i % 2));
         CHECK(secp256k1_ecdsa_recover(data->ctx, &pubkey, &sig, data->msg));
-        CHECK(secp256k1_ec_pubkey_serialize(data->ctx, pubkeyc, &pubkeylen, &pubkey, SECP256K1_EC_COMPRESSED));
+        CHECK(cosmos_secp256k1_ec_pubkey_serialize(data->ctx, pubkeyc, &pubkeylen, &pubkey, SECP256K1_EC_COMPRESSED));
         for (j = 0; j < 32; j++) {
             data->sig[j + 32] = data->msg[j];    /* Move former message to S. */
             data->msg[j] = data->sig[j];         /* Move former R to message. */

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/bench_recover.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/bench_recover.c
@@ -51,7 +51,7 @@ void bench_recover_setup(void* arg) {
 int main(void) {
     bench_recover_t data;
 
-    data.ctx = secp256k1_context_create(SECP256K1_CONTEXT_VERIFY);
+    data.ctx = cosmos_secp256k1_context_create(SECP256K1_CONTEXT_VERIFY);
 
     run_benchmark("ecdsa_recover", bench_recover, bench_recover_setup, NULL, &data, 10, 20000);
 

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/bench_recover.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/bench_recover.c
@@ -55,6 +55,6 @@ int main(void) {
 
     run_benchmark("ecdsa_recover", bench_recover, bench_recover_setup, NULL, &data, 10, 20000);
 
-    secp256k1_context_destroy(data.ctx);
+    cosmos_secp256k1_context_destroy(data.ctx);
     return 0;
 }

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/bench_recover.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/bench_recover.c
@@ -26,7 +26,7 @@ void bench_recover(void* arg) {
         size_t pubkeylen = 33;
         secp256k1_ecdsa_recoverable_signature sig;
         CHECK(secp256k1_ecdsa_recoverable_signature_parse_compact(data->ctx, &sig, data->sig, i % 2));
-        CHECK(secp256k1_ecdsa_recover(data->ctx, &pubkey, &sig, data->msg));
+        CHECK(cosmos_secp256k1_ecdsa_recover(data->ctx, &pubkey, &sig, data->msg));
         CHECK(cosmos_secp256k1_ec_pubkey_serialize(data->ctx, pubkeyc, &pubkeylen, &pubkey, SECP256K1_EC_COMPRESSED));
         for (j = 0; j < 32; j++) {
             data->sig[j + 32] = data->msg[j];    /* Move former message to S. */

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/bench_recover.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/bench_recover.c
@@ -25,7 +25,7 @@ void bench_recover(void* arg) {
         int j;
         size_t pubkeylen = 33;
         secp256k1_ecdsa_recoverable_signature sig;
-        CHECK(secp256k1_ecdsa_recoverable_signature_parse_compact(data->ctx, &sig, data->sig, i % 2));
+        CHECK(cosmos_secp256k1_ecdsa_recoverable_signature_parse_compact(data->ctx, &sig, data->sig, i % 2));
         CHECK(cosmos_secp256k1_ecdsa_recover(data->ctx, &pubkey, &sig, data->msg));
         CHECK(cosmos_secp256k1_ec_pubkey_serialize(data->ctx, pubkeyc, &pubkeylen, &pubkey, SECP256K1_EC_COMPRESSED));
         for (j = 0; j < 32; j++) {

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/bench_schnorr_verify.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/bench_schnorr_verify.c
@@ -40,7 +40,7 @@ static void benchmark_schnorr_init(void* arg) {
         }
         secp256k1_schnorr_sign(data->ctx, data->sigs[k].sig, data->msg, data->sigs[k].key, NULL, NULL);
         data->sigs[k].pubkeylen = 33;
-        CHECK(secp256k1_ec_pubkey_create(data->ctx, &pubkey, data->sigs[k].key));
+        CHECK(cosmos_secp256k1_ec_pubkey_create(data->ctx, &pubkey, data->sigs[k].key));
         CHECK(cosmos_secp256k1_ec_pubkey_serialize(data->ctx, data->sigs[k].pubkey, &data->sigs[k].pubkeylen, &pubkey, SECP256K1_EC_COMPRESSED));
     }
 }

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/bench_schnorr_verify.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/bench_schnorr_verify.c
@@ -52,7 +52,7 @@ static void benchmark_schnorr_verify(void* arg) {
     for (i = 0; i < 20000 / data->numsigs; i++) {
         secp256k1_pubkey pubkey;
         data->sigs[0].sig[(i >> 8) % 64] ^= (i & 0xFF);
-        CHECK(secp256k1_ec_pubkey_parse(data->ctx, &pubkey, data->sigs[0].pubkey, data->sigs[0].pubkeylen));
+        CHECK(cosmos_secp256k1_ec_pubkey_parse(data->ctx, &pubkey, data->sigs[0].pubkey, data->sigs[0].pubkeylen));
         CHECK(secp256k1_schnorr_verify(data->ctx, data->sigs[0].sig, data->msg, &pubkey) == ((i & 0xFF) == 0));
         data->sigs[0].sig[(i >> 8) % 64] ^= (i & 0xFF);
     }

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/bench_schnorr_verify.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/bench_schnorr_verify.c
@@ -68,6 +68,6 @@ int main(void) {
     data.numsigs = 1;
     run_benchmark("schnorr_verify", benchmark_schnorr_verify, benchmark_schnorr_init, NULL, &data, 10, 20000);
 
-    secp256k1_context_destroy(data.ctx);
+    cosmos_secp256k1_context_destroy(data.ctx);
     return 0;
 }

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/bench_schnorr_verify.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/bench_schnorr_verify.c
@@ -63,7 +63,7 @@ static void benchmark_schnorr_verify(void* arg) {
 int main(void) {
     benchmark_schnorr_verify_t data;
 
-    data.ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY);
+    data.ctx = cosmos_secp256k1_context_create(SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY);
 
     data.numsigs = 1;
     run_benchmark("schnorr_verify", benchmark_schnorr_verify, benchmark_schnorr_init, NULL, &data, 10, 20000);

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/bench_schnorr_verify.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/bench_schnorr_verify.c
@@ -41,7 +41,7 @@ static void benchmark_schnorr_init(void* arg) {
         secp256k1_schnorr_sign(data->ctx, data->sigs[k].sig, data->msg, data->sigs[k].key, NULL, NULL);
         data->sigs[k].pubkeylen = 33;
         CHECK(secp256k1_ec_pubkey_create(data->ctx, &pubkey, data->sigs[k].key));
-        CHECK(secp256k1_ec_pubkey_serialize(data->ctx, data->sigs[k].pubkey, &data->sigs[k].pubkeylen, &pubkey, SECP256K1_EC_COMPRESSED));
+        CHECK(cosmos_secp256k1_ec_pubkey_serialize(data->ctx, data->sigs[k].pubkey, &data->sigs[k].pubkeylen, &pubkey, SECP256K1_EC_COMPRESSED));
     }
 }
 

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/bench_sign.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/bench_sign.c
@@ -35,7 +35,7 @@ static void bench_sign(void* arg) {
         size_t siglen = 74;
         int j;
         secp256k1_ecdsa_signature signature;
-        CHECK(secp256k1_ecdsa_sign(data->ctx, &signature, data->msg, data->key, NULL, NULL));
+        CHECK(cosmos_secp256k1_ecdsa_sign(data->ctx, &signature, data->msg, data->key, NULL, NULL));
         CHECK(secp256k1_ecdsa_signature_serialize_der(data->ctx, sig, &siglen, &signature));
         for (j = 0; j < 32; j++) {
             data->msg[j] = sig[j];

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/bench_sign.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/bench_sign.c
@@ -51,6 +51,6 @@ int main(void) {
 
     run_benchmark("ecdsa_sign", bench_sign, bench_sign_setup, NULL, &data, 10, 20000);
 
-    secp256k1_context_destroy(data.ctx);
+    cosmos_secp256k1_context_destroy(data.ctx);
     return 0;
 }

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/bench_sign.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/bench_sign.c
@@ -36,7 +36,7 @@ static void bench_sign(void* arg) {
         int j;
         secp256k1_ecdsa_signature signature;
         CHECK(cosmos_secp256k1_ecdsa_sign(data->ctx, &signature, data->msg, data->key, NULL, NULL));
-        CHECK(secp256k1_ecdsa_signature_serialize_der(data->ctx, sig, &siglen, &signature));
+        CHECK(cosmos_secp256k1_ecdsa_signature_serialize_der(data->ctx, sig, &siglen, &signature));
         for (j = 0; j < 32; j++) {
             data->msg[j] = sig[j];
             data->key[j] = sig[j + 32];

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/bench_sign.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/bench_sign.c
@@ -47,7 +47,7 @@ static void bench_sign(void* arg) {
 int main(void) {
     bench_sign_t data;
 
-    data.ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN);
+    data.ctx = cosmos_secp256k1_context_create(SECP256K1_CONTEXT_SIGN);
 
     run_benchmark("ecdsa_sign", bench_sign, bench_sign_setup, NULL, &data, 10, 20000);
 

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/bench_verify.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/bench_verify.c
@@ -95,7 +95,7 @@ int main(void) {
     }
     data.siglen = 72;
     CHECK(cosmos_secp256k1_ecdsa_sign(data.ctx, &sig, data.msg, data.key, NULL, NULL));
-    CHECK(secp256k1_ecdsa_signature_serialize_der(data.ctx, data.sig, &data.siglen, &sig));
+    CHECK(cosmos_secp256k1_ecdsa_signature_serialize_der(data.ctx, data.sig, &data.siglen, &sig));
     CHECK(secp256k1_ec_pubkey_create(data.ctx, &pubkey, data.key));
     data.pubkeylen = 33;
     CHECK(cosmos_secp256k1_ec_pubkey_serialize(data.ctx, data.pubkey, &data.pubkeylen, &pubkey, SECP256K1_EC_COMPRESSED) == 1);

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/bench_verify.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/bench_verify.c
@@ -40,7 +40,7 @@ static void benchmark_verify(void* arg) {
         data->sig[data->siglen - 1] ^= (i & 0xFF);
         data->sig[data->siglen - 2] ^= ((i >> 8) & 0xFF);
         data->sig[data->siglen - 3] ^= ((i >> 16) & 0xFF);
-        CHECK(secp256k1_ec_pubkey_parse(data->ctx, &pubkey, data->pubkey, data->pubkeylen) == 1);
+        CHECK(cosmos_secp256k1_ec_pubkey_parse(data->ctx, &pubkey, data->pubkey, data->pubkeylen) == 1);
         CHECK(secp256k1_ecdsa_signature_parse_der(data->ctx, &sig, data->sig, data->siglen) == 1);
         CHECK(secp256k1_ecdsa_verify(data->ctx, &sig, data->msg, &pubkey) == (i == 0));
         data->sig[data->siglen - 1] ^= (i & 0xFF);

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/bench_verify.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/bench_verify.c
@@ -98,7 +98,7 @@ int main(void) {
     CHECK(secp256k1_ecdsa_signature_serialize_der(data.ctx, data.sig, &data.siglen, &sig));
     CHECK(secp256k1_ec_pubkey_create(data.ctx, &pubkey, data.key));
     data.pubkeylen = 33;
-    CHECK(secp256k1_ec_pubkey_serialize(data.ctx, data.pubkey, &data.pubkeylen, &pubkey, SECP256K1_EC_COMPRESSED) == 1);
+    CHECK(cosmos_secp256k1_ec_pubkey_serialize(data.ctx, data.pubkey, &data.pubkeylen, &pubkey, SECP256K1_EC_COMPRESSED) == 1);
 
     run_benchmark("ecdsa_verify", benchmark_verify, NULL, NULL, &data, 10, 20000);
 #ifdef ENABLE_OPENSSL_TESTS

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/bench_verify.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/bench_verify.c
@@ -107,6 +107,6 @@ int main(void) {
     EC_GROUP_free(data.ec_group);
 #endif
 
-    secp256k1_context_destroy(data.ctx);
+    cosmos_secp256k1_context_destroy(data.ctx);
     return 0;
 }

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/bench_verify.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/bench_verify.c
@@ -96,7 +96,7 @@ int main(void) {
     data.siglen = 72;
     CHECK(cosmos_secp256k1_ecdsa_sign(data.ctx, &sig, data.msg, data.key, NULL, NULL));
     CHECK(cosmos_secp256k1_ecdsa_signature_serialize_der(data.ctx, data.sig, &data.siglen, &sig));
-    CHECK(secp256k1_ec_pubkey_create(data.ctx, &pubkey, data.key));
+    CHECK(cosmos_secp256k1_ec_pubkey_create(data.ctx, &pubkey, data.key));
     data.pubkeylen = 33;
     CHECK(cosmos_secp256k1_ec_pubkey_serialize(data.ctx, data.pubkey, &data.pubkeylen, &pubkey, SECP256K1_EC_COMPRESSED) == 1);
 

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/bench_verify.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/bench_verify.c
@@ -42,7 +42,7 @@ static void benchmark_verify(void* arg) {
         data->sig[data->siglen - 3] ^= ((i >> 16) & 0xFF);
         CHECK(cosmos_secp256k1_ec_pubkey_parse(data->ctx, &pubkey, data->pubkey, data->pubkeylen) == 1);
         CHECK(secp256k1_ecdsa_signature_parse_der(data->ctx, &sig, data->sig, data->siglen) == 1);
-        CHECK(secp256k1_ecdsa_verify(data->ctx, &sig, data->msg, &pubkey) == (i == 0));
+        CHECK(cosmos_secp256k1_ecdsa_verify(data->ctx, &sig, data->msg, &pubkey) == (i == 0));
         data->sig[data->siglen - 1] ^= (i & 0xFF);
         data->sig[data->siglen - 2] ^= ((i >> 8) & 0xFF);
         data->sig[data->siglen - 3] ^= ((i >> 16) & 0xFF);

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/bench_verify.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/bench_verify.c
@@ -85,7 +85,7 @@ int main(void) {
     secp256k1_ecdsa_signature sig;
     benchmark_verify_t data;
 
-    data.ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY);
+    data.ctx = cosmos_secp256k1_context_create(SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY);
 
     for (i = 0; i < 32; i++) {
         data.msg[i] = 1 + i;

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/bench_verify.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/bench_verify.c
@@ -41,7 +41,7 @@ static void benchmark_verify(void* arg) {
         data->sig[data->siglen - 2] ^= ((i >> 8) & 0xFF);
         data->sig[data->siglen - 3] ^= ((i >> 16) & 0xFF);
         CHECK(cosmos_secp256k1_ec_pubkey_parse(data->ctx, &pubkey, data->pubkey, data->pubkeylen) == 1);
-        CHECK(secp256k1_ecdsa_signature_parse_der(data->ctx, &sig, data->sig, data->siglen) == 1);
+        CHECK(cosmos_secp256k1_ecdsa_signature_parse_der(data->ctx, &sig, data->sig, data->siglen) == 1);
         CHECK(cosmos_secp256k1_ecdsa_verify(data->ctx, &sig, data->msg, &pubkey) == (i == 0));
         data->sig[data->siglen - 1] ^= (i & 0xFF);
         data->sig[data->siglen - 2] ^= ((i >> 8) & 0xFF);

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/bench_verify.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/bench_verify.c
@@ -94,7 +94,7 @@ int main(void) {
         data.key[i] = 33 + i;
     }
     data.siglen = 72;
-    CHECK(secp256k1_ecdsa_sign(data.ctx, &sig, data.msg, data.key, NULL, NULL));
+    CHECK(cosmos_secp256k1_ecdsa_sign(data.ctx, &sig, data.msg, data.key, NULL, NULL));
     CHECK(secp256k1_ecdsa_signature_serialize_der(data.ctx, data.sig, &data.siglen, &sig));
     CHECK(secp256k1_ec_pubkey_create(data.ctx, &pubkey, data.key));
     data.pubkeylen = 33;

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/group_impl.h
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/group_impl.h
@@ -14,7 +14,7 @@
 /* These points can be generated in sage as follows:
  *
  * 0. Setup a worksheet with the following parameters.
- *   b = 4  # whatever CURVE_B will be set to
+ *   b = 4  # whatever COSMOS_CURVE_B will be set to
  *   F = FiniteField (0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F)
  *   C = EllipticCurve ([F (0), F (b)])
  *
@@ -45,7 +45,7 @@ const secp256k1_ge secp256k1_ge_const_g = SECP256K1_GE_CONST(
     0x48DF246C, 0x808DAE72, 0xCFE52572, 0x7F0501ED
 );
 
-const int CURVE_B = 4;
+const int COSMOS_CURVE_B = 4;
 #  elif EXHAUSTIVE_TEST_ORDER == 13
 const secp256k1_ge secp256k1_ge_const_g = SECP256K1_GE_CONST(
     0xedc60018, 0xa51a786b, 0x2ea91f4d, 0x4c9416c0,
@@ -53,7 +53,7 @@ const secp256k1_ge secp256k1_ge_const_g = SECP256K1_GE_CONST(
     0x54cb1b6b, 0xdc8c1273, 0x087844ea, 0x43f4603e,
     0x0eaf9a43, 0xf6effe55, 0x939f806d, 0x37adf8ac
 );
-const int CURVE_B = 2;
+const int COSMOS_CURVE_B = 2;
 #  else
 #    error No known generator for the specified exhaustive test group order.
 #  endif
@@ -68,7 +68,7 @@ static const secp256k1_ge secp256k1_ge_const_g = SECP256K1_GE_CONST(
     0xFD17B448UL, 0xA6855419UL, 0x9C47D08FUL, 0xFB10D4B8UL
 );
 
-const int CURVE_B = 7;
+const int COSMOS_CURVE_B = 7;
 #endif
 
 static void secp256k1_ge_set_gej_zinv(secp256k1_ge *r, const secp256k1_gej *a, const secp256k1_fe *zi) {
@@ -219,7 +219,7 @@ static int secp256k1_ge_set_xquad(secp256k1_ge *r, const secp256k1_fe *x) {
     secp256k1_fe_sqr(&x2, x);
     secp256k1_fe_mul(&x3, x, &x2);
     r->infinity = 0;
-    secp256k1_fe_set_int(&c, CURVE_B);
+    secp256k1_fe_set_int(&c, COSMOS_CURVE_B);
     secp256k1_fe_add(&c, &x3);
     return secp256k1_fe_sqrt(&r->y, &c);
 }
@@ -278,7 +278,7 @@ static int secp256k1_gej_is_valid_var(const secp256k1_gej *a) {
     secp256k1_fe_sqr(&x3, &a->x); secp256k1_fe_mul(&x3, &x3, &a->x);
     secp256k1_fe_sqr(&z2, &a->z);
     secp256k1_fe_sqr(&z6, &z2); secp256k1_fe_mul(&z6, &z6, &z2);
-    secp256k1_fe_mul_int(&z6, CURVE_B);
+    secp256k1_fe_mul_int(&z6, COSMOS_CURVE_B);
     secp256k1_fe_add(&x3, &z6);
     secp256k1_fe_normalize_weak(&x3);
     return secp256k1_fe_equal_var(&y2, &x3);
@@ -292,7 +292,7 @@ static int secp256k1_ge_is_valid_var(const secp256k1_ge *a) {
     /* y^2 = x^3 + 7 */
     secp256k1_fe_sqr(&y2, &a->y);
     secp256k1_fe_sqr(&x3, &a->x); secp256k1_fe_mul(&x3, &x3, &a->x);
-    secp256k1_fe_set_int(&c, CURVE_B);
+    secp256k1_fe_set_int(&c, COSMOS_CURVE_B);
     secp256k1_fe_add(&x3, &c);
     secp256k1_fe_normalize_weak(&x3);
     return secp256k1_fe_equal_var(&y2, &x3);

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/java/org/bitcoin/NativeSecp256k1.java
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/java/org/bitcoin/NativeSecp256k1.java
@@ -69,7 +69,7 @@ public class NativeSecp256k1 {
 
         r.lock();
         try {
-          return secp256k1_ecdsa_verify(byteBuff, Secp256k1Context.getContext(), signature.length, pub.length) == 1;
+          return cosmos_secp256k1_ecdsa_verify(byteBuff, Secp256k1Context.getContext(), signature.length, pub.length) == 1;
         } finally {
           r.unlock();
         }
@@ -431,7 +431,7 @@ public class NativeSecp256k1 {
 
     private static native void secp256k1_destroy_context(long context);
 
-    private static native int secp256k1_ecdsa_verify(ByteBuffer byteBuff, long context, int sigLen, int pubLen);
+    private static native int cosmos_secp256k1_ecdsa_verify(ByteBuffer byteBuff, long context, int sigLen, int pubLen);
 
     private static native byte[][] cosmos_secp256k1_ecdsa_sign(ByteBuffer byteBuff, long context);
 

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/java/org/bitcoin/NativeSecp256k1.java
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/java/org/bitcoin/NativeSecp256k1.java
@@ -411,7 +411,7 @@ public class NativeSecp256k1 {
 
         w.lock();
         try {
-          return secp256k1_context_randomize(byteBuff, Secp256k1Context.getContext()) == 1;
+          return cosmos_secp256k1_context_randomize(byteBuff, Secp256k1Context.getContext()) == 1;
         } finally {
           w.unlock();
         }
@@ -419,7 +419,7 @@ public class NativeSecp256k1 {
 
     private static native long secp256k1_ctx_clone(long context);
 
-    private static native int secp256k1_context_randomize(ByteBuffer byteBuff, long context);
+    private static native int cosmos_secp256k1_context_randomize(ByteBuffer byteBuff, long context);
 
     private static native byte[][] secp256k1_privkey_tweak_add(ByteBuffer byteBuff, long context);
 

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/java/org/bitcoin/NativeSecp256k1.java
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/java/org/bitcoin/NativeSecp256k1.java
@@ -166,7 +166,7 @@ public class NativeSecp256k1 {
 
         r.lock();
         try {
-          retByteArray = secp256k1_ec_pubkey_create(byteBuff, Secp256k1Context.getContext());
+          retByteArray = cosmos_secp256k1_ec_pubkey_create(byteBuff, Secp256k1Context.getContext());
         } finally {
           r.unlock();
         }
@@ -437,7 +437,7 @@ public class NativeSecp256k1 {
 
     private static native int cosmos_secp256k1_ec_seckey_verify(ByteBuffer byteBuff, long context);
 
-    private static native byte[][] secp256k1_ec_pubkey_create(ByteBuffer byteBuff, long context);
+    private static native byte[][] cosmos_secp256k1_ec_pubkey_create(ByteBuffer byteBuff, long context);
 
     private static native byte[][] cosmos_secp256k1_ec_pubkey_parse(ByteBuffer byteBuff, long context, int inputLen);
 

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/java/org/bitcoin/NativeSecp256k1.java
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/java/org/bitcoin/NativeSecp256k1.java
@@ -439,7 +439,7 @@ public class NativeSecp256k1 {
 
     private static native byte[][] secp256k1_ec_pubkey_create(ByteBuffer byteBuff, long context);
 
-    private static native byte[][] secp256k1_ec_pubkey_parse(ByteBuffer byteBuff, long context, int inputLen);
+    private static native byte[][] cosmos_secp256k1_ec_pubkey_parse(ByteBuffer byteBuff, long context, int inputLen);
 
     private static native byte[][] secp256k1_ecdh(ByteBuffer byteBuff, long context, int inputLen);
 

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/java/org/bitcoin/NativeSecp256k1.java
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/java/org/bitcoin/NativeSecp256k1.java
@@ -101,7 +101,7 @@ public class NativeSecp256k1 {
 
         r.lock();
         try {
-          retByteArray = secp256k1_ecdsa_sign(byteBuff, Secp256k1Context.getContext());
+          retByteArray = cosmos_secp256k1_ecdsa_sign(byteBuff, Secp256k1Context.getContext());
         } finally {
           r.unlock();
         }
@@ -433,7 +433,7 @@ public class NativeSecp256k1 {
 
     private static native int secp256k1_ecdsa_verify(ByteBuffer byteBuff, long context, int sigLen, int pubLen);
 
-    private static native byte[][] secp256k1_ecdsa_sign(ByteBuffer byteBuff, long context);
+    private static native byte[][] cosmos_secp256k1_ecdsa_sign(ByteBuffer byteBuff, long context);
 
     private static native int secp256k1_ec_seckey_verify(ByteBuffer byteBuff, long context);
 

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/java/org/bitcoin/NativeSecp256k1.java
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/java/org/bitcoin/NativeSecp256k1.java
@@ -134,7 +134,7 @@ public class NativeSecp256k1 {
 
         r.lock();
         try {
-          return secp256k1_ec_seckey_verify(byteBuff,Secp256k1Context.getContext()) == 1;
+          return cosmos_secp256k1_ec_seckey_verify(byteBuff,Secp256k1Context.getContext()) == 1;
         } finally {
           r.unlock();
         }
@@ -435,7 +435,7 @@ public class NativeSecp256k1 {
 
     private static native byte[][] cosmos_secp256k1_ecdsa_sign(ByteBuffer byteBuff, long context);
 
-    private static native int secp256k1_ec_seckey_verify(ByteBuffer byteBuff, long context);
+    private static native int cosmos_secp256k1_ec_seckey_verify(ByteBuffer byteBuff, long context);
 
     private static native byte[][] secp256k1_ec_pubkey_create(ByteBuffer byteBuff, long context);
 

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/java/org_bitcoin_NativeSecp256k1.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/java/org_bitcoin_NativeSecp256k1.c
@@ -55,7 +55,7 @@ SECP256K1_API jint JNICALL Java_org_bitcoin_NativeSecp256k1_secp256k1_1ecdsa_1ve
   secp256k1_ecdsa_signature sig;
   secp256k1_pubkey pubkey;
 
-  int ret = secp256k1_ecdsa_signature_parse_der(ctx, &sig, sigdata, siglen);
+  int ret = cosmos_secp256k1_ecdsa_signature_parse_der(ctx, &sig, sigdata, siglen);
 
   if( ret ) {
     ret = cosmos_secp256k1_ec_pubkey_parse(ctx, &pubkey, pubdata, publen);

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/java/org_bitcoin_NativeSecp256k1.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/java/org_bitcoin_NativeSecp256k1.c
@@ -253,7 +253,7 @@ SECP256K1_API jobjectArray JNICALL Java_org_bitcoin_NativeSecp256k1_secp256k1_1p
   int ret = cosmos_secp256k1_ec_pubkey_parse(ctx, &pubkey, pkey, publen);
 
   if( ret ) {
-    ret = secp256k1_ec_pubkey_tweak_add(ctx, &pubkey, tweak);
+    ret = cosmos_secp256k1_ec_pubkey_tweak_add(ctx, &pubkey, tweak);
   }
 
   if( ret ) {

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/java/org_bitcoin_NativeSecp256k1.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/java/org_bitcoin_NativeSecp256k1.c
@@ -135,7 +135,7 @@ SECP256K1_API jobjectArray JNICALL Java_org_bitcoin_NativeSecp256k1_secp256k1_1e
   jbyteArray pubkeyArray, intsByteArray;
   unsigned char intsarray[2];
 
-  int ret = secp256k1_ec_pubkey_create(ctx, &pubkey, secKey);
+  int ret = cosmos_secp256k1_ec_pubkey_create(ctx, &pubkey, secKey);
 
   unsigned char outputSer[65];
   size_t outputLen = 65;

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/java/org_bitcoin_NativeSecp256k1.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/java/org_bitcoin_NativeSecp256k1.c
@@ -178,7 +178,7 @@ SECP256K1_API jobjectArray JNICALL Java_org_bitcoin_NativeSecp256k1_secp256k1_1p
 
   int privkeylen = 32;
 
-  int ret = secp256k1_ec_privkey_tweak_add(ctx, privkey, tweak);
+  int ret = cosmos_ secp256k1_ec_privkey_tweak_add(ctx, privkey, tweak);
 
   intsarray[0] = privkeylen;
   intsarray[1] = ret;

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/java/org_bitcoin_NativeSecp256k1.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/java/org_bitcoin_NativeSecp256k1.c
@@ -83,7 +83,7 @@ SECP256K1_API jobjectArray JNICALL Java_org_bitcoin_NativeSecp256k1_secp256k1_1e
 
   secp256k1_ecdsa_signature sig[72];
 
-  int ret = secp256k1_ecdsa_sign(ctx, sig, data, secKey, NULL, NULL );
+  int ret = cosmos_secp256k1_ecdsa_sign(ctx, sig, data, secKey, NULL, NULL );
 
   unsigned char outputSer[72];
   size_t outputLen = 72;

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/java/org_bitcoin_NativeSecp256k1.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/java/org_bitcoin_NativeSecp256k1.c
@@ -213,7 +213,7 @@ SECP256K1_API jobjectArray JNICALL Java_org_bitcoin_NativeSecp256k1_secp256k1_1p
 
   int privkeylen = 32;
 
-  int ret = secp256k1_ec_privkey_tweak_mul(ctx, privkey, tweak);
+  int ret = cosmos_secp256k1_ec_privkey_tweak_mul(ctx, privkey, tweak);
 
   intsarray[0] = privkeylen;
   intsarray[1] = ret;

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/java/org_bitcoin_NativeSecp256k1.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/java/org_bitcoin_NativeSecp256k1.c
@@ -297,7 +297,7 @@ SECP256K1_API jobjectArray JNICALL Java_org_bitcoin_NativeSecp256k1_secp256k1_1p
   int ret = cosmos_secp256k1_ec_pubkey_parse(ctx, &pubkey, pkey, publen);
 
   if ( ret ) {
-    ret = secp256k1_ec_pubkey_tweak_mul(ctx, &pubkey, tweak);
+    ret = cosmos_secp256k1_ec_pubkey_tweak_mul(ctx, &pubkey, tweak);
   }
 
   if( ret ) {

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/java/org_bitcoin_NativeSecp256k1.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/java/org_bitcoin_NativeSecp256k1.c
@@ -12,7 +12,7 @@ SECP256K1_API jlong JNICALL Java_org_bitcoin_NativeSecp256k1_secp256k1_1ctx_1clo
 {
   const secp256k1_context *ctx = (secp256k1_context*)(uintptr_t)ctx_l;
 
-  jlong ctx_clone_l = (uintptr_t) secp256k1_context_clone(ctx);
+  jlong ctx_clone_l = (uintptr_t) cosmos_secp256k1_context_clone(ctx);
 
   (void)classObject;(void)env;
 

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/java/org_bitcoin_NativeSecp256k1.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/java/org_bitcoin_NativeSecp256k1.c
@@ -29,7 +29,7 @@ SECP256K1_API jint JNICALL Java_org_bitcoin_NativeSecp256k1_secp256k1_1context_1
 
   (void)classObject;
 
-  return secp256k1_context_randomize(ctx, seed);
+  return cosmos_secp256k1_context_randomize(ctx, seed);
 
 }
 

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/java/org_bitcoin_NativeSecp256k1.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/java/org_bitcoin_NativeSecp256k1.c
@@ -120,7 +120,7 @@ SECP256K1_API jint JNICALL Java_org_bitcoin_NativeSecp256k1_secp256k1_1ec_1secke
 
   (void)classObject;
 
-  return secp256k1_ec_seckey_verify(ctx, secKey);
+  return cosmos_secp256k1_ec_seckey_verify(ctx, secKey);
 }
 
 SECP256K1_API jobjectArray JNICALL Java_org_bitcoin_NativeSecp256k1_secp256k1_1ec_1pubkey_1create

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/java/org_bitcoin_NativeSecp256k1.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/java/org_bitcoin_NativeSecp256k1.c
@@ -141,7 +141,7 @@ SECP256K1_API jobjectArray JNICALL Java_org_bitcoin_NativeSecp256k1_secp256k1_1e
   size_t outputLen = 65;
 
   if( ret ) {
-    int ret2 = secp256k1_ec_pubkey_serialize(ctx,outputSer, &outputLen, &pubkey,SECP256K1_EC_UNCOMPRESSED );(void)ret2;
+    int ret2 = cosmos_secp256k1_ec_pubkey_serialize(ctx,outputSer, &outputLen, &pubkey,SECP256K1_EC_UNCOMPRESSED );(void)ret2;
   }
 
   intsarray[0] = outputLen;
@@ -257,7 +257,7 @@ SECP256K1_API jobjectArray JNICALL Java_org_bitcoin_NativeSecp256k1_secp256k1_1p
   }
 
   if( ret ) {
-    int ret2 = secp256k1_ec_pubkey_serialize(ctx,outputSer, &outputLen, &pubkey,SECP256K1_EC_UNCOMPRESSED );(void)ret2;
+    int ret2 = cosmos_secp256k1_ec_pubkey_serialize(ctx,outputSer, &outputLen, &pubkey,SECP256K1_EC_UNCOMPRESSED );(void)ret2;
   }
 
   intsarray[0] = outputLen;
@@ -301,7 +301,7 @@ SECP256K1_API jobjectArray JNICALL Java_org_bitcoin_NativeSecp256k1_secp256k1_1p
   }
 
   if( ret ) {
-    int ret2 = secp256k1_ec_pubkey_serialize(ctx,outputSer, &outputLen, &pubkey,SECP256K1_EC_UNCOMPRESSED );(void)ret2;
+    int ret2 = cosmos_secp256k1_ec_pubkey_serialize(ctx,outputSer, &outputLen, &pubkey,SECP256K1_EC_UNCOMPRESSED );(void)ret2;
   }
 
   intsarray[0] = outputLen;

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/java/org_bitcoin_NativeSecp256k1.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/java/org_bitcoin_NativeSecp256k1.c
@@ -89,7 +89,7 @@ SECP256K1_API jobjectArray JNICALL Java_org_bitcoin_NativeSecp256k1_secp256k1_1e
   size_t outputLen = 72;
 
   if( ret ) {
-    int ret2 = secp256k1_ecdsa_signature_serialize_der(ctx,outputSer, &outputLen, sig ); (void)ret2;
+    int ret2 = cosmos_secp256k1_ecdsa_signature_serialize_der(ctx,outputSer, &outputLen, sig ); (void)ret2;
   }
 
   intsarray[0] = outputLen;

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/java/org_bitcoin_NativeSecp256k1.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/java/org_bitcoin_NativeSecp256k1.c
@@ -58,7 +58,7 @@ SECP256K1_API jint JNICALL Java_org_bitcoin_NativeSecp256k1_secp256k1_1ecdsa_1ve
   int ret = secp256k1_ecdsa_signature_parse_der(ctx, &sig, sigdata, siglen);
 
   if( ret ) {
-    ret = secp256k1_ec_pubkey_parse(ctx, &pubkey, pubdata, publen);
+    ret = cosmos_secp256k1_ec_pubkey_parse(ctx, &pubkey, pubdata, publen);
 
     if( ret ) {
       ret = secp256k1_ecdsa_verify(ctx, &sig, data, &pubkey);
@@ -250,7 +250,7 @@ SECP256K1_API jobjectArray JNICALL Java_org_bitcoin_NativeSecp256k1_secp256k1_1p
   size_t outputLen = 65;
 
   secp256k1_pubkey pubkey;
-  int ret = secp256k1_ec_pubkey_parse(ctx, &pubkey, pkey, publen);
+  int ret = cosmos_secp256k1_ec_pubkey_parse(ctx, &pubkey, pkey, publen);
 
   if( ret ) {
     ret = secp256k1_ec_pubkey_tweak_add(ctx, &pubkey, tweak);
@@ -294,7 +294,7 @@ SECP256K1_API jobjectArray JNICALL Java_org_bitcoin_NativeSecp256k1_secp256k1_1p
   size_t outputLen = 65;
 
   secp256k1_pubkey pubkey;
-  int ret = secp256k1_ec_pubkey_parse(ctx, &pubkey, pkey, publen);
+  int ret = cosmos_secp256k1_ec_pubkey_parse(ctx, &pubkey, pkey, publen);
 
   if ( ret ) {
     ret = secp256k1_ec_pubkey_tweak_mul(ctx, &pubkey, tweak);
@@ -346,7 +346,7 @@ SECP256K1_API jobjectArray JNICALL Java_org_bitcoin_NativeSecp256k1_secp256k1_1e
   unsigned char nonce_res[32];
   size_t outputLen = 32;
 
-  int ret = secp256k1_ec_pubkey_parse(ctx, &pubkey, pubdata, publen);
+  int ret = cosmos_secp256k1_ec_pubkey_parse(ctx, &pubkey, pubdata, publen);
 
   if (ret) {
     ret = secp256k1_ecdh(

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/java/org_bitcoin_NativeSecp256k1.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/java/org_bitcoin_NativeSecp256k1.c
@@ -38,7 +38,7 @@ SECP256K1_API void JNICALL Java_org_bitcoin_NativeSecp256k1_secp256k1_1destroy_1
 {
   secp256k1_context *ctx = (secp256k1_context*)(uintptr_t)ctx_l;
 
-  secp256k1_context_destroy(ctx);
+  cosmos_secp256k1_context_destroy(ctx);
 
   (void)classObject;(void)env;
 }

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/java/org_bitcoin_NativeSecp256k1.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/java/org_bitcoin_NativeSecp256k1.c
@@ -61,7 +61,7 @@ SECP256K1_API jint JNICALL Java_org_bitcoin_NativeSecp256k1_secp256k1_1ecdsa_1ve
     ret = cosmos_secp256k1_ec_pubkey_parse(ctx, &pubkey, pubdata, publen);
 
     if( ret ) {
-      ret = secp256k1_ecdsa_verify(ctx, &sig, data, &pubkey);
+      ret = cosmos_secp256k1_ecdsa_verify(ctx, &sig, data, &pubkey);
     }
   }
 

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/java/org_bitcoin_NativeSecp256k1.h
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/java/org_bitcoin_NativeSecp256k1.h
@@ -18,7 +18,7 @@ SECP256K1_API jlong JNICALL Java_org_bitcoin_NativeSecp256k1_secp256k1_1ctx_1clo
 
 /*
  * Class:     org_bitcoin_NativeSecp256k1
- * Method:    secp256k1_context_randomize
+ * Method:    cosmos_secp256k1_context_randomize
  * Signature: (Ljava/nio/ByteBuffer;J)I
  */
 SECP256K1_API jint JNICALL Java_org_bitcoin_NativeSecp256k1_secp256k1_1context_1randomize

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/java/org_bitcoin_NativeSecp256k1.h
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/java/org_bitcoin_NativeSecp256k1.h
@@ -66,7 +66,7 @@ SECP256K1_API void JNICALL Java_org_bitcoin_NativeSecp256k1_secp256k1_1destroy_1
 
 /*
  * Class:     org_bitcoin_NativeSecp256k1
- * Method:    secp256k1_ecdsa_verify
+ * Method:    cosmos_secp256k1_ecdsa_verify
  * Signature: (Ljava/nio/ByteBuffer;JII)I
  */
 SECP256K1_API jint JNICALL Java_org_bitcoin_NativeSecp256k1_secp256k1_1ecdsa_1verify

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/java/org_bitcoin_NativeSecp256k1.h
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/java/org_bitcoin_NativeSecp256k1.h
@@ -74,7 +74,7 @@ SECP256K1_API jint JNICALL Java_org_bitcoin_NativeSecp256k1_secp256k1_1ecdsa_1ve
 
 /*
  * Class:     org_bitcoin_NativeSecp256k1
- * Method:    secp256k1_ecdsa_sign
+ * Method:    cosmos_secp256k1_ecdsa_sign
  * Signature: (Ljava/nio/ByteBuffer;J)[[B
  */
 SECP256K1_API jobjectArray JNICALL Java_org_bitcoin_NativeSecp256k1_secp256k1_1ecdsa_1sign

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/java/org_bitcoin_NativeSecp256k1.h
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/java/org_bitcoin_NativeSecp256k1.h
@@ -90,7 +90,7 @@ SECP256K1_API jint JNICALL Java_org_bitcoin_NativeSecp256k1_secp256k1_1ec_1secke
 
 /*
  * Class:     org_bitcoin_NativeSecp256k1
- * Method:    secp256k1_ec_pubkey_create
+ * Method:    cosmos_secp256k1_ec_pubkey_create
  * Signature: (Ljava/nio/ByteBuffer;J)[[B
  */
 SECP256K1_API jobjectArray JNICALL Java_org_bitcoin_NativeSecp256k1_secp256k1_1ec_1pubkey_1create

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/java/org_bitcoin_NativeSecp256k1.h
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/java/org_bitcoin_NativeSecp256k1.h
@@ -98,7 +98,7 @@ SECP256K1_API jobjectArray JNICALL Java_org_bitcoin_NativeSecp256k1_secp256k1_1e
 
 /*
  * Class:     org_bitcoin_NativeSecp256k1
- * Method:    secp256k1_ec_pubkey_parse
+ * Method:    cosmos_secp256k1_ec_pubkey_parse
  * Signature: (Ljava/nio/ByteBuffer;JI)[[B
  */
 SECP256K1_API jobjectArray JNICALL Java_org_bitcoin_NativeSecp256k1_secp256k1_1ec_1pubkey_1parse

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/java/org_bitcoin_NativeSecp256k1.h
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/java/org_bitcoin_NativeSecp256k1.h
@@ -82,7 +82,7 @@ SECP256K1_API jobjectArray JNICALL Java_org_bitcoin_NativeSecp256k1_secp256k1_1e
 
 /*
  * Class:     org_bitcoin_NativeSecp256k1
- * Method:    secp256k1_ec_seckey_verify
+ * Method:    cosmos_secp256k1_ec_seckey_verify
  * Signature: (Ljava/nio/ByteBuffer;J)I
  */
 SECP256K1_API jint JNICALL Java_org_bitcoin_NativeSecp256k1_secp256k1_1ec_1seckey_1verify

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/java/org_bitcoin_Secp256k1Context.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/java/org_bitcoin_Secp256k1Context.c
@@ -6,7 +6,7 @@
 SECP256K1_API jlong JNICALL Java_org_bitcoin_Secp256k1Context_secp256k1_1init_1context
   (JNIEnv* env, jclass classObject)
 {
-  secp256k1_context *ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY);
+  secp256k1_context *ctx = cosmos_secp256k1_context_create(SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY);
 
   (void)classObject;(void)env;
 

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/modules/ecdh/tests_impl.h
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/modules/ecdh/tests_impl.h
@@ -17,7 +17,7 @@ void test_ecdh_api(void) {
     s_one[31] = 1;
 
     secp256k1_context_set_error_callback(tctx, counting_illegal_callback_fn, &ecount);
-    secp256k1_context_set_illegal_callback(tctx, counting_illegal_callback_fn, &ecount);
+    cosmos_secp256k1_context_set_illegal_callback(tctx, counting_illegal_callback_fn, &ecount);
     CHECK(secp256k1_ec_pubkey_create(tctx, &point, s_one) == 1);
 
     /* Check all NULLs are detected */

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/modules/ecdh/tests_impl.h
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/modules/ecdh/tests_impl.h
@@ -16,7 +16,7 @@ void test_ecdh_api(void) {
     int32_t ecount = 0;
     s_one[31] = 1;
 
-    secp256k1_context_set_error_callback(tctx, counting_illegal_callback_fn, &ecount);
+    cosmos_secp256k1_context_set_error_callback(tctx, counting_illegal_callback_fn, &ecount);
     cosmos_secp256k1_context_set_illegal_callback(tctx, counting_illegal_callback_fn, &ecount);
     CHECK(cosmos_secp256k1_ec_pubkey_create(tctx, &point, s_one) == 1);
 

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/modules/ecdh/tests_impl.h
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/modules/ecdh/tests_impl.h
@@ -9,7 +9,7 @@
 
 void test_ecdh_api(void) {
     /* Setup context that just counts errors */
-    secp256k1_context *tctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN);
+    secp256k1_context *tctx = cosmos_secp256k1_context_create(SECP256K1_CONTEXT_SIGN);
     secp256k1_pubkey point;
     unsigned char res[32];
     unsigned char s_one[32] = { 0 };

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/modules/ecdh/tests_impl.h
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/modules/ecdh/tests_impl.h
@@ -60,7 +60,7 @@ void test_ecdh_generator_basepoint(void) {
         CHECK(secp256k1_ecdh(ctx, output_ecdh, &point[0], s_b32) == 1);
         /* compute "explicitly" */
         CHECK(secp256k1_ec_pubkey_create(ctx, &point[1], s_b32) == 1);
-        CHECK(secp256k1_ec_pubkey_serialize(ctx, point_ser, &point_ser_len, &point[1], SECP256K1_EC_COMPRESSED) == 1);
+        CHECK(cosmos_secp256k1_ec_pubkey_serialize(ctx, point_ser, &point_ser_len, &point[1], SECP256K1_EC_COMPRESSED) == 1);
         CHECK(point_ser_len == sizeof(point_ser));
         secp256k1_sha256_initialize(&sha);
         secp256k1_sha256_write(&sha, point_ser, point_ser_len);

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/modules/ecdh/tests_impl.h
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/modules/ecdh/tests_impl.h
@@ -33,7 +33,7 @@ void test_ecdh_api(void) {
     CHECK(ecount == 3);
 
     /* Cleanup */
-    secp256k1_context_destroy(tctx);
+    cosmos_secp256k1_context_destroy(tctx);
 }
 
 void test_ecdh_generator_basepoint(void) {

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/modules/ecdh/tests_impl.h
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/modules/ecdh/tests_impl.h
@@ -18,7 +18,7 @@ void test_ecdh_api(void) {
 
     secp256k1_context_set_error_callback(tctx, counting_illegal_callback_fn, &ecount);
     cosmos_secp256k1_context_set_illegal_callback(tctx, counting_illegal_callback_fn, &ecount);
-    CHECK(secp256k1_ec_pubkey_create(tctx, &point, s_one) == 1);
+    CHECK(cosmos_secp256k1_ec_pubkey_create(tctx, &point, s_one) == 1);
 
     /* Check all NULLs are detected */
     CHECK(secp256k1_ecdh(tctx, res, &point, s_one) == 1);
@@ -56,10 +56,10 @@ void test_ecdh_generator_basepoint(void) {
         secp256k1_scalar_get_b32(s_b32, &s);
 
         /* compute using ECDH function */
-        CHECK(secp256k1_ec_pubkey_create(ctx, &point[0], s_one) == 1);
+        CHECK(cosmos_secp256k1_ec_pubkey_create(ctx, &point[0], s_one) == 1);
         CHECK(secp256k1_ecdh(ctx, output_ecdh, &point[0], s_b32) == 1);
         /* compute "explicitly" */
-        CHECK(secp256k1_ec_pubkey_create(ctx, &point[1], s_b32) == 1);
+        CHECK(cosmos_secp256k1_ec_pubkey_create(ctx, &point[1], s_b32) == 1);
         CHECK(cosmos_secp256k1_ec_pubkey_serialize(ctx, point_ser, &point_ser_len, &point[1], SECP256K1_EC_COMPRESSED) == 1);
         CHECK(point_ser_len == sizeof(point_ser));
         secp256k1_sha256_initialize(&sha);
@@ -86,7 +86,7 @@ void test_bad_scalar(void) {
     /* Create random point */
     random_scalar_order(&rand);
     secp256k1_scalar_get_b32(s_rand, &rand);
-    CHECK(secp256k1_ec_pubkey_create(ctx, &point, s_rand) == 1);
+    CHECK(cosmos_secp256k1_ec_pubkey_create(ctx, &point, s_rand) == 1);
 
     /* Try to multiply it by bad values */
     CHECK(secp256k1_ecdh(ctx, output, &point, s_zero) == 0);

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/modules/recovery/main_impl.h
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/modules/recovery/main_impl.h
@@ -167,7 +167,7 @@ int secp256k1_ecdsa_sign_recoverable(const secp256k1_context* ctx, secp256k1_ecd
     return ret;
 }
 
-int secp256k1_ecdsa_recover(const secp256k1_context* ctx, secp256k1_pubkey *pubkey, const secp256k1_ecdsa_recoverable_signature *signature, const unsigned char *msg32) {
+int cosmos_secp256k1_ecdsa_recover(const secp256k1_context* ctx, secp256k1_pubkey *pubkey, const secp256k1_ecdsa_recoverable_signature *signature, const unsigned char *msg32) {
     secp256k1_ge q;
     secp256k1_scalar r, s;
     secp256k1_scalar m;

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/modules/recovery/main_impl.h
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/modules/recovery/main_impl.h
@@ -120,7 +120,7 @@ static int secp256k1_ecdsa_sig_recover(const secp256k1_ecmult_context *ctx, cons
     return !secp256k1_gej_is_infinity(&qj);
 }
 
-int secp256k1_ecdsa_sign_recoverable(const secp256k1_context* ctx, secp256k1_ecdsa_recoverable_signature *signature, const unsigned char *msg32, const unsigned char *seckey, secp256k1_nonce_function noncefp, const void* noncedata) {
+int cosmos_secp256k1_ecdsa_sign_recoverable(const secp256k1_context* ctx, secp256k1_ecdsa_recoverable_signature *signature, const unsigned char *msg32, const unsigned char *seckey, secp256k1_nonce_function noncefp, const void* noncedata) {
     secp256k1_scalar r, s;
     secp256k1_scalar sec, non, msg;
     int recid;

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/modules/recovery/main_impl.h
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/modules/recovery/main_impl.h
@@ -35,7 +35,7 @@ static void secp256k1_ecdsa_recoverable_signature_save(secp256k1_ecdsa_recoverab
     sig->data[64] = recid;
 }
 
-int secp256k1_ecdsa_recoverable_signature_parse_compact(const secp256k1_context* ctx, secp256k1_ecdsa_recoverable_signature* sig, const unsigned char *input64, int recid) {
+int cosmos_secp256k1_ecdsa_recoverable_signature_parse_compact(const secp256k1_context* ctx, secp256k1_ecdsa_recoverable_signature* sig, const unsigned char *input64, int recid) {
     secp256k1_scalar r, s;
     int ret = 1;
     int overflow = 0;

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/modules/recovery/main_impl.h
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/modules/recovery/main_impl.h
@@ -57,7 +57,7 @@ int cosmos_secp256k1_ecdsa_recoverable_signature_parse_compact(const secp256k1_c
     return ret;
 }
 
-int secp256k1_ecdsa_recoverable_signature_serialize_compact(const secp256k1_context* ctx, unsigned char *output64, int *recid, const secp256k1_ecdsa_recoverable_signature* sig) {
+int cosmos_secp256k1_ecdsa_recoverable_signature_serialize_compact(const secp256k1_context* ctx, unsigned char *output64, int *recid, const secp256k1_ecdsa_recoverable_signature* sig) {
     secp256k1_scalar r, s;
 
     (void)ctx;

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/modules/recovery/main_impl.h
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/modules/recovery/main_impl.h
@@ -71,7 +71,7 @@ int secp256k1_ecdsa_recoverable_signature_serialize_compact(const secp256k1_cont
     return 1;
 }
 
-int secp256k1_ecdsa_recoverable_signature_convert(const secp256k1_context* ctx, secp256k1_ecdsa_signature* sig, const secp256k1_ecdsa_recoverable_signature* sigin) {
+int cosmos_secp256k1_ecdsa_recoverable_signature_convert(const secp256k1_context* ctx, secp256k1_ecdsa_signature* sig, const secp256k1_ecdsa_recoverable_signature* sigin) {
     secp256k1_scalar r, s;
     int recid;
 

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/modules/recovery/main_impl.h
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/modules/recovery/main_impl.h
@@ -132,7 +132,7 @@ int cosmos_secp256k1_ecdsa_sign_recoverable(const secp256k1_context* ctx, secp25
     ARG_CHECK(signature != NULL);
     ARG_CHECK(seckey != NULL);
     if (noncefp == NULL) {
-        noncefp = secp256k1_nonce_function_default;
+        noncefp = cosmos_secp256k1_nonce_function_default;
     }
 
     secp256k1_scalar_set_b32(&sec, seckey, &overflow);

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/modules/recovery/tests_impl.h
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/modules/recovery/tests_impl.h
@@ -296,38 +296,38 @@ void test_ecdsa_recovery_edge_cases(void) {
         };
         CHECK(cosmos_secp256k1_ecdsa_recoverable_signature_parse_compact(ctx, &rsig, sigb64, recid) == 1);
         CHECK(cosmos_secp256k1_ecdsa_recover(ctx, &pubkeyb, &rsig, msg32) == 1);
-        CHECK(secp256k1_ecdsa_signature_parse_der(ctx, &sig, sigbder, sizeof(sigbder)) == 1);
+        CHECK(cosmos_secp256k1_ecdsa_signature_parse_der(ctx, &sig, sigbder, sizeof(sigbder)) == 1);
         CHECK(cosmos_secp256k1_ecdsa_verify(ctx, &sig, msg32, &pubkeyb) == 1);
         for (recid2 = 0; recid2 < 4; recid2++) {
             secp256k1_pubkey pubkey2b;
             CHECK(cosmos_secp256k1_ecdsa_recoverable_signature_parse_compact(ctx, &rsig, sigb64, recid2) == 1);
             CHECK(cosmos_secp256k1_ecdsa_recover(ctx, &pubkey2b, &rsig, msg32) == 1);
             /* Verifying with (order + r,4) should always fail. */
-            CHECK(secp256k1_ecdsa_signature_parse_der(ctx, &sig, sigbderlong, sizeof(sigbderlong)) == 1);
+            CHECK(cosmos_secp256k1_ecdsa_signature_parse_der(ctx, &sig, sigbderlong, sizeof(sigbderlong)) == 1);
             CHECK(cosmos_secp256k1_ecdsa_verify(ctx, &sig, msg32, &pubkeyb) == 0);
         }
         /* DER parsing tests. */
         /* Zero length r/s. */
-        CHECK(secp256k1_ecdsa_signature_parse_der(ctx, &sig, sigcder_zr, sizeof(sigcder_zr)) == 0);
-        CHECK(secp256k1_ecdsa_signature_parse_der(ctx, &sig, sigcder_zs, sizeof(sigcder_zs)) == 0);
+        CHECK(cosmos_secp256k1_ecdsa_signature_parse_der(ctx, &sig, sigcder_zr, sizeof(sigcder_zr)) == 0);
+        CHECK(cosmos_secp256k1_ecdsa_signature_parse_der(ctx, &sig, sigcder_zs, sizeof(sigcder_zs)) == 0);
         /* Leading zeros. */
-        CHECK(secp256k1_ecdsa_signature_parse_der(ctx, &sig, sigbderalt1, sizeof(sigbderalt1)) == 0);
-        CHECK(secp256k1_ecdsa_signature_parse_der(ctx, &sig, sigbderalt2, sizeof(sigbderalt2)) == 0);
-        CHECK(secp256k1_ecdsa_signature_parse_der(ctx, &sig, sigbderalt3, sizeof(sigbderalt3)) == 0);
-        CHECK(secp256k1_ecdsa_signature_parse_der(ctx, &sig, sigbderalt4, sizeof(sigbderalt4)) == 0);
+        CHECK(cosmos_secp256k1_ecdsa_signature_parse_der(ctx, &sig, sigbderalt1, sizeof(sigbderalt1)) == 0);
+        CHECK(cosmos_secp256k1_ecdsa_signature_parse_der(ctx, &sig, sigbderalt2, sizeof(sigbderalt2)) == 0);
+        CHECK(cosmos_secp256k1_ecdsa_signature_parse_der(ctx, &sig, sigbderalt3, sizeof(sigbderalt3)) == 0);
+        CHECK(cosmos_secp256k1_ecdsa_signature_parse_der(ctx, &sig, sigbderalt4, sizeof(sigbderalt4)) == 0);
         sigbderalt3[4] = 1;
-        CHECK(secp256k1_ecdsa_signature_parse_der(ctx, &sig, sigbderalt3, sizeof(sigbderalt3)) == 1);
+        CHECK(cosmos_secp256k1_ecdsa_signature_parse_der(ctx, &sig, sigbderalt3, sizeof(sigbderalt3)) == 1);
         CHECK(cosmos_secp256k1_ecdsa_verify(ctx, &sig, msg32, &pubkeyb) == 0);
         sigbderalt4[7] = 1;
-        CHECK(secp256k1_ecdsa_signature_parse_der(ctx, &sig, sigbderalt4, sizeof(sigbderalt4)) == 1);
+        CHECK(cosmos_secp256k1_ecdsa_signature_parse_der(ctx, &sig, sigbderalt4, sizeof(sigbderalt4)) == 1);
         CHECK(cosmos_secp256k1_ecdsa_verify(ctx, &sig, msg32, &pubkeyb) == 0);
         /* Damage signature. */
         sigbder[7]++;
-        CHECK(secp256k1_ecdsa_signature_parse_der(ctx, &sig, sigbder, sizeof(sigbder)) == 1);
+        CHECK(cosmos_secp256k1_ecdsa_signature_parse_der(ctx, &sig, sigbder, sizeof(sigbder)) == 1);
         CHECK(cosmos_secp256k1_ecdsa_verify(ctx, &sig, msg32, &pubkeyb) == 0);
         sigbder[7]--;
-        CHECK(secp256k1_ecdsa_signature_parse_der(ctx, &sig, sigbder, 6) == 0);
-        CHECK(secp256k1_ecdsa_signature_parse_der(ctx, &sig, sigbder, sizeof(sigbder) - 1) == 0);
+        CHECK(cosmos_secp256k1_ecdsa_signature_parse_der(ctx, &sig, sigbder, 6) == 0);
+        CHECK(cosmos_secp256k1_ecdsa_signature_parse_der(ctx, &sig, sigbder, sizeof(sigbder) - 1) == 0);
         for(i = 0; i < 8; i++) {
             int c;
             unsigned char orig = sigbder[i];
@@ -337,7 +337,7 @@ void test_ecdsa_recovery_edge_cases(void) {
                     continue;
                 }
                 sigbder[i] = c;
-                CHECK(secp256k1_ecdsa_signature_parse_der(ctx, &sig, sigbder, sizeof(sigbder)) == 0 || cosmos_secp256k1_ecdsa_verify(ctx, &sig, msg32, &pubkeyb) == 0);
+                CHECK(cosmos_secp256k1_ecdsa_signature_parse_der(ctx, &sig, sigbder, sizeof(sigbder)) == 0 || cosmos_secp256k1_ecdsa_verify(ctx, &sig, msg32, &pubkeyb) == 0);
             }
             sigbder[i] = orig;
         }
@@ -360,13 +360,13 @@ void test_ecdsa_recovery_edge_cases(void) {
         secp256k1_pubkey pubkeyc;
         CHECK(cosmos_secp256k1_ecdsa_recoverable_signature_parse_compact(ctx, &rsig, sigc64, 0) == 1);
         CHECK(cosmos_secp256k1_ecdsa_recover(ctx, &pubkeyc, &rsig, msg32) == 1);
-        CHECK(secp256k1_ecdsa_signature_parse_der(ctx, &sig, sigcder, sizeof(sigcder)) == 1);
+        CHECK(cosmos_secp256k1_ecdsa_signature_parse_der(ctx, &sig, sigcder, sizeof(sigcder)) == 1);
         CHECK(cosmos_secp256k1_ecdsa_verify(ctx, &sig, msg32, &pubkeyc) == 1);
         sigcder[4] = 0;
         sigc64[31] = 0;
         CHECK(cosmos_secp256k1_ecdsa_recoverable_signature_parse_compact(ctx, &rsig, sigc64, 0) == 1);
         CHECK(cosmos_secp256k1_ecdsa_recover(ctx, &pubkeyb, &rsig, msg32) == 0);
-        CHECK(secp256k1_ecdsa_signature_parse_der(ctx, &sig, sigcder, sizeof(sigcder)) == 1);
+        CHECK(cosmos_secp256k1_ecdsa_signature_parse_der(ctx, &sig, sigcder, sizeof(sigcder)) == 1);
         CHECK(cosmos_secp256k1_ecdsa_verify(ctx, &sig, msg32, &pubkeyc) == 0);
         sigcder[4] = 1;
         sigcder[7] = 0;
@@ -374,7 +374,7 @@ void test_ecdsa_recovery_edge_cases(void) {
         sigc64[63] = 0;
         CHECK(cosmos_secp256k1_ecdsa_recoverable_signature_parse_compact(ctx, &rsig, sigc64, 0) == 1);
         CHECK(cosmos_secp256k1_ecdsa_recover(ctx, &pubkeyb, &rsig, msg32) == 0);
-        CHECK(secp256k1_ecdsa_signature_parse_der(ctx, &sig, sigcder, sizeof(sigcder)) == 1);
+        CHECK(cosmos_secp256k1_ecdsa_signature_parse_der(ctx, &sig, sigcder, sizeof(sigcder)) == 1);
         CHECK(cosmos_secp256k1_ecdsa_verify(ctx, &sig, msg32, &pubkeyc) == 0);
     }
 }

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/modules/recovery/tests_impl.h
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/modules/recovery/tests_impl.h
@@ -64,28 +64,28 @@ void test_ecdsa_recovery_api(void) {
 
     /* Check bad contexts and NULLs for signing */
     ecount = 0;
-    CHECK(secp256k1_ecdsa_sign_recoverable(none, &recsig, message, privkey, NULL, NULL) == 0);
+    CHECK(cosmos_secp256k1_ecdsa_sign_recoverable(none, &recsig, message, privkey, NULL, NULL) == 0);
     CHECK(ecount == 1);
-    CHECK(secp256k1_ecdsa_sign_recoverable(sign, &recsig, message, privkey, NULL, NULL) == 1);
+    CHECK(cosmos_secp256k1_ecdsa_sign_recoverable(sign, &recsig, message, privkey, NULL, NULL) == 1);
     CHECK(ecount == 1);
-    CHECK(secp256k1_ecdsa_sign_recoverable(vrfy, &recsig, message, privkey, NULL, NULL) == 0);
+    CHECK(cosmos_secp256k1_ecdsa_sign_recoverable(vrfy, &recsig, message, privkey, NULL, NULL) == 0);
     CHECK(ecount == 2);
-    CHECK(secp256k1_ecdsa_sign_recoverable(both, &recsig, message, privkey, NULL, NULL) == 1);
+    CHECK(cosmos_secp256k1_ecdsa_sign_recoverable(both, &recsig, message, privkey, NULL, NULL) == 1);
     CHECK(ecount == 2);
-    CHECK(secp256k1_ecdsa_sign_recoverable(both, NULL, message, privkey, NULL, NULL) == 0);
+    CHECK(cosmos_secp256k1_ecdsa_sign_recoverable(both, NULL, message, privkey, NULL, NULL) == 0);
     CHECK(ecount == 3);
-    CHECK(secp256k1_ecdsa_sign_recoverable(both, &recsig, NULL, privkey, NULL, NULL) == 0);
+    CHECK(cosmos_secp256k1_ecdsa_sign_recoverable(both, &recsig, NULL, privkey, NULL, NULL) == 0);
     CHECK(ecount == 4);
-    CHECK(secp256k1_ecdsa_sign_recoverable(both, &recsig, message, NULL, NULL, NULL) == 0);
+    CHECK(cosmos_secp256k1_ecdsa_sign_recoverable(both, &recsig, message, NULL, NULL, NULL) == 0);
     CHECK(ecount == 5);
     /* This will fail or succeed randomly, and in either case will not ARG_CHECK failure */
-    secp256k1_ecdsa_sign_recoverable(both, &recsig, message, privkey, recovery_test_nonce_function, NULL);
+    cosmos_secp256k1_ecdsa_sign_recoverable(both, &recsig, message, privkey, recovery_test_nonce_function, NULL);
     CHECK(ecount == 5);
     /* These will all fail, but not in ARG_CHECK way */
-    CHECK(secp256k1_ecdsa_sign_recoverable(both, &recsig, message, zero_privkey, NULL, NULL) == 0);
-    CHECK(secp256k1_ecdsa_sign_recoverable(both, &recsig, message, over_privkey, NULL, NULL) == 0);
+    CHECK(cosmos_secp256k1_ecdsa_sign_recoverable(both, &recsig, message, zero_privkey, NULL, NULL) == 0);
+    CHECK(cosmos_secp256k1_ecdsa_sign_recoverable(both, &recsig, message, over_privkey, NULL, NULL) == 0);
     /* This one will succeed. */
-    CHECK(secp256k1_ecdsa_sign_recoverable(both, &recsig, message, privkey, NULL, NULL) == 1);
+    CHECK(cosmos_secp256k1_ecdsa_sign_recoverable(both, &recsig, message, privkey, NULL, NULL) == 1);
     CHECK(ecount == 5);
 
     /* Check signing with a goofy nonce function */
@@ -117,7 +117,7 @@ void test_ecdsa_recovery_api(void) {
     CHECK(cosmos_secp256k1_ecdsa_recoverable_signature_convert(both, &normal_sig, &recsig) == 1);
 
     /* Check NULLs for de/serialization */
-    CHECK(secp256k1_ecdsa_sign_recoverable(both, &recsig, message, privkey, NULL, NULL) == 1);
+    CHECK(cosmos_secp256k1_ecdsa_sign_recoverable(both, &recsig, message, privkey, NULL, NULL) == 1);
     ecount = 0;
     CHECK(secp256k1_ecdsa_recoverable_signature_serialize_compact(both, NULL, &recid, &recsig) == 0);
     CHECK(ecount == 1);
@@ -173,15 +173,15 @@ void test_ecdsa_recovery_end_to_end(void) {
 
     /* Serialize/parse compact and verify/recover. */
     extra[0] = 0;
-    CHECK(secp256k1_ecdsa_sign_recoverable(ctx, &rsignature[0], message, privkey, NULL, NULL) == 1);
+    CHECK(cosmos_secp256k1_ecdsa_sign_recoverable(ctx, &rsignature[0], message, privkey, NULL, NULL) == 1);
     CHECK(cosmos_secp256k1_ecdsa_sign(ctx, &signature[0], message, privkey, NULL, NULL) == 1);
-    CHECK(secp256k1_ecdsa_sign_recoverable(ctx, &rsignature[4], message, privkey, NULL, NULL) == 1);
-    CHECK(secp256k1_ecdsa_sign_recoverable(ctx, &rsignature[1], message, privkey, NULL, extra) == 1);
+    CHECK(cosmos_secp256k1_ecdsa_sign_recoverable(ctx, &rsignature[4], message, privkey, NULL, NULL) == 1);
+    CHECK(cosmos_secp256k1_ecdsa_sign_recoverable(ctx, &rsignature[1], message, privkey, NULL, extra) == 1);
     extra[31] = 1;
-    CHECK(secp256k1_ecdsa_sign_recoverable(ctx, &rsignature[2], message, privkey, NULL, extra) == 1);
+    CHECK(cosmos_secp256k1_ecdsa_sign_recoverable(ctx, &rsignature[2], message, privkey, NULL, extra) == 1);
     extra[31] = 0;
     extra[0] = 1;
-    CHECK(secp256k1_ecdsa_sign_recoverable(ctx, &rsignature[3], message, privkey, NULL, extra) == 1);
+    CHECK(cosmos_secp256k1_ecdsa_sign_recoverable(ctx, &rsignature[3], message, privkey, NULL, extra) == 1);
     CHECK(secp256k1_ecdsa_recoverable_signature_serialize_compact(ctx, sig, &recid, &rsignature[4]) == 1);
     CHECK(cosmos_secp256k1_ecdsa_recoverable_signature_convert(ctx, &signature[4], &rsignature[4]) == 1);
     CHECK(memcmp(&signature[4], &signature[0], 64) == 0);

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/modules/recovery/tests_impl.h
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/modules/recovery/tests_impl.h
@@ -53,10 +53,10 @@ void test_ecdsa_recovery_api(void) {
     secp256k1_context_set_error_callback(sign, counting_illegal_callback_fn, &ecount);
     secp256k1_context_set_error_callback(vrfy, counting_illegal_callback_fn, &ecount);
     secp256k1_context_set_error_callback(both, counting_illegal_callback_fn, &ecount);
-    secp256k1_context_set_illegal_callback(none, counting_illegal_callback_fn, &ecount);
-    secp256k1_context_set_illegal_callback(sign, counting_illegal_callback_fn, &ecount);
-    secp256k1_context_set_illegal_callback(vrfy, counting_illegal_callback_fn, &ecount);
-    secp256k1_context_set_illegal_callback(both, counting_illegal_callback_fn, &ecount);
+    cosmos_secp256k1_context_set_illegal_callback(none, counting_illegal_callback_fn, &ecount);
+    cosmos_secp256k1_context_set_illegal_callback(sign, counting_illegal_callback_fn, &ecount);
+    cosmos_secp256k1_context_set_illegal_callback(vrfy, counting_illegal_callback_fn, &ecount);
+    cosmos_secp256k1_context_set_illegal_callback(both, counting_illegal_callback_fn, &ecount);
 
     /* Construct and verify corresponding public key. */
     CHECK(secp256k1_ec_seckey_verify(ctx, privkey) == 1);

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/modules/recovery/tests_impl.h
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/modules/recovery/tests_impl.h
@@ -49,10 +49,10 @@ void test_ecdsa_recovery_api(void) {
                                        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
                                        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff };
 
-    secp256k1_context_set_error_callback(none, counting_illegal_callback_fn, &ecount);
-    secp256k1_context_set_error_callback(sign, counting_illegal_callback_fn, &ecount);
-    secp256k1_context_set_error_callback(vrfy, counting_illegal_callback_fn, &ecount);
-    secp256k1_context_set_error_callback(both, counting_illegal_callback_fn, &ecount);
+    cosmos_secp256k1_context_set_error_callback(none, counting_illegal_callback_fn, &ecount);
+    cosmos_secp256k1_context_set_error_callback(sign, counting_illegal_callback_fn, &ecount);
+    cosmos_secp256k1_context_set_error_callback(vrfy, counting_illegal_callback_fn, &ecount);
+    cosmos_secp256k1_context_set_error_callback(both, counting_illegal_callback_fn, &ecount);
     cosmos_secp256k1_context_set_illegal_callback(none, counting_illegal_callback_fn, &ecount);
     cosmos_secp256k1_context_set_illegal_callback(sign, counting_illegal_callback_fn, &ecount);
     cosmos_secp256k1_context_set_illegal_callback(vrfy, counting_illegal_callback_fn, &ecount);

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/modules/recovery/tests_impl.h
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/modules/recovery/tests_impl.h
@@ -108,7 +108,7 @@ void test_ecdsa_recovery_api(void) {
     CHECK(ecount == 5);
 
     /* Check NULLs for conversion */
-    CHECK(secp256k1_ecdsa_sign(both, &normal_sig, message, privkey, NULL, NULL) == 1);
+    CHECK(cosmos_secp256k1_ecdsa_sign(both, &normal_sig, message, privkey, NULL, NULL) == 1);
     ecount = 0;
     CHECK(cosmos_secp256k1_ecdsa_recoverable_signature_convert(both, NULL, &recsig) == 0);
     CHECK(ecount == 1);
@@ -174,7 +174,7 @@ void test_ecdsa_recovery_end_to_end(void) {
     /* Serialize/parse compact and verify/recover. */
     extra[0] = 0;
     CHECK(secp256k1_ecdsa_sign_recoverable(ctx, &rsignature[0], message, privkey, NULL, NULL) == 1);
-    CHECK(secp256k1_ecdsa_sign(ctx, &signature[0], message, privkey, NULL, NULL) == 1);
+    CHECK(cosmos_secp256k1_ecdsa_sign(ctx, &signature[0], message, privkey, NULL, NULL) == 1);
     CHECK(secp256k1_ecdsa_sign_recoverable(ctx, &rsignature[4], message, privkey, NULL, NULL) == 1);
     CHECK(secp256k1_ecdsa_sign_recoverable(ctx, &rsignature[1], message, privkey, NULL, extra) == 1);
     extra[31] = 1;

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/modules/recovery/tests_impl.h
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/modules/recovery/tests_impl.h
@@ -119,13 +119,13 @@ void test_ecdsa_recovery_api(void) {
     /* Check NULLs for de/serialization */
     CHECK(cosmos_secp256k1_ecdsa_sign_recoverable(both, &recsig, message, privkey, NULL, NULL) == 1);
     ecount = 0;
-    CHECK(secp256k1_ecdsa_recoverable_signature_serialize_compact(both, NULL, &recid, &recsig) == 0);
+    CHECK(cosmos_secp256k1_ecdsa_recoverable_signature_serialize_compact(both, NULL, &recid, &recsig) == 0);
     CHECK(ecount == 1);
-    CHECK(secp256k1_ecdsa_recoverable_signature_serialize_compact(both, sig, NULL, &recsig) == 0);
+    CHECK(cosmos_secp256k1_ecdsa_recoverable_signature_serialize_compact(both, sig, NULL, &recsig) == 0);
     CHECK(ecount == 2);
-    CHECK(secp256k1_ecdsa_recoverable_signature_serialize_compact(both, sig, &recid, NULL) == 0);
+    CHECK(cosmos_secp256k1_ecdsa_recoverable_signature_serialize_compact(both, sig, &recid, NULL) == 0);
     CHECK(ecount == 3);
-    CHECK(secp256k1_ecdsa_recoverable_signature_serialize_compact(both, sig, &recid, &recsig) == 1);
+    CHECK(cosmos_secp256k1_ecdsa_recoverable_signature_serialize_compact(both, sig, &recid, &recsig) == 1);
 
     CHECK(cosmos_secp256k1_ecdsa_recoverable_signature_parse_compact(both, NULL, sig, recid) == 0);
     CHECK(ecount == 4);
@@ -182,7 +182,7 @@ void test_ecdsa_recovery_end_to_end(void) {
     extra[31] = 0;
     extra[0] = 1;
     CHECK(cosmos_secp256k1_ecdsa_sign_recoverable(ctx, &rsignature[3], message, privkey, NULL, extra) == 1);
-    CHECK(secp256k1_ecdsa_recoverable_signature_serialize_compact(ctx, sig, &recid, &rsignature[4]) == 1);
+    CHECK(cosmos_secp256k1_ecdsa_recoverable_signature_serialize_compact(ctx, sig, &recid, &rsignature[4]) == 1);
     CHECK(cosmos_secp256k1_ecdsa_recoverable_signature_convert(ctx, &signature[4], &rsignature[4]) == 1);
     CHECK(memcmp(&signature[4], &signature[0], 64) == 0);
     CHECK(cosmos_secp256k1_ecdsa_verify(ctx, &signature[4], message, &pubkey) == 1);
@@ -195,7 +195,7 @@ void test_ecdsa_recovery_end_to_end(void) {
     CHECK(cosmos_secp256k1_ecdsa_recover(ctx, &recpubkey, &rsignature[4], message) == 1);
     CHECK(memcmp(&pubkey, &recpubkey, sizeof(pubkey)) == 0);
     /* Serialize/destroy/parse signature and verify again. */
-    CHECK(secp256k1_ecdsa_recoverable_signature_serialize_compact(ctx, sig, &recid, &rsignature[4]) == 1);
+    CHECK(cosmos_secp256k1_ecdsa_recoverable_signature_serialize_compact(ctx, sig, &recid, &rsignature[4]) == 1);
     sig[secp256k1_rand_bits(6)] += 1 + secp256k1_rand_int(255);
     CHECK(cosmos_secp256k1_ecdsa_recoverable_signature_parse_compact(ctx, &rsignature[4], sig, recid) == 1);
     CHECK(cosmos_secp256k1_ecdsa_recoverable_signature_convert(ctx, &signature[4], &rsignature[4]) == 1);

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/modules/recovery/tests_impl.h
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/modules/recovery/tests_impl.h
@@ -30,10 +30,10 @@ static int recovery_test_nonce_function(unsigned char *nonce32, const unsigned c
 
 void test_ecdsa_recovery_api(void) {
     /* Setup contexts that just count errors */
-    secp256k1_context *none = secp256k1_context_create(SECP256K1_CONTEXT_NONE);
-    secp256k1_context *sign = secp256k1_context_create(SECP256K1_CONTEXT_SIGN);
-    secp256k1_context *vrfy = secp256k1_context_create(SECP256K1_CONTEXT_VERIFY);
-    secp256k1_context *both = secp256k1_context_create(SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY);
+    secp256k1_context *none = cosmos_secp256k1_context_create(SECP256K1_CONTEXT_NONE);
+    secp256k1_context *sign = cosmos_secp256k1_context_create(SECP256K1_CONTEXT_SIGN);
+    secp256k1_context *vrfy = cosmos_secp256k1_context_create(SECP256K1_CONTEXT_VERIFY);
+    secp256k1_context *both = cosmos_secp256k1_context_create(SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY);
     secp256k1_pubkey pubkey;
     secp256k1_pubkey recpubkey;
     secp256k1_ecdsa_signature normal_sig;

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/modules/recovery/tests_impl.h
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/modules/recovery/tests_impl.h
@@ -141,10 +141,10 @@ void test_ecdsa_recovery_api(void) {
     CHECK(ecount == 7);
 
     /* cleanup */
-    secp256k1_context_destroy(none);
-    secp256k1_context_destroy(sign);
-    secp256k1_context_destroy(vrfy);
-    secp256k1_context_destroy(both);
+    cosmos_secp256k1_context_destroy(none);
+    cosmos_secp256k1_context_destroy(sign);
+    cosmos_secp256k1_context_destroy(vrfy);
+    cosmos_secp256k1_context_destroy(both);
 }
 
 void test_ecdsa_recovery_end_to_end(void) {

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/modules/recovery/tests_impl.h
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/modules/recovery/tests_impl.h
@@ -127,17 +127,17 @@ void test_ecdsa_recovery_api(void) {
     CHECK(ecount == 3);
     CHECK(secp256k1_ecdsa_recoverable_signature_serialize_compact(both, sig, &recid, &recsig) == 1);
 
-    CHECK(secp256k1_ecdsa_recoverable_signature_parse_compact(both, NULL, sig, recid) == 0);
+    CHECK(cosmos_secp256k1_ecdsa_recoverable_signature_parse_compact(both, NULL, sig, recid) == 0);
     CHECK(ecount == 4);
-    CHECK(secp256k1_ecdsa_recoverable_signature_parse_compact(both, &recsig, NULL, recid) == 0);
+    CHECK(cosmos_secp256k1_ecdsa_recoverable_signature_parse_compact(both, &recsig, NULL, recid) == 0);
     CHECK(ecount == 5);
-    CHECK(secp256k1_ecdsa_recoverable_signature_parse_compact(both, &recsig, sig, -1) == 0);
+    CHECK(cosmos_secp256k1_ecdsa_recoverable_signature_parse_compact(both, &recsig, sig, -1) == 0);
     CHECK(ecount == 6);
-    CHECK(secp256k1_ecdsa_recoverable_signature_parse_compact(both, &recsig, sig, 5) == 0);
+    CHECK(cosmos_secp256k1_ecdsa_recoverable_signature_parse_compact(both, &recsig, sig, 5) == 0);
     CHECK(ecount == 7);
     /* overflow in signature will fail but not affect ecount */
     memcpy(sig, over_privkey, 32);
-    CHECK(secp256k1_ecdsa_recoverable_signature_parse_compact(both, &recsig, sig, recid) == 0);
+    CHECK(cosmos_secp256k1_ecdsa_recoverable_signature_parse_compact(both, &recsig, sig, recid) == 0);
     CHECK(ecount == 7);
 
     /* cleanup */
@@ -187,17 +187,17 @@ void test_ecdsa_recovery_end_to_end(void) {
     CHECK(memcmp(&signature[4], &signature[0], 64) == 0);
     CHECK(cosmos_secp256k1_ecdsa_verify(ctx, &signature[4], message, &pubkey) == 1);
     memset(&rsignature[4], 0, sizeof(rsignature[4]));
-    CHECK(secp256k1_ecdsa_recoverable_signature_parse_compact(ctx, &rsignature[4], sig, recid) == 1);
+    CHECK(cosmos_secp256k1_ecdsa_recoverable_signature_parse_compact(ctx, &rsignature[4], sig, recid) == 1);
     CHECK(cosmos_secp256k1_ecdsa_recoverable_signature_convert(ctx, &signature[4], &rsignature[4]) == 1);
     CHECK(cosmos_secp256k1_ecdsa_verify(ctx, &signature[4], message, &pubkey) == 1);
     /* Parse compact (with recovery id) and recover. */
-    CHECK(secp256k1_ecdsa_recoverable_signature_parse_compact(ctx, &rsignature[4], sig, recid) == 1);
+    CHECK(cosmos_secp256k1_ecdsa_recoverable_signature_parse_compact(ctx, &rsignature[4], sig, recid) == 1);
     CHECK(cosmos_secp256k1_ecdsa_recover(ctx, &recpubkey, &rsignature[4], message) == 1);
     CHECK(memcmp(&pubkey, &recpubkey, sizeof(pubkey)) == 0);
     /* Serialize/destroy/parse signature and verify again. */
     CHECK(secp256k1_ecdsa_recoverable_signature_serialize_compact(ctx, sig, &recid, &rsignature[4]) == 1);
     sig[secp256k1_rand_bits(6)] += 1 + secp256k1_rand_int(255);
-    CHECK(secp256k1_ecdsa_recoverable_signature_parse_compact(ctx, &rsignature[4], sig, recid) == 1);
+    CHECK(cosmos_secp256k1_ecdsa_recoverable_signature_parse_compact(ctx, &rsignature[4], sig, recid) == 1);
     CHECK(cosmos_secp256k1_ecdsa_recoverable_signature_convert(ctx, &signature[4], &rsignature[4]) == 1);
     CHECK(cosmos_secp256k1_ecdsa_verify(ctx, &signature[4], message, &pubkey) == 0);
     /* Recover again */
@@ -242,13 +242,13 @@ void test_ecdsa_recovery_edge_cases(void) {
     secp256k1_ecdsa_signature sig;
     int recid;
 
-    CHECK(secp256k1_ecdsa_recoverable_signature_parse_compact(ctx, &rsig, sig64, 0));
+    CHECK(cosmos_secp256k1_ecdsa_recoverable_signature_parse_compact(ctx, &rsig, sig64, 0));
     CHECK(!cosmos_secp256k1_ecdsa_recover(ctx, &pubkey, &rsig, msg32));
-    CHECK(secp256k1_ecdsa_recoverable_signature_parse_compact(ctx, &rsig, sig64, 1));
+    CHECK(cosmos_secp256k1_ecdsa_recoverable_signature_parse_compact(ctx, &rsig, sig64, 1));
     CHECK(cosmos_secp256k1_ecdsa_recover(ctx, &pubkey, &rsig, msg32));
-    CHECK(secp256k1_ecdsa_recoverable_signature_parse_compact(ctx, &rsig, sig64, 2));
+    CHECK(cosmos_secp256k1_ecdsa_recoverable_signature_parse_compact(ctx, &rsig, sig64, 2));
     CHECK(!cosmos_secp256k1_ecdsa_recover(ctx, &pubkey, &rsig, msg32));
-    CHECK(secp256k1_ecdsa_recoverable_signature_parse_compact(ctx, &rsig, sig64, 3));
+    CHECK(cosmos_secp256k1_ecdsa_recoverable_signature_parse_compact(ctx, &rsig, sig64, 3));
     CHECK(!cosmos_secp256k1_ecdsa_recover(ctx, &pubkey, &rsig, msg32));
 
     for (recid = 0; recid < 4; recid++) {
@@ -294,13 +294,13 @@ void test_ecdsa_recovery_edge_cases(void) {
             0xE6, 0xAF, 0x48, 0xA0, 0x3B, 0xBF, 0xD2, 0x5E,
             0x8C, 0xD0, 0x36, 0x41, 0x45, 0x02, 0x01, 0x04
         };
-        CHECK(secp256k1_ecdsa_recoverable_signature_parse_compact(ctx, &rsig, sigb64, recid) == 1);
+        CHECK(cosmos_secp256k1_ecdsa_recoverable_signature_parse_compact(ctx, &rsig, sigb64, recid) == 1);
         CHECK(cosmos_secp256k1_ecdsa_recover(ctx, &pubkeyb, &rsig, msg32) == 1);
         CHECK(secp256k1_ecdsa_signature_parse_der(ctx, &sig, sigbder, sizeof(sigbder)) == 1);
         CHECK(cosmos_secp256k1_ecdsa_verify(ctx, &sig, msg32, &pubkeyb) == 1);
         for (recid2 = 0; recid2 < 4; recid2++) {
             secp256k1_pubkey pubkey2b;
-            CHECK(secp256k1_ecdsa_recoverable_signature_parse_compact(ctx, &rsig, sigb64, recid2) == 1);
+            CHECK(cosmos_secp256k1_ecdsa_recoverable_signature_parse_compact(ctx, &rsig, sigb64, recid2) == 1);
             CHECK(cosmos_secp256k1_ecdsa_recover(ctx, &pubkey2b, &rsig, msg32) == 1);
             /* Verifying with (order + r,4) should always fail. */
             CHECK(secp256k1_ecdsa_signature_parse_der(ctx, &sig, sigbderlong, sizeof(sigbderlong)) == 1);
@@ -358,13 +358,13 @@ void test_ecdsa_recovery_edge_cases(void) {
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
         };
         secp256k1_pubkey pubkeyc;
-        CHECK(secp256k1_ecdsa_recoverable_signature_parse_compact(ctx, &rsig, sigc64, 0) == 1);
+        CHECK(cosmos_secp256k1_ecdsa_recoverable_signature_parse_compact(ctx, &rsig, sigc64, 0) == 1);
         CHECK(cosmos_secp256k1_ecdsa_recover(ctx, &pubkeyc, &rsig, msg32) == 1);
         CHECK(secp256k1_ecdsa_signature_parse_der(ctx, &sig, sigcder, sizeof(sigcder)) == 1);
         CHECK(cosmos_secp256k1_ecdsa_verify(ctx, &sig, msg32, &pubkeyc) == 1);
         sigcder[4] = 0;
         sigc64[31] = 0;
-        CHECK(secp256k1_ecdsa_recoverable_signature_parse_compact(ctx, &rsig, sigc64, 0) == 1);
+        CHECK(cosmos_secp256k1_ecdsa_recoverable_signature_parse_compact(ctx, &rsig, sigc64, 0) == 1);
         CHECK(cosmos_secp256k1_ecdsa_recover(ctx, &pubkeyb, &rsig, msg32) == 0);
         CHECK(secp256k1_ecdsa_signature_parse_der(ctx, &sig, sigcder, sizeof(sigcder)) == 1);
         CHECK(cosmos_secp256k1_ecdsa_verify(ctx, &sig, msg32, &pubkeyc) == 0);
@@ -372,7 +372,7 @@ void test_ecdsa_recovery_edge_cases(void) {
         sigcder[7] = 0;
         sigc64[31] = 1;
         sigc64[63] = 0;
-        CHECK(secp256k1_ecdsa_recoverable_signature_parse_compact(ctx, &rsig, sigc64, 0) == 1);
+        CHECK(cosmos_secp256k1_ecdsa_recoverable_signature_parse_compact(ctx, &rsig, sigc64, 0) == 1);
         CHECK(cosmos_secp256k1_ecdsa_recover(ctx, &pubkeyb, &rsig, msg32) == 0);
         CHECK(secp256k1_ecdsa_signature_parse_der(ctx, &sig, sigcder, sizeof(sigcder)) == 1);
         CHECK(cosmos_secp256k1_ecdsa_verify(ctx, &sig, msg32, &pubkeyc) == 0);

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/modules/recovery/tests_impl.h
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/modules/recovery/tests_impl.h
@@ -185,11 +185,11 @@ void test_ecdsa_recovery_end_to_end(void) {
     CHECK(secp256k1_ecdsa_recoverable_signature_serialize_compact(ctx, sig, &recid, &rsignature[4]) == 1);
     CHECK(cosmos_secp256k1_ecdsa_recoverable_signature_convert(ctx, &signature[4], &rsignature[4]) == 1);
     CHECK(memcmp(&signature[4], &signature[0], 64) == 0);
-    CHECK(secp256k1_ecdsa_verify(ctx, &signature[4], message, &pubkey) == 1);
+    CHECK(cosmos_secp256k1_ecdsa_verify(ctx, &signature[4], message, &pubkey) == 1);
     memset(&rsignature[4], 0, sizeof(rsignature[4]));
     CHECK(secp256k1_ecdsa_recoverable_signature_parse_compact(ctx, &rsignature[4], sig, recid) == 1);
     CHECK(cosmos_secp256k1_ecdsa_recoverable_signature_convert(ctx, &signature[4], &rsignature[4]) == 1);
-    CHECK(secp256k1_ecdsa_verify(ctx, &signature[4], message, &pubkey) == 1);
+    CHECK(cosmos_secp256k1_ecdsa_verify(ctx, &signature[4], message, &pubkey) == 1);
     /* Parse compact (with recovery id) and recover. */
     CHECK(secp256k1_ecdsa_recoverable_signature_parse_compact(ctx, &rsignature[4], sig, recid) == 1);
     CHECK(cosmos_secp256k1_ecdsa_recover(ctx, &recpubkey, &rsignature[4], message) == 1);
@@ -199,7 +199,7 @@ void test_ecdsa_recovery_end_to_end(void) {
     sig[secp256k1_rand_bits(6)] += 1 + secp256k1_rand_int(255);
     CHECK(secp256k1_ecdsa_recoverable_signature_parse_compact(ctx, &rsignature[4], sig, recid) == 1);
     CHECK(cosmos_secp256k1_ecdsa_recoverable_signature_convert(ctx, &signature[4], &rsignature[4]) == 1);
-    CHECK(secp256k1_ecdsa_verify(ctx, &signature[4], message, &pubkey) == 0);
+    CHECK(cosmos_secp256k1_ecdsa_verify(ctx, &signature[4], message, &pubkey) == 0);
     /* Recover again */
     CHECK(cosmos_secp256k1_ecdsa_recover(ctx, &recpubkey, &rsignature[4], message) == 0 ||
           memcmp(&pubkey, &recpubkey, sizeof(pubkey)) != 0);
@@ -297,14 +297,14 @@ void test_ecdsa_recovery_edge_cases(void) {
         CHECK(secp256k1_ecdsa_recoverable_signature_parse_compact(ctx, &rsig, sigb64, recid) == 1);
         CHECK(cosmos_secp256k1_ecdsa_recover(ctx, &pubkeyb, &rsig, msg32) == 1);
         CHECK(secp256k1_ecdsa_signature_parse_der(ctx, &sig, sigbder, sizeof(sigbder)) == 1);
-        CHECK(secp256k1_ecdsa_verify(ctx, &sig, msg32, &pubkeyb) == 1);
+        CHECK(cosmos_secp256k1_ecdsa_verify(ctx, &sig, msg32, &pubkeyb) == 1);
         for (recid2 = 0; recid2 < 4; recid2++) {
             secp256k1_pubkey pubkey2b;
             CHECK(secp256k1_ecdsa_recoverable_signature_parse_compact(ctx, &rsig, sigb64, recid2) == 1);
             CHECK(cosmos_secp256k1_ecdsa_recover(ctx, &pubkey2b, &rsig, msg32) == 1);
             /* Verifying with (order + r,4) should always fail. */
             CHECK(secp256k1_ecdsa_signature_parse_der(ctx, &sig, sigbderlong, sizeof(sigbderlong)) == 1);
-            CHECK(secp256k1_ecdsa_verify(ctx, &sig, msg32, &pubkeyb) == 0);
+            CHECK(cosmos_secp256k1_ecdsa_verify(ctx, &sig, msg32, &pubkeyb) == 0);
         }
         /* DER parsing tests. */
         /* Zero length r/s. */
@@ -317,14 +317,14 @@ void test_ecdsa_recovery_edge_cases(void) {
         CHECK(secp256k1_ecdsa_signature_parse_der(ctx, &sig, sigbderalt4, sizeof(sigbderalt4)) == 0);
         sigbderalt3[4] = 1;
         CHECK(secp256k1_ecdsa_signature_parse_der(ctx, &sig, sigbderalt3, sizeof(sigbderalt3)) == 1);
-        CHECK(secp256k1_ecdsa_verify(ctx, &sig, msg32, &pubkeyb) == 0);
+        CHECK(cosmos_secp256k1_ecdsa_verify(ctx, &sig, msg32, &pubkeyb) == 0);
         sigbderalt4[7] = 1;
         CHECK(secp256k1_ecdsa_signature_parse_der(ctx, &sig, sigbderalt4, sizeof(sigbderalt4)) == 1);
-        CHECK(secp256k1_ecdsa_verify(ctx, &sig, msg32, &pubkeyb) == 0);
+        CHECK(cosmos_secp256k1_ecdsa_verify(ctx, &sig, msg32, &pubkeyb) == 0);
         /* Damage signature. */
         sigbder[7]++;
         CHECK(secp256k1_ecdsa_signature_parse_der(ctx, &sig, sigbder, sizeof(sigbder)) == 1);
-        CHECK(secp256k1_ecdsa_verify(ctx, &sig, msg32, &pubkeyb) == 0);
+        CHECK(cosmos_secp256k1_ecdsa_verify(ctx, &sig, msg32, &pubkeyb) == 0);
         sigbder[7]--;
         CHECK(secp256k1_ecdsa_signature_parse_der(ctx, &sig, sigbder, 6) == 0);
         CHECK(secp256k1_ecdsa_signature_parse_der(ctx, &sig, sigbder, sizeof(sigbder) - 1) == 0);
@@ -337,7 +337,7 @@ void test_ecdsa_recovery_edge_cases(void) {
                     continue;
                 }
                 sigbder[i] = c;
-                CHECK(secp256k1_ecdsa_signature_parse_der(ctx, &sig, sigbder, sizeof(sigbder)) == 0 || secp256k1_ecdsa_verify(ctx, &sig, msg32, &pubkeyb) == 0);
+                CHECK(secp256k1_ecdsa_signature_parse_der(ctx, &sig, sigbder, sizeof(sigbder)) == 0 || cosmos_secp256k1_ecdsa_verify(ctx, &sig, msg32, &pubkeyb) == 0);
             }
             sigbder[i] = orig;
         }
@@ -361,13 +361,13 @@ void test_ecdsa_recovery_edge_cases(void) {
         CHECK(secp256k1_ecdsa_recoverable_signature_parse_compact(ctx, &rsig, sigc64, 0) == 1);
         CHECK(cosmos_secp256k1_ecdsa_recover(ctx, &pubkeyc, &rsig, msg32) == 1);
         CHECK(secp256k1_ecdsa_signature_parse_der(ctx, &sig, sigcder, sizeof(sigcder)) == 1);
-        CHECK(secp256k1_ecdsa_verify(ctx, &sig, msg32, &pubkeyc) == 1);
+        CHECK(cosmos_secp256k1_ecdsa_verify(ctx, &sig, msg32, &pubkeyc) == 1);
         sigcder[4] = 0;
         sigc64[31] = 0;
         CHECK(secp256k1_ecdsa_recoverable_signature_parse_compact(ctx, &rsig, sigc64, 0) == 1);
         CHECK(cosmos_secp256k1_ecdsa_recover(ctx, &pubkeyb, &rsig, msg32) == 0);
         CHECK(secp256k1_ecdsa_signature_parse_der(ctx, &sig, sigcder, sizeof(sigcder)) == 1);
-        CHECK(secp256k1_ecdsa_verify(ctx, &sig, msg32, &pubkeyc) == 0);
+        CHECK(cosmos_secp256k1_ecdsa_verify(ctx, &sig, msg32, &pubkeyc) == 0);
         sigcder[4] = 1;
         sigcder[7] = 0;
         sigc64[31] = 1;
@@ -375,7 +375,7 @@ void test_ecdsa_recovery_edge_cases(void) {
         CHECK(secp256k1_ecdsa_recoverable_signature_parse_compact(ctx, &rsig, sigc64, 0) == 1);
         CHECK(cosmos_secp256k1_ecdsa_recover(ctx, &pubkeyb, &rsig, msg32) == 0);
         CHECK(secp256k1_ecdsa_signature_parse_der(ctx, &sig, sigcder, sizeof(sigcder)) == 1);
-        CHECK(secp256k1_ecdsa_verify(ctx, &sig, msg32, &pubkeyc) == 0);
+        CHECK(cosmos_secp256k1_ecdsa_verify(ctx, &sig, msg32, &pubkeyc) == 0);
     }
 }
 

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/modules/recovery/tests_impl.h
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/modules/recovery/tests_impl.h
@@ -92,19 +92,19 @@ void test_ecdsa_recovery_api(void) {
 
     /* Check bad contexts and NULLs for recovery */
     ecount = 0;
-    CHECK(secp256k1_ecdsa_recover(none, &recpubkey, &recsig, message) == 0);
+    CHECK(cosmos_secp256k1_ecdsa_recover(none, &recpubkey, &recsig, message) == 0);
     CHECK(ecount == 1);
-    CHECK(secp256k1_ecdsa_recover(sign, &recpubkey, &recsig, message) == 0);
+    CHECK(cosmos_secp256k1_ecdsa_recover(sign, &recpubkey, &recsig, message) == 0);
     CHECK(ecount == 2);
-    CHECK(secp256k1_ecdsa_recover(vrfy, &recpubkey, &recsig, message) == 1);
+    CHECK(cosmos_secp256k1_ecdsa_recover(vrfy, &recpubkey, &recsig, message) == 1);
     CHECK(ecount == 2);
-    CHECK(secp256k1_ecdsa_recover(both, &recpubkey, &recsig, message) == 1);
+    CHECK(cosmos_secp256k1_ecdsa_recover(both, &recpubkey, &recsig, message) == 1);
     CHECK(ecount == 2);
-    CHECK(secp256k1_ecdsa_recover(both, NULL, &recsig, message) == 0);
+    CHECK(cosmos_secp256k1_ecdsa_recover(both, NULL, &recsig, message) == 0);
     CHECK(ecount == 3);
-    CHECK(secp256k1_ecdsa_recover(both, &recpubkey, NULL, message) == 0);
+    CHECK(cosmos_secp256k1_ecdsa_recover(both, &recpubkey, NULL, message) == 0);
     CHECK(ecount == 4);
-    CHECK(secp256k1_ecdsa_recover(both, &recpubkey, &recsig, NULL) == 0);
+    CHECK(cosmos_secp256k1_ecdsa_recover(both, &recpubkey, &recsig, NULL) == 0);
     CHECK(ecount == 5);
 
     /* Check NULLs for conversion */
@@ -192,7 +192,7 @@ void test_ecdsa_recovery_end_to_end(void) {
     CHECK(secp256k1_ecdsa_verify(ctx, &signature[4], message, &pubkey) == 1);
     /* Parse compact (with recovery id) and recover. */
     CHECK(secp256k1_ecdsa_recoverable_signature_parse_compact(ctx, &rsignature[4], sig, recid) == 1);
-    CHECK(secp256k1_ecdsa_recover(ctx, &recpubkey, &rsignature[4], message) == 1);
+    CHECK(cosmos_secp256k1_ecdsa_recover(ctx, &recpubkey, &rsignature[4], message) == 1);
     CHECK(memcmp(&pubkey, &recpubkey, sizeof(pubkey)) == 0);
     /* Serialize/destroy/parse signature and verify again. */
     CHECK(secp256k1_ecdsa_recoverable_signature_serialize_compact(ctx, sig, &recid, &rsignature[4]) == 1);
@@ -201,7 +201,7 @@ void test_ecdsa_recovery_end_to_end(void) {
     CHECK(cosmos_secp256k1_ecdsa_recoverable_signature_convert(ctx, &signature[4], &rsignature[4]) == 1);
     CHECK(secp256k1_ecdsa_verify(ctx, &signature[4], message, &pubkey) == 0);
     /* Recover again */
-    CHECK(secp256k1_ecdsa_recover(ctx, &recpubkey, &rsignature[4], message) == 0 ||
+    CHECK(cosmos_secp256k1_ecdsa_recover(ctx, &recpubkey, &rsignature[4], message) == 0 ||
           memcmp(&pubkey, &recpubkey, sizeof(pubkey)) != 0);
 }
 
@@ -243,13 +243,13 @@ void test_ecdsa_recovery_edge_cases(void) {
     int recid;
 
     CHECK(secp256k1_ecdsa_recoverable_signature_parse_compact(ctx, &rsig, sig64, 0));
-    CHECK(!secp256k1_ecdsa_recover(ctx, &pubkey, &rsig, msg32));
+    CHECK(!cosmos_secp256k1_ecdsa_recover(ctx, &pubkey, &rsig, msg32));
     CHECK(secp256k1_ecdsa_recoverable_signature_parse_compact(ctx, &rsig, sig64, 1));
-    CHECK(secp256k1_ecdsa_recover(ctx, &pubkey, &rsig, msg32));
+    CHECK(cosmos_secp256k1_ecdsa_recover(ctx, &pubkey, &rsig, msg32));
     CHECK(secp256k1_ecdsa_recoverable_signature_parse_compact(ctx, &rsig, sig64, 2));
-    CHECK(!secp256k1_ecdsa_recover(ctx, &pubkey, &rsig, msg32));
+    CHECK(!cosmos_secp256k1_ecdsa_recover(ctx, &pubkey, &rsig, msg32));
     CHECK(secp256k1_ecdsa_recoverable_signature_parse_compact(ctx, &rsig, sig64, 3));
-    CHECK(!secp256k1_ecdsa_recover(ctx, &pubkey, &rsig, msg32));
+    CHECK(!cosmos_secp256k1_ecdsa_recover(ctx, &pubkey, &rsig, msg32));
 
     for (recid = 0; recid < 4; recid++) {
         int i;
@@ -295,13 +295,13 @@ void test_ecdsa_recovery_edge_cases(void) {
             0x8C, 0xD0, 0x36, 0x41, 0x45, 0x02, 0x01, 0x04
         };
         CHECK(secp256k1_ecdsa_recoverable_signature_parse_compact(ctx, &rsig, sigb64, recid) == 1);
-        CHECK(secp256k1_ecdsa_recover(ctx, &pubkeyb, &rsig, msg32) == 1);
+        CHECK(cosmos_secp256k1_ecdsa_recover(ctx, &pubkeyb, &rsig, msg32) == 1);
         CHECK(secp256k1_ecdsa_signature_parse_der(ctx, &sig, sigbder, sizeof(sigbder)) == 1);
         CHECK(secp256k1_ecdsa_verify(ctx, &sig, msg32, &pubkeyb) == 1);
         for (recid2 = 0; recid2 < 4; recid2++) {
             secp256k1_pubkey pubkey2b;
             CHECK(secp256k1_ecdsa_recoverable_signature_parse_compact(ctx, &rsig, sigb64, recid2) == 1);
-            CHECK(secp256k1_ecdsa_recover(ctx, &pubkey2b, &rsig, msg32) == 1);
+            CHECK(cosmos_secp256k1_ecdsa_recover(ctx, &pubkey2b, &rsig, msg32) == 1);
             /* Verifying with (order + r,4) should always fail. */
             CHECK(secp256k1_ecdsa_signature_parse_der(ctx, &sig, sigbderlong, sizeof(sigbderlong)) == 1);
             CHECK(secp256k1_ecdsa_verify(ctx, &sig, msg32, &pubkeyb) == 0);
@@ -359,13 +359,13 @@ void test_ecdsa_recovery_edge_cases(void) {
         };
         secp256k1_pubkey pubkeyc;
         CHECK(secp256k1_ecdsa_recoverable_signature_parse_compact(ctx, &rsig, sigc64, 0) == 1);
-        CHECK(secp256k1_ecdsa_recover(ctx, &pubkeyc, &rsig, msg32) == 1);
+        CHECK(cosmos_secp256k1_ecdsa_recover(ctx, &pubkeyc, &rsig, msg32) == 1);
         CHECK(secp256k1_ecdsa_signature_parse_der(ctx, &sig, sigcder, sizeof(sigcder)) == 1);
         CHECK(secp256k1_ecdsa_verify(ctx, &sig, msg32, &pubkeyc) == 1);
         sigcder[4] = 0;
         sigc64[31] = 0;
         CHECK(secp256k1_ecdsa_recoverable_signature_parse_compact(ctx, &rsig, sigc64, 0) == 1);
-        CHECK(secp256k1_ecdsa_recover(ctx, &pubkeyb, &rsig, msg32) == 0);
+        CHECK(cosmos_secp256k1_ecdsa_recover(ctx, &pubkeyb, &rsig, msg32) == 0);
         CHECK(secp256k1_ecdsa_signature_parse_der(ctx, &sig, sigcder, sizeof(sigcder)) == 1);
         CHECK(secp256k1_ecdsa_verify(ctx, &sig, msg32, &pubkeyc) == 0);
         sigcder[4] = 1;
@@ -373,7 +373,7 @@ void test_ecdsa_recovery_edge_cases(void) {
         sigc64[31] = 1;
         sigc64[63] = 0;
         CHECK(secp256k1_ecdsa_recoverable_signature_parse_compact(ctx, &rsig, sigc64, 0) == 1);
-        CHECK(secp256k1_ecdsa_recover(ctx, &pubkeyb, &rsig, msg32) == 0);
+        CHECK(cosmos_secp256k1_ecdsa_recover(ctx, &pubkeyb, &rsig, msg32) == 0);
         CHECK(secp256k1_ecdsa_signature_parse_der(ctx, &sig, sigcder, sizeof(sigcder)) == 1);
         CHECK(secp256k1_ecdsa_verify(ctx, &sig, msg32, &pubkeyc) == 0);
     }

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/modules/recovery/tests_impl.h
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/modules/recovery/tests_impl.h
@@ -60,7 +60,7 @@ void test_ecdsa_recovery_api(void) {
 
     /* Construct and verify corresponding public key. */
     CHECK(cosmos_secp256k1_ec_seckey_verify(ctx, privkey) == 1);
-    CHECK(secp256k1_ec_pubkey_create(ctx, &pubkey, privkey) == 1);
+    CHECK(cosmos_secp256k1_ec_pubkey_create(ctx, &pubkey, privkey) == 1);
 
     /* Check bad contexts and NULLs for signing */
     ecount = 0;
@@ -169,7 +169,7 @@ void test_ecdsa_recovery_end_to_end(void) {
 
     /* Construct and verify corresponding public key. */
     CHECK(cosmos_secp256k1_ec_seckey_verify(ctx, privkey) == 1);
-    CHECK(secp256k1_ec_pubkey_create(ctx, &pubkey, privkey) == 1);
+    CHECK(cosmos_secp256k1_ec_pubkey_create(ctx, &pubkey, privkey) == 1);
 
     /* Serialize/parse compact and verify/recover. */
     extra[0] = 0;

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/modules/recovery/tests_impl.h
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/modules/recovery/tests_impl.h
@@ -59,7 +59,7 @@ void test_ecdsa_recovery_api(void) {
     cosmos_secp256k1_context_set_illegal_callback(both, counting_illegal_callback_fn, &ecount);
 
     /* Construct and verify corresponding public key. */
-    CHECK(secp256k1_ec_seckey_verify(ctx, privkey) == 1);
+    CHECK(cosmos_secp256k1_ec_seckey_verify(ctx, privkey) == 1);
     CHECK(secp256k1_ec_pubkey_create(ctx, &pubkey, privkey) == 1);
 
     /* Check bad contexts and NULLs for signing */
@@ -168,7 +168,7 @@ void test_ecdsa_recovery_end_to_end(void) {
     }
 
     /* Construct and verify corresponding public key. */
-    CHECK(secp256k1_ec_seckey_verify(ctx, privkey) == 1);
+    CHECK(cosmos_secp256k1_ec_seckey_verify(ctx, privkey) == 1);
     CHECK(secp256k1_ec_pubkey_create(ctx, &pubkey, privkey) == 1);
 
     /* Serialize/parse compact and verify/recover. */

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/modules/recovery/tests_impl.h
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/modules/recovery/tests_impl.h
@@ -110,11 +110,11 @@ void test_ecdsa_recovery_api(void) {
     /* Check NULLs for conversion */
     CHECK(secp256k1_ecdsa_sign(both, &normal_sig, message, privkey, NULL, NULL) == 1);
     ecount = 0;
-    CHECK(secp256k1_ecdsa_recoverable_signature_convert(both, NULL, &recsig) == 0);
+    CHECK(cosmos_secp256k1_ecdsa_recoverable_signature_convert(both, NULL, &recsig) == 0);
     CHECK(ecount == 1);
-    CHECK(secp256k1_ecdsa_recoverable_signature_convert(both, &normal_sig, NULL) == 0);
+    CHECK(cosmos_secp256k1_ecdsa_recoverable_signature_convert(both, &normal_sig, NULL) == 0);
     CHECK(ecount == 2);
-    CHECK(secp256k1_ecdsa_recoverable_signature_convert(both, &normal_sig, &recsig) == 1);
+    CHECK(cosmos_secp256k1_ecdsa_recoverable_signature_convert(both, &normal_sig, &recsig) == 1);
 
     /* Check NULLs for de/serialization */
     CHECK(secp256k1_ecdsa_sign_recoverable(both, &recsig, message, privkey, NULL, NULL) == 1);
@@ -183,12 +183,12 @@ void test_ecdsa_recovery_end_to_end(void) {
     extra[0] = 1;
     CHECK(secp256k1_ecdsa_sign_recoverable(ctx, &rsignature[3], message, privkey, NULL, extra) == 1);
     CHECK(secp256k1_ecdsa_recoverable_signature_serialize_compact(ctx, sig, &recid, &rsignature[4]) == 1);
-    CHECK(secp256k1_ecdsa_recoverable_signature_convert(ctx, &signature[4], &rsignature[4]) == 1);
+    CHECK(cosmos_secp256k1_ecdsa_recoverable_signature_convert(ctx, &signature[4], &rsignature[4]) == 1);
     CHECK(memcmp(&signature[4], &signature[0], 64) == 0);
     CHECK(secp256k1_ecdsa_verify(ctx, &signature[4], message, &pubkey) == 1);
     memset(&rsignature[4], 0, sizeof(rsignature[4]));
     CHECK(secp256k1_ecdsa_recoverable_signature_parse_compact(ctx, &rsignature[4], sig, recid) == 1);
-    CHECK(secp256k1_ecdsa_recoverable_signature_convert(ctx, &signature[4], &rsignature[4]) == 1);
+    CHECK(cosmos_secp256k1_ecdsa_recoverable_signature_convert(ctx, &signature[4], &rsignature[4]) == 1);
     CHECK(secp256k1_ecdsa_verify(ctx, &signature[4], message, &pubkey) == 1);
     /* Parse compact (with recovery id) and recover. */
     CHECK(secp256k1_ecdsa_recoverable_signature_parse_compact(ctx, &rsignature[4], sig, recid) == 1);
@@ -198,7 +198,7 @@ void test_ecdsa_recovery_end_to_end(void) {
     CHECK(secp256k1_ecdsa_recoverable_signature_serialize_compact(ctx, sig, &recid, &rsignature[4]) == 1);
     sig[secp256k1_rand_bits(6)] += 1 + secp256k1_rand_int(255);
     CHECK(secp256k1_ecdsa_recoverable_signature_parse_compact(ctx, &rsignature[4], sig, recid) == 1);
-    CHECK(secp256k1_ecdsa_recoverable_signature_convert(ctx, &signature[4], &rsignature[4]) == 1);
+    CHECK(cosmos_secp256k1_ecdsa_recoverable_signature_convert(ctx, &signature[4], &rsignature[4]) == 1);
     CHECK(secp256k1_ecdsa_verify(ctx, &signature[4], message, &pubkey) == 0);
     /* Recover again */
     CHECK(secp256k1_ecdsa_recover(ctx, &recpubkey, &rsignature[4], message) == 0 ||

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/secp256k1.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/secp256k1.c
@@ -145,7 +145,7 @@ static void secp256k1_pubkey_save(secp256k1_pubkey* pubkey, secp256k1_ge* ge) {
     }
 }
 
-int secp256k1_ec_pubkey_parse(const secp256k1_context* ctx, secp256k1_pubkey* pubkey, const unsigned char *input, size_t inputlen) {
+int cosmos_secp256k1_ec_pubkey_parse(const secp256k1_context* ctx, secp256k1_pubkey* pubkey, const unsigned char *input, size_t inputlen) {
     secp256k1_ge Q;
 
     VERIFY_CHECK(ctx != NULL);

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/secp256k1.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/secp256k1.c
@@ -399,7 +399,7 @@ int cosmos_secp256k1_ec_seckey_verify(const secp256k1_context* ctx, const unsign
     return ret;
 }
 
-int secp256k1_ec_pubkey_create(const secp256k1_context* ctx, secp256k1_pubkey *pubkey, const unsigned char *seckey) {
+int cosmos_secp256k1_ec_pubkey_create(const secp256k1_context* ctx, secp256k1_pubkey *pubkey, const unsigned char *seckey) {
     secp256k1_gej pj;
     secp256k1_ge p;
     secp256k1_scalar sec;

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/secp256k1.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/secp256k1.c
@@ -87,7 +87,7 @@ secp256k1_context* cosmos_secp256k1_context_clone(const secp256k1_context* ctx) 
     return ret;
 }
 
-void secp256k1_context_destroy(secp256k1_context* ctx) {
+void cosmos_secp256k1_context_destroy(secp256k1_context* ctx) {
     if (ctx != NULL) {
         secp256k1_ecmult_context_clear(&ctx->ecmult_ctx);
         secp256k1_ecmult_gen_context_clear(&ctx->ecmult_gen_ctx);

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/secp256k1.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/secp256k1.c
@@ -256,7 +256,7 @@ int secp256k1_ecdsa_signature_serialize_der(const secp256k1_context* ctx, unsign
     return secp256k1_ecdsa_sig_serialize(output, outputlen, &r, &s);
 }
 
-int secp256k1_ecdsa_signature_serialize_compact(const secp256k1_context* ctx, unsigned char *output64, const secp256k1_ecdsa_signature* sig) {
+int cosmos_secp256k1_ecdsa_signature_serialize_compact(const secp256k1_context* ctx, unsigned char *output64, const secp256k1_ecdsa_signature* sig) {
     secp256k1_scalar r, s;
 
     VERIFY_CHECK(ctx != NULL);

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/secp256k1.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/secp256k1.c
@@ -340,7 +340,7 @@ static int nonce_function_rfc6979(unsigned char *nonce32, const unsigned char *m
 const secp256k1_nonce_function cosmos_secp256k1_nonce_function_rfc6979 = nonce_function_rfc6979;
 const secp256k1_nonce_function secp256k1_nonce_function_default = nonce_function_rfc6979;
 
-int secp256k1_ecdsa_sign(const secp256k1_context* ctx, secp256k1_ecdsa_signature *signature, const unsigned char *msg32, const unsigned char *seckey, secp256k1_nonce_function noncefp, const void* noncedata) {
+int cosmos_secp256k1_ecdsa_sign(const secp256k1_context* ctx, secp256k1_ecdsa_signature *signature, const unsigned char *msg32, const unsigned char *seckey, secp256k1_nonce_function noncefp, const void* noncedata) {
     secp256k1_scalar r, s;
     secp256k1_scalar sec, non, msg;
     int ret = 0;

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/secp256k1.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/secp256k1.c
@@ -160,7 +160,7 @@ int secp256k1_ec_pubkey_parse(const secp256k1_context* ctx, secp256k1_pubkey* pu
     return 1;
 }
 
-int secp256k1_ec_pubkey_serialize(const secp256k1_context* ctx, unsigned char *output, size_t *outputlen, const secp256k1_pubkey* pubkey, unsigned int flags) {
+int cosmos_secp256k1_ec_pubkey_serialize(const secp256k1_context* ctx, unsigned char *output, size_t *outputlen, const secp256k1_pubkey* pubkey, unsigned int flags) {
     secp256k1_ge Q;
     size_t len;
     int ret = 0;

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/secp256k1.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/secp256k1.c
@@ -288,7 +288,7 @@ int cosmos_secp256k1_ecdsa_signature_normalize(const secp256k1_context* ctx, sec
     return ret;
 }
 
-int secp256k1_ecdsa_verify(const secp256k1_context* ctx, const secp256k1_ecdsa_signature *sig, const unsigned char *msg32, const secp256k1_pubkey *pubkey) {
+int cosmos_secp256k1_ecdsa_verify(const secp256k1_context* ctx, const secp256k1_ecdsa_signature *sig, const unsigned char *msg32, const secp256k1_pubkey *pubkey) {
     secp256k1_ge q;
     secp256k1_scalar r, s;
     secp256k1_scalar m;

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/secp256k1.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/secp256k1.c
@@ -269,7 +269,7 @@ int secp256k1_ecdsa_signature_serialize_compact(const secp256k1_context* ctx, un
     return 1;
 }
 
-int secp256k1_ecdsa_signature_normalize(const secp256k1_context* ctx, secp256k1_ecdsa_signature *sigout, const secp256k1_ecdsa_signature *sigin) {
+int cosmos_secp256k1_ecdsa_signature_normalize(const secp256k1_context* ctx, secp256k1_ecdsa_signature *sigout, const secp256k1_ecdsa_signature *sigin) {
     secp256k1_scalar r, s;
     int ret = 0;
 

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/secp256k1.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/secp256k1.c
@@ -338,7 +338,7 @@ static int nonce_function_rfc6979(unsigned char *nonce32, const unsigned char *m
 }
 
 const secp256k1_nonce_function cosmos_secp256k1_nonce_function_rfc6979 = nonce_function_rfc6979;
-const secp256k1_nonce_function secp256k1_nonce_function_default = nonce_function_rfc6979;
+const secp256k1_nonce_function cosmos_secp256k1_nonce_function_default = nonce_function_rfc6979;
 
 int cosmos_secp256k1_ecdsa_sign(const secp256k1_context* ctx, secp256k1_ecdsa_signature *signature, const unsigned char *msg32, const unsigned char *seckey, secp256k1_nonce_function noncefp, const void* noncedata) {
     secp256k1_scalar r, s;
@@ -351,7 +351,7 @@ int cosmos_secp256k1_ecdsa_sign(const secp256k1_context* ctx, secp256k1_ecdsa_si
     ARG_CHECK(signature != NULL);
     ARG_CHECK(seckey != NULL);
     if (noncefp == NULL) {
-        noncefp = secp256k1_nonce_function_default;
+        noncefp = cosmos_secp256k1_nonce_function_default;
     }
 
     secp256k1_scalar_set_b32(&sec, seckey, &overflow);

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/secp256k1.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/secp256k1.c
@@ -522,7 +522,7 @@ int cosmos_secp256k1_context_randomize(secp256k1_context* ctx, const unsigned ch
     return 1;
 }
 
-int secp256k1_ec_pubkey_combine(const secp256k1_context* ctx, secp256k1_pubkey *pubnonce, const secp256k1_pubkey * const *pubnonces, size_t n) {
+int cosmos_secp256k1_ec_pubkey_combine(const secp256k1_context* ctx, secp256k1_pubkey *pubnonce, const secp256k1_pubkey * const *pubnonces, size_t n) {
     size_t i;
     secp256k1_gej Qj;
     secp256k1_ge Q;

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/secp256k1.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/secp256k1.c
@@ -491,7 +491,7 @@ int cosmos_secp256k1_ec_privkey_tweak_mul(const secp256k1_context* ctx, unsigned
     return ret;
 }
 
-int secp256k1_ec_pubkey_tweak_mul(const secp256k1_context* ctx, secp256k1_pubkey *pubkey, const unsigned char *tweak) {
+int cosmos_secp256k1_ec_pubkey_tweak_mul(const secp256k1_context* ctx, secp256k1_pubkey *pubkey, const unsigned char *tweak) {
     secp256k1_ge p;
     secp256k1_scalar factor;
     int ret = 0;

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/secp256k1.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/secp256k1.c
@@ -223,7 +223,7 @@ int secp256k1_ecdsa_signature_parse_der(const secp256k1_context* ctx, secp256k1_
     }
 }
 
-int secp256k1_ecdsa_signature_parse_compact(const secp256k1_context* ctx, secp256k1_ecdsa_signature* sig, const unsigned char *input64) {
+int cosmos_secp256k1_ecdsa_signature_parse_compact(const secp256k1_context* ctx, secp256k1_ecdsa_signature* sig, const unsigned char *input64) {
     secp256k1_scalar r, s;
     int ret = 1;
     int overflow = 0;

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/secp256k1.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/secp256k1.c
@@ -96,7 +96,7 @@ void secp256k1_context_destroy(secp256k1_context* ctx) {
     }
 }
 
-void secp256k1_context_set_illegal_callback(secp256k1_context* ctx, void (*fun)(const char* message, void* data), const void* data) {
+void cosmos_secp256k1_context_set_illegal_callback(secp256k1_context* ctx, void (*fun)(const char* message, void* data), const void* data) {
     if (fun == NULL) {
         fun = default_illegal_callback_fn;
     }

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/secp256k1.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/secp256k1.c
@@ -469,7 +469,7 @@ int secp256k1_ec_pubkey_tweak_add(const secp256k1_context* ctx, secp256k1_pubkey
     return ret;
 }
 
-int secp256k1_ec_privkey_tweak_mul(const secp256k1_context* ctx, unsigned char *seckey, const unsigned char *tweak) {
+int cosmos_secp256k1_ec_privkey_tweak_mul(const secp256k1_context* ctx, unsigned char *seckey, const unsigned char *tweak) {
     secp256k1_scalar factor;
     secp256k1_scalar sec;
     int ret = 0;

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/secp256k1.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/secp256k1.c
@@ -78,7 +78,7 @@ secp256k1_context* secp256k1_context_create(unsigned int flags) {
     return ret;
 }
 
-secp256k1_context* secp256k1_context_clone(const secp256k1_context* ctx) {
+secp256k1_context* cosmos_secp256k1_context_clone(const secp256k1_context* ctx) {
     secp256k1_context* ret = (secp256k1_context*)checked_malloc(&ctx->error_callback, sizeof(secp256k1_context));
     ret->illegal_callback = ctx->illegal_callback;
     ret->error_callback = ctx->error_callback;

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/secp256k1.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/secp256k1.c
@@ -386,7 +386,7 @@ int cosmos_secp256k1_ecdsa_sign(const secp256k1_context* ctx, secp256k1_ecdsa_si
     return ret;
 }
 
-int secp256k1_ec_seckey_verify(const secp256k1_context* ctx, const unsigned char *seckey) {
+int cosmos_secp256k1_ec_seckey_verify(const secp256k1_context* ctx, const unsigned char *seckey) {
     secp256k1_scalar sec;
     int ret;
     int overflow;

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/secp256k1.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/secp256k1.c
@@ -422,7 +422,7 @@ int secp256k1_ec_pubkey_create(const secp256k1_context* ctx, secp256k1_pubkey *p
     return ret;
 }
 
-int secp256k1_ec_privkey_tweak_add(const secp256k1_context* ctx, unsigned char *seckey, const unsigned char *tweak) {
+int cosmos_secp256k1_ec_privkey_tweak_add(const secp256k1_context* ctx, unsigned char *seckey, const unsigned char *tweak) {
     secp256k1_scalar term;
     secp256k1_scalar sec;
     int ret = 0;

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/secp256k1.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/secp256k1.c
@@ -515,7 +515,7 @@ int cosmos_secp256k1_ec_pubkey_tweak_mul(const secp256k1_context* ctx, secp256k1
     return ret;
 }
 
-int secp256k1_context_randomize(secp256k1_context* ctx, const unsigned char *seed32) {
+int cosmos_secp256k1_context_randomize(secp256k1_context* ctx, const unsigned char *seed32) {
     VERIFY_CHECK(ctx != NULL);
     ARG_CHECK(secp256k1_ecmult_gen_context_is_built(&ctx->ecmult_gen_ctx));
     secp256k1_ecmult_gen_blind(&ctx->ecmult_gen_ctx, seed32);

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/secp256k1.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/secp256k1.c
@@ -244,7 +244,7 @@ int cosmos_secp256k1_ecdsa_signature_parse_compact(const secp256k1_context* ctx,
     return ret;
 }
 
-int secp256k1_ecdsa_signature_serialize_der(const secp256k1_context* ctx, unsigned char *output, size_t *outputlen, const secp256k1_ecdsa_signature* sig) {
+int cosmos_secp256k1_ecdsa_signature_serialize_der(const secp256k1_context* ctx, unsigned char *output, size_t *outputlen, const secp256k1_ecdsa_signature* sig) {
     secp256k1_scalar r, s;
 
     VERIFY_CHECK(ctx != NULL);

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/secp256k1.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/secp256k1.c
@@ -53,7 +53,7 @@ struct secp256k1_context_struct {
     secp256k1_callback error_callback;
 };
 
-secp256k1_context* secp256k1_context_create(unsigned int flags) {
+secp256k1_context* cosmos_secp256k1_context_create(unsigned int flags) {
     secp256k1_context* ret = (secp256k1_context*)checked_malloc(&default_error_callback, sizeof(secp256k1_context));
     ret->illegal_callback = default_illegal_callback;
     ret->error_callback = default_error_callback;

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/secp256k1.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/secp256k1.c
@@ -445,7 +445,7 @@ int secp256k1_ec_privkey_tweak_add(const secp256k1_context* ctx, unsigned char *
     return ret;
 }
 
-int secp256k1_ec_pubkey_tweak_add(const secp256k1_context* ctx, secp256k1_pubkey *pubkey, const unsigned char *tweak) {
+int cosmos_secp256k1_ec_pubkey_tweak_add(const secp256k1_context* ctx, secp256k1_pubkey *pubkey, const unsigned char *tweak) {
     secp256k1_ge p;
     secp256k1_scalar term;
     int ret = 0;

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/secp256k1.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/secp256k1.c
@@ -207,7 +207,7 @@ static void secp256k1_ecdsa_signature_save(secp256k1_ecdsa_signature* sig, const
     }
 }
 
-int secp256k1_ecdsa_signature_parse_der(const secp256k1_context* ctx, secp256k1_ecdsa_signature* sig, const unsigned char *input, size_t inputlen) {
+int cosmos_secp256k1_ecdsa_signature_parse_der(const secp256k1_context* ctx, secp256k1_ecdsa_signature* sig, const unsigned char *input, size_t inputlen) {
     secp256k1_scalar r, s;
 
     VERIFY_CHECK(ctx != NULL);

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/secp256k1.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/secp256k1.c
@@ -104,7 +104,7 @@ void cosmos_secp256k1_context_set_illegal_callback(secp256k1_context* ctx, void 
     ctx->illegal_callback.data = data;
 }
 
-void secp256k1_context_set_error_callback(secp256k1_context* ctx, void (*fun)(const char* message, void* data), const void* data) {
+void cosmos_secp256k1_context_set_error_callback(secp256k1_context* ctx, void (*fun)(const char* message, void* data), const void* data) {
     if (fun == NULL) {
         fun = default_error_callback_fn;
     }

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/secp256k1.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/secp256k1.c
@@ -337,7 +337,7 @@ static int nonce_function_rfc6979(unsigned char *nonce32, const unsigned char *m
    return 1;
 }
 
-const secp256k1_nonce_function secp256k1_nonce_function_rfc6979 = nonce_function_rfc6979;
+const secp256k1_nonce_function cosmos_secp256k1_nonce_function_rfc6979 = nonce_function_rfc6979;
 const secp256k1_nonce_function secp256k1_nonce_function_default = nonce_function_rfc6979;
 
 int secp256k1_ecdsa_sign(const secp256k1_context* ctx, secp256k1_ecdsa_signature *signature, const unsigned char *msg32, const unsigned char *seckey, secp256k1_nonce_function noncefp, const void* noncedata) {

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/tests.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/tests.c
@@ -191,9 +191,9 @@ void run_context_tests(void) {
     CHECK(cosmos_secp256k1_ecdsa_sign(sign, &sig, ctmp, ctmp, NULL, NULL) == 1);
     VG_CHECK(&sig, sizeof(sig));
     CHECK(ecount2 == 10);
-    CHECK(secp256k1_ecdsa_verify(sign, &sig, ctmp, &pubkey) == 0);
+    CHECK(cosmos_secp256k1_ecdsa_verify(sign, &sig, ctmp, &pubkey) == 0);
     CHECK(ecount2 == 11);
-    CHECK(secp256k1_ecdsa_verify(vrfy, &sig, ctmp, &pubkey) == 1);
+    CHECK(cosmos_secp256k1_ecdsa_verify(vrfy, &sig, ctmp, &pubkey) == 1);
     CHECK(ecount == 2);
     CHECK(cosmos_secp256k1_ec_pubkey_tweak_add(sign, &pubkey, ctmp) == 0);
     CHECK(ecount2 == 12);
@@ -3513,38 +3513,38 @@ void test_ecdsa_end_to_end(void) {
     CHECK(memcmp(&signature[1], &signature[3], sizeof(signature[0])) != 0);
     CHECK(memcmp(&signature[2], &signature[3], sizeof(signature[0])) != 0);
     /* Verify. */
-    CHECK(secp256k1_ecdsa_verify(ctx, &signature[0], message, &pubkey) == 1);
-    CHECK(secp256k1_ecdsa_verify(ctx, &signature[1], message, &pubkey) == 1);
-    CHECK(secp256k1_ecdsa_verify(ctx, &signature[2], message, &pubkey) == 1);
-    CHECK(secp256k1_ecdsa_verify(ctx, &signature[3], message, &pubkey) == 1);
+    CHECK(cosmos_secp256k1_ecdsa_verify(ctx, &signature[0], message, &pubkey) == 1);
+    CHECK(cosmos_secp256k1_ecdsa_verify(ctx, &signature[1], message, &pubkey) == 1);
+    CHECK(cosmos_secp256k1_ecdsa_verify(ctx, &signature[2], message, &pubkey) == 1);
+    CHECK(cosmos_secp256k1_ecdsa_verify(ctx, &signature[3], message, &pubkey) == 1);
     /* Test lower-S form, malleate, verify and fail, test again, malleate again */
     CHECK(!cosmos_secp256k1_ecdsa_signature_normalize(ctx, NULL, &signature[0]));
     secp256k1_ecdsa_signature_load(ctx, &r, &s, &signature[0]);
     secp256k1_scalar_negate(&s, &s);
     secp256k1_ecdsa_signature_save(&signature[5], &r, &s);
-    CHECK(secp256k1_ecdsa_verify(ctx, &signature[5], message, &pubkey) == 0);
+    CHECK(cosmos_secp256k1_ecdsa_verify(ctx, &signature[5], message, &pubkey) == 0);
     CHECK(cosmos_secp256k1_ecdsa_signature_normalize(ctx, NULL, &signature[5]));
     CHECK(cosmos_secp256k1_ecdsa_signature_normalize(ctx, &signature[5], &signature[5]));
     CHECK(!cosmos_secp256k1_ecdsa_signature_normalize(ctx, NULL, &signature[5]));
     CHECK(!cosmos_secp256k1_ecdsa_signature_normalize(ctx, &signature[5], &signature[5]));
-    CHECK(secp256k1_ecdsa_verify(ctx, &signature[5], message, &pubkey) == 1);
+    CHECK(cosmos_secp256k1_ecdsa_verify(ctx, &signature[5], message, &pubkey) == 1);
     secp256k1_scalar_negate(&s, &s);
     secp256k1_ecdsa_signature_save(&signature[5], &r, &s);
     CHECK(!cosmos_secp256k1_ecdsa_signature_normalize(ctx, NULL, &signature[5]));
-    CHECK(secp256k1_ecdsa_verify(ctx, &signature[5], message, &pubkey) == 1);
+    CHECK(cosmos_secp256k1_ecdsa_verify(ctx, &signature[5], message, &pubkey) == 1);
     CHECK(memcmp(&signature[5], &signature[0], 64) == 0);
 
     /* Serialize/parse DER and verify again */
     CHECK(secp256k1_ecdsa_signature_serialize_der(ctx, sig, &siglen, &signature[0]) == 1);
     memset(&signature[0], 0, sizeof(signature[0]));
     CHECK(secp256k1_ecdsa_signature_parse_der(ctx, &signature[0], sig, siglen) == 1);
-    CHECK(secp256k1_ecdsa_verify(ctx, &signature[0], message, &pubkey) == 1);
+    CHECK(cosmos_secp256k1_ecdsa_verify(ctx, &signature[0], message, &pubkey) == 1);
     /* Serialize/destroy/parse DER and verify again. */
     siglen = 74;
     CHECK(secp256k1_ecdsa_signature_serialize_der(ctx, sig, &siglen, &signature[0]) == 1);
     sig[secp256k1_rand_int(siglen)] += 1 + secp256k1_rand_int(255);
     CHECK(secp256k1_ecdsa_signature_parse_der(ctx, &signature[0], sig, siglen) == 0 ||
-          secp256k1_ecdsa_verify(ctx, &signature[0], message, &pubkey) == 0);
+          cosmos_secp256k1_ecdsa_verify(ctx, &signature[0], message, &pubkey) == 0);
 }
 
 void test_random_pubkeys(void) {
@@ -4161,18 +4161,18 @@ void test_ecdsa_edge_cases(void) {
         CHECK(ecount == 3);
         CHECK(cosmos_secp256k1_ecdsa_sign(ctx, &sig, msg, key, precomputed_nonce_function, nonce2) == 1);
         CHECK(secp256k1_ec_pubkey_create(ctx, &pubkey, key) == 1);
-        CHECK(secp256k1_ecdsa_verify(ctx, NULL, msg, &pubkey) == 0);
+        CHECK(cosmos_secp256k1_ecdsa_verify(ctx, NULL, msg, &pubkey) == 0);
         CHECK(ecount == 4);
-        CHECK(secp256k1_ecdsa_verify(ctx, &sig, NULL, &pubkey) == 0);
+        CHECK(cosmos_secp256k1_ecdsa_verify(ctx, &sig, NULL, &pubkey) == 0);
         CHECK(ecount == 5);
-        CHECK(secp256k1_ecdsa_verify(ctx, &sig, msg, NULL) == 0);
+        CHECK(cosmos_secp256k1_ecdsa_verify(ctx, &sig, msg, NULL) == 0);
         CHECK(ecount == 6);
-        CHECK(secp256k1_ecdsa_verify(ctx, &sig, msg, &pubkey) == 1);
+        CHECK(cosmos_secp256k1_ecdsa_verify(ctx, &sig, msg, &pubkey) == 1);
         CHECK(ecount == 6);
         CHECK(secp256k1_ec_pubkey_create(ctx, &pubkey, NULL) == 0);
         CHECK(ecount == 7);
         /* That pubkeyload fails via an ARGCHECK is a little odd but makes sense because pubkeys are an opaque data type. */
-        CHECK(secp256k1_ecdsa_verify(ctx, &sig, msg, &pubkey) == 0);
+        CHECK(cosmos_secp256k1_ecdsa_verify(ctx, &sig, msg, &pubkey) == 0);
         CHECK(ecount == 8);
         siglen = 72;
         CHECK(secp256k1_ecdsa_signature_serialize_der(ctx, NULL, &siglen, &sig) == 0);

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/tests.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/tests.c
@@ -195,9 +195,9 @@ void run_context_tests(void) {
     CHECK(ecount2 == 11);
     CHECK(secp256k1_ecdsa_verify(vrfy, &sig, ctmp, &pubkey) == 1);
     CHECK(ecount == 2);
-    CHECK(secp256k1_ec_pubkey_tweak_add(sign, &pubkey, ctmp) == 0);
+    CHECK(cosmos_secp256k1_ec_pubkey_tweak_add(sign, &pubkey, ctmp) == 0);
     CHECK(ecount2 == 12);
-    CHECK(secp256k1_ec_pubkey_tweak_add(vrfy, &pubkey, ctmp) == 1);
+    CHECK(cosmos_secp256k1_ec_pubkey_tweak_add(vrfy, &pubkey, ctmp) == 1);
     CHECK(ecount == 2);
     CHECK(cosmos_secp256k1_ec_pubkey_tweak_mul(sign, &pubkey, ctmp) == 0);
     CHECK(ecount2 == 13);
@@ -3170,7 +3170,7 @@ void run_eckey_edge_case_test(void) {
     CHECK(secp256k1_ec_privkey_tweak_add(ctx, ctmp, ctmp2) == 1);
     CHECK(memcmp(orderc, ctmp, 31) == 0 && ctmp[31] == 0x40);
     memcpy(&pubkey2, &pubkey, sizeof(pubkey));
-    CHECK(secp256k1_ec_pubkey_tweak_add(ctx, &pubkey, ctmp2) == 1);
+    CHECK(cosmos_secp256k1_ec_pubkey_tweak_add(ctx, &pubkey, ctmp2) == 1);
     CHECK(memcmp(&pubkey, &pubkey2, sizeof(pubkey)) == 0);
     /* Multiply tweak of zero zeroizes the output. */
     CHECK(cosmos_secp256k1_ec_privkey_tweak_mul(ctx, ctmp, ctmp2) == 0);
@@ -3189,7 +3189,7 @@ void run_eckey_edge_case_test(void) {
     CHECK(memcmp(zeros, ctmp, 32) == 0);
     memcpy(ctmp, orderc, 32);
     ctmp[31] = 0x40;
-    CHECK(secp256k1_ec_pubkey_tweak_add(ctx, &pubkey, orderc) == 0);
+    CHECK(cosmos_secp256k1_ec_pubkey_tweak_add(ctx, &pubkey, orderc) == 0);
     CHECK(memcmp(&pubkey, zeros, sizeof(pubkey)) == 0);
     memcpy(&pubkey, &pubkey2, sizeof(pubkey));
     CHECK(cosmos_secp256k1_ec_pubkey_tweak_mul(ctx, &pubkey, orderc) == 0);
@@ -3200,7 +3200,7 @@ void run_eckey_edge_case_test(void) {
     CHECK(secp256k1_ec_privkey_tweak_add(ctx, ctmp2, ctmp) == 0);
     CHECK(memcmp(zeros, ctmp2, 32) == 0);
     ctmp2[31] = 1;
-    CHECK(secp256k1_ec_pubkey_tweak_add(ctx, &pubkey, ctmp2) == 0);
+    CHECK(cosmos_secp256k1_ec_pubkey_tweak_add(ctx, &pubkey, ctmp2) == 0);
     CHECK(memcmp(&pubkey, zeros, sizeof(pubkey)) == 0);
     memcpy(&pubkey, &pubkey2, sizeof(pubkey));
     /* Tweak computation wraps and results in a key of 1. */
@@ -3208,12 +3208,12 @@ void run_eckey_edge_case_test(void) {
     CHECK(secp256k1_ec_privkey_tweak_add(ctx, ctmp2, ctmp) == 1);
     CHECK(memcmp(ctmp2, zeros, 31) == 0 && ctmp2[31] == 1);
     ctmp2[31] = 2;
-    CHECK(secp256k1_ec_pubkey_tweak_add(ctx, &pubkey, ctmp2) == 1);
+    CHECK(cosmos_secp256k1_ec_pubkey_tweak_add(ctx, &pubkey, ctmp2) == 1);
     ctmp2[31] = 1;
     CHECK(secp256k1_ec_pubkey_create(ctx, &pubkey2, ctmp2) == 1);
     CHECK(memcmp(&pubkey, &pubkey2, sizeof(pubkey)) == 0);
     /* Tweak mul * 2 = 1+1. */
-    CHECK(secp256k1_ec_pubkey_tweak_add(ctx, &pubkey, ctmp2) == 1);
+    CHECK(cosmos_secp256k1_ec_pubkey_tweak_add(ctx, &pubkey, ctmp2) == 1);
     ctmp2[31] = 2;
     CHECK(cosmos_secp256k1_ec_pubkey_tweak_mul(ctx, &pubkey2, ctmp2) == 1);
     CHECK(memcmp(&pubkey, &pubkey2, sizeof(pubkey)) == 0);
@@ -3223,7 +3223,7 @@ void run_eckey_edge_case_test(void) {
     CHECK(ecount == 0);
     /* Zeroize pubkey on parse error. */
     memset(&pubkey, 0, 32);
-    CHECK(secp256k1_ec_pubkey_tweak_add(ctx, &pubkey, ctmp2) == 0);
+    CHECK(cosmos_secp256k1_ec_pubkey_tweak_add(ctx, &pubkey, ctmp2) == 0);
     CHECK(ecount == 1);
     CHECK(memcmp(&pubkey, zeros, sizeof(pubkey)) == 0);
     memcpy(&pubkey, &pubkey2, sizeof(pubkey));
@@ -3240,9 +3240,9 @@ void run_eckey_edge_case_test(void) {
     ecount = 0;
     memset(ctmp2, 0, 32);
     ctmp2[31] = 4;
-    CHECK(secp256k1_ec_pubkey_tweak_add(ctx, NULL, ctmp2) == 0);
+    CHECK(cosmos_secp256k1_ec_pubkey_tweak_add(ctx, NULL, ctmp2) == 0);
     CHECK(ecount == 1);
-    CHECK(secp256k1_ec_pubkey_tweak_add(ctx, &pubkey, NULL) == 0);
+    CHECK(cosmos_secp256k1_ec_pubkey_tweak_add(ctx, &pubkey, NULL) == 0);
     CHECK(ecount == 2);
     ecount = 0;
     memset(ctmp2, 0, 32);
@@ -3470,7 +3470,7 @@ void test_ecdsa_end_to_end(void) {
         secp256k1_pubkey pubkey2;
         secp256k1_rand256_test(rnd);
         ret1 = secp256k1_ec_privkey_tweak_add(ctx, privkey, rnd);
-        ret2 = secp256k1_ec_pubkey_tweak_add(ctx, &pubkey, rnd);
+        ret2 = cosmos_secp256k1_ec_pubkey_tweak_add(ctx, &pubkey, rnd);
         CHECK(ret1 == ret2);
         if (ret1 == 0) {
             return;

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/tests.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/tests.c
@@ -3117,14 +3117,14 @@ void run_eckey_edge_case_test(void) {
     size_t len;
     int32_t ecount;
     /* Group order is too large, reject. */
-    CHECK(secp256k1_ec_seckey_verify(ctx, orderc) == 0);
+    CHECK(cosmos_secp256k1_ec_seckey_verify(ctx, orderc) == 0);
     VG_UNDEF(&pubkey, sizeof(pubkey));
     CHECK(secp256k1_ec_pubkey_create(ctx, &pubkey, orderc) == 0);
     VG_CHECK(&pubkey, sizeof(pubkey));
     CHECK(memcmp(&pubkey, zeros, sizeof(secp256k1_pubkey)) == 0);
     /* Maximum value is too large, reject. */
     memset(ctmp, 255, 32);
-    CHECK(secp256k1_ec_seckey_verify(ctx, ctmp) == 0);
+    CHECK(cosmos_secp256k1_ec_seckey_verify(ctx, ctmp) == 0);
     memset(&pubkey, 1, sizeof(pubkey));
     VG_UNDEF(&pubkey, sizeof(pubkey));
     CHECK(secp256k1_ec_pubkey_create(ctx, &pubkey, ctmp) == 0);
@@ -3132,7 +3132,7 @@ void run_eckey_edge_case_test(void) {
     CHECK(memcmp(&pubkey, zeros, sizeof(secp256k1_pubkey)) == 0);
     /* Zero is too small, reject. */
     memset(ctmp, 0, 32);
-    CHECK(secp256k1_ec_seckey_verify(ctx, ctmp) == 0);
+    CHECK(cosmos_secp256k1_ec_seckey_verify(ctx, ctmp) == 0);
     memset(&pubkey, 1, sizeof(pubkey));
     VG_UNDEF(&pubkey, sizeof(pubkey));
     CHECK(secp256k1_ec_pubkey_create(ctx, &pubkey, ctmp) == 0);
@@ -3140,7 +3140,7 @@ void run_eckey_edge_case_test(void) {
     CHECK(memcmp(&pubkey, zeros, sizeof(secp256k1_pubkey)) == 0);
     /* One must be accepted. */
     ctmp[31] = 0x01;
-    CHECK(secp256k1_ec_seckey_verify(ctx, ctmp) == 1);
+    CHECK(cosmos_secp256k1_ec_seckey_verify(ctx, ctmp) == 1);
     memset(&pubkey, 0, sizeof(pubkey));
     VG_UNDEF(&pubkey, sizeof(pubkey));
     CHECK(secp256k1_ec_pubkey_create(ctx, &pubkey, ctmp) == 1);
@@ -3150,7 +3150,7 @@ void run_eckey_edge_case_test(void) {
     /* Group order + 1 is too large, reject. */
     memcpy(ctmp, orderc, 32);
     ctmp[31] = 0x42;
-    CHECK(secp256k1_ec_seckey_verify(ctx, ctmp) == 0);
+    CHECK(cosmos_secp256k1_ec_seckey_verify(ctx, ctmp) == 0);
     memset(&pubkey, 1, sizeof(pubkey));
     VG_UNDEF(&pubkey, sizeof(pubkey));
     CHECK(secp256k1_ec_pubkey_create(ctx, &pubkey, ctmp) == 0);
@@ -3158,7 +3158,7 @@ void run_eckey_edge_case_test(void) {
     CHECK(memcmp(&pubkey, zeros, sizeof(secp256k1_pubkey)) == 0);
     /* -1 must be accepted. */
     ctmp[31] = 0x40;
-    CHECK(secp256k1_ec_seckey_verify(ctx, ctmp) == 1);
+    CHECK(cosmos_secp256k1_ec_seckey_verify(ctx, ctmp) == 1);
     memset(&pubkey, 0, sizeof(pubkey));
     VG_UNDEF(&pubkey, sizeof(pubkey));
     CHECK(secp256k1_ec_pubkey_create(ctx, &pubkey, ctmp) == 1);
@@ -3233,9 +3233,9 @@ void run_eckey_edge_case_test(void) {
     CHECK(memcmp(&pubkey2, zeros, sizeof(pubkey2)) == 0);
     /* Plain argument errors. */
     ecount = 0;
-    CHECK(secp256k1_ec_seckey_verify(ctx, ctmp) == 1);
+    CHECK(cosmos_secp256k1_ec_seckey_verify(ctx, ctmp) == 1);
     CHECK(ecount == 0);
-    CHECK(secp256k1_ec_seckey_verify(ctx, NULL) == 0);
+    CHECK(cosmos_secp256k1_ec_seckey_verify(ctx, NULL) == 0);
     CHECK(ecount == 1);
     ecount = 0;
     memset(ctmp2, 0, 32);
@@ -3449,7 +3449,7 @@ void test_ecdsa_end_to_end(void) {
     }
 
     /* Construct and verify corresponding public key. */
-    CHECK(secp256k1_ec_seckey_verify(ctx, privkey) == 1);
+    CHECK(cosmos_secp256k1_ec_seckey_verify(ctx, privkey) == 1);
     CHECK(secp256k1_ec_pubkey_create(ctx, &pubkey, privkey) == 1);
 
     /* Verify exporting and importing public key. */

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/tests.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/tests.c
@@ -153,7 +153,7 @@ void run_context_tests(void) {
     ecount2 = 10;
     cosmos_secp256k1_context_set_illegal_callback(vrfy, counting_illegal_callback_fn, &ecount);
     cosmos_secp256k1_context_set_illegal_callback(sign, counting_illegal_callback_fn, &ecount2);
-    secp256k1_context_set_error_callback(sign, counting_illegal_callback_fn, NULL);
+    cosmos_secp256k1_context_set_error_callback(sign, counting_illegal_callback_fn, NULL);
     CHECK(vrfy->error_callback.fn != sign->error_callback.fn);
 
     /*** clone and destroy all of them to make sure cloning was complete ***/
@@ -169,7 +169,7 @@ void run_context_tests(void) {
     /* Verify that the error callback makes it across the clone. */
     CHECK(vrfy->error_callback.fn != sign->error_callback.fn);
     /* And that it resets back to default. */
-    secp256k1_context_set_error_callback(sign, NULL, NULL);
+    cosmos_secp256k1_context_set_error_callback(sign, NULL, NULL);
     CHECK(vrfy->error_callback.fn == sign->error_callback.fn);
 
     /*** attempt to use them ***/

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/tests.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/tests.c
@@ -2734,7 +2734,7 @@ void ec_pubkey_parse_pointtest(const unsigned char *input, int xvalid, int yvali
                 VG_CHECK(&pubkey, sizeof(pubkey));
                 outl = 65;
                 VG_UNDEF(pubkeyo, 65);
-                CHECK(secp256k1_ec_pubkey_serialize(ctx, pubkeyo, &outl, &pubkey, SECP256K1_EC_COMPRESSED) == 1);
+                CHECK(cosmos_secp256k1_ec_pubkey_serialize(ctx, pubkeyo, &outl, &pubkey, SECP256K1_EC_COMPRESSED) == 1);
                 VG_CHECK(pubkeyo, outl);
                 CHECK(outl == 33);
                 CHECK(memcmp(&pubkeyo[1], &pubkeyc[1], 32) == 0);
@@ -2749,7 +2749,7 @@ void ec_pubkey_parse_pointtest(const unsigned char *input, int xvalid, int yvali
                     VG_CHECK(&pubkey, sizeof(pubkey));
                     outl = 65;
                     VG_UNDEF(pubkeyo, 65);
-                    CHECK(secp256k1_ec_pubkey_serialize(ctx, pubkeyo, &outl, &pubkey, SECP256K1_EC_UNCOMPRESSED) == 1);
+                    CHECK(cosmos_secp256k1_ec_pubkey_serialize(ctx, pubkeyo, &outl, &pubkey, SECP256K1_EC_UNCOMPRESSED) == 1);
                     VG_CHECK(pubkeyo, outl);
                     CHECK(outl == 65);
                     CHECK(pubkeyo[0] == 4);
@@ -3052,27 +3052,27 @@ void run_ec_pubkey_parse_test(void) {
     VG_CHECK(&ge.infinity, sizeof(ge.infinity));
     ge_equals_ge(&secp256k1_ge_const_g, &ge);
     CHECK(ecount == 0);
-    /* secp256k1_ec_pubkey_serialize illegal args. */
+    /* cosmos_secp256k1_ec_pubkey_serialize illegal args. */
     ecount = 0;
     len = 65;
-    CHECK(secp256k1_ec_pubkey_serialize(ctx, NULL, &len, &pubkey, SECP256K1_EC_UNCOMPRESSED) == 0);
+    CHECK(cosmos_secp256k1_ec_pubkey_serialize(ctx, NULL, &len, &pubkey, SECP256K1_EC_UNCOMPRESSED) == 0);
     CHECK(ecount == 1);
     CHECK(len == 0);
-    CHECK(secp256k1_ec_pubkey_serialize(ctx, sout, NULL, &pubkey, SECP256K1_EC_UNCOMPRESSED) == 0);
+    CHECK(cosmos_secp256k1_ec_pubkey_serialize(ctx, sout, NULL, &pubkey, SECP256K1_EC_UNCOMPRESSED) == 0);
     CHECK(ecount == 2);
     len = 65;
     VG_UNDEF(sout, 65);
-    CHECK(secp256k1_ec_pubkey_serialize(ctx, sout, &len, NULL, SECP256K1_EC_UNCOMPRESSED) == 0);
+    CHECK(cosmos_secp256k1_ec_pubkey_serialize(ctx, sout, &len, NULL, SECP256K1_EC_UNCOMPRESSED) == 0);
     VG_CHECK(sout, 65);
     CHECK(ecount == 3);
     CHECK(len == 0);
     len = 65;
-    CHECK(secp256k1_ec_pubkey_serialize(ctx, sout, &len, &pubkey, ~0) == 0);
+    CHECK(cosmos_secp256k1_ec_pubkey_serialize(ctx, sout, &len, &pubkey, ~0) == 0);
     CHECK(ecount == 4);
     CHECK(len == 0);
     len = 65;
     VG_UNDEF(sout, 65);
-    CHECK(secp256k1_ec_pubkey_serialize(ctx, sout, &len, &pubkey, SECP256K1_EC_UNCOMPRESSED) == 1);
+    CHECK(cosmos_secp256k1_ec_pubkey_serialize(ctx, sout, &len, &pubkey, SECP256K1_EC_UNCOMPRESSED) == 1);
     VG_CHECK(sout, 65);
     CHECK(ecount == 4);
     CHECK(len == 65);
@@ -3300,8 +3300,8 @@ void run_eckey_edge_case_test(void) {
     CHECK(memcmp(&pubkey, zeros, sizeof(secp256k1_pubkey)) > 0);
     CHECK(ecount == 3);
     len = 33;
-    CHECK(secp256k1_ec_pubkey_serialize(ctx, ctmp, &len, &pubkey, SECP256K1_EC_COMPRESSED) == 1);
-    CHECK(secp256k1_ec_pubkey_serialize(ctx, ctmp2, &len, &pubkey_negone, SECP256K1_EC_COMPRESSED) == 1);
+    CHECK(cosmos_secp256k1_ec_pubkey_serialize(ctx, ctmp, &len, &pubkey, SECP256K1_EC_COMPRESSED) == 1);
+    CHECK(cosmos_secp256k1_ec_pubkey_serialize(ctx, ctmp2, &len, &pubkey_negone, SECP256K1_EC_COMPRESSED) == 1);
     CHECK(memcmp(ctmp, ctmp2, 33) == 0);
     /* Result is infinity. */
     pubkeys[0] = &pubkey_one;
@@ -3321,8 +3321,8 @@ void run_eckey_edge_case_test(void) {
     CHECK(memcmp(&pubkey, zeros, sizeof(secp256k1_pubkey)) > 0);
     CHECK(ecount == 3);
     len = 33;
-    CHECK(secp256k1_ec_pubkey_serialize(ctx, ctmp, &len, &pubkey, SECP256K1_EC_COMPRESSED) == 1);
-    CHECK(secp256k1_ec_pubkey_serialize(ctx, ctmp2, &len, &pubkey_one, SECP256K1_EC_COMPRESSED) == 1);
+    CHECK(cosmos_secp256k1_ec_pubkey_serialize(ctx, ctmp, &len, &pubkey, SECP256K1_EC_COMPRESSED) == 1);
+    CHECK(cosmos_secp256k1_ec_pubkey_serialize(ctx, ctmp2, &len, &pubkey_one, SECP256K1_EC_COMPRESSED) == 1);
     CHECK(memcmp(ctmp, ctmp2, 33) == 0);
     /* Adds to two. */
     pubkeys[1] = &pubkey_one;
@@ -3453,7 +3453,7 @@ void test_ecdsa_end_to_end(void) {
     CHECK(secp256k1_ec_pubkey_create(ctx, &pubkey, privkey) == 1);
 
     /* Verify exporting and importing public key. */
-    CHECK(secp256k1_ec_pubkey_serialize(ctx, pubkeyc, &pubkeyclen, &pubkey, secp256k1_rand_bits(1) == 1 ? SECP256K1_EC_COMPRESSED : SECP256K1_EC_UNCOMPRESSED));
+    CHECK(cosmos_secp256k1_ec_pubkey_serialize(ctx, pubkeyc, &pubkeyclen, &pubkey, secp256k1_rand_bits(1) == 1 ? SECP256K1_EC_COMPRESSED : SECP256K1_EC_UNCOMPRESSED));
     memset(&pubkey, 0, sizeof(pubkey));
     CHECK(secp256k1_ec_pubkey_parse(ctx, &pubkey, pubkeyc, pubkeyclen) == 1);
 

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/tests.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/tests.c
@@ -3518,19 +3518,19 @@ void test_ecdsa_end_to_end(void) {
     CHECK(secp256k1_ecdsa_verify(ctx, &signature[2], message, &pubkey) == 1);
     CHECK(secp256k1_ecdsa_verify(ctx, &signature[3], message, &pubkey) == 1);
     /* Test lower-S form, malleate, verify and fail, test again, malleate again */
-    CHECK(!secp256k1_ecdsa_signature_normalize(ctx, NULL, &signature[0]));
+    CHECK(!cosmos_secp256k1_ecdsa_signature_normalize(ctx, NULL, &signature[0]));
     secp256k1_ecdsa_signature_load(ctx, &r, &s, &signature[0]);
     secp256k1_scalar_negate(&s, &s);
     secp256k1_ecdsa_signature_save(&signature[5], &r, &s);
     CHECK(secp256k1_ecdsa_verify(ctx, &signature[5], message, &pubkey) == 0);
-    CHECK(secp256k1_ecdsa_signature_normalize(ctx, NULL, &signature[5]));
-    CHECK(secp256k1_ecdsa_signature_normalize(ctx, &signature[5], &signature[5]));
-    CHECK(!secp256k1_ecdsa_signature_normalize(ctx, NULL, &signature[5]));
-    CHECK(!secp256k1_ecdsa_signature_normalize(ctx, &signature[5], &signature[5]));
+    CHECK(cosmos_secp256k1_ecdsa_signature_normalize(ctx, NULL, &signature[5]));
+    CHECK(cosmos_secp256k1_ecdsa_signature_normalize(ctx, &signature[5], &signature[5]));
+    CHECK(!cosmos_secp256k1_ecdsa_signature_normalize(ctx, NULL, &signature[5]));
+    CHECK(!cosmos_secp256k1_ecdsa_signature_normalize(ctx, &signature[5], &signature[5]));
     CHECK(secp256k1_ecdsa_verify(ctx, &signature[5], message, &pubkey) == 1);
     secp256k1_scalar_negate(&s, &s);
     secp256k1_ecdsa_signature_save(&signature[5], &r, &s);
-    CHECK(!secp256k1_ecdsa_signature_normalize(ctx, NULL, &signature[5]));
+    CHECK(!cosmos_secp256k1_ecdsa_signature_normalize(ctx, NULL, &signature[5]));
     CHECK(secp256k1_ecdsa_verify(ctx, &signature[5], message, &pubkey) == 1);
     CHECK(memcmp(&signature[5], &signature[0], 64) == 0);
 
@@ -4194,7 +4194,7 @@ void test_ecdsa_edge_cases(void) {
         CHECK(secp256k1_ecdsa_signature_serialize_der(ctx, signature, &siglen, &sig) == 0);
         CHECK(ecount == 13);
         ecount = 0;
-        CHECK(secp256k1_ecdsa_signature_normalize(ctx, NULL, NULL) == 0);
+        CHECK(cosmos_secp256k1_ecdsa_signature_normalize(ctx, NULL, NULL) == 0);
         CHECK(ecount == 1);
         CHECK(secp256k1_ecdsa_signature_serialize_compact(ctx, NULL, &sig) == 0);
         CHECK(ecount == 2);

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/tests.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/tests.c
@@ -3173,7 +3173,7 @@ void run_eckey_edge_case_test(void) {
     CHECK(secp256k1_ec_pubkey_tweak_add(ctx, &pubkey, ctmp2) == 1);
     CHECK(memcmp(&pubkey, &pubkey2, sizeof(pubkey)) == 0);
     /* Multiply tweak of zero zeroizes the output. */
-    CHECK(secp256k1_ec_privkey_tweak_mul(ctx, ctmp, ctmp2) == 0);
+    CHECK(cosmos_secp256k1_ec_privkey_tweak_mul(ctx, ctmp, ctmp2) == 0);
     CHECK(memcmp(zeros, ctmp, 32) == 0);
     CHECK(secp256k1_ec_pubkey_tweak_mul(ctx, &pubkey, ctmp2) == 0);
     CHECK(memcmp(&pubkey, zeros, sizeof(pubkey)) == 0);
@@ -3185,7 +3185,7 @@ void run_eckey_edge_case_test(void) {
     CHECK(memcmp(zeros, ctmp, 32) == 0);
     memcpy(ctmp, orderc, 32);
     ctmp[31] = 0x40;
-    CHECK(secp256k1_ec_privkey_tweak_mul(ctx, ctmp, orderc) == 0);
+    CHECK(cosmos_secp256k1_ec_privkey_tweak_mul(ctx, ctmp, orderc) == 0);
     CHECK(memcmp(zeros, ctmp, 32) == 0);
     memcpy(ctmp, orderc, 32);
     ctmp[31] = 0x40;
@@ -3260,9 +3260,9 @@ void run_eckey_edge_case_test(void) {
     ecount = 0;
     memset(ctmp2, 0, 32);
     ctmp2[31] = 1;
-    CHECK(secp256k1_ec_privkey_tweak_mul(ctx, NULL, ctmp2) == 0);
+    CHECK(cosmos_secp256k1_ec_privkey_tweak_mul(ctx, NULL, ctmp2) == 0);
     CHECK(ecount == 1);
-    CHECK(secp256k1_ec_privkey_tweak_mul(ctx, ctmp, NULL) == 0);
+    CHECK(cosmos_secp256k1_ec_privkey_tweak_mul(ctx, ctmp, NULL) == 0);
     CHECK(ecount == 2);
     ecount = 0;
     CHECK(secp256k1_ec_pubkey_create(ctx, NULL, ctmp) == 0);
@@ -3486,7 +3486,7 @@ void test_ecdsa_end_to_end(void) {
         unsigned char rnd[32];
         secp256k1_pubkey pubkey2;
         secp256k1_rand256_test(rnd);
-        ret1 = secp256k1_ec_privkey_tweak_mul(ctx, privkey, rnd);
+        ret1 = cosmos_secp256k1_ec_privkey_tweak_mul(ctx, privkey, rnd);
         ret2 = secp256k1_ec_pubkey_tweak_mul(ctx, &pubkey, rnd);
         CHECK(ret1 == ret2);
         if (ret1 == 0) {

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/tests.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/tests.c
@@ -185,10 +185,10 @@ void run_context_tests(void) {
     VG_UNDEF(&pubkey, sizeof(pubkey));
     CHECK(secp256k1_ec_pubkey_create(sign, &pubkey, ctmp) == 1);
     VG_CHECK(&pubkey, sizeof(pubkey));
-    CHECK(secp256k1_ecdsa_sign(vrfy, &sig, ctmp, ctmp, NULL, NULL) == 0);
+    CHECK(cosmos_secp256k1_ecdsa_sign(vrfy, &sig, ctmp, ctmp, NULL, NULL) == 0);
     CHECK(ecount == 2);
     VG_UNDEF(&sig, sizeof(sig));
-    CHECK(secp256k1_ecdsa_sign(sign, &sig, ctmp, ctmp, NULL, NULL) == 1);
+    CHECK(cosmos_secp256k1_ecdsa_sign(sign, &sig, ctmp, ctmp, NULL, NULL) == 1);
     VG_CHECK(&sig, sizeof(sig));
     CHECK(ecount2 == 10);
     CHECK(secp256k1_ecdsa_verify(sign, &sig, ctmp, &pubkey) == 0);
@@ -3497,14 +3497,14 @@ void test_ecdsa_end_to_end(void) {
     }
 
     /* Sign. */
-    CHECK(secp256k1_ecdsa_sign(ctx, &signature[0], message, privkey, NULL, NULL) == 1);
-    CHECK(secp256k1_ecdsa_sign(ctx, &signature[4], message, privkey, NULL, NULL) == 1);
-    CHECK(secp256k1_ecdsa_sign(ctx, &signature[1], message, privkey, NULL, extra) == 1);
+    CHECK(cosmos_secp256k1_ecdsa_sign(ctx, &signature[0], message, privkey, NULL, NULL) == 1);
+    CHECK(cosmos_secp256k1_ecdsa_sign(ctx, &signature[4], message, privkey, NULL, NULL) == 1);
+    CHECK(cosmos_secp256k1_ecdsa_sign(ctx, &signature[1], message, privkey, NULL, extra) == 1);
     extra[31] = 1;
-    CHECK(secp256k1_ecdsa_sign(ctx, &signature[2], message, privkey, NULL, extra) == 1);
+    CHECK(cosmos_secp256k1_ecdsa_sign(ctx, &signature[2], message, privkey, NULL, extra) == 1);
     extra[31] = 0;
     extra[0] = 1;
-    CHECK(secp256k1_ecdsa_sign(ctx, &signature[3], message, privkey, NULL, extra) == 1);
+    CHECK(cosmos_secp256k1_ecdsa_sign(ctx, &signature[3], message, privkey, NULL, extra) == 1);
     CHECK(memcmp(&signature[0], &signature[4], sizeof(signature[0])) == 0);
     CHECK(memcmp(&signature[0], &signature[1], sizeof(signature[0])) != 0);
     CHECK(memcmp(&signature[0], &signature[2], sizeof(signature[0])) != 0);
@@ -4148,18 +4148,18 @@ void test_ecdsa_edge_cases(void) {
         };
         ecount = 0;
         secp256k1_context_set_illegal_callback(ctx, counting_illegal_callback_fn, &ecount);
-        CHECK(secp256k1_ecdsa_sign(ctx, &sig, msg, key, precomputed_nonce_function, nonce) == 0);
-        CHECK(secp256k1_ecdsa_sign(ctx, &sig, msg, key, precomputed_nonce_function, nonce2) == 0);
+        CHECK(cosmos_secp256k1_ecdsa_sign(ctx, &sig, msg, key, precomputed_nonce_function, nonce) == 0);
+        CHECK(cosmos_secp256k1_ecdsa_sign(ctx, &sig, msg, key, precomputed_nonce_function, nonce2) == 0);
         msg[31] = 0xaa;
-        CHECK(secp256k1_ecdsa_sign(ctx, &sig, msg, key, precomputed_nonce_function, nonce) == 1);
+        CHECK(cosmos_secp256k1_ecdsa_sign(ctx, &sig, msg, key, precomputed_nonce_function, nonce) == 1);
         CHECK(ecount == 0);
-        CHECK(secp256k1_ecdsa_sign(ctx, NULL, msg, key, precomputed_nonce_function, nonce2) == 0);
+        CHECK(cosmos_secp256k1_ecdsa_sign(ctx, NULL, msg, key, precomputed_nonce_function, nonce2) == 0);
         CHECK(ecount == 1);
-        CHECK(secp256k1_ecdsa_sign(ctx, &sig, NULL, key, precomputed_nonce_function, nonce2) == 0);
+        CHECK(cosmos_secp256k1_ecdsa_sign(ctx, &sig, NULL, key, precomputed_nonce_function, nonce2) == 0);
         CHECK(ecount == 2);
-        CHECK(secp256k1_ecdsa_sign(ctx, &sig, msg, NULL, precomputed_nonce_function, nonce2) == 0);
+        CHECK(cosmos_secp256k1_ecdsa_sign(ctx, &sig, msg, NULL, precomputed_nonce_function, nonce2) == 0);
         CHECK(ecount == 3);
-        CHECK(secp256k1_ecdsa_sign(ctx, &sig, msg, key, precomputed_nonce_function, nonce2) == 1);
+        CHECK(cosmos_secp256k1_ecdsa_sign(ctx, &sig, msg, key, precomputed_nonce_function, nonce2) == 1);
         CHECK(secp256k1_ec_pubkey_create(ctx, &pubkey, key) == 1);
         CHECK(secp256k1_ecdsa_verify(ctx, NULL, msg, &pubkey) == 0);
         CHECK(ecount == 4);
@@ -4228,31 +4228,31 @@ void test_ecdsa_edge_cases(void) {
         msg[31] = 1;
         /* High key results in signature failure. */
         memset(key, 0xFF, 32);
-        CHECK(secp256k1_ecdsa_sign(ctx, &sig, msg, key, NULL, extra) == 0);
+        CHECK(cosmos_secp256k1_ecdsa_sign(ctx, &sig, msg, key, NULL, extra) == 0);
         CHECK(is_empty_signature(&sig));
         /* Zero key results in signature failure. */
         memset(key, 0, 32);
-        CHECK(secp256k1_ecdsa_sign(ctx, &sig, msg, key, NULL, extra) == 0);
+        CHECK(cosmos_secp256k1_ecdsa_sign(ctx, &sig, msg, key, NULL, extra) == 0);
         CHECK(is_empty_signature(&sig));
         /* Nonce function failure results in signature failure. */
         key[31] = 1;
-        CHECK(secp256k1_ecdsa_sign(ctx, &sig, msg, key, nonce_function_test_fail, extra) == 0);
+        CHECK(cosmos_secp256k1_ecdsa_sign(ctx, &sig, msg, key, nonce_function_test_fail, extra) == 0);
         CHECK(is_empty_signature(&sig));
         /* The retry loop successfully makes its way to the first good value. */
-        CHECK(secp256k1_ecdsa_sign(ctx, &sig, msg, key, nonce_function_test_retry, extra) == 1);
+        CHECK(cosmos_secp256k1_ecdsa_sign(ctx, &sig, msg, key, nonce_function_test_retry, extra) == 1);
         CHECK(!is_empty_signature(&sig));
-        CHECK(secp256k1_ecdsa_sign(ctx, &sig2, msg, key, nonce_function_rfc6979, extra) == 1);
+        CHECK(cosmos_secp256k1_ecdsa_sign(ctx, &sig2, msg, key, nonce_function_rfc6979, extra) == 1);
         CHECK(!is_empty_signature(&sig2));
         CHECK(memcmp(&sig, &sig2, sizeof(sig)) == 0);
         /* The default nonce function is deterministic. */
-        CHECK(secp256k1_ecdsa_sign(ctx, &sig2, msg, key, NULL, extra) == 1);
+        CHECK(cosmos_secp256k1_ecdsa_sign(ctx, &sig2, msg, key, NULL, extra) == 1);
         CHECK(!is_empty_signature(&sig2));
         CHECK(memcmp(&sig, &sig2, sizeof(sig)) == 0);
         /* The default nonce function changes output with different messages. */
         for(i = 0; i < 256; i++) {
             int j;
             msg[0] = i;
-            CHECK(secp256k1_ecdsa_sign(ctx, &sig2, msg, key, NULL, extra) == 1);
+            CHECK(cosmos_secp256k1_ecdsa_sign(ctx, &sig2, msg, key, NULL, extra) == 1);
             CHECK(!is_empty_signature(&sig2));
             secp256k1_ecdsa_signature_load(ctx, &sr[i], &ss, &sig2);
             for (j = 0; j < i; j++) {
@@ -4265,7 +4265,7 @@ void test_ecdsa_edge_cases(void) {
         for(i = 256; i < 512; i++) {
             int j;
             key[0] = i - 256;
-            CHECK(secp256k1_ecdsa_sign(ctx, &sig2, msg, key, NULL, extra) == 1);
+            CHECK(cosmos_secp256k1_ecdsa_sign(ctx, &sig2, msg, key, NULL, extra) == 1);
             CHECK(!is_empty_signature(&sig2));
             secp256k1_ecdsa_signature_load(ctx, &sr[i], &ss, &sig2);
             for (j = 0; j < i; j++) {

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/tests.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/tests.c
@@ -2730,7 +2730,7 @@ void ec_pubkey_parse_pointtest(const unsigned char *input, int xvalid, int yvali
                 memset(&pubkey, 0, sizeof(pubkey));
                 VG_UNDEF(&pubkey, sizeof(pubkey));
                 ecount = 0;
-                CHECK(secp256k1_ec_pubkey_parse(ctx, &pubkey, pubkeyc, pubkeyclen) == 1);
+                CHECK(cosmos_secp256k1_ec_pubkey_parse(ctx, &pubkey, pubkeyc, pubkeyclen) == 1);
                 VG_CHECK(&pubkey, sizeof(pubkey));
                 outl = 65;
                 VG_UNDEF(pubkeyo, 65);
@@ -2761,7 +2761,7 @@ void ec_pubkey_parse_pointtest(const unsigned char *input, int xvalid, int yvali
                 memset(&pubkey, 0xfe, sizeof(pubkey));
                 ecount = 0;
                 VG_UNDEF(&pubkey, sizeof(pubkey));
-                CHECK(secp256k1_ec_pubkey_parse(ctx, &pubkey, pubkeyc, pubkeyclen) == 0);
+                CHECK(cosmos_secp256k1_ec_pubkey_parse(ctx, &pubkey, pubkeyc, pubkeyclen) == 0);
                 VG_CHECK(&pubkey, sizeof(pubkey));
                 CHECK(ecount == 0);
                 CHECK(secp256k1_pubkey_load(ctx, &ge, &pubkey) == 0);
@@ -2968,7 +2968,7 @@ void run_ec_pubkey_parse_test(void) {
     ecount = 0;
     VG_UNDEF(shortkey, 2);
     VG_UNDEF(&pubkey, sizeof(pubkey));
-    CHECK(secp256k1_ec_pubkey_parse(ctx, &pubkey, shortkey, 0) == 0);
+    CHECK(cosmos_secp256k1_ec_pubkey_parse(ctx, &pubkey, shortkey, 0) == 0);
     VG_CHECK(&pubkey, sizeof(pubkey));
     CHECK(ecount == 0);
     CHECK(secp256k1_pubkey_load(ctx, &ge, &pubkey) == 0);
@@ -2980,7 +2980,7 @@ void run_ec_pubkey_parse_test(void) {
         shortkey[0] = i;
         VG_UNDEF(&shortkey[1], 1);
         VG_UNDEF(&pubkey, sizeof(pubkey));
-        CHECK(secp256k1_ec_pubkey_parse(ctx, &pubkey, shortkey, 1) == 0);
+        CHECK(cosmos_secp256k1_ec_pubkey_parse(ctx, &pubkey, shortkey, 1) == 0);
         VG_CHECK(&pubkey, sizeof(pubkey));
         CHECK(ecount == 0);
         CHECK(secp256k1_pubkey_load(ctx, &ge, &pubkey) == 0);
@@ -2993,7 +2993,7 @@ void run_ec_pubkey_parse_test(void) {
         shortkey[0] = i & 255;
         shortkey[1] = i >> 8;
         VG_UNDEF(&pubkey, sizeof(pubkey));
-        CHECK(secp256k1_ec_pubkey_parse(ctx, &pubkey, shortkey, 2) == 0);
+        CHECK(cosmos_secp256k1_ec_pubkey_parse(ctx, &pubkey, shortkey, 2) == 0);
         VG_CHECK(&pubkey, sizeof(pubkey));
         CHECK(ecount == 0);
         CHECK(secp256k1_pubkey_load(ctx, &ge, &pubkey) == 0);
@@ -3003,19 +3003,19 @@ void run_ec_pubkey_parse_test(void) {
     ecount = 0;
     VG_UNDEF(&pubkey, sizeof(pubkey));
     /* 33 bytes claimed on otherwise valid input starting with 0x04, fail, zeroize output, no illegal arg error. */
-    CHECK(secp256k1_ec_pubkey_parse(ctx, &pubkey, pubkeyc, 33) == 0);
+    CHECK(cosmos_secp256k1_ec_pubkey_parse(ctx, &pubkey, pubkeyc, 33) == 0);
     VG_CHECK(&pubkey, sizeof(pubkey));
     CHECK(ecount == 0);
     CHECK(secp256k1_pubkey_load(ctx, &ge, &pubkey) == 0);
     CHECK(ecount == 1);
     /* NULL pubkey, illegal arg error. Pubkey isn't rewritten before this step, since it's NULL into the parser. */
-    CHECK(secp256k1_ec_pubkey_parse(ctx, NULL, pubkeyc, 65) == 0);
+    CHECK(cosmos_secp256k1_ec_pubkey_parse(ctx, NULL, pubkeyc, 65) == 0);
     CHECK(ecount == 2);
     /* NULL input string. Illegal arg and zeroize output. */
     memset(&pubkey, 0xfe, sizeof(pubkey));
     ecount = 0;
     VG_UNDEF(&pubkey, sizeof(pubkey));
-    CHECK(secp256k1_ec_pubkey_parse(ctx, &pubkey, NULL, 65) == 0);
+    CHECK(cosmos_secp256k1_ec_pubkey_parse(ctx, &pubkey, NULL, 65) == 0);
     VG_CHECK(&pubkey, sizeof(pubkey));
     CHECK(ecount == 1);
     CHECK(secp256k1_pubkey_load(ctx, &ge, &pubkey) == 0);
@@ -3024,7 +3024,7 @@ void run_ec_pubkey_parse_test(void) {
     memset(&pubkey, 0xfe, sizeof(pubkey));
     ecount = 0;
     VG_UNDEF(&pubkey, sizeof(pubkey));
-    CHECK(secp256k1_ec_pubkey_parse(ctx, &pubkey, pubkeyc, 64) == 0);
+    CHECK(cosmos_secp256k1_ec_pubkey_parse(ctx, &pubkey, pubkeyc, 64) == 0);
     VG_CHECK(&pubkey, sizeof(pubkey));
     CHECK(ecount == 0);
     CHECK(secp256k1_pubkey_load(ctx, &ge, &pubkey) == 0);
@@ -3033,7 +3033,7 @@ void run_ec_pubkey_parse_test(void) {
     memset(&pubkey, 0xfe, sizeof(pubkey));
     ecount = 0;
     VG_UNDEF(&pubkey, sizeof(pubkey));
-    CHECK(secp256k1_ec_pubkey_parse(ctx, &pubkey, pubkeyc, 66) == 0);
+    CHECK(cosmos_secp256k1_ec_pubkey_parse(ctx, &pubkey, pubkeyc, 66) == 0);
     VG_CHECK(&pubkey, sizeof(pubkey));
     CHECK(ecount == 0);
     CHECK(secp256k1_pubkey_load(ctx, &ge, &pubkey) == 0);
@@ -3042,7 +3042,7 @@ void run_ec_pubkey_parse_test(void) {
     memset(&pubkey, 0, sizeof(pubkey));
     ecount = 0;
     VG_UNDEF(&pubkey, sizeof(pubkey));
-    CHECK(secp256k1_ec_pubkey_parse(ctx, &pubkey, pubkeyc, 65) == 1);
+    CHECK(cosmos_secp256k1_ec_pubkey_parse(ctx, &pubkey, pubkeyc, 65) == 1);
     VG_CHECK(&pubkey, sizeof(pubkey));
     CHECK(ecount == 0);
     VG_UNDEF(&ge, sizeof(ge));
@@ -3079,11 +3079,11 @@ void run_ec_pubkey_parse_test(void) {
     /* Multiple illegal args. Should still set arg error only once. */
     ecount = 0;
     ecount2 = 11;
-    CHECK(secp256k1_ec_pubkey_parse(ctx, NULL, NULL, 65) == 0);
+    CHECK(cosmos_secp256k1_ec_pubkey_parse(ctx, NULL, NULL, 65) == 0);
     CHECK(ecount == 1);
     /* Does the illegal arg callback actually change the behavior? */
     secp256k1_context_set_illegal_callback(ctx, uncounting_illegal_callback_fn, &ecount2);
-    CHECK(secp256k1_ec_pubkey_parse(ctx, NULL, NULL, 65) == 0);
+    CHECK(cosmos_secp256k1_ec_pubkey_parse(ctx, NULL, NULL, 65) == 0);
     CHECK(ecount == 1);
     CHECK(ecount2 == 10);
     secp256k1_context_set_illegal_callback(ctx, NULL, NULL);
@@ -3455,7 +3455,7 @@ void test_ecdsa_end_to_end(void) {
     /* Verify exporting and importing public key. */
     CHECK(cosmos_secp256k1_ec_pubkey_serialize(ctx, pubkeyc, &pubkeyclen, &pubkey, secp256k1_rand_bits(1) == 1 ? SECP256K1_EC_COMPRESSED : SECP256K1_EC_UNCOMPRESSED));
     memset(&pubkey, 0, sizeof(pubkey));
-    CHECK(secp256k1_ec_pubkey_parse(ctx, &pubkey, pubkeyc, pubkeyclen) == 1);
+    CHECK(cosmos_secp256k1_ec_pubkey_parse(ctx, &pubkey, pubkeyc, pubkeyclen) == 1);
 
     /* Verify private key import and export. */
     CHECK(ec_privkey_export_der(ctx, seckey, &seckeylen, privkey, secp256k1_rand_bits(1) == 1));

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/tests.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/tests.c
@@ -160,10 +160,10 @@ void run_context_tests(void) {
     {
         secp256k1_context *ctx_tmp;
 
-        ctx_tmp = none; none = cosmos_secp256k1_context_clone(none); secp256k1_context_destroy(ctx_tmp);
-        ctx_tmp = sign; sign = cosmos_secp256k1_context_clone(sign); secp256k1_context_destroy(ctx_tmp);
-        ctx_tmp = vrfy; vrfy = cosmos_secp256k1_context_clone(vrfy); secp256k1_context_destroy(ctx_tmp);
-        ctx_tmp = both; both = cosmos_secp256k1_context_clone(both); secp256k1_context_destroy(ctx_tmp);
+        ctx_tmp = none; none = cosmos_secp256k1_context_clone(none); cosmos_secp256k1_context_destroy(ctx_tmp);
+        ctx_tmp = sign; sign = cosmos_secp256k1_context_clone(sign); cosmos_secp256k1_context_destroy(ctx_tmp);
+        ctx_tmp = vrfy; vrfy = cosmos_secp256k1_context_clone(vrfy); cosmos_secp256k1_context_destroy(ctx_tmp);
+        ctx_tmp = both; both = cosmos_secp256k1_context_clone(both); cosmos_secp256k1_context_destroy(ctx_tmp);
     }
 
     /* Verify that the error callback makes it across the clone. */
@@ -228,12 +228,12 @@ void run_context_tests(void) {
     CHECK(secp256k1_ecdsa_sig_verify(&both->ecmult_ctx, &sigr, &sigs, &pub, &msg));
 
     /* cleanup */
-    secp256k1_context_destroy(none);
-    secp256k1_context_destroy(sign);
-    secp256k1_context_destroy(vrfy);
-    secp256k1_context_destroy(both);
+    cosmos_secp256k1_context_destroy(none);
+    cosmos_secp256k1_context_destroy(sign);
+    cosmos_secp256k1_context_destroy(vrfy);
+    cosmos_secp256k1_context_destroy(both);
     /* Defined as no-op. */
-    secp256k1_context_destroy(NULL);
+    cosmos_secp256k1_context_destroy(NULL);
 }
 
 /***** HASH TESTS *****/
@@ -4518,7 +4518,7 @@ int main(int argc, char **argv) {
     printf("random run = %02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x\n", run32[0], run32[1], run32[2], run32[3], run32[4], run32[5], run32[6], run32[7], run32[8], run32[9], run32[10], run32[11], run32[12], run32[13], run32[14], run32[15]);
 
     /* shutdown */
-    secp256k1_context_destroy(ctx);
+    cosmos_secp256k1_context_destroy(ctx);
 
     printf("no problems found\n");
     return 0;

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/tests.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/tests.c
@@ -160,10 +160,10 @@ void run_context_tests(void) {
     {
         secp256k1_context *ctx_tmp;
 
-        ctx_tmp = none; none = secp256k1_context_clone(none); secp256k1_context_destroy(ctx_tmp);
-        ctx_tmp = sign; sign = secp256k1_context_clone(sign); secp256k1_context_destroy(ctx_tmp);
-        ctx_tmp = vrfy; vrfy = secp256k1_context_clone(vrfy); secp256k1_context_destroy(ctx_tmp);
-        ctx_tmp = both; both = secp256k1_context_clone(both); secp256k1_context_destroy(ctx_tmp);
+        ctx_tmp = none; none = cosmos_secp256k1_context_clone(none); secp256k1_context_destroy(ctx_tmp);
+        ctx_tmp = sign; sign = cosmos_secp256k1_context_clone(sign); secp256k1_context_destroy(ctx_tmp);
+        ctx_tmp = vrfy; vrfy = cosmos_secp256k1_context_clone(vrfy); secp256k1_context_destroy(ctx_tmp);
+        ctx_tmp = both; both = cosmos_secp256k1_context_clone(both); secp256k1_context_destroy(ctx_tmp);
     }
 
     /* Verify that the error callback makes it across the clone. */

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/tests.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/tests.c
@@ -2164,7 +2164,7 @@ void test_ec_combine(void) {
         secp256k1_ecmult_gen(&ctx->ecmult_gen_ctx, &Qj, &sum);
         secp256k1_ge_set_gej(&Q, &Qj);
         secp256k1_pubkey_save(&sd, &Q);
-        CHECK(secp256k1_ec_pubkey_combine(ctx, &sd2, d, i) == 1);
+        CHECK(cosmos_secp256k1_ec_pubkey_combine(ctx, &sd2, d, i) == 1);
         CHECK(memcmp(&sd, &sd2, sizeof(sd)) == 0);
     }
 }
@@ -3271,7 +3271,7 @@ void run_eckey_edge_case_test(void) {
     CHECK(secp256k1_ec_pubkey_create(ctx, &pubkey, NULL) == 0);
     CHECK(ecount == 2);
     CHECK(memcmp(&pubkey, zeros, sizeof(secp256k1_pubkey)) == 0);
-    /* secp256k1_ec_pubkey_combine tests. */
+    /* cosmos_secp256k1_ec_pubkey_combine tests. */
     ecount = 0;
     pubkeys[0] = &pubkey_one;
     VG_UNDEF(&pubkeys[0], sizeof(secp256k1_pubkey *));
@@ -3279,23 +3279,23 @@ void run_eckey_edge_case_test(void) {
     VG_UNDEF(&pubkeys[2], sizeof(secp256k1_pubkey *));
     memset(&pubkey, 255, sizeof(secp256k1_pubkey));
     VG_UNDEF(&pubkey, sizeof(secp256k1_pubkey));
-    CHECK(secp256k1_ec_pubkey_combine(ctx, &pubkey, pubkeys, 0) == 0);
+    CHECK(cosmos_secp256k1_ec_pubkey_combine(ctx, &pubkey, pubkeys, 0) == 0);
     VG_CHECK(&pubkey, sizeof(secp256k1_pubkey));
     CHECK(memcmp(&pubkey, zeros, sizeof(secp256k1_pubkey)) == 0);
     CHECK(ecount == 1);
-    CHECK(secp256k1_ec_pubkey_combine(ctx, NULL, pubkeys, 1) == 0);
+    CHECK(cosmos_secp256k1_ec_pubkey_combine(ctx, NULL, pubkeys, 1) == 0);
     CHECK(memcmp(&pubkey, zeros, sizeof(secp256k1_pubkey)) == 0);
     CHECK(ecount == 2);
     memset(&pubkey, 255, sizeof(secp256k1_pubkey));
     VG_UNDEF(&pubkey, sizeof(secp256k1_pubkey));
-    CHECK(secp256k1_ec_pubkey_combine(ctx, &pubkey, NULL, 1) == 0);
+    CHECK(cosmos_secp256k1_ec_pubkey_combine(ctx, &pubkey, NULL, 1) == 0);
     VG_CHECK(&pubkey, sizeof(secp256k1_pubkey));
     CHECK(memcmp(&pubkey, zeros, sizeof(secp256k1_pubkey)) == 0);
     CHECK(ecount == 3);
     pubkeys[0] = &pubkey_negone;
     memset(&pubkey, 255, sizeof(secp256k1_pubkey));
     VG_UNDEF(&pubkey, sizeof(secp256k1_pubkey));
-    CHECK(secp256k1_ec_pubkey_combine(ctx, &pubkey, pubkeys, 1) == 1);
+    CHECK(cosmos_secp256k1_ec_pubkey_combine(ctx, &pubkey, pubkeys, 1) == 1);
     VG_CHECK(&pubkey, sizeof(secp256k1_pubkey));
     CHECK(memcmp(&pubkey, zeros, sizeof(secp256k1_pubkey)) > 0);
     CHECK(ecount == 3);
@@ -3308,7 +3308,7 @@ void run_eckey_edge_case_test(void) {
     pubkeys[1] = &pubkey_negone;
     memset(&pubkey, 255, sizeof(secp256k1_pubkey));
     VG_UNDEF(&pubkey, sizeof(secp256k1_pubkey));
-    CHECK(secp256k1_ec_pubkey_combine(ctx, &pubkey, pubkeys, 2) == 0);
+    CHECK(cosmos_secp256k1_ec_pubkey_combine(ctx, &pubkey, pubkeys, 2) == 0);
     VG_CHECK(&pubkey, sizeof(secp256k1_pubkey));
     CHECK(memcmp(&pubkey, zeros, sizeof(secp256k1_pubkey)) == 0);
     CHECK(ecount == 3);
@@ -3316,7 +3316,7 @@ void run_eckey_edge_case_test(void) {
     pubkeys[2] = &pubkey_one;
     memset(&pubkey, 255, sizeof(secp256k1_pubkey));
     VG_UNDEF(&pubkey, sizeof(secp256k1_pubkey));
-    CHECK(secp256k1_ec_pubkey_combine(ctx, &pubkey, pubkeys, 3) == 1);
+    CHECK(cosmos_secp256k1_ec_pubkey_combine(ctx, &pubkey, pubkeys, 3) == 1);
     VG_CHECK(&pubkey, sizeof(secp256k1_pubkey));
     CHECK(memcmp(&pubkey, zeros, sizeof(secp256k1_pubkey)) > 0);
     CHECK(ecount == 3);
@@ -3328,7 +3328,7 @@ void run_eckey_edge_case_test(void) {
     pubkeys[1] = &pubkey_one;
     memset(&pubkey, 255, sizeof(secp256k1_pubkey));
     VG_UNDEF(&pubkey, sizeof(secp256k1_pubkey));
-    CHECK(secp256k1_ec_pubkey_combine(ctx, &pubkey, pubkeys, 2) == 1);
+    CHECK(cosmos_secp256k1_ec_pubkey_combine(ctx, &pubkey, pubkeys, 2) == 1);
     VG_CHECK(&pubkey, sizeof(secp256k1_pubkey));
     CHECK(memcmp(&pubkey, zeros, sizeof(secp256k1_pubkey)) > 0);
     CHECK(ecount == 3);

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/tests.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/tests.c
@@ -151,8 +151,8 @@ void run_context_tests(void) {
 
     ecount = 0;
     ecount2 = 10;
-    secp256k1_context_set_illegal_callback(vrfy, counting_illegal_callback_fn, &ecount);
-    secp256k1_context_set_illegal_callback(sign, counting_illegal_callback_fn, &ecount2);
+    cosmos_secp256k1_context_set_illegal_callback(vrfy, counting_illegal_callback_fn, &ecount);
+    cosmos_secp256k1_context_set_illegal_callback(sign, counting_illegal_callback_fn, &ecount2);
     secp256k1_context_set_error_callback(sign, counting_illegal_callback_fn, NULL);
     CHECK(vrfy->error_callback.fn != sign->error_callback.fn);
 
@@ -207,8 +207,8 @@ void run_context_tests(void) {
     CHECK(ecount == 3);
     CHECK(secp256k1_context_randomize(sign, NULL) == 1);
     CHECK(ecount2 == 13);
-    secp256k1_context_set_illegal_callback(vrfy, NULL, NULL);
-    secp256k1_context_set_illegal_callback(sign, NULL, NULL);
+    cosmos_secp256k1_context_set_illegal_callback(vrfy, NULL, NULL);
+    cosmos_secp256k1_context_set_illegal_callback(sign, NULL, NULL);
 
     /* This shouldn't leak memory, due to already-set tests. */
     secp256k1_ecmult_gen_context_build(&sign->ecmult_gen_ctx, NULL);
@@ -2704,7 +2704,7 @@ void ec_pubkey_parse_pointtest(const unsigned char *input, int xvalid, int yvali
     size_t pubkeyclen;
     int32_t ecount;
     ecount = 0;
-    secp256k1_context_set_illegal_callback(ctx, counting_illegal_callback_fn, &ecount);
+    cosmos_secp256k1_context_set_illegal_callback(ctx, counting_illegal_callback_fn, &ecount);
     for (pubkeyclen = 3; pubkeyclen <= 65; pubkeyclen++) {
         /* Smaller sizes are tested exhaustively elsewhere. */
         int32_t i;
@@ -2769,7 +2769,7 @@ void ec_pubkey_parse_pointtest(const unsigned char *input, int xvalid, int yvali
             }
         }
     }
-    secp256k1_context_set_illegal_callback(ctx, NULL, NULL);
+    cosmos_secp256k1_context_set_illegal_callback(ctx, NULL, NULL);
 }
 
 void run_ec_pubkey_parse_test(void) {
@@ -2962,7 +2962,7 @@ void run_ec_pubkey_parse_test(void) {
     ecount = 0;
     /* Nothing should be reading this far into pubkeyc. */
     VG_UNDEF(&pubkeyc[65], 1);
-    secp256k1_context_set_illegal_callback(ctx, counting_illegal_callback_fn, &ecount);
+    cosmos_secp256k1_context_set_illegal_callback(ctx, counting_illegal_callback_fn, &ecount);
     /* Zero length claimed, fail, zeroize, no illegal arg error. */
     memset(&pubkey, 0xfe, sizeof(pubkey));
     ecount = 0;
@@ -3082,11 +3082,11 @@ void run_ec_pubkey_parse_test(void) {
     CHECK(cosmos_secp256k1_ec_pubkey_parse(ctx, NULL, NULL, 65) == 0);
     CHECK(ecount == 1);
     /* Does the illegal arg callback actually change the behavior? */
-    secp256k1_context_set_illegal_callback(ctx, uncounting_illegal_callback_fn, &ecount2);
+    cosmos_secp256k1_context_set_illegal_callback(ctx, uncounting_illegal_callback_fn, &ecount2);
     CHECK(cosmos_secp256k1_ec_pubkey_parse(ctx, NULL, NULL, 65) == 0);
     CHECK(ecount == 1);
     CHECK(ecount2 == 10);
-    secp256k1_context_set_illegal_callback(ctx, NULL, NULL);
+    cosmos_secp256k1_context_set_illegal_callback(ctx, NULL, NULL);
     /* Try a bunch of prefabbed points with all possible encodings. */
     for (i = 0; i < SECP256K1_EC_PARSE_TEST_NVALID; i++) {
         ec_pubkey_parse_pointtest(valid[i], 1, 1);
@@ -3219,7 +3219,7 @@ void run_eckey_edge_case_test(void) {
     CHECK(memcmp(&pubkey, &pubkey2, sizeof(pubkey)) == 0);
     /* Test argument errors. */
     ecount = 0;
-    secp256k1_context_set_illegal_callback(ctx, counting_illegal_callback_fn, &ecount);
+    cosmos_secp256k1_context_set_illegal_callback(ctx, counting_illegal_callback_fn, &ecount);
     CHECK(ecount == 0);
     /* Zeroize pubkey on parse error. */
     memset(&pubkey, 0, 32);
@@ -3332,7 +3332,7 @@ void run_eckey_edge_case_test(void) {
     VG_CHECK(&pubkey, sizeof(secp256k1_pubkey));
     CHECK(memcmp(&pubkey, zeros, sizeof(secp256k1_pubkey)) > 0);
     CHECK(ecount == 3);
-    secp256k1_context_set_illegal_callback(ctx, NULL, NULL);
+    cosmos_secp256k1_context_set_illegal_callback(ctx, NULL, NULL);
 }
 
 void random_sign(secp256k1_scalar *sigr, secp256k1_scalar *sigs, const secp256k1_scalar *key, const secp256k1_scalar *msg, int *recid) {
@@ -4147,7 +4147,7 @@ void test_ecdsa_edge_cases(void) {
             0x65, 0xdf, 0xdd, 0x31, 0xb9, 0x3e, 0x29, 0xa9,
         };
         ecount = 0;
-        secp256k1_context_set_illegal_callback(ctx, counting_illegal_callback_fn, &ecount);
+        cosmos_secp256k1_context_set_illegal_callback(ctx, counting_illegal_callback_fn, &ecount);
         CHECK(cosmos_secp256k1_ecdsa_sign(ctx, &sig, msg, key, precomputed_nonce_function, nonce) == 0);
         CHECK(cosmos_secp256k1_ecdsa_sign(ctx, &sig, msg, key, precomputed_nonce_function, nonce2) == 0);
         msg[31] = 0xaa;
@@ -4211,7 +4211,7 @@ void test_ecdsa_edge_cases(void) {
         memset(signature, 255, 64);
         CHECK(cosmos_secp256k1_ecdsa_signature_parse_compact(ctx, &sig, signature) == 0);
         CHECK(ecount == 5);
-        secp256k1_context_set_illegal_callback(ctx, NULL, NULL);
+        cosmos_secp256k1_context_set_illegal_callback(ctx, NULL, NULL);
     }
 
     /* Nonce function corner cases. */

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/tests.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/tests.c
@@ -3535,13 +3535,13 @@ void test_ecdsa_end_to_end(void) {
     CHECK(memcmp(&signature[5], &signature[0], 64) == 0);
 
     /* Serialize/parse DER and verify again */
-    CHECK(secp256k1_ecdsa_signature_serialize_der(ctx, sig, &siglen, &signature[0]) == 1);
+    CHECK(cosmos_secp256k1_ecdsa_signature_serialize_der(ctx, sig, &siglen, &signature[0]) == 1);
     memset(&signature[0], 0, sizeof(signature[0]));
     CHECK(cosmos_secp256k1_ecdsa_signature_parse_der(ctx, &signature[0], sig, siglen) == 1);
     CHECK(cosmos_secp256k1_ecdsa_verify(ctx, &signature[0], message, &pubkey) == 1);
     /* Serialize/destroy/parse DER and verify again. */
     siglen = 74;
-    CHECK(secp256k1_ecdsa_signature_serialize_der(ctx, sig, &siglen, &signature[0]) == 1);
+    CHECK(cosmos_secp256k1_ecdsa_signature_serialize_der(ctx, sig, &siglen, &signature[0]) == 1);
     sig[secp256k1_rand_int(siglen)] += 1 + secp256k1_rand_int(255);
     CHECK(cosmos_secp256k1_ecdsa_signature_parse_der(ctx, &signature[0], sig, siglen) == 0 ||
           cosmos_secp256k1_ecdsa_verify(ctx, &signature[0], message, &pubkey) == 0);
@@ -3660,7 +3660,7 @@ int test_ecdsa_der_parse(const unsigned char *sig, size_t siglen, int certainly_
         valid_der = (memcmp(compact_der, zeroes, 32) != 0) && (memcmp(compact_der + 32, zeroes, 32) != 0);
     }
     if (valid_der) {
-        ret |= (!secp256k1_ecdsa_signature_serialize_der(ctx, roundtrip_der, &len_der, &sig_der)) << 1;
+        ret |= (!cosmos_secp256k1_ecdsa_signature_serialize_der(ctx, roundtrip_der, &len_der, &sig_der)) << 1;
         roundtrips_der = (len_der == siglen) && memcmp(roundtrip_der, sig, siglen) == 0;
     }
 
@@ -3670,7 +3670,7 @@ int test_ecdsa_der_parse(const unsigned char *sig, size_t siglen, int certainly_
         valid_der_lax = (memcmp(compact_der_lax, zeroes, 32) != 0) && (memcmp(compact_der_lax + 32, zeroes, 32) != 0);
     }
     if (valid_der_lax) {
-        ret |= (!secp256k1_ecdsa_signature_serialize_der(ctx, roundtrip_der_lax, &len_der_lax, &sig_der_lax)) << 11;
+        ret |= (!cosmos_secp256k1_ecdsa_signature_serialize_der(ctx, roundtrip_der_lax, &len_der_lax, &sig_der_lax)) << 11;
         roundtrips_der_lax = (len_der_lax == siglen) && memcmp(roundtrip_der_lax, sig, siglen) == 0;
     }
 
@@ -4175,13 +4175,13 @@ void test_ecdsa_edge_cases(void) {
         CHECK(cosmos_secp256k1_ecdsa_verify(ctx, &sig, msg, &pubkey) == 0);
         CHECK(ecount == 8);
         siglen = 72;
-        CHECK(secp256k1_ecdsa_signature_serialize_der(ctx, NULL, &siglen, &sig) == 0);
+        CHECK(cosmos_secp256k1_ecdsa_signature_serialize_der(ctx, NULL, &siglen, &sig) == 0);
         CHECK(ecount == 9);
-        CHECK(secp256k1_ecdsa_signature_serialize_der(ctx, signature, NULL, &sig) == 0);
+        CHECK(cosmos_secp256k1_ecdsa_signature_serialize_der(ctx, signature, NULL, &sig) == 0);
         CHECK(ecount == 10);
-        CHECK(secp256k1_ecdsa_signature_serialize_der(ctx, signature, &siglen, NULL) == 0);
+        CHECK(cosmos_secp256k1_ecdsa_signature_serialize_der(ctx, signature, &siglen, NULL) == 0);
         CHECK(ecount == 11);
-        CHECK(secp256k1_ecdsa_signature_serialize_der(ctx, signature, &siglen, &sig) == 1);
+        CHECK(cosmos_secp256k1_ecdsa_signature_serialize_der(ctx, signature, &siglen, &sig) == 1);
         CHECK(ecount == 11);
         CHECK(cosmos_secp256k1_ecdsa_signature_parse_der(ctx, NULL, signature, siglen) == 0);
         CHECK(ecount == 12);
@@ -4191,7 +4191,7 @@ void test_ecdsa_edge_cases(void) {
         CHECK(ecount == 13);
         siglen = 10;
         /* Too little room for a signature does not fail via ARGCHECK. */
-        CHECK(secp256k1_ecdsa_signature_serialize_der(ctx, signature, &siglen, &sig) == 0);
+        CHECK(cosmos_secp256k1_ecdsa_signature_serialize_der(ctx, signature, &siglen, &sig) == 0);
         CHECK(ecount == 13);
         ecount = 0;
         CHECK(cosmos_secp256k1_ecdsa_signature_normalize(ctx, NULL, NULL) == 0);

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/tests.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/tests.c
@@ -4202,14 +4202,14 @@ void test_ecdsa_edge_cases(void) {
         CHECK(ecount == 3);
         CHECK(secp256k1_ecdsa_signature_serialize_compact(ctx, signature, &sig) == 1);
         CHECK(ecount == 3);
-        CHECK(secp256k1_ecdsa_signature_parse_compact(ctx, NULL, signature) == 0);
+        CHECK(cosmos_secp256k1_ecdsa_signature_parse_compact(ctx, NULL, signature) == 0);
         CHECK(ecount == 4);
-        CHECK(secp256k1_ecdsa_signature_parse_compact(ctx, &sig, NULL) == 0);
+        CHECK(cosmos_secp256k1_ecdsa_signature_parse_compact(ctx, &sig, NULL) == 0);
         CHECK(ecount == 5);
-        CHECK(secp256k1_ecdsa_signature_parse_compact(ctx, &sig, signature) == 1);
+        CHECK(cosmos_secp256k1_ecdsa_signature_parse_compact(ctx, &sig, signature) == 1);
         CHECK(ecount == 5);
         memset(signature, 255, 64);
-        CHECK(secp256k1_ecdsa_signature_parse_compact(ctx, &sig, signature) == 0);
+        CHECK(cosmos_secp256k1_ecdsa_signature_parse_compact(ctx, &sig, signature) == 0);
         CHECK(ecount == 5);
         secp256k1_context_set_illegal_callback(ctx, NULL, NULL);
     }

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/tests.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/tests.c
@@ -3656,7 +3656,7 @@ int test_ecdsa_der_parse(const unsigned char *sig, size_t siglen, int certainly_
 
     parsed_der = secp256k1_ecdsa_signature_parse_der(ctx, &sig_der, sig, siglen);
     if (parsed_der) {
-        ret |= (!secp256k1_ecdsa_signature_serialize_compact(ctx, compact_der, &sig_der)) << 0;
+        ret |= (!cosmos_secp256k1_ecdsa_signature_serialize_compact(ctx, compact_der, &sig_der)) << 0;
         valid_der = (memcmp(compact_der, zeroes, 32) != 0) && (memcmp(compact_der + 32, zeroes, 32) != 0);
     }
     if (valid_der) {
@@ -3666,7 +3666,7 @@ int test_ecdsa_der_parse(const unsigned char *sig, size_t siglen, int certainly_
 
     parsed_der_lax = ecdsa_signature_parse_der_lax(ctx, &sig_der_lax, sig, siglen);
     if (parsed_der_lax) {
-        ret |= (!secp256k1_ecdsa_signature_serialize_compact(ctx, compact_der_lax, &sig_der_lax)) << 10;
+        ret |= (!cosmos_secp256k1_ecdsa_signature_serialize_compact(ctx, compact_der_lax, &sig_der_lax)) << 10;
         valid_der_lax = (memcmp(compact_der_lax, zeroes, 32) != 0) && (memcmp(compact_der_lax + 32, zeroes, 32) != 0);
     }
     if (valid_der_lax) {
@@ -4196,11 +4196,11 @@ void test_ecdsa_edge_cases(void) {
         ecount = 0;
         CHECK(cosmos_secp256k1_ecdsa_signature_normalize(ctx, NULL, NULL) == 0);
         CHECK(ecount == 1);
-        CHECK(secp256k1_ecdsa_signature_serialize_compact(ctx, NULL, &sig) == 0);
+        CHECK(cosmos_secp256k1_ecdsa_signature_serialize_compact(ctx, NULL, &sig) == 0);
         CHECK(ecount == 2);
-        CHECK(secp256k1_ecdsa_signature_serialize_compact(ctx, signature, NULL) == 0);
+        CHECK(cosmos_secp256k1_ecdsa_signature_serialize_compact(ctx, signature, NULL) == 0);
         CHECK(ecount == 3);
-        CHECK(secp256k1_ecdsa_signature_serialize_compact(ctx, signature, &sig) == 1);
+        CHECK(cosmos_secp256k1_ecdsa_signature_serialize_compact(ctx, signature, &sig) == 1);
         CHECK(ecount == 3);
         CHECK(cosmos_secp256k1_ecdsa_signature_parse_compact(ctx, NULL, signature) == 0);
         CHECK(ecount == 4);

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/tests.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/tests.c
@@ -3537,13 +3537,13 @@ void test_ecdsa_end_to_end(void) {
     /* Serialize/parse DER and verify again */
     CHECK(secp256k1_ecdsa_signature_serialize_der(ctx, sig, &siglen, &signature[0]) == 1);
     memset(&signature[0], 0, sizeof(signature[0]));
-    CHECK(secp256k1_ecdsa_signature_parse_der(ctx, &signature[0], sig, siglen) == 1);
+    CHECK(cosmos_secp256k1_ecdsa_signature_parse_der(ctx, &signature[0], sig, siglen) == 1);
     CHECK(cosmos_secp256k1_ecdsa_verify(ctx, &signature[0], message, &pubkey) == 1);
     /* Serialize/destroy/parse DER and verify again. */
     siglen = 74;
     CHECK(secp256k1_ecdsa_signature_serialize_der(ctx, sig, &siglen, &signature[0]) == 1);
     sig[secp256k1_rand_int(siglen)] += 1 + secp256k1_rand_int(255);
-    CHECK(secp256k1_ecdsa_signature_parse_der(ctx, &signature[0], sig, siglen) == 0 ||
+    CHECK(cosmos_secp256k1_ecdsa_signature_parse_der(ctx, &signature[0], sig, siglen) == 0 ||
           cosmos_secp256k1_ecdsa_verify(ctx, &signature[0], message, &pubkey) == 0);
 }
 
@@ -3654,7 +3654,7 @@ int test_ecdsa_der_parse(const unsigned char *sig, size_t siglen, int certainly_
     int parsed_openssl, valid_openssl = 0, roundtrips_openssl = 0;
 #endif
 
-    parsed_der = secp256k1_ecdsa_signature_parse_der(ctx, &sig_der, sig, siglen);
+    parsed_der = cosmos_secp256k1_ecdsa_signature_parse_der(ctx, &sig_der, sig, siglen);
     if (parsed_der) {
         ret |= (!cosmos_secp256k1_ecdsa_signature_serialize_compact(ctx, compact_der, &sig_der)) << 0;
         valid_der = (memcmp(compact_der, zeroes, 32) != 0) && (memcmp(compact_der + 32, zeroes, 32) != 0);
@@ -4183,11 +4183,11 @@ void test_ecdsa_edge_cases(void) {
         CHECK(ecount == 11);
         CHECK(secp256k1_ecdsa_signature_serialize_der(ctx, signature, &siglen, &sig) == 1);
         CHECK(ecount == 11);
-        CHECK(secp256k1_ecdsa_signature_parse_der(ctx, NULL, signature, siglen) == 0);
+        CHECK(cosmos_secp256k1_ecdsa_signature_parse_der(ctx, NULL, signature, siglen) == 0);
         CHECK(ecount == 12);
-        CHECK(secp256k1_ecdsa_signature_parse_der(ctx, &sig, NULL, siglen) == 0);
+        CHECK(cosmos_secp256k1_ecdsa_signature_parse_der(ctx, &sig, NULL, siglen) == 0);
         CHECK(ecount == 13);
-        CHECK(secp256k1_ecdsa_signature_parse_der(ctx, &sig, signature, siglen) == 1);
+        CHECK(cosmos_secp256k1_ecdsa_signature_parse_der(ctx, &sig, signature, siglen) == 1);
         CHECK(ecount == 13);
         siglen = 10;
         /* Too little room for a signature does not fail via ARGCHECK. */

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/tests.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/tests.c
@@ -199,9 +199,9 @@ void run_context_tests(void) {
     CHECK(ecount2 == 12);
     CHECK(secp256k1_ec_pubkey_tweak_add(vrfy, &pubkey, ctmp) == 1);
     CHECK(ecount == 2);
-    CHECK(secp256k1_ec_pubkey_tweak_mul(sign, &pubkey, ctmp) == 0);
+    CHECK(cosmos_secp256k1_ec_pubkey_tweak_mul(sign, &pubkey, ctmp) == 0);
     CHECK(ecount2 == 13);
-    CHECK(secp256k1_ec_pubkey_tweak_mul(vrfy, &pubkey, ctmp) == 1);
+    CHECK(cosmos_secp256k1_ec_pubkey_tweak_mul(vrfy, &pubkey, ctmp) == 1);
     CHECK(ecount == 2);
     CHECK(secp256k1_context_randomize(vrfy, ctmp) == 0);
     CHECK(ecount == 3);
@@ -3175,7 +3175,7 @@ void run_eckey_edge_case_test(void) {
     /* Multiply tweak of zero zeroizes the output. */
     CHECK(cosmos_secp256k1_ec_privkey_tweak_mul(ctx, ctmp, ctmp2) == 0);
     CHECK(memcmp(zeros, ctmp, 32) == 0);
-    CHECK(secp256k1_ec_pubkey_tweak_mul(ctx, &pubkey, ctmp2) == 0);
+    CHECK(cosmos_secp256k1_ec_pubkey_tweak_mul(ctx, &pubkey, ctmp2) == 0);
     CHECK(memcmp(&pubkey, zeros, sizeof(pubkey)) == 0);
     memcpy(&pubkey, &pubkey2, sizeof(pubkey));
     /* Overflowing key tweak zeroizes. */
@@ -3192,7 +3192,7 @@ void run_eckey_edge_case_test(void) {
     CHECK(secp256k1_ec_pubkey_tweak_add(ctx, &pubkey, orderc) == 0);
     CHECK(memcmp(&pubkey, zeros, sizeof(pubkey)) == 0);
     memcpy(&pubkey, &pubkey2, sizeof(pubkey));
-    CHECK(secp256k1_ec_pubkey_tweak_mul(ctx, &pubkey, orderc) == 0);
+    CHECK(cosmos_secp256k1_ec_pubkey_tweak_mul(ctx, &pubkey, orderc) == 0);
     CHECK(memcmp(&pubkey, zeros, sizeof(pubkey)) == 0);
     memcpy(&pubkey, &pubkey2, sizeof(pubkey));
     /* Private key tweaks results in a key of zero. */
@@ -3215,7 +3215,7 @@ void run_eckey_edge_case_test(void) {
     /* Tweak mul * 2 = 1+1. */
     CHECK(secp256k1_ec_pubkey_tweak_add(ctx, &pubkey, ctmp2) == 1);
     ctmp2[31] = 2;
-    CHECK(secp256k1_ec_pubkey_tweak_mul(ctx, &pubkey2, ctmp2) == 1);
+    CHECK(cosmos_secp256k1_ec_pubkey_tweak_mul(ctx, &pubkey2, ctmp2) == 1);
     CHECK(memcmp(&pubkey, &pubkey2, sizeof(pubkey)) == 0);
     /* Test argument errors. */
     ecount = 0;
@@ -3228,7 +3228,7 @@ void run_eckey_edge_case_test(void) {
     CHECK(memcmp(&pubkey, zeros, sizeof(pubkey)) == 0);
     memcpy(&pubkey, &pubkey2, sizeof(pubkey));
     memset(&pubkey2, 0, 32);
-    CHECK(secp256k1_ec_pubkey_tweak_mul(ctx, &pubkey2, ctmp2) == 0);
+    CHECK(cosmos_secp256k1_ec_pubkey_tweak_mul(ctx, &pubkey2, ctmp2) == 0);
     CHECK(ecount == 2);
     CHECK(memcmp(&pubkey2, zeros, sizeof(pubkey2)) == 0);
     /* Plain argument errors. */
@@ -3247,9 +3247,9 @@ void run_eckey_edge_case_test(void) {
     ecount = 0;
     memset(ctmp2, 0, 32);
     ctmp2[31] = 4;
-    CHECK(secp256k1_ec_pubkey_tweak_mul(ctx, NULL, ctmp2) == 0);
+    CHECK(cosmos_secp256k1_ec_pubkey_tweak_mul(ctx, NULL, ctmp2) == 0);
     CHECK(ecount == 1);
-    CHECK(secp256k1_ec_pubkey_tweak_mul(ctx, &pubkey, NULL) == 0);
+    CHECK(cosmos_secp256k1_ec_pubkey_tweak_mul(ctx, &pubkey, NULL) == 0);
     CHECK(ecount == 2);
     ecount = 0;
     memset(ctmp2, 0, 32);
@@ -3487,7 +3487,7 @@ void test_ecdsa_end_to_end(void) {
         secp256k1_pubkey pubkey2;
         secp256k1_rand256_test(rnd);
         ret1 = cosmos_secp256k1_ec_privkey_tweak_mul(ctx, privkey, rnd);
-        ret2 = secp256k1_ec_pubkey_tweak_mul(ctx, &pubkey, rnd);
+        ret2 = cosmos_secp256k1_ec_pubkey_tweak_mul(ctx, &pubkey, rnd);
         CHECK(ret1 == ret2);
         if (ret1 == 0) {
             return;

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/tests.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/tests.c
@@ -139,10 +139,10 @@ void run_context_tests(void) {
     unsigned char ctmp[32];
     int32_t ecount;
     int32_t ecount2;
-    secp256k1_context *none = secp256k1_context_create(SECP256K1_CONTEXT_NONE);
-    secp256k1_context *sign = secp256k1_context_create(SECP256K1_CONTEXT_SIGN);
-    secp256k1_context *vrfy = secp256k1_context_create(SECP256K1_CONTEXT_VERIFY);
-    secp256k1_context *both = secp256k1_context_create(SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY);
+    secp256k1_context *none = cosmos_secp256k1_context_create(SECP256K1_CONTEXT_NONE);
+    secp256k1_context *sign = cosmos_secp256k1_context_create(SECP256K1_CONTEXT_SIGN);
+    secp256k1_context *vrfy = cosmos_secp256k1_context_create(SECP256K1_CONTEXT_VERIFY);
+    secp256k1_context *both = cosmos_secp256k1_context_create(SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY);
 
     secp256k1_gej pubj;
     secp256k1_ge pub;
@@ -4435,7 +4435,7 @@ int main(int argc, char **argv) {
 
     /* initialize */
     run_context_tests();
-    ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY);
+    ctx = cosmos_secp256k1_context_create(SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY);
     if (secp256k1_rand_bits(1)) {
         secp256k1_rand256(run32);
         CHECK(secp256k1_context_randomize(ctx, secp256k1_rand_bits(1) ? run32 : NULL));

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/tests.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/tests.c
@@ -203,9 +203,9 @@ void run_context_tests(void) {
     CHECK(ecount2 == 13);
     CHECK(cosmos_secp256k1_ec_pubkey_tweak_mul(vrfy, &pubkey, ctmp) == 1);
     CHECK(ecount == 2);
-    CHECK(secp256k1_context_randomize(vrfy, ctmp) == 0);
+    CHECK(cosmos_secp256k1_context_randomize(vrfy, ctmp) == 0);
     CHECK(ecount == 3);
-    CHECK(secp256k1_context_randomize(sign, NULL) == 1);
+    CHECK(cosmos_secp256k1_context_randomize(sign, NULL) == 1);
     CHECK(ecount2 == 13);
     cosmos_secp256k1_context_set_illegal_callback(vrfy, NULL, NULL);
     cosmos_secp256k1_context_set_illegal_callback(sign, NULL, NULL);
@@ -4438,7 +4438,7 @@ int main(int argc, char **argv) {
     ctx = cosmos_secp256k1_context_create(SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY);
     if (secp256k1_rand_bits(1)) {
         secp256k1_rand256(run32);
-        CHECK(secp256k1_context_randomize(ctx, secp256k1_rand_bits(1) ? run32 : NULL));
+        CHECK(cosmos_secp256k1_context_randomize(ctx, secp256k1_rand_bits(1) ? run32 : NULL));
     }
 
     run_rand_bits();

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/tests.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/tests.c
@@ -3167,7 +3167,7 @@ void run_eckey_edge_case_test(void) {
     pubkey_negone = pubkey;
     /* Tweak of zero leaves the value changed. */
     memset(ctmp2, 0, 32);
-    CHECK(secp256k1_ec_privkey_tweak_add(ctx, ctmp, ctmp2) == 1);
+    CHECK(cosmos_secp256k1_ec_privkey_tweak_add(ctx, ctmp, ctmp2) == 1);
     CHECK(memcmp(orderc, ctmp, 31) == 0 && ctmp[31] == 0x40);
     memcpy(&pubkey2, &pubkey, sizeof(pubkey));
     CHECK(cosmos_secp256k1_ec_pubkey_tweak_add(ctx, &pubkey, ctmp2) == 1);
@@ -3181,7 +3181,7 @@ void run_eckey_edge_case_test(void) {
     /* Overflowing key tweak zeroizes. */
     memcpy(ctmp, orderc, 32);
     ctmp[31] = 0x40;
-    CHECK(secp256k1_ec_privkey_tweak_add(ctx, ctmp, orderc) == 0);
+    CHECK(cosmos_secp256k1_ec_privkey_tweak_add(ctx, ctmp, orderc) == 0);
     CHECK(memcmp(zeros, ctmp, 32) == 0);
     memcpy(ctmp, orderc, 32);
     ctmp[31] = 0x40;
@@ -3197,7 +3197,7 @@ void run_eckey_edge_case_test(void) {
     memcpy(&pubkey, &pubkey2, sizeof(pubkey));
     /* Private key tweaks results in a key of zero. */
     ctmp2[31] = 1;
-    CHECK(secp256k1_ec_privkey_tweak_add(ctx, ctmp2, ctmp) == 0);
+    CHECK(cosmos_secp256k1_ec_privkey_tweak_add(ctx, ctmp2, ctmp) == 0);
     CHECK(memcmp(zeros, ctmp2, 32) == 0);
     ctmp2[31] = 1;
     CHECK(cosmos_secp256k1_ec_pubkey_tweak_add(ctx, &pubkey, ctmp2) == 0);
@@ -3205,7 +3205,7 @@ void run_eckey_edge_case_test(void) {
     memcpy(&pubkey, &pubkey2, sizeof(pubkey));
     /* Tweak computation wraps and results in a key of 1. */
     ctmp2[31] = 2;
-    CHECK(secp256k1_ec_privkey_tweak_add(ctx, ctmp2, ctmp) == 1);
+    CHECK(cosmos_secp256k1_ec_privkey_tweak_add(ctx, ctmp2, ctmp) == 1);
     CHECK(memcmp(ctmp2, zeros, 31) == 0 && ctmp2[31] == 1);
     ctmp2[31] = 2;
     CHECK(cosmos_secp256k1_ec_pubkey_tweak_add(ctx, &pubkey, ctmp2) == 1);
@@ -3253,9 +3253,9 @@ void run_eckey_edge_case_test(void) {
     CHECK(ecount == 2);
     ecount = 0;
     memset(ctmp2, 0, 32);
-    CHECK(secp256k1_ec_privkey_tweak_add(ctx, NULL, ctmp2) == 0);
+    CHECK(cosmos_secp256k1_ec_privkey_tweak_add(ctx, NULL, ctmp2) == 0);
     CHECK(ecount == 1);
-    CHECK(secp256k1_ec_privkey_tweak_add(ctx, ctmp, NULL) == 0);
+    CHECK(cosmos_secp256k1_ec_privkey_tweak_add(ctx, ctmp, NULL) == 0);
     CHECK(ecount == 2);
     ecount = 0;
     memset(ctmp2, 0, 32);
@@ -3469,7 +3469,7 @@ void test_ecdsa_end_to_end(void) {
         unsigned char rnd[32];
         secp256k1_pubkey pubkey2;
         secp256k1_rand256_test(rnd);
-        ret1 = secp256k1_ec_privkey_tweak_add(ctx, privkey, rnd);
+        ret1 = cosmos_secp256k1_ec_privkey_tweak_add(ctx, privkey, rnd);
         ret2 = cosmos_secp256k1_ec_pubkey_tweak_add(ctx, &pubkey, rnd);
         CHECK(ret1 == ret2);
         if (ret1 == 0) {

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/tests.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/tests.c
@@ -180,10 +180,10 @@ void run_context_tests(void) {
 
     /* Verify context-type checking illegal-argument errors. */
     memset(ctmp, 1, 32);
-    CHECK(secp256k1_ec_pubkey_create(vrfy, &pubkey, ctmp) == 0);
+    CHECK(cosmos_secp256k1_ec_pubkey_create(vrfy, &pubkey, ctmp) == 0);
     CHECK(ecount == 1);
     VG_UNDEF(&pubkey, sizeof(pubkey));
-    CHECK(secp256k1_ec_pubkey_create(sign, &pubkey, ctmp) == 1);
+    CHECK(cosmos_secp256k1_ec_pubkey_create(sign, &pubkey, ctmp) == 1);
     VG_CHECK(&pubkey, sizeof(pubkey));
     CHECK(cosmos_secp256k1_ecdsa_sign(vrfy, &sig, ctmp, ctmp, NULL, NULL) == 0);
     CHECK(ecount == 2);
@@ -3119,7 +3119,7 @@ void run_eckey_edge_case_test(void) {
     /* Group order is too large, reject. */
     CHECK(cosmos_secp256k1_ec_seckey_verify(ctx, orderc) == 0);
     VG_UNDEF(&pubkey, sizeof(pubkey));
-    CHECK(secp256k1_ec_pubkey_create(ctx, &pubkey, orderc) == 0);
+    CHECK(cosmos_secp256k1_ec_pubkey_create(ctx, &pubkey, orderc) == 0);
     VG_CHECK(&pubkey, sizeof(pubkey));
     CHECK(memcmp(&pubkey, zeros, sizeof(secp256k1_pubkey)) == 0);
     /* Maximum value is too large, reject. */
@@ -3127,7 +3127,7 @@ void run_eckey_edge_case_test(void) {
     CHECK(cosmos_secp256k1_ec_seckey_verify(ctx, ctmp) == 0);
     memset(&pubkey, 1, sizeof(pubkey));
     VG_UNDEF(&pubkey, sizeof(pubkey));
-    CHECK(secp256k1_ec_pubkey_create(ctx, &pubkey, ctmp) == 0);
+    CHECK(cosmos_secp256k1_ec_pubkey_create(ctx, &pubkey, ctmp) == 0);
     VG_CHECK(&pubkey, sizeof(pubkey));
     CHECK(memcmp(&pubkey, zeros, sizeof(secp256k1_pubkey)) == 0);
     /* Zero is too small, reject. */
@@ -3135,7 +3135,7 @@ void run_eckey_edge_case_test(void) {
     CHECK(cosmos_secp256k1_ec_seckey_verify(ctx, ctmp) == 0);
     memset(&pubkey, 1, sizeof(pubkey));
     VG_UNDEF(&pubkey, sizeof(pubkey));
-    CHECK(secp256k1_ec_pubkey_create(ctx, &pubkey, ctmp) == 0);
+    CHECK(cosmos_secp256k1_ec_pubkey_create(ctx, &pubkey, ctmp) == 0);
     VG_CHECK(&pubkey, sizeof(pubkey));
     CHECK(memcmp(&pubkey, zeros, sizeof(secp256k1_pubkey)) == 0);
     /* One must be accepted. */
@@ -3143,7 +3143,7 @@ void run_eckey_edge_case_test(void) {
     CHECK(cosmos_secp256k1_ec_seckey_verify(ctx, ctmp) == 1);
     memset(&pubkey, 0, sizeof(pubkey));
     VG_UNDEF(&pubkey, sizeof(pubkey));
-    CHECK(secp256k1_ec_pubkey_create(ctx, &pubkey, ctmp) == 1);
+    CHECK(cosmos_secp256k1_ec_pubkey_create(ctx, &pubkey, ctmp) == 1);
     VG_CHECK(&pubkey, sizeof(pubkey));
     CHECK(memcmp(&pubkey, zeros, sizeof(secp256k1_pubkey)) > 0);
     pubkey_one = pubkey;
@@ -3153,7 +3153,7 @@ void run_eckey_edge_case_test(void) {
     CHECK(cosmos_secp256k1_ec_seckey_verify(ctx, ctmp) == 0);
     memset(&pubkey, 1, sizeof(pubkey));
     VG_UNDEF(&pubkey, sizeof(pubkey));
-    CHECK(secp256k1_ec_pubkey_create(ctx, &pubkey, ctmp) == 0);
+    CHECK(cosmos_secp256k1_ec_pubkey_create(ctx, &pubkey, ctmp) == 0);
     VG_CHECK(&pubkey, sizeof(pubkey));
     CHECK(memcmp(&pubkey, zeros, sizeof(secp256k1_pubkey)) == 0);
     /* -1 must be accepted. */
@@ -3161,7 +3161,7 @@ void run_eckey_edge_case_test(void) {
     CHECK(cosmos_secp256k1_ec_seckey_verify(ctx, ctmp) == 1);
     memset(&pubkey, 0, sizeof(pubkey));
     VG_UNDEF(&pubkey, sizeof(pubkey));
-    CHECK(secp256k1_ec_pubkey_create(ctx, &pubkey, ctmp) == 1);
+    CHECK(cosmos_secp256k1_ec_pubkey_create(ctx, &pubkey, ctmp) == 1);
     VG_CHECK(&pubkey, sizeof(pubkey));
     CHECK(memcmp(&pubkey, zeros, sizeof(secp256k1_pubkey)) > 0);
     pubkey_negone = pubkey;
@@ -3210,7 +3210,7 @@ void run_eckey_edge_case_test(void) {
     ctmp2[31] = 2;
     CHECK(cosmos_secp256k1_ec_pubkey_tweak_add(ctx, &pubkey, ctmp2) == 1);
     ctmp2[31] = 1;
-    CHECK(secp256k1_ec_pubkey_create(ctx, &pubkey2, ctmp2) == 1);
+    CHECK(cosmos_secp256k1_ec_pubkey_create(ctx, &pubkey2, ctmp2) == 1);
     CHECK(memcmp(&pubkey, &pubkey2, sizeof(pubkey)) == 0);
     /* Tweak mul * 2 = 1+1. */
     CHECK(cosmos_secp256k1_ec_pubkey_tweak_add(ctx, &pubkey, ctmp2) == 1);
@@ -3265,10 +3265,10 @@ void run_eckey_edge_case_test(void) {
     CHECK(cosmos_secp256k1_ec_privkey_tweak_mul(ctx, ctmp, NULL) == 0);
     CHECK(ecount == 2);
     ecount = 0;
-    CHECK(secp256k1_ec_pubkey_create(ctx, NULL, ctmp) == 0);
+    CHECK(cosmos_secp256k1_ec_pubkey_create(ctx, NULL, ctmp) == 0);
     CHECK(ecount == 1);
     memset(&pubkey, 1, sizeof(pubkey));
-    CHECK(secp256k1_ec_pubkey_create(ctx, &pubkey, NULL) == 0);
+    CHECK(cosmos_secp256k1_ec_pubkey_create(ctx, &pubkey, NULL) == 0);
     CHECK(ecount == 2);
     CHECK(memcmp(&pubkey, zeros, sizeof(secp256k1_pubkey)) == 0);
     /* cosmos_secp256k1_ec_pubkey_combine tests. */
@@ -3450,7 +3450,7 @@ void test_ecdsa_end_to_end(void) {
 
     /* Construct and verify corresponding public key. */
     CHECK(cosmos_secp256k1_ec_seckey_verify(ctx, privkey) == 1);
-    CHECK(secp256k1_ec_pubkey_create(ctx, &pubkey, privkey) == 1);
+    CHECK(cosmos_secp256k1_ec_pubkey_create(ctx, &pubkey, privkey) == 1);
 
     /* Verify exporting and importing public key. */
     CHECK(cosmos_secp256k1_ec_pubkey_serialize(ctx, pubkeyc, &pubkeyclen, &pubkey, secp256k1_rand_bits(1) == 1 ? SECP256K1_EC_COMPRESSED : SECP256K1_EC_UNCOMPRESSED));
@@ -3475,7 +3475,7 @@ void test_ecdsa_end_to_end(void) {
         if (ret1 == 0) {
             return;
         }
-        CHECK(secp256k1_ec_pubkey_create(ctx, &pubkey2, privkey) == 1);
+        CHECK(cosmos_secp256k1_ec_pubkey_create(ctx, &pubkey2, privkey) == 1);
         CHECK(memcmp(&pubkey, &pubkey2, sizeof(pubkey)) == 0);
     }
 
@@ -3492,7 +3492,7 @@ void test_ecdsa_end_to_end(void) {
         if (ret1 == 0) {
             return;
         }
-        CHECK(secp256k1_ec_pubkey_create(ctx, &pubkey2, privkey) == 1);
+        CHECK(cosmos_secp256k1_ec_pubkey_create(ctx, &pubkey2, privkey) == 1);
         CHECK(memcmp(&pubkey, &pubkey2, sizeof(pubkey)) == 0);
     }
 
@@ -4160,7 +4160,7 @@ void test_ecdsa_edge_cases(void) {
         CHECK(cosmos_secp256k1_ecdsa_sign(ctx, &sig, msg, NULL, precomputed_nonce_function, nonce2) == 0);
         CHECK(ecount == 3);
         CHECK(cosmos_secp256k1_ecdsa_sign(ctx, &sig, msg, key, precomputed_nonce_function, nonce2) == 1);
-        CHECK(secp256k1_ec_pubkey_create(ctx, &pubkey, key) == 1);
+        CHECK(cosmos_secp256k1_ec_pubkey_create(ctx, &pubkey, key) == 1);
         CHECK(cosmos_secp256k1_ecdsa_verify(ctx, NULL, msg, &pubkey) == 0);
         CHECK(ecount == 4);
         CHECK(cosmos_secp256k1_ecdsa_verify(ctx, &sig, NULL, &pubkey) == 0);
@@ -4169,7 +4169,7 @@ void test_ecdsa_edge_cases(void) {
         CHECK(ecount == 6);
         CHECK(cosmos_secp256k1_ecdsa_verify(ctx, &sig, msg, &pubkey) == 1);
         CHECK(ecount == 6);
-        CHECK(secp256k1_ec_pubkey_create(ctx, &pubkey, NULL) == 0);
+        CHECK(cosmos_secp256k1_ec_pubkey_create(ctx, &pubkey, NULL) == 0);
         CHECK(ecount == 7);
         /* That pubkeyload fails via an ARGCHECK is a little odd but makes sense because pubkeys are an opaque data type. */
         CHECK(cosmos_secp256k1_ecdsa_verify(ctx, &sig, msg, &pubkey) == 0);

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/tests_exhaustive.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/tests_exhaustive.c
@@ -308,7 +308,7 @@ void test_exhaustive_recovery_sign(const secp256k1_context *ctx, const secp256k1
                 secp256k1_scalar_get_b32(sk32, &sk);
                 secp256k1_scalar_get_b32(msg32, &msg);
 
-                secp256k1_ecdsa_sign_recoverable(ctx, &rsig, msg32, sk32, secp256k1_nonce_function_smallint, &k);
+                cosmos_secp256k1_ecdsa_sign_recoverable(ctx, &rsig, msg32, sk32, secp256k1_nonce_function_smallint, &k);
 
                 /* Check directly */
                 secp256k1_ecdsa_recoverable_signature_load(ctx, &r, &s, &recid, &rsig);

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/tests_exhaustive.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/tests_exhaustive.c
@@ -464,7 +464,7 @@ int main(void) {
     test_exhaustive_recovery_verify(ctx, group, EXHAUSTIVE_TEST_ORDER);
 #endif
 
-    secp256k1_context_destroy(ctx);
+    cosmos_secp256k1_context_destroy(ctx);
     return 0;
 }
 

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/tests_exhaustive.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/tests_exhaustive.c
@@ -258,7 +258,7 @@ void test_exhaustive_sign(const secp256k1_context *ctx, const secp256k1_ge *grou
                 secp256k1_scalar_get_b32(sk32, &sk);
                 secp256k1_scalar_get_b32(msg32, &msg);
 
-                secp256k1_ecdsa_sign(ctx, &sig, msg32, sk32, secp256k1_nonce_function_smallint, &k);
+                cosmos_secp256k1_ecdsa_sign(ctx, &sig, msg32, sk32, secp256k1_nonce_function_smallint, &k);
 
                 secp256k1_ecdsa_signature_load(ctx, &r, &s, &sig);
                 /* Note that we compute expected_r *after* signing -- this is important

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/tests_exhaustive.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/tests_exhaustive.c
@@ -235,7 +235,7 @@ void test_exhaustive_verify(const secp256k1_context *ctx, const secp256k1_ge *gr
                     secp256k1_pubkey_save(&pk, &nonconst_ge);
                     secp256k1_scalar_get_b32(msg32, &msg_s);
                     CHECK(should_verify ==
-                          secp256k1_ecdsa_verify(ctx, &sig, msg32, &pk));
+                          cosmos_secp256k1_ecdsa_verify(ctx, &sig, msg32, &pk));
                 }
             }
         }

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/tests_exhaustive.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/tests_exhaustive.c
@@ -332,7 +332,7 @@ void test_exhaustive_recovery_sign(const secp256k1_context *ctx, const secp256k1
                 CHECK(recid == expected_recid);
 
                 /* Convert to a standard sig then check */
-                secp256k1_ecdsa_recoverable_signature_convert(ctx, &sig, &rsig);
+                cosmos_secp256k1_ecdsa_recoverable_signature_convert(ctx, &sig, &rsig);
                 secp256k1_ecdsa_signature_load(ctx, &r, &s, &sig);
                 /* Note that we compute expected_r *after* signing -- this is important
                  * because our nonce-computing function function might change k during
@@ -399,7 +399,7 @@ void test_exhaustive_recovery_verify(const secp256k1_context *ctx, const secp256
 
                     /* Verify by converting to a standard signature and calling verify */
                     secp256k1_ecdsa_recoverable_signature_save(&rsig, &r_s, &s_s, recid);
-                    secp256k1_ecdsa_recoverable_signature_convert(ctx, &sig, &rsig);
+                    cosmos_secp256k1_ecdsa_recoverable_signature_convert(ctx, &sig, &rsig);
                     memcpy(&nonconst_ge, &group[sk_s], sizeof(nonconst_ge));
                     secp256k1_pubkey_save(&pk, &nonconst_ge);
                     CHECK(should_verify ==

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/tests_exhaustive.c
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/tests_exhaustive.c
@@ -417,7 +417,7 @@ int main(void) {
     secp256k1_ge group[EXHAUSTIVE_TEST_ORDER];
 
     /* Build context */
-    secp256k1_context *ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY);
+    secp256k1_context *ctx = cosmos_secp256k1_context_create(SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY);
 
     /* TODO set z = 1, then do num_tests runs with random z values */
 

--- a/crypto/keys/secp256k1/internal/secp256k1/panic_cb.go
+++ b/crypto/keys/secp256k1/internal/secp256k1/panic_cb.go
@@ -18,7 +18,7 @@ func cosmos_secp256k1GoPanicIllegal(msg *C.char, data unsafe.Pointer) {
 	panic("illegal argument: " + C.GoString(msg))
 }
 
-//export secp256k1GoPanicError
-func secp256k1GoPanicError(msg *C.char, data unsafe.Pointer) {
+//export cosmos_secp256k1GoPanicError
+func cosmos_secp256k1GoPanicError(msg *C.char, data unsafe.Pointer) {
 	panic("internal error: " + C.GoString(msg))
 }

--- a/crypto/keys/secp256k1/internal/secp256k1/panic_cb.go
+++ b/crypto/keys/secp256k1/internal/secp256k1/panic_cb.go
@@ -13,8 +13,8 @@ import "unsafe"
 // Callbacks for converting libsecp256k1 internal faults into
 // recoverable Go panics.
 
-//export secp256k1GoPanicIllegal
-func secp256k1GoPanicIllegal(msg *C.char, data unsafe.Pointer) {
+//export cosmos_secp256k1GoPanicIllegal
+func cosmos_secp256k1GoPanicIllegal(msg *C.char, data unsafe.Pointer) {
 	panic("illegal argument: " + C.GoString(msg))
 }
 

--- a/crypto/keys/secp256k1/internal/secp256k1/scalar_mult_cgo.go
+++ b/crypto/keys/secp256k1/internal/secp256k1/scalar_mult_cgo.go
@@ -17,7 +17,7 @@ import (
 
 #include "libsecp256k1/include/secp256k1.h"
 
-extern int secp256k1_ext_scalar_mul(const secp256k1_context* ctx, const unsigned char *point, const unsigned char *scalar);
+extern int cosmos_secp256k1_ext_scalar_mul(const secp256k1_context* ctx, const unsigned char *point, const unsigned char *scalar);
 
 */
 import "C"
@@ -40,7 +40,7 @@ func (BitCurve *BitCurve) ScalarMult(Bx, By *big.Int, scalar []byte) (*big.Int, 
 
 	pointPtr := (*C.uchar)(unsafe.Pointer(&point[0]))
 	scalarPtr := (*C.uchar)(unsafe.Pointer(&scalar[0]))
-	res := C.secp256k1_ext_scalar_mul(context, pointPtr, scalarPtr)
+	res := C.cosmos_secp256k1_ext_scalar_mul(context, pointPtr, scalarPtr)
 
 	// Unpack the result and clear temporaries.
 	x := new(big.Int).SetBytes(point[:32])

--- a/crypto/keys/secp256k1/internal/secp256k1/secp256.go
+++ b/crypto/keys/secp256k1/internal/secp256k1/secp256.go
@@ -32,7 +32,7 @@ package secp256k1
 
 typedef void (*callbackFunc) (const char* msg, void* data);
 extern void cosmos_secp256k1GoPanicIllegal(const char* msg, void* data);
-extern void secp256k1GoPanicError(const char* msg, void* data);
+extern void cosmos_secp256k1GoPanicError(const char* msg, void* data);
 */
 import "C"
 
@@ -48,7 +48,7 @@ func init() {
 	// around 20 ms on a modern CPU.
 	context = C.secp256k1_context_create_sign_verify()
 	C.cosmos_secp256k1_context_set_illegal_callback(context, C.callbackFunc(C.cosmos_secp256k1GoPanicIllegal), nil)
-	C.secp256k1_context_set_error_callback(context, C.callbackFunc(C.secp256k1GoPanicError), nil)
+	C.secp256k1_context_set_error_callback(context, C.callbackFunc(C.cosmos_secp256k1GoPanicError), nil)
 }
 
 var (

--- a/crypto/keys/secp256k1/internal/secp256k1/secp256.go
+++ b/crypto/keys/secp256k1/internal/secp256k1/secp256.go
@@ -47,7 +47,7 @@ var context *C.secp256k1_context
 func init() {
 	// around 20 ms on a modern CPU.
 	context = C.secp256k1_context_create_sign_verify()
-	C.secp256k1_context_set_illegal_callback(context, C.callbackFunc(C.cosmos_secp256k1GoPanicIllegal), nil)
+	C.cosmos_secp256k1_context_set_illegal_callback(context, C.callbackFunc(C.cosmos_secp256k1GoPanicIllegal), nil)
 	C.secp256k1_context_set_error_callback(context, C.callbackFunc(C.secp256k1GoPanicError), nil)
 }
 

--- a/crypto/keys/secp256k1/internal/secp256k1/secp256.go
+++ b/crypto/keys/secp256k1/internal/secp256k1/secp256.go
@@ -81,7 +81,7 @@ func Sign(msg, seckey []byte) ([]byte, error) {
 
 	var (
 		msgdata   = (*C.uchar)(unsafe.Pointer(&msg[0]))
-		noncefunc = C.secp256k1_nonce_function_rfc6979
+		noncefunc = C.cosmos_secp256k1_nonce_function_rfc6979
 		sigstruct C.secp256k1_ecdsa_recoverable_signature
 	)
 	if C.secp256k1_ecdsa_sign_recoverable(context, &sigstruct, msgdata, seckeydata, noncefunc, nil) == 0 {

--- a/crypto/keys/secp256k1/internal/secp256k1/secp256.go
+++ b/crypto/keys/secp256k1/internal/secp256k1/secp256.go
@@ -93,7 +93,7 @@ func Sign(msg, seckey []byte) ([]byte, error) {
 		sigdata = (*C.uchar)(unsafe.Pointer(&sig[0]))
 		recid   C.int
 	)
-	C.secp256k1_ecdsa_recoverable_signature_serialize_compact(context, sigdata, &recid, &sigstruct)
+	C.cosmos_secp256k1_ecdsa_recoverable_signature_serialize_compact(context, sigdata, &recid, &sigstruct)
 	sig[64] = byte(recid) // add back recid to get 65 bytes sig
 	return sig, nil
 }

--- a/crypto/keys/secp256k1/internal/secp256k1/secp256.go
+++ b/crypto/keys/secp256k1/internal/secp256k1/secp256.go
@@ -84,7 +84,7 @@ func Sign(msg, seckey []byte) ([]byte, error) {
 		noncefunc = C.cosmos_secp256k1_nonce_function_rfc6979
 		sigstruct C.secp256k1_ecdsa_recoverable_signature
 	)
-	if C.secp256k1_ecdsa_sign_recoverable(context, &sigstruct, msgdata, seckeydata, noncefunc, nil) == 0 {
+	if C.cosmos_secp256k1_ecdsa_sign_recoverable(context, &sigstruct, msgdata, seckeydata, noncefunc, nil) == 0 {
 		return nil, ErrSignFailed
 	}
 

--- a/crypto/keys/secp256k1/internal/secp256k1/secp256.go
+++ b/crypto/keys/secp256k1/internal/secp256k1/secp256.go
@@ -75,7 +75,7 @@ func Sign(msg, seckey []byte) ([]byte, error) {
 		return nil, ErrInvalidKey
 	}
 	seckeydata := (*C.uchar)(unsafe.Pointer(&seckey[0]))
-	if C.secp256k1_ec_seckey_verify(context, seckeydata) != 1 {
+	if C.cosmos_secp256k1_ec_seckey_verify(context, seckeydata) != 1 {
 		return nil, ErrInvalidKey
 	}
 

--- a/crypto/keys/secp256k1/internal/secp256k1/secp256.go
+++ b/crypto/keys/secp256k1/internal/secp256k1/secp256.go
@@ -48,7 +48,7 @@ func init() {
 	// around 20 ms on a modern CPU.
 	context = C.secp256k1_context_create_sign_verify()
 	C.cosmos_secp256k1_context_set_illegal_callback(context, C.callbackFunc(C.cosmos_secp256k1GoPanicIllegal), nil)
-	C.secp256k1_context_set_error_callback(context, C.callbackFunc(C.cosmos_secp256k1GoPanicError), nil)
+	C.cosmos_secp256k1_context_set_error_callback(context, C.callbackFunc(C.cosmos_secp256k1GoPanicError), nil)
 }
 
 var (

--- a/crypto/keys/secp256k1/internal/secp256k1/secp256.go
+++ b/crypto/keys/secp256k1/internal/secp256k1/secp256.go
@@ -31,7 +31,7 @@ package secp256k1
 #include "ext.h"
 
 typedef void (*callbackFunc) (const char* msg, void* data);
-extern void secp256k1GoPanicIllegal(const char* msg, void* data);
+extern void cosmos_secp256k1GoPanicIllegal(const char* msg, void* data);
 extern void secp256k1GoPanicError(const char* msg, void* data);
 */
 import "C"
@@ -47,7 +47,7 @@ var context *C.secp256k1_context
 func init() {
 	// around 20 ms on a modern CPU.
 	context = C.secp256k1_context_create_sign_verify()
-	C.secp256k1_context_set_illegal_callback(context, C.callbackFunc(C.secp256k1GoPanicIllegal), nil)
+	C.secp256k1_context_set_illegal_callback(context, C.callbackFunc(C.cosmos_secp256k1GoPanicIllegal), nil)
 	C.secp256k1_context_set_error_callback(context, C.callbackFunc(C.secp256k1GoPanicError), nil)
 }
 


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

Closes:
#18232

This PR rename all duplicate symbols that any project using the SDK alongside with go-ethereum could get
 
<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] added `!` to the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/build/building-modules/01-intro.md)
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] updated the relevant documentation or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] run `make lint` and `make test`
* [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] confirmed all author checklist items have been addressed 
* [ ] reviewed state machine logic
* [ ] reviewed API design and naming
* [ ] reviewed documentation is accurate
* [ ] reviewed tests and test coverage
* [ ] manually tested (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

Refactor:
- The cryptographic library `secp256k1` has been replaced with `cosmos_secp256k1` across the codebase. This change is internal and should not affect the end-user experience.

Style:
- Function and variable names related to the `secp256k1` library have been updated to include the prefix "cosmos_". This change is part of the codebase's internal refactoring and does not impact the functionality from an end-user perspective.

Documentation:
- Comments in the code have been updated to reflect the switch from `secp256k1` to `cosmos_secp256k1`. This change is primarily for developers and does not affect end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->