### PR TITLE
feat(client): add `WithFromName` to tx factory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (crypto | x/auth) [#14372](https://github.com/cosmos/cosmos-sdk/pull/18194) Key checks on signatures antehandle.
 * (staking) [#18506](https://github.com/cosmos/cosmos-sdk/pull/18506) Detect the length of the ed25519 pubkey in CreateValidator to prevent panic.
 * (tx) [#18772](https://github.com/cosmos/cosmos-sdk/pull/18772) Remove misleading gas wanted from tx simulation failure log.
+* (tx) [#18852](https://github.com/cosmos/cosmos-sdk/pull/18852) Add `WithFromName` to tx factory.
 
 ### Bug Fixes
 

--- a/client/tx/factory.go
+++ b/client/tx/factory.go
@@ -191,6 +191,7 @@ func (f Factory) WithKeybase(keybase keyring.Keyring) Factory {
 }
 
 // WithFromName returns a copy of the Factory with updated fromName
+// fromName will be use for building a simulation tx.
 func (f Factory) WithFromName(fromName string) Factory {
 	f.fromName = fromName
 	return f

--- a/client/tx/factory.go
+++ b/client/tx/factory.go
@@ -132,6 +132,7 @@ func (f Factory) Fees() sdk.Coins                           { return f.fees }
 func (f Factory) GasPrices() sdk.DecCoins                   { return f.gasPrices }
 func (f Factory) AccountRetriever() client.AccountRetriever { return f.accountRetriever }
 func (f Factory) TimeoutHeight() uint64                     { return f.timeoutHeight }
+func (f Factory) FromName() string                          { return f.fromName }
 
 // SimulateAndExecute returns the option to simulate and then execute the transaction
 // using the gas from the simulation results
@@ -186,6 +187,12 @@ func (f Factory) WithGasPrices(gasPrices string) Factory {
 // WithKeybase returns a copy of the Factory with updated Keybase.
 func (f Factory) WithKeybase(keybase keyring.Keyring) Factory {
 	f.keybase = keybase
+	return f
+}
+
+// WithFromName returns a copy of the Factory with updated fromName
+func (f Factory) WithFromName(fromName string) Factory {
+	f.fromName = fromName
 	return f
 }
 


### PR DESCRIPTION
# Description

Closes: #XXXX

In recent 0.47.7 version tx.Factory added new feild `fromName` , but it is only only set by `NewFactoryCLI` 
we need to set `fromName` using `withFromName()` because we need use this to simulate the txn without using `NewFactoryCLI`

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage
