### PR TITLE
refactor(tools/hubl): don't use nil panic

### DIFF
--- a/tools/hubl/internal/compat.go
+++ b/tools/hubl/internal/compat.go
@@ -59,7 +59,7 @@ func loadFileDescriptorsGRPCReflection(ctx context.Context, client *grpc.ClientC
 
 			switch res := in.MessageResponse.(type) {
 			case *grpc_reflection_v1alpha.ServerReflectionResponse_ErrorResponse:
-				panic(err)
+				panic(res.ErrorResponse.String())
 			case *grpc_reflection_v1alpha.ServerReflectionResponse_ListServicesResponse:
 				waitListServiceRes <- res.ListServicesResponse //nolint:staticcheck // we want to use the deprecated field
 			case *grpc_reflection_v1alpha.ServerReflectionResponse_FileDescriptorResponse:

--- a/tools/hubl/internal/compat.go
+++ b/tools/hubl/internal/compat.go
@@ -59,7 +59,7 @@ func loadFileDescriptorsGRPCReflection(ctx context.Context, client *grpc.ClientC
 
 			switch res := in.MessageResponse.(type) {
 			case *grpc_reflection_v1alpha.ServerReflectionResponse_ErrorResponse:
-				panic(res.ErrorResponse.String())
+				panic(res.ErrorResponse.String()) //nolint:staticcheck // we want to use the deprecated field
 			case *grpc_reflection_v1alpha.ServerReflectionResponse_ListServicesResponse:
 				waitListServiceRes <- res.ListServicesResponse //nolint:staticcheck // we want to use the deprecated field
 			case *grpc_reflection_v1alpha.ServerReflectionResponse_FileDescriptorResponse:


### PR DESCRIPTION
```go
if err != nil {
	panic(err)
}
```

Since err has been checked above, it's better to panic with a detailed error message instead of a nil