### PR TITLE
chore: typo/spelling fix

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -15,7 +15,7 @@ utilities.
 
 It is vital that the root command of an application uses `PersistentPreRun()` cobra command
 property for executing the command, so all child commands have access to the server and client contexts.
-These contexts are set as their default values initially and maybe modified,
+These contexts are set as their default values initially and may be modified,
 scoped to the command, in their respective `PersistentPreRun()` functions. Note that
 the `client.Context` is typically pre-populated with "default" values that may be
 useful for all commands to inherit and override if necessary.


### PR DESCRIPTION
Fixing improper usage of adverb "maybe" to the words "may be".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Corrected grammar in the server documentation regarding context modification in command execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->