### PR TITLE
chore: write gentx info to cmd.ErrOrStderr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -186,6 +186,7 @@ Every module contains its own CHANGELOG.md. Please refer to the module you are i
 * (server) [#20140](https://github.com/cosmos/cosmos-sdk/pull/20140) Remove embedded grpc-web proxy in favor of standalone grpc-web proxy. [Envoy Proxy](https://www.envoyproxy.io/docs/envoy/latest/start/start)
 * (client) [#20255](https://github.com/cosmos/cosmos-sdk/pull/20255) Use comet proofOp proto type instead of sdk version to avoid needing to translate to later be proven in the merkle proof runtime. 
 * (all) [#19726](https://github.com/cosmos/cosmos-sdk/pull/19726) Integrate comet v1
+* (client) [#20616](https://github.com/cosmos/cosmos-sdk/pull/20616) gentx subcommand output goes to `cmd.ErrOrStderr()` instead of being hardcoded to `os.Stderr`
 
 ### Client Breaking Changes
 

--- a/x/genutil/client/cli/collect.go
+++ b/x/genutil/client/cli/collect.go
@@ -52,7 +52,7 @@ func CollectGenTxsCmd(genBalIterator types.GenesisBalancesIterator, validator ty
 
 			toPrint.AppMessage = appMessage
 
-			return displayInfo(toPrint)
+			return displayInfo(cmd.ErrOrStderr(), toPrint)
 		},
 	}
 

--- a/x/genutil/client/cli/init.go
+++ b/x/genutil/client/cli/init.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 
@@ -58,13 +59,13 @@ func newPrintInfo(moniker, chainID, nodeID, genTxsDir string, appMessage json.Ra
 	}
 }
 
-func displayInfo(info printInfo) error {
+func displayInfo(dst io.Writer, info printInfo) error {
 	out, err := json.MarshalIndent(info, "", " ")
 	if err != nil {
 		return err
 	}
 
-	_, err = fmt.Fprintf(os.Stderr, "%s\n", out)
+	_, err = fmt.Fprintf(dst, "%s\n", out)
 
 	return err
 }
@@ -175,7 +176,7 @@ func InitCmd(mm *module.Manager) *cobra.Command {
 			toPrint := newPrintInfo(config.Moniker, chainID, nodeID, "", appState)
 
 			cfg.WriteConfigFile(filepath.Join(config.RootDir, "config", "config.toml"), config)
-			return displayInfo(toPrint)
+			return displayInfo(cmd.ErrOrStderr(), toPrint)
 		},
 	}
 


### PR DESCRIPTION
The "init" and "collect-gentxs" subcommands were hardcoded to write directly to os.Stderr. This made it impossible to write tests against the output. Instead, write to cmd.ErrOrStderr, which will still default to os.Stderr, but will also allow tests to intercept the cobra Command's stderr value in case there is a need to assert against that output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling by directing output to the appropriate error stream for better diagnostics in the `gentx` subcommand.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->