### PR TITLE
fix(testutil): mock logger missing method Warn

### DIFF
--- a/testutil/mock/logger.go
+++ b/testutil/mock/logger.go
@@ -99,6 +99,23 @@ func (mr *MockLoggerMockRecorder) Info(arg0 interface{}, arg1 ...interface{}) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Info", reflect.TypeOf((*MockLogger)(nil).Info), varargs...)
 }
 
+// Warn mocks base method.
+func (m *MockLogger) Warn(arg0 string, arg1 ...interface{}) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0}
+	for _, a := range arg1 {
+		varargs = append(varargs, a)
+	}
+	m.ctrl.Call(m, "Warn", varargs...)
+}
+
+// Warn indicates an expected call of Warn.
+func (mr *MockLoggerMockRecorder) Warn(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0}, arg1...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Warn", reflect.TypeOf((*MockLogger)(nil).Warn), varargs...)
+}
+
 // With mocks base method.
 func (m *MockLogger) With(arg0 ...interface{}) log.Logger {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
# Description

Ref: #18898 

fix errors
```shell
types/context_test.go:72:23: cannot use logger (variable of type *mock.MockLogger) as "cosmossdk.io/log".Logger value in argument to ctx.WithLogger: *mock.MockLogger does not implement "cosmossdk.io/log".Logger (missing method Warn)
types/context_test.go:98:39: cannot use logger (variable of type *mock.MockLogger) as "cosmossdk.io/log".Logger value in argument to types.NewContext: *mock.MockLogger does not implement "cosmossdk.io/log".Logger (missing method Warn)
```
