### PR TITLE
fix(store/v2): using `defer` to ensure close db handle

### DIFF
--- a/store/v2/commitment/metadata.go
+++ b/store/v2/commitment/metadata.go
@@ -59,36 +59,41 @@ func (m *MetadataStore) GetCommitInfo(version uint64) (*proof.CommitInfo, error)
 	return cInfo, nil
 }
 
-func (m *MetadataStore) flushCommitInfo(version uint64, cInfo *proof.CommitInfo) error {
+func (m *MetadataStore) flushCommitInfo(version uint64, cInfo *proof.CommitInfo) (err error) {
 	// do nothing if commit info is nil, as will be the case for an empty, initializing store
 	if cInfo == nil {
-		return nil
+		return
 	}
 
 	batch := m.kv.NewBatch()
-	defer batch.Close()
+	defer func() {
+		cErr := batch.Close()
+		if err == nil {
+			err = cErr
+		}
+	}()
 	cInfoKey := []byte(fmt.Sprintf(commitInfoKeyFmt, version))
 	value, err := cInfo.Marshal()
 	if err != nil {
-		return err
+		return
 	}
-	if err := batch.Set(cInfoKey, value); err != nil {
-		return err
+	if err = batch.Set(cInfoKey, value); err != nil {
+		return
 	}
 
 	var buf bytes.Buffer
 	buf.Grow(encoding.EncodeUvarintSize(version))
-	if err := encoding.EncodeUvarint(&buf, version); err != nil {
-		return err
+	if err = encoding.EncodeUvarint(&buf, version); err != nil {
+		return
 	}
-	if err := batch.Set([]byte(latestVersionKey), buf.Bytes()); err != nil {
-		return err
+	if err = batch.Set([]byte(latestVersionKey), buf.Bytes()); err != nil {
+		return
 	}
 
-	if err := batch.WriteSync(); err != nil {
-		return err
+	if err = batch.WriteSync(); err != nil {
+		return
 	}
-	return nil
+	return
 }
 
 func (m *MetadataStore) deleteCommitInfo(version uint64) error {

--- a/store/v2/commitment/metadata.go
+++ b/store/v2/commitment/metadata.go
@@ -62,7 +62,7 @@ func (m *MetadataStore) GetCommitInfo(version uint64) (*proof.CommitInfo, error)
 func (m *MetadataStore) flushCommitInfo(version uint64, cInfo *proof.CommitInfo) (err error) {
 	// do nothing if commit info is nil, as will be the case for an empty, initializing store
 	if cInfo == nil {
-		return
+		return nil
 	}
 
 	batch := m.kv.NewBatch()
@@ -75,25 +75,25 @@ func (m *MetadataStore) flushCommitInfo(version uint64, cInfo *proof.CommitInfo)
 	cInfoKey := []byte(fmt.Sprintf(commitInfoKeyFmt, version))
 	value, err := cInfo.Marshal()
 	if err != nil {
-		return
+		return err
 	}
-	if err = batch.Set(cInfoKey, value); err != nil {
-		return
+	if err := batch.Set(cInfoKey, value); err != nil {
+		return err
 	}
 
 	var buf bytes.Buffer
 	buf.Grow(encoding.EncodeUvarintSize(version))
-	if err = encoding.EncodeUvarint(&buf, version); err != nil {
-		return
+	if err := encoding.EncodeUvarint(&buf, version); err != nil {
+		return err
 	}
-	if err = batch.Set([]byte(latestVersionKey), buf.Bytes()); err != nil {
-		return
+	if err := batch.Set([]byte(latestVersionKey), buf.Bytes()); err != nil {
+		return err
 	}
 
-	if err = batch.WriteSync(); err != nil {
-		return
+	if err := batch.WriteSync(); err != nil {
+		return err
 	}
-	return
+	return nil
 }
 
 func (m *MetadataStore) deleteCommitInfo(version uint64) error {

--- a/store/v2/commitment/metadata.go
+++ b/store/v2/commitment/metadata.go
@@ -66,6 +66,7 @@ func (m *MetadataStore) flushCommitInfo(version uint64, cInfo *proof.CommitInfo)
 	}
 
 	batch := m.kv.NewBatch()
+	defer batch.Close()
 	cInfoKey := []byte(fmt.Sprintf(commitInfoKeyFmt, version))
 	value, err := cInfo.Marshal()
 	if err != nil {
@@ -87,7 +88,7 @@ func (m *MetadataStore) flushCommitInfo(version uint64, cInfo *proof.CommitInfo)
 	if err := batch.WriteSync(); err != nil {
 		return err
 	}
-	return batch.Close()
+	return nil
 }
 
 func (m *MetadataStore) deleteCommitInfo(version uint64) error {


### PR DESCRIPTION
`batch` will miss to close if oprations of `batch` encount error, this PR uses `defer` to avoid this

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling for the commitment metadata storage process to ensure more reliable operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->