### PR TITLE
refactor: remove unneeded generic type parameters

### DIFF
--- a/server/v2/api/grpc/server.go
+++ b/server/v2/api/grpc/server.go
@@ -21,7 +21,7 @@ import (
 	"cosmossdk.io/server/v2/api/grpc/gogoreflection"
 )
 
-type GRPCServer[AppT serverv2.AppI[T], T transaction.Tx] struct {
+type GRPCServer[T transaction.Tx] struct {
 	logger log.Logger
 	config *Config
 
@@ -33,13 +33,13 @@ type GRPCService interface {
 	RegisterGRPCServer(gogogrpc.Server)
 }
 
-func New[AppT serverv2.AppI[T], T transaction.Tx]() *GRPCServer[AppT, T] {
-	return &GRPCServer[AppT, T]{}
+func New[T transaction.Tx]() *GRPCServer[T] {
+	return &GRPCServer[T]{}
 }
 
 // Init returns a correctly configured and initialized gRPC server.
 // Note, the caller is responsible for starting the server.
-func (g *GRPCServer[AppT, T]) Init(appI AppT, v *viper.Viper, logger log.Logger) error {
+func (g *GRPCServer[T]) Init(appI serverv2.AppI[T], v *viper.Viper, logger log.Logger) error {
 	cfg := DefaultConfig()
 	if v != nil {
 		if err := v.Sub(g.Name()).Unmarshal(&cfg); err != nil {
@@ -66,11 +66,11 @@ func (g *GRPCServer[AppT, T]) Init(appI AppT, v *viper.Viper, logger log.Logger)
 	return nil
 }
 
-func (g *GRPCServer[AppT, T]) Name() string {
+func (g *GRPCServer[T]) Name() string {
 	return "grpc-server"
 }
 
-func (g *GRPCServer[AppT, T]) Start(ctx context.Context) error {
+func (g *GRPCServer[T]) Start(ctx context.Context) error {
 	listener, err := net.Listen("tcp", g.config.Address)
 	if err != nil {
 		return fmt.Errorf("failed to listen on address %s: %w", g.config.Address, err)
@@ -93,14 +93,14 @@ func (g *GRPCServer[AppT, T]) Start(ctx context.Context) error {
 	return err
 }
 
-func (g *GRPCServer[AppT, T]) Stop(ctx context.Context) error {
+func (g *GRPCServer[T]) Stop(ctx context.Context) error {
 	g.logger.Info("stopping gRPC server...", "address", g.config.Address)
 	g.grpcSrv.GracefulStop()
 
 	return nil
 }
 
-func (g *GRPCServer[AppT, T]) Config() any {
+func (g *GRPCServer[T]) Config() any {
 	if g.config == nil || g.config == (&Config{}) {
 		return DefaultConfig()
 	}

--- a/server/v2/cometbft/commands.go
+++ b/server/v2/cometbft/commands.go
@@ -28,7 +28,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/version"
 )
 
-func (s *CometBFTServer[AppT, T]) rpcClient(cmd *cobra.Command) (rpc.CometRPC, error) {
+func (s *CometBFTServer[T]) rpcClient(cmd *cobra.Command) (rpc.CometRPC, error) {
 	if s.config.Standalone {
 		client, err := rpchttp.New(client.GetConfigFromCmd(cmd).RPC.ListenAddress)
 		if err != nil {
@@ -51,7 +51,7 @@ func (s *CometBFTServer[AppT, T]) rpcClient(cmd *cobra.Command) (rpc.CometRPC, e
 }
 
 // StatusCommand returns the command to return the status of the network.
-func (s *CometBFTServer[AppT, T]) StatusCommand() *cobra.Command {
+func (s *CometBFTServer[T]) StatusCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "status",
 		Short: "Query remote node for status",
@@ -82,7 +82,7 @@ func (s *CometBFTServer[AppT, T]) StatusCommand() *cobra.Command {
 }
 
 // ShowNodeIDCmd - ported from CometBFT, dump node ID to stdout
-func (s *CometBFTServer[AppT, T]) ShowNodeIDCmd() *cobra.Command {
+func (s *CometBFTServer[T]) ShowNodeIDCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "show-node-id",
 		Short: "Show this node's ID",
@@ -100,7 +100,7 @@ func (s *CometBFTServer[AppT, T]) ShowNodeIDCmd() *cobra.Command {
 }
 
 // ShowValidatorCmd - ported from CometBFT, show this node's validator info
-func (s *CometBFTServer[AppT, T]) ShowValidatorCmd() *cobra.Command {
+func (s *CometBFTServer[T]) ShowValidatorCmd() *cobra.Command {
 	cmd := cobra.Command{
 		Use:   "show-validator",
 		Short: "Show this node's CometBFT validator info",
@@ -134,7 +134,7 @@ func (s *CometBFTServer[AppT, T]) ShowValidatorCmd() *cobra.Command {
 }
 
 // ShowAddressCmd - show this node's validator address
-func (s *CometBFTServer[AppT, T]) ShowAddressCmd() *cobra.Command {
+func (s *CometBFTServer[T]) ShowAddressCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "show-address",
 		Short: "Shows this node's CometBFT validator consensus address",
@@ -153,7 +153,7 @@ func (s *CometBFTServer[AppT, T]) ShowAddressCmd() *cobra.Command {
 }
 
 // VersionCmd prints CometBFT and ABCI version numbers.
-func (s *CometBFTServer[AppT, T]) VersionCmd() *cobra.Command {
+func (s *CometBFTServer[T]) VersionCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "version",
 		Short: "Print CometBFT libraries' version",
@@ -181,7 +181,7 @@ func (s *CometBFTServer[AppT, T]) VersionCmd() *cobra.Command {
 }
 
 // QueryBlocksCmd returns a command to search through blocks by events.
-func (s *CometBFTServer[AppT, T]) QueryBlocksCmd() *cobra.Command {
+func (s *CometBFTServer[T]) QueryBlocksCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "blocks",
 		Short: "Query for paginated blocks that match a set of events",
@@ -231,7 +231,7 @@ for. Each module documents its respective events under 'xx_events.md'.
 }
 
 // QueryBlockCmd implements the default command for a Block query.
-func (s *CometBFTServer[AppT, T]) QueryBlockCmd() *cobra.Command {
+func (s *CometBFTServer[T]) QueryBlockCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "block --type=[height|hash] [height|hash]",
 		Short: "Query for a committed block by height, hash, or event(s)",
@@ -318,7 +318,7 @@ $ %s query block --%s=%s <hash>
 }
 
 // QueryBlockResultsCmd implements the default command for a BlockResults query.
-func (s *CometBFTServer[AppT, T]) QueryBlockResultsCmd() *cobra.Command {
+func (s *CometBFTServer[T]) QueryBlockResultsCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "block-results [height]",
 		Short: "Query for a committed block's results by height",
@@ -383,7 +383,7 @@ func parseOptionalHeight(heightStr string) (*int64, error) {
 	return &tmp, nil
 }
 
-func (s *CometBFTServer[AppT, T]) BootstrapStateCmd() *cobra.Command {
+func (s *CometBFTServer[T]) BootstrapStateCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "bootstrap-state",
 		Short: "Bootstrap CometBFT state at an arbitrary block height using a light client",

--- a/server/v2/commands.go
+++ b/server/v2/commands.go
@@ -35,11 +35,11 @@ func Execute(rootCmd *cobra.Command, envPrefix, defaultHome string) error {
 
 // Commands creates the start command of an application and gives back the CLIConfig containing all the server commands.
 // This API is for advanced user only, most users should use AddCommands instead that abstract more.
-func Commands[AppT AppI[T], T transaction.Tx](
+func Commands[T transaction.Tx](
 	rootCmd *cobra.Command,
-	newApp AppCreator[AppT, T],
+	newApp AppCreator[T],
 	logger log.Logger,
-	components ...ServerComponent[AppT, T],
+	components ...ServerComponent[T],
 ) (CLIConfig, error) {
 	if len(components) == 0 {
 		return CLIConfig{}, errors.New("no components provided")
@@ -101,11 +101,11 @@ func Commands[AppT AppI[T], T transaction.Tx](
 
 // AddCommands add the server commands to the root command
 // It configure the config handling and the logger handling
-func AddCommands[AppT AppI[T], T transaction.Tx](
+func AddCommands[T transaction.Tx](
 	rootCmd *cobra.Command,
-	newApp AppCreator[AppT, T],
+	newApp AppCreator[T],
 	logger log.Logger,
-	components ...ServerComponent[AppT, T],
+	components ...ServerComponent[T],
 ) error {
 	cmds, err := Commands(rootCmd, newApp, logger, components...)
 	if err != nil {
@@ -158,7 +158,7 @@ func AddCommands[AppT AppI[T], T transaction.Tx](
 }
 
 // configHandle writes the default config to the home directory if it does not exist and sets the server context
-func configHandle[AppT AppI[T], T transaction.Tx](s *Server[AppT, T], cmd *cobra.Command) error {
+func configHandle[T transaction.Tx](s *Server[T], cmd *cobra.Command) error {
 	home, err := cmd.Flags().GetString(FlagHome)
 	if err != nil {
 		return err

--- a/server/v2/server.go
+++ b/server/v2/server.go
@@ -18,12 +18,12 @@ import (
 )
 
 // ServerComponent is a server module that can be started and stopped.
-type ServerComponent[AppT AppI[T], T transaction.Tx] interface {
+type ServerComponent[T transaction.Tx] interface {
 	Name() string
 
 	Start(context.Context) error
 	Stop(context.Context) error
-	Init(AppT, *viper.Viper, log.Logger) error
+	Init(AppI[T], *viper.Viper, log.Logger) error
 }
 
 // HasCLICommands is a server module that has CLI commands.
@@ -41,7 +41,7 @@ type HasStartFlags interface {
 	StartCmdFlags() *pflag.FlagSet
 }
 
-var _ ServerComponent[AppI[transaction.Tx], transaction.Tx] = (*Server[AppI[transaction.Tx], transaction.Tx])(nil)
+var _ ServerComponent[transaction.Tx] = (*Server[transaction.Tx])(nil)
 
 // Configs returns a viper instance of the config file
 func ReadConfig(configPath string) (*viper.Viper, error) {
@@ -63,26 +63,26 @@ func ReadConfig(configPath string) (*viper.Viper, error) {
 	return v, nil
 }
 
-type Server[AppT AppI[T], T transaction.Tx] struct {
+type Server[T transaction.Tx] struct {
 	logger     log.Logger
-	components []ServerComponent[AppT, T]
+	components []ServerComponent[T]
 }
 
-func NewServer[AppT AppI[T], T transaction.Tx](
-	logger log.Logger, components ...ServerComponent[AppT, T],
-) *Server[AppT, T] {
-	return &Server[AppT, T]{
+func NewServer[T transaction.Tx](
+	logger log.Logger, components ...ServerComponent[T],
+) *Server[T] {
+	return &Server[T]{
 		logger:     logger,
 		components: components,
 	}
 }
 
-func (s *Server[AppT, T]) Name() string {
+func (s *Server[T]) Name() string {
 	return "server"
 }
 
 // Start starts all components concurrently.
-func (s *Server[AppT, T]) Start(ctx context.Context) error {
+func (s *Server[T]) Start(ctx context.Context) error {
 	s.logger.Info("starting servers...")
 
 	g, ctx := errgroup.WithContext(ctx)
@@ -103,7 +103,7 @@ func (s *Server[AppT, T]) Start(ctx context.Context) error {
 }
 
 // Stop stops all components concurrently.
-func (s *Server[AppT, T]) Stop(ctx context.Context) error {
+func (s *Server[T]) Stop(ctx context.Context) error {
 	s.logger.Info("stopping servers...")
 
 	g, ctx := errgroup.WithContext(ctx)
@@ -118,7 +118,7 @@ func (s *Server[AppT, T]) Stop(ctx context.Context) error {
 }
 
 // CLICommands returns all CLI commands of all components.
-func (s *Server[AppT, T]) CLICommands() CLIConfig {
+func (s *Server[T]) CLICommands() CLIConfig {
 	compart := func(name string, cmds ...*cobra.Command) *cobra.Command {
 		if len(cmds) == 1 && strings.HasPrefix(cmds[0].Use, name) {
 			return cmds[0]
@@ -146,7 +146,7 @@ func (s *Server[AppT, T]) CLICommands() CLIConfig {
 }
 
 // Configs returns all configs of all server components.
-func (s *Server[AppT, T]) Configs() map[string]any {
+func (s *Server[T]) Configs() map[string]any {
 	cfgs := make(map[string]any)
 	for _, mod := range s.components {
 		if configmod, ok := mod.(HasConfig); ok {
@@ -159,8 +159,8 @@ func (s *Server[AppT, T]) Configs() map[string]any {
 }
 
 // Configs returns all configs of all server components.
-func (s *Server[AppT, T]) Init(appI AppT, v *viper.Viper, logger log.Logger) error {
-	var components []ServerComponent[AppT, T]
+func (s *Server[T]) Init(appI AppI[T], v *viper.Viper, logger log.Logger) error {
+	var components []ServerComponent[T]
 	for _, mod := range s.components {
 		mod := mod
 		if err := mod.Init(appI, v, logger); err != nil {
@@ -176,7 +176,7 @@ func (s *Server[AppT, T]) Init(appI AppT, v *viper.Viper, logger log.Logger) err
 
 // WriteConfig writes the config to the given path.
 // Note: it does not use viper.WriteConfigAs because we do not want to store flag values in the config.
-func (s *Server[AppT, T]) WriteConfig(configPath string) error {
+func (s *Server[T]) WriteConfig(configPath string) error {
 	cfgs := s.Configs()
 	b, err := toml.Marshal(cfgs)
 	if err != nil {
@@ -208,7 +208,7 @@ func (s *Server[AppT, T]) WriteConfig(configPath string) error {
 }
 
 // Flags returns all flags of all server components.
-func (s *Server[AppT, T]) StartFlags() []*pflag.FlagSet {
+func (s *Server[T]) StartFlags() []*pflag.FlagSet {
 	flags := []*pflag.FlagSet{}
 	for _, mod := range s.components {
 		if startmod, ok := mod.(HasStartFlags); ok {

--- a/server/v2/server_test.go
+++ b/server/v2/server_test.go
@@ -58,7 +58,7 @@ func TestServer(t *testing.T) {
 	}
 
 	logger := log.NewLogger(os.Stdout)
-	grpcServer := grpc.New[serverv2.AppI[transaction.Tx], transaction.Tx]()
+	grpcServer := grpc.New[transaction.Tx]()
 	if err := grpcServer.Init(&mockApp[transaction.Tx]{}, v, logger); err != nil {
 		t.Log(err)
 		t.Fail()

--- a/server/v2/types.go
+++ b/server/v2/types.go
@@ -9,7 +9,7 @@ import (
 	"cosmossdk.io/server/v2/appmanager"
 )
 
-type AppCreator[AppT AppI[T], T transaction.Tx] func(log.Logger, *viper.Viper) AppT
+type AppCreator[T transaction.Tx] func(log.Logger, *viper.Viper) AppI[T]
 
 type AppI[T transaction.Tx] interface {
 	GetAppManager() *appmanager.AppManager[T]


### PR DESCRIPTION
There is no apparent reason to introduce the generic parameter serverv2.AppI[T] when that type is always derived from T.

The code compiles fine after removing the parameter, but there are other pre-existing build failures preventing CI from passing.

See further discussion in #20789.