### PR TITLE
docs: Fix typos, broken link, spacing in diagram

### DIFF
--- a/docs/learn/beginner/01-tx-lifecycle.md
+++ b/docs/learn/beginner/01-tx-lifecycle.md
@@ -164,44 +164,44 @@ As mentioned throughout the documentation `BeginBlock`, `ExecuteTx` and `EndBloc
 Although every full-node operates individually and locally, the outcome is always consistent and unequivocal. This is because the state changes brought about by the messages are predictable, and the transactions are specifically sequenced in the proposed block.
 
 ```text
-		-----------------------
-		|Receive Block Proposal|
-		-----------------------
-							|
-				v
+		--------------------------
+		| Receive Block Proposal |
+		--------------------------
+					|
+					v
 		-------------------------
-		| FinalizeBlock	        |
-		          |
-			  v
-				-------------------
-				| BeginBlock	    | 
-				-------------------
-		          |
-			  v
+		|     FinalizeBlock	    |
+		-------------------------
+		            |
+			  		v
+			-------------------
+			|   BeginBlock	  | 
+			-------------------
+		            |
+			        v
 			--------------------
 			| ExecuteTx(tx0)   |
 			| ExecuteTx(tx1)   |
 			| ExecuteTx(tx2)   |
 			| ExecuteTx(tx3)   |
-			|	.	      |
-			|	.	      |
-			|	.	      |
+			|	    .	       |
+			|		.		   |
+			|		.	       |
 			-------------------
-		          |
-			  v
+		            |
+			        v
 			--------------------
-			| EndBlock	      |
+			|    EndBlock      |
 			--------------------
-		-------------------------
+		            |
+			        v
+		-----------------------
+		|      Consensus      |
+		-----------------------
 		          |
-			  v
+			      v
 		-----------------------
-		| Consensus	      |
-		-----------------------
-		          |
-			  v
-		-----------------------
-		| Commit	      |
+		|     Commit	      |
 		-----------------------
 ```
 

--- a/docs/learn/beginner/02-query-lifecycle.md
+++ b/docs/learn/beginner/02-query-lifecycle.md
@@ -76,7 +76,7 @@ The first thing that is created in the execution of a CLI command is a `client.C
 * **Codec**: The [encoder/decoder](../advanced/05-encoding.md) used by the application, used to marshal the parameters and query before making the CometBFT RPC request and unmarshal the returned response into a JSON object. The default codec used by the CLI is Protobuf.
 * **Account Decoder**: The account decoder from the [`auth`](../../build/modules/auth/README.md) module, which translates `[]byte`s into accounts.
 * **RPC Client**: The CometBFT RPC Client, or node, to which requests are relayed.
-* **Keyring**: A [Key Manager]../beginner/03-accounts.md#keyring) used to sign transactions and handle other operations with keys.
+* **Keyring**: A [Key Manager](../beginner/03-accounts.md#keyring) used to sign transactions and handle other operations with keys.
 * **Output Writer**: A [Writer](https://pkg.go.dev/io/#Writer) used to output the response.
 * **Configurations**: The flags configured by the user for this command, including `--height`, specifying the height of the blockchain to query, and `--indent`, which indicates to add an indent to the JSON response.
 

--- a/docs/learn/beginner/02-query-lifecycle.md
+++ b/docs/learn/beginner/02-query-lifecycle.md
@@ -134,7 +134,7 @@ Once a result is received from the querier, `baseapp` begins the process of retu
 
 ## Response
 
-Since `Query()` is an ABCI function, `baseapp` returns the response as an [`abci.ResponseQuery`](https://docs.cometbft.com/master/spec/abci/abci.html#query-2) type. The `client.Context` `Query()` routine receives the response and.
+Since `Query()` is an ABCI function, `baseapp` returns the response as an [`abci.ResponseQuery`](https://docs.cometbft.com/master/spec/abci/abci.html#query-2) type. The `client.Context` `Query()` routine receives the response.
 
 ### CLI Response
 


### PR DESCRIPTION
# Description

Closes: #18971

Edits `docs/learn/beginner/01-tx-lifecycle.md` and `docs/learn/beginner/02-query-lifecycle.md` to remove and fix some typos that I notice while going through the documentation. This points to https://docs.cosmos.network/main/learn/beginner/tx-lifecycle and https://docs.cosmos.network/main/learn/beginner/query-lifecycle respectively. I reviewed the effected changes in the built in markdown renderer in visual studio code to make sure that the spacing in the tx lifecycle state changes diagram particularly, looks acceptable.

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [x] confirmed `!` in the type prefix if API or client breaking change
* [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [x] provided a link to the relevant issue or specification
* [x] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
     - docs shouldn't affect tests
* [ ] added a changelog entry to `CHANGELOG.md`
     - seems like overkill for a minor change
* [x] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed
     - I don't know how to do this, but it seems that docs wouldn't affect CI really...

