### PR TITLE
refactor: use `errors.New` to replace `fmt.Errorf` with no parameters

### DIFF
--- a/schema/appdata/async_test.go
+++ b/schema/appdata/async_test.go
@@ -2,7 +2,7 @@ package appdata
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"sync"
 	"testing"
 )
@@ -78,7 +78,7 @@ func TestAsyncListenerMux(t *testing.T) {
 			calls1 = append(calls1, name)
 		})
 		listener1.Commit = func(data CommitData) (completionCallback func() error, err error) {
-			return nil, fmt.Errorf("error")
+			return nil, errors.New("error")
 		}
 		listener2 := callCollector(2, func(name string, _ int, _ Packet) {
 			calls2 = append(calls2, name)
@@ -141,7 +141,7 @@ func TestAsyncListener(t *testing.T) {
 		})
 
 		listener.OnKVPair = func(updates KVPairData) error {
-			return fmt.Errorf("error")
+			return errors.New("error")
 		}
 
 		res := AsyncListener(AsyncListenerOptions{BufferSize: 16}, listener)

--- a/server/v2/stf/util.go
+++ b/server/v2/stf/util.go
@@ -2,7 +2,7 @@ package stf
 
 import (
 	"context"
-	"fmt"
+	"errors"
 )
 
 // getExecutionCtxFromContext tries to get the execution context from the given go context.
@@ -16,5 +16,5 @@ func getExecutionCtxFromContext(ctx context.Context) (*executionContext, error) 
 		return value, nil
 	}
 
-	return nil, fmt.Errorf("failed to get executionContext from context")
+	return nil, errors.New("failed to get executionContext from context")
 }

--- a/server/v2/store/snapshot.go
+++ b/server/v2/store/snapshot.go
@@ -337,12 +337,12 @@ func (s *StoreComponent[T]) LoadArchiveCmd() *cobra.Command {
 
 			savedSnapshot := <-quitChan
 			if savedSnapshot == nil {
-				return fmt.Errorf("failed to save snapshot")
+				return errors.New("failed to save snapshot")
 			}
 
 			if !reflect.DeepEqual(&snapshot, savedSnapshot) {
 				_ = snapshotStore.Delete(snapshot.Height, snapshot.Format)
-				return fmt.Errorf("invalid archive, the saved snapshot is not equal to the original one")
+				return errors.New("invalid archive, the saved snapshot is not equal to the original one")
 			}
 
 			return nil

--- a/store/v2/root/factory.go
+++ b/store/v2/root/factory.go
@@ -139,9 +139,9 @@ func CreateRootStore(opts *FactoryOptions) (store.RootStore, error) {
 			case SCTypeIavl:
 				return iavl.NewIavlTree(db.NewPrefixDB(opts.SCRawDB, []byte(key)), opts.Logger, storeOpts.IavlConfig), nil
 			case SCTypeIavlV2:
-				return nil, fmt.Errorf("iavl v2 not supported")
+				return nil, errors.New("iavl v2 not supported")
 			default:
-				return nil, fmt.Errorf("unsupported commitment store type")
+				return nil, errors.New("unsupported commitment store type")
 			}
 		}
 	}

--- a/store/v2/root/store.go
+++ b/store/v2/root/store.go
@@ -245,7 +245,7 @@ func (s *Store) LoadVersion(version uint64) error {
 // NOTE: It cannot be called while the store is migrating.
 func (s *Store) LoadVersionAndUpgrade(version uint64, upgrades *corestore.StoreUpgrades) error {
 	if upgrades == nil {
-		return fmt.Errorf("upgrades cannot be nil")
+		return errors.New("upgrades cannot be nil")
 	}
 
 	if s.telemetry != nil {
@@ -253,7 +253,7 @@ func (s *Store) LoadVersionAndUpgrade(version uint64, upgrades *corestore.StoreU
 	}
 
 	if s.isMigrating {
-		return fmt.Errorf("cannot upgrade while migrating")
+		return errors.New("cannot upgrade while migrating")
 	}
 
 	if err := s.loadVersion(version, upgrades); err != nil {
@@ -283,7 +283,7 @@ func (s *Store) loadVersion(v uint64, upgrades *corestore.StoreUpgrades) error {
 		// if upgrades are provided, we need to load the version and apply the upgrades
 		upgradeableStore, ok := s.stateCommitment.(store.UpgradeableStore)
 		if !ok {
-			return fmt.Errorf("SC store does not support upgrades")
+			return errors.New("SC store does not support upgrades")
 		}
 		if err := upgradeableStore.LoadVersionAndUpgrade(v, upgrades); err != nil {
 			return fmt.Errorf("failed to load SS version with upgrades %d: %w", v, err)

--- a/x/distribution/keeper/validator.go
+++ b/x/distribution/keeper/validator.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/pkg/errors"
+	pkgerr "github.com/pkg/errors"
 
 	"cosmossdk.io/collections"
 	"cosmossdk.io/math"
@@ -56,7 +56,7 @@ func (k Keeper) IncrementValidatorPeriod(ctx context.Context, val sdk.ValidatorI
 
 	// fetch current rewards
 	rewards, err := k.ValidatorCurrentRewards.Get(ctx, valBz)
-	if err != nil && !errors.Is(err, collections.ErrNotFound) {
+	if err != nil && !pkgerr.Is(err, collections.ErrNotFound) {
 		return 0, err
 	}
 
@@ -72,7 +72,7 @@ func (k Keeper) IncrementValidatorPeriod(ctx context.Context, val sdk.ValidatorI
 		}
 
 		outstanding, err := k.ValidatorOutstandingRewards.Get(ctx, valBz)
-		if err != nil && !errors.Is(err, collections.ErrNotFound) {
+		if err != nil && !pkgerr.Is(err, collections.ErrNotFound) {
 			return 0, err
 		}
 

--- a/x/distribution/keeper/validator.go
+++ b/x/distribution/keeper/validator.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/pkg/errors"
@@ -144,7 +145,7 @@ func (k Keeper) decrementReferenceCount(ctx context.Context, valAddr sdk.ValAddr
 	}
 
 	if historical.ReferenceCount == 0 {
-		return fmt.Errorf("cannot set negative reference count")
+		return errors.New("cannot set negative reference count")
 	}
 	historical.ReferenceCount--
 	if historical.ReferenceCount == 0 {

--- a/x/genutil/genesis.go
+++ b/x/genutil/genesis.go
@@ -2,7 +2,7 @@ package genutil
 
 import (
 	"context"
-	"fmt"
+	"errors"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/types/module"
@@ -22,7 +22,7 @@ func InitGenesis(
 	txEncodingConfig client.TxEncodingConfig,
 ) (validatorUpdates []module.ValidatorUpdate, err error) {
 	if deliverTx == nil {
-		return nil, fmt.Errorf("deliverTx (genesis.TxHandler) not defined, verify x/genutil wiring")
+		return nil, errors.New("deliverTx (genesis.TxHandler) not defined, verify x/genutil wiring")
 	}
 
 	if len(genesisState.GenTxs) > 0 {


### PR DESCRIPTION
# Description

Similar to #20943

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
	- Improved error handling across multiple functions for clearer and more consistent error messages.

- **Chores**
	- Streamlined error creation by replacing `fmt.Errorf` with `errors.New` throughout the codebase for enhanced readability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->