### PR TITLE
fix(simapp): use correct store keys for upgrade

### DIFF
--- a/simapp/upgrades.go
+++ b/simapp/upgrades.go
@@ -36,11 +36,11 @@ func (app SimApp) RegisterUpgradeHandlers() {
 	if upgradeInfo.Name == UpgradeName && !app.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
 		storeUpgrades := storetypes.StoreUpgrades{
 			Added: []string{
-				accounts.ModuleName,
-				protocolpooltypes.ModuleName,
+				accounts.StoreKey,
+				protocolpooltypes.StoreKey,
 			},
 			Deleted: []string{
-				crisistypes.ModuleName, // The SDK discontinued the crisis module in v0.51.0
+				crisistypes.StoreKey, // The SDK discontinued the crisis module in v0.51.0
 			},
 		}
 


### PR DESCRIPTION
# Description

This fixes a 🐛 as the store key for accounts is not the module name. To be consistent, I have used the store keys for the other types as well
---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [x] confirmed `!` in the type prefix if API or client breaking change
* [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] ~~provided a link to the relevant issue or specification~~
* [x] reviewed "Files changed" and left comments if necessary
* [ ] ~~included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)~~
* [ ] ~~added a changelog entry to `CHANGELOG.md`~~
* [ ] ~~updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)~~
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage
