### PR TITLE
fix: remove stray fmt.Println

### DIFF
--- a/x/consensus/keeper/keeper.go
+++ b/x/consensus/keeper/keeper.go
@@ -178,7 +178,6 @@ func (k Keeper) ValidatorPubKeyTypes(ctx context.Context) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	fmt.Println("keyhere")
 	if params.Validator == nil {
 		return []string{}, errors.New("validator pub key types is nil")
 	}


### PR DESCRIPTION
This was introduced in #21480.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Removed unnecessary debug print statement, enhancing code cleanliness without affecting functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->