### PR TITLE
fix(x/group): orm codespace name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
+### Bug Fixes
+
+* (x/group) [#20750](https://github.com/cosmos/cosmos-sdk/pull/20750) x/group shouldn't claim "orm" error codespace. This prevents any chain Cosmos SDK `v0.47` chain to use the ORM module.
+
 ## [v0.47.12](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.47.12) - 2024-06-10
 
 ## Improvements

--- a/x/group/errors/orm.go
+++ b/x/group/errors/orm.go
@@ -4,8 +4,8 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/errors"
 )
 
-// mathCodespace is the codespace for all errors defined in orm package
-const ormCodespace = "orm"
+// ormCodespace is the codespace for all errors defined in orm package
+const ormCodespace = "legacy_orm"
 
 var (
 	// ErrORMIteratorDone defines an error when an iterator is done


### PR DESCRIPTION
# Description

`x/group` shouldn't claim `"orm"` codespace. This was fixed in v0.50, but should be backported to v0.47. This prevents the upgrade of Regen Ledger to v0.47:

```
panic: error with code 11 is already registered: "can't update object with missing or invalid primary key"

goroutine 1 [running]:
cosmossdk.io/errors.RegisterWithGRPCCode({0x2b8eb61, 0x3}, 0xb, 0x2, {0x2b9e38d, 0xd})
	/home/robert/go/pkg/mod/cosmossdk.io/errors@v1.0.1/errors.go:43 +0x265
cosmossdk.io/errors.Register({0x2b8eb61?, 0x0?}, 0x96be10?, {0x2b9e38d?, 0x5552090?})
	/home/robert/go/pkg/mod/cosmossdk.io/errors@v1.0.1/errors.go:35 +0x28
github.com/cosmos/cosmos-sdk/x/group/errors.init()
	/home/robert/projects/cosmos/regen/cosmos-sdk/x/group/errors/orm.go:12 +0x2f3
```
