### PR TITLE
fix(cosmovisor): fixed cosmovisor add-upgrade permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,7 +117,6 @@ Every module contains its own CHANGELOG.md. Please refer to the module you are i
 * (x/bank) [#20028](https://github.com/cosmos/cosmos-sdk/pull/20028) Align query with multi denoms for send-enabled.
 * (cli) [#20020](https://github.com/cosmos/cosmos-sdk/pull/20020) Make bootstrap-state command support both new and legacy genesis format.
 * (baseapp) [#19616](https://github.com/cosmos/cosmos-sdk/pull/19616) Don't share gas meter in tx execution.
-* (cosmovisor) [#20062](https://github.com/cosmos/cosmos-sdk/pull/20062) Fixed cosmovisor add-upgrade permissions
 
 ### API Breaking Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,7 @@ Every module contains its own CHANGELOG.md. Please refer to the module you are i
 * (x/bank) [#20028](https://github.com/cosmos/cosmos-sdk/pull/20028) Align query with multi denoms for send-enabled.
 * (cli) [#20020](https://github.com/cosmos/cosmos-sdk/pull/20020) Make bootstrap-state command support both new and legacy genesis format.
 * (baseapp) [#19616](https://github.com/cosmos/cosmos-sdk/pull/19616) Don't share gas meter in tx execution.
+* (cosmovisor) [#20062](https://github.com/cosmos/cosmos-sdk/pull/20062) Fixed cosmovisor add-upgrade permissions
 
 ### API Breaking Changes
 

--- a/tools/cosmovisor/CHANGELOG.md
+++ b/tools/cosmovisor/CHANGELOG.md
@@ -35,6 +35,8 @@ Ref: https://keepachangelog.com/en/1.0.0/
 # Changelog
 
 ## [Unreleased]
+* [#20062](https://github.com/cosmos/cosmos-sdk/pull/20062) Fixed cosmovisor add-upgrade permissions
+
 
 ## v1.5.0 - 2023-07-17
 

--- a/tools/cosmovisor/cmd/cosmovisor/add_upgrade.go
+++ b/tools/cosmovisor/cmd/cosmovisor/add_upgrade.go
@@ -110,6 +110,7 @@ func saveOrAbort(path string, data []byte, force bool) error {
 		return fmt.Errorf("failed to check if file exists: %w", err)
 	}
 
+	//nolint:gosec // We need broader permissions to make it executable
 	if err := os.WriteFile(path, data, 0o755); err != nil {
 		return fmt.Errorf("failed to write binary to location: %w", err)
 	}

--- a/tools/cosmovisor/cmd/cosmovisor/add_upgrade.go
+++ b/tools/cosmovisor/cmd/cosmovisor/add_upgrade.go
@@ -54,7 +54,7 @@ func AddUpgrade(cmd *cobra.Command, args []string) error {
 
 	// create upgrade dir
 	upgradeLocation := cfg.UpgradeDir(upgradeName)
-	if err := os.MkdirAll(path.Join(upgradeLocation, "bin"), 0o750); err != nil {
+	if err := os.MkdirAll(path.Join(upgradeLocation, "bin"), 0o755); err != nil {
 		return fmt.Errorf("failed to create upgrade directory: %w", err)
 	}
 
@@ -110,7 +110,7 @@ func saveOrAbort(path string, data []byte, force bool) error {
 		return fmt.Errorf("failed to check if file exists: %w", err)
 	}
 
-	if err := os.WriteFile(path, data, 0o600); err != nil {
+	if err := os.WriteFile(path, data, 0o755); err != nil {
 		return fmt.Errorf("failed to write binary to location: %w", err)
 	}
 

--- a/tools/cosmovisor/cmd/cosmovisor/add_upgrade.go
+++ b/tools/cosmovisor/cmd/cosmovisor/add_upgrade.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path"
-	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -94,7 +93,7 @@ func AddUpgrade(cmd *cobra.Command, args []string) error {
 			return err
 		}
 
-		logger.Info(fmt.Sprintf("%s created, %s upgrade binary will switch at height %d", filepath.Join(cfg.UpgradeInfoFilePath(), upgradetypes.UpgradeInfoFilename), upgradeName, upgradeHeight))
+		logger.Info(fmt.Sprintf("%s created, %s upgrade binary will switch at height %d", cfg.UpgradeInfoFilePath(), upgradeName, upgradeHeight))
 	}
 
 	return nil


### PR DESCRIPTION
# Description

Closes: #20061

Sets file permissions for upgrade directory and the binary itself to 0755 (owner can do everything, others can read and execute) when adding an upgrade through the `cosmovisor add-upgrade` command.

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [x] confirmed `!` in the type prefix if API or client breaking change
* [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [x] provided a link to the relevant issue or specification
* [x] reviewed "Files changed" and left comments if necessary
* [x] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [x] added a changelog entry to `CHANGELOG.md`
* [x] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Enhanced file and directory permission settings for improved functionality.
	- Updated permissions for adding upgrades in the `cosmovisor` module.
	- Fixed file permission settings to ensure proper functionality.
	- Added a fix to address cosmovisor add-upgrade permissions.
	- Documented permission fix in the CHANGELOG.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->