### PR TITLE
refactor(x/auth): allow empty public keys for GetSignBytesAdapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,7 +80,7 @@ Every module contains its own CHANGELOG.md. Please refer to the module you are i
 * (crypto/keys) [#18026](https://github.com/cosmos/cosmos-sdk/pull/18026) Made public key generation constant time on `secp256k1`
 * (crypto | x/auth) [#14372](https://github.com/cosmos/cosmos-sdk/pull/18194) Key checks on signatures antehandle.
 * (types) [#18963](https://github.com/cosmos/cosmos-sdk/pull/18963) Swap out amino json encoding of `ABCIMessageLogs` for std lib json encoding
-* (x/auth) [#](https://github.com/cosmos/cosmos-sdk/pull/) Allow empty public keys in `GetSignBytesAdapter`.
+* (x/auth) [#19651](https://github.com/cosmos/cosmos-sdk/pull/19651) Allow empty public keys in `GetSignBytesAdapter`.
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ Every module contains its own CHANGELOG.md. Please refer to the module you are i
 * (crypto/keys) [#18026](https://github.com/cosmos/cosmos-sdk/pull/18026) Made public key generation constant time on `secp256k1`
 * (crypto | x/auth) [#14372](https://github.com/cosmos/cosmos-sdk/pull/18194) Key checks on signatures antehandle.
 * (types) [#18963](https://github.com/cosmos/cosmos-sdk/pull/18963) Swap out amino json encoding of `ABCIMessageLogs` for std lib json encoding
+* (x/auth) [#](https://github.com/cosmos/cosmos-sdk/pull/) Allow empty public keys in `GetSignBytesAdapter`.
 
 ### Bug Fixes
 

--- a/x/auth/signing/adapter.go
+++ b/x/auth/signing/adapter.go
@@ -41,20 +41,24 @@ func GetSignBytesAdapter(
 		return nil, err
 	}
 
-	anyPk, err := codectypes.NewAnyWithValue(signerData.PubKey)
-	if err != nil {
-		return nil, err
-	}
+	var pubKey *anypb.Any
+	if signerData.PubKey != nil {
+		anyPk, err := codectypes.NewAnyWithValue(signerData.PubKey)
+		if err != nil {
+			return nil, err
+		}
 
+		pubKey = &anypb.Any{
+			TypeUrl: anyPk.TypeUrl,
+			Value:   anyPk.Value,
+		}
+	}
 	txSignerData := txsigning.SignerData{
 		ChainID:       signerData.ChainID,
 		AccountNumber: signerData.AccountNumber,
 		Sequence:      signerData.Sequence,
 		Address:       signerData.Address,
-		PubKey: &anypb.Any{
-			TypeUrl: anyPk.TypeUrl,
-			Value:   anyPk.Value,
-		},
+		PubKey:        pubKey,
 	}
 	// Generate the bytes to be signed.
 	return handlerMap.GetSignBytes(ctx, txSignMode, txSignerData, txData)

--- a/x/auth/signing/adapter_test.go
+++ b/x/auth/signing/adapter_test.go
@@ -1,0 +1,32 @@
+package signing_test
+
+import (
+	"context"
+	"testing"
+
+	authsign "cosmossdk.io/x/auth/signing"
+	"github.com/cosmos/cosmos-sdk/testutil/testdata"
+	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
+	"github.com/cosmos/cosmos-sdk/types/tx/signing"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetSignBytesAdapterNoPublicKey(t *testing.T) {
+	encodingConfig := moduletestutil.MakeTestEncodingConfig()
+	txConfig := encodingConfig.TxConfig
+	_, _, addr := testdata.KeyTestPubAddr()
+	signerData := authsign.SignerData{
+		Address:       addr.String(),
+		ChainID:       "test-chain",
+		AccountNumber: 11,
+		Sequence:      15,
+	}
+	w := txConfig.NewTxBuilder()
+	_, err := authsign.GetSignBytesAdapter(
+		context.Background(),
+		txConfig.SignModeHandler(),
+		signing.SignMode_SIGN_MODE_DIRECT,
+		signerData,
+		w.GetTx())
+	require.NoError(t, err)
+}

--- a/x/auth/signing/adapter_test.go
+++ b/x/auth/signing/adapter_test.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	authsign "cosmossdk.io/x/auth/signing"
+
 	"github.com/cosmos/cosmos-sdk/testutil/testdata"
 	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
 	"github.com/cosmos/cosmos-sdk/types/tx/signing"
-	"github.com/stretchr/testify/require"
 )
 
 func TestGetSignBytesAdapterNoPublicKey(t *testing.T) {


### PR DESCRIPTION
# Description

to avoid error like in https://github.com/cosmos/cosmos-sdk/issues/19094

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the authentication mechanism to support transactions without public keys, improving flexibility and use cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->