### PR TITLE
docs: fix some markdown syntax

### DIFF
--- a/docs/learn/advanced/00-baseapp.md
+++ b/docs/learn/advanced/00-baseapp.md
@@ -354,7 +354,7 @@ The response contains:
 https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/x/auth/ante/basic.go#L102
 ```
 
-* `Events ([]cmn.KVPair)`: Key-Value tags for filtering and indexing transactions (eg. by account). See [`event`s](./08-events.md) for more.
+* `Events ([]cmn.KVPair)`: Key-Value tags for filtering and indexing transactions (eg. by account). See [`events`](./08-events.md) for more.
 * `Codespace (string)`: Namespace for the Code.
 
 #### RecheckTx
@@ -495,7 +495,7 @@ Each transaction returns a response to the underlying consensus engine of type [
 * `Info (string):` Additional information. May be non-deterministic.
 * `GasWanted (int64)`: Amount of gas requested for transaction. It is provided by users when they generate the transaction.
 * `GasUsed (int64)`: Amount of gas consumed by transaction. During transaction execution, this value is computed by multiplying the standard cost of a transaction byte by the size of the raw transaction, and by adding gas each time a read/write to the store occurs.
-* `Events ([]cmn.KVPair)`: Key-Value tags for filtering and indexing transactions (eg. by account). See [`event`s](./08-events.md) for more.
+* `Events ([]cmn.KVPair)`: Key-Value tags for filtering and indexing transactions (eg. by account). See [`events`](./08-events.md) for more.
 * `Codespace (string)`: Namespace for the Code.
 
 #### EndBlock 

--- a/docs/learn/advanced/08-events.md
+++ b/docs/learn/advanced/08-events.md
@@ -4,7 +4,7 @@ sidebar_position: 1
 # Events
 
 :::note Synopsis
-`Event`s are objects that contain information about the execution of the application. They are mainly used by service providers like block explorers and wallet to track the execution of various messages and index transactions.
+`Events` are objects that contain information about the execution of the application. They are mainly used by service providers like block explorers and wallet to track the execution of various messages and index transactions.
 :::
 
 :::note Pre-requisite Readings


### PR DESCRIPTION
# Description

the original one separated one word into two. see the below screenshots from cosmos website.
![image](https://github.com/cosmos/cosmos-sdk/assets/150209682/64aadafb-958a-4080-ab28-60c5c2f99e23)
![image](https://github.com/cosmos/cosmos-sdk/assets/150209682/81dda63a-9945-4d8a-9b97-1a661d78dea4)

so i fixed the markdown syntax to make the word display properly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected a typo in the advanced learning documentation, changing `event`s to `events` for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->