### PR TITLE
chore: typo fix

### DIFF
--- a/x/staking/keeper/delegation_test.go
+++ b/x/staking/keeper/delegation_test.go
@@ -675,7 +675,7 @@ func (s *KeeperTestSuite) TestUnbondingAllDelegationFromValidator() {
 	require.ErrorIs(err, stakingtypes.ErrNoValidatorFound)
 }
 
-// Make sure that that the retrieving the delegations doesn't affect the state
+// Make sure that the retrieving the delegations doesn't affect the state
 func (s *KeeperTestSuite) TestGetRedelegationsFromSrcValidator() {
 	ctx, keeper := s.ctx, s.stakingKeeper
 	require := s.Require()


### PR DESCRIPTION
Fixed double usage of the word "that" in a comment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Corrected a typo in a comment within the delegation tests to clarify the impact of retrieving delegations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->