### PR TITLE
docs(x/epochs): fix note box display failure

### DIFF
--- a/x/epochs/README.md
+++ b/x/epochs/README.md
@@ -144,7 +144,7 @@ Query the currently running epochInfos
 <appd> query epochs epoch-infos
 ```
 
-::: details Example
+:::details Example
 
 An example output:
 
@@ -176,7 +176,7 @@ Query the current epoch by the specified identifier
 <appd> query epochs current-epoch [identifier]
 ```
 
-::: details Example
+:::details Example
 
 Query the current `day` epoch:
 
@@ -189,3 +189,5 @@ Which in this example outputs:
 ```sh
 current_epoch: "183"
 ```
+
+:::


### PR DESCRIPTION
# Description
These 2 boxes are not working on [the doc website](https://docs.cosmos.network/main/build/modules/epochs). 
![image](https://github.com/user-attachments/assets/ea25de75-8639-42d4-bd85-a9f332532190)

![image](https://github.com/user-attachments/assets/e5f57379-96b2-4d01-891a-72c39c9834eb)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Improved formatting and consistency in the README documentation.
	- Introduced a new collapsible section for additional information or examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->