### PR TITLE
fix(textual): error if a formatted coin contains a comma

### DIFF
--- a/x/tx/CHANGELOG.md
+++ b/x/tx/CHANGELOG.md
@@ -31,6 +31,10 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
+### Bug Fixes
+
+* [#19265](https://github.com/cosmos/cosmos-sdk/pull/19265) Reject denoms that contain a comma.
+
 ### Improvements
 
 * [#18857](https://github.com/cosmos/cosmos-sdk/pull/18857) Moved `FormatCoins` from `core/coins` to this package under `signing/textual`.

--- a/x/tx/signing/textual/coins.go
+++ b/x/tx/signing/textual/coins.go
@@ -284,6 +284,12 @@ func FormatCoins(coins []*basev1beta1.Coin, metadata []*bankv1beta1.Metadata) (s
 		if err != nil {
 			return "", err
 		}
+
+		// If a coin contains a comma, return an error given that the output
+		// could be misinterpreted by the user as 2 different coins.
+		if strings.Contains(formatted[i], ",") {
+			return "", fmt.Errorf("coin %s contains a comma", formatted[i])
+		}
 	}
 
 	if len(coins) == 0 {

--- a/x/tx/signing/textual/internal/testdata/coin.json
+++ b/x/tx/signing/textual/internal/testdata/coin.json
@@ -327,5 +327,10 @@
   {"text":"", "error": true},
   {"text":"1COSM", "error": true},
   {"text":"1  COSM", "error": true},
-  {"text":" 1  COSM", "error": true}
+  {"text":" 1  COSM", "error": true},
+  {
+    "proto": {"amount": "10000000", "denom": "point, 222222 point"},
+    "metadata": {"display": "POINT", "base": "point", "denom_units": [{"denom": "point", "exponent": 0}, {"denom": "POINT", "exponent": 0}]},
+    "error": true
+  }
 ]


### PR DESCRIPTION
# Description

Currently if a coin is `amount: 123 denom: ATOM, 123 STAKE`, it will be displayed to the user in a screen as `123 ATOM, 123 STAKE`. Now with this fix, the value renderer will error if it sees a comma.

This is not an issue for x/bank transactions given that we check with a regex those denoms, but it could be an issue for any other module that does not check for denoms when handling coins.

There could be other cases in which a `;` could be passed and the user mistakenly takes it as a separator, but I don't think we should make the checks in the formatter that extensive

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage
