### PR TITLE
chore: fix some comments

### DIFF
--- a/api/cosmos/accounts/v1/query.pulsar.go
+++ b/api/cosmos/accounts/v1/query.pulsar.go
@@ -4322,7 +4322,7 @@ func (x *AccountQueryResponse) GetResponse() *anypb.Any {
 	return nil
 }
 
-// SchemaResponse is the response type for the Query/Schema RPC method.
+// SchemaRequest is the request type for the Query/Schema RPC method.
 type SchemaRequest struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache

--- a/x/accounts/proto/cosmos/accounts/v1/query.proto
+++ b/x/accounts/proto/cosmos/accounts/v1/query.proto
@@ -32,7 +32,7 @@ message AccountQueryResponse {
   google.protobuf.Any response = 1;
 }
 
-// SchemaResponse is the response type for the Query/Schema RPC method.
+// SchemaRequest is the request type for the Query/Schema RPC method.
 message SchemaRequest {
   // account_type defines the account type to query the schema for.
   string account_type = 1;

--- a/x/accounts/v1/query.pb.go
+++ b/x/accounts/v1/query.pb.go
@@ -129,7 +129,7 @@ func (m *AccountQueryResponse) GetResponse() *any.Any {
 	return nil
 }
 
-// SchemaResponse is the response type for the Query/Schema RPC method.
+// SchemaRequest is the request type for the Query/Schema RPC method.
 type SchemaRequest struct {
 	// account_type defines the account type to query the schema for.
 	AccountType string `protobuf:"bytes,1,opt,name=account_type,json=accountType,proto3" json:"account_type,omitempty"`

--- a/x/auth/types/tx.pb.go
+++ b/x/auth/types/tx.pb.go
@@ -7,12 +7,12 @@ import (
 	context "context"
 	fmt "fmt"
 	_ "github.com/cosmos/cosmos-proto"
-	types "github.com/cosmos/cosmos-sdk/codec/types"
 	_ "github.com/cosmos/cosmos-sdk/types/msgservice"
 	_ "github.com/cosmos/cosmos-sdk/types/tx/amino"
 	_ "github.com/cosmos/gogoproto/gogoproto"
 	grpc1 "github.com/cosmos/gogoproto/grpc"
 	proto "github.com/cosmos/gogoproto/proto"
+	any "github.com/cosmos/gogoproto/types/any"
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
@@ -133,8 +133,8 @@ var xxx_messageInfo_MsgUpdateParamsResponse proto.InternalMessageInfo
 
 // MsgNonAtomicExec defines the Msg/NonAtomicExec request type.
 type MsgNonAtomicExec struct {
-	Signer string       `protobuf:"bytes,1,opt,name=signer,proto3" json:"signer,omitempty"`
-	Msgs   []*types.Any `protobuf:"bytes,2,rep,name=msgs,proto3" json:"msgs,omitempty"`
+	Signer string     `protobuf:"bytes,1,opt,name=signer,proto3" json:"signer,omitempty"`
+	Msgs   []*any.Any `protobuf:"bytes,2,rep,name=msgs,proto3" json:"msgs,omitempty"`
 }
 
 func (m *MsgNonAtomicExec) Reset()         { *m = MsgNonAtomicExec{} }
@@ -177,7 +177,7 @@ func (m *MsgNonAtomicExec) GetSigner() string {
 	return ""
 }
 
-func (m *MsgNonAtomicExec) GetMsgs() []*types.Any {
+func (m *MsgNonAtomicExec) GetMsgs() []*any.Any {
 	if m != nil {
 		return m.Msgs
 	}
@@ -187,8 +187,8 @@ func (m *MsgNonAtomicExec) GetMsgs() []*types.Any {
 // NonAtomicExecResult defines the response structure for executing a
 // MsgNonAtomicExec.
 type NonAtomicExecResult struct {
-	Error string     `protobuf:"bytes,1,opt,name=error,proto3" json:"error,omitempty"`
-	Resp  *types.Any `protobuf:"bytes,2,opt,name=resp,proto3" json:"resp,omitempty"`
+	Error string   `protobuf:"bytes,1,opt,name=error,proto3" json:"error,omitempty"`
+	Resp  *any.Any `protobuf:"bytes,2,opt,name=resp,proto3" json:"resp,omitempty"`
 }
 
 func (m *NonAtomicExecResult) Reset()         { *m = NonAtomicExecResult{} }
@@ -231,7 +231,7 @@ func (m *NonAtomicExecResult) GetError() string {
 	return ""
 }
 
-func (m *NonAtomicExecResult) GetResp() *types.Any {
+func (m *NonAtomicExecResult) GetResp() *any.Any {
 	if m != nil {
 		return m.Resp
 	}
@@ -989,7 +989,7 @@ func (m *MsgNonAtomicExec) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.Msgs = append(m.Msgs, &types.Any{})
+			m.Msgs = append(m.Msgs, &any.Any{})
 			if err := m.Msgs[len(m.Msgs)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
@@ -1106,7 +1106,7 @@ func (m *NonAtomicExecResult) Unmarshal(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if m.Resp == nil {
-				m.Resp = &types.Any{}
+				m.Resp = &any.Any{}
 			}
 			if err := m.Resp.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err


### PR DESCRIPTION
# Description

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

 fix some wrong comments

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
  - Renamed the message type from `SchemaResponse` to `SchemaRequest` in the accounts service for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->