### PR TITLE
fix(server): consensus failure while restart node with wrong `chainId` in genesis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
+### Bug Fixes
+
+* (server) [#18920](https://github.com/cosmos/cosmos-sdk/pull/18920) fixes consensus failure while restart node with wrong `chainId` in genesis
+
 ### Improvements
 
 * (client/tx) [#18852](https://github.com/cosmos/cosmos-sdk/pull/18852) Add `WithFromName` to tx factory.

--- a/server/util.go
+++ b/server/util.go
@@ -25,6 +25,8 @@ import (
 	tmcmd "github.com/cometbft/cometbft/cmd/cometbft/commands"
 	tmcfg "github.com/cometbft/cometbft/config"
 	tmlog "github.com/cometbft/cometbft/libs/log"
+	"github.com/cometbft/cometbft/node"
+	tmstore "github.com/cometbft/cometbft/store"
 	tmtypes "github.com/cometbft/cometbft/types"
 
 	"github.com/cosmos/cosmos-sdk/baseapp"
@@ -459,13 +461,13 @@ func DefaultBaseappOptions(appOpts types.AppOptions) []func(*baseapp.BaseApp) {
 	homeDir := cast.ToString(appOpts.Get(flags.FlagHome))
 	chainID := cast.ToString(appOpts.Get(flags.FlagChainID))
 	if chainID == "" {
-		// fallback to genesis chain-id
-		appGenesis, err := tmtypes.GenesisDocFromFile(filepath.Join(homeDir, "config", "genesis.json"))
+		// read the chainID from home directory (either from comet or genesis).
+		chainId, err := readChainIdFromHome(homeDir)
 		if err != nil {
 			panic(err)
 		}
 
-		chainID = appGenesis.ChainID
+		chainID = chainId
 	}
 
 	snapshotStore, err := GetSnapshotStore(appOpts)
@@ -498,6 +500,40 @@ func DefaultBaseappOptions(appOpts types.AppOptions) []func(*baseapp.BaseApp) {
 		baseapp.SetIAVLLazyLoading(cast.ToBool(appOpts.Get(FlagIAVLLazyLoading))),
 		baseapp.SetChainID(chainID),
 	}
+}
+
+// readChainIdFromHome reads chain id from home directory.
+func readChainIdFromHome(homeDir string) (string, error) {
+	cfg := tmcfg.DefaultConfig()
+	cfg.SetRoot(homeDir)
+
+	// if the node's current height is not zero then try to read the chainID from comet db.
+	db, err := node.DefaultDBProvider(&node.DBContext{ID: "blockstore", Config: cfg})
+	if err != nil {
+		return "", err
+	}
+
+	blockStore := tmstore.NewBlockStore(db)
+	defer func() {
+		if err := blockStore.Close(); err != nil {
+			panic(err)
+		}
+	}()
+
+	// if the blockStore.LoadBaseMeta() is nil (no blocks are created/synced so far), fallback to genesis chain-id
+	if blockStore.LoadBaseMeta() == nil {
+		appGenesis, err := tmtypes.GenesisDocFromFile(filepath.Join(homeDir, "config", "genesis.json"))
+
+		if err != nil {
+			return "", err
+		}
+
+		return appGenesis.ChainID, nil
+	}
+
+	chainID := blockStore.LoadBaseMeta().Header.ChainID
+
+	return chainID, nil
 }
 
 func GetSnapshotStore(appOpts types.AppOptions) (*snapshots.Store, error) {

--- a/server/util.go
+++ b/server/util.go
@@ -523,7 +523,6 @@ func readChainIdFromHome(homeDir string) (string, error) {
 	// if the blockStore.LoadBaseMeta() is nil (no blocks are created/synced so far), fallback to genesis chain-id
 	if blockStore.LoadBaseMeta() == nil {
 		appGenesis, err := tmtypes.GenesisDocFromFile(filepath.Join(homeDir, "config", "genesis.json"))
-
 		if err != nil {
 			return "", err
 		}

--- a/server/util.go
+++ b/server/util.go
@@ -520,19 +520,18 @@ func readChainIdFromHome(homeDir string) (string, error) {
 		}
 	}()
 
-	// if the blockStore.LoadBaseMeta() is nil (no blocks are created/synced so far), fallback to genesis chain-id
-	if blockStore.LoadBaseMeta() == nil {
-		appGenesis, err := tmtypes.GenesisDocFromFile(filepath.Join(homeDir, "config", "genesis.json"))
-		if err != nil {
-			return "", err
-		}
-
-		return appGenesis.ChainID, nil
+	// if the blockStore.LoadBaseMeta() is nil (no blocks are created/synced so far), fallback to genesis chain-id.
+	baseMeta := blockStore.LoadBaseMeta()
+	if baseMeta != nil {
+		return baseMeta.Header.ChainID, nil
 	}
 
-	chainID := blockStore.LoadBaseMeta().Header.ChainID
+	appGenesis, err := tmtypes.GenesisDocFromFile(filepath.Join(homeDir, "config", "genesis.json"))
+	if err != nil {
+		return "", err
+	}
 
-	return chainID, nil
+	return appGenesis.ChainID, nil
 }
 
 func GetSnapshotStore(appOpts types.AppOptions) (*snapshots.Store, error) {


### PR DESCRIPTION
# Description

Closes: #18781

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage
