### PR TITLE
refactor(client/v2): use address codec instead of global

### DIFF
--- a/client/v2/autocli/builder.go
+++ b/client/v2/autocli/builder.go
@@ -1,13 +1,10 @@
 package autocli
 
 import (
-	"errors"
-
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc"
 
 	"cosmossdk.io/client/v2/autocli/flag"
-	"cosmossdk.io/client/v2/autocli/keyring"
 	authtx "cosmossdk.io/x/auth/tx"
 
 	"github.com/cosmos/cosmos-sdk/client"
@@ -35,32 +32,6 @@ type Builder struct {
 
 // ValidateAndComplete the builder fields.
 // It returns an error if any of the required fields are missing.
-// If the Logger is nil, it will be set to a nop logger.
-// If the keyring is nil, it will be set to a no keyring.
 func (b *Builder) ValidateAndComplete() error {
-	if b.Builder.AddressCodec == nil {
-		return errors.New("address codec is required in flag builder")
-	}
-
-	if b.Builder.ValidatorAddressCodec == nil {
-		return errors.New("validator address codec is required in flag builder")
-	}
-
-	if b.Builder.ConsensusAddressCodec == nil {
-		return errors.New("consensus address codec is required in flag builder")
-	}
-
-	if b.Builder.Keyring == nil {
-		b.Keyring = keyring.NoKeyring{}
-	}
-
-	if b.Builder.TypeResolver == nil {
-		return errors.New("type resolver is required in flag builder")
-	}
-
-	if b.Builder.FileResolver == nil {
-		return errors.New("file resolver is required in flag builder")
-	}
-
-	return nil
+	return b.Builder.ValidateAndComplete()
 }

--- a/client/v2/autocli/flag/address.go
+++ b/client/v2/autocli/flag/address.go
@@ -13,7 +13,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec/types"
 	cryptocodec "github.com/cosmos/cosmos-sdk/crypto/codec"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
-	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 type addressStringType struct{}
@@ -133,6 +132,10 @@ func (a *consensusAddressValue) Set(s string) error {
 		return fmt.Errorf("input isn't a pubkey %w or is an invalid account address: %w", err, err2)
 	}
 
-	a.value = sdk.ConsAddress(pk.Address()).String()
+	a.value, err = a.addressCodec.BytesToString(pk.Address())
+	if err != nil {
+		return fmt.Errorf("invalid account address or key name: %w", err)
+	}
+
 	return nil
 }

--- a/client/v2/autocli/flag/address.go
+++ b/client/v2/autocli/flag/address.go
@@ -134,7 +134,7 @@ func (a *consensusAddressValue) Set(s string) error {
 
 	a.value, err = a.addressCodec.BytesToString(pk.Address())
 	if err != nil {
-		return fmt.Errorf("invalid account address or key name: %w", err)
+		return fmt.Errorf("invalid pubkey address: %w", err)
 	}
 
 	return nil

--- a/client/v2/autocli/flag/builder.go
+++ b/client/v2/autocli/flag/builder.go
@@ -2,10 +2,10 @@ package flag
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 
-	"github.com/cockroachdb/errors"
 	cosmos_proto "github.com/cosmos/cosmos-proto"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"

--- a/client/v2/autocli/flag/builder.go
+++ b/client/v2/autocli/flag/builder.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/cockroachdb/errors"
 	cosmos_proto "github.com/cosmos/cosmos-proto"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -71,6 +72,37 @@ func (b *Builder) init() {
 		b.scalarFlagTypes[ValidatorAddressStringScalarType] = validatorAddressStringType{}
 		b.scalarFlagTypes[ConsensusAddressStringScalarType] = consensusAddressStringType{}
 	}
+}
+
+// ValidateAndComplete the flag builder fields.
+// It returns an error if any of the required fields are missing.
+// If the keyring is nil, it will be set to a no keyring.
+func (b *Builder) ValidateAndComplete() error {
+	if b.AddressCodec == nil {
+		return errors.New("address codec is required in flag builder")
+	}
+
+	if b.ValidatorAddressCodec == nil {
+		return errors.New("validator address codec is required in flag builder")
+	}
+
+	if b.ConsensusAddressCodec == nil {
+		return errors.New("consensus address codec is required in flag builder")
+	}
+
+	if b.Keyring == nil {
+		b.Keyring = keyring.NoKeyring{}
+	}
+
+	if b.TypeResolver == nil {
+		return errors.New("type resolver is required in flag builder")
+	}
+
+	if b.FileResolver == nil {
+		return errors.New("file resolver is required in flag builder")
+	}
+
+	return nil
 }
 
 // DefineMessageFlagType allows to extend custom protobuf message type handling for flags (and positional arguments).

--- a/client/v2/autocli/query_test.go
+++ b/client/v2/autocli/query_test.go
@@ -729,6 +729,5 @@ func TestDurationMarshal(t *testing.T) {
 
 	out, err := runCmd(fixture.conn, fixture.b, buildModuleQueryCommand, "echo", "1", "abc", "--duration", "1s")
 	assert.NilError(t, err)
-	fmt.Println(out.String())
 	assert.Assert(t, strings.Contains(out.String(), "duration: 1s"))
 }


### PR DESCRIPTION
# Description

Tiny nits when looking at client/v2 code

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage
