### PR TITLE
imp(staking): detect the length of the ed25519 pubkey in CreateValidator to prevent panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * [#17733](https://github.com/cosmos/cosmos-sdk/pull/17733) Ensure `buf export` exports all proto dependencies
 * (version) [#18063](https://github.com/cosmos/cosmos-sdk/pull/18063) Include additional information in the Info struct. This change enhances the Info struct by adding support for additional information through the ExtraInfo field
 * (crypto | x/auth) [#14372](https://github.com/cosmos/cosmos-sdk/pull/18194) Key checks on signatures antehandle.
+* (staking) [#18506](https://github.com/cosmos/cosmos-sdk/pull/18506) Detect the length of the ed25519 pubkey in CreateValidator to prevent panic.
 
 ### Bug Fixes
 

--- a/types/staking.go
+++ b/types/staking.go
@@ -22,6 +22,9 @@ var (
 
 	// DefaultPowerReduction is the default amount of staking tokens required for 1 unit of consensus-engine power
 	DefaultPowerReduction = sdkmath.NewIntFromUint64(1000000)
+
+	// PubKeyEd25519Type is ed25519 for type the consensus params validator pub_key_types params
+	PubKeyEd25519Type = "ed25519"
 )
 
 // TokensToConsensusPower - convert input tokens to potential consensus-engine power

--- a/x/staking/keeper/msg_server.go
+++ b/x/staking/keeper/msg_server.go
@@ -82,7 +82,7 @@ func (k msgServer) CreateValidator(ctx context.Context, msg *types.MsgCreateVali
 			)
 		}
 
-		if pkType == "ed25519" && len(pk.Bytes()) != ed25519.PubKeySize {
+		if pkType == sdk.PubKeyEd25519Type && len(pk.Bytes()) != ed25519.PubKeySize {
 			return nil, errorsmod.Wrapf(
 				types.ErrConsensusPubKeyLenInvalid,
 				"got: %d, expected: %d", len(pk.Bytes()), ed25519.PubKeySize,

--- a/x/staking/keeper/msg_server_test.go
+++ b/x/staking/keeper/msg_server_test.go
@@ -48,7 +48,7 @@ func (s *KeeperTestSuite) TestMsgCreateValidator() {
 
 	ctx = ctx.WithConsensusParams(cmtproto.ConsensusParams{
 		Validator: &cmtproto.ValidatorParams{
-			PubKeyTypes: []string{"ed25519"},
+			PubKeyTypes: []string{sdk.PubKeyEd25519Type},
 		},
 	})
 

--- a/x/staking/keeper/msg_server_test.go
+++ b/x/staking/keeper/msg_server_test.go
@@ -71,7 +71,7 @@ func (s *KeeperTestSuite) TestMsgCreateValidator() {
 				DelegatorAddress:  Addr.String(),
 				ValidatorAddress:  ValAddr.String(),
 				Pubkey:            pubkey,
-				Value:             sdk.NewInt64Coin("stake", 10000),
+				Value:             sdk.NewInt64Coin(sdk.DefaultBondDenom, 10000),
 			},
 			expErr:    true,
 			expErrMsg: "empty description",
@@ -91,7 +91,7 @@ func (s *KeeperTestSuite) TestMsgCreateValidator() {
 				DelegatorAddress:  Addr.String(),
 				ValidatorAddress:  sdk.AccAddress([]byte("invalid")).String(),
 				Pubkey:            pubkey,
-				Value:             sdk.NewInt64Coin("stake", 10000),
+				Value:             sdk.NewInt64Coin(sdk.DefaultBondDenom, 10000),
 			},
 			expErr:    true,
 			expErrMsg: "invalid validator address",
@@ -111,7 +111,7 @@ func (s *KeeperTestSuite) TestMsgCreateValidator() {
 				DelegatorAddress:  Addr.String(),
 				ValidatorAddress:  ValAddr.String(),
 				Pubkey:            nil,
-				Value:             sdk.NewInt64Coin("stake", 10000),
+				Value:             sdk.NewInt64Coin(sdk.DefaultBondDenom, 10000),
 			},
 			expErr:    true,
 			expErrMsg: "empty validator public key",
@@ -131,7 +131,7 @@ func (s *KeeperTestSuite) TestMsgCreateValidator() {
 				DelegatorAddress:  Addr.String(),
 				ValidatorAddress:  ValAddr.String(),
 				Pubkey:            pubkeyInvalidLen,
-				Value:             sdk.NewInt64Coin("stake", 10000),
+				Value:             sdk.NewInt64Coin(sdk.DefaultBondDenom, 10000),
 			},
 			expErr:    true,
 			expErrMsg: "consensus pubkey len is invalid",
@@ -151,7 +151,7 @@ func (s *KeeperTestSuite) TestMsgCreateValidator() {
 				DelegatorAddress:  Addr.String(),
 				ValidatorAddress:  ValAddr.String(),
 				Pubkey:            pubkey,
-				Value:             sdk.NewInt64Coin("stake", 0),
+				Value:             sdk.NewInt64Coin(sdk.DefaultBondDenom, 0),
 			},
 			expErr:    true,
 			expErrMsg: "invalid delegation amount",
@@ -191,7 +191,7 @@ func (s *KeeperTestSuite) TestMsgCreateValidator() {
 				DelegatorAddress:  Addr.String(),
 				ValidatorAddress:  ValAddr.String(),
 				Pubkey:            pubkey,
-				Value:             sdk.NewInt64Coin("stake", 10000),
+				Value:             sdk.NewInt64Coin(sdk.DefaultBondDenom, 10000),
 			},
 			expErr:    true,
 			expErrMsg: "minimum self delegation must be a positive integer",
@@ -211,7 +211,7 @@ func (s *KeeperTestSuite) TestMsgCreateValidator() {
 				DelegatorAddress:  Addr.String(),
 				ValidatorAddress:  ValAddr.String(),
 				Pubkey:            pubkey,
-				Value:             sdk.NewInt64Coin("stake", 10000),
+				Value:             sdk.NewInt64Coin(sdk.DefaultBondDenom, 10000),
 			},
 			expErr:    true,
 			expErrMsg: "minimum self delegation must be a positive integer",
@@ -231,7 +231,7 @@ func (s *KeeperTestSuite) TestMsgCreateValidator() {
 				DelegatorAddress:  Addr.String(),
 				ValidatorAddress:  ValAddr.String(),
 				Pubkey:            pubkey,
-				Value:             sdk.NewInt64Coin("stake", 10),
+				Value:             sdk.NewInt64Coin(sdk.DefaultBondDenom, 10),
 			},
 			expErr:    true,
 			expErrMsg: "validator's self delegation must be greater than their minimum self delegation",
@@ -255,7 +255,7 @@ func (s *KeeperTestSuite) TestMsgCreateValidator() {
 				DelegatorAddress:  Addr.String(),
 				ValidatorAddress:  ValAddr.String(),
 				Pubkey:            pubkey,
-				Value:             sdk.NewInt64Coin("stake", 10000),
+				Value:             sdk.NewInt64Coin(sdk.DefaultBondDenom, 10000),
 			},
 			expErr: false,
 		},
@@ -285,7 +285,7 @@ func (s *KeeperTestSuite) TestMsgEditValidator() {
 	require.NotNil(pk)
 
 	comm := stakingtypes.NewCommissionRates(math.LegacyNewDec(0), math.LegacyNewDec(0), math.LegacyNewDec(0))
-	msg, err := stakingtypes.NewMsgCreateValidator(ValAddr.String(), pk, sdk.NewCoin("stake", math.NewInt(10)), stakingtypes.Description{Moniker: "NewVal"}, comm, math.OneInt())
+	msg, err := stakingtypes.NewMsgCreateValidator(ValAddr.String(), pk, sdk.NewCoin(sdk.DefaultBondDenom, math.NewInt(10)), stakingtypes.Description{Moniker: "NewVal"}, comm, math.OneInt())
 	require.NoError(err)
 
 	res, err := msgServer.CreateValidator(ctx, msg)
@@ -459,7 +459,7 @@ func (s *KeeperTestSuite) TestMsgDelegate() {
 
 	comm := stakingtypes.NewCommissionRates(math.LegacyNewDec(0), math.LegacyNewDec(0), math.LegacyNewDec(0))
 
-	msg, err := stakingtypes.NewMsgCreateValidator(ValAddr.String(), pk, sdk.NewCoin("stake", math.NewInt(10)), stakingtypes.Description{Moniker: "NewVal"}, comm, math.OneInt())
+	msg, err := stakingtypes.NewMsgCreateValidator(ValAddr.String(), pk, sdk.NewCoin(sdk.DefaultBondDenom, math.NewInt(10)), stakingtypes.Description{Moniker: "NewVal"}, comm, math.OneInt())
 	require.NoError(err)
 
 	res, err := msgServer.CreateValidator(ctx, msg)

--- a/x/staking/types/errors.go
+++ b/x/staking/types/errors.go
@@ -51,4 +51,5 @@ var (
 	// consensus key errors
 	ErrConsensusPubKeyAlreadyUsedForValidator = errors.Register(ModuleName, 46, "consensus pubkey is already used for a validator")
 	ErrExceedingMaxConsPubKeyRotations        = errors.Register(ModuleName, 47, "exceeding maximum consensus pubkey rotations within unbonding period")
+	ErrConsensusPubKeyLenInvalid              = errors.Register(ModuleName, 48, "consensus pubkey len is invalid")
 )


### PR DESCRIPTION
## Description

Using the command `simd tx staking create-validator --pubkey='{@type:/cosmos.crypto.ed25519.PubKey,key:bHVrZQ==}'` 
 (the latest main branch has been read validator info from the file. I am just doing a demonstration here.) to create a validator will cause a panic. In my actual test, the receipt of the transaction looks like this:
<img width="2289" alt="ed25519-1" src="https://github.com/cosmos/cosmos-sdk/assets/9688029/11a43b68-60a5-4389-b737-8f9f56c6984c">


Because the length of the key is incorrect, it should be 32 bytes. So i added a check for the length of the pubkey in the `CreateValidator` function to prevent a panic.

Note: Since it is currently not possible to send transactions using the CLI command, as mentioned in bug https://github.com/cosmos/cosmos-sdk/issues/18122 , I actually tested this using evmos. I have only completed the unit tests and meet the expectations. Please test it yourself using the CLI command.A transaction receipt sent for testing after modification on evmos is as follows:
<img width="1234" alt="ed25519-2" src="https://github.com/cosmos/cosmos-sdk/assets/9688029/9ba4cc88-4889-48c2-8c45-f36c5e19b743">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced the staking module to prevent potential system panic by validating the length of the ed25519 public key during validator creation.
  
- **Documentation**
  - Updated CHANGELOG.md to reflect the new pull request addressing public key validation.

- **Tests**
  - Expanded test coverage to include scenarios with invalid consensus public key lengths.

- **Error Handling**
  - Introduced a new error code for invalid consensus public key length to improve clarity in error responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->