### PR TITLE
fix(store/commitment/iavl): honor tree.Remove error firstly

### DIFF
--- a/store/CHANGELOG.md
+++ b/store/CHANGELOG.md
@@ -33,6 +33,10 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 * [#17158](https://github.com/cosmos/cosmos-sdk/pull/17158) Start the goroutine after need to create a snapshot.
 
+### Bug fixes
+
+* [#18651](https://github.com/cosmos/cosmos-sdk/pull/18651) Propagate iavl.MutableTree.Remove errors firstly to the caller instead of returning a synthesized error firstly.
+
 
 ## [v1.0.0-alpha.1](https://github.com/cosmos/cosmos-sdk/releases/tag/store%2Fv1.0.0-alpha.1) - 2023-07-11
 
@@ -54,7 +58,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Bug Fixes
 
-* [#16588](https://github.com/cosmos/cosmos-sdk/pull/16588) Propogate the Snapshotter's failure to the caller, (it will create a empty snapshot silently before).
+* [#16588](https://github.com/cosmos/cosmos-sdk/pull/16588) Propagate the Snapshotter's failure to the caller, (it will create a empty snapshot silently before).
 
 ## [v0.1.0-alpha.1](https://github.com/cosmos/cosmos-sdk/releases/tag/store%2Fv0.1.0-alpha.1) - 2023-03-17
 

--- a/store/commitment/iavl/tree.go
+++ b/store/commitment/iavl/tree.go
@@ -29,10 +29,13 @@ func NewIavlTree(db dbm.DB, logger log.Logger, cfg *Config) *IavlTree {
 // Remove removes the given key from the tree.
 func (t *IavlTree) Remove(key []byte) error {
 	_, res, err := t.tree.Remove(key)
+	if err != nil {
+		return err
+	}
 	if !res {
 		return fmt.Errorf("key %x not found", key)
 	}
-	return err
+	return nil
 }
 
 // Set sets the given key-value pair in the tree.


### PR DESCRIPTION
Previously the check was if !res and then it would return the error below but that has a consequence of ignoring/swallowing up the error returned by (*iavl.MutableTree).Remove. Even more is the fact that when !res, an error occurred and it could be anything else, thus checking against the error firstly ensures that we only return a synthesized error when we are certain the key wasn't in the tree.

Fixes #18650

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling for tree removal operations, ensuring that accurate error messages are propagated to the user.
  - Snapshot failures are now correctly reported to the user, rather than creating an empty snapshot without notification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->