### PR TITLE
fix: Implement gogoproto customtype to secp256r1 keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,7 @@ Every module contains its own CHANGELOG.md. Please refer to the module you are i
 * [#19833](https://github.com/cosmos/cosmos-sdk/pull/19833) Fix some places in which we call Remove inside a Walk.
 * [#19851](https://github.com/cosmos/cosmos-sdk/pull/19851) Fix some places in which we call Remove inside a Walk (x/staking and x/gov).
 * (baseapp) [#19970](https://github.com/cosmos/cosmos-sdk/pull/19970) Fix default config values to use no-op mempool as default.
+* (crypto) [#20027](https://github.com/cosmos/cosmos-sdk/pull/20027) secp256r1 keys now implement gogoproto's customtype interface.
 
 ### API Breaking Changes
 

--- a/crypto/keys/secp256r1/privkey.go
+++ b/crypto/keys/secp256r1/privkey.go
@@ -1,9 +1,13 @@
 package secp256r1
 
 import (
+	"encoding/base64"
+
 	"github.com/cosmos/cosmos-sdk/crypto/keys/internal/ecdsa"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 )
+
+var _ customProtobufType = (*ecdsaSK)(nil)
 
 // GenPrivKey generates a new secp256r1 private key. It uses operating system randomness.
 func GenPrivKey() (*PrivKey, error) {
@@ -50,6 +54,27 @@ func (m *PrivKey) Equals(other cryptotypes.LedgerPrivKey) bool {
 
 type ecdsaSK struct {
 	ecdsa.PrivKey
+}
+
+// Marshal implements customProtobufType.
+func (sk ecdsaSK) Marshal() ([]byte, error) {
+	return sk.PrivKey.Bytes(), nil
+}
+
+// MarshalJSON implements customProtobufType.
+func (sk ecdsaSK) MarshalJSON() ([]byte, error) {
+	b64 := base64.StdEncoding.EncodeToString(sk.PrivKey.Bytes())
+	return []byte(b64), nil
+}
+
+// UnmarshalJSON implements customProtobufType.
+func (sk *ecdsaSK) UnmarshalJSON(data []byte) error {
+	bz, err := base64.StdEncoding.DecodeString(string(data))
+	if err != nil {
+		return err
+	}
+
+	return sk.PrivKey.Unmarshal(bz, secp256r1, fieldSize)
 }
 
 // Size implements proto.Marshaler interface

--- a/crypto/keys/secp256r1/privkey_internal_test.go
+++ b/crypto/keys/secp256r1/privkey_internal_test.go
@@ -113,3 +113,14 @@ func (suite *SKSuite) TestSize() {
 	var nilPk *ecdsaSK
 	require.Equal(0, nilPk.Size(), "nil value must have zero size")
 }
+
+func (suite *SKSuite) TestJson() {
+	require := suite.Require()
+	asd := suite.sk.(*PrivKey)
+	bz, err := asd.Secret.MarshalJSON()
+	require.NoError(err)
+
+	sk := &ecdsaSK{}
+	require.NoError(sk.UnmarshalJSON(bz))
+	require.Equal(suite.sk.(*PrivKey).Secret, sk)
+}

--- a/crypto/keys/secp256r1/pubkey_internal_test.go
+++ b/crypto/keys/secp256r1/pubkey_internal_test.go
@@ -126,3 +126,14 @@ func (suite *PKSuite) TestSize() {
 	var nilPk *ecdsaPK
 	require.Equal(0, nilPk.Size(), "nil value must have zero size")
 }
+
+func (suite *PKSuite) TestJson() {
+	require := suite.Require()
+
+	bz, err := suite.pk.Key.MarshalJSON()
+	require.NoError(err)
+
+	pk := &ecdsaPK{}
+	require.NoError(pk.UnmarshalJSON(bz))
+	require.Equal(suite.pk.Key, pk)
+}


### PR DESCRIPTION
# Description

These 2 types are being used as `customtypes` in the proto files, but to do it they need to implement this specific interface.

Closes: #19956

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced JSON support for private and public keys, including marshaling and unmarshaling capabilities.
- **Tests**
	- Added tests for JSON functionality in key handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->