### PR TITLE
fix: Dedup Vote Extensions in `ValidateVoteExtensions`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (simulation) [#17911](https://github.com/cosmos/cosmos-sdk/pull/17911) Fix all problems with executing command `make test-sim-custom-genesis-fast` for simulation test.
 * (simulation) [#18196](https://github.com/cosmos/cosmos-sdk/pull/18196) Fix the problem of `validator set is empty after InitGenesis` in simulation test.
 * (baseapp) [#18551](https://github.com/cosmos/cosmos-sdk/pull/18551) Fix SelectTxForProposal the calculation method of tx bytes size is inconsistent with CometBFT
+* (baseapp) [#18895](https://github.com/cosmos/cosmos-sdk/pull/18895) Fix de-duplicating vote extensions during validation in ValidateVoteExtensions.
 
 ### API Breaking Changes
 

--- a/baseapp/abci_utils.go
+++ b/baseapp/abci_utils.go
@@ -100,7 +100,7 @@ func ValidateVoteExtensions(
 		// Ensure that the validator has not already submitted a vote extension.
 		valConsAddr := sdk.ConsAddress(vote.Validator.Address)
 		if _, ok := cache[valConsAddr.String()]; ok {
-			continue
+			return fmt.Errorf("duplicate validator; validator %s has already submitted a vote extension", valConsAddr.String())
 		}
 		cache[valConsAddr.String()] = struct{}{}
 

--- a/baseapp/abci_utils.go
+++ b/baseapp/abci_utils.go
@@ -72,6 +72,7 @@ func ValidateVoteExtensions(
 		sumVP int64
 	)
 
+	cache := make(map[string]struct{})
 	for _, vote := range extCommit.Votes {
 		totalVP += vote.Validator.Power
 
@@ -96,7 +97,13 @@ func ValidateVoteExtensions(
 			return fmt.Errorf("vote extensions enabled; received empty vote extension signature at height %d", currentHeight)
 		}
 
+		// Ensure that the validator has not already submitted a vote extension.
 		valConsAddr := sdk.ConsAddress(vote.Validator.Address)
+		if _, ok := cache[valConsAddr.String()]; ok {
+			continue
+		}
+		cache[valConsAddr.String()] = struct{}{}
+
 		pubKeyProto, err := valStore.GetPubKeyByConsAddr(ctx, valConsAddr)
 		if err != nil {
 			return fmt.Errorf("failed to get validator %X public key: %w", valConsAddr, err)

--- a/baseapp/abci_utils_test.go
+++ b/baseapp/abci_utils_test.go
@@ -196,6 +196,41 @@ func (s *ABCIUtilsTestSuite) TestValidateVoteExtensionsSingleVoteAbsent() {
 	s.Require().NoError(baseapp.ValidateVoteExtensions(s.ctx, s.valStore, 3, chainID, llc))
 }
 
+// check ValidateVoteExtensions works with duplicate votes
+func (s *ABCIUtilsTestSuite) TestValidateVoteExtensionsDuplicateVotes() {
+	ext := []byte("vote-extension")
+	cve := cmtproto.CanonicalVoteExtension{
+		Extension: ext,
+		Height:    2,
+		Round:     int64(0),
+		ChainId:   chainID,
+	}
+
+	bz, err := marshalDelimitedFn(&cve)
+	s.Require().NoError(err)
+
+	extSig0, err := s.vals[0].privKey.Sign(bz)
+	s.Require().NoError(err)
+
+	ve := abci.ExtendedVoteInfo{
+		Validator:          s.vals[0].toValidator(333),
+		VoteExtension:      ext,
+		ExtensionSignature: extSig0,
+		BlockIdFlag:        cmtproto.BlockIDFlagCommit,
+	}
+
+	llc := abci.ExtendedCommitInfo{
+		Round: 0,
+		Votes: []abci.ExtendedVoteInfo{
+			ve,
+			ve,
+			ve,
+		},
+	}
+	// expect fail (duplicate votes)
+	s.Require().Error(baseapp.ValidateVoteExtensions(s.ctx, s.valStore, 3, chainID, llc))
+}
+
 // check ValidateVoteExtensions works when a single node has submitted a BlockID_Nil
 func (s *ABCIUtilsTestSuite) TestValidateVoteExtensionsSingleVoteNil() {
 	ext := []byte("vote-extension")

--- a/baseapp/abci_utils_test.go
+++ b/baseapp/abci_utils_test.go
@@ -224,7 +224,6 @@ func (s *ABCIUtilsTestSuite) TestValidateVoteExtensionsDuplicateVotes() {
 		Votes: []abci.ExtendedVoteInfo{
 			ve,
 			ve,
-			ve,
 		},
 	}
 	// expect fail (duplicate votes)


### PR DESCRIPTION
# Description

Closes: #18893
---
This PR resolves issue opened in #18893. This PR adds a validator address cache to `ValidateVoteExtensions` which ensure's that multiple of the same vote extensions cannot be included in the extended commit info.

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [x] confirmed `!` in the type prefix if API or client breaking change
* [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [x] provided a link to the relevant issue or specification
* [x] reviewed "Files changed" and left comments if necessary
* [x] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [x] added a changelog entry to `CHANGELOG.md`
* [x] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage
