### PR TITLE
chore: run make proto-all

### DIFF
--- a/api/cosmos/gov/v1/gov.pulsar.go
+++ b/api/cosmos/gov/v1/gov.pulsar.go
@@ -7726,7 +7726,7 @@ type Params struct {
 	// burn deposits if quorum with vote type no_veto is met
 	BurnVoteVeto bool `protobuf:"varint,15,opt,name=burn_vote_veto,json=burnVoteVeto,proto3" json:"burn_vote_veto,omitempty"`
 	// The ratio representing the proportion of the deposit value minimum that must be met when making a deposit.
-	// Default value: 0.01. Meaning that for a chain with a min_deposit of 1000stake, a deposit of 1stake would be
+	// Default value: 0.01. Meaning that for a chain with a min_deposit of 100stake, a deposit of 1stake would be
 	// required.
 	//
 	// Since: cosmos-sdk 0.50

--- a/x/gov/types/v1/gov.pb.go
+++ b/x/gov/types/v1/gov.pb.go
@@ -796,7 +796,7 @@ type Params struct {
 	// burn deposits if quorum with vote type no_veto is met
 	BurnVoteVeto bool `protobuf:"varint,15,opt,name=burn_vote_veto,json=burnVoteVeto,proto3" json:"burn_vote_veto,omitempty"`
 	// The ratio representing the proportion of the deposit value minimum that must be met when making a deposit.
-	// Default value: 0.01. Meaning that for a chain with a min_deposit of 1000stake, a deposit of 1stake would be
+	// Default value: 0.01. Meaning that for a chain with a min_deposit of 100stake, a deposit of 1stake would be
 	// required.
 	//
 	// Since: cosmos-sdk 0.50


### PR DESCRIPTION
Discovered after running make while making go.mod spinout changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

Refactor:
- Adjusted the default value of the `min_deposit` parameter in the `Params` struct from 1000stake to 100stake. This change lowers the minimum deposit required for a chain, making it more accessible for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->