### PR TITLE
refactor(internal): change `testutil.ResetArgs` to a test helper function

### DIFF
--- a/internal/testutil/cmd.go
+++ b/internal/testutil/cmd.go
@@ -1,8 +1,8 @@
 package testutil
 
 import (
-	"fmt"
 	"strings"
+	"testing"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -18,7 +18,8 @@ import (
 //  3. the custom implementations of pflag.SliceValue that are split by comma ","
 //
 // see https://github.com/spf13/cobra/issues/2079#issuecomment-1867991505 for more detail info
-func ResetArgs(cmd *cobra.Command) {
+func ResetArgs(t *testing.T, cmd *cobra.Command) {
+	t.Helper()
 	// if flags haven't been parsed yet, there is no need to reset the args
 	if !cmd.Flags().Parsed() {
 		return
@@ -37,13 +38,13 @@ func ResetArgs(cmd *cobra.Command) {
 				defSliceVal = strings.Split(defVal, ",")
 			}
 			if err := v.Replace(defSliceVal); err != nil {
-				panic(fmt.Errorf("error resetting argument <%s> with default value <%+v>: %v", pf.Name, defSliceVal, err))
+				t.Errorf("error resetting argument <%s> with default value <%+v>: %v", pf.Name, defSliceVal, err)
 			}
 			return
 		}
 		// handle pflag.Value
 		if err := pf.Value.Set(pf.DefValue); err != nil {
-			panic(fmt.Errorf("error resetting argument <%s> with default value <%s>: %v", pf.Name, pf.DefValue, err))
+			t.Errorf("error resetting argument <%s> with default value <%s>: %v", pf.Name, pf.DefValue, err)
 		}
 	})
 }


### PR DESCRIPTION
## Description

As the function's [comment](https://github.com/cosmos/cosmos-sdk/blob/main/internal/testutil/cmd.go#L11) described, I think `testutil.ResetArgs` is indeed well suited to be a test helper function.

## Motivation
It's designed for unit testing, so it's ok to own a param `t *testing.T`. And with `t *testing.T` being introduced, now we can remove the `panic`, replacing it with `t.Error`, this is more friendly to unit tests.

## Test
I have reconstructed the test cases and split them into groups, making them more clearer and easier to understand
