### PR TITLE
refactor(server/v2): bring back preblock 

### DIFF
--- a/server/v2/appmanager/appmanager.go
+++ b/server/v2/appmanager/appmanager.go
@@ -135,7 +135,6 @@ func (a AppManager[T]) Query(ctx context.Context, version uint64, request appman
 }
 
 func (a AppManager[T]) QueryWitStateChanges(ctx context.Context, changeset []store.ChangeSet, request transaction.Type) (response transaction.Type, err error) {
-
 	// // otherwise rely on latest available state.
 	// _, queryState, err := a.db.StateLatest()
 	// if err != nil {

--- a/server/v2/appmanager/go.mod
+++ b/server/v2/appmanager/go.mod
@@ -15,7 +15,6 @@ require (
 	cosmossdk.io/store/v2 v2.0.0-00010101000000-000000000000
 	github.com/cosmos/cosmos-db v1.0.0
 	github.com/stretchr/testify v1.8.4
-	google.golang.org/protobuf v1.32.0
 )
 
 require (
@@ -71,5 +70,6 @@ require (
 	golang.org/x/text v0.14.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240108191215-35c7eff3a6b1 // indirect
 	google.golang.org/grpc v1.60.1 // indirect
+	google.golang.org/protobuf v1.32.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/server/v2/cometbft/abci.go
+++ b/server/v2/cometbft/abci.go
@@ -350,8 +350,8 @@ func (c *Consensus[T]) FinalizeBlock(ctx context.Context, req *abci.RequestFinal
 	}
 
 	events := []event.Event{}
-	events = append(events, resp.BeginBlockEvents...)
 	events = append(events, resp.PreBlockEvents...)
+	events = append(events, resp.BeginBlockEvents...)
 	for _, tx := range resp.TxResults {
 		events = append(events, tx.Events...)
 	}

--- a/server/v2/cometbft/abci.go
+++ b/server/v2/cometbft/abci.go
@@ -351,7 +351,7 @@ func (c *Consensus[T]) FinalizeBlock(ctx context.Context, req *abci.RequestFinal
 
 	events := []event.Event{}
 	events = append(events, resp.BeginBlockEvents...)
-	events = append(events, resp.UpgradeBlockEvents...)
+	events = append(events, resp.PreBlockEvents...)
 	for _, tx := range resp.TxResults {
 		events = append(events, tx.Events...)
 	}

--- a/server/v2/cometbft/go.mod
+++ b/server/v2/cometbft/go.mod
@@ -23,6 +23,7 @@ require (
 	cosmossdk.io/store/v2 v2.0.0-00010101000000-000000000000
 	github.com/cometbft/cometbft v0.38.2
 	github.com/cosmos/gogoproto v1.4.11
+	github.com/cosmos/ics23/go v0.10.0
 	google.golang.org/protobuf v1.32.0
 )
 
@@ -39,7 +40,6 @@ require (
 	github.com/cometbft/cometbft-db v0.9.1 // indirect
 	github.com/cosmos/cosmos-db v1.0.0 // indirect
 	github.com/cosmos/cosmos-proto v1.0.0-beta.3 // indirect
-	github.com/cosmos/ics23/go v0.10.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0 // indirect
 	github.com/dgraph-io/badger/v2 v2.2007.4 // indirect

--- a/server/v2/core/appmanager/app.go
+++ b/server/v2/core/appmanager/app.go
@@ -37,12 +37,12 @@ type BlockRequest[T any] struct {
 }
 
 type BlockResponse struct {
-	Apphash            []byte
-	ValidatorUpdates   []ValidatorUpdate
-	UpgradeBlockEvents []event.Event
-	BeginBlockEvents   []event.Event
-	TxResults          []TxResult
-	EndBlockEvents     []event.Event
+	Apphash          []byte
+	ValidatorUpdates []ValidatorUpdate
+	PreBlockEvents   []event.Event
+	BeginBlockEvents []event.Event
+	TxResults        []TxResult
+	EndBlockEvents   []event.Event
 }
 
 type RequestInitChain struct {

--- a/server/v2/core/store/gas.go
+++ b/server/v2/core/store/gas.go
@@ -10,7 +10,7 @@ type Gas = uint64
 
 // GasMeter defines an interface for gas consumption tracking.
 type GasMeter interface {
-	//TODO: modify to new interface (marko)
+	// TODO: modify to new interface (marko)
 	// GasConsumed returns the amount of gas consumed so far.
 	GasConsumed() Gas
 	// GasConsumedToLimit returns the gas limit if gas consumed is past the limit,

--- a/server/v2/stf/gas.go
+++ b/server/v2/stf/gas.go
@@ -26,7 +26,7 @@ type Store struct {
 // TODO: users should be able to swap gas store implementations in order to have different gas configs, do this later as it will be easier later on
 
 // TODO: add this to stf
-func New( gc store.GasConfig) store.WritableState {
+func New(gc store.GasConfig) store.WritableState {
 	return &Store{
 		gasConfig: gc,
 	}

--- a/server/v2/stf/stf.go
+++ b/server/v2/stf/stf.go
@@ -209,6 +209,13 @@ func (s STF[T]) preBlock(ctx context.Context, state store.WritableState, txs []T
 	if err != nil {
 		return nil, err
 	}
+
+	for i, e := range pbCtx.events {
+		pbCtx.events[i].Attributes = append(
+			e.Attributes,
+			coreevent.Attribute{Key: "mode", Value: "PreBlock"},
+		)
+	}
 	// TODO deprecate consensus params on context (marko)
 	// TODO: update consensus module to accept consensus messages (facu)
 

--- a/server/v2/stf/stf.go
+++ b/server/v2/stf/stf.go
@@ -20,7 +20,7 @@ type STF[T transaction.Tx] struct {
 	handleMsg   func(ctx context.Context, msg transaction.Type) (msgResp transaction.Type, err error)
 	handleQuery func(ctx context.Context, req transaction.Type) (resp transaction.Type, err error)
 
-	doUpgradeBlock    func(ctx context.Context) (bool, error) // TODO: look into preblock for vote extensions
+	doPreBlock        func(ctx context.Context, txs []T) error
 	doBeginBlock      func(ctx context.Context) error
 	doEndBlock        func(ctx context.Context) error
 	doValidatorUpdate func(ctx context.Context) ([]appmanager.ValidatorUpdate, error)
@@ -40,7 +40,7 @@ func (s STF[T]) DeliverBlock(ctx context.Context, block *appmanager.BlockRequest
 	newState = s.branch(state)
 
 	// upgrade block is called separate from begin block in order to refresh state updates
-	upgradeBlockEvents, err := s.upgradeBlock(ctx, newState)
+	preBlockEvents, err := s.preBlock(ctx, newState, block.Txs)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -69,6 +69,7 @@ func (s STF[T]) DeliverBlock(ctx context.Context, block *appmanager.BlockRequest
 
 	// execute txs
 	txResults := make([]appmanager.TxResult, len(block.Txs))
+	// TODO: skip first tx if vote extensions are enabled (marko)
 	for i, txBytes := range block.Txs {
 		// check if we need to return early or continue delivering txs
 		select {
@@ -85,11 +86,11 @@ func (s STF[T]) DeliverBlock(ctx context.Context, block *appmanager.BlockRequest
 	}
 
 	return &appmanager.BlockResponse{
-		UpgradeBlockEvents: upgradeBlockEvents,
-		BeginBlockEvents:   beginBlockEvents,
-		TxResults:          txResults,
-		EndBlockEvents:     endBlockEvents,
-		ValidatorUpdates:   valset,
+		PreBlockEvents:   preBlockEvents,
+		BeginBlockEvents: beginBlockEvents,
+		TxResults:        txResults,
+		EndBlockEvents:   endBlockEvents,
+		ValidatorUpdates: valset,
 	}, newState, nil
 }
 
@@ -202,17 +203,14 @@ func (s STF[T]) runTxMsgs(ctx context.Context, state store.WritableState, gasLim
 	return msgResps, nil
 }
 
-func (s STF[T]) upgradeBlock(ctx context.Context, state store.WritableState) ([]event.Event, error) {
+func (s STF[T]) preBlock(ctx context.Context, state store.WritableState, txs []T) ([]event.Event, error) {
 	pbCtx := s.makeContext(ctx, []transaction.Identity{runtimeIdentity}, state, 0) // TODO: gas limit
-	refresh, err := s.doUpgradeBlock(pbCtx)
+	err := s.doPreBlock(pbCtx, txs)
 	if err != nil {
 		return nil, err
 	}
 	// TODO deprecate consensus params on context (marko)
 	// TODO: update consensus module to accept consensus messages (facu)
-	if refresh {
-		// TODO: maybe remove
-	}
 
 	return pbCtx.events, nil
 }

--- a/server/v2/stf/stf_router.go
+++ b/server/v2/stf/stf_router.go
@@ -83,7 +83,6 @@ func (b *msgRouterBuilder) Build() (MsgHandler, error) {
 
 func buildHandler(handler MsgHandler, preHandlers []PreMsgHandler, postHandlers []PostMsgHandler) MsgHandler {
 	return func(ctx context.Context, msg transaction.Type) (msgResp transaction.Type, err error) {
-
 		if len(preHandlers) != 0 {
 			for _, preHandler := range preHandlers {
 				if err := preHandler(ctx, msg); err != nil {

--- a/server/v2/stf/stf_test.go
+++ b/server/v2/stf/stf_test.go
@@ -27,7 +27,7 @@ func TestSTF(t *testing.T) {
 			kvSet(t, ctx, "exec")
 			return nil, nil
 		},
-		doUpgradeBlock: func(ctx context.Context) (bool, error) { return false, nil },
+		doPreBlock: func(ctx context.Context, txs []mock.Tx) error { return nil },
 		doBeginBlock: func(ctx context.Context) error {
 			kvSet(t, ctx, "begin-block")
 			return nil
@@ -158,7 +158,7 @@ func cloneSTF[T transaction.Tx](stf *STF[T]) *STF[T] {
 	return &STF[T]{
 		handleMsg:         stf.handleMsg,
 		handleQuery:       stf.handleQuery,
-		doUpgradeBlock:    stf.doUpgradeBlock,
+		doPreBlock:        stf.doPreBlock,
 		doBeginBlock:      stf.doBeginBlock,
 		doEndBlock:        stf.doEndBlock,
 		doValidatorUpdate: stf.doValidatorUpdate,

--- a/server/v2/stf/types.go
+++ b/server/v2/stf/types.go
@@ -1,8 +1,9 @@
 package stf
 
 import (
-	"cosmossdk.io/server/v2/core/transaction"
 	"google.golang.org/protobuf/proto"
+
+	"cosmossdk.io/server/v2/core/transaction"
 )
 
 func typeName(msg transaction.Type) string {


### PR DESCRIPTION
# Description

this pr brings back preblock in the same way it exists in baseapp 

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage
