### PR TITLE
chore: remove extra events in bank to help track

### DIFF
--- a/x/bank/keeper/keeper.go
+++ b/x/bank/keeper/keeper.go
@@ -156,10 +156,6 @@ func (k BaseKeeper) DelegateCoins(ctx context.Context, delegatorAddr, moduleAccA
 	if err != nil {
 		return err
 	}
-	sdkCtx := sdk.UnwrapSDKContext(ctx)
-	sdkCtx.EventManager().EmitEvent(
-		types.NewCoinSpentEvent(delAddrStr, amt),
-	)
 
 	err = k.addCoins(ctx, moduleAccAddr, amt)
 	if err != nil {
@@ -378,10 +374,6 @@ func (k BaseKeeper) MintCoins(ctx context.Context, moduleName string, amounts sd
 	if err != nil {
 		return err
 	}
-	// emit mint event
-	sdkCtx.EventManager().EmitEvent(
-		types.NewCoinMintEvent(addrStr, amounts),
-	)
 
 	return nil
 }
@@ -417,11 +409,6 @@ func (k BaseKeeper) BurnCoins(ctx context.Context, address []byte, amounts sdk.C
 	if err != nil {
 		return err
 	}
-	// emit burn event
-	sdkCtx := sdk.UnwrapSDKContext(ctx)
-	sdkCtx.EventManager().EmitEvent(
-		types.NewCoinBurnEvent(addrStr, amounts),
-	)
 
 	return nil
 }

--- a/x/bank/keeper/send.go
+++ b/x/bank/keeper/send.go
@@ -290,10 +290,6 @@ func (k BaseSendKeeper) subUnlockedCoins(ctx context.Context, addr sdk.AccAddres
 	if err != nil {
 		return err
 	}
-	sdkCtx := sdk.UnwrapSDKContext(ctx)
-	sdkCtx.EventManager().EmitEvent(
-		types.NewCoinSpentEvent(addrStr, amt),
-	)
 
 	return nil
 }
@@ -319,12 +315,6 @@ func (k BaseSendKeeper) addCoins(ctx context.Context, addr sdk.AccAddress, amt s
 	if err != nil {
 		return err
 	}
-
-	// emit coin received event
-	sdkCtx := sdk.UnwrapSDKContext(ctx)
-	sdkCtx.EventManager().EmitEvent(
-		types.NewCoinReceivedEvent(addrStr, amt),
-	)
 
 	return nil
 }


### PR DESCRIPTION
# Description

State streaming was shipped in order to get state data out of the state machine. In the past this was attempted to do via events. Since state streaming is here, works and is used in production we should reduce the overall amount of state related events to get people using state streaming. 

This came up from a conversation in slack with dev from osmosis. 

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage
