### PR TITLE
fix(sims): skip operations that use denoms that can't be sent

### DIFF
--- a/testutil/mock/types_module_module.go
+++ b/testutil/mock/types_module_module.go
@@ -9,8 +9,8 @@ import (
 	json "encoding/json"
 	reflect "reflect"
 
+	legacy "cosmossdk.io/core/legacy"
 	client "github.com/cosmos/cosmos-sdk/client"
-	codec "github.com/cosmos/cosmos-sdk/codec"
 	types "github.com/cosmos/cosmos-sdk/types"
 	module "github.com/cosmos/cosmos-sdk/types/module"
 	gomock "github.com/golang/mock/gomock"
@@ -67,7 +67,7 @@ func (mr *MockAppModuleBasicMockRecorder) RegisterGRPCGatewayRoutes(arg0, arg1 i
 }
 
 // RegisterLegacyAminoCodec mocks base method.
-func (m *MockAppModuleBasic) RegisterLegacyAminoCodec(arg0 *codec.LegacyAmino) {
+func (m *MockAppModuleBasic) RegisterLegacyAminoCodec(arg0 legacy.Amino) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "RegisterLegacyAminoCodec", arg0)
 }
@@ -265,7 +265,7 @@ func (m *MockHasAminoCodec) EXPECT() *MockHasAminoCodecMockRecorder {
 }
 
 // RegisterLegacyAminoCodec mocks base method.
-func (m *MockHasAminoCodec) RegisterLegacyAminoCodec(arg0 *codec.LegacyAmino) {
+func (m *MockHasAminoCodec) RegisterLegacyAminoCodec(arg0 legacy.Amino) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "RegisterLegacyAminoCodec", arg0)
 }

--- a/x/distribution/testutil/expected_keepers_mocks.go
+++ b/x/distribution/testutil/expected_keepers_mocks.go
@@ -156,6 +156,20 @@ func (mr *MockBankKeeperMockRecorder) GetAllBalances(ctx, addr interface{}) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllBalances", reflect.TypeOf((*MockBankKeeper)(nil).GetAllBalances), ctx, addr)
 }
 
+// IsSendEnabledDenom mocks base method.
+func (m *MockBankKeeper) IsSendEnabledDenom(ctx context.Context, denom string) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsSendEnabledDenom", ctx, denom)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsSendEnabledDenom indicates an expected call of IsSendEnabledDenom.
+func (mr *MockBankKeeperMockRecorder) IsSendEnabledDenom(ctx, denom interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsSendEnabledDenom", reflect.TypeOf((*MockBankKeeper)(nil).IsSendEnabledDenom), ctx, denom)
+}
+
 // MintCoins mocks base method.
 func (m *MockBankKeeper) MintCoins(ctx context.Context, moduleName string, amt types0.Coins) error {
 	m.ctrl.T.Helper()

--- a/x/distribution/types/expected_keepers.go
+++ b/x/distribution/types/expected_keepers.go
@@ -31,6 +31,7 @@ type BankKeeper interface {
 	SendCoinsFromAccountToModule(ctx context.Context, senderAddr sdk.AccAddress, recipientModule string, amt sdk.Coins) error
 
 	BlockedAddr(addr sdk.AccAddress) bool
+	IsSendEnabledDenom(ctx context.Context, denom string) bool
 }
 
 // PoolKeeper defines the expected interface needed to fund & distribute pool balances.

--- a/x/simulation/simulate.go
+++ b/x/simulation/simulate.go
@@ -354,8 +354,8 @@ func createBlockSimulator(tb testing.TB, testingMode bool, w io.Writer, params P
 				logWriter.PrintLogs()
 				tb.Fatalf(`error on block  %d/%d, operation (%d/%d) from x/%s:
 %v
-Comment: %s, Name: %s`,
-					header.Height, config.NumBlocks, opCount, blocksize, opMsg.Route, err, opMsg.Comment, opMsg.Name)
+Comment: %s`,
+					header.Height, config.NumBlocks, opCount, blocksize, opMsg.Route, err, opMsg.Comment)
 			}
 
 			queueOperations(operationQueue, timeOperationQueue, futureOps)

--- a/x/simulation/simulate.go
+++ b/x/simulation/simulate.go
@@ -354,8 +354,8 @@ func createBlockSimulator(tb testing.TB, testingMode bool, w io.Writer, params P
 				logWriter.PrintLogs()
 				tb.Fatalf(`error on block  %d/%d, operation (%d/%d) from x/%s:
 %v
-Comment: %s`,
-					header.Height, config.NumBlocks, opCount, blocksize, opMsg.Route, err, opMsg.Comment)
+Comment: %s, Name: %s`,
+					header.Height, config.NumBlocks, opCount, blocksize, opMsg.Route, err, opMsg.Comment, opMsg.Name)
 			}
 
 			queueOperations(operationQueue, timeOperationQueue, futureOps)

--- a/x/staking/simulation/operations.go
+++ b/x/staking/simulation/operations.go
@@ -450,6 +450,10 @@ func SimulateMsgUndelegate(
 			delAddr, val.GetOperator(), sdk.NewCoin(bondDenom, unbondAmt),
 		)
 
+		if !bk.IsSendEnabledDenom(ctx, bondDenom) {
+			return simtypes.NoOpMsg(types.ModuleName, sdk.MsgTypeURL(msg), "bond denom send not enabled"), nil, nil
+		}
+
 		// need to retrieve the simulation account associated with delegation to retrieve PrivKey
 		var simAccount simtypes.Account
 
@@ -710,6 +714,10 @@ func SimulateMsgBeginRedelegate(
 		bondDenom, err := k.BondDenom(ctx)
 		if err != nil {
 			return simtypes.NoOpMsg(types.ModuleName, msgType, "bond denom not found"), nil, err
+		}
+
+		if !bk.IsSendEnabledDenom(ctx, bondDenom) {
+			return simtypes.NoOpMsg(types.ModuleName, msgType, "bond denom send not enabled"), nil, nil
 		}
 
 		msg := types.NewMsgBeginRedelegate(

--- a/x/staking/testutil/expected_keepers_mocks.go
+++ b/x/staking/testutil/expected_keepers_mocks.go
@@ -202,6 +202,20 @@ func (mr *MockBankKeeperMockRecorder) GetSupply(ctx, denom interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSupply", reflect.TypeOf((*MockBankKeeper)(nil).GetSupply), ctx, denom)
 }
 
+// IsSendEnabledDenom mocks base method.
+func (m *MockBankKeeper) IsSendEnabledDenom(ctx context.Context, denom string) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsSendEnabledDenom", ctx, denom)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsSendEnabledDenom indicates an expected call of IsSendEnabledDenom.
+func (mr *MockBankKeeperMockRecorder) IsSendEnabledDenom(ctx, denom interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsSendEnabledDenom", reflect.TypeOf((*MockBankKeeper)(nil).IsSendEnabledDenom), ctx, denom)
+}
+
 // LockedCoins mocks base method.
 func (m *MockBankKeeper) LockedCoins(ctx context.Context, addr types2.AccAddress) types2.Coins {
 	m.ctrl.T.Helper()

--- a/x/staking/types/expected_keepers.go
+++ b/x/staking/types/expected_keepers.go
@@ -40,6 +40,7 @@ type BankKeeper interface {
 	DelegateCoinsFromAccountToModule(ctx context.Context, senderAddr sdk.AccAddress, recipientModule string, amt sdk.Coins) error
 
 	BurnCoins(context.Context, []byte, sdk.Coins) error
+	IsSendEnabledDenom(ctx context.Context, denom string) bool
 }
 
 // ValidatorSet expected properties for the set of all validators (noalias)


### PR DESCRIPTION
# Description

Follow up to #20343. 

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Added checks for withdrawable coins before sending rewards.
  - Implemented checks to ensure denominations are sendable before undelegating and redelegating in staking operations.

- **Improvements**
  - Enhanced reliability of rewards and staking operations by verifying sendability of denominations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->