### PR TITLE
fix(simapp): fix default home

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,7 +91,8 @@ Every module contains its own CHANGELOG.md. Please refer to the module you are i
 * (abci): [#19200](https://github.com/cosmos/cosmos-sdk/pull/19200) Ensure that sdk side ve math matches cometbft
 * (server) [#18994](https://github.com/cosmos/cosmos-sdk/pull/18994) Update server context directly rather than a reference to a sub-object
 * (crypto) [#19371](https://github.com/cosmos/cosmos-sdk/pull/19371) Avoid cli redundant log in stdout, log to stderr instead.
- 
+* (client) [#19393](https://github.com/cosmos/cosmos-sdk/pull/19393/) Add `ReadDefaultValuesFromDefaultClientConfig` to populate the default values from the default client config in client.Context without creating a app folder.
+
 ### API Breaking Changes
 
 * (server) [#18303](https://github.com/cosmos/cosmos-sdk/pull/18303) `x/genutil` now handles the application export. `server.AddCommands` does not take an `AppExporter` but instead `genutilcli.Commands` does.

--- a/client/config/config.go
+++ b/client/config/config.go
@@ -44,6 +44,7 @@ func ReadFromClientConfig(ctx client.Context) (client.Context, error) {
 // ReadDefaultValuesFromDefaultClientConfig reads default values from default client.toml file and updates them in client.Context
 // The client.toml is then discarded.
 func ReadDefaultValuesFromDefaultClientConfig(ctx client.Context, customClientTemplate string, customConfig interface{}) (client.Context, error) {
+	prevHomeDir := ctx.HomeDir
 	dir, err := os.MkdirTemp("", "simapp")
 	if err != nil {
 		return ctx, fmt.Errorf("couldn't create temp dir: %w", err)
@@ -56,7 +57,7 @@ func ReadDefaultValuesFromDefaultClientConfig(ctx client.Context, customClientTe
 		return ctx, fmt.Errorf("couldn't create client config: %w", err)
 	}
 
-	ctx.HomeDir = ""
+	ctx.HomeDir = prevHomeDir
 	return ctx, nil
 }
 

--- a/client/config/config.go
+++ b/client/config/config.go
@@ -36,8 +36,28 @@ type Config struct {
 
 // ReadFromClientConfig reads values from client.toml file and updates them in client.Context
 // It uses CreateClientConfig internally with no custom template and custom config.
+// Deprecated: use CreateClientConfig instead.
 func ReadFromClientConfig(ctx client.Context) (client.Context, error) {
 	return CreateClientConfig(ctx, "", nil)
+}
+
+// ReadDefaultValuesFromDefaultClientConfig reads default values from default client.toml file and updates them in client.Context
+// The client.toml is then discarded.
+func ReadDefaultValuesFromDefaultClientConfig(ctx client.Context, customClientTemplate string, customConfig interface{}) (client.Context, error) {
+	dir, err := os.MkdirTemp("", "simapp")
+	if err != nil {
+		return ctx, fmt.Errorf("couldn't create temp dir: %w", err)
+	}
+	defer os.RemoveAll(dir)
+
+	ctx.HomeDir = dir
+	ctx, err = CreateClientConfig(ctx, customClientTemplate, customConfig)
+	if err != nil {
+		return ctx, fmt.Errorf("couldn't create client config: %w", err)
+	}
+
+	ctx.HomeDir = ""
+	return ctx, nil
 }
 
 // CreateClientConfig reads the client.toml file and returns a new populated client.Context

--- a/simapp/simd/cmd/root.go
+++ b/simapp/simd/cmd/root.go
@@ -108,7 +108,7 @@ func NewRootCmd() *cobra.Command {
 	// autocli opts
 	customClientTemplate, customClientConfig := initClientConfig()
 	var err error
-	initClientCtx, err = config.CreateClientConfig(initClientCtx, customClientTemplate, customClientConfig)
+	initClientCtx, err = config.ReadDefaultValuesFromDefaultClientConfig(initClientCtx, customClientTemplate, customClientConfig)
 	if err != nil {
 		panic(err)
 	}

--- a/simapp/simd/cmd/root_v2.go
+++ b/simapp/simd/cmd/root_v2.go
@@ -115,7 +115,7 @@ func ProvideClientContext(
 		WithAddressCodec(addressCodec).
 		WithValidatorAddressCodec(validatorAddressCodec).
 		WithConsensusAddressCodec(consensusAddressCodec).
-		WithHomeDir(simapp.DefaultNodeHome).
+		WithHomeDir(tempDir()).
 		WithViper("") // uses by default the binary name as prefix
 
 	// Read the config to overwrite the default values with the values from the config file
@@ -124,6 +124,7 @@ func ProvideClientContext(
 	if err != nil {
 		panic(err)
 	}
+	clientCtx.HomeDir = ""
 
 	// textual is enabled by default, we need to re-create the tx config grpc instead of bank keeper.
 	txConfigOpts.TextualCoinMetadataQueryFn = authtxconfig.NewGRPCCoinMetadataQueryFn(clientCtx)

--- a/simapp/simd/cmd/root_v2.go
+++ b/simapp/simd/cmd/root_v2.go
@@ -115,16 +115,15 @@ func ProvideClientContext(
 		WithAddressCodec(addressCodec).
 		WithValidatorAddressCodec(validatorAddressCodec).
 		WithConsensusAddressCodec(consensusAddressCodec).
-		WithHomeDir(tempDir()).
+		WithHomeDir(simapp.DefaultNodeHome).
 		WithViper("") // uses by default the binary name as prefix
 
 	// Read the config to overwrite the default values with the values from the config file
 	customClientTemplate, customClientConfig := initClientConfig()
-	clientCtx, err = config.CreateClientConfig(clientCtx, customClientTemplate, customClientConfig)
+	clientCtx, err = config.ReadDefaultValuesFromDefaultClientConfig(clientCtx, customClientTemplate, customClientConfig)
 	if err != nil {
 		panic(err)
 	}
-	clientCtx.HomeDir = ""
 
 	// textual is enabled by default, we need to re-create the tx config grpc instead of bank keeper.
 	txConfigOpts.TextualCoinMetadataQueryFn = authtxconfig.NewGRPCCoinMetadataQueryFn(clientCtx)


### PR DESCRIPTION
# Description

Closes: https://github.com/cosmos/cosmos-sdk/issues/18868

For reference, a temporary workaround, without adding this api (and thus needing 0.50.4) is this commit: https://github.com/cosmos/cosmos-sdk/commit/b9de0f3ec3541aeb5e1a20fc75fa07d01a1a8794

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Deprecated `ReadFromClientConfig` in favor of `CreateClientConfig` for improved configuration management.
	- Introduced `ReadDefaultValuesFromDefaultClientConfig` to streamline reading default configuration values.
- **Chores**
	- Updated initialization processes in `root.go` and `root_v2.go` to utilize new configuration reading approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->