### PR TITLE
docs: fix typo in Contribution guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -344,7 +344,7 @@ Members must:
 * Be active contributors to the Cosmos SDK, and furthermore should be continuously making substantial contributions
   to the project's codebase, review process, documentation and ADRs
 * Have stake in the Cosmos SDK project, represented by:
-    * Being a client / user of the Comsos SDK
+    * Being a client / user of the Cosmos SDK
     * "[giving back](https://www.debian.org/social_contract)" to the software
 * Delegate representation in case of vacation or absence
 


### PR DESCRIPTION
# Description

Fix misspelt "Cosmos" in Contribution guide.

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [x] included the correct `docs:` prefix in the PR title
* [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [x] followed the [documentation writing guidelines](https://github.com/cosmos/cosmos-sdk/blob/main/docs/DOC_WRITING_GUIDELINES.md)
* [x] reviewed "Files changed" and left comments if necessary
* [x] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct `docs:` prefix in the PR title
* [ ] confirmed all author checklist items have been addressed 
* [ ] confirmed that this PR only changes documentation
* [ ] reviewed content for consistency
* [ ] reviewed content for thoroughness
* [ ] reviewed content for spelling and grammar
* [ ] tested instructions (if applicable)
