### PR TITLE
refactor: use errors.New to replace fmt.Errorf with no parameters

### DIFF
--- a/codec/proto_codec.go
+++ b/codec/proto_codec.go
@@ -144,7 +144,7 @@ func (pc *ProtoCodec) MustUnmarshalLengthPrefixed(bz []byte, ptr gogoproto.Messa
 // implements proto.Message. For interface please use the codec.MarshalInterfaceJSON
 func (pc *ProtoCodec) MarshalJSON(o gogoproto.Message) ([]byte, error) { //nolint:stdmethods // we don't want to implement Marshaler interface
 	if o == nil {
-		return nil, fmt.Errorf("cannot protobuf JSON encode nil")
+		return nil, errors.New("cannot protobuf JSON encode nil")
 	}
 	return ProtoMarshalJSON(o, pc.interfaceRegistry)
 }

--- a/codec/types/any_test.go
+++ b/codec/types/any_test.go
@@ -1,7 +1,7 @@
 package types_test
 
 import (
-	"fmt"
+	"errors"
 	"runtime"
 	"testing"
 
@@ -17,7 +17,7 @@ type errOnMarshal struct {
 
 var _ proto.Message = (*errOnMarshal)(nil)
 
-var errAlways = fmt.Errorf("always erroring")
+var errAlways = errors.New("always erroring")
 
 func (eom *errOnMarshal) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return nil, errAlways

--- a/codec/types/interface_registry.go
+++ b/codec/types/interface_registry.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 
@@ -138,7 +139,7 @@ type InterfaceRegistryOptions struct {
 // NewInterfaceRegistryWithOptions returns a new InterfaceRegistry with the given options.
 func NewInterfaceRegistryWithOptions(options InterfaceRegistryOptions) (InterfaceRegistry, error) {
 	if options.ProtoFiles == nil {
-		return nil, fmt.Errorf("proto files must be provided")
+		return nil, errors.New("proto files must be provided")
 	}
 
 	options.SigningOptions.FileResolver = options.ProtoFiles
@@ -284,7 +285,7 @@ func (registry *interfaceRegistry) UnpackAny(any *Any, iface interface{}) error 
 
 	rv := reflect.ValueOf(iface)
 	if rv.Kind() != reflect.Ptr {
-		return fmt.Errorf("UnpackAny expects a pointer")
+		return errors.New("UnpackAny expects a pointer")
 	}
 
 	rt := rv.Elem().Type()
@@ -366,9 +367,9 @@ func UnpackInterfaces(x interface{}, unpacker AnyUnpacker) error {
 type failingAddressCodec struct{}
 
 func (f failingAddressCodec) StringToBytes(string) ([]byte, error) {
-	return nil, fmt.Errorf("InterfaceRegistry requires a proper address codec implementation to do address conversion")
+	return nil, errors.New("InterfaceRegistry requires a proper address codec implementation to do address conversion")
 }
 
 func (f failingAddressCodec) BytesToString([]byte) (string, error) {
-	return "", fmt.Errorf("InterfaceRegistry requires a proper address codec implementation to do address conversion")
+	return "", errors.New("InterfaceRegistry requires a proper address codec implementation to do address conversion")
 }

--- a/math/int.go
+++ b/math/int.go
@@ -550,7 +550,7 @@ var stringsBuilderPool = &sync.Pool{
 // (instead of manipulating the int or math.Int object).
 func FormatInt(v string) (string, error) {
 	if len(v) == 0 {
-		return "", fmt.Errorf("cannot format empty string")
+		return "", errors.New("cannot format empty string")
 	}
 
 	sign := ""

--- a/x/tx/decode/decode.go
+++ b/x/tx/decode/decode.go
@@ -1,13 +1,13 @@
 package decode
 
 import (
-	"fmt"
+	"errors"
 
 	"github.com/cosmos/cosmos-proto/anyutil"
 	"google.golang.org/protobuf/proto"
 
 	v1beta1 "cosmossdk.io/api/cosmos/tx/v1beta1"
-	"cosmossdk.io/errors"
+	errorsmod "cosmossdk.io/errors"
 	"cosmossdk.io/x/tx/signing"
 )
 
@@ -33,7 +33,7 @@ type Options struct {
 // NewDecoder creates a new Decoder for decoding transactions.
 func NewDecoder(options Options) (*Decoder, error) {
 	if options.SigningContext == nil {
-		return nil, fmt.Errorf("signing context is required")
+		return nil, errors.New("signing context is required")
 	}
 
 	return &Decoder{
@@ -46,7 +46,7 @@ func (d *Decoder) Decode(txBytes []byte) (*DecodedTx, error) {
 	// Make sure txBytes follow ADR-027.
 	err := rejectNonADR027TxRaw(txBytes)
 	if err != nil {
-		return nil, errors.Wrap(ErrTxDecode, err.Error())
+		return nil, errorsmod.Wrap(ErrTxDecode, err.Error())
 	}
 
 	var raw v1beta1.TxRaw
@@ -55,7 +55,7 @@ func (d *Decoder) Decode(txBytes []byte) (*DecodedTx, error) {
 	fileResolver := d.signingCtx.FileResolver()
 	err = RejectUnknownFieldsStrict(txBytes, raw.ProtoReflect().Descriptor(), fileResolver)
 	if err != nil {
-		return nil, errors.Wrap(ErrTxDecode, err.Error())
+		return nil, errorsmod.Wrap(ErrTxDecode, err.Error())
 	}
 
 	err = proto.Unmarshal(txBytes, &raw)
@@ -68,12 +68,12 @@ func (d *Decoder) Decode(txBytes []byte) (*DecodedTx, error) {
 	// allow non-critical unknown fields in TxBody
 	txBodyHasUnknownNonCriticals, err := RejectUnknownFields(raw.BodyBytes, body.ProtoReflect().Descriptor(), true, fileResolver)
 	if err != nil {
-		return nil, errors.Wrap(ErrTxDecode, err.Error())
+		return nil, errorsmod.Wrap(ErrTxDecode, err.Error())
 	}
 
 	err = proto.Unmarshal(raw.BodyBytes, &body)
 	if err != nil {
-		return nil, errors.Wrap(ErrTxDecode, err.Error())
+		return nil, errorsmod.Wrap(ErrTxDecode, err.Error())
 	}
 
 	var authInfo v1beta1.AuthInfo
@@ -81,12 +81,12 @@ func (d *Decoder) Decode(txBytes []byte) (*DecodedTx, error) {
 	// reject all unknown proto fields in AuthInfo
 	err = RejectUnknownFieldsStrict(raw.AuthInfoBytes, authInfo.ProtoReflect().Descriptor(), fileResolver)
 	if err != nil {
-		return nil, errors.Wrap(ErrTxDecode, err.Error())
+		return nil, errorsmod.Wrap(ErrTxDecode, err.Error())
 	}
 
 	err = proto.Unmarshal(raw.AuthInfoBytes, &authInfo)
 	if err != nil {
-		return nil, errors.Wrap(ErrTxDecode, err.Error())
+		return nil, errorsmod.Wrap(ErrTxDecode, err.Error())
 	}
 
 	theTx := &v1beta1.Tx{
@@ -101,12 +101,12 @@ func (d *Decoder) Decode(txBytes []byte) (*DecodedTx, error) {
 	for _, anyMsg := range body.Messages {
 		msg, signerErr := anyutil.Unpack(anyMsg, fileResolver, d.signingCtx.TypeResolver())
 		if signerErr != nil {
-			return nil, errors.Wrap(ErrTxDecode, signerErr.Error())
+			return nil, errorsmod.Wrap(ErrTxDecode, signerErr.Error())
 		}
 		msgs = append(msgs, msg)
 		ss, signerErr := d.signingCtx.GetSigners(msg)
 		if signerErr != nil {
-			return nil, errors.Wrap(ErrTxDecode, signerErr.Error())
+			return nil, errorsmod.Wrap(ErrTxDecode, signerErr.Error())
 		}
 		for _, s := range ss {
 			_, seen := seenSigners[string(s)]

--- a/x/tx/signing/aminojson/aminojson.go
+++ b/x/tx/signing/aminojson/aminojson.go
@@ -2,6 +2,7 @@ package aminojson
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"google.golang.org/protobuf/reflect/protoregistry"
@@ -78,7 +79,7 @@ func (h SignModeHandler) GetSignBytes(_ context.Context, signerData signing.Sign
 
 	f := txData.AuthInfo.Fee
 	if f == nil {
-		return nil, fmt.Errorf("fee cannot be nil when tipper is not signer")
+		return nil, errors.New("fee cannot be nil when tipper is not signer")
 	}
 	fee = &aminojsonpb.AminoSignFee{
 		Amount:  f.Amount,

--- a/x/tx/signing/aminojson/json_marshal_test.go
+++ b/x/tx/signing/aminojson/json_marshal_test.go
@@ -2,6 +2,7 @@ package aminojson_test
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"reflect"
@@ -197,7 +198,7 @@ func TestMarshalDuration(t *testing.T) {
 		fields := msg.Descriptor().Fields()
 		secondsField := fields.ByName(secondsName)
 		if secondsField == nil {
-			return fmt.Errorf("expected seconds field")
+			return errors.New("expected seconds field")
 		}
 		seconds := msg.Get(secondsField).Int()
 

--- a/x/tx/signing/aminojson/time.go
+++ b/x/tx/signing/aminojson/time.go
@@ -1,6 +1,7 @@
 package aminojson
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -19,12 +20,12 @@ func marshalTimestamp(_ *Encoder, message protoreflect.Message, writer io.Writer
 	fields := message.Descriptor().Fields()
 	secondsField := fields.ByName(secondsName)
 	if secondsField == nil {
-		return fmt.Errorf("expected seconds field")
+		return errors.New("expected seconds field")
 	}
 
 	nanosField := fields.ByName(nanosName)
 	if nanosField == nil {
-		return fmt.Errorf("expected nanos field")
+		return errors.New("expected nanos field")
 	}
 
 	seconds := message.Get(secondsField).Int()
@@ -53,7 +54,7 @@ func marshalDuration(_ *Encoder, message protoreflect.Message, writer io.Writer)
 	fields := message.Descriptor().Fields()
 	secondsField := fields.ByName(secondsName)
 	if secondsField == nil {
-		return fmt.Errorf("expected seconds field")
+		return errors.New("expected seconds field")
 	}
 
 	// todo
@@ -65,7 +66,7 @@ func marshalDuration(_ *Encoder, message protoreflect.Message, writer io.Writer)
 
 	nanosField := fields.ByName(nanosName)
 	if nanosField == nil {
-		return fmt.Errorf("expected nanos field")
+		return errors.New("expected nanos field")
 	}
 
 	nanos := message.Get(nanosField).Int()

--- a/x/tx/signing/context.go
+++ b/x/tx/signing/context.go
@@ -221,7 +221,7 @@ func (c *Context) makeGetSignersFunc(descriptor protoreflect.MessageDescriptor) 
 			var fieldGetter func(protoreflect.Message, int) ([][]byte, error)
 			fieldGetter = func(msg protoreflect.Message, depth int) ([][]byte, error) {
 				if depth > c.maxRecursionDepth {
-					return nil, fmt.Errorf("maximum recursion depth exceeded")
+					return nil, errors.New("maximum recursion depth exceeded")
 				}
 				desc := msg.Descriptor()
 				signerFields, err := getSignersFieldNames(desc)

--- a/x/tx/signing/directaux/direct_aux.go
+++ b/x/tx/signing/directaux/direct_aux.go
@@ -2,6 +2,7 @@ package directaux
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/cosmos/cosmos-proto/anyutil"
@@ -34,7 +35,7 @@ func NewSignModeHandler(options SignModeHandlerOptions) (SignModeHandler, error)
 	h := SignModeHandler{}
 
 	if options.SignersContext == nil {
-		return h, fmt.Errorf("signers context is required")
+		return h, errors.New("signers context is required")
 	}
 	h.signersContext = options.SignersContext
 
@@ -60,7 +61,7 @@ func (h SignModeHandler) Mode() signingv1beta1.SignMode {
 // https://github.com/cosmos/cosmos-sdk/blob/4a6a1e3cb8de459891cb0495052589673d14ef51/x/auth/tx/builder.go#L142
 func (h SignModeHandler) getFirstSigner(txData signing.TxData) ([]byte, error) {
 	if len(txData.Body.Messages) == 0 {
-		return nil, fmt.Errorf("no signer found")
+		return nil, errors.New("no signer found")
 	}
 
 	msg, err := anyutil.Unpack(txData.Body.Messages[0], h.fileResolver, h.typeResolver)

--- a/x/tx/signing/textual/any.go
+++ b/x/tx/signing/textual/any.go
@@ -2,6 +2,7 @@ package textual
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -74,7 +75,7 @@ func (ar anyValueRenderer) Format(ctx context.Context, v protoreflect.Value) ([]
 // Parse implements the ValueRenderer interface.
 func (ar anyValueRenderer) Parse(ctx context.Context, screens []Screen) (protoreflect.Value, error) {
 	if len(screens) == 0 {
-		return nilValue, fmt.Errorf("expect at least one screen")
+		return nilValue, errors.New("expect at least one screen")
 	}
 	if screens[0].Indent != 0 {
 		return nilValue, fmt.Errorf("bad indentation: want 0, got %d", screens[0].Indent)

--- a/x/tx/signing/textual/coin_test.go
+++ b/x/tx/signing/textual/coin_test.go
@@ -3,6 +3,7 @@ package textual_test
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"testing"
@@ -55,7 +56,7 @@ func TestMetadataQuerier(t *testing.T) {
 	require.Error(t, err)
 
 	// Errors if metadata querier returns an error
-	expErr := fmt.Errorf("mock error")
+	expErr := errors.New("mock error")
 	txt, err := textual.NewSignModeHandler(textual.SignModeOptions{
 		CoinMetadataQuerier: func(_ context.Context, _ string) (*bankv1beta1.Metadata, error) {
 			return nil, expErr

--- a/x/tx/signing/textual/coins.go
+++ b/x/tx/signing/textual/coins.go
@@ -2,6 +2,7 @@ package textual
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -32,7 +33,7 @@ var _ RepeatedValueRenderer = coinsValueRenderer{}
 
 func (vr coinsValueRenderer) Format(ctx context.Context, v protoreflect.Value) ([]Screen, error) {
 	if vr.coinMetadataQuerier == nil {
-		return nil, fmt.Errorf("expected non-nil coin metadata querier")
+		return nil, errors.New("expected non-nil coin metadata querier")
 	}
 
 	// Since this value renderer has a FormatRepeated method, the Format one
@@ -58,7 +59,7 @@ func (vr coinsValueRenderer) Format(ctx context.Context, v protoreflect.Value) (
 
 func (vr coinsValueRenderer) FormatRepeated(ctx context.Context, v protoreflect.Value) ([]Screen, error) {
 	if vr.coinMetadataQuerier == nil {
-		return nil, fmt.Errorf("expected non-nil coin metadata querier")
+		return nil, errors.New("expected non-nil coin metadata querier")
 	}
 
 	protoCoins := v.List()

--- a/x/tx/signing/textual/handler.go
+++ b/x/tx/signing/textual/handler.go
@@ -3,6 +3,7 @@ package textual
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 
@@ -67,7 +68,7 @@ type SignModeHandler struct {
 // NewSignModeHandler returns a new SignModeHandler which generates sign bytes and provides  value renderers.
 func NewSignModeHandler(o SignModeOptions) (*SignModeHandler, error) {
 	if o.CoinMetadataQuerier == nil {
-		return nil, fmt.Errorf("coinMetadataQuerier must be non-empty")
+		return nil, errors.New("coinMetadataQuerier must be non-empty")
 	}
 	if o.FileResolver == nil {
 		o.FileResolver = protoregistry.GlobalFiles
@@ -134,7 +135,7 @@ func (r *SignModeHandler) GetFieldValueRenderer(fd protoreflect.FieldDescriptor)
 		}
 
 		if fd.IsMap() {
-			return nil, fmt.Errorf("value renderers cannot format value of type map")
+			return nil, errors.New("value renderers cannot format value of type map")
 		}
 		return NewMessageValueRenderer(r, md), nil
 	case fd.Kind() == protoreflect.BoolKind:


### PR DESCRIPTION
Parameterless errors should be using errors.New instead of fmt.Errorf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved error handling mechanism across the application by standardizing error message creation for enhanced consistency and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->