### PR TITLE
perf: Speedup sdk.Int overflow checks

### DIFF
--- a/math/CHANGELOG.md
+++ b/math/CHANGELOG.md
@@ -42,6 +42,7 @@ Ref: https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.j
 * [#18421](https://github.com/cosmos/cosmos-sdk/pull/18421) Add mutative api for `LegacyDec.BigInt()`.
 
 * [#18874](https://github.com/cosmos/cosmos-sdk/pull/18874) Speedup `math.Int.Mul` by removing a duplicate overflow check
+* [#19386](https://github.com/cosmos/cosmos-sdk/pull/19386) Speedup `math.Int` overflow checks
 
 ### Bug Fixes
 

--- a/math/int.go
+++ b/math/int.go
@@ -14,6 +14,10 @@ import (
 // MaxBitLen defines the maximum bit length supported bit Int and Uint types.
 const MaxBitLen = 256
 
+// maxWordLen defines the maximum word length supported by Int and Uint types.
+// Note: This can only be used in checks if MaxBitLen % 64 == 0
+const maxWordLen = MaxBitLen / 64
+
 // Integer errors
 var (
 	// ErrIntOverflow is the error returned when an integer overflow occurs
@@ -71,7 +75,7 @@ func unmarshalText(i *big.Int, text string) error {
 		return err
 	}
 
-	if i.BitLen() > MaxBitLen {
+	if len(i.Bits()) > maxWordLen {
 		return fmt.Errorf("integer out of range: %s", text)
 	}
 
@@ -128,7 +132,7 @@ func NewIntFromBigInt(i *big.Int) Int {
 		return Int{}
 	}
 
-	if i.BitLen() > MaxBitLen {
+	if len(i.Bits()) > maxWordLen {
 		panic("NewIntFromBigInt() out of bound")
 	}
 
@@ -143,7 +147,7 @@ func NewIntFromBigIntMut(i *big.Int) Int {
 		return Int{}
 	}
 
-	if i.BitLen() > MaxBitLen {
+	if len(i.Bits()) > maxWordLen {
 		panic("NewIntFromBigInt() out of bound")
 	}
 
@@ -157,7 +161,7 @@ func NewIntFromString(s string) (res Int, ok bool) {
 		return
 	}
 	// Check overflow
-	if i.BitLen() > MaxBitLen {
+	if len(i.Bits()) > maxWordLen {
 		ok = false
 		return
 	}
@@ -175,7 +179,7 @@ func NewIntWithDecimal(n int64, dec int) Int {
 	i.Mul(big.NewInt(n), exp)
 
 	// Check overflow
-	if i.BitLen() > MaxBitLen {
+	if len(i.Bits()) > maxWordLen {
 		panic("NewIntWithDecimal() out of bound")
 	}
 	return Int{i}
@@ -285,7 +289,7 @@ func (i Int) AddRaw(i2 int64) Int {
 func (i Int) SafeAdd(i2 Int) (res Int, err error) {
 	res = Int{add(i.i, i2.i)}
 	// Check overflow
-	if res.i.BitLen() > MaxBitLen {
+	if len(res.i.Bits()) > maxWordLen {
 		return Int{}, ErrIntOverflow
 	}
 	return res, nil
@@ -310,7 +314,7 @@ func (i Int) SubRaw(i2 int64) Int {
 func (i Int) SafeSub(i2 Int) (res Int, err error) {
 	res = Int{sub(i.i, i2.i)}
 	// Check overflow/underflow
-	if res.i.BitLen() > MaxBitLen {
+	if len(res.i.Bits()) > maxWordLen {
 		return Int{}, ErrIntOverflow
 	}
 	return res, nil
@@ -335,7 +339,7 @@ func (i Int) MulRaw(i2 int64) Int {
 func (i Int) SafeMul(i2 Int) (res Int, err error) {
 	res = Int{mul(i.i, i2.i)}
 	// Check overflow
-	if res.i.BitLen() > MaxBitLen {
+	if len(res.i.Bits()) > maxWordLen {
 		return Int{}, ErrIntOverflow
 	}
 	return res, nil
@@ -497,7 +501,7 @@ func (i *Int) Unmarshal(data []byte) error {
 		return err
 	}
 
-	if i.i.BitLen() > MaxBitLen {
+	if len(i.i.Bits()) > maxWordLen {
 		return fmt.Errorf("integer out of range; got: %d, max: %d", i.i.BitLen(), MaxBitLen)
 	}
 

--- a/math/int_test.go
+++ b/math/int_test.go
@@ -687,3 +687,25 @@ func BenchmarkIntSize(b *testing.B) {
 	}
 	sink = nil
 }
+
+func BenchmarkIntOverflowCheckTime(b *testing.B) {
+	var ints = []*big.Int{}
+
+	for _, st := range sizeTests {
+		ii, _ := math.NewIntFromString(st.s)
+		ints = append(ints, ii.BigInt())
+	}
+	b.ResetTimer()
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		for j, _ := range sizeTests {
+			got := math.NewIntFromBigIntMut(ints[j])
+			sink = got
+		}
+	}
+	if sink == nil {
+		b.Fatal("Benchmark did not run!")
+	}
+	sink = nil
+}


### PR DESCRIPTION
This PR speedsup all sdk.Int math ops, especially for smaller Int arithmetic.

Currently sdk.Int overflow checks compare against bigint.BitLen(), which is a complex method as it aims to be:
- constant time
- give granularity into how many bits are present in the final word. See: https://cs.opensource.google/go/go/+/refs/tags/go1.22.0:src/math/big/nat.go;l=654-674

We see this taking 1.1 seconds of the Osmosis epoch time! (Used to be 5+ seconds, until we moved more math to native bigInt math. Now its just 1.1 second in converting these final results into sdk.Int)

This PR notices that we only need to check if its greater than 256 bits, which is equivalent to checking if it takes 4 words. Note in the code, we use bits.UintSize, so it works on 32 bit machines as well.

So we change this to using int.Bits() which returns an []big.Word, with no copies, and hence will be much faster.

Notice that here in the tests we test the precise overflow bounds: https://github.com/cosmos/cosmos-sdk/blob/main/math/int_test.go#L175-L185

therefore this should be state compatible. (And I tested it with the tests under this)

Out of some abundance of caution, its possible that the most significant word could be all zeroes. To handle this edge case, we say that if the bigint uses too many words, then run the fallback (slower) BitLen logic, thus ensuring it will always be compatible.

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [x] confirmed `!` in the type prefix if API or client breaking change
* [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [x] provided a link to the relevant issue or specification
* [x] reviewed "Files changed" and left comments if necessary
* [x] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [x] added a changelog entry to `CHANGELOG.md`
* [x] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [x] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Enhanced performance and reliability by improving the handling of maximum word length for integer types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->