### PR TITLE
docs(client/keys): add tips of how to remove all keys

### DIFF
--- a/client/keys/delete.go
+++ b/client/keys/delete.go
@@ -29,7 +29,7 @@ only the public key references stored locally, i.e.
 private keys stored in a ledger device cannot be deleted with the CLI.
 
 Tips: 
-1. removing all keys by running: %s keys list -n |xargs %s keys delete -y
+1. Removing all keys by running: %s keys list -n |xargs %s keys delete
 `, version.AppName, version.AppName),
 		Args: cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/client/keys/delete.go
+++ b/client/keys/delete.go
@@ -2,12 +2,14 @@ package keys
 
 import (
 	"bufio"
+	"fmt"
 
 	"github.com/spf13/cobra"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/input"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
+	"github.com/cosmos/cosmos-sdk/version"
 )
 
 const (
@@ -20,12 +22,15 @@ func DeleteKeyCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "delete <name>...",
 		Short: "Delete the given keys",
-		Long: `Delete keys from the Keybase backend.
+		Long: fmt.Sprintf(`Delete keys from the Keybase backend.
 
 Note that removing offline or ledger keys will remove
 only the public key references stored locally, i.e.
 private keys stored in a ledger device cannot be deleted with the CLI.
-`,
+
+Tips: 
+1. removing all keys by running: %s keys list -n |xargs %s keys delete -y
+`, version.AppName, version.AppName),
 		Args: cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			buf := bufio.NewReader(cmd.InOrStdin())

--- a/client/keys/list.go
+++ b/client/keys/list.go
@@ -19,7 +19,7 @@ along with their associated name and address.`,
 		RunE: runListCmd,
 	}
 
-	cmd.Flags().BoolP(flagListNames, "n", false, "List names only")
+	cmd.Flags().BoolP(flagListNames, "n", false, "List names only. Deprecated, please use `keys list --output json | jq .[].name`")
 	return cmd
 }
 

--- a/client/keys/list.go
+++ b/client/keys/list.go
@@ -19,7 +19,7 @@ along with their associated name and address.`,
 		RunE: runListCmd,
 	}
 
-	cmd.Flags().BoolP(flagListNames, "n", false, "List names only. Deprecated, please use `keys list --output json | jq .[].name`")
+	cmd.Flags().BoolP(flagListNames, "n", false, "List names only")
 	return cmd
 }
 


### PR DESCRIPTION
Ref #18942 [comment](https://github.com/cosmos/cosmos-sdk/pull/18942#issuecomment-1877132881)

I think we should add a tip on how to remove all keys, this is useful when we do some tests for app `<simd>`. 

This may be easy for the developers who are familiar with `cosmos-sdk`, but for a newer, the first thought may be "Is there a subcommand or option for `keys delete` that could be used to delete all keys"