### PR TITLE
feat(x/tx): Sort JSON attributes for "inline_json" encoder

### DIFF
--- a/x/tx/signing/aminojson/encoder.go
+++ b/x/tx/signing/aminojson/encoder.go
@@ -93,12 +93,9 @@ func nullSliceAsEmptyEncoder(enc *Encoder, v protoreflect.Value, w io.Writer) er
 func cosmosInlineJSON(_ *Encoder, v protoreflect.Value, w io.Writer) error {
 	switch bz := v.Interface().(type) {
 	case []byte:
-		if !json.Valid(bz) {
-			return errors.New("invalid JSON bytes")
-		}
 		json, err := sortedJsonStringify(bz)
 		if err != nil {
-			return errors.Wrap(err, "invalid JSON bytes")
+			return errors.Wrap(err, "could not normalize JSON")
 		}
 		_, err = w.Write(json)
 		return err
@@ -224,7 +221,7 @@ func sortedObject(obj interface{}) interface{} {
 func sortedJsonStringify(jsonBytes []byte) ([]byte, error) {
 	var obj interface{}
 	if err := json.Unmarshal(jsonBytes, &obj); err != nil {
-		return nil, err
+		return nil, errors.New("invalid JSON bytes")
 	}
 	sorted := sortedObject(obj)
 	jsonData, err := json.Marshal(sorted)

--- a/x/tx/signing/aminojson/encoder.go
+++ b/x/tx/signing/aminojson/encoder.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"sort"
 
 	"github.com/pkg/errors"
 	"google.golang.org/protobuf/reflect/protoreflect"
@@ -95,7 +96,11 @@ func cosmosInlineJSON(_ *Encoder, v protoreflect.Value, w io.Writer) error {
 		if !json.Valid(bz) {
 			return errors.New("invalid JSON bytes")
 		}
-		_, err := w.Write(bz)
+		json, err := sortedJsonStringify(bz)
+		if err != nil {
+			return errors.Wrap(err, "invalid JSON bytes")
+		}
+		_, err = w.Write(json)
 		return err
 	default:
 		return fmt.Errorf("unsupported type %T", bz)
@@ -188,4 +193,43 @@ func thresholdStringEncoder(enc *Encoder, msg protoreflect.Message, w io.Writer)
 	}
 	_, err = io.WriteString(w, `}`)
 	return err
+}
+
+// sortedObject returns a new object that mirrors the structure of the original
+// but with all maps having their keys sorted.
+func sortedObject(obj interface{}) interface{} {
+	switch v := obj.(type) {
+	case map[string]interface{}:
+		sortedKeys := make([]string, 0, len(v))
+		for key := range v {
+			sortedKeys = append(sortedKeys, key)
+		}
+		sort.Strings(sortedKeys)
+		result := make(map[string]interface{})
+		for _, key := range sortedKeys {
+			result[key] = sortedObject(v[key])
+		}
+		return result
+	case []interface{}:
+		for i, val := range v {
+			v[i] = sortedObject(val)
+		}
+		return v
+	default:
+		return obj
+	}
+}
+
+// sortedJsonStringify returns a JSON with objects sorted by key.
+func sortedJsonStringify(jsonBytes []byte) ([]byte, error) {
+	var obj interface{}
+	if err := json.Unmarshal(jsonBytes, &obj); err != nil {
+		return nil, err
+	}
+	sorted := sortedObject(obj)
+	jsonData, err := json.Marshal(sorted)
+	if err != nil {
+		return nil, err
+	}
+	return jsonData, nil
 }

--- a/x/tx/signing/aminojson/encoder_test.go
+++ b/x/tx/signing/aminojson/encoder_test.go
@@ -26,10 +26,10 @@ func TestCosmosInlineJSON(t *testing.T) {
 			wantErr:    false,
 			wantOutput: `[1,2,3]`,
 		},
-		"supported type - valid JSON is not normalized": {
+		"supported type - valid JSON is normalized": {
 			value:      protoreflect.ValueOfBytes([]byte(`[1, 2, 3]`)),
 			wantErr:    false,
-			wantOutput: `[1, 2, 3]`,
+			wantOutput: `[1,2,3]`,
 		},
 		"supported type - valid JSON array (empty)": {
 			value:      protoreflect.ValueOfBytes([]byte(`[]`)),
@@ -89,6 +89,86 @@ func TestCosmosInlineJSON(t *testing.T) {
 			}
 			require.NoError(t, err)
 			assert.Equal(t, tc.wantOutput, buf.String())
+		})
+	}
+}
+
+func TestSortedJsonStringify(t *testing.T) {
+	tests := map[string]struct {
+		input      []byte
+		wantOutput string
+	}{
+		"leaves true unchanged": {
+			input:      []byte(`true`),
+			wantOutput: "true",
+		},
+		"leaves false unchanged": {
+			input:      []byte(`false`),
+			wantOutput: "false",
+		},
+		"leaves string unchanged": {
+			input:      []byte(`"aabbccdd"`),
+			wantOutput: `"aabbccdd"`,
+		},
+		"leaves number unchanged": {
+			input:      []byte(`75`),
+			wantOutput: "75",
+		},
+		"leaves nil unchanged": {
+			input:      []byte(`null`),
+			wantOutput: "null",
+		},
+		"leaves simple array unchanged": {
+			input:      []byte(`[5, 6, 7, 1]`),
+			wantOutput: "[5,6,7,1]",
+		},
+		"leaves complex array unchanged": {
+			input:      []byte(`[5, ["a", "b"], true, null, 1]`),
+			wantOutput: `[5,["a","b"],true,null,1]`,
+		},
+		"sorts empty object": {
+			input:      []byte(`{}`),
+			wantOutput: `{}`,
+		},
+		"sorts single key object": {
+			input:      []byte(`{"a": 3}`),
+			wantOutput: `{"a":3}`,
+		},
+		"sorts multiple keys object": {
+			input:      []byte(`{"a": 3, "b": 2, "c": 1}`),
+			wantOutput: `{"a":3,"b":2,"c":1}`,
+		},
+		"sorts unsorted object": {
+			input:      []byte(`{"b": 2, "a": 3, "c": 1}`),
+			wantOutput: `{"a":3,"b":2,"c":1}`,
+		},
+		"sorts unsorted complex object": {
+			input:      []byte(`{"aaa": true, "aa": true, "a": true}`),
+			wantOutput: `{"a":true,"aa":true,"aaa":true}`,
+		},
+		"sorts nested objects": {
+			input:      []byte(`{"x": {"y": {"z": null}}}`),
+			wantOutput: `{"x":{"y":{"z":null}}}`,
+		},
+		"sorts deeply nested unsorted objects": {
+			input:      []byte(`{"b": {"z": true, "x": true, "y": true}, "a": true, "c": true}`),
+			wantOutput: `{"a":true,"b":{"x":true,"y":true,"z":true},"c":true}`,
+		},
+		"sorts objects in array sorted": {
+			input:      []byte(`[1, 2, {"x": {"y": {"z": null}}}, 4]`),
+			wantOutput: `[1,2,{"x":{"y":{"z":null}}},4]`,
+		},
+		"sorts objects in array unsorted": {
+			input:      []byte(`[1, 2, {"b": {"z": true, "x": true, "y": true}, "a": true, "c": true}, 4]`),
+			wantOutput: `[1,2,{"a":true,"b":{"x":true,"y":true,"z":true},"c":true},4]`,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, err := sortedJsonStringify(tc.input)
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantOutput, string(got))
 		})
 	}
 }


### PR DESCRIPTION
Follow up on #19919 

This PR fixes the "inline_json" encoder implementation by adding recursive sorting of the JSON fields and formatting (remove white spaces) 

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced JSON processing to ensure outputs are consistently sorted, improving readability and standardization across different systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->