### PR TITLE
chore: fix broken link

### DIFF
--- a/docs/build/packages/README.md
+++ b/docs/build/packages/README.md
@@ -20,12 +20,12 @@ For more information on SDK tooling, see the [Tooling](https://docs.cosmos.netwo
 
 ## State Management
 
-* [Collections](./02-collections.md) - State management library
-* [ORM](./03-orm.md) - State management library
+* [Collections](../../../collections/README.md) - State management library
+* [ORM](../../../orm/README.md) - State management library
 
 ## Automation
 
-* [Depinject](./01-depinject.md) - Dependency injection framework
+* [Depinject](../../../depinject/README.md) - Dependency injection framework
 * [Client/v2](https://pkg.go.dev/cosmossdk.io/client/v2) - Library powering [AutoCLI](https://docs.cosmos.network/main/core/autocli)
 
 ## Utilities


### PR DESCRIPTION
Fix broken link for ORM/Collections/Depinject

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated links in the documentation to ensure users can access the "Collections," "ORM," and "Depinject" sections without encountering broken links, enhancing overall navigability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->