### PR TITLE
refactor(x/accounts): Skip Importing Unregistered Genesis Account Types

### DIFF
--- a/x/accounts/genesis.go
+++ b/x/accounts/genesis.go
@@ -80,7 +80,13 @@ func (k Keeper) ImportState(ctx context.Context, genState *v1.GenesisState) erro
 }
 
 func (k Keeper) importAccount(ctx context.Context, acc *v1.GenesisAccount) error {
-	// TODO: maybe check if impl exists?
+	// Check if the account type exists in the registered accounts
+	_, ok := k.accounts[acc.AccountType]
+	if !ok {
+		// If the account type does not exist, return an error
+		return fmt.Errorf("account type %s not found in the registered accounts", acc.AccountType)
+	}
+
 	addrBytes, err := k.addressCodec.StringToBytes(acc.Address)
 	if err != nil {
 		return err

--- a/x/accounts/genesis_test.go
+++ b/x/accounts/genesis_test.go
@@ -8,6 +8,7 @@ import (
 
 	"cosmossdk.io/collections/colltest"
 	"cosmossdk.io/x/accounts/internal/implementation"
+	v1 "cosmossdk.io/x/accounts/v1"
 )
 
 func TestGenesis(t *testing.T) {
@@ -47,4 +48,29 @@ func TestGenesis(t *testing.T) {
 	resp, err = k.Query(ctx, addr2, &types.DoubleValue{})
 	require.NoError(t, err)
 	require.Equal(t, &types.UInt64Value{Value: 20}, resp)
+}
+
+func TestImportAccountError(t *testing.T) {
+	// Initialize the keeper and context for testing
+	k, ctx := newKeeper(t, func(deps implementation.Dependencies) (string, implementation.Account, error) {
+		acc, err := NewTestAccount(deps)
+		return "test", acc, err
+	})
+
+	// Define a mock GenesisAccount with a non-existent account type
+	acc := &v1.GenesisAccount{
+		Address:       "test-address",
+		AccountType:   "non-existent-type",
+		AccountNumber: 1,
+		State:         nil,
+	}
+
+	// Attempt to import the mock GenesisAccount into the state
+	err := k.importAccount(ctx, acc)
+
+	// Assert that an error is returned
+	require.Error(t, err)
+
+	// Assert that the error message contains the expected substring
+	require.Contains(t, err.Error(), "account type non-existent-type not found in the registered accounts")
 }


### PR DESCRIPTION
# Description

Skip Importing Unregistered Genesis Account Types in x/accounts/genesis.go

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced the account import process to verify account types before importing, ensuring reliability and preventing errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->