### PR TITLE
refactor(bank): migrate to use env var

### DIFF
--- a/simapp/app.go
+++ b/simapp/app.go
@@ -308,8 +308,8 @@ func NewSimApp(
 	app.AuthKeeper = authkeeper.NewAccountKeeper(appCodec, runtime.NewKVStoreService(keys[authtypes.StoreKey]), authtypes.ProtoBaseAccount, maccPerms, addressCodec, sdk.Bech32MainPrefix, authtypes.NewModuleAddress(govtypes.ModuleName).String())
 
 	app.BankKeeper = bankkeeper.NewBaseKeeper(
+		runtime.NewEnvironment(runtime.NewKVStoreService(keys[banktypes.StoreKey]), logger),
 		appCodec,
-		runtime.NewKVStoreService(keys[banktypes.StoreKey]),
 		app.AuthKeeper,
 		BlockedAddresses(),
 		authtypes.NewModuleAddress(govtypes.ModuleName).String(),

--- a/tests/integration/bank/keeper/deterministic_test.go
+++ b/tests/integration/bank/keeper/deterministic_test.go
@@ -90,8 +90,9 @@ func initDeterministicFixture(t *testing.T) *deterministicFixture {
 		accountKeeper.GetAuthority(): false,
 	}
 	bankKeeper := keeper.NewBaseKeeper(
+
+		runtime.NewEnvironment(runtime.NewKVStoreService(keys[banktypes.StoreKey]), log.NewNopLogger()),
 		cdc,
-		runtime.NewKVStoreService(keys[banktypes.StoreKey]),
 		accountKeeper,
 		blockedAddresses,
 		authority.String(),

--- a/tests/integration/distribution/keeper/msg_server_test.go
+++ b/tests/integration/distribution/keeper/msg_server_test.go
@@ -97,8 +97,8 @@ func initFixture(t *testing.T) *fixture {
 		accountKeeper.GetAuthority(): false,
 	}
 	bankKeeper := bankkeeper.NewBaseKeeper(
+		runtime.NewEnvironment(runtime.NewKVStoreService(keys[banktypes.StoreKey]), log.NewNopLogger()),
 		cdc,
-		runtime.NewKVStoreService(keys[banktypes.StoreKey]),
 		accountKeeper,
 		blockedAddresses,
 		authority.String(),

--- a/tests/integration/evidence/keeper/infraction_test.go
+++ b/tests/integration/evidence/keeper/infraction_test.go
@@ -117,8 +117,8 @@ func initFixture(tb testing.TB) *fixture {
 		accountKeeper.GetAuthority(): false,
 	}
 	bankKeeper := bankkeeper.NewBaseKeeper(
+		runtime.NewEnvironment(runtime.NewKVStoreService(keys[banktypes.StoreKey]), log.NewNopLogger()),
 		cdc,
-		runtime.NewKVStoreService(keys[banktypes.StoreKey]),
 		accountKeeper,
 		blockedAddresses,
 		authority.String(),

--- a/tests/integration/gov/keeper/keeper_test.go
+++ b/tests/integration/gov/keeper/keeper_test.go
@@ -84,8 +84,8 @@ func initFixture(tb testing.TB) *fixture {
 		accountKeeper.GetAuthority(): false,
 	}
 	bankKeeper := bankkeeper.NewBaseKeeper(
+		runtime.NewEnvironment(runtime.NewKVStoreService(keys[banktypes.StoreKey]), log.NewNopLogger()),
 		cdc,
-		runtime.NewKVStoreService(keys[banktypes.StoreKey]),
 		accountKeeper,
 		blockedAddresses,
 		authority.String(),

--- a/tests/integration/slashing/keeper/keeper_test.go
+++ b/tests/integration/slashing/keeper/keeper_test.go
@@ -85,8 +85,8 @@ func initFixture(tb testing.TB) *fixture {
 		accountKeeper.GetAuthority(): false,
 	}
 	bankKeeper := bankkeeper.NewBaseKeeper(
+		runtime.NewEnvironment(runtime.NewKVStoreService(keys[banktypes.StoreKey]), log.NewNopLogger()),
 		cdc,
-		runtime.NewKVStoreService(keys[banktypes.StoreKey]),
 		accountKeeper,
 		blockedAddresses,
 		authority.String(),

--- a/tests/integration/staking/keeper/common_test.go
+++ b/tests/integration/staking/keeper/common_test.go
@@ -134,8 +134,8 @@ func initFixture(tb testing.TB) *fixture {
 		accountKeeper.GetAuthority(): false,
 	}
 	bankKeeper := bankkeeper.NewBaseKeeper(
+		runtime.NewEnvironment(runtime.NewKVStoreService(keys[banktypes.StoreKey]), log.NewNopLogger()),
 		cdc,
-		runtime.NewKVStoreService(keys[banktypes.StoreKey]),
 		accountKeeper,
 		blockedAddresses,
 		authority.String(),

--- a/tests/integration/staking/keeper/deterministic_test.go
+++ b/tests/integration/staking/keeper/deterministic_test.go
@@ -98,8 +98,8 @@ func initDeterministicFixture(t *testing.T) *deterministicFixture {
 		accountKeeper.GetAuthority(): false,
 	}
 	bankKeeper := bankkeeper.NewBaseKeeper(
+		runtime.NewEnvironment(runtime.NewKVStoreService(keys[banktypes.StoreKey]), log.NewNopLogger()),
 		cdc,
-		runtime.NewKVStoreService(keys[banktypes.StoreKey]),
 		accountKeeper,
 		blockedAddresses,
 		authority.String(),

--- a/x/auth/vesting/fuzz_test.go
+++ b/x/auth/vesting/fuzz_test.go
@@ -107,8 +107,8 @@ func FuzzMsgServerCreateVestingAccount(f *testing.F) {
 		authKeeper := banktestutil.NewMockAccountKeeper(ctrl)
 		authKeeper.EXPECT().AddressCodec().Return(address.NewBech32Codec("cosmos")).AnyTimes()
 		bankKeeper := keeper.NewBaseKeeper(
+			runtime.NewEnvironment(storeService, log.NewNopLogger()),
 			encCfg.Codec,
-			storeService,
 			authKeeper,
 			map[string]bool{accAddrs[4].String(): true},
 			authtypes.NewModuleAddress(banktypes.GovModuleName).String(),

--- a/x/bank/CHANGELOG.md
+++ b/x/bank/CHANGELOG.md
@@ -40,5 +40,6 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### API Breaking Changes
 
 * [#17569](https://github.com/cosmos/cosmos-sdk/pull/17569) `BurnCoins` takes an address instead of a module name
+* [#19477](https://github.com/cosmos/cosmos-sdk/pull/19477) `appmodule.Environment` is passed to bank `NewKeeper`
 
 ### Bug Fixes

--- a/x/bank/depinject.go
+++ b/x/bank/depinject.go
@@ -3,7 +3,6 @@ package bank
 import (
 	modulev1 "cosmossdk.io/api/cosmos/bank/module/v1"
 	"cosmossdk.io/core/appmodule"
-	"cosmossdk.io/core/store"
 	"cosmossdk.io/depinject"
 	"cosmossdk.io/depinject/appconfig"
 	"cosmossdk.io/log"
@@ -28,10 +27,10 @@ func init() {
 type ModuleInputs struct {
 	depinject.In
 
-	Config       *modulev1.Module
-	Cdc          codec.Codec
-	StoreService store.KVStoreService
-	Logger       log.Logger
+	Config      *modulev1.Module
+	Cdc         codec.Codec
+	Environment appmodule.Environment
+	Logger      log.Logger
 
 	AccountKeeper types.AccountKeeper
 }
@@ -79,8 +78,8 @@ func ProvideModule(in ModuleInputs) ModuleOutputs {
 	}
 
 	bankKeeper := keeper.NewBaseKeeper(
+		in.Environment,
 		in.Cdc,
-		in.StoreService,
 		in.AccountKeeper,
 		blockedAddresses,
 		authStr,

--- a/x/bank/keeper/collections_test.go
+++ b/x/bank/keeper/collections_test.go
@@ -30,7 +30,7 @@ func TestBankStateCompatibility(t *testing.T) {
 	ctx := testCtx.Ctx.WithHeaderInfo(header.Info{Time: time.Now()})
 	encCfg := moduletestutil.MakeTestEncodingConfig()
 
-	storeService := runtime.NewKVStoreService(key)
+	env := runtime.NewEnvironment(runtime.NewKVStoreService(key), log.NewNopLogger())
 
 	// gomock initializations
 	ctrl := gomock.NewController(t)
@@ -38,8 +38,8 @@ func TestBankStateCompatibility(t *testing.T) {
 	authKeeper.EXPECT().AddressCodec().Return(address.NewBech32Codec("cosmos")).AnyTimes()
 
 	k := keeper.NewBaseKeeper(
+		env,
 		encCfg.Codec,
-		storeService,
 		authKeeper,
 		map[string]bool{accAddrs[4].String(): true},
 		authtypes.NewModuleAddress(banktypes.GovModuleName).String(),
@@ -56,7 +56,7 @@ func TestBankStateCompatibility(t *testing.T) {
 	)
 	require.NoError(t, err)
 	// we set the index key to the old value.
-	require.NoError(t, storeService.OpenKVStore(ctx).Set(rawKey, bankDenomAddressLegacyIndexValue))
+	require.NoError(t, env.KVStoreService.OpenKVStore(ctx).Set(rawKey, bankDenomAddressLegacyIndexValue))
 
 	// test walking is ok
 	err = k.Balances.Indexes.Denom.Walk(ctx, nil, func(indexingKey string, indexedKey sdk.AccAddress) (stop bool, err error) {
@@ -79,7 +79,7 @@ func TestBankStateCompatibility(t *testing.T) {
 	err = k.Balances.Indexes.Denom.Reference(ctx, collections.Join(sdk.AccAddress("test"), "atom"), math.ZeroInt(), nil)
 	require.NoError(t, err)
 
-	newRawValue, err := storeService.OpenKVStore(ctx).Get(rawKey)
+	newRawValue, err := env.KVStoreService.OpenKVStore(ctx).Get(rawKey)
 	require.NoError(t, err)
 	require.Equal(t, []byte{}, newRawValue)
 }

--- a/x/bank/keeper/grpc_query.go
+++ b/x/bank/keeper/grpc_query.go
@@ -172,7 +172,7 @@ func (k BaseKeeper) DenomsMetadata(c context.Context, req *types.QueryDenomsMeta
 	if req == nil {
 		return nil, status.Errorf(codes.InvalidArgument, "empty request")
 	}
-	kvStore := runtime.KVStoreAdapter(k.storeService.OpenKVStore(c))
+	kvStore := runtime.KVStoreAdapter(k.environment.KVStoreService.OpenKVStore(c))
 	store := prefix.NewStore(kvStore, types.DenomMetadataPrefix)
 
 	metadatas := []types.Metadata{}

--- a/x/bank/keeper/keeper.go
+++ b/x/bank/keeper/keeper.go
@@ -387,7 +387,6 @@ func (k BaseKeeper) MintCoins(ctx context.Context, moduleName string, amounts sd
 		event.NewAttribute(types.AttributeKeyReceiver, addrStr),
 		event.NewAttribute(sdk.AttributeKeyAmount, amounts.String()),
 	)
-
 }
 
 // BurnCoins burns coins deletes coins from the balance of an account.

--- a/x/bank/keeper/keeper.go
+++ b/x/bank/keeper/keeper.go
@@ -349,7 +349,6 @@ func (k BaseKeeper) UndelegateCoinsFromModuleToAccount(
 // MintCoins creates new coins from thin air and adds it to the module account.
 // An error is returned if the module account does not exist or is unauthorized.
 func (k BaseKeeper) MintCoins(ctx context.Context, moduleName string, amounts sdk.Coins) error {
-
 	err := k.mintCoinsRestrictionFn(ctx, amounts)
 	if err != nil {
 		k.logger.Error(fmt.Sprintf("Module %q attempted to mint coins %s it doesn't have permission for, error %v", moduleName, amounts, err))
@@ -381,14 +380,14 @@ func (k BaseKeeper) MintCoins(ctx context.Context, moduleName string, amounts sd
 	if err != nil {
 		return err
 	}
+
 	// emit mint event
-	k.environment.EventService.EventManager(ctx).EmitKV(
+	return k.environment.EventService.EventManager(ctx).EmitKV(
 		types.EventTypeCoinReceived,
 		event.NewAttribute(types.AttributeKeyReceiver, addrStr),
 		event.NewAttribute(sdk.AttributeKeyAmount, amounts.String()),
 	)
 
-	return nil
 }
 
 // BurnCoins burns coins deletes coins from the balance of an account.

--- a/x/bank/keeper/keeper.go
+++ b/x/bank/keeper/keeper.go
@@ -383,8 +383,8 @@ func (k BaseKeeper) MintCoins(ctx context.Context, moduleName string, amounts sd
 
 	// emit mint event
 	return k.environment.EventService.EventManager(ctx).EmitKV(
-		types.EventTypeCoinReceived,
-		event.NewAttribute(types.AttributeKeyReceiver, addrStr),
+		types.EventTypeCoinMint,
+		event.NewAttribute(types.AttributeKeyMinter, addrStr),
 		event.NewAttribute(sdk.AttributeKeyAmount, amounts.String()),
 	)
 }

--- a/x/bank/keeper/keeper_test.go
+++ b/x/bank/keeper/keeper_test.go
@@ -131,7 +131,7 @@ func (suite *KeeperTestSuite) SetupTest() {
 	ctx := testCtx.Ctx.WithHeaderInfo(header.Info{Time: time.Now()})
 	encCfg := moduletestutil.MakeTestEncodingConfig()
 
-	storeService := runtime.NewKVStoreService(key)
+	env := runtime.NewEnvironment(runtime.NewKVStoreService(key), log.NewNopLogger())
 
 	// gomock initializations
 	ctrl := gomock.NewController(suite.T())
@@ -140,8 +140,8 @@ func (suite *KeeperTestSuite) SetupTest() {
 	suite.ctx = ctx
 	suite.authKeeper = authKeeper
 	suite.bankKeeper = keeper.NewBaseKeeper(
+		env,
 		encCfg.Codec,
-		storeService,
 		suite.authKeeper,
 		map[string]bool{accAddrs[4].String(): true},
 		authtypes.NewModuleAddress(banktypes.GovModuleName).String(),
@@ -300,11 +300,11 @@ func (suite *KeeperTestSuite) TestPrependSendRestriction() {
 }
 
 func (suite *KeeperTestSuite) TestGetAuthority() {
-	storeService := runtime.NewKVStoreService(storetypes.NewKVStoreKey(banktypes.StoreKey))
+	env := runtime.NewEnvironment(runtime.NewKVStoreService(storetypes.NewKVStoreKey(banktypes.StoreKey)), log.NewNopLogger())
 	NewKeeperWithAuthority := func(authority string) keeper.BaseKeeper {
 		return keeper.NewBaseKeeper(
+			env,
 			moduletestutil.MakeTestEncodingConfig().Codec,
-			storeService,
 			suite.authKeeper,
 			nil,
 			authority,

--- a/x/bank/keeper/send.go
+++ b/x/bank/keeper/send.go
@@ -5,7 +5,8 @@ import (
 	"fmt"
 
 	"cosmossdk.io/collections"
-	"cosmossdk.io/core/store"
+	"cosmossdk.io/core/appmodule"
+	"cosmossdk.io/core/event"
 	errorsmod "cosmossdk.io/errors"
 	"cosmossdk.io/log"
 	"cosmossdk.io/math"
@@ -55,10 +56,10 @@ var _ SendKeeper = (*BaseSendKeeper)(nil)
 type BaseSendKeeper struct {
 	BaseViewKeeper
 
-	cdc          codec.BinaryCodec
-	ak           types.AccountKeeper
-	storeService store.KVStoreService
-	logger       log.Logger
+	cdc         codec.BinaryCodec
+	ak          types.AccountKeeper
+	environment appmodule.Environment
+	logger      log.Logger
 
 	// list of addresses that are restricted from receiving transactions
 	blockedAddrs map[string]bool
@@ -71,8 +72,8 @@ type BaseSendKeeper struct {
 }
 
 func NewBaseSendKeeper(
+	env appmodule.Environment,
 	cdc codec.BinaryCodec,
-	storeService store.KVStoreService,
 	ak types.AccountKeeper,
 	blockedAddrs map[string]bool,
 	authority string,
@@ -83,10 +84,10 @@ func NewBaseSendKeeper(
 	}
 
 	return BaseSendKeeper{
-		BaseViewKeeper:  NewBaseViewKeeper(cdc, storeService, ak, logger),
+		BaseViewKeeper:  NewBaseViewKeeper(env, cdc, ak, logger),
 		cdc:             cdc,
 		ak:              ak,
-		storeService:    storeService,
+		environment:     env,
 		blockedAddrs:    blockedAddrs,
 		authority:       authority,
 		logger:          logger,
@@ -156,8 +157,6 @@ func (k BaseSendKeeper) InputOutputCoins(ctx context.Context, input types.Input,
 		return err
 	}
 
-	sdkCtx := sdk.UnwrapSDKContext(ctx)
-
 	var outAddress sdk.AccAddress
 	for _, out := range outputs {
 		outAddress, err = k.ak.AddressCodec().StringToBytes(out.Address)
@@ -174,14 +173,11 @@ func (k BaseSendKeeper) InputOutputCoins(ctx context.Context, input types.Input,
 			return err
 		}
 
-		sdkCtx.EventManager().EmitEvent(
-			sdk.NewEvent(
-				types.EventTypeTransfer,
-				sdk.NewAttribute(types.AttributeKeyRecipient, out.Address),
-				sdk.NewAttribute(sdk.AttributeKeyAmount, out.Coins.String()),
-			),
+		return k.environment.EventService.EventManager(ctx).EmitKV(
+			types.EventTypeTransfer,
+			event.NewAttribute(types.AttributeKeyRecipient, out.Address),
+			event.NewAttribute(sdk.AttributeKeyAmount, out.Coins.String()),
 		)
-
 	}
 
 	return nil
@@ -215,17 +211,12 @@ func (k BaseSendKeeper) SendCoins(ctx context.Context, fromAddr, toAddr sdk.AccA
 		return err
 	}
 
-	sdkCtx := sdk.UnwrapSDKContext(ctx)
-	sdkCtx.EventManager().EmitEvent(
-		sdk.NewEvent(
-			types.EventTypeTransfer,
-			sdk.NewAttribute(types.AttributeKeyRecipient, toAddrString),
-			sdk.NewAttribute(types.AttributeKeySender, fromAddrString),
-			sdk.NewAttribute(sdk.AttributeKeyAmount, amt.String()),
-		),
+	return k.environment.EventService.EventManager(ctx).EmitKV(
+		types.EventTypeTransfer,
+		event.NewAttribute(types.AttributeKeyRecipient, toAddrString),
+		event.NewAttribute(types.AttributeKeySender, fromAddrString),
+		event.NewAttribute(sdk.AttributeKeyAmount, amt.String()),
 	)
-
-	return nil
 }
 
 // subUnlockedCoins removes the unlocked amt coins of the given account. An error is
@@ -270,12 +261,12 @@ func (k BaseSendKeeper) subUnlockedCoins(ctx context.Context, addr sdk.AccAddres
 	if err != nil {
 		return err
 	}
-	sdkCtx := sdk.UnwrapSDKContext(ctx)
-	sdkCtx.EventManager().EmitEvent(
-		types.NewCoinSpentEvent(addrStr, amt),
-	)
 
-	return nil
+	return k.environment.EventService.EventManager(ctx).EmitKV(
+		types.EventTypeCoinSpent,
+		event.NewAttribute(types.AttributeKeySpender, addrStr),
+		event.NewAttribute(sdk.AttributeKeyAmount, amt.String()),
+	)
 }
 
 // addCoins increase the addr balance by the given amt. Fails if the provided
@@ -300,13 +291,12 @@ func (k BaseSendKeeper) addCoins(ctx context.Context, addr sdk.AccAddress, amt s
 		return err
 	}
 
-	// emit coin received event
-	sdkCtx := sdk.UnwrapSDKContext(ctx)
-	sdkCtx.EventManager().EmitEvent(
-		types.NewCoinReceivedEvent(addrStr, amt),
+	return k.environment.EventService.EventManager(ctx).EmitKV(
+		types.EventTypeCoinReceived,
+		event.NewAttribute(types.AttributeKeyReceiver, addrStr),
+		event.NewAttribute(sdk.AttributeKeyAmount, amt.String()),
 	)
 
-	return nil
 }
 
 // setBalance sets the coin balance for an account by address.

--- a/x/bank/keeper/send.go
+++ b/x/bank/keeper/send.go
@@ -173,11 +173,13 @@ func (k BaseSendKeeper) InputOutputCoins(ctx context.Context, input types.Input,
 			return err
 		}
 
-		return k.environment.EventService.EventManager(ctx).EmitKV(
+		if err := k.environment.EventService.EventManager(ctx).EmitKV(
 			types.EventTypeTransfer,
 			event.NewAttribute(types.AttributeKeyRecipient, out.Address),
 			event.NewAttribute(sdk.AttributeKeyAmount, out.Coins.String()),
-		)
+		); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -296,7 +298,6 @@ func (k BaseSendKeeper) addCoins(ctx context.Context, addr sdk.AccAddress, amt s
 		event.NewAttribute(types.AttributeKeyReceiver, addrStr),
 		event.NewAttribute(sdk.AttributeKeyAmount, amt.String()),
 	)
-
 }
 
 // setBalance sets the coin balance for an account by address.

--- a/x/bank/types/events.go
+++ b/x/bank/types/events.go
@@ -22,39 +22,3 @@ const (
 	AttributeKeyMinter   = "minter"
 	AttributeKeyBurner   = "burner"
 )
-
-// NewCoinSpentEvent constructs a new coin spent sdk.Event
-func NewCoinSpentEvent(spender string, amount sdk.Coins) sdk.Event {
-	return sdk.NewEvent(
-		EventTypeCoinSpent,
-		sdk.NewAttribute(AttributeKeySpender, spender),
-		sdk.NewAttribute(sdk.AttributeKeyAmount, amount.String()),
-	)
-}
-
-// NewCoinReceivedEvent constructs a new coin received sdk.Event
-func NewCoinReceivedEvent(receiver string, amount sdk.Coins) sdk.Event {
-	return sdk.NewEvent(
-		EventTypeCoinReceived,
-		sdk.NewAttribute(AttributeKeyReceiver, receiver),
-		sdk.NewAttribute(sdk.AttributeKeyAmount, amount.String()),
-	)
-}
-
-// NewCoinMintEvent construct a new coin minted sdk.Event
-func NewCoinMintEvent(minter string, amount sdk.Coins) sdk.Event {
-	return sdk.NewEvent(
-		EventTypeCoinMint,
-		sdk.NewAttribute(AttributeKeyMinter, minter),
-		sdk.NewAttribute(sdk.AttributeKeyAmount, amount.String()),
-	)
-}
-
-// NewCoinBurnEvent constructs a new coin burned sdk.Event
-func NewCoinBurnEvent(burner string, amount sdk.Coins) sdk.Event {
-	return sdk.NewEvent(
-		EventTypeCoinBurn,
-		sdk.NewAttribute(AttributeKeyBurner, burner),
-		sdk.NewAttribute(sdk.AttributeKeyAmount, amount.String()),
-	)
-}

--- a/x/distribution/migrations/v4/migrate_funds_test.go
+++ b/x/distribution/migrations/v4/migrate_funds_test.go
@@ -57,8 +57,8 @@ func TestFundsMigration(t *testing.T) {
 
 	// create bank keeper
 	bankKeeper := bankkeeper.NewBaseKeeper(
+		runtime.NewEnvironment(runtime.NewKVStoreService(keys[banktypes.StoreKey]), log.NewNopLogger()),
 		encCfg.Codec,
-		runtime.NewKVStoreService(keys[banktypes.StoreKey]),
 		accountKeeper,
 		map[string]bool{},
 		authority.String(),


### PR DESCRIPTION
# Description

ref https://github.com/cosmos/cosmos-sdk/issues/19290

migrate bank module to use env variable 

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Enhanced the initialization of `BankKeeper` for improved environment handling and logging capabilities.
	- Updated various integration tests to align with the new `BankKeeper` initialization method, optimizing component interactions and event logic.
	- Modified the `bankKeeper` setup in the `FuzzMsgServerCreateVestingAccount` function for better environment and logging integration.

- **Tests**
	- Adjustments made across multiple integration test files to support the updated `BankKeeper` initialization and environment setup.

- **Chores**
	- Internal code maintenance with no direct impact on end-user functionalities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->