### PR TITLE
perf: Use Dec Bigintmut API

### DIFF
--- a/math/dec.go
+++ b/math/dec.go
@@ -132,7 +132,7 @@ func LegacyNewDecFromInt(i Int) LegacyDec {
 // CONTRACT: prec <= Precision
 func LegacyNewDecFromIntWithPrec(i Int, prec int64) LegacyDec {
 	return LegacyDec{
-		new(big.Int).Mul(i.BigInt(), precisionMultiplier(prec)),
+		new(big.Int).Mul(i.BigIntMut(), precisionMultiplier(prec)),
 	}
 }
 
@@ -351,7 +351,7 @@ func (d LegacyDec) MulInt(i Int) LegacyDec {
 }
 
 func (d LegacyDec) MulIntMut(i Int) LegacyDec {
-	d.i.Mul(d.i, i.BigInt())
+	d.i.Mul(d.i, i.BigIntMut())
 	if d.i.BitLen() > maxDecBitLen {
 		panic("Int overflow")
 	}
@@ -434,7 +434,7 @@ func (d LegacyDec) QuoInt(i Int) LegacyDec {
 }
 
 func (d LegacyDec) QuoIntMut(i Int) LegacyDec {
-	d.i.Quo(d.i, i.BigInt())
+	d.i.Quo(d.i, i.BigIntMut())
 	return d
 }
 
@@ -692,7 +692,7 @@ func (d LegacyDec) RoundInt64() int64 {
 
 // RoundInt round the decimal using bankers rounding
 func (d LegacyDec) RoundInt() Int {
-	return NewIntFromBigInt(chopPrecisionAndRoundNonMutative(d.i))
+	return NewIntFromBigIntMut(chopPrecisionAndRoundNonMutative(d.i))
 }
 
 // chopPrecisionAndTruncate is similar to chopPrecisionAndRound,
@@ -718,7 +718,7 @@ func (d LegacyDec) TruncateInt64() int64 {
 
 // TruncateInt truncates the decimals from the number and returns an Int
 func (d LegacyDec) TruncateInt() Int {
-	return NewIntFromBigInt(chopPrecisionAndTruncateNonMutative(d.i))
+	return NewIntFromBigIntMut(chopPrecisionAndTruncateNonMutative(d.i))
 }
 
 // TruncateDec truncates the decimals from the number and returns a Dec


### PR DESCRIPTION
# Description

Minor speed improvements by using the BigIntMut API's, instead of Int.BigInt(), when safe.

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage
