### PR TITLE
chore: fix the note box syntax error

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Updating the docs
 
-::note
+:::note
 The documentation is built from [cosmos-sdk-docs repo](https://github.com/cosmos/cosmos-sdk-docs) and is hosted on [docs.cosmos.network](https://docs.cosmos.network).
 :::
 

--- a/x/protocolpool/README.md
+++ b/x/protocolpool/README.md
@@ -82,7 +82,7 @@ This message sends coins directly from the sender to the community pool.
 
 :::tip
 If you know the protocolpool module account address, you can directly use bank `send` transaction instead.
-::::
+:::
 
 ```protobuf reference
 https://github.com/cosmos/cosmos-sdk/blob/97724493d792517ba2be8969078b5f92ad04d79c/proto/cosmos/protocolpool/v1/tx.proto#L32-L42


### PR DESCRIPTION
# Description
 fixed two syntaxes to make the blocks show as expected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated note syntax in `docs/README.md` for improved readability.
  - Corrected formatting of a tip block in `protocolpool` module documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->