### PR TITLE
refactor: decouple from sdk/codec in amino codec usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,7 @@ Every module contains its own CHANGELOG.md. Please refer to the module you are i
 
 ### API Breaking Changes
 
+* (types)[#20369](https://github.com/cosmos/cosmos-sdk/pull/20369) The signature of `HasAminoCodec` has changed to accept a `core/legacy.Amino` interface instead of `codec.LegacyAmino`.
 * (x/simulation)[#20056](https://github.com/cosmos/cosmos-sdk/pull/20056) `SimulateFromSeed` now takes an address codec as argument.
 * (x/crisis) [#20043](https://github.com/cosmos/cosmos-sdk/pull/20043) Changed `NewMsgVerifyInvariant` to accept a string as argument instead of an `AccAddress`.
 * (x/genutil) [#19926](https://github.com/cosmos/cosmos-sdk/pull/19926) Removal of the Address.String() method and related changes:

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -186,6 +186,13 @@ The signature of the extension interface `HasRegisterInterfaces` has been change
 +func (AppModule) RegisterInterfaces(registry registry.InterfaceRegistrar) {
 ```
 
+The signature of the extension interface `HasAminoCodec` has been changed to accept a `cosmossdk.io/core/legacy.Amino` instead of a `codec.LegacyAmino`. Modules should update their `HasAminoCodec` implementation to accept a `cosmossdk.io/core/legacy.Amino` interface.
+
+```diff
+-func (AppModule) RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
++func (AppModule) RegisterLegacyAminoCodec(cdc legacy.Amino) {
+```
+
 ##### Simulation
 
 `MsgSimulatorFn` has been updated to return an error. Its context argument has been removed, and an address.Codec has

--- a/codec/amino.go
+++ b/codec/amino.go
@@ -32,9 +32,9 @@ func NewLegacyAmino() *LegacyAmino {
 
 // RegisterEvidences registers CometBFT evidence types with the provided Amino
 // codec.
-func RegisterEvidences(cdc *LegacyAmino) {
-	cdc.Amino.RegisterInterface((*cmttypes.Evidence)(nil), nil)
-	cdc.Amino.RegisterConcrete(&cmttypes.DuplicateVoteEvidence{}, "tendermint/DuplicateVoteEvidence", nil)
+func RegisterEvidences(cdc legacy.Amino) {
+	cdc.RegisterInterface((*cmttypes.Evidence)(nil), nil)
+	cdc.RegisterConcrete(&cmttypes.DuplicateVoteEvidence{}, "tendermint/DuplicateVoteEvidence")
 }
 
 // MarshalJSONIndent provides a utility for indented JSON encoding of an object
@@ -178,12 +178,15 @@ func (*LegacyAmino) UnpackAny(*types.Any, interface{}) error {
 	return errors.New("AminoCodec can't handle unpack protobuf Any's")
 }
 
-func (cdc *LegacyAmino) RegisterInterface(ptr interface{}, iopts *amino.InterfaceOptions) {
-	cdc.Amino.RegisterInterface(ptr, iopts)
+func (cdc *LegacyAmino) RegisterInterface(ptr interface{}, iopts *legacy.InterfaceOptions) {
+	cdc.Amino.RegisterInterface(ptr, &amino.InterfaceOptions{
+		Priority:           iopts.Priority,
+		AlwaysDisambiguate: iopts.AlwaysDisambiguate,
+	})
 }
 
-func (cdc *LegacyAmino) RegisterConcrete(o interface{}, name string, copts *amino.ConcreteOptions) {
-	cdc.Amino.RegisterConcrete(o, name, copts)
+func (cdc *LegacyAmino) RegisterConcrete(o interface{}, name string) {
+	cdc.Amino.RegisterConcrete(o, name, nil)
 }
 
 func (cdc *LegacyAmino) MarshalJSONIndent(o interface{}, prefix, indent string) ([]byte, error) {

--- a/codec/amino.go
+++ b/codec/amino.go
@@ -7,9 +7,10 @@ import (
 	"fmt"
 	"io"
 
-	"cosmossdk.io/core/legacy"
 	cmttypes "github.com/cometbft/cometbft/types"
 	"github.com/tendermint/go-amino"
+
+	"cosmossdk.io/core/legacy"
 
 	"github.com/cosmos/cosmos-sdk/codec/types"
 )

--- a/codec/amino.go
+++ b/codec/amino.go
@@ -179,10 +179,14 @@ func (*LegacyAmino) UnpackAny(*types.Any, interface{}) error {
 }
 
 func (cdc *LegacyAmino) RegisterInterface(ptr interface{}, iopts *legacy.InterfaceOptions) {
-	cdc.Amino.RegisterInterface(ptr, &amino.InterfaceOptions{
-		Priority:           iopts.Priority,
-		AlwaysDisambiguate: iopts.AlwaysDisambiguate,
-	})
+	if iopts == nil {
+		cdc.Amino.RegisterInterface(ptr, nil)
+	} else {
+		cdc.Amino.RegisterInterface(ptr, &amino.InterfaceOptions{
+			Priority:           iopts.Priority,
+			AlwaysDisambiguate: iopts.AlwaysDisambiguate,
+		})
+	}
 }
 
 func (cdc *LegacyAmino) RegisterConcrete(o interface{}, name string) {

--- a/codec/amino.go
+++ b/codec/amino.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 
+	"cosmossdk.io/core/legacy"
 	cmttypes "github.com/cometbft/cometbft/types"
 	"github.com/tendermint/go-amino"
 
@@ -22,6 +23,8 @@ type LegacyAmino struct {
 func (cdc *LegacyAmino) Seal() {
 	cdc.Amino.Seal()
 }
+
+var _ legacy.Amino = &LegacyAmino{}
 
 func NewLegacyAmino() *LegacyAmino {
 	return &LegacyAmino{amino.NewCodec()}

--- a/codec/amino_codec_test.go
+++ b/codec/amino_codec_test.go
@@ -17,8 +17,8 @@ func createTestCodec() *codec.LegacyAmino {
 	cdc.RegisterInterface((*testdata.Animal)(nil), nil)
 	// NOTE: since we unmarshal interface using pointers, we need to register a pointer
 	// types here.
-	cdc.RegisterConcrete(&testdata.Dog{}, "testdata/Dog", nil)
-	cdc.RegisterConcrete(&testdata.Cat{}, "testdata/Cat", nil)
+	cdc.RegisterConcrete(&testdata.Dog{}, "testdata/Dog")
+	cdc.RegisterConcrete(&testdata.Cat{}, "testdata/Cat")
 
 	return cdc
 }

--- a/codec/depinject.go
+++ b/codec/depinject.go
@@ -1,0 +1,38 @@
+package codec
+
+import (
+	"github.com/cosmos/gogoproto/proto"
+
+	"cosmossdk.io/core/address"
+	"cosmossdk.io/x/tx/signing"
+
+	"github.com/cosmos/cosmos-sdk/codec/types"
+)
+
+func ProvideInterfaceRegistry(
+	addressCodec address.Codec,
+	validatorAddressCodec address.ValidatorAddressCodec,
+	customGetSigners []signing.CustomGetSigner,
+) (types.InterfaceRegistry, error) {
+	signingOptions := signing.Options{
+		AddressCodec:          addressCodec,
+		ValidatorAddressCodec: validatorAddressCodec,
+	}
+	for _, signer := range customGetSigners {
+		signingOptions.DefineCustomGetSigners(signer.MsgType, signer.Fn)
+	}
+
+	interfaceRegistry, err := types.NewInterfaceRegistryWithOptions(types.InterfaceRegistryOptions{
+		ProtoFiles:     proto.HybridResolver,
+		SigningOptions: signingOptions,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if err := interfaceRegistry.SigningContext().Validate(); err != nil {
+		return nil, err
+	}
+
+	return interfaceRegistry, nil
+}

--- a/codec/depinject.go
+++ b/codec/depinject.go
@@ -38,6 +38,6 @@ func ProvideInterfaceRegistry(
 	return interfaceRegistry, nil
 }
 
-func ProvideCodecs() legacy.Amino {
-	return NewLegacyAmino()
+func ProvideCodecs(interfaceRegistry types.InterfaceRegistry) (legacy.Amino, *ProtoCodec) {
+	return NewLegacyAmino(), NewProtoCodec(interfaceRegistry)
 }

--- a/codec/depinject.go
+++ b/codec/depinject.go
@@ -4,6 +4,7 @@ import (
 	"github.com/cosmos/gogoproto/proto"
 
 	"cosmossdk.io/core/address"
+	"cosmossdk.io/core/legacy"
 	"cosmossdk.io/x/tx/signing"
 
 	"github.com/cosmos/cosmos-sdk/codec/types"
@@ -35,4 +36,8 @@ func ProvideInterfaceRegistry(
 	}
 
 	return interfaceRegistry, nil
+}
+
+func ProvideCodecs() legacy.Amino {
+	return NewLegacyAmino()
 }

--- a/codec/depinject.go
+++ b/codec/depinject.go
@@ -38,6 +38,10 @@ func ProvideInterfaceRegistry(
 	return interfaceRegistry, nil
 }
 
-func ProvideCodecs(interfaceRegistry types.InterfaceRegistry) (legacy.Amino, *ProtoCodec) {
-	return NewLegacyAmino(), NewProtoCodec(interfaceRegistry)
+func ProvideLegacyAmino() legacy.Amino {
+	return NewLegacyAmino()
+}
+
+func ProvideProtoCodec(interfaceRegistry types.InterfaceRegistry) *ProtoCodec {
+	return NewProtoCodec(interfaceRegistry)
 }

--- a/codec/legacy/amino_msg.go
+++ b/codec/legacy/amino_msg.go
@@ -3,7 +3,6 @@ package legacy
 import (
 	"fmt"
 
-
 	"cosmossdk.io/core/legacy"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"

--- a/codec/legacy/amino_msg.go
+++ b/codec/legacy/amino_msg.go
@@ -1,18 +1,18 @@
 package legacy
 
 import (
+	"cosmossdk.io/core/legacy"
 	"fmt"
 
-	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 // RegisterAminoMsg first checks that the msgName is <40 chars
 // (else this would break ledger nano signing: https://github.com/cosmos/cosmos-sdk/issues/10870),
 // then registers the concrete msg type with amino.
-func RegisterAminoMsg(cdc *codec.LegacyAmino, msg sdk.Msg, msgName string) {
+func RegisterAminoMsg(cdc legacy.Amino, msg sdk.Msg, msgName string) {
 	if len(msgName) > 39 {
 		panic(fmt.Errorf("msg name %s is too long to be registered with amino", msgName))
 	}
-	cdc.RegisterConcrete(msg, msgName, nil)
+	cdc.RegisterConcrete(msg, msgName)
 }

--- a/codec/legacy/amino_msg.go
+++ b/codec/legacy/amino_msg.go
@@ -1,8 +1,10 @@
 package legacy
 
 import (
-	"cosmossdk.io/core/legacy"
 	"fmt"
+
+
+	"cosmossdk.io/core/legacy"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )

--- a/core/legacy/amino.go
+++ b/core/legacy/amino.go
@@ -2,8 +2,13 @@ package legacy
 
 type Amino interface {
 	// RegisterInterface registers an interface and its concrete type with the Amino codec.
-	RegisterInterface(interfacePtr, cdcType interface{})
+	RegisterInterface(interfacePtr any, iopts *InterfaceOptions)
 
 	// RegisterConcrete registers a concrete type with the Amino codec.
 	RegisterConcrete(cdcType interface{}, name string)
+}
+
+type InterfaceOptions struct {
+	Priority           []string // Disamb priority.
+	AlwaysDisambiguate bool     // If true, include disamb for all types.
 }

--- a/core/legacy/amino.go
+++ b/core/legacy/amino.go
@@ -1,0 +1,9 @@
+package legacy
+
+type Amino interface {
+	// RegisterInterface registers an interface and its concrete type with the Amino codec.
+	RegisterInterface(interfacePtr, cdcType interface{})
+
+	// RegisterConcrete registers a concrete type with the Amino codec.
+	RegisterConcrete(cdcType interface{}, name string)
+}

--- a/crypto/codec/amino.go
+++ b/crypto/codec/amino.go
@@ -1,8 +1,9 @@
 package codec
 
 import (
-	"cosmossdk.io/core/legacy"
 	"github.com/cometbft/cometbft/crypto/sr25519"
+
+	"cosmossdk.io/core/legacy"
 
 	"github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
 	kmultisig "github.com/cosmos/cosmos-sdk/crypto/keys/multisig"

--- a/crypto/codec/amino.go
+++ b/crypto/codec/amino.go
@@ -1,9 +1,9 @@
 package codec
 
 import (
+	"cosmossdk.io/core/legacy"
 	"github.com/cometbft/cometbft/crypto/sr25519"
 
-	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
 	kmultisig "github.com/cosmos/cosmos-sdk/crypto/keys/multisig"
 	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
@@ -12,22 +12,22 @@ import (
 
 // RegisterCrypto registers all crypto dependency types with the provided Amino
 // codec.
-func RegisterCrypto(cdc *codec.LegacyAmino) {
+func RegisterCrypto(cdc legacy.Amino) {
 	cdc.RegisterInterface((*cryptotypes.PubKey)(nil), nil)
 	cdc.RegisterConcrete(sr25519.PubKey{},
-		sr25519.PubKeyName, nil)
+		sr25519.PubKeyName)
 	cdc.RegisterConcrete(&ed25519.PubKey{},
-		ed25519.PubKeyName, nil)
+		ed25519.PubKeyName)
 	cdc.RegisterConcrete(&secp256k1.PubKey{},
-		secp256k1.PubKeyName, nil)
+		secp256k1.PubKeyName)
 	cdc.RegisterConcrete(&kmultisig.LegacyAminoPubKey{},
-		kmultisig.PubKeyAminoRoute, nil)
+		kmultisig.PubKeyAminoRoute)
 
 	cdc.RegisterInterface((*cryptotypes.PrivKey)(nil), nil)
 	cdc.RegisterConcrete(sr25519.PrivKey{},
-		sr25519.PrivKeyName, nil)
+		sr25519.PrivKeyName)
 	cdc.RegisterConcrete(&ed25519.PrivKey{},
-		ed25519.PrivKeyName, nil)
+		ed25519.PrivKeyName)
 	cdc.RegisterConcrete(&secp256k1.PrivKey{},
-		secp256k1.PrivKeyName, nil)
+		secp256k1.PrivKeyName)
 }

--- a/crypto/keyring/codec.go
+++ b/crypto/keyring/codec.go
@@ -13,9 +13,9 @@ func init() {
 // RegisterLegacyAminoCodec registers concrete types and interfaces on the given codec.
 func RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
 	cdc.RegisterInterface((*LegacyInfo)(nil), nil)
-	cdc.RegisterConcrete(hd.BIP44Params{}, "crypto/keys/hd/BIP44Params", nil)
-	cdc.RegisterConcrete(legacyLocalInfo{}, "crypto/keys/localInfo", nil)
-	cdc.RegisterConcrete(legacyLedgerInfo{}, "crypto/keys/ledgerInfo", nil)
-	cdc.RegisterConcrete(legacyOfflineInfo{}, "crypto/keys/offlineInfo", nil)
-	cdc.RegisterConcrete(LegacyMultiInfo{}, "crypto/keys/multiInfo", nil)
+	cdc.RegisterConcrete(hd.BIP44Params{}, "crypto/keys/hd/BIP44Params")
+	cdc.RegisterConcrete(legacyLocalInfo{}, "crypto/keys/localInfo")
+	cdc.RegisterConcrete(legacyLedgerInfo{}, "crypto/keys/ledgerInfo")
+	cdc.RegisterConcrete(legacyOfflineInfo{}, "crypto/keys/offlineInfo")
+	cdc.RegisterConcrete(LegacyMultiInfo{}, "crypto/keys/multiInfo")
 }

--- a/crypto/keys/multisig/codec.go
+++ b/crypto/keys/multisig/codec.go
@@ -22,11 +22,11 @@ var AminoCdc = codec.NewLegacyAmino()
 func init() {
 	AminoCdc.RegisterInterface((*cryptotypes.PubKey)(nil), nil)
 	AminoCdc.RegisterConcrete(ed25519.PubKey{},
-		ed25519.PubKeyName, nil)
+		ed25519.PubKeyName)
 	AminoCdc.RegisterConcrete(sr25519.PubKey{},
-		sr25519.PubKeyName, nil)
+		sr25519.PubKeyName)
 	AminoCdc.RegisterConcrete(&secp256k1.PubKey{},
-		secp256k1.PubKeyName, nil)
+		secp256k1.PubKeyName)
 	AminoCdc.RegisterConcrete(&LegacyAminoPubKey{},
-		PubKeyAminoRoute, nil)
+		PubKeyAminoRoute)
 }

--- a/crypto/ledger/amino.go
+++ b/crypto/ledger/amino.go
@@ -15,5 +15,5 @@ func init() {
 // RegisterAmino registers all go-crypto related types in the given (amino) codec.
 func RegisterAmino(cdc *codec.LegacyAmino) {
 	cdc.RegisterConcrete(PrivKeyLedgerSecp256k1{},
-		"tendermint/PrivKeyLedgerSecp256k1", nil)
+		"tendermint/PrivKeyLedgerSecp256k1")
 }

--- a/runtime/app.go
+++ b/runtime/app.go
@@ -10,6 +10,7 @@ import (
 	runtimev1alpha1 "cosmossdk.io/api/cosmos/app/runtime/v1alpha1"
 	appv1alpha1 "cosmossdk.io/api/cosmos/app/v1alpha1"
 	"cosmossdk.io/core/appmodule"
+	"cosmossdk.io/core/legacy"
 	"cosmossdk.io/log"
 	storetypes "cosmossdk.io/store/types"
 	authtx "cosmossdk.io/x/auth/tx"
@@ -46,7 +47,7 @@ type App struct {
 	storeKeys         []storetypes.StoreKey
 	interfaceRegistry codectypes.InterfaceRegistry
 	cdc               codec.Codec
-	amino             *codec.LegacyAmino
+	amino             legacy.Amino
 	baseAppOptions    []BaseAppOption
 	msgServiceRouter  *baseapp.MsgServiceRouter
 	grpcQueryRouter   *baseapp.GRPCQueryRouter

--- a/runtime/module.go
+++ b/runtime/module.go
@@ -96,7 +96,8 @@ func init() {
 			// to decouple runtime from sdk/codec ProvideInterfaceReistry can be registered from the app
 			// i.e. in the call to depinject.Inject(...)
 			codec.ProvideInterfaceRegistry,
-			codec.ProvideCodecs,
+			codec.ProvideLegacyAmino,
+			codec.ProvideProtoCodec,
 			ProvideKVStoreKey,
 			ProvideTransientStoreKey,
 			ProvideMemoryStoreKey,

--- a/simapp/app_di.go
+++ b/simapp/app_di.go
@@ -12,6 +12,7 @@ import (
 	dbm "github.com/cosmos/cosmos-db"
 	"github.com/spf13/cast"
 
+	"cosmossdk.io/core/legacy"
 	"cosmossdk.io/depinject"
 	"cosmossdk.io/log"
 	storetypes "cosmossdk.io/store/types"
@@ -67,7 +68,7 @@ var (
 // capabilities aren't needed for testing.
 type SimApp struct {
 	*runtime.App
-	legacyAmino       *codec.LegacyAmino
+	legacyAmino       legacy.Amino
 	appCodec          codec.Codec
 	txConfig          client.TxConfig
 	interfaceRegistry codectypes.InterfaceRegistry
@@ -342,7 +343,12 @@ func (app *SimApp) Close() error {
 // NOTE: This is solely to be used for testing purposes as it may be desirable
 // for modules to register their own custom testing types.
 func (app *SimApp) LegacyAmino() *codec.LegacyAmino {
-	return app.legacyAmino
+	switch cdc := app.legacyAmino.(type) {
+	case *codec.LegacyAmino:
+		return cdc
+	default:
+		panic("unexpected codec type")
+	}
 }
 
 // AppCodec returns SimApp's app codec.

--- a/simapp/simd/cmd/root_di.go
+++ b/simapp/simd/cmd/root_di.go
@@ -12,6 +12,7 @@ import (
 	"cosmossdk.io/client/v2/autocli"
 	clientv2keyring "cosmossdk.io/client/v2/autocli/keyring"
 	"cosmossdk.io/core/address"
+	"cosmossdk.io/core/legacy"
 	"cosmossdk.io/depinject"
 	"cosmossdk.io/log"
 	"cosmossdk.io/simapp"
@@ -100,7 +101,7 @@ func ProvideClientContext(
 	appCodec codec.Codec,
 	interfaceRegistry codectypes.InterfaceRegistry,
 	txConfigOpts tx.ConfigOptions,
-	legacyAmino *codec.LegacyAmino,
+	legacyAmino legacy.Amino,
 	addressCodec address.Codec,
 	validatorAddressCodec address.ValidatorAddressCodec,
 	consensusAddressCodec address.ConsensusAddressCodec,
@@ -109,10 +110,18 @@ func ProvideClientContext(
 ) client.Context {
 	var err error
 
+	var amino *codec.LegacyAmino
+	switch cdc := legacyAmino.(type) {
+	case *codec.LegacyAmino:
+		amino = cdc
+	default:
+		panic("ProvideClientContext requires a *codec.LegacyAmino instance")
+	}
+
 	clientCtx := client.Context{}.
 		WithCodec(appCodec).
 		WithInterfaceRegistry(interfaceRegistry).
-		WithLegacyAmino(legacyAmino).
+		WithLegacyAmino(amino).
 		WithInput(os.Stdin).
 		WithAccountRetriever(types.AccountRetriever{}).
 		WithAddressCodec(addressCodec).

--- a/simapp/simd/cmd/root_di.go
+++ b/simapp/simd/cmd/root_di.go
@@ -110,11 +110,8 @@ func ProvideClientContext(
 ) client.Context {
 	var err error
 
-	var amino *codec.LegacyAmino
-	switch cdc := legacyAmino.(type) {
-	case *codec.LegacyAmino:
-		amino = cdc
-	default:
+	amino, ok := legacyAmino.(*codec.LegacyAmino)
+	if !ok {
 		panic("ProvideClientContext requires a *codec.LegacyAmino instance")
 	}
 

--- a/std/codec.go
+++ b/std/codec.go
@@ -2,6 +2,7 @@ package std
 
 import (
 	"cosmossdk.io/core/legacy"
+
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/codec/types"
 	cryptocodec "github.com/cosmos/cosmos-sdk/crypto/codec"

--- a/std/codec.go
+++ b/std/codec.go
@@ -1,6 +1,7 @@
 package std
 
 import (
+	"cosmossdk.io/core/legacy"
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/codec/types"
 	cryptocodec "github.com/cosmos/cosmos-sdk/crypto/codec"
@@ -9,7 +10,7 @@ import (
 )
 
 // RegisterLegacyAminoCodec registers types with the Amino codec.
-func RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
+func RegisterLegacyAminoCodec(cdc legacy.Amino) {
 	sdk.RegisterLegacyAminoCodec(cdc)
 	cryptocodec.RegisterCrypto(cdc)
 	codec.RegisterEvidences(cdc)

--- a/tests/sims/authz/operations_test.go
+++ b/tests/sims/authz/operations_test.go
@@ -57,7 +57,6 @@ type SimTestSuite struct {
 	ctx sdk.Context
 
 	app               *runtime.App
-	legacyAmino       *codec.LegacyAmino
 	codec             codec.Codec
 	interfaceRegistry codectypes.InterfaceRegistry
 	txConfig          client.TxConfig
@@ -72,7 +71,6 @@ func (suite *SimTestSuite) SetupTest() {
 			AppConfig,
 			depinject.Supply(log.NewNopLogger()),
 		),
-		&suite.legacyAmino,
 		&suite.codec,
 		&suite.interfaceRegistry,
 		&suite.txConfig,

--- a/tests/sims/feegrant/operations_test.go
+++ b/tests/sims/feegrant/operations_test.go
@@ -49,7 +49,6 @@ type SimTestSuite struct {
 	accountKeeper     authkeeper.AccountKeeper
 	bankKeeper        bankkeeper.Keeper
 	cdc               codec.Codec
-	legacyAmino       *codec.LegacyAmino
 }
 
 func (suite *SimTestSuite) SetupTest() {
@@ -74,7 +73,6 @@ func (suite *SimTestSuite) SetupTest() {
 		&suite.interfaceRegistry,
 		&suite.txConfig,
 		&suite.cdc,
-		&suite.legacyAmino,
 	)
 	suite.Require().NoError(err)
 

--- a/tests/sims/slashing/operations_test.go
+++ b/tests/sims/slashing/operations_test.go
@@ -47,7 +47,6 @@ type SimTestSuite struct {
 	accounts []simtypes.Account
 
 	app               *runtime.App
-	legacyAmino       *codec.LegacyAmino
 	codec             codec.Codec
 	interfaceRegistry codectypes.InterfaceRegistry
 	txConfig          client.TxConfig
@@ -86,7 +85,6 @@ func (suite *SimTestSuite) SetupTest() {
 			depinject.Supply(log.NewNopLogger()),
 		),
 		startupCfg,
-		&suite.legacyAmino,
 		&suite.codec,
 		&suite.interfaceRegistry,
 		&suite.txConfig,

--- a/testutil/network/network.go
+++ b/testutil/network/network.go
@@ -21,6 +21,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"cosmossdk.io/core/address"
+	"cosmossdk.io/core/legacy"
 	"cosmossdk.io/depinject"
 	"cosmossdk.io/log"
 	sdkmath "cosmossdk.io/math"
@@ -184,7 +185,7 @@ func DefaultConfigWithAppConfig(appConfig depinject.Config) (Config, error) {
 	var (
 		appBuilder            *runtime.AppBuilder
 		txConfig              client.TxConfig
-		legacyAmino           *codec.LegacyAmino
+		legacyAmino           legacy.Amino
 		cdc                   codec.Codec
 		interfaceRegistry     codectypes.InterfaceRegistry
 		addressCodec          address.Codec
@@ -214,7 +215,11 @@ func DefaultConfigWithAppConfig(appConfig depinject.Config) (Config, error) {
 	})
 	cfg.Codec = cdc
 	cfg.TxConfig = txConfig
-	cfg.LegacyAmino = legacyAmino
+	amino, ok := legacyAmino.(*codec.LegacyAmino)
+	if !ok {
+		return Config{}, errors.New("legacyAmino must be a *codec.LegacyAmino")
+	}
+	cfg.LegacyAmino = amino
 	cfg.InterfaceRegistry = interfaceRegistry
 	cfg.GenesisState = appBuilder.DefaultGenesis()
 	cfg.AppConstructor = func(val ValidatorI) servertypes.Application {

--- a/types/codec.go
+++ b/types/codec.go
@@ -1,9 +1,9 @@
 package types
 
 import (
+	"cosmossdk.io/core/legacy"
 	coretransaction "cosmossdk.io/core/transaction"
 
-	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/codec/types"
 )
 
@@ -13,7 +13,7 @@ const (
 )
 
 // RegisterLegacyAminoCodec registers the sdk message type.
-func RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
+func RegisterLegacyAminoCodec(cdc legacy.Amino) {
 	cdc.RegisterInterface((*coretransaction.Msg)(nil), nil)
 	cdc.RegisterInterface((*Tx)(nil), nil)
 }

--- a/types/module/core_module.go
+++ b/types/module/core_module.go
@@ -9,11 +9,11 @@ import (
 
 	"cosmossdk.io/core/appmodule"
 	"cosmossdk.io/core/genesis"
+	"cosmossdk.io/core/legacy"
 	"cosmossdk.io/core/registry"
 	storetypes "cosmossdk.io/store/types"
 
 	"github.com/cosmos/cosmos-sdk/client"
-	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -198,9 +198,9 @@ func (c coreAppModuleAdaptor) RegisterInterfaces(reg registry.InterfaceRegistrar
 }
 
 // RegisterLegacyAminoCodec implements HasAminoCodec
-func (c coreAppModuleAdaptor) RegisterLegacyAminoCodec(amino *codec.LegacyAmino) {
+func (c coreAppModuleAdaptor) RegisterLegacyAminoCodec(amino legacy.Amino) {
 	if mod, ok := c.module.(interface {
-		RegisterLegacyAminoCodec(amino *codec.LegacyAmino)
+		RegisterLegacyAminoCodec(amino legacy.Amino)
 	}); ok {
 		mod.RegisterLegacyAminoCodec(amino)
 	}

--- a/types/module/module.go
+++ b/types/module/module.go
@@ -34,12 +34,12 @@ import (
 	"cosmossdk.io/core/appmodule"
 	appmodulev2 "cosmossdk.io/core/appmodule/v2"
 	"cosmossdk.io/core/genesis"
+	"cosmossdk.io/core/legacy"
 	"cosmossdk.io/core/registry"
 	errorsmod "cosmossdk.io/errors"
 	storetypes "cosmossdk.io/store/types"
 
 	"github.com/cosmos/cosmos-sdk/client"
-	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
@@ -78,7 +78,7 @@ type HasGenesisBasics interface {
 // HasAminoCodec is the interface for modules that have amino codec registration.
 // Deprecated: modules should not need to register their own amino codecs.
 type HasAminoCodec interface {
-	RegisterLegacyAminoCodec(*codec.LegacyAmino)
+	RegisterLegacyAminoCodec(legacy.Amino)
 }
 
 // HasGRPCGateway is the interface for modules to register their gRPC gateway routes.
@@ -299,7 +299,7 @@ func (m *Manager) SetOrderMigrations(moduleNames ...string) {
 }
 
 // RegisterLegacyAminoCodec registers all module codecs
-func (m *Manager) RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
+func (m *Manager) RegisterLegacyAminoCodec(cdc legacy.Amino) {
 	for _, b := range m.Modules {
 		if mod, ok := b.(HasAminoCodec); ok {
 			mod.RegisterLegacyAminoCodec(cdc)

--- a/x/auth/ante/testutil_test.go
+++ b/x/auth/ante/testutil_test.go
@@ -108,7 +108,7 @@ func SetupTestSuite(t *testing.T, isCheckTx bool) *AnteTestSuite {
 	require.NoError(t, err)
 
 	// We're using TestMsg encoding in some tests, so register it here.
-	suite.encCfg.Amino.RegisterConcrete(&testdata.TestMsg{}, "testdata.TestMsg", nil)
+	suite.encCfg.Amino.RegisterConcrete(&testdata.TestMsg{}, "testdata.TestMsg")
 	testdata.RegisterInterfaces(suite.encCfg.InterfaceRegistry)
 
 	suite.clientCtx = client.Context{}.

--- a/x/auth/migrations/legacytx/codec.go
+++ b/x/auth/migrations/legacytx/codec.go
@@ -1,9 +1,9 @@
 package legacytx
 
 import (
-	"github.com/cosmos/cosmos-sdk/codec"
+	"cosmossdk.io/core/legacy"
 )
 
-func RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
-	cdc.RegisterConcrete(StdTx{}, "cosmos-sdk/StdTx", nil)
+func RegisterLegacyAminoCodec(cdc legacy.Amino) {
+	cdc.RegisterConcrete(StdTx{}, "cosmos-sdk/StdTx")
 }

--- a/x/auth/module.go
+++ b/x/auth/module.go
@@ -2,7 +2,6 @@ package auth
 
 import (
 	"context"
-	"cosmossdk.io/core/legacy"
 	"encoding/json"
 	"fmt"
 
@@ -10,6 +9,7 @@ import (
 	"google.golang.org/grpc"
 
 	"cosmossdk.io/core/appmodule"
+	"cosmossdk.io/core/legacy"
 	"cosmossdk.io/core/registry"
 	"cosmossdk.io/x/auth/keeper"
 	"cosmossdk.io/x/auth/simulation"

--- a/x/auth/module.go
+++ b/x/auth/module.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"context"
+	"cosmossdk.io/core/legacy"
 	"encoding/json"
 	"fmt"
 
@@ -48,7 +49,12 @@ type AppModule struct {
 func (am AppModule) IsAppModule() {}
 
 // NewAppModule creates a new AppModule object
-func NewAppModule(cdc codec.Codec, accountKeeper keeper.AccountKeeper, ak types.AccountsModKeeper, randGenAccountsFn types.RandomGenesisAccountsFn) AppModule {
+func NewAppModule(
+	cdc codec.Codec,
+	accountKeeper keeper.AccountKeeper,
+	ak types.AccountsModKeeper,
+	randGenAccountsFn types.RandomGenesisAccountsFn,
+) AppModule {
 	return AppModule{
 		accountKeeper:     accountKeeper,
 		randGenAccountsFn: randGenAccountsFn,
@@ -63,7 +69,7 @@ func (AppModule) Name() string {
 }
 
 // RegisterLegacyAminoCodec registers the auth module's types for the given codec.
-func (AppModule) RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
+func (AppModule) RegisterLegacyAminoCodec(cdc legacy.Amino) {
 	types.RegisterLegacyAminoCodec(cdc)
 }
 

--- a/x/auth/types/codec.go
+++ b/x/auth/types/codec.go
@@ -1,11 +1,11 @@
 package types
 
 import (
+	corelegacy "cosmossdk.io/core/legacy"
 	"cosmossdk.io/core/registry"
 	coretransaction "cosmossdk.io/core/transaction"
 	"cosmossdk.io/x/auth/migrations/legacytx"
 
-	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/codec/legacy"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -13,14 +13,14 @@ import (
 
 // RegisterLegacyAminoCodec registers the account interfaces and concrete types on the
 // provided LegacyAmino codec. These types are used for Amino JSON serialization
-func RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
+func RegisterLegacyAminoCodec(cdc corelegacy.Amino) {
 	cdc.RegisterInterface((*sdk.ModuleAccountI)(nil), nil)
 	cdc.RegisterInterface((*GenesisAccount)(nil), nil)
 	cdc.RegisterInterface((*sdk.AccountI)(nil), nil)
-	cdc.RegisterConcrete(&BaseAccount{}, "cosmos-sdk/BaseAccount", nil)
-	cdc.RegisterConcrete(&ModuleAccount{}, "cosmos-sdk/ModuleAccount", nil)
-	cdc.RegisterConcrete(Params{}, "cosmos-sdk/x/auth/Params", nil)
-	cdc.RegisterConcrete(&ModuleCredential{}, "cosmos-sdk/GroupAccountCredential", nil)
+	cdc.RegisterConcrete(&BaseAccount{}, "cosmos-sdk/BaseAccount")
+	cdc.RegisterConcrete(&ModuleAccount{}, "cosmos-sdk/ModuleAccount")
+	cdc.RegisterConcrete(Params{}, "cosmos-sdk/x/auth/Params")
+	cdc.RegisterConcrete(&ModuleCredential{}, "cosmos-sdk/GroupAccountCredential")
 
 	legacy.RegisterAminoMsg(cdc, &MsgUpdateParams{}, "cosmos-sdk/x/auth/MsgUpdateParams")
 

--- a/x/auth/vesting/module.go
+++ b/x/auth/vesting/module.go
@@ -2,11 +2,11 @@ package vesting
 
 import (
 	"cosmossdk.io/core/appmodule"
+	"cosmossdk.io/core/legacy"
 	"cosmossdk.io/core/registry"
 	"cosmossdk.io/x/auth/keeper"
 	"cosmossdk.io/x/auth/vesting/types"
 
-	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/types/module"
 )
 
@@ -38,8 +38,8 @@ func (AppModule) Name() string {
 	return types.ModuleName
 }
 
-// RegisterCodec registers the module's types with the given codec.
-func (AppModule) RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
+// RegisterLegacyAminoCodec registers the module's types with the given codec.
+func (AppModule) RegisterLegacyAminoCodec(cdc legacy.Amino) {
 	types.RegisterLegacyAminoCodec(cdc)
 }
 

--- a/x/auth/vesting/types/codec.go
+++ b/x/auth/vesting/types/codec.go
@@ -1,12 +1,12 @@
 package types
 
 import (
+	corelegacy "cosmossdk.io/core/legacy"
 	"cosmossdk.io/core/registry"
 	coretransaction "cosmossdk.io/core/transaction"
 	authtypes "cosmossdk.io/x/auth/types"
 	"cosmossdk.io/x/auth/vesting/exported"
 
-	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/codec/legacy"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/msgservice"
@@ -14,13 +14,13 @@ import (
 
 // RegisterLegacyAminoCodec registers the vesting interfaces and concrete types on the
 // provided LegacyAmino codec. These types are used for Amino JSON serialization
-func RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
+func RegisterLegacyAminoCodec(cdc corelegacy.Amino) {
 	cdc.RegisterInterface((*exported.VestingAccount)(nil), nil)
-	cdc.RegisterConcrete(&BaseVestingAccount{}, "cosmos-sdk/BaseVestingAccount", nil)
-	cdc.RegisterConcrete(&ContinuousVestingAccount{}, "cosmos-sdk/ContinuousVestingAccount", nil)
-	cdc.RegisterConcrete(&DelayedVestingAccount{}, "cosmos-sdk/DelayedVestingAccount", nil)
-	cdc.RegisterConcrete(&PeriodicVestingAccount{}, "cosmos-sdk/PeriodicVestingAccount", nil)
-	cdc.RegisterConcrete(&PermanentLockedAccount{}, "cosmos-sdk/PermanentLockedAccount", nil)
+	cdc.RegisterConcrete(&BaseVestingAccount{}, "cosmos-sdk/BaseVestingAccount")
+	cdc.RegisterConcrete(&ContinuousVestingAccount{}, "cosmos-sdk/ContinuousVestingAccount")
+	cdc.RegisterConcrete(&DelayedVestingAccount{}, "cosmos-sdk/DelayedVestingAccount")
+	cdc.RegisterConcrete(&PeriodicVestingAccount{}, "cosmos-sdk/PeriodicVestingAccount")
+	cdc.RegisterConcrete(&PermanentLockedAccount{}, "cosmos-sdk/PermanentLockedAccount")
 	legacy.RegisterAminoMsg(cdc, &MsgCreateVestingAccount{}, "cosmos-sdk/MsgCreateVestingAccount")
 	legacy.RegisterAminoMsg(cdc, &MsgCreatePermanentLockedAccount{}, "cosmos-sdk/MsgCreatePermLockedAccount")
 	legacy.RegisterAminoMsg(cdc, &MsgCreatePeriodicVestingAccount{}, "cosmos-sdk/MsgCreatePeriodVestAccount")

--- a/x/authz/codec.go
+++ b/x/authz/codec.go
@@ -1,25 +1,25 @@
 package authz
 
 import (
+	corelegacy "cosmossdk.io/core/legacy"
 	"cosmossdk.io/core/registry"
 	coretransaction "cosmossdk.io/core/transaction"
 	bank "cosmossdk.io/x/bank/types"
 	staking "cosmossdk.io/x/staking/types"
 
-	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/codec/legacy"
 	"github.com/cosmos/cosmos-sdk/types/msgservice"
 )
 
 // RegisterLegacyAminoCodec registers the necessary x/authz interfaces and concrete types
 // on the provided LegacyAmino codec. These types are used for Amino JSON serialization.
-func RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
+func RegisterLegacyAminoCodec(cdc corelegacy.Amino) {
 	legacy.RegisterAminoMsg(cdc, &MsgGrant{}, "cosmos-sdk/MsgGrant")
 	legacy.RegisterAminoMsg(cdc, &MsgRevoke{}, "cosmos-sdk/MsgRevoke")
 	legacy.RegisterAminoMsg(cdc, &MsgExec{}, "cosmos-sdk/MsgExec")
 
 	cdc.RegisterInterface((*Authorization)(nil), nil)
-	cdc.RegisterConcrete(&GenericAuthorization{}, "cosmos-sdk/GenericAuthorization", nil)
+	cdc.RegisterConcrete(&GenericAuthorization{}, "cosmos-sdk/GenericAuthorization")
 }
 
 // RegisterInterfaces registers the interfaces types with the interface registry

--- a/x/authz/module/module.go
+++ b/x/authz/module/module.go
@@ -2,6 +2,7 @@ package module
 
 import (
 	"context"
+	"cosmossdk.io/core/legacy"
 	"encoding/json"
 	"fmt"
 
@@ -50,7 +51,13 @@ type AppModule struct {
 }
 
 // NewAppModule creates a new AppModule object
-func NewAppModule(cdc codec.Codec, keeper keeper.Keeper, ak authz.AccountKeeper, bk authz.BankKeeper, registry cdctypes.InterfaceRegistry) AppModule {
+func NewAppModule(
+	cdc codec.Codec,
+	keeper keeper.Keeper,
+	ak authz.AccountKeeper,
+	bk authz.BankKeeper,
+	registry cdctypes.InterfaceRegistry,
+) AppModule {
 	return AppModule{
 		cdc:           cdc,
 		keeper:        keeper,
@@ -87,7 +94,7 @@ func (am AppModule) RegisterMigrations(mr appmodule.MigrationRegistrar) error {
 }
 
 // RegisterLegacyAminoCodec registers the authz module's types for the given codec.
-func (AppModule) RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
+func (AppModule) RegisterLegacyAminoCodec(cdc legacy.Amino) {
 	authz.RegisterLegacyAminoCodec(cdc)
 }
 

--- a/x/authz/module/module.go
+++ b/x/authz/module/module.go
@@ -2,7 +2,6 @@ package module
 
 import (
 	"context"
-	"cosmossdk.io/core/legacy"
 	"encoding/json"
 	"fmt"
 
@@ -11,6 +10,7 @@ import (
 	"google.golang.org/grpc"
 
 	"cosmossdk.io/core/appmodule"
+	"cosmossdk.io/core/legacy"
 	"cosmossdk.io/core/registry"
 	"cosmossdk.io/errors"
 	"cosmossdk.io/x/authz"

--- a/x/bank/module.go
+++ b/x/bank/module.go
@@ -10,6 +10,7 @@ import (
 	"google.golang.org/grpc"
 
 	"cosmossdk.io/core/appmodule"
+	"cosmossdk.io/core/legacy"
 	"cosmossdk.io/core/registry"
 	"cosmossdk.io/x/bank/client/cli"
 	"cosmossdk.io/x/bank/keeper"
@@ -63,7 +64,7 @@ func (am AppModule) IsAppModule() {}
 func (AppModule) Name() string { return types.ModuleName }
 
 // RegisterLegacyAminoCodec registers the bank module's types on the LegacyAmino codec.
-func (AppModule) RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
+func (AppModule) RegisterLegacyAminoCodec(cdc legacy.Amino) {
 	types.RegisterLegacyAminoCodec(cdc)
 }
 

--- a/x/bank/types/codec.go
+++ b/x/bank/types/codec.go
@@ -1,24 +1,24 @@
 package types
 
 import (
+	corelegacy "cosmossdk.io/core/legacy"
 	"cosmossdk.io/core/registry"
 	coretransaction "cosmossdk.io/core/transaction"
 
-	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/codec/legacy"
 	"github.com/cosmos/cosmos-sdk/types/msgservice"
 )
 
 // RegisterLegacyAminoCodec registers the necessary x/bank interfaces and concrete types
 // on the provided LegacyAmino codec. These types are used for Amino JSON serialization.
-func RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
+func RegisterLegacyAminoCodec(cdc corelegacy.Amino) {
 	legacy.RegisterAminoMsg(cdc, &MsgSend{}, "cosmos-sdk/MsgSend")
 	legacy.RegisterAminoMsg(cdc, &MsgMultiSend{}, "cosmos-sdk/MsgMultiSend")
 	legacy.RegisterAminoMsg(cdc, &MsgUpdateParams{}, "cosmos-sdk/x/bank/MsgUpdateParams")
 	legacy.RegisterAminoMsg(cdc, &MsgSetSendEnabled{}, "cosmos-sdk/MsgSetSendEnabled")
 
-	cdc.RegisterConcrete(&SendAuthorization{}, "cosmos-sdk/SendAuthorization", nil)
-	cdc.RegisterConcrete(&Params{}, "cosmos-sdk/x/bank/Params", nil)
+	cdc.RegisterConcrete(&SendAuthorization{}, "cosmos-sdk/SendAuthorization")
+	cdc.RegisterConcrete(&Params{}, "cosmos-sdk/x/bank/Params")
 }
 
 func RegisterInterfaces(registrar registry.InterfaceRegistrar) {

--- a/x/consensus/module.go
+++ b/x/consensus/module.go
@@ -7,6 +7,7 @@ import (
 	"google.golang.org/grpc"
 
 	"cosmossdk.io/core/appmodule"
+	"cosmossdk.io/core/legacy"
 	"cosmossdk.io/core/registry"
 	"cosmossdk.io/x/consensus/keeper"
 	"cosmossdk.io/x/consensus/types"
@@ -49,7 +50,7 @@ func (AppModule) IsAppModule() {}
 func (AppModule) Name() string { return types.ModuleName }
 
 // RegisterLegacyAminoCodec registers the consensus module's types on the LegacyAmino codec.
-func (AppModule) RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
+func (AppModule) RegisterLegacyAminoCodec(cdc legacy.Amino) {
 	types.RegisterLegacyAminoCodec(cdc)
 }
 

--- a/x/consensus/types/codec.go
+++ b/x/consensus/types/codec.go
@@ -1,10 +1,10 @@
 package types
 
 import (
+	corelegacy "cosmossdk.io/core/legacy"
 	"cosmossdk.io/core/registry"
 	coretransaction "cosmossdk.io/core/transaction"
 
-	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/codec/legacy"
 	"github.com/cosmos/cosmos-sdk/types/msgservice"
 )
@@ -20,6 +20,6 @@ func RegisterInterfaces(registrar registry.InterfaceRegistrar) {
 
 // RegisterLegacyAminoCodec registers the necessary x/consensus interfaces and concrete types
 // on the provided LegacyAmino codec. These types are used for Amino JSON serialization.
-func RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
+func RegisterLegacyAminoCodec(cdc corelegacy.Amino) {
 	legacy.RegisterAminoMsg(cdc, &MsgUpdateParams{}, "cosmos-sdk/x/consensus/MsgUpdateParams")
 }

--- a/x/crisis/module.go
+++ b/x/crisis/module.go
@@ -9,6 +9,7 @@ import (
 	"google.golang.org/grpc"
 
 	"cosmossdk.io/core/appmodule"
+	"cosmossdk.io/core/legacy"
 	"cosmossdk.io/core/registry"
 
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -66,7 +67,7 @@ func (AppModule) Name() string {
 }
 
 // RegisterLegacyAminoCodec registers the crisis module's types on the given LegacyAmino codec.
-func (AppModule) RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
+func (AppModule) RegisterLegacyAminoCodec(cdc legacy.Amino) {
 	types.RegisterLegacyAminoCodec(cdc)
 }
 

--- a/x/crisis/types/codec.go
+++ b/x/crisis/types/codec.go
@@ -1,17 +1,17 @@
 package types
 
 import (
+	corelegacy "cosmossdk.io/core/legacy"
 	"cosmossdk.io/core/registry"
 	coretransaction "cosmossdk.io/core/transaction"
 
-	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/codec/legacy"
 	"github.com/cosmos/cosmos-sdk/types/msgservice"
 )
 
 // RegisterLegacyAminoCodec registers the necessary x/crisis interfaces and concrete types
 // on the provided LegacyAmino codec. These types are used for Amino JSON serialization.
-func RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
+func RegisterLegacyAminoCodec(cdc corelegacy.Amino) {
 	legacy.RegisterAminoMsg(cdc, &MsgVerifyInvariant{}, "cosmos-sdk/MsgVerifyInvariant")
 	legacy.RegisterAminoMsg(cdc, &MsgUpdateParams{}, "cosmos-sdk/x/crisis/MsgUpdateParams")
 }

--- a/x/distribution/module.go
+++ b/x/distribution/module.go
@@ -10,6 +10,7 @@ import (
 	"google.golang.org/grpc"
 
 	"cosmossdk.io/core/appmodule"
+	"cosmossdk.io/core/legacy"
 	"cosmossdk.io/core/registry"
 	"cosmossdk.io/x/distribution/client/cli"
 	"cosmossdk.io/x/distribution/keeper"
@@ -75,7 +76,7 @@ func (AppModule) Name() string {
 }
 
 // RegisterLegacyAminoCodec registers the distribution module's types for the given codec.
-func (AppModule) RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
+func (AppModule) RegisterLegacyAminoCodec(cdc legacy.Amino) {
 	types.RegisterLegacyAminoCodec(cdc)
 }
 

--- a/x/distribution/types/codec.go
+++ b/x/distribution/types/codec.go
@@ -1,10 +1,10 @@
 package types
 
 import (
+	corelegacy "cosmossdk.io/core/legacy"
 	"cosmossdk.io/core/registry"
 	coretransaction "cosmossdk.io/core/transaction"
 
-	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/codec/legacy"
 	"github.com/cosmos/cosmos-sdk/types/msgservice"
 )
@@ -12,14 +12,14 @@ import (
 // RegisterLegacyAminoCodec registers the necessary x/distribution interfaces
 // and concrete types on the provided LegacyAmino codec. These types are used
 // for Amino JSON serialization.
-func RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
+func RegisterLegacyAminoCodec(cdc corelegacy.Amino) {
 	legacy.RegisterAminoMsg(cdc, &MsgWithdrawDelegatorReward{}, "cosmos-sdk/MsgWithdrawDelegationReward")
 	legacy.RegisterAminoMsg(cdc, &MsgWithdrawValidatorCommission{}, "cosmos-sdk/MsgWithdrawValCommission")
 	legacy.RegisterAminoMsg(cdc, &MsgSetWithdrawAddress{}, "cosmos-sdk/MsgModifyWithdrawAddress")
 	legacy.RegisterAminoMsg(cdc, &MsgUpdateParams{}, "cosmos-sdk/distribution/MsgUpdateParams")
 	legacy.RegisterAminoMsg(cdc, &MsgDepositValidatorRewardsPool{}, "cosmos-sdk/distr/MsgDepositValRewards")
 
-	cdc.RegisterConcrete(Params{}, "cosmos-sdk/x/distribution/Params", nil)
+	cdc.RegisterConcrete(Params{}, "cosmos-sdk/x/distribution/Params")
 }
 
 func RegisterInterfaces(registrar registry.InterfaceRegistrar) {

--- a/x/epochs/module.go
+++ b/x/epochs/module.go
@@ -9,6 +9,7 @@ import (
 	"google.golang.org/grpc"
 
 	"cosmossdk.io/core/appmodule"
+	"cosmossdk.io/core/legacy"
 	"cosmossdk.io/x/epochs/keeper"
 	"cosmossdk.io/x/epochs/simulation"
 	"cosmossdk.io/x/epochs/types"
@@ -55,8 +56,7 @@ func (AppModule) Name() string {
 }
 
 // RegisterLegacyAminoCodec registers the epochs module's types for the given codec.
-func (AppModule) RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
-}
+func (AppModule) RegisterLegacyAminoCodec(cdc legacy.Amino) {}
 
 // RegisterGRPCGatewayRoutes registers the gRPC Gateway routes for the epochs module.
 func (AppModule) RegisterGRPCGatewayRoutes(clientCtx client.Context, mux *gwruntime.ServeMux) {

--- a/x/evidence/module.go
+++ b/x/evidence/module.go
@@ -11,6 +11,7 @@ import (
 
 	"cosmossdk.io/core/appmodule"
 	"cosmossdk.io/core/comet"
+	"cosmossdk.io/core/legacy"
 	"cosmossdk.io/core/registry"
 	eviclient "cosmossdk.io/x/evidence/client"
 	"cosmossdk.io/x/evidence/client/cli"
@@ -65,7 +66,7 @@ func (AppModule) Name() string {
 }
 
 // RegisterLegacyAminoCodec registers the evidence module's types to the LegacyAmino codec.
-func (AppModule) RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
+func (AppModule) RegisterLegacyAminoCodec(cdc legacy.Amino) {
 	types.RegisterLegacyAminoCodec(cdc)
 }
 

--- a/x/evidence/types/codec.go
+++ b/x/evidence/types/codec.go
@@ -1,21 +1,21 @@
 package types
 
 import (
+	corelegacy "cosmossdk.io/core/legacy"
 	"cosmossdk.io/core/registry"
 	coretransaction "cosmossdk.io/core/transaction"
 	"cosmossdk.io/x/evidence/exported"
 
-	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/codec/legacy"
 	"github.com/cosmos/cosmos-sdk/types/msgservice"
 )
 
 // RegisterLegacyAminoCodec registers all the necessary types and interfaces for the
 // evidence module.
-func RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
+func RegisterLegacyAminoCodec(cdc corelegacy.Amino) {
 	cdc.RegisterInterface((*exported.Evidence)(nil), nil)
 	legacy.RegisterAminoMsg(cdc, &MsgSubmitEvidence{}, "cosmos-sdk/MsgSubmitEvidence")
-	cdc.RegisterConcrete(&Equivocation{}, "cosmos-sdk/Equivocation", nil)
+	cdc.RegisterConcrete(&Equivocation{}, "cosmos-sdk/Equivocation")
 }
 
 // RegisterInterfaces registers the interfaces types with the interface registry.

--- a/x/feegrant/codec.go
+++ b/x/feegrant/codec.go
@@ -1,24 +1,24 @@
 package feegrant
 
 import (
+	corelegacy "cosmossdk.io/core/legacy"
 	"cosmossdk.io/core/registry"
 	coretransaction "cosmossdk.io/core/transaction"
 
-	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/codec/legacy"
 	"github.com/cosmos/cosmos-sdk/types/msgservice"
 )
 
 // RegisterLegacyAminoCodec registers the necessary x/feegrant interfaces and concrete types
 // on the provided LegacyAmino codec. These types are used for Amino JSON serialization.
-func RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
+func RegisterLegacyAminoCodec(cdc corelegacy.Amino) {
 	legacy.RegisterAminoMsg(cdc, &MsgGrantAllowance{}, "cosmos-sdk/MsgGrantAllowance")
 	legacy.RegisterAminoMsg(cdc, &MsgRevokeAllowance{}, "cosmos-sdk/MsgRevokeAllowance")
 
 	cdc.RegisterInterface((*FeeAllowanceI)(nil), nil)
-	cdc.RegisterConcrete(&BasicAllowance{}, "cosmos-sdk/BasicAllowance", nil)
-	cdc.RegisterConcrete(&PeriodicAllowance{}, "cosmos-sdk/PeriodicAllowance", nil)
-	cdc.RegisterConcrete(&AllowedMsgAllowance{}, "cosmos-sdk/AllowedMsgAllowance", nil)
+	cdc.RegisterConcrete(&BasicAllowance{}, "cosmos-sdk/BasicAllowance")
+	cdc.RegisterConcrete(&PeriodicAllowance{}, "cosmos-sdk/PeriodicAllowance")
+	cdc.RegisterConcrete(&AllowedMsgAllowance{}, "cosmos-sdk/AllowedMsgAllowance")
 }
 
 // RegisterInterfaces registers the interfaces types with the interface registry

--- a/x/feegrant/module/module.go
+++ b/x/feegrant/module/module.go
@@ -10,6 +10,7 @@ import (
 	"google.golang.org/grpc"
 
 	"cosmossdk.io/core/appmodule"
+	"cosmossdk.io/core/legacy"
 	"cosmossdk.io/core/registry"
 	"cosmossdk.io/errors"
 	"cosmossdk.io/x/feegrant"
@@ -66,7 +67,7 @@ func (AppModule) Name() string {
 }
 
 // RegisterLegacyAminoCodec registers the feegrant module's types for the given codec.
-func (AppModule) RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
+func (AppModule) RegisterLegacyAminoCodec(cdc legacy.Amino) {
 	feegrant.RegisterLegacyAminoCodec(cdc)
 }
 

--- a/x/gov/module.go
+++ b/x/gov/module.go
@@ -10,6 +10,7 @@ import (
 	"google.golang.org/grpc"
 
 	"cosmossdk.io/core/appmodule"
+	"cosmossdk.io/core/legacy"
 	"cosmossdk.io/core/registry"
 	govclient "cosmossdk.io/x/gov/client"
 	"cosmossdk.io/x/gov/client/cli"
@@ -79,7 +80,7 @@ func (AppModule) Name() string {
 }
 
 // RegisterLegacyAminoCodec registers the gov module's types for the given codec.
-func (AppModule) RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
+func (AppModule) RegisterLegacyAminoCodec(cdc legacy.Amino) {
 	v1beta1.RegisterLegacyAminoCodec(cdc)
 	v1.RegisterLegacyAminoCodec(cdc)
 }

--- a/x/gov/types/v1/codec.go
+++ b/x/gov/types/v1/codec.go
@@ -1,17 +1,17 @@
 package v1
 
 import (
+	corelegacy "cosmossdk.io/core/legacy"
 	"cosmossdk.io/core/registry"
 	coretransaction "cosmossdk.io/core/transaction"
 
-	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/codec/legacy"
 	"github.com/cosmos/cosmos-sdk/types/msgservice"
 )
 
 // RegisterLegacyAminoCodec registers all the necessary types and interfaces for the
 // governance module.
-func RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
+func RegisterLegacyAminoCodec(cdc corelegacy.Amino) {
 	legacy.RegisterAminoMsg(cdc, &MsgSubmitProposal{}, "cosmos-sdk/v1/MsgSubmitProposal")
 	legacy.RegisterAminoMsg(cdc, &MsgSubmitMultipleChoiceProposal{}, "gov/MsgSubmitMultipleChoiceProposal")
 	legacy.RegisterAminoMsg(cdc, &MsgDeposit{}, "cosmos-sdk/v1/MsgDeposit")

--- a/x/gov/types/v1beta1/codec.go
+++ b/x/gov/types/v1beta1/codec.go
@@ -1,23 +1,23 @@
 package v1beta1
 
 import (
+	corelegacy "cosmossdk.io/core/legacy"
 	"cosmossdk.io/core/registry"
 	coretransaction "cosmossdk.io/core/transaction"
 
-	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/codec/legacy"
 	"github.com/cosmos/cosmos-sdk/types/msgservice"
 )
 
 // RegisterLegacyAminoCodec registers all the necessary types and interfaces for the
 // governance module.
-func RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
+func RegisterLegacyAminoCodec(cdc corelegacy.Amino) {
 	cdc.RegisterInterface((*Content)(nil), nil)
 	legacy.RegisterAminoMsg(cdc, &MsgSubmitProposal{}, "cosmos-sdk/MsgSubmitProposal")
 	legacy.RegisterAminoMsg(cdc, &MsgDeposit{}, "cosmos-sdk/MsgDeposit")
 	legacy.RegisterAminoMsg(cdc, &MsgVote{}, "cosmos-sdk/MsgVote")
 	legacy.RegisterAminoMsg(cdc, &MsgVoteWeighted{}, "cosmos-sdk/MsgVoteWeighted")
-	cdc.RegisterConcrete(&TextProposal{}, "cosmos-sdk/TextProposal", nil)
+	cdc.RegisterConcrete(&TextProposal{}, "cosmos-sdk/TextProposal")
 }
 
 // RegisterInterfaces registers the interfaces types with the Interface Registry.

--- a/x/group/codec.go
+++ b/x/group/codec.go
@@ -1,10 +1,10 @@
 package group
 
 import (
+	corelegacy "cosmossdk.io/core/legacy"
 	"cosmossdk.io/core/registry"
 	coretransaction "cosmossdk.io/core/transaction"
 
-	codectypes "github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/codec/legacy"
 	"github.com/cosmos/cosmos-sdk/types/msgservice"
 )
@@ -12,10 +12,10 @@ import (
 // RegisterLegacyAminoCodec registers all the necessary group module concrete
 // types and interfaces with the provided codec reference.
 // These types are used for Amino JSON serialization.
-func RegisterLegacyAminoCodec(cdc *codectypes.LegacyAmino) {
+func RegisterLegacyAminoCodec(cdc corelegacy.Amino) {
 	cdc.RegisterInterface((*DecisionPolicy)(nil), nil)
-	cdc.RegisterConcrete(&ThresholdDecisionPolicy{}, "cosmos-sdk/ThresholdDecisionPolicy", nil)
-	cdc.RegisterConcrete(&PercentageDecisionPolicy{}, "cosmos-sdk/PercentageDecisionPolicy", nil)
+	cdc.RegisterConcrete(&ThresholdDecisionPolicy{}, "cosmos-sdk/ThresholdDecisionPolicy")
+	cdc.RegisterConcrete(&PercentageDecisionPolicy{}, "cosmos-sdk/PercentageDecisionPolicy")
 
 	legacy.RegisterAminoMsg(cdc, &MsgCreateGroup{}, "cosmos-sdk/MsgCreateGroup")
 	legacy.RegisterAminoMsg(cdc, &MsgUpdateGroupMembers{}, "cosmos-sdk/MsgUpdateGroupMembers")

--- a/x/group/module/module.go
+++ b/x/group/module/module.go
@@ -10,6 +10,7 @@ import (
 	"google.golang.org/grpc"
 
 	"cosmossdk.io/core/appmodule"
+	"cosmossdk.io/core/legacy"
 	"cosmossdk.io/core/registry"
 	"cosmossdk.io/x/group"
 	"cosmossdk.io/x/group/client/cli"
@@ -88,7 +89,7 @@ func (AppModule) RegisterInterfaces(registrar registry.InterfaceRegistrar) {
 }
 
 // RegisterLegacyAminoCodec registers the group module's types for the given codec.
-func (AppModule) RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
+func (AppModule) RegisterLegacyAminoCodec(cdc legacy.Amino) {
 	group.RegisterLegacyAminoCodec(cdc)
 }
 

--- a/x/mint/module.go
+++ b/x/mint/module.go
@@ -9,6 +9,7 @@ import (
 	"google.golang.org/grpc"
 
 	"cosmossdk.io/core/appmodule"
+	"cosmossdk.io/core/legacy"
 	"cosmossdk.io/core/registry"
 	"cosmossdk.io/x/mint/keeper"
 	"cosmossdk.io/x/mint/simulation"
@@ -77,7 +78,7 @@ func (AppModule) Name() string {
 }
 
 // RegisterLegacyAminoCodec registers the mint module's types on the given LegacyAmino codec.
-func (AppModule) RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
+func (AppModule) RegisterLegacyAminoCodec(cdc legacy.Amino) {
 	types.RegisterLegacyAminoCodec(cdc)
 }
 

--- a/x/mint/types/codec.go
+++ b/x/mint/types/codec.go
@@ -1,17 +1,17 @@
 package types
 
 import (
+	corelegacy "cosmossdk.io/core/legacy"
 	"cosmossdk.io/core/registry"
 	coretransaction "cosmossdk.io/core/transaction"
 
-	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/codec/legacy"
 	"github.com/cosmos/cosmos-sdk/types/msgservice"
 )
 
 // RegisterLegacyAminoCodec registers concrete types on the LegacyAmino codec
-func RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
-	cdc.RegisterConcrete(Params{}, "cosmos-sdk/x/mint/Params", nil)
+func RegisterLegacyAminoCodec(cdc corelegacy.Amino) {
+	cdc.RegisterConcrete(Params{}, "cosmos-sdk/x/mint/Params")
 	legacy.RegisterAminoMsg(cdc, &MsgUpdateParams{}, "cosmos-sdk/x/mint/MsgUpdateParams")
 }
 

--- a/x/params/keeper/common_test.go
+++ b/x/params/keeper/common_test.go
@@ -34,7 +34,7 @@ type s struct {
 func createTestCodec() *codec.LegacyAmino {
 	cdc := codec.NewLegacyAmino()
 	sdk.RegisterLegacyAminoCodec(cdc)
-	cdc.RegisterConcrete(s{}, "test/s", nil)
-	cdc.RegisterConcrete(invalid{}, "test/invalid", nil)
+	cdc.RegisterConcrete(s{}, "test/s")
+	cdc.RegisterConcrete(invalid{}, "test/invalid")
 	return cdc
 }

--- a/x/params/module.go
+++ b/x/params/module.go
@@ -7,12 +7,12 @@ import (
 	"google.golang.org/grpc"
 
 	"cosmossdk.io/core/appmodule"
+	"cosmossdk.io/core/legacy"
 	"cosmossdk.io/core/registry"
 	"cosmossdk.io/x/params/keeper"
 	"cosmossdk.io/x/params/types/proposal"
 
 	"github.com/cosmos/cosmos-sdk/client"
-	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
 )
@@ -52,7 +52,7 @@ func (AppModule) Name() string {
 }
 
 // RegisterLegacyAminoCodec registers the params module's types on the given LegacyAmino codec.
-func (AppModule) RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
+func (AppModule) RegisterLegacyAminoCodec(cdc legacy.Amino) {
 	proposal.RegisterLegacyAminoCodec(cdc)
 }
 

--- a/x/params/types/proposal/codec.go
+++ b/x/params/types/proposal/codec.go
@@ -1,15 +1,14 @@
 package proposal
 
 import (
+	"cosmossdk.io/core/legacy"
 	"cosmossdk.io/core/registry"
 	govtypes "cosmossdk.io/x/gov/types/v1beta1"
-
-	"github.com/cosmos/cosmos-sdk/codec"
 )
 
 // RegisterLegacyAminoCodec registers all necessary param module types with a given LegacyAmino codec.
-func RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
-	cdc.RegisterConcrete(&ParameterChangeProposal{}, "cosmos-sdk/ParameterChangeProposal", nil)
+func RegisterLegacyAminoCodec(cdc legacy.Amino) {
+	cdc.RegisterConcrete(&ParameterChangeProposal{}, "cosmos-sdk/ParameterChangeProposal")
 }
 
 func RegisterInterfaces(registrar registry.InterfaceRegistrar) {

--- a/x/protocolpool/module.go
+++ b/x/protocolpool/module.go
@@ -9,6 +9,7 @@ import (
 	"google.golang.org/grpc"
 
 	"cosmossdk.io/core/appmodule"
+	"cosmossdk.io/core/legacy"
 	"cosmossdk.io/core/registry"
 	"cosmossdk.io/x/protocolpool/keeper"
 	"cosmossdk.io/x/protocolpool/types"
@@ -60,7 +61,7 @@ func (AppModule) IsAppModule() {}
 func (AppModule) Name() string { return types.ModuleName }
 
 // RegisterLegacyAminoCodec registers the pool module's types on the LegacyAmino codec.
-func (AppModule) RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {}
+func (AppModule) RegisterLegacyAminoCodec(cdc legacy.Amino) {}
 
 // RegisterGRPCGatewayRoutes registers the gRPC Gateway routes
 func (AppModule) RegisterGRPCGatewayRoutes(clientCtx client.Context, mux *gwruntime.ServeMux) {

--- a/x/slashing/depinject.go
+++ b/x/slashing/depinject.go
@@ -35,7 +35,6 @@ type ModuleInputs struct {
 	Config       *modulev1.Module
 	Environment  appmodule.Environment
 	Cdc          codec.Codec
-	LegacyAmino  *codec.LegacyAmino
 	Registry     cdctypes.InterfaceRegistry
 	CometService comet.Service
 
@@ -64,7 +63,7 @@ func ProvideModule(in ModuleInputs) ModuleOutputs {
 		panic(fmt.Errorf("unable to decode authority in slashing: %w", err))
 	}
 
-	k := keeper.NewKeeper(in.Environment, in.Cdc, in.LegacyAmino, in.StakingKeeper, authStr)
+	k := keeper.NewKeeper(in.Environment, in.Cdc, nil, in.StakingKeeper, authStr)
 	m := NewAppModule(in.Cdc, k, in.AccountKeeper, in.BankKeeper, in.StakingKeeper, in.Registry, in.CometService)
 	return ModuleOutputs{
 		Keeper: k,

--- a/x/slashing/keeper/keeper.go
+++ b/x/slashing/keeper/keeper.go
@@ -20,7 +20,8 @@ import (
 type Keeper struct {
 	appmodule.Environment
 
-	cdc         codec.BinaryCodec
+	cdc codec.BinaryCodec
+	// deprecated!
 	legacyAmino *codec.LegacyAmino
 	sk          types.StakingKeeper
 

--- a/x/slashing/module.go
+++ b/x/slashing/module.go
@@ -10,6 +10,7 @@ import (
 
 	"cosmossdk.io/core/appmodule"
 	"cosmossdk.io/core/comet"
+	"cosmossdk.io/core/legacy"
 	"cosmossdk.io/core/registry"
 	"cosmossdk.io/x/slashing/keeper"
 	"cosmossdk.io/x/slashing/simulation"
@@ -81,7 +82,7 @@ func (AppModule) Name() string {
 }
 
 // RegisterLegacyAminoCodec registers the slashing module's types for the given codec.
-func (AppModule) RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
+func (AppModule) RegisterLegacyAminoCodec(cdc legacy.Amino) {
 	types.RegisterLegacyAminoCodec(cdc)
 }
 

--- a/x/slashing/types/codec.go
+++ b/x/slashing/types/codec.go
@@ -1,17 +1,17 @@
 package types
 
 import (
+	corelegacy "cosmossdk.io/core/legacy"
 	"cosmossdk.io/core/registry"
 	coretransaction "cosmossdk.io/core/transaction"
 
-	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/codec/legacy"
 	"github.com/cosmos/cosmos-sdk/types/msgservice"
 )
 
 // RegisterLegacyAminoCodec registers concrete types on LegacyAmino codec
-func RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
-	cdc.RegisterConcrete(Params{}, "cosmos-sdk/x/slashing/Params", nil)
+func RegisterLegacyAminoCodec(cdc corelegacy.Amino) {
+	cdc.RegisterConcrete(Params{}, "cosmos-sdk/x/slashing/Params")
 	legacy.RegisterAminoMsg(cdc, &MsgUnjail{}, "cosmos-sdk/MsgUnjail")
 	legacy.RegisterAminoMsg(cdc, &MsgUpdateParams{}, "cosmos-sdk/x/slashing/MsgUpdateParams")
 }

--- a/x/staking/module.go
+++ b/x/staking/module.go
@@ -10,6 +10,7 @@ import (
 	"google.golang.org/grpc"
 
 	"cosmossdk.io/core/appmodule"
+	"cosmossdk.io/core/legacy"
 	"cosmossdk.io/core/registry"
 	"cosmossdk.io/depinject"
 	"cosmossdk.io/x/staking/client/cli"
@@ -76,7 +77,7 @@ func (AppModule) Name() string {
 }
 
 // RegisterLegacyAminoCodec registers the staking module's types on the given LegacyAmino codec.
-func (AppModule) RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
+func (AppModule) RegisterLegacyAminoCodec(cdc legacy.Amino) {
 	types.RegisterLegacyAminoCodec(cdc)
 }
 

--- a/x/staking/types/codec.go
+++ b/x/staking/types/codec.go
@@ -1,17 +1,17 @@
 package types
 
 import (
+	corelegacy "cosmossdk.io/core/legacy"
 	"cosmossdk.io/core/registry"
 	coretransaction "cosmossdk.io/core/transaction"
 
-	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/codec/legacy"
 	"github.com/cosmos/cosmos-sdk/types/msgservice"
 )
 
 // RegisterLegacyAminoCodec registers the necessary x/staking interfaces and concrete types
 // on the provided LegacyAmino codec. These types are used for Amino JSON serialization.
-func RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
+func RegisterLegacyAminoCodec(cdc corelegacy.Amino) {
 	legacy.RegisterAminoMsg(cdc, &MsgCreateValidator{}, "cosmos-sdk/MsgCreateValidator")
 	legacy.RegisterAminoMsg(cdc, &MsgEditValidator{}, "cosmos-sdk/MsgEditValidator")
 	legacy.RegisterAminoMsg(cdc, &MsgDelegate{}, "cosmos-sdk/MsgDelegate")
@@ -22,10 +22,10 @@ func RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
 	legacy.RegisterAminoMsg(cdc, &MsgRotateConsPubKey{}, "cosmos-sdk/MsgRotateConsPubKey")
 
 	cdc.RegisterInterface((*isStakeAuthorization_Validators)(nil), nil)
-	cdc.RegisterConcrete(&StakeAuthorization_AllowList{}, "cosmos-sdk/StakeAuthorization/AllowList", nil)
-	cdc.RegisterConcrete(&StakeAuthorization_DenyList{}, "cosmos-sdk/StakeAuthorization/DenyList", nil)
-	cdc.RegisterConcrete(&StakeAuthorization{}, "cosmos-sdk/StakeAuthorization", nil)
-	cdc.RegisterConcrete(Params{}, "cosmos-sdk/x/staking/Params", nil)
+	cdc.RegisterConcrete(&StakeAuthorization_AllowList{}, "cosmos-sdk/StakeAuthorization/AllowList")
+	cdc.RegisterConcrete(&StakeAuthorization_DenyList{}, "cosmos-sdk/StakeAuthorization/DenyList")
+	cdc.RegisterConcrete(&StakeAuthorization{}, "cosmos-sdk/StakeAuthorization")
+	cdc.RegisterConcrete(Params{}, "cosmos-sdk/x/staking/Params")
 }
 
 // RegisterInterfaces registers the x/staking interfaces types with the interface registry

--- a/x/upgrade/module.go
+++ b/x/upgrade/module.go
@@ -10,19 +10,15 @@ import (
 	"google.golang.org/grpc"
 
 	"cosmossdk.io/core/appmodule"
+	"cosmossdk.io/core/legacy"
 	"cosmossdk.io/core/registry"
 	"cosmossdk.io/x/upgrade/client/cli"
 	"cosmossdk.io/x/upgrade/keeper"
 	"cosmossdk.io/x/upgrade/types"
 
 	"github.com/cosmos/cosmos-sdk/client"
-	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/types/module"
 )
-
-func init() {
-	types.RegisterLegacyAminoCodec(codec.NewLegacyAmino())
-}
 
 // ConsensusVersion defines the current x/upgrade module consensus version.
 const ConsensusVersion uint64 = 3
@@ -61,7 +57,7 @@ func (AppModule) Name() string {
 }
 
 // RegisterLegacyAminoCodec registers the upgrade types on the LegacyAmino codec
-func (AppModule) RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
+func (AppModule) RegisterLegacyAminoCodec(cdc legacy.Amino) {
 	types.RegisterLegacyAminoCodec(cdc)
 }
 

--- a/x/upgrade/types/codec.go
+++ b/x/upgrade/types/codec.go
@@ -1,19 +1,19 @@
 package types
 
 import (
+	corelegacy "cosmossdk.io/core/legacy"
 	"cosmossdk.io/core/registry"
 	coretransaction "cosmossdk.io/core/transaction"
 
-	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/codec/legacy"
 	"github.com/cosmos/cosmos-sdk/types/msgservice"
 )
 
 // RegisterLegacyAminoCodec registers concrete types on the LegacyAmino codec
-func RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
-	cdc.RegisterConcrete(Plan{}, "cosmos-sdk/Plan", nil)
-	cdc.RegisterConcrete(&SoftwareUpgradeProposal{}, "cosmos-sdk/SoftwareUpgradeProposal", nil)
-	cdc.RegisterConcrete(&CancelSoftwareUpgradeProposal{}, "cosmos-sdk/CancelSoftwareUpgradeProposal", nil)
+func RegisterLegacyAminoCodec(cdc corelegacy.Amino) {
+	cdc.RegisterConcrete(Plan{}, "cosmos-sdk/Plan")
+	cdc.RegisterConcrete(&SoftwareUpgradeProposal{}, "cosmos-sdk/SoftwareUpgradeProposal")
+	cdc.RegisterConcrete(&CancelSoftwareUpgradeProposal{}, "cosmos-sdk/CancelSoftwareUpgradeProposal")
 	legacy.RegisterAminoMsg(cdc, &MsgSoftwareUpgrade{}, "cosmos-sdk/MsgSoftwareUpgrade")
 	legacy.RegisterAminoMsg(cdc, &MsgCancelUpgrade{}, "cosmos-sdk/MsgCancelUpgrade")
 }


### PR DESCRIPTION
# Description

Proposal to remove the hard coupling on sdk/codec in runtime, runtime/v2 (#20320), and modules.

- Define interface for `core/legacy.Amino`
- `HasAminoCodec` now accepts that interface instead of the type in `codec`
- Update usages and implement of `HasAminoCodec.RegisterAminoCodec` accordingly
- Move `ProvideInterfaceRegistry` to codec.  This will allow runtime/v2 to avoid a direct dependency on sdk/codec.

The new interface that modules will call through to register amino types looks like:
```go
package legacy

type Amino interface {
	// RegisterInterface registers an interface and its concrete type with the Amino codec.
	RegisterInterface(interfacePtr any, iopts *InterfaceOptions)

	// RegisterConcrete registers a concrete type with the Amino codec.
	RegisterConcrete(cdcType interface{}, name string)
}

type InterfaceOptions struct {
	Priority           []string // Disamb priority.
	AlwaysDisambiguate bool     // If true, include disamb for all types.
}
```

This is breaking on module implementations, they must adjust their `HasAminoCodec` implementation to accept the interface instead of type.

Also note that the sig of `RegisterConrete` dropped an unused parameter which was always passed in as `nil`.  It is an empty struct in `go-amino`: https://github.com/tendermint/go-amino/blob/8e779b71f40d175cd1302d3cd41a75b005225a7a/codec.go#L103-L104

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
    - Enhanced registration functions for types and interfaces in multiple modules, improving compatibility with legacy systems.
    - Added provisioning functions for interface registry and codec creation, enhancing system configuration capabilities.

- **Refactor**
    - Updated function signatures and import paths to align with new standards for smoother operations and maintenance.

- **Bug Fixes**
    - Corrected argument handling in registration functions for improved system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->