### PR TITLE
fix(sims): OOM at sim-multi-seed-long run

### DIFF
--- a/.github/workflows/sims-nightly.yml
+++ b/.github/workflows/sims-nightly.yml
@@ -2,10 +2,11 @@ name: Sims Nightly (Long)
 # Release Sims workflow runs long-lived (multi-seed & large block size) simulations
 # This workflow only runs mightly at 8am UTC and on releases
 on:
-  schedule:
-    - cron: "0 8 * * *"
-  release:
-    types: [published]
+  pull_request:
+  merge_group:
+  push:
+    branches:
+      - main
 
 permissions:
   contents: read
@@ -24,6 +25,8 @@ jobs:
           go-version: "1.23"
           check-latest: true
       - name: test-sim-multi-seed-long
+        env:
+          GOMEMLIMIT: 14GiB
         run: |
           make test-sim-multi-seed-long
 

--- a/.github/workflows/sims-nightly.yml
+++ b/.github/workflows/sims-nightly.yml
@@ -2,11 +2,10 @@ name: Sims Nightly (Long)
 # Release Sims workflow runs long-lived (multi-seed & large block size) simulations
 # This workflow only runs mightly at 8am UTC and on releases
 on:
-  pull_request:
-  merge_group:
-  push:
-    branches:
-      - main
+  schedule:
+    - cron: "0 8 * * *"
+  release:
+    types: [published]
 
 permissions:
   contents: read
@@ -26,7 +25,7 @@ jobs:
           check-latest: true
       - name: test-sim-multi-seed-long
         env:
-          GOMEMLIMIT: 14GiB
+          GOMEMLIMIT: 14GiB # reserve 2 GiB as buffer for GC to avoid OOM
         run: |
           make test-sim-multi-seed-long
 

--- a/scripts/build/simulations.mk
+++ b/scripts/build/simulations.mk
@@ -44,7 +44,7 @@ test-sim-custom-genesis-multi-seed:
 
 test-sim-multi-seed-long:
 	@echo "Running long multi-seed application simulation. This may take awhile!"
-	@cd ${CURRENT_DIR}/simapp && go test -mod=readonly -timeout=1h -tags='sims' -run TestFullAppSimulation \
+	@cd ${CURRENT_DIR}/simapp && go test -mod=readonly -timeout=2h -tags='sims' -run TestFullAppSimulation \
 		-NumBlocks=150 -Period=50
 
 test-sim-multi-seed-short:

--- a/x/simulation/client/cli/flags.go
+++ b/x/simulation/client/cli/flags.go
@@ -46,7 +46,7 @@ func GetSimulatorFlags() {
 	flag.IntVar(&FlagBlockSizeValue, "BlockSize", 200, "operations per block")
 	flag.BoolVar(&FlagLeanValue, "Lean", false, "lean simulation log output")
 	flag.BoolVar(&FlagCommitValue, "Commit", true, "have the simulation commit")
-	flag.StringVar(&FlagDBBackendValue, "DBBackend", "goleveldb", "custom db backend type")
+	flag.StringVar(&FlagDBBackendValue, "DBBackend", "goleveldb", "custom db backend type: goleveldb, memdb")
 
 	// simulation flags
 	flag.BoolVar(&FlagEnabledValue, "Enabled", false, "enable the simulation")


### PR DESCRIPTION
Resolves #21415 

With this PR, the `GOMEMLIMIT` is set for the `test-sim-multi-seed-long` CI run. The  variable sets a soft memory limit for the Go runtime. With the additional buffer the GC prevents the OOM. 

Also the `app.Close()` method is called within the test forks to release resources as soon as possible.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new method for proper application closure in the simulation framework, enhancing resource management.
	- Expanded help text for database backend configuration to clarify acceptable values.

- **Improvements**
	- Increased timeout for specific tests to ensure successful completion without timing out.
	- Added an environment variable to improve memory management during test execution.

- **Bug Fixes**
	- Enhanced error handling during cleanup to prevent potential memory leaks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->