### PR TITLE
docs: fix note blocks display failure

### DIFF
--- a/docs/build/building-apps/03-app-upgrade.md
+++ b/docs/build/building-apps/03-app-upgrade.md
@@ -52,9 +52,9 @@ be a matter of minutes and not even require them to be awake at that time.
 
 ## Integrating With An App
 
-::tip
+:::tip
 The following is not required for users using `depinject` / app v2, this is abstracted for them.
-::
+:::
 
 In addition to basic module wiring, setup the upgrade Keeper for the app and then define a `PreBlocker` that calls the upgrade
 keeper's PreBlocker method:

--- a/docs/learn/advanced/01-transactions.md
+++ b/docs/learn/advanced/01-transactions.md
@@ -32,10 +32,9 @@ It contains the following methods:
 
 * **GetMsgs:** unwraps the transaction and returns a list of contained `sdk.Msg`s - one transaction may have one or multiple messages, which are defined by module developers.
 * **ValidateBasic:** lightweight, [_stateless_](../beginner/01-tx-lifecycle.md#types-of-checks) checks used by ABCI messages [`CheckTx`](./00-baseapp.md#checktx) and [`DeliverTx`](./00-baseapp.md#delivertx) to make sure transactions are not invalid. For example, the [`auth`](https://github.com/cosmos/cosmos-sdk/tree/main/x/auth) module's `ValidateBasic` function checks that its transactions are signed by the correct number of signers and that the fees do not exceed what the user's maximum. When [`runTx`](./00-baseapp.md#runtx) is checking a transaction created from the [`auth`](https://github.com/cosmos/cosmos-sdk/tree/main/x/auth/) module, it first runs `ValidateBasic` on each message, then runs the `auth` module AnteHandler which calls `ValidateBasic` for the transaction itself.
-
-    :::note
-    This function is different from the deprecated `sdk.Msg` [`ValidateBasic`](../beginner/01-tx-lifecycle.md#ValidateBasic) methods, which was performing basic validity checks on messages only.
-    :::
+:::note
+This function is different from the deprecated `sdk.Msg` [`ValidateBasic`](../beginner/01-tx-lifecycle.md#ValidateBasic) methods, which was performing basic validity checks on messages only.
+:::
 
 As a developer, you should rarely manipulate `Tx` directly, as `Tx` is really an intermediate type used for transaction generation. Instead, developers should prefer the `TxBuilder` interface, which you can learn more about [below](#transaction-generation).
 


### PR DESCRIPTION
# Description

the 2 note blocks on the doc website are not displaying as expected. 

[tip block](https://docs.cosmos.network/v0.50/build/building-apps/app-upgrade) is not working due to  using `::` instead of `:::`
![image](https://github.com/cosmos/cosmos-sdk/assets/150209682/5285c4f6-65af-4456-9450-5f0553d15bbe)

[note block](https://docs.cosmos.network/v0.50/learn/advanced/transactions) is not working due to being an element of the upper list.
![image](https://github.com/cosmos/cosmos-sdk/assets/150209682/3ea66089-d0ce-45f2-bb03-80c0e7d33aa9)

