### PR TITLE
refactor(store): avoid using mutexes in PrefixDB and pruning.Manager

### DIFF
--- a/store/db/prefixdb.go
+++ b/store/db/prefixdb.go
@@ -3,7 +3,6 @@ package db
 import (
 	"bytes"
 	"fmt"
-	"sync"
 
 	corestore "cosmossdk.io/core/store"
 	"cosmossdk.io/store/v2"
@@ -11,7 +10,6 @@ import (
 
 // PrefixDB wraps a namespace of another database as a logical database.
 type PrefixDB struct {
-	mtx    sync.Mutex
 	prefix []byte
 	db     store.RawDB
 }
@@ -108,8 +106,6 @@ func (pdb *PrefixDB) NewBatchWithSize(size int) store.RawBatch {
 
 // Close implements RawDB.
 func (pdb *PrefixDB) Close() error {
-	pdb.mtx.Lock()
-	defer pdb.mtx.Unlock()
 
 	return pdb.db.Close()
 }

--- a/store/pruning/manager_test.go
+++ b/store/pruning/manager_test.go
@@ -76,6 +76,7 @@ func (s *PruningTestSuite) TestPruning() {
 		s.Require().NoError(err)
 
 		err = s.ss.ApplyChangeset(version, cs)
+		s.T().Log("stored version", version)
 		s.Require().NoError(err)
 		s.manager.Prune(version)
 	}

--- a/store/pruning/options.go
+++ b/store/pruning/options.go
@@ -14,6 +14,11 @@ type Options struct {
 	Sync bool
 }
 
+// ShouldPrune returns if we should prune given the height.
+func (o Options) ShouldPrune(height uint64) bool {
+	return o.Interval > 0 && height > o.KeepRecent && height%o.Interval == 0
+}
+
 // DefaultOptions returns the default pruning options.
 // Interval is set to 0, which means no pruning will be done.
 func DefaultOptions() Options {

--- a/store/snapshots/manager.go
+++ b/store/snapshots/manager.go
@@ -3,7 +3,6 @@ package snapshots
 import (
 	"bytes"
 	"crypto/sha256"
-	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -71,8 +70,6 @@ const (
 
 	snapshotMaxItemSize = int(64e6) // SDK has no key/value size limit, so we set an arbitrary limit
 )
-
-var ErrOptsZeroSnapshotInterval = errors.New("snaphot-interval must not be 0")
 
 // NewManager creates a new manager.
 func NewManager(store *Store, opts SnapshotOptions, commitSnapshotter CommitSnapshotter, storageSnapshotter StorageSnapshotter, extensions map[string]ExtensionSnapshotter, logger log.Logger) *Manager {


### PR DESCRIPTION
# Description

This PR makes locking mechanisms in PrefixDB and pruning.Manager less agressive.

Specifically: 
- removes locking in prefixDB since it's not needed.
- refactors pruning.Manager to use only atomics, also creates a pruner instance to manage pruning logic since logic between sc and ss was duplicated.

Next steps would be to remove mutex usage in memdb.



<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage
