### PR TITLE
fix(math): Backport of pull requests #17352 and #18214 to feature/v.0.47.x-ics-lsm branch

### DIFF
--- a/math/int.go
+++ b/math/int.go
@@ -104,6 +104,7 @@ func NewIntFromUint64(n uint64) Int {
 
 // NewIntFromBigInt constructs Int from big.Int. If the provided big.Int is nil,
 // it returns an empty instance. This function panics if the bit length is > 256.
+// Note, the caller can safely mutate the argument after this function returns.
 func NewIntFromBigInt(i *big.Int) Int {
 	if i == nil {
 		return Int{}
@@ -112,7 +113,7 @@ func NewIntFromBigInt(i *big.Int) Int {
 	if i.BitLen() > MaxBitLen {
 		panic("NewIntFromBigInt() out of bound")
 	}
-	return Int{i}
+	return Int{new(big.Int).Set(i)}
 }
 
 // NewIntFromString constructs Int from string

--- a/math/int_test.go
+++ b/math/int_test.go
@@ -43,6 +43,19 @@ func (s *intTestSuite) TestFromUint64() {
 	}
 }
 
+func (s *intTestSuite) TestNewIntFromBigInt() {
+	i := math.NewIntFromBigInt(nil)
+	s.Require().True(i.IsNil())
+
+	r := big.NewInt(42)
+	i = math.NewIntFromBigInt(r)
+	s.Require().Equal(r, i.BigInt())
+
+	// modify r and ensure i doesn't change
+	r = r.SetInt64(100)
+	s.Require().NotEqual(r, i.BigInt())
+}
+
 func (s *intTestSuite) TestIntPanic() {
 	// Max Int = 2^256-1 = 1.1579209e+77
 	// Min Int = -(2^256-1) = -1.1579209e+77

--- a/math/uint.go
+++ b/math/uint.go
@@ -235,7 +235,7 @@ func checkNewUint(i *big.Int) (Uint, error) {
 	if err := UintOverflow(i); err != nil {
 		return Uint{}, err
 	}
-	return Uint{i}, nil
+	return Uint{new(big.Int).Set(i)}, nil
 }
 
 // RelativePow raises x to the power of n, where x (and the result, z) are scaled by factor b

--- a/math/uint_test.go
+++ b/math/uint_test.go
@@ -260,6 +260,16 @@ func (s *uintTestSuite) TestParseUint() {
 	}
 }
 
+func (s *uintTestSuite) TestNewUintFromBigInt() {
+	r := big.NewInt(42)
+	i := sdkmath.NewUintFromBigInt(r)
+	s.Require().Equal(r, i.BigInt())
+
+	// modify r and ensure i doesn't change
+	r = r.SetInt64(100)
+	s.Require().NotEqual(r, i.BigInt())
+}
+
 func randuint() sdkmath.Uint {
 	return sdkmath.NewUint(rand.Uint64())
 }


### PR DESCRIPTION
# Description

Backporting PRs #17352 and #18214: Defend NewIntFromBigInt and NewUIntFromBigInt argument mutation.

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage
