### PR TITLE
feat:(tools/cosmovisor): Introduce a new optional config variable for setting custom path to application data directory

### DIFF
--- a/tools/cosmovisor/args.go
+++ b/tools/cosmovisor/args.go
@@ -31,6 +31,7 @@ const (
 	EnvShutdownGrace            = "DAEMON_SHUTDOWN_GRACE"
 	EnvSkipBackup               = "UNSAFE_SKIP_BACKUP"
 	EnvDataBackupPath           = "DAEMON_DATA_BACKUP_DIR"
+	EnvDataPath                 = "DAEMON_DATA_DIR"
 	EnvInterval                 = "DAEMON_POLL_INTERVAL"
 	EnvPreupgradeMaxRetries     = "DAEMON_PREUPGRADE_MAX_RETRIES"
 	EnvDisableLogs              = "COSMOVISOR_DISABLE_LOGS"
@@ -45,6 +46,7 @@ const (
 	genesisDir  = "genesis"
 	upgradesDir = "upgrades"
 	currentLink = "current"
+	dataDir     = "data"
 
 	cfgFileName  = "config"
 	cfgExtension = "toml"
@@ -62,6 +64,7 @@ type Config struct {
 	PollInterval             time.Duration `toml:"daemon_poll_interval" mapstructure:"daemon_poll_interval" default:"300ms"`
 	UnsafeSkipBackup         bool          `toml:"unsafe_skip_backup" mapstructure:"unsafe_skip_backup" default:"false"`
 	DataBackupPath           string        `toml:"daemon_data_backup_dir" mapstructure:"daemon_data_backup_dir"`
+	DataPath                 string        `toml:"daemon_data_dir" mapstructure:"daemon_data_dir"`
 	PreUpgradeMaxRetries     int           `toml:"daemon_preupgrade_max_retries" mapstructure:"daemon_preupgrade_max_retries" default:"0"`
 	DisableLogs              bool          `toml:"cosmovisor_disable_logs" mapstructure:"cosmovisor_disable_logs" default:"false"`
 	ColorLogs                bool          `toml:"cosmovisor_color_logs" mapstructure:"cosmovisor_color_logs" default:"true"`
@@ -106,7 +109,17 @@ func (cfg *Config) BaseUpgradeDir() string {
 
 // UpgradeInfoFilePath is the expected upgrade-info filename created by `x/upgrade/keeper`.
 func (cfg *Config) UpgradeInfoFilePath() string {
-	return filepath.Join(cfg.Home, "data", upgradetypes.UpgradeInfoFilename)
+	return filepath.Join(cfg.DataDirPath(), upgradetypes.UpgradeInfoFilename)
+}
+
+func (cfg *Config) DataDirPath() string {
+	if cfg.DataPath != "" {
+		// Return the Absolute path defined by user
+		return cfg.DataPath
+	}
+	// Otherwise, return the default path
+	return filepath.Join(cfg.Home, dataDir)
+
 }
 
 // SymLinkToGenesis creates a symbolic link from "./current" to the genesis directory.
@@ -209,6 +222,7 @@ func GetConfigFromEnv() (*Config, error) {
 		Home:             os.Getenv(EnvHome),
 		Name:             os.Getenv(EnvName),
 		DataBackupPath:   os.Getenv(EnvDataBackupPath),
+		DataPath:         os.Getenv(EnvDataPath),
 		CustomPreUpgrade: os.Getenv(EnvCustomPreupgrade),
 	}
 
@@ -339,6 +353,20 @@ func (cfg *Config) validate() []error {
 			errs = append(errs, fmt.Errorf("cannot stat home dir: %w", err))
 		case !info.IsDir():
 			errs = append(errs, fmt.Errorf("%s is not a directory", cfg.Root()))
+		}
+	}
+	// validate DataPath
+	switch {
+	case cfg.DataPath == "":
+		break
+	case !filepath.IsAbs(cfg.DataPath):
+		errs = append(errs, fmt.Errorf("%s must be an absolute path", cfg.DataPath))
+	default:
+		switch info, err := os.Stat(cfg.DataPath); {
+		case err != nil:
+			errs = append(errs, fmt.Errorf("%q must be a valid directory: %w", cfg.DataPath, err))
+		case !info.IsDir():
+			errs = append(errs, fmt.Errorf("%q must be a valid directory", cfg.DataPath))
 		}
 	}
 
@@ -539,6 +567,7 @@ func (cfg Config) DetailString() string {
 		{EnvInterval, cfg.PollInterval.String()},
 		{EnvSkipBackup, fmt.Sprintf("%t", cfg.UnsafeSkipBackup)},
 		{EnvDataBackupPath, cfg.DataBackupPath},
+		{EnvDataPath, cfg.DataPath},
 		{EnvPreupgradeMaxRetries, fmt.Sprintf("%d", cfg.PreUpgradeMaxRetries)},
 		{EnvDisableLogs, fmt.Sprintf("%t", cfg.DisableLogs)},
 		{EnvColorLogs, fmt.Sprintf("%t", cfg.ColorLogs)},
@@ -553,6 +582,7 @@ func (cfg Config) DetailString() string {
 		{"Genesis Bin", cfg.GenesisBin()},
 		{"Monitored File", cfg.UpgradeInfoFilePath()},
 		{"Data Backup Dir", cfg.DataBackupPath},
+		{"Data Dir", cfg.DataDirPath()},
 	}
 
 	var sb strings.Builder

--- a/tools/cosmovisor/args.go
+++ b/tools/cosmovisor/args.go
@@ -109,17 +109,11 @@ func (cfg *Config) BaseUpgradeDir() string {
 
 // UpgradeInfoFilePath is the expected upgrade-info filename created by `x/upgrade/keeper`.
 func (cfg *Config) UpgradeInfoFilePath() string {
-	return filepath.Join(cfg.DataDirPath(), upgradetypes.UpgradeInfoFilename)
+	return filepath.Join(cfg.DataPath, upgradetypes.UpgradeInfoFilename)
 }
 
-func (cfg *Config) DataDirPath() string {
-	if cfg.DataPath != "" {
-		// Return the Absolute path defined by user
-		return cfg.DataPath
-	}
-	// Otherwise, return the default path
+func (cfg *Config) DefaultDataDirPath() string {
 	return filepath.Join(cfg.Home, dataDir)
-
 }
 
 // SymLinkToGenesis creates a symbolic link from "./current" to the genesis directory.
@@ -228,6 +222,10 @@ func GetConfigFromEnv() (*Config, error) {
 
 	if cfg.DataBackupPath == "" {
 		cfg.DataBackupPath = cfg.Home
+	}
+
+	if cfg.DataPath == "" {
+		cfg.DataPath = cfg.DefaultDataDirPath()
 	}
 
 	var err error
@@ -582,7 +580,7 @@ func (cfg Config) DetailString() string {
 		{"Genesis Bin", cfg.GenesisBin()},
 		{"Monitored File", cfg.UpgradeInfoFilePath()},
 		{"Data Backup Dir", cfg.DataBackupPath},
-		{"Data Dir", cfg.DataDirPath()},
+		{"Data Dir", cfg.DataPath},
 	}
 
 	var sb strings.Builder

--- a/tools/cosmovisor/args_test.go
+++ b/tools/cosmovisor/args_test.go
@@ -424,7 +424,7 @@ func (s *argsTestSuite) TestDetailString() {
 	pollInterval := 406 * time.Millisecond
 	unsafeSkipBackup := false
 	dataBackupPath := "/home"
-	dataPath := ""
+	dataPath := "/home/data"
 	preupgradeMaxRetries := 8
 	cfg := &Config{
 		Home:                     home,
@@ -460,7 +460,7 @@ func (s *argsTestSuite) TestDetailString() {
 		fmt.Sprintf("Genesis Bin: %s", home),
 		fmt.Sprintf("Monitored File: %s", home),
 		fmt.Sprintf("Data Backup Dir: %s", home),
-		fmt.Sprintf("Data Dir: %s/data", home),
+		fmt.Sprintf("Data Dir: %s", dataPath),
 	}
 
 	actual := cfg.DetailString()
@@ -514,6 +514,7 @@ func (s *argsTestSuite) TestGetConfigFromEnv() {
 	relPath := filepath.Join("testdata", "validate")
 	absPath, perr := filepath.Abs(relPath)
 	s.Require().NoError(perr)
+	dataDirPath := filepath.Join(absPath, "/data")
 
 	tests := []struct {
 		name             string
@@ -546,14 +547,14 @@ func (s *argsTestSuite) TestGetConfigFromEnv() {
 		{
 			name:             "all good",
 			envVals:          cosmovisorEnv{absPath, "testname", "true", "true", "false", "600ms", "true", "", "", "303ms", "1", "false", "true", "kitchen", "preupgrade.sh", "true", "10s"},
-			expectedCfg:      newConfig(absPath, "testname", true, true, false, 600, true, absPath, "", 303, 1, false, true, time.Kitchen, "preupgrade.sh", true, 10000000000),
+			expectedCfg:      newConfig(absPath, "testname", true, true, false, 600, true, absPath, dataDirPath, 303, 1, false, true, time.Kitchen, "preupgrade.sh", true, 10000000000),
 			expectedErrCount: 0,
 		},
 		{
 			name:             "nothing set",
 			envVals:          cosmovisorEnv{"", "", "", "", "", "", "", "", "", "", "", "false", "false", "", "", "", ""},
 			expectedCfg:      nil,
-			expectedErrCount: 3,
+			expectedErrCount: 4,
 		},
 		// Note: Home and Name tests are done in TestValidate
 		// timeformat tests are done in the TestTimeFormat
@@ -566,25 +567,25 @@ func (s *argsTestSuite) TestGetConfigFromEnv() {
 		{
 			name:             "download bin not set",
 			envVals:          cosmovisorEnv{absPath, "testname", "", "true", "false", "600ms", "true", "", "", "303ms", "1", "false", "true", "kitchen", "", "", ""},
-			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, true, absPath, "", 303, 1, false, true, time.Kitchen, "", false, 0),
+			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, true, absPath, dataDirPath, 303, 1, false, true, time.Kitchen, "", false, 0),
 			expectedErrCount: 0,
 		},
 		{
 			name:             "download bin true",
 			envVals:          cosmovisorEnv{absPath, "testname", "true", "true", "false", "600ms", "true", "", "", "303ms", "1", "false", "true", "kitchen", "preupgrade.sh", "", ""},
-			expectedCfg:      newConfig(absPath, "testname", true, true, false, 600, true, absPath, "", 303, 1, false, true, time.Kitchen, "preupgrade.sh", false, 0),
+			expectedCfg:      newConfig(absPath, "testname", true, true, false, 600, true, absPath, dataDirPath, 303, 1, false, true, time.Kitchen, "preupgrade.sh", false, 0),
 			expectedErrCount: 0,
 		},
 		{
 			name:             "download bin false",
 			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "true", "", "", "303ms", "1", "false", "true", "kitchen", "preupgrade.sh", "", ""},
-			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, true, absPath, "", 303, 1, false, true, time.Kitchen, "preupgrade.sh", false, 0),
+			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, true, absPath, dataDirPath, 303, 1, false, true, time.Kitchen, "preupgrade.sh", false, 0),
 			expectedErrCount: 0,
 		},
 		{
 			name:             "download ensure checksum true",
 			envVals:          cosmovisorEnv{absPath, "testname", "true", "false", "false", "600ms", "true", "", "", "303ms", "1", "false", "true", "kitchen", "preupgrade.sh", "", ""},
-			expectedCfg:      newConfig(absPath, "testname", true, false, false, 600, true, absPath, "", 303, 1, false, true, time.Kitchen, "preupgrade.sh", false, 0),
+			expectedCfg:      newConfig(absPath, "testname", true, false, false, 600, true, absPath, dataDirPath, 303, 1, false, true, time.Kitchen, "preupgrade.sh", false, 0),
 			expectedErrCount: 0,
 		},
 		{
@@ -596,19 +597,19 @@ func (s *argsTestSuite) TestGetConfigFromEnv() {
 		{
 			name:             "restart upgrade not set",
 			envVals:          cosmovisorEnv{absPath, "testname", "true", "true", "", "600ms", "true", "", "", "303ms", "1", "false", "true", "kitchen", "preupgrade.sh", "", ""},
-			expectedCfg:      newConfig(absPath, "testname", true, true, true, 600, true, absPath, "", 303, 1, false, true, time.Kitchen, "preupgrade.sh", false, 0),
+			expectedCfg:      newConfig(absPath, "testname", true, true, true, 600, true, absPath, dataDirPath, 303, 1, false, true, time.Kitchen, "preupgrade.sh", false, 0),
 			expectedErrCount: 0,
 		},
 		{
 			name:             "restart upgrade true",
 			envVals:          cosmovisorEnv{absPath, "testname", "true", "true", "true", "600ms", "true", "", "", "303ms", "1", "false", "true", "kitchen", "preupgrade.sh", "", ""},
-			expectedCfg:      newConfig(absPath, "testname", true, true, true, 600, true, absPath, "", 303, 1, false, true, time.Kitchen, "preupgrade.sh", false, 0),
+			expectedCfg:      newConfig(absPath, "testname", true, true, true, 600, true, absPath, dataDirPath, 303, 1, false, true, time.Kitchen, "preupgrade.sh", false, 0),
 			expectedErrCount: 0,
 		},
 		{
 			name:             "restart upgrade true",
 			envVals:          cosmovisorEnv{absPath, "testname", "true", "true", "false", "600ms", "true", "", "", "303ms", "1", "false", "true", "kitchen", "preupgrade.sh", "", ""},
-			expectedCfg:      newConfig(absPath, "testname", true, true, false, 600, true, absPath, "", 303, 1, false, true, time.Kitchen, "preupgrade.sh", false, 0),
+			expectedCfg:      newConfig(absPath, "testname", true, true, false, 600, true, absPath, dataDirPath, 303, 1, false, true, time.Kitchen, "preupgrade.sh", false, 0),
 			expectedErrCount: 0,
 		},
 		{
@@ -620,19 +621,19 @@ func (s *argsTestSuite) TestGetConfigFromEnv() {
 		{
 			name:             "skip unsafe backups not set",
 			envVals:          cosmovisorEnv{absPath, "testname", "true", "true", "false", "600ms", "", "", "", "303ms", "1", "false", "true", "kitchen", "preupgrade.sh", "", ""},
-			expectedCfg:      newConfig(absPath, "testname", true, true, false, 600, false, absPath, "", 303, 1, false, true, time.Kitchen, "preupgrade.sh", false, 0),
+			expectedCfg:      newConfig(absPath, "testname", true, true, false, 600, false, absPath, dataDirPath, 303, 1, false, true, time.Kitchen, "preupgrade.sh", false, 0),
 			expectedErrCount: 0,
 		},
 		{
 			name:             "skip unsafe backups true",
 			envVals:          cosmovisorEnv{absPath, "testname", "true", "true", "false", "600ms", "true", "", "", "303ms", "1", "false", "true", "kitchen", "preupgrade.sh", "", ""},
-			expectedCfg:      newConfig(absPath, "testname", true, true, false, 600, true, absPath, "", 303, 1, false, true, time.Kitchen, "preupgrade.sh", false, 0),
+			expectedCfg:      newConfig(absPath, "testname", true, true, false, 600, true, absPath, dataDirPath, 303, 1, false, true, time.Kitchen, "preupgrade.sh", false, 0),
 			expectedErrCount: 0,
 		},
 		{
 			name:             "skip unsafe backups false",
 			envVals:          cosmovisorEnv{absPath, "testname", "true", "true", "false", "600ms", "false", "", "", "303ms", "1", "false", "true", "kitchen", "preupgrade.sh", "", ""},
-			expectedCfg:      newConfig(absPath, "testname", true, true, false, 600, false, absPath, "", 303, 1, false, true, time.Kitchen, "preupgrade.sh", false, 0),
+			expectedCfg:      newConfig(absPath, "testname", true, true, false, 600, false, absPath, dataDirPath, 303, 1, false, true, time.Kitchen, "preupgrade.sh", false, 0),
 			expectedErrCount: 0,
 		},
 		{
@@ -650,7 +651,7 @@ func (s *argsTestSuite) TestGetConfigFromEnv() {
 		{
 			name:             "poll interval not set",
 			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "", "", "1", "false", "false", "kitchen", "preupgrade.sh", "", ""},
-			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, false, absPath, "", 300, 1, false, false, time.Kitchen, "preupgrade.sh", false, 0),
+			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, false, absPath, dataDirPath, 300, 1, false, false, time.Kitchen, "preupgrade.sh", false, 0),
 			expectedErrCount: 0,
 		},
 		{
@@ -662,7 +663,7 @@ func (s *argsTestSuite) TestGetConfigFromEnv() {
 		{
 			name:             "poll interval 1s",
 			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "", "1s", "1", "false", "false", "kitchen", "preupgrade.sh", "", ""},
-			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, false, absPath, "", 1000, 1, false, false, time.Kitchen, "preupgrade.sh", false, 0),
+			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, false, absPath, dataDirPath, 1000, 1, false, false, time.Kitchen, "preupgrade.sh", false, 0),
 			expectedErrCount: 0,
 		},
 		{
@@ -686,7 +687,7 @@ func (s *argsTestSuite) TestGetConfigFromEnv() {
 		{
 			name:             "restart delay not set",
 			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "", "false", "", "", "303ms", "1", "false", "false", "kitchen", "preupgrade.sh", "", ""},
-			expectedCfg:      newConfig(absPath, "testname", false, true, false, 0, false, absPath, "", 303, 1, false, false, time.Kitchen, "preupgrade.sh", false, 0),
+			expectedCfg:      newConfig(absPath, "testname", false, true, false, 0, false, absPath, dataDirPath, 303, 1, false, false, time.Kitchen, "preupgrade.sh", false, 0),
 			expectedErrCount: 0,
 		},
 		{
@@ -698,7 +699,7 @@ func (s *argsTestSuite) TestGetConfigFromEnv() {
 		{
 			name:             "restart delay 1s",
 			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "1s", "false", "", "", "303ms", "1", "false", "false", "kitchen", "preupgrade.sh", "", ""},
-			expectedCfg:      newConfig(absPath, "testname", false, true, false, 1000, false, absPath, "", 303, 1, false, false, time.Kitchen, "preupgrade.sh", false, 0),
+			expectedCfg:      newConfig(absPath, "testname", false, true, false, 1000, false, absPath, dataDirPath, 303, 1, false, false, time.Kitchen, "preupgrade.sh", false, 0),
 			expectedErrCount: 0,
 		},
 		{
@@ -716,19 +717,19 @@ func (s *argsTestSuite) TestGetConfigFromEnv() {
 		{
 			name:             "prepupgrade max retries 0",
 			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "", "406ms", "0", "false", "false", "kitchen", "preupgrade.sh", "", ""},
-			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, false, absPath, "", 406, 0, false, false, time.Kitchen, "preupgrade.sh", false, 0),
+			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, false, absPath, dataDirPath, 406, 0, false, false, time.Kitchen, "preupgrade.sh", false, 0),
 			expectedErrCount: 0,
 		},
 		{
 			name:             "prepupgrade max retries not set",
 			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "", "406ms", "", "false", "false", "kitchen", "preupgrade.sh", "", ""},
-			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, false, absPath, "", 406, 0, false, false, time.Kitchen, "preupgrade.sh", false, 0),
+			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, false, absPath, dataDirPath, 406, 0, false, false, time.Kitchen, "preupgrade.sh", false, 0),
 			expectedErrCount: 0,
 		},
 		{
 			name:             "prepupgrade max retries 5",
 			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "", "406ms", "5", "false", "false", "kitchen", "preupgrade.sh", "", ""},
-			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, false, absPath, "", 406, 5, false, false, time.Kitchen, "preupgrade.sh", false, 0),
+			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, false, absPath, dataDirPath, 406, 5, false, false, time.Kitchen, "preupgrade.sh", false, 0),
 			expectedErrCount: 0,
 		},
 		{
@@ -740,7 +741,7 @@ func (s *argsTestSuite) TestGetConfigFromEnv() {
 		{
 			name:             "disable logs good",
 			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "", "406ms", "", "true", "false", "kitchen", "preupgrade.sh", "", ""},
-			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, false, absPath, "", 406, 0, true, false, time.Kitchen, "preupgrade.sh", false, 0),
+			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, false, absPath, dataDirPath, 406, 0, true, false, time.Kitchen, "preupgrade.sh", false, 0),
 			expectedErrCount: 0,
 		},
 		{
@@ -752,19 +753,19 @@ func (s *argsTestSuite) TestGetConfigFromEnv() {
 		{
 			name:             "disable logs color good",
 			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "", "406ms", "", "true", "false", "kitchen", "preupgrade.sh", "", ""},
-			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, false, absPath, "", 406, 0, true, false, time.Kitchen, "preupgrade.sh", false, 0),
+			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, false, absPath, dataDirPath, 406, 0, true, false, time.Kitchen, "preupgrade.sh", false, 0),
 			expectedErrCount: 0,
 		},
 		{
 			name:             "disable logs timestamp",
 			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "", "406ms", "", "true", "false", "", "preupgrade.sh", "", ""},
-			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, false, absPath, "", 406, 0, true, false, "", "preupgrade.sh", false, 0),
+			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, false, absPath, dataDirPath, 406, 0, true, false, "", "preupgrade.sh", false, 0),
 			expectedErrCount: 0,
 		},
 		{
 			name:             "enable rf3339 logs timestamp",
 			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "", "406ms", "", "true", "true", "rfc3339", "preupgrade.sh", "", ""},
-			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, false, absPath, "", 406, 0, true, true, time.RFC3339, "preupgrade.sh", false, 0),
+			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, false, absPath, dataDirPath, 406, 0, true, true, time.RFC3339, "preupgrade.sh", false, 0),
 			expectedErrCount: 0,
 		},
 		{
@@ -776,7 +777,7 @@ func (s *argsTestSuite) TestGetConfigFromEnv() {
 		{
 			name:             "disable recase good",
 			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "", "406ms", "", "true", "true", "rfc3339", "preupgrade.sh", "true", ""},
-			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, false, absPath, "", 406, 0, true, true, time.RFC3339, "preupgrade.sh", true, 0),
+			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, false, absPath, dataDirPath, 406, 0, true, true, time.RFC3339, "preupgrade.sh", true, 0),
 			expectedErrCount: 0,
 		},
 		{
@@ -787,7 +788,7 @@ func (s *argsTestSuite) TestGetConfigFromEnv() {
 		{
 			name:             "shutdown grace good",
 			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "", "406ms", "", "true", "true", "rfc3339", "preupgrade.sh", "true", "15s"},
-			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, false, absPath, "", 406, 0, true, true, time.RFC3339, "preupgrade.sh", true, 15000000000),
+			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, false, absPath, dataDirPath, 406, 0, true, true, time.RFC3339, "preupgrade.sh", true, 15000000000),
 			expectedErrCount: 0,
 		},
 
@@ -796,11 +797,16 @@ func (s *argsTestSuite) TestGetConfigFromEnv() {
 			envVals:          cosmovisorEnv{absPath, "testname", "true", "true", "false", "600ms", "", "", relPath, "303ms", "1", "false", "true", "kitchen", "preupgrade.sh", "", ""},
 			expectedErrCount: 1,
 		},
-
 		{
 			name:             "data dir good (abs path)",
 			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", absPath, "406ms", "", "true", "true", "rfc3339", "preupgrade.sh", "true", ""},
 			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, false, absPath, absPath, 406, 0, true, true, time.RFC3339, "preupgrade.sh", true, 0),
+			expectedErrCount: 0,
+		},
+		{
+			name:             "data dir good (empty path)",
+			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "", "406ms", "", "true", "true", "rfc3339", "preupgrade.sh", "true", ""},
+			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, false, absPath, dataDirPath, 406, 0, true, true, time.RFC3339, "preupgrade.sh", true, 0),
 			expectedErrCount: 0,
 		},
 	}

--- a/tools/cosmovisor/args_test.go
+++ b/tools/cosmovisor/args_test.go
@@ -33,6 +33,7 @@ type cosmovisorEnv struct {
 	RestartDelay             string
 	SkipBackup               string
 	DataBackupPath           string
+	DataPath                 string
 	Interval                 string
 	PreupgradeMaxRetries     string
 	DisableLogs              string
@@ -60,6 +61,7 @@ func (c cosmovisorEnv) ToMap() map[string]envMap {
 		EnvShutdownGrace:            {val: c.ShutdownGrace, allowEmpty: false},
 		EnvSkipBackup:               {val: c.SkipBackup, allowEmpty: false},
 		EnvDataBackupPath:           {val: c.DataBackupPath, allowEmpty: false},
+		EnvDataPath:                 {val: c.DataPath, allowEmpty: true},
 		EnvInterval:                 {val: c.Interval, allowEmpty: false},
 		EnvPreupgradeMaxRetries:     {val: c.PreupgradeMaxRetries, allowEmpty: false},
 		EnvDisableLogs:              {val: c.DisableLogs, allowEmpty: false},
@@ -91,6 +93,8 @@ func (c *cosmovisorEnv) Set(envVar, envVal string) {
 		c.SkipBackup = envVal
 	case EnvDataBackupPath:
 		c.DataBackupPath = envVal
+	case EnvDataPath:
+		c.DataPath = envVal
 	case EnvInterval:
 		c.Interval = envVal
 	case EnvPreupgradeMaxRetries:
@@ -229,6 +233,14 @@ func (s *argsTestSuite) TestValidate() {
 			cfg:   Config{Home: absPath, Name: "bind", UnsafeSkipBackup: true, DataBackupPath: relPath},
 			valid: true,
 		},
+		"happy with empty data path": {
+			cfg:   Config{Home: absPath, Name: "bind", UnsafeSkipBackup: true, DataPath: ""},
+			valid: true,
+		},
+		"happy with absolute data path": {
+			cfg:   Config{Home: absPath, Name: "bind", UnsafeSkipBackup: true, DataPath: absPath},
+			valid: true,
+		},
 		"missing home": {
 			cfg:   Config{Name: "bind"},
 			valid: false,
@@ -261,9 +273,18 @@ func (s *argsTestSuite) TestValidate() {
 			cfg:   Config{Home: absPath, Name: "bind", DataBackupPath: relPath},
 			valid: false,
 		},
+		"no such data path dir": {
+			cfg:   Config{Home: absPath, Name: "bind", UnsafeSkipBackup: true, DataPath: filepath.FromSlash("/no/such/dir")},
+			valid: false,
+		},
+		"relative data path": {
+			cfg:   Config{Home: absPath, Name: "bind", UnsafeSkipBackup: true, DataPath: relPath},
+			valid: false,
+		},
 	}
 
-	for _, tc := range cases {
+	for title, tc := range cases {
+		fmt.Println(title)
 		errs := tc.cfg.validate()
 		if tc.valid {
 			s.Require().Len(errs, 0)
@@ -403,6 +424,7 @@ func (s *argsTestSuite) TestDetailString() {
 	pollInterval := 406 * time.Millisecond
 	unsafeSkipBackup := false
 	dataBackupPath := "/home"
+	dataPath := ""
 	preupgradeMaxRetries := 8
 	cfg := &Config{
 		Home:                     home,
@@ -413,6 +435,7 @@ func (s *argsTestSuite) TestDetailString() {
 		PollInterval:             pollInterval,
 		UnsafeSkipBackup:         unsafeSkipBackup,
 		DataBackupPath:           dataBackupPath,
+		DataPath:                 dataPath,
 		PreUpgradeMaxRetries:     preupgradeMaxRetries,
 	}
 
@@ -426,6 +449,7 @@ func (s *argsTestSuite) TestDetailString() {
 		fmt.Sprintf("%s: %s", EnvInterval, pollInterval),
 		fmt.Sprintf("%s: %t", EnvSkipBackup, unsafeSkipBackup),
 		fmt.Sprintf("%s: %s", EnvDataBackupPath, home),
+		fmt.Sprintf("%s: %s", EnvDataPath, dataPath),
 		fmt.Sprintf("%s: %d", EnvPreupgradeMaxRetries, preupgradeMaxRetries),
 		fmt.Sprintf("%s: %t", EnvDisableLogs, cfg.DisableLogs),
 		fmt.Sprintf("%s: %t", EnvColorLogs, cfg.ColorLogs),
@@ -436,6 +460,7 @@ func (s *argsTestSuite) TestDetailString() {
 		fmt.Sprintf("Genesis Bin: %s", home),
 		fmt.Sprintf("Monitored File: %s", home),
 		fmt.Sprintf("Data Backup Dir: %s", home),
+		fmt.Sprintf("Data Dir: %s/data", home),
 	}
 
 	actual := cfg.DetailString()
@@ -453,6 +478,7 @@ var newConfig = func(
 	restartDelay int,
 	skipBackup bool,
 	dataBackupPath string,
+	dataPath string,
 	interval, preupgradeMaxRetries int,
 	disableLogs, colorLogs bool,
 	timeFormatLogs string,
@@ -470,6 +496,7 @@ var newConfig = func(
 		PollInterval:             time.Millisecond * time.Duration(interval),
 		UnsafeSkipBackup:         skipBackup,
 		DataBackupPath:           dataBackupPath,
+		DataPath:                 dataPath,
 		PreUpgradeMaxRetries:     preupgradeMaxRetries,
 		DisableLogs:              disableLogs,
 		ColorLogs:                colorLogs,
@@ -505,6 +532,7 @@ func (s *argsTestSuite) TestGetConfigFromEnv() {
 				RestartDelay:             "bad",
 				SkipBackup:               "bad",
 				DataBackupPath:           "bad",
+				DataPath:                 "bad",
 				Interval:                 "bad",
 				PreupgradeMaxRetries:     "bad",
 				TimeFormatLogs:           "bad",
@@ -513,17 +541,17 @@ func (s *argsTestSuite) TestGetConfigFromEnv() {
 				ShutdownGrace:            "bad",
 			},
 			expectedCfg:      nil,
-			expectedErrCount: 13,
+			expectedErrCount: 14,
 		},
 		{
 			name:             "all good",
-			envVals:          cosmovisorEnv{absPath, "testname", "true", "true", "false", "600ms", "true", "", "303ms", "1", "false", "true", "kitchen", "preupgrade.sh", "true", "10s"},
-			expectedCfg:      newConfig(absPath, "testname", true, true, false, 600, true, absPath, 303, 1, false, true, time.Kitchen, "preupgrade.sh", true, 10000000000),
+			envVals:          cosmovisorEnv{absPath, "testname", "true", "true", "false", "600ms", "true", "", "", "303ms", "1", "false", "true", "kitchen", "preupgrade.sh", "true", "10s"},
+			expectedCfg:      newConfig(absPath, "testname", true, true, false, 600, true, absPath, "", 303, 1, false, true, time.Kitchen, "preupgrade.sh", true, 10000000000),
 			expectedErrCount: 0,
 		},
 		{
 			name:             "nothing set",
-			envVals:          cosmovisorEnv{"", "", "", "", "", "", "", "", "", "", "false", "false", "", "", "", ""},
+			envVals:          cosmovisorEnv{"", "", "", "", "", "", "", "", "", "", "", "false", "false", "", "", "", ""},
 			expectedCfg:      nil,
 			expectedErrCount: 3,
 		},
@@ -531,235 +559,248 @@ func (s *argsTestSuite) TestGetConfigFromEnv() {
 		// timeformat tests are done in the TestTimeFormat
 		{
 			name:             "download bin bad",
-			envVals:          cosmovisorEnv{absPath, "testname", "bad", "true", "false", "600ms", "true", "", "303ms", "1", "false", "true", "kitchen", "", "", ""},
+			envVals:          cosmovisorEnv{absPath, "testname", "bad", "true", "false", "600ms", "true", "", "", "303ms", "1", "false", "true", "kitchen", "", "", ""},
 			expectedCfg:      nil,
 			expectedErrCount: 1,
 		},
 		{
 			name:             "download bin not set",
-			envVals:          cosmovisorEnv{absPath, "testname", "", "true", "false", "600ms", "true", "", "303ms", "1", "false", "true", "kitchen", "", "", ""},
-			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, true, absPath, 303, 1, false, true, time.Kitchen, "", false, 0),
+			envVals:          cosmovisorEnv{absPath, "testname", "", "true", "false", "600ms", "true", "", "", "303ms", "1", "false", "true", "kitchen", "", "", ""},
+			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, true, absPath, "", 303, 1, false, true, time.Kitchen, "", false, 0),
 			expectedErrCount: 0,
 		},
 		{
 			name:             "download bin true",
-			envVals:          cosmovisorEnv{absPath, "testname", "true", "true", "false", "600ms", "true", "", "303ms", "1", "false", "true", "kitchen", "preupgrade.sh", "", ""},
-			expectedCfg:      newConfig(absPath, "testname", true, true, false, 600, true, absPath, 303, 1, false, true, time.Kitchen, "preupgrade.sh", false, 0),
+			envVals:          cosmovisorEnv{absPath, "testname", "true", "true", "false", "600ms", "true", "", "", "303ms", "1", "false", "true", "kitchen", "preupgrade.sh", "", ""},
+			expectedCfg:      newConfig(absPath, "testname", true, true, false, 600, true, absPath, "", 303, 1, false, true, time.Kitchen, "preupgrade.sh", false, 0),
 			expectedErrCount: 0,
 		},
 		{
 			name:             "download bin false",
-			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "true", "", "303ms", "1", "false", "true", "kitchen", "preupgrade.sh", "", ""},
-			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, true, absPath, 303, 1, false, true, time.Kitchen, "preupgrade.sh", false, 0),
+			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "true", "", "", "303ms", "1", "false", "true", "kitchen", "preupgrade.sh", "", ""},
+			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, true, absPath, "", 303, 1, false, true, time.Kitchen, "preupgrade.sh", false, 0),
 			expectedErrCount: 0,
 		},
 		{
 			name:             "download ensure checksum true",
-			envVals:          cosmovisorEnv{absPath, "testname", "true", "false", "false", "600ms", "true", "", "303ms", "1", "false", "true", "kitchen", "preupgrade.sh", "", ""},
-			expectedCfg:      newConfig(absPath, "testname", true, false, false, 600, true, absPath, 303, 1, false, true, time.Kitchen, "preupgrade.sh", false, 0),
+			envVals:          cosmovisorEnv{absPath, "testname", "true", "false", "false", "600ms", "true", "", "", "303ms", "1", "false", "true", "kitchen", "preupgrade.sh", "", ""},
+			expectedCfg:      newConfig(absPath, "testname", true, false, false, 600, true, absPath, "", 303, 1, false, true, time.Kitchen, "preupgrade.sh", false, 0),
 			expectedErrCount: 0,
 		},
 		{
 			name:             "restart upgrade bad",
-			envVals:          cosmovisorEnv{absPath, "testname", "true", "true", "bad", "600ms", "true", "", "303ms", "1", "false", "true", "kitchen", "preupgrade.sh", "", ""},
+			envVals:          cosmovisorEnv{absPath, "testname", "true", "true", "bad", "600ms", "true", "", "", "303ms", "1", "false", "true", "kitchen", "preupgrade.sh", "", ""},
 			expectedCfg:      nil,
 			expectedErrCount: 1,
 		},
 		{
 			name:             "restart upgrade not set",
-			envVals:          cosmovisorEnv{absPath, "testname", "true", "true", "", "600ms", "true", "", "303ms", "1", "false", "true", "kitchen", "preupgrade.sh", "", ""},
-			expectedCfg:      newConfig(absPath, "testname", true, true, true, 600, true, absPath, 303, 1, false, true, time.Kitchen, "preupgrade.sh", false, 0),
+			envVals:          cosmovisorEnv{absPath, "testname", "true", "true", "", "600ms", "true", "", "", "303ms", "1", "false", "true", "kitchen", "preupgrade.sh", "", ""},
+			expectedCfg:      newConfig(absPath, "testname", true, true, true, 600, true, absPath, "", 303, 1, false, true, time.Kitchen, "preupgrade.sh", false, 0),
 			expectedErrCount: 0,
 		},
 		{
 			name:             "restart upgrade true",
-			envVals:          cosmovisorEnv{absPath, "testname", "true", "true", "true", "600ms", "true", "", "303ms", "1", "false", "true", "kitchen", "preupgrade.sh", "", ""},
-			expectedCfg:      newConfig(absPath, "testname", true, true, true, 600, true, absPath, 303, 1, false, true, time.Kitchen, "preupgrade.sh", false, 0),
+			envVals:          cosmovisorEnv{absPath, "testname", "true", "true", "true", "600ms", "true", "", "", "303ms", "1", "false", "true", "kitchen", "preupgrade.sh", "", ""},
+			expectedCfg:      newConfig(absPath, "testname", true, true, true, 600, true, absPath, "", 303, 1, false, true, time.Kitchen, "preupgrade.sh", false, 0),
 			expectedErrCount: 0,
 		},
 		{
 			name:             "restart upgrade true",
-			envVals:          cosmovisorEnv{absPath, "testname", "true", "true", "false", "600ms", "true", "", "303ms", "1", "false", "true", "kitchen", "preupgrade.sh", "", ""},
-			expectedCfg:      newConfig(absPath, "testname", true, true, false, 600, true, absPath, 303, 1, false, true, time.Kitchen, "preupgrade.sh", false, 0),
+			envVals:          cosmovisorEnv{absPath, "testname", "true", "true", "false", "600ms", "true", "", "", "303ms", "1", "false", "true", "kitchen", "preupgrade.sh", "", ""},
+			expectedCfg:      newConfig(absPath, "testname", true, true, false, 600, true, absPath, "", 303, 1, false, true, time.Kitchen, "preupgrade.sh", false, 0),
 			expectedErrCount: 0,
 		},
 		{
 			name:             "skip unsafe backups bad",
-			envVals:          cosmovisorEnv{absPath, "testname", "true", "true", "false", "600ms", "bad", "", "303ms", "1", "false", "true", "kitchen", "preupgrade.sh", "", ""},
+			envVals:          cosmovisorEnv{absPath, "testname", "true", "true", "false", "600ms", "bad", "", "", "303ms", "1", "false", "true", "kitchen", "preupgrade.sh", "", ""},
 			expectedCfg:      nil,
 			expectedErrCount: 1,
 		},
 		{
 			name:             "skip unsafe backups not set",
-			envVals:          cosmovisorEnv{absPath, "testname", "true", "true", "false", "600ms", "", "", "303ms", "1", "false", "true", "kitchen", "preupgrade.sh", "", ""},
-			expectedCfg:      newConfig(absPath, "testname", true, true, false, 600, false, absPath, 303, 1, false, true, time.Kitchen, "preupgrade.sh", false, 0),
+			envVals:          cosmovisorEnv{absPath, "testname", "true", "true", "false", "600ms", "", "", "", "303ms", "1", "false", "true", "kitchen", "preupgrade.sh", "", ""},
+			expectedCfg:      newConfig(absPath, "testname", true, true, false, 600, false, absPath, "", 303, 1, false, true, time.Kitchen, "preupgrade.sh", false, 0),
 			expectedErrCount: 0,
 		},
 		{
 			name:             "skip unsafe backups true",
-			envVals:          cosmovisorEnv{absPath, "testname", "true", "true", "false", "600ms", "true", "", "303ms", "1", "false", "true", "kitchen", "preupgrade.sh", "", ""},
-			expectedCfg:      newConfig(absPath, "testname", true, true, false, 600, true, absPath, 303, 1, false, true, time.Kitchen, "preupgrade.sh", false, 0),
+			envVals:          cosmovisorEnv{absPath, "testname", "true", "true", "false", "600ms", "true", "", "", "303ms", "1", "false", "true", "kitchen", "preupgrade.sh", "", ""},
+			expectedCfg:      newConfig(absPath, "testname", true, true, false, 600, true, absPath, "", 303, 1, false, true, time.Kitchen, "preupgrade.sh", false, 0),
 			expectedErrCount: 0,
 		},
 		{
 			name:             "skip unsafe backups false",
-			envVals:          cosmovisorEnv{absPath, "testname", "true", "true", "false", "600ms", "false", "", "303ms", "1", "false", "true", "kitchen", "preupgrade.sh", "", ""},
-			expectedCfg:      newConfig(absPath, "testname", true, true, false, 600, false, absPath, 303, 1, false, true, time.Kitchen, "preupgrade.sh", false, 0),
+			envVals:          cosmovisorEnv{absPath, "testname", "true", "true", "false", "600ms", "false", "", "", "303ms", "1", "false", "true", "kitchen", "preupgrade.sh", "", ""},
+			expectedCfg:      newConfig(absPath, "testname", true, true, false, 600, false, absPath, "", 303, 1, false, true, time.Kitchen, "preupgrade.sh", false, 0),
 			expectedErrCount: 0,
 		},
 		{
 			name:             "poll interval bad",
-			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "bad", "1", "false", "true", "kitchen", "preupgrade.sh", "", ""},
+			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "", "bad", "1", "false", "true", "kitchen", "preupgrade.sh", "", ""},
 			expectedCfg:      nil,
 			expectedErrCount: 1,
 		},
 		{
 			name:             "poll interval 0",
-			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "0", "1", "false", "true", "kitchen", "preupgrade.sh", "", ""},
+			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "", "0", "1", "false", "true", "kitchen", "preupgrade.sh", "", ""},
 			expectedCfg:      nil,
 			expectedErrCount: 1,
 		},
 		{
 			name:             "poll interval not set",
-			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "", "1", "false", "false", "kitchen", "preupgrade.sh", "", ""},
-			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, false, absPath, 300, 1, false, false, time.Kitchen, "preupgrade.sh", false, 0),
+			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "", "", "1", "false", "false", "kitchen", "preupgrade.sh", "", ""},
+			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, false, absPath, "", 300, 1, false, false, time.Kitchen, "preupgrade.sh", false, 0),
 			expectedErrCount: 0,
 		},
 		{
 			name:             "poll interval 600",
-			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "600", "1", "false", "true", "kitchen", "preupgrade.sh", "", ""},
+			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "", "600", "1", "false", "true", "kitchen", "preupgrade.sh", "", ""},
 			expectedCfg:      nil,
 			expectedErrCount: 1,
 		},
 		{
 			name:             "poll interval 1s",
-			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "1s", "1", "false", "false", "kitchen", "preupgrade.sh", "", ""},
-			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, false, absPath, 1000, 1, false, false, time.Kitchen, "preupgrade.sh", false, 0),
+			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "", "1s", "1", "false", "false", "kitchen", "preupgrade.sh", "", ""},
+			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, false, absPath, "", 1000, 1, false, false, time.Kitchen, "preupgrade.sh", false, 0),
 			expectedErrCount: 0,
 		},
 		{
 			name:             "poll interval -3m",
-			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "-3m", "1", "false", "true", "kitchen", "preupgrade.sh", "", ""},
+			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "", "-3m", "1", "false", "true", "kitchen", "preupgrade.sh", "", ""},
 			expectedCfg:      nil,
 			expectedErrCount: 1,
 		},
 		{
 			name:             "restart delay bad",
-			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "bad", "false", "", "303ms", "1", "false", "true", "kitchen", "preupgrade.sh", "", ""},
+			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "bad", "false", "", "", "303ms", "1", "false", "true", "kitchen", "preupgrade.sh", "", ""},
 			expectedCfg:      nil,
 			expectedErrCount: 1,
 		},
 		{
 			name:             "restart delay 0",
-			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "0", "false", "", "303ms", "1", "false", "true", "kitchen", "preupgrade.sh", "", ""},
+			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "0", "false", "", "", "303ms", "1", "false", "true", "kitchen", "preupgrade.sh", "", ""},
 			expectedCfg:      nil,
 			expectedErrCount: 1,
 		},
 		{
 			name:             "restart delay not set",
-			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "", "false", "", "303ms", "1", "false", "false", "kitchen", "preupgrade.sh", "", ""},
-			expectedCfg:      newConfig(absPath, "testname", false, true, false, 0, false, absPath, 303, 1, false, false, time.Kitchen, "preupgrade.sh", false, 0),
+			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "", "false", "", "", "303ms", "1", "false", "false", "kitchen", "preupgrade.sh", "", ""},
+			expectedCfg:      newConfig(absPath, "testname", false, true, false, 0, false, absPath, "", 303, 1, false, false, time.Kitchen, "preupgrade.sh", false, 0),
 			expectedErrCount: 0,
 		},
 		{
 			name:             "restart delay 600",
-			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600", "false", "", "300ms", "1", "false", "true", "kitchen", "preupgrade.sh", "", ""},
+			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600", "false", "", "", "300ms", "1", "false", "true", "kitchen", "preupgrade.sh", "", ""},
 			expectedCfg:      nil,
 			expectedErrCount: 1,
 		},
 		{
 			name:             "restart delay 1s",
-			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "1s", "false", "", "303ms", "1", "false", "false", "kitchen", "preupgrade.sh", "", ""},
-			expectedCfg:      newConfig(absPath, "testname", false, true, false, 1000, false, absPath, 303, 1, false, false, time.Kitchen, "preupgrade.sh", false, 0),
+			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "1s", "false", "", "", "303ms", "1", "false", "false", "kitchen", "preupgrade.sh", "", ""},
+			expectedCfg:      newConfig(absPath, "testname", false, true, false, 1000, false, absPath, "", 303, 1, false, false, time.Kitchen, "preupgrade.sh", false, 0),
 			expectedErrCount: 0,
 		},
 		{
 			name:             "restart delay -3m",
-			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "-3m", "false", "", "303ms", "1", "false", "true", "kitchen", "preupgrade.sh", "", ""},
+			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "-3m", "false", "", "", "303ms", "1", "false", "true", "kitchen", "preupgrade.sh", "", ""},
 			expectedCfg:      nil,
 			expectedErrCount: 1,
 		},
 		{
 			name:             "prepupgrade max retries bad",
-			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "406ms", "bad", "false", "true", "kitchen", "preupgrade.sh", "", ""},
+			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "", "406ms", "bad", "false", "true", "kitchen", "preupgrade.sh", "", ""},
 			expectedCfg:      nil,
 			expectedErrCount: 1,
 		},
 		{
 			name:             "prepupgrade max retries 0",
-			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "406ms", "0", "false", "false", "kitchen", "preupgrade.sh", "", ""},
-			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, false, absPath, 406, 0, false, false, time.Kitchen, "preupgrade.sh", false, 0),
+			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "", "406ms", "0", "false", "false", "kitchen", "preupgrade.sh", "", ""},
+			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, false, absPath, "", 406, 0, false, false, time.Kitchen, "preupgrade.sh", false, 0),
 			expectedErrCount: 0,
 		},
 		{
 			name:             "prepupgrade max retries not set",
-			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "406ms", "", "false", "false", "kitchen", "preupgrade.sh", "", ""},
-			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, false, absPath, 406, 0, false, false, time.Kitchen, "preupgrade.sh", false, 0),
+			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "", "406ms", "", "false", "false", "kitchen", "preupgrade.sh", "", ""},
+			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, false, absPath, "", 406, 0, false, false, time.Kitchen, "preupgrade.sh", false, 0),
 			expectedErrCount: 0,
 		},
 		{
 			name:             "prepupgrade max retries 5",
-			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "406ms", "5", "false", "false", "kitchen", "preupgrade.sh", "", ""},
-			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, false, absPath, 406, 5, false, false, time.Kitchen, "preupgrade.sh", false, 0),
+			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "", "406ms", "5", "false", "false", "kitchen", "preupgrade.sh", "", ""},
+			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, false, absPath, "", 406, 5, false, false, time.Kitchen, "preupgrade.sh", false, 0),
 			expectedErrCount: 0,
 		},
 		{
 			name:             "disable logs bad",
-			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "406ms", "5", "bad", "true", "kitchen", "preupgrade.sh", "", ""},
+			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "", "406ms", "5", "bad", "true", "kitchen", "preupgrade.sh", "", ""},
 			expectedCfg:      nil,
 			expectedErrCount: 1,
 		},
 		{
 			name:             "disable logs good",
-			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "406ms", "", "true", "false", "kitchen", "preupgrade.sh", "", ""},
-			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, false, absPath, 406, 0, true, false, time.Kitchen, "preupgrade.sh", false, 0),
+			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "", "406ms", "", "true", "false", "kitchen", "preupgrade.sh", "", ""},
+			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, false, absPath, "", 406, 0, true, false, time.Kitchen, "preupgrade.sh", false, 0),
 			expectedErrCount: 0,
 		},
 		{
 			name:             "disable logs color bad",
-			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "406ms", "5", "true", "bad", "kitchen", "preupgrade.sh", "", ""},
+			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "", "406ms", "5", "true", "bad", "kitchen", "preupgrade.sh", "", ""},
 			expectedCfg:      nil,
 			expectedErrCount: 1,
 		},
 		{
 			name:             "disable logs color good",
-			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "406ms", "", "true", "false", "kitchen", "preupgrade.sh", "", ""},
-			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, false, absPath, 406, 0, true, false, time.Kitchen, "preupgrade.sh", false, 0),
+			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "", "406ms", "", "true", "false", "kitchen", "preupgrade.sh", "", ""},
+			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, false, absPath, "", 406, 0, true, false, time.Kitchen, "preupgrade.sh", false, 0),
 			expectedErrCount: 0,
 		},
 		{
 			name:             "disable logs timestamp",
-			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "406ms", "", "true", "false", "", "preupgrade.sh", "", ""},
-			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, false, absPath, 406, 0, true, false, "", "preupgrade.sh", false, 0),
+			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "", "406ms", "", "true", "false", "", "preupgrade.sh", "", ""},
+			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, false, absPath, "", 406, 0, true, false, "", "preupgrade.sh", false, 0),
 			expectedErrCount: 0,
 		},
 		{
 			name:             "enable rf3339 logs timestamp",
-			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "406ms", "", "true", "true", "rfc3339", "preupgrade.sh", "", ""},
-			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, false, absPath, 406, 0, true, true, time.RFC3339, "preupgrade.sh", false, 0),
+			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "", "406ms", "", "true", "true", "rfc3339", "preupgrade.sh", "", ""},
+			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, false, absPath, "", 406, 0, true, true, time.RFC3339, "preupgrade.sh", false, 0),
 			expectedErrCount: 0,
 		},
 		{
 			name:             "invalid logs timestamp format",
-			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "406ms", "", "true", "true", "invalid", "preupgrade.sh", "", ""},
+			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "", "406ms", "", "true", "true", "invalid", "preupgrade.sh", "", ""},
 			expectedCfg:      nil,
 			expectedErrCount: 1,
 		},
 		{
 			name:             "disable recase good",
-			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "406ms", "", "true", "true", "rfc3339", "preupgrade.sh", "true", ""},
-			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, false, absPath, 406, 0, true, true, time.RFC3339, "preupgrade.sh", true, 0),
+			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "", "406ms", "", "true", "true", "rfc3339", "preupgrade.sh", "true", ""},
+			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, false, absPath, "", 406, 0, true, true, time.RFC3339, "preupgrade.sh", true, 0),
 			expectedErrCount: 0,
 		},
 		{
 			name:             "disable recase bad",
-			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "406ms", "", "true", "true", "rfc3339", "preupgrade.sh", "bad", ""},
+			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "", "406ms", "", "true", "true", "rfc3339", "preupgrade.sh", "bad", ""},
 			expectedErrCount: 1,
 		},
 		{
 			name:             "shutdown grace good",
-			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "406ms", "", "true", "true", "rfc3339", "preupgrade.sh", "true", "15s"},
-			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, false, absPath, 406, 0, true, true, time.RFC3339, "preupgrade.sh", true, 15000000000),
+			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", "", "406ms", "", "true", "true", "rfc3339", "preupgrade.sh", "true", "15s"},
+			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, false, absPath, "", 406, 0, true, true, time.RFC3339, "preupgrade.sh", true, 15000000000),
+			expectedErrCount: 0,
+		},
+
+		{
+			name:             "data dir bad (relative path)",
+			envVals:          cosmovisorEnv{absPath, "testname", "true", "true", "false", "600ms", "", "", relPath, "303ms", "1", "false", "true", "kitchen", "preupgrade.sh", "", ""},
+			expectedErrCount: 1,
+		},
+
+		{
+			name:             "data dir good (abs path)",
+			envVals:          cosmovisorEnv{absPath, "testname", "false", "true", "false", "600ms", "false", "", absPath, "406ms", "", "true", "true", "rfc3339", "preupgrade.sh", "true", ""},
+			expectedCfg:      newConfig(absPath, "testname", false, true, false, 600, false, absPath, absPath, 406, 0, true, true, time.RFC3339, "preupgrade.sh", true, 0),
 			expectedErrCount: 0,
 		},
 	}
@@ -796,7 +837,7 @@ func (s *argsTestSuite) setUpDir() string {
 func (s *argsTestSuite) setupConfig(home string) string {
 	s.T().Helper()
 
-	cfg := newConfig(home, "test", true, true, true, 406, false, home, 8, 0, false, true, "kitchen", "", true, 10000000000)
+	cfg := newConfig(home, "test", true, true, true, 406, false, home, home, 8, 0, false, true, "kitchen", "", true, 10000000000)
 	path := filepath.Join(home, rootName, "config.toml")
 	f, err := os.Create(path)
 	s.Require().NoError(err)
@@ -826,7 +867,7 @@ func (s *argsTestSuite) TestConfigFromFile() {
 		{
 			name: "valid config",
 			expectedCfg: func() *Config {
-				return newConfig(home, "test", true, true, true, 406, false, home, 8, 0, false, true, time.Kitchen, "", true, 10000000000)
+				return newConfig(home, "test", true, true, true, 406, false, home, home, 8, 0, false, true, time.Kitchen, "", true, 10000000000)
 			},
 			filePath:      cfgFilePath,
 			expectedError: "",
@@ -841,18 +882,18 @@ func (s *argsTestSuite) TestConfigFromFile() {
 				os.Setenv(EnvName, "env-name")
 			},
 			expectedCfg: func() *Config {
-				return newConfig(home, "env-name", true, true, true, 406, false, home, 8, 0, false, true, time.Kitchen, "", true, 10000000000)
+				return newConfig(home, "env-name", true, true, true, 406, false, home, home, 8, 0, false, true, time.Kitchen, "", true, 10000000000)
 			},
 		},
 		{
 			name: "empty config file path will load config from ENV variables",
 			expectedCfg: func() *Config {
-				return newConfig(home, "test", true, true, true, 406, false, home, 8, 0, false, true, time.Kitchen, "", true, 10000000000)
+				return newConfig(home, "test", true, true, true, 406, false, home, home, 8, 0, false, true, time.Kitchen, "", true, 10000000000)
 			},
 			filePath:      "",
 			expectedError: "",
 			malleate: func() {
-				s.setEnv(s.T(), &cosmovisorEnv{home, "test", "true", "true", "true", "406ms", "false", home, "8ms", "0", "false", "true", "kitchen", "", "true", "10s"})
+				s.setEnv(s.T(), &cosmovisorEnv{home, "test", "true", "true", "true", "406ms", "false", home, home, "8ms", "0", "false", "true", "kitchen", "", "true", "10s"})
 			},
 		},
 	}

--- a/tools/cosmovisor/cmd/cosmovisor/init.go
+++ b/tools/cosmovisor/cmd/cosmovisor/init.go
@@ -129,6 +129,10 @@ func getConfigForInitCmd() (*cosmovisor.Config, error) {
 		cfg.DataBackupPath = cfg.Home
 	}
 
+	if cfg.DataPath == "" {
+		cfg.DataPath = cfg.DefaultDataDirPath()
+	}
+
 	if len(cfg.Name) == 0 {
 		errs = append(errs, fmt.Errorf("%s is not set", cosmovisor.EnvName))
 	}

--- a/tools/cosmovisor/process.go
+++ b/tools/cosmovisor/process.go
@@ -186,8 +186,8 @@ func (l Launcher) doBackup() error {
 
 		l.logger.Info("starting to take backup of data directory", "backup start time", st)
 
-		// copy the $DAEMON_HOME/data to a backup dir
-		if err = copy.Copy(filepath.Join(l.cfg.Home, "data"), dst); err != nil {
+		// copy the data dir to a backup dir
+		if err = copy.Copy(filepath.Join(l.cfg.DataDirPath()), dst); err != nil {
 			return fmt.Errorf("error while taking data backup: %w", err)
 		}
 

--- a/tools/cosmovisor/process.go
+++ b/tools/cosmovisor/process.go
@@ -187,7 +187,7 @@ func (l Launcher) doBackup() error {
 		l.logger.Info("starting to take backup of data directory", "backup start time", st)
 
 		// copy the data dir to a backup dir
-		if err = copy.Copy(filepath.Join(l.cfg.DataDirPath()), dst); err != nil {
+		if err = copy.Copy(filepath.Join(l.cfg.DataPath), dst); err != nil {
 			return fmt.Errorf("error while taking data backup: %w", err)
 		}
 

--- a/tools/cosmovisor/process.go
+++ b/tools/cosmovisor/process.go
@@ -187,7 +187,7 @@ func (l Launcher) doBackup() error {
 		l.logger.Info("starting to take backup of data directory", "backup start time", st)
 
 		// copy the data dir to a backup dir
-		if err = copy.Copy(filepath.Join(l.cfg.DataPath), dst); err != nil {
+		if err = copy.Copy(l.cfg.DataPath, dst); err != nil {
 			return fmt.Errorf("error while taking data backup: %w", err)
 		}
 

--- a/tools/cosmovisor/testdata/custom-data-path/cosmovisor/genesis/bin/dummyd
+++ b/tools/cosmovisor/testdata/custom-data-path/cosmovisor/genesis/bin/dummyd
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+echo Genesis $@
+sleep 1
+test -z $4 && exit 1001
+echo 'UPGRADE "chain2" NEEDED at height: 49: {}'
+echo '{"name":"chain2","height":49,"info":""}' > $4
+sleep 2
+echo Never should be printed!!!

--- a/tools/cosmovisor/testdata/custom-data-path/cosmovisor/upgrades/chain2/bin/dummyd
+++ b/tools/cosmovisor/testdata/custom-data-path/cosmovisor/upgrades/chain2/bin/dummyd
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+echo chain 2 is live!
+echo Args: $@
+sleep 1
+echo Finished successfully


### PR DESCRIPTION
# Description

Closes:  #20947

Introduces the configuration `DataPath` to allow users to set an arbitrary location for the application data directory. This option can be set through the environment variable `DAEMON_DATA_DIR` or via the configuration TOML file using `daemon_data_dir`.

These changes are designed to be backward compatible, meaning they won't affect existing users unless they explicitly set an absolute path for this configuration.


---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title, you can find examples of the prefixes below:
    <!-- * `feat`: A new feature
    * `fix`: A bug fix
    * `docs`: Documentation only changes
    * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
    * `refactor`: A code change that neither fixes a bug nor adds a feature
    * `perf`: A code change that improves performance
    * `test`: Adding missing tests or correcting existing tests
    * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
    * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
    * `chore`: Other changes that don't modify src or test files
    * `revert`: Reverts a previous commit -->
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

Please see [Pull Request Reviewer section in the contributing guide](../CONTRIBUTING.md#reviewer) for more information on how to review a pull request.

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage