### PR TITLE
feat(server): add custom start handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,9 @@ Every module contains its own CHANGELOG.md. Please refer to the module you are i
 
 ### Improvements
 
+* (server) [#19854](https://github.com/cosmos/cosmos-sdk/pull/19854) Add customizability to start command.
+    * Add `StartCmdOptions` in `server.AddCommands` instead of `servertypes.ModuleInitFlags`. To set custom flags set them in the `StartCmdOptions` struct on the `AddFlags` field.
+    * Add `StartCommandHandler` to `StartCmdOptions` to allow custom start command handlers. Users now have total control over how the app starts.
 * (types) [#19672](https://github.com/cosmos/cosmos-sdk/pull/19672) `PreBlock` now returns only an error for consistency with server/v2. The SDK has upgraded x/upgrade accordingly. `ResponsePreBlock` hence has been removed.
 * (server) [#19455](https://github.com/cosmos/cosmos-sdk/pull/19455) Allow calling back into the application struct in PostSetup.
 * (types) [#19512](https://github.com/cosmos/cosmos-sdk/pull/19512) The notion of basic manager does not exist anymore (and all related helpers).
@@ -102,6 +105,7 @@ Every module contains its own CHANGELOG.md. Please refer to the module you are i
 
 ### API Breaking Changes
 
+* (server) [#19854](https://github.com/cosmos/cosmos-sdk/pull/19854) Remove `servertypes.ModuleInitFlags` types and from `server.AddCommands` as `StartCmdOptions` already achieves the same goal.
 * (types) [#19792](https://github.com/cosmos/cosmos-sdk/pull/19792) In `MsgSimulatorFn` `sdk.Context` argument is replaced for an `address.Codec`. It also returns an error.
 * (types) [#19742](https://github.com/cosmos/cosmos-sdk/pull/19742) Removes the use of `Accounts.String`
     * `SimulationState` now has address and validator codecs as fields.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -31,6 +31,13 @@ clientCtx = clientCtx.
 
 Refer to SimApp `root_v2.go` and `root.go` for an example with an app v2 and a legacy app.
 
+Additionally, a simplification of the start command leads to the following change:
+
+```diff
+- server.AddCommands(rootCmd, newApp, func(startCmd *cobra.Command) {})
++ server.AddCommands(rootCmd, newApp, server.StartCmdOptions[servertypes.Application]{})
+```
+
 #### Server (`app.go`)
 
 ##### Module Manager

--- a/docs/build/building-apps/05-app-testnet.md
+++ b/docs/build/building-apps/05-app-testnet.md
@@ -195,8 +195,8 @@ Before we can run the testnet we must plug everything together.
 in `root.go`, in the `initRootCmd` function we add:
 
 ```diff
-  server.AddCommands(rootCmd, simapp.DefaultNodeHome, newApp, createMerlinAppAndExport, addModuleInitFlags)
-	++ server.AddTestnetCreatorCommand(rootCmd, simapp.DefaultNodeHome, newTestnetApp, addModuleInitFlags)
+server.AddCommands(rootCmd, simapp.DefaultNodeHome, newApp, createMerlinAppAndExport)
++server.AddTestnetCreatorCommand(rootCmd, simapp.DefaultNodeHome, newTestnetApp)
 ```
 
 Next we will add a newTestnetApp helper function:

--- a/server/types/app.go
+++ b/server/types/app.go
@@ -8,7 +8,6 @@ import (
 	cmttypes "github.com/cometbft/cometbft/types"
 	dbm "github.com/cosmos/cosmos-db"
 	"github.com/cosmos/gogoproto/grpc"
-	"github.com/spf13/cobra"
 
 	"cosmossdk.io/log"
 	"cosmossdk.io/store/snapshots"
@@ -67,9 +66,6 @@ type (
 	// AppCreator is a function that allows us to lazily initialize an
 	// application using various configurations.
 	AppCreator[T Application] func(log.Logger, dbm.DB, io.Writer, AppOptions) T
-
-	// ModuleInitFlags takes a start command and adds modules specific init flags.
-	ModuleInitFlags func(startCmd *cobra.Command)
 
 	// ExportedApp represents an exported app state, along with
 	// validators, consensus params and latest app height.

--- a/server/util.go
+++ b/server/util.go
@@ -324,7 +324,7 @@ func interceptConfigs(rootViper *viper.Viper, customAppTemplate string, customCo
 }
 
 // AddCommands add server commands
-func AddCommands[T types.Application](rootCmd *cobra.Command, appCreator types.AppCreator[T], addStartFlags types.ModuleInitFlags) {
+func AddCommands[T types.Application](rootCmd *cobra.Command, appCreator types.AppCreator[T], opts StartCmdOptions[T]) {
 	cometCmd := &cobra.Command{
 		Use:     "comet",
 		Aliases: []string{"cometbft", "tendermint"},
@@ -341,11 +341,7 @@ func AddCommands[T types.Application](rootCmd *cobra.Command, appCreator types.A
 		BootstrapStateCmd(appCreator),
 	)
 
-	startCmd := StartCmd(appCreator)
-	if addStartFlags != nil {
-		addStartFlags(startCmd)
-	}
-
+	startCmd := StartCmdWithOptions(appCreator, opts)
 	rootCmd.AddCommand(
 		startCmd,
 		cometCmd,
@@ -354,10 +350,15 @@ func AddCommands[T types.Application](rootCmd *cobra.Command, appCreator types.A
 	)
 }
 
+// AddCommandsWithStartCmdOptions adds server commands with the provided StartCmdOptions.
+// Deprecated: Use AddCommands directly instead.
+func AddCommandsWithStartCmdOptions[T types.Application](rootCmd *cobra.Command, appCreator types.AppCreator[T], opts StartCmdOptions[T]) {
+	AddCommands(rootCmd, appCreator, opts)
+}
+
 // AddTestnetCreatorCommand allows chains to create a testnet from the state existing in their node's data directory.
-func AddTestnetCreatorCommand[T types.Application](rootCmd *cobra.Command, appCreator types.AppCreator[T], addStartFlags types.ModuleInitFlags) {
+func AddTestnetCreatorCommand[T types.Application](rootCmd *cobra.Command, appCreator types.AppCreator[T]) {
 	testnetCreateCmd := InPlaceTestnetCreator(appCreator)
-	addStartFlags(testnetCreateCmd)
 	rootCmd.AddCommand(testnetCreateCmd)
 }
 

--- a/simapp/simd/cmd/commands.go
+++ b/simapp/simd/cmd/commands.go
@@ -23,8 +23,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/pruning"
 	"github.com/cosmos/cosmos-sdk/client/rpc"
 	"github.com/cosmos/cosmos-sdk/client/snapshot"
-	"github.com/cosmos/cosmos-sdk/codec"
-	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/cosmos/cosmos-sdk/server"
 	servertypes "github.com/cosmos/cosmos-sdk/server/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -35,8 +33,6 @@ import (
 func initRootCmd(
 	rootCmd *cobra.Command,
 	txConfig client.TxConfig,
-	interfaceRegistry codectypes.InterfaceRegistry,
-	appCodec codec.Codec,
 	moduleManager *module.Manager,
 ) {
 	cfg := sdk.GetConfig()
@@ -51,7 +47,7 @@ func initRootCmd(
 		snapshot.Cmd(newApp),
 	)
 
-	server.AddCommands(rootCmd, newApp, func(startCmd *cobra.Command) {})
+	server.AddCommands(rootCmd, newApp, server.StartCmdOptions[servertypes.Application]{})
 
 	// add keybase, auxiliary RPC, query, genesis, and tx child commands
 	rootCmd.AddCommand(

--- a/simapp/simd/cmd/root.go
+++ b/simapp/simd/cmd/root.go
@@ -110,7 +110,7 @@ func NewRootCmd() *cobra.Command {
 		},
 	}
 
-	initRootCmd(rootCmd, encodingConfig.TxConfig, encodingConfig.InterfaceRegistry, encodingConfig.Codec, tempApp.ModuleManager)
+	initRootCmd(rootCmd, encodingConfig.TxConfig, tempApp.ModuleManager)
 
 	// autocli opts
 	customClientTemplate, customClientConfig := initClientConfig()

--- a/simapp/simd/cmd/root_di.go
+++ b/simapp/simd/cmd/root_di.go
@@ -87,7 +87,7 @@ func NewRootCmd() *cobra.Command {
 		},
 	}
 
-	initRootCmd(rootCmd, clientCtx.TxConfig, clientCtx.InterfaceRegistry, clientCtx.Codec, moduleManager)
+	initRootCmd(rootCmd, clientCtx.TxConfig, moduleManager)
 
 	if err := autoCliOpts.EnhanceRootCommand(rootCmd); err != nil {
 		panic(err)


### PR DESCRIPTION
# Description

Support custom starting app logic. This allows forks of the SDK only modifying the start command to only replace their start logic. Backport to v0.50 **won't** contain the api improvements (breakage) but will be additive only.


Use case:

Replace the need a forking the sdk for things like: https://github.com/cosmos/cosmos-sdk/compare/release/v0.50.x...rollkit:cosmos-sdk:release/v0.50.x

How to use:

Set `StartCommandHandler` and `AddFlags` in `StartCmdOptions` when calling `AddCommands`.

> Why method like `startAPIServer`, `startGrpcServer` or other private methods in `start.go` are not simply public to make creating `StartCommandHandler` less verbose?

Because we do not to provide any api guarantee for those functions. If you are re-implementing SDK's start command, you should know what you are doing and can reimplement those functions yourself.

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Added customizability to the server's start command for enhanced flexibility.
- **Changes**
	- Streamlined server module operations by enabling callback into the application struct post-setup.
	- Simplified function calls in the building apps documentation by removing specific parameters.
	- Refactored server startup logic to improve code efficiency and error handling.
- **Bug Fixes**
	- Ensured consistency in the `PreBlock` function by adjusting its return type.
- **Refactor**
	- Removed outdated concepts such as basic manager and `ModuleInitFlags` to clean up the codebase.
	- Updated command addition functions to support new start command customization options.
	- Adjusted command initialization in the simulation application for clarity and efficiency.
- **Documentation**
	- Updated building apps documentation to reflect changes in function call parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->