### PR TITLE
fix(x/authz)!: limit expired authz grant pruning to 200 per block

### DIFF
--- a/x/authz/keeper/keeper.go
+++ b/x/authz/keeper/keeper.go
@@ -384,6 +384,11 @@ func (k Keeper) DequeueAndDeleteExpiredGrants(ctx sdk.Context, limit int) error 
 
 	count := 0
 	for ; iterator.Valid(); iterator.Next() {
+		// limit the amount of iterations to avoid taking too much time
+		if count >= limit {
+			return nil
+		}
+
 		var queueItem authz.GrantQueueItem
 		if err := k.cdc.Unmarshal(iterator.Value(), &queueItem); err != nil {
 			return err
@@ -400,11 +405,7 @@ func (k Keeper) DequeueAndDeleteExpiredGrants(ctx sdk.Context, limit int) error 
 			store.Delete(grantStoreKey(grantee, granter, typeURL))
 		}
 
-		// limit the amount of iterations to avoid taking too much time
 		count++
-		if count == limit {
-			return nil
-		}
 	}
 
 	return nil

--- a/x/authz/keeper/keeper_test.go
+++ b/x/authz/keeper/keeper_test.go
@@ -370,6 +370,7 @@ func (s *TestSuite) TestDequeueAllGrantsQueue() {
 	require.NoError(err)
 
 	newCtx := s.ctx.WithBlockTime(exp.AddDate(1, 0, 0))
+	// setting a high limit so all grants are dequeued
 	err = s.authzKeeper.DequeueAndDeleteExpiredGrants(newCtx, 200)
 	require.NoError(err)
 
@@ -385,6 +386,74 @@ func (s *TestSuite) TestDequeueAllGrantsQueue() {
 	authzs, err = s.authzKeeper.GetAuthorizations(newCtx, grantee1, granter)
 	require.NoError(err)
 	require.Len(authzs, 0)
+
+	authzs, err = s.authzKeeper.GetAuthorizations(newCtx, granter, grantee)
+	require.NoError(err)
+	require.Len(authzs, 1)
+}
+
+func (s *TestSuite) TestDequeueGrantsQueueEdgecases() {
+	require := s.Require()
+	addrs := s.addrs
+	granter := addrs[0]
+	grantee := addrs[1]
+	grantee1 := addrs[2]
+	exp := s.ctx.BlockTime().AddDate(0, 0, 1)
+	a := banktypes.SendAuthorization{SpendLimit: coins100}
+
+	// create few authorizations
+	err := s.authzKeeper.SaveGrant(s.ctx, grantee, granter, &a, &exp)
+	require.NoError(err)
+
+	err = s.authzKeeper.SaveGrant(s.ctx, grantee1, granter, &a, &exp)
+	require.NoError(err)
+
+	exp2 := exp.AddDate(0, 1, 0)
+	err = s.authzKeeper.SaveGrant(s.ctx, granter, grantee1, &a, &exp2)
+	require.NoError(err)
+
+	exp2 = exp.AddDate(2, 0, 0)
+	err = s.authzKeeper.SaveGrant(s.ctx, granter, grantee, &a, &exp2)
+	require.NoError(err)
+
+	newCtx := s.ctx.WithBlockTime(exp.AddDate(1, 0, 0))
+	err = s.authzKeeper.DequeueAndDeleteExpiredGrants(newCtx, 0)
+	require.NoError(err)
+
+	s.T().Log("verify no pruning happens when limit is 0")
+	authzs, err := s.authzKeeper.GetAuthorizations(newCtx, grantee, granter)
+	require.NoError(err)
+	require.Len(authzs, 1)
+
+	authzs, err = s.authzKeeper.GetAuthorizations(newCtx, granter, grantee1)
+	require.NoError(err)
+	require.Len(authzs, 1)
+
+	authzs, err = s.authzKeeper.GetAuthorizations(newCtx, grantee1, granter)
+	require.NoError(err)
+	require.Len(authzs, 1)
+
+	authzs, err = s.authzKeeper.GetAuthorizations(newCtx, granter, grantee)
+	require.NoError(err)
+	require.Len(authzs, 1)
+
+	// expecting to prune 1 record when limit is 1
+	newCtx = s.ctx.WithBlockTime(exp.AddDate(1, 0, 0))
+	err = s.authzKeeper.DequeueAndDeleteExpiredGrants(newCtx, 1)
+	require.NoError(err)
+
+	s.T().Log("verify 1 record is prunded when limit is 1")
+	authzs, err = s.authzKeeper.GetAuthorizations(newCtx, grantee, granter)
+	require.NoError(err)
+	require.Len(authzs, 0)
+
+	authzs, err = s.authzKeeper.GetAuthorizations(newCtx, granter, grantee1)
+	require.NoError(err)
+	require.Len(authzs, 1)
+
+	authzs, err = s.authzKeeper.GetAuthorizations(newCtx, grantee1, granter)
+	require.NoError(err)
+	require.Len(authzs, 1)
 
 	authzs, err = s.authzKeeper.GetAuthorizations(newCtx, granter, grantee)
 	require.NoError(err)

--- a/x/authz/keeper/keeper_test.go
+++ b/x/authz/keeper/keeper_test.go
@@ -370,7 +370,7 @@ func (s *TestSuite) TestDequeueAllGrantsQueue() {
 	require.NoError(err)
 
 	newCtx := s.ctx.WithBlockTime(exp.AddDate(1, 0, 0))
-	err = s.authzKeeper.DequeueAndDeleteExpiredGrants(newCtx)
+	err = s.authzKeeper.DequeueAndDeleteExpiredGrants(newCtx, 200)
 	require.NoError(err)
 
 	s.T().Log("verify expired grants are pruned from the state")

--- a/x/authz/module/abci.go
+++ b/x/authz/module/abci.go
@@ -8,7 +8,7 @@ import (
 // BeginBlocker is called at the beginning of every block
 func BeginBlocker(ctx sdk.Context, keeper keeper.Keeper) {
 	// delete all the mature grants
-	if err := keeper.DequeueAndDeleteExpiredGrants(ctx); err != nil {
+	if err := keeper.DequeueAndDeleteExpiredGrants(ctx, 200); err != nil {
 		panic(err)
 	}
 }


### PR DESCRIPTION
# Description

This is a partial backport of https://github.com/cosmos/cosmos-sdk/pull/18737.

Txs and events were not migrated.

AutoCLI was not migrated because it does not exist on v47.



---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [x] confirmed `!` in the type prefix if API or client breaking change
* [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [x] reviewed "Files changed" and left comments if necessary
* [x] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage
