### PR TITLE
refactor(server): alias AppOptions to coreserver.DynamicConfig

### DIFF
--- a/server/types/app.go
+++ b/server/types/app.go
@@ -8,6 +8,7 @@ import (
 	cmttypes "github.com/cometbft/cometbft/types"
 	"github.com/cosmos/gogoproto/grpc"
 
+	"cosmossdk.io/core/server"
 	corestore "cosmossdk.io/core/store"
 	"cosmossdk.io/log"
 	"cosmossdk.io/store/snapshots"
@@ -26,9 +27,7 @@ type (
 	// literal defined on the server Context. Note, casting Get calls may not yield
 	// the expected types and could result in type assertion errors. It is recommend
 	// to either use the cast package or perform manual conversion for safety.
-	AppOptions interface {
-		Get(string) interface{}
-	}
+	AppOptions = server.DynamicConfig
 
 	// Application defines an application interface that wraps abci.Application.
 	// The interface defines the necessary contracts to be implemented in order

--- a/server/util_test.go
+++ b/server/util_test.go
@@ -492,4 +492,8 @@ func (m mapGetter) Get(key string) interface{} {
 	return m[key]
 }
 
+func (m mapGetter) GetString(key string) string {
+	return m[key].(string)
+}
+
 var _ servertypes.AppOptions = mapGetter{}

--- a/testutil/sims/app_helpers.go
+++ b/testutil/sims/app_helpers.go
@@ -307,6 +307,15 @@ func (m AppOptionsMap) Get(key string) interface{} {
 	return v
 }
 
+func (m AppOptionsMap) GetString(key string) string {
+	v, ok := m[key]
+	if !ok {
+		return ""
+	}
+
+	return v.(string)
+}
+
 func NewAppOptionsWithFlagHome(homePath string) servertypes.AppOptions {
 	return AppOptionsMap{
 		flags.FlagHome: homePath,

--- a/testutils/sims/runner.go
+++ b/testutils/sims/runner.go
@@ -235,6 +235,10 @@ func (f AppOptionsFn) Get(k string) any {
 	return f(k)
 }
 
+func (f AppOptionsFn) GetString(k string) string {
+	return f(k).(string)
+}
+
 // FauxMerkleModeOpt returns a BaseApp option to use a dbStoreAdapter instead of
 // an IAVLStore for faster simulation speed.
 func FauxMerkleModeOpt(bapp *baseapp.BaseApp) {


### PR DESCRIPTION
# Description

To limit breaking changes, I went with the alias way.
I have verified that depinject would still resolve it properly the alias in x/upgrade (https://github.com/cosmos/cosmos-sdk/blob/57f35dc/x/upgrade/depinject.go#L44) when providing AppOptions (https://github.com/cosmos/cosmos-sdk/blob/57f35dcdfe362dd20b5be6a13b251f9392c0cf97/simapp/app_di.go#L133)

Closes: https://github.com/cosmos/cosmos-sdk/issues/21660

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title, you can find examples of the prefixes below:
    <!-- * `feat`: A new feature
    * `fix`: A bug fix
    * `docs`: Documentation only changes
    * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
    * `refactor`: A code change that neither fixes a bug nor adds a feature
    * `perf`: A code change that improves performance
    * `test`: Adding missing tests or correcting existing tests
    * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
    * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
    * `chore`: Other changes that don't modify src or test files
    * `revert`: Reverts a previous commit -->
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

Please see [Pull Request Reviewer section in the contributing guide](../CONTRIBUTING.md#reviewer) for more information on how to review a pull request.

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced `GetString` method for `mapGetter` to retrieve string values safely.
	- Added `GetString` method for `AppOptionsMap` to enhance type safety when accessing string values.
	- Added `GetString` method for `AppOptionsFn` to improve type safety in client code.

- **Improvements**
	- Streamlined `AppOptions` interface for better integration and maintainability by using `server.DynamicConfig`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->