### PR TITLE
docs(tools/cosmovisor): Fix CHANGELOG

### DIFF
--- a/tools/cosmovisor/CHANGELOG.md
+++ b/tools/cosmovisor/CHANGELOG.md
@@ -75,7 +75,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### API Breaking Changes
 
-* [#13603](https://github.com/cosmos-sdk/pull/13603) Rename cosmovisor package to `cosmossdk.io/tools/cosmovisor`.
+* [#13603](https://github.com/cosmos/cosmos-sdk/pull/13603) Rename cosmovisor package to `cosmossdk.io/tools/cosmovisor`.
 
 ## v1.3.0 - 2022-09-11
 


### PR DESCRIPTION
Fix path for API Breaking Changes PR link

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the CHANGELOG for the `cosmovisor` package to correct the GitHub link related to a breaking change, ensuring users are directed to the appropriate repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->