### PR TITLE
refactor(store/v2): get rid of `WorkingHash`

### DIFF
--- a/store/v2/root/migrate_test.go
+++ b/store/v2/root/migrate_test.go
@@ -108,8 +108,6 @@ func (s *MigrateStoreTestSuite) TestMigrateState() {
 				cs.Add([]byte(storeKey), []byte(fmt.Sprintf("key-%d-%d", latestVersion, i)), []byte(fmt.Sprintf("value-%d-%d", latestVersion, i)), false)
 			}
 		}
-		_, err := s.rootStore.WorkingHash(cs)
-		s.Require().NoError(err)
 		_, err = s.rootStore.Commit(cs)
 		s.Require().NoError(err)
 
@@ -156,8 +154,6 @@ func (s *MigrateStoreTestSuite) TestMigrateState() {
 				cs.Add([]byte(storeKey), []byte(fmt.Sprintf("key-%d-%d", version, i)), []byte(fmt.Sprintf("value-%d-%d", version, i)), false)
 			}
 		}
-		_, err := s.rootStore.WorkingHash(cs)
-		s.Require().NoError(err)
 		_, err = s.rootStore.Commit(cs)
 		s.Require().NoError(err)
 	}

--- a/store/v2/root/store_test.go
+++ b/store/v2/root/store_test.go
@@ -94,14 +94,9 @@ func (s *RootStoreTestSuite) TestQuery() {
 	cs := corestore.NewChangeset()
 	cs.Add(testStoreKeyBytes, []byte("foo"), []byte("bar"), false)
 
-	workingHash, err := s.rootStore.WorkingHash(cs)
-	s.Require().NoError(err)
-	s.Require().NotNil(workingHash)
-
 	commitHash, err := s.rootStore.Commit(cs)
 	s.Require().NoError(err)
 	s.Require().NotNil(commitHash)
-	s.Require().Equal(workingHash, commitHash)
 
 	// ensure the proof is non-nil for the corresponding version
 	result, err := s.rootStore.Query([]byte(testStoreKey), 1, []byte("foo"), true)
@@ -146,9 +141,7 @@ func (s *RootStoreTestSuite) TestQueryProof() {
 	cs.Add(testStoreKey3Bytes, []byte("key4"), []byte("value4"), false)
 
 	// commit
-	_, err := s.rootStore.WorkingHash(cs)
-	s.Require().NoError(err)
-	_, err = s.rootStore.Commit(cs)
+	_, err := s.rootStore.Commit(cs)
 	s.Require().NoError(err)
 
 	// query proof for testStoreKey
@@ -174,14 +167,9 @@ func (s *RootStoreTestSuite) TestLoadVersion() {
 		cs := corestore.NewChangeset()
 		cs.Add(testStoreKeyBytes, []byte("key"), []byte(val), false)
 
-		workingHash, err := s.rootStore.WorkingHash(cs)
-		s.Require().NoError(err)
-		s.Require().NotNil(workingHash)
-
 		commitHash, err := s.rootStore.Commit(cs)
 		s.Require().NoError(err)
 		s.Require().NotNil(commitHash)
-		s.Require().Equal(workingHash, commitHash)
 	}
 
 	// ensure the latest version is correct
@@ -219,14 +207,9 @@ func (s *RootStoreTestSuite) TestLoadVersion() {
 		cs := corestore.NewChangeset()
 		cs.Add(testStoreKeyBytes, []byte("key"), []byte(val), false)
 
-		workingHash, err := s.rootStore.WorkingHash(cs)
-		s.Require().NoError(err)
-		s.Require().NotNil(workingHash)
-
 		commitHash, err := s.rootStore.Commit(cs)
 		s.Require().NoError(err)
 		s.Require().NotNil(commitHash)
-		s.Require().Equal(workingHash, commitHash)
 	}
 
 	// ensure the latest version is correct
@@ -259,17 +242,9 @@ func (s *RootStoreTestSuite) TestCommit() {
 		cs.Add(testStoreKeyBytes, []byte(key), []byte(val), false)
 	}
 
-	// committing w/o calling WorkingHash should error
-	_, err = s.rootStore.Commit(cs)
-	s.Require().Error(err)
-
-	// execute WorkingHash and Commit
-	wHash, err := s.rootStore.WorkingHash(cs)
-	s.Require().NoError(err)
-
 	cHash, err := s.rootStore.Commit(cs)
 	s.Require().NoError(err)
-	s.Require().Equal(wHash, cHash)
+	s.Require().NotNil(cHash)
 
 	// ensure latest version is updated
 	lv, err = s.rootStore.GetLatestVersion()
@@ -305,13 +280,10 @@ func (s *RootStoreTestSuite) TestStateAt() {
 			cs.Add(testStoreKeyBytes, []byte(key), []byte(val), false)
 		}
 
-		// execute WorkingHash and Commit
-		wHash, err := s.rootStore.WorkingHash(cs)
-		s.Require().NoError(err)
-
+		// execute Commit
 		cHash, err := s.rootStore.Commit(cs)
 		s.Require().NoError(err)
-		s.Require().Equal(wHash, cHash)
+		s.Require().NotNil(cHash)
 	}
 
 	lv, err := s.rootStore.GetLatestVersion()

--- a/store/v2/store.go
+++ b/store/v2/store.go
@@ -49,20 +49,11 @@ type RootStore interface {
 	// queries based on block time need to be supported.
 	SetCommitHeader(h *coreheader.Info)
 
-	// WorkingHash returns the current WIP commitment hash by applying the Changeset
-	// to the SC backend. Typically, WorkingHash() is called prior to Commit() and
-	// must be applied with the exact same Changeset. This is because WorkingHash()
-	// is responsible for writing the Changeset to the SC backend and returning the
-	// resulting root hash. Then, Commit() would return this hash and flush writes
-	// to disk.
-	WorkingHash(cs *corestore.Changeset) ([]byte, error)
-
 	// Commit should be responsible for taking the provided changeset and flushing
 	// it to disk. Note, depending on the implementation, the changeset, at this
 	// point, may already be written to the SC backends. Commit() should ensure
 	// the changeset is committed to all SC and SC backends and flushed to disk.
-	// It must return a hash of the merkle-ized committed state. This hash should
-	// be the same as the hash returned by WorkingHash() prior to calling Commit().
+	// It must return a hash of the merkle-ized committed state.
 	Commit(cs *corestore.Changeset) ([]byte, error)
 
 	// LastCommitID returns a CommitID pertaining to the last commitment.


### PR DESCRIPTION
# Description

Closes: #20239 

The final piece of store/v2 API cleanup, untouched the `WorkingHash` logic of `commitment` and `iavl` for the future use-case.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified the commit process by integrating the `WorkingHash` functionality into the `Commit` method.
  - Removed redundant `workingHash` field and related assertions in tests.

- **Bug Fixes**
  - Improved error handling and assertions in various test functions to ensure accuracy and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->