### PR TITLE
feat(server): cmd flag to disable colored logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (x/bank) [#17569](https://github.com/cosmos/cosmos-sdk/pull/17569) Introduce a new message type, `MsgBurn`, to burn coins.
 * (server) [#17094](https://github.com/cosmos/cosmos-sdk/pull/17094) Add duration `shutdown-grace` for resource clean up (closing database handles) before exit.
 * (x/auth/vesting) [#17810](https://github.com/cosmos/cosmos-sdk/pull/17810) Add the ability to specify a start time for continuous vesting accounts.
+* (server) [#18478](https://github.com/cosmos/cosmos-sdk/pull/18478) CMD flag to disable colored logs.
 
 ### Improvements
 

--- a/client/flags/flags.go
+++ b/client/flags/flags.go
@@ -86,9 +86,9 @@ const (
 	// This differs from FlagOutputDocument that is used to set the output file.
 	FlagOutput = "output"
 	// Logging flags
-	FlagLogLevel   = "log_level"
-	FlagLogFormat  = "log_format"
-	FlagLogColored = "log_colored"
+	FlagLogLevel      = "log_level"
+	FlagLogFormat     = "log_format"
+	FlagLogNotColored = "log_not_colored"
 )
 
 // List of supported output formats

--- a/client/flags/flags.go
+++ b/client/flags/flags.go
@@ -88,6 +88,7 @@ const (
 	// Logging flags
 	FlagLogLevel  = "log_level"
 	FlagLogFormat = "log_format"
+	FlagColorLogs = "log_colored"
 )
 
 // List of supported output formats

--- a/client/flags/flags.go
+++ b/client/flags/flags.go
@@ -86,9 +86,9 @@ const (
 	// This differs from FlagOutputDocument that is used to set the output file.
 	FlagOutput = "output"
 	// Logging flags
-	FlagLogLevel      = "log_level"
-	FlagLogFormat     = "log_format"
-	FlagLogNotColored = "log_not_colored"
+	FlagLogLevel   = "log_level"
+	FlagLogFormat  = "log_format"
+	FlagLogNoColor = "log_no_color"
 )
 
 // List of supported output formats

--- a/client/flags/flags.go
+++ b/client/flags/flags.go
@@ -86,9 +86,9 @@ const (
 	// This differs from FlagOutputDocument that is used to set the output file.
 	FlagOutput = "output"
 	// Logging flags
-	FlagLogLevel  = "log_level"
-	FlagLogFormat = "log_format"
-	FlagColorLogs = "log_colored"
+	FlagLogLevel   = "log_level"
+	FlagLogFormat  = "log_format"
+	FlagLogColored = "log_colored"
 )
 
 // List of supported output formats

--- a/server/cmd/execute.go
+++ b/server/cmd/execute.go
@@ -28,7 +28,7 @@ func Execute(rootCmd *cobra.Command, envPrefix, defaultHome string) error {
 	rootCmd.PersistentFlags().String(flags.FlagLogLevel, zerolog.InfoLevel.String(), "The logging level (trace|debug|info|warn|error|fatal|panic|disabled or '*:<level>,<key>:<level>')")
 	// NOTE: The default logger is only checking for the "json" value, any other value will default to plain text.
 	rootCmd.PersistentFlags().String(flags.FlagLogFormat, "plain", "The logging format (json|plain)")
-	rootCmd.PersistentFlags().Bool(flags.FlagLogNotColored, false, "Disable colored logs")
+	rootCmd.PersistentFlags().Bool(flags.FlagLogNoColor, false, "Disable colored logs")
 
 	executor := cmtcli.PrepareBaseCmd(rootCmd, envPrefix, defaultHome)
 	return executor.ExecuteContext(ctx)

--- a/server/cmd/execute.go
+++ b/server/cmd/execute.go
@@ -28,7 +28,7 @@ func Execute(rootCmd *cobra.Command, envPrefix, defaultHome string) error {
 	rootCmd.PersistentFlags().String(flags.FlagLogLevel, zerolog.InfoLevel.String(), "The logging level (trace|debug|info|warn|error|fatal|panic|disabled or '*:<level>,<key>:<level>')")
 	// NOTE: The default logger is only checking for the "json" value, any other value will default to plain text.
 	rootCmd.PersistentFlags().String(flags.FlagLogFormat, "plain", "The logging format (json|plain)")
-	rootCmd.PersistentFlags().Bool(flags.FlagColorLogs, false, "Enable colored logs")
+	rootCmd.PersistentFlags().Bool(flags.FlagLogColored, false, "Enable colored logs")
 
 	executor := cmtcli.PrepareBaseCmd(rootCmd, envPrefix, defaultHome)
 	return executor.ExecuteContext(ctx)

--- a/server/cmd/execute.go
+++ b/server/cmd/execute.go
@@ -28,6 +28,7 @@ func Execute(rootCmd *cobra.Command, envPrefix, defaultHome string) error {
 	rootCmd.PersistentFlags().String(flags.FlagLogLevel, zerolog.InfoLevel.String(), "The logging level (trace|debug|info|warn|error|fatal|panic|disabled or '*:<level>,<key>:<level>')")
 	// NOTE: The default logger is only checking for the "json" value, any other value will default to plain text.
 	rootCmd.PersistentFlags().String(flags.FlagLogFormat, "plain", "The logging format (json|plain)")
+	rootCmd.PersistentFlags().Bool(flags.FlagColorLogs, false, "Enable colored logs")
 
 	executor := cmtcli.PrepareBaseCmd(rootCmd, envPrefix, defaultHome)
 	return executor.ExecuteContext(ctx)

--- a/server/cmd/execute.go
+++ b/server/cmd/execute.go
@@ -28,7 +28,7 @@ func Execute(rootCmd *cobra.Command, envPrefix, defaultHome string) error {
 	rootCmd.PersistentFlags().String(flags.FlagLogLevel, zerolog.InfoLevel.String(), "The logging level (trace|debug|info|warn|error|fatal|panic|disabled or '*:<level>,<key>:<level>')")
 	// NOTE: The default logger is only checking for the "json" value, any other value will default to plain text.
 	rootCmd.PersistentFlags().String(flags.FlagLogFormat, "plain", "The logging format (json|plain)")
-	rootCmd.PersistentFlags().Bool(flags.FlagLogColored, false, "Enable colored logs")
+	rootCmd.PersistentFlags().Bool(flags.FlagLogNotColored, false, "Disable colored logs")
 
 	executor := cmtcli.PrepareBaseCmd(rootCmd, envPrefix, defaultHome)
 	return executor.ExecuteContext(ctx)

--- a/server/util.go
+++ b/server/util.go
@@ -173,6 +173,9 @@ func CreateSDKLogger(ctx *Context, out io.Writer) (log.Logger, error) {
 	if ctx.Viper.GetString(flags.FlagLogFormat) == flags.OutputFormatJSON {
 		opts = append(opts, log.OutputJSONOption())
 	}
+	opts = append(opts,
+		log.ColorOption(ctx.Viper.GetBool(flags.FlagColorLogs)),
+		log.TraceOption(ctx.Viper.GetBool("trace"))) // cmtcli.TraceFlag
 
 	// check and set filter level or keys for the logger if any
 	logLvlStr := ctx.Viper.GetString(flags.FlagLogLevel)
@@ -193,9 +196,6 @@ func CreateSDKLogger(ctx *Context, out io.Writer) (log.Logger, error) {
 	default:
 		opts = append(opts, log.LevelOption(logLvl))
 	}
-
-	// Check if the CometBFT flag for trace logging is set and enable stack traces if so.
-	opts = append(opts, log.TraceOption(ctx.Viper.GetBool("trace"))) // cmtcli.TraceFlag
 
 	return log.NewLogger(out, opts...), nil
 }

--- a/server/util.go
+++ b/server/util.go
@@ -174,7 +174,7 @@ func CreateSDKLogger(ctx *Context, out io.Writer) (log.Logger, error) {
 		opts = append(opts, log.OutputJSONOption())
 	}
 	opts = append(opts,
-		log.ColorOption(!ctx.Viper.GetBool(flags.FlagLogNotColored)),
+		log.ColorOption(!ctx.Viper.GetBool(flags.FlagLogNoColor)),
 		// We use CometBFT flag (cmtcli.TraceFlag) for trace logging.
 		log.TraceOption(ctx.Viper.GetBool(FlagTrace)))
 

--- a/server/util.go
+++ b/server/util.go
@@ -175,7 +175,8 @@ func CreateSDKLogger(ctx *Context, out io.Writer) (log.Logger, error) {
 	}
 	opts = append(opts,
 		log.ColorOption(ctx.Viper.GetBool(flags.FlagLogColored)),
-		log.TraceOption(ctx.Viper.GetBool("trace"))) // cmtcli.TraceFlag
+		// CometBFT flag (cmtcli.TraceFlag) for trace logging.
+		log.TraceOption(ctx.Viper.GetBool(FlagTrace)))
 
 	// check and set filter level or keys for the logger if any
 	logLvlStr := ctx.Viper.GetString(flags.FlagLogLevel)

--- a/server/util.go
+++ b/server/util.go
@@ -174,7 +174,7 @@ func CreateSDKLogger(ctx *Context, out io.Writer) (log.Logger, error) {
 		opts = append(opts, log.OutputJSONOption())
 	}
 	opts = append(opts,
-		log.ColorOption(ctx.Viper.GetBool(flags.FlagLogColored)),
+		log.ColorOption(!ctx.Viper.GetBool(flags.FlagLogNotColored)),
 		// We use CometBFT flag (cmtcli.TraceFlag) for trace logging.
 		log.TraceOption(ctx.Viper.GetBool(FlagTrace)))
 

--- a/server/util.go
+++ b/server/util.go
@@ -174,7 +174,7 @@ func CreateSDKLogger(ctx *Context, out io.Writer) (log.Logger, error) {
 		opts = append(opts, log.OutputJSONOption())
 	}
 	opts = append(opts,
-		log.ColorOption(ctx.Viper.GetBool(flags.FlagColorLogs)),
+		log.ColorOption(ctx.Viper.GetBool(flags.FlagLogColored)),
 		log.TraceOption(ctx.Viper.GetBool("trace"))) // cmtcli.TraceFlag
 
 	// check and set filter level or keys for the logger if any

--- a/server/util.go
+++ b/server/util.go
@@ -175,7 +175,7 @@ func CreateSDKLogger(ctx *Context, out io.Writer) (log.Logger, error) {
 	}
 	opts = append(opts,
 		log.ColorOption(ctx.Viper.GetBool(flags.FlagLogColored)),
-		// CometBFT flag (cmtcli.TraceFlag) for trace logging.
+		// We use CometBFT flag (cmtcli.TraceFlag) for trace logging.
 		log.TraceOption(ctx.Viper.GetBool(FlagTrace)))
 
 	// check and set filter level or keys for the logger if any


### PR DESCRIPTION
## Description

Ref: #13699

Colored logs should be optional. Enforcing colored logs will make the log capture ugly and non dev friendly.
Common use case is to stream logs to a logging service (eg Google logs). With colored logs, this will contain all color codes, making the log browsing very unfriendly.

This PR adds a new global flag: `log_colored`. By default it's false (so this PR changes the default behavior), meaning that logs are not colored by default. When set, just by adding `--log_colored` the behavior will be as "now". This setting is more system friendly.

Note, I was thinking to use more traditional name scheme with `-` for connecting words (so `log-colored` instead of `log_colored`), but other log related flags are using `_` (eg: `log_level`).

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [x] added `!` to the type prefix if API or client breaking change
* [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [x] provided a link to the relevant issue or specification
* [x] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/build/building-modules/01-intro.md)
* [x] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [x] added a changelog entry to `CHANGELOG.md`
* [x] included comments for [documenting Go code](https://blog.golang.org/godoc)
* [x] updated the relevant documentation or specification
* [x] reviewed "Files changed" and left comments if necessary
* [x] run `make lint` and `make test`
* [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] confirmed all author checklist items have been addressed 
* [ ] reviewed state machine logic
* [ ] reviewed API design and naming
* [ ] reviewed documentation is accurate
* [ ] reviewed tests and test coverage
* [ ] manually tested (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new command-line flag to enable or disable colored logs, enhancing user control over log output preferences.

- **Refactor**
  - Consolidated log options to simplify the logging setup process.

- **Documentation**
  - Updated CHANGELOG.md to reflect the new flag for controlling log colorization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->