### PR TITLE
docs(client/debug): correct and improve  `debug pubkey-raw` command example

### DIFF
--- a/client/debug/main.go
+++ b/client/debug/main.go
@@ -185,9 +185,10 @@ func PubkeyRawCmd() *cobra.Command {
 		Short: "Decode a ED25519 or secp256k1 pubkey from hex, base64, or bech32",
 		Long:  "Decode a pubkey from hex, base64, or bech32.",
 		Example: fmt.Sprintf(`
-%s debug pubkey-raw TWFuIGlzIGRpc3Rpbmd1aXNoZWQsIG5vdCBvbmx5IGJ5IGhpcyByZWFzb24sIGJ1dCBieSB0aGlz
-%s debug pubkey-raw cosmos1e0jnq2sun3dzjh8p2xq95kk0expwmd7shwjpfg
-			`, version.AppName, version.AppName),
+%s debug pubkey-raw 8FCA9D6D1F80947FD5E9A05309259746F5F72541121766D5F921339DD061174A
+%s debug pubkey-raw j8qdbR+AlH/V6aBTCSWXRvX3JUESF2bV+SEzndBhF0o=
+%s debug pubkey-raw cosmospub1zcjduepq3l9f6mglsz28l40f5pfsjfvhgm6lwf2pzgtkd40eyyeem5rpza9q47axrz
+			`, version.AppName, version.AppName, version.AppName),
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clientCtx := client.GetClientContextFromCmd(cmd)


### PR DESCRIPTION
# Description

```shell
$ simd debug pubkey-raw TWFuIGlzIGRpc3Rpbmd1aXNoZWQsIG5vdCBvbmx5IGJ5IGhpcyByZWFzb24sIGJ1dCBieSB0aGlz

pubkey 'TWFuIGlzIGRpc3Rpbmd1aXNoZWQsIG5vdCBvbmx5IGJ5IGhpcyByZWFzb24sIGJ1dCBieSB0aGlz' invalid; expected hex, base64, or bech32 of correct size

$ simd debug pubkey-raw cosmos1e0jnq2sun3dzjh8p2xq95kk0expwmd7shwjpfg

pubkey 'cosmos1e0jnq2sun3dzjh8p2xq95kk0expwmd7shwjpfg' invalid; expected hex, base64, or bech32 of correct size
```

The given examples in `simd debug pubkey-raw` help message couldn't work.

This PR corrects and improves the example of `simd debug pubkey-raw`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated example usage for the `PubkeyRawCmd` command to include more relevant public key representations (hexadecimal, base64, and bech32).
  
- **Bug Fixes**
  - Improved clarity and utility of command examples for better user understanding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->