### PR TITLE
Deactivate chain upgrade test

### DIFF
--- a/tests/systemtests/upgrade_test.go
+++ b/tests/systemtests/upgrade_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 func TestChainUpgrade(t *testing.T) {
+	t.Skip("Deactivated until there is a migration path for comet. See https://github.com/cosmos/cosmos-sdk/issues/20318")
 	// Scenario:
 	// start a legacy chain with some state
 	// when a chain upgrade proposal is executed


### PR DESCRIPTION
# Description
It is failing due to https://github.com/cosmos/cosmos-sdk/issues/20318


## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Temporarily disabled a system test for chain upgrades pending the development of a migration path for comet.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->