### PR TITLE
style(x/auth): improve code readability and update exported function comment

### DIFF
--- a/x/auth/client/tx.go
+++ b/x/auth/client/tx.go
@@ -98,7 +98,7 @@ func SignTxWithSignerAddress(txFactory tx.Factory, clientCtx client.Context, add
 	return tx.Sign(clientCtx.CmdContext, txFactory, name, txBuilder, overwrite)
 }
 
-// Read and decode a StdTx from the given filename. Can pass "-" to read from stdin.
+// ReadTxFromFile read and decode a StdTx from the given filename. Can pass "-" to read from stdin.
 func ReadTxFromFile(ctx client.Context, filename string) (tx sdk.Tx, err error) {
 	var bytes []byte
 
@@ -115,11 +115,10 @@ func ReadTxFromFile(ctx client.Context, filename string) (tx sdk.Tx, err error) 
 	return ctx.TxConfig.TxJSONDecoder()(bytes)
 }
 
-// Read and decode a multi transactions (must be in Txs format) from the given filename.
+// ReadTxsFromFile read and decode a multi transactions (must be in Txs format) from the given filename.
 // Can pass "-" to read from stdin.
-func ReadTxsFromFile(ctx client.Context, filename string) (tx []sdk.Tx, err error) {
+func ReadTxsFromFile(ctx client.Context, filename string) (txs []sdk.Tx, err error) {
 	var fileBuff []byte
-	var txs []sdk.Tx
 
 	if filename == "-" {
 		fileBuff, err = io.ReadAll(os.Stdin)


### PR DESCRIPTION
# Description

Ref #18692 

### Improve readability
Following function `ReadTxsFromFile` looks odd:
1. define out param with `tx []sdk.Tx`
2. then define a new variable named `txs []sdk.Tx`
3. `tx, err := txDecoder(txBytes)` another `tx` variable is defined

Although this does no effect for running, but it's odd and worse for read.

```go
func ReadTxsFromFile(ctx client.Context, filename string) (tx []sdk.Tx, err error) {
	var fileBuff []byte
	var txs []sdk.Tx

	if filename == "-" {
		fileBuff, err = io.ReadAll(os.Stdin)
	} else {
		fileBuff, err = os.ReadFile(filename)
	}

	if err != nil {
		return nil, fmt.Errorf("failed to read batch txs from file %s: %w", filename, err)
	}

	// In SignBatchCmd, the output prints each tx line by line separated by "\n".
	// So we split the output bytes to slice of tx bytes,
	// last element always be empty bytes.
	txsBytes := bytes.Split(fileBuff, []byte("\n"))
	txDecoder := ctx.TxConfig.TxJSONDecoder()
	for _, txBytes := range txsBytes {
		if len(txBytes) == 0 {
			continue
		}
		tx, err := txDecoder(txBytes)
		if err != nil {
			return nil, err
		}
		txs = append(txs, tx)
	}
	return txs, nil
}
```