### PR TITLE
perf: Remove unneeded cmp in Ceil and marshalTo

### DIFF
--- a/math/CHANGELOG.md
+++ b/math/CHANGELOG.md
@@ -43,6 +43,7 @@ Ref: https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.j
 
 * [#18874](https://github.com/cosmos/cosmos-sdk/pull/18874) Speedup `math.Int.Mul` by removing a duplicate overflow check
 * [#19386](https://github.com/cosmos/cosmos-sdk/pull/19386) Speedup `math.Int` overflow checks
+* [#19467](https://github.com/cosmos/cosmos-sdk/pull/19467) Slightly speedup `math.LegacyDec` `Ceil` and `MarshalTo` methods
 
 ### Bug Fixes
 

--- a/math/dec.go
+++ b/math/dec.go
@@ -734,11 +734,9 @@ func (d LegacyDec) Ceil() LegacyDec {
 	quo, rem = quo.QuoRem(tmp, precisionReuse, rem)
 
 	// no need to round with a zero remainder regardless of sign
-	if rem.Cmp(zeroInt) == 0 {
+	if rem.Sign() == 0 {
 		return LegacyNewDecFromBigInt(quo)
-	}
-
-	if rem.Sign() == -1 {
+	} else if rem.Sign() == -1 {
 		return LegacyNewDecFromBigInt(quo)
 	}
 

--- a/math/dec.go
+++ b/math/dec.go
@@ -845,7 +845,7 @@ func (d *LegacyDec) MarshalTo(data []byte) (n int, err error) {
 		i = new(big.Int)
 	}
 
-	if i.Cmp(zeroInt) == 0 {
+	if i.Sign() == 0 {
 		copy(data, []byte{0x30})
 		return 1, nil
 	}


### PR DESCRIPTION
# Description

Pretty slight performance speedup to Dec, by removing an unneeded Cmp against 0, with just using Sign.

This isn't that big of a systemic impact, but noticed it while I was looking at some code so thought I'd make a driveby PR.

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [x] confirmed `!` in the type prefix if API or client breaking change
* [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [x] reviewed "Files changed" and left comments if necessary
* [x] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [x] added a changelog entry to `CHANGELOG.md`
* [x] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage
