### PR TITLE
feat(server/v2): add Verify block call 

### DIFF
--- a/server/v2/appmanager/service.go
+++ b/server/v2/appmanager/service.go
@@ -80,18 +80,18 @@ func (a AppManager[T]) BuildBlock(ctx context.Context, height uint64, totalSize 
 	return txs, nil
 }
 
-func (a AppManager[T]) VerifyBlock(ctx context.Context, height uint64, txs []T) (bool, error) {
+func (a AppManager[T]) VerifyBlock(ctx context.Context, height uint64, txs []T) error {
 	currentState, err := a.db.NewStateAt(height)
 	if err != nil {
 		return false, fmt.Errorf("unable to create new state for height %d: %w", height, err)
 	}
 
-	verified, err := a.processHandler(ctx, txs, currentState)
+	err := a.processHandler(ctx, txs, currentState)
 	if err != nil {
-		return false, err
+		return err
 	}
 
-	return verified, nil
+	return nil
 }
 
 func (a AppManager[T]) DeliverBlock(ctx context.Context, block appmanager.BlockRequest) (*appmanager.BlockResponse, Hash, error) {

--- a/server/v2/core/appmanager/app.go
+++ b/server/v2/core/appmanager/app.go
@@ -17,7 +17,7 @@ import (
 type PrepareHandler[T transaction.Tx] func(context.Context, uint32, mempool.Mempool[T], store.ReadonlyState) ([]T, error)
 
 // ProcessHandler is a function that takes a list of transactions and returns a boolean and an error. If the verification of a transaction fails, the boolean is false and the error is non-nil.
-type ProcessHandler[T transaction.Tx] func(context.Context, []T, store.ReadonlyState) (bool, error)
+type ProcessHandler[T transaction.Tx] func(context.Context, []T, store.ReadonlyState) error
 
 type Type = proto.Message
 

--- a/server/v2/core/appmanager/app.go
+++ b/server/v2/core/appmanager/app.go
@@ -16,6 +16,9 @@ import (
 // In the block building phase the transactions from the mempool can be verified, executed right away or lazily.
 type PrepareHandler[T transaction.Tx] func(context.Context, uint32, mempool.Mempool[T], store.ReadonlyState) ([]T, error)
 
+// ProcessHandler is a function that takes a list of transactions and returns a boolean and an error. If the verification of a transaction fails, the boolean is false and the error is non-nil.
+type ProcessHandler[T transaction.Tx] func(context.Context, []T, store.ReadonlyState) (bool, error)
+
 type Type = proto.Message
 
 type App[T transaction.Tx] interface {


### PR DESCRIPTION
# Description

This pr adds VerifyBlock to the app manager in server/v2. The app manager has a new method for the prepare handler in which application developers can set a handler to verify contents of the block 

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage
