### PR TITLE
feat(x/tx): add custom type encoder

### DIFF
--- a/docs/build/building-modules/05-protobuf-annotations.md
+++ b/docs/build/building-modules/05-protobuf-annotations.md
@@ -125,3 +125,9 @@ Encoding instructs the amino json marshaler how to encode certain fields that ma
 ```proto reference
 https://github.com/cosmos/cosmos-sdk/blob/e8f28bf5db18b8d6b7e0d94b542ce4cf48fed9d6/proto/cosmos/bank/v1beta1/genesis.proto#L23
 ```
+
+Another example is how `bytes` is encoded when using the amino json encoding format. The `bytes_as_string` option tells the json marshaler [how to encode bytes as string](https://github.com/pinosu/cosmos-sdk/blob/9879ece09c58068402782fa2096199dc89a23d13/x/tx/signing/aminojson/json_marshal.go#L75).
+
+```proto
+(amino.encoding)         = "bytes_as_string",
+```

--- a/x/tx/CHANGELOG.md
+++ b/x/tx/CHANGELOG.md
@@ -31,6 +31,10 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
+### Features
+
+* [#19786](https://github.com/cosmos/cosmos-sdk/pull/19786) Add bytes as string option to encoder.
+
 ### Improvements
 
 * [#19845](https://github.com/cosmos/cosmos-sdk/pull/19845) Use hybrid resolver instead of only protov2 registry

--- a/x/tx/signing/aminojson/encoder.go
+++ b/x/tx/signing/aminojson/encoder.go
@@ -81,6 +81,17 @@ func nullSliceAsEmptyEncoder(enc *Encoder, v protoreflect.Value, w io.Writer) er
 	}
 }
 
+// cosmosInlineJson replicates the behavior at:
+// https://github.com/CosmWasm/wasmd/blob/08567ff20e372e4f4204a91ca64a371538742bed/x/wasm/types/tx.go#L20-L22
+func cosmosInlineJson(_ *Encoder, v protoreflect.Value, w io.Writer) error {
+	blob, err := json.RawMessage(v.Bytes()).MarshalJSON()
+	if err != nil {
+		return err
+	}
+	_, err = w.Write(blob)
+	return err
+}
+
 // keyFieldEncoder replicates the behavior at described at:
 // https://github.com/cosmos/cosmos-sdk/blob/b49f948b36bc991db5be431607b475633aed697e/proto/cosmos/crypto/secp256k1/keys.proto#L16
 // The message is treated if it were bytes directly without the key field specified.

--- a/x/tx/signing/aminojson/encoder.go
+++ b/x/tx/signing/aminojson/encoder.go
@@ -81,15 +81,20 @@ func nullSliceAsEmptyEncoder(enc *Encoder, v protoreflect.Value, w io.Writer) er
 	}
 }
 
-// cosmosInlineJson replicates the behavior at:
+// cosmosBytesAsString replicates the behavior at:
 // https://github.com/CosmWasm/wasmd/blob/08567ff20e372e4f4204a91ca64a371538742bed/x/wasm/types/tx.go#L20-L22
-func cosmosInlineJson(_ *Encoder, v protoreflect.Value, w io.Writer) error {
-	blob, err := json.RawMessage(v.Bytes()).MarshalJSON()
-	if err != nil {
+func cosmosBytesAsString(_ *Encoder, v protoreflect.Value, w io.Writer) error {
+	switch bz := v.Interface().(type) {
+	case []byte:
+		blob, err := json.RawMessage(bz).MarshalJSON()
+		if err != nil {
+			return err
+		}
+		_, err = w.Write(blob)
 		return err
+	default:
+		return fmt.Errorf("unsupported type %T", bz)
 	}
-	_, err = w.Write(blob)
-	return err
 }
 
 // keyFieldEncoder replicates the behavior at described at:

--- a/x/tx/signing/aminojson/encoder_test.go
+++ b/x/tx/signing/aminojson/encoder_test.go
@@ -1,0 +1,51 @@
+package aminojson
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"gotest.tools/v3/assert"
+)
+
+func TestCosmosBytesAsString(t *testing.T) {
+	cases := map[string]struct {
+		value      protoreflect.Value
+		wantErr    bool
+		wantOutput string
+	}{
+		"valid bytes - json": {
+			value:      protoreflect.ValueOfBytes([]byte(`{"test":"value"}`)),
+			wantErr:    false,
+			wantOutput: `{"test":"value"}`,
+		},
+		"valid bytes - string": {
+			value:      protoreflect.ValueOfBytes([]byte(`foo`)),
+			wantErr:    false,
+			wantOutput: `foo`,
+		},
+		"unsupported type - bool": {
+			value:   protoreflect.ValueOfBool(true),
+			wantErr: true,
+		},
+		"unsupported type - int64": {
+			value:   protoreflect.ValueOfInt64(1),
+			wantErr: true,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			var buf bytes.Buffer
+			err := cosmosBytesAsString(nil, tc.value, &buf)
+
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantOutput, buf.String())
+		})
+	}
+}

--- a/x/tx/signing/aminojson/json_marshal.go
+++ b/x/tx/signing/aminojson/json_marshal.go
@@ -73,6 +73,7 @@ func NewEncoder(options EncoderOptions) Encoder {
 		},
 		aminoFieldEncoders: map[string]FieldEncoder{
 			"legacy_coins": nullSliceAsEmptyEncoder,
+			"inline_json":  cosmosInlineJson,
 		},
 		protoTypeEncoders: map[string]MessageEncoder{
 			"google.protobuf.Timestamp": marshalTimestamp,

--- a/x/tx/signing/aminojson/json_marshal.go
+++ b/x/tx/signing/aminojson/json_marshal.go
@@ -72,8 +72,8 @@ func NewEncoder(options EncoderOptions) Encoder {
 			"threshold_string": thresholdStringEncoder,
 		},
 		aminoFieldEncoders: map[string]FieldEncoder{
-			"legacy_coins": nullSliceAsEmptyEncoder,
-			"inline_json":  cosmosInlineJson,
+			"legacy_coins":    nullSliceAsEmptyEncoder,
+			"bytes_as_string": cosmosBytesAsString,
 		},
 		protoTypeEncoders: map[string]MessageEncoder{
 			"google.protobuf.Timestamp": marshalTimestamp,


### PR DESCRIPTION
# Description

Closes: #19785 

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced JSON marshaling for improved data handling and encoding, introducing functions to handle `protoreflect.Value` and `[]byte` values more efficiently.
	- Added the ability to encode bytes as strings in the unreleased version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->