### PR TITLE
refactor(core): remove consensus events

### DIFF
--- a/core/event/service.go
+++ b/core/event/service.go
@@ -18,7 +18,7 @@ type Service interface {
 type Manager interface {
 	// Emit emits events represented as a protobuf message (as described in ADR 032).
 	//
-	// Callers SHOULD assume that these events will not be included in consensus. These events
+	// Callers SHOULD assume that these events will not be included in consensus.
 	Emit(event protoiface.MessageV1) error
 
 	// EmitKV emits an event based on an event and kv-pair attributes.

--- a/core/event/service.go
+++ b/core/event/service.go
@@ -18,9 +18,7 @@ type Service interface {
 type Manager interface {
 	// Emit emits events represented as a protobuf message (as described in ADR 032).
 	//
-	// Callers SHOULD assume that these events may be included in consensus. These events
-	// MUST be emitted deterministically and adding, removing or changing these events SHOULD
-	// be considered state-machine breaking.
+	// Callers SHOULD assume that these events will not be included in consensus. These events
 	Emit(event protoiface.MessageV1) error
 
 	// EmitKV emits an event based on an event and kv-pair attributes.
@@ -28,11 +26,4 @@ type Manager interface {
 	// These events will not be part of consensus and adding, removing or changing these events is
 	// not a state-machine breaking change.
 	EmitKV(eventType string, attrs ...Attribute) error
-
-	// EmitNonConsensus emits events represented as a protobuf message (as described in ADR 032), without
-	// including it in blockchain consensus.
-	//
-	// These events will not be part of consensus and adding, removing or changing events is
-	// not a state-machine breaking change.
-	EmitNonConsensus(event protoiface.MessageV1) error
 }

--- a/runtime/events.go
+++ b/runtime/events.go
@@ -49,9 +49,3 @@ func (e Events) EmitKV(eventType string, attrs ...event.Attribute) error {
 	e.EventManagerI.EmitEvents(sdk.Events{sdk.NewEvent(eventType, attributes...)})
 	return nil
 }
-
-// EmitNonConsensus emits an typed event that is defined in the protobuf file.
-// In the future these events will be added to consensus.
-func (e Events) EmitNonConsensus(event protoiface.MessageV1) error {
-	return e.EventManagerI.EmitTypedEvent(event)
-}

--- a/x/accounts/utils_test.go
+++ b/x/accounts/utils_test.go
@@ -33,10 +33,6 @@ func (e eventService) EmitKV(eventType string, attrs ...event.Attribute) error {
 	return nil
 }
 
-func (e eventService) EmitNonConsensus(event protoiface.MessageV1) error {
-	return nil
-}
-
 func (e eventService) EventManager(ctx context.Context) event.Manager { return e }
 
 var _ InterfaceRegistry = (*interfaceRegistry)(nil)


### PR DESCRIPTION
# Description

As discussed in the team call we will remove non consensus key from the events service and assume all events are not in consensus. This was added but its unclear if this will be added in the future. 

We are moving core into v1 and would like the api we use to be present, future apis that are unused should be removed 



---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Updated event management to clarify that emitted events are not part of the consensus process, simplifying the interface by removing redundant methods.
	- Removed `EmitNonConsensus` method from various files to streamline event handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->