### PR TITLE
fix(x/epochs): Fix init genesis

### DIFF
--- a/x/epochs/keeper/epoch.go
+++ b/x/epochs/keeper/epoch.go
@@ -28,8 +28,9 @@ func (k Keeper) AddEpochInfo(ctx context.Context, epoch types.EpochInfo) error {
 	if epoch.StartTime.IsZero() {
 		epoch.StartTime = k.environment.HeaderService.GetHeaderInfo(ctx).Time
 	}
-	epoch.CurrentEpochStartHeight = k.environment.HeaderService.GetHeaderInfo(ctx).Height
-
+	if epoch.CurrentEpochStartHeight == 0 {
+		epoch.CurrentEpochStartHeight = k.environment.HeaderService.GetHeaderInfo(ctx).Height
+	}	
 	return k.EpochInfo.Set(ctx, epoch.Identifier, epoch)
 }
 

--- a/x/epochs/keeper/epoch.go
+++ b/x/epochs/keeper/epoch.go
@@ -30,7 +30,7 @@ func (k Keeper) AddEpochInfo(ctx context.Context, epoch types.EpochInfo) error {
 	}
 	if epoch.CurrentEpochStartHeight == 0 {
 		epoch.CurrentEpochStartHeight = k.environment.HeaderService.GetHeaderInfo(ctx).Height
-	}	
+	}
 	return k.EpochInfo.Set(ctx, epoch.Identifier, epoch)
 }
 


### PR DESCRIPTION
# Description

Check if `CurrentEpochStartHeight` exists in genesis ( case export then import), if not set as current block height
Fix: https://github.com/cosmos/cosmos-sdk/actions/runs/8552789438/job/23436209884

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved reliability in epoch tracking by ensuring the current epoch start height is correctly initialized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->