### PR TITLE
fix(x/feegrant): fix sims

### DIFF
--- a/x/feegrant/CHANGELOG.md
+++ b/x/feegrant/CHANGELOG.md
@@ -29,6 +29,10 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 * [#14649](https://github.com/cosmos/cosmos-sdk/pull/14649) The `x/feegrant` module is extracted to have a separate go.mod file which allows it to be a standalone module.
 
+### Bug Fixes
+
+* []() Always set all allowances when current block time is zero.
+
 ## [v0.1.0](https://github.com/cosmos/cosmos-sdk/releases/tag/x/feegrant/v0.1.0) - 2023-11-07
 
 ### Features

--- a/x/feegrant/CHANGELOG.md
+++ b/x/feegrant/CHANGELOG.md
@@ -29,10 +29,6 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 * [#14649](https://github.com/cosmos/cosmos-sdk/pull/14649) The `x/feegrant` module is extracted to have a separate go.mod file which allows it to be a standalone module.
 
-### Bug Fixes
-
-* []() Always set all allowances when current block time is zero.
-
 ## [v0.1.0](https://github.com/cosmos/cosmos-sdk/releases/tag/x/feegrant/v0.1.0) - 2023-11-07
 
 ### Features

--- a/x/feegrant/keeper/keeper.go
+++ b/x/feegrant/keeper/keeper.go
@@ -9,12 +9,10 @@ import (
 	"cosmossdk.io/core/store"
 	errorsmod "cosmossdk.io/errors"
 	"cosmossdk.io/log"
-	storetypes "cosmossdk.io/store/types"
 	"cosmossdk.io/x/auth/ante"
 	"cosmossdk.io/x/feegrant"
 
 	"github.com/cosmos/cosmos-sdk/codec"
-	"github.com/cosmos/cosmos-sdk/runtime"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
@@ -85,7 +83,8 @@ func (k Keeper) GrantAllowance(ctx context.Context, granter, grantee sdk.AccAddr
 
 	// expiration shouldn't be in the past.
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
-	if exp != nil && exp.Before(sdkCtx.HeaderInfo().Time) {
+	now := sdkCtx.HeaderInfo().Time
+	if exp != nil && !now.IsZero() && exp.Before(now) {
 		return errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "expiration is before current block time")
 	}
 
@@ -106,9 +105,13 @@ func (k Keeper) GrantAllowance(ctx context.Context, granter, grantee sdk.AccAddr
 		return err
 	}
 
-	err = feeAllowance.UpdatePeriodReset(sdkCtx.HeaderInfo().Time)
-	if err != nil {
-		return err
+	// if block time is not zero, update the period reset
+	// if it is zero, it could be genesis initialization, so we don't need to update the period reset
+	if !now.IsZero() {
+		err = feeAllowance.UpdatePeriodReset(now)
+		if err != nil {
+			return err
+		}
 	}
 
 	grant, err := feegrant.NewGrant(granterStr, granteeStr, feeAllowance)
@@ -224,18 +227,9 @@ func (k Keeper) GetAllowance(ctx context.Context, granter, grantee sdk.AccAddres
 // Callback to get all data, returns true to stop, false to keep reading
 // Calling this without pagination is very expensive and only designed for export genesis
 func (k Keeper) IterateAllFeeAllowances(ctx context.Context, cb func(grant feegrant.Grant) bool) error {
-	store := k.storeService.OpenKVStore(ctx)
-	iter := storetypes.KVStorePrefixIterator(runtime.KVStoreAdapter(store), feegrant.FeeAllowanceKeyPrefix)
-	defer iter.Close()
-
-	err := k.FeeAllowance.Walk(ctx, nil, func(key collections.Pair[sdk.AccAddress, sdk.AccAddress], grant feegrant.Grant) (stop bool, err error) {
+	return k.FeeAllowance.Walk(ctx, nil, func(key collections.Pair[sdk.AccAddress, sdk.AccAddress], grant feegrant.Grant) (stop bool, err error) {
 		return cb(grant), nil
 	})
-	if err != nil {
-		return err
-	}
-
-	return nil
 }
 
 // UseGrantedFees will try to pay the given fee from the granter's account as requested by the grantee

--- a/x/feegrant/keeper/keeper.go
+++ b/x/feegrant/keeper/keeper.go
@@ -84,7 +84,7 @@ func (k Keeper) GrantAllowance(ctx context.Context, granter, grantee sdk.AccAddr
 	// expiration shouldn't be in the past.
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
 	now := sdkCtx.HeaderInfo().Time
-	if exp != nil && !now.IsZero() && exp.Before(now) {
+	if exp != nil && exp.Before(now) {
 		return errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "expiration is before current block time")
 	}
 


### PR DESCRIPTION
# Description

This fix uncovered a bug in feegrant, where at genesis import (block time 0) all allowances would be skipped: https://github.com/cosmos/cosmos-sdk/pull/19338

We don't need a changelog because x/feegrant on release/v0.50.x uses `BlockTime()` instead of the header info and wasn't subject to the bug. 

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Fixed an issue in the fee grant module where setting allowances failed when the current block time was zero.
- **Refactor**
	- Improved efficiency in handling specific cases within the fee grant module, enhancing overall performance and simplification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->