### PR TITLE
refactor(schema)!: use type references rather than embedding enum types

### DIFF
--- a/indexer/postgres/column.go
+++ b/indexer/postgres/column.go
@@ -25,7 +25,7 @@ func (tm *objectIndexer) createColumnDefinition(writer io.Writer, field schema.F
 	} else {
 		switch field.Kind {
 		case schema.EnumKind:
-			_, err = fmt.Fprintf(writer, "%q", enumTypeName(tm.moduleName, field.EnumType))
+			_, err = fmt.Fprintf(writer, "%q", enumTypeName(tm.moduleName, field.ReferencedType))
 			if err != nil {
 				return err
 			}

--- a/indexer/postgres/enum.go
+++ b/indexer/postgres/enum.go
@@ -63,6 +63,6 @@ func createEnumTypeSql(writer io.Writer, moduleName string, enum schema.EnumType
 }
 
 // enumTypeName returns the name of the enum type scoped to the module.
-func enumTypeName(moduleName string, enumName string) string {
+func enumTypeName(moduleName, enumName string) string {
 	return fmt.Sprintf("%s_%s", moduleName, enumName)
 }

--- a/indexer/postgres/enum.go
+++ b/indexer/postgres/enum.go
@@ -12,7 +12,7 @@ import (
 
 // createEnumType creates an enum type in the database.
 func (m *moduleIndexer) createEnumType(ctx context.Context, conn dbConn, enum schema.EnumType) error {
-	typeName := enumTypeName(m.moduleName, enum)
+	typeName := enumTypeName(m.moduleName, enum.Name)
 	row := conn.QueryRowContext(ctx, "SELECT 1 FROM pg_type WHERE typname = $1", typeName)
 	var res interface{}
 	if err := row.Scan(&res); err != nil {
@@ -40,7 +40,7 @@ func (m *moduleIndexer) createEnumType(ctx context.Context, conn dbConn, enum sc
 
 // createEnumTypeSql generates a CREATE TYPE statement for the enum definition.
 func createEnumTypeSql(writer io.Writer, moduleName string, enum schema.EnumType) error {
-	_, err := fmt.Fprintf(writer, "CREATE TYPE %q AS ENUM (", enumTypeName(moduleName, enum))
+	_, err := fmt.Fprintf(writer, "CREATE TYPE %q AS ENUM (", enumTypeName(moduleName, enum.Name))
 	if err != nil {
 		return err
 	}
@@ -52,7 +52,7 @@ func createEnumTypeSql(writer io.Writer, moduleName string, enum schema.EnumType
 				return err
 			}
 		}
-		_, err = fmt.Fprintf(writer, "'%s'", value)
+		_, err = fmt.Fprintf(writer, "'%s'", value.Name)
 		if err != nil {
 			return err
 		}
@@ -63,6 +63,6 @@ func createEnumTypeSql(writer io.Writer, moduleName string, enum schema.EnumType
 }
 
 // enumTypeName returns the name of the enum type scoped to the module.
-func enumTypeName(moduleName string, enum schema.EnumType) string {
-	return fmt.Sprintf("%s_%s", moduleName, enum.Name)
+func enumTypeName(moduleName string, enumName string) string {
+	return fmt.Sprintf("%s_%s", moduleName, enumName)
 }

--- a/indexer/postgres/internal/testdata/example_schema.go
+++ b/indexer/postgres/internal/testdata/example_schema.go
@@ -29,26 +29,20 @@ func init() {
 
 		switch i {
 		case schema.EnumKind:
-			field.EnumType = MyEnum
+			field.ReferencedType = MyEnum.Name
 		default:
 		}
 
 		AllKindsObject.ValueFields = append(AllKindsObject.ValueFields, field)
 	}
 
-	ExampleSchema = mustModuleSchema([]schema.ObjectType{
+	ExampleSchema = schema.MustNewModuleSchema(
 		AllKindsObject,
 		SingletonObject,
 		VoteObject,
-	})
-}
-
-func mustModuleSchema(objectTypes []schema.ObjectType) schema.ModuleSchema {
-	s, err := schema.NewModuleSchema(objectTypes)
-	if err != nil {
-		panic(err)
-	}
-	return s
+		MyEnum,
+		VoteType,
+	)
 }
 
 var SingletonObject = schema.ObjectType{
@@ -64,9 +58,9 @@ var SingletonObject = schema.ObjectType{
 			Nullable: true,
 		},
 		{
-			Name:     "an_enum",
-			Kind:     schema.EnumKind,
-			EnumType: MyEnum,
+			Name:           "an_enum",
+			Kind:           schema.EnumKind,
+			ReferencedType: MyEnum.Name,
 		},
 	},
 }
@@ -85,18 +79,28 @@ var VoteObject = schema.ObjectType{
 	},
 	ValueFields: []schema.Field{
 		{
-			Name: "vote",
-			Kind: schema.EnumKind,
-			EnumType: schema.EnumType{
-				Name:   "vote_type",
-				Values: []string{"yes", "no", "abstain"},
-			},
+			Name:           "vote",
+			Kind:           schema.EnumKind,
+			ReferencedType: VoteType.Name,
 		},
 	},
 	RetainDeletions: true,
 }
 
+var VoteType = schema.EnumType{
+	Name: "vote_type",
+	Values: []schema.EnumValueDefinition{
+		{Name: "yes", Value: 1},
+		{Name: "no", Value: 2},
+		{Name: "abstain", Value: 3},
+	},
+}
+
 var MyEnum = schema.EnumType{
-	Name:   "my_enum",
-	Values: []string{"a", "b", "c"},
+	Name: "my_enum",
+	Values: []schema.EnumValueDefinition{
+		{Name: "a", Value: 1},
+		{Name: "b", Value: 2},
+		{Name: "c", Value: 3},
+	},
 }

--- a/schema/decoding/decoding_test.go
+++ b/schema/decoding/decoding_test.go
@@ -371,24 +371,22 @@ func (e exampleBankModule) subBalance(acct, denom string, amount uint64) error {
 
 func init() {
 	var err error
-	exampleBankSchema, err = schema.NewModuleSchema([]schema.ObjectType{
-		{
-			Name: "balances",
-			KeyFields: []schema.Field{
-				{
-					Name: "account",
-					Kind: schema.StringKind,
-				},
-				{
-					Name: "denom",
-					Kind: schema.StringKind,
-				},
+	exampleBankSchema, err = schema.NewModuleSchema(schema.ObjectType{
+		Name: "balances",
+		KeyFields: []schema.Field{
+			{
+				Name: "account",
+				Kind: schema.StringKind,
 			},
-			ValueFields: []schema.Field{
-				{
-					Name: "amount",
-					Kind: schema.Uint64Kind,
-				},
+			{
+				Name: "denom",
+				Kind: schema.StringKind,
+			},
+		},
+		ValueFields: []schema.Field{
+			{
+				Name: "amount",
+				Kind: schema.Uint64Kind,
 			},
 		},
 	})
@@ -437,16 +435,12 @@ type oneValueModule struct {
 
 func init() {
 	var err error
-	oneValueModSchema, err = schema.NewModuleSchema(
-		[]schema.ObjectType{
-			{
-				Name: "item",
-				ValueFields: []schema.Field{
-					{Name: "value", Kind: schema.StringKind},
-				},
-			},
+	oneValueModSchema, err = schema.NewModuleSchema(schema.ObjectType{
+		Name: "item",
+		ValueFields: []schema.Field{
+			{Name: "value", Kind: schema.StringKind},
 		},
-	)
+	})
 	if err != nil {
 		panic(err)
 	}

--- a/schema/decoding/resolver_test.go
+++ b/schema/decoding/resolver_test.go
@@ -10,7 +10,7 @@ import (
 type modA struct{}
 
 func (m modA) ModuleCodec() (schema.ModuleCodec, error) {
-	modSchema, err := schema.NewModuleSchema([]schema.ObjectType{{Name: "A", KeyFields: []schema.Field{{Name: "field1", Kind: schema.StringKind}}}})
+	modSchema, err := schema.NewModuleSchema(schema.ObjectType{Name: "A", KeyFields: []schema.Field{{Name: "field1", Kind: schema.StringKind}}})
 	if err != nil {
 		return schema.ModuleCodec{}, err
 	}
@@ -22,7 +22,7 @@ func (m modA) ModuleCodec() (schema.ModuleCodec, error) {
 type modB struct{}
 
 func (m modB) ModuleCodec() (schema.ModuleCodec, error) {
-	modSchema, err := schema.NewModuleSchema([]schema.ObjectType{{Name: "B", KeyFields: []schema.Field{{Name: "field2", Kind: schema.StringKind}}}})
+	modSchema, err := schema.NewModuleSchema(schema.ObjectType{Name: "B", KeyFields: []schema.Field{{Name: "field2", Kind: schema.StringKind}}})
 	if err != nil {
 		return schema.ModuleCodec{}, err
 	}

--- a/schema/diff/diff_test.go
+++ b/schema/diff/diff_test.go
@@ -18,11 +18,11 @@ func TestCompareModuleSchemas(t *testing.T) {
 	}{
 		{
 			name: "no change",
-			oldSchema: mustModuleSchema(t, schema.ObjectType{
+			oldSchema: requireModuleSchema(t, schema.ObjectType{
 				Name:      "object1",
 				KeyFields: []schema.Field{{Name: "key1", Kind: schema.StringKind}},
 			}),
-			newSchema: mustModuleSchema(t, schema.ObjectType{
+			newSchema: requireModuleSchema(t, schema.ObjectType{
 				Name:      "object1",
 				KeyFields: []schema.Field{{Name: "key1", Kind: schema.StringKind}},
 			}),
@@ -32,8 +32,8 @@ func TestCompareModuleSchemas(t *testing.T) {
 		},
 		{
 			name:      "object type added",
-			oldSchema: mustModuleSchema(t),
-			newSchema: mustModuleSchema(t, schema.ObjectType{
+			oldSchema: requireModuleSchema(t),
+			newSchema: requireModuleSchema(t, schema.ObjectType{
 				Name:      "object1",
 				KeyFields: []schema.Field{{Name: "key1", Kind: schema.StringKind}},
 			}),
@@ -49,11 +49,11 @@ func TestCompareModuleSchemas(t *testing.T) {
 		},
 		{
 			name: "object type removed",
-			oldSchema: mustModuleSchema(t, schema.ObjectType{
+			oldSchema: requireModuleSchema(t, schema.ObjectType{
 				Name:      "object1",
 				KeyFields: []schema.Field{{Name: "key1", Kind: schema.StringKind}},
 			}),
-			newSchema: mustModuleSchema(t),
+			newSchema: requireModuleSchema(t),
 			diff: ModuleSchemaDiff{
 				RemovedObjectTypes: []schema.ObjectType{
 					{
@@ -66,11 +66,11 @@ func TestCompareModuleSchemas(t *testing.T) {
 		},
 		{
 			name: "object type changed, key field added",
-			oldSchema: mustModuleSchema(t, schema.ObjectType{
+			oldSchema: requireModuleSchema(t, schema.ObjectType{
 				Name:      "object1",
 				KeyFields: []schema.Field{{Name: "key1", Kind: schema.StringKind}},
 			}),
-			newSchema: mustModuleSchema(t, schema.ObjectType{
+			newSchema: requireModuleSchema(t, schema.ObjectType{
 				Name:      "object1",
 				KeyFields: []schema.Field{{Name: "key1", Kind: schema.StringKind}, {Name: "key2", Kind: schema.StringKind}},
 			}),
@@ -90,11 +90,11 @@ func TestCompareModuleSchemas(t *testing.T) {
 		},
 		{
 			name: "object type changed, nullable value field added",
-			oldSchema: mustModuleSchema(t, schema.ObjectType{
+			oldSchema: requireModuleSchema(t, schema.ObjectType{
 				Name:      "object1",
 				KeyFields: []schema.Field{{Name: "key1", Kind: schema.StringKind}},
 			}),
-			newSchema: mustModuleSchema(t, schema.ObjectType{
+			newSchema: requireModuleSchema(t, schema.ObjectType{
 				Name:        "object1",
 				KeyFields:   []schema.Field{{Name: "key1", Kind: schema.StringKind}},
 				ValueFields: []schema.Field{{Name: "value1", Kind: schema.StringKind, Nullable: true}},
@@ -113,11 +113,11 @@ func TestCompareModuleSchemas(t *testing.T) {
 		},
 		{
 			name: "object type changed, non-nullable value field added",
-			oldSchema: mustModuleSchema(t, schema.ObjectType{
+			oldSchema: requireModuleSchema(t, schema.ObjectType{
 				Name:      "object1",
 				KeyFields: []schema.Field{{Name: "key1", Kind: schema.StringKind}},
 			}),
-			newSchema: mustModuleSchema(t, schema.ObjectType{
+			newSchema: requireModuleSchema(t, schema.ObjectType{
 				Name:        "object1",
 				KeyFields:   []schema.Field{{Name: "key1", Kind: schema.StringKind}},
 				ValueFields: []schema.Field{{Name: "value1", Kind: schema.StringKind}},
@@ -136,11 +136,11 @@ func TestCompareModuleSchemas(t *testing.T) {
 		},
 		{
 			name: "object type changed, fields reordered",
-			oldSchema: mustModuleSchema(t, schema.ObjectType{
+			oldSchema: requireModuleSchema(t, schema.ObjectType{
 				Name:      "object1",
 				KeyFields: []schema.Field{{Name: "key1", Kind: schema.StringKind}, {Name: "key2", Kind: schema.StringKind}},
 			}),
-			newSchema: mustModuleSchema(t, schema.ObjectType{
+			newSchema: requireModuleSchema(t, schema.ObjectType{
 				Name:      "object1",
 				KeyFields: []schema.Field{{Name: "key2", Kind: schema.StringKind}, {Name: "key1", Kind: schema.StringKind}},
 			}),
@@ -159,22 +159,23 @@ func TestCompareModuleSchemas(t *testing.T) {
 		},
 		{
 			name: "enum type added, nullable value field added",
-			oldSchema: mustModuleSchema(t, schema.ObjectType{
+			oldSchema: requireModuleSchema(t, schema.ObjectType{
 				Name:      "object1",
 				KeyFields: []schema.Field{{Name: "key1", Kind: schema.Int32Kind}},
 			}),
-			newSchema: mustModuleSchema(t, schema.ObjectType{
+			newSchema: requireModuleSchema(t, schema.ObjectType{
 				Name:      "object1",
 				KeyFields: []schema.Field{{Name: "key1", Kind: schema.Int32Kind}},
 				ValueFields: []schema.Field{
 					{
-						Name:     "value1",
-						Kind:     schema.EnumKind,
-						EnumType: schema.EnumType{Name: "enum1", Values: []string{"a", "b"}},
-						Nullable: true,
+						Name:           "value1",
+						Kind:           schema.EnumKind,
+						ReferencedType: "enum1",
+						Nullable:       true,
 					},
 				},
-			}),
+			},
+				schema.EnumType{Name: "enum1", Values: []schema.EnumValueDefinition{{Name: "a", Value: 1}, {Name: "b", Value: 2}}}),
 			diff: ModuleSchemaDiff{
 				ChangedObjectTypes: []ObjectTypeDiff{
 					{
@@ -182,35 +183,37 @@ func TestCompareModuleSchemas(t *testing.T) {
 						ValueFieldsDiff: FieldsDiff{
 							Added: []schema.Field{
 								{
-									Name:     "value1",
-									Kind:     schema.EnumKind,
-									EnumType: schema.EnumType{Name: "enum1", Values: []string{"a", "b"}},
-									Nullable: true,
+									Name:           "value1",
+									Kind:           schema.EnumKind,
+									ReferencedType: "enum1",
+									Nullable:       true,
 								},
 							},
 						},
 					},
 				},
 				AddedEnumTypes: []schema.EnumType{
-					{Name: "enum1", Values: []string{"a", "b"}},
+					{Name: "enum1", Values: []schema.EnumValueDefinition{{Name: "a", Value: 1}, {Name: "b", Value: 2}}},
 				},
 			},
 			hasCompatibleChanges: true,
 		},
 		{
 			name: "enum type removed",
-			oldSchema: mustModuleSchema(t, schema.ObjectType{
-				Name:      "object1",
-				KeyFields: []schema.Field{{Name: "key1", Kind: schema.Int32Kind}},
-				ValueFields: []schema.Field{
-					{
-						Name:     "value1",
-						Kind:     schema.EnumKind,
-						EnumType: schema.EnumType{Name: "enum1", Values: []string{"a", "b"}},
+			oldSchema: requireModuleSchema(t,
+				schema.ObjectType{
+					Name:      "object1",
+					KeyFields: []schema.Field{{Name: "key1", Kind: schema.Int32Kind}},
+					ValueFields: []schema.Field{
+						{
+							Name:           "value1",
+							Kind:           schema.EnumKind,
+							ReferencedType: "enum1",
+						},
 					},
 				},
-			}),
-			newSchema: mustModuleSchema(t, schema.ObjectType{
+				schema.EnumType{Name: "enum1", Values: []schema.EnumValueDefinition{{Name: "a", Value: 1}, {Name: "b", Value: 2}}}),
+			newSchema: requireModuleSchema(t, schema.ObjectType{
 				Name:      "object1",
 				KeyFields: []schema.Field{{Name: "key1", Kind: schema.Int32Kind}},
 			}),
@@ -221,35 +224,33 @@ func TestCompareModuleSchemas(t *testing.T) {
 						ValueFieldsDiff: FieldsDiff{
 							Removed: []schema.Field{
 								{
-									Name:     "value1",
-									Kind:     schema.EnumKind,
-									EnumType: schema.EnumType{Name: "enum1", Values: []string{"a", "b"}},
+									Name:           "value1",
+									Kind:           schema.EnumKind,
+									ReferencedType: "enum1",
 								},
 							},
 						},
 					},
 				},
 				RemovedEnumTypes: []schema.EnumType{
-					{Name: "enum1", Values: []string{"a", "b"}},
+					{Name: "enum1", Values: []schema.EnumValueDefinition{{Name: "a", Value: 1}, {Name: "b", Value: 2}}},
 				},
 			},
 			hasCompatibleChanges: false,
 		},
 		{
 			name: "enum value added",
-			oldSchema: mustModuleSchema(t, schema.ObjectType{
-				Name:      "object1",
-				KeyFields: []schema.Field{{Name: "key1", Kind: schema.EnumKind, EnumType: schema.EnumType{Name: "enum1", Values: []string{"a"}}}},
-			}),
-			newSchema: mustModuleSchema(t, schema.ObjectType{
-				Name:      "object1",
-				KeyFields: []schema.Field{{Name: "key1", Kind: schema.EnumKind, EnumType: schema.EnumType{Name: "enum1", Values: []string{"a", "b"}}}},
-			}),
+			oldSchema: requireModuleSchema(t,
+				schema.EnumType{Name: "enum1", Values: []schema.EnumValueDefinition{{Name: "a", Value: 1}}},
+			),
+			newSchema: requireModuleSchema(t,
+				schema.EnumType{Name: "enum1", Values: []schema.EnumValueDefinition{{Name: "a", Value: 1}, {Name: "b", Value: 2}}},
+			),
 			diff: ModuleSchemaDiff{
 				ChangedEnumTypes: []EnumTypeDiff{
 					{
 						Name:        "enum1",
-						AddedValues: []string{"b"},
+						AddedValues: []schema.EnumValueDefinition{{Name: "b", Value: 2}},
 					},
 				},
 			},
@@ -257,19 +258,17 @@ func TestCompareModuleSchemas(t *testing.T) {
 		},
 		{
 			name: "enum value removed",
-			oldSchema: mustModuleSchema(t, schema.ObjectType{
-				Name:      "object1",
-				KeyFields: []schema.Field{{Name: "key1", Kind: schema.EnumKind, EnumType: schema.EnumType{Name: "enum1", Values: []string{"a", "b", "c"}}}},
-			}),
-			newSchema: mustModuleSchema(t, schema.ObjectType{
-				Name:      "object1",
-				KeyFields: []schema.Field{{Name: "key1", Kind: schema.EnumKind, EnumType: schema.EnumType{Name: "enum1", Values: []string{"a", "b"}}}},
-			}),
+			oldSchema: requireModuleSchema(t,
+				schema.EnumType{Name: "enum1", Values: []schema.EnumValueDefinition{{Name: "a", Value: 1}, {Name: "b", Value: 2}, {Name: "c", Value: 3}}},
+			),
+			newSchema: requireModuleSchema(t,
+				schema.EnumType{Name: "enum1", Values: []schema.EnumValueDefinition{{Name: "a", Value: 1}, {Name: "b", Value: 2}}},
+			),
 			diff: ModuleSchemaDiff{
 				ChangedEnumTypes: []EnumTypeDiff{
 					{
 						Name:          "enum1",
-						RemovedValues: []string{"c"},
+						RemovedValues: []schema.EnumValueDefinition{{Name: "c", Value: 3}},
 					},
 				},
 			},
@@ -277,32 +276,38 @@ func TestCompareModuleSchemas(t *testing.T) {
 		},
 		{
 			name: "object type and enum type name switched",
-			oldSchema: mustModuleSchema(t, schema.ObjectType{
-				Name:      "foo",
-				KeyFields: []schema.Field{{Name: "key1", Kind: schema.EnumKind, EnumType: schema.EnumType{Name: "bar", Values: []string{"a"}}}},
-			}),
-			newSchema: mustModuleSchema(t, schema.ObjectType{
-				Name:      "bar",
-				KeyFields: []schema.Field{{Name: "key1", Kind: schema.EnumKind, EnumType: schema.EnumType{Name: "foo", Values: []string{"a"}}}},
-			}),
+			oldSchema: requireModuleSchema(t,
+				schema.ObjectType{
+					Name:      "foo",
+					KeyFields: []schema.Field{{Name: "key1", Kind: schema.EnumKind, ReferencedType: "bar"}},
+				},
+				schema.EnumType{Name: "bar", Values: []schema.EnumValueDefinition{{Name: "a", Value: 1}}},
+			),
+			newSchema: requireModuleSchema(t,
+				schema.ObjectType{
+					Name:      "bar",
+					KeyFields: []schema.Field{{Name: "key1", Kind: schema.EnumKind, ReferencedType: "foo"}},
+				},
+				schema.EnumType{Name: "foo", Values: []schema.EnumValueDefinition{{Name: "a", Value: 1}}},
+			),
 			diff: ModuleSchemaDiff{
 				RemovedObjectTypes: []schema.ObjectType{
 					{
 						Name:      "foo",
-						KeyFields: []schema.Field{{Name: "key1", Kind: schema.EnumKind, EnumType: schema.EnumType{Name: "bar", Values: []string{"a"}}}},
+						KeyFields: []schema.Field{{Name: "key1", Kind: schema.EnumKind, ReferencedType: "bar"}},
 					},
 				},
 				AddedObjectTypes: []schema.ObjectType{
 					{
 						Name:      "bar",
-						KeyFields: []schema.Field{{Name: "key1", Kind: schema.EnumKind, EnumType: schema.EnumType{Name: "foo", Values: []string{"a"}}}},
+						KeyFields: []schema.Field{{Name: "key1", Kind: schema.EnumKind, ReferencedType: "foo"}},
 					},
 				},
 				RemovedEnumTypes: []schema.EnumType{
-					{Name: "bar", Values: []string{"a"}},
+					{Name: "bar", Values: []schema.EnumValueDefinition{{Name: "a", Value: 1}}},
 				},
 				AddedEnumTypes: []schema.EnumType{
-					{Name: "foo", Values: []string{"a"}},
+					{Name: "foo", Values: []schema.EnumValueDefinition{{Name: "a", Value: 1}}},
 				},
 			},
 			hasCompatibleChanges: false,
@@ -326,8 +331,8 @@ func TestCompareModuleSchemas(t *testing.T) {
 	}
 }
 
-func mustModuleSchema(t *testing.T, objectTypes ...schema.ObjectType) schema.ModuleSchema {
-	s, err := schema.NewModuleSchema(objectTypes)
+func requireModuleSchema(t *testing.T, types ...schema.Type) schema.ModuleSchema {
+	s, err := schema.NewModuleSchema(types...)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/schema/diff/enum_diff.go
+++ b/schema/diff/enum_diff.go
@@ -14,7 +14,7 @@ type EnumTypeDiff struct {
 	RemovedValues []schema.EnumValueDefinition
 
 	// ChangedValues is a list of values whose numeric values were changed.
-	ChangedValues []EnumValueDiff
+	ChangedValues []EnumValueDefinitionDiff
 
 	// OldNumericKind is the numeric kind used to represent the enum values numerically in the old enum type.
 	// It will be empty if the kind did not change.
@@ -25,9 +25,15 @@ type EnumTypeDiff struct {
 	NewNumericKind schema.Kind
 }
 
-type EnumValueDiff struct {
-	Name     string
+// EnumValueDefinitionDiff represents the difference between two enum values definitions.
+type EnumValueDefinitionDiff struct {
+	// Name is the name of the enum value.
+	Name string
+
+	// OldValue is the old numeric value of the enum value.
 	OldValue int32
+
+	// NewValue is the new numeric value of the enum value.
 	NewValue int32
 }
 
@@ -53,7 +59,7 @@ func compareEnumType(oldEnum, newEnum schema.EnumType) EnumTypeDiff {
 		if !ok {
 			diff.RemovedValues = append(diff.RemovedValues, v)
 		} else if newV.Value != v.Value {
-			diff.ChangedValues = append(diff.ChangedValues, EnumValueDiff{
+			diff.ChangedValues = append(diff.ChangedValues, EnumValueDefinitionDiff{
 				Name:     v.Name,
 				OldValue: v.Value,
 				NewValue: newV.Value,

--- a/schema/diff/enum_diff.go
+++ b/schema/diff/enum_diff.go
@@ -17,9 +17,11 @@ type EnumTypeDiff struct {
 	ChangedValues []EnumValueDiff
 
 	// OldNumericKind is the numeric kind used to represent the enum values numerically in the old enum type.
+	// It will be empty if the kind did not change.
 	OldNumericKind schema.Kind
 
 	// NewNumericKind is the numeric kind used to represent the enum values numerically in the new enum type.
+	// It will be empty if the kind did not change.
 	NewNumericKind schema.Kind
 }
 
@@ -31,9 +33,12 @@ type EnumValueDiff struct {
 
 func compareEnumType(oldEnum, newEnum schema.EnumType) EnumTypeDiff {
 	diff := EnumTypeDiff{
-		Name:           oldEnum.TypeName(),
-		OldNumericKind: oldEnum.GetNumericKind(),
-		NewNumericKind: newEnum.GetNumericKind(),
+		Name: oldEnum.TypeName(),
+	}
+
+	if oldEnum.GetNumericKind() != newEnum.GetNumericKind() {
+		diff.OldNumericKind = oldEnum.GetNumericKind()
+		diff.NewNumericKind = newEnum.GetNumericKind()
 	}
 
 	newValues := make(map[string]schema.EnumValueDefinition)
@@ -47,8 +52,7 @@ func compareEnumType(oldEnum, newEnum schema.EnumType) EnumTypeDiff {
 		newV, ok := newValues[v.Name]
 		if !ok {
 			diff.RemovedValues = append(diff.RemovedValues, v)
-		}
-		if newV.Value != v.Value {
+		} else if newV.Value != v.Value {
 			diff.ChangedValues = append(diff.ChangedValues, EnumValueDiff{
 				Name:     v.Name,
 				OldValue: v.Value,

--- a/schema/diff/enum_diff_test.go
+++ b/schema/diff/enum_diff_test.go
@@ -52,6 +52,35 @@ func Test_compareEnumType(t *testing.T) {
 			},
 			hasCompatibleChanges: false,
 		},
+		{
+			name: "value changed",
+			oldEnum: schema.EnumType{
+				Values: []schema.EnumValueDefinition{{Name: "a", Value: 1}, {Name: "b", Value: 2}},
+			},
+			newEnum: schema.EnumType{
+				Values: []schema.EnumValueDefinition{{Name: "a", Value: 1}, {Name: "b", Value: 3}},
+			},
+			diff: EnumTypeDiff{
+				ChangedValues: []EnumValueDefinitionDiff{{Name: "b", OldValue: 2, NewValue: 3}},
+			},
+			hasCompatibleChanges: false,
+		},
+		{
+			name: "numeric kind changed",
+			oldEnum: schema.EnumType{
+				NumericKind: schema.Int32Kind,
+				Values:      []schema.EnumValueDefinition{{Name: "a", Value: 1}},
+			},
+			newEnum: schema.EnumType{
+				NumericKind: schema.Int16Kind,
+				Values:      []schema.EnumValueDefinition{{Name: "a", Value: 1}},
+			},
+			diff: EnumTypeDiff{
+				OldNumericKind: schema.Int32Kind,
+				NewNumericKind: schema.Int16Kind,
+			},
+			hasCompatibleChanges: false,
+		},
 	}
 
 	for _, tc := range tt {

--- a/schema/diff/enum_diff_test.go
+++ b/schema/diff/enum_diff_test.go
@@ -18,10 +18,10 @@ func Test_compareEnumType(t *testing.T) {
 		{
 			name: "no change",
 			oldEnum: schema.EnumType{
-				Values: []string{"a", "b"},
+				Values: []schema.EnumValueDefinition{{Name: "a", Value: 1}, {Name: "b", Value: 2}},
 			},
 			newEnum: schema.EnumType{
-				Values: []string{"a", "b"},
+				Values: []schema.EnumValueDefinition{{Name: "a", Value: 1}, {Name: "b", Value: 2}},
 			},
 			diff:                 EnumTypeDiff{},
 			hasCompatibleChanges: true,
@@ -29,26 +29,26 @@ func Test_compareEnumType(t *testing.T) {
 		{
 			name: "value added",
 			oldEnum: schema.EnumType{
-				Values: []string{"a"},
+				Values: []schema.EnumValueDefinition{{Name: "a", Value: 1}},
 			},
 			newEnum: schema.EnumType{
-				Values: []string{"a", "b"},
+				Values: []schema.EnumValueDefinition{{Name: "a", Value: 1}, {Name: "b", Value: 2}},
 			},
 			diff: EnumTypeDiff{
-				AddedValues: []string{"b"},
+				AddedValues: []schema.EnumValueDefinition{{Name: "b", Value: 2}},
 			},
 			hasCompatibleChanges: true,
 		},
 		{
 			name: "value removed",
 			oldEnum: schema.EnumType{
-				Values: []string{"a", "b"},
+				Values: []schema.EnumValueDefinition{{Name: "a", Value: 1}, {Name: "b", Value: 2}},
 			},
 			newEnum: schema.EnumType{
-				Values: []string{"a"},
+				Values: []schema.EnumValueDefinition{{Name: "a", Value: 1}},
 			},
 			diff: EnumTypeDiff{
-				RemovedValues: []string{"b"},
+				RemovedValues: []schema.EnumValueDefinition{{Name: "b", Value: 2}},
 			},
 			hasCompatibleChanges: false,
 		},

--- a/schema/diff/field_diff.go
+++ b/schema/diff/field_diff.go
@@ -3,7 +3,7 @@ package diff
 import "cosmossdk.io/schema"
 
 // FieldDiff represents the difference between two fields.
-// The KindChanged, NullableChanged, and EnumTypeChanged methods can be used to determine
+// The KindChanged, NullableChanged, and ReferenceTypeChanged methods can be used to determine
 // what specific changes were made to the field.
 type FieldDiff struct {
 	// Name is the name of the field.
@@ -21,13 +21,13 @@ type FieldDiff struct {
 	// NewNullable is the new nullable property of the field.
 	NewNullable bool
 
-	// OldEnumType is the name of the old enum type of the field.
-	// It will be empty if the field is not an enum type or if there was no change.
-	OldEnumType string
+	// OldEnumType is the name of the old referenced type.
+	// It will be empty if the field is not a reference type or if there was no change.
+	OldReferenceType string
 
-	// NewEnumType is the name of the new enum type of the field.
-	// It will be empty if the field is not an enum type or if there was no change.
-	NewEnumType string
+	// NewEnumType is the name of the new referenced type.
+	// It will be empty if the field is not a reference type or if there was no change.
+	NewReferencedType string
 }
 
 func compareField(oldField, newField schema.Field) FieldDiff {
@@ -42,16 +42,17 @@ func compareField(oldField, newField schema.Field) FieldDiff {
 	diff.OldNullable = oldField.Nullable
 	diff.NewNullable = newField.Nullable
 
-	if oldField.EnumType.Name != newField.EnumType.Name {
-		diff.OldEnumType = oldField.EnumType.Name
-		diff.NewEnumType = newField.EnumType.Name
+	if oldField.ReferencedType != newField.ReferencedType {
+		diff.OldReferenceType = oldField.ReferencedType
+		diff.NewReferencedType = newField.ReferencedType
 	}
+
 	return diff
 }
 
 // Empty returns true if the field diff has no changes.
 func (d FieldDiff) Empty() bool {
-	return !d.KindChanged() && !d.NullableChanged() && !d.EnumTypeChanged()
+	return !d.KindChanged() && !d.NullableChanged() && !d.ReferenceTypeChanged()
 }
 
 // KindChanged returns true if the field kind changed.
@@ -64,10 +65,7 @@ func (d FieldDiff) NullableChanged() bool {
 	return d.OldNullable != d.NewNullable
 }
 
-// EnumTypeChanged returns true if the field enum type changed.
-// Note that if the enum type name remained the same but the values of
-// the enum type changed, that won't be reported here but rather in the
-// ModuleSchemaDiff's ChangedEnumTypes field.
-func (d FieldDiff) EnumTypeChanged() bool {
-	return d.OldEnumType != d.NewEnumType
+// ReferenceTypeChanged returns true if the referenced type changed.
+func (d FieldDiff) ReferenceTypeChanged() bool {
+	return d.OldReferenceType != d.NewReferencedType
 }

--- a/schema/diff/field_diff.go
+++ b/schema/diff/field_diff.go
@@ -21,11 +21,11 @@ type FieldDiff struct {
 	// NewNullable is the new nullable property of the field.
 	NewNullable bool
 
-	// OldEnumType is the name of the old referenced type.
+	// OldReferencedType is the name of the old referenced type.
 	// It will be empty if the field is not a reference type or if there was no change.
-	OldReferenceType string
+	OldReferencedType string
 
-	// NewEnumType is the name of the new referenced type.
+	// NewReferencedType is the name of the new referenced type.
 	// It will be empty if the field is not a reference type or if there was no change.
 	NewReferencedType string
 }
@@ -43,7 +43,7 @@ func compareField(oldField, newField schema.Field) FieldDiff {
 	diff.NewNullable = newField.Nullable
 
 	if oldField.ReferencedType != newField.ReferencedType {
-		diff.OldReferenceType = oldField.ReferencedType
+		diff.OldReferencedType = oldField.ReferencedType
 		diff.NewReferencedType = newField.ReferencedType
 	}
 
@@ -67,5 +67,5 @@ func (d FieldDiff) NullableChanged() bool {
 
 // ReferenceTypeChanged returns true if the referenced type changed.
 func (d FieldDiff) ReferenceTypeChanged() bool {
-	return d.OldReferenceType != d.NewReferencedType
+	return d.OldReferencedType != d.NewReferencedType
 }

--- a/schema/diff/field_diff_test.go
+++ b/schema/diff/field_diff_test.go
@@ -39,11 +39,11 @@ func Test_compareField(t *testing.T) {
 			trueF: FieldDiff.NullableChanged,
 		},
 		{
-			oldField: schema.Field{Kind: schema.EnumKind, EnumType: schema.EnumType{Name: "old"}},
-			newField: schema.Field{Kind: schema.EnumKind, EnumType: schema.EnumType{Name: "new"}},
+			oldField: schema.Field{Kind: schema.EnumKind, ReferencedType: "old"},
+			newField: schema.Field{Kind: schema.EnumKind, ReferencedType: "new"},
 			wantDiff: FieldDiff{
-				OldEnumType: "old",
-				NewEnumType: "new",
+				OldReferencedType: "old",
+				NewReferencedType: "new",
 			},
 			trueF: FieldDiff.ReferenceTypeChanged,
 		},

--- a/schema/diff/field_diff_test.go
+++ b/schema/diff/field_diff_test.go
@@ -45,7 +45,7 @@ func Test_compareField(t *testing.T) {
 				OldEnumType: "old",
 				NewEnumType: "new",
 			},
-			trueF: FieldDiff.EnumTypeChanged,
+			trueF: FieldDiff.ReferenceTypeChanged,
 		},
 	}
 

--- a/schema/enum.go
+++ b/schema/enum.go
@@ -62,12 +62,12 @@ func (e EnumType) Validate(Schema) error {
 		}
 
 		if names[v.Name] {
-			return fmt.Errorf("duplicate enum definition name %q for enum %s", v, e.Name)
+			return fmt.Errorf("duplicate enum value name %q for enum %s", v.Name, e.Name)
 		}
 		names[v.Name] = true
 
 		if values[v.Value] {
-			return fmt.Errorf("duplicate enum definition numeric value %d for enum %s", v.Value, e.Name)
+			return fmt.Errorf("duplicate enum numeric value %d for enum %s", v.Value, e.Name)
 		}
 		values[v.Value] = true
 	}

--- a/schema/enum.go
+++ b/schema/enum.go
@@ -8,12 +8,10 @@ import (
 // EnumType represents the definition of an enum type.
 type EnumType struct {
 	// Name is the name of the enum type.
-	// It must conform to the QualifiedNameFormat regular expression.
+	// It must conform to the NameFormat regular expression.
 	// Its name must be unique between all enum types and object types in the module.
 	// The same enum, however, can be used in multiple object types and fields as long as the
 	// definition is identical each time.
-	// In addition, if it is qualified, then instances of the same enum type in different modules
-	// must be identical.
 	Name string
 
 	// Values is a list of distinct, non-empty values that are part of the enum type.
@@ -26,7 +24,7 @@ type EnumType struct {
 	NumericKind Kind
 }
 
-// EnumValueDefinitio represents a value in an enum type.
+// EnumValueDefinition represents a value in an enum type.
 type EnumValueDefinition struct {
 	// Name is the name of the enum value.
 	// It must conform to the NameFormat regular expression.

--- a/schema/enum.go
+++ b/schema/enum.go
@@ -68,6 +68,29 @@ func (e EnumType) Validate(Schema) error {
 			return fmt.Errorf("duplicate enum numeric value %d for enum %s", v.Value, e.Name)
 		}
 		values[v.Value] = true
+
+		switch e.GetNumericKind() {
+		case Int8Kind:
+			if v.Value < -128 || v.Value > 127 {
+				return fmt.Errorf("enum value %q for enum %s is out of range for Int8Kind", v.Name, e.Name)
+			}
+		case Uint8Kind:
+			if v.Value < 0 || v.Value > 255 {
+				return fmt.Errorf("enum value %q for enum %s is out of range for Uint8Kind", v.Name, e.Name)
+			}
+		case Int16Kind:
+			if v.Value < -32768 || v.Value > 32767 {
+				return fmt.Errorf("enum value %q for enum %s is out of range for Int16Kind", v.Name, e.Name)
+			}
+		case Uint16Kind:
+			if v.Value < 0 || v.Value > 65535 {
+				return fmt.Errorf("enum value %q for enum %s is out of range for Uint16Kind", v.Name, e.Name)
+			}
+		case Int32Kind:
+			// no range check needed
+		default:
+			return fmt.Errorf("invalid numeric kind %s for enum %s", e.NumericKind, e.Name)
+		}
 	}
 	return nil
 }

--- a/schema/enum_test.go
+++ b/schema/enum_test.go
@@ -15,7 +15,7 @@ func TestEnumDefinition_Validate(t *testing.T) {
 			name: "valid enum",
 			enum: EnumType{
 				Name:   "test",
-				Values: []string{"a", "b", "c"},
+				Values: []EnumValueDefinition{{Name: "a", Value: 1}, {Name: "b", Value: 2}, {Name: "c", Value: 3}},
 			},
 			errContains: "",
 		},
@@ -23,7 +23,7 @@ func TestEnumDefinition_Validate(t *testing.T) {
 			name: "empty name",
 			enum: EnumType{
 				Name:   "",
-				Values: []string{"a", "b", "c"},
+				Values: []EnumValueDefinition{{Name: "a", Value: 1}, {Name: "b", Value: 2}, {Name: "c", Value: 3}},
 			},
 			errContains: "invalid enum definition name",
 		},
@@ -31,31 +31,39 @@ func TestEnumDefinition_Validate(t *testing.T) {
 			name: "empty values",
 			enum: EnumType{
 				Name:   "test",
-				Values: []string{},
+				Values: []EnumValueDefinition{},
 			},
 			errContains: "enum definition values cannot be empty",
 		},
 		{
-			name: "empty value",
+			name: "empty value name",
 			enum: EnumType{
 				Name:   "test",
-				Values: []string{"a", "", "c"},
+				Values: []EnumValueDefinition{{Name: "a", Value: 1}, {Name: "", Value: 2}, {Name: "c", Value: 3}},
 			},
 			errContains: "invalid enum definition value",
 		},
 		{
-			name: "duplicate value",
+			name: "duplicate value name",
 			enum: EnumType{
 				Name:   "test",
-				Values: []string{"a", "b", "a"},
+				Values: []EnumValueDefinition{{Name: "a", Value: 1}, {Name: "a", Value: 2}, {Name: "c", Value: 3}},
 			},
-			errContains: "duplicate enum definition value \"a\" for enum test",
+			errContains: `duplicate enum value name "a" for enum test`,
+		},
+		{
+			name: "duplicate value numeric",
+			enum: EnumType{
+				Name:   "test",
+				Values: []EnumValueDefinition{{Name: "a", Value: 1}, {Name: "b", Value: 1}, {Name: "c", Value: 3}},
+			},
+			errContains: `duplicate enum numeric value 1 for enum test`,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := tt.enum.Validate()
+			err := tt.enum.Validate(EmptySchema{})
 			if tt.errContains == "" {
 				if err != nil {
 					t.Errorf("expected valid enum definition to pass validation, got: %v", err)
@@ -74,7 +82,7 @@ func TestEnumDefinition_Validate(t *testing.T) {
 func TestEnumDefinition_ValidateValue(t *testing.T) {
 	enum := EnumType{
 		Name:   "test",
-		Values: []string{"a", "b", "c"},
+		Values: []EnumValueDefinition{{Name: "a", Value: 1}, {Name: "b", Value: 2}, {Name: "c", Value: 3}},
 	}
 
 	tests := []struct {

--- a/schema/enum_test.go
+++ b/schema/enum_test.go
@@ -59,6 +59,51 @@ func TestEnumDefinition_Validate(t *testing.T) {
 			},
 			errContains: `duplicate enum numeric value 1 for enum test`,
 		},
+		{
+			name: "invalid numeric kind",
+			enum: EnumType{
+				Name:        "test",
+				NumericKind: StringKind,
+				Values:      []EnumValueDefinition{{Name: "a", Value: 1}, {Name: "b", Value: 2}, {Name: "c", Value: 3}},
+			},
+			errContains: "invalid numeric kind",
+		},
+		{
+			name: "out of range value for Int8Kind",
+			enum: EnumType{
+				Name:        "test",
+				NumericKind: Int8Kind,
+				Values:      []EnumValueDefinition{{Name: "a", Value: -129}},
+			},
+			errContains: "out of range",
+		},
+		{
+			name: "out of range value for Uint8Kind",
+			enum: EnumType{
+				Name:        "test",
+				NumericKind: Uint8Kind,
+				Values:      []EnumValueDefinition{{Name: "a", Value: -1}},
+			},
+			errContains: "out of range",
+		},
+		{
+			name: "out of range value for Int16Kind",
+			enum: EnumType{
+				Name:        "test",
+				NumericKind: Int16Kind,
+				Values:      []EnumValueDefinition{{Name: "a", Value: -32769}},
+			},
+			errContains: "out of range",
+		},
+		{
+			name: "out of range value for Uint16Kind",
+			enum: EnumType{
+				Name:        "test",
+				NumericKind: Uint16Kind,
+				Values:      []EnumValueDefinition{{Name: "a", Value: -1}},
+			},
+			errContains: "out of range",
+		},
 	}
 
 	for _, tt := range tests {

--- a/schema/field.go
+++ b/schema/field.go
@@ -33,7 +33,7 @@ func (c Field) Validate(schema Schema) error {
 	switch c.Kind {
 	case EnumKind:
 		if c.ReferencedType == "" {
-			return fmt.Errorf("enum field %q must have a type", c.Name)
+			return fmt.Errorf("enum field %q must have a referenced type", c.Name)
 		}
 
 		ty, ok := schema.LookupType(c.ReferencedType)
@@ -46,7 +46,7 @@ func (c Field) Validate(schema Schema) error {
 		}
 	default:
 		if c.ReferencedType != "" {
-			return fmt.Errorf("field %q with kind %q cannot have a type", c.Name, c.Kind)
+			return fmt.Errorf("field %q with kind %q cannot have a referenced type", c.Name, c.Kind)
 		}
 	}
 
@@ -56,7 +56,7 @@ func (c Field) Validate(schema Schema) error {
 // ValidateValue validates that the value conforms to the field's kind and nullability.
 // Unlike Kind.ValidateValue, it also checks that the value conforms to the EnumType
 // if the field is an EnumKind.
-func (c Field) ValidateValue(value interface{}) error {
+func (c Field) ValidateValue(value interface{}, schema Schema) error {
 	if value == nil {
 		if !c.Nullable {
 			return fmt.Errorf("field %q cannot be null", c.Name)
@@ -66,14 +66,6 @@ func (c Field) ValidateValue(value interface{}) error {
 	err := c.Kind.ValidateValueType(value)
 	if err != nil {
 		return fmt.Errorf("invalid value for field %q: %v", c.Name, err) //nolint:errorlint // false positive due to using go1.12
-	}
-
-	return nil
-}
-
-func (c Field) ValidateValueWithSchema(value interface{}, schema Schema) error {
-	if err := c.ValidateValue(value); err != nil {
-		return err
 	}
 
 	switch c.Kind {

--- a/schema/field.go
+++ b/schema/field.go
@@ -13,15 +13,12 @@ type Field struct {
 	// Nullable indicates whether null values are accepted for the field. Key fields CANNOT be nullable.
 	Nullable bool
 
-	// EnumType is the definition of the enum type and is only valid when Kind is EnumKind.
-	// The same enum types can be reused in the same module schema, but they always must contain
-	// the same values for the same enum name. This possibly introduces some duplication of
-	// definitions but makes it easier to reason about correctness and validation in isolation.
-	EnumType EnumType
+	// ReferencedType is the referenced type name when Kind is EnumKind.
+	ReferencedType string
 }
 
 // Validate validates the field.
-func (c Field) Validate() error {
+func (c Field) Validate(schema Schema) error {
 	// valid name
 	if !ValidateName(c.Name) {
 		return fmt.Errorf("invalid field name %q", c.Name)
@@ -33,12 +30,24 @@ func (c Field) Validate() error {
 	}
 
 	// enum definition only valid with EnumKind
-	if c.Kind == EnumKind {
-		if err := c.EnumType.Validate(); err != nil {
-			return fmt.Errorf("invalid enum definition for field %q: %v", c.Name, err) //nolint:errorlint // false positive due to using go1.12
+	switch c.Kind {
+	case EnumKind:
+		if c.ReferencedType == "" {
+			return fmt.Errorf("enum field %q must have a type", c.Name)
 		}
-	} else if c.Kind != EnumKind && (c.EnumType.Name != "" || c.EnumType.Values != nil) {
-		return fmt.Errorf("enum definition is only valid for field %q with type EnumKind", c.Name)
+
+		ty, ok := schema.LookupType(c.ReferencedType)
+		if !ok {
+			return fmt.Errorf("enum field %q references unknown type %q", c.Name, c.ReferencedType)
+		}
+
+		if _, ok := ty.(EnumType); !ok {
+			return fmt.Errorf("enum field %q references non-enum type %q", c.Name, c.ReferencedType)
+		}
+	default:
+		if c.ReferencedType != "" {
+			return fmt.Errorf("field %q with kind %q cannot have a type", c.Name, c.Kind)
+		}
 	}
 
 	return nil
@@ -59,8 +68,29 @@ func (c Field) ValidateValue(value interface{}) error {
 		return fmt.Errorf("invalid value for field %q: %v", c.Name, err) //nolint:errorlint // false positive due to using go1.12
 	}
 
-	if c.Kind == EnumKind {
-		return c.EnumType.ValidateValue(value.(string))
+	return nil
+}
+
+func (c Field) ValidateValueWithSchema(value interface{}, schema Schema) error {
+	if err := c.ValidateValue(value); err != nil {
+		return err
+	}
+
+	switch c.Kind {
+	case EnumKind:
+		ty, ok := schema.LookupType(c.ReferencedType)
+		if !ok {
+			return fmt.Errorf("enum field %q references unknown type %q", c.Name, c.ReferencedType)
+		}
+		enumType, ok := ty.(EnumType)
+		if !ok {
+			return fmt.Errorf("enum field %q references non-enum type %q", c.Name, c.ReferencedType)
+		}
+		err := enumType.ValidateValue(value.(string))
+		if err != nil {
+			return fmt.Errorf("invalid value for enum field %q: %v", c.Name, err)
+		}
+	default:
 	}
 
 	return nil

--- a/schema/field_test.go
+++ b/schema/field_test.go
@@ -36,35 +36,35 @@ func TestField_Validate(t *testing.T) {
 			errContains: "invalid field kind",
 		},
 		{
-			name: "invalid enum definition",
+			name: "missing enum type",
 			field: Field{
 				Name: "field1",
 				Kind: EnumKind,
 			},
-			errContains: "invalid enum definition",
+			errContains: `enum field "field1" must have a referenced type`,
 		},
 		{
 			name: "enum definition with non-EnumKind",
 			field: Field{
-				Name:     "field1",
-				Kind:     StringKind,
-				EnumType: EnumType{Name: "enum"},
+				Name:           "field1",
+				Kind:           StringKind,
+				ReferencedType: "enum",
 			},
-			errContains: "enum definition is only valid for field \"field1\" with type EnumKind",
+			errContains: `field "field1" with kind "string" cannot have a referenced type`,
 		},
 		{
 			name: "valid enum",
 			field: Field{
-				Name:     "field1",
-				Kind:     EnumKind,
-				EnumType: EnumType{Name: "enum", Values: []string{"a", "b"}},
+				Name:           "field1",
+				Kind:           EnumKind,
+				ReferencedType: "enum",
 			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := tt.field.Validate()
+			err := tt.field.Validate(testEnumSchema)
 			if tt.errContains == "" {
 				if err != nil {
 					t.Errorf("expected no error, got: %v", err)
@@ -128,9 +128,9 @@ func TestField_ValidateValue(t *testing.T) {
 		{
 			name: "valid enum",
 			field: Field{
-				Name:     "field1",
-				Kind:     EnumKind,
-				EnumType: EnumType{Name: "enum", Values: []string{"a", "b"}},
+				Name:           "field1",
+				Kind:           EnumKind,
+				ReferencedType: "enum",
 			},
 			value:       "a",
 			errContains: "",
@@ -138,9 +138,9 @@ func TestField_ValidateValue(t *testing.T) {
 		{
 			name: "invalid enum",
 			field: Field{
-				Name:     "field1",
-				Kind:     EnumKind,
-				EnumType: EnumType{Name: "enum", Values: []string{"a", "b"}},
+				Name:           "field1",
+				Kind:           EnumKind,
+				ReferencedType: "enum",
 			},
 			value:       "c",
 			errContains: "not a valid enum value",
@@ -149,7 +149,7 @@ func TestField_ValidateValue(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := tt.field.ValidateValue(tt.value)
+			err := tt.field.ValidateValue(tt.value, testEnumSchema)
 			if tt.errContains == "" {
 				if err != nil {
 					t.Errorf("expected no error, got: %v", err)
@@ -164,3 +164,8 @@ func TestField_ValidateValue(t *testing.T) {
 		})
 	}
 }
+
+var testEnumSchema = MustNewModuleSchema(EnumType{
+	Name:   "enum",
+	Values: []EnumValueDefinition{{Name: "a", Value: 1}, {Name: "b", Value: 2}},
+})

--- a/schema/fields.go
+++ b/schema/fields.go
@@ -4,16 +4,16 @@ import "fmt"
 
 // ValidateObjectKey validates that the value conforms to the set of fields as a Key in an ObjectUpdate.
 // See ObjectUpdate.Key for documentation on the requirements of such keys.
-func ValidateObjectKey(keyFields []Field, value interface{}) error {
-	return validateFieldsValue(keyFields, value)
+func ValidateObjectKey(keyFields []Field, value interface{}, schema Schema) error {
+	return validateFieldsValue(keyFields, value, schema)
 }
 
 // ValidateObjectValue validates that the value conforms to the set of fields as a Value in an ObjectUpdate.
 // See ObjectUpdate.Value for documentation on the requirements of such values.
-func ValidateObjectValue(valueFields []Field, value interface{}) error {
+func ValidateObjectValue(valueFields []Field, value interface{}, schema Schema) error {
 	valueUpdates, ok := value.(ValueUpdates)
 	if !ok {
-		return validateFieldsValue(valueFields, value)
+		return validateFieldsValue(valueFields, value, schema)
 	}
 
 	values := map[string]interface{}{}
@@ -31,7 +31,7 @@ func ValidateObjectValue(valueFields []Field, value interface{}) error {
 			continue
 		}
 
-		if err := field.ValidateValue(v); err != nil {
+		if err := field.ValidateValue(v, schema); err != nil {
 			return err
 		}
 
@@ -45,13 +45,13 @@ func ValidateObjectValue(valueFields []Field, value interface{}) error {
 	return nil
 }
 
-func validateFieldsValue(fields []Field, value interface{}) error {
+func validateFieldsValue(fields []Field, value interface{}, schema Schema) error {
 	if len(fields) == 0 {
 		return nil
 	}
 
 	if len(fields) == 1 {
-		return fields[0].ValidateValue(value)
+		return fields[0].ValidateValue(value, schema)
 	}
 
 	values, ok := value.([]interface{})
@@ -63,7 +63,7 @@ func validateFieldsValue(fields []Field, value interface{}) error {
 		return fmt.Errorf("expected %d key fields, got %d values", len(fields), len(value.([]interface{})))
 	}
 	for i, field := range fields {
-		if err := field.ValidateValue(values[i]); err != nil {
+		if err := field.ValidateValue(values[i], schema); err != nil {
 			return err
 		}
 	}

--- a/schema/fields_test.go
+++ b/schema/fields_test.go
@@ -56,7 +56,7 @@ func TestValidateForKeyFields(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := ValidateObjectKey(tt.keyFields, tt.key)
+			err := ValidateObjectKey(tt.keyFields, tt.key, EmptySchema{})
 			if tt.errContains == "" {
 				if err != nil {
 					t.Fatalf("unexpected error: %v", err)
@@ -128,7 +128,7 @@ func TestValidateForValueFields(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := ValidateObjectValue(tt.valueFields, tt.value)
+			err := ValidateObjectValue(tt.valueFields, tt.value, EmptySchema{})
 			if tt.errContains == "" {
 				if err != nil {
 					t.Fatalf("unexpected error: %v", err)

--- a/schema/module_schema.go
+++ b/schema/module_schema.go
@@ -12,7 +12,7 @@ type ModuleSchema struct {
 
 // NewModuleSchema constructs a new ModuleSchema and validates it. Any module schema returned without an error
 // is guaranteed to be valid.
-func NewModuleSchema(types []Type) (ModuleSchema, error) {
+func NewModuleSchema(types ...Type) (ModuleSchema, error) {
 	typeMap := map[string]Type{}
 
 	for _, typ := range types {
@@ -31,6 +31,16 @@ func NewModuleSchema(types []Type) (ModuleSchema, error) {
 	}
 
 	return res, nil
+}
+
+// MustNewModuleSchema constructs a new ModuleSchema and panics if it is invalid.
+// This should only be used in test code or static initialization where it is safe to panic!
+func MustNewModuleSchema(types ...Type) ModuleSchema {
+	sch, err := NewModuleSchema(types...)
+	if err != nil {
+		panic(err)
+	}
+	return sch
 }
 
 // Validate validates the module schema.
@@ -57,7 +67,7 @@ func (s ModuleSchema) ValidateObjectUpdate(update ObjectUpdate) error {
 		return fmt.Errorf("type %q is not an object type", update.TypeName)
 	}
 
-	return objTyp.ValidateObjectUpdate(update)
+	return objTyp.ValidateObjectUpdate(update, s)
 }
 
 // LookupType looks up a type by name in the module schema.

--- a/schema/module_schema_test.go
+++ b/schema/module_schema_test.go
@@ -9,13 +9,13 @@ import (
 func TestModuleSchema_Validate(t *testing.T) {
 	tests := []struct {
 		name        string
-		objectTypes []ObjectType
+		types       []Type
 		errContains string
 	}{
 		{
 			name: "valid module schema",
-			objectTypes: []ObjectType{
-				{
+			types: []Type{
+				ObjectType{
 					Name: "object1",
 					KeyFields: []Field{
 						{
@@ -29,8 +29,8 @@ func TestModuleSchema_Validate(t *testing.T) {
 		},
 		{
 			name: "invalid object type",
-			objectTypes: []ObjectType{
-				{
+			types: []Type{
+				ObjectType{
 					Name: "",
 					KeyFields: []Field{
 						{
@@ -43,121 +43,31 @@ func TestModuleSchema_Validate(t *testing.T) {
 			errContains: "invalid object type name",
 		},
 		{
-			name: "same enum with missing values",
-			objectTypes: []ObjectType{
-				{
-					Name: "object1",
-					KeyFields: []Field{
-						{
-							Name: "k",
-							Kind: EnumKind,
-							EnumType: EnumType{
-								Name:   "enum1",
-								Values: []string{"a", "b"},
-							},
-						},
-					},
-					ValueFields: []Field{
-						{
-							Name: "v",
-							Kind: EnumKind,
-							EnumType: EnumType{
-								Name:   "enum1",
-								Values: []string{"a", "b", "c"},
-							},
-						},
-					},
-				},
-			},
-			errContains: "different number of values",
-		},
-		{
-			name: "same enum with different values",
-			objectTypes: []ObjectType{
-				{
-					Name: "object1",
-					KeyFields: []Field{
-						{
-							Name: "k",
-							Kind: EnumKind,
-							EnumType: EnumType{
-								Name:   "enum1",
-								Values: []string{"a", "b"},
-							},
-						},
-					},
-				},
-				{
-					Name: "object2",
-					KeyFields: []Field{
-						{
-							Name: "k",
-							Kind: EnumKind,
-							EnumType: EnumType{
-								Name:   "enum1",
-								Values: []string{"a", "c"},
-							},
-						},
-					},
-				},
-			},
-			errContains: "different values",
-		},
-		{
-			name: "same enum",
-			objectTypes: []ObjectType{
-				{
-					Name: "object1",
-					KeyFields: []Field{
-						{
-							Name: "k",
-							Kind: EnumKind,
-							EnumType: EnumType{
-								Name:   "enum1",
-								Values: []string{"a", "b"},
-							},
-						},
-					},
-				},
-				{
-					Name: "object2",
-					KeyFields: []Field{
-						{
-							Name: "k",
-							Kind: EnumKind,
-							EnumType: EnumType{
-								Name:   "enum1",
-								Values: []string{"a", "b"},
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			objectTypes: []ObjectType{
-				{
+			name: "duplicate type name",
+			types: []Type{
+				ObjectType{
 					Name: "type1",
 					ValueFields: []Field{
 						{
-							Name: "field1",
-							Kind: EnumKind,
-							EnumType: EnumType{
-								Name:   "type1",
-								Values: []string{"a", "b"},
-							},
+							Name:           "field1",
+							Kind:           EnumKind,
+							ReferencedType: "type1",
 						},
 					},
 				},
+				EnumType{
+					Name:   "type1",
+					Values: []EnumValueDefinition{{Name: "a", Value: 1}},
+				},
 			},
-			errContains: "enum \"type1\" already exists as a different non-enum type",
+			errContains: `duplicate type "type1"`,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// because validate is called when calling NewModuleSchema, we just call NewModuleSchema
-			_, err := NewModuleSchema(tt.objectTypes)
+			_, err := NewModuleSchema(tt.types...)
 			if tt.errContains == "" {
 				if err != nil {
 					t.Fatalf("unexpected error: %v", err)
@@ -180,8 +90,8 @@ func TestModuleSchema_ValidateObjectUpdate(t *testing.T) {
 	}{
 		{
 			name: "valid object update",
-			moduleSchema: requireModuleSchema(t, []ObjectType{
-				{
+			moduleSchema: requireModuleSchema(t,
+				ObjectType{
 					Name: "object1",
 					KeyFields: []Field{
 						{
@@ -190,7 +100,6 @@ func TestModuleSchema_ValidateObjectUpdate(t *testing.T) {
 						},
 					},
 				},
-			},
 			),
 			objectUpdate: ObjectUpdate{
 				TypeName: "object1",
@@ -200,8 +109,8 @@ func TestModuleSchema_ValidateObjectUpdate(t *testing.T) {
 		},
 		{
 			name: "object type not found",
-			moduleSchema: requireModuleSchema(t, []ObjectType{
-				{
+			moduleSchema: requireModuleSchema(t,
+				ObjectType{
 					Name: "object1",
 					KeyFields: []Field{
 						{
@@ -210,7 +119,6 @@ func TestModuleSchema_ValidateObjectUpdate(t *testing.T) {
 						},
 					},
 				},
-			},
 			),
 			objectUpdate: ObjectUpdate{
 				TypeName: "object2",
@@ -220,21 +128,21 @@ func TestModuleSchema_ValidateObjectUpdate(t *testing.T) {
 		},
 		{
 			name: "type name refers to an enum",
-			moduleSchema: requireModuleSchema(t, []ObjectType{
-				{
-					Name: "obj1",
-					KeyFields: []Field{
-						{
-							Name: "field1",
-							Kind: EnumKind,
-							EnumType: EnumType{
-								Name:   "enum1",
-								Values: []string{"a", "b"},
-							},
-						},
+			moduleSchema: requireModuleSchema(t, ObjectType{
+				Name: "obj1",
+				KeyFields: []Field{
+					{
+						Name:           "field1",
+						Kind:           EnumKind,
+						ReferencedType: "enum1",
 					},
 				},
-			}),
+			},
+				EnumType{
+					Name:   "enum1",
+					Values: []EnumValueDefinition{{Name: "a", Value: 1}, {Name: "b", Value: 2}},
+				},
+			),
 			objectUpdate: ObjectUpdate{
 				TypeName: "enum1",
 				Key:      "a",
@@ -259,9 +167,9 @@ func TestModuleSchema_ValidateObjectUpdate(t *testing.T) {
 	}
 }
 
-func requireModuleSchema(t *testing.T, objectTypes []ObjectType) ModuleSchema {
+func requireModuleSchema(t *testing.T, types ...Type) ModuleSchema {
 	t.Helper()
-	moduleSchema, err := NewModuleSchema(objectTypes)
+	moduleSchema, err := NewModuleSchema(types...)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -269,14 +177,12 @@ func requireModuleSchema(t *testing.T, objectTypes []ObjectType) ModuleSchema {
 }
 
 func TestModuleSchema_LookupType(t *testing.T) {
-	moduleSchema := requireModuleSchema(t, []ObjectType{
-		{
-			Name: "object1",
-			KeyFields: []Field{
-				{
-					Name: "field1",
-					Kind: StringKind,
-				},
+	moduleSchema := requireModuleSchema(t, ObjectType{
+		Name: "object1",
+		KeyFields: []Field{
+			{
+				Name: "field1",
+				Kind: StringKind,
 			},
 		},
 	})
@@ -298,34 +204,36 @@ func TestModuleSchema_LookupType(t *testing.T) {
 
 func exampleSchema(t *testing.T) ModuleSchema {
 	t.Helper()
-	return requireModuleSchema(t, []ObjectType{
-		{
+	return requireModuleSchema(t,
+		ObjectType{
 			Name: "object1",
 			KeyFields: []Field{
 				{
-					Name: "field1",
-					Kind: EnumKind,
-					EnumType: EnumType{
-						Name:   "enum2",
-						Values: []string{"d", "e", "f"},
-					},
+					Name:           "field1",
+					Kind:           EnumKind,
+					ReferencedType: "enum2",
 				},
 			},
 		},
-		{
+		ObjectType{
 			Name: "object2",
 			KeyFields: []Field{
 				{
-					Name: "field1",
-					Kind: EnumKind,
-					EnumType: EnumType{
-						Name:   "enum1",
-						Values: []string{"a", "b", "c"},
-					},
+					Name:           "field1",
+					Kind:           EnumKind,
+					ReferencedType: "enum1",
 				},
 			},
 		},
-	})
+		EnumType{
+			Name:   "enum1",
+			Values: []EnumValueDefinition{{Name: "a", Value: 1}, {Name: "b", Value: 2}, {Name: "c", Value: 3}},
+		},
+		EnumType{
+			Name:   "enum2",
+			Values: []EnumValueDefinition{{Name: "d", Value: 4}, {Name: "e", Value: 5}, {Name: "f", Value: 6}},
+		},
+	)
 }
 
 func TestModuleSchema_Types(t *testing.T) {

--- a/schema/name.go
+++ b/schema/name.go
@@ -13,22 +13,3 @@ var nameRegex = regexp.MustCompile(NameFormat)
 func ValidateName(name string) bool {
 	return nameRegex.MatchString(name)
 }
-
-// QualifiedNameFormat is the regular expression that a qualified name must match.
-// A qualified name is a dot-separated list of names, where each name must match NameFormat.
-// A qualified name must be at least one character long and can be at most 127 characters long.
-const QualifiedNameFormat = `^[a-zA-Z_][a-zA-Z0-9_]*(\.[a-zA-Z_][a-zA-Z0-9_]*)*$`
-
-var qualifiedNameRegex = regexp.MustCompile(QualifiedNameFormat)
-
-func ValidateQualifiedName(name string) bool {
-	if !qualifiedNameRegex.MatchString(name) {
-		return false
-	}
-
-	if len(name) > 127 {
-		return false
-	}
-
-	return true
-}

--- a/schema/name.go
+++ b/schema/name.go
@@ -4,8 +4,8 @@ import "regexp"
 
 // NameFormat is the regular expression that a name must match.
 // A name must start with a letter or underscore and can only contain letters, numbers, and underscores.
-// A name must be at least one character long and can be at most 63 characters long.
-const NameFormat = `^[a-zA-Z_][a-zA-Z0-9_]{0,62}$`
+// A name must be at least one character long and can be at most 64 characters long.
+const NameFormat = `^[a-zA-Z_][a-zA-Z0-9_]{0,63}$`
 
 var nameRegex = regexp.MustCompile(NameFormat)
 

--- a/schema/name.go
+++ b/schema/name.go
@@ -4,12 +4,31 @@ import "regexp"
 
 // NameFormat is the regular expression that a name must match.
 // A name must start with a letter or underscore and can only contain letters, numbers, and underscores.
-// A name must be at least one character long and can be at most 64 characters long.
-const NameFormat = `^[a-zA-Z_][a-zA-Z0-9_]{0,63}$`
+// A name must be at least one character long and can be at most 63 characters long.
+const NameFormat = `^[a-zA-Z_][a-zA-Z0-9_]{0,62}$`
 
 var nameRegex = regexp.MustCompile(NameFormat)
 
 // ValidateName checks if the given name is a valid name conforming to NameFormat.
 func ValidateName(name string) bool {
 	return nameRegex.MatchString(name)
+}
+
+// QualifiedNameFormat is the regular expression that a qualified name must match.
+// A qualified name is a dot-separated list of names, where each name must match NameFormat.
+// A qualified name must be at least one character long and can be at most 127 characters long.
+const QualifiedNameFormat = `^[a-zA-Z_][a-zA-Z0-9_]*(\.[a-zA-Z_][a-zA-Z0-9_]*)*$`
+
+var qualifiedNameRegex = regexp.MustCompile(QualifiedNameFormat)
+
+func ValidateQualifiedName(name string) bool {
+	if !qualifiedNameRegex.MatchString(name) {
+		return false
+	}
+
+	if len(name) > 127 {
+		return false
+	}
+
+	return true
 }

--- a/schema/object_type.go
+++ b/schema/object_type.go
@@ -82,12 +82,12 @@ func (o ObjectType) Validate(schema Schema) error {
 }
 
 // ValidateObjectUpdate validates that the update conforms to the object type.
-func (o ObjectType) ValidateObjectUpdate(update ObjectUpdate) error {
+func (o ObjectType) ValidateObjectUpdate(update ObjectUpdate, schema Schema) error {
 	if o.Name != update.TypeName {
 		return fmt.Errorf("object type name %q does not match update type name %q", o.Name, update.TypeName)
 	}
 
-	if err := ValidateObjectKey(o.KeyFields, update.Key); err != nil {
+	if err := ValidateObjectKey(o.KeyFields, update.Key, schema); err != nil {
 		return fmt.Errorf("invalid key for object type %q: %v", update.TypeName, err) //nolint:errorlint // false positive due to using go1.12
 	}
 
@@ -95,5 +95,5 @@ func (o ObjectType) ValidateObjectUpdate(update ObjectUpdate) error {
 		return nil
 	}
 
-	return ValidateObjectValue(o.ValueFields, update.Value)
+	return ValidateObjectValue(o.ValueFields, update.Value, schema)
 }

--- a/schema/object_type_test.go
+++ b/schema/object_type_test.go
@@ -163,33 +163,6 @@ func TestObjectType_Validate(t *testing.T) {
 			errContains: "key field \"field1\" cannot be nullable",
 		},
 		{
-			name: "duplicate incompatible enum",
-			objectType: ObjectType{
-				Name: "objectWithEnums",
-				KeyFields: []Field{
-					{
-						Name: "key",
-						Kind: EnumKind,
-						EnumType: EnumType{
-							Name:   "enum1",
-							Values: []string{"a", "b"},
-						},
-					},
-				},
-				ValueFields: []Field{
-					{
-						Name: "value",
-						Kind: EnumKind,
-						EnumType: EnumType{
-							Name:   "enum1",
-							Values: []string{"c", "b"},
-						},
-					},
-				},
-			},
-			errContains: "enum \"enum1\" has different values",
-		},
-		{
 			name: "float32 key field",
 			objectType: ObjectType{
 				Name: "o1",
@@ -232,7 +205,7 @@ func TestObjectType_Validate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := tt.objectType.Validate()
+			err := tt.objectType.Validate(EmptySchema{})
 			if tt.errContains == "" {
 				if err != nil {
 					t.Fatalf("unexpected error: %v", err)
@@ -294,7 +267,7 @@ func TestObjectType_ValidateObjectUpdate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := tt.objectType.ValidateObjectUpdate(tt.object)
+			err := tt.objectType.ValidateObjectUpdate(tt.object, EmptySchema{})
 			if tt.errContains == "" {
 				if err != nil {
 					t.Fatalf("unexpected error: %v", err)

--- a/schema/testing/app.go
+++ b/schema/testing/app.go
@@ -14,7 +14,7 @@ var AppSchemaGen = rapid.Custom(func(t *rapid.T) map[string]schema.ModuleSchema 
 	numModules := rapid.IntRange(1, 10).Draw(t, "numModules")
 	for i := 0; i < numModules; i++ {
 		moduleName := NameGen.Draw(t, "moduleName")
-		moduleSchema := ModuleSchemaGen.Draw(t, fmt.Sprintf("moduleSchema[%s]", moduleName))
+		moduleSchema := ModuleSchemaGen().Draw(t, fmt.Sprintf("moduleSchema[%s]", moduleName))
 		schema[moduleName] = moduleSchema
 	}
 	return schema

--- a/schema/testing/appdatasim/testdata/app_sim_example_schema.txt
+++ b/schema/testing/appdatasim/testdata/app_sim_example_schema.txt
@@ -4,158 +4,158 @@ StartBlock: {1 <nil> <nil>}
 OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"RetainDeletions","Key":"","Value":[4602,"NwsAtcME5moByAKKwXU="],"Delete":false},{"TypeName":"Simple","Key":"","Value":[-89,"fgY="],"Delete":false}]}
 OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"Singleton","Key":null,"Value":["֑Ⱥ|@!`",""],"Delete":false}]}
 OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"TwoKeys","Key":["a\u003c",-84],"Value":null,"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_integer","Key":"11598611","Value":["016807","-016339012"],"Delete":false},{"TypeName":"test_uint16","Key":9407,"Value":{"valNotNull":0,"valNullable":null},"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_int16","Key":-4371,"Value":{"valNotNull":-3532,"valNullable":-15},"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"Simple","Key":"\u000b𝜛࣢Ⱥ +\u001c","Value":{"Value1":-28,"Value2":"AAE5AAAAATgB"},"Delete":false},{"TypeName":"RetainDeletions","Key":".(","Value":[116120837,"/wwIyAAUciAC"],"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_bool","Key":false,"Value":[false,false],"Delete":false},{"TypeName":"test_float64","Key":2818,"Value":{"valNotNull":1.036618793083456e+225,"valNullable":-0.0006897732815340143},"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_decimal","Key":"561415.19400226923121396E-2","Value":{"valNotNull":"-24080E11","valNullable":"192.3"},"Delete":false},{"TypeName":"test_int8","Key":-95,"Value":{"valNotNull":-101,"valNullable":null},"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"ManyValues","Key":"?Ⱥ","Value":{"Value1":2,"Value2":"2w==","Value3":0.05580937396734953,"Value4":16164100},"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"ThreeKeys","Key":["৴ि𐞬a",-681,12863],"Value":1,"Delete":false},{"TypeName":"RetainDeletions","Key":"৯aࠤာAᬺⅤaȺ￡Ρᵧa󠁳|𝙮 ﻿A","Value":{"Value1":440,"Value2":"9Q=="},"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_float32","Key":-874,"Value":[-0.8046875,null],"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_address","Key":"CB4HBgJQBuoBFAIs4xcFRwfaoUJr4f4ACzQ5wX4qPkMAACsA1Ev/Fg==","Value":["xRQCHzcOCGqADAZNAQExHwAaBQISEagYGF4F5wEWFN/JGgHkAsYchgUCA2YRUneug+wEABUjRaAKBOoQAOATEg==","CUXz/xMEAP8BNw0PvPUBNF7rSPPDAQHTBg71MEsKHg=="],"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_duration","Key":-1168504079346,"Value":{"valNotNull":-9566526662547645,"valNullable":-1936738738498935},"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"RetainDeletions","Key":"+","Value":[3,"A2k="],"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_time","Key":"1969-12-31T19:00:19.631216449-05:00","Value":{"valNotNull":"1969-12-31T18:59:59.999999998-05:00","valNullable":null},"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"Simple","Key":"\u0026ắA","Value":[-507,"AFLIDwIESxgAgQEDAS8="],"Delete":false},{"TypeName":"ManyValues","Key":"῭𝚰ഃȺAᶊ?","Value":[-6,"GDU=",-11992.413883053847,57],"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_int8","Key":98,"Value":[-4,-83],"Delete":false},{"TypeName":"test_string","Key":"ਃÙ࣢Ⱥ +\u001c","Value":{"valNotNull":"𐹹aa","valNullable":"aa"},"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"Simple","Key":"_ _^.ෛ᧰;1A","Value":{"Value1":-29,"Value2":"9w=="},"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"Simple","Key":"ᾏ","Value":{"Value1":773,"Value2":"9QEUBwEOAg=="},"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_bool","Key":true,"Value":{"valNotNull":false,"valNullable":null},"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_uint64","Key":5388077,"Value":[1382203,null],"Delete":false},{"TypeName":"test_int16","Key":151,"Value":[-19691,3],"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"TwoKeys","Key":["|󺪆𝅲＝鄖_.;ǀ⃣%; #~",16],"Value":null,"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"ManyValues","Key":"¨¹^Z_{/ a","Value":[-645,"ABQBAw==",0.33674474700582796,2023],"Delete":false},{"TypeName":"RetainDeletions","Key":"𝅲𝡇","Value":{"Value1":3666,"Value2":"PLgAFjwIEw=="},"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_int32","Key":13,"Value":[1,639842],"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"TwoKeys","Key":["[",-5782],"Value":null,"Delete":false}]}
 Commit: {}
 StartBlock: {2 <nil> <nil>}
 OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"RetainDeletions","Key":"ᾢ","Value":[3,"AQQF3LYA"],"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"ManyValues","Key":"_; ᾚ ǲA{˭҄\nA ^$?ᾦ,:\u003c\"?_\u0014;|","Value":{"Value1":-15,"Value2":"PED/","Value3":7.997156312768529e-26,"Value4":33975920899014},"Delete":false},{"TypeName":"Simple","Key":"","Value":[-2,"FwY="],"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_address","Key":"NACQYgAaAwcFAK/IAQEFWgcArAEpMAA=","Value":["Bz4X2gtkAw4DU4hgA72EAv8AE4IAAAMGAS40AgL/",null],"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_address","Key":"CB4HBgJQBuoBFAIs4xcFRwfaoUJr4f4ACzQ5wX4qPkMAACsA1Ev/Fg==","Value":null,"Delete":true},{"TypeName":"test_address","Key":"CB4HBgJQBuoBFAIs4xcFRwfaoUJr4f4ACzQ5wX4qPkMAACsA1Ev/Fg==","Value":{"valNullable":null},"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_bytes","Key":"AA==","Value":{"valNotNull":"FRcD","valNullable":"K53/"},"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"Singleton","Key":null,"Value":{"Value":"℘A⤯","Value2":"ALZMCik="},"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"TwoKeys","Key":[" (弡𞥃",124],"Value":null,"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_bool","Key":true,"Value":[false,null],"Delete":false},{"TypeName":"test_integer","Key":"64","Value":["-307711","-2"],"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"ManyValues","Key":"?Ⱥ","Value":[-278,"AgYltOwK",-6.0083863735198975,429016],"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_decimal","Key":"-97E-70","Value":{"valNotNull":"-650530110","valNullable":null},"Delete":false},{"TypeName":"test_decimal","Key":"561415.19400226923121396E-2","Value":null,"Delete":true}]}
+OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"ManyValues","Key":"_; ᾚ ǲA{˭҄\nA ^$?ᾦ,:\u003c\"?_\u0014;|","Value":{"Value1":-15,"Value2":"PED/","Value3":7.997156312768529e-26,"Value4":33975920899014},"Delete":false},{"TypeName":"Simple","Key":"$#","Value":[2114984433,"M/80"],"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_string","Key":"a]\u003e/a֍)!\"˂A","Value":["",null],"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"Simple","Key":" Ⅻ\t%a","Value":{"Value1":12733,"Value2":"hAL/"},"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_address","Key":"AAEgvwGmbgFqAAGkMQAYlBICzQEYAgsBFRcDAiud/ykGAitFA6tJA04SB+8DwBMAAQxXDyz/","Value":["GwADWP8AMB6z0AZCDgEDMv8DfQEQ","DAHaBAOt3g16AQAfNQEBeQYBAlv/AfgKUi0YAgg="],"Delete":false},{"TypeName":"test_duration","Key":468,"Value":[-52600,null],"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"Simple","Key":": Ⱥ","Value":[-14,"fmoD3wY="],"Delete":false},{"TypeName":"TwoKeys","Key":["Ⱥ꙱ǈ",12],"Value":null,"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"ThreeKeys","Key":["$",-1,774000],"Value":-11,"Delete":false},{"TypeName":"RetainDeletions","Key":"","Value":[-889,"AWoJAQI+4wEDAAD/A14DNwCH7O7QtACtCh4JCrwID+GQawo="],"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_bool","Key":false,"Value":[true,false],"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"Simple","Key":"\"رऻ","Value":[-9237464,"BQ4CYQ=="],"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"RetainDeletions","Key":"ᾎⅰ\u000bA*","Value":{"Value1":0,"Value2":"AA=="},"Delete":false}]}
 Commit: {}
 StartBlock: {3 <nil> <nil>}
-OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_int32","Key":897,"Value":[454,-2],"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_float32","Key":-874,"Value":null,"Delete":true}]}
-OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_uint8","Key":0,"Value":[1,null],"Delete":false},{"TypeName":"test_decimal","Key":"-97E-70","Value":["36141e01","50562961530924372552"],"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"ThreeKeys","Key":["৴ि𐞬a",-681,12863],"Value":null,"Delete":true}]}
-OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_bytes","Key":"AAD/AAAFAAEAUQ==","Value":{"valNotNull":"Nw==","valNullable":"AABdSw=="},"Delete":false},{"TypeName":"test_enum","Key":"baz","Value":["bar",null],"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_address","Key":"CB4HBgJQBuoBFAIs4xcFRwfaoUJr4f4ACzQ5wX4qPkMAACsA1Ev/Fg==","Value":null,"Delete":true},{"TypeName":"test_uint16","Key":9407,"Value":[15,3],"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_integer","Key":"433032","Value":{"valNotNull":"711","valNullable":null},"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_string","Key":"~?ʳ~$ₜ\\","Value":["*¾",null],"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_uint32","Key":995,"Value":{"valNotNull":7,"valNullable":null},"Delete":false},{"TypeName":"test_time","Key":"1969-12-31T18:59:59.999999971-05:00","Value":{"valNotNull":"1969-12-31T18:59:59.999999994-05:00","valNullable":"1969-12-31T18:59:59.999580498-05:00"},"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_string","Key":"aή⃢\t{ǁ","Value":{"valNotNull":"ሢ϶","valNullable":null},"Delete":false},{"TypeName":"test_uint8","Key":2,"Value":{"valNotNull":17,"valNullable":null},"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"ThreeKeys","Key":["A*۽~ǲ₱ {",-8,2],"Value":{"Value1":1056454},"Delete":false},{"TypeName":"TwoKeys","Key":["mA৴ pa _〩ãᛮǅ𑣠ʰA%a",1],"Value":null,"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_int32","Key":-103,"Value":{"valNotNull":-1887959808,"valNullable":2096073436},"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_bool","Key":true,"Value":null,"Delete":true}]}
+OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"ManyValues","Key":"","Value":{"Value1":-4,"Value2":"","Value3":5.199354003997906e-290,"Value4":2703222758},"Delete":false},{"TypeName":"ThreeKeys","Key":["$",-1,774000],"Value":11281,"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_uint8","Key":7,"Value":{"valNotNull":1,"valNullable":150},"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"Simple","Key":"_ _^.ෛ᧰;1A","Value":[-1,"LP8="],"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_integer","Key":"-7261530924372552","Value":["080207094","-598415299"],"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_float64","Key":-368,"Value":{"valNotNull":1.142364501953125,"valNullable":4.509373305100153e-141},"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"ManyValues","Key":"_; ᾚ ǲA{˭҄\nA ^$?ᾦ,:\u003c\"?_\u0014;|","Value":{"Value1":-102862,"Value3":-0.4372412548364082,"Value4":3369109024730919},"Delete":false},{"TypeName":"Simple","Key":"$#","Value":[-15470,"sgAB"],"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_decimal","Key":"2.78157850","Value":{"valNotNull":"-2.564","valNullable":null},"Delete":false},{"TypeName":"test_int64","Key":9223372036854775807,"Value":[-9223372036854775808,6033],"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"ManyValues","Key":"↓ʰ/₱ {","Value":{"Value1":2147483647,"Value2":"","Value3":-4.236080089134453e-9,"Value4":3392046},"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"RetainDeletions","Key":"~ᾈ\u0004󱜏a _〩ãᛮǅ𑣠ʰA%a","Value":{"Value1":361,"Value2":"AVpAjeACFY7Tph5n"},"Delete":false}]}
 Commit: {}
 StartBlock: {4 <nil> <nil>}
 OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_duration","Key":-152,"Value":{"valNotNull":1476419818092,"valNullable":-163469},"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"Simple","Key":"‮","Value":[-1,"GwE="],"Delete":false},{"TypeName":"ManyValues","Key":"_; ᾚ ǲA{˭҄\nA ^$?ᾦ,:\u003c\"?_\u0014;|","Value":[0,"APMAAh8=",2.6405210300043274e-261,4678],"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"RetainDeletions","Key":"+","Value":[-265,"7v+nXKjOoQ=="],"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"TwoKeys","Key":[" (弡𞥃",124],"Value":null,"Delete":true}]}
-OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_int64","Key":-1,"Value":{"valNotNull":2070362465348116,"valNullable":null},"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_address","Key":"NACQYgAaAwcFAK/IAQEFWgcArAEpMAA=","Value":["AKjiCQIBAyv/AAD8AcQADwD/AEP7eg==","C2YHNQMBaxQz0wAPGXQqGQYCAAPQAhUB05AB7QUAbnLpM7hyjBwAb+QAdJmb/0hGGAMzEoat/wYeAQ=="],"Delete":false},{"TypeName":"test_float64","Key":5224,"Value":[-1683.1097246298846,null],"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_bytes","Key":"AA==","Value":["Md4BCACgAADoAG8cHQ5tB0c1HAA=",null],"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"TwoKeys","Key":["a\u003c",-84],"Value":null,"Delete":true}]}
-OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_uint8","Key":2,"Value":null,"Delete":true}]}
-OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_float32","Key":-218792,"Value":[1.0914612,null],"Delete":false},{"TypeName":"test_duration","Key":-9223372036854775808,"Value":{"valNotNull":399806,"valNullable":-336},"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"Simple","Key":"‮","Value":[-1,"GwE="],"Delete":false},{"TypeName":"ManyValues","Key":"↓ʰ/₱ {","Value":[1,"",4.1017235364794545e-228,25],"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"RetainDeletions","Key":"ᾎⅰ\u000bA*","Value":null,"Delete":true},{"TypeName":"Singleton","Key":null,"Value":{"Value2":""},"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_enum","Key":"foo","Value":{"valNotNull":"baz","valNullable":"bar"},"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_decimal","Key":"-618.7416010936009","Value":["4",null],"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"ThreeKeys","Key":["",11,107],"Value":{"Value1":-31402597},"Delete":false},{"TypeName":"Simple","Key":"\"رऻ","Value":null,"Delete":true}]}
+OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_uint16","Key":24,"Value":[0,null],"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_uint8","Key":61,"Value":[6,6],"Delete":false},{"TypeName":"test_int64","Key":9223372036854775807,"Value":null,"Delete":true}]}
+OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"Simple","Key":"\u0026ắA","Value":null,"Delete":true},{"TypeName":"ManyValues","Key":"","Value":{"Value4":7},"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"RetainDeletions","Key":"؁〩a_𞥟","Value":[-9890928,"5AB0mZv/SEYYAzMShq3/Bh4B"],"Delete":false}]}
 Commit: {}
 StartBlock: {5 <nil> <nil>}
-OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_bool","Key":true,"Value":null,"Delete":true},{"TypeName":"test_int8","Key":-6,"Value":{"valNotNull":122,"valNullable":null},"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_bool","Key":false,"Value":{"valNullable":false},"Delete":false},{"TypeName":"test_address","Key":"UQMARFtfJYloAQ5FAQE+P5ezAZMCP82oChQBYQA5AA0LT19MujQyf/8FbQMDawAM","Value":["zQIdDAwCA1MfywMMFUrXCRcsAAC3OAYBAAyUCi36BQQAAuUkAACrBgAHAgUCAcYAJgM=","HAIBmK0DtgEBBwEBLzEFjXltUcIBBAFcAuZTALIBmAeVArgXLpEyAwAd2rwXD/+2wOT37ekWAr4EAEvnhw=="],"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"ManyValues","Key":"?Ⱥ","Value":{"Value4":80},"Delete":false},{"TypeName":"RetainDeletions","Key":"﻿@‮:","Value":[3016,"AQ=="],"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_bytes","Key":"AAD/AAAFAAEAUQ==","Value":null,"Delete":true},{"TypeName":"test_decimal","Key":"800","Value":["7119101",null],"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"RetainDeletions","Key":"","Value":{"Value2":"LpIWCQoAbw=="},"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_uint64","Key":96,"Value":[2,null],"Delete":false},{"TypeName":"test_uint8","Key":0,"Value":[178,null],"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"RetainDeletions","Key":"৯aࠤာAᬺⅤaȺ￡Ρᵧa󠁳|𝙮 ﻿A","Value":{"Value2":""},"Delete":false},{"TypeName":"Singleton","Key":null,"Value":{"Value":"/ᾪ蹯a_ ᛮ!؋aض©-?﻿","Value2":"4A=="},"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"ThreeKeys","Key":["Ⱥേ҈a҉Ⱥ",-114036639,4],"Value":2147483647,"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_string","Key":"aή⃢\t{ǁ","Value":null,"Delete":true}]}
-OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_duration","Key":-40715358873,"Value":{"valNotNull":-35986926993,"valNullable":null},"Delete":false},{"TypeName":"test_time","Key":"1969-12-31T18:59:59.981789806-05:00","Value":["1969-12-31T18:57:57.72625051-05:00","1969-12-26T16:36:45.679781385-05:00"],"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_decimal","Key":"-40530.610059","Value":{"valNotNull":"-344079482.57151","valNullable":null},"Delete":false},{"TypeName":"test_enum","Key":"baz","Value":{"valNotNull":"bar","valNullable":"baz"},"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_float32","Key":-218792,"Value":null,"Delete":true},{"TypeName":"test_address","Key":"NACQYgAaAwcFAK/IAQEFWgcArAEpMAA=","Value":{"valNullable":null},"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_decimal","Key":"-97E-70","Value":null,"Delete":true}]}
-OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_bytes","Key":"AA==","Value":null,"Delete":true},{"TypeName":"test_bytes","Key":"Bw==","Value":["AwYGBg2V","EWShfAE="],"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"Simple","Key":"A","Value":[3939571,"oAE="],"Delete":false},{"TypeName":"ThreeKeys","Key":["a .౺ऻ\u0026",-1,0],"Value":-343368,"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"TwoKeys","Key":["`ҡ",-483],"Value":null,"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"ManyValues","Key":"aⅭȺ\ta\u0026A୵","Value":{"Value1":1627290802,"Value2":"DQA=","Value3":70375169.64453125,"Value4":7578767657429368},"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"Simple","Key":"󠇯$ aḍa\r","Value":[59,""],"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"TwoKeys","Key":["mA৴ pa _〩ãᛮǅ𑣠ʰA%a",1],"Value":null,"Delete":true}]}
+OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_bool","Key":false,"Value":null,"Delete":true},{"TypeName":"test_int8","Key":-6,"Value":{"valNotNull":122,"valNullable":null},"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"ManyValues","Key":"¨¹^Z_{/ a","Value":{"Value4":80},"Delete":false},{"TypeName":"RetainDeletions","Key":"﻿@‮:","Value":[3016,"AQ=="],"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_bytes","Key":"AQ==","Value":{"valNotNull":"ogMIrOI=","valNullable":null},"Delete":false},{"TypeName":"test_float32","Key":-463,"Value":{"valNotNull":-58786,"valNullable":null},"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"ManyValues","Key":"῭𝚰ഃȺAᶊ?","Value":[-1164946,"",1.176159974717759e+49,1691822],"Delete":false},{"TypeName":"RetainDeletions","Key":"#\\","Value":[1,"FQMCAG04AaQN"],"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_decimal","Key":"2.78157850","Value":null,"Delete":true},{"TypeName":"test_uint64","Key":43469486790,"Value":{"valNotNull":49,"valNullable":null},"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"TwoKeys","Key":["\"A",-2147483648],"Value":null,"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_int32","Key":-103,"Value":[2147483647,null],"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"Singleton","Key":null,"Value":{"Value2":"BmoB"},"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"TwoKeys","Key":["#",0],"Value":null,"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_string","Key":"","Value":["₦~＄",""],"Delete":false},{"TypeName":"test_int64","Key":-9943728846472,"Value":{"valNotNull":-3216,"valNullable":null},"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"RetainDeletions","Key":"!\u0003ᾩ̴+a","Value":{"Value1":314182053,"Value2":"Gxc="},"Delete":false},{"TypeName":"TwoKeys","Key":["a\u003c",-84],"Value":null,"Delete":true}]}
+OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"ManyValues","Key":"?﻿","Value":{"Value1":-6813,"Value2":"AhRPdlAC","Value3":0.00182342529296875,"Value4":2},"Delete":false},{"TypeName":"ManyValues","Key":"յ","Value":[2147483647,"AA==",4.804339095791555e-248,395354],"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"ManyValues","Key":"","Value":null,"Delete":true}]}
+OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_uint8","Key":61,"Value":{"valNullable":255},"Delete":false},{"TypeName":"test_int64","Key":-3,"Value":[-6367,null],"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"TwoKeys","Key":["@",2],"Value":null,"Delete":false},{"TypeName":"TwoKeys","Key":["Ⱥ꙱ǈ",12],"Value":null,"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"TwoKeys","Key":["|󺪆𝅲＝鄖_.;ǀ⃣%; #~",16],"Value":null,"Delete":true},{"TypeName":"ThreeKeys","Key":["$",-1,774000],"Value":{"Value1":-2147483648},"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_enum","Key":"bar","Value":{"valNotNull":"bar","valNullable":"baz"},"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_uint32","Key":1275013456,"Value":[0,null],"Delete":false},{"TypeName":"test_decimal","Key":"-924017190.947061628950076222998262213","Value":{"valNotNull":"5063","valNullable":null},"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"ManyValues","Key":"\t","Value":{"Value1":17694,"Value2":"","Value3":-3.0734751418966004,"Value4":1505826045},"Delete":false}]}
 Commit: {}
 StartBlock: {6 <nil> <nil>}
-OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"TwoKeys","Key":["A𞥟",981],"Value":null,"Delete":false},{"TypeName":"ManyValues","Key":"ᵕ؏­􏿽A","Value":{"Value1":-317,"Value2":"AA==","Value3":-37.62890625,"Value4":232},"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_address","Key":"NACQYgAaAwcFAK/IAQEFWgcArAEpMAA=","Value":{"valNotNull":"HBwBHAY6AAKO+UwDKRICAT0lgRRvCRvHFFoNAigBAUEDHoQUfB2qApRB/z41AAubARsBATQg3gCppQMAAQwHAQ=="},"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_decimal","Key":"-40530.610059","Value":["-2","88111430.0122412446"],"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_uint8","Key":0,"Value":null,"Delete":true},{"TypeName":"test_time","Key":"1969-12-31T18:59:59.981789806-05:00","Value":null,"Delete":true}]}
-OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"Singleton","Key":null,"Value":{"Value":"","Value2":"NeIMrxEMAgI="},"Delete":false},{"TypeName":"RetainDeletions","Key":"꙲󽬺","Value":[835552366,"ngY="],"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"ThreeKeys","Key":["\u0026AȺ#˼%֘_ŕ,A",-467,98],"Value":{"Value1":145},"Delete":false},{"TypeName":"RetainDeletions","Key":"?aa₽A\u001b=⇂́ᯫ𖽦ᩣ","Value":{"Value1":0,"Value2":""},"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"TwoKeys","Key":["`ҡ",-483],"Value":null,"Delete":true}]}
-OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"Simple","Key":"","Value":{"Value1":1174095848,"Value2":"AR//A0kBNVwGGGsHANYAAAAtJQ=="},"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_uint64","Key":3,"Value":[14481555953,496],"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"ManyValues","Key":"ൌ{ ༿","Value":[1110340689,"AQ==",0.00018342199999210607,1],"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"RetainDeletions","Key":"৯aࠤာAᬺⅤaȺ￡Ρᵧa󠁳|𝙮 ﻿A","Value":null,"Delete":true},{"TypeName":"ManyValues","Key":"aⅭȺ\ta\u0026A୵","Value":null,"Delete":true}]}
-OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"Simple","Key":"A","Value":{"Value2":"NwIDBwkD/8I="},"Delete":false},{"TypeName":"Simple","Key":"a ¥﻿𐅝`B܆Å$*","Value":{"Value1":2147483647,"Value2":"4gYDABg="},"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_decimal","Key":"19201864880978510.28381871008156E9","Value":["14793512",null],"Delete":false},{"TypeName":"test_enum","Key":"baz","Value":null,"Delete":true}]}
-OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"Simple","Key":"󠇯$ aḍa\r","Value":[-9,"0AEFPHM="],"Delete":false},{"TypeName":"ThreeKeys","Key":["",0,3265605],"Value":-3703028,"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"ThreeKeys","Key":["Ⱥേ҈a҉Ⱥ",-114036639,4],"Value":{"Value1":502},"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"TwoKeys","Key":["A𞥟",981],"Value":null,"Delete":false},{"TypeName":"ManyValues","Key":"¨¹^Z_{/ a","Value":[-1060712359,"",14247.827343544246,589],"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"RetainDeletions","Key":"̅Ⱥ‮","Value":[1,"AA=="],"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_integer","Key":"-902404257","Value":["-34617","11684004"],"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"Singleton","Key":null,"Value":{"Value":"\u0011.-A©Aa"},"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_decimal","Key":"-618.7416010936009","Value":["-2","88111430.0122412446"],"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_uint8","Key":7,"Value":null,"Delete":true},{"TypeName":"test_time","Key":"1969-12-31T19:00:19.631216449-05:00","Value":null,"Delete":true}]}
+OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_uint8","Key":3,"Value":[105,null],"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_duration","Key":100403021838,"Value":[1547,null],"Delete":false},{"TypeName":"test_uint8","Key":61,"Value":[0,17],"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"RetainDeletions","Key":",a _ŕ,A","Value":{"Value1":-2956,"Value2":"b8ABC3UL"},"Delete":false},{"TypeName":"TwoKeys","Key":["#",0],"Value":null,"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"RetainDeletions","Key":"A","Value":[-1634,"xYV1wGkDTQQD5w=="],"Delete":false},{"TypeName":"TwoKeys","Key":["\"A",-2147483648],"Value":null,"Delete":true}]}
+OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_address","Key":"AAEgvwGmbgFqAAGkMQAYlBICzQEYAgsBFRcDAiud/ykGAitFA6tJA04SB+8DwBMAAQxXDyz/","Value":["BFEKBowcIgQV/wCLEmwagiSjAANRA/EELQFeGDQtGv/5rdA1AAMeuQEoF8eoAQ==","HXoB/wT4E1QBVHuwBhkBAecMS5cABRkBIychAQhyHAdtbnvkAQcAUQEAAiIJAQczcAEDAAAA2uiNAQEAY4d1Aw=="],"Delete":false},{"TypeName":"test_string","Key":"a]\u003e/a֍)!\"˂A","Value":null,"Delete":true}]}
+OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_uint16","Key":24,"Value":null,"Delete":true}]}
+OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_bool","Key":true,"Value":[true,null],"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"Simple","Key":"~_̀\u000b","Value":[1,""],"Delete":false},{"TypeName":"RetainDeletions","Key":"𑇕|िaA\u003eA˖Aࢍ󾊥","Value":[-41836,"qUoBBFA="],"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"TwoKeys","Key":["Ⱥ꙱ǈ",12],"Value":null,"Delete":false}]}
 Commit: {}
 StartBlock: {7 <nil> <nil>}
-OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_bool","Key":true,"Value":{"valNotNull":true,"valNullable":true},"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"Simple","Key":"‮","Value":{"Value2":""},"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_bool","Key":false,"Value":[false,null],"Delete":false},{"TypeName":"test_bool","Key":false,"Value":{"valNullable":true},"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"TwoKeys","Key":["A𞥟",981],"Value":null,"Delete":true}]}
-OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"TwoKeys","Key":["ः𒑨ǲ؅",-2],"Value":null,"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"ThreeKeys","Key":["@(\u0001\u0001\tᛰᾚ𐺭a'ᵆᾭaa",16,817744173394],"Value":{"Value1":-2},"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_bytes","Key":"Bw==","Value":{"valNotNull":"AWNXAw=="},"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_decimal","Key":"-85","Value":["-2511998","-077.01427082957E-7"],"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_int16","Key":-4371,"Value":null,"Delete":true}]}
-OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_enum","Key":"foo","Value":{"valNotNull":"foo","valNullable":null},"Delete":false},{"TypeName":"test_uint32","Key":522395,"Value":[2730,3],"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_address","Key":"sucDH0r/CmEAgjcBB7H1AgAcEtI=","Value":["GVr4AxwBAN14AAYApgFuif8HrpAE9FcABBcPAGpHAQLtE3UmLQwOAjgrEMMC4w//","irH/SwYtmFOeC3EE/wEdAxnJCn8Oapb/tWjEj28BLhs1"],"Delete":false},{"TypeName":"test_address","Key":"NACQYgAaAwcFAK/IAQEFWgcArAEpMAA=","Value":["AwIBAz8EAA5dZQEATgEBAnG+p3MPVwYAEV1dBwMDAQADCgYEJQcD+EgAAAcB","t3xyAAYBDQQHAgHH1ANoVw//Pv+nAP89Ao8OANr3BUIBAg=="],"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_uint8","Key":7,"Value":[190,null],"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_bool","Key":false,"Value":[true,null],"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_integer","Key":"-7261530924372552","Value":null,"Delete":true}]}
+OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"Singleton","Key":null,"Value":null,"Delete":true}]}
+OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_bool","Key":true,"Value":[true,false],"Delete":false},{"TypeName":"test_int16","Key":3,"Value":[0,null],"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"ThreeKeys","Key":["A˜Ľ᠔",191623,168792497866039],"Value":{"Value1":87},"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"ManyValues","Key":"🚞;aীǲ","Value":{"Value1":294,"Value2":"BATeW2cC","Value3":5.9263472855091095,"Value4":23},"Delete":false},{"TypeName":"Simple","Key":"\taaaa𐅋́{󠁐 #\t\u001bץः𒐟𐅘᭢a","Value":[-23103798,"AwcGAg=="],"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_int16","Key":453,"Value":{"valNotNull":15040,"valNullable":3},"Delete":false},{"TypeName":"test_enum","Key":"bar","Value":{"valNullable":"bar"},"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"RetainDeletions","Key":"ᾢ","Value":[-4,"AtkOBQphAII3AQ=="],"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"ThreeKeys","Key":["±?󠀮_? ‍*🄑󠇯",-40,138699519114],"Value":{"Value1":-275850},"Delete":false},{"TypeName":"TwoKeys","Key":["#/\u003c_",-5],"Value":null,"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"RetainDeletions","Key":"","Value":null,"Delete":true},{"TypeName":"ThreeKeys","Key":["$",-1,774000],"Value":null,"Delete":true}]}
+OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"ManyValues","Key":"_; ᾚ ǲA{˭҄\nA ^$?ᾦ,:\u003c\"?_\u0014;|","Value":{"Value3":8.808423392052715e-20,"Value4":0},"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"ManyValues","Key":"?﻿","Value":null,"Delete":true},{"TypeName":"Simple","Key":";|⃝⤎?‮","Value":[8706,"AI8mhQ=="],"Delete":false}]}
 Commit: {}
 StartBlock: {8 <nil> <nil>}
-OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"Simple","Key":"\u000b𝜛࣢Ⱥ +\u001c","Value":[0,""],"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"Simple","Key":"‮","Value":[0,""],"Delete":false}]}
 OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_decimal","Key":"8E4","Value":{"valNotNull":"4043421E29","valNullable":null},"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_address","Key":"NACQYgAaAwcFAK/IAQEFWgcArAEpMAA=","Value":null,"Delete":true}]}
-OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"TwoKeys","Key":["ः𒑨ǲ؅",-2],"Value":null,"Delete":true}]}
-OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"TwoKeys","Key":["",55175],"Value":null,"Delete":false},{"TypeName":"RetainDeletions","Key":"?aa₽A\u001b=⇂́ᯫ𖽦ᩣ","Value":{"Value1":3},"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_duration","Key":-9223372036854775808,"Value":[-4,-805402038367],"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_bool","Key":false,"Value":null,"Delete":true},{"TypeName":"test_int32","Key":-24,"Value":[1,null],"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"RetainDeletions","Key":"҉߃ ","Value":[-526,""],"Delete":false},{"TypeName":"Simple","Key":"A","Value":[59,"Kw=="],"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_address","Key":"UQMARFtfJYloAQ5FAQE+P5ezAZMCP82oChQBYQA5AA0LT19MujQyf/8FbQMDawAM","Value":["CRRWVxf/DVOzCAMAClAsCT0BAP8BPQ==",null],"Delete":false},{"TypeName":"test_enum","Key":"baz","Value":["bar","foo"],"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_bytes","Key":"BQ==","Value":{"valNotNull":"AQYYDVF9MQF2","valNullable":"qQU="},"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_int64","Key":-1,"Value":null,"Delete":true}]}
-OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_integer","Key":"433032","Value":{"valNotNull":"25","valNullable":"937"},"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_int16","Key":9863,"Value":[1851,null],"Delete":false},{"TypeName":"test_decimal","Key":"800","Value":["0448127215514e88",null],"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"Simple","Key":"","Value":null,"Delete":true}]}
-OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"RetainDeletions","Key":"﻿@‮:","Value":null,"Delete":true},{"TypeName":"ManyValues","Key":"ᵕ؏­􏿽A","Value":null,"Delete":true}]}
-OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"RetainDeletions","Key":"'","Value":{"Value1":-611,"Value2":"AgqTAG4="},"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"Singleton","Key":null,"Value":["$?A","BAtu"],"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"TwoKeys","Key":["h ʶ?\\A魘",47994411],"Value":null,"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_uint64","Key":96,"Value":{"valNotNull":4576150250879893,"valNullable":329},"Delete":false},{"TypeName":"test_duration","Key":-152,"Value":null,"Delete":true}]}
-OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"Simple","Key":"󴵠","Value":[-3,"QwH/FQ=="],"Delete":false},{"TypeName":"ThreeKeys","Key":["_\u001b\u0026㉉",7,3662],"Value":{"Value1":-3316206},"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_address","Key":"AAEgvwGmbgFqAAGkMQAYlBICzQEYAgsBFRcDAiud/ykGAitFA6tJA04SB+8DwBMAAQxXDyz/","Value":{"valNullable":"BOYwACUAABLY7gECcQYUogBeNQE="},"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"RetainDeletions","Key":"?+‌᭵̄$߃ ","Value":[-526,""],"Delete":false},{"TypeName":"Simple","Key":" Ⅻ\t%a","Value":{"Value1":-3584},"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_time","Key":"1969-12-31T19:00:00.000000081-05:00","Value":{"valNotNull":"1969-12-31T18:59:59.999998159-05:00","valNullable":null},"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_uint8","Key":1,"Value":[56,54],"Delete":false},{"TypeName":"test_uint32","Key":6,"Value":{"valNotNull":13,"valNullable":null},"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_bool","Key":true,"Value":null,"Delete":true},{"TypeName":"test_int8","Key":98,"Value":{"valNotNull":25,"valNullable":-49},"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"RetainDeletions","Key":"A","Value":null,"Delete":true}]}
+OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"ThreeKeys","Key":["A˜Ľ᠔",191623,168792497866039],"Value":{"Value1":87072},"Delete":false},{"TypeName":"TwoKeys","Key":["aA\u003c‌ऻ⁠\r#﻿#﹍/$ͥ",-4],"Value":null,"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_bytes","Key":"AQ==","Value":null,"Delete":true},{"TypeName":"test_uint64","Key":271328219,"Value":[9960,1],"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_uint64","Key":43469486790,"Value":null,"Delete":true},{"TypeName":"test_float64","Key":-368,"Value":{"valNotNull":-3.9541311264038086,"valNullable":null},"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"Singleton","Key":null,"Value":["","DTQAB6ENAQ=="],"Delete":false},{"TypeName":"ManyValues","Key":"յ","Value":[248203,"",-29237.73048098229,108708571677],"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_float64","Key":-2,"Value":[1.1408884758148922e-229,null],"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_uint64","Key":5388077,"Value":{"valNotNull":4576150250879893,"valNullable":329},"Delete":false},{"TypeName":"test_duration","Key":-152,"Value":null,"Delete":true}]}
+OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_uint8","Key":3,"Value":[1,null],"Delete":false},{"TypeName":"test_bool","Key":false,"Value":{"valNullable":true},"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"ManyValues","Key":"\t","Value":{"Value2":"ABU=","Value3":-2.1604673743609532e-204},"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"ManyValues","Key":"꙱؁\t­","Value":[-3,"",1.3442634946997238e+307,1561872634],"Delete":false},{"TypeName":"ManyValues","Key":"A⃟`?+₯~ী²a𞥃💵𐴸-/","Value":{"Value1":1647,"Value2":"aocGBA==","Value3":700057251012346200,"Value4":22},"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_enum","Key":"baz","Value":["foo","foo"],"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"ManyValues","Key":"ƻ̄n","Value":[-4385933,"9QARXRwUUPU=",3.130815935698223e+222,46],"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"RetainDeletions","Key":"ऻ^￦́Ì'\u0017A:ĕ\u0026\\⁡\r$a","Value":[-27600,"LAYJAzkABc0A"],"Delete":false},{"TypeName":"TwoKeys","Key":[" ",2],"Value":null,"Delete":false}]}
 Commit: {}
 StartBlock: {9 <nil> <nil>}
-OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"TwoKeys","Key":["h ʶ?\\A魘",47994411],"Value":null,"Delete":true}]}
-OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"Simple","Key":"_�é","Value":{"Value1":9,"Value2":"Ywc="},"Delete":false},{"TypeName":"Singleton","Key":null,"Value":null,"Delete":true}]}
-OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"RetainDeletions","Key":"A%aa ¹­ ᾏaĵ¨","Value":[9,"A/faBuYCCecZ3ATQAQcC3gAsizI="],"Delete":false},{"TypeName":"ThreeKeys","Key":[" {a",2790155,310794],"Value":{"Value1":312},"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_int32","Key":892,"Value":[-3,null],"Delete":false},{"TypeName":"test_duration","Key":-9223372036854775808,"Value":[-722503,113854019],"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_duration","Key":-40715358873,"Value":[12,null],"Delete":false},{"TypeName":"test_int16","Key":0,"Value":[3089,null],"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_decimal","Key":"19201864880978510.28381871008156E9","Value":null,"Delete":true}]}
-OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"ThreeKeys","Key":["",0,3265605],"Value":null,"Delete":true}]}
-OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_bool","Key":false,"Value":{"valNotNull":false,"valNullable":null},"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_decimal","Key":"82509790016910","Value":{"valNotNull":"-51151","valNullable":null},"Delete":false},{"TypeName":"test_address","Key":"UQMARFtfJYloAQ5FAQE+P5ezAZMCP82oChQBYQA5AA0LT19MujQyf/8FbQMDawAM","Value":{"valNotNull":"xbA200EFExwKoFrhCgcAYwFvDgEBXAH8AADJAAQFDfgITwIFDh8BAXQMRUwBAgY8/wANBCQGANqvCWL/AYwA+g==","valNullable":"OgPvFo8DAA+2AgEBBM4BXSAA/wCBlzxUAVoC/wQBAbIMKiwD/0MBKAF4Bv8BAoIOUwALFSMuVgIAAZddBQEDBA=="},"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_integer","Key":"64","Value":["13","-732"],"Delete":false},{"TypeName":"test_float32","Key":-2147483648,"Value":{"valNotNull":-0.38865662,"valNullable":null},"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"ManyValues","Key":"ൌ{ ༿","Value":{"Value1":-152,"Value3":-204.96875},"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"Simple","Key":"‮","Value":{"Value1":-44227},"Delete":false},{"TypeName":"Simple","Key":"A","Value":[837,"Aw=="],"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"Simple","Key":"�-\u003e𝟆Ⱥ`Ṙ|¤﮺̺","Value":[1137505,"UQAXACIMig=="],"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"TwoKeys","Key":["#",0],"Value":null,"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"ThreeKeys","Key":["�é",4,5],"Value":-21,"Delete":false},{"TypeName":"RetainDeletions","Key":"ǀȺA%aa ¹­ ᾏaĵ¨","Value":[9,"A/faBuYCCecZ3ATQAQcC3gAsizI="],"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_bool","Key":true,"Value":{"valNotNull":false,"valNullable":null},"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"ManyValues","Key":"@d𒐽\u001b⃠","Value":[83523,"fgihAbYBRq4BAR4ATWUwAAADAUgDCZEI",5.463114807757741e-9,2],"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_uint8","Key":146,"Value":[2,null],"Delete":false},{"TypeName":"test_uint16","Key":36451,"Value":[2,null],"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"ThreeKeys","Key":["±?󠀮_? ‍*🄑󠇯",-40,138699519114],"Value":null,"Delete":true}]}
+OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_integer","Key":"-902404257","Value":null,"Delete":true},{"TypeName":"test_bool","Key":false,"Value":null,"Delete":true}]}
+OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_int8","Key":98,"Value":[-45,16],"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"Simple","Key":"V:\u0004","Value":{"Value1":-2,"Value2":""},"Delete":false},{"TypeName":"ManyValues","Key":"A⃟`?+₯~ী²a𞥃💵𐴸-/","Value":null,"Delete":true}]}
+OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"RetainDeletions","Key":"~ᾈ\u0004󱜏a _〩ãᛮǅ𑣠ʰA%a","Value":null,"Delete":true},{"TypeName":"Simple","Key":"$#","Value":null,"Delete":true}]}
+OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"ManyValues","Key":"B;ᛮ\"𐅕\u0026؀ा󠁿","Value":[7541152,"",-3.2742207969630795e+66,1],"Delete":false},{"TypeName":"Simple","Key":"A{","Value":[4,"BQ34"],"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_uint8","Key":1,"Value":[18,1],"Delete":false},{"TypeName":"test_bytes","Key":"xxV9kyMR","Value":["SwFUlRYWA7Q1C5MCMA==",null],"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"Simple","Key":"~_̀\u000b","Value":[2147483647,"WgL/BAEBsg=="],"Delete":false}]}
 Commit: {}
 StartBlock: {10 <nil> <nil>}
-OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_duration","Key":87208838869,"Value":[-9725,4968373],"Delete":false},{"TypeName":"test_duration","Key":-40715358873,"Value":null,"Delete":true}]}
-OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"RetainDeletions","Key":"","Value":[-1,"FQIK"],"Delete":false},{"TypeName":"Singleton","Key":null,"Value":{"Value":"ǈ$࿇ ᾙ☇﻿؄ೲȺ","Value2":"ADei6AACZTMDDss="},"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_bool","Key":false,"Value":[true,null],"Delete":false},{"TypeName":"test_enum","Key":"baz","Value":{"valNotNull":"baz","valNullable":"baz"},"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"ThreeKeys","Key":[" {a",2790155,310794],"Value":{"Value1":1},"Delete":false},{"TypeName":"RetainDeletions","Key":"\u0026 ٱȺ+҉@","Value":[63,"AAE="],"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_float64","Key":2818,"Value":[-1.0781831287525041e+139,111.37014762980289],"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_address","Key":"sucDH0r/CmEAgjcBB7H1AgAcEtI=","Value":{"valNotNull":"em2zQwR2O7EAAAYLk23QBADE/wA="},"Delete":false},{"TypeName":"test_address","Key":"UQMARFtfJYloAQ5FAQE+P5ezAZMCP82oChQBYQA5AA0LT19MujQyf/8FbQMDawAM","Value":null,"Delete":true}]}
-OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"ManyValues","Key":"","Value":[-188,"",-2632691.375,17],"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"ThreeKeys","Key":["A]$",-125,43],"Value":12654289,"Delete":false},{"TypeName":"RetainDeletions","Key":"+","Value":{"Value2":"ARM="},"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_uint8","Key":35,"Value":[0,51],"Delete":false},{"TypeName":"test_uint8","Key":107,"Value":[4,null],"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_decimal","Key":"-85","Value":{"valNotNull":"-25"},"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"ThreeKeys","Key":["_\u001b\u0026㉉",7,3662],"Value":{"Value1":-80},"Delete":false},{"TypeName":"RetainDeletions","Key":"'","Value":[5521,"kwsBjw=="],"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"ThreeKeys","Key":["@(\u0001\u0001\tᛰᾚ𐺭a'ᵆᾭaa",16,817744173394],"Value":-1,"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"ManyValues","Key":"ǋ#߁#҉♰ᾜȺ൜堯Ⱥ៵\"","Value":{"Value1":-10,"Value2":"jg==","Value3":-0.11867497289509932,"Value4":24065},"Delete":false},{"TypeName":"RetainDeletions","Key":"","Value":{"Value1":2204165,"Value2":"Jg=="},"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"ThreeKeys","Key":["A*۽~ǲ₱ {",-8,2],"Value":{"Value1":624},"Delete":false},{"TypeName":"ManyValues","Key":"ڥ\u0026\u000b","Value":{"Value1":0,"Value2":"BmQD","Value3":-6.822989118840796e-47,"Value4":654213},"Delete":false}]}
-OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"ThreeKeys","Key":["{Ⱥ\t$࿐(#",117624,128273],"Value":14,"Delete":false},{"TypeName":"RetainDeletions","Key":"A%aa ¹­ ᾏaĵ¨","Value":{"Value2":"Av8="},"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_duration","Key":87208838869,"Value":[-9725,4968373],"Delete":false},{"TypeName":"test_duration","Key":100403021838,"Value":null,"Delete":true}]}
+OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"RetainDeletions","Key":"","Value":[-1,"FQIK"],"Delete":false},{"TypeName":"Singleton","Key":null,"Value":["%﻿؄ೲȺ","ADei6AACZTMDDss="],"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_time","Key":"1969-12-31T18:59:59.999999999-05:00","Value":["1969-12-31T19:00:00.000000203-05:00","1969-12-31T18:59:59.988846518-05:00"],"Delete":false},{"TypeName":"test_bool","Key":true,"Value":{"valNotNull":false,"valNullable":true},"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"RetainDeletions","Key":"ȺAª","Value":{"Value1":5,"Value2":"ByIBAAF0"},"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"ManyValues","Key":"ʱ? ﻿-@","Value":[26,"BQ==",40371.625,136914],"Delete":false},{"TypeName":"RetainDeletions","Key":"?+‌᭵̄$߃ ","Value":[-4,"AWcfjgc="],"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"RetainDeletions","Key":"𝅲𝡇","Value":[3,"AQX4eAM="],"Delete":false},{"TypeName":"ManyValues","Key":"\t","Value":{"Value4":1956},"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_int64","Key":-12,"Value":{"valNotNull":-121,"valNullable":-2},"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"ManyValues","Key":"","Value":[-23,"AQ==",-1.448908652612274e-70,579180],"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"RetainDeletions","Key":",a _ŕ,A","Value":null,"Delete":true}]}
+OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_bytes","Key":"xxV9kyMR","Value":null,"Delete":true}]}
+OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_float32","Key":-463,"Value":[-3.594342e-17,6.4607563e-37],"Delete":false},{"TypeName":"test_bytes","Key":"","Value":["IBEeAY8BAC1uKQU=",null],"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"ThreeKeys","Key":["",11,107],"Value":{"Value1":-80},"Delete":false},{"TypeName":"RetainDeletions","Key":"#\\","Value":[5521,"kwsBjw=="],"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"Simple","Key":"˚~%!ˍ˃\"ᾜȺ൜堯Ⱥ៵\"","Value":{"Value1":-10,"Value2":"jg=="},"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"all_kinds","Updates":[{"TypeName":"test_bool","Key":false,"Value":[true,null],"Delete":false}]}
+OnObjectUpdate: {"ModuleName":"test_cases","Updates":[{"TypeName":"ThreeKeys","Key":["A⒄a𲎯ڥ\u0026\u000b",1,0],"Value":{"Value1":154068889},"Delete":false},{"TypeName":"ManyValues","Key":"~ʳ{ {Ⱥ\t$࿐(#","Value":{"Value1":-26,"Value2":"","Value3":121.70742593632353,"Value4":1762146},"Delete":false}]}
 Commit: {}

--- a/schema/testing/appdatasim/testdata/diff_example.txt
+++ b/schema/testing/appdatasim/testdata/diff_example.txt
@@ -2,68 +2,69 @@ App State Diff:
 MODULE COUNT ERROR: expected 2, got 1
 Module all_kinds
   Object Collection test_address
-    OBJECT COUNT ERROR: expected 14, got 13
-    Object key=0x34009062001a03070500afc80101055a0700ac01293000: NOT FOUND
-    Object key=0x5b01cd8d349b030278030112d8e6020f00000600cc2f66016a016d01: NOT FOUND
+    OBJECT COUNT ERROR: expected 12, got 7
+    Object key=0x00000306012e340202ff01a4310018941202cd0118020b01151703022b9dff2906022b4503ab49034e1207ef03c01300010c570f2cff: NOT FOUND
+    Object key=0x0000190f0405000a0501050288020000000100ff003b4d4b010700ff6f0e530a0e010104067a63b602055c000e0100: NOT FOUND
+    Object key=0x010901a813050300274200409f0200000b362f1c: NOT FOUND
+    Object key=0x01df2d00000627ff00fc0d9901003a93680000007501ff00010215290d000d0712: NOT FOUND
+    Object key=0x0200010d1a0100db010100ad8b1d0103180088bb0742258a66010303000c001200b200273e0d2051cc8656ff8304aa1d7e01: NOT FOUND
+    Object key=0x030201140105cc030101f5c9e4a7dafe1703f918000001cd01070309031901f007030a1371d4181bedf9c7340e82b8e655789f830106800c01a90701010d0f04: NOT FOUND
+    Object key=0x43063c0003f6218d29280001002e0e352f630100f70d073a01010e039a077a3d00379d0100b9018302fddb3000131939469d0172bc1614343802f916
+      valNotNull: expected [6 3 149 0 1 1 95 3 5 115 6 61 5 80 15 105 31 231 0 13 222 115 183 0 193 1 0 126 181 21], got [0 8 30 7 6 2 80 6 234 1 20 2 44 227 23 5 71 7 218 161 66 107 225 254 0 11 52 57 193 126 42 62 67 0 0 43 0 212 75 255 22]
+      valNullable: expected [124 169 52 6 86 99 120 2 25 0 71 192 164 7 162 0 1 0 5 0 24 246 1 198 14 57 3 3 1 1 1], got [196 2 95 46 3 0 0 208 251 25 73 62 53 1 6 0 30 0 4 217 1 10 116 0 11 130 11 253 204 45 43 57 6 6 63 75 7 183 195 65 0 143 3 89 2 3 0 33 234 58 12 15 16 0 115 12 190 7 0 218]
+      Object key=0x810100146300390103010105021f8a2f1300000b07b7ff0207078e701700b8ee008d003709cfc800062bff00d3120010019a01ec0e058f03500039f8029601: NOT FOUND
     Object Collection test_bool
-    Object key=false
-      valNotNull: expected true, got false
-      Object key=true
+    Object key=true
       valNotNull: expected true, got false
       Object Collection test_bytes
-    Object key=0x09: NOT FOUND
-    Object Collection test_decimal
-    OBJECT COUNT ERROR: expected 6, got 5
-    Object key=-99910.16: NOT FOUND
-    Object key=309967364: NOT FOUND
+    OBJECT COUNT ERROR: expected 3, got 1
+    Object key=0x: NOT FOUND
+    Object key=0xc2d7: NOT FOUND
+    Object key=0xff661b1c00
+      valNotNull: expected [255 0 24 235 0 84 11], got [17]
+      valNullable: expected [1 18 6], got [0 8 1 170 90 0 1 201 97 138 53 2]
+      Object Collection test_decimal
+    OBJECT COUNT ERROR: expected 3, got 0
+    Object key=0.00041: NOT FOUND
+    Object key=2236909734871917105: NOT FOUND
+    Object key=3.9672E+5: NOT FOUND
     Object Collection test_duration
-    OBJECT COUNT ERROR: expected 8, got 7
-    Object key=-3m19.124749496s: NOT FOUND
-    Object key=45ns: NOT FOUND
+    OBJECT COUNT ERROR: expected 1, got 2
+    Object Collection test_enum
+    Object key=baz: NOT FOUND
     Object Collection test_float32
-    Object key=-2: NOT FOUND
+    OBJECT COUNT ERROR: expected 4, got 3
+    Object key=-16: NOT FOUND
+    Object key=-5: NOT FOUND
+    Object Collection test_int16
+    OBJECT COUNT ERROR: expected 5, got 4
+    Object key=3518: NOT FOUND
     Object Collection test_int32
-    OBJECT COUNT ERROR: expected 1, got 0
-    Object key=-148250689: NOT FOUND
+    OBJECT COUNT ERROR: expected 3, got 4
     Object Collection test_int64
+    Object key=-53052092: NOT FOUND
+    Object Collection test_int8
     OBJECT COUNT ERROR: expected 4, got 3
-    Object key=1086011412347477: NOT FOUND
-    Object key=881248243728748743
-      valNotNull: expected 1, got -154
-      valNullable: expected 363352528, got nil
-      Object Collection test_int8
-    Object key=53
-      valNotNull: expected -7, got 58
-      valNullable: expected 15, got -10
-      Object Collection test_integer
-    OBJECT COUNT ERROR: expected 4, got 3
-    Object key=12
-      valNotNull: expected -3, got 101
-      Object key=4: NOT FOUND
+    Object key=0: NOT FOUND
     Object Collection test_string
-    Object key=
-    #[ǅ¦&?=: NOT FOUND
-    Object Collection test_time
-    Object key=1969-12-31 19:00:00.001598687 -0500 EST
-      valNullable: expected nil, got 1969-12-31 19:00:00.000000033 -0500 EST
-      Object Collection test_uint16
-    OBJECT COUNT ERROR: expected 4, got 3
-    Object key=1478: NOT FOUND
+    OBJECT COUNT ERROR: expected 6, got 4
+    Object key=;֏!A$⍈̈#a²𒑮{: NOT FOUND
+    Object key=a]>/a֍)!"˂A: NOT FOUND
+    Object key=҉೫ᾙ
+    
+      valNotNull: expected @۰a?, got ҉"🏿᷾꜌-?𒑮
+      valNullable: expected nil, got 
+      Object key=ਃÙ࣢Ⱥ +
+      valNotNull: expected \^𞻱⅗�, got 𐹹aa
+      valNullable: expected nil, got aa
+      Object Collection test_time
+    Object key=1969-12-31 18:59:59.99999818 -0500 EST: NOT FOUND
     Object Collection test_uint32
-    OBJECT COUNT ERROR: expected 3, got 2
-    Object key=0
-      valNotNull: expected 1, got 26
-      valNullable: expected 321283034, got 2
-      Object key=23067: NOT FOUND
+    OBJECT COUNT ERROR: expected 2, got 3
     Object Collection test_uint64
-    OBJECT COUNT ERROR: expected 2, got 0
-    Object key=1: NOT FOUND
-    Object key=50508131: NOT FOUND
+    OBJECT COUNT ERROR: expected 2, got 3
     Object Collection test_uint8
     OBJECT COUNT ERROR: expected 2, got 1
-    Object key=119
-      valNotNull: expected 6, got 30
-      valNullable: expected nil, got 7
-      Object key=72: NOT FOUND
+    Object key=0: NOT FOUND
     Module test_cases: actual module NOT FOUND
 BlockNum: expected 2, got 1

--- a/schema/testing/enum.go
+++ b/schema/testing/enum.go
@@ -15,6 +15,14 @@ var enumNumericKindGen = rapid.SampledFrom([]schema.Kind{
 	schema.Uint16Kind,
 })
 
+var enumNumericValueGens = map[schema.Kind]*rapid.Generator[int32]{
+	schema.Int8Kind:   rapid.Map(rapid.Int8(), func(a int8) int32 { return int32(a) }),
+	schema.Int16Kind:  rapid.Map(rapid.Int16(), func(a int16) int32 { return int32(a) }),
+	schema.Int32Kind:  rapid.Map(rapid.Int32(), func(a int32) int32 { return a }),
+	schema.Uint8Kind:  rapid.Map(rapid.Uint8(), func(a uint8) int32 { return int32(a) }),
+	schema.Uint16Kind: rapid.Map(rapid.Uint16(), func(a uint16) int32 { return int32(a) }),
+}
+
 // EnumType generates random valid EnumTypes.
 func EnumType() *rapid.Generator[schema.EnumType] {
 	return rapid.Custom(func(t *rapid.T) schema.EnumType {
@@ -23,10 +31,10 @@ func EnumType() *rapid.Generator[schema.EnumType] {
 			NumericKind: enumNumericKindGen.Draw(t, "numericKind"),
 		}
 
-		// we generate enum field values using FieldValueGen, which is a generator for random field values
-		numericValueGen := FieldValueGen(schema.Field{Kind: enum.GetNumericKind()}, schema.EmptySchema{})
-		numericValues := rapid.SliceOfNDistinct(rapid.Map(numericValueGen, func(a any) int32 { return a.(int32) }), 1, 10,
-			func(a int32) int32 { return a }).Draw(t, "values")
+		numericValueGen := enumNumericValueGens[enum.GetNumericKind()]
+		numericValues := rapid.SliceOfNDistinct(numericValueGen, 1, 10, func(e int32) int32 {
+			return e
+		}).Draw(t, "values")
 		n := len(numericValues)
 		names := rapid.SliceOfNDistinct(NameGen, n, n, func(a string) string { return a }).Draw(t, "names")
 		values := make([]schema.EnumValueDefinition, n)

--- a/schema/testing/enum.go
+++ b/schema/testing/enum.go
@@ -6,14 +6,36 @@ import (
 	"cosmossdk.io/schema"
 )
 
-var enumValuesGen = rapid.SliceOfNDistinct(NameGen, 1, 10, func(x string) string { return x })
+var enumNumericKindGen = rapid.SampledFrom([]schema.Kind{
+	schema.InvalidKind,
+	schema.Int8Kind,
+	schema.Int16Kind,
+	schema.Int32Kind,
+	schema.Uint8Kind,
+	schema.Uint16Kind,
+})
 
 // EnumType generates random valid EnumTypes.
-var EnumType = rapid.Custom(func(t *rapid.T) schema.EnumType {
-	enum := schema.EnumType{
-		Name:   NameGen.Draw(t, "name"),
-		Values: enumValuesGen.Draw(t, "values"),
-	}
+func EnumType() *rapid.Generator[schema.EnumType] {
+	return rapid.Custom(func(t *rapid.T) schema.EnumType {
+		enum := schema.EnumType{
+			Name:        NameGen.Draw(t, "name"),
+			NumericKind: enumNumericKindGen.Draw(t, "numericKind"),
+		}
 
-	return enum
-})
+		// we generate enum field values using FieldValueGen, which is a generator for random field values
+		numericValueGen := FieldValueGen(schema.Field{Kind: enum.GetNumericKind()}, schema.EmptySchema{})
+		numericValues := rapid.SliceOfNDistinct(rapid.Map(numericValueGen, func(a any) int32 { return a.(int32) }), 1, 10,
+			func(a int32) int32 { return a }).Draw(t, "values")
+		n := len(numericValues)
+		names := rapid.SliceOfNDistinct(NameGen, n, n, func(a string) string { return a }).Draw(t, "names")
+		values := make([]schema.EnumValueDefinition, n)
+		for i, v := range numericValues {
+			values[i] = schema.EnumValueDefinition{Name: names[i], Value: v}
+		}
+
+		enum.Values = values
+
+		return enum
+	})
+}

--- a/schema/testing/enum_test.go
+++ b/schema/testing/enum_test.go
@@ -5,11 +5,13 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"pgregory.net/rapid"
+
+	"cosmossdk.io/schema"
 )
 
 func TestEnumType(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
-		enumType := EnumType.Draw(t, "enum")
-		require.NoError(t, enumType.Validate())
+		enumType := EnumType().Draw(t, "enum")
+		require.NoError(t, enumType.Validate(schema.EmptySchema{}))
 	})
 }

--- a/schema/testing/example_schema.go
+++ b/schema/testing/example_schema.go
@@ -10,8 +10,8 @@ import (
 // that can be used in reproducible unit testing and property based testing.
 var ExampleAppSchema = map[string]schema.ModuleSchema{
 	"all_kinds": mkAllKindsModule(),
-	"test_cases": MustNewModuleSchema([]schema.ObjectType{
-		{
+	"test_cases": schema.MustNewModuleSchema(
+		schema.ObjectType{
 			Name:      "Singleton",
 			KeyFields: []schema.Field{},
 			ValueFields: []schema.Field{
@@ -25,7 +25,7 @@ var ExampleAppSchema = map[string]schema.ModuleSchema{
 				},
 			},
 		},
-		{
+		schema.ObjectType{
 			Name: "Simple",
 			KeyFields: []schema.Field{
 				{
@@ -44,7 +44,7 @@ var ExampleAppSchema = map[string]schema.ModuleSchema{
 				},
 			},
 		},
-		{
+		schema.ObjectType{
 			Name: "TwoKeys",
 			KeyFields: []schema.Field{
 				{
@@ -57,7 +57,7 @@ var ExampleAppSchema = map[string]schema.ModuleSchema{
 				},
 			},
 		},
-		{
+		schema.ObjectType{
 			Name: "ThreeKeys",
 			KeyFields: []schema.Field{
 				{
@@ -80,7 +80,7 @@ var ExampleAppSchema = map[string]schema.ModuleSchema{
 				},
 			},
 		},
-		{
+		schema.ObjectType{
 			Name: "ManyValues",
 			KeyFields: []schema.Field{
 				{
@@ -107,7 +107,7 @@ var ExampleAppSchema = map[string]schema.ModuleSchema{
 				},
 			},
 		},
-		{
+		schema.ObjectType{
 			Name: "RetainDeletions",
 			KeyFields: []schema.Field{
 				{
@@ -127,18 +127,18 @@ var ExampleAppSchema = map[string]schema.ModuleSchema{
 			},
 			RetainDeletions: true,
 		},
-	}),
+	),
 }
 
 func mkAllKindsModule() schema.ModuleSchema {
-	var objTypes []schema.ObjectType
+	types := []schema.Type{testEnum}
 	for i := 1; i < int(schema.MAX_VALID_KIND); i++ {
 		kind := schema.Kind(i)
 		typ := mkTestObjectType(kind)
-		objTypes = append(objTypes, typ)
+		types = append(types, typ)
 	}
 
-	return MustNewModuleSchema(objTypes)
+	return schema.MustNewModuleSchema(types...)
 }
 
 func mkTestObjectType(kind schema.Kind) schema.ObjectType {
@@ -147,7 +147,7 @@ func mkTestObjectType(kind schema.Kind) schema.ObjectType {
 	}
 
 	if kind == schema.EnumKind {
-		field.EnumType = testEnum
+		field.ReferencedType = testEnum.Name
 	}
 
 	keyField := field
@@ -170,5 +170,5 @@ func mkTestObjectType(kind schema.Kind) schema.ObjectType {
 
 var testEnum = schema.EnumType{
 	Name:   "test_enum_type",
-	Values: []string{"foo", "bar", "baz"},
+	Values: []schema.EnumValueDefinition{{Name: "foo", Value: 1}, {Name: "bar", Value: 2}, {Name: "baz", Value: 3}},
 }

--- a/schema/testing/field.go
+++ b/schema/testing/field.go
@@ -2,6 +2,7 @@ package schematesting
 
 import (
 	"fmt"
+	"slices"
 	"time"
 
 	"pgregory.net/rapid"
@@ -18,32 +19,47 @@ var (
 )
 
 // FieldGen generates random Field's based on the validity criteria of fields.
-var FieldGen = rapid.Custom(func(t *rapid.T) schema.Field {
-	kind := kindGen.Draw(t, "kind")
-	field := schema.Field{
-		Name:     NameGen.Draw(t, "name"),
-		Kind:     kind,
-		Nullable: boolGen.Draw(t, "nullable"),
-	}
+func FieldGen(sch schema.Schema) *rapid.Generator[schema.Field] {
+	enumTypes := slices.DeleteFunc(slices.Collect(sch.Types), func(t schema.Type) bool {
+		_, ok := t.(schema.EnumType)
+		return !ok
+	})
+	enumTypeSelector := rapid.SampledFrom(enumTypes)
 
-	switch kind {
-	case schema.EnumKind:
-		field.EnumType = EnumType.Draw(t, "enumDefinition")
-	default:
-	}
+	return rapid.Custom(func(t *rapid.T) schema.Field {
+		kind := kindGen.Draw(t, "kind")
+		field := schema.Field{
+			Name:     NameGen.Draw(t, "name"),
+			Kind:     kind,
+			Nullable: boolGen.Draw(t, "nullable"),
+		}
 
-	return field
-})
+		switch kind {
+		case schema.EnumKind:
+			if len(enumTypes) == 0 {
+				// if we have no enum types, fall back to string
+				field.Kind = schema.StringKind
+			} else {
+				field.ReferencedType = enumTypeSelector.Draw(t, "enumType").TypeName()
+			}
+		default:
+		}
+
+		return field
+	})
+}
 
 // KeyFieldGen generates random key fields based on the validity criteria of key fields.
-var KeyFieldGen = FieldGen.Filter(func(f schema.Field) bool {
-	return !f.Nullable && f.Kind.ValidKeyKind()
-})
+func KeyFieldGen(sch schema.Schema) *rapid.Generator[schema.Field] {
+	return FieldGen(sch).Filter(func(f schema.Field) bool {
+		return !f.Nullable && f.Kind.ValidKeyKind()
+	})
+}
 
 // FieldValueGen generates random valid values for the field, aiming to exercise the full range of possible
 // values for the field.
-func FieldValueGen(field schema.Field) *rapid.Generator[any] {
-	gen := baseFieldValue(field)
+func FieldValueGen(field schema.Field, sch schema.Schema) *rapid.Generator[any] {
+	gen := baseFieldValue(field, sch)
 
 	if field.Nullable {
 		return rapid.OneOf(gen, rapid.Just[any](nil)).AsAny()
@@ -52,7 +68,7 @@ func FieldValueGen(field schema.Field) *rapid.Generator[any] {
 	return gen
 }
 
-func baseFieldValue(field schema.Field) *rapid.Generator[any] {
+func baseFieldValue(field schema.Field, sch schema.Schema) *rapid.Generator[any] {
 	switch field.Kind {
 	case schema.StringKind:
 		return rapid.StringOf(rapid.Rune().Filter(func(r rune) bool {
@@ -97,25 +113,33 @@ func baseFieldValue(field schema.Field) *rapid.Generator[any] {
 	case schema.AddressKind:
 		return rapid.SliceOfN(rapid.Byte(), 20, 64).AsAny()
 	case schema.EnumKind:
-		return rapid.SampledFrom(field.EnumType.Values).AsAny()
+		typ, found := sch.LookupType(field.ReferencedType)
+		enumTyp, ok := typ.(schema.EnumType)
+		if !found || !ok {
+			panic(fmt.Errorf("enum type %q not found", field.ReferencedType))
+		}
+
+		return rapid.Map(rapid.SampledFrom(enumTyp.Values), func(v schema.EnumValueDefinition) string {
+			return v.Name
+		}).AsAny()
 	default:
 		panic(fmt.Errorf("unexpected kind: %v", field.Kind))
 	}
 }
 
 // ObjectKeyGen generates a value that is valid for the provided object key fields.
-func ObjectKeyGen(keyFields []schema.Field) *rapid.Generator[any] {
+func ObjectKeyGen(keyFields []schema.Field, sch schema.Schema) *rapid.Generator[any] {
 	if len(keyFields) == 0 {
 		return rapid.Just[any](nil)
 	}
 
 	if len(keyFields) == 1 {
-		return FieldValueGen(keyFields[0])
+		return FieldValueGen(keyFields[0], sch)
 	}
 
 	gens := make([]*rapid.Generator[any], len(keyFields))
 	for i, field := range keyFields {
-		gens[i] = FieldValueGen(field)
+		gens[i] = FieldValueGen(field, sch)
 	}
 
 	return rapid.Custom(func(t *rapid.T) any {
@@ -132,7 +156,7 @@ func ObjectKeyGen(keyFields []schema.Field) *rapid.Generator[any] {
 // are valid for insertion (in the case forUpdate is false) or for update (in the case forUpdate is true).
 // Values that are for update may skip some fields in a ValueUpdates instance whereas values for insertion
 // will always contain all values.
-func ObjectValueGen(valueFields []schema.Field, forUpdate bool) *rapid.Generator[any] {
+func ObjectValueGen(valueFields []schema.Field, forUpdate bool, sch schema.Schema) *rapid.Generator[any] {
 	if len(valueFields) == 0 {
 		// if we have no value fields, always return nil
 		return rapid.Just[any](nil)
@@ -140,7 +164,7 @@ func ObjectValueGen(valueFields []schema.Field, forUpdate bool) *rapid.Generator
 
 	gens := make([]*rapid.Generator[any], len(valueFields))
 	for i, field := range valueFields {
-		gens[i] = FieldValueGen(field)
+		gens[i] = FieldValueGen(field, sch)
 	}
 	return rapid.Custom(func(t *rapid.T) any {
 		// return ValueUpdates 50% of the time

--- a/schema/testing/field_test.go
+++ b/schema/testing/field_test.go
@@ -5,12 +5,14 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"pgregory.net/rapid"
+
+	"cosmossdk.io/schema"
 )
 
 func TestField(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
-		field := FieldGen.Draw(t, "field")
-		require.NoError(t, field.Validate())
+		field := FieldGen(testEnumSchema).Draw(t, "field")
+		require.NoError(t, field.Validate(testEnumSchema))
 	})
 }
 
@@ -19,8 +21,13 @@ func TestFieldValue(t *testing.T) {
 }
 
 var checkFieldValue = func(t *rapid.T) {
-	field := FieldGen.Draw(t, "field")
-	require.NoError(t, field.Validate())
-	fieldValue := FieldValueGen(field).Draw(t, "fieldValue")
-	require.NoError(t, field.ValidateValue(fieldValue))
+	field := FieldGen(testEnumSchema).Draw(t, "field")
+	require.NoError(t, field.Validate(testEnumSchema))
+	fieldValue := FieldValueGen(field, testEnumSchema).Draw(t, "fieldValue")
+	require.NoError(t, field.ValidateValue(fieldValue, testEnumSchema))
 }
+
+var testEnumSchema = schema.MustNewModuleSchema(schema.EnumType{
+	Name:   "test_enum",
+	Values: []schema.EnumValueDefinition{{Name: "a", Value: 1}, {Name: "b", Value: 2}},
+})

--- a/schema/testing/module_schema.go
+++ b/schema/testing/module_schema.go
@@ -1,8 +1,6 @@
 package schematesting
 
 import (
-	"slices"
-
 	"pgregory.net/rapid"
 
 	"cosmossdk.io/schema"
@@ -17,13 +15,9 @@ func ModuleSchemaGen() *rapid.Generator[schema.ModuleSchema] {
 		if err != nil {
 			t.Fatal(err)
 		}
+
 		objectTypes := distinctTypes(ObjectTypeGen(tempSchema)).Draw(t, "objectTypes")
 		allTypes := append(enumTypes, objectTypes...)
-
-		// remove duplicate type names
-		slices.CompactFunc(allTypes, func(s schema.Type, s2 schema.Type) bool {
-			return s.TypeName() == s2.TypeName()
-		})
 
 		modSchema, err := schema.NewModuleSchema(allTypes...)
 		if err != nil {

--- a/schema/testing/module_schema_test.go
+++ b/schema/testing/module_schema_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestModuleSchema(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
-		schema := ModuleSchemaGen.Draw(t, "schema")
+		schema := ModuleSchemaGen().Draw(t, "schema")
 		require.NoError(t, schema.Validate())
 	})
 }

--- a/schema/testing/name.go
+++ b/schema/testing/name.go
@@ -8,8 +8,3 @@ import (
 
 // NameGen validates valid names that match the NameFormat regex.
 var NameGen = rapid.StringMatching(schema.NameFormat)
-
-// QualifiedNameGen validates valid qualified names that match the QualifiedNameFormat regex.
-var QualifiedNameGen = rapid.StringMatching(schema.QualifiedNameFormat).Filter(func(x string) bool {
-	return len(x) < 64
-})

--- a/schema/testing/name.go
+++ b/schema/testing/name.go
@@ -8,3 +8,8 @@ import (
 
 // NameGen validates valid names that match the NameFormat regex.
 var NameGen = rapid.StringMatching(schema.NameFormat)
+
+// QualifiedNameGen validates valid qualified names that match the QualifiedNameFormat regex.
+var QualifiedNameGen = rapid.StringMatching(schema.QualifiedNameFormat).Filter(func(x string) bool {
+	return len(x) < 64
+})

--- a/schema/testing/object.go
+++ b/schema/testing/object.go
@@ -18,9 +18,12 @@ func ObjectTypeGen(sch schema.Schema) *rapid.Generator[schema.ObjectType] {
 	})
 
 	return rapid.Custom(func(t *rapid.T) schema.ObjectType {
-
 		typ := schema.ObjectType{
-			Name: NameGen.Draw(t, "name"),
+			Name: NameGen.Filter(func(s string) bool {
+				// filter out names that already exist in the schema
+				_, found := sch.LookupType(s)
+				return !found
+			}).Draw(t, "name"),
 		}
 
 		typ.KeyFields = keyFieldsGen.Draw(t, "keyFields")

--- a/schema/testing/object_test.go
+++ b/schema/testing/object_test.go
@@ -9,16 +9,16 @@ import (
 
 func TestObject(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
-		objectType := ObjectTypeGen.Draw(t, "object")
-		require.NoError(t, objectType.Validate())
+		objectType := ObjectTypeGen(testEnumSchema).Draw(t, "object")
+		require.NoError(t, objectType.Validate(testEnumSchema))
 	})
 }
 
 func TestObjectUpdate(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
-		objectType := ObjectTypeGen.Draw(t, "object")
-		require.NoError(t, objectType.Validate())
-		update := ObjectInsertGen(objectType).Draw(t, "update")
-		require.NoError(t, objectType.ValidateObjectUpdate(update))
+		objectType := ObjectTypeGen(testEnumSchema).Draw(t, "object")
+		require.NoError(t, objectType.Validate(testEnumSchema))
+		update := ObjectInsertGen(objectType, testEnumSchema).Draw(t, "update")
+		require.NoError(t, objectType.ValidateObjectUpdate(update, testEnumSchema))
 	})
 }

--- a/schema/testing/statesim/module.go
+++ b/schema/testing/statesim/module.go
@@ -25,7 +25,7 @@ func NewModule(name string, moduleSchema schema.ModuleSchema, options Options) *
 	var objectTypeNames []string
 
 	moduleSchema.ObjectTypes(func(objectType schema.ObjectType) bool {
-		objectCollection := NewObjectCollection(objectType, options)
+		objectCollection := NewObjectCollection(objectType, options, moduleSchema)
 		objectCollections.Set(objectType.Name, objectCollection)
 		objectTypeNames = append(objectTypeNames, objectType.Name)
 		return true

--- a/schema/testing/statesim/object_coll.go
+++ b/schema/testing/statesim/object_coll.go
@@ -14,15 +14,16 @@ import (
 type ObjectCollection struct {
 	options           Options
 	objectType        schema.ObjectType
+	sch               schema.Schema
 	objects           *btree.Map[string, schema.ObjectUpdate]
 	updateGen         *rapid.Generator[schema.ObjectUpdate]
 	valueFieldIndices map[string]int
 }
 
 // NewObjectCollection creates a new ObjectCollection for the given object type.
-func NewObjectCollection(objectType schema.ObjectType, options Options) *ObjectCollection {
+func NewObjectCollection(objectType schema.ObjectType, options Options, sch schema.Schema) *ObjectCollection {
 	objects := &btree.Map[string, schema.ObjectUpdate]{}
-	updateGen := schematesting.ObjectUpdateGen(objectType, objects)
+	updateGen := schematesting.ObjectUpdateGen(objectType, objects, sch)
 	valueFieldIndices := make(map[string]int, len(objectType.ValueFields))
 	for i, field := range objectType.ValueFields {
 		valueFieldIndices[field.Name] = i
@@ -31,6 +32,7 @@ func NewObjectCollection(objectType schema.ObjectType, options Options) *ObjectC
 	return &ObjectCollection{
 		options:           options,
 		objectType:        objectType,
+		sch:               sch,
 		objects:           objects,
 		updateGen:         updateGen,
 		valueFieldIndices: valueFieldIndices,
@@ -43,7 +45,7 @@ func (o *ObjectCollection) ApplyUpdate(update schema.ObjectUpdate) error {
 		return fmt.Errorf("update type name %q does not match object type name %q", update.TypeName, o.objectType.Name)
 	}
 
-	err := o.objectType.ValidateObjectUpdate(update)
+	err := o.objectType.ValidateObjectUpdate(update, o.sch)
 	if err != nil {
 		return err
 	}

--- a/schema/type.go
+++ b/schema/type.go
@@ -1,10 +1,27 @@
 package schema
 
 // Type is an interface that all types in the schema implement.
-// Currently these are ObjectType and EnumType.
+// Currently, these are ObjectType and EnumType.
 type Type interface {
 	// TypeName returns the type's name.
 	TypeName() string
 
+	// Validate validates the type.
+	Validate(Schema) error
+
+	// isType is a private method that ensures that only types in this package can be marked as types.
 	isType()
 }
+
+type Schema interface {
+	LookupType(name string) (Type, bool)
+	Types(f func(Type) bool)
+}
+
+type emptySchema struct{}
+
+func (emptySchema) LookupType(name string) (Type, bool) {
+	return nil, false
+}
+
+func (emptySchema) Types(f func(Type) bool) {}

--- a/schema/type.go
+++ b/schema/type.go
@@ -18,10 +18,12 @@ type Schema interface {
 	Types(f func(Type) bool)
 }
 
-type emptySchema struct{}
+// EmptySchema is a schema that contains no types.
+// It can be used in Validate methods when there is no schema needed or available.
+type EmptySchema struct{}
 
-func (emptySchema) LookupType(name string) (Type, bool) {
+func (EmptySchema) LookupType(name string) (Type, bool) {
 	return nil, false
 }
 
-func (emptySchema) Types(f func(Type) bool) {}
+func (EmptySchema) Types(f func(Type) bool) {}

--- a/schema/type.go
+++ b/schema/type.go
@@ -13,8 +13,13 @@ type Type interface {
 	isType()
 }
 
+// Schema represents something that has types and allows them to be looked up by name.
+// Currently, the only implementation is ModuleSchema.
 type Schema interface {
+	// LookupType looks up a type by name.
 	LookupType(name string) (Type, bool)
+
+	// Types calls the given function for each type in the schema.
 	Types(f func(Type) bool)
 }
 
@@ -22,8 +27,10 @@ type Schema interface {
 // It can be used in Validate methods when there is no schema needed or available.
 type EmptySchema struct{}
 
+// LookupType always returns false because there are no types in an EmptySchema.
 func (EmptySchema) LookupType(name string) (Type, bool) {
 	return nil, false
 }
 
+// Types does nothing because there are no types in an EmptySchema.
 func (EmptySchema) Types(f func(Type) bool) {}


### PR DESCRIPTION
# Description

This refactors how enum types are handled in two ways:
1. enum types are referenced rather than embedded
2. enum values also have a numeric value in addition to a string name

This is a bit of code churn now, but it will make the system more extensible later if we want to add any other sort of referenced type (such as structs). Enum numeric values are also important for cross lang if we want to have a binary encoding to handle that.

One particular side effect of this on `schema` APIs is that many methods now take a `Schema` parameter so that referenced types can be looked up.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title, you can find examples of the prefixes below:
    <!-- * `feat`: A new feature
    * `fix`: A bug fix
    * `docs`: Documentation only changes
    * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
    * `refactor`: A code change that neither fixes a bug nor adds a feature
    * `perf`: A code change that improves performance
    * `test`: Adding missing tests or correcting existing tests
    * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
    * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
    * `chore`: Other changes that don't modify src or test files
    * `revert`: Reverts a previous commit -->
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

Please see [Pull Request Reviewer section in the contributing guide](../CONTRIBUTING.md#reviewer) for more information on how to review a pull request.

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced enum type handling with a more structured representation for better clarity and validation.
	- Introduced new schema validation capabilities allowing for more robust type management.
	- Added convenience methods for schema creation and validation, improving usability.

- **Bug Fixes**
	- Improved error handling and validation logic across various components, ensuring better data integrity and consistency.

- **Refactor**
	- Streamlined schema initialization and validation processes, enhancing code readability and maintainability.

- **Tests**
	- Updated test cases to reflect changes in data structures and validation logic, ensuring comprehensive coverage and accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->