### PR TITLE
refactor(schema)!: move bech32 address prefixes to a higher level

### DIFF
--- a/schema/field.go
+++ b/schema/field.go
@@ -13,10 +13,6 @@ type Field struct {
 	// Nullable indicates whether null values are accepted for the field. Key fields CANNOT be nullable.
 	Nullable bool
 
-	// AddressPrefix is the address prefix of the field's kind, currently only used for Bech32AddressKind.
-	// TODO: in a future update, stricter criteria and validation for address prefixes should be added.
-	AddressPrefix string
-
 	// EnumDefinition is the definition of the enum type and is only valid when Kind is EnumKind.
 	// The same enum types can be reused in the same module schema, but they always must contain
 	// the same values for the same enum name. This possibly introduces some duplication of
@@ -34,13 +30,6 @@ func (c Field) Validate() error {
 	// valid kind
 	if err := c.Kind.Validate(); err != nil {
 		return fmt.Errorf("invalid field kind for %q: %v", c.Name, err) //nolint:errorlint // false positive due to using go1.12
-	}
-
-	// address prefix only valid with Bech32AddressKind
-	if c.Kind == Bech32AddressKind && c.AddressPrefix == "" {
-		return fmt.Errorf("missing address prefix for field %q", c.Name)
-	} else if c.Kind != Bech32AddressKind && c.AddressPrefix != "" {
-		return fmt.Errorf("address prefix is only valid for field %q with type Bech32AddressKind", c.Name)
 	}
 
 	// enum definition only valid with EnumKind

--- a/schema/field_test.go
+++ b/schema/field_test.go
@@ -36,23 +36,6 @@ func TestField_Validate(t *testing.T) {
 			errContains: "invalid field kind",
 		},
 		{
-			name: "missing address prefix",
-			field: Field{
-				Name: "field1",
-				Kind: Bech32AddressKind,
-			},
-			errContains: "missing address prefix",
-		},
-		{
-			name: "address prefix with non-Bech32AddressKind",
-			field: Field{
-				Name:          "field1",
-				Kind:          StringKind,
-				AddressPrefix: "prefix",
-			},
-			errContains: "address prefix is only valid for field \"field1\" with type Bech32AddressKind",
-		},
-		{
 			name: "invalid enum definition",
 			field: Field{
 				Name: "field1",

--- a/schema/kind.go
+++ b/schema/kind.go
@@ -72,10 +72,10 @@ const (
 	// Float64Kind is a float64 type and values of this type must be of the go type float64.
 	Float64Kind
 
-	// Bech32AddressKind is a bech32 address type and values of this type must be of the go type []byte.
-	// Fields of this type are expected to set the AddressPrefix field in the field definition to the
-	// bech32 address prefix so that indexers can properly convert them to strings.
-	Bech32AddressKind
+	// AddressKind represents an account address and must be of type []byte. Addresses usually have a
+	// human-readable rendering, such as bech32, and tooling should provide a way for apps to define a
+	// string encoder for friendly user-facing display.
+	AddressKind
 
 	// EnumKind is an enum type and values of this type must be of the go type string.
 	// Fields of this type are expected to set the EnumDefinition field in the field definition to the enum
@@ -150,7 +150,7 @@ func (t Kind) String() string {
 		return "float32"
 	case Float64Kind:
 		return "float64"
-	case Bech32AddressKind:
+	case AddressKind:
 		return "bech32address"
 	case EnumKind:
 		return "enum"
@@ -254,7 +254,7 @@ func (t Kind) ValidateValueType(value interface{}) error {
 		if !ok {
 			return fmt.Errorf("expected float64, got %T", value)
 		}
-	case Bech32AddressKind:
+	case AddressKind:
 		_, ok := value.([]byte)
 		if !ok {
 			return fmt.Errorf("expected []byte, got %T", value)
@@ -321,7 +321,7 @@ var (
 )
 
 // KindForGoValue finds the simplest kind that can represent the given go value. It will not, however,
-// return kinds such as IntegerStringKind, DecimalStringKind, Bech32AddressKind, or EnumKind which all can be
+// return kinds such as IntegerStringKind, DecimalStringKind, AddressKind, or EnumKind which all can be
 // represented as strings.
 func KindForGoValue(value interface{}) Kind {
 	switch value.(type) {

--- a/schema/kind_test.go
+++ b/schema/kind_test.go
@@ -59,8 +59,8 @@ func TestKind_ValidateValueType(t *testing.T) {
 		{kind: DecimalStringKind, value: "1", valid: true},
 		{kind: DecimalStringKind, value: "1.1e4", valid: true},
 		{kind: DecimalStringKind, value: int32(1), valid: false},
-		{kind: Bech32AddressKind, value: []byte("hello"), valid: true},
-		{kind: Bech32AddressKind, value: 1, valid: false},
+		{kind: AddressKind, value: []byte("hello"), valid: true},
+		{kind: AddressKind, value: 1, valid: false},
 		{kind: BoolKind, value: true, valid: true},
 		{kind: BoolKind, value: false, valid: true},
 		{kind: BoolKind, value: 1, valid: false},
@@ -213,7 +213,7 @@ func TestKind_String(t *testing.T) {
 		{Float64Kind, "float64"},
 		{JSONKind, "json"},
 		{EnumKind, "enum"},
-		{Bech32AddressKind, "bech32address"},
+		{AddressKind, "bech32address"},
 		{InvalidKind, "invalid(0)"},
 	}
 	for i, tt := range tests {


### PR DESCRIPTION
# Description

This is a small refactor of address handling in `schema` which does not require modules to specify bech32 address prefixes. I see this as preferable because it moves handling of bech32 rendering to a higher level. Ideally, modules should not need to care how addresses are rendered for clients and should not need to know about bech32 prefixes or whether the standardized address encoding is even bech32. With this design, indexers would receive an address codec instance and use that for all modules and objects in an app when indexing.

One thing that remains to be decided with this new approach is how to handle other types of addresses such as validator addresses.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title, you can find examples of the prefixes below:
    <!-- * `feat`: A new feature
    * `fix`: A bug fix
    * `docs`: Documentation only changes
    * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
    * `refactor`: A code change that neither fixes a bug nor adds a feature
    * `perf`: A code change that improves performance
    * `test`: Adding missing tests or correcting existing tests
    * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
    * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
    * `chore`: Other changes that don't modify src or test files
    * `revert`: Reverts a previous commit -->
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

Please see [Pull Request Reviewer section in the contributing guide](../CONTRIBUTING.md#reviewer) for more information on how to review a pull request.

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The representation of account address types has been updated to reflect a broader scope, allowing for better usability.
  
- **Bug Fixes**
	- Removed validation logic related to the `AddressPrefix`, simplifying the validation process for various field types.
  
- **Documentation**
	- Enhanced comments and documentation to clarify the expected handling of address types, improving code clarity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->