### PR TITLE
refactor(store/v2): set tuned value for default pruning options

### DIFF
--- a/store/options.go
+++ b/store/options.go
@@ -1,5 +1,10 @@
 package store
 
+const (
+	pruneDefaultKeepRecent = 362880
+	pruneDefaultInterval   = 10
+)
+
 // PruneOptions defines the pruning configuration.
 type PruneOptions struct {
 	// KeepRecent sets the number of recent versions to keep.
@@ -11,11 +16,10 @@ type PruneOptions struct {
 }
 
 // DefaultPruneOptions returns the default pruning options.
-// Interval is set to 0, which means no pruning will be done.
 func DefaultPruneOptions() *PruneOptions {
 	return &PruneOptions{
-		KeepRecent: 0,
-		Interval:   0,
+		KeepRecent: pruneDefaultKeepRecent,
+		Interval:   pruneDefaultInterval,
 	}
 }
 


### PR DESCRIPTION
# Description

Closes: [#19421](https://github.com/cosmos/cosmos-sdk/issues/19421)

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage
