### PR TITLE
feat: [ADR-070] Unordered Transactions (2/2)

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -5,6 +5,70 @@ Note, always read the **SimApp** section for more information on application wir
 
 ## [Unreleased]
 
+### Unordered Transactions
+
+The Cosmos SDK now supports unordered transactions. This means that transactions
+can be executed in any order and doesn't require the client to deal with or manage
+nonces. This also means the order of execution is not guaranteed. To enable unordered
+transactions in your application:
+
+* Update the `App` constructor to create, load, and save the unordered transaction
+  manager.
+
+	```go
+	func NewApp(...) *App {
+		// ...
+
+		// create, start, and load the unordered tx manager
+		utxDataDir := filepath.Join(cast.ToString(appOpts.Get(flags.FlagHome)), "data")
+		app.UnorderedTxManager = unorderedtx.NewManager(utxDataDir)
+		app.UnorderedTxManager.Start()
+
+		if err := app.UnorderedTxManager.OnInit(); err != nil {
+			panic(fmt.Errorf("failed to initialize unordered tx manager: %w", err))
+		}
+	}
+	```
+
+* Add the decorator to the existing AnteHandler chain, which should be as early
+  as possible.
+
+	```go
+	anteDecorators := []sdk.AnteDecorator{
+		ante.NewSetUpContextDecorator(),
+		// ...
+		ante.NewUnorderedTxDecorator(unorderedtx.DefaultMaxUnOrderedTTL, app.UnorderedTxManager),
+		// ...
+	}
+
+	return sdk.ChainAnteDecorators(anteDecorators...), nil
+	```
+
+* Create or update the App's `Close()` method to close the unordered tx manager.
+  Note, this is critical as it ensures the manager's state is written to file
+	such that when the node restarts, it can recover the state to provide replay
+	protection.
+
+	```go
+	func (app *App) Close() error {
+		// ...
+
+		// close the unordered tx manager
+		if e := app.UnorderedTxManager.Close(); e != nil {
+			err = errors.Join(err, e)
+		}
+
+		return err
+	}
+	```
+
+To submit an unordered transaction, the client must set the `unordered` flag to
+`true` and ensure a reasonable `timeout_height` is set. The `timeout_height` is
+used as a TTL for the transaction and is used to provide replay protection. See
+[ADR-070](https://github.com/cosmos/cosmos-sdk/blob/main/docs/architecture/adr-070-unordered-account.md)
+for more details.
+
+
 ### Params
 
 * Params Migrations were removed. It is required to migrate to 0.50 prior to upgrading to .51.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -80,7 +80,6 @@ used as a TTL for the transaction and is used to provide replay protection. See
 [ADR-070](https://github.com/cosmos/cosmos-sdk/blob/main/docs/architecture/adr-070-unordered-account.md)
 for more details.
 
-
 ### Params
 
 * Params Migrations were removed. It is required to migrate to 0.50 prior to upgrading to .51.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -46,8 +46,8 @@ transactions in your application:
 
 * Create or update the App's `Close()` method to close the unordered tx manager.
   Note, this is critical as it ensures the manager's state is written to file
-	such that when the node restarts, it can recover the state to provide replay
-	protection.
+  such that when the node restarts, it can recover the state to provide replay
+  protection.
 
 	```go
 	func (app *App) Close() error {

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -44,6 +44,18 @@ transactions in your application:
 	return sdk.ChainAnteDecorators(anteDecorators...), nil
 	```
 
+* If the App has a SnapshotManager defined, you must also register the extension
+  for the TxManager.
+
+	```go
+	if manager := app.SnapshotManager(); manager != nil {
+		err := manager.RegisterExtensions(unorderedtx.NewSnapshotter(app.UnorderedTxManager))
+		if err != nil {
+			panic(fmt.Errorf("failed to register snapshot extension: %s", err))
+		}
+	}
+	```
+
 * Create or update the App's `Close()` method to close the unordered tx manager.
   Note, this is critical as it ensures the manager's state is written to file
   such that when the node restarts, it can recover the state to provide replay

--- a/docs/architecture/adr-070-unordered-account.md
+++ b/docs/architecture/adr-070-unordered-account.md
@@ -278,14 +278,22 @@ func (d *DedupTxDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool,
 
 Wire the `OnNewBlock` method of `UnorderedTxManager` into the BaseApp's ABCI `Commit` event.
 
-### Start Up
+### State Management
 
-On start up, the node needs to re-fill the tx hash dictionary of `UnorderedTxManager`
-by scanning `MaxUnOrderedTTL` number of historical blocks for existing un-expired
-un-ordered transactions.
+On start up, the node needs to ensure the TxManager's state contains all un-expired
+transactions that have been committed to the chain. This is critical since if the
+state is not properly initialized, the node will not reject duplicate transactions
+and thus will not provide replay protection.
 
-An alternative design is to store the tx hash dictionary in kv store, then no need
-to warm up on start up.
+We propose to write all un-expired unordered transactions from the TxManager's to
+file on disk. On start up, the node will read this file and re-populate the TxManager's
+map. The write to file will happen when the node gracefully shuts down on `Close()`.
+
+Note, this is not a perfect solution, in the context of store v1. With store v2,
+we can omit explicit file handling altogether and simply write the all the transactions
+to non-consensus state, i.e State Storage (SS).
+
+Alternatively, we can write all the transactions to consensus state.
 
 ## Consequences
 

--- a/docs/architecture/adr-070-unordered-account.md
+++ b/docs/architecture/adr-070-unordered-account.md
@@ -283,7 +283,7 @@ Wire the `OnNewBlock` method of `UnorderedTxManager` into the BaseApp's ABCI `Co
 On start up, the node needs to ensure the TxManager's state contains all un-expired
 transactions that have been committed to the chain. This is critical since if the
 state is not properly initialized, the node will not reject duplicate transactions
-and thus will not provide replay protection.
+and thus will not provide replay protection, and will likely get an app hash mismatch error.
 
 We propose to write all un-expired unordered transactions from the TxManager's to
 file on disk. On start up, the node will read this file and re-populate the TxManager's

--- a/simapp/ante.go
+++ b/simapp/ante.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 
 	"cosmossdk.io/x/auth/ante"
+	"cosmossdk.io/x/auth/ante/unorderedtx"
 	circuitante "cosmossdk.io/x/circuit/ante"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -13,6 +14,7 @@ import (
 type HandlerOptions struct {
 	ante.HandlerOptions
 	CircuitKeeper circuitante.CircuitBreaker
+	TxManager     *unorderedtx.Manager
 }
 
 // NewAnteHandler returns an AnteHandler that checks and increments sequence
@@ -37,6 +39,7 @@ func NewAnteHandler(options HandlerOptions) (sdk.AnteHandler, error) {
 		ante.NewExtensionOptionsDecorator(options.ExtensionOptionChecker),
 		ante.NewValidateBasicDecorator(),
 		ante.NewTxTimeoutHeightDecorator(),
+		ante.NewUnorderedTxDecorator(unorderedtx.DefaultMaxUnOrderedTTL, options.TxManager),
 		ante.NewValidateMemoDecorator(options.AccountKeeper),
 		ante.NewConsumeGasForTxSizeDecorator(options.AccountKeeper),
 		ante.NewDeductFeeDecorator(options.AccountKeeper, options.BankKeeper, options.FeegrantKeeper, options.TxFeeChecker),

--- a/simapp/app.go
+++ b/simapp/app.go
@@ -532,14 +532,14 @@ func NewSimApp(
 	}
 
 	// register custom snapshot extensions (if any)
-	// if manager := app.SnapshotManager(); manager != nil {
-	// 	err := manager.RegisterExtensions(
-	// 		unorderedtx.NewSnapshotter(app.UnorderedTxManager),
-	// 	)
-	// 	if err != nil {
-	// 		panic(fmt.Errorf("failed to register snapshot extension: %s", err))
-	// 	}
-	// }
+	if manager := app.SnapshotManager(); manager != nil {
+		err := manager.RegisterExtensions(
+			unorderedtx.NewSnapshotter(app.UnorderedTxManager),
+		)
+		if err != nil {
+			panic(fmt.Errorf("failed to register snapshot extension: %s", err))
+		}
+	}
 
 	app.sm.RegisterStoreDecoders()
 

--- a/simapp/app.go
+++ b/simapp/app.go
@@ -26,6 +26,7 @@ import (
 	"cosmossdk.io/x/accounts/testing/counter"
 	"cosmossdk.io/x/auth"
 	"cosmossdk.io/x/auth/ante"
+	"cosmossdk.io/x/auth/ante/unorderedtx"
 	authcodec "cosmossdk.io/x/auth/codec"
 	authkeeper "cosmossdk.io/x/auth/keeper"
 	"cosmossdk.io/x/auth/posthandler"
@@ -168,6 +169,8 @@ type SimApp struct {
 	// the module manager
 	ModuleManager      *module.Manager
 	BasicModuleManager module.BasicManager
+
+	UnorderedTxManager *unorderedtx.Manager
 
 	// simulation manager
 	sm *module.SimulationManager
@@ -519,6 +522,25 @@ func NewSimApp(
 	}
 	app.sm = module.NewSimulationManagerFromAppModules(app.ModuleManager.Modules, overrideModules)
 
+	// create, start, and load the unordered tx manager
+	utxDataDir := filepath.Join(cast.ToString(appOpts.Get(flags.FlagHome)), "data")
+	app.UnorderedTxManager = unorderedtx.NewManager(utxDataDir)
+	app.UnorderedTxManager.Start()
+
+	if err := app.UnorderedTxManager.OnInit(); err != nil {
+		panic(fmt.Errorf("failed to initialize unordered tx manager: %w", err))
+	}
+
+	// register custom snapshot extensions (if any)
+	// if manager := app.SnapshotManager(); manager != nil {
+	// 	err := manager.RegisterExtensions(
+	// 		unorderedtx.NewSnapshotter(app.UnorderedTxManager),
+	// 	)
+	// 	if err != nil {
+	// 		panic(fmt.Errorf("failed to register snapshot extension: %s", err))
+	// 	}
+	// }
+
 	app.sm.RegisterStoreDecoders()
 
 	// initialize stores
@@ -598,6 +620,12 @@ func (app *SimApp) setPostHandler() {
 	}
 
 	app.SetPostHandler(postHandler)
+}
+
+// Close implements the Application interface and closes all necessary application
+// resources.
+func (app *SimApp) Close() error {
+	return app.UnorderedTxManager.Close()
 }
 
 // Name returns the name of the App

--- a/simapp/app.go
+++ b/simapp/app.go
@@ -601,6 +601,7 @@ func (app *SimApp) setAnteHandler(txConfig client.TxConfig) {
 				SigGasConsumer:  ante.DefaultSigVerificationGasConsumer,
 			},
 			&app.CircuitKeeper,
+			app.UnorderedTxManager,
 		},
 	)
 	if err != nil {

--- a/simapp/app_v2.go
+++ b/simapp/app_v2.go
@@ -262,8 +262,8 @@ func NewSimApp(
 	// 	return app.App.InitChainer(ctx, req)
 	// })
 
-	dataDir := filepath.Join(cast.ToString(appOpts.Get(flags.FlagHome)), "data")
-	app.UnorderedTxManager = unorderedtx.NewManager(dataDir)
+	utxDataDir := filepath.Join(cast.ToString(appOpts.Get(flags.FlagHome)), "data")
+	app.UnorderedTxManager = unorderedtx.NewManager(utxDataDir)
 	app.UnorderedTxManager.Start()
 
 	if err := app.UnorderedTxManager.OnInit(); err != nil {

--- a/simapp/app_v2.go
+++ b/simapp/app_v2.go
@@ -272,14 +272,14 @@ func NewSimApp(
 	}
 
 	// register custom snapshot extensions (if any)
-	// if manager := app.SnapshotManager(); manager != nil {
-	// 	err := manager.RegisterExtensions(
-	// 		unorderedtx.NewSnapshotter(app.UnorderedTxManager),
-	// 	)
-	// 	if err != nil {
-	// 		panic(fmt.Errorf("failed to register snapshot extension: %s", err))
-	// 	}
-	// }
+	if manager := app.SnapshotManager(); manager != nil {
+		err := manager.RegisterExtensions(
+			unorderedtx.NewSnapshotter(app.UnorderedTxManager),
+		)
+		if err != nil {
+			panic(fmt.Errorf("failed to register snapshot extension: %s", err))
+		}
+	}
 
 	if err := app.Load(loadLatest); err != nil {
 		panic(err)

--- a/simapp/app_v2.go
+++ b/simapp/app_v2.go
@@ -3,16 +3,19 @@
 package simapp
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 
 	dbm "github.com/cosmos/cosmos-db"
+	"github.com/spf13/cast"
 
 	"cosmossdk.io/depinject"
 	"cosmossdk.io/log"
 	storetypes "cosmossdk.io/store/types"
 	"cosmossdk.io/x/auth"
+	"cosmossdk.io/x/auth/ante/unorderedtx"
 	authkeeper "cosmossdk.io/x/auth/keeper"
 	authsims "cosmossdk.io/x/auth/simulation"
 	authtypes "cosmossdk.io/x/auth/types"
@@ -34,6 +37,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/codec"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/cosmos/cosmos-sdk/runtime"
@@ -63,6 +67,8 @@ type SimApp struct {
 	appCodec          codec.Codec
 	txConfig          client.TxConfig
 	interfaceRegistry codectypes.InterfaceRegistry
+
+	UnorderedTxManager *unorderedtx.Manager
 
 	// keepers
 	AuthKeeper            authkeeper.AccountKeeper
@@ -256,11 +262,35 @@ func NewSimApp(
 	// 	return app.App.InitChainer(ctx, req)
 	// })
 
+	dataDir := filepath.Join(cast.ToString(appOpts.Get(flags.FlagHome)), "data")
+	app.UnorderedTxManager = unorderedtx.NewManager(dataDir)
+	app.UnorderedTxManager.Start()
+
+	if err := app.UnorderedTxManager.OnInit(); err != nil {
+		panic(fmt.Errorf("failed to initialize unordered tx manager: %w", err))
+	}
+
+	// register custom snapshot extensions (if any)
+	// if manager := app.SnapshotManager(); manager != nil {
+	// 	err := manager.RegisterExtensions(
+	// 		unorderedtx.NewSnapshotter(app.UnorderedTxManager),
+	// 	)
+	// 	if err != nil {
+	// 		panic(fmt.Errorf("failed to register snapshot extension: %s", err))
+	// 	}
+	// }
+
 	if err := app.Load(loadLatest); err != nil {
 		panic(err)
 	}
 
 	return app
+}
+
+// Close implements the Application interface and closes all necessary application
+// resources.
+func (app *SimApp) Close() error {
+	return app.UnorderedTxManager.Close()
 }
 
 // LegacyAmino returns SimApp's amino codec.

--- a/simapp/app_v2.go
+++ b/simapp/app_v2.go
@@ -262,6 +262,7 @@ func NewSimApp(
 	// 	return app.App.InitChainer(ctx, req)
 	// })
 
+	// create, start, and load the unordered tx manager
 	utxDataDir := filepath.Join(cast.ToString(appOpts.Get(flags.FlagHome)), "data")
 	app.UnorderedTxManager = unorderedtx.NewManager(utxDataDir)
 	app.UnorderedTxManager.Start()

--- a/x/auth/ante/unordered.go
+++ b/x/auth/ante/unordered.go
@@ -51,6 +51,9 @@ func (d *UnorderedTxDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate b
 	if ttl == 0 {
 		return ctx, errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "unordered transaction must have timeout_height set")
 	}
+	if ttl < uint64(ctx.BlockHeight()) {
+		return ctx, errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "unordered transaction has a timeout_height that has already passed")
+	}
 	if ttl > uint64(ctx.BlockHeight())+d.maxUnOrderedTTL {
 		return ctx, errorsmod.Wrapf(sdkerrors.ErrInvalidRequest, "unordered tx ttl exceeds %d", d.maxUnOrderedTTL)
 	}

--- a/x/auth/ante/unordered_test.go
+++ b/x/auth/ante/unordered_test.go
@@ -16,8 +16,10 @@ import (
 )
 
 func TestUnorderedTxDecorator_OrderedTx(t *testing.T) {
-	txm := unorderedtx.NewManager()
-	defer txm.Close()
+	txm := unorderedtx.NewManager(t.TempDir())
+	defer func() {
+		require.NoError(t, txm.Close())
+	}()
 
 	txm.Start()
 
@@ -31,8 +33,10 @@ func TestUnorderedTxDecorator_OrderedTx(t *testing.T) {
 }
 
 func TestUnorderedTxDecorator_UnorderedTx_NoTTL(t *testing.T) {
-	txm := unorderedtx.NewManager()
-	defer txm.Close()
+	txm := unorderedtx.NewManager(t.TempDir())
+	defer func() {
+		require.NoError(t, txm.Close())
+	}()
 
 	txm.Start()
 
@@ -46,8 +50,10 @@ func TestUnorderedTxDecorator_UnorderedTx_NoTTL(t *testing.T) {
 }
 
 func TestUnorderedTxDecorator_UnorderedTx_InvalidTTL(t *testing.T) {
-	txm := unorderedtx.NewManager()
-	defer txm.Close()
+	txm := unorderedtx.NewManager(t.TempDir())
+	defer func() {
+		require.NoError(t, txm.Close())
+	}()
 
 	txm.Start()
 
@@ -61,8 +67,10 @@ func TestUnorderedTxDecorator_UnorderedTx_InvalidTTL(t *testing.T) {
 }
 
 func TestUnorderedTxDecorator_UnorderedTx_AlreadyExists(t *testing.T) {
-	txm := unorderedtx.NewManager()
-	defer txm.Close()
+	txm := unorderedtx.NewManager(t.TempDir())
+	defer func() {
+		require.NoError(t, txm.Close())
+	}()
 
 	txm.Start()
 
@@ -79,8 +87,10 @@ func TestUnorderedTxDecorator_UnorderedTx_AlreadyExists(t *testing.T) {
 }
 
 func TestUnorderedTxDecorator_UnorderedTx_ValidCheckTx(t *testing.T) {
-	txm := unorderedtx.NewManager()
-	defer txm.Close()
+	txm := unorderedtx.NewManager(t.TempDir())
+	defer func() {
+		require.NoError(t, txm.Close())
+	}()
 
 	txm.Start()
 
@@ -94,8 +104,10 @@ func TestUnorderedTxDecorator_UnorderedTx_ValidCheckTx(t *testing.T) {
 }
 
 func TestUnorderedTxDecorator_UnorderedTx_ValidDeliverTx(t *testing.T) {
-	txm := unorderedtx.NewManager()
-	defer txm.Close()
+	txm := unorderedtx.NewManager(t.TempDir())
+	defer func() {
+		require.NoError(t, txm.Close())
+	}()
 
 	txm.Start()
 

--- a/x/auth/ante/unorderedtx/manager.go
+++ b/x/auth/ante/unorderedtx/manager.go
@@ -82,6 +82,10 @@ func (m *Manager) OnInit() error {
 	panic("not implemented")
 }
 
+func (m *Manager) OnClose() error {
+	panic("not implemented")
+}
+
 // OnNewBlock sends the latest block number to the background purge loop, which
 // should be called in ABCI Commit event.
 func (m *Manager) OnNewBlock(blockHeight uint64) {

--- a/x/auth/ante/unorderedtx/manager.go
+++ b/x/auth/ante/unorderedtx/manager.go
@@ -127,7 +127,7 @@ func (m *Manager) OnInit() error {
 
 	var (
 		r   = bufio.NewReader(f)
-		buf = make([]byte, 32+8)
+		buf = make([]byte, chunkSize)
 	)
 	for {
 		n, err := io.ReadFull(r, buf)
@@ -143,9 +143,9 @@ func (m *Manager) OnInit() error {
 		}
 
 		var txHash TxHash
-		copy(txHash[:], buf[:32])
+		copy(txHash[:], buf[:txHashSize])
 
-		m.Add(txHash, binary.BigEndian.Uint64(buf[32:]))
+		m.Add(txHash, binary.BigEndian.Uint64(buf[txHashSize:]))
 	}
 
 	return nil
@@ -274,12 +274,12 @@ func (m *Manager) batchReceive() (uint64, bool) {
 }
 
 func unorderedTxToBytes(txHash TxHash, ttl uint64) []byte {
-	chunk := make([]byte, 32+8)
-	copy(chunk[:32], txHash[:])
+	chunk := make([]byte, chunkSize)
+	copy(chunk[:txHashSize], txHash[:])
 
-	ttlBz := make([]byte, 8)
+	ttlBz := make([]byte, ttlSize)
 	binary.BigEndian.PutUint64(ttlBz, ttl)
-	copy(chunk[32:], ttlBz)
+	copy(chunk[txHashSize:], ttlBz)
 
 	return chunk
 }

--- a/x/auth/ante/unorderedtx/manager.go
+++ b/x/auth/ante/unorderedtx/manager.go
@@ -73,6 +73,7 @@ func (m *Manager) Start() {
 
 // Close must be called when a node gracefully shuts down. Typically, this should
 // be called in an application's Close() function, which is called by the server.
+// Note, Start() must be called in order for Close() to not hang.
 //
 // It will free all necessary resources as well as writing all unexpired unordered
 // transactions along with their TTL values to file.

--- a/x/auth/ante/unorderedtx/manager.go
+++ b/x/auth/ante/unorderedtx/manager.go
@@ -130,7 +130,7 @@ func (m *Manager) OnInit() error {
 		buf = make([]byte, 32+8)
 	)
 	for {
-		n, err := r.Read(buf)
+		n, err := io.ReadFull(r, buf)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
 				break

--- a/x/auth/ante/unorderedtx/manager.go
+++ b/x/auth/ante/unorderedtx/manager.go
@@ -164,6 +164,8 @@ func (m *Manager) OnNewBlock(blockHeight uint64) {
 	m.blockCh <- blockHeight
 }
 
+// flushToFile writes all unexpired unordered transactions along with their TTL
+// to file, overwriting the existing file if it exists.
 func (m *Manager) flushToFile() error {
 	f, err := os.Create(filepath.Join(m.dataDir, dirName, fileName))
 	if err != nil {

--- a/x/auth/ante/unorderedtx/manager.go
+++ b/x/auth/ante/unorderedtx/manager.go
@@ -163,15 +163,15 @@ func (m *Manager) exportSnapshot(height uint64, snapshotWriter func([]byte) erro
 			continue
 		}
 
-		chunk := unconfirmedTxToBytes(txHash, ttl)
+		chunk := unorderedTxToBytes(txHash, ttl)
 
 		if _, err := w.Write(chunk); err != nil {
-			return fmt.Errorf("failed to write unconfirmed tx to buffer: %w", err)
+			return fmt.Errorf("failed to write unordered tx to buffer: %w", err)
 		}
 	}
 
 	if err := w.Flush(); err != nil {
-		return fmt.Errorf("failed to flush unconfirmed txs buffer: %w", err)
+		return fmt.Errorf("failed to flush unordered txs buffer: %w", err)
 	}
 
 	return snapshotWriter(buf.Bytes())
@@ -182,21 +182,21 @@ func (m *Manager) exportSnapshot(height uint64, snapshotWriter func([]byte) erro
 func (m *Manager) flushToFile() error {
 	f, err := os.Create(filepath.Join(m.dataDir, dirName, fileName))
 	if err != nil {
-		return fmt.Errorf("failed to create unconfirmed txs file: %w", err)
+		return fmt.Errorf("failed to create unordered txs file: %w", err)
 	}
 	defer f.Close()
 
 	w := bufio.NewWriter(f)
 	for txHash, ttl := range m.txHashes {
-		chunk := unconfirmedTxToBytes(txHash, ttl)
+		chunk := unorderedTxToBytes(txHash, ttl)
 
 		if _, err = w.Write(chunk); err != nil {
-			return fmt.Errorf("failed to write unconfirmed tx to buffer: %w", err)
+			return fmt.Errorf("failed to write unordered tx to buffer: %w", err)
 		}
 	}
 
 	if err = w.Flush(); err != nil {
-		return fmt.Errorf("failed to flush unconfirmed txs buffer: %w", err)
+		return fmt.Errorf("failed to flush unordered txs buffer: %w", err)
 	}
 
 	return nil
@@ -265,7 +265,7 @@ func (m *Manager) batchReceive() (uint64, bool) {
 	}
 }
 
-func unconfirmedTxToBytes(txHash TxHash, ttl uint64) []byte {
+func unorderedTxToBytes(txHash TxHash, ttl uint64) []byte {
 	chunk := make([]byte, 32+8)
 	copy(chunk[:32], txHash[:])
 

--- a/x/auth/ante/unorderedtx/manager.go
+++ b/x/auth/ante/unorderedtx/manager.go
@@ -10,8 +10,11 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sort"
 	"sync"
 	"time"
+
+	"golang.org/x/exp/maps"
 )
 
 const (
@@ -158,7 +161,11 @@ func (m *Manager) exportSnapshot(height uint64, snapshotWriter func([]byte) erro
 	var buf bytes.Buffer
 	w := bufio.NewWriter(&buf)
 
-	for txHash, ttl := range m.txHashes {
+	keys := maps.Keys(m.txHashes)
+	sort.Slice(keys, func(i, j int) bool { return bytes.Compare(keys[i][:], keys[j][:]) < 0 })
+
+	for _, txHash := range keys {
+		ttl := m.txHashes[txHash]
 		if height > ttl {
 			// skip expired txs that have yet to be purged
 			continue

--- a/x/auth/ante/unorderedtx/manager.go
+++ b/x/auth/ante/unorderedtx/manager.go
@@ -74,7 +74,15 @@ func (m *Manager) Add(txHash TxHash, ttl uint64) {
 	m.txHashes[txHash] = ttl
 }
 
-// OnNewBlock send the latest block number to the background purge loop, which
+func (m *Manager) Export() any {
+	panic("not implemented")
+}
+
+func (m *Manager) OnInit() error {
+	panic("not implemented")
+}
+
+// OnNewBlock sends the latest block number to the background purge loop, which
 // should be called in ABCI Commit event.
 func (m *Manager) OnNewBlock(blockHeight uint64) {
 	m.blockCh <- blockHeight

--- a/x/auth/ante/unorderedtx/manager.go
+++ b/x/auth/ante/unorderedtx/manager.go
@@ -17,6 +17,9 @@ const (
 	// DefaultMaxUnOrderedTTL defines the default maximum TTL an un-ordered transaction
 	// can set.
 	DefaultMaxUnOrderedTTL = 1024
+
+	dirName  = "unordered_txs"
+	fileName = "data"
 )
 
 // TxHash defines a transaction hash type alias, which is a fixed array of 32 bytes.
@@ -48,7 +51,7 @@ type Manager struct {
 }
 
 func NewManager(dataDir string) *Manager {
-	path := filepath.Join(dataDir, "unordered_txs")
+	path := filepath.Join(dataDir, dirName)
 	if _, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
 		_ = os.Mkdir(path, os.ModePerm)
 	}
@@ -117,7 +120,7 @@ func (m *Manager) Add(txHash TxHash, ttl uint64) {
 // OnInit must be called when a node starts up. Typically, this should be called
 // in an application's constructor, which is called by the server.
 func (m *Manager) OnInit() error {
-	f, err := os.Open(filepath.Join(m.dataDir, "unordered_txs", "unordered_txs"))
+	f, err := os.Open(filepath.Join(m.dataDir, dirName, fileName))
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			// File does not exist, which we can assume that there are no unexpired
@@ -162,7 +165,7 @@ func (m *Manager) OnNewBlock(blockHeight uint64) {
 }
 
 func (m *Manager) flushToFile() error {
-	f, err := os.Create(filepath.Join(m.dataDir, "unordered_txs", "unordered_txs"))
+	f, err := os.Create(filepath.Join(m.dataDir, dirName, fileName))
 	if err != nil {
 		return fmt.Errorf("failed to create unconfirmed txs file: %w", err)
 	}

--- a/x/auth/ante/unorderedtx/manager.go
+++ b/x/auth/ante/unorderedtx/manager.go
@@ -33,7 +33,7 @@ type Manager struct {
 	// dataDir defines the directory to store unexpired unordered transactions
 	//
 	// XXX: Note, ideally we avoid the need to store unexpired unordered transactions
-	// directly to file. However, store v1 does not allow such a primitive. However,
+	// directly to file. However, store v1 does not allow such a primitive. But,
 	// once store v2 is fully integrated, we can remove manual file handling and
 	// store the unexpired unordered transactions directly to SS.
 	//

--- a/x/auth/ante/unorderedtx/snapshotter.go
+++ b/x/auth/ante/unorderedtx/snapshotter.go
@@ -1,0 +1,35 @@
+package unorderedtx
+
+import (
+	snapshot "cosmossdk.io/store/snapshots/types"
+)
+
+var _ snapshot.ExtensionSnapshotter = &Snapshotter{}
+
+// SnapshotFormat defines the snapshot format of exported unordered transactions.
+// No protobuf envelope, no metadata.
+const SnapshotFormat = 1
+
+type Snapshotter struct {
+	m *Manager
+}
+
+func (s *Snapshotter) SnapshotName() string {
+	panic("not implemented!")
+}
+
+func (s *Snapshotter) SnapshotFormat() uint32 {
+	panic("not implemented!")
+}
+
+func (s *Snapshotter) SupportedFormats() []uint32 {
+	panic("not implemented!")
+}
+
+func (s *Snapshotter) SnapshotExtension(height uint64, payloadWriter snapshot.ExtensionPayloadWriter) error {
+	panic("not implemented!")
+}
+
+func (s *Snapshotter) RestoreExtension(height uint64, format uint32, payloadReader snapshot.ExtensionPayloadReader) error {
+	panic("not implemented!")
+}

--- a/x/auth/ante/unorderedtx/snapshotter.go
+++ b/x/auth/ante/unorderedtx/snapshotter.go
@@ -6,30 +6,43 @@ import (
 
 var _ snapshot.ExtensionSnapshotter = &Snapshotter{}
 
-// SnapshotFormat defines the snapshot format of exported unordered transactions.
-// No protobuf envelope, no metadata.
-const SnapshotFormat = 1
+const (
+	// SnapshotFormat defines the snapshot format of exported unordered transactions.
+	// No protobuf envelope, no metadata.
+	SnapshotFormat = 1
+
+	// SnapshotName defines the snapshot name of exported unordered transactions.
+	SnapshotName = "unordered_txs"
+)
 
 type Snapshotter struct {
 	m *Manager
 }
 
+func NewSnapshotter(m *Manager) *Snapshotter {
+	return &Snapshotter{m: m}
+}
+
 func (s *Snapshotter) SnapshotName() string {
-	panic("not implemented!")
+	return SnapshotName
 }
 
 func (s *Snapshotter) SnapshotFormat() uint32 {
-	panic("not implemented!")
+	return SnapshotFormat
 }
 
 func (s *Snapshotter) SupportedFormats() []uint32 {
-	panic("not implemented!")
+	return []uint32{SnapshotFormat}
 }
 
 func (s *Snapshotter) SnapshotExtension(height uint64, payloadWriter snapshot.ExtensionPayloadWriter) error {
-	panic("not implemented!")
+	return s.m.exportSnapshot(height, payloadWriter)
 }
 
-func (s *Snapshotter) RestoreExtension(height uint64, format uint32, payloadReader snapshot.ExtensionPayloadReader) error {
-	panic("not implemented!")
+func (s *Snapshotter) RestoreExtension(_ uint64, format uint32, payloadReader snapshot.ExtensionPayloadReader) error {
+	if format == SnapshotFormat {
+		return s.restore(payloadReader)
+	}
+
+	return snapshot.ErrUnknownFormat
 }

--- a/x/auth/ante/unorderedtx/snapshotter.go
+++ b/x/auth/ante/unorderedtx/snapshotter.go
@@ -67,7 +67,11 @@ func (s *Snapshotter) restore(height uint64, payloadReader snapshot.ExtensionPay
 		copy(txHash[:], payload[i:i+32])
 
 		ttl := binary.BigEndian.Uint64(payload[i+32 : i+40])
-		s.m.Add(txHash, ttl)
+
+		if height < ttl {
+			// only add unordered transactions that are still valid, i.e. unexpired
+			s.m.Add(txHash, ttl)
+		}
 
 		i += 40
 	}

--- a/x/auth/ante/unorderedtx/snapshotter.go
+++ b/x/auth/ante/unorderedtx/snapshotter.go
@@ -56,9 +56,11 @@ func (s *Snapshotter) restore(height uint64, payloadReader snapshot.ExtensionPay
 	// the payload should be the entire set of unordered transactions
 	payload, err := payloadReader()
 	if err != nil {
-		if !errors.Is(err, io.EOF) {
-			return err
+		if errors.Is(err, io.EOF) {
+			return io.ErrUnexpectedEOF
 		}
+
+		return err
 	}
 
 	var i int

--- a/x/auth/ante/unorderedtx/snapshotter_test.go
+++ b/x/auth/ante/unorderedtx/snapshotter_test.go
@@ -1,0 +1,35 @@
+package unorderedtx_test
+
+import (
+	"testing"
+
+	"cosmossdk.io/x/auth/ante/unorderedtx"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSnapshotter_SnapshotExtension(t *testing.T) {
+	dataDir := t.TempDir()
+	txm := unorderedtx.NewManager(dataDir)
+	txm.Start()
+
+	defer txm.Close()
+
+	// add a handful of unordered txs
+	for i := 0; i < 100; i++ {
+		txm.Add([32]byte{byte(i)}, 100)
+	}
+
+	var unorderedTxBz []byte
+	s := unorderedtx.NewSnapshotter(txm)
+	w := func(bz []byte) error {
+		unorderedTxBz = bz
+		return nil
+	}
+
+	err := s.SnapshotExtension(50, w)
+	require.NoError(t, err)
+	require.NotEmpty(t, unorderedTxBz)
+}
+
+func TestSnapshotter_RestoreExtension(t *testing.T) {
+}

--- a/x/auth/ante/unorderedtx/snapshotter_test.go
+++ b/x/auth/ante/unorderedtx/snapshotter_test.go
@@ -3,8 +3,9 @@ package unorderedtx_test
 import (
 	"testing"
 
-	"cosmossdk.io/x/auth/ante/unorderedtx"
 	"github.com/stretchr/testify/require"
+
+	"cosmossdk.io/x/auth/ante/unorderedtx"
 )
 
 func TestSnapshotter(t *testing.T) {


### PR DESCRIPTION
# Description

https://github.com/cosmos/cosmos-sdk/pull/18641 addresses the core implementation of unordered txs. However, a crucial component to safely support unordered txs is the ability to ensure the map that stores them is durable and consistent[1] across all nodes.

Specifically, when a node restarts, the unordered tx manager (map), needs to be populated with all NON-STALE unordered txs that have been committed so far, i.e. unordered transactions whose TTL value is yet to expire.

We propose to do this by simply writing to a file. However, we also need to address the case of where a new node joins a network via state sync. As it will naturally not have this file, we will also implement a snapshotter extension that will allow the manager (map) to be populated.

Ref:

* [1] The map only needs to be consistent across all nodes for transactions that are NOT stale. i.e. Consider set A to be the set of all unordered txs that are NOT stale. Consider set B to be the set of all unordered txs that are either NOT stale or some that are stale. Nodes only need to be consistent across set A. It doesn't matter if some nodes have unpurged stale txs -- they'll eventually be cleaned up.

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage
