### PR TITLE
feat(Coin): new feature CoinFromString constructs coin from string and test

### DIFF
--- a/types/coin.go
+++ b/types/coin.go
@@ -957,3 +957,35 @@ func NormalizeCoins(coins []DecCoin) Coins {
 
 	return result
 }
+
+// CoinFromString constructs coin from string
+func NewCoinFromString(stringCoin string) (Coin, error) {
+	// Check if the first character is a digit
+	if len(stringCoin) == 0 || !unicode.IsDigit(rune(stringCoin[0])) {
+		return Coin{}, fmt.Errorf("invalid input: %s", stringCoin)
+	}
+
+	var amountPart string
+	var denomPart string
+	// Iterate through the input string
+	for i, char := range stringCoin {
+		if unicode.IsDigit(char) {
+			amountPart += string(char)
+		} else {
+			denomPart = stringCoin[i:]
+			break
+		}
+	}
+
+	// Check amount and denom
+	if amountPart == "" || !MatchDenom(denomPart) {
+		return Coin{}, fmt.Errorf("invalid input: %s", stringCoin)
+	}
+	// convert amount
+	amountInt, ok := math.NewIntFromString(amountPart)
+	if !ok {
+		return Coin{}, fmt.Errorf("invalid input: %s", stringCoin)
+	}
+
+	return NewCoin(denomPart, amountInt), nil
+}

--- a/types/coin_test.go
+++ b/types/coin_test.go
@@ -1488,3 +1488,15 @@ func (s *coinTestSuite) TestParseCoin() {
 		}
 	}
 }
+
+func (s *coinTestSuite) TestNewCoinFromString() {
+	a, err := sdk.NewCoinFromString("1000atom")
+	s.NoError(err)
+	s.Equal(a, sdk.NewInt64Coin("atom", 1000))
+
+	_, err = sdk.NewCoinFromString("1000:usdt")
+	s.Error(err)
+
+	_, err = sdk.NewCoinFromString("u1000atom")
+	s.Error(err)
+}


### PR DESCRIPTION
# Description
I don't see a feature that supports converting from string to coin. It would be convenient to have such a feature added

PR includes:
- Added feature allowing conversion from string to sdk.Coin (NewCoinFromString)
- Added TestNewCoinFromString


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Implemented a function to create a Coin object from a string representation.

- **Tests**
  - Added unit tests to validate the new coin creation function.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->