### PR TITLE
chore: libsecp256k1: Update badge

### DIFF
--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/README.md
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/README.md
@@ -1,7 +1,7 @@
 libsecp256k1
 ============
 
-[![Build Status](https://travis-ci.org/bitcoin-core/secp256k1.svg?branch=master)](https://travis-ci.org/bitcoin-core/secp256k1)
+[![Build Status](https://img.shields.io/badge/irc.libera.chat-%23secp256k1-success)](https://web.libera.chat/#secp256k1)
 
 Optimized C library for EC operations on curve secp256k1.
 


### PR DESCRIPTION
The old badge is outdated , I found this new link from [bitcoin-core](https://github.com/bitcoin-core/secp256k1/blob/master/README.md?plain=1#L5C55-L5C60)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the README.md to change the build status badge link from Travis CI to the IRC channel on Libera Chat, enhancing community engagement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->