### PR TITLE
chore: fix spelling errors

### DIFF
--- a/schema/appdata/data.go
+++ b/schema/appdata/data.go
@@ -78,7 +78,7 @@ type Event struct {
 	Attributes ToEventAttributes
 }
 
-// BlockStage represents the stage of block processsing for an event.
+// BlockStage represents the stage of block processing for an event.
 type BlockStage int32
 
 const (

--- a/server/v2/cometbft/abci_test.go
+++ b/server/v2/cometbft/abci_test.go
@@ -448,7 +448,7 @@ func TestConsensus_PrepareProposal_With_Handler_NoOpMempool(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, len(res.Txs), 0)
 
-	// have tx exeed MaxTxBytes
+	// have tx exceed MaxTxBytes
 	// each mock tx has 128 bytes, should select 2 txs
 	res, err = c.PrepareProposal(context.Background(), &abciproto.PrepareProposalRequest{
 		Height:     1,
@@ -525,7 +525,7 @@ func TestConsensus_ProcessProposal_With_Handler(t *testing.T) {
 
 	c.processProposalHandler = handlers.NewDefaultProposalHandler(c.mempool).ProcessHandler()
 
-	// exeed max gas
+	// exceed max gas
 	res, err := c.ProcessProposal(context.Background(), &abciproto.ProcessProposalRequest{
 		Height: 1,
 		Txs:    [][]byte{mockTx.Bytes(), mockTx.Bytes(), mockTx.Bytes(), mockTx.Bytes()},

--- a/server/v2/cometbft/internal/mock/mock_store.go
+++ b/server/v2/cometbft/internal/mock/mock_store.go
@@ -18,7 +18,7 @@ import (
 
 type MockStore struct {
 	Storage  storev2.VersionedDatabase
-	Commiter storev2.Committer
+	Committer storev2.Committer
 }
 
 func NewMockStorage(logger log.Logger, dir string) storev2.VersionedDatabase {
@@ -38,7 +38,7 @@ func NewMockCommiter(logger log.Logger, actors ...string) storev2.Committer {
 }
 
 func NewMockStore(ss storev2.VersionedDatabase, sc storev2.Committer) *MockStore {
-	return &MockStore{Storage: ss, Commiter: sc}
+	return &MockStore{Storage: ss, Committer: sc}
 }
 
 func (s *MockStore) GetLatestVersion() (uint64, error) {
@@ -66,18 +66,18 @@ func (s *MockStore) Commit(changeset *corestore.Changeset) (corestore.Hash, erro
 		return []byte{}, err
 	}
 
-	err = s.Commiter.WriteChangeset(changeset)
+	err = s.Committer.WriteChangeset(changeset)
 	if err != nil {
 		return []byte{}, err
 	}
 
-	commitInfo, err := s.Commiter.Commit(v + 1)
+	commitInfo, err := s.Committer.Commit(v + 1)
 	fmt.Println("commitInfo", commitInfo, err)
 	return []byte{}, err
 }
 
 func (s *MockStore) StateAt(version uint64) (corestore.ReaderMap, error) {
-	info, err := s.Commiter.GetCommitInfo(version)
+	info, err := s.Committer.GetCommitInfo(version)
 	if err != nil || info == nil {
 		return nil, fmt.Errorf("failed to get commit info for version %d: %w", version, err)
 	}
@@ -89,7 +89,7 @@ func (s *MockStore) GetStateStorage() storev2.VersionedDatabase {
 }
 
 func (s *MockStore) GetStateCommitment() storev2.Committer {
-	return s.Commiter
+	return s.Committer
 }
 
 type Result struct {
@@ -121,7 +121,7 @@ func (s *MockStore) LastCommitID() (proof.CommitID, error) {
 }
 
 func (s *MockStore) SetInitialVersion(v uint64) error {
-	return s.Commiter.SetInitialVersion(v)
+	return s.Committer.SetInitialVersion(v)
 }
 
 func (s *MockStore) WorkingHash(changeset *corestore.Changeset) (corestore.Hash, error) {
@@ -131,7 +131,7 @@ func (s *MockStore) WorkingHash(changeset *corestore.Changeset) (corestore.Hash,
 		return []byte{}, err
 	}
 
-	err = s.Commiter.WriteChangeset(changeset)
+	err = s.Committer.WriteChangeset(changeset)
 	if err != nil {
 		return []byte{}, err
 	}


### PR DESCRIPTION
This PR fixes typos in the codebase.
Please review it, and merge if everything is fine.
If there are proto changes, run `make proto-gen` and commit the changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected the spelling of "processing" in comments related to the `BlockStage` type.
	- Fixed the misspelling of "exceed" in comments within test functions.
	- Renamed the `Commiter` field to `Committer` in the `MockStore` struct for clarity.

These changes enhance the readability of the code without affecting functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->