### PR TITLE
fix(x/tx): concurrent map writes when calling GetSigners

### DIFF
--- a/simapp/app.go
+++ b/simapp/app.go
@@ -213,6 +213,10 @@ func NewSimApp(
 	signingCtx := interfaceRegistry.SigningContext()
 	txConfig := authtx.NewTxConfig(appCodec, signingCtx.AddressCodec(), signingCtx.ValidatorAddressCodec(), authtx.DefaultSignModes)
 
+	if err := signingCtx.Validate(); err != nil {
+		panic(err)
+	}
+
 	std.RegisterLegacyAminoCodec(legacyAmino)
 	std.RegisterInterfaces(interfaceRegistry)
 

--- a/simapp/app.go
+++ b/simapp/app.go
@@ -603,11 +603,6 @@ func NewSimApp(
 		}
 	}
 
-	// validate SigningContext to pre-fill internal signers funcs map
-	if err = app.interfaceRegistry.SigningContext().Validate(); err != nil {
-		panic(err)
-	}
-
 	return app
 }
 

--- a/simapp/app.go
+++ b/simapp/app.go
@@ -603,6 +603,11 @@ func NewSimApp(
 		}
 	}
 
+	// validate SigningContext to pre-fill internal signers funcs map
+	if err = app.interfaceRegistry.SigningContext().Validate(); err != nil {
+		panic(err)
+	}
+
 	return app
 }
 

--- a/x/tx/CHANGELOG.md
+++ b/x/tx/CHANGELOG.md
@@ -35,7 +35,7 @@ Since v0.13.0, x/tx follows Cosmos SDK semver: https://github.com/cosmos/cosmos-
 
 ### Improvements
 
-* [#21073](https://github.com/cosmos/cosmos-sdk/pull/21073) Add write-only mutex in Context to protect `getSignersFuncs` map from concurrent writes.
+* [#21073](https://github.com/cosmos/cosmos-sdk/pull/21073) In Context use sync.Map `getSignersFuncs` map from concurrent writes, we also call Validate when creating the Context.
 
 ## [v0.13.3](https://github.com/cosmos/cosmos-sdk/releases/tag/x/tx/v0.13.3) - 2024-04-22
 

--- a/x/tx/CHANGELOG.md
+++ b/x/tx/CHANGELOG.md
@@ -33,6 +33,10 @@ Since v0.13.0, x/tx follows Cosmos SDK semver: https://github.com/cosmos/cosmos-
 
 ## [Unreleased]
 
+### Improvements
+
+* [#21073](https://github.com/cosmos/cosmos-sdk/pull/21073) Add write-only mutex in Context to protect `getSignersFuncs` map from concurrent writes.
+
 ## [v0.13.3](https://github.com/cosmos/cosmos-sdk/releases/tag/x/tx/v0.13.3) - 2024-04-22
 
 ### Improvements

--- a/x/tx/signing/context.go
+++ b/x/tx/signing/context.go
@@ -165,7 +165,7 @@ func (c *Context) Validate() error {
 					errs = append(errs, fmt.Errorf("a custom signer function as been defined for message %s which already has a signer field defined with (cosmos.msg.v1.signer)", md.FullName()))
 					continue
 				}
-				_, err := c.getGetSignersFn(md, true)
+				_, err := c.getGetSignersFn(md)
 				if err != nil {
 					errs = append(errs, err)
 				}
@@ -333,17 +333,13 @@ func (c *Context) getAddressCodec(field protoreflect.FieldDescriptor) address.Co
 	return addrCdc
 }
 
-func (c *Context) getGetSignersFn(messageDescriptor protoreflect.MessageDescriptor, add bool) (GetSignersFunc, error) {
+func (c *Context) getGetSignersFn(messageDescriptor protoreflect.MessageDescriptor) (GetSignersFunc, error) {
 	f, ok := c.customGetSignerFuncs[messageDescriptor.FullName()]
 	if ok {
 		return f, nil
 	}
 	f, ok = c.getSignersFuncs[messageDescriptor.FullName()]
 	if !ok {
-		if !add {
-			return nil, fmt.Errorf("no GetSignersFunc found for message %s; have you called Validate()?", messageDescriptor.FullName())
-		}
-
 		var err error
 		f, err = c.makeGetSignersFunc(messageDescriptor)
 		if err != nil {
@@ -357,7 +353,7 @@ func (c *Context) getGetSignersFn(messageDescriptor protoreflect.MessageDescript
 
 // GetSigners returns the signers for a given message.
 func (c *Context) GetSigners(msg proto.Message) ([][]byte, error) {
-	f, err := c.getGetSignersFn(msg.ProtoReflect().Descriptor(), false)
+	f, err := c.getGetSignersFn(msg.ProtoReflect().Descriptor())
 	if err != nil {
 		return nil, err
 	}

--- a/x/tx/signing/context.go
+++ b/x/tx/signing/context.go
@@ -116,10 +116,6 @@ func NewContext(options Options) (*Context, error) {
 		maxRecursionDepth:     options.MaxRecursionDepth,
 	}
 
-	if err := c.Validate(); err != nil {
-		return nil, err
-	}
-
 	return c, nil
 }
 

--- a/x/tx/signing/context.go
+++ b/x/tx/signing/context.go
@@ -3,6 +3,7 @@ package signing
 import (
 	"errors"
 	"fmt"
+	"sync"
 
 	cosmos_proto "github.com/cosmos/cosmos-proto"
 	gogoproto "github.com/cosmos/gogoproto/proto"
@@ -29,7 +30,7 @@ type Context struct {
 	typeResolver          protoregistry.MessageTypeResolver
 	addressCodec          address.Codec
 	validatorAddressCodec address.Codec
-	getSignersFuncs       map[protoreflect.FullName]GetSignersFunc
+	getSignersFuncs       sync.Map
 	customGetSignerFuncs  map[protoreflect.FullName]GetSignersFunc
 	maxRecursionDepth     int
 }
@@ -110,7 +111,7 @@ func NewContext(options Options) (*Context, error) {
 		typeResolver:          protoTypes,
 		addressCodec:          options.AddressCodec,
 		validatorAddressCodec: options.ValidatorAddressCodec,
-		getSignersFuncs:       map[protoreflect.FullName]GetSignersFunc{},
+		getSignersFuncs:       sync.Map{},
 		customGetSignerFuncs:  customGetSignerFuncs,
 		maxRecursionDepth:     options.MaxRecursionDepth,
 	}
@@ -338,14 +339,17 @@ func (c *Context) getGetSignersFn(messageDescriptor protoreflect.MessageDescript
 	if ok {
 		return f, nil
 	}
-	f, ok = c.getSignersFuncs[messageDescriptor.FullName()]
+
+	loadedFn, ok := c.getSignersFuncs.Load(messageDescriptor.FullName())
 	if !ok {
 		var err error
 		f, err = c.makeGetSignersFunc(messageDescriptor)
 		if err != nil {
 			return nil, err
 		}
-		c.getSignersFuncs[messageDescriptor.FullName()] = f
+		c.getSignersFuncs.Store(messageDescriptor.FullName(), f)
+	} else {
+		f = loadedFn.(GetSignersFunc)
 	}
 
 	return f, nil

--- a/x/tx/signing/context.go
+++ b/x/tx/signing/context.go
@@ -165,7 +165,7 @@ func (c *Context) Validate() error {
 					errs = append(errs, fmt.Errorf("a custom signer function as been defined for message %s which already has a signer field defined with (cosmos.msg.v1.signer)", md.FullName()))
 					continue
 				}
-				_, err := c.getGetSignersFn(md)
+				_, err := c.getGetSignersFn(md, true)
 				if err != nil {
 					errs = append(errs, err)
 				}
@@ -333,14 +333,23 @@ func (c *Context) getAddressCodec(field protoreflect.FieldDescriptor) address.Co
 	return addrCdc
 }
 
-func (c *Context) getGetSignersFn(messageDescriptor protoreflect.MessageDescriptor) (GetSignersFunc, error) {
+func (c *Context) getGetSignersFn(messageDescriptor protoreflect.MessageDescriptor, add bool) (GetSignersFunc, error) {
 	f, ok := c.customGetSignerFuncs[messageDescriptor.FullName()]
 	if ok {
 		return f, nil
 	}
 	f, ok = c.getSignersFuncs[messageDescriptor.FullName()]
 	if !ok {
-		return nil, fmt.Errorf("no GetSignersFunc found for message %s; have you called Validate()?", messageDescriptor.FullName())
+		if !add {
+			return nil, fmt.Errorf("no GetSignersFunc found for message %s; have you called Validate()?", messageDescriptor.FullName())
+		}
+
+		var err error
+		f, err = c.makeGetSignersFunc(messageDescriptor)
+		if err != nil {
+			return nil, err
+		}
+		c.getSignersFuncs[messageDescriptor.FullName()] = f
 	}
 
 	return f, nil
@@ -348,7 +357,7 @@ func (c *Context) getGetSignersFn(messageDescriptor protoreflect.MessageDescript
 
 // GetSigners returns the signers for a given message.
 func (c *Context) GetSigners(msg proto.Message) ([][]byte, error) {
-	f, err := c.getGetSignersFn(msg.ProtoReflect().Descriptor())
+	f, err := c.getGetSignersFn(msg.ProtoReflect().Descriptor(), false)
 	if err != nil {
 		return nil, err
 	}

--- a/x/tx/signing/context_test.go
+++ b/x/tx/signing/context_test.go
@@ -58,24 +58,12 @@ func TestGetGetSignersFnConcurrent(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	msg := &bankv1beta1.MsgSend{
-		FromAddress: hex.EncodeToString([]byte("foo")),
-	}
-
-	desc := msg.ProtoReflect().Descriptor()
-
-	// err = ctx.Validate()
-	// require.NoError(t, err)
-
-	for i := 0; i < 100; i++ {
+	desc := (&testpb.RepeatedSigner{}).ProtoReflect().Descriptor()
+	for i := 0; i < 50; i++ {
 		go func() {
 			_, _ = ctx.getGetSignersFn(desc)
 		}()
 	}
-
-	// signers, err := fn(msg)
-	// require.NoError(t, err)
-	// require.Equal(t, [][]byte{[]byte("foo")}, signers)
 }
 
 func TestGetSigners(t *testing.T) {
@@ -277,9 +265,8 @@ func TestDefineCustomGetSigners(t *testing.T) {
 	options.DefineCustomGetSigners(proto.MessageName(simpleSigner), func(msg proto.Message) ([][]byte, error) {
 		return [][]byte{[]byte("qux")}, nil
 	})
-	context, err = NewContext(options)
-	require.NoError(t, err)
-	require.ErrorContains(t, context.Validate(), "a custom signer function as been defined for message SimpleSigner")
+	_, err = NewContext(options)
+	require.ErrorContains(t, err, "a custom signer function as been defined for message SimpleSigner")
 }
 
 type dummyAddressCodec struct{}

--- a/x/tx/signing/context_test.go
+++ b/x/tx/signing/context_test.go
@@ -265,8 +265,9 @@ func TestDefineCustomGetSigners(t *testing.T) {
 	options.DefineCustomGetSigners(proto.MessageName(simpleSigner), func(msg proto.Message) ([][]byte, error) {
 		return [][]byte{[]byte("qux")}, nil
 	})
-	_, err = NewContext(options)
-	require.ErrorContains(t, err, "a custom signer function as been defined for message SimpleSigner")
+	context, err = NewContext(options)
+	require.NoError(t, err)
+	require.ErrorContains(t, context.Validate(), "a custom signer function as been defined for message SimpleSigner")
 }
 
 type dummyAddressCodec struct{}

--- a/x/tx/signing/context_test.go
+++ b/x/tx/signing/context_test.go
@@ -51,6 +51,33 @@ var deeplyNestedRepeatedSigner = &testpb.DeeplyNestedRepeatedSigner{
 	},
 }
 
+func TestGetGetSignersFnConcurrent(t *testing.T) {
+	ctx, err := NewContext(Options{
+		AddressCodec:          dummyAddressCodec{},
+		ValidatorAddressCodec: dummyValidatorAddressCodec{},
+	})
+	require.NoError(t, err)
+
+	msg := &bankv1beta1.MsgSend{
+		FromAddress: hex.EncodeToString([]byte("foo")),
+	}
+
+	desc := msg.ProtoReflect().Descriptor()
+
+	// err = ctx.Validate()
+	// require.NoError(t, err)
+
+	for i := 0; i < 100; i++ {
+		go func() {
+			_, _ = ctx.getGetSignersFn(desc)
+		}()
+	}
+
+	// signers, err := fn(msg)
+	// require.NoError(t, err)
+	// require.Equal(t, [][]byte{[]byte("foo")}, signers)
+}
+
 func TestGetSigners(t *testing.T) {
 	ctx, err := NewContext(Options{
 		AddressCodec:          dummyAddressCodec{},


### PR DESCRIPTION
# Description

Whenever GetSigners is called and the `getSignerFn` hasn't been set for the message type, it will set it on an internal map. If this is called in 2 or more places at the same time it will cause a concurrent map write issue.

To avoid this, developers must call `interfaceRegistry.SigningContext().Validate()` when creating the app (depinject users don't need this as it's being done when providing the interfaceRegistry).

Also, a write only mutex has been added as a defensive measure in case there's any unhandled case (most likely because of a misconfiguration, or usage of multiple instances of SigningContexts). **This shouldn't add any overhead to well configured binaries, and little to misconfigured ones.**

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title, you can find examples of the prefixes below:
    <!-- * `feat`: A new feature
    * `fix`: A bug fix
    * `docs`: Documentation only changes
    * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
    * `refactor`: A code change that neither fixes a bug nor adds a feature
    * `perf`: A code change that improves performance
    * `test`: Adding missing tests or correcting existing tests
    * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
    * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
    * `chore`: Other changes that don't modify src or test files
    * `revert`: Reverts a previous commit -->
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

Please see [Pull Request Reviewer section in the contributing guide](../CONTRIBUTING.md#reviewer) for more information on how to review a pull request.

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a validation step during context initialization to enhance robustness and error handling.
	- Improved the method for retrieving signer functions to utilize thread-safe access for better reliability.
	- Added new tests to ensure concurrency behavior of signer function retrieval.

- **Bug Fixes**
	- Resolved potential data corruption issues by safeguarding access to the signers' function map with concurrency controls.

- **Documentation**
	- Updated the changelog for the `x/tx` module to reflect recent improvements and enhancements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->