### PR TITLE
fix: Fix data race test coverage.

### DIFF
--- a/testutil/network/network.go
+++ b/testutil/network/network.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"testing"
 	"time"
@@ -647,29 +648,29 @@ func (n *Network) LatestHeight() (int64, error) {
 	timeout := time.NewTimer(time.Second * 5)
 	defer timeout.Stop()
 
-	var latestHeight int64
+	var latestHeight atomic.Int64
 	val := n.Validators[0]
 	queryClient := cmtservice.NewServiceClient(val.clientCtx)
 
 	for {
 		select {
 		case <-timeout.C:
-			return latestHeight, errors.New("timeout exceeded waiting for block")
+			return latestHeight.Load(), errors.New("timeout exceeded waiting for block")
 		case <-ticker.C:
 			done := make(chan struct{})
 			go func() {
 				res, err := queryClient.GetLatestBlock(context.Background(), &cmtservice.GetLatestBlockRequest{})
 				if err == nil && res != nil {
-					latestHeight = res.SdkBlock.Header.Height
+					latestHeight.Store(res.SdkBlock.Header.Height)
 				}
 				done <- struct{}{}
 			}()
 			select {
 			case <-timeout.C:
-				return latestHeight, errors.New("timeout exceeded waiting for block")
+				return latestHeight.Load(), errors.New("timeout exceeded waiting for block")
 			case <-done:
-				if latestHeight != 0 {
-					return latestHeight, nil
+				if latestHeight.Load() != 0 {
+					return latestHeight.Load(), nil
 				}
 			}
 		}


### PR DESCRIPTION
# Description

The `latestHeight` value accessed by goroutines are not protected, so there will be a data race problem. This PR protect `latestHeight` by change it to a atomic variable.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced thread safety by modifying how `latestHeight` is accessed, ensuring safe concurrent operations to prevent race conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->