### PR TITLE
feat!: `max-event-size` config to limit size of events stored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ Every module contains its own CHANGELOG.md. Please refer to the module you are i
 * (client) [#19870](https://github.com/cosmos/cosmos-sdk/pull/19870) Add new query command `wait-tx`. Alias `event-query-tx-for` to `wait-tx` for backward compatibility.
 * (crypto/keyring) [#20212](https://github.com/cosmos/cosmos-sdk/pull/20212) Expose the db keyring used in the keystore.
 * (genutil) [#19971](https://github.com/cosmos/cosmos-sdk/pull/19971) Allow manually setting the consensus key type in genesis
+* (server) [#20708](https://github.com/cosmos/cosmos-sdk/pull/20708) Add `max-event-size` config to app.toml to limit the size of events stored.
 
 ### Improvements
 

--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -774,6 +774,18 @@ func (app *BaseApp) deliverTx(tx []byte) *abci.ExecTxResult {
 		return resp
 	}
 
+	// If the application has set a maximum event size, check the size of each event attribute.
+	// If the size of any attribute exceeds the maximum, set the attribute value to a placeholder.
+	if sdk.MaxEventSize > 0 {
+		for i, event := range result.Events {
+			for j, attr := range event.Attributes {
+				if len([]byte(attr.Key))+len([]byte(attr.Value)) > sdk.MaxEventSize {
+					result.Events[i].Attributes[j].Value = "evt val too large, inc max-event-size in config.toml"
+				}
+			}
+		}
+	}
+
 	resp = &abci.ExecTxResult{
 		GasWanted: int64(gInfo.GasWanted),
 		GasUsed:   int64(gInfo.GasUsed),

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -91,6 +91,10 @@ type BaseConfig struct {
 	// AppDBBackend defines the type of Database to use for the application and snapshots databases.
 	// An empty string indicates that the CometBFT config's DBBackend value should be used.
 	AppDBBackend string `mapstructure:"app-db-backend"`
+
+	// MaxEventSize defines the maximum size of an attribute (key + value) of an event that will be stored in the block results.
+	// If an attribute is larger than this size, it will be replaced with a placeholder in the block results.
+	MaxEventSize int `mapstructure:"max-event-size" json:"max-event-size"`
 }
 
 // APIConfig defines the API listener configuration.
@@ -223,6 +227,7 @@ func DefaultConfig() *Config {
 			IAVLCacheSize:       781250,
 			IAVLDisableFastNode: false,
 			AppDBBackend:        "",
+			MaxEventSize:        1000000, // 1MB
 		},
 		Telemetry: telemetry.Config{
 			Enabled:      false,
@@ -264,6 +269,7 @@ func GetConfig(v *viper.Viper) (Config, error) {
 	if err := v.Unmarshal(conf); err != nil {
 		return Config{}, fmt.Errorf("error extracting app config: %w", err)
 	}
+	sdk.MaxEventSize = conf.BaseConfig.MaxEventSize
 	return *conf, nil
 }
 

--- a/server/config/toml.go
+++ b/server/config/toml.go
@@ -86,6 +86,10 @@ iavl-disable-fastnode = {{ .BaseConfig.IAVLDisableFastNode }}
 # The fallback is the db_backend value set in CometBFT's config.toml.
 app-db-backend = "{{ .BaseConfig.AppDBBackend }}"
 
+# Maximum event size in bytes that is stored in the block results. 0 means no limit
+# If an attribute of an event is larger than the max size, the attribute will be replaced with a placeholder.
+max-event-size = {{ .BaseConfig.MaxEventSize }}
+
 ###############################################################################
 ###                         Telemetry Configuration                         ###
 ###############################################################################

--- a/server/config/toml.go
+++ b/server/config/toml.go
@@ -86,7 +86,7 @@ iavl-disable-fastnode = {{ .BaseConfig.IAVLDisableFastNode }}
 # The fallback is the db_backend value set in CometBFT's config.toml.
 app-db-backend = "{{ .BaseConfig.AppDBBackend }}"
 
-# Maximum event size in bytes that is stored in the block results. 0 means no limit
+# Maximum event size in bytes that is stored in the block results. 0 means no limit.
 # If an attribute of an event is larger than the max size, the attribute will be replaced with a placeholder.
 max-event-size = {{ .BaseConfig.MaxEventSize }}
 

--- a/types/events.go
+++ b/types/events.go
@@ -15,6 +15,8 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 )
 
+var MaxEventSize = 0
+
 type EventManagerI interface {
 	Events() Events
 	ABCIEvents() []abci.Event


### PR DESCRIPTION
# Description

Closes: #XXXX

We have recently had issues with massive IBC events being persisted in block results, resulting in slowed down block syncing / consensus. Even after we upgrade to IBC v8, it's likely a matter of time before some other massive events exploit occurs that will bog down nodes once again. We should allow nodes to specify how large events they want to store, and if an event is greater than this size, a placeholder is set. 

This PR introduces a `max-event-size` config to the `app.toml`. If an event attribute's size is greater than this value, it gets replaced by a placeholder. I think this implies a client breaking change since the expectation of events is now changed, but if it's not considered breaking than I will remove the "!" from the title.

Also, notice we opted to check length on a per attribute basis. We do this because indexers and explorers may still want the smaller attributes such as accounts sending to accounts and how much, which tend to be smaller in size.

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title, you can find examples of the prefixes below:
    <!-- * `feat`: A new feature
    * `fix`: A bug fix
    * `docs`: Documentation only changes
    * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
    * `refactor`: A code change that neither fixes a bug nor adds a feature
    * `perf`: A code change that improves performance
    * `test`: Adding missing tests or correcting existing tests
    * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
    * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
    * `chore`: Other changes that don't modify src or test files
    * `revert`: Reverts a previous commit -->
* [x] confirmed `!` in the type prefix if API or client breaking change
* [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [x] provided a link to the relevant issue or specification
* [x] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [x] added a changelog entry to `CHANGELOG.md`
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

Please see [Pull Request Reviewer section in the contributing guide](../CONTRIBUTING.md#reviewer) for more information on how to review a pull request.

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a `max-event-size` configuration parameter to limit the size of stored events.
  - Added logic to truncate event attributes exceeding the specified maximum size in transaction delivery.
  - Updated configuration to include the `MaxEventSize` field for setting the maximum event size in block results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->