### PR TITLE
feat(client): replace `event-query-tx-for` with `wait-tx`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ Every module contains its own CHANGELOG.md. Please refer to the module you are i
 * (gRPC) [#19049](https://github.com/cosmos/cosmos-sdk/pull/19049) Add debug log prints for each gRPC request.
 * (x/consensus) [#19483](https://github.com/cosmos/cosmos-sdk/pull/19483) Add consensus messages registration to consensus module.
 * (types) [#19759](https://github.com/cosmos/cosmos-sdk/pull/19759) Align SignerExtractionAdapter in PriorityNonceMempool Remove.
+* (client) [#19870](https://github.com/cosmos/cosmos-sdk/pull/19870) Replace `event-query-tx-for` command with a new one called `wait-tx`
 
 ### Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,7 @@ Every module contains its own CHANGELOG.md. Please refer to the module you are i
 * (gRPC) [#19049](https://github.com/cosmos/cosmos-sdk/pull/19049) Add debug log prints for each gRPC request.
 * (x/consensus) [#19483](https://github.com/cosmos/cosmos-sdk/pull/19483) Add consensus messages registration to consensus module.
 * (types) [#19759](https://github.com/cosmos/cosmos-sdk/pull/19759) Align SignerExtractionAdapter in PriorityNonceMempool Remove.
-* (client) [#19870](https://github.com/cosmos/cosmos-sdk/pull/19870) Replace `event-query-tx-for` command with a new one called `wait-tx`
+* (client) [#19870](https://github.com/cosmos/cosmos-sdk/pull/19870) Add new query command `wait-tx`. Alias `event-query-tx-for` to `wait-tx` for backward compatibility.
 
 ### Improvements
 

--- a/client/rpc/tx.go
+++ b/client/rpc/tx.go
@@ -3,7 +3,9 @@ package rpc
 import (
 	"context"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
+	"io"
 	"strings"
 	"time"
 
@@ -16,7 +18,10 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/cosmos/cosmos-sdk/version"
 )
+
+const TimeoutFlag = "timeout"
 
 func newTxResponseCheckTx(res *coretypes.ResultBroadcastTxCommit) *sdk.TxResponse {
 	if res == nil {
@@ -84,18 +89,30 @@ func newResponseFormatBroadcastTxCommit(res *coretypes.ResultBroadcastTxCommit) 
 	return newTxResponseDeliverTx(res)
 }
 
-// QueryEventForTxCmd returns a CLI command that subscribes to a WebSocket connection and waits for a transaction event with the given hash.
-func QueryEventForTxCmd() *cobra.Command {
+// WaitTx returns a CLI command that waits for a transaction with the given hash to be included in a block.
+func WaitTxCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "event-query-tx-for [hash]",
-		Short: "Query for a transaction by hash",
+		Use:   "wait-tx [hash]",
+		Short: "Wait for a transaction to be included in a block",
 		Long:  `Subscribes to a CometBFT WebSocket connection and waits for a transaction event with the given hash.`,
-		Args:  cobra.ExactArgs(1),
+		Example: fmt.Sprintf(`By providing the transaction hash:
+$ %[1]sd q wait-tx [hash]
+
+Or, by piping a "tx" command:
+$ %[1]sd tx [flags] | %[1]sd q wait-tx
+`, version.AppName),
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clientCtx, err := client.GetClientTxContext(cmd)
 			if err != nil {
 				return err
 			}
+
+			timeout, err := cmd.Flags().GetDuration(TimeoutFlag)
+			if err != nil {
+				return err
+			}
+
 			c, err := rpchttp.New(clientCtx.NodeURI, "/websocket")
 			if err != nil {
 				return err
@@ -105,11 +122,34 @@ func QueryEventForTxCmd() *cobra.Command {
 			}
 			defer c.Stop() //nolint:errcheck // ignore stop error
 
-			ctx, cancel := context.WithTimeout(context.Background(), time.Second*15)
+			ctx, cancel := context.WithTimeout(context.Background(), timeout)
 			defer cancel()
 
-			hash := args[0]
-			query := fmt.Sprintf("%s='%s' AND %s='%s'", tmtypes.EventTypeKey, tmtypes.EventTx, tmtypes.TxHashKey, hash)
+			var hash []byte
+			if len(args) == 0 {
+				// read hash from stdin
+				in, err := io.ReadAll(cmd.InOrStdin())
+				if err != nil {
+					return err
+				}
+				hashByt, err := parseHashFromInput(in)
+				if err != nil {
+					return err
+				}
+
+				hash = hashByt
+			} else {
+				// read hash from args
+				hashByt, err := hex.DecodeString(args[0])
+				if err != nil {
+					return err
+				}
+
+				hash = hashByt
+			}
+
+			// subscribe to websocket events
+			query := fmt.Sprintf("%s='%s' AND %s='%X'", tmtypes.EventTypeKey, tmtypes.EventTx, tmtypes.TxHashKey, hash)
 			const subscriber = "subscriber"
 			eventCh, err := c.Subscribe(ctx, subscriber, query)
 			if err != nil {
@@ -117,6 +157,19 @@ func QueryEventForTxCmd() *cobra.Command {
 			}
 			defer c.UnsubscribeAll(context.Background(), subscriber) //nolint:errcheck // ignore unsubscribe error
 
+			// return immediately if tx is already included in a block
+			res, err := c.Tx(ctx, hash, false)
+			if err == nil {
+				// tx already included in a block
+				res := &coretypes.ResultBroadcastTxCommit{
+					TxResult: res.TxResult,
+					Hash:     res.Hash,
+					Height:   res.Height,
+				}
+				return clientCtx.PrintProto(newResponseFormatBroadcastTxCommit(res))
+			}
+
+			// tx not yet included in a block, wait for event on websocket
 			select {
 			case evt := <-eventCh:
 				if txe, ok := evt.Data.(tmtypes.EventDataTx); ok {
@@ -128,13 +181,32 @@ func QueryEventForTxCmd() *cobra.Command {
 					return clientCtx.PrintProto(newResponseFormatBroadcastTxCommit(res))
 				}
 			case <-ctx.Done():
-				return errors.ErrLogic.Wrapf("timed out waiting for event, the transaction could have already been included or wasn't yet included")
+				return errors.ErrLogic.Wrapf("timed out waiting for transaction %X to be included in a block", hash)
 			}
 			return nil
 		},
 	}
 
-	flags.AddTxFlagsToCmd(cmd)
+	cmd.Flags().Duration(TimeoutFlag, 15*time.Second, "The maximum time to wait for the transaction to be included in a block")
+	flags.AddQueryFlagsToCmd(cmd)
 
 	return cmd
+}
+
+func parseHashFromInput(in []byte) ([]byte, error) {
+	var resultTx coretypes.ResultTx
+	if err := json.Unmarshal(in, &resultTx); err == nil {
+		// input was JSON, return the hash
+		return resultTx.Hash, nil
+	}
+
+	// try to parse the hash from the output of a tx command
+	lines := strings.Split(string(in), "\n")
+	for _, line := range lines {
+		if strings.HasPrefix(line, "txhash:") {
+			hash := strings.TrimSpace(line[len("txhash:"):])
+			return hex.DecodeString(hash)
+		}
+	}
+	return nil, fmt.Errorf("txhash not found")
 }

--- a/client/rpc/tx.go
+++ b/client/rpc/tx.go
@@ -89,12 +89,18 @@ func newResponseFormatBroadcastTxCommit(res *coretypes.ResultBroadcastTxCommit) 
 	return newTxResponseDeliverTx(res)
 }
 
+// QueryEventForTxCmd is an alias for WaitTxCmd, kept for backwards compatibility.
+func QueryEventForTxCmd() *cobra.Command {
+	return WaitTxCmd()
+}
+
 // WaitTx returns a CLI command that waits for a transaction with the given hash to be included in a block.
 func WaitTxCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "wait-tx [hash]",
-		Short: "Wait for a transaction to be included in a block",
-		Long:  `Subscribes to a CometBFT WebSocket connection and waits for a transaction event with the given hash.`,
+		Use:     "wait-tx [hash]",
+		Aliases: []string{"event-query-tx-for"},
+		Short:   "Wait for a transaction to be included in a block",
+		Long:    `Subscribes to a CometBFT WebSocket connection and waits for a transaction event with the given hash.`,
 		Example: fmt.Sprintf(`By providing the transaction hash:
 $ %[1]sd q wait-tx [hash]
 

--- a/simapp/simd/cmd/commands.go
+++ b/simapp/simd/cmd/commands.go
@@ -85,7 +85,7 @@ func queryCommand() *cobra.Command {
 	}
 
 	cmd.AddCommand(
-		rpc.QueryEventForTxCmd(),
+		rpc.WaitTxCmd(),
 		server.QueryBlockCmd(),
 		authcmd.QueryTxsByEventsCmd(),
 		server.QueryBlocksCmd(),


### PR DESCRIPTION
# Description

Closes: #19821 

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

After removing `BROADCAST_MODE_BLOCK` that allowed the client to wait for the transaction to be included in the block, checking if your transaction was successful or not involves a bit more work.

After discussing in #19821, adding a flag such as `--wait` would require mixing CometBFT RPC and SDK commands which are agnostic. So, the current solution is a separate command.

The new `wait-tx` commands features the following improvements over the removed `event-query-tx-for`:

- timeout is configurable using `--timeout`, instead of hardcoded and fixed 15 seconds
- if the tx was already present in an older block, return it without errors (the websocket event won't be fired again, so it's implemented by querying the Tx RPC after subscribing)
- add ability to pipe `wait-tx` to the normal `tx` subcommands, the hash will be parsed from stdin and the tx will be waited. Making `wait-tx` more convenient to use.

Note on the last point: the code tries to parse the stdin as json (e.g. works with `appd tx some foo -o json | appd q wait-tx`), if not, it tried to parse it as `key: value` pairs and looks for `txhash`. Maybe it's a bit brittle but I think it's good enough, comments?

## Example usage

By providing the transaction hash:
```
$ appd q wait-tx [hash]
```

Or, by piping a "tx" command:
```
$ appd tx foo bar | appd q wait-tx
# works with -o json too
$ appd tx foo bar -o json | appd q wait-tx
```

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [x] confirmed `!` in the type prefix if API or client breaking change
* [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [x] provided a link to the relevant issue or specification
* [x] reviewed "Files changed" and left comments if necessary
* [x] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [x] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced `WaitTxCmd` function to include features like handling timeouts, reading transaction hashes, subscribing to websocket events, and checking inclusion status.
	- Added `parseHashFromInput` function to extract transaction hashes.
	- Updated `queryCommand` to utilize `rpc.WaitTxCmd()` instead of `rpc.QueryEventForTxCmd()`.
	- Introduced `wait-tx` command in the `client` module, replacing `event-query-tx-for` command in the `CHANGELOG.md`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->