### PR TITLE
docs: Update Discord Link to new Vanity URL

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,14 +62,14 @@ The Cosmos SDK has many stakeholders contributing and shaping the project. The C
 
 The developers work in sprints, which are available in a [GitHub Project](https://github.com/orgs/cosmos/projects/26/views/22). The current EPICs are pinned at the top of the [issues list](https://github.com/cosmos/cosmos-sdk/issues).
 
-The important development announcements are shared on [Discord](https://discord.com/invite/cosmosnetwork) in the `#dev-announcements` channel.
+The important development announcements are shared on [Discord](https://discord.gg/interchain) in the `#dev-announcements` channel.
 
 To synchronize we have few major meetings:
 
 * Cosmos SDK Sprint Review on Monday and Thursday at 14:00 UTC (limited participation to core devs).
 * Cosmos SDK Community Call on Thursday at 16:00 UTC.
 
-If you would like to join one of the community call, then please contact us on [Discord](https://discord.com/invite/cosmosnetwork) or reach out directly to Marko (@tac0turtle).
+If you would like to join one of the community call, then please contact us on [Discord](https://discord.gg/interchain) or reach out directly to Marko (@tac0turtle).
 
 ## Architecture Decision Records (ADR)
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   </a>
 </div>
 <div align="center">
-  <a href="https://discord.gg/cosmosnetwork">
+  <a href="https://discord.gg/interchain">
     <img alt="Discord" src="https://img.shields.io/discord/669268347736686612.svg" />
   </a>
   <a href="https://sourcegraph.com/github.com/cosmos/cosmos-sdk?badge">
@@ -49,7 +49,7 @@ For more information, see the [Cosmos SDK Documentation](https://docs.cosmos.net
 ## Contributing
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md) for details on how to contribute and participate in our [dev calls](./CONTRIBUTING.md#teams-dev-calls).
-If you want to follow the updates or learn more about the latest design then join our [Discord](https://discord.gg/cosmosnetwork).
+If you want to follow the updates or learn more about the latest design then join our [Discord](https://discord.gg/interchain).
 
 ## Tools and Frameworks
 

--- a/docs/Introduction.md
+++ b/docs/Introduction.md
@@ -33,5 +33,5 @@ Check out the docs for the various parts of the Cosmos stack.
 ## Help & Support
 
 * [**GitHub Discussions**](https://github.com/orgs/cosmos/discussions) - Ask questions and discuss SDK development on GitHub.
-* [**Discord**](https://discord.gg/cosmosnetwork) - Chat with Cosmos developers on Discord.
+* [**Discord**](https://discord.gg/interchain) - Chat with Cosmos developers on Discord.
 * [**Found an issue?**](https://github.com/cosmos/cosmos-sdk/edit/main/docs/docs/README.md) - Help us improve this page by suggesting edits on GitHub.


### PR DESCRIPTION
# Description

This commit changes the `docs/README/CONTRIBUTING` discord link `discord.gg/cosmosnetwork` and `discord.com/invite/cosmosnetwork` -> `discord.gg/interchain` to reflect the new vanity URL we have migrated the server to.

@samricotta approved bypass of the checklist

Thanks team, good to be here!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated Discord links across project documentation for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->