### PR TITLE
fix(x/staking,x/auth):  regenerate mock to fix test

### DIFF
--- a/x/auth/ante/expected_keepers.go
+++ b/x/auth/ante/expected_keepers.go
@@ -30,4 +30,5 @@ type FeegrantKeeper interface {
 
 type ConsensusKeeper interface {
 	Params(context.Context, *consensustypes.QueryParamsRequest) (*consensustypes.QueryParamsResponse, error)
+	GetCometInfo(context.Context, *consensustypes.QueryGetCometInfoRequest) (*consensustypes.QueryGetCometInfoResponse, error)
 }

--- a/x/auth/ante/testutil/expected_keepers_mocks.go
+++ b/x/auth/ante/testutil/expected_keepers_mocks.go
@@ -195,6 +195,21 @@ func (m *MockConsensusKeeper) EXPECT() *MockConsensusKeeperMockRecorder {
 	return m.recorder
 }
 
+// GetCometInfo mocks base method.
+func (m *MockConsensusKeeper) GetCometInfo(arg0 context.Context, arg1 *types0.QueryGetCometInfoRequest) (*types0.QueryGetCometInfoResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCometInfo", arg0, arg1)
+	ret0, _ := ret[0].(*types0.QueryGetCometInfoResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetCometInfo indicates an expected call of GetCometInfo.
+func (mr *MockConsensusKeeperMockRecorder) GetCometInfo(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCometInfo", reflect.TypeOf((*MockConsensusKeeper)(nil).GetCometInfo), arg0, arg1)
+}
+
 // Params mocks base method.
 func (m *MockConsensusKeeper) Params(arg0 context.Context, arg1 *types0.QueryParamsRequest) (*types0.QueryParamsResponse, error) {
 	m.ctrl.T.Helper()

--- a/x/staking/testutil/expected_keepers_mocks.go
+++ b/x/staking/testutil/expected_keepers_mocks.go
@@ -765,6 +765,21 @@ func (m *MockConsensusKeeper) EXPECT() *MockConsensusKeeperMockRecorder {
 	return m.recorder
 }
 
+// GetCometInfo mocks base method.
+func (m *MockConsensusKeeper) GetCometInfo(arg0 context.Context, arg1 *types.QueryGetCometInfoRequest) (*types.QueryGetCometInfoResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCometInfo", arg0, arg1)
+	ret0, _ := ret[0].(*types.QueryGetCometInfoResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetCometInfo indicates an expected call of GetCometInfo.
+func (mr *MockConsensusKeeperMockRecorder) GetCometInfo(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCometInfo", reflect.TypeOf((*MockConsensusKeeper)(nil).GetCometInfo), arg0, arg1)
+}
+
 // Params mocks base method.
 func (m *MockConsensusKeeper) Params(arg0 context.Context, arg1 *types.QueryParamsRequest) (*types.QueryParamsResponse, error) {
 	m.ctrl.T.Helper()

--- a/x/staking/types/expected_keepers.go
+++ b/x/staking/types/expected_keepers.go
@@ -118,4 +118,5 @@ func (StakingHooksWrapper) IsOnePerModuleType() {}
 
 type ConsensusKeeper interface {
 	Params(context.Context, *consensustypes.QueryParamsRequest) (*consensustypes.QueryParamsResponse, error)
+	GetCometInfo(context.Context, *consensustypes.QueryGetCometInfoRequest) (*consensustypes.QueryGetCometInfoResponse, error)
 }


### PR DESCRIPTION
# Description
```shell
Error: keeper/keeper_test.go:87:50: cannot use ck (variable of type *"cosmossdk.io/x/staking/testutil".MockConsensusKeeper) as "cosmossdk.io/x/consensus/types".QueryServer value in argument to consensustypes.RegisterQueryServer: *"cosmossdk.io/x/staking/testutil".MockConsensusKeeper does not implement "cosmossdk.io/x/consensus/types".QueryServer (missing method GetCometInfo)
FAIL	cosmossdk.io/x/staking/keeper [build failed]
```

Regenerate mocks to fix test failed issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced the ability to retrieve comet information through the new `GetCometInfo` method in the ConsensusKeeper interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->