### PR TITLE
chore(store/v2): use core iterator

### DIFF
--- a/store/kv/branch/store.go
+++ b/store/kv/branch/store.go
@@ -8,6 +8,7 @@ import (
 
 	"golang.org/x/exp/maps"
 
+	corestore "cosmossdk.io/core/store"
 	"cosmossdk.io/store/v2"
 	"cosmossdk.io/store/v2/kv/trace"
 )
@@ -212,11 +213,11 @@ func (s *Store) Write() {
 // Note, writes that happen on the KVStore over an iterator will not affect the
 // iterator. This is because when an iterator is created, it takes a current
 // snapshot of the changeset.
-func (s *Store) Iterator(start, end []byte) store.Iterator {
+func (s *Store) Iterator(start, end []byte) corestore.Iterator {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	var parentItr store.Iterator
+	var parentItr corestore.Iterator
 	if s.parent != nil {
 		parentItr = s.parent.Iterator(start, end)
 	} else {
@@ -238,11 +239,11 @@ func (s *Store) Iterator(start, end []byte) store.Iterator {
 // Note, writes that happen on the KVStore over an iterator will not affect the
 // iterator. This is because when an iterator is created, it takes a current
 // snapshot of the changeset.
-func (s *Store) ReverseIterator(start, end []byte) store.Iterator {
+func (s *Store) ReverseIterator(start, end []byte) corestore.Iterator {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	var parentItr store.Iterator
+	var parentItr corestore.Iterator
 	if s.parent != nil {
 		parentItr = s.parent.ReverseIterator(start, end)
 	} else {
@@ -256,7 +257,7 @@ func (s *Store) ReverseIterator(start, end []byte) store.Iterator {
 	return s.newIterator(parentItr, start, end, true)
 }
 
-func (s *Store) newIterator(parentItr store.Iterator, start, end []byte, reverse bool) *iterator {
+func (s *Store) newIterator(parentItr corestore.Iterator, start, end []byte, reverse bool) *iterator {
 	startStr := string(start)
 	endStr := string(end)
 
@@ -305,7 +306,7 @@ func (s *Store) newIterator(parentItr store.Iterator, start, end []byte, reverse
 	}
 
 	// call Next() to move the iterator to the first key/value entry
-	_ = itr.Next()
+	itr.Next()
 
 	return itr
 }

--- a/store/kv/mem/iterator.go
+++ b/store/kv/mem/iterator.go
@@ -6,10 +6,11 @@ import (
 	"github.com/tidwall/btree"
 	"golang.org/x/exp/slices"
 
+	corestore "cosmossdk.io/core/store"
 	"cosmossdk.io/store/v2"
 )
 
-var _ store.Iterator = (*iterator)(nil)
+var _ corestore.Iterator = (*iterator)(nil)
 
 type iterator struct {
 	treeItr btree.IterG[store.KVPair]
@@ -19,7 +20,7 @@ type iterator struct {
 	valid   bool
 }
 
-func newIterator(tree *btree.BTreeG[store.KVPair], start, end []byte, reverse bool) store.Iterator {
+func newIterator(tree *btree.BTreeG[store.KVPair], start, end []byte, reverse bool) corestore.Iterator {
 	if (start != nil && len(start) == 0) || (end != nil && len(end) == 0) {
 		panic(store.ErrKeyEmpty)
 	}
@@ -83,11 +84,7 @@ func (itr *iterator) Value() []byte {
 	return slices.Clone(itr.treeItr.Item().Value)
 }
 
-func (itr *iterator) Next() bool {
-	if !itr.valid {
-		return false
-	}
-
+func (itr *iterator) Next() {
 	if !itr.reverse {
 		itr.valid = itr.treeItr.Next()
 	} else {
@@ -98,11 +95,11 @@ func (itr *iterator) Next() bool {
 		itr.valid = itr.keyInRange(itr.Key())
 	}
 
-	return itr.valid
 }
 
-func (itr *iterator) Close() {
+func (itr *iterator) Close() error {
 	itr.treeItr.Release()
+	return nil
 }
 
 func (itr *iterator) Error() error {

--- a/store/kv/mem/store.go
+++ b/store/kv/mem/store.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/tidwall/btree"
 
+	corestore "cosmossdk.io/core/store"
 	"cosmossdk.io/store/v2"
 )
 
@@ -92,10 +93,10 @@ func (s *Store) Reset(_ uint64) error {
 	return nil
 }
 
-func (s *Store) Iterator(start, end []byte) store.Iterator {
+func (s *Store) Iterator(start, end []byte) corestore.Iterator {
 	return newIterator(s.tree, start, end, false)
 }
 
-func (s *Store) ReverseIterator(start, end []byte) store.Iterator {
+func (s *Store) ReverseIterator(start, end []byte) corestore.Iterator {
 	return newIterator(s.tree, start, end, true)
 }

--- a/store/kv/trace/iterator.go
+++ b/store/kv/trace/iterator.go
@@ -3,18 +3,19 @@ package trace
 import (
 	"io"
 
+	corestore "cosmossdk.io/core/store"
 	"cosmossdk.io/store/v2"
 )
 
-var _ store.Iterator = (*iterator)(nil)
+var _ corestore.Iterator = (*iterator)(nil)
 
 type iterator struct {
-	parent  store.Iterator
+	parent  corestore.Iterator
 	writer  io.Writer
 	context store.TraceContext
 }
 
-func newIterator(w io.Writer, parent store.Iterator, tc store.TraceContext) store.Iterator {
+func newIterator(w io.Writer, parent corestore.Iterator, tc store.TraceContext) corestore.Iterator {
 	return &iterator{
 		parent:  parent,
 		writer:  w,
@@ -30,16 +31,16 @@ func (itr *iterator) Valid() bool {
 	return itr.parent.Valid()
 }
 
-func (itr *iterator) Next() bool {
-	return itr.parent.Next()
+func (itr *iterator) Next() {
+	itr.parent.Next()
 }
 
 func (itr *iterator) Error() error {
 	return itr.parent.Error()
 }
 
-func (itr *iterator) Close() {
-	itr.parent.Close()
+func (itr *iterator) Close() error {
+	return itr.parent.Close()
 }
 
 func (itr *iterator) Key() []byte {

--- a/store/kv/trace/store.go
+++ b/store/kv/trace/store.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/cockroachdb/errors"
 
+	corestore "cosmossdk.io/core/store"
 	"cosmossdk.io/store/v2"
 )
 
@@ -98,11 +99,11 @@ func (s *Store) BranchWithTrace(_ io.Writer, _ store.TraceContext) store.Branche
 	panic(fmt.Sprintf("cannot call BranchWithTrace() on %T", s))
 }
 
-func (s *Store) Iterator(start, end []byte) store.Iterator {
+func (s *Store) Iterator(start, end []byte) corestore.Iterator {
 	return newIterator(s.writer, s.parent.Iterator(start, end), s.context)
 }
 
-func (s *Store) ReverseIterator(start, end []byte) store.Iterator {
+func (s *Store) ReverseIterator(start, end []byte) corestore.Iterator {
 	return newIterator(s.writer, s.parent.ReverseIterator(start, end), s.context)
 }
 

--- a/store/storage/sqlite/db.go
+++ b/store/storage/sqlite/db.go
@@ -10,6 +10,7 @@ import (
 
 	_ "github.com/mattn/go-sqlite3"
 
+	corestore "cosmossdk.io/core/store"
 	"cosmossdk.io/store/v2"
 	"cosmossdk.io/store/v2/storage"
 )
@@ -214,7 +215,7 @@ func (db *Database) Prune(version uint64) error {
 	return nil
 }
 
-func (db *Database) Iterator(storeKey string, version uint64, start, end []byte) (store.Iterator, error) {
+func (db *Database) Iterator(storeKey string, version uint64, start, end []byte) (corestore.Iterator, error) {
 	if (start != nil && len(start) == 0) || (end != nil && len(end) == 0) {
 		return nil, store.ErrKeyEmpty
 	}
@@ -226,7 +227,7 @@ func (db *Database) Iterator(storeKey string, version uint64, start, end []byte)
 	return newIterator(db, storeKey, version, start, end, false)
 }
 
-func (db *Database) ReverseIterator(storeKey string, version uint64, start, end []byte) (store.Iterator, error) {
+func (db *Database) ReverseIterator(storeKey string, version uint64, start, end []byte) (corestore.Iterator, error) {
 	if (start != nil && len(start) == 0) || (end != nil && len(end) == 0) {
 		return nil, store.ErrKeyEmpty
 	}

--- a/store/storage/sqlite/iterator.go
+++ b/store/storage/sqlite/iterator.go
@@ -8,10 +8,10 @@ import (
 
 	"golang.org/x/exp/slices"
 
-	"cosmossdk.io/store/v2"
+	corestore "cosmossdk.io/core/store"
 )
 
-var _ store.Iterator = (*iterator)(nil)
+var _ corestore.Iterator = (*iterator)(nil)
 
 type iterator struct {
 	statement  *sql.Stmt
@@ -100,7 +100,7 @@ func newIterator(db *Database, storeKey string, targetVersion uint64, start, end
 	return itr, nil
 }
 
-func (itr *iterator) Close() {
+func (itr *iterator) Close() error {
 	if itr.statement != nil {
 		_ = itr.statement.Close()
 	}
@@ -108,6 +108,8 @@ func (itr *iterator) Close() {
 	itr.valid = false
 	itr.statement = nil
 	itr.rows = nil
+
+	return nil
 }
 
 // Domain returns the domain of the iterator. The caller must not modify the
@@ -143,14 +145,12 @@ func (itr *iterator) Valid() bool {
 	return true
 }
 
-func (itr *iterator) Next() bool {
+func (itr *iterator) Next() {
 	if itr.rows.Next() {
 		itr.parseRow()
-		return itr.Valid()
 	}
 
 	itr.valid = false
-	return itr.valid
 }
 
 func (itr *iterator) Error() error {

--- a/store/storage/store.go
+++ b/store/storage/store.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"fmt"
 
+	corestore "cosmossdk.io/core/store"
 	"cosmossdk.io/store/v2"
 	"cosmossdk.io/store/v2/snapshots"
 )
@@ -74,12 +75,12 @@ func (ss *StorageStore) SetLatestVersion(version uint64) error {
 }
 
 // Iterator returns an iterator over the specified domain and prefix.
-func (ss *StorageStore) Iterator(storeKey string, version uint64, start, end []byte) (store.Iterator, error) {
+func (ss *StorageStore) Iterator(storeKey string, version uint64, start, end []byte) (corestore.Iterator, error) {
 	return ss.db.Iterator(storeKey, version, start, end)
 }
 
 // ReverseIterator returns an iterator over the specified domain and prefix in reverse.
-func (ss *StorageStore) ReverseIterator(storeKey string, version uint64, start, end []byte) (store.Iterator, error) {
+func (ss *StorageStore) ReverseIterator(storeKey string, version uint64, start, end []byte) (corestore.Iterator, error) {
 	return ss.db.ReverseIterator(storeKey, version, start, end)
 }
 

--- a/store/store.go
+++ b/store/store.go
@@ -4,6 +4,7 @@ import (
 	"io"
 
 	coreheader "cosmossdk.io/core/header"
+	corestore "cosmossdk.io/core/store"
 	"cosmossdk.io/store/v2/metrics"
 )
 
@@ -148,11 +149,11 @@ type KVStore interface {
 	//
 	// CONTRACT: No writes may happen within a domain while an iterator exists over
 	// it, with the exception of a branched/cached KVStore.
-	Iterator(start, end []byte) Iterator
+	Iterator(start, end []byte) corestore.Iterator
 
 	// ReverseIterator creates a new reverse Iterator over the domain [start, end).
 	// It has the some properties and contracts as Iterator.
-	ReverseIterator(start, end []byte) Iterator
+	ReverseIterator(start, end []byte) corestore.Iterator
 }
 
 // BranchedKVStore defines an interface for a branched a KVStore. It extends KVStore


### PR DESCRIPTION
# Description

ref #17576

use iterator from cosmossdk.io/core/store

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage
