### PR TITLE
ci: fix x/authz golangci-lint run failed

### DIFF
--- a/x/authz/go.mod
+++ b/x/authz/go.mod
@@ -166,6 +166,7 @@ replace github.com/cosmos/cosmos-sdk => ../../.
 
 // TODO remove post spinning out all modules
 replace (
+	cosmossdk.io/api => ../../api
 	cosmossdk.io/x/auth => ../auth
 	cosmossdk.io/x/bank => ../bank
 	cosmossdk.io/x/distribution => ../distribution


### PR DESCRIPTION
fix `golangci-lint run` for `x/authz`, as module `x/gov` go.mod was changed by [PR 18428](https://github.com/cosmos/cosmos-sdk/pull/18428) with `replace cosmossdk.io/api => ../../api`

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] confirmed all author checklist items have been addressed 
* [ ] reviewed state machine logic
* [ ] reviewed API design and naming
* [ ] reviewed documentation is accurate
* [ ] reviewed tests and test coverage
* [ ] manually tested (if applicable)
