### PR TITLE
docs: use the right link for app.go[Supplementary Omission]

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1040,7 +1040,7 @@ The `simapp` package **should not be imported in your own app**. Instead, you sh
 
 #### App Wiring
 
-SimApp's `app_v2.go` is using [App Wiring](https://docs.cosmos.network/main/build/building-apps/app-go-v2), the dependency injection framework of the Cosmos SDK.
+SimApp's `app_di.go` is using [App Wiring](https://docs.cosmos.network/main/build/building-apps/app-go-di), the dependency injection framework of the Cosmos SDK.
 This means that modules are injected directly into SimApp thanks to a [configuration file](https://github.com/cosmos/cosmos-sdk/blob/v0.47.0-rc1/simapp/app_config.go).
 The previous behavior, without the dependency injection framework, is still present in [`app.go`](https://github.com/cosmos/cosmos-sdk/blob/v0.47.0-rc1/simapp/app.go) and is not going anywhere.
 

--- a/docs/build/building-modules/15-depinject.md
+++ b/docs/build/building-modules/15-depinject.md
@@ -127,4 +127,4 @@ The module is now ready to be used with `depinject` by a chain developer.
 
 ## Integrate in an application
 
-The App Wiring is done in `app_config.go` / `app.yaml` and `app_di.go` and is explained in detail in the [overview of `app_di.go`](https://docs.cosmos.network/main/build/building-apps/app-go-v2).
+The App Wiring is done in `app_config.go` / `app.yaml` and `app_di.go` and is explained in detail in the [overview of `app_di.go`](https://docs.cosmos.network/main/build/building-apps/app-go-di).


### PR DESCRIPTION
Similar to [21585](https://github.com/cosmos/cosmos-sdk/pull/21585), with some additional supplements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Documentation**
	- Updated references in documentation from `app_v2.go` to `app_di.go` for clarity on dependency injection.
	- Revised link to the updated overview of `app_di.go` to ensure users have access to the latest information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->