### PR TITLE
fix(x/gov): grpc query tally for failed proposal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@ Every module contains its own CHANGELOG.md. Please refer to the module you are i
 
 ### Bug Fixes
 
+* (x/gov) [#19725](https://github.com/cosmos/cosmos-sdk/pull/19725) Fetch a failed proposal tally from proposal.FinalTallyResult in the gprc query.
 * (baseapp) [#18727](https://github.com/cosmos/cosmos-sdk/pull/18727) Ensure that `BaseApp.Init` firstly returns any errors from a nil commit multistore instead of panicking on nil dereferencing and before sealing the app.
 * (client) [#18622](https://github.com/cosmos/cosmos-sdk/pull/18622) Fixed a potential under/overflow from `uint64->int64` when computing gas fees as a LegacyDec.
 * (client/keys) [#18562](https://github.com/cosmos/cosmos-sdk/pull/18562) `keys delete` won't terminate when a key is not found.

--- a/x/gov/keeper/grpc_query.go
+++ b/x/gov/keeper/grpc_query.go
@@ -319,7 +319,7 @@ func (q queryServer) TallyResult(ctx context.Context, req *v1.QueryTallyResultRe
 	case proposal.Status == v1.StatusDepositPeriod:
 		tallyResult = v1.EmptyTallyResult()
 
-	case proposal.Status == v1.StatusPassed || proposal.Status == v1.StatusRejected:
+	case proposal.Status == v1.StatusPassed || proposal.Status == v1.StatusRejected || proposal.Status == v1.StatusFailed:
 		tallyResult = *proposal.FinalTallyResult
 
 	default:

--- a/x/gov/keeper/grpc_query_test.go
+++ b/x/gov/keeper/grpc_query_test.go
@@ -1640,6 +1640,48 @@ func (suite *KeeperTestSuite) TestGRPCQueryTallyResult() {
 			},
 			true,
 		},
+		{
+			"proposal status failed",
+			func() {
+				propTime := time.Now()
+				proposal := v1.Proposal{
+					Id:     1,
+					Status: v1.StatusFailed,
+					FinalTallyResult: &v1.TallyResult{
+						YesCount:         "4",
+						AbstainCount:     "1",
+						NoCount:          "0",
+						NoWithVetoCount:  "0",
+						OptionOneCount:   "4",
+						OptionTwoCount:   "1",
+						OptionThreeCount: "0",
+						OptionFourCount:  "0",
+						SpamCount:        "0",
+					},
+					SubmitTime:      &propTime,
+					VotingStartTime: &propTime,
+					VotingEndTime:   &propTime,
+					Metadata:        "proposal metadata",
+				}
+				err := suite.govKeeper.Proposals.Set(suite.ctx, proposal.Id, proposal)
+				suite.Require().NoError(err)
+
+				req = &v1.QueryTallyResultRequest{ProposalId: proposal.Id}
+
+				expTally = &v1.TallyResult{
+					YesCount:         "4",
+					AbstainCount:     "1",
+					NoCount:          "0",
+					NoWithVetoCount:  "0",
+					OptionOneCount:   "4",
+					OptionTwoCount:   "1",
+					OptionThreeCount: "0",
+					OptionFourCount:  "0",
+					SpamCount:        "0",
+				}
+			},
+			true,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -1775,6 +1817,39 @@ func (suite *KeeperTestSuite) TestLegacyGRPCQueryTallyResult() {
 				expTally = &v1beta1.TallyResult{
 					Yes:        math.NewInt(0),
 					Abstain:    math.NewInt(0),
+					No:         math.NewInt(0),
+					NoWithVeto: math.NewInt(0),
+				}
+			},
+			true,
+		},
+		{
+			"proposal status failed",
+			func() {
+				propTime := time.Now()
+				proposal := v1.Proposal{
+					Id:     1,
+					Status: v1.StatusFailed,
+					FinalTallyResult: &v1.TallyResult{
+						YesCount:        "4",
+						AbstainCount:    "1",
+						NoCount:         "0",
+						NoWithVetoCount: "0",
+						SpamCount:       "0",
+					},
+					SubmitTime:      &propTime,
+					VotingStartTime: &propTime,
+					VotingEndTime:   &propTime,
+					Metadata:        "proposal metadata",
+				}
+				err := suite.govKeeper.Proposals.Set(suite.ctx, proposal.Id, proposal)
+				suite.Require().NoError(err)
+
+				req = &v1beta1.QueryTallyResultRequest{ProposalId: proposal.Id}
+
+				expTally = &v1beta1.TallyResult{
+					Yes:        math.NewInt(4),
+					Abstain:    math.NewInt(1),
 					No:         math.NewInt(0),
 					NoWithVeto: math.NewInt(0),
 				}


### PR DESCRIPTION
# Description

Closes: #XXXX

The query for a failed proposal tally should fetch from proposal.FinalTallyResult rather than tallying from votes again, as they are all removed after the proposal has failed.


---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
	- Fixed a bug in the `x/gov` module related to fetching failed proposal tallies.

- **New Features**
	- Enhanced the proposal system to handle and display results for proposals with a 'Failed' status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->