### PR TITLE
fix: in-place-testnet edgecases

### DIFF
--- a/server/start.go
+++ b/server/start.go
@@ -857,21 +857,15 @@ func testnetify(ctx *Context, home string, testnetAppCreator types.AppCreator, d
 	block.LastCommit.Signatures[0].Signature = vote.Signature
 	block.LastCommit.Signatures = []cmttypes.CommitSig{block.LastCommit.Signatures[0]}
 
-	// Create a commit signed from our validator and save it
-	seenCommit := cmttypes.Commit{
-		Height:  state.LastBlockHeight,
-		Round:   vote.Round,
-		BlockID: state.LastBlockID,
-		Signatures: []cmttypes.CommitSig{
-			{
-				BlockIDFlag:      cmttypes.BlockIDFlagCommit,
-				Signature:        vote.Signature,
-				ValidatorAddress: validatorAddress,
-				Timestamp:        vote.Timestamp,
-			},
-		},
-	}
-	err = blockStore.SaveSeenCommit(state.LastBlockHeight, &seenCommit)
+	// Load the seenCommit of the lastBlockHeight and modify it to be signed from our validator
+	seenCommit := blockStore.LoadSeenCommit(state.LastBlockHeight)
+	seenCommit.BlockID = state.LastBlockID
+	seenCommit.Round = vote.Round
+	seenCommit.Signatures[0].Signature = vote.Signature
+	seenCommit.Signatures[0].ValidatorAddress = validatorAddress
+	seenCommit.Signatures[0].Timestamp = vote.Timestamp
+	seenCommit.Signatures = []cmttypes.CommitSig{seenCommit.Signatures[0]}
+	err = blockStore.SaveSeenCommit(state.LastBlockHeight, seenCommit)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
# Description

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

Killing a node, setting a halt height, and gracefully shutting down cause varying states of the block height across app/blockStore/state. This PR handles these states properly.

Additionally, there was an edge case where if prometheus was enabled, it would panic due to setting it a second time in testnetify. We don't actually need the metrics provider to match what the user wants in testnetify since this is just used temporarily while setting up the application, so we use the default config of instrumentation to prevent this panic from happening.

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated metrics provider configuration for better performance and reliability.
	- Improved handling of block and state heights to enhance node robustness under various conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->