### PR TITLE
fix(distribution): wrong codec usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,11 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 * (staking) [#20444](https://github.com/cosmos/cosmos-sdk/pull/20444) Disable tokenization of shares from redelegations.
 
+### Bugfixes
+
+* (distribution) [#20463](https://github.com/cosmos/cosmos-sdk/pull/20463) Fix wrong
+  codec used for `MsgWithdrawTokenizeShareRecordReward.GetSignBytes()`.
+
 ## v0.47.13-ics-lsm
 
 This is a special cosmos-sdk release with support for both ICS and LSM.

--- a/x/distribution/types/msg.go
+++ b/x/distribution/types/msg.go
@@ -3,7 +3,6 @@ package types
 import (
 	"errors"
 
-	"github.com/cosmos/cosmos-sdk/codec/legacy"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
@@ -253,7 +252,7 @@ func (msg MsgWithdrawTokenizeShareRecordReward) GetSigners() []sdk.AccAddress {
 
 // get the bytes for the message signer to sign on
 func (msg MsgWithdrawTokenizeShareRecordReward) GetSignBytes() []byte {
-	bz := legacy.Cdc.MustMarshalJSON(&msg)
+	bz := ModuleCdc.MustMarshalJSON(&msg)
 	return sdk.MustSortJSON(bz)
 }
 


### PR DESCRIPTION
# Description

Closes: #XXXX

`MsgWithdrawTokenizeShareRecordReward.GetSignBytes()` uses `legacy.Cdc` instead of `ModuleCdc`. As a result it's not marshalled properly into the amino-json format, because it's not registered in `legacy.Cdc`.

The expected format is:
```json
{"type":"cosmos-sdk/MsgWithdrawTokenizeReward","value":{"owner_address":"cosmos...","record_id":"2"}
```
The current format is:
```json
{"owner_address":"cosmos...","record_id":"2"}
```

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [x] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [x] added a changelog entry to `CHANGELOG.md`
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage
