### PR TITLE
refactor: Add `--fast` flag to accelerate lint for git pre-commit hook

### DIFF
--- a/scripts/hooks/pre-commit.sh
+++ b/scripts/hooks/pre-commit.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # lint modified go files
-golangci-lint run --fix --new -c .golangci.yml
+golangci-lint run --fix --new --fast -c .golangci.yml


### PR DESCRIPTION
# Description

Related #19075

This is inspired by [cometbft/cometbft](https://github.com/cometbft/cometbft), `--fast` flag would make lint more faster

```shell
$ golangci-lint run --help |grep fast
 --fast   Run only fast linters from enabled linters set (first run won't be fast)
```

