### PR TITLE
docs(store): fix cometbft doc version

### DIFF
--- a/store/snapshots/README.md
+++ b/store/snapshots/README.md
@@ -11,8 +11,8 @@ This document describes the Cosmos SDK implementation of the ABCI state sync
 interface, for more information on CometBFT state sync in general see:
 
 * [CometBFT State Sync for Developers](https://medium.com/cometbft/cometbft-core-state-sync-for-developers-70a96ba3ee35)
-* [ABCI State Sync Spec](https://docs.cometbft.com/v0.37/spec/p2p/messages/state-sync)
-* [ABCI State Sync Method/Type Reference](https://docs.cometbft.com/v0.37/spec/p2p/messages/state-sync)
+* [ABCI State Sync Spec](https://docs.cometbft.com/v0.38/spec/p2p/legacy-docs/messages/state-sync)
+* [ABCI State Sync Method/Type Reference](https://docs.cometbft.com/v0.38/spec/p2p/legacy-docs/messages/state-sync)
 
 ## Overview
 

--- a/store/snapshots/README.md
+++ b/store/snapshots/README.md
@@ -11,6 +11,7 @@ This document describes the Cosmos SDK implementation of the ABCI state sync
 interface, for more information on CometBFT state sync in general see:
 
 * [CometBFT State Sync for Developers](https://medium.com/cometbft/cometbft-core-state-sync-for-developers-70a96ba3ee35)
+* [CometBFT State Sync](https://docs.cometbft.com/v0.38/core/state-sync)
 * [ABCI State Sync Spec](https://docs.cometbft.com/v0.38/spec/p2p/legacy-docs/messages/state-sync)
 * [ABCI State Sync Method/Type Reference](https://docs.cometbft.com/v0.38/spec/p2p/legacy-docs/messages/state-sync)
 


### PR DESCRIPTION
The old 0.37 version's path is expired. Updated with 0.38 and correct path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Documentation**
	- Updated links in the README to point to the latest version (0.38) of the CometBFT documentation for the ABCI state sync interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->