### PR TITLE
fix(store/v2): Asynchronous pruning

### DIFF
--- a/store/pruning/README.md
+++ b/store/pruning/README.md
@@ -10,6 +10,5 @@ Generally, there are three configurable parameters for pruning options:
 
 - `pruning-keep-recent`: the number of recent versions to keep.
 - `pruning-interval`: the interval between two pruning operations.
-- `pruning-sync`: the flag to sync/async the pruning operation.
 
 Different options will be applied to the state storage and commitment. The pruning option have an effect on the snapshot operation, but it will not manage the conflict resolution in SDK, it is the responsibility of the dedicated backend.

--- a/store/pruning/helper_test.go
+++ b/store/pruning/helper_test.go
@@ -1,0 +1,27 @@
+package pruning
+
+type busyPruningStore struct {
+	ch chan struct{}
+
+	count int // count of Prune calls
+}
+
+func newBusyPruningStore() *busyPruningStore {
+	return &busyPruningStore{
+		ch: make(chan struct{}),
+	}
+}
+
+func (s *busyPruningStore) Prune(version uint64) error {
+	<-s.ch
+	s.count++
+	return nil
+}
+
+func (s *busyPruningStore) finishPruning() {
+	s.ch <- struct{}{}
+}
+
+func (s *busyPruningStore) Close() {
+	close(s.ch)
+}

--- a/store/pruning/options.go
+++ b/store/pruning/options.go
@@ -8,10 +8,6 @@ type Options struct {
 	// Interval sets the number of how often to prune.
 	// If set to 0, no pruning will be done.
 	Interval uint64
-
-	// Sync when set to true ensure that pruning will be performed
-	// synchronously, otherwise by default it will be done asynchronously.
-	Sync bool
 }
 
 // DefaultOptions returns the default pruning options.
@@ -20,6 +16,5 @@ func DefaultOptions() Options {
 	return Options{
 		KeepRecent: 0,
 		Interval:   0,
-		Sync:       false,
 	}
 }

--- a/store/pruning/pruning.go
+++ b/store/pruning/pruning.go
@@ -1,0 +1,7 @@
+package pruning
+
+// PruningStore is an interface to handle pruning of SS and SC backends.
+type PruningStore interface {
+	// Prune attempts to prune all versions up to and including the provided version argument.
+	Prune(version uint64) error
+}

--- a/store/root/store.go
+++ b/store/root/store.go
@@ -56,10 +56,7 @@ func New(
 	ssOpts, scOpts pruning.Options,
 	m metrics.StoreMetrics,
 ) (store.RootStore, error) {
-	pruningManager := pruning.NewManager(logger, ss, sc)
-	pruningManager.SetStorageOptions(ssOpts)
-	pruningManager.SetCommitmentOptions(scOpts)
-	pruningManager.Start()
+	pruningManager := pruning.NewManager(logger, ss, sc, ssOpts, scOpts)
 
 	return &Store{
 		logger:          logger.With("module", "root_store"),
@@ -81,8 +78,6 @@ func (s *Store) Close() (err error) {
 	s.stateCommitment = nil
 	s.lastCommitInfo = nil
 	s.commitHeader = nil
-
-	s.pruningManager.Stop()
 
 	return err
 }


### PR DESCRIPTION
# Description

Closes: #19353

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

- Decoupling the storage and commitment layer from the pruning manager
- Add unit-tests
---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Removed the `pruning-sync` flag, making pruning operations asynchronous by default.
	- Overhauled the `Manager` structure in the pruning package for more efficient concurrent pruning operations, including the introduction of atomic variables and the `PruningStore` interface.
	- Adjusted the initialization and closing behavior of the `pruningManager` in the store logic to streamline operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->