### PR TITLE
docs: add authz reference info in the circuit antehandler

### DIFF
--- a/x/circuit/ante/circuit.go
+++ b/x/circuit/ante/circuit.go
@@ -24,6 +24,10 @@ func NewCircuitBreakerDecorator(ck CircuitBreaker) CircuitBreakerDecorator {
 	}
 }
 
+// If you copy this as reference and your app has the authz module enabled, you must either:
+// - recessively check for nested authz.Exec messages in this function.
+// - or error early if a nested authz grant is found.
+// The circuit AnteHandler handles this with baseapp's service router: https://github.com/cosmos/cosmos-sdk/issues/18632.
 func (cbd CircuitBreakerDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (sdk.Context, error) {
 	// loop through all the messages and check if the message type is allowed
 	for _, msg := range tx.GetMsgs() {

--- a/x/circuit/ante/circuit.go
+++ b/x/circuit/ante/circuit.go
@@ -25,7 +25,7 @@ func NewCircuitBreakerDecorator(ck CircuitBreaker) CircuitBreakerDecorator {
 }
 
 // If you copy this as reference and your app has the authz module enabled, you must either:
-// - recessively check for nested authz.Exec messages in this function.
+// - recursively check for nested authz.Exec messages in this function.
 // - or error early if a nested authz grant is found.
 // The circuit AnteHandler handles this with baseapp's service router: https://github.com/cosmos/cosmos-sdk/issues/18632.
 func (cbd CircuitBreakerDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (sdk.Context, error) {


### PR DESCRIPTION
# Description

Ref: https://github.com/cosmos/cosmos-sdk/issues/18632#issuecomment-2057671028

Teams are using the circuit ante as reference to copy into their networks. If their network uses authz, there is a security issue right away for them w/ nested authz Exec bypasses [if you don't recursively check](https://github.com/CosmosContracts/juno/blob/v21.0.0/app/decorators/change_rate_decorator.go#L48-L64) or block like dydx does. 

Maybe the SDK should disallow nested authz Exec's anyways as a security precaution? Is there any actual reason to allow this. I can't think of a valid use case

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Documentation**
	- Enhanced comments for better understanding of nested `authz.Exec` messages handling in the `AnteHandle` method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->