### PR TITLE
refactor: tx_multisign/tx_sign refactor to improved readability and maintainability

### DIFF
--- a/x/auth/client/cli/tx_multisign.go
+++ b/x/auth/client/cli/tx_multisign.go
@@ -9,7 +9,6 @@ import (
 	"github.com/spf13/viper"
 	"google.golang.org/protobuf/types/known/anypb"
 
-	errorsmod "cosmossdk.io/errors"
 	authclient "cosmossdk.io/x/auth/client"
 	"cosmossdk.io/x/auth/signing"
 	txsigning "cosmossdk.io/x/tx/signing"
@@ -18,7 +17,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/tx"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
-	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	kmultisig "github.com/cosmos/cosmos-sdk/crypto/keys/multisig"
 	"github.com/cosmos/cosmos-sdk/crypto/types/multisig"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -68,11 +66,15 @@ The SIGN_MODE_DIRECT sign mode is not supported.'
 
 func makeMultiSignCmd() func(cmd *cobra.Command, args []string) (err error) {
 	return func(cmd *cobra.Command, args []string) (err error) {
+		file := args[0]
+		name := args[1]
+		sigsRaw := args[2:]
+
 		clientCtx, err := client.GetClientTxContext(cmd)
 		if err != nil {
 			return err
 		}
-		parsedTx, err := authclient.ReadTxFromFile(clientCtx, args[0])
+		parsedTx, err := authclient.ReadTxFromFile(clientCtx, file)
 		if err != nil {
 			return err
 		}
@@ -91,7 +93,7 @@ func makeMultiSignCmd() func(cmd *cobra.Command, args []string) (err error) {
 			return err
 		}
 
-		k, err := getMultisigRecord(clientCtx, args[1])
+		k, err := clientCtx.Keyring.Key(name)
 		if err != nil {
 			return err
 		}
@@ -117,8 +119,8 @@ func makeMultiSignCmd() func(cmd *cobra.Command, args []string) (err error) {
 		}
 
 		// read each signature and add it to the multisig if valid
-		for i := 2; i < len(args); i++ {
-			sigs, err := unmarshalSignatureJSON(clientCtx, args[i])
+		for i := 0; i < len(sigsRaw); i++ {
+			sigs, err := unmarshalSignatureJSON(clientCtx, sigsRaw[i])
 			if err != nil {
 				return err
 			}
@@ -176,7 +178,7 @@ func makeMultiSignCmd() func(cmd *cobra.Command, args []string) (err error) {
 		sigOnly, _ := cmd.Flags().GetBool(flagSigOnly)
 
 		var json []byte
-		json, err = marshalSignatureJSON(txCfg, txBuilder, sigOnly)
+		json, err = marshalSignatureJSON(txCfg, txBuilder.GetTx(), sigOnly)
 		if err != nil {
 			return err
 		}
@@ -233,6 +235,9 @@ func makeBatchMultisignCmd() func(cmd *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, args []string) (err error) {
 		var clientCtx client.Context
 
+		file, name := args[0], args[1]
+		sigFiles := args[2:]
+
 		clientCtx, err = client.GetClientTxContext(cmd)
 		if err != nil {
 			return err
@@ -248,19 +253,19 @@ func makeBatchMultisignCmd() func(cmd *cobra.Command, args []string) error {
 		}
 
 		// reads tx from args[0]
-		scanner, err := authclient.ReadTxsFromInput(txCfg, args[0])
+		scanner, err := authclient.ReadTxsFromInput(txCfg, file)
 		if err != nil {
 			return err
 		}
 
-		k, err := getMultisigRecord(clientCtx, args[1])
+		k, err := clientCtx.Keyring.Key(name)
 		if err != nil {
 			return err
 		}
 
 		var signatureBatch [][]signingtypes.SignatureV2
-		for i := 2; i < len(args); i++ {
-			sigs, err := readSignaturesFromFile(clientCtx, args[i])
+		for i := 0; i < len(sigFiles); i++ {
+			sigs, err := readSignaturesFromFile(clientCtx, sigFiles[i])
 			if err != nil {
 				return err
 			}
@@ -292,7 +297,7 @@ func makeBatchMultisignCmd() func(cmd *cobra.Command, args []string) error {
 		clientCtx.WithOutput(cmd.OutOrStdout())
 
 		for i := 0; scanner.Scan(); i++ {
-			txBldr, err := txCfg.WrapTxBuilder(scanner.Tx())
+			txBuilder, err := txCfg.WrapTxBuilder(scanner.Tx())
 			if err != nil {
 				return err
 			}
@@ -318,7 +323,7 @@ func makeBatchMultisignCmd() func(cmd *cobra.Command, args []string) error {
 				},
 			}
 
-			builtTx := txBldr.GetTx()
+			builtTx := txBuilder.GetTx()
 			adaptableTx, ok := builtTx.(signing.V2AdaptableTx)
 			if !ok {
 				return fmt.Errorf("expected Tx to be signing.V2AdaptableTx, got %T", builtTx)
@@ -343,14 +348,14 @@ func makeBatchMultisignCmd() func(cmd *cobra.Command, args []string) error {
 				Sequence: txFactory.Sequence(),
 			}
 
-			err = txBldr.SetSignatures(sigV2)
+			err = txBuilder.SetSignatures(sigV2)
 			if err != nil {
 				return err
 			}
 
 			sigOnly, _ := cmd.Flags().GetBool(flagSigOnly)
 			var json []byte
-			json, err = marshalSignatureJSON(txCfg, txBldr, sigOnly)
+			json, err = marshalSignatureJSON(txCfg, txBuilder.GetTx(), sigOnly)
 			if err != nil {
 				return err
 			}
@@ -397,14 +402,4 @@ func readSignaturesFromFile(ctx client.Context, filename string) (sigs []signing
 		sigs = append(sigs, sig...)
 	}
 	return sigs, nil
-}
-
-func getMultisigRecord(clientCtx client.Context, name string) (*keyring.Record, error) {
-	kb := clientCtx.Keyring
-	multisigRecord, err := kb.Key(name)
-	if err != nil {
-		return nil, errorsmod.Wrap(err, "error getting keybase multisig account")
-	}
-
-	return multisigRecord, nil
 }

--- a/x/auth/client/cli/tx_multisign.go
+++ b/x/auth/client/cli/tx_multisign.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/viper"
 	"google.golang.org/protobuf/types/known/anypb"
 
+	errorsmod "cosmossdk.io/errors"
 	authclient "cosmossdk.io/x/auth/client"
 	"cosmossdk.io/x/auth/signing"
 	txsigning "cosmossdk.io/x/tx/signing"
@@ -95,7 +96,7 @@ func makeMultiSignCmd() func(cmd *cobra.Command, args []string) (err error) {
 
 		k, err := clientCtx.Keyring.Key(name)
 		if err != nil {
-			return err
+			return errorsmod.Wrap(err, "error getting keybase multisig account")
 		}
 		pubKey, err := k.GetPubKey()
 		if err != nil {
@@ -260,7 +261,7 @@ func makeBatchMultisignCmd() func(cmd *cobra.Command, args []string) error {
 
 		k, err := clientCtx.Keyring.Key(name)
 		if err != nil {
-			return err
+			return errorsmod.Wrap(err, "error getting keybase multisig account")
 		}
 
 		var signatureBatch [][]signingtypes.SignatureV2

--- a/x/auth/client/cli/tx_sign.go
+++ b/x/auth/client/cli/tx_sign.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	errorsmod "cosmossdk.io/errors"
 	authclient "cosmossdk.io/x/auth/client"
 	"cosmossdk.io/x/auth/signing"
 
@@ -356,7 +357,7 @@ func signTx(cmd *cobra.Command, clientCtx client.Context, txFactory tx.Factory, 
 		}
 		multisigkey, err := clientCtx.Keyring.Key(multisigName)
 		if err != nil {
-			return err
+			return errorsmod.Wrap(err, "error getting keybase multisig account")
 		}
 		multisigPubKey, err := multisigkey.GetPubKey()
 		if err != nil {

--- a/x/auth/client/cli/tx_sign.go
+++ b/x/auth/client/cli/tx_sign.go
@@ -95,26 +95,23 @@ func makeSignBatchCmd() func(cmd *cobra.Command, args []string) error {
 			return err
 		}
 
-		if !clientCtx.Offline {
-			txFactory = txFactory.WithAccountNumber(0).WithSequence(0)
-			if multisigKey == "" {
-				from, err := cmd.Flags().GetString(flags.FlagFrom)
-				if err != nil {
-					return err
-				}
-
-				fromAddr, _, _, err := client.GetFromFields(clientCtx, txFactory.Keybase(), from)
-				if err != nil {
-					return err
-				}
-
-				fromAcc, err := txFactory.AccountRetriever().GetAccount(clientCtx, fromAddr)
-				if err != nil {
-					return err
-				}
-
-				txFactory = txFactory.WithAccountNumber(fromAcc.GetAccountNumber()).WithSequence(fromAcc.GetSequence())
+		if !clientCtx.Offline && multisigKey == "" {
+			from, err := cmd.Flags().GetString(flags.FlagFrom)
+			if err != nil {
+				return err
 			}
+
+			fromAddr, _, _, err := client.GetFromFields(clientCtx, txFactory.Keybase(), from)
+			if err != nil {
+				return err
+			}
+
+			fromAcc, err := txFactory.AccountRetriever().GetAccount(clientCtx, fromAddr)
+			if err != nil {
+				return err
+			}
+
+			txFactory = txFactory.WithAccountNumber(fromAcc.GetAccountNumber()).WithSequence(fromAcc.GetSequence())
 		}
 
 		appendMessagesToSingleTx, _ := cmd.Flags().GetBool(flagAppend)

--- a/x/auth/client/cli/tx_sign.go
+++ b/x/auth/client/cli/tx_sign.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spf13/cobra"
 
 	authclient "cosmossdk.io/x/auth/client"
+	"cosmossdk.io/x/auth/signing"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
@@ -73,9 +74,8 @@ func makeSignBatchCmd() func(cmd *cobra.Command, args []string) error {
 			return err
 		}
 		txCfg := clientCtx.TxConfig
-		printSignatureOnly, _ := cmd.Flags().GetBool(flagSigOnly)
 
-		ms, err := cmd.Flags().GetString(flagMultisig)
+		multisigKey, err := cmd.Flags().GetString(flagMultisig)
 		if err != nil {
 			return err
 		}
@@ -95,38 +95,37 @@ func makeSignBatchCmd() func(cmd *cobra.Command, args []string) error {
 		}
 
 		if !clientCtx.Offline {
-			if ms == "" {
+			txFactory = txFactory.WithAccountNumber(0).WithSequence(0)
+			if multisigKey == "" {
 				from, err := cmd.Flags().GetString(flags.FlagFrom)
 				if err != nil {
 					return err
 				}
 
-				addr, _, _, err := client.GetFromFields(clientCtx, txFactory.Keybase(), from)
+				fromAddr, _, _, err := client.GetFromFields(clientCtx, txFactory.Keybase(), from)
 				if err != nil {
 					return err
 				}
 
-				acc, err := txFactory.AccountRetriever().GetAccount(clientCtx, addr)
+				fromAcc, err := txFactory.AccountRetriever().GetAccount(clientCtx, fromAddr)
 				if err != nil {
 					return err
 				}
 
-				txFactory = txFactory.WithAccountNumber(acc.GetAccountNumber()).WithSequence(acc.GetSequence())
-			} else {
-				txFactory = txFactory.WithAccountNumber(0).WithSequence(0)
+				txFactory = txFactory.WithAccountNumber(fromAcc.GetAccountNumber()).WithSequence(fromAcc.GetSequence())
 			}
 		}
 
 		appendMessagesToSingleTx, _ := cmd.Flags().GetBool(flagAppend)
 		// Combines all tx msgs and create single signed transaction
 		if appendMessagesToSingleTx {
-			txBuilder := clientCtx.TxConfig.NewTxBuilder()
+			txBuilder := txCfg.NewTxBuilder()
 			msgs := make([]sdk.Msg, 0)
 			newGasLimit := uint64(0)
 
 			for scanner.Scan() {
 				unsignedStdTx := scanner.Tx()
-				fe, err := clientCtx.TxConfig.WrapTxBuilder(unsignedStdTx)
+				fe, err := txCfg.WrapTxBuilder(unsignedStdTx)
 				if err != nil {
 					return err
 				}
@@ -151,18 +150,11 @@ func makeSignBatchCmd() func(cmd *cobra.Command, args []string) error {
 			txBuilder.SetGasLimit(newGasLimit)
 
 			// sign the txs
-			if ms == "" {
-				from, _ := cmd.Flags().GetString(flags.FlagFrom)
-				if err := sign(clientCtx, txBuilder, txFactory, from); err != nil {
-					return err
-				}
-			} else {
-				if err := multisigSign(clientCtx, txBuilder, txFactory, ms); err != nil {
-					return err
-				}
-			}
+			from, _ := cmd.Flags().GetString(flags.FlagFrom)
+			sigTxOrMultisig(clientCtx, txBuilder, txFactory, from, multisigKey)
 
-			json, err := marshalSignatureJSON(txCfg, txBuilder, printSignatureOnly)
+			sigOnly, _ := cmd.Flags().GetBool(flagSigOnly)
+			json, err := marshalSignatureJSON(txCfg, txBuilder.GetTx(), sigOnly)
 			if err != nil {
 				return err
 			}
@@ -179,18 +171,11 @@ func makeSignBatchCmd() func(cmd *cobra.Command, args []string) error {
 				}
 
 				// sign the txs
-				if ms == "" {
-					from, _ := cmd.Flags().GetString(flags.FlagFrom)
-					if err := sign(clientCtx, txBuilder, txFactory, from); err != nil {
-						return err
-					}
-				} else {
-					if err := multisigSign(clientCtx, txBuilder, txFactory, ms); err != nil {
-						return err
-					}
-				}
+				from, _ := cmd.Flags().GetString(flags.FlagFrom)
+				sigTxOrMultisig(clientCtx, txBuilder, txFactory, from, multisigKey)
 
-				json, err := marshalSignatureJSON(txCfg, txBuilder, printSignatureOnly)
+				printSigOnly, _ := cmd.Flags().GetBool(flagSigOnly)
+				json, err := marshalSignatureJSON(txCfg, txBuilder.GetTx(), printSigOnly)
 				if err != nil {
 					return err
 				}
@@ -198,12 +183,17 @@ func makeSignBatchCmd() func(cmd *cobra.Command, args []string) error {
 			}
 		}
 
-		if err := scanner.UnmarshalErr(); err != nil {
-			return err
-		}
-
 		return scanner.UnmarshalErr()
 	}
+}
+
+func sigTxOrMultisig(clientCtx client.Context, txBuilder client.TxBuilder, txFactory tx.Factory, from string, multisigKey string) (err error) {
+	if multisigKey == "" {
+		err = sign(clientCtx, txBuilder, txFactory, from)
+	} else {
+		err = multisigSign(clientCtx, txBuilder, txFactory, multisigKey)
+	}
+	return err
 }
 
 func sign(clientCtx client.Context, txBuilder client.TxBuilder, txFactory tx.Factory, from string) error {
@@ -322,7 +312,7 @@ func makeSignCmd() func(cmd *cobra.Command, args []string) error {
 	}
 }
 
-func signTx(cmd *cobra.Command, clientCtx client.Context, txF tx.Factory, newTx sdk.Tx) error {
+func signTx(cmd *cobra.Command, clientCtx client.Context, txFactory tx.Factory, newTx sdk.Tx) error {
 	f := cmd.Flags()
 	txCfg := clientCtx.TxConfig
 	txBuilder, err := txCfg.WrapTxBuilder(newTx)
@@ -330,12 +320,12 @@ func signTx(cmd *cobra.Command, clientCtx client.Context, txF tx.Factory, newTx 
 		return err
 	}
 
-	printSignatureOnly, err := cmd.Flags().GetBool(flagSigOnly)
+	sigOnly, err := cmd.Flags().GetBool(flagSigOnly)
 	if err != nil {
 		return err
 	}
 
-	multisig, err := cmd.Flags().GetString(flagMultisig)
+	multisigKey, err := cmd.Flags().GetString(flagMultisig)
 	if err != nil {
 		return err
 	}
@@ -345,7 +335,7 @@ func signTx(cmd *cobra.Command, clientCtx client.Context, txF tx.Factory, newTx 
 		return err
 	}
 
-	_, fromName, _, err := client.GetFromFields(clientCtx, txF.Keybase(), from)
+	_, fromName, _, err := client.GetFromFields(clientCtx, txFactory.Keybase(), from)
 	if err != nil {
 		return fmt.Errorf("error getting account from keybase: %w", err)
 	}
@@ -355,13 +345,16 @@ func signTx(cmd *cobra.Command, clientCtx client.Context, txF tx.Factory, newTx 
 		return err
 	}
 
-	if multisig != "" {
+	if multisigKey != "" {
+		sigOnly = true
+
+		// get the multisig key by name
 		// Bech32 decode error, maybe it's a name, we try to fetch from keyring
-		multisigAddr, multisigName, _, err := client.GetFromFields(clientCtx, txF.Keybase(), multisig)
+		multisigAddr, multisigName, _, err := client.GetFromFields(clientCtx, txFactory.Keybase(), multisigKey)
 		if err != nil {
 			return fmt.Errorf("error getting account from keybase: %w", err)
 		}
-		multisigkey, err := getMultisigRecord(clientCtx, multisigName)
+		multisigkey, err := clientCtx.Keyring.Key(multisigName)
 		if err != nil {
 			return err
 		}
@@ -390,13 +383,12 @@ func signTx(cmd *cobra.Command, clientCtx client.Context, txF tx.Factory, newTx 
 			return fmt.Errorf("signing key is not a part of multisig key")
 		}
 		err = authclient.SignTxWithSignerAddress(
-			txF, clientCtx, multisigAddr, fromName, txBuilder, clientCtx.Offline, overwrite)
+			txFactory, clientCtx, multisigAddr, fromName, txBuilder, clientCtx.Offline, overwrite)
 		if err != nil {
 			return err
 		}
-		printSignatureOnly = true
 	} else {
-		err = authclient.SignTx(txF, clientCtx, clientCtx.FromName, txBuilder, clientCtx.Offline, overwrite)
+		err = authclient.SignTx(txFactory, clientCtx, clientCtx.FromName, txBuilder, clientCtx.Offline, overwrite)
 	}
 	if err != nil {
 		return err
@@ -412,7 +404,7 @@ func signTx(cmd *cobra.Command, clientCtx client.Context, txF tx.Factory, newTx 
 	clientCtx.WithOutput(cmd.OutOrStdout())
 
 	var json []byte
-	json, err = marshalSignatureJSON(txCfg, txBuilder, printSignatureOnly)
+	json, err = marshalSignatureJSON(txCfg, txBuilder.GetTx(), sigOnly)
 	if err != nil {
 		return err
 	}
@@ -422,15 +414,14 @@ func signTx(cmd *cobra.Command, clientCtx client.Context, txF tx.Factory, newTx 
 	return err
 }
 
-func marshalSignatureJSON(txConfig client.TxConfig, txBldr client.TxBuilder, signatureOnly bool) ([]byte, error) {
-	parsedTx := txBldr.GetTx()
+func marshalSignatureJSON(txConfig client.TxConfig, tx signing.Tx, signatureOnly bool) ([]byte, error) {
 	if signatureOnly {
-		sigs, err := parsedTx.GetSignaturesV2()
+		sigs, err := tx.GetSignaturesV2()
 		if err != nil {
 			return nil, err
 		}
 		return txConfig.MarshalSignatureJSON(sigs)
 	}
 
-	return txConfig.TxJSONEncoder()(parsedTx)
+	return txConfig.TxJSONEncoder()(tx)
 }


### PR DESCRIPTION
## Description

This PR focuses on refactoring the tx_multisign.go and tx_sign.go files in `x/auth/client/cli`.

- In func `makeMultiSignCmd` use meaningful names instead of args[N]
- Remove `getMultisigRecord` which seems not very meaningful
- In makeSignBatchCmd, the if control flow can be simplified. btw `txFactory = txFactory.WithAccountNumber(0).WithSequence(0)` this line may also be removed because it seems to be the default value.
- merge duplicated code in two branch in makeSignBatchCmd
- Other trivial simplification

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [x] added `!` to the type prefix if API or client breaking change
* [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [NA] provided a link to the relevant issue or specification
* [x] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/build/building-modules/01-intro.md)
* [x] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [NA] added a changelog entry to `CHANGELOG.md`
* [NA] included comments for [documenting Go code](https://blog.golang.org/godoc)
* [NA] updated the relevant documentation or specification
* [NA] reviewed "Files changed" and left comments if necessary
* [X] run `make lint` and `make test`
* [WAITING] confirmed all CI checks have passed

NA explain: *changes do not introduce any functional changes to the behavior of the code*

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] confirmed all author checklist items have been addressed 
* [ ] reviewed state machine logic
* [ ] reviewed API design and naming
* [ ] reviewed documentation is accurate
* [ ] reviewed tests and test coverage
* [ ] manually tested (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Enhanced transaction signing and multisig functionality for improved user experience.
	- Streamlined error handling and key retrieval processes.
	- Optimized code readability by replacing direct use of arguments with named variables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->