### PR TITLE
chore(all): replace all `fmt.Errorf` without paramters with `errors.New`

### DIFF
--- a/indexer/postgres/params.go
+++ b/indexer/postgres/params.go
@@ -1,6 +1,7 @@
 package postgres
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -18,7 +19,7 @@ func (tm *objectIndexer) bindKeyParams(key interface{}) ([]interface{}, []string
 	} else {
 		key, ok := key.([]interface{})
 		if !ok {
-			return nil, nil, fmt.Errorf("expected key to be a slice")
+			return nil, nil, errors.New("expected key to be a slice")
 		}
 
 		return tm.bindParams(tm.typ.KeyFields, key)
@@ -55,7 +56,7 @@ func (tm *objectIndexer) bindValueParams(value interface{}) (params []interface{
 	} else {
 		values, ok := value.([]interface{})
 		if !ok {
-			return nil, nil, fmt.Errorf("expected values to be a slice")
+			return nil, nil, errors.New("expected values to be a slice")
 		}
 
 		return tm.bindParams(tm.typ.ValueFields, values)

--- a/server/v2/cometbft/commands.go
+++ b/server/v2/cometbft/commands.go
@@ -33,7 +33,7 @@ func rpcClient(cmd *cobra.Command) (rpc.CometRPC, error) {
 		return nil, err
 	}
 	if rpcURI == "" {
-		return nil, fmt.Errorf("rpc URI is empty")
+		return nil, errors.New("rpc URI is empty")
 	}
 
 	return rpchttp.New(rpcURI)

--- a/x/bank/v2/keeper/query_server.go
+++ b/x/bank/v2/keeper/query_server.go
@@ -2,7 +2,7 @@ package keeper
 
 import (
 	"context"
-	"fmt"
+	"errors"
 
 	"cosmossdk.io/x/bank/v2/types"
 )
@@ -21,7 +21,7 @@ func NewQuerier(k *Keeper) types.QueryServer {
 // Params implements types.QueryServer.
 func (q querier) Params(ctx context.Context, req *types.QueryParamsRequest) (*types.QueryParamsResponse, error) {
 	if req == nil {
-		return nil, fmt.Errorf("empty request")
+		return nil, errors.New("empty request")
 	}
 
 	params, err := q.params.Get(ctx)


### PR DESCRIPTION
# Description

This PR cleans up all `fmt.Errorf` without parameters with `errors.New` among whole codebase


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling in various components by simplifying error message creation, enhancing clarity and consistency across the application.
	- Streamlined error responses for empty request scenarios and type mismatches.

- **Chores**
	- Updated import statements to reflect the new error handling approach, removing unnecessary dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->