### PR TITLE
refactor(x/tx/decode): bulletproof against protowire.ConsumeTag potential varint overflows

### DIFF
--- a/x/tx/decode/adr027.go
+++ b/x/tx/decode/adr027.go
@@ -24,6 +24,14 @@ func rejectNonADR027TxRaw(txBytes []byte) error {
 		if m < 0 {
 			return fmt.Errorf("invalid length; %w", protowire.ParseError(m))
 		}
+
+		// Paranoia from possible varint decoding which can trivially
+		// be wrong due to the precarious nature of the format being tricked:
+		// https://cyber.orijtech.com/advisory/varint-decode-limitless
+		if m > len(txBytes) {
+			return fmt.Errorf("invalid length from decoding (%d) > len(txBytes) (%d)", m, len(txBytes))
+		}
+
 		// TxRaw only has bytes fields.
 		if wireType != protowire.BytesType {
 			return fmt.Errorf("expected %d wire type, got %d", protowire.BytesType, wireType)


### PR DESCRIPTION
This change adds extra validation against varint decoding to ensure that rejectNonADR027TxRaw doesn't panic when we try to slice txBytes[m:] due to the fact that varint decoding can be trivially fooled by adding extraneous bytes peppered with 0x80, as investigated at https://cyber.orijtech.com/advisory/varint-decode-limitless

/cc @elias-orijtech 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced input validation for transaction processing to ensure data integrity and prevent potential decoding issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->