### PR TITLE
fix(x/bank): disallow duplicated addresses when sanitizing the genesis bank balances

### DIFF
--- a/x/bank/types/balance.go
+++ b/x/bank/types/balance.go
@@ -68,12 +68,11 @@ func SanitizeGenesisBalances(balances []Balance) []Balance {
 	for i := range balances {
 		addr, _ := sdk.AccAddressFromBech32(balances[i].Address)
 		addresses[i] = addr
+		if _, exists := existingAddresses[string(addr)]; exists {
+			panic("duplicate account in genesis state")
+		}
 		existingAddresses[string(addr)] = true
 	}
-
-	if len(existingAddresses) != len(balances) {
-		panic("duplicate account in genesis state")
-        }
 
 	// 2. Sort balances.
 	sort.Sort(balanceByAddress{addresses: addresses, balances: balances})

--- a/x/bank/types/balance.go
+++ b/x/bank/types/balance.go
@@ -51,7 +51,7 @@ func (b balanceByAddress) Swap(i, j int) {
 	b.balances[i], b.balances[j] = b.balances[j], b.balances[i]
 }
 
-// SanitizeGenesisBalances sorts addresses and coin sets.
+// SanitizeGenesisBalances checks for duplicates and sorts addresses and coin sets.
 func SanitizeGenesisBalances(balances []Balance) []Balance {
 	// Given that this function sorts balances, using the standard library's
 	// Quicksort based algorithms, we have algorithmic complexities of:
@@ -64,10 +64,16 @@ func SanitizeGenesisBalances(balances []Balance) []Balance {
 
 	// 1. Retrieve the address equivalents for each Balance's address.
 	addresses := make([]sdk.AccAddress, len(balances))
+	existingAddresses := map[string]bool{}
 	for i := range balances {
 		addr, _ := sdk.AccAddressFromBech32(balances[i].Address)
 		addresses[i] = addr
+		existingAddresses[string(addr)] = true
 	}
+
+	if len(existingAddresses) != len(balances) {
+		panic("duplicate account in genesis state")
+        }
 
 	// 2. Sort balances.
 	sort.Sort(balanceByAddress{addresses: addresses, balances: balances})

--- a/x/bank/types/balance.go
+++ b/x/bank/types/balance.go
@@ -71,7 +71,7 @@ func SanitizeGenesisBalances(balances []Balance) []Balance {
 		addr, _ := sdk.AccAddressFromBech32(balances[i].Address)
 		addresses[i] = addr
 		if _, exists := seen[string(addr)]; exists {
-			panic(fmt.Errorf("genesis state has a duplicate account: %q", balances[i].Address))
+			panic(fmt.Sprintf("genesis state has a duplicate account: %q aka %x", balances[i].Address, addr))
 		}
 		seen[string(addr)] = struct{}{}
 	}

--- a/x/bank/types/balance_test.go
+++ b/x/bank/types/balance_test.go
@@ -188,8 +188,10 @@ func TestSanitizeBalancesDuplicates(t *testing.T) {
 	}
 
 	// 2. Add duplicate
-	balances = append(balances, balances[3])
-	expectedError := fmt.Sprintf("genesis state has a duplicate account: %q", balances[3].Address)
+	dupIdx := 3
+	balances = append(balances, balances[dupIdx])
+	addr, _ := sdk.AccAddressFromBech32(balances[dupIdx].Address)
+	expectedError := fmt.Sprintf("genesis state has a duplicate account: %q aka %x", balances[dupIdx].Address, addr)
 
 	// 3. Add more balances
 	coin2 := sdk.NewCoin("coinbench", tokens)
@@ -203,7 +205,7 @@ func TestSanitizeBalancesDuplicates(t *testing.T) {
 	}
 
 	// 4. Execute SanitizeGenesisBalances and expect an error
-	require.PanicsWithError(t, expectedError, func() {
+	require.PanicsWithValue(t, expectedError, func() {
 		bank.SanitizeGenesisBalances(balances)
 	}, "SanitizeGenesisBalances should panic with duplicate accounts")
 }

--- a/x/bank/types/balance_test.go
+++ b/x/bank/types/balance_test.go
@@ -1,6 +1,7 @@
 package types_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -169,6 +170,42 @@ func TestSanitizeBalances(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestSanitizeBalancesDuplicates(t *testing.T) {
+	// 1. Generate balances
+	tokens := sdk.TokensFromConsensusPower(81, sdk.DefaultPowerReduction)
+	coin := sdk.NewCoin("benchcoin", tokens)
+	coins := sdk.Coins{coin}
+	addrs, _ := makeRandomAddressesAndPublicKeys(13)
+
+	var balances []bank.Balance
+	for _, addr := range addrs {
+		balances = append(balances, bank.Balance{
+			Address: addr.String(),
+			Coins:   coins,
+		})
+	}
+
+	// 2. Add duplicate
+	balances = append(balances, balances[3])
+	expectedError := fmt.Sprintf("genesis state has a duplicate account: %q", balances[3].Address)
+
+	// 3. Add more balances
+	coin2 := sdk.NewCoin("coinbench", tokens)
+	coins2 := sdk.Coins{coin2, coin}
+	addrs2, _ := makeRandomAddressesAndPublicKeys(31)
+	for _, addr := range addrs2 {
+		balances = append(balances, bank.Balance{
+			Address: addr.String(),
+			Coins:   coins2,
+		})
+	}
+
+	// 4. Execute SanitizeGenesisBalances and expect an error
+	require.PanicsWithError(t, expectedError, func() {
+		bank.SanitizeGenesisBalances(balances)
+	}, "SanitizeGenesisBalances should panic with duplicate accounts")
 }
 
 func makeRandomAddressesAndPublicKeys(n int) (accL []sdk.AccAddress, pkL []*ed25519.PubKey) {


### PR DESCRIPTION
## Description

This small PR makes fixes the chance of having duplicated addresses when the genesis bank balances are sorted. We had some discussion with the cosmos-sdk security teams about this, since the lack of this check will produce false positives on invariant failing in the bank module.

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [x] added `!` to the type prefix if API or client breaking change
* [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/build/building-modules/01-intro.md)
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [x] included comments for [documenting Go code](https://blog.golang.org/godoc)
* [x] updated the relevant documentation or specification
* [x] reviewed "Files changed" and left comments if necessary
* [ ] run `make lint` and `make test`
* [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] confirmed all author checklist items have been addressed 
* [ ] reviewed state machine logic
* [ ] reviewed API design and naming
* [ ] reviewed documentation is accurate
* [ ] reviewed tests and test coverage
* [ ] manually tested (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced the integrity of account balance initialization by preventing duplicate account addresses during the genesis state setup. Users can now be assured that each account address is unique upon creation, avoiding potential conflicts or errors in account balance assignments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->