### PR TITLE
refactor!: turn MsgsV2 into ReflectMessages to make it less confusing

### DIFF
--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -15,15 +15,16 @@ import (
 	dbm "github.com/cosmos/cosmos-db"
 	"github.com/cosmos/gogoproto/proto"
 	"golang.org/x/exp/maps"
-	protov2 "google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
 
-	"cosmossdk.io/core/header"
 	errorsmod "cosmossdk.io/errors"
 	"cosmossdk.io/log"
 	"cosmossdk.io/store"
 	storemetrics "cosmossdk.io/store/metrics"
 	"cosmossdk.io/store/snapshots"
 	storetypes "cosmossdk.io/store/types"
+
+	"cosmossdk.io/core/header"
 
 	"github.com/cosmos/cosmos-sdk/baseapp/oe"
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -938,9 +939,9 @@ func (app *BaseApp) runTx(mode execMode, txBytes []byte) (gInfo sdk.GasInfo, res
 	// Attempt to execute all messages and only update state if all messages pass
 	// and we're in DeliverTx. Note, runMsgs will never return a reference to a
 	// Result if any single message fails or does not have a registered Handler.
-	msgsV2, err := tx.GetMsgsV2()
+	reflectMsgs, err := tx.GetReflectMessages()
 	if err == nil {
-		result, err = app.runMsgs(runMsgCtx, msgs, msgsV2, mode)
+		result, err = app.runMsgs(runMsgCtx, msgs, reflectMsgs, mode)
 	}
 
 	// Run optional postHandlers (should run regardless of the execution result).
@@ -986,7 +987,7 @@ func (app *BaseApp) runTx(mode execMode, txBytes []byte) (gInfo sdk.GasInfo, res
 // and DeliverTx. An error is returned if any single message fails or if a
 // Handler does not exist for a given message route. Otherwise, a reference to a
 // Result is returned. The caller must not commit state if an error is returned.
-func (app *BaseApp) runMsgs(ctx sdk.Context, msgs []sdk.Msg, msgsV2 []protov2.Message, mode execMode) (*sdk.Result, error) {
+func (app *BaseApp) runMsgs(ctx sdk.Context, msgs []sdk.Msg, reflectMsgs []protoreflect.Message, mode execMode) (*sdk.Result, error) {
 	events := sdk.EmptyEvents()
 	msgResponses := make([]*codectypes.Any, 0, len(msgs))
 
@@ -1008,7 +1009,7 @@ func (app *BaseApp) runMsgs(ctx sdk.Context, msgs []sdk.Msg, msgsV2 []protov2.Me
 		}
 
 		// create message events
-		msgEvents, err := createEvents(app.cdc, msgResult.GetEvents(), msg, msgsV2[i])
+		msgEvents, err := createEvents(app.cdc, msgResult.GetEvents(), msg, reflectMsgs[i])
 		if err != nil {
 			return nil, errorsmod.Wrapf(err, "failed to create message events; message index: %d", i)
 		}
@@ -1054,12 +1055,12 @@ func makeABCIData(msgResponses []*codectypes.Any) ([]byte, error) {
 	return proto.Marshal(&sdk.TxMsgData{MsgResponses: msgResponses})
 }
 
-func createEvents(cdc codec.Codec, events sdk.Events, msg sdk.Msg, msgV2 protov2.Message) (sdk.Events, error) {
+func createEvents(cdc codec.Codec, events sdk.Events, msg sdk.Msg, reflectMsg protoreflect.Message) (sdk.Events, error) {
 	eventMsgName := sdk.MsgTypeURL(msg)
 	msgEvent := sdk.NewEvent(sdk.EventTypeMessage, sdk.NewAttribute(sdk.AttributeKeyAction, eventMsgName))
 
 	// we set the signer attribute as the sender
-	signers, err := cdc.GetMsgV2Signers(msgV2)
+	signers, err := cdc.GetReflectMsgSigners(reflectMsg)
 	if err != nil {
 		return nil, err
 	}

--- a/codec/codec.go
+++ b/codec/codec.go
@@ -3,7 +3,7 @@ package codec
 import (
 	"github.com/cosmos/gogoproto/proto"
 	"google.golang.org/grpc/encoding"
-	protov2 "google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
 
 	"github.com/cosmos/cosmos-sdk/codec/types"
 )
@@ -24,17 +24,19 @@ type (
 		InterfaceRegistry() types.InterfaceRegistry
 
 		// GetMsgAnySigners returns the signers of the given message encoded in a protobuf Any
-		// as well as the decoded google.golang.org/protobuf/proto.Message that was used to
-		// extract the signers so that this can be used in other contexts.
-		GetMsgAnySigners(msg *types.Any) ([][]byte, protov2.Message, error)
+		// as well as the decoded protoreflect.Message that was used to extract the
+		// signers so that this can be used in other context where proto reflection
+		// is needed.
+		GetMsgAnySigners(msg *types.Any) ([][]byte, protoreflect.Message, error)
 
-		// GetMsgV2Signers returns the signers of the given message.
-		GetMsgV2Signers(msg protov2.Message) ([][]byte, error)
+		// GetMsgSigners returns the signers of the given message plus the
+		// decoded protoreflect.Message that was used to extract the
+		// signers so that this can be used in other context where proto reflection
+		// is needed.
+		GetMsgSigners(msg proto.Message) ([][]byte, protoreflect.Message, error)
 
-		// GetMsgV1Signers returns the signers of the given message plus the
-		// decoded google.golang.org/protobuf/proto.Message that was used to extract the
-		// signers so that this can be used in other contexts.
-		GetMsgV1Signers(msg proto.Message) ([][]byte, protov2.Message, error)
+		// GetReflectMsgSigners returns the signers of the given reflected proto message.
+		GetReflectMsgSigners(msg protoreflect.Message) ([][]byte, error)
 
 		// mustEmbedCodec requires that all implementations of Codec embed an official implementation from the codec
 		// package. This allows new methods to be added to the Codec interface without breaking backwards compatibility.

--- a/codec/proto_codec.go
+++ b/codec/proto_codec.go
@@ -299,7 +299,7 @@ func (pc *ProtoCodec) InterfaceRegistry() types.InterfaceRegistry {
 	return pc.interfaceRegistry
 }
 
-func (pc ProtoCodec) GetMsgAnySigners(msg *types.Any) ([][]byte, proto.Message, error) {
+func (pc ProtoCodec) GetMsgAnySigners(msg *types.Any) ([][]byte, protoreflect.Message, error) {
 	msgv2, err := anyutil.Unpack(&anypb.Any{
 		TypeUrl: msg.TypeUrl,
 		Value:   msg.Value,
@@ -309,17 +309,17 @@ func (pc ProtoCodec) GetMsgAnySigners(msg *types.Any) ([][]byte, proto.Message, 
 	}
 
 	signers, err := pc.interfaceRegistry.SigningContext().GetSigners(msgv2)
-	return signers, msgv2, err
+	return signers, msgv2.ProtoReflect(), err
 }
 
-func (pc *ProtoCodec) GetMsgV2Signers(msg proto.Message) ([][]byte, error) {
-	return pc.interfaceRegistry.SigningContext().GetSigners(msg)
+func (pc *ProtoCodec) GetReflectMsgSigners(msg protoreflect.Message) ([][]byte, error) {
+	return pc.interfaceRegistry.SigningContext().GetSigners(msg.Interface())
 }
 
-func (pc *ProtoCodec) GetMsgV1Signers(msg gogoproto.Message) ([][]byte, proto.Message, error) {
+func (pc *ProtoCodec) GetMsgSigners(msg gogoproto.Message) ([][]byte, protoreflect.Message, error) {
 	if msgV2, ok := msg.(proto.Message); ok {
 		signers, err := pc.interfaceRegistry.SigningContext().GetSigners(msgV2)
-		return signers, msgV2, err
+		return signers, msgV2.ProtoReflect(), err
 	}
 	a, err := types.NewAnyWithValue(msg)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -187,6 +187,7 @@ replace (
 	cosmossdk.io/x/auth => ./x/auth
 	cosmossdk.io/x/bank => ./x/bank
 	cosmossdk.io/x/staking => ./x/staking
+	cosmossdk.io/x/tx => ./x/tx
 )
 
 replace github.com/cosmos/iavl => github.com/cosmos/iavl v1.0.1 // TODO remove

--- a/server/mock/tx.go
+++ b/server/mock/tx.go
@@ -4,10 +4,11 @@ import (
 	"bytes"
 	"fmt"
 
-	protov2 "google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+
+	errorsmod "cosmossdk.io/errors"
 
 	bankv1beta1 "cosmossdk.io/api/cosmos/bank/v1beta1"
-	errorsmod "cosmossdk.io/errors"
 	"cosmossdk.io/x/auth/signing"
 
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
@@ -103,8 +104,8 @@ func (msg *KVStoreTx) GetMsgs() []sdk.Msg {
 	return []sdk.Msg{msg}
 }
 
-func (msg *KVStoreTx) GetMsgsV2() ([]protov2.Message, error) {
-	return []protov2.Message{&bankv1beta1.MsgSend{FromAddress: msg.address.String()}}, nil // this is a hack for tests
+func (msg *KVStoreTx) GetReflectMessages() ([]protoreflect.Message, error) {
+	return []protoreflect.Message{(&bankv1beta1.MsgSend{FromAddress: msg.address.String()}).ProtoReflect()}, nil // this is a hack for tests
 }
 
 func (msg *KVStoreTx) GetSignBytes() []byte {

--- a/types/mempool/mempool_test.go
+++ b/types/mempool/mempool_test.go
@@ -7,11 +7,12 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	protov2 "google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+
+	"cosmossdk.io/log"
 
 	_ "cosmossdk.io/api/cosmos/counter/v1"
 	_ "cosmossdk.io/api/cosmos/crypto/secp256k1"
-	"cosmossdk.io/log"
 	"cosmossdk.io/x/auth/signing"
 
 	codectestutil "github.com/cosmos/cosmos-sdk/codec/testutil"
@@ -77,7 +78,7 @@ var (
 
 func (tx testTx) GetMsgs() []sdk.Msg { return nil }
 
-func (tx testTx) GetMsgsV2() ([]protov2.Message, error) { return nil, nil }
+func (tx testTx) GetReflectMsgs() ([]protoreflect.Message, error) { return nil, nil }
 
 func (tx testTx) ValidateBasic() error { return nil }
 
@@ -93,7 +94,7 @@ func (sigErrTx) Size() int64 { return 0 }
 
 func (sigErrTx) GetMsgs() []sdk.Msg { return nil }
 
-func (sigErrTx) GetMsgsV2() ([]protov2.Message, error) { return nil, nil }
+func (sigErrTx) GetReflectMessages() ([]protoreflect.Message, error) { return nil, nil }
 
 func (sigErrTx) ValidateBasic() error { return nil }
 

--- a/types/mempool/signer_extraction_adapater_test.go
+++ b/types/mempool/signer_extraction_adapater_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/mempool"
@@ -20,7 +20,7 @@ func (n nonVerifiableTx) GetMsgs() []sdk.Msg {
 	panic("not implemented")
 }
 
-func (n nonVerifiableTx) GetMsgsV2() ([]proto.Message, error) {
+func (n nonVerifiableTx) GetReflectMessages() ([]protoreflect.Message, error) {
 	panic("not implemented")
 }
 

--- a/types/tx/types.go
+++ b/types/tx/types.go
@@ -3,7 +3,7 @@ package tx
 import (
 	"fmt"
 
-	protov2 "google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
 
 	errorsmod "cosmossdk.io/errors"
 
@@ -97,18 +97,18 @@ func (t *Tx) ValidateBasic() error {
 // GetSigners retrieves all the signers of a tx.
 // This includes all unique signers of the messages (in order),
 // as well as the FeePayer (if specified and not already included).
-func (t *Tx) GetSigners(cdc codec.Codec) ([][]byte, []protov2.Message, error) {
+func (t *Tx) GetSigners(cdc codec.Codec) ([][]byte, []protoreflect.Message, error) {
 	var signers [][]byte
 	seen := map[string]bool{}
 
-	var msgsv2 []protov2.Message
+	var reflectMsgs []protoreflect.Message
 	for _, msg := range t.Body.Messages {
-		xs, msgv2, err := cdc.GetMsgAnySigners(msg)
+		xs, reflectMsg, err := cdc.GetMsgAnySigners(msg)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		msgsv2 = append(msgsv2, msgv2)
+		reflectMsgs = append(reflectMsgs, reflectMsg)
 
 		for _, signer := range xs {
 			if !seen[string(signer)] {
@@ -133,7 +133,7 @@ func (t *Tx) GetSigners(cdc codec.Codec) ([][]byte, []protov2.Message, error) {
 		seen[string(feePayerAddr)] = true
 	}
 
-	return signers, msgsv2, nil
+	return signers, reflectMsgs, nil
 }
 
 func (t *Tx) GetGas() uint64 {

--- a/types/tx_msg.go
+++ b/types/tx_msg.go
@@ -6,7 +6,7 @@ import (
 	strings "strings"
 
 	"github.com/cosmos/gogoproto/proto"
-	protov2 "google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
 
 	"github.com/cosmos/cosmos-sdk/codec"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
@@ -52,8 +52,13 @@ type (
 	Tx interface {
 		HasMsgs
 
-		// GetMsgsV2 gets the transaction's messages as google.golang.org/protobuf/proto.Message's.
-		GetMsgsV2() ([]protov2.Message, error)
+		// GetReflectMessages gets a reflected version of the transaction's messages
+		// that can be used by dynamic APIs. These messages should not be used for actual
+		// processing as they cannot be guaranteed to be what handlers are expecting, but
+		// they can be used for dynamically pulling specific fields from the message such
+		// as signers or validation data. Message process should ALWAYS use the messages
+		// returned by GetMsgs for actual processing.
+		GetReflectMessages() ([]protoreflect.Message, error)
 	}
 
 	// FeeTx defines the interface to be implemented by Tx to use the FeeDecorators

--- a/x/auth/go.mod
+++ b/x/auth/go.mod
@@ -174,4 +174,5 @@ replace (
 	cosmossdk.io/x/accounts => ../accounts
 	cosmossdk.io/x/bank => ../bank
 	cosmossdk.io/x/staking => ../staking
+	cosmossdk.io/x/tx => ../tx
 )

--- a/x/auth/tx/gogotx.go
+++ b/x/auth/tx/gogotx.go
@@ -6,16 +6,18 @@ import (
 	"strings"
 
 	"github.com/cosmos/gogoproto/proto"
-	protov2 "google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
 	anypb "google.golang.org/protobuf/types/known/anypb"
 
-	"cosmossdk.io/core/address"
 	errorsmod "cosmossdk.io/errors"
 	"cosmossdk.io/math"
-	"cosmossdk.io/x/auth/ante"
-	authsigning "cosmossdk.io/x/auth/signing"
+
 	"cosmossdk.io/x/tx/decode"
 	txsigning "cosmossdk.io/x/tx/signing"
+
+	"cosmossdk.io/core/address"
+	"cosmossdk.io/x/auth/ante"
+	authsigning "cosmossdk.io/x/auth/signing"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -115,7 +117,7 @@ func (w *gogoTxWrapper) GetMsgs() []sdk.Msg {
 	return w.msgsV1
 }
 
-func (w *gogoTxWrapper) GetMsgsV2() ([]protov2.Message, error) {
+func (w *gogoTxWrapper) GetReflectMessages() ([]protoreflect.Message, error) {
 	return w.decodedTx.Messages, nil
 }
 

--- a/x/tx/decode/decode.go
+++ b/x/tx/decode/decode.go
@@ -5,15 +5,17 @@ import (
 
 	"github.com/cosmos/cosmos-proto/anyutil"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
 
 	v1beta1 "cosmossdk.io/api/cosmos/tx/v1beta1"
 	errorsmod "cosmossdk.io/errors"
+
 	"cosmossdk.io/x/tx/signing"
 )
 
 // DecodedTx contains the decoded transaction, its signers, and other flags.
 type DecodedTx struct {
-	Messages                     []proto.Message
+	Messages                     []protoreflect.Message
 	Tx                           *v1beta1.Tx
 	TxRaw                        *v1beta1.TxRaw
 	Signers                      [][]byte
@@ -96,14 +98,14 @@ func (d *Decoder) Decode(txBytes []byte) (*DecodedTx, error) {
 	}
 
 	var signers [][]byte
-	var msgs []proto.Message
+	var msgs []protoreflect.Message
 	seenSigners := map[string]struct{}{}
 	for _, anyMsg := range body.Messages {
 		msg, signerErr := anyutil.Unpack(anyMsg, fileResolver, d.signingCtx.TypeResolver())
 		if signerErr != nil {
 			return nil, errorsmod.Wrap(ErrTxDecode, signerErr.Error())
 		}
-		msgs = append(msgs, msg)
+		msgs = append(msgs, msg.ProtoReflect())
 		ss, signerErr := d.signingCtx.GetSigners(msg)
 		if signerErr != nil {
 			return nil, errorsmod.Wrap(ErrTxDecode, signerErr.Error())


### PR DESCRIPTION
# Description

This is an alternative to #19817 that rather than just removing stuff, names things more clearly removing any mention of V2 and instead distinguishing a "reflected" version of the message from the actual version.

For instance, it's probably confusing when there is `GetMsgs` and `GetMsgsV2` - which one am I supposed to use?

Now, `GetMsgsV2` is `GetReflectMessages` which returns `protoreflect.Message` not `protov2.Message` and the documentation clearly states that `GetMsgs` returns the actual messages and `GetReflectMessages` is just for performing some dynamic read operations (like get signers) on those messages. Hopefully this is clearer and obviates the need to do some of the less efficient stuff in #19817.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage
