### PR TITLE
refactor(x/bank): remove duplicate logger

### DIFF
--- a/simapp/app.go
+++ b/simapp/app.go
@@ -308,7 +308,6 @@ func NewSimApp(
 		app.AuthKeeper,
 		BlockedAddresses(),
 		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
-		logger,
 	)
 
 	// optional: enable sign mode textual by overwriting the default tx config (after setting the bank keeper)

--- a/tests/integration/bank/keeper/deterministic_test.go
+++ b/tests/integration/bank/keeper/deterministic_test.go
@@ -96,7 +96,6 @@ func initDeterministicFixture(t *testing.T) *deterministicFixture {
 		accountKeeper,
 		blockedAddresses,
 		authority.String(),
-		log.NewNopLogger(),
 	)
 
 	authModule := auth.NewAppModule(cdc, accountKeeper, authsims.RandomGenesisAccounts)

--- a/tests/integration/distribution/keeper/msg_server_test.go
+++ b/tests/integration/distribution/keeper/msg_server_test.go
@@ -102,7 +102,6 @@ func initFixture(t *testing.T) *fixture {
 		accountKeeper,
 		blockedAddresses,
 		authority.String(),
-		log.NewNopLogger(),
 	)
 
 	stakingKeeper := stakingkeeper.NewKeeper(cdc, runtime.NewEnvironment(runtime.NewKVStoreService(keys[stakingtypes.StoreKey]), log.NewNopLogger()), accountKeeper, bankKeeper, authority.String(), addresscodec.NewBech32Codec(sdk.Bech32PrefixValAddr), addresscodec.NewBech32Codec(sdk.Bech32PrefixConsAddr))

--- a/tests/integration/evidence/keeper/infraction_test.go
+++ b/tests/integration/evidence/keeper/infraction_test.go
@@ -122,7 +122,6 @@ func initFixture(tb testing.TB) *fixture {
 		accountKeeper,
 		blockedAddresses,
 		authority.String(),
-		log.NewNopLogger(),
 	)
 
 	stakingKeeper := stakingkeeper.NewKeeper(cdc, runtime.NewEnvironment(runtime.NewKVStoreService(keys[stakingtypes.StoreKey]), log.NewNopLogger()), accountKeeper, bankKeeper, authority.String(), addresscodec.NewBech32Codec(sdk.Bech32PrefixValAddr), addresscodec.NewBech32Codec(sdk.Bech32PrefixConsAddr))

--- a/tests/integration/gov/keeper/keeper_test.go
+++ b/tests/integration/gov/keeper/keeper_test.go
@@ -89,7 +89,6 @@ func initFixture(tb testing.TB) *fixture {
 		accountKeeper,
 		blockedAddresses,
 		authority.String(),
-		log.NewNopLogger(),
 	)
 
 	stakingKeeper := stakingkeeper.NewKeeper(cdc, runtime.NewEnvironment(runtime.NewKVStoreService(keys[stakingtypes.StoreKey]), log.NewNopLogger()), accountKeeper, bankKeeper, authority.String(), addresscodec.NewBech32Codec(sdk.Bech32PrefixValAddr), addresscodec.NewBech32Codec(sdk.Bech32PrefixConsAddr))

--- a/tests/integration/slashing/keeper/keeper_test.go
+++ b/tests/integration/slashing/keeper/keeper_test.go
@@ -90,7 +90,6 @@ func initFixture(tb testing.TB) *fixture {
 		accountKeeper,
 		blockedAddresses,
 		authority.String(),
-		log.NewNopLogger(),
 	)
 
 	stakingKeeper := stakingkeeper.NewKeeper(cdc, runtime.NewEnvironment(runtime.NewKVStoreService(keys[stakingtypes.StoreKey]), log.NewNopLogger()), accountKeeper, bankKeeper, authority.String(), addresscodec.NewBech32Codec(sdk.Bech32PrefixValAddr), addresscodec.NewBech32Codec(sdk.Bech32PrefixConsAddr))

--- a/tests/integration/staking/keeper/common_test.go
+++ b/tests/integration/staking/keeper/common_test.go
@@ -139,7 +139,6 @@ func initFixture(tb testing.TB) *fixture {
 		accountKeeper,
 		blockedAddresses,
 		authority.String(),
-		log.NewNopLogger(),
 	)
 
 	stakingKeeper := stakingkeeper.NewKeeper(cdc, runtime.NewEnvironment(runtime.NewKVStoreService(keys[types.StoreKey]), log.NewNopLogger()), accountKeeper, bankKeeper, authority.String(), addresscodec.NewBech32Codec(sdk.Bech32PrefixValAddr), addresscodec.NewBech32Codec(sdk.Bech32PrefixConsAddr))

--- a/tests/integration/staking/keeper/deterministic_test.go
+++ b/tests/integration/staking/keeper/deterministic_test.go
@@ -103,7 +103,6 @@ func initDeterministicFixture(t *testing.T) *deterministicFixture {
 		accountKeeper,
 		blockedAddresses,
 		authority.String(),
-		log.NewNopLogger(),
 	)
 
 	stakingKeeper := stakingkeeper.NewKeeper(cdc, runtime.NewEnvironment(runtime.NewKVStoreService(keys[stakingtypes.StoreKey]), log.NewNopLogger()), accountKeeper, bankKeeper, authority.String(), addresscodec.NewBech32Codec(sdk.Bech32PrefixValAddr), addresscodec.NewBech32Codec(sdk.Bech32PrefixConsAddr))

--- a/x/accounts/keeper.go
+++ b/x/accounts/keeper.go
@@ -14,7 +14,6 @@ import (
 	"cosmossdk.io/collections"
 	"cosmossdk.io/core/address"
 	"cosmossdk.io/core/appmodule"
-	"cosmossdk.io/log"
 	"cosmossdk.io/x/accounts/accountstd"
 	"cosmossdk.io/x/accounts/internal/implementation"
 
@@ -74,7 +73,6 @@ func NewKeeper(
 	sb := collections.NewSchemaBuilder(env.KVStoreService)
 	keeper := Keeper{
 		environment:      env,
-		logger:           env.Logger,
 		addressCodec:     addressCodec,
 		msgRouter:        execRouter,
 		signerProvider:   signerProvider,
@@ -108,7 +106,6 @@ type Keeper struct {
 	signerProvider   SignerProvider
 	queryRouter      QueryRouter
 	makeSendCoinsMsg coinsTransferMsgFunc
-	logger           log.Logger
 
 	accounts map[string]implementation.Implementation
 

--- a/x/auth/keeper/keeper.go
+++ b/x/auth/keeper/keeper.go
@@ -82,7 +82,7 @@ func (a AccountsIndexes) IndexesList() []collections.Index[sdk.AccAddress, sdk.A
 type AccountKeeper struct {
 	addressCodec address.Codec
 
-	Environment  appmodule.Environment
+	environment  appmodule.Environment
 	cdc          codec.BinaryCodec
 	permAddrs    map[string]types.PermissionsForAddress
 	bech32Prefix string
@@ -124,7 +124,7 @@ func NewAccountKeeper(
 	ak := AccountKeeper{
 		addressCodec:  ac,
 		bech32Prefix:  bech32Prefix,
-		Environment:   env,
+		environment:   env,
 		proto:         proto,
 		cdc:           cdc,
 		permAddrs:     permAddrs,
@@ -154,7 +154,7 @@ func (ak AccountKeeper) AddressCodec() address.Codec {
 
 // Logger returns a module-specific logger.
 func (ak AccountKeeper) Logger(ctx context.Context) log.Logger {
-	return ak.Environment.Logger.With("module", "x/"+types.ModuleName)
+	return ak.environment.Logger.With("module", "x/"+types.ModuleName)
 }
 
 // GetPubKey Returns the PubKey of the account at address

--- a/x/auth/keeper/migrations.go
+++ b/x/auth/keeper/migrations.go
@@ -42,7 +42,7 @@ func (m Migrator) Migrate3to4(ctx context.Context) error {
 // It migrates the GlobalAccountNumber from being a protobuf defined value to a
 // big-endian encoded uint64, it also migrates it to use a more canonical prefix.
 func (m Migrator) Migrate4To5(ctx context.Context) error {
-	return v5.Migrate(ctx, m.keeper.Environment.KVStoreService, m.keeper.AccountNumber)
+	return v5.Migrate(ctx, m.keeper.environment.KVStoreService, m.keeper.AccountNumber)
 }
 
 // V45_SetAccount implements V45_SetAccount
@@ -51,7 +51,7 @@ func (m Migrator) Migrate4To5(ctx context.Context) error {
 // NOTE: This is used for testing purposes only.
 func (m Migrator) V45SetAccount(ctx context.Context, acc sdk.AccountI) error {
 	addr := acc.GetAddress()
-	store := m.keeper.Environment.KVStoreService.OpenKVStore(ctx)
+	store := m.keeper.environment.KVStoreService.OpenKVStore(ctx)
 
 	bz, err := m.keeper.Accounts.ValueCodec().Encode(acc)
 	if err != nil {

--- a/x/bank/depinject.go
+++ b/x/bank/depinject.go
@@ -5,7 +5,6 @@ import (
 	"cosmossdk.io/core/appmodule"
 	"cosmossdk.io/depinject"
 	"cosmossdk.io/depinject/appconfig"
-	"cosmossdk.io/log"
 	authtypes "cosmossdk.io/x/auth/types"
 	"cosmossdk.io/x/bank/keeper"
 	"cosmossdk.io/x/bank/types"
@@ -30,7 +29,6 @@ type ModuleInputs struct {
 	Config      *modulev1.Module
 	Cdc         codec.Codec
 	Environment appmodule.Environment
-	Logger      log.Logger
 
 	AccountKeeper types.AccountKeeper
 }
@@ -83,7 +81,6 @@ func ProvideModule(in ModuleInputs) ModuleOutputs {
 		in.AccountKeeper,
 		blockedAddresses,
 		authStr,
-		in.Logger,
 	)
 	m := NewAppModule(in.Cdc, bankKeeper, in.AccountKeeper)
 

--- a/x/bank/keeper/collections_test.go
+++ b/x/bank/keeper/collections_test.go
@@ -43,7 +43,6 @@ func TestBankStateCompatibility(t *testing.T) {
 		authKeeper,
 		map[string]bool{accAddrs[4].String(): true},
 		authtypes.NewModuleAddress(banktypes.GovModuleName).String(),
-		log.NewNopLogger(),
 	)
 
 	// test we can decode balances without problems

--- a/x/bank/keeper/keeper.go
+++ b/x/bank/keeper/keeper.go
@@ -348,7 +348,7 @@ func (k BaseKeeper) UndelegateCoinsFromModuleToAccount(
 func (k BaseKeeper) MintCoins(ctx context.Context, moduleName string, amounts sdk.Coins) error {
 	err := k.mintCoinsRestrictionFn(ctx, amounts)
 	if err != nil {
-		k.logger.Error(fmt.Sprintf("Module %q attempted to mint coins %s it doesn't have permission for, error %v", moduleName, amounts, err))
+		k.Logger().Error(fmt.Sprintf("Module %q attempted to mint coins %s it doesn't have permission for, error %v", moduleName, amounts, err))
 		return err
 	}
 	acc := k.ak.GetModuleAccount(ctx, moduleName)
@@ -371,7 +371,7 @@ func (k BaseKeeper) MintCoins(ctx context.Context, moduleName string, amounts sd
 		k.setSupply(ctx, supply)
 	}
 
-	k.logger.Debug("minted coins from module account", "amount", amounts.String(), "from", moduleName)
+	k.Logger().Debug("minted coins from module account", "amount", amounts.String(), "from", moduleName)
 
 	addrStr, err := k.ak.AddressCodec().BytesToString(acc.GetAddress())
 	if err != nil {
@@ -411,7 +411,7 @@ func (k BaseKeeper) BurnCoins(ctx context.Context, address []byte, amounts sdk.C
 		k.setSupply(ctx, supply)
 	}
 
-	k.logger.Debug("burned tokens from account", "amount", amounts.String(), "from", address)
+	k.Logger().Debug("burned tokens from account", "amount", amounts.String(), "from", address)
 
 	addrStr, err := k.ak.AddressCodec().BytesToString(acc.GetAddress())
 	if err != nil {

--- a/x/bank/keeper/keeper.go
+++ b/x/bank/keeper/keeper.go
@@ -61,7 +61,6 @@ type BaseKeeper struct {
 	cdc                    codec.BinaryCodec
 	environment            appmodule.Environment
 	mintCoinsRestrictionFn types.MintingRestrictionFn
-	logger                 log.Logger
 }
 
 // GetPaginatedTotalSupply queries for the supply, ignoring 0 coins, with a given pagination
@@ -88,22 +87,20 @@ func NewBaseKeeper(
 	ak types.AccountKeeper,
 	blockedAddrs map[string]bool,
 	authority string,
-	logger log.Logger,
 ) BaseKeeper {
 	if _, err := ak.AddressCodec().StringToBytes(authority); err != nil {
 		panic(fmt.Errorf("invalid bank authority address: %w", err))
 	}
 
 	// add the module name to the logger
-	logger = logger.With(log.ModuleKey, "x/"+types.ModuleName)
+	env.Logger = env.Logger.With(log.ModuleKey, "x/"+types.ModuleName)
 
 	return BaseKeeper{
-		BaseSendKeeper:         NewBaseSendKeeper(env, cdc, ak, blockedAddrs, authority, logger),
+		BaseSendKeeper:         NewBaseSendKeeper(env, cdc, ak, blockedAddrs, authority),
 		ak:                     ak,
 		cdc:                    cdc,
 		environment:            env,
 		mintCoinsRestrictionFn: types.NoOpMintingRestrictionFn,
-		logger:                 logger,
 	}
 }
 

--- a/x/bank/keeper/keeper_test.go
+++ b/x/bank/keeper/keeper_test.go
@@ -145,7 +145,6 @@ func (suite *KeeperTestSuite) SetupTest() {
 		suite.authKeeper,
 		map[string]bool{accAddrs[4].String(): true},
 		authtypes.NewModuleAddress(banktypes.GovModuleName).String(),
-		log.NewNopLogger(),
 	)
 
 	banktypes.RegisterInterfaces(encCfg.InterfaceRegistry)
@@ -308,7 +307,6 @@ func (suite *KeeperTestSuite) TestGetAuthority() {
 			suite.authKeeper,
 			nil,
 			authority,
-			log.NewNopLogger(),
 		)
 	}
 

--- a/x/bank/keeper/send.go
+++ b/x/bank/keeper/send.go
@@ -8,7 +8,6 @@ import (
 	"cosmossdk.io/core/appmodule"
 	"cosmossdk.io/core/event"
 	errorsmod "cosmossdk.io/errors"
-	"cosmossdk.io/log"
 	"cosmossdk.io/math"
 	"cosmossdk.io/x/bank/types"
 
@@ -59,7 +58,6 @@ type BaseSendKeeper struct {
 	cdc         codec.BinaryCodec
 	ak          types.AccountKeeper
 	environment appmodule.Environment
-	logger      log.Logger
 
 	// list of addresses that are restricted from receiving transactions
 	blockedAddrs map[string]bool
@@ -77,20 +75,18 @@ func NewBaseSendKeeper(
 	ak types.AccountKeeper,
 	blockedAddrs map[string]bool,
 	authority string,
-	logger log.Logger,
 ) BaseSendKeeper {
 	if _, err := ak.AddressCodec().StringToBytes(authority); err != nil {
 		panic(fmt.Errorf("invalid bank authority address: %w", err))
 	}
 
 	return BaseSendKeeper{
-		BaseViewKeeper:  NewBaseViewKeeper(env, cdc, ak, logger),
+		BaseViewKeeper:  NewBaseViewKeeper(env, cdc, ak),
 		cdc:             cdc,
 		ak:              ak,
 		environment:     env,
 		blockedAddrs:    blockedAddrs,
 		authority:       authority,
-		logger:          logger,
 		sendRestriction: newSendRestriction(),
 	}
 }

--- a/x/bank/keeper/view.go
+++ b/x/bank/keeper/view.go
@@ -59,7 +59,6 @@ type BaseViewKeeper struct {
 	cdc         codec.BinaryCodec
 	environment appmodule.Environment
 	ak          types.AccountKeeper
-	logger      log.Logger
 
 	Schema        collections.Schema
 	Supply        collections.Map[string, math.Int]
@@ -70,13 +69,12 @@ type BaseViewKeeper struct {
 }
 
 // NewBaseViewKeeper returns a new BaseViewKeeper.
-func NewBaseViewKeeper(env appmodule.Environment, cdc codec.BinaryCodec, ak types.AccountKeeper, logger log.Logger) BaseViewKeeper {
+func NewBaseViewKeeper(env appmodule.Environment, cdc codec.BinaryCodec, ak types.AccountKeeper) BaseViewKeeper {
 	sb := collections.NewSchemaBuilder(env.KVStoreService)
 	k := BaseViewKeeper{
 		cdc:           cdc,
 		environment:   env,
 		ak:            ak,
-		logger:        logger,
 		Supply:        collections.NewMap(sb, types.SupplyKey, "supply", collections.StringKey, sdk.IntValue),
 		DenomMetadata: collections.NewMap(sb, types.DenomMetadataPrefix, "denom_metadata", collections.StringKey, codec.CollValue[types.Metadata](cdc)),
 		SendEnabled:   collections.NewMap(sb, types.SendEnabledPrefix, "send_enabled", collections.StringKey, codec.BoolValue), // NOTE: we use a bool value which uses protobuf to retain state backwards compat
@@ -99,7 +97,7 @@ func (k BaseViewKeeper) HasBalance(ctx context.Context, addr sdk.AccAddress, amt
 
 // Logger returns a module-specific logger.
 func (k BaseViewKeeper) Logger() log.Logger {
-	return k.logger
+	return k.environment.Logger
 }
 
 // GetAllBalances returns all the account balances for the given account address.


### PR DESCRIPTION
# Description

x/bank doesn't need to have a logger in its keeper given that it holds environement.

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Simplified logger usage by removing the `logger` parameter and related initializations in multiple components.
	- Updated references from `Environment` to `environment` in specific structs, impacting method calls and initialization.
- **Tests**
	- Streamlined test setups by removing redundant logger initializations for improved efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->