### PR TITLE
chore(x/auth,x/accounts): use `errors.New` to replace `fmt.Errorf` with no parameters

### DIFF
--- a/x/accounts/defaults/lockup/lockup.go
+++ b/x/accounts/defaults/lockup/lockup.go
@@ -3,7 +3,7 @@ package lockup
 import (
 	"bytes"
 	"context"
-	"fmt"
+	"errors"
 	"time"
 
 	"github.com/cosmos/gogoproto/proto"
@@ -349,7 +349,7 @@ func (bva *BaseLockup) WithdrawUnlockedCoins(
 		}
 	}
 	if len(amount) == 0 {
-		return nil, fmt.Errorf("no tokens available for withdrawing")
+		return nil, errors.New("no tokens available for withdrawing")
 	}
 
 	msgSend := &banktypes.MsgSend{
@@ -379,7 +379,7 @@ func (bva *BaseLockup) checkSender(ctx context.Context, sender string) error {
 		return sdkerrors.ErrInvalidAddress.Wrapf("invalid sender address: %s", err.Error())
 	}
 	if !bytes.Equal(owner, senderBytes) {
-		return fmt.Errorf("sender is not the owner of this vesting account")
+		return errors.New("sender is not the owner of this vesting account")
 	}
 
 	return nil

--- a/x/accounts/defaults/lockup/utils_test.go
+++ b/x/accounts/defaults/lockup/utils_test.go
@@ -2,7 +2,7 @@ package lockup
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"testing"
 
 	gogoproto "github.com/cosmos/gogoproto/proto"
@@ -87,7 +87,7 @@ func newMockContext(t *testing.T) (context.Context, store.KVStoreService) {
 			case "/cosmos.bank.v1beta1.MsgSend":
 				return &banktypes.MsgSendResponse{}, nil
 			default:
-				return nil, fmt.Errorf("unrecognized request type")
+				return nil, errors.New("unrecognized request type")
 			}
 		}, func(ctx context.Context, req, resp ProtoMsg) error {
 			_, ok := req.(*banktypes.QueryBalanceRequest)

--- a/x/accounts/keeper.go
+++ b/x/accounts/keeper.go
@@ -331,10 +331,10 @@ func (k Keeper) makeAccountContext(ctx context.Context, accountNumber uint64, ac
 		nil,
 		nil,
 		func(ctx context.Context, sender []byte, msg, msgResp implementation.ProtoMsg) error {
-			return fmt.Errorf("cannot execute in query context")
+			return errors.New("cannot execute in query context")
 		},
 		func(ctx context.Context, sender []byte, msg implementation.ProtoMsg) (implementation.ProtoMsg, error) {
-			return nil, fmt.Errorf("cannot execute in query context")
+			return nil, errors.New("cannot execute in query context")
 		},
 		k.queryModule,
 	)

--- a/x/auth/ante/sigverify.go
+++ b/x/auth/ante/sigverify.go
@@ -623,7 +623,7 @@ func CountSubKeys(pub cryptotypes.PubKey) int {
 // as well as the aggregated signature.
 func signatureDataToBz(data signing.SignatureData) ([][]byte, error) {
 	if data == nil {
-		return nil, fmt.Errorf("got empty SignatureData")
+		return nil, errors.New("got empty SignatureData")
 	}
 
 	switch data := data.(type) {

--- a/x/auth/client/cli/tx_multisign.go
+++ b/x/auth/client/cli/tx_multisign.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -137,7 +138,7 @@ func makeMultiSignCmd() func(cmd *cobra.Command, args []string) (err error) {
 			}
 
 			if txFactory.ChainID() == "" {
-				return fmt.Errorf("set the chain id with either the --chain-id flag or config file")
+				return errors.New("set the chain id with either the --chain-id flag or config file")
 			}
 
 			for _, sig := range sigs {

--- a/x/auth/client/cli/validate_sigs.go
+++ b/x/auth/client/cli/validate_sigs.go
@@ -2,7 +2,7 @@ package cli
 
 import (
 	"bytes"
-	"fmt"
+	"errors"
 
 	"github.com/spf13/cobra"
 	"google.golang.org/protobuf/types/known/anypb"
@@ -52,7 +52,7 @@ func makeValidateSignaturesCmd() func(cmd *cobra.Command, args []string) error {
 		}
 
 		if !printAndValidateSigs(cmd, clientCtx, txBldr.ChainID(), stdTx, clientCtx.Offline) {
-			return fmt.Errorf("signatures validation failed")
+			return errors.New("signatures validation failed")
 		}
 
 		return nil

--- a/x/auth/client/tx.go
+++ b/x/auth/client/tx.go
@@ -3,6 +3,7 @@ package client
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -142,7 +143,7 @@ func ReadTxsFromFile(ctx client.Context, filename string) (txs []sdk.Tx, err err
 // Unlike ReadTxFromFile, this function does not decode the txs.
 func ReadTxsFromInput(txCfg client.TxConfig, filenames ...string) (scanner *BatchScanner, err error) {
 	if len(filenames) == 0 {
-		return nil, fmt.Errorf("no file name provided")
+		return nil, errors.New("no file name provided")
 	}
 
 	var infile io.Reader = os.Stdin

--- a/x/auth/client/tx.go
+++ b/x/auth/client/tx.go
@@ -16,7 +16,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/tx"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/cosmos/cosmos-sdk/types/errors"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/cosmos-sdk/types/tx/signing"
 )
 
@@ -54,7 +54,7 @@ func SignTx(txFactory tx.Factory, clientCtx client.Context, name string, txBuild
 		return err
 	}
 	if !isTxSigner(addr, signers) {
-		return fmt.Errorf("%w: %s", errors.ErrorInvalidSigner, name)
+		return fmt.Errorf("%w: %s", sdkerrors.ErrorInvalidSigner, name)
 	}
 	if !offline {
 		txFactory, err = populateAccountFromState(txFactory, clientCtx, addr)

--- a/x/auth/migrations/legacytx/stdsign.go
+++ b/x/auth/migrations/legacytx/stdsign.go
@@ -7,7 +7,7 @@ import (
 
 	"sigs.k8s.io/yaml"
 
-	"cosmossdk.io/errors"
+	errorsmod "cosmossdk.io/errors"
 
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/codec/legacy"
@@ -173,7 +173,7 @@ func pubKeySigToSigData(cdc *codec.LegacyAmino, key cryptotypes.PubKey, sig []by
 		if bitArray.GetIndex(i) {
 			data, err := pubKeySigToSigData(cdc, pubKeys[i], multiSig.Sigs[sigIdx])
 			if err != nil {
-				return nil, errors.Wrapf(err, "Unable to convert Signature to SigData %d", sigIdx)
+				return nil, errorsmod.Wrapf(err, "Unable to convert Signature to SigData %d", sigIdx)
 			}
 
 			sigDatas[sigIdx] = data

--- a/x/auth/migrations/legacytx/stdsign.go
+++ b/x/auth/migrations/legacytx/stdsign.go
@@ -2,6 +2,7 @@ package legacytx
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"sigs.k8s.io/yaml"
@@ -62,7 +63,7 @@ func mustSortJSON(bz []byte) []byte {
 // Deprecated: Please use x/tx/signing/aminojson instead.
 func StdSignBytes(chainID string, accnum, sequence, timeout uint64, fee StdFee, msgs []sdk.Msg, memo string) []byte {
 	if RegressionTestingAminoCodec == nil {
-		panic(fmt.Errorf("must set RegressionTestingAminoCodec before calling StdSignBytes"))
+		panic(errors.New("must set RegressionTestingAminoCodec before calling StdSignBytes"))
 	}
 	msgsBytes := make([]json.RawMessage, 0, len(msgs))
 	for _, msg := range msgs {

--- a/x/auth/tx/builder.go
+++ b/x/auth/tx/builder.go
@@ -1,6 +1,7 @@
 package tx
 
 import (
+	"errors"
 	"fmt"
 
 	"google.golang.org/protobuf/proto"
@@ -241,7 +242,7 @@ func (w *builder) SetNonCriticalExtensionOptions(extOpts ...*codectypes.Any) {
 	w.nonCriticalExtensionOptions = extOpts
 }
 
-func (w *builder) AddAuxSignerData(data tx.AuxSignerData) error { return fmt.Errorf("not supported") }
+func (w *builder) AddAuxSignerData(data tx.AuxSignerData) error { return errors.New("not supported") }
 
 func (w *builder) getFee() (fee *txv1beta1.Fee, err error) {
 	granterStr := ""

--- a/x/auth/tx/config.go
+++ b/x/auth/tx/config.go
@@ -149,7 +149,7 @@ func NewSigningHandlerMap(configOpts ConfigOptions) (*txsigning.HandlerMap, erro
 				TypeResolver:        signingOpts.TypeResolver,
 			})
 			if configOpts.TextualCoinMetadataQueryFn == nil {
-				return nil, fmt.Errorf("cannot enable SIGN_MODE_TEXTUAL without a TextualCoinMetadataQueryFn")
+				return nil, errors.New("cannot enable SIGN_MODE_TEXTUAL without a TextualCoinMetadataQueryFn")
 			}
 			if err != nil {
 				return nil, err

--- a/x/auth/tx/config/depinject.go
+++ b/x/auth/tx/config/depinject.go
@@ -2,6 +2,7 @@ package tx
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	gogoproto "github.com/cosmos/gogoproto/proto"
@@ -144,7 +145,7 @@ func ProvideModule(in ModuleInputs) ModuleOutputs {
 
 func newAnteHandler(txConfig client.TxConfig, in ModuleInputs) (sdk.AnteHandler, error) {
 	if in.BankKeeper == nil {
-		return nil, fmt.Errorf("both AccountKeeper and BankKeeper are required")
+		return nil, errors.New("both AccountKeeper and BankKeeper are required")
 	}
 
 	anteHandler, err := ante.NewAnteHandler(

--- a/x/auth/tx/sigs.go
+++ b/x/auth/tx/sigs.go
@@ -1,6 +1,7 @@
 package tx
 
 import (
+	"errors"
 	"fmt"
 
 	txv1beta1 "cosmossdk.io/api/cosmos/tx/v1beta1"
@@ -105,7 +106,7 @@ func decodeMultisignatures(bz []byte) ([][]byte, error) {
 	// malleability in the protobuf message. Basically an attacker could bloat a MultiSignature message with unknown
 	// fields, thus bloating the transaction and causing it to fail.
 	if len(multisig.XXX_unrecognized) > 0 {
-		return nil, fmt.Errorf("rejecting unrecognized fields found in MultiSignature")
+		return nil, errors.New("rejecting unrecognized fields found in MultiSignature")
 	}
 	return multisig.Signatures, nil
 }

--- a/x/auth/types/account.go
+++ b/x/auth/types/account.go
@@ -207,7 +207,7 @@ func (ma ModuleAccount) GetPermissions() []string {
 
 // SetPubKey - Implements AccountI
 func (ma ModuleAccount) SetPubKey(pubKey cryptotypes.PubKey) error {
-	return fmt.Errorf("not supported for module accounts")
+	return errors.New("not supported for module accounts")
 }
 
 // Validate checks for errors on the account fields

--- a/x/auth/types/credentials.go
+++ b/x/auth/types/credentials.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
@@ -12,7 +13,7 @@ import (
 // NewBaseAccountWithPubKey creates an account with an a pubkey.
 func NewBaseAccountWithPubKey(pubkey cryptotypes.PubKey) (*BaseAccount, error) {
 	if pubkey == nil {
-		return nil, fmt.Errorf("pubkey cannot be nil")
+		return nil, errors.New("pubkey cannot be nil")
 	}
 
 	baseAccount := NewBaseAccountWithAddress(sdk.AccAddress(pubkey.Address()))

--- a/x/auth/types/params_test.go
+++ b/x/auth/types/params_test.go
@@ -1,7 +1,7 @@
 package types_test
 
 import (
-	"fmt"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -26,15 +26,15 @@ func TestParams_Validate(t *testing.T) {
 	}{
 		{"default params", types.DefaultParams(), nil},
 		{"invalid tx signature limit", types.NewParams(types.DefaultMaxMemoCharacters, 0, types.DefaultTxSizeCostPerByte,
-			types.DefaultSigVerifyCostED25519, types.DefaultSigVerifyCostSecp256k1), fmt.Errorf("invalid tx signature limit: 0")},
+			types.DefaultSigVerifyCostED25519, types.DefaultSigVerifyCostSecp256k1), errors.New("invalid tx signature limit: 0")},
 		{"invalid ED25519 signature verification cost", types.NewParams(types.DefaultMaxMemoCharacters, types.DefaultTxSigLimit, types.DefaultTxSizeCostPerByte,
-			0, types.DefaultSigVerifyCostSecp256k1), fmt.Errorf("invalid ED25519 signature verification cost: 0")},
+			0, types.DefaultSigVerifyCostSecp256k1), errors.New("invalid ED25519 signature verification cost: 0")},
 		{"invalid SECK256k1 signature verification cost", types.NewParams(types.DefaultMaxMemoCharacters, types.DefaultTxSigLimit, types.DefaultTxSizeCostPerByte,
-			types.DefaultSigVerifyCostED25519, 0), fmt.Errorf("invalid SECK256k1 signature verification cost: 0")},
+			types.DefaultSigVerifyCostED25519, 0), errors.New("invalid SECK256k1 signature verification cost: 0")},
 		{"invalid max memo characters", types.NewParams(0, types.DefaultTxSigLimit, types.DefaultTxSizeCostPerByte,
-			types.DefaultSigVerifyCostED25519, types.DefaultSigVerifyCostSecp256k1), fmt.Errorf("invalid max memo characters: 0")},
+			types.DefaultSigVerifyCostED25519, types.DefaultSigVerifyCostSecp256k1), errors.New("invalid max memo characters: 0")},
 		{"invalid tx size cost per byte", types.NewParams(types.DefaultMaxMemoCharacters, types.DefaultTxSigLimit, 0,
-			types.DefaultSigVerifyCostED25519, types.DefaultSigVerifyCostSecp256k1), fmt.Errorf("invalid tx size cost per byte: 0")},
+			types.DefaultSigVerifyCostED25519, types.DefaultSigVerifyCostSecp256k1), errors.New("invalid tx size cost per byte: 0")},
 	}
 	for _, tt := range tests {
 		tt := tt

--- a/x/auth/types/permissions.go
+++ b/x/auth/types/permissions.go
@@ -1,7 +1,7 @@
 package types
 
 import (
-	"fmt"
+	"errors"
 	"strings"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -52,7 +52,7 @@ func (pa PermissionsForAddress) GetPermissions() []string {
 func validatePermissions(permissions ...string) error {
 	for _, perm := range permissions {
 		if strings.TrimSpace(perm) == "" {
-			return fmt.Errorf("module permission is empty")
+			return errors.New("module permission is empty")
 		}
 	}
 	return nil


### PR DESCRIPTION
Similar to pr 20943.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
	- Streamlined error handling across multiple functions for improved clarity and consistency.
	- Enhanced error message reporting by utilizing a simpler error creation method.

- **Refactor**
	- Standardized error generation in various components, moving from formatted messages to direct error instantiation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->