### PR TITLE
docs: fixed typo in `client/broadcast.go`

### DIFF
--- a/client/broadcast.go
+++ b/client/broadcast.go
@@ -42,7 +42,7 @@ func CheckTendermintError(err error, tx cmttypes.Tx) *sdk.TxResponse {
 
 // CheckCometError checks if the error returned from BroadcastTx is a
 // CometBFT error that is returned before the tx is submitted due to
-// precondition checks that failed. If an CometBFT error is detected, this
+// precondition checks that failed. If a CometBFT error is detected, this
 // function returns the correct code back in TxResponse.
 //
 // TODO: Avoid brittle string matching in favor of error matching. This requires


### PR DESCRIPTION
an CometBFT -> a CometBFT

# Description

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [x] confirmed `!` in the type prefix if API or client breaking change
* [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [x] provided a link to the relevant issue or specification
* [x] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
	- Corrected a typo in internal documentation in the `CheckCometError` function.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->