### PR TITLE
docs: fix broken links

### DIFF
--- a/docs/learn/advanced/03-node.md
+++ b/docs/learn/advanced/03-node.md
@@ -93,4 +93,4 @@ Upon starting, the node will bootstrap its RPC and P2P server and start dialing 
 
 ## Other commands
 <!-- markdown-link-check-disable-next-line -->
-To discover how to concretely run a node and interact with it, please refer to our [Running a Node, API and CLI](../../user/run-node/01-run-node.md#configuring-the-node-using-apptoml-and-configtoml) guide.
+To discover how to concretely run a node and interact with it, please refer to our [Running a Node, API and CLI](https://github.com/cosmos/developer-portal/blob/main/tutorials/3-run-node/index.md) guide.

--- a/docs/learn/advanced/06-grpc_rest.md
+++ b/docs/learn/advanced/06-grpc_rest.md
@@ -45,7 +45,7 @@ The `grpc.Server` is a concrete gRPC server, which spawns and serves all gRPC qu
 `~/.simapp` is the directory where the node's configuration and databases are stored. By default, it's set to `~/.{app_name}`.
 :::
 <!-- markdown-link-check-disable-next-line -->
-Once the gRPC server is started, you can send requests to it using a gRPC client. Some examples are given in our [Interact with the Node](../../user/run-node/01-run-node.md#configuring-the-node-using-apptoml-and-configtoml) tutorial.
+Once the gRPC server is started, you can send requests to it using a gRPC client. Some examples are given in our [Interact with the Node](https://github.com/cosmos/cosmos-sdk-docs/blob/main/docs/user/run-node/02-interact-node.md) tutorial.
 
 An overview of all available gRPC endpoints shipped with the Cosmos SDK is [Protobuf documentation](https://buf.build/cosmos/cosmos-sdk).
 

--- a/docs/learn/advanced/07-cli.md
+++ b/docs/learn/advanced/07-cli.md
@@ -164,7 +164,7 @@ Read more about [AutoCLI](https://docs.cosmos.network/main/core/autocli) in its 
 
 ## Flags
 
-Flags are used to modify commands; developers can include them in a `flags.go` file with their CLI. Users can explicitly include them in commands or pre-configure them by inside their <!-- markdown-link-check-disable-line -->[`app.toml`](../../user/run-node/01-run-node.md#configuring-the-node-using-apptoml-and-configtoml). Commonly pre-configured flags include the `--node` to connect to and `--chain-id` of the blockchain the user wishes to interact with.
+Flags are used to modify commands; developers can include them in a `flags.go` file with their CLI. Users can explicitly include them in commands or pre-configure them by inside their <!-- markdown-link-check-disable-line -->[`app.toml`](https://github.com/cosmos/cosmos-sdk-docs/blob/main/docs/user/run-node/01-run-node.md#configuring-the-node-using-apptoml-and-configtoml). Commonly pre-configured flags include the `--node` to connect to and `--chain-id` of the blockchain the user wishes to interact with.
 
 A *persistent* flag (as opposed to a *local* flag) added to a command transcends all of its children: subcommands will inherit the configured values for these flags. Additionally, all flags have default values when they are added to commands; some toggle an option off but others are empty values that the user needs to override to create valid commands. A flag can be explicitly marked as *required* so that an error is automatically thrown if the user does not provide a value, but it is also acceptable to handle unexpected missing flags differently.
 

--- a/docs/learn/beginner/00-app-anatomy.md
+++ b/docs/learn/beginner/00-app-anatomy.md
@@ -207,7 +207,7 @@ Each module should also implement the `RegisterServices` method as part of the [
 
 ### gRPC `Query` Services
 
-gRPC `Query` services allow users to query the state using [gRPC](https://grpc.io). They are enabled by default, and can be configured under the `grpc.enable` and `grpc.address` fields inside <!-- markdown-link-check-disable-line -->[`app.toml`](../../user/run-node/01-run-node.md#configuring-the-node-using-apptoml-and-configtoml).
+gRPC `Query` services allow users to query the state using [gRPC](https://grpc.io). They are enabled by default, and can be configured under the `grpc.enable` and `grpc.address` fields inside <!-- markdown-link-check-disable-line -->[`app.toml`](https://github.com/cosmos/cosmos-sdk-docs/blob/main/docs/user/run-node/01-run-node.md#configuring-the-node-using-apptoml-and-configtoml).
 
 gRPC `Query` services are defined in the module's Protobuf definition files, specifically inside `query.proto`. The `query.proto` definition file exposes a single `Query` [Protobuf service](https://developers.google.com/protocol-buffers/docs/proto#services). Each gRPC query endpoint corresponds to a service method, starting with the `rpc` keyword, inside the `Query` service.
 

--- a/docs/learn/beginner/02-query-lifecycle.md
+++ b/docs/learn/beginner/02-query-lifecycle.md
@@ -35,7 +35,7 @@ Note that the general format is as follows:
 simd query [moduleName] [command] <arguments> --flag <flagArg>
 ```
 
-To provide values such as `--node` (the full-node the CLI connects to), the user can use the <!-- markdown-link-check-disable-line -->[`app.toml`](../../user/run-node/01-run-node.md#configuring-the-node-using-apptoml-and-configtoml) config file to set them or provide them as flags.
+To provide values such as `--node` (the full-node the CLI connects to), the user can use the <!-- markdown-link-check-disable-line -->[`app.toml`](https://github.com/cosmos/cosmos-sdk-docs/blob/main/docs/user/run-node/01-run-node.md#configuring-the-node-using-apptoml-and-configtoml) config file to set them or provide them as flags.
 
 The CLI understands a specific set of commands, defined in a hierarchical structure by the application developer: from the [root command](../advanced/07-cli.md#root-command) (`simd`), the type of command (`Myquery`), the module that contains the command (`staking`), and command itself (`delegations`). Thus, the CLI knows exactly which module handles this command and directly passes the call there.
 


### PR DESCRIPTION
# Description
Fixed broken links to tutorials/docs that were caused by migration to [cosmos-sdk-docs](https://github.com/cosmos/cosmos-sdk-docs)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated several links in the advanced and beginner sections to point to correct GitHub locations.
  - Corrected a broken link related to including flags in commands with a CLI tool.
  - Improved reference links for better clarity in documentation related to running a node, gRPC services, and query lifecycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->