### PR TITLE
fix(client/snapshot): fix loose defers in for loop in DumpArchive

### DIFF
--- a/client/snapshot/dump.go
+++ b/client/snapshot/dump.go
@@ -84,27 +84,9 @@ func DumpArchiveCmd() *cobra.Command {
 
 			for i := uint32(0); i < snapshot.Chunks; i++ {
 				path := snapshotStore.PathChunk(height, uint32(format), i)
-				file, err := os.Open(path)
-				if err != nil {
-					return fmt.Errorf("failed to open chunk file %s: %w", path, err)
-				}
-				defer file.Close()
-
-				st, err := file.Stat()
-				if err != nil {
-					return fmt.Errorf("failed to stat chunk file %s: %w", path, err)
-				}
-
-				if err := tarWriter.WriteHeader(&tar.Header{
-					Name: strconv.FormatUint(uint64(i), 10),
-					Mode: 0o644,
-					Size: st.Size(),
-				}); err != nil {
-					return fmt.Errorf("failed to write chunk header to tar: %w", err)
-				}
-
-				if _, err := io.Copy(tarWriter, file); err != nil {
-					return fmt.Errorf("failed to write chunk to tar: %w", err)
+				tarName := strconv.FormatUint(uint64(i), 10)
+				if err := processChunk(tarWriter, path, tarName); err != nil {
+					return err
 				}
 			}
 
@@ -123,4 +105,31 @@ func DumpArchiveCmd() *cobra.Command {
 	cmd.Flags().StringP("output", "o", "", "output file")
 
 	return cmd
+}
+
+func processChunk(tarWriter *tar.Writer, path, tarName string) error {
+	file, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("failed to open chunk file %s: %w", path, err)
+	}
+	defer file.Close()
+
+	st, err := file.Stat()
+	if err != nil {
+		return fmt.Errorf("failed to stat chunk file %s: %w", path, err)
+	}
+
+	if err := tarWriter.WriteHeader(&tar.Header{
+		Name: tarName,
+		Mode: 0o644,
+		Size: st.Size(),
+	}); err != nil {
+		return fmt.Errorf("failed to write chunk header to tar: %w", err)
+	}
+
+	if _, err := io.Copy(tarWriter, file); err != nil {
+		return fmt.Errorf("failed to write chunk to tar: %w", err)
+	}
+
+	return nil
 }


### PR DESCRIPTION
Reported by Github security code scanning and a legitimate loose pattern in which defers for open files were created per loop: defers only execute when a function is returning not after every iteration of a loop hence this can exhaust resources.

The fix for this is to extract the per-loop code into a helper function, thus any per-loop action occurs in there and each chunk is processed then all associated resources released before moving onto the next one.

Fixes https://github.com/cosmos/cosmos-sdk/security/code-scanning/8779
Fixes #18321

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

Refactor:
- Enhanced code readability in the `DumpArchiveCmd` function within the `client/snapshot/dump.go` file. The logic for opening and processing chunk files has been moved to a new `processChunk` function. This change does not directly impact end-users but sets the stage for more efficient code maintenance and potential feature enhancements in the future.

Chores:
- Added a `defer` statement to close the `traceWriter` variable in the `x/genutil/client/cli/export.go` file. This ensures proper resource cleanup and improves the overall stability of the application. No user-facing changes are expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->