### PR TITLE
ci: Use intermediate variable for PR title

### DIFF
--- a/.github/workflows/fork-cherry-pick.yml
+++ b/.github/workflows/fork-cherry-pick.yml
@@ -35,5 +35,6 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.PRBOT_PAT }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          gh pr create --repo cosmos/cosmos-sdk --base main --head "${{ github.event.repository.owner.login }}:pr-patch-${{ github.sha }}" --title "${{ github.event.pull_request.title }}" --body "Automated PR for commit: ${{ github.sha }} from ${{ github.repository }}"
+          gh pr create --repo cosmos/cosmos-sdk --base main --head "${{ github.event.repository.owner.login }}:pr-patch-${{ github.sha }}" --title "$PR_TITLE" --body "Automated PR for commit: ${{ github.sha }} from ${{ github.repository }}"


### PR DESCRIPTION
`github.event.pull_request.title` is potentially untrusted. Avoid using it directly in inline scripts. instead, pass it through an environment variable.

See https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions for more details.