### PR TITLE
fix(client/tx): avoid integer uint64->int64 overflow by big.Int conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Bug Fixes
 
+* (client) [#18622](https://github.com/cosmos/cosmos-sdk/pull/18622) Fixed a potential under/overflow from `uint64->int64` when computing gas fees as a LegacyDec.
 * (client/keys) [#18562](https://github.com/cosmos/cosmos-sdk/pull/18562) `keys delete` won't terminate when a key is not found
 * (server) [#18537](https://github.com/cosmos/cosmos-sdk/pull/18537) Fix panic when defining minimum gas config as `100stake;100uatom`. Use a `,` delimiter instead of `;`. Fixes the server config getter to use the correct delimiter.
 * [#18531](https://github.com/cosmos/cosmos-sdk/pull/18531) Baseapp's `GetConsensusParams` returns an empty struct instead of panicking if no params are found.

--- a/client/tx/factory.go
+++ b/client/tx/factory.go
@@ -3,6 +3,7 @@ package tx
 import (
 	"errors"
 	"fmt"
+	"math/big"
 	"os"
 	"strings"
 
@@ -311,7 +312,9 @@ func (f Factory) BuildUnsignedTx(msgs ...sdk.Msg) (client.TxBuilder, error) {
 			return nil, errors.New("cannot provide both fees and gas prices")
 		}
 
-		glDec := math.LegacyNewDec(int64(f.gas))
+		// f.gas is a uint64 and we should convert to LegacyDec
+		// without the risk of under/overflow via uint64->int64.
+		glDec := math.LegacyNewDecFromBigInt(new(big.Int).SetUint64(f.gas))
 
 		// Derive the fees based on the provided gas prices, where
 		// fee = ceil(gasPrice * gasLimit).


### PR DESCRIPTION
Avoids a potential uint64->int64 overflow when creating math.LegacyDec, instead opting to use big.Int.SetUint64(x)

Fixes https://github.com/cosmos/cosmos-sdk/security/code-scanning/9412

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the fee derivation logic to prevent potential underflow or overflow issues during gas fee calculations.
  - Enhanced the `keys delete` command to terminate correctly when a specified key is not found.
  - Resolved a configuration parsing error by adjusting the delimiter for minimum gas settings.
  - Updated the `GetConsensusParams` function to return an empty struct instead of causing a panic when no parameters are detected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->