### PR TITLE
fix: use proper `db_backend` type when reading chain-id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Bug Fixes
 
-* (baseapp) [19573](https://github.com/cosmos/cosmos-sdk/pull/19573) fix: use proper `db_backend` type when reading chain-id
+* (server) [#19573](https://github.com/cosmos/cosmos-sdk/pull/19573) Use proper `db_backend` type when reading chain-id
 
 ## [v0.47.9](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.47.9) - 2024-02-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
+### Bug Fixes
+
+* (baseapp) [19573](https://github.com/cosmos/cosmos-sdk/pull/19573) fix: use proper `db_backend` type when reading chain-id
+
 ## [v0.47.9](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.47.9) - 2024-02-19
 
 ### Bug Fixes

--- a/server/util.go
+++ b/server/util.go
@@ -462,7 +462,8 @@ func DefaultBaseappOptions(appOpts types.AppOptions) []func(*baseapp.BaseApp) {
 	chainID := cast.ToString(appOpts.Get(flags.FlagChainID))
 	if chainID == "" {
 		// read the chainID from home directory (either from comet or genesis).
-		chainId, err := readChainIdFromHome(homeDir)
+		dbBackend := cast.ToString(appOpts.Get("db_backend"))
+		chainId, err := readChainIdFromHome(homeDir, dbBackend)
 		if err != nil {
 			panic(err)
 		}
@@ -503,9 +504,10 @@ func DefaultBaseappOptions(appOpts types.AppOptions) []func(*baseapp.BaseApp) {
 }
 
 // readChainIdFromHome reads chain id from home directory.
-func readChainIdFromHome(homeDir string) (string, error) {
+func readChainIdFromHome(homeDir string, dbBackend string) (string, error) {
 	cfg := tmcfg.DefaultConfig()
 	cfg.SetRoot(homeDir)
+	cfg.BaseConfig.DBBackend = dbBackend
 
 	// if the node's current height is not zero then try to read the chainID from comet db.
 	db, err := node.DefaultDBProvider(&node.DBContext{ID: "blockstore", Config: cfg})


### PR DESCRIPTION
# Description

Closes: #XXXX

We noticed that after upgrading to cosmos-sdk v0.47.8+, our node panics upon restart. We traced the issue to https://github.com/cosmos/cosmos-sdk/pull/18920/files, which changes the way the node creates `DefaultBaseappOptions` at startup time.

Specifically, [this line](https://github.com/cosmos/cosmos-sdk/pull/18920/files#diff-f7a5b3de7e2284cfc3a3deca80a48a336566e6bc0b682a90156e691d876f38a2R507) assumes that the node uses `goleveldb` and tries to read the db files in `goleveldb` format, but our nodes use `rocksdb` by default.

After a node stop and restart, the node panics with

```
nibid start
panic: failed to initialize database: EOF

goroutine 24 [running]:
github.com/cosmos/cosmos-sdk/server.DefaultBaseappOptions({0x4551480, 0x4000df9340})
	/home/ubuntu/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.47.9/server/util.go:467 +0x734
github.com/NibiruChain/nibiru/cmd/nibid/cmd.appCreator.newApp({{{0x458c7c0, 0x4000fe0480}, {0x45a4600, 0x4000fe8680}, {0x4594380, 0x4000ef4140}, 0x4000206060}}, {0x457f180, 0x40016cf1f0}, {0x4598438, ...}, ...)
	/home/ubuntu/projects/nibiru/nibiru/cmd/nibid/cmd/root.go:246 +0x64
github.com/cosmos/cosmos-sdk/server.startInProcess(_, {{0x0, 0x0, 0x0}, {0x4598df0, 0x4001664420}, 0x0, {0x4000e214e8, 0x11}, {0x45a4600, ...}, ...}, ...)
	/home/ubuntu/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.47.9/server/start.go:353 +0x31c
github.com/cosmos/cosmos-sdk/server.StartCmd.func2.2()
	/home/ubuntu/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.47.9/server/start.go:153 +0x48
github.com/cosmos/cosmos-sdk/server.wrapCPUProfile.func2()
	/home/ubuntu/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.47.9/server/start.go:617 +0x30
created by github.com/cosmos/cosmos-sdk/server.wrapCPUProfile in goroutine 1
	/home/ubuntu/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.47.9/server/start.go:616 +0x1d0
```

The fix is to respect the `db_backend` flag in the config. The bug is on both `v0.47.8` and `v0.47.9`.

We'd ideally like to backport this feature onto a `v0.47.10` release, because upgrading to `v0.50` now is a much larger effort. 

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage
