### PR TITLE
docs(server): wrong function comments

### DIFF
--- a/server/v2/cometbft/abci.go
+++ b/server/v2/cometbft/abci.go
@@ -103,7 +103,7 @@ func (c *Consensus[T]) SetStreamingManager(sm streaming.Manager) {
 	c.streaming = sm
 }
 
-// RegisterExtensions registers the given extensions with the consensus module's snapshot manager.
+// RegisterSnapshotExtensions registers the given extensions with the consensus module's snapshot manager.
 // It allows additional snapshotter implementations to be used for creating and restoring snapshots.
 func (c *Consensus[T]) RegisterSnapshotExtensions(extensions ...snapshots.ExtensionSnapshotter) error {
 	if err := c.snapshotManager.RegisterExtensions(extensions...); err != nil {

--- a/server/v2/config.go
+++ b/server/v2/config.go
@@ -28,7 +28,7 @@ func ReadConfig(configPath string) (*viper.Viper, error) {
 	return v, nil
 }
 
-// UnmarshalSubconfig unmarshals the given subconfig from the viper instance.
+// UnmarshalSubConfig unmarshals the given subconfig from the viper instance.
 // It unmarshals the config, env, flags into the target struct.
 // Use this instead of viper.Sub because viper does not unmarshal flags.
 func UnmarshalSubConfig(v *viper.Viper, subName string, target any) error {


### PR DESCRIPTION
# Description

Related to #19585.

These were introduced by PR #20989 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation Improvements**
	- Updated method name and documentation for `RegisterSnapshotExtensions` to enhance clarity regarding its functionality.
	- Corrected casing in the documentation for the `UnmarshalSubConfig` function for consistency with its signature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->