### PR TITLE
fix(simapp): duplicated import

### DIFF
--- a/simapp/app.go
+++ b/simapp/app.go
@@ -52,7 +52,6 @@ import (
 	"cosmossdk.io/x/consensus"
 	consensusparamkeeper "cosmossdk.io/x/consensus/keeper"
 	consensusparamtypes "cosmossdk.io/x/consensus/types"
-	consensustypes "cosmossdk.io/x/consensus/types"
 	distr "cosmossdk.io/x/distribution"
 	distrkeeper "cosmossdk.io/x/distribution/keeper"
 	distrtypes "cosmossdk.io/x/distribution/types"
@@ -81,7 +80,6 @@ import (
 	"cosmossdk.io/x/protocolpool"
 	poolkeeper "cosmossdk.io/x/protocolpool/keeper"
 	pooltypes "cosmossdk.io/x/protocolpool/types"
-	protocolpooltypes "cosmossdk.io/x/protocolpool/types"
 	"cosmossdk.io/x/slashing"
 	slashingkeeper "cosmossdk.io/x/slashing/keeper"
 	slashingtypes "cosmossdk.io/x/slashing/types"
@@ -440,26 +438,26 @@ func NewSimApp(
 	// NOTE: Any module instantiated in the module manager that is later modified
 	// must be passed by reference here.
 	app.ModuleManager = module.NewManagerFromMap(map[string]appmodule.AppModule{
-		genutiltypes.ModuleName:      genutil.NewAppModule(appCodec, app.AuthKeeper, app.StakingKeeper, app, txConfig, genutiltypes.DefaultMessageValidator),
-		accounts.ModuleName:          accounts.NewAppModule(appCodec, app.AccountsKeeper),
-		authtypes.ModuleName:         auth.NewAppModule(appCodec, app.AuthKeeper, app.AccountsKeeper, authsims.RandomGenesisAccounts),
-		vestingtypes.ModuleName:      vesting.NewAppModule(app.AuthKeeper, app.BankKeeper),
-		banktypes.ModuleName:         bank.NewAppModule(appCodec, app.BankKeeper, app.AuthKeeper),
-		feegrant.ModuleName:          feegrantmodule.NewAppModule(appCodec, app.AuthKeeper, app.BankKeeper, app.FeeGrantKeeper, app.interfaceRegistry),
-		govtypes.ModuleName:          gov.NewAppModule(appCodec, &app.GovKeeper, app.AuthKeeper, app.BankKeeper, app.PoolKeeper),
-		minttypes.ModuleName:         mint.NewAppModule(appCodec, app.MintKeeper, app.AuthKeeper, nil),
-		slashingtypes.ModuleName:     slashing.NewAppModule(appCodec, app.SlashingKeeper, app.AuthKeeper, app.BankKeeper, app.StakingKeeper, app.interfaceRegistry, cometService),
-		distrtypes.ModuleName:        distr.NewAppModule(appCodec, app.DistrKeeper, app.AuthKeeper, app.BankKeeper, app.StakingKeeper, app.PoolKeeper),
-		stakingtypes.ModuleName:      staking.NewAppModule(appCodec, app.StakingKeeper, app.AuthKeeper, app.BankKeeper),
-		upgradetypes.ModuleName:      upgrade.NewAppModule(app.UpgradeKeeper),
-		evidencetypes.ModuleName:     evidence.NewAppModule(appCodec, app.EvidenceKeeper, cometService),
-		authz.ModuleName:             authzmodule.NewAppModule(appCodec, app.AuthzKeeper, app.AuthKeeper, app.BankKeeper, app.interfaceRegistry),
-		group.ModuleName:             groupmodule.NewAppModule(appCodec, app.GroupKeeper, app.AuthKeeper, app.BankKeeper, app.interfaceRegistry),
-		nft.ModuleName:               nftmodule.NewAppModule(appCodec, app.NFTKeeper, app.AuthKeeper, app.BankKeeper, app.interfaceRegistry),
-		consensustypes.ModuleName:    consensus.NewAppModule(appCodec, app.ConsensusParamsKeeper),
-		circuittypes.ModuleName:      circuit.NewAppModule(appCodec, app.CircuitKeeper),
-		protocolpooltypes.ModuleName: protocolpool.NewAppModule(appCodec, app.PoolKeeper, app.AuthKeeper, app.BankKeeper),
-		epochstypes.ModuleName:       epochs.NewAppModule(appCodec, app.EpochsKeeper),
+		genutiltypes.ModuleName:        genutil.NewAppModule(appCodec, app.AuthKeeper, app.StakingKeeper, app, txConfig, genutiltypes.DefaultMessageValidator),
+		accounts.ModuleName:            accounts.NewAppModule(appCodec, app.AccountsKeeper),
+		authtypes.ModuleName:           auth.NewAppModule(appCodec, app.AuthKeeper, app.AccountsKeeper, authsims.RandomGenesisAccounts),
+		vestingtypes.ModuleName:        vesting.NewAppModule(app.AuthKeeper, app.BankKeeper),
+		banktypes.ModuleName:           bank.NewAppModule(appCodec, app.BankKeeper, app.AuthKeeper),
+		feegrant.ModuleName:            feegrantmodule.NewAppModule(appCodec, app.AuthKeeper, app.BankKeeper, app.FeeGrantKeeper, app.interfaceRegistry),
+		govtypes.ModuleName:            gov.NewAppModule(appCodec, &app.GovKeeper, app.AuthKeeper, app.BankKeeper, app.PoolKeeper),
+		minttypes.ModuleName:           mint.NewAppModule(appCodec, app.MintKeeper, app.AuthKeeper, nil),
+		slashingtypes.ModuleName:       slashing.NewAppModule(appCodec, app.SlashingKeeper, app.AuthKeeper, app.BankKeeper, app.StakingKeeper, app.interfaceRegistry, cometService),
+		distrtypes.ModuleName:          distr.NewAppModule(appCodec, app.DistrKeeper, app.AuthKeeper, app.BankKeeper, app.StakingKeeper, app.PoolKeeper),
+		stakingtypes.ModuleName:        staking.NewAppModule(appCodec, app.StakingKeeper, app.AuthKeeper, app.BankKeeper),
+		upgradetypes.ModuleName:        upgrade.NewAppModule(app.UpgradeKeeper),
+		evidencetypes.ModuleName:       evidence.NewAppModule(appCodec, app.EvidenceKeeper, cometService),
+		authz.ModuleName:               authzmodule.NewAppModule(appCodec, app.AuthzKeeper, app.AuthKeeper, app.BankKeeper, app.interfaceRegistry),
+		group.ModuleName:               groupmodule.NewAppModule(appCodec, app.GroupKeeper, app.AuthKeeper, app.BankKeeper, app.interfaceRegistry),
+		nft.ModuleName:                 nftmodule.NewAppModule(appCodec, app.NFTKeeper, app.AuthKeeper, app.BankKeeper, app.interfaceRegistry),
+		consensusparamtypes.ModuleName: consensus.NewAppModule(appCodec, app.ConsensusParamsKeeper),
+		circuittypes.ModuleName:        circuit.NewAppModule(appCodec, app.CircuitKeeper),
+		pooltypes.ModuleName:           protocolpool.NewAppModule(appCodec, app.PoolKeeper, app.AuthKeeper, app.BankKeeper),
+		epochstypes.ModuleName:         epochs.NewAppModule(appCodec, app.EpochsKeeper),
 	})
 
 	app.ModuleManager.RegisterLegacyAminoCodec(legacyAmino)


### PR DESCRIPTION
# Description

Found this issue from https://github.com/cosmos/cosmos-sdk/actions/runs/10036658062/job/27734825890?pr=21011

```shell
linting module cosmossdk.io/simapp [2024-07-22T07:50:49+00:00]
Error: app.go:83:2: ST1019: package "cosmossdk.io/x/protocolpool/types" is being imported more than once (stylecheck)
	pooltypes "cosmossdk.io/x/protocolpool/types"
	^
Error: app.go:84:2: ST1019(related information): other import of "cosmossdk.io/x/protocolpool/types" (stylecheck)
	protocolpooltypes "cosmossdk.io/x/protocolpool/types"
	^
Error: app.go:54:2: ST1019: package "cosmossdk.io/x/consensus/types" is being imported more than once (stylecheck)
	consensusparamtypes "cosmossdk.io/x/consensus/types"
	^
Error: app.go:55:2: ST1019(related information): other import of "cosmossdk.io/x/consensus/types" (stylecheck)
	consensustypes "cosmossdk.io/x/consensus/types"
	^
linting module cosmossdk.io/log [2024-07-22T07:52:18+00:00]
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Improved clarity and correctness in module management by updating import references.
	- Streamlined the instantiation of modules for better organization and adherence to naming conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->