### PR TITLE
fix(server/v2): make CometBFTServer implement HasStartFlags

### DIFF
--- a/server/v2/cometbft/server.go
+++ b/server/v2/cometbft/server.go
@@ -196,8 +196,8 @@ func getGenDocProvider(cfg *cmtcfg.Config) func() (node.ChecksummedGenesisDoc, e
 	}
 }
 
-func (s *CometBFTServer[T]) StartCmdFlags() pflag.FlagSet {
-	flags := *pflag.NewFlagSet("cometbft", pflag.ExitOnError)
+func (s *CometBFTServer[T]) StartCmdFlags() *pflag.FlagSet {
+	flags := pflag.NewFlagSet("cometbft", pflag.ExitOnError)
 	flags.Bool(flagWithComet, true, "Run abci app embedded in-process with CometBFT")
 	flags.String(flagAddress, "tcp://127.0.0.1:26658", "Listen address")
 	flags.String(flagTransport, "socket", "Transport protocol: socket, grpc")

--- a/server/v2/cometbft/server.go
+++ b/server/v2/cometbft/server.go
@@ -46,6 +46,8 @@ const (
 )
 
 var _ serverv2.ServerComponent[transaction.Tx] = (*CometBFTServer[transaction.Tx])(nil)
+var _ serverv2.HasCLICommands = (*CometBFTServer[transaction.Tx])(nil)
+var _ serverv2.HasStartFlags = (*CometBFTServer[transaction.Tx])(nil)
 
 type CometBFTServer[T transaction.Tx] struct {
 	Node   *node.Node


### PR DESCRIPTION
Changes: `CometBFTServer.StartCmdFlags()` now returns a pointer to a FlagSet as specified by the `HasStartFlags` interface.

Targeted issue: A v2 Server holding a CometBFTServer as a component would skip adding the comet start flags when calling `Server.StartFlags()`.


---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title, you can find examples of the prefixes below:
    <!-- * `feat`: A new feature
    * `fix`: A bug fix
    * `docs`: Documentation only changes
    * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
    * `refactor`: A code change that neither fixes a bug nor adds a feature
    * `perf`: A code change that improves performance
    * `test`: Adding missing tests or correcting existing tests
    * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
    * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
    * `chore`: Other changes that don't modify src or test files
    * `revert`: Reverts a previous commit -->
* [x] confirmed `!` in the type prefix if API or client breaking change
* [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [x] provided a link to the relevant issue or specification
* [x] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

Please see [Pull Request Reviewer section in the contributing guide](../CONTRIBUTING.md#reviewer) for more information on how to review a pull request.

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for `HasCLICommands` and `HasStartFlags` interfaces, enhancing command-line interaction and configuration options.

- **Improvements**
  - Improved the `StartCmdFlags` method to return a pointer, optimizing flag configuration handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->