### PR TITLE
feat(bank): reserve proto field numbers used by Penumbra

### DIFF
--- a/proto/cosmos/bank/v1beta1/bank.proto
+++ b/proto/cosmos/bank/v1beta1/bank.proto
@@ -122,4 +122,14 @@ message Metadata {
   //
   // Since: cosmos-sdk 0.46
   string uri_hash = 8 [(gogoproto.customname) = "URIHash"];
+
+  // Used by Penumbra for the Penumbra asset ID.
+  // Reserved here to ensure cross-system compatibility.
+  reserved 1984;
+  reserved "penumbra_asset_id";
+
+  // Used by the cosmos asset registry to record images (logos), in json-schema extensions to this message.
+  // Reserved here to align with Penumbra's upstreaming of those extensions into its proto definitions.
+  reserved 1985;
+  reserved "images";
 }


### PR DESCRIPTION
Penumbra does not use the Cosmos SDK, but it does intend to interoperate with it. One point of interoperability is in asset metadata. The SDK provides a `bank.Metadata` message with metadata about an asset. Penumbra has a corresponding metadata message whose fields are a strict superset of the `bank.Metadata` message, so that Penumbra can parse SDK assets and vice versa.

This commit reserves two fields, by number and name, in order to ensure this compatibility can extend into the future.

First, it reserves a `penumbra_asset_id` field, numbered `1984`.

Unlike the SDK, which identifies tokens by a "base denom" using the bank module, Penumbra identifies tokens using an "asset ID", an element of the finite field we use for SNARK proofs.  For SDK-compatible assets, the asset ID is computed as a hash of the base denom string.  Penumbra clients need to be able to match asset IDs with metadata, so we extended the metadata spec with an asset ID, and chose a name and field number we thought would be unlikely to conflict with the SDK.

The compatibility story is as follows: since the asset ID can be computed from the base denom, Penumbra's Rust libraries can parse SDK metadata without problems, computing the asset ID if it is missing and filling it in.  And since proto parsers are expected to ignore unknown fields, SDK tooling can simply ignore and discard the unknown field.

(Why, then, include it at all? Because computing the asset ID involves Penumbra-specific cryptography, which may not be easily accessible in every language wishing to work with Penumbra data, such as Typescript).

Reserving this name and field number ensures that Penumbra and the SDK remain compatible going forward.

Second, it reserves an `images` field, numbered `1985`.

This corresponds to the `images` structure defined in the cosmos asset registry:

https://github.com/cosmos/chain-registry/blob/42d163653ba1d32397d4dea48611c4b11f4c7e82/assetlist.schema.json#L136-L175

That repo notes that it is intended to be a strict superset of the SDK's proto definitions, to permit the possibility of upstreaming into the SDK at some future point.  However, Penumbra's client tooling is entirely proto-based, so we cannot make use of the fields without upstreaming them into our protos, which we did.  Because the json schema only specifies a name, not a field number, we had to choose a field number when we upstreamed the definitions. We chose 1985, to follow our previous extension.

Reserving the `images` field name with the same field number as Penumbra used ensures that, in the event that the SDK chose to upstream this extension into its protos, we would retain Penumbra<>SDK data format compatibility for both ProtoJSON and binary Protobuf encodings.
