### PR TITLE
refactor(hubl): handle the case when grpc endpoints is nil

### DIFF
--- a/tools/hubl/internal/registry.go
+++ b/tools/hubl/internal/registry.go
@@ -41,10 +41,8 @@ func GetChainRegistryEntry(chain string) (*ChainRegistryEntry, error) {
 	cleanEntries := make([]*APIEntry, 0)
 	for i, apiEntry := range data.APIs.GRPC {
 		// clean-up the http(s):// prefix
-		if strings.Contains(apiEntry.Address, "https://") {
-			data.APIs.GRPC[i].Address = strings.Replace(apiEntry.Address, "https://", "", 1)
-		} else if strings.Contains(apiEntry.Address, "http://") {
-			data.APIs.GRPC[i].Address = strings.Replace(apiEntry.Address, "http://", "", 1)
+		if idx := strings.Index(apiEntry.Address, "://"); idx != -1 {
+			data.APIs.GRPC[i].Address = apiEntry.Address[idx+3:]
 		}
 
 		// remove trailing slashes
@@ -59,25 +57,29 @@ func GetChainRegistryEntry(chain string) (*ChainRegistryEntry, error) {
 	}
 
 	data.APIs.GRPC = cleanEntries
-	fmt.Printf("Found data for %s in the chain registry\n", chain)
 	return data, nil
 }
 
 func SelectGRPCEndpoints(chain string) (string, error) {
 	entry, err := GetChainRegistryEntry(chain)
-	if err != nil {
-		fmt.Printf("Unable to load data for %s in the chain registry. Specify a custom gRPC endpoint manually.\n", chain)
+	if err != nil || len(entry.APIs.GRPC) == 0 {
+		if err != nil {
+			// print error here so that user can know what happened and decide what to do next
+			fmt.Printf("Failed to load data for %s in the chain registry: %v\n", chain, err)
+		} else {
+			fmt.Printf("Found empty gRPC endpoint of %s in the chain registry.\n", chain)
+		}
+		fmt.Println("Specify a custom gRPC endpoint manually.")
 		prompt := &promptui.Prompt{
 			Label: "Enter a gRPC endpoint that you trust",
 		}
 		return prompt.Run()
 	}
+	fmt.Printf("Found data for %s in the chain registry\n", chain)
 
 	var items []string
-	if entry != nil {
-		for _, apiEntry := range entry.APIs.GRPC {
-			items = append(items, fmt.Sprintf("%s: %s", apiEntry.Provider, apiEntry.Address))
-		}
+	for _, apiEntry := range entry.APIs.GRPC {
+		items = append(items, fmt.Sprintf("%s: %s", apiEntry.Provider, apiEntry.Address))
 	}
 	prompt := promptui.SelectWithAdd{
 		Label:    fmt.Sprintf("Select a gRPC endpoint that you trust for the %s network", chain),


### PR DESCRIPTION
- refactor clean-up the http(s):// prefix
- add handle of case when there is no grpc endpoints return
- print error message when get chaun registry error


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved logic for cleaning API addresses by removing "https://" or "http://".
  - Enhanced error handling and user prompts for gRPC endpoint selection.
  - Streamlined the process for specifying custom gRPC endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->