### PR TITLE
test: proof-of-concept of using the standard go fuzzing during the executing of the simapp simulation

### DIFF
--- a/types/simulation/config.go
+++ b/types/simulation/config.go
@@ -11,6 +11,7 @@ type Config struct {
 	ExportStatsPath    string // custom file path to save the exported simulation statistics JSON
 
 	Seed               int64  // simulation random seed
+        Seeds              [] int64 // Added
 	InitialBlockHeight int    // initial block to start the simulation
 	GenesisTime        int64  // genesis time to start the simulation
 	NumBlocks          int    // number of new blocks to simulate from the initial block height

--- a/types/simulation/rand_util.go
+++ b/types/simulation/rand_util.go
@@ -152,14 +152,7 @@ func RandSubsetCoins(r *rand.Rand, coins sdk.Coins) sdk.Coins {
 //
 // NOTE: not crypto safe.
 func DeriveRand(r *rand.Rand) *rand.Rand {
-	const num = 8 // TODO what's a good number?  Too large is too slow.
-	ms := multiSource(make([]rand.Source, num))
-
-	for i := 0; i < num; i++ {
-		ms[i] = rand.NewSource(r.Int63())
-	}
-
-	return rand.New(ms)
+     return r
 }
 
 type multiSource []rand.Source

--- a/x/staking/types/validator.go
+++ b/x/staking/types/validator.go
@@ -310,6 +310,9 @@ func (v Validator) TokensFromShares(shares math.LegacyDec) math.LegacyDec {
 
 // calculate the token worth of provided shares, truncated
 func (v Validator) TokensFromSharesTruncated(shares math.LegacyDec) math.LegacyDec {
+	if (v.DelegatorShares.IsZero()) {
+		panic("v.DelegatorShares is zero");
+	}
 	return (shares.MulInt(v.Tokens)).QuoTruncate(v.DelegatorShares)
 }
 


### PR DESCRIPTION
# Description

This is a proof-of-concept for improving the testing when running the [high-level simulation (simapp)](https://docs.cosmos.network/v0.47/core/simulation) using smart fuzzing. This is NOT in a merging state, since it requires a good amount of discussion and changes. 

The problem is simple: the `simapp` will only perform random exploration based on single seed for exploring the chain state. This PR enhance the `simapp` using [go fuzzing](https://go.dev/doc/security/fuzz/) with a minimal amount of changes. 

The idea is simple: we modified how the `Source` of a random seed is used to produce random values. This modified `Source` will allow the fuzzing engine to add or mutate "deterministic bytes" that are going to be used as random values directly. Initially, the random generation will be the same as the current `simapp`, but over the time, the fuzzer will have more and more control to randomly explore the input state.

To test the random exploration, just use go fuzzing as the simapp. For instance:

```
$ cd simapp
$ go test -mod=readonly -fuzz=FuzzFullAppSimulation -GenesisTime=1688995849 -Enabled=true -NumBlocks=2 -BlockSize=5 -Commit=true -Seed=0 -Period=1 -Verbose=1 -run=_
```

Using this new approach, we found a number of small bugs that resulted in a few PRs: #16951, #16978, #18542. 

If you are interested in this approach, we need to discuss the next steps. In particular, we need to know how the UI can be modified to support both the usage of a single random seed (as it is now) and this new approach.

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage
