### PR TITLE
chore: linting fixes

### DIFF
--- a/store/db/rocksdb_noflag.go
+++ b/store/db/rocksdb_noflag.go
@@ -6,7 +6,6 @@ package db
 import (
 	corestore "cosmossdk.io/core/store"
 	"cosmossdk.io/store/v2"
-	"github.com/linxGnu/grocksdb"
 )
 
 var (
@@ -19,7 +18,7 @@ var (
 type RocksDB struct {
 }
 
-func NewRocksDB(dataDir string) (*RocksDB, error) {
+func NewRocksDB(name, dataDir string) (*RocksDB, error) {
 	panic("rocksdb must be built with -tags rocksdb")
 
 }
@@ -59,10 +58,6 @@ func (db *RocksDB) NewBatchWithSize(_ int) store.RawBatch {
 var _ corestore.Iterator = (*rocksDBIterator)(nil)
 
 type rocksDBIterator struct {
-}
-
-func newRocksDBIterator(src *grocksdb.Iterator, start, end []byte, reverse bool) *rocksDBIterator {
-	panic("rocksdb must be built with -tags rocksdb")
 }
 
 func (itr *rocksDBIterator) Domain() (start, end []byte) {
@@ -121,15 +116,5 @@ func (b *rocksDBBatch) Close() error {
 }
 
 func (b *rocksDBBatch) GetByteSize() (int, error) {
-	panic("rocksdb must be built with -tags rocksdb")
-}
-
-func readOnlySlice(s *grocksdb.Slice) []byte {
-	panic("rocksdb must be built with -tags rocksdb")
-}
-
-// copyAndFreeSlice will copy a given RocksDB slice and free it. If the slice
-// does not exist, <nil> will be returned.
-func copyAndFreeSlice(s *grocksdb.Slice) []byte {
 	panic("rocksdb must be built with -tags rocksdb")
 }

--- a/store/proof/commit_info.go
+++ b/store/proof/commit_info.go
@@ -75,7 +75,7 @@ func (ci *CommitInfo) GetStoreProof(storeKey []byte) ([]byte, *CommitmentOp, err
 	leaves := make([][]byte, len(ci.StoreInfos))
 	for i, si := range ci.StoreInfos {
 		var err error
-		leaves[i], err = LeafHash([]byte(si.Name), si.GetHash())
+		leaves[i], err = LeafHash(si.Name, si.GetHash())
 		if err != nil {
 			return nil, nil, err
 		}
@@ -85,7 +85,7 @@ func (ci *CommitInfo) GetStoreProof(storeKey []byte) ([]byte, *CommitmentOp, err
 	}
 
 	rootHash, inners := ProofFromByteSlices(leaves, index)
-	commitmentOp := ConvertCommitmentOp(inners, []byte(storeKey), ci.StoreInfos[index].GetHash())
+	commitmentOp := ConvertCommitmentOp(inners, storeKey, ci.StoreInfos[index].GetHash())
 
 	return rootHash, &commitmentOp, nil
 }
@@ -96,7 +96,7 @@ func (ci *CommitInfo) encodedSize() int {
 	size += encoding.EncodeVarintSize(ci.Timestamp.UnixNano())
 	size += encoding.EncodeUvarintSize(uint64(len(ci.StoreInfos)))
 	for _, storeInfo := range ci.StoreInfos {
-		size += encoding.EncodeBytesSize([]byte(storeInfo.Name))
+		size += encoding.EncodeBytesSize(storeInfo.Name)
 		size += encoding.EncodeBytesSize(storeInfo.CommitID.Hash)
 	}
 	return size
@@ -124,7 +124,7 @@ func (ci *CommitInfo) Marshal() ([]byte, error) {
 		return nil, err
 	}
 	for _, si := range ci.StoreInfos {
-		if err := encoding.EncodeBytes(&buf, []byte(si.Name)); err != nil {
+		if err := encoding.EncodeBytes(&buf, si.Name); err != nil {
 			return nil, err
 		}
 		if err := encoding.EncodeBytes(&buf, si.CommitID.Hash); err != nil {

--- a/x/params/types/common_test.go
+++ b/x/params/types/common_test.go
@@ -78,18 +78,18 @@ func validateMaxRedelegationEntries(i interface{}) error {
 
 func (p *params) ParamSetPairs() types.ParamSetPairs {
 	return types.ParamSetPairs{
-		{keyUnbondingTime, &p.UnbondingTime, validateUnbondingTime},
-		{keyMaxValidators, &p.MaxValidators, validateMaxValidators},
-		{keyBondDenom, &p.BondDenom, validateBondDenom},
+		types.ParamSetPair{Key: keyUnbondingTime, Value: &p.UnbondingTime, ValidatorFn: validateUnbondingTime},
+		types.ParamSetPair{Key: keyMaxValidators, Value: &p.MaxValidators, ValidatorFn: validateMaxValidators},
+		types.ParamSetPair{Key: keyBondDenom, Value: &p.BondDenom, ValidatorFn: validateBondDenom},
 	}
 }
 
 func (p *paramsV2) ParamSetPairs() types.ParamSetPairs {
 	return types.ParamSetPairs{
-		{keyUnbondingTime, &p.UnbondingTime, validateUnbondingTime},
-		{keyMaxValidators, &p.MaxValidators, validateMaxValidators},
-		{keyBondDenom, &p.BondDenom, validateBondDenom},
-		{keyMaxRedelegationEntries, &p.MaxRedelegationEntries, validateMaxRedelegationEntries},
+		types.ParamSetPair{Key: keyUnbondingTime, Value: &p.UnbondingTime, ValidatorFn: validateUnbondingTime},
+		types.ParamSetPair{Key: keyMaxValidators, Value: &p.MaxValidators, ValidatorFn: validateMaxValidators},
+		types.ParamSetPair{Key: keyBondDenom, Value: &p.BondDenom, ValidatorFn: validateBondDenom},
+		types.ParamSetPair{Key: keyMaxRedelegationEntries, Value: &p.MaxRedelegationEntries, ValidatorFn: validateMaxRedelegationEntries},
 	}
 }
 


### PR DESCRIPTION
# Description

Some minor linting fixes and fix noflag rocksdb

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved database initialization by adding a `name` parameter and removing obsolete code.
	- Enhanced performance and code clarity in proof commitment operations.
	- Updated parameter set handling for tests to use a more explicit and type-safe approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->