### PR TITLE
chore: fix spelling errors

### DIFF
--- a/docs/architecture/PROCESS.md
+++ b/docs/architecture/PROCESS.md
@@ -8,7 +8,7 @@
 
 ## What is an ADR? 
 
-An ADR is a document to document an implementation and design that may or may not have been discussed in an RFC. While an RFC is meant to replace synchoronus communication in a distributed environment, an ADR is meant to document an already made decision. An ADR won't come with much of a communication overhead because the discussion was recorded in an RFC or a synchronous discussion. If the consensus came from a synchoronus discussion then a short excerpt should be added to the ADR to explain the goals. 
+An ADR is a document to document an implementation and design that may or may not have been discussed in an RFC. While an RFC is meant to replace synchronous communication in a distributed environment, an ADR is meant to document an already made decision. An ADR won't come with much of a communication overhead because the discussion was recorded in an RFC or a synchronous discussion. If the consensus came from a synchoronus discussion then a short excerpt should be added to the ADR to explain the goals. 
 
 ## ADR life cycle
 

--- a/docs/architecture/adr-069-gov-improvements.md
+++ b/docs/architecture/adr-069-gov-improvements.md
@@ -82,7 +82,7 @@ A new vote option `SPAM` will be added and distinguished from those voting optio
 
 Multiple choice proposals, contrary to any other proposal type, cannot have messages to execute. They are only text proposals.
 
-Submitting a new multiple choice proposal will use a different message than the [`v1.MsgSubmitProposal`][5]. This is done in order to simplify the proposal submittion and allow defining the voting options directly.
+Submitting a new multiple choice proposal will use a different message than the [`v1.MsgSubmitProposal`][5]. This is done in order to simplify the proposal submission and allow defining the voting options directly.
 
 
 ```protobuf

--- a/docs/rfc/PROCESS.md
+++ b/docs/rfc/PROCESS.md
@@ -14,7 +14,7 @@ The main difference the Cosmos SDK is defining as a differentiation between RFC 
 
 ## RFC life cycle
 
-RFC creation is an **iterative** process. An RFC is meant as a distributed colloboration session, it may have many comments and is usually the bi-product of no working group or synchornous communication 
+RFC creation is an **iterative** process. An RFC is meant as a distributed colloboration session, it may have many comments and is usually the bi-product of no working group or synchronous communication 
 
 1. Proposals could start with a new GitHub Issue,  be a result of existing Issues or a discussion.
 
@@ -28,7 +28,7 @@ RFC creation is an **iterative** process. An RFC is meant as a distributed collo
 
 6. If there is consensus and enough feedback then the RFC can be accepted. 
 
-> Note: An RFC is written when there is no working group or team session on the problem. RFC's are meant as a distributed white boarding session. If there is a working group on the proposal there is no need to have an RFC as there is synchornous whiteboarding going on. 
+> Note: An RFC is written when there is no working group or team session on the problem. RFC's are meant as a distributed white boarding session. If there is a working group on the proposal there is no need to have an RFC as there is synchronous whiteboarding going on. 
 
 ### RFC status
 
@@ -53,7 +53,7 @@ DRAFT -> PROPOSED -> LAST CALL yyyy-mm-dd -> ACCEPTED | REJECTED -> SUPERSEDED b
 * `LAST CALL <date for the last call>`: [optional] clear notify that we are close to accept updates. Changing a status to `LAST CALL` means that social consensus (of Cosmos SDK maintainers) has been reached and we still want to give it a time to let the community react or analyze.
 * `ACCEPTED`: ADR which will represent a currently implemented or to be implemented architecture design.
 * `REJECTED`: ADR can go from PROPOSED or ACCEPTED to rejected if the consensus among project stakeholders will decide so.
-* `SUPERSEEDED by ADR-xxx`: ADR which has been superseded by a new ADR.
+* `SUPERSEDED by ADR-xxx`: ADR which has been superseded by a new ADR.
 * `ABANDONED`: the ADR is no longer pursued by the original authors.
 
 ## Language used in RFC

--- a/docs/rfc/rfc-001-tx-validation.md
+++ b/docs/rfc/rfc-001-tx-validation.md
@@ -6,7 +6,7 @@
 
 ## Background
 
-Transation Validation is crucial to a functioning state machine. Within the Cosmos SDK there are two validation flows, one is outside the message server and the other within. The flow outside of the message server is the `ValidateBasic` function. It is called in the antehandler on both `CheckTx` and `DeliverTx`. There is an overhead and sometimes duplication of validation within these two flows. This extra validation provides an additional check before entering the mempool.
+Transaction Validation is crucial to a functioning state machine. Within the Cosmos SDK there are two validation flows, one is outside the message server and the other within. The flow outside of the message server is the `ValidateBasic` function. It is called in the antehandler on both `CheckTx` and `DeliverTx`. There is an overhead and sometimes duplication of validation within these two flows. This extra validation provides an additional check before entering the mempool.
 
 With the deprecation of [`GetSigners`](https://github.com/cosmos/cosmos-sdk/issues/11275) we have the optionality to remove [sdk.Msg](https://github.com/cosmos/cosmos-sdk/blob/16a5404f8e00ddcf8857c8a55dca2f7c109c29bc/types/tx_msg.go#L16) and the `ValidateBasic` function. 
 

--- a/store/proof.go
+++ b/store/proof.go
@@ -123,7 +123,7 @@ func (op CommitmentOp) Run(args [][]byte) ([][]byte, error) {
 }
 
 // ProofFromByteSlices computes the proof from the given leaves. An iteration will be
-// perfomed for each level of the tree, where each iteration hashes together the bottom most
+// performed for each level of the tree, where each iteration hashes together the bottom most
 // nodes. If the length of the bottom most nodes is odd, then the last node will be saved
 // for the next iteration.
 //
@@ -163,7 +163,7 @@ func ProofFromByteSlices(leaves [][]byte, index int) (rootHash []byte, inners []
 		// saved until the next iteration).
 		if index < n-1 || index&1 == 1 {
 			inner := &ics23.InnerOp{Hash: ics23.HashOp_SHA256}
-			//Iif proof index is even then child is from left, suffix is populated
+			//If proof index is even then child is from left, suffix is populated
 			// otherwise, child is from right and the prefix is populated.
 			if index&1 == 0 {
 				// inner op(prefix=0x01 | child | suffix=leaves[index+1])

--- a/x/staking/README.md
+++ b/x/staking/README.md
@@ -1631,7 +1631,7 @@ simd tx staking edit-validator [flags]
 Example:
 
 ```bash
-simd tx staking edit-validator --moniker "new_moniker_name" --website "new_webiste_url" --from mykey
+simd tx staking edit-validator --moniker "new_moniker_name" --website "new_website_url" --from mykey
 ```
 
 ##### redelegate


### PR DESCRIPTION
This PR fixes typos in the codebase.
Please review it, and merge if everything is fine.
If there are proto changes, run `make proto-gen` and commit the changes.