### PR TITLE
mempool: add a slightly more helpful error message on signature verification failure

### DIFF
--- a/x/auth/ante/sigverify.go
+++ b/x/auth/ante/sigverify.go
@@ -361,7 +361,7 @@ func (svd SigVerificationDecorator) verifySig(ctx sdk.Context, tx sdk.Tx, acc sd
 		if OnlyLegacyAminoSigners(sig.Data) {
 			// If all signers are using SIGN_MODE_LEGACY_AMINO, we rely on VerifySignature to check account sequence number,
 			// and therefore communicate sequence number as a potential cause of error.
-			errMsg = fmt.Sprintf("signature verification failed; please verify account number (%d), sequence (%d) and chain-id (%s)", accNum, acc.GetSequence(), chainID)
+			errMsg = fmt.Sprintf("signature verification failed; please verify account number (%d), sequence (%d) and chain-id (%s): (%s)", accNum, acc.GetSequence(), chainID, err.Error())
 		} else {
 			errMsg = fmt.Sprintf("signature verification failed; please verify account number (%d) and chain-id (%s): (%s)", accNum, chainID, err.Error())
 		}

--- a/x/auth/signing/verify.go
+++ b/x/auth/signing/verify.go
@@ -2,6 +2,7 @@ package signing
 
 import (
 	"context"
+	"encoding/hex"
 	"fmt"
 
 	signingv1beta1 "cosmossdk.io/api/cosmos/tx/signing/v1beta1"
@@ -78,7 +79,7 @@ func VerifySignature(
 			return err
 		}
 		if !pubKey.VerifySignature(signBytes, data.Signature) {
-			return fmt.Errorf("unable to verify single signer signature")
+			return fmt.Errorf("unable to verify single signer signature '%s' for signBytes '%s'", hex.EncodeToString(data.Signature), hex.EncodeToString(signBytes))
 		}
 		return nil
 


### PR DESCRIPTION
This is very helpful when debugging signing code on clients.

Co-authored-by: @sampocs