### PR TITLE
ci: Add GitHub Action for go mod tidy and mocks

### DIFF
--- a/.github/workflows/pr-go-mod-tidy-mocks.yml
+++ b/.github/workflows/pr-go-mod-tidy-mocks.yml
@@ -1,4 +1,4 @@
-name: 'PR Go Mod Tidy and Mocks'
+name: 'Checks dependencies and mocks generation'
 on:
   pull_request:
     branches:
@@ -30,7 +30,7 @@ jobs:
           }
 
   generate-mocks:
-    name: Generate Mocks
+    name: Check up to date mocks
     runs-on: ubuntu-latest
     steps:
       - name: Check out code

--- a/.github/workflows/pr-go-mod-tidy-mocks.yml
+++ b/.github/workflows/pr-go-mod-tidy-mocks.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 'stable'
+          go-version: 'latest'
       - name: Run go mod tidy
         run: ./scripts/go-mod-tidy-all.sh
       - name: Check for diffs
@@ -37,7 +37,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 'stable'
+          go-version: 'latest'
       - name: Generate mocks
         run: make mocks
       - name: Check for diffs

--- a/.github/workflows/pr-go-mod-tidy-mocks.yml
+++ b/.github/workflows/pr-go-mod-tidy-mocks.yml
@@ -1,0 +1,48 @@
+name: 'PR Go Mod Tidy and Mocks'
+on:
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: ci-${{ github.ref }}-pr-go-mod-tidy-mocks
+  cancel-in-progress: true
+
+jobs:
+  go-mod-tidy:
+    name: Check go mod tidy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 'stable'
+      - name: Run go mod tidy
+        run: ./scripts/go-mod-tidy-all.sh
+      - name: Check for diffs
+        run: |
+          git diff --exit-code || {
+            echo "Please run './scripts/go-mod-tidy-all.sh' and commit the changes";
+            exit 1;
+          }
+
+  generate-mocks:
+    name: Generate Mocks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 'stable'
+      - name: Generate mocks
+        run: make mocks
+      - name: Check for diffs
+        run: |
+          git diff --exit-code || {
+            echo "Please run 'make mocks' and commit the changes";
+            exit 1;
+          }

--- a/.github/workflows/pr-go-mod-tidy-mocks.yml
+++ b/.github/workflows/pr-go-mod-tidy-mocks.yml
@@ -14,11 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
-          go-version: 'latest'
+          go-version: "1.22"
+          check-latest: true
       - name: Run go mod tidy
         run: ./scripts/go-mod-tidy-all.sh
       - name: Check for diffs
@@ -33,11 +34,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
-          go-version: 'latest'
+          go-version: "1.22"
+          check-latest: true
       - name: Generate mocks
         run: make mocks
       - name: Check for diffs

--- a/testutil/mock/logger.go
+++ b/testutil/mock/logger.go
@@ -7,7 +7,7 @@ package mock
 import (
 	reflect "reflect"
 
-	log "cosmossdk.io/log"
+	log "cosmossdk.io/core/log"
 	gomock "github.com/golang/mock/gomock"
 )
 


### PR DESCRIPTION
Adds a new GitHub Action workflow to ensure code consistency across pull requests.

- **Introduces a new workflow file** `.github/workflows/pr-go-mod-tidy-mocks.yml` that triggers on pull requests to the main branch.
- **Configures concurrency** to run this workflow in parallel with other CI jobs, with a unique group identifier and cancellation of in-progress runs.
- **Defines two jobs** within the workflow:
  - The first job, `go-mod-tidy`, checks out the code, sets up Go, runs `./scripts/go-mod-tidy-all.sh`, and fails if there are any diffs, indicating the need for the contributor to run the script and commit changes.
  - The second job, `generate-mocks`, follows a similar pattern for generating mocks with `make mocks` and fails if there are uncommitted changes resulting from the command.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/cosmos/cosmos-sdk?shareId=9d58b7fd-6e92-4f6d-83f6-749f7008926b).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Introduced a new GitHub Actions workflow to ensure dependencies are tidy and generate mocks for testing on pull requests to the main branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->