### PR TITLE
feat(accounts): Add codec.BinaryCodec and Gas to dependencies.

### DIFF
--- a/api/cosmos/accounts/testing/counter/v1/counter.pulsar.go
+++ b/api/cosmos/accounts/testing/counter/v1/counter.pulsar.go
@@ -1581,6 +1581,942 @@ func (x *fastReflection_MsgIncreaseCounterResponse) ProtoMethods() *protoiface.M
 }
 
 var (
+	md_MsgTestDependencies protoreflect.MessageDescriptor
+)
+
+func init() {
+	file_cosmos_accounts_testing_counter_v1_counter_proto_init()
+	md_MsgTestDependencies = File_cosmos_accounts_testing_counter_v1_counter_proto.Messages().ByName("MsgTestDependencies")
+}
+
+var _ protoreflect.Message = (*fastReflection_MsgTestDependencies)(nil)
+
+type fastReflection_MsgTestDependencies MsgTestDependencies
+
+func (x *MsgTestDependencies) ProtoReflect() protoreflect.Message {
+	return (*fastReflection_MsgTestDependencies)(x)
+}
+
+func (x *MsgTestDependencies) slowProtoReflect() protoreflect.Message {
+	mi := &file_cosmos_accounts_testing_counter_v1_counter_proto_msgTypes[4]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+var _fastReflection_MsgTestDependencies_messageType fastReflection_MsgTestDependencies_messageType
+var _ protoreflect.MessageType = fastReflection_MsgTestDependencies_messageType{}
+
+type fastReflection_MsgTestDependencies_messageType struct{}
+
+func (x fastReflection_MsgTestDependencies_messageType) Zero() protoreflect.Message {
+	return (*fastReflection_MsgTestDependencies)(nil)
+}
+func (x fastReflection_MsgTestDependencies_messageType) New() protoreflect.Message {
+	return new(fastReflection_MsgTestDependencies)
+}
+func (x fastReflection_MsgTestDependencies_messageType) Descriptor() protoreflect.MessageDescriptor {
+	return md_MsgTestDependencies
+}
+
+// Descriptor returns message descriptor, which contains only the protobuf
+// type information for the message.
+func (x *fastReflection_MsgTestDependencies) Descriptor() protoreflect.MessageDescriptor {
+	return md_MsgTestDependencies
+}
+
+// Type returns the message type, which encapsulates both Go and protobuf
+// type information. If the Go type information is not needed,
+// it is recommended that the message descriptor be used instead.
+func (x *fastReflection_MsgTestDependencies) Type() protoreflect.MessageType {
+	return _fastReflection_MsgTestDependencies_messageType
+}
+
+// New returns a newly allocated and mutable empty message.
+func (x *fastReflection_MsgTestDependencies) New() protoreflect.Message {
+	return new(fastReflection_MsgTestDependencies)
+}
+
+// Interface unwraps the message reflection interface and
+// returns the underlying ProtoMessage interface.
+func (x *fastReflection_MsgTestDependencies) Interface() protoreflect.ProtoMessage {
+	return (*MsgTestDependencies)(x)
+}
+
+// Range iterates over every populated field in an undefined order,
+// calling f for each field descriptor and value encountered.
+// Range returns immediately if f returns false.
+// While iterating, mutating operations may only be performed
+// on the current field descriptor.
+func (x *fastReflection_MsgTestDependencies) Range(f func(protoreflect.FieldDescriptor, protoreflect.Value) bool) {
+}
+
+// Has reports whether a field is populated.
+//
+// Some fields have the property of nullability where it is possible to
+// distinguish between the default value of a field and whether the field
+// was explicitly populated with the default value. Singular message fields,
+// member fields of a oneof, and proto2 scalar fields are nullable. Such
+// fields are populated only if explicitly set.
+//
+// In other cases (aside from the nullable cases above),
+// a proto3 scalar field is populated if it contains a non-zero value, and
+// a repeated field is populated if it is non-empty.
+func (x *fastReflection_MsgTestDependencies) Has(fd protoreflect.FieldDescriptor) bool {
+	switch fd.FullName() {
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: cosmos.accounts.testing.counter.v1.MsgTestDependencies"))
+		}
+		panic(fmt.Errorf("message cosmos.accounts.testing.counter.v1.MsgTestDependencies does not contain field %s", fd.FullName()))
+	}
+}
+
+// Clear clears the field such that a subsequent Has call reports false.
+//
+// Clearing an extension field clears both the extension type and value
+// associated with the given field number.
+//
+// Clear is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_MsgTestDependencies) Clear(fd protoreflect.FieldDescriptor) {
+	switch fd.FullName() {
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: cosmos.accounts.testing.counter.v1.MsgTestDependencies"))
+		}
+		panic(fmt.Errorf("message cosmos.accounts.testing.counter.v1.MsgTestDependencies does not contain field %s", fd.FullName()))
+	}
+}
+
+// Get retrieves the value for a field.
+//
+// For unpopulated scalars, it returns the default value, where
+// the default value of a bytes scalar is guaranteed to be a copy.
+// For unpopulated composite types, it returns an empty, read-only view
+// of the value; to obtain a mutable reference, use Mutable.
+func (x *fastReflection_MsgTestDependencies) Get(descriptor protoreflect.FieldDescriptor) protoreflect.Value {
+	switch descriptor.FullName() {
+	default:
+		if descriptor.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: cosmos.accounts.testing.counter.v1.MsgTestDependencies"))
+		}
+		panic(fmt.Errorf("message cosmos.accounts.testing.counter.v1.MsgTestDependencies does not contain field %s", descriptor.FullName()))
+	}
+}
+
+// Set stores the value for a field.
+//
+// For a field belonging to a oneof, it implicitly clears any other field
+// that may be currently set within the same oneof.
+// For extension fields, it implicitly stores the provided ExtensionType.
+// When setting a composite type, it is unspecified whether the stored value
+// aliases the source's memory in any way. If the composite value is an
+// empty, read-only value, then it panics.
+//
+// Set is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_MsgTestDependencies) Set(fd protoreflect.FieldDescriptor, value protoreflect.Value) {
+	switch fd.FullName() {
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: cosmos.accounts.testing.counter.v1.MsgTestDependencies"))
+		}
+		panic(fmt.Errorf("message cosmos.accounts.testing.counter.v1.MsgTestDependencies does not contain field %s", fd.FullName()))
+	}
+}
+
+// Mutable returns a mutable reference to a composite type.
+//
+// If the field is unpopulated, it may allocate a composite value.
+// For a field belonging to a oneof, it implicitly clears any other field
+// that may be currently set within the same oneof.
+// For extension fields, it implicitly stores the provided ExtensionType
+// if not already stored.
+// It panics if the field does not contain a composite type.
+//
+// Mutable is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_MsgTestDependencies) Mutable(fd protoreflect.FieldDescriptor) protoreflect.Value {
+	switch fd.FullName() {
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: cosmos.accounts.testing.counter.v1.MsgTestDependencies"))
+		}
+		panic(fmt.Errorf("message cosmos.accounts.testing.counter.v1.MsgTestDependencies does not contain field %s", fd.FullName()))
+	}
+}
+
+// NewField returns a new value that is assignable to the field
+// for the given descriptor. For scalars, this returns the default value.
+// For lists, maps, and messages, this returns a new, empty, mutable value.
+func (x *fastReflection_MsgTestDependencies) NewField(fd protoreflect.FieldDescriptor) protoreflect.Value {
+	switch fd.FullName() {
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: cosmos.accounts.testing.counter.v1.MsgTestDependencies"))
+		}
+		panic(fmt.Errorf("message cosmos.accounts.testing.counter.v1.MsgTestDependencies does not contain field %s", fd.FullName()))
+	}
+}
+
+// WhichOneof reports which field within the oneof is populated,
+// returning nil if none are populated.
+// It panics if the oneof descriptor does not belong to this message.
+func (x *fastReflection_MsgTestDependencies) WhichOneof(d protoreflect.OneofDescriptor) protoreflect.FieldDescriptor {
+	switch d.FullName() {
+	default:
+		panic(fmt.Errorf("%s is not a oneof field in cosmos.accounts.testing.counter.v1.MsgTestDependencies", d.FullName()))
+	}
+	panic("unreachable")
+}
+
+// GetUnknown retrieves the entire list of unknown fields.
+// The caller may only mutate the contents of the RawFields
+// if the mutated bytes are stored back into the message with SetUnknown.
+func (x *fastReflection_MsgTestDependencies) GetUnknown() protoreflect.RawFields {
+	return x.unknownFields
+}
+
+// SetUnknown stores an entire list of unknown fields.
+// The raw fields must be syntactically valid according to the wire format.
+// An implementation may panic if this is not the case.
+// Once stored, the caller must not mutate the content of the RawFields.
+// An empty RawFields may be passed to clear the fields.
+//
+// SetUnknown is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_MsgTestDependencies) SetUnknown(fields protoreflect.RawFields) {
+	x.unknownFields = fields
+}
+
+// IsValid reports whether the message is valid.
+//
+// An invalid message is an empty, read-only value.
+//
+// An invalid message often corresponds to a nil pointer of the concrete
+// message type, but the details are implementation dependent.
+// Validity is not part of the protobuf data model, and may not
+// be preserved in marshaling or other operations.
+func (x *fastReflection_MsgTestDependencies) IsValid() bool {
+	return x != nil
+}
+
+// ProtoMethods returns optional fastReflectionFeature-path implementations of various operations.
+// This method may return nil.
+//
+// The returned methods type is identical to
+// "google.golang.org/protobuf/runtime/protoiface".Methods.
+// Consult the protoiface package documentation for details.
+func (x *fastReflection_MsgTestDependencies) ProtoMethods() *protoiface.Methods {
+	size := func(input protoiface.SizeInput) protoiface.SizeOutput {
+		x := input.Message.Interface().(*MsgTestDependencies)
+		if x == nil {
+			return protoiface.SizeOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Size:              0,
+			}
+		}
+		options := runtime.SizeInputToOptions(input)
+		_ = options
+		var n int
+		var l int
+		_ = l
+		if x.unknownFields != nil {
+			n += len(x.unknownFields)
+		}
+		return protoiface.SizeOutput{
+			NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+			Size:              n,
+		}
+	}
+
+	marshal := func(input protoiface.MarshalInput) (protoiface.MarshalOutput, error) {
+		x := input.Message.Interface().(*MsgTestDependencies)
+		if x == nil {
+			return protoiface.MarshalOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Buf:               input.Buf,
+			}, nil
+		}
+		options := runtime.MarshalInputToOptions(input)
+		_ = options
+		size := options.Size(x)
+		dAtA := make([]byte, size)
+		i := len(dAtA)
+		_ = i
+		var l int
+		_ = l
+		if x.unknownFields != nil {
+			i -= len(x.unknownFields)
+			copy(dAtA[i:], x.unknownFields)
+		}
+		if input.Buf != nil {
+			input.Buf = append(input.Buf, dAtA...)
+		} else {
+			input.Buf = dAtA
+		}
+		return protoiface.MarshalOutput{
+			NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+			Buf:               input.Buf,
+		}, nil
+	}
+	unmarshal := func(input protoiface.UnmarshalInput) (protoiface.UnmarshalOutput, error) {
+		x := input.Message.Interface().(*MsgTestDependencies)
+		if x == nil {
+			return protoiface.UnmarshalOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Flags:             input.Flags,
+			}, nil
+		}
+		options := runtime.UnmarshalInputToOptions(input)
+		_ = options
+		dAtA := input.Buf
+		l := len(dAtA)
+		iNdEx := 0
+		for iNdEx < l {
+			preIndex := iNdEx
+			var wire uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				wire |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			fieldNum := int32(wire >> 3)
+			wireType := int(wire & 0x7)
+			if wireType == 4 {
+				return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: MsgTestDependencies: wiretype end group for non-group")
+			}
+			if fieldNum <= 0 {
+				return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: MsgTestDependencies: illegal tag %d (wire type %d)", fieldNum, wire)
+			}
+			switch fieldNum {
+			default:
+				iNdEx = preIndex
+				skippy, err := runtime.Skip(dAtA[iNdEx:])
+				if err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				if (skippy < 0) || (iNdEx+skippy) < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if (iNdEx + skippy) > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				if !options.DiscardUnknown {
+					x.unknownFields = append(x.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+				}
+				iNdEx += skippy
+			}
+		}
+
+		if iNdEx > l {
+			return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+		}
+		return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, nil
+	}
+	return &protoiface.Methods{
+		NoUnkeyedLiterals: struct{}{},
+		Flags:             protoiface.SupportMarshalDeterministic | protoiface.SupportUnmarshalDiscardUnknown,
+		Size:              size,
+		Marshal:           marshal,
+		Unmarshal:         unmarshal,
+		Merge:             nil,
+		CheckInitialized:  nil,
+	}
+}
+
+var (
+	md_MsgTestDependenciesResponse            protoreflect.MessageDescriptor
+	fd_MsgTestDependenciesResponse_chain_id   protoreflect.FieldDescriptor
+	fd_MsgTestDependenciesResponse_address    protoreflect.FieldDescriptor
+	fd_MsgTestDependenciesResponse_before_gas protoreflect.FieldDescriptor
+	fd_MsgTestDependenciesResponse_after_gas  protoreflect.FieldDescriptor
+)
+
+func init() {
+	file_cosmos_accounts_testing_counter_v1_counter_proto_init()
+	md_MsgTestDependenciesResponse = File_cosmos_accounts_testing_counter_v1_counter_proto.Messages().ByName("MsgTestDependenciesResponse")
+	fd_MsgTestDependenciesResponse_chain_id = md_MsgTestDependenciesResponse.Fields().ByName("chain_id")
+	fd_MsgTestDependenciesResponse_address = md_MsgTestDependenciesResponse.Fields().ByName("address")
+	fd_MsgTestDependenciesResponse_before_gas = md_MsgTestDependenciesResponse.Fields().ByName("before_gas")
+	fd_MsgTestDependenciesResponse_after_gas = md_MsgTestDependenciesResponse.Fields().ByName("after_gas")
+}
+
+var _ protoreflect.Message = (*fastReflection_MsgTestDependenciesResponse)(nil)
+
+type fastReflection_MsgTestDependenciesResponse MsgTestDependenciesResponse
+
+func (x *MsgTestDependenciesResponse) ProtoReflect() protoreflect.Message {
+	return (*fastReflection_MsgTestDependenciesResponse)(x)
+}
+
+func (x *MsgTestDependenciesResponse) slowProtoReflect() protoreflect.Message {
+	mi := &file_cosmos_accounts_testing_counter_v1_counter_proto_msgTypes[5]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+var _fastReflection_MsgTestDependenciesResponse_messageType fastReflection_MsgTestDependenciesResponse_messageType
+var _ protoreflect.MessageType = fastReflection_MsgTestDependenciesResponse_messageType{}
+
+type fastReflection_MsgTestDependenciesResponse_messageType struct{}
+
+func (x fastReflection_MsgTestDependenciesResponse_messageType) Zero() protoreflect.Message {
+	return (*fastReflection_MsgTestDependenciesResponse)(nil)
+}
+func (x fastReflection_MsgTestDependenciesResponse_messageType) New() protoreflect.Message {
+	return new(fastReflection_MsgTestDependenciesResponse)
+}
+func (x fastReflection_MsgTestDependenciesResponse_messageType) Descriptor() protoreflect.MessageDescriptor {
+	return md_MsgTestDependenciesResponse
+}
+
+// Descriptor returns message descriptor, which contains only the protobuf
+// type information for the message.
+func (x *fastReflection_MsgTestDependenciesResponse) Descriptor() protoreflect.MessageDescriptor {
+	return md_MsgTestDependenciesResponse
+}
+
+// Type returns the message type, which encapsulates both Go and protobuf
+// type information. If the Go type information is not needed,
+// it is recommended that the message descriptor be used instead.
+func (x *fastReflection_MsgTestDependenciesResponse) Type() protoreflect.MessageType {
+	return _fastReflection_MsgTestDependenciesResponse_messageType
+}
+
+// New returns a newly allocated and mutable empty message.
+func (x *fastReflection_MsgTestDependenciesResponse) New() protoreflect.Message {
+	return new(fastReflection_MsgTestDependenciesResponse)
+}
+
+// Interface unwraps the message reflection interface and
+// returns the underlying ProtoMessage interface.
+func (x *fastReflection_MsgTestDependenciesResponse) Interface() protoreflect.ProtoMessage {
+	return (*MsgTestDependenciesResponse)(x)
+}
+
+// Range iterates over every populated field in an undefined order,
+// calling f for each field descriptor and value encountered.
+// Range returns immediately if f returns false.
+// While iterating, mutating operations may only be performed
+// on the current field descriptor.
+func (x *fastReflection_MsgTestDependenciesResponse) Range(f func(protoreflect.FieldDescriptor, protoreflect.Value) bool) {
+	if x.ChainId != "" {
+		value := protoreflect.ValueOfString(x.ChainId)
+		if !f(fd_MsgTestDependenciesResponse_chain_id, value) {
+			return
+		}
+	}
+	if x.Address != "" {
+		value := protoreflect.ValueOfString(x.Address)
+		if !f(fd_MsgTestDependenciesResponse_address, value) {
+			return
+		}
+	}
+	if x.BeforeGas != uint64(0) {
+		value := protoreflect.ValueOfUint64(x.BeforeGas)
+		if !f(fd_MsgTestDependenciesResponse_before_gas, value) {
+			return
+		}
+	}
+	if x.AfterGas != uint64(0) {
+		value := protoreflect.ValueOfUint64(x.AfterGas)
+		if !f(fd_MsgTestDependenciesResponse_after_gas, value) {
+			return
+		}
+	}
+}
+
+// Has reports whether a field is populated.
+//
+// Some fields have the property of nullability where it is possible to
+// distinguish between the default value of a field and whether the field
+// was explicitly populated with the default value. Singular message fields,
+// member fields of a oneof, and proto2 scalar fields are nullable. Such
+// fields are populated only if explicitly set.
+//
+// In other cases (aside from the nullable cases above),
+// a proto3 scalar field is populated if it contains a non-zero value, and
+// a repeated field is populated if it is non-empty.
+func (x *fastReflection_MsgTestDependenciesResponse) Has(fd protoreflect.FieldDescriptor) bool {
+	switch fd.FullName() {
+	case "cosmos.accounts.testing.counter.v1.MsgTestDependenciesResponse.chain_id":
+		return x.ChainId != ""
+	case "cosmos.accounts.testing.counter.v1.MsgTestDependenciesResponse.address":
+		return x.Address != ""
+	case "cosmos.accounts.testing.counter.v1.MsgTestDependenciesResponse.before_gas":
+		return x.BeforeGas != uint64(0)
+	case "cosmos.accounts.testing.counter.v1.MsgTestDependenciesResponse.after_gas":
+		return x.AfterGas != uint64(0)
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: cosmos.accounts.testing.counter.v1.MsgTestDependenciesResponse"))
+		}
+		panic(fmt.Errorf("message cosmos.accounts.testing.counter.v1.MsgTestDependenciesResponse does not contain field %s", fd.FullName()))
+	}
+}
+
+// Clear clears the field such that a subsequent Has call reports false.
+//
+// Clearing an extension field clears both the extension type and value
+// associated with the given field number.
+//
+// Clear is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_MsgTestDependenciesResponse) Clear(fd protoreflect.FieldDescriptor) {
+	switch fd.FullName() {
+	case "cosmos.accounts.testing.counter.v1.MsgTestDependenciesResponse.chain_id":
+		x.ChainId = ""
+	case "cosmos.accounts.testing.counter.v1.MsgTestDependenciesResponse.address":
+		x.Address = ""
+	case "cosmos.accounts.testing.counter.v1.MsgTestDependenciesResponse.before_gas":
+		x.BeforeGas = uint64(0)
+	case "cosmos.accounts.testing.counter.v1.MsgTestDependenciesResponse.after_gas":
+		x.AfterGas = uint64(0)
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: cosmos.accounts.testing.counter.v1.MsgTestDependenciesResponse"))
+		}
+		panic(fmt.Errorf("message cosmos.accounts.testing.counter.v1.MsgTestDependenciesResponse does not contain field %s", fd.FullName()))
+	}
+}
+
+// Get retrieves the value for a field.
+//
+// For unpopulated scalars, it returns the default value, where
+// the default value of a bytes scalar is guaranteed to be a copy.
+// For unpopulated composite types, it returns an empty, read-only view
+// of the value; to obtain a mutable reference, use Mutable.
+func (x *fastReflection_MsgTestDependenciesResponse) Get(descriptor protoreflect.FieldDescriptor) protoreflect.Value {
+	switch descriptor.FullName() {
+	case "cosmos.accounts.testing.counter.v1.MsgTestDependenciesResponse.chain_id":
+		value := x.ChainId
+		return protoreflect.ValueOfString(value)
+	case "cosmos.accounts.testing.counter.v1.MsgTestDependenciesResponse.address":
+		value := x.Address
+		return protoreflect.ValueOfString(value)
+	case "cosmos.accounts.testing.counter.v1.MsgTestDependenciesResponse.before_gas":
+		value := x.BeforeGas
+		return protoreflect.ValueOfUint64(value)
+	case "cosmos.accounts.testing.counter.v1.MsgTestDependenciesResponse.after_gas":
+		value := x.AfterGas
+		return protoreflect.ValueOfUint64(value)
+	default:
+		if descriptor.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: cosmos.accounts.testing.counter.v1.MsgTestDependenciesResponse"))
+		}
+		panic(fmt.Errorf("message cosmos.accounts.testing.counter.v1.MsgTestDependenciesResponse does not contain field %s", descriptor.FullName()))
+	}
+}
+
+// Set stores the value for a field.
+//
+// For a field belonging to a oneof, it implicitly clears any other field
+// that may be currently set within the same oneof.
+// For extension fields, it implicitly stores the provided ExtensionType.
+// When setting a composite type, it is unspecified whether the stored value
+// aliases the source's memory in any way. If the composite value is an
+// empty, read-only value, then it panics.
+//
+// Set is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_MsgTestDependenciesResponse) Set(fd protoreflect.FieldDescriptor, value protoreflect.Value) {
+	switch fd.FullName() {
+	case "cosmos.accounts.testing.counter.v1.MsgTestDependenciesResponse.chain_id":
+		x.ChainId = value.Interface().(string)
+	case "cosmos.accounts.testing.counter.v1.MsgTestDependenciesResponse.address":
+		x.Address = value.Interface().(string)
+	case "cosmos.accounts.testing.counter.v1.MsgTestDependenciesResponse.before_gas":
+		x.BeforeGas = value.Uint()
+	case "cosmos.accounts.testing.counter.v1.MsgTestDependenciesResponse.after_gas":
+		x.AfterGas = value.Uint()
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: cosmos.accounts.testing.counter.v1.MsgTestDependenciesResponse"))
+		}
+		panic(fmt.Errorf("message cosmos.accounts.testing.counter.v1.MsgTestDependenciesResponse does not contain field %s", fd.FullName()))
+	}
+}
+
+// Mutable returns a mutable reference to a composite type.
+//
+// If the field is unpopulated, it may allocate a composite value.
+// For a field belonging to a oneof, it implicitly clears any other field
+// that may be currently set within the same oneof.
+// For extension fields, it implicitly stores the provided ExtensionType
+// if not already stored.
+// It panics if the field does not contain a composite type.
+//
+// Mutable is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_MsgTestDependenciesResponse) Mutable(fd protoreflect.FieldDescriptor) protoreflect.Value {
+	switch fd.FullName() {
+	case "cosmos.accounts.testing.counter.v1.MsgTestDependenciesResponse.chain_id":
+		panic(fmt.Errorf("field chain_id of message cosmos.accounts.testing.counter.v1.MsgTestDependenciesResponse is not mutable"))
+	case "cosmos.accounts.testing.counter.v1.MsgTestDependenciesResponse.address":
+		panic(fmt.Errorf("field address of message cosmos.accounts.testing.counter.v1.MsgTestDependenciesResponse is not mutable"))
+	case "cosmos.accounts.testing.counter.v1.MsgTestDependenciesResponse.before_gas":
+		panic(fmt.Errorf("field before_gas of message cosmos.accounts.testing.counter.v1.MsgTestDependenciesResponse is not mutable"))
+	case "cosmos.accounts.testing.counter.v1.MsgTestDependenciesResponse.after_gas":
+		panic(fmt.Errorf("field after_gas of message cosmos.accounts.testing.counter.v1.MsgTestDependenciesResponse is not mutable"))
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: cosmos.accounts.testing.counter.v1.MsgTestDependenciesResponse"))
+		}
+		panic(fmt.Errorf("message cosmos.accounts.testing.counter.v1.MsgTestDependenciesResponse does not contain field %s", fd.FullName()))
+	}
+}
+
+// NewField returns a new value that is assignable to the field
+// for the given descriptor. For scalars, this returns the default value.
+// For lists, maps, and messages, this returns a new, empty, mutable value.
+func (x *fastReflection_MsgTestDependenciesResponse) NewField(fd protoreflect.FieldDescriptor) protoreflect.Value {
+	switch fd.FullName() {
+	case "cosmos.accounts.testing.counter.v1.MsgTestDependenciesResponse.chain_id":
+		return protoreflect.ValueOfString("")
+	case "cosmos.accounts.testing.counter.v1.MsgTestDependenciesResponse.address":
+		return protoreflect.ValueOfString("")
+	case "cosmos.accounts.testing.counter.v1.MsgTestDependenciesResponse.before_gas":
+		return protoreflect.ValueOfUint64(uint64(0))
+	case "cosmos.accounts.testing.counter.v1.MsgTestDependenciesResponse.after_gas":
+		return protoreflect.ValueOfUint64(uint64(0))
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: cosmos.accounts.testing.counter.v1.MsgTestDependenciesResponse"))
+		}
+		panic(fmt.Errorf("message cosmos.accounts.testing.counter.v1.MsgTestDependenciesResponse does not contain field %s", fd.FullName()))
+	}
+}
+
+// WhichOneof reports which field within the oneof is populated,
+// returning nil if none are populated.
+// It panics if the oneof descriptor does not belong to this message.
+func (x *fastReflection_MsgTestDependenciesResponse) WhichOneof(d protoreflect.OneofDescriptor) protoreflect.FieldDescriptor {
+	switch d.FullName() {
+	default:
+		panic(fmt.Errorf("%s is not a oneof field in cosmos.accounts.testing.counter.v1.MsgTestDependenciesResponse", d.FullName()))
+	}
+	panic("unreachable")
+}
+
+// GetUnknown retrieves the entire list of unknown fields.
+// The caller may only mutate the contents of the RawFields
+// if the mutated bytes are stored back into the message with SetUnknown.
+func (x *fastReflection_MsgTestDependenciesResponse) GetUnknown() protoreflect.RawFields {
+	return x.unknownFields
+}
+
+// SetUnknown stores an entire list of unknown fields.
+// The raw fields must be syntactically valid according to the wire format.
+// An implementation may panic if this is not the case.
+// Once stored, the caller must not mutate the content of the RawFields.
+// An empty RawFields may be passed to clear the fields.
+//
+// SetUnknown is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_MsgTestDependenciesResponse) SetUnknown(fields protoreflect.RawFields) {
+	x.unknownFields = fields
+}
+
+// IsValid reports whether the message is valid.
+//
+// An invalid message is an empty, read-only value.
+//
+// An invalid message often corresponds to a nil pointer of the concrete
+// message type, but the details are implementation dependent.
+// Validity is not part of the protobuf data model, and may not
+// be preserved in marshaling or other operations.
+func (x *fastReflection_MsgTestDependenciesResponse) IsValid() bool {
+	return x != nil
+}
+
+// ProtoMethods returns optional fastReflectionFeature-path implementations of various operations.
+// This method may return nil.
+//
+// The returned methods type is identical to
+// "google.golang.org/protobuf/runtime/protoiface".Methods.
+// Consult the protoiface package documentation for details.
+func (x *fastReflection_MsgTestDependenciesResponse) ProtoMethods() *protoiface.Methods {
+	size := func(input protoiface.SizeInput) protoiface.SizeOutput {
+		x := input.Message.Interface().(*MsgTestDependenciesResponse)
+		if x == nil {
+			return protoiface.SizeOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Size:              0,
+			}
+		}
+		options := runtime.SizeInputToOptions(input)
+		_ = options
+		var n int
+		var l int
+		_ = l
+		l = len(x.ChainId)
+		if l > 0 {
+			n += 1 + l + runtime.Sov(uint64(l))
+		}
+		l = len(x.Address)
+		if l > 0 {
+			n += 1 + l + runtime.Sov(uint64(l))
+		}
+		if x.BeforeGas != 0 {
+			n += 1 + runtime.Sov(uint64(x.BeforeGas))
+		}
+		if x.AfterGas != 0 {
+			n += 1 + runtime.Sov(uint64(x.AfterGas))
+		}
+		if x.unknownFields != nil {
+			n += len(x.unknownFields)
+		}
+		return protoiface.SizeOutput{
+			NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+			Size:              n,
+		}
+	}
+
+	marshal := func(input protoiface.MarshalInput) (protoiface.MarshalOutput, error) {
+		x := input.Message.Interface().(*MsgTestDependenciesResponse)
+		if x == nil {
+			return protoiface.MarshalOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Buf:               input.Buf,
+			}, nil
+		}
+		options := runtime.MarshalInputToOptions(input)
+		_ = options
+		size := options.Size(x)
+		dAtA := make([]byte, size)
+		i := len(dAtA)
+		_ = i
+		var l int
+		_ = l
+		if x.unknownFields != nil {
+			i -= len(x.unknownFields)
+			copy(dAtA[i:], x.unknownFields)
+		}
+		if x.AfterGas != 0 {
+			i = runtime.EncodeVarint(dAtA, i, uint64(x.AfterGas))
+			i--
+			dAtA[i] = 0x20
+		}
+		if x.BeforeGas != 0 {
+			i = runtime.EncodeVarint(dAtA, i, uint64(x.BeforeGas))
+			i--
+			dAtA[i] = 0x18
+		}
+		if len(x.Address) > 0 {
+			i -= len(x.Address)
+			copy(dAtA[i:], x.Address)
+			i = runtime.EncodeVarint(dAtA, i, uint64(len(x.Address)))
+			i--
+			dAtA[i] = 0x12
+		}
+		if len(x.ChainId) > 0 {
+			i -= len(x.ChainId)
+			copy(dAtA[i:], x.ChainId)
+			i = runtime.EncodeVarint(dAtA, i, uint64(len(x.ChainId)))
+			i--
+			dAtA[i] = 0xa
+		}
+		if input.Buf != nil {
+			input.Buf = append(input.Buf, dAtA...)
+		} else {
+			input.Buf = dAtA
+		}
+		return protoiface.MarshalOutput{
+			NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+			Buf:               input.Buf,
+		}, nil
+	}
+	unmarshal := func(input protoiface.UnmarshalInput) (protoiface.UnmarshalOutput, error) {
+		x := input.Message.Interface().(*MsgTestDependenciesResponse)
+		if x == nil {
+			return protoiface.UnmarshalOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Flags:             input.Flags,
+			}, nil
+		}
+		options := runtime.UnmarshalInputToOptions(input)
+		_ = options
+		dAtA := input.Buf
+		l := len(dAtA)
+		iNdEx := 0
+		for iNdEx < l {
+			preIndex := iNdEx
+			var wire uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				wire |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			fieldNum := int32(wire >> 3)
+			wireType := int(wire & 0x7)
+			if wireType == 4 {
+				return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: MsgTestDependenciesResponse: wiretype end group for non-group")
+			}
+			if fieldNum <= 0 {
+				return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: MsgTestDependenciesResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+			}
+			switch fieldNum {
+			case 1:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field ChainId", wireType)
+				}
+				var stringLen uint64
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					stringLen |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				intStringLen := int(stringLen)
+				if intStringLen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + intStringLen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				x.ChainId = string(dAtA[iNdEx:postIndex])
+				iNdEx = postIndex
+			case 2:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field Address", wireType)
+				}
+				var stringLen uint64
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					stringLen |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				intStringLen := int(stringLen)
+				if intStringLen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + intStringLen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				x.Address = string(dAtA[iNdEx:postIndex])
+				iNdEx = postIndex
+			case 3:
+				if wireType != 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field BeforeGas", wireType)
+				}
+				x.BeforeGas = 0
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					x.BeforeGas |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+			case 4:
+				if wireType != 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field AfterGas", wireType)
+				}
+				x.AfterGas = 0
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					x.AfterGas |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+			default:
+				iNdEx = preIndex
+				skippy, err := runtime.Skip(dAtA[iNdEx:])
+				if err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				if (skippy < 0) || (iNdEx+skippy) < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if (iNdEx + skippy) > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				if !options.DiscardUnknown {
+					x.unknownFields = append(x.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+				}
+				iNdEx += skippy
+			}
+		}
+
+		if iNdEx > l {
+			return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+		}
+		return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, nil
+	}
+	return &protoiface.Methods{
+		NoUnkeyedLiterals: struct{}{},
+		Flags:             protoiface.SupportMarshalDeterministic | protoiface.SupportUnmarshalDiscardUnknown,
+		Size:              size,
+		Marshal:           marshal,
+		Unmarshal:         unmarshal,
+		Merge:             nil,
+		CheckInitialized:  nil,
+	}
+}
+
+var (
 	md_QueryCounterRequest protoreflect.MessageDescriptor
 )
 
@@ -1598,7 +2534,7 @@ func (x *QueryCounterRequest) ProtoReflect() protoreflect.Message {
 }
 
 func (x *QueryCounterRequest) slowProtoReflect() protoreflect.Message {
-	mi := &file_cosmos_accounts_testing_counter_v1_counter_proto_msgTypes[4]
+	mi := &file_cosmos_accounts_testing_counter_v1_counter_proto_msgTypes[6]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1956,7 +2892,7 @@ func (x *QueryCounterResponse) ProtoReflect() protoreflect.Message {
 }
 
 func (x *QueryCounterResponse) slowProtoReflect() protoreflect.Message {
-	mi := &file_cosmos_accounts_testing_counter_v1_counter_proto_msgTypes[5]
+	mi := &file_cosmos_accounts_testing_counter_v1_counter_proto_msgTypes[7]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2492,6 +3428,97 @@ func (x *MsgIncreaseCounterResponse) GetNewAmount() uint64 {
 	return 0
 }
 
+// MsgTestDependencies is used to test the dependencies.
+type MsgTestDependencies struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+}
+
+func (x *MsgTestDependencies) Reset() {
+	*x = MsgTestDependencies{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_cosmos_accounts_testing_counter_v1_counter_proto_msgTypes[4]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *MsgTestDependencies) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*MsgTestDependencies) ProtoMessage() {}
+
+// Deprecated: Use MsgTestDependencies.ProtoReflect.Descriptor instead.
+func (*MsgTestDependencies) Descriptor() ([]byte, []int) {
+	return file_cosmos_accounts_testing_counter_v1_counter_proto_rawDescGZIP(), []int{4}
+}
+
+// MsgTestDependenciesResponse is used to test the dependencies.
+type MsgTestDependenciesResponse struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	// chain_id is used to test that the header service correctly works.
+	ChainId string `protobuf:"bytes,1,opt,name=chain_id,json=chainId,proto3" json:"chain_id,omitempty"`
+	// address is used to test address codec.
+	Address string `protobuf:"bytes,2,opt,name=address,proto3" json:"address,omitempty"`
+	// before_gas is used to test the gas meter reporting.
+	BeforeGas uint64 `protobuf:"varint,3,opt,name=before_gas,json=beforeGas,proto3" json:"before_gas,omitempty"`
+	// after_gas is used to test gas meter increasing.
+	AfterGas uint64 `protobuf:"varint,4,opt,name=after_gas,json=afterGas,proto3" json:"after_gas,omitempty"`
+}
+
+func (x *MsgTestDependenciesResponse) Reset() {
+	*x = MsgTestDependenciesResponse{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_cosmos_accounts_testing_counter_v1_counter_proto_msgTypes[5]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *MsgTestDependenciesResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*MsgTestDependenciesResponse) ProtoMessage() {}
+
+// Deprecated: Use MsgTestDependenciesResponse.ProtoReflect.Descriptor instead.
+func (*MsgTestDependenciesResponse) Descriptor() ([]byte, []int) {
+	return file_cosmos_accounts_testing_counter_v1_counter_proto_rawDescGZIP(), []int{5}
+}
+
+func (x *MsgTestDependenciesResponse) GetChainId() string {
+	if x != nil {
+		return x.ChainId
+	}
+	return ""
+}
+
+func (x *MsgTestDependenciesResponse) GetAddress() string {
+	if x != nil {
+		return x.Address
+	}
+	return ""
+}
+
+func (x *MsgTestDependenciesResponse) GetBeforeGas() uint64 {
+	if x != nil {
+		return x.BeforeGas
+	}
+	return 0
+}
+
+func (x *MsgTestDependenciesResponse) GetAfterGas() uint64 {
+	if x != nil {
+		return x.AfterGas
+	}
+	return 0
+}
+
 // QueryCounterRequest is used to query the counter value.
 type QueryCounterRequest struct {
 	state         protoimpl.MessageState
@@ -2502,7 +3529,7 @@ type QueryCounterRequest struct {
 func (x *QueryCounterRequest) Reset() {
 	*x = QueryCounterRequest{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_cosmos_accounts_testing_counter_v1_counter_proto_msgTypes[4]
+		mi := &file_cosmos_accounts_testing_counter_v1_counter_proto_msgTypes[6]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -2516,7 +3543,7 @@ func (*QueryCounterRequest) ProtoMessage() {}
 
 // Deprecated: Use QueryCounterRequest.ProtoReflect.Descriptor instead.
 func (*QueryCounterRequest) Descriptor() ([]byte, []int) {
-	return file_cosmos_accounts_testing_counter_v1_counter_proto_rawDescGZIP(), []int{4}
+	return file_cosmos_accounts_testing_counter_v1_counter_proto_rawDescGZIP(), []int{6}
 }
 
 // QueryCounterResponse returns the counter value.
@@ -2532,7 +3559,7 @@ type QueryCounterResponse struct {
 func (x *QueryCounterResponse) Reset() {
 	*x = QueryCounterResponse{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_cosmos_accounts_testing_counter_v1_counter_proto_msgTypes[5]
+		mi := &file_cosmos_accounts_testing_counter_v1_counter_proto_msgTypes[7]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -2546,7 +3573,7 @@ func (*QueryCounterResponse) ProtoMessage() {}
 
 // Deprecated: Use QueryCounterResponse.ProtoReflect.Descriptor instead.
 func (*QueryCounterResponse) Descriptor() ([]byte, []int) {
-	return file_cosmos_accounts_testing_counter_v1_counter_proto_rawDescGZIP(), []int{5}
+	return file_cosmos_accounts_testing_counter_v1_counter_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *QueryCounterResponse) GetValue() uint64 {
@@ -2575,30 +3602,40 @@ var file_cosmos_accounts_testing_counter_v1_counter_proto_rawDesc = []byte{
 	0x63, 0x72, 0x65, 0x61, 0x73, 0x65, 0x43, 0x6f, 0x75, 0x6e, 0x74, 0x65, 0x72, 0x52, 0x65, 0x73,
 	0x70, 0x6f, 0x6e, 0x73, 0x65, 0x12, 0x1d, 0x0a, 0x0a, 0x6e, 0x65, 0x77, 0x5f, 0x61, 0x6d, 0x6f,
 	0x75, 0x6e, 0x74, 0x18, 0x01, 0x20, 0x01, 0x28, 0x04, 0x52, 0x09, 0x6e, 0x65, 0x77, 0x41, 0x6d,
-	0x6f, 0x75, 0x6e, 0x74, 0x22, 0x15, 0x0a, 0x13, 0x51, 0x75, 0x65, 0x72, 0x79, 0x43, 0x6f, 0x75,
-	0x6e, 0x74, 0x65, 0x72, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x22, 0x2c, 0x0a, 0x14, 0x51,
-	0x75, 0x65, 0x72, 0x79, 0x43, 0x6f, 0x75, 0x6e, 0x74, 0x65, 0x72, 0x52, 0x65, 0x73, 0x70, 0x6f,
-	0x6e, 0x73, 0x65, 0x12, 0x14, 0x0a, 0x05, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x18, 0x01, 0x20, 0x01,
-	0x28, 0x04, 0x52, 0x05, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x42, 0xa2, 0x02, 0x0a, 0x26, 0x63, 0x6f,
-	0x6d, 0x2e, 0x63, 0x6f, 0x73, 0x6d, 0x6f, 0x73, 0x2e, 0x61, 0x63, 0x63, 0x6f, 0x75, 0x6e, 0x74,
-	0x73, 0x2e, 0x74, 0x65, 0x73, 0x74, 0x69, 0x6e, 0x67, 0x2e, 0x63, 0x6f, 0x75, 0x6e, 0x74, 0x65,
-	0x72, 0x2e, 0x76, 0x31, 0x42, 0x0c, 0x43, 0x6f, 0x75, 0x6e, 0x74, 0x65, 0x72, 0x50, 0x72, 0x6f,
-	0x74, 0x6f, 0x50, 0x01, 0x5a, 0x3d, 0x63, 0x6f, 0x73, 0x6d, 0x6f, 0x73, 0x73, 0x64, 0x6b, 0x2e,
-	0x69, 0x6f, 0x2f, 0x61, 0x70, 0x69, 0x2f, 0x63, 0x6f, 0x73, 0x6d, 0x6f, 0x73, 0x2f, 0x61, 0x63,
-	0x63, 0x6f, 0x75, 0x6e, 0x74, 0x73, 0x2f, 0x74, 0x65, 0x73, 0x74, 0x69, 0x6e, 0x67, 0x2f, 0x63,
-	0x6f, 0x75, 0x6e, 0x74, 0x65, 0x72, 0x2f, 0x76, 0x31, 0x3b, 0x63, 0x6f, 0x75, 0x6e, 0x74, 0x65,
-	0x72, 0x76, 0x31, 0xa2, 0x02, 0x04, 0x43, 0x41, 0x54, 0x43, 0xaa, 0x02, 0x22, 0x43, 0x6f, 0x73,
-	0x6d, 0x6f, 0x73, 0x2e, 0x41, 0x63, 0x63, 0x6f, 0x75, 0x6e, 0x74, 0x73, 0x2e, 0x54, 0x65, 0x73,
-	0x74, 0x69, 0x6e, 0x67, 0x2e, 0x43, 0x6f, 0x75, 0x6e, 0x74, 0x65, 0x72, 0x2e, 0x56, 0x31, 0xca,
-	0x02, 0x22, 0x43, 0x6f, 0x73, 0x6d, 0x6f, 0x73, 0x5c, 0x41, 0x63, 0x63, 0x6f, 0x75, 0x6e, 0x74,
-	0x73, 0x5c, 0x54, 0x65, 0x73, 0x74, 0x69, 0x6e, 0x67, 0x5c, 0x43, 0x6f, 0x75, 0x6e, 0x74, 0x65,
-	0x72, 0x5c, 0x56, 0x31, 0xe2, 0x02, 0x2e, 0x43, 0x6f, 0x73, 0x6d, 0x6f, 0x73, 0x5c, 0x41, 0x63,
-	0x63, 0x6f, 0x75, 0x6e, 0x74, 0x73, 0x5c, 0x54, 0x65, 0x73, 0x74, 0x69, 0x6e, 0x67, 0x5c, 0x43,
-	0x6f, 0x75, 0x6e, 0x74, 0x65, 0x72, 0x5c, 0x56, 0x31, 0x5c, 0x47, 0x50, 0x42, 0x4d, 0x65, 0x74,
-	0x61, 0x64, 0x61, 0x74, 0x61, 0xea, 0x02, 0x26, 0x43, 0x6f, 0x73, 0x6d, 0x6f, 0x73, 0x3a, 0x3a,
-	0x41, 0x63, 0x63, 0x6f, 0x75, 0x6e, 0x74, 0x73, 0x3a, 0x3a, 0x54, 0x65, 0x73, 0x74, 0x69, 0x6e,
-	0x67, 0x3a, 0x3a, 0x43, 0x6f, 0x75, 0x6e, 0x74, 0x65, 0x72, 0x3a, 0x3a, 0x56, 0x31, 0x62, 0x06,
-	0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
+	0x6f, 0x75, 0x6e, 0x74, 0x22, 0x15, 0x0a, 0x13, 0x4d, 0x73, 0x67, 0x54, 0x65, 0x73, 0x74, 0x44,
+	0x65, 0x70, 0x65, 0x6e, 0x64, 0x65, 0x6e, 0x63, 0x69, 0x65, 0x73, 0x22, 0x8e, 0x01, 0x0a, 0x1b,
+	0x4d, 0x73, 0x67, 0x54, 0x65, 0x73, 0x74, 0x44, 0x65, 0x70, 0x65, 0x6e, 0x64, 0x65, 0x6e, 0x63,
+	0x69, 0x65, 0x73, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x12, 0x19, 0x0a, 0x08, 0x63,
+	0x68, 0x61, 0x69, 0x6e, 0x5f, 0x69, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x07, 0x63,
+	0x68, 0x61, 0x69, 0x6e, 0x49, 0x64, 0x12, 0x18, 0x0a, 0x07, 0x61, 0x64, 0x64, 0x72, 0x65, 0x73,
+	0x73, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52, 0x07, 0x61, 0x64, 0x64, 0x72, 0x65, 0x73, 0x73,
+	0x12, 0x1d, 0x0a, 0x0a, 0x62, 0x65, 0x66, 0x6f, 0x72, 0x65, 0x5f, 0x67, 0x61, 0x73, 0x18, 0x03,
+	0x20, 0x01, 0x28, 0x04, 0x52, 0x09, 0x62, 0x65, 0x66, 0x6f, 0x72, 0x65, 0x47, 0x61, 0x73, 0x12,
+	0x1b, 0x0a, 0x09, 0x61, 0x66, 0x74, 0x65, 0x72, 0x5f, 0x67, 0x61, 0x73, 0x18, 0x04, 0x20, 0x01,
+	0x28, 0x04, 0x52, 0x08, 0x61, 0x66, 0x74, 0x65, 0x72, 0x47, 0x61, 0x73, 0x22, 0x15, 0x0a, 0x13,
+	0x51, 0x75, 0x65, 0x72, 0x79, 0x43, 0x6f, 0x75, 0x6e, 0x74, 0x65, 0x72, 0x52, 0x65, 0x71, 0x75,
+	0x65, 0x73, 0x74, 0x22, 0x2c, 0x0a, 0x14, 0x51, 0x75, 0x65, 0x72, 0x79, 0x43, 0x6f, 0x75, 0x6e,
+	0x74, 0x65, 0x72, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x12, 0x14, 0x0a, 0x05, 0x76,
+	0x61, 0x6c, 0x75, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x04, 0x52, 0x05, 0x76, 0x61, 0x6c, 0x75,
+	0x65, 0x42, 0xa2, 0x02, 0x0a, 0x26, 0x63, 0x6f, 0x6d, 0x2e, 0x63, 0x6f, 0x73, 0x6d, 0x6f, 0x73,
+	0x2e, 0x61, 0x63, 0x63, 0x6f, 0x75, 0x6e, 0x74, 0x73, 0x2e, 0x74, 0x65, 0x73, 0x74, 0x69, 0x6e,
+	0x67, 0x2e, 0x63, 0x6f, 0x75, 0x6e, 0x74, 0x65, 0x72, 0x2e, 0x76, 0x31, 0x42, 0x0c, 0x43, 0x6f,
+	0x75, 0x6e, 0x74, 0x65, 0x72, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x50, 0x01, 0x5a, 0x3d, 0x63, 0x6f,
+	0x73, 0x6d, 0x6f, 0x73, 0x73, 0x64, 0x6b, 0x2e, 0x69, 0x6f, 0x2f, 0x61, 0x70, 0x69, 0x2f, 0x63,
+	0x6f, 0x73, 0x6d, 0x6f, 0x73, 0x2f, 0x61, 0x63, 0x63, 0x6f, 0x75, 0x6e, 0x74, 0x73, 0x2f, 0x74,
+	0x65, 0x73, 0x74, 0x69, 0x6e, 0x67, 0x2f, 0x63, 0x6f, 0x75, 0x6e, 0x74, 0x65, 0x72, 0x2f, 0x76,
+	0x31, 0x3b, 0x63, 0x6f, 0x75, 0x6e, 0x74, 0x65, 0x72, 0x76, 0x31, 0xa2, 0x02, 0x04, 0x43, 0x41,
+	0x54, 0x43, 0xaa, 0x02, 0x22, 0x43, 0x6f, 0x73, 0x6d, 0x6f, 0x73, 0x2e, 0x41, 0x63, 0x63, 0x6f,
+	0x75, 0x6e, 0x74, 0x73, 0x2e, 0x54, 0x65, 0x73, 0x74, 0x69, 0x6e, 0x67, 0x2e, 0x43, 0x6f, 0x75,
+	0x6e, 0x74, 0x65, 0x72, 0x2e, 0x56, 0x31, 0xca, 0x02, 0x22, 0x43, 0x6f, 0x73, 0x6d, 0x6f, 0x73,
+	0x5c, 0x41, 0x63, 0x63, 0x6f, 0x75, 0x6e, 0x74, 0x73, 0x5c, 0x54, 0x65, 0x73, 0x74, 0x69, 0x6e,
+	0x67, 0x5c, 0x43, 0x6f, 0x75, 0x6e, 0x74, 0x65, 0x72, 0x5c, 0x56, 0x31, 0xe2, 0x02, 0x2e, 0x43,
+	0x6f, 0x73, 0x6d, 0x6f, 0x73, 0x5c, 0x41, 0x63, 0x63, 0x6f, 0x75, 0x6e, 0x74, 0x73, 0x5c, 0x54,
+	0x65, 0x73, 0x74, 0x69, 0x6e, 0x67, 0x5c, 0x43, 0x6f, 0x75, 0x6e, 0x74, 0x65, 0x72, 0x5c, 0x56,
+	0x31, 0x5c, 0x47, 0x50, 0x42, 0x4d, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74, 0x61, 0xea, 0x02, 0x26,
+	0x43, 0x6f, 0x73, 0x6d, 0x6f, 0x73, 0x3a, 0x3a, 0x41, 0x63, 0x63, 0x6f, 0x75, 0x6e, 0x74, 0x73,
+	0x3a, 0x3a, 0x54, 0x65, 0x73, 0x74, 0x69, 0x6e, 0x67, 0x3a, 0x3a, 0x43, 0x6f, 0x75, 0x6e, 0x74,
+	0x65, 0x72, 0x3a, 0x3a, 0x56, 0x31, 0x62, 0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
 }
 
 var (
@@ -2613,14 +3650,16 @@ func file_cosmos_accounts_testing_counter_v1_counter_proto_rawDescGZIP() []byte 
 	return file_cosmos_accounts_testing_counter_v1_counter_proto_rawDescData
 }
 
-var file_cosmos_accounts_testing_counter_v1_counter_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
+var file_cosmos_accounts_testing_counter_v1_counter_proto_msgTypes = make([]protoimpl.MessageInfo, 8)
 var file_cosmos_accounts_testing_counter_v1_counter_proto_goTypes = []interface{}{
-	(*MsgInit)(nil),                    // 0: cosmos.accounts.testing.counter.v1.MsgInit
-	(*MsgInitResponse)(nil),            // 1: cosmos.accounts.testing.counter.v1.MsgInitResponse
-	(*MsgIncreaseCounter)(nil),         // 2: cosmos.accounts.testing.counter.v1.MsgIncreaseCounter
-	(*MsgIncreaseCounterResponse)(nil), // 3: cosmos.accounts.testing.counter.v1.MsgIncreaseCounterResponse
-	(*QueryCounterRequest)(nil),        // 4: cosmos.accounts.testing.counter.v1.QueryCounterRequest
-	(*QueryCounterResponse)(nil),       // 5: cosmos.accounts.testing.counter.v1.QueryCounterResponse
+	(*MsgInit)(nil),                     // 0: cosmos.accounts.testing.counter.v1.MsgInit
+	(*MsgInitResponse)(nil),             // 1: cosmos.accounts.testing.counter.v1.MsgInitResponse
+	(*MsgIncreaseCounter)(nil),          // 2: cosmos.accounts.testing.counter.v1.MsgIncreaseCounter
+	(*MsgIncreaseCounterResponse)(nil),  // 3: cosmos.accounts.testing.counter.v1.MsgIncreaseCounterResponse
+	(*MsgTestDependencies)(nil),         // 4: cosmos.accounts.testing.counter.v1.MsgTestDependencies
+	(*MsgTestDependenciesResponse)(nil), // 5: cosmos.accounts.testing.counter.v1.MsgTestDependenciesResponse
+	(*QueryCounterRequest)(nil),         // 6: cosmos.accounts.testing.counter.v1.QueryCounterRequest
+	(*QueryCounterResponse)(nil),        // 7: cosmos.accounts.testing.counter.v1.QueryCounterResponse
 }
 var file_cosmos_accounts_testing_counter_v1_counter_proto_depIdxs = []int32{
 	0, // [0:0] is the sub-list for method output_type
@@ -2685,7 +3724,7 @@ func file_cosmos_accounts_testing_counter_v1_counter_proto_init() {
 			}
 		}
 		file_cosmos_accounts_testing_counter_v1_counter_proto_msgTypes[4].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*QueryCounterRequest); i {
+			switch v := v.(*MsgTestDependencies); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -2697,6 +3736,30 @@ func file_cosmos_accounts_testing_counter_v1_counter_proto_init() {
 			}
 		}
 		file_cosmos_accounts_testing_counter_v1_counter_proto_msgTypes[5].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*MsgTestDependenciesResponse); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_cosmos_accounts_testing_counter_v1_counter_proto_msgTypes[6].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*QueryCounterRequest); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_cosmos_accounts_testing_counter_v1_counter_proto_msgTypes[7].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*QueryCounterResponse); i {
 			case 0:
 				return &v.state
@@ -2715,7 +3778,7 @@ func file_cosmos_accounts_testing_counter_v1_counter_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: file_cosmos_accounts_testing_counter_v1_counter_proto_rawDesc,
 			NumEnums:      0,
-			NumMessages:   6,
+			NumMessages:   8,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/codec/collections.go
+++ b/codec/collections.go
@@ -52,7 +52,10 @@ type protoMessage[T any] interface {
 }
 
 // CollValue inits a collections.ValueCodec for a generic gogo protobuf message.
-func CollValue[T any, PT protoMessage[T]](cdc BinaryCodec) collcodec.ValueCodec[T] {
+func CollValue[T any, PT protoMessage[T]](cdc interface {
+	Marshal(proto.Message) ([]byte, error)
+	Unmarshal([]byte, proto.Message) error
+}) collcodec.ValueCodec[T] {
 	return &collValue[T, PT]{cdc.(Codec), proto.MessageName(PT(new(T)))}
 }
 

--- a/codec/collections.go
+++ b/codec/collections.go
@@ -55,7 +55,8 @@ type protoMessage[T any] interface {
 func CollValue[T any, PT protoMessage[T]](cdc interface {
 	Marshal(proto.Message) ([]byte, error)
 	Unmarshal([]byte, proto.Message) error
-}) collcodec.ValueCodec[T] {
+},
+) collcodec.ValueCodec[T] {
 	return &collValue[T, PT]{cdc.(Codec), proto.MessageName(PT(new(T)))}
 }
 

--- a/proto/cosmos/accounts/testing/counter/v1/counter.proto
+++ b/proto/cosmos/accounts/testing/counter/v1/counter.proto
@@ -26,6 +26,21 @@ message MsgIncreaseCounterResponse {
   uint64 new_amount = 1;
 }
 
+// MsgTestDependencies is used to test the dependencies.
+message MsgTestDependencies {}
+
+// MsgTestDependenciesResponse is used to test the dependencies.
+message MsgTestDependenciesResponse {
+  // chain_id is used to test that the header service correctly works.
+  string chain_id = 1;
+  // address is used to test address codec.
+  string address = 2;
+  // before_gas is used to test the gas meter reporting.
+  uint64 before_gas = 3;
+  // after_gas is used to test gas meter increasing.
+  uint64 after_gas = 4;
+}
+
 // QueryCounterRequest is used to query the counter value.
 message QueryCounterRequest {}
 

--- a/runtime/gas.go
+++ b/runtime/gas.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"cosmossdk.io/core/gas"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 

--- a/runtime/gas.go
+++ b/runtime/gas.go
@@ -1,0 +1,29 @@
+package runtime
+
+import (
+	"context"
+
+	"cosmossdk.io/core/gas"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+var _ gas.Service = (*GasService)(nil)
+
+type GasService struct{}
+
+func (g GasService) GetGasMeter(ctx context.Context) gas.Meter {
+	sdkCtx := sdk.UnwrapSDKContext(ctx)
+	return sdkCtx.GasMeter()
+}
+
+func (g GasService) GetBlockGasMeter(ctx context.Context) gas.Meter {
+	return sdk.UnwrapSDKContext(ctx).BlockGasMeter()
+}
+
+func (g GasService) WithGasMeter(ctx context.Context, meter gas.Meter) context.Context {
+	return sdk.UnwrapSDKContext(ctx).WithGasMeter(meter)
+}
+
+func (g GasService) WithBlockGasMeter(ctx context.Context, meter gas.Meter) context.Context {
+	return sdk.UnwrapSDKContext(ctx).WithBlockGasMeter(meter)
+}

--- a/simapp/app.go
+++ b/simapp/app.go
@@ -286,10 +286,12 @@ func NewSimApp(
 	app.AuthKeeper = authkeeper.NewAccountKeeper(appCodec, runtime.NewKVStoreService(keys[authtypes.StoreKey]), authtypes.ProtoBaseAccount, maccPerms, authcodec.NewBech32Codec(sdk.Bech32MainPrefix), sdk.Bech32MainPrefix, authtypes.NewModuleAddress(govtypes.ModuleName).String())
 
 	accountsKeeper, err := accounts.NewKeeper(
+		appCodec,
 		runtime.NewKVStoreService(keys[accounts.StoreKey]),
 		runtime.EventService{},
 		runtime.HeaderService{},
 		runtime.BranchService{},
+		runtime.GasService{},
 		app.AuthKeeper.AddressCodec(),
 		appCodec,
 		app.MsgServiceRouter(),

--- a/simapp/app.go
+++ b/simapp/app.go
@@ -281,9 +281,9 @@ func NewSimApp(
 	app.ConsensusParamsKeeper = consensusparamkeeper.NewKeeper(appCodec, runtime.NewKVStoreService(keys[consensusparamtypes.StoreKey]), authtypes.NewModuleAddress(govtypes.ModuleName).String(), runtime.EventService{})
 	bApp.SetParamStore(app.ConsensusParamsKeeper.ParamsStore)
 
-	// add keepers
+	addressCodec := authcodec.NewBech32Codec(sdk.Bech32MainPrefix)
 
-	app.AuthKeeper = authkeeper.NewAccountKeeper(appCodec, runtime.NewKVStoreService(keys[authtypes.StoreKey]), authtypes.ProtoBaseAccount, maccPerms, authcodec.NewBech32Codec(sdk.Bech32MainPrefix), sdk.Bech32MainPrefix, authtypes.NewModuleAddress(govtypes.ModuleName).String())
+	// add keepers
 
 	accountsKeeper, err := accounts.NewKeeper(
 		appCodec,
@@ -292,7 +292,7 @@ func NewSimApp(
 		runtime.HeaderService{},
 		runtime.BranchService{},
 		runtime.GasService{},
-		app.AuthKeeper.AddressCodec(),
+		addressCodec,
 		appCodec,
 		app.MsgServiceRouter(),
 		app.GRPCQueryRouter(),
@@ -304,8 +304,9 @@ func NewSimApp(
 	if err != nil {
 		panic(err)
 	}
-
 	app.AccountsKeeper = accountsKeeper
+
+	app.AuthKeeper = authkeeper.NewAccountKeeper(appCodec, runtime.NewKVStoreService(keys[authtypes.StoreKey]), authtypes.ProtoBaseAccount, maccPerms, addressCodec, sdk.Bech32MainPrefix, authtypes.NewModuleAddress(govtypes.ModuleName).String())
 
 	app.BankKeeper = bankkeeper.NewBaseKeeper(
 		appCodec,

--- a/tests/e2e/accounts/wiring_test.go
+++ b/tests/e2e/accounts/wiring_test.go
@@ -1,0 +1,46 @@
+//go:build app_v1
+
+package accounts
+
+import (
+	"testing"
+
+	"cosmossdk.io/core/header"
+	counterv1 "cosmossdk.io/x/accounts/testing/counter/v1"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDependencies aims to test wiring between different account components,
+// inherited from the runtime, specifically:
+// - address codec
+// - binary codec
+// - header service
+// - gas service
+func TestDependencies(t *testing.T) {
+	app := setupApp(t)
+	ak := app.AccountsKeeper
+	ctx := sdk.NewContext(app.CommitMultiStore(), false, app.Logger()).WithHeaderInfo(header.Info{ChainID: "chain-id"})
+
+	_, counterAddr, err := ak.Init(ctx, "counter", accCreator, &counterv1.MsgInit{
+		InitialValue: 0,
+	})
+	require.NoError(t, err)
+	// test dependencies
+	r, err := ak.Execute(ctx, counterAddr, []byte("test"), &counterv1.MsgTestDependencies{})
+	require.NoError(t, err)
+	res := r.(*counterv1.MsgTestDependenciesResponse)
+
+	// test gas
+	require.NotZero(t, res.BeforeGas)
+	require.NotZero(t, res.AfterGas)
+	require.Equal(t, uint64(10), res.AfterGas-res.BeforeGas)
+
+	// test header service
+	require.Equal(t, ctx.HeaderInfo().ChainID, res.ChainId)
+
+	// test address codec
+	wantAddr, err := app.AuthKeeper.AddressCodec().BytesToString(counterAddr)
+	require.NoError(t, err)
+	require.Equal(t, wantAddr, res.Address)
+}

--- a/x/accounts/internal/implementation/encoding.go
+++ b/x/accounts/internal/implementation/encoding.go
@@ -6,9 +6,18 @@ import (
 	"strings"
 
 	"github.com/cosmos/gogoproto/proto"
+	"google.golang.org/protobuf/runtime/protoiface"
 
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 )
+
+type ProtoMsg = protoiface.MessageV1
+
+// ProtoMsgG is a generic interface for protobuf messages.
+type ProtoMsgG[T any] interface {
+	*T
+	protoiface.MessageV1
+}
 
 type Any = codectypes.Any
 

--- a/x/accounts/internal/implementation/implementation.go
+++ b/x/accounts/internal/implementation/implementation.go
@@ -8,6 +8,7 @@ import (
 	"cosmossdk.io/core/address"
 	"cosmossdk.io/core/gas"
 	"cosmossdk.io/core/header"
+
 	"github.com/cosmos/cosmos-sdk/codec"
 )
 

--- a/x/accounts/internal/implementation/implementation.go
+++ b/x/accounts/internal/implementation/implementation.go
@@ -6,7 +6,9 @@ import (
 
 	"cosmossdk.io/collections"
 	"cosmossdk.io/core/address"
+	"cosmossdk.io/core/gas"
 	"cosmossdk.io/core/header"
+	"github.com/cosmos/cosmos-sdk/codec"
 )
 
 // Dependencies are passed to the constructor of a smart account.
@@ -14,6 +16,8 @@ type Dependencies struct {
 	SchemaBuilder *collections.SchemaBuilder
 	AddressCodec  address.Codec
 	HeaderService header.Service
+	GasService    gas.Service
+	StateCodec    codec.BinaryCodec
 }
 
 // AccountCreatorFunc is a function that creates an account.
@@ -22,8 +26,10 @@ type AccountCreatorFunc = func(deps Dependencies) (string, Account, error)
 // MakeAccountsMap creates a map of account names to account implementations
 // from a list of account creator functions.
 func MakeAccountsMap(
+	cdc codec.BinaryCodec,
 	addressCodec address.Codec,
 	hs header.Service,
+	gs gas.Service,
 	accounts []AccountCreatorFunc,
 ) (map[string]Implementation, error) {
 	accountsMap := make(map[string]Implementation, len(accounts))
@@ -33,6 +39,8 @@ func MakeAccountsMap(
 			SchemaBuilder: stateSchemaBuilder,
 			AddressCodec:  addressCodec,
 			HeaderService: headerService{hs},
+			GasService:    gasService{gs},
+			StateCodec:    cdc,
 		}
 		name, accountInterface, err := makeAccount(deps)
 		if err != nil {

--- a/x/accounts/internal/implementation/implementation.go
+++ b/x/accounts/internal/implementation/implementation.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"fmt"
 
+	gogoproto "github.com/cosmos/gogoproto/proto"
+
 	"cosmossdk.io/collections"
 	"cosmossdk.io/core/address"
 	"cosmossdk.io/core/gas"
 	"cosmossdk.io/core/header"
-	gogoproto "github.com/cosmos/gogoproto/proto"
 
 	"github.com/cosmos/cosmos-sdk/codec"
 )

--- a/x/accounts/internal/implementation/protoaccount.go
+++ b/x/accounts/internal/implementation/protoaccount.go
@@ -5,16 +5,7 @@ import (
 	"fmt"
 
 	"google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/runtime/protoiface"
 )
-
-type ProtoMsg = protoiface.MessageV1
-
-// ProtoMsgG is a generic interface for protobuf messages.
-type ProtoMsgG[T any] interface {
-	*T
-	protoiface.MessageV1
-}
 
 // RegisterInitHandler registers an initialisation handler for a smart account that uses protobuf.
 func RegisterInitHandler[

--- a/x/accounts/keeper.go
+++ b/x/accounts/keeper.go
@@ -8,8 +8,6 @@ import (
 	"errors"
 	"fmt"
 
-	"cosmossdk.io/core/gas"
-	"github.com/cosmos/cosmos-sdk/codec"
 	gogoproto "github.com/cosmos/gogoproto/proto"
 	"google.golang.org/protobuf/proto"
 
@@ -17,10 +15,13 @@ import (
 	"cosmossdk.io/core/address"
 	"cosmossdk.io/core/branch"
 	"cosmossdk.io/core/event"
+	"cosmossdk.io/core/gas"
 	"cosmossdk.io/core/header"
 	"cosmossdk.io/core/store"
 	"cosmossdk.io/x/accounts/accountstd"
 	"cosmossdk.io/x/accounts/internal/implementation"
+
+	"github.com/cosmos/cosmos-sdk/codec"
 )
 
 var (

--- a/x/accounts/keeper.go
+++ b/x/accounts/keeper.go
@@ -8,6 +8,8 @@ import (
 	"errors"
 	"fmt"
 
+	"cosmossdk.io/core/gas"
+	"github.com/cosmos/cosmos-sdk/codec"
 	gogoproto "github.com/cosmos/gogoproto/proto"
 	"google.golang.org/protobuf/proto"
 
@@ -61,10 +63,12 @@ type InterfaceRegistry interface {
 }
 
 func NewKeeper(
+	cdc codec.BinaryCodec,
 	ss store.KVStoreService,
 	es event.Service,
 	hs header.Service,
 	bs branch.Service,
+	gs gas.Service,
 	addressCodec address.Codec,
 	signerProvider SignerProvider,
 	execRouter MsgRouter,
@@ -92,7 +96,7 @@ func NewKeeper(
 		return Keeper{}, err
 	}
 	keeper.Schema = schema
-	keeper.accounts, err = implementation.MakeAccountsMap(keeper.addressCodec, hs, accounts)
+	keeper.accounts, err = implementation.MakeAccountsMap(cdc, keeper.addressCodec, hs, gs, accounts)
 	if err != nil {
 		return Keeper{}, err
 	}

--- a/x/accounts/testing/counter/counter.go
+++ b/x/accounts/testing/counter/counter.go
@@ -6,13 +6,18 @@ import (
 	"fmt"
 
 	"cosmossdk.io/collections"
+	"cosmossdk.io/core/address"
+	"cosmossdk.io/core/gas"
+	"cosmossdk.io/core/header"
 	"cosmossdk.io/x/accounts/accountstd"
 	counterv1 "cosmossdk.io/x/accounts/testing/counter/v1"
+	"github.com/cosmos/cosmos-sdk/codec"
 )
 
 var (
-	OwnerPrefix   = collections.NewPrefix(0)
-	CounterPrefix = collections.NewPrefix(1)
+	OwnerPrefix          = collections.NewPrefix(0)
+	CounterPrefix        = collections.NewPrefix(1)
+	TestStateCodecPrefix = collections.NewPrefix(2)
 )
 
 var _ accountstd.Interface = (*Account)(nil)
@@ -20,8 +25,12 @@ var _ accountstd.Interface = (*Account)(nil)
 // NewAccount creates a new account.
 func NewAccount(d accountstd.Dependencies) (Account, error) {
 	return Account{
-		Owner:   collections.NewItem(d.SchemaBuilder, OwnerPrefix, "owner", collections.BytesValue),
-		Counter: collections.NewItem(d.SchemaBuilder, CounterPrefix, "counter", collections.Uint64Value),
+		Owner:          collections.NewItem(d.SchemaBuilder, OwnerPrefix, "owner", collections.BytesValue),
+		Counter:        collections.NewItem(d.SchemaBuilder, CounterPrefix, "counter", collections.Uint64Value),
+		TestStateCodec: collections.NewItem(d.SchemaBuilder, TestStateCodecPrefix, "test_state_codec", codec.CollValue[counterv1.MsgTestDependencies](d.StateCodec)),
+		hs:             d.HeaderService,
+		addressCodec:   d.AddressCodec,
+		gs:             d.GasService,
 	}, nil
 }
 
@@ -32,6 +41,13 @@ type Account struct {
 	Owner collections.Item[[]byte]
 	// Counter is the counter value.
 	Counter collections.Item[uint64]
+	// TestStateCodec is used to test the binary codec provided by the runtime.
+	// It simply stores the MsgInit.
+	TestStateCodec collections.Item[counterv1.MsgTestDependencies]
+
+	hs           header.Service
+	addressCodec address.Codec
+	gs           gas.Service
 }
 
 func (a Account) Init(ctx context.Context, msg *counterv1.MsgInit) (*counterv1.MsgInitResponse, error) {
@@ -79,12 +95,43 @@ func (a Account) QueryCounter(ctx context.Context, _ *counterv1.QueryCounterRequ
 	}, nil
 }
 
+func (a Account) TestDependencies(ctx context.Context, _ *counterv1.MsgTestDependencies) (*counterv1.MsgTestDependenciesResponse, error) {
+	// test binary codec
+	err := a.TestStateCodec.Set(ctx, counterv1.MsgTestDependencies{})
+	if err != nil {
+		return nil, err
+	}
+
+	// test address codec
+	me := accountstd.Whoami(ctx)
+	meStr, err := a.addressCodec.BytesToString(me)
+	if err != nil {
+		return nil, err
+	}
+
+	// test header service
+	chainID := a.hs.GetHeaderInfo(ctx).ChainID
+
+	// test gas meter
+	gasBefore := a.gs.GetGasMeter(ctx).GasConsumedToLimit()
+	a.gs.GetGasMeter(ctx).ConsumeGas(10, "test")
+	gasAfter := a.gs.GetGasMeter(ctx).GasConsumedToLimit()
+
+	return &counterv1.MsgTestDependenciesResponse{
+		ChainId:   chainID,
+		Address:   meStr,
+		BeforeGas: gasBefore,
+		AfterGas:  gasAfter,
+	}, nil
+}
+
 func (a Account) RegisterInitHandler(builder *accountstd.InitBuilder) {
 	accountstd.RegisterInitHandler(builder, a.Init)
 }
 
 func (a Account) RegisterExecuteHandlers(builder *accountstd.ExecuteBuilder) {
 	accountstd.RegisterExecuteHandler(builder, a.IncreaseCounter)
+	accountstd.RegisterExecuteHandler(builder, a.TestDependencies)
 }
 
 func (a Account) RegisterQueryHandlers(builder *accountstd.QueryBuilder) {

--- a/x/accounts/testing/counter/counter.go
+++ b/x/accounts/testing/counter/counter.go
@@ -28,7 +28,7 @@ func NewAccount(d accountstd.Dependencies) (Account, error) {
 	return Account{
 		Owner:          collections.NewItem(d.SchemaBuilder, OwnerPrefix, "owner", collections.BytesValue),
 		Counter:        collections.NewItem(d.SchemaBuilder, CounterPrefix, "counter", collections.Uint64Value),
-		TestStateCodec: collections.NewItem(d.SchemaBuilder, TestStateCodecPrefix, "test_state_codec", codec.CollValue[counterv1.MsgTestDependencies](d.StateCodec)),
+		TestStateCodec: collections.NewItem(d.SchemaBuilder, TestStateCodecPrefix, "test_state_codec", codec.CollValue[counterv1.MsgTestDependencies](d.LegacyStateCodec)),
 		hs:             d.HeaderService,
 		addressCodec:   d.AddressCodec,
 		gs:             d.GasService,

--- a/x/accounts/testing/counter/counter.go
+++ b/x/accounts/testing/counter/counter.go
@@ -11,6 +11,7 @@ import (
 	"cosmossdk.io/core/header"
 	"cosmossdk.io/x/accounts/accountstd"
 	counterv1 "cosmossdk.io/x/accounts/testing/counter/v1"
+
 	"github.com/cosmos/cosmos-sdk/codec"
 )
 

--- a/x/accounts/testing/counter/v1/counter.pb.go
+++ b/x/accounts/testing/counter/v1/counter.pb.go
@@ -198,6 +198,116 @@ func (m *MsgIncreaseCounterResponse) GetNewAmount() uint64 {
 	return 0
 }
 
+// MsgTestDependencies is used to test the dependencies.
+type MsgTestDependencies struct {
+}
+
+func (m *MsgTestDependencies) Reset()         { *m = MsgTestDependencies{} }
+func (m *MsgTestDependencies) String() string { return proto.CompactTextString(m) }
+func (*MsgTestDependencies) ProtoMessage()    {}
+func (*MsgTestDependencies) Descriptor() ([]byte, []int) {
+	return fileDescriptor_21c9320877186411, []int{4}
+}
+func (m *MsgTestDependencies) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *MsgTestDependencies) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_MsgTestDependencies.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *MsgTestDependencies) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_MsgTestDependencies.Merge(m, src)
+}
+func (m *MsgTestDependencies) XXX_Size() int {
+	return m.Size()
+}
+func (m *MsgTestDependencies) XXX_DiscardUnknown() {
+	xxx_messageInfo_MsgTestDependencies.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_MsgTestDependencies proto.InternalMessageInfo
+
+// MsgTestDependenciesResponse is used to test the dependencies.
+type MsgTestDependenciesResponse struct {
+	// chain_id is used to test that the header service correctly works.
+	ChainId string `protobuf:"bytes,1,opt,name=chain_id,json=chainId,proto3" json:"chain_id,omitempty"`
+	// address is used to test address codec.
+	Address string `protobuf:"bytes,2,opt,name=address,proto3" json:"address,omitempty"`
+	// before_gas is used to test the gas meter reporting.
+	BeforeGas uint64 `protobuf:"varint,3,opt,name=before_gas,json=beforeGas,proto3" json:"before_gas,omitempty"`
+	// after_gas is used to test gas meter increasing.
+	AfterGas uint64 `protobuf:"varint,4,opt,name=after_gas,json=afterGas,proto3" json:"after_gas,omitempty"`
+}
+
+func (m *MsgTestDependenciesResponse) Reset()         { *m = MsgTestDependenciesResponse{} }
+func (m *MsgTestDependenciesResponse) String() string { return proto.CompactTextString(m) }
+func (*MsgTestDependenciesResponse) ProtoMessage()    {}
+func (*MsgTestDependenciesResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_21c9320877186411, []int{5}
+}
+func (m *MsgTestDependenciesResponse) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *MsgTestDependenciesResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_MsgTestDependenciesResponse.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *MsgTestDependenciesResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_MsgTestDependenciesResponse.Merge(m, src)
+}
+func (m *MsgTestDependenciesResponse) XXX_Size() int {
+	return m.Size()
+}
+func (m *MsgTestDependenciesResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_MsgTestDependenciesResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_MsgTestDependenciesResponse proto.InternalMessageInfo
+
+func (m *MsgTestDependenciesResponse) GetChainId() string {
+	if m != nil {
+		return m.ChainId
+	}
+	return ""
+}
+
+func (m *MsgTestDependenciesResponse) GetAddress() string {
+	if m != nil {
+		return m.Address
+	}
+	return ""
+}
+
+func (m *MsgTestDependenciesResponse) GetBeforeGas() uint64 {
+	if m != nil {
+		return m.BeforeGas
+	}
+	return 0
+}
+
+func (m *MsgTestDependenciesResponse) GetAfterGas() uint64 {
+	if m != nil {
+		return m.AfterGas
+	}
+	return 0
+}
+
 // QueryCounterRequest is used to query the counter value.
 type QueryCounterRequest struct {
 }
@@ -206,7 +316,7 @@ func (m *QueryCounterRequest) Reset()         { *m = QueryCounterRequest{} }
 func (m *QueryCounterRequest) String() string { return proto.CompactTextString(m) }
 func (*QueryCounterRequest) ProtoMessage()    {}
 func (*QueryCounterRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_21c9320877186411, []int{4}
+	return fileDescriptor_21c9320877186411, []int{6}
 }
 func (m *QueryCounterRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -245,7 +355,7 @@ func (m *QueryCounterResponse) Reset()         { *m = QueryCounterResponse{} }
 func (m *QueryCounterResponse) String() string { return proto.CompactTextString(m) }
 func (*QueryCounterResponse) ProtoMessage()    {}
 func (*QueryCounterResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_21c9320877186411, []int{5}
+	return fileDescriptor_21c9320877186411, []int{7}
 }
 func (m *QueryCounterResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -286,6 +396,8 @@ func init() {
 	proto.RegisterType((*MsgInitResponse)(nil), "cosmos.accounts.testing.counter.v1.MsgInitResponse")
 	proto.RegisterType((*MsgIncreaseCounter)(nil), "cosmos.accounts.testing.counter.v1.MsgIncreaseCounter")
 	proto.RegisterType((*MsgIncreaseCounterResponse)(nil), "cosmos.accounts.testing.counter.v1.MsgIncreaseCounterResponse")
+	proto.RegisterType((*MsgTestDependencies)(nil), "cosmos.accounts.testing.counter.v1.MsgTestDependencies")
+	proto.RegisterType((*MsgTestDependenciesResponse)(nil), "cosmos.accounts.testing.counter.v1.MsgTestDependenciesResponse")
 	proto.RegisterType((*QueryCounterRequest)(nil), "cosmos.accounts.testing.counter.v1.QueryCounterRequest")
 	proto.RegisterType((*QueryCounterResponse)(nil), "cosmos.accounts.testing.counter.v1.QueryCounterResponse")
 }
@@ -295,24 +407,30 @@ func init() {
 }
 
 var fileDescriptor_21c9320877186411 = []byte{
-	// 264 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x32, 0x48, 0xce, 0x2f, 0xce,
-	0xcd, 0x2f, 0xd6, 0x4f, 0x4c, 0x4e, 0xce, 0x2f, 0xcd, 0x2b, 0x29, 0xd6, 0x2f, 0x49, 0x2d, 0x2e,
-	0xc9, 0xcc, 0x4b, 0xd7, 0x07, 0x73, 0x53, 0x8b, 0xf4, 0xcb, 0x0c, 0x61, 0x4c, 0xbd, 0x82, 0xa2,
-	0xfc, 0x92, 0x7c, 0x21, 0x25, 0x88, 0x0e, 0x3d, 0x98, 0x0e, 0x3d, 0xa8, 0x0e, 0x3d, 0x98, 0xb2,
-	0x32, 0x43, 0x25, 0x3d, 0x2e, 0x76, 0xdf, 0xe2, 0x74, 0xcf, 0xbc, 0xcc, 0x12, 0x21, 0x65, 0x2e,
-	0xde, 0xcc, 0xbc, 0xcc, 0x92, 0xcc, 0xc4, 0x9c, 0xf8, 0xb2, 0xc4, 0x9c, 0xd2, 0x54, 0x09, 0x46,
-	0x05, 0x46, 0x0d, 0x96, 0x20, 0x1e, 0xa8, 0x60, 0x18, 0x48, 0x4c, 0x49, 0x90, 0x8b, 0x1f, 0xaa,
-	0x3e, 0x28, 0xb5, 0xb8, 0x20, 0x3f, 0xaf, 0x38, 0x55, 0x49, 0x87, 0x4b, 0x08, 0x2c, 0x94, 0x5c,
-	0x94, 0x9a, 0x58, 0x9c, 0xea, 0x0c, 0x31, 0x5b, 0x48, 0x8c, 0x8b, 0x2d, 0x31, 0x17, 0xc4, 0x86,
-	0x1a, 0x03, 0xe5, 0x29, 0x59, 0x73, 0x49, 0x61, 0xaa, 0x86, 0x99, 0x25, 0x24, 0xcb, 0xc5, 0x95,
-	0x97, 0x5a, 0x1e, 0x8f, 0xa2, 0x93, 0x33, 0x2f, 0xb5, 0xdc, 0x11, 0xa2, 0x59, 0x94, 0x4b, 0x38,
-	0xb0, 0x34, 0xb5, 0xa8, 0x12, 0xae, 0xad, 0xb0, 0x34, 0xb5, 0xb8, 0x44, 0x49, 0x87, 0x4b, 0x04,
-	0x55, 0x18, 0x6a, 0x9a, 0x08, 0x17, 0x2b, 0xb2, 0x4f, 0x20, 0x1c, 0x27, 0x97, 0x13, 0x8f, 0xe4,
-	0x18, 0x2f, 0x3c, 0x92, 0x63, 0x7c, 0xf0, 0x48, 0x8e, 0x71, 0xc2, 0x63, 0x39, 0x86, 0x0b, 0x8f,
-	0xe5, 0x18, 0x6e, 0x3c, 0x96, 0x63, 0x88, 0xd2, 0x82, 0x04, 0x58, 0x71, 0x4a, 0xb6, 0x5e, 0x66,
-	0xbe, 0x7e, 0x05, 0xbe, 0xa0, 0x4e, 0x62, 0x03, 0x87, 0xb1, 0x31, 0x20, 0x00, 0x00, 0xff, 0xff,
-	0x5e, 0xe6, 0x3d, 0x27, 0x97, 0x01, 0x00, 0x00,
+	// 363 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x7c, 0x92, 0x4f, 0x4f, 0xdb, 0x40,
+	0x10, 0xc5, 0xe3, 0x36, 0xcd, 0x9f, 0x51, 0xab, 0xaa, 0x6e, 0x5a, 0xb9, 0x8d, 0x6a, 0x55, 0xee,
+	0xa5, 0x42, 0x91, 0x4d, 0xc4, 0x91, 0x13, 0x10, 0x29, 0xca, 0x21, 0x07, 0x22, 0xc4, 0x81, 0x8b,
+	0xb5, 0xb1, 0x27, 0x66, 0x45, 0xb2, 0x1b, 0x3c, 0xeb, 0x04, 0xbe, 0x04, 0xe2, 0x63, 0x71, 0xcc,
+	0x91, 0x23, 0x4a, 0xbe, 0x08, 0xf2, 0xae, 0x1d, 0x11, 0x81, 0xb8, 0xed, 0xfb, 0xcd, 0xbc, 0xa7,
+	0x67, 0xef, 0xc2, 0x7e, 0x24, 0x69, 0x26, 0x29, 0x60, 0x51, 0x24, 0x33, 0xa1, 0x28, 0x50, 0x48,
+	0x8a, 0x8b, 0x24, 0xd0, 0x12, 0xd3, 0x60, 0xd1, 0x2d, 0x8f, 0xfe, 0x3c, 0x95, 0x4a, 0xda, 0x9e,
+	0x71, 0xf8, 0xa5, 0xc3, 0x2f, 0x1c, 0x7e, 0xb9, 0xb6, 0xe8, 0x7a, 0x3e, 0xd4, 0x87, 0x94, 0x0c,
+	0x04, 0x57, 0xf6, 0x3f, 0xf8, 0xc2, 0x05, 0x57, 0x9c, 0x4d, 0xc3, 0x05, 0x9b, 0x66, 0xe8, 0x58,
+	0x7f, 0xad, 0xff, 0xd5, 0xd1, 0xe7, 0x02, 0x9e, 0xe7, 0xcc, 0xfb, 0x06, 0x5f, 0x8b, 0xfd, 0x11,
+	0xd2, 0x5c, 0x0a, 0x42, 0xaf, 0x03, 0xb6, 0x46, 0x51, 0x8a, 0x8c, 0xf0, 0xc4, 0x64, 0xdb, 0x3f,
+	0xa1, 0xc6, 0x66, 0xf9, 0xb9, 0x88, 0x29, 0x94, 0x77, 0x08, 0xbf, 0x5f, 0x6f, 0x97, 0x59, 0xf6,
+	0x1f, 0x00, 0x81, 0xcb, 0x70, 0xc7, 0xd9, 0x14, 0xb8, 0x3c, 0x32, 0xe6, 0x1f, 0xf0, 0x7d, 0x48,
+	0xc9, 0x19, 0x92, 0xea, 0xe1, 0x1c, 0x45, 0x8c, 0x22, 0xe2, 0x48, 0xde, 0x9d, 0x05, 0xed, 0x37,
+	0xf8, 0x36, 0xf5, 0x17, 0x34, 0xa2, 0x4b, 0xc6, 0x45, 0xc8, 0x63, 0x9d, 0xd9, 0x1c, 0xd5, 0xb5,
+	0x1e, 0xc4, 0xb6, 0x03, 0x75, 0x16, 0xc7, 0x29, 0x12, 0x39, 0x1f, 0xcc, 0xa4, 0x90, 0x79, 0x95,
+	0x31, 0x4e, 0x64, 0x8a, 0x61, 0xc2, 0xc8, 0xf9, 0x68, 0xaa, 0x18, 0xd2, 0x67, 0x64, 0xb7, 0xa1,
+	0xc9, 0x26, 0x0a, 0x53, 0x3d, 0xad, 0xea, 0x69, 0x43, 0x83, 0x3e, 0xa3, 0xbc, 0xe7, 0x69, 0x86,
+	0xe9, 0xed, 0xf6, 0xf3, 0xae, 0x33, 0x24, 0xe5, 0x75, 0xa0, 0xb5, 0x8b, 0x8b, 0x7e, 0x2d, 0xf8,
+	0xf4, 0xf2, 0x8f, 0x1b, 0x71, 0xdc, 0x7b, 0x58, 0xbb, 0xd6, 0x6a, 0xed, 0x5a, 0x4f, 0x6b, 0xd7,
+	0xba, 0xdf, 0xb8, 0x95, 0xd5, 0xc6, 0xad, 0x3c, 0x6e, 0xdc, 0xca, 0xc5, 0x9e, 0xb9, 0x58, 0x8a,
+	0xaf, 0x7c, 0x2e, 0x83, 0x9b, 0xf7, 0x9e, 0xc4, 0xb8, 0xa6, 0xdf, 0xc2, 0xc1, 0x73, 0x00, 0x00,
+	0x00, 0xff, 0xff, 0xda, 0x84, 0xf8, 0xfc, 0x3f, 0x02, 0x00, 0x00,
 }
 
 func (m *MsgInit) Marshal() (dAtA []byte, err error) {
@@ -422,6 +540,76 @@ func (m *MsgIncreaseCounterResponse) MarshalToSizedBuffer(dAtA []byte) (int, err
 	return len(dAtA) - i, nil
 }
 
+func (m *MsgTestDependencies) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *MsgTestDependencies) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *MsgTestDependencies) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	return len(dAtA) - i, nil
+}
+
+func (m *MsgTestDependenciesResponse) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *MsgTestDependenciesResponse) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *MsgTestDependenciesResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.AfterGas != 0 {
+		i = encodeVarintCounter(dAtA, i, uint64(m.AfterGas))
+		i--
+		dAtA[i] = 0x20
+	}
+	if m.BeforeGas != 0 {
+		i = encodeVarintCounter(dAtA, i, uint64(m.BeforeGas))
+		i--
+		dAtA[i] = 0x18
+	}
+	if len(m.Address) > 0 {
+		i -= len(m.Address)
+		copy(dAtA[i:], m.Address)
+		i = encodeVarintCounter(dAtA, i, uint64(len(m.Address)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.ChainId) > 0 {
+		i -= len(m.ChainId)
+		copy(dAtA[i:], m.ChainId)
+		i = encodeVarintCounter(dAtA, i, uint64(len(m.ChainId)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
 func (m *QueryCounterRequest) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
@@ -525,6 +713,38 @@ func (m *MsgIncreaseCounterResponse) Size() (n int) {
 	_ = l
 	if m.NewAmount != 0 {
 		n += 1 + sovCounter(uint64(m.NewAmount))
+	}
+	return n
+}
+
+func (m *MsgTestDependencies) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	return n
+}
+
+func (m *MsgTestDependenciesResponse) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.ChainId)
+	if l > 0 {
+		n += 1 + l + sovCounter(uint64(l))
+	}
+	l = len(m.Address)
+	if l > 0 {
+		n += 1 + l + sovCounter(uint64(l))
+	}
+	if m.BeforeGas != 0 {
+		n += 1 + sovCounter(uint64(m.BeforeGas))
+	}
+	if m.AfterGas != 0 {
+		n += 1 + sovCounter(uint64(m.AfterGas))
 	}
 	return n
 }
@@ -788,6 +1008,208 @@ func (m *MsgIncreaseCounterResponse) Unmarshal(dAtA []byte) error {
 				b := dAtA[iNdEx]
 				iNdEx++
 				m.NewAmount |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		default:
+			iNdEx = preIndex
+			skippy, err := skipCounter(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthCounter
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *MsgTestDependencies) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowCounter
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: MsgTestDependencies: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: MsgTestDependencies: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		default:
+			iNdEx = preIndex
+			skippy, err := skipCounter(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthCounter
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *MsgTestDependenciesResponse) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowCounter
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: MsgTestDependenciesResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: MsgTestDependenciesResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ChainId", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowCounter
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthCounter
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthCounter
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.ChainId = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Address", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowCounter
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthCounter
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthCounter
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Address = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 3:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field BeforeGas", wireType)
+			}
+			m.BeforeGas = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowCounter
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.BeforeGas |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 4:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field AfterGas", wireType)
+			}
+			m.AfterGas = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowCounter
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.AfterGas |= uint64(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}

--- a/x/accounts/utils_test.go
+++ b/x/accounts/utils_test.go
@@ -47,7 +47,7 @@ func (i interfaceRegistry) RegisterImplementations(any, ...gogoproto.Message) {}
 func newKeeper(t *testing.T, accounts ...implementation.AccountCreatorFunc) (Keeper, context.Context) {
 	t.Helper()
 	ss, ctx := colltest.MockStore()
-	m, err := NewKeeper(ss, eventService{}, nil, nil, addressCodec{}, nil, nil, nil, interfaceRegistry{}, accounts...)
+	m, err := NewKeeper(nil, ss, eventService{}, nil, nil, nil, addressCodec{}, nil, nil, nil, interfaceRegistry{}, accounts...)
 	require.NoError(t, err)
 	return m, ctx
 }


### PR DESCRIPTION
# Description

This PR allows accounts to have access to the binary codec, which is required for saving in state protobuf objects, and the gas service which is useful for AA implementers that need to consume gas (eg: sig verify gas cost). 


<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage
