### PR TITLE
perf: Remove duplicate overflow check from int.Mul

### DIFF
--- a/math/CHANGELOG.md
+++ b/math/CHANGELOG.md
@@ -41,6 +41,8 @@ Ref: https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.j
 
 * [#18421](https://github.com/cosmos/cosmos-sdk/pull/18421) Add mutative api for `LegacyDec.BigInt()`.
 
+* [#18874](https://github.com/cosmos/cosmos-sdk/pull/18874) Speedup `math.Int.Mul` by removing a duplicate overflow check
+
 ### Bug Fixes
 
 * [#18519](https://github.com/cosmos/cosmos-sdk/pull/18519) Prevent Overflow in `Dec.Ceil()`.

--- a/math/int.go
+++ b/math/int.go
@@ -333,12 +333,8 @@ func (i Int) MulRaw(i2 int64) Int {
 
 // SafeMul multiples Int from another and returns an error if overflow
 func (i Int) SafeMul(i2 Int) (res Int, err error) {
-	// Check overflow
-	if i.i.BitLen()+i2.i.BitLen()-1 > MaxBitLen {
-		return Int{}, ErrIntOverflow
-	}
 	res = Int{mul(i.i, i2.i)}
-	// Check overflow if sign of both are same
+	// Check overflow
 	if res.i.BitLen() > MaxBitLen {
 		return Int{}, ErrIntOverflow
 	}


### PR DESCRIPTION
Remove a duplicate Overflow check from int.Mul

Note that big.Int's bitlength is the bit len of the absolute value of a number.

(In any base) if I multiply a `x` digit integer by a `y` digit integer, the resulting answer's digit-length is at most `x + y - 1`. You prove this to yourself by considering the result if you take a number bigger than the biggest `x` and `y` digit number.

I'll fix the base to `2` to explain this.

`2^x` is bigger than any x digit number, same for `2^y` and y.

`2^x * 2^y = 2^(x + y)` which is the smallest x+y digit number. Therefore the maximum product of a x digit and y digit number must be less than `2^(x+y)` which means its at most `x+y-1` bits.

This is the bit length check we are already doing!

So it suffices to just do one of the two checks.

In this pr I have opted to just do the latter check, because that is one bitlength check. (Whereas the check before mul is 2 bitlen checks) I think this is the better decision if:
- The goal is to give high speed to the average user of this operation
- We assume Ints are typically constructed from trusted inputs (e.g. guaranteed to be less MaxBitLength already)
- Unsafe operations erroring is very rare in production.


---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [x] confirmed `!` in the type prefix if API or client breaking change
* [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [x] provided a link to the relevant issue or specification
* [x] reviewed "Files changed" and left comments if necessary
* [x] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [x] added a changelog entry to `CHANGELOG.md`
* [x] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [x] confirmed all CI checks have passed - Failing leaking resource check is for sure unrelated. (its in CLI code)

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage
