### PR TITLE
chore(x/gov): clean validation code

### DIFF
--- a/x/gov/keeper/keeper.go
+++ b/x/gov/keeper/keeper.go
@@ -193,22 +193,22 @@ func (k Keeper) ModuleAccountAddress() sdk.AccAddress {
 // validateProposalLengths checks message metadata, summary and title
 // to have the expected length otherwise returns an error.
 func (k Keeper) validateProposalLengths(metadata, title, summary string) error {
-    if err := k.assertMetadataLength(metadata); err != nil {
-        return err
-    }
-    if err := k.assertSummaryLength(summary); err != nil {
-        return err
-    }
-    if err := k.assertTitleLength(title); err != nil {
-        return err
-    }
-    return nil
+	if err := k.assertMetadataLength(metadata); err != nil {
+		return err
+	}
+	if err := k.assertSummaryLength(summary); err != nil {
+		return err
+	}
+	if err := k.assertTitleLength(title); err != nil {
+		return err
+	}
+	return nil
 }
 
 // assertTitleLength returns an error if given title length
 // is greater than a pre-defined MaxTitleLen.
 func (k Keeper) assertTitleLength(title string) error {
-	if title != "" && uint64(len(title)) > k.config.MaxTitleLen {
+	if uint64(len(title)) > k.config.MaxTitleLen {
 		return types.ErrTitleTooLong.Wrapf("got title with length %d", len(title))
 	}
 	return nil
@@ -217,7 +217,7 @@ func (k Keeper) assertTitleLength(title string) error {
 // assertMetadataLength returns an error if given metadata length
 // is greater than a pre-defined MaxMetadataLen.
 func (k Keeper) assertMetadataLength(metadata string) error {
-	if metadata != "" && uint64(len(metadata)) > k.config.MaxMetadataLen {
+	if uint64(len(metadata)) > k.config.MaxMetadataLen {
 		return types.ErrMetadataTooLong.Wrapf("got metadata with length %d", len(metadata))
 	}
 	return nil
@@ -226,7 +226,7 @@ func (k Keeper) assertMetadataLength(metadata string) error {
 // assertSummaryLength returns an error if given summary length
 // is greater than a pre-defined MaxSummaryLen.
 func (k Keeper) assertSummaryLength(summary string) error {
-	if summary != "" && uint64(len(summary)) > k.config.MaxSummaryLen {
+	if uint64(len(summary)) > k.config.MaxSummaryLen {
 		return types.ErrSummaryTooLong.Wrapf("got summary with length %d", len(summary))
 	}
 	return nil


### PR DESCRIPTION
## Description

Based on the following comment from [odeke-em](https://github.com/odeke-em) in another PR https://github.com/cosmos/cosmos-sdk/pull/18448#discussion_r1390331143. I decided to clean also this code. 

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] added `!` to the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/build/building-modules/01-intro.md)
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] updated the relevant documentation or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] run `make lint` and `make test`
* [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] confirmed all author checklist items have been addressed 
* [ ] reviewed state machine logic
* [ ] reviewed API design and naming
* [ ] reviewed documentation is accurate
* [ ] reviewed tests and test coverage
* [ ] manually tested (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Simplified the validation process for proposal lengths in the governance module, enhancing efficiency and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->