### PR TITLE
fix(x/staking): Ensure We Return Correct ValidatorSet Updates

### DIFF
--- a/x/staking/keeper/val_state_change.go
+++ b/x/staking/keeper/val_state_change.go
@@ -564,8 +564,8 @@ func (k Keeper) getLastValidatorsByAddr(ctx context.Context) (validatorsByAddr, 
 	return last, nil
 }
 
-// given a map of remaining validators to previous bonded power
-// returns the list of validators to be unbonded, sorted by operator address
+// sortNoLongerBonded is given a map of remaining validators to previous bonded
+// power returns the list of validators to be unbonded, sorted by operator address.
 func sortNoLongerBonded(last validatorsByAddr, ac address.Codec) ([][]byte, error) {
 	// sort the map keys for determinism
 	noLongerBonded := make([][]byte, len(last))
@@ -576,6 +576,7 @@ func sortNoLongerBonded(last validatorsByAddr, ac address.Codec) ([][]byte, erro
 		if err != nil {
 			return nil, err
 		}
+
 		noLongerBonded[index] = valAddrBytes
 		index++
 	}


### PR DESCRIPTION
# Description

This is a followup to https://github.com/cosmos/cosmos-sdk/pull/19226 in that it actually ensures the ABCI validator updates returned to CometBFT during EndBlock are correct for cases when `MaxValidators` **decreases**.

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage
