### PR TITLE
docs: fixing typo and update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@
     * [Pull Request Templates](#pull-request-templates)
     * [Requesting Reviews](#requesting-reviews)
     * [Updating Documentation](#updating-documentation)
-    * [RFC & ADR](#RFC%20&%20ADR)
+    * [RFC & ADR](#rfc--adr)
 * [Dependencies](#dependencies)
     * [`go.work`](#gowork)
     * [`go.mod`](#gomod)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@
     * [Pull Request Templates](#pull-request-templates)
     * [Requesting Reviews](#requesting-reviews)
     * [Updating Documentation](#updating-documentation)
-    * [RFC & ADR](#RFC & ADR)
+    * [RFC & ADR](#RFC%20&%20ADR)
 * [Dependencies](#dependencies)
     * [`go.work`](#gowork)
     * [`go.mod`](#gomod)


### PR DESCRIPTION
In the text "Contributing" to the Cosmos SDK, there's a minor inconsistency in the table of contents link for "RFC & ADR." The link is written as #RFC & ADR, but it should follow the standard URL encoding for spaces in HTML, which is %20. Therefore, the correct link should be #RFC%20&%20ADR to ensure it functions correctly as a hyperlink in markdown format. This correction will align the link with common markdown and HTML practices for URL encoding.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated URL fragment identifiers in the contributing guidelines for better accessibility and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->