### PR TITLE
refactor(log): refactor `logger.go` to remove unused case conditions

### DIFF
--- a/log/CHANGELOG.md
+++ b/log/CHANGELOG.md
@@ -26,7 +26,8 @@ Each entry must include the Github issue reference in the following format:
 
 * [#18916](https://github.com/cosmos/cosmos-sdk/pull/18916) Introduce an option for setting hooks.
 * [#18429](https://github.com/cosmos/cosmos-sdk/pull/18429) Support customization of log json marshal.
-* [#18898](https://github.com/cosmos/cosmos-sdk/pull/18898) Add `WARN` level. 
+* [#18898](https://github.com/cosmos/cosmos-sdk/pull/18898) Add `WARN` level.
+* [#19275](https://github.com/cosmos/cosmos-sdk/pull/19275) Refactor logger.go to remove unused case conditions 
 
 ## [v1.2.1](https://github.com/cosmos/cosmos-sdk/releases/tag/log/v1.2.1) - 2023-08-25
 

--- a/log/logger.go
+++ b/log/logger.go
@@ -1,7 +1,6 @@
 package log
 
 import (
-	"encoding"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -14,10 +13,6 @@ import (
 func init() {
 	zerolog.InterfaceMarshalFunc = func(i any) ([]byte, error) {
 		switch v := i.(type) {
-		case json.Marshaler:
-			return json.Marshal(i)
-		case encoding.TextMarshaler:
-			return json.Marshal(i)
 		case fmt.Stringer:
 			return json.Marshal(v.String())
 		default:
@@ -65,10 +60,6 @@ type Logger interface {
 func WithJSONMarshal(marshaler func(v any) ([]byte, error)) {
 	zerolog.InterfaceMarshalFunc = func(i any) ([]byte, error) {
 		switch v := i.(type) {
-		case json.Marshaler:
-			return marshaler(i)
-		case encoding.TextMarshaler:
-			return marshaler(i)
 		case fmt.Stringer:
 			return marshaler(v.String())
 		default:


### PR DESCRIPTION
This commit removes unused case conditions related to `json.Marshaler` and `encoding.TextMarshaler` in the logger.go file. The removal of these conditions simplifies the code and improves
 readability.

# Description

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [x] confirmed `!` in the type prefix if API or client breaking change
* [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [x] provided a link to the relevant issue or specification
* [x] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [x] added a changelog entry to `CHANGELOG.md`
* [x] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [x] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [x] confirmed all author checklist items have been addressed
* [x] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage

