### PR TITLE
test: use correct key types when creating validators

### DIFF
--- a/tests/integration/staking/simulation/operations_test.go
+++ b/tests/integration/staking/simulation/operations_test.go
@@ -74,7 +74,7 @@ func (s *SimTestSuite) SetupTest() {
 
 	// create validator set with single validator
 	account := accounts[0]
-	cmtPk, err := cryptocodec.ToCmtPubKeyInterface(account.PubKey)
+	cmtPk, err := cryptocodec.ToCmtPubKeyInterface(account.ConsKey.PubKey())
 	require.NoError(s.T(), err)
 	validator := cmttypes.NewValidator(cmtPk, 1)
 
@@ -277,7 +277,7 @@ func (s *SimTestSuite) TestSimulateMsgDelegate() {
 	require.Equal("cosmos1p8wcgrjr4pjju90xg6u9cgq55dxwq8j7u4x9a0", msg.DelegatorAddress)
 	require.Equal("stake", msg.Amount.Denom)
 	require.Equal(sdk.MsgTypeURL(&types.MsgDelegate{}), sdk.MsgTypeURL(&msg))
-	require.Equal("cosmosvaloper1tnh2q55v8wyygtt9srz5safamzdengsn9dsd7z", msg.ValidatorAddress)
+	require.Equal("cosmosvaloper122js6qry7nlgp63gcse8muknspuxur77vj3kkr", msg.ValidatorAddress)
 	require.Len(futureOperations, 0)
 }
 

--- a/tests/sims/slashing/operations_test.go
+++ b/tests/sims/slashing/operations_test.go
@@ -67,7 +67,7 @@ func (suite *SimTestSuite) SetupTest() {
 	// create validator (non random as using a seed)
 	createValidator := func() (*cmttypes.ValidatorSet, error) {
 		account := accounts[0]
-		cmtPk, err := cryptocodec.ToCmtPubKeyInterface(account.PubKey)
+		cmtPk, err := cryptocodec.ToCmtPubKeyInterface(account.ConsKey.PubKey())
 		if err != nil {
 			return nil, fmt.Errorf("failed to create pubkey: %w", err)
 		}


### PR DESCRIPTION
# Description

Closes: #19253

Use the consensus key when creating validators in the tests module.

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [X] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [X] confirmed `!` in the type prefix if API or client breaking change
* [X] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [X] provided a link to the relevant issue or specification
* [X] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage
