### PR TITLE
ci: centralized job for rocksdb libaries cache

### DIFF
--- a/.github/scripts/install-rocksdb-deps.sh
+++ b/.github/scripts/install-rocksdb-deps.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+sudo apt update && sudo apt-get install -y libsnappy-dev zlib1g-dev libbz2-dev liblz4-dev libzstd-dev build-essential

--- a/.github/scripts/install-rocksdb.sh
+++ b/.github/scripts/install-rocksdb.sh
@@ -6,9 +6,6 @@ if [ -z "$ROCKSDB_VERSION" ]; then
   exit 1
 fi
 
-# Update and install dependencies
-sudo apt update && sudo apt-get install -y libsnappy-dev zlib1g-dev libbz2-dev liblz4-dev libzstd-dev build-essential
-
 # Clone RocksDB repository
 git clone https://github.com/facebook/rocksdb.git /home/runner/rocksdb
 cd /home/runner/rocksdb || exit 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,18 +38,12 @@ jobs:
             /usr/local/lib/librocksdb.*
             /usr/local/include/rocksdb
           key: ${{ runner.os }}-rocksdb-${{ env.ROCKSDB_VERSION }}-${{ matrix.go-arch }}
+      - name: Install rocksdb deps
+        if: matrix.go-arch == 'amd64'
+        run: ./.github/scripts/install-rocksdb-deps.sh
       - name: Install rocksdb
         if: matrix.go-arch == 'amd64' && steps.cache-rocksdb.outputs.cache-hit != 'true'
-        id: install_rocksdb
         run: ./.github/scripts/install-rocksdb.sh
-      - name: Saves rocksdb libraries cache
-        if: matrix.go-arch == 'amd64' && steps.install_rocksdb.outcome == 'success'
-        uses: actions/cache/save@v4
-        with:
-          path: |
-            /usr/local/lib/librocksdb.*
-            /usr/local/include/rocksdb
-          key: ${{ runner.os }}-rocksdb-${{ env.ROCKSDB_VERSION }}-${{ matrix.go-arch }}
         ###################
         #### Build App ####
         ###################

--- a/.github/workflows/cache-rocksdb.yml
+++ b/.github/workflows/cache-rocksdb.yml
@@ -1,0 +1,60 @@
+name: Cache rocksdb libraries
+on:
+  push:
+    paths:
+      - build.mk
+  schedule:
+    - cron: "*/15 * * * *" # Every 15 minutes
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+
+  check-cache-rocksdb:
+    runs-on: ubuntu-latest
+    outputs:
+      cache-hit: ${{ steps.cache-rocksdb.outputs.cache-hit }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get rocksdb version
+        run: ./.github/scripts/get-rocksdb-version.sh
+
+      - name: Fix permissions for cache
+        run: sudo chown $(whoami) /usr/local/lib /usr/local/include
+
+      - name: Restore rocksdb libraries cache
+        id: cache-rocksdb
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            /usr/local/lib/librocksdb.*
+            /usr/local/include/rocksdb
+          key: ${{ runner.os }}-rocksdb-${{ env.ROCKSDB_VERSION }}-amd64
+
+
+  save-cache-rocksdb:
+    runs-on: ubuntu-latest
+    needs: check-cache-rocksdb
+    if: needs.check-cache-rocksdb.outputs.cache-hit != 'true'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get rocksdb version
+        run: ./.github/scripts/get-rocksdb-version.sh
+
+      - name: Install rocksdb deps
+        run: ./.github/scripts/install-rocksdb-deps.sh
+      - name: Install rocksdb
+        run: ./.github/scripts/install-rocksdb.sh
+
+      - name: Saves rocksdb libraries cache
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            /usr/local/lib/librocksdb.*
+            /usr/local/include/rocksdb
+          key: ${{ runner.os }}-rocksdb-${{ env.ROCKSDB_VERSION }}-amd64

--- a/.github/workflows/cache-rocksdb.yml
+++ b/.github/workflows/cache-rocksdb.yml
@@ -13,6 +13,7 @@ permissions:
 jobs:
 
   check-cache-rocksdb:
+    name: Check existing cache
     runs-on: ubuntu-latest
     outputs:
       cache-hit: ${{ steps.cache-rocksdb.outputs.cache-hit }}
@@ -37,6 +38,7 @@ jobs:
 
 
   save-cache-rocksdb:
+    name: Build rocksdb libraries and save cache
     runs-on: ubuntu-latest
     needs: check-cache-rocksdb
     if: needs.check-cache-rocksdb.outputs.cache-hit != 'true'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -39,18 +39,11 @@ jobs:
             /usr/local/lib/librocksdb.*
             /usr/local/include/rocksdb
           key: ${{ runner.os }}-rocksdb-${{ env.ROCKSDB_VERSION }}-amd64
+      - name: Install rocksdb deps
+        run: ./.github/scripts/install-rocksdb-deps.sh
       - name: Install rocksdb
-        if: env.GIT_DIFF && steps.cache-rocksdb.outputs.cache-hit != 'true'
-        id: install_rocksdb
+        if: steps.cache-rocksdb.outputs.cache-hit != 'true'
         run: ./.github/scripts/install-rocksdb.sh
-      - name: Saves rocksdb libraries cache
-        if: steps.install_rocksdb.outcome == 'success'
-        uses: actions/cache/save@v4
-        with:
-          path: |
-            /usr/local/lib/librocksdb.*
-            /usr/local/include/rocksdb
-          key: ${{ runner.os }}-rocksdb-${{ env.ROCKSDB_VERSION }}-amd64
       - name: run linting (long)
         if: env.GIT_DIFF
         id: lint_long

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -801,20 +801,10 @@ jobs:
             /usr/local/include/rocksdb
           key: ${{ runner.os }}-rocksdb-${{ env.ROCKSDB_VERSION }}-amd64
       - name: Install rocksdb deps
-        run: |
-          sudo apt-get update && sudo apt-get install -y libsnappy-dev zlib1g-dev libbz2-dev liblz4-dev libzstd-dev
+        run: ./.github/scripts/install-rocksdb-deps.sh
       - name: Install rocksdb
         if: steps.cache-rocksdb.outputs.cache-hit != 'true'
-        id: install_rocksdb
         run: ./.github/scripts/install-rocksdb.sh
-      - name: Saves rocksdb libraries cache
-        if: steps.install_rocksdb.outcome == 'success'
-        uses: actions/cache/save@v4
-        with:
-          path: |
-            /usr/local/lib/librocksdb.*
-            /usr/local/include/rocksdb
-          key: ${{ runner.os }}-rocksdb-${{ env.ROCKSDB_VERSION }}-amd64
       - name: tests
         if: env.GIT_DIFF
         run: |
@@ -861,20 +851,10 @@ jobs:
             /usr/local/include/rocksdb
           key: ${{ runner.os }}-rocksdb-${{ env.ROCKSDB_VERSION }}-amd64
       - name: Install rocksdb deps
-        run: |
-          sudo apt-get update && sudo apt-get install -y libsnappy-dev zlib1g-dev libbz2-dev liblz4-dev libzstd-dev
+        run: ./.github/scripts/install-rocksdb-deps.sh
       - name: Install rocksdb
-        if: env.GIT_DIFF && steps.cache-rocksdb.outputs.cache-hit != 'true'
-        id: install_rocksdb
+        if: steps.cache-rocksdb.outputs.cache-hit != 'true'
         run: ./.github/scripts/install-rocksdb.sh
-      - name: Saves rocksdb libraries cache
-        if: steps.install_rocksdb.outcome == 'success'
-        uses: actions/cache/save@v4
-        with:
-          path: |
-            /usr/local/lib/librocksdb.*
-            /usr/local/include/rocksdb
-          key: ${{ runner.os }}-rocksdb-${{ env.ROCKSDB_VERSION }}-amd64
       - name: test & coverage report creation
         if: env.GIT_DIFF
         run: |


### PR DESCRIPTION
# Description

RocksDB cache is now managed in a centralized job, to avoid concurrency issues when multiple jobs tries to save a cache using the same key.
This job is executed : 
- once every 15 minutes
- when rocksdb version may have been changed (git diff contains build.mk)

RocksDB libraries installation and cache saving only occurs when cache is not alive.

Tested on my fork :

[execution #1](https://github.com/auricom/cosmos-sdk/actions/runs/10812444400/job/29994216256) : does not find cache, builds rocks, save cache. duration : 10mn
[execution #2](https://github.com/auricom/cosmos-sdk/actions/runs/10812642450) : does find the cache, exit. duration : 20s

There is a fallback on jobs requiring rocksdb libraries - if centralized job did not have the time to build the cache, installation will be done locally.

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title, you can find examples of the prefixes below:
    <!-- * `feat`: A new feature
    * `fix`: A bug fix
    * `docs`: Documentation only changes
    * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
    * `refactor`: A code change that neither fixes a bug nor adds a feature
    * `perf`: A code change that improves performance
    * `test`: Adding missing tests or correcting existing tests
    * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
    * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
    * `chore`: Other changes that don't modify src or test files
    * `revert`: Reverts a previous commit -->
* [x] confirmed `!` in the type prefix if API or client breaking change
* [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [x] provided a link to the relevant issue or specification
* [x] reviewed "Files changed" and left comments if necessary
* [x] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ x added a changelog entry to `CHANGELOG.md`
* [x] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [x] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

Please see [Pull Request Reviewer section in the contributing guide](../CONTRIBUTING.md#reviewer) for more information on how to review a pull request.

I have...

* [x] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [x] confirmed all author checklist items have been addressed
* [x] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a script to automate the installation of RocksDB dependencies, simplifying the setup process for developers.
	- Added a caching workflow for RocksDB libraries to optimize build times.

- **Bug Fixes**
	- Improved the installation process by removing outdated dependency commands from existing scripts.

- **Refactor**
	- Streamlined the GitHub Actions workflows by consolidating dependency management and simplifying cache handling. 

- **Chores**
	- Updated workflows to enhance maintainability and efficiency in the CI/CD pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->