### PR TITLE
chore: sort linters in golangci-lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,12 +21,12 @@ build-tags:
 linters:
   disable-all: true
   enable:
-    - errcheck
     - dogsled
+    - errcheck
     - exportloopref
+    - gci
     - goconst
     - gocritic
-    - gci
     - gofumpt
     - gosec
     - gosimple
@@ -35,11 +35,11 @@ linters:
     - misspell
     - nakedret
     - nolintlint
-    - staticcheck
     - revive
+    - staticcheck
     - stylecheck
-    - typecheck
     - thelper
+    - typecheck
     - unconvert
     - unused
 


### PR DESCRIPTION
Make it easier to see if a linter has already been added