### PR TITLE
test: add overflow test for coin Add

### DIFF
--- a/types/coin_test.go
+++ b/types/coin_test.go
@@ -2,6 +2,7 @@ package types_test
 
 import (
 	"fmt"
+	"math/big"
 	"strings"
 	"testing"
 
@@ -156,6 +157,9 @@ func (s *coinTestSuite) TestCoinsDenoms() {
 }
 
 func (s *coinTestSuite) TestAddCoin() {
+	// 2**256 - 1 value to check for overflows
+	maxUint256 := math.NewIntFromBigInt(new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 256), big.NewInt(1)))
+
 	cases := []struct {
 		inputOne    sdk.Coin
 		inputTwo    sdk.Coin
@@ -165,6 +169,10 @@ func (s *coinTestSuite) TestAddCoin() {
 		{sdk.NewInt64Coin(testDenom1, 1), sdk.NewInt64Coin(testDenom1, 1), sdk.NewInt64Coin(testDenom1, 2), false},
 		{sdk.NewInt64Coin(testDenom1, 1), sdk.NewInt64Coin(testDenom1, 0), sdk.NewInt64Coin(testDenom1, 1), false},
 		{sdk.NewInt64Coin(testDenom1, 1), sdk.NewInt64Coin(testDenom2, 1), sdk.NewInt64Coin(testDenom1, 1), true},
+
+		// addition cannot lead to a number with more than 256 bits
+		{sdk.NewCoin(testDenom1, maxUint256), sdk.NewCoin(testDenom1, math.NewInt(0)), sdk.NewCoin(testDenom1, maxUint256), false},
+		{sdk.NewCoin(testDenom1, maxUint256), sdk.NewCoin(testDenom1, math.NewInt(1)), sdk.NewInt64Coin(testDenom1, 1), true},
 	}
 
 	for tcIndex, tc := range cases {


### PR DESCRIPTION
# Description

theres no check for when we add coins that values go above 2**256.  PR adds such a test.

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [x] confirmed `!` in the type prefix if API or client breaking change
* [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [x] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Enhanced testing for handling large integer calculations to prevent overflow errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->