### PR TITLE
feat(server/v2): add valsetupdate API

### DIFF
--- a/server/v2/appmanager/service.go
+++ b/server/v2/appmanager/service.go
@@ -5,12 +5,11 @@ import (
 	"fmt"
 	"sync/atomic"
 
-	"cosmossdk.io/server/v2/mempool"
-	"cosmossdk.io/server/v2/stf"
-
 	"cosmossdk.io/server/v2/core/appmanager"
 	"cosmossdk.io/server/v2/core/store"
 	"cosmossdk.io/server/v2/core/transaction"
+	"cosmossdk.io/server/v2/mempool"
+	"cosmossdk.io/server/v2/stf"
 )
 
 type AppManagerBuilder[T transaction.Tx] struct {

--- a/server/v2/appmanager/service.go
+++ b/server/v2/appmanager/service.go
@@ -83,10 +83,10 @@ func (a AppManager[T]) BuildBlock(ctx context.Context, height uint64, totalSize 
 func (a AppManager[T]) VerifyBlock(ctx context.Context, height uint64, txs []T) error {
 	currentState, err := a.db.NewStateAt(height)
 	if err != nil {
-		return false, fmt.Errorf("unable to create new state for height %d: %w", height, err)
+		return fmt.Errorf("unable to create new state for height %d: %w", height, err)
 	}
 
-	err := a.processHandler(ctx, txs, currentState)
+	err = a.processHandler(ctx, txs, currentState)
 	if err != nil {
 		return err
 	}

--- a/server/v2/core/transaction/validation.go
+++ b/server/v2/core/transaction/validation.go
@@ -26,6 +26,6 @@ type Handler func(ctx context.Context, tx Tx) (newCtx context.Context, err error
 type Validator[T Tx] interface {
 	// Validate validates the transactions
 	// it returns the context used and a map of which txs failed.
-	// It does not take into account what information is needed to be returned to the consensus engine, this must be extracted from teh context
+	// It does not take into account what information is needed to be returned to the consensus engine, this must be extracted from the context
 	Validate(ctx context.Context, txs []T) (context.Context, map[[32]byte]error)
 }

--- a/server/v2/grpc/server.go
+++ b/server/v2/grpc/server.go
@@ -9,9 +9,9 @@ import (
 	"google.golang.org/grpc"
 
 	"cosmossdk.io/log"
-
 	"cosmossdk.io/server/v2/grpc/gogoreflection"
 	reflection "cosmossdk.io/server/v2/grpc/reflection/v2alpha1"
+
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"

--- a/server/v2/grpcweb/server.go
+++ b/server/v2/grpcweb/server.go
@@ -3,10 +3,11 @@ package grpcweb
 import (
 	"net/http"
 
-	"cosmossdk.io/log"
 	"github.com/gorilla/mux"
 	"github.com/improbable-eng/grpc-web/go/grpcweb"
 	"google.golang.org/grpc"
+
+	"cosmossdk.io/log"
 )
 
 type Server struct {

--- a/server/v2/stf/mock/tx.go
+++ b/server/v2/stf/mock/tx.go
@@ -4,9 +4,10 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 
-	"cosmossdk.io/server/v2/core/transaction"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
+
+	"cosmossdk.io/server/v2/core/transaction"
 )
 
 var _ transaction.Tx = Tx{}

--- a/server/v2/stf/stf.go
+++ b/server/v2/stf/stf.go
@@ -23,8 +23,9 @@ type STF[T transaction.Tx] struct {
 	handleMsg   func(ctx context.Context, msg Type) (msgResp Type, err error)
 	handleQuery func(ctx context.Context, req Type) (resp Type, err error)
 
-	doBeginBlock func(ctx context.Context) error
-	doEndBlock   func(ctx context.Context) error
+	doBeginBlock      func(ctx context.Context) error
+	doEndBlock        func(ctx context.Context) error
+	doValidatorUpdate func(ctx context.Context) ([]appmanager.ValidatorUpdate, error)
 
 	doTxValidation func(ctx context.Context, tx T) error
 
@@ -56,10 +57,19 @@ func (s STF[T]) DeliverBlock(ctx context.Context, block appmanager.BlockRequest,
 		return nil, nil, err
 	}
 
+	events, valset, err := s.validatorUpdates(ctx, newState, block)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// append endblock events to the end of the block events
+	endBlockEvents = append(endBlockEvents, events...)
+
 	return &appmanager.BlockResponse{
 		BeginBlockEvents: beginBlockEvents,
 		TxResults:        txResults,
 		EndBlockEvents:   endBlockEvents,
+		ValidatorUpdates: valset,
 	}, newState, nil
 }
 
@@ -130,13 +140,22 @@ func (s STF[T]) beginBlock(ctx context.Context, state store.WritableState) (begi
 	return bbCtx.events, nil
 }
 
-func (s STF[T]) endBlock(ctx context.Context, store store.WritableState, block appmanager.BlockRequest) (endBlockEvents []event.Event, err error) {
-	ebCtx := s.makeContext(ctx, []Identity{runtimeIdentity}, store, 0) // TODO: gas limit
+func (s STF[T]) endBlock(ctx context.Context, state store.WritableState, block appmanager.BlockRequest) (endBlockEvents []event.Event, err error) {
+	ebCtx := s.makeContext(ctx, []Identity{runtimeIdentity}, state, 0) // TODO: gas limit
 	err = s.doEndBlock(ebCtx)
 	if err != nil {
 		return nil, err
 	}
 	return ebCtx.events, nil
+}
+
+func (s STF[T]) validatorUpdates(ctx context.Context, state store.WritableState, block appmanager.BlockRequest) ([]event.Event, []appmanager.ValidatorUpdate, error) {
+	ebCtx := s.makeContext(ctx, []Identity{runtimeIdentity}, state, 0) // TODO: gas limit
+	valSetUpdates, err := s.doValidatorUpdate(ebCtx)
+	if err != nil {
+		return nil, nil, err
+	}
+	return ebCtx.events, valSetUpdates, nil
 }
 
 // Simulate simulates the execution of a tx on the provided state.
@@ -194,7 +213,7 @@ func (s STF[T]) makeContext(
 }
 
 // applyStateChanges writes the changes in state from src to dst.
-func applyStateChanges(dst store.WritableState, src store.WritableState) error {
+func applyStateChanges(dst, src store.WritableState) error {
 	changes, err := src.ChangeSets()
 	if err != nil {
 		return err

--- a/server/v2/stf/stf_builder.go
+++ b/server/v2/stf/stf_builder.go
@@ -89,8 +89,10 @@ func (s *STFBuilder[T]) AddModule(m appmanager.Module[T]) {
 	// TODO: check if is not nil, etc.
 	s.beginBlockers[m.Name()] = m.BeginBlocker()
 	s.endBlockers[m.Name()] = m.EndBlocker()
-	if m.UpdateValidators() != nil {
+	if s.valSetUpdate == nil && m.UpdateValidators() != nil {
 		s.valSetUpdate = m.UpdateValidators()
+	} else if s.valSetUpdate != nil && m.UpdateValidators() != nil {
+		s.err = errors.Join(s.err, fmt.Errorf("multiple modules are trying to update validators"))
 	}
 	s.txValidators[m.Name()] = m.TxValidator()
 }

--- a/server/v2/stf/stf_builder.go
+++ b/server/v2/stf/stf_builder.go
@@ -28,7 +28,7 @@ type STFBuilder[T transaction.Tx] struct {
 	txValidators       map[string]func(ctx context.Context, tx T) error
 	beginBlockers      map[string]func(ctx context.Context) error
 	endBlockers        map[string]func(ctx context.Context) error
-	valSetUpdate       func(ctx context.Context) (appmanager.ValidatorUpdate, error)
+	valSetUpdate       func(ctx context.Context) ([]appmanager.ValidatorUpdate, error)
 	txCodec            transaction.Codec[T]
 }
 
@@ -89,6 +89,9 @@ func (s *STFBuilder[T]) AddModule(m appmanager.Module[T]) {
 	// TODO: check if is not nil, etc.
 	s.beginBlockers[m.Name()] = m.BeginBlocker()
 	s.endBlockers[m.Name()] = m.EndBlocker()
+	if m.UpdateValidators() != nil {
+		s.valSetUpdate = m.UpdateValidators()
+	}
 	s.txValidators[m.Name()] = m.TxValidator()
 }
 

--- a/server/v2/stf/stf_test.go
+++ b/server/v2/stf/stf_test.go
@@ -5,12 +5,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
 	"cosmossdk.io/server/v2/core/appmanager"
 	"cosmossdk.io/server/v2/core/store"
 	"cosmossdk.io/server/v2/core/transaction"
 	"cosmossdk.io/server/v2/stf/mock"
-	"github.com/stretchr/testify/require"
-	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
 func TestSTF(t *testing.T) {
@@ -94,16 +95,19 @@ func TestSTF(t *testing.T) {
 }
 
 func kvSet(t *testing.T, ctx context.Context, v string) {
+	t.Helper()
 	require.NoError(t, ctx.(*executionContext).store.Set([]byte(v), []byte(v)))
 }
 
 func stateHas(t *testing.T, state store.ReadonlyState, key string) {
+	t.Helper()
 	has, err := state.Has([]byte(key))
 	require.NoError(t, err)
 	require.Truef(t, has, "state did not have key: %s", key)
 }
 
 func stateNotHas(t *testing.T, state store.ReadonlyState, key string) {
+	t.Helper()
 	has, err := state.Has([]byte(key))
 	require.NoError(t, err)
 	require.Falsef(t, has, "state was not supposed to have key: %s", key)

--- a/server/v2/transaction/codec.go
+++ b/server/v2/transaction/codec.go
@@ -1,10 +1,9 @@
 package transaction
 
 import (
+	"cosmossdk.io/server/v2/core/transaction"
 	txdecoder "cosmossdk.io/x/tx/decode"
 	"cosmossdk.io/x/tx/signing"
-
-	"cosmossdk.io/server/v2/core/transaction"
 )
 
 var _ transaction.Codec[transaction.Tx] = Codec[txdecoder.DecodedTx]{}


### PR DESCRIPTION
# Description

This pr adds an api for validator set updates. This can only be called by one module in a chain. It is always called after endblocker, avoiding the need for ordering the module along side other modules 

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage
