### PR TITLE
chores: removed typo, corrected grammatical error

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The version matrix below shows which versions of the Cosmos SDK, modules and lib
 
 #### Core Dependencies
 
-Core Dependencies are the core libraries that a application may depend on.
+Core Dependencies are the core libraries that an application may depend on.
 
 > Note: the ❌ signals that the version of the Cosmos SDK does not need to import the dependency.
 

--- a/telemetry/wrapper.go
+++ b/telemetry/wrapper.go
@@ -90,7 +90,7 @@ func SetGaugeWithLabels(keys []string, val float32, labels []metrics.Label) {
 	metrics.SetGaugeWithLabels(keys, val, append(labels, globalLabels...))
 }
 
-// MeasureSince provides a wrapper functionality for emitting a a time measure
+// MeasureSince provides a wrapper functionality for emitting a time measure
 // metric with global labels (if any).
 func MeasureSince(start time.Time, keys ...string) {
 	if !IsTelemetryEnabled() {


### PR DESCRIPTION
# Description

chores: removed typo, corrected grammatical error

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [X] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [X] confirmed `!` in the type prefix if API or client breaking change
* [X] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [X] provided a link to the relevant issue or specification
* [X] reviewed "Files changed" and left comments if necessary
* [X] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [X] added a changelog entry to `CHANGELOG.md`
* [X] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [X] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Corrected grammatical errors in the core dependencies description.
- **Style**
	- Improved comment clarity in the telemetry code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->