### PR TITLE
test: Write config to temp folder instead

### DIFF
--- a/server/v2/server_test.go
+++ b/server/v2/server_test.go
@@ -75,12 +75,11 @@ func TestServer(t *testing.T) {
 	require.Equal(t, serverCfgs[mockServer.Name()].(*mockServerConfig).MockFieldOne, MockServerDefaultConfig().MockFieldOne)
 
 	// write config
-	err = server.WriteConfig(configPath)
+	tempDir := t.TempDir()
+	require.NoError(t, server.WriteConfig(tempDir))                                          // writes app.toml
+	require.NoError(t, os.WriteFile(filepath.Join(tempDir, "config.toml"), []byte{}, 0o600)) // any config.toml
+	v, err = serverv2.ReadConfig(tempDir)
 	require.NoError(t, err)
-
-	v, err = serverv2.ReadConfig(configPath)
-	require.NoError(t, err)
-
 	require.Equal(t, v.GetString(grpcServer.Name()+".address"), grpc.DefaultConfig().Address)
 
 	// start empty


### PR DESCRIPTION
# Description

The `TestServer` test writes to the `testdata` folder which is easily added and causes failures later.
With this PR, the config file is written to a temp folder instead.

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

Please see [Pull Request Reviewer section in the contributing guide](../CONTRIBUTING.md#reviewer) for more information on how to review a pull request.

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the reliability of server configuration tests by using a temporary directory for configuration files, enhancing test isolation and cleanup.
  
- **Tests**
	- Updated test configurations to ensure they read from a temporary location, improving maintainability and reducing dependencies on external file paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->