### PR TITLE
fix: make help won't work

### DIFF
--- a/scripts/build/localnet.mk
+++ b/scripts/build/localnet.mk
@@ -27,7 +27,7 @@ localnet-debug: localnet-stop localnet-build-dlv localnet-build-nodes
 .PHONY: localnet-start localnet-stop localnet-debug localnet-build-env localnet-build-dlv localnet-build-nodes
 
 #? help: Get more info on make commands.
-help: Makefile
+help:
 	@echo " Choose a command run in "$(PROJECT_NAME)":"
-	@sed -n 's/^#?//p' $< | column -t -s ':' |  sort | sed -e 's/^/ /'
+	@cat $(MAKEFILE_LIST) | sed -n 's/^#?//p' | column -t -s ':' |  sort | sed -e 's/^/ /'
 .PHONY: help


### PR DESCRIPTION
Since Makefile has been split into multiple `.mk` files in #20759, `make help` won't work correctly now.

![image](https://github.com/user-attachments/assets/fbacd556-c59e-4ef9-881b-6bfdd3483ba2)

This PR fixes the `help` target.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the help command to provide a more comprehensive overview of available commands and their descriptions, improving usability for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->