### PR TITLE
style: package "slashing/types" is being imported more than once

### DIFF
--- a/x/slashing/keeper/keeper_test.go
+++ b/x/slashing/keeper/keeper_test.go
@@ -15,7 +15,6 @@ import (
 	authtypes "cosmossdk.io/x/auth/types"
 	slashingkeeper "cosmossdk.io/x/slashing/keeper"
 	slashingtestutil "cosmossdk.io/x/slashing/testutil"
-	"cosmossdk.io/x/slashing/types"
 	slashingtypes "cosmossdk.io/x/slashing/types"
 
 	"github.com/cosmos/cosmos-sdk/baseapp"
@@ -55,7 +54,7 @@ func (s *KeeperTestSuite) SetupTest() {
 	s.stakingKeeper.EXPECT().ValidatorAddressCodec().Return(address.NewBech32Codec("cosmosvaloper")).AnyTimes()
 	s.stakingKeeper.EXPECT().ConsensusAddressCodec().Return(address.NewBech32Codec("cosmosvalcons")).AnyTimes()
 
-	authStr, err := address.NewBech32Codec("cosmos").BytesToString(authtypes.NewModuleAddress(types.GovModuleName))
+	authStr, err := address.NewBech32Codec("cosmos").BytesToString(authtypes.NewModuleAddress(slashingtypes.GovModuleName))
 	s.Require().NoError(err)
 
 	s.ctx = ctx


### PR DESCRIPTION
fix x/slashing/keeper/keeper_test.go import, package "cosmossdk.io/x/slashing/types" is being imported more than once

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Updated the setup function in the slashing module's test suite to reflect changes in module structure or naming convention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->