### PR TITLE
docs: update diagram to be shown properly

### DIFF
--- a/docs/learn/beginner/01-tx-lifecycle.md
+++ b/docs/learn/beginner/01-tx-lifecycle.md
@@ -164,45 +164,45 @@ As mentioned throughout the documentation `BeginBlock`, `ExecuteTx` and `EndBloc
 Although every full-node operates individually and locally, the outcome is always consistent and unequivocal. This is because the state changes brought about by the messages are predictable, and the transactions are specifically sequenced in the proposed block.
 
 ```text
-		--------------------------
-		| Receive Block Proposal |
-		--------------------------
-					|
-					v
-		-------------------------
-		|     FinalizeBlock	    |
-		-------------------------
-		            |
-			  		v
-			-------------------
-			|   BeginBlock	  | 
-			-------------------
-		            |
-			        v
-			--------------------
-			| ExecuteTx(tx0)   |
-			| ExecuteTx(tx1)   |
-			| ExecuteTx(tx2)   |
-			| ExecuteTx(tx3)   |
-			|	    .	       |
-			|		.		   |
-			|		.	       |
-			-------------------
-		            |
-			        v
-			--------------------
-			|    EndBlock      |
-			--------------------
-		            |
-			        v
-		-----------------------
-		|      Consensus      |
-		-----------------------
-		          |
-			      v
-		-----------------------
-		|     Commit	      |
-		-----------------------
+        --------------------------
+        | Receive Block Proposal |
+        --------------------------
+                    |
+                    v
+        -------------------------
+        |     FinalizeBlock      |
+        -------------------------
+                    |
+                    v
+            -------------------
+            |   BeginBlock     | 
+            -------------------
+                    |
+                    v
+            --------------------
+            | ExecuteTx(tx0)   |
+            | ExecuteTx(tx1)   |
+            | ExecuteTx(tx2)   |
+            | ExecuteTx(tx3)   |
+            |       .          |
+            |       .          |
+            |       .          |
+            -------------------
+                    |
+                    v
+            --------------------
+            |    EndBlock      |
+            --------------------
+                    |
+                    v
+        -------------------------
+        |       Consensus        |
+        -------------------------
+                    |
+                    v
+        -------------------------
+        |         Commit         |
+        -------------------------
 ```
 
 ### Transaction Execution


### PR DESCRIPTION
# Description

the diagram in the[ transaction lifecycle part ](https://docs.cosmos.network/v0.50/learn/beginner/tx-lifecycle)is not displaying correctly because of the tab and space usage at the same time. see below screenshot. by only using space( like all the other diagrams in the docs), it can display correctly.
![image](https://github.com/cosmos/cosmos-sdk/assets/150894831/fe97faeb-79b1-4d58-9dd5-e9c6d7a7ff0a)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Reformatted the transaction lifecycle diagram for improved readability and alignment. No changes to functionality or logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->