### PR TITLE
ci: Use GITHUB_OUTPUT over set-output command

### DIFF
--- a/.github/workflows/dependabot-update-all.yml
+++ b/.github/workflows/dependabot-update-all.yml
@@ -25,8 +25,8 @@ jobs:
           # Extract the dependency name from the PR title
           # Example: "build(deps): Bump github.com/cosmos/cosmos-sdk from 0.46.0 to 0.47.0"
           # Extracts "github.com/cosmos/cosmos-sdk" and "0.47.0"
-          echo "::set-output name=name::$(echo "${{ github.event.pull_request.title }}" | cut -d ' ' -f 3)"
-          echo "::set-output name=version::$(echo "${{ github.event.pull_request.title }}" | cut -d ' ' -f 7)"
+          echo "name=$(echo "${{ github.event.pull_request.title }}" | cut -d ' ' -f 3)" >> $GITHUB_OUTPUT
+          echo "version=$(echo "${{ github.event.pull_request.title }}" | cut -d ' ' -f 7)" >> $GITHUB_OUTPUT
       - name: Update all Go modules
         run: |
           ./scripts/go-update-dep-all.sh ${{ format('{0}@v{1}', steps.deps.outputs.name, steps.deps.outputs.version) }}


### PR DESCRIPTION
# Description

`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage
