### PR TITLE
chore(types): deprecate acc address stringer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@ Every module contains its own CHANGELOG.md. Please refer to the module you are i
 
 ### Deprecated
 
-* (types) [#21435](https://github.com/cosmos/cosmos-sdk/pull/21435) The string methods on `AccAddress` and `ValAddress` have been deprecated. This is done because those are still using the deprecated global `sdk.Config`. Use an `address.Codec` instead.
+* (types) [#21435](https://github.com/cosmos/cosmos-sdk/pull/21435) The `String()` method on `AccAddress`, `ValAddress` and `ConsAddress` have been deprecated. This is done because those are still using the deprecated global `sdk.Config`. Use an `address.Codec` instead.
 
 ## [v0.52.0](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.52.0) - 2024-XX-XX
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,8 +50,11 @@ Every module contains its own CHANGELOG.md. Please refer to the module you are i
 
 * (baseapp) [#21256](https://github.com/cosmos/cosmos-sdk/pull/21256) Halt height will not commit the block indicated, meaning that if halt-height is set to 10, only blocks until 9 (included) will be committed. This is to go back to the original behavior before a change was introduced in v0.50.0.
 
-
 ### API Breaking Changes
+
+### Deprecated
+
+* (types) [#21435](https://github.com/cosmos/cosmos-sdk/pull/21435) The string methods on `AccAddress` and `ValAddress` have been deprecated. This is done because those are still using the deprecated global `sdk.Config`. Use an `address.Codec` instead.
 
 ## [v0.52.0](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.52.0) - 2024-XX-XX
 

--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,7 @@ include scripts/build/build.mk
 
 .DEFAULT_GOAL := help
 
-###############################################################################
-###                          Tools & Dependencies                           ###
-###############################################################################
-
+#? go.sum: Run go mod tidy and ensure dependencies have not been modified
 go.sum: go.mod
 	echo "Ensure dependencies have not been modified ..." >&2
 	go mod verify

--- a/types/address.go
+++ b/types/address.go
@@ -180,6 +180,7 @@ func AccAddressFromHexUnsafe(address string) (addr AccAddress, err error) {
 }
 
 // MustAccAddressFromBech32 calls AccAddressFromBech32 and panics on error.
+// Deprecated: Use an address.Codec to convert addresses from and to string/bytes.
 func MustAccAddressFromBech32(address string) AccAddress {
 	addr, err := AccAddressFromBech32(address)
 	if err != nil {
@@ -190,6 +191,7 @@ func MustAccAddressFromBech32(address string) AccAddress {
 }
 
 // AccAddressFromBech32 creates an AccAddress from a Bech32 string.
+// Deprecated: Use an address.Codec to convert addresses from and to string/bytes.
 func AccAddressFromBech32(address string) (addr AccAddress, err error) {
 	bech32PrefixAccAddr := GetConfig().GetBech32AccountAddrPrefix()
 
@@ -330,6 +332,7 @@ func ValAddressFromHex(address string) (addr ValAddress, err error) {
 }
 
 // ValAddressFromBech32 creates a ValAddress from a Bech32 string.
+// Deprecated: Use an address.Codec to convert addresses from and to string/bytes.
 func ValAddressFromBech32(address string) (addr ValAddress, err error) {
 	bech32PrefixValAddr := GetConfig().GetBech32ValidatorAddrPrefix()
 
@@ -338,6 +341,7 @@ func ValAddressFromBech32(address string) (addr ValAddress, err error) {
 }
 
 // MustValAddressFromBech32 calls ValAddressFromBech32 and panics on error.
+// Deprecated: Use an address.Codec to convert addresses from and to string/bytes.
 func MustValAddressFromBech32(address string) ValAddress {
 	addr, err := ValAddressFromBech32(address)
 	if err != nil {
@@ -483,6 +487,7 @@ func ConsAddressFromHex(address string) (addr ConsAddress, err error) {
 }
 
 // ConsAddressFromBech32 creates a ConsAddress from a Bech32 string.
+// Deprecated: Use an address.Codec to convert addresses from and to string/bytes.
 func ConsAddressFromBech32(address string) (addr ConsAddress, err error) {
 	bech32PrefixConsAddr := GetConfig().GetBech32ConsensusAddrPrefix()
 

--- a/types/address.go
+++ b/types/address.go
@@ -149,6 +149,7 @@ type Address interface {
 	Marshal() ([]byte, error)
 	MarshalJSON() ([]byte, error)
 	Bytes() []byte
+	// Deprecated: Use an address.Codec to convert addresses from and to string/bytes.
 	String() string
 	Format(s fmt.State, verb rune)
 }
@@ -281,6 +282,7 @@ func (aa AccAddress) Bytes() []byte {
 }
 
 // String implements the Stringer interface.
+// Deprecated: Use an address.Codec to convert addresses from and to string/bytes.
 func (aa AccAddress) String() string {
 	if aa.Empty() {
 		return ""
@@ -432,6 +434,7 @@ func (va ValAddress) Bytes() []byte {
 }
 
 // String implements the Stringer interface.
+// Deprecated: Use an address.Codec to convert addresses from and to string/bytes.
 func (va ValAddress) String() string {
 	if va.Empty() {
 		return ""
@@ -579,6 +582,7 @@ func (ca ConsAddress) Bytes() []byte {
 }
 
 // String implements the Stringer interface.
+// Deprecated: Use an address.Codec to convert addresses from and to string/bytes.
 func (ca ConsAddress) String() string {
 	if ca.Empty() {
 		return ""

--- a/types/config.go
+++ b/types/config.go
@@ -10,8 +10,16 @@ import (
 // DefaultKeyringServiceName defines a default service name for the keyring.
 const DefaultKeyringServiceName = "cosmos"
 
+func KeyringServiceName() string {
+	if len(version.Name) == 0 {
+		return DefaultKeyringServiceName
+	}
+	return version.Name
+}
+
 // Config is the structure that holds the SDK configuration parameters.
-// This could be used to initialize certain configuration parameters for the SDK.
+// Deprecated: The global SDK config is deprecated and users should prefer using an address codec.
+// Users should still set the global config until the Stringer interface on `AccAddress`, `ValAddress`, and `ConsAddress` is removed.
 type Config struct {
 	bech32AddressPrefix map[string]string
 	mtx                 sync.RWMutex
@@ -139,11 +147,4 @@ func (config *Config) GetBech32ValidatorPubPrefix() string {
 // GetBech32ConsensusPubPrefix returns the Bech32 prefix for consensus node public key
 func (config *Config) GetBech32ConsensusPubPrefix() string {
 	return config.bech32AddressPrefix["consensus_pub"]
-}
-
-func KeyringServiceName() string {
-	if len(version.Name) == 0 {
-		return DefaultKeyringServiceName
-	}
-	return version.Name
 }

--- a/types/config.go
+++ b/types/config.go
@@ -19,7 +19,7 @@ func KeyringServiceName() string {
 
 // Config is the structure that holds the SDK configuration parameters.
 // Deprecated: The global SDK config is deprecated and users should prefer using an address codec.
-// Users should still set the global config until the Stringer interface on `AccAddress`, `ValAddress`, and `ConsAddress` is removed.
+// Users must still set the global config until the Stringer interface on `AccAddress`, `ValAddress`, and `ConsAddress` is removed.
 type Config struct {
 	bech32AddressPrefix map[string]string
 	mtx                 sync.RWMutex


### PR DESCRIPTION
# Description

ref: https://github.com/cosmos/cosmos-sdk/issues/21430#issuecomment-2314519967

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title, you can find examples of the prefixes below:
    <!-- * `feat`: A new feature
    * `fix`: A bug fix
    * `docs`: Documentation only changes
    * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
    * `refactor`: A code change that neither fixes a bug nor adds a feature
    * `perf`: A code change that improves performance
    * `test`: Adding missing tests or correcting existing tests
    * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
    * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
    * `chore`: Other changes that don't modify src or test files
    * `revert`: Reverts a previous commit -->
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

Please see [Pull Request Reviewer section in the contributing guide](../CONTRIBUTING.md#reviewer) for more information on how to review a pull request.

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Introduced a new function to dynamically retrieve the keyring service name based on version state.
  
- **Deprecations**
  - Deprecated the `String()` method for `AccAddress`, `ValAddress`, and `ConsAddress`, urging users to use the `address.Codec` for address conversions.
  - Updated CHANGELOG to reflect the deprecation of the global SDK configuration.

- **Documentation**
  - Added detailed deprecation notices in relevant areas to guide users on transitioning to the new methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->