### PR TITLE
refactor: use errors.New to replace fmt.Errorf with no parameters

### DIFF
--- a/x/accounts/defaults/base/account.go
+++ b/x/accounts/defaults/base/account.go
@@ -2,6 +2,7 @@ package base
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	dcrd_secp256k1 "github.com/decred/dcrd/dcrec/secp256k1/v4"
@@ -59,7 +60,7 @@ func (a Account) Init(ctx context.Context, msg *v1.MsgInit) (*v1.MsgInitResponse
 
 func (a Account) SwapPubKey(ctx context.Context, msg *v1.MsgSwapPubKey) (*v1.MsgSwapPubKeyResponse, error) {
 	if !accountstd.SenderIsSelf(ctx) {
-		return nil, fmt.Errorf("unauthorized")
+		return nil, errors.New("unauthorized")
 	}
 
 	return &v1.MsgSwapPubKeyResponse{}, a.verifyAndSetPubKey(ctx, msg.NewPubKey)
@@ -76,7 +77,7 @@ func (a Account) verifyAndSetPubKey(ctx context.Context, key []byte) error {
 // Authenticate implements the authentication flow of an abstracted base account.
 func (a Account) Authenticate(ctx context.Context, msg *aa_interface_v1.MsgAuthenticate) (*aa_interface_v1.MsgAuthenticateResponse, error) {
 	if !accountstd.SenderIsAccountsModule(ctx) {
-		return nil, fmt.Errorf("unauthorized: only accounts module is allowed to call this")
+		return nil, errors.New("unauthorized: only accounts module is allowed to call this")
 	}
 
 	pubKey, signerData, err := a.computeSignerData(ctx)
@@ -107,7 +108,7 @@ func (a Account) Authenticate(ctx context.Context, msg *aa_interface_v1.MsgAuthe
 	}
 
 	if !pubKey.VerifySignature(signBytes, signature) {
-		return nil, fmt.Errorf("signature verification failed")
+		return nil, errors.New("signature verification failed")
 	}
 
 	return &aa_interface_v1.MsgAuthenticateResponse{}, nil

--- a/x/accounts/testing/account_abstraction/minimal.go
+++ b/x/accounts/testing/account_abstraction/minimal.go
@@ -2,7 +2,7 @@ package account_abstraction
 
 import (
 	"context"
-	"fmt"
+	"errors"
 
 	"cosmossdk.io/api/cosmos/crypto/secp256k1"
 	"cosmossdk.io/collections"
@@ -39,7 +39,7 @@ func (a MinimalAbstractedAccount) Init(ctx context.Context, msg *rotationv1.MsgI
 }
 
 func (a MinimalAbstractedAccount) RotatePubKey(ctx context.Context, msg *rotationv1.MsgRotatePubKey) (*rotationv1.MsgRotatePubKeyResponse, error) {
-	return nil, fmt.Errorf("not implemented")
+	return nil, errors.New("not implemented")
 }
 
 // Authenticate authenticates the account, auth always passess.
@@ -50,7 +50,7 @@ func (a MinimalAbstractedAccount) Authenticate(ctx context.Context, msg *account
 
 // QueryAuthenticateMethods queries the authentication methods of the account.
 func (a MinimalAbstractedAccount) QueryAuthenticateMethods(ctx context.Context, req *account_abstractionv1.QueryAuthenticationMethods) (*account_abstractionv1.QueryAuthenticationMethodsResponse, error) {
-	return nil, fmt.Errorf("not implemented")
+	return nil, errors.New("not implemented")
 }
 
 func (a MinimalAbstractedAccount) RegisterInitHandler(builder *accountstd.InitBuilder) {

--- a/x/accounts/testing/counter/counter.go
+++ b/x/accounts/testing/counter/counter.go
@@ -3,7 +3,7 @@ package counter
 import (
 	"bytes"
 	"context"
-	"fmt"
+	"errors"
 
 	"cosmossdk.io/collections"
 	"cosmossdk.io/core/address"
@@ -71,7 +71,7 @@ func (a Account) IncreaseCounter(ctx context.Context, msg *counterv1.MsgIncrease
 		return nil, err
 	}
 	if !bytes.Equal(sender, owner) {
-		return nil, fmt.Errorf("sender is not the owner of the account")
+		return nil, errors.New("sender is not the owner of the account")
 	}
 	counter, err := a.Counter.Get(ctx)
 	if err != nil {
@@ -123,7 +123,7 @@ func (a Account) TestDependencies(ctx context.Context, _ *counterv1.MsgTestDepen
 	// test funds
 	funds := accountstd.Funds(ctx)
 	if len(funds) == 0 {
-		return nil, fmt.Errorf("expected funds")
+		return nil, errors.New("expected funds")
 	}
 
 	return &counterv1.MsgTestDependenciesResponse{

--- a/x/distribution/client/cli/tx.go
+++ b/x/distribution/client/cli/tx.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -60,7 +61,7 @@ func NewWithdrawAllRewardsCmd() *cobra.Command {
 			// The transaction cannot be generated offline since it requires a query
 			// to get all the validators.
 			if clientCtx.Offline {
-				return fmt.Errorf("cannot generate tx in offline mode")
+				return errors.New("cannot generate tx in offline mode")
 			}
 
 			queryClient := types.NewQueryClient(clientCtx)

--- a/x/distribution/migrations/v4/migrate_funds.go
+++ b/x/distribution/migrations/v4/migrate_funds.go
@@ -2,6 +2,7 @@ package v4
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"cosmossdk.io/x/distribution/types"
@@ -26,7 +27,7 @@ func MigrateFunds(ctx context.Context, bankKeeper types.BankKeeper, feePool type
 	// check the migrated balance from pool module account is same as fee pool balance
 	balances := bankKeeper.GetAllBalances(ctx, poolMacc.GetAddress())
 	if !balances.Equal(poolBal) {
-		return types.FeePool{}, fmt.Errorf("pool module account balance is not same as FeePool balance after migration")
+		return types.FeePool{}, errors.New("pool module account balance is not same as FeePool balance after migration")
 	}
 
 	return types.FeePool{DecimalPool: remainder}, nil

--- a/x/feegrant/client/cli/tx.go
+++ b/x/feegrant/client/cli/tx.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -136,11 +137,11 @@ Examples:
 				}
 
 				if periodClock <= 0 {
-					return fmt.Errorf("period clock was not set")
+					return errors.New("period clock was not set")
 				}
 
 				if periodLimit == nil {
-					return fmt.Errorf("period limit was not set")
+					return errors.New("period limit was not set")
 				}
 
 				periodReset := getPeriodReset(periodClock)

--- a/x/staking/client/cli/utils.go
+++ b/x/staking/client/cli/utils.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"os"
 
 	errorsmod "cosmossdk.io/errors"
@@ -56,7 +55,7 @@ func parseAndValidateValidatorJSON(cdc codec.Codec, path string) (validator, err
 	}
 
 	if v.Amount == "" {
-		return validator{}, fmt.Errorf("must specify amount of coins to bond")
+		return validator{}, errors.New("must specify amount of coins to bond")
 	}
 	amount, err := sdk.ParseCoinNormalized(v.Amount)
 	if err != nil {
@@ -64,7 +63,7 @@ func parseAndValidateValidatorJSON(cdc codec.Codec, path string) (validator, err
 	}
 
 	if v.PubKey == nil {
-		return validator{}, fmt.Errorf("must specify the JSON encoded pubkey")
+		return validator{}, errors.New("must specify the JSON encoded pubkey")
 	}
 	var pk cryptotypes.PubKey
 	if err := cdc.UnmarshalInterfaceJSON(v.PubKey, &pk); err != nil {
@@ -72,7 +71,7 @@ func parseAndValidateValidatorJSON(cdc codec.Codec, path string) (validator, err
 	}
 
 	if v.Moniker == "" {
-		return validator{}, fmt.Errorf("must specify the moniker name")
+		return validator{}, errors.New("must specify the moniker name")
 	}
 
 	commissionRates, err := buildCommissionRates(v.CommissionRate, v.CommissionMaxRate, v.CommissionMaxChange)
@@ -81,7 +80,7 @@ func parseAndValidateValidatorJSON(cdc codec.Codec, path string) (validator, err
 	}
 
 	if v.MinSelfDelegation == "" {
-		return validator{}, fmt.Errorf("must specify minimum self delegation")
+		return validator{}, errors.New("must specify minimum self delegation")
 	}
 	minSelfDelegation, ok := math.NewIntFromString(v.MinSelfDelegation)
 	if !ok {


### PR DESCRIPTION
Remaining parameterless errors should be using errors.New

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced error handling across various components by adopting the `errors` package for more consistent and improved practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->