### PR TITLE
docs(log): fixed incorrect changelog date

### DIFF
--- a/log/CHANGELOG.md
+++ b/log/CHANGELOG.md
@@ -22,7 +22,7 @@ Each entry must include the Github issue reference in the following format:
 
 ## [Unreleased]
 
-## [v1.3.0](https://github.com/cosmos/cosmos-sdk/releases/tag/log/v1.3.0) - 2023-01-10
+## [v1.3.0](https://github.com/cosmos/cosmos-sdk/releases/tag/log/v1.3.0) - 2024-01-10
 
 * [#18916](https://github.com/cosmos/cosmos-sdk/pull/18916) Introduce an option for setting hooks.
 * [#18429](https://github.com/cosmos/cosmos-sdk/pull/18429) Support customization of log json marshal.


### PR DESCRIPTION
2023-01-10 -> 2024-01-10

# Description

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [x] confirmed `!` in the type prefix if API or client breaking change
* [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [x] provided a link to the relevant issue or specification
* [x] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
  - docs shouldn't affect tests
* [ ] added a changelog entry to `CHANGELOG.md`
  - I don't think it's necessary to fix typo in CHANGELOG.md.
* [x] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [x] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [x] confirmed all author checklist items have been addressed
* [x] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage