### PR TITLE
chore(x/staking,x/upgrade): replace `fmt.Errorf` without parameters with `errors.New`

### DIFF
--- a/x/params/types/common_test.go
+++ b/x/params/types/common_test.go
@@ -39,7 +39,7 @@ func validateUnbondingTime(i interface{}) error {
 	}
 
 	if v < (24 * time.Hour) {
-		return fmt.Errorf("unbonding time must be at least one day")
+		return errors.New("unbonding time must be at least one day")
 	}
 
 	return nil

--- a/x/protocolpool/types/genesis.go
+++ b/x/protocolpool/types/genesis.go
@@ -1,9 +1,9 @@
 package types
 
 import (
-	"fmt"
+	"errors"
 
-	"cosmossdk.io/errors"
+	errorsmod "cosmossdk.io/errors"
 	"cosmossdk.io/math"
 
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
@@ -40,41 +40,41 @@ func ValidateGenesis(gs *GenesisState) error {
 
 func validateBudget(bp Budget) error {
 	if bp.RecipientAddress == "" {
-		return fmt.Errorf("recipient cannot be empty")
+		return errors.New("recipient cannot be empty")
 	}
 
 	// Validate BudgetPerTranche
 	if bp.BudgetPerTranche == nil || bp.BudgetPerTranche.IsZero() {
-		return fmt.Errorf("budget per tranche cannot be zero")
+		return errors.New("budget per tranche cannot be zero")
 	}
 	if err := bp.BudgetPerTranche.Validate(); err != nil {
-		return errors.Wrap(sdkerrors.ErrInvalidCoins, bp.BudgetPerTranche.String())
+		return errorsmod.Wrap(sdkerrors.ErrInvalidCoins, bp.BudgetPerTranche.String())
 	}
 
 	if bp.TranchesLeft == 0 {
-		return fmt.Errorf("invalid budget proposal: tranches must be greater than zero")
+		return errors.New("invalid budget proposal: tranches must be greater than zero")
 	}
 
 	if bp.Period == nil || *bp.Period == 0 {
-		return fmt.Errorf("invalid budget proposal: period length should be greater than zero")
+		return errors.New("invalid budget proposal: period length should be greater than zero")
 	}
 	return nil
 }
 
 func validateContinuousFund(cf ContinuousFund) error {
 	if cf.Recipient == "" {
-		return fmt.Errorf("recipient cannot be empty")
+		return errors.New("recipient cannot be empty")
 	}
 
 	// Validate percentage
 	if cf.Percentage.IsNil() || cf.Percentage.IsZero() {
-		return fmt.Errorf("percentage cannot be zero or empty")
+		return errors.New("percentage cannot be zero or empty")
 	}
 	if cf.Percentage.IsNegative() {
-		return fmt.Errorf("percentage cannot be negative")
+		return errors.New("percentage cannot be negative")
 	}
 	if cf.Percentage.GT(math.LegacyOneDec()) {
-		return fmt.Errorf("percentage cannot be greater than one")
+		return errors.New("percentage cannot be greater than one")
 	}
 	return nil
 }

--- a/x/simulation/simulate.go
+++ b/x/simulation/simulate.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"math/rand"
@@ -113,7 +114,7 @@ func SimulateFromSeedX(
 	// At least 2 accounts must be added here, otherwise when executing SimulateMsgSend
 	// two accounts will be selected to meet the conditions from != to and it will fall into an infinite loop.
 	if len(accs) <= 1 {
-		return params, fmt.Errorf("at least two genesis accounts are required")
+		return params, errors.New("at least two genesis accounts are required")
 	}
 
 	config.ChainID = chainID

--- a/x/staking/keeper/delegation.go
+++ b/x/staking/keeper/delegation.go
@@ -719,7 +719,7 @@ func (k Keeper) Delegate(
 	// all non bonded
 	if subtractAccount {
 		if tokenSrc == types.Bonded {
-			return math.LegacyZeroDec(), fmt.Errorf("delegation token source cannot be bonded; expected Unbonded or Unbonding, got Bonded")
+			return math.LegacyZeroDec(), errors.New("delegation token source cannot be bonded; expected Unbonded or Unbonding, got Bonded")
 		}
 
 		var sendName string

--- a/x/staking/keeper/slash.go
+++ b/x/staking/keeper/slash.go
@@ -190,7 +190,7 @@ func (k Keeper) Slash(ctx context.Context, consAddr sdk.ConsAddress, infractionH
 			return math.NewInt(0), err
 		}
 	default:
-		return math.NewInt(0), fmt.Errorf("invalid validator status")
+		return math.NewInt(0), errors.New("invalid validator status")
 	}
 
 	k.Logger.Info(
@@ -415,7 +415,7 @@ func (k Keeper) SlashRedelegation(ctx context.Context, srcValidator types.Valida
 		case dstValidator.IsUnbonded() || dstValidator.IsUnbonding():
 			notBondedBurnedAmount = notBondedBurnedAmount.Add(tokensToBurn)
 		default:
-			return math.ZeroInt(), fmt.Errorf("unknown validator status")
+			return math.ZeroInt(), errors.New("unknown validator status")
 		}
 	}
 

--- a/x/staking/keeper/val_state_change.go
+++ b/x/staking/keeper/val_state_change.go
@@ -3,6 +3,7 @@ package keeper
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 
@@ -172,7 +173,7 @@ func (k Keeper) ApplyAndReturnValidatorSetUpdates(ctx context.Context) ([]appmod
 		}
 
 		if validator.Jailed {
-			return nil, fmt.Errorf("should never retrieve a jailed validator from the power store")
+			return nil, errors.New("should never retrieve a jailed validator from the power store")
 		}
 
 		// if we get to a zero-power validator (which we don't bond),
@@ -198,7 +199,7 @@ func (k Keeper) ApplyAndReturnValidatorSetUpdates(ctx context.Context) ([]appmod
 		case validator.IsBonded():
 			// no state change
 		default:
-			return nil, fmt.Errorf("unexpected validator status")
+			return nil, errors.New("unexpected validator status")
 		}
 
 		// fetch the old power bytes

--- a/x/staking/keeper/validator.go
+++ b/x/staking/keeper/validator.go
@@ -542,7 +542,7 @@ func (k Keeper) unbondMatureValidators(
 		}
 
 		if !val.IsUnbonding() {
-			return fmt.Errorf("unexpected validator in unbonding queue; status was not unbonding")
+			return errors.New("unexpected validator in unbonding queue; status was not unbonding")
 		}
 
 		// if the ref count is not zero, early exit.

--- a/x/staking/types/params.go
+++ b/x/staking/types/params.go
@@ -188,7 +188,7 @@ func ValidatePowerReduction(i interface{}) error {
 	}
 
 	if v.LT(math.NewInt(1)) {
-		return fmt.Errorf("power reduction cannot be lower than 1")
+		return errors.New("power reduction cannot be lower than 1")
 	}
 
 	return nil

--- a/x/upgrade/keeper/keeper.go
+++ b/x/upgrade/keeper/keeper.go
@@ -415,7 +415,7 @@ func (k Keeper) HasHandler(name string) bool {
 func (k Keeper) ApplyUpgrade(ctx context.Context, plan types.Plan) error {
 	handler := k.upgradeHandlers[plan.Name]
 	if handler == nil {
-		return fmt.Errorf("ApplyUpgrade should never be called without first checking HasHandler")
+		return errors.New("ApplyUpgrade should never be called without first checking HasHandler")
 	}
 
 	vm, err := k.GetModuleVersionMap(ctx)

--- a/x/upgrade/keeper/migrations.go
+++ b/x/upgrade/keeper/migrations.go
@@ -3,6 +3,7 @@ package keeper
 import (
 	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 
 	storetypes "cosmossdk.io/core/store"
@@ -63,7 +64,7 @@ func (m Migrator) Migrate2to3(ctx context.Context) error {
 
 func migrateAppVersion(ctx context.Context, keeper *Keeper) error {
 	if keeper.versionModifier == nil {
-		return fmt.Errorf("version modifier is not set")
+		return errors.New("version modifier is not set")
 	}
 
 	store := keeper.KVStoreService.OpenKVStore(ctx)


### PR DESCRIPTION
Similar to #20993 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling across various functions by standardizing error message creation, enhancing clarity and maintainability.
	- Adjusted error messages in functions related to validation and delegation to be simpler and more consistent.
- **Chores**
	- Updated import statements for the `errors` package to support new error handling practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->