### PR TITLE
ci: fix `make lint` reported issues

### DIFF
--- a/store/database.go
+++ b/store/database.go
@@ -3,8 +3,9 @@ package store
 import (
 	"io"
 
-	corestore "cosmossdk.io/core/store"
 	ics23 "github.com/cosmos/ics23/go"
+
+	corestore "cosmossdk.io/core/store"
 )
 
 // Reader wraps the Has and Get method of a backing data store.

--- a/store/proof.go
+++ b/store/proof.go
@@ -163,7 +163,7 @@ func ProofFromByteSlices(leaves [][]byte, index int) (rootHash []byte, inners []
 		// saved until the next iteration).
 		if index < n-1 || index&1 == 1 {
 			inner := &ics23.InnerOp{Hash: ics23.HashOp_SHA256}
-			//If proof index is even then child is from left, suffix is populated
+			// If proof index is even then child is from left, suffix is populated
 			// otherwise, child is from right and the prefix is populated.
 			if index&1 == 0 {
 				// inner op(prefix=0x01 | child | suffix=leaves[index+1])
@@ -190,7 +190,7 @@ func ProofFromByteSlices(leaves [][]byte, index int) (rootHash []byte, inners []
 	}
 
 	rootHash = leaves[0]
-	return
+	return rootHash, inners
 }
 
 // ConvertCommitmentOp converts the given merkle proof into an CommitmentOp.

--- a/store/storage/pebbledb/iterator.go
+++ b/store/storage/pebbledb/iterator.go
@@ -180,7 +180,6 @@ func (itr *iterator) Next() {
 	}
 
 	itr.valid = false
-	return
 }
 
 func (itr *iterator) Valid() bool {

--- a/store/storage/sqlite/iterator.go
+++ b/store/storage/sqlite/iterator.go
@@ -152,7 +152,6 @@ func (itr *iterator) Next() {
 	}
 
 	itr.valid = false
-	return
 }
 
 func (itr *iterator) Error() error {


### PR DESCRIPTION
# Description

This pr fixes all the issues reported by running `make lint`, except for the linting of module `cosmossdk.io/simapp` with `--build-tags=app_v1`.

```shell
linting module cosmossdk.io/simapp [2024-01-15T09:48:10+00:00]
app_config.go:70:2: var `moduleAccPerms` is unused (unused)
        moduleAccPerms = []*authmodulev1.ModuleAccountPermission{
        ^
app_config.go:82:2: var `blockAccAddrs` is unused (unused)
        blockAccAddrs = []string{
        ^
app_config.go:95:2: var `appConfig` is unused (unused)
        appConfig = appconfig.Compose(&appv1alpha1.Config{
        ^
```

## Motivation

If the issues reported by linting `cosmossdk.io/simapp` with `--build-tags=app_v1` could be fixed, I think we could add a git hook for `make lint`, this will prevent contributors from pushing their commits without running `make lint`, reduce the times that team members ask contributors to fix their lint-ci error

![image](https://github.com/cosmos/cosmos-sdk/assets/150114626/9e4068a8-f1df-4ec4-8f25-c72d466aefd5)
