### PR TITLE
fix(store/v2): error info maybe covered by `err = batch.Close()`

### DIFF
--- a/store/v2/commitment/metadata.go
+++ b/store/v2/commitment/metadata.go
@@ -113,7 +113,10 @@ func (m *MetadataStore) flushCommitInfo(version uint64, cInfo *proof.CommitInfo)
 func (m *MetadataStore) flushRemovedStoreKeys(version uint64, storeKeys []string) (err error) {
 	batch := m.kv.NewBatch()
 	defer func() {
-		err = batch.Close()
+		cErr := batch.Close()
+		if err == nil {
+			err = cErr
+		}
 	}()
 
 	for _, storeKey := range storeKeys {


### PR DESCRIPTION
# Description

`err` would be nil if `batch.Close()` returns nil, thus the `error` returned by others operation would be covered.