### PR TITLE
chore(tools/confix/cmd): fix typo in view.go

### DIFF
--- a/tools/confix/cmd/view.go
+++ b/tools/confix/cmd/view.go
@@ -12,7 +12,7 @@ import (
 )
 
 func ViewCommand() *cobra.Command {
-	flagOutputFomat := "output-format"
+	flagOutputFormat := "output-format"
 
 	cmd := &cobra.Command{
 		Use:   "view [config]",
@@ -31,7 +31,7 @@ func ViewCommand() *cobra.Command {
 				return err
 			}
 
-			if format, _ := cmd.Flags().GetString(flagOutputFomat); format == "toml" {
+			if format, _ := cmd.Flags().GetString(flagOutputFormat); format == "toml" {
 				cmd.Println(string(file))
 				return nil
 			}
@@ -48,7 +48,7 @@ func ViewCommand() *cobra.Command {
 	}
 
 	// output flag
-	cmd.Flags().String(flagOutputFomat, "toml", "Output format (json|toml)")
+	cmd.Flags().String(flagOutputFormat, "toml", "Output format (json|toml)")
 
 	return cmd
 }


### PR DESCRIPTION
# Description

Work through this file and update '`flagOutputFomat`' to '`flagOutputFormat`' to make it more clear.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected a typo in the command-line interface, ensuring the output format flag is now properly recognized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->