### PR TITLE
fix(baseapp): fix BaseApp.getContext data races

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
   
 ### Bug Fixes
 
+* (baseapp) [#18383](https://github.com/cosmos/cosmos-sdk/pull/18383) Fixed a data race inside BaseApp.getContext, found by end-to-end (e2e) tests.
 * (client/server) [#18345](https://github.com/cosmos/cosmos-sdk/pull/18345) Consistently set viper prefix in client and server. It defaults for the binary name for both client and server.
 * (server) [#18254](https://github.com/cosmos/cosmos-sdk/pull/18254) Don't hardcode gRPC address to localhost.
 * (x/slashing) [#18016](https://github.com/cosmos/cosmos-sdk/pull/18016) Fixed builder function for missed blocks key (`validatorMissedBlockBitArrayPrefixKey`) in slashing/migration/v4

--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -6,6 +6,7 @@ import (
 	"math"
 	"sort"
 	"strconv"
+	"sync"
 
 	"github.com/cockroachdb/errors"
 	abci "github.com/cometbft/cometbft/abci/types"
@@ -59,6 +60,7 @@ var _ servertypes.ABCI = (*BaseApp)(nil)
 // BaseApp reflects the ABCI application implementation.
 type BaseApp struct {
 	// initialized on creation
+	mu                sync.Mutex // mu protects the fields below.
 	logger            log.Logger
 	name              string                      // application name from abci.BlockInfo
 	db                dbm.DB                      // common DB backend
@@ -641,6 +643,9 @@ func (app *BaseApp) getBlockGasMeter(ctx sdk.Context) storetypes.GasMeter {
 
 // retrieve the context for the tx w/ txBytes and other memoized values.
 func (app *BaseApp) getContextForTx(mode execMode, txBytes []byte) sdk.Context {
+	app.mu.Lock()
+	defer app.mu.Unlock()
+
 	modeState := app.getState(mode)
 	if modeState == nil {
 		panic(fmt.Sprintf("state is nil for mode %v", mode))

--- a/baseapp/genesis.go
+++ b/baseapp/genesis.go
@@ -12,7 +12,7 @@ var _ genesis.TxHandler = (*BaseApp)(nil)
 
 // ExecuteGenesisTx implements genesis.GenesisState from
 // cosmossdk.io/core/genesis to set initial state in genesis
-func (ba BaseApp) ExecuteGenesisTx(tx []byte) error {
+func (ba *BaseApp) ExecuteGenesisTx(tx []byte) error {
 	res := ba.deliverTx(tx)
 
 	if res.Code != types.CodeTypeOK {


### PR DESCRIPTION
This change adds a mutex to BaseApp and firstly locks it when invoking (*BaseApp).getContextForTx. Ideally the (types/sdk).Context should be concurrency safe mirroring the Go standard library's context.Context.

Fixes #18382

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Addressed a data race issue for improved stability.
	- Fixed a builder function for missed blocks key in slashing/migration/v4.
- **Improvements**
	- Enhanced consistency in setting viper prefix in client and server.
	- Removed hardcoded gRPC address to localhost in the server for better flexibility.
- **Refactor**
	- Modified the `ExecuteGenesisTx` method to a pointer receiver for better state management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->