### PR TITLE
docs: Fix typo in adr-003-dynamic-capability-store.md

### DIFF
--- a/docs/architecture/adr-003-dynamic-capability-store.md
+++ b/docs/architecture/adr-003-dynamic-capability-store.md
@@ -85,21 +85,21 @@ It MUST be called before `InitialiseAndSeal`.
 
 ```go
 func (ck CapabilityKeeper) ScopeToModule(moduleName string) ScopedCapabilityKeeper {
-	if k.sealed {
+	if ck.sealed {
 		panic("cannot scope to module via a sealed capability keeper")
 	}
 
-	if _, ok := k.scopedModules[moduleName]; ok {
+	if _, ok := ck.scopedModules[moduleName]; ok {
 		panic(fmt.Sprintf("cannot create multiple scoped keepers for the same module name: %s", moduleName))
 	}
 
-	k.scopedModules[moduleName] = struct{}{}
+	ck.scopedModules[moduleName] = struct{}{}
 
 	return ScopedKeeper{
-		cdc:      k.cdc,
-		storeKey: k.storeKey,
-		memKey:   k.memKey,
-		capMap:   k.capMap,
+		cdc:      ck.cdc,
+		storeKey: ck.storeKey,
+		memKey:   ck.memKey,
+		capMap:   ck.capMap,
 		module:   moduleName,
 	}
 }


### PR DESCRIPTION
# Description

Fix the variable from k to ck for consistent and correct reference within the ScopeToModule method of the CapabilityKeeper struct.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [x] confirmed `!` in the type prefix if API or client breaking change
* [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [x] provided a link to the relevant issue or specification
* [x] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [x] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage
