### PR TITLE
refactor(tx)!: remove many signers to one message

### DIFF
--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -1051,8 +1051,8 @@ func createEvents(cdc codec.Codec, events sdk.Events, msg sdk.Msg, msgV2 protov2
 	if err != nil {
 		return nil, err
 	}
-	if len(signers) > 0 && signers[0] != nil {
-		addrStr, err := cdc.InterfaceRegistry().SigningContext().AddressCodec().BytesToString(signers[0])
+	if signers != nil {
+		addrStr, err := cdc.InterfaceRegistry().SigningContext().AddressCodec().BytesToString(signers)
 		if err != nil {
 			return nil, err
 		}

--- a/codec/codec.go
+++ b/codec/codec.go
@@ -26,15 +26,15 @@ type (
 		// GetMsgAnySigners returns the signers of the given message encoded in a protobuf Any
 		// as well as the decoded google.golang.org/protobuf/proto.Message that was used to
 		// extract the signers so that this can be used in other contexts.
-		GetMsgAnySigners(msg *types.Any) ([][]byte, protov2.Message, error)
+		GetMsgAnySigners(msg *types.Any) ([]byte, protov2.Message, error)
 
 		// GetMsgV2Signers returns the signers of the given message.
-		GetMsgV2Signers(msg protov2.Message) ([][]byte, error)
+		GetMsgV2Signers(msg protov2.Message) ([]byte, error)
 
 		// GetMsgV1Signers returns the signers of the given message plus the
 		// decoded google.golang.org/protobuf/proto.Message that was used to extract the
 		// signers so that this can be used in other contexts.
-		GetMsgV1Signers(msg proto.Message) ([][]byte, protov2.Message, error)
+		GetMsgV1Signers(msg proto.Message) ([]byte, protov2.Message, error)
 
 		// mustEmbedCodec requires that all implementations of Codec embed an official implementation from the codec
 		// package. This allows new methods to be added to the Codec interface without breaking backwards compatibility.

--- a/codec/proto_codec.go
+++ b/codec/proto_codec.go
@@ -299,7 +299,7 @@ func (pc *ProtoCodec) InterfaceRegistry() types.InterfaceRegistry {
 	return pc.interfaceRegistry
 }
 
-func (pc ProtoCodec) GetMsgAnySigners(msg *types.Any) ([][]byte, proto.Message, error) {
+func (pc ProtoCodec) GetMsgAnySigners(msg *types.Any) ([]byte, proto.Message, error) {
 	msgv2, err := anyutil.Unpack(&anypb.Any{
 		TypeUrl: msg.TypeUrl,
 		Value:   msg.Value,
@@ -312,11 +312,11 @@ func (pc ProtoCodec) GetMsgAnySigners(msg *types.Any) ([][]byte, proto.Message, 
 	return signers, msgv2, err
 }
 
-func (pc *ProtoCodec) GetMsgV2Signers(msg proto.Message) ([][]byte, error) {
+func (pc *ProtoCodec) GetMsgV2Signers(msg proto.Message) ([]byte, error) {
 	return pc.interfaceRegistry.SigningContext().GetSigners(msg)
 }
 
-func (pc *ProtoCodec) GetMsgV1Signers(msg gogoproto.Message) ([][]byte, proto.Message, error) {
+func (pc *ProtoCodec) GetMsgV1Signers(msg gogoproto.Message) ([]byte, proto.Message, error) {
 	if msgV2, ok := msg.(proto.Message); ok {
 		signers, err := pc.interfaceRegistry.SigningContext().GetSigners(msgV2)
 		return signers, msgV2, err

--- a/types/tx/types.go
+++ b/types/tx/types.go
@@ -110,11 +110,9 @@ func (t *Tx) GetSigners(cdc codec.Codec) ([][]byte, []protov2.Message, error) {
 
 		msgsv2 = append(msgsv2, msgv2)
 
-		for _, signer := range xs {
-			if !seen[string(signer)] {
-				signers = append(signers, signer)
-				seen[string(signer)] = true
-			}
+		if !seen[string(xs)] {
+			signers = append(signers, xs)
+			seen[string(xs)] = true
 		}
 	}
 

--- a/x/accounts/keeper.go
+++ b/x/accounts/keeper.go
@@ -51,7 +51,7 @@ type MsgRouter interface {
 // SignerProvider defines an interface used to get the expected sender from a message.
 type SignerProvider interface {
 	// GetMsgV1Signers returns the signers of the message.
-	GetMsgV1Signers(msg gogoproto.Message) ([][]byte, proto.Message, error)
+	GetMsgV1Signers(msg gogoproto.Message) ([]byte, proto.Message, error)
 }
 
 // BranchExecutor defines an interface used to execute ops in a branch.
@@ -336,7 +336,7 @@ func (k Keeper) sendModuleMessage(ctx context.Context, sender []byte, msg, msgRe
 	if len(wantSenders) != 1 {
 		return fmt.Errorf("expected only one signer, got %d", len(wantSenders))
 	}
-	if !bytes.Equal(sender, wantSenders[0]) {
+	if !bytes.Equal(sender, wantSenders) {
 		return fmt.Errorf("%w: sender does not match expected sender", ErrUnauthorized)
 	}
 	messageName := implementation.MessageName(msg)

--- a/x/accounts/utils_test.go
+++ b/x/accounts/utils_test.go
@@ -66,12 +66,12 @@ var _ SignerProvider = (*mockSigner)(nil)
 
 type mockSigner func(msg implementation.ProtoMsg) ([]byte, error)
 
-func (m mockSigner) GetMsgV1Signers(msg gogoproto.Message) ([][]byte, proto.Message, error) {
+func (m mockSigner) GetMsgV1Signers(msg gogoproto.Message) ([]byte, proto.Message, error) {
 	s, err := m(msg)
 	if err != nil {
 		return nil, nil, err
 	}
-	return [][]byte{s}, nil, nil
+	return s, nil, nil
 }
 
 var _ MsgRouter = (*mockExec)(nil)

--- a/x/authz/keeper/keeper.go
+++ b/x/authz/keeper/keeper.go
@@ -103,11 +103,7 @@ func (k Keeper) DispatchActions(ctx context.Context, grantee sdk.AccAddress, msg
 			return nil, err
 		}
 
-		if len(signers) != 1 {
-			return nil, authz.ErrAuthorizationNumOfSigners
-		}
-
-		granter := signers[0]
+		granter := signers
 
 		// If granter != grantee then check authorization.Accept, otherwise we
 		// implicitly accept.

--- a/x/gov/keeper/proposal.go
+++ b/x/gov/keeper/proposal.go
@@ -56,13 +56,10 @@ func (k Keeper) SubmitProposal(ctx context.Context, messages []sdk.Msg, metadata
 		if err != nil {
 			return v1.Proposal{}, err
 		}
-		if len(signers) != 1 {
-			return v1.Proposal{}, types.ErrInvalidSigner
-		}
 
 		// assert that the governance module account is the only signer of the messages
-		if !bytes.Equal(signers[0], k.GetGovernanceAccount(ctx).GetAddress()) {
-			return v1.Proposal{}, errorsmod.Wrapf(types.ErrInvalidSigner, sdk.AccAddress(signers[0]).String())
+		if !bytes.Equal(signers, k.GetGovernanceAccount(ctx).GetAddress()) {
+			return v1.Proposal{}, errorsmod.Wrapf(types.ErrInvalidSigner, sdk.AccAddress(signers).String())
 		}
 
 		// use the msg service router to see that there is a valid route for that message.

--- a/x/tx/decode/decode.go
+++ b/x/tx/decode/decode.go
@@ -107,7 +107,7 @@ func (d *Decoder) Decode(txBytes []byte) (*DecodedTx, error) {
 		if signerErr != nil {
 			return nil, errors.Wrap(ErrTxDecode, signerErr.Error())
 		}
-		signers = append(signers, ss...)
+		signers = append(signers, ss)
 	}
 
 	return &DecodedTx{


### PR DESCRIPTION
# Description

Closes: #18759 

this pr proposes removing multiple signers from a single message, but not a transaction. This pr removes it outright instead of disabling it only. we can do either approach wanted to get started on this

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage
