### PR TITLE
refactor: set `help` as default target of Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ include scripts/build/testing.mk
 include scripts/build/documentation.mk
 include scripts/build/build.mk
 
+.DEFAULT_GOAL := help
+
 ###############################################################################
 ###                          Tools & Dependencies                           ###
 ###############################################################################


### PR DESCRIPTION
# Description

It's odd that run `make` will execute the `setup-pre-commit` target. Let's set the `help` target as the default so that it can display all available commands by default.

![image](https://github.com/user-attachments/assets/b4094e21-e8ed-4ba2-bbee-977fa9d4b7cf)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- The Makefile now defaults to providing help information when executed without a specific target, improving user guidance and experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->