### PR TITLE
feat(server/v2/cometbft): wire mempool config

### DIFF
--- a/server/v2/cometbft/config.go
+++ b/server/v2/cometbft/config.go
@@ -1,9 +1,9 @@
 package cometbft
 
 import (
-	"cosmossdk.io/server/v2/cometbft/mempool"
-
 	cmtcfg "github.com/cometbft/cometbft/config"
+
+	"cosmossdk.io/server/v2/cometbft/mempool"
 )
 
 // Config is the configuration for the CometBFT application

--- a/server/v2/cometbft/config.go
+++ b/server/v2/cometbft/config.go
@@ -1,6 +1,8 @@
 package cometbft
 
 import (
+	"cosmossdk.io/server/v2/cometbft/mempool"
+
 	cmtcfg "github.com/cometbft/cometbft/config"
 )
 
@@ -20,6 +22,7 @@ func DefaultAppTomlConfig() *AppTomlConfig {
 		Transport:       "socket",
 		Trace:           false,
 		Standalone:      false,
+		Mempool:         mempool.DefaultConfig(),
 	}
 }
 
@@ -32,6 +35,9 @@ type AppTomlConfig struct {
 	Transport       string   `mapstructure:"transport" toml:"transport" comment:"transport defines the CometBFT RPC server transport protocol: socket, grpc"`
 	Trace           bool     `mapstructure:"trace" toml:"trace" comment:"trace enables the CometBFT RPC server to output trace information about its internal operations."`
 	Standalone      bool     `mapstructure:"standalone" toml:"standalone" comment:"standalone starts the application without the CometBFT node. The node should be started separately."`
+
+	// Sub configs
+	Mempool mempool.Config `mapstructure:"mempool" toml:"mempool" comment:"mempool defines the configuration for the SDK built-in app-side mempool implementations."`
 }
 
 // CfgOption is a function that allows to overwrite the default server configuration.

--- a/server/v2/cometbft/flags.go
+++ b/server/v2/cometbft/flags.go
@@ -51,10 +51,11 @@ func prefix(f string) string {
 
 // Server flags
 var (
-	Standalone     = prefix("standalone")
-	FlagAddress    = prefix("address")
-	FlagTransport  = prefix("transport")
-	FlagHaltHeight = prefix("halt-height")
-	FlagHaltTime   = prefix("halt-time")
-	FlagTrace      = prefix("trace")
+	Standalone        = prefix("standalone")
+	FlagAddress       = prefix("address")
+	FlagTransport     = prefix("transport")
+	FlagHaltHeight    = prefix("halt-height")
+	FlagHaltTime      = prefix("halt-time")
+	FlagTrace         = prefix("trace")
+	FlagMempoolMaxTxs = prefix("mempool.max-txs")
 )

--- a/server/v2/cometbft/mempool/config.go
+++ b/server/v2/cometbft/mempool/config.go
@@ -1,11 +1,16 @@
 package mempool
 
-// Config defines the configurations for the SDK built-in app-side mempool
-// implementations.
+var DefaultMaxTx = -1
+
+// Config defines the configurations for the SDK built-in app-side mempool implementations.
 type Config struct {
-	// MaxTxs defines the behavior of the mempool. A negative value indicates
-	// the mempool is disabled entirely, zero indicates that the mempool is
-	// unbounded in how many txs it may contain, and a positive value indicates
-	// the maximum amount of txs it may contain.
-	MaxTxs int `mapstructure:"max-txs"`
+	// MaxTxs defines the maximum number of transactions that can be in the mempool.
+	MaxTxs int `mapstructure:"max-txs" toml:"max-txs" comment:"max-txs defines the maximum number of transactions that can be in the mempool. A value of 0 indicates an unbounded mempool, a negative value disables the app-side mempool."`
+}
+
+// DefaultConfig returns a default configuration for the SDK built-in app-side mempool implementations.
+func DefaultConfig() Config {
+	return Config{
+		MaxTxs: DefaultMaxTx,
+	}
 }

--- a/server/v2/cometbft/mempool/doc.go
+++ b/server/v2/cometbft/mempool/doc.go
@@ -1,6 +1,2 @@
-/*
-The mempool package defines a few mempool services which can be used in conjunction with your consensus implementation
-
-*/
-
+// Package mempool defines a few mempool services which can be used in conjunction with your consensus implementation.
 package mempool

--- a/server/v2/cometbft/options.go
+++ b/server/v2/cometbft/options.go
@@ -9,14 +9,15 @@ import (
 )
 
 // ServerOptions defines the options for the CometBFT server.
+// Options are func that are able to take CometBFT app.toml section config and config.toml config.
 type ServerOptions[T transaction.Tx] struct {
-	Mempool                    mempool.Mempool[T]
+	Mempool                    func(cfg map[string]any) mempool.Mempool[T]
 	PrepareProposalHandler     handlers.PrepareHandler[T]
 	ProcessProposalHandler     handlers.ProcessHandler[T]
 	VerifyVoteExtensionHandler handlers.VerifyVoteExtensionhandler
 	ExtendVoteHandler          handlers.ExtendVoteHandler
 
-	SnapshotOptions snapshots.SnapshotOptions
+	SnapshotOptions func(cfg map[string]any) snapshots.SnapshotOptions
 
 	AddrPeerFilter types.PeerFilter // filter peers by address and port
 	IdPeerFilter   types.PeerFilter // filter peers by node ID
@@ -26,12 +27,12 @@ type ServerOptions[T transaction.Tx] struct {
 // It defaults to a NoOpMempool and NoOp handlers.
 func DefaultServerOptions[T transaction.Tx]() ServerOptions[T] {
 	return ServerOptions[T]{
-		Mempool:                    mempool.NoOpMempool[T]{},
+		Mempool:                    func(cfg map[string]any) mempool.Mempool[T] { return mempool.NoOpMempool[T]{} },
 		PrepareProposalHandler:     handlers.NoOpPrepareProposal[T](),
 		ProcessProposalHandler:     handlers.NoOpProcessProposal[T](),
 		VerifyVoteExtensionHandler: handlers.NoOpVerifyVoteExtensionHandler(),
 		ExtendVoteHandler:          handlers.NoOpExtendVote(),
-		SnapshotOptions:            snapshots.NewSnapshotOptions(0, 0),
+		SnapshotOptions:            func(cfg map[string]any) snapshots.SnapshotOptions { return snapshots.NewSnapshotOptions(0, 0) },
 		AddrPeerFilter:             nil,
 		IdPeerFilter:               nil,
 	}

--- a/server/v2/cometbft/options.go
+++ b/server/v2/cometbft/options.go
@@ -9,14 +9,14 @@ import (
 )
 
 // ServerOptions defines the options for the CometBFT server.
-// Options are func that are able to take CometBFT app.toml section config and config.toml config.
+// When an options takes a map[string]any, it is able to access the app.tom's cometbft section and the config.toml config.
 type ServerOptions[T transaction.Tx] struct {
-	Mempool                    func(cfg map[string]any) mempool.Mempool[T]
 	PrepareProposalHandler     handlers.PrepareHandler[T]
 	ProcessProposalHandler     handlers.ProcessHandler[T]
 	VerifyVoteExtensionHandler handlers.VerifyVoteExtensionhandler
 	ExtendVoteHandler          handlers.ExtendVoteHandler
 
+	Mempool         func(cfg map[string]any) mempool.Mempool[T]
 	SnapshotOptions func(cfg map[string]any) snapshots.SnapshotOptions
 
 	AddrPeerFilter types.PeerFilter // filter peers by address and port
@@ -27,11 +27,11 @@ type ServerOptions[T transaction.Tx] struct {
 // It defaults to a NoOpMempool and NoOp handlers.
 func DefaultServerOptions[T transaction.Tx]() ServerOptions[T] {
 	return ServerOptions[T]{
-		Mempool:                    func(cfg map[string]any) mempool.Mempool[T] { return mempool.NoOpMempool[T]{} },
 		PrepareProposalHandler:     handlers.NoOpPrepareProposal[T](),
 		ProcessProposalHandler:     handlers.NoOpProcessProposal[T](),
 		VerifyVoteExtensionHandler: handlers.NoOpVerifyVoteExtensionHandler(),
 		ExtendVoteHandler:          handlers.NoOpExtendVote(),
+		Mempool:                    func(cfg map[string]any) mempool.Mempool[T] { return mempool.NoOpMempool[T]{} },
 		SnapshotOptions:            func(cfg map[string]any) snapshots.SnapshotOptions { return snapshots.NewSnapshotOptions(0, 0) },
 		AddrPeerFilter:             nil,
 		IdPeerFilter:               nil,

--- a/server/v2/cometbft/options.go
+++ b/server/v2/cometbft/options.go
@@ -9,7 +9,7 @@ import (
 )
 
 // ServerOptions defines the options for the CometBFT server.
-// When an options takes a map[string]any, it is able to access the app.tom's cometbft section and the config.toml config.
+// When an option takes a map[string]any, it can access the app.tom's cometbft section and the config.toml config.
 type ServerOptions[T transaction.Tx] struct {
 	PrepareProposalHandler     handlers.PrepareHandler[T]
 	ProcessProposalHandler     handlers.ProcessHandler[T]

--- a/server/v2/cometbft/server.go
+++ b/server/v2/cometbft/server.go
@@ -24,6 +24,7 @@ import (
 	"cosmossdk.io/log"
 	serverv2 "cosmossdk.io/server/v2"
 	cometlog "cosmossdk.io/server/v2/cometbft/log"
+	"cosmossdk.io/server/v2/cometbft/mempool"
 	"cosmossdk.io/server/v2/cometbft/types"
 	"cosmossdk.io/store/v2/snapshots"
 
@@ -105,7 +106,7 @@ func (s *CometBFTServer[T]) Init(appI serverv2.AppI[T], cfg map[string]any, logg
 		appI.Name(),
 		appI.GetConsensusAuthority(),
 		appI.GetAppManager(),
-		s.serverOptions.Mempool,
+		s.serverOptions.Mempool(cfg),
 		indexEvents,
 		appI.GetGPRCMethodsToMessageMap(),
 		store,
@@ -127,7 +128,7 @@ func (s *CometBFTServer[T]) Init(appI serverv2.AppI[T], cfg map[string]any, logg
 	if err != nil {
 		return err
 	}
-	consensus.snapshotManager = snapshots.NewManager(snapshotStore, s.serverOptions.SnapshotOptions, sc, ss, nil, s.logger)
+	consensus.snapshotManager = snapshots.NewManager(snapshotStore, s.serverOptions.SnapshotOptions(cfg), sc, ss, nil, s.logger)
 
 	s.Consensus = consensus
 
@@ -240,6 +241,7 @@ func (s *CometBFTServer[T]) StartCmdFlags() *pflag.FlagSet {
 	flags.Uint64(FlagHaltTime, 0, "Minimum block time (in Unix seconds) at which to gracefully halt the chain and shutdown the node")
 	flags.Bool(FlagTrace, false, "Provide full stack traces for errors in ABCI Log")
 	flags.Bool(Standalone, false, "Run app without CometBFT")
+	flags.Int(FlagMempoolMaxTxs, mempool.DefaultMaxTx, "Sets MaxTx value for the app-side mempool")
 
 	// add comet flags, we use an empty command to avoid duplicating CometBFT's AddNodeFlags.
 	// we can then merge the flag sets.

--- a/server/v2/commands.go
+++ b/server/v2/commands.go
@@ -38,14 +38,14 @@ func AddCommands[T transaction.Tx](
 	rootCmd *cobra.Command,
 	newApp AppCreator[T],
 	logger log.Logger,
-	serverCfg ServerConfig,
+	globalServerCfg ServerConfig,
 	components ...ServerComponent[T],
 ) error {
 	if len(components) == 0 {
 		return errors.New("no components provided")
 	}
 
-	server := NewServer(logger, serverCfg, components...)
+	server := NewServer(logger, globalServerCfg, components...)
 	originalPersistentPreRunE := rootCmd.PersistentPreRunE
 	rootCmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
 		// set the default command outputs

--- a/simapp/v2/simdv2/cmd/commands.go
+++ b/simapp/v2/simdv2/cmd/commands.go
@@ -74,7 +74,11 @@ func initRootCmd[T transaction.Tx](
 		newApp,
 		logger,
 		initServerConfig(),
-		cometbft.New(&genericTxDecoder[T]{txConfig}, cometbft.DefaultServerOptions[T]()),
+		cometbft.New(
+			&genericTxDecoder[T]{txConfig},
+			initCometOptions[T](),
+			initCometConfig(),
+		),
 		grpc.New[T](),
 		store.New[T](newApp),
 	); err != nil {

--- a/simapp/v2/simdv2/cmd/config.go
+++ b/simapp/v2/simdv2/cmd/config.go
@@ -91,13 +91,17 @@ func initCometConfig() cometbft.CfgOption {
 func initCometOptions[T transaction.Tx]() cometbft.ServerOptions[T] {
 	serverOptions := cometbft.DefaultServerOptions[T]()
 
-	// TOOD mempool interface doesn't match!
+	// TODO mempool interface doesn't match!
 
 	// overwrite app mempool, using max-txs option
-	// if maxTxs := cast.ToInt(cfg.Get(cometbft.FlagMempoolMaxTxs)); maxTxs >= 0 {
-	// 	serverOptions.Mempool = mempool.NewSenderNonceMempool(
-	// 		mempool.SenderNonceMaxTxOpt(maxTxs),
-	// 	)
+	// serverOptions.Mempool = func(cfg map[string]any) mempool.Mempool[T] {
+	// 	if maxTxs := cast.ToInt(cfg[cometbft.FlagMempoolMaxTxs]); maxTxs >= 0 {
+	// 		return mempool.NewSenderNonceMempool(
+	// 			mempool.SenderNonceMaxTxOpt(maxTxs),
+	// 		)
+	// 	}
+
+	// 	return mempool.NoOpMempool[T]{}
 	// }
 
 	return serverOptions

--- a/simapp/v2/simdv2/cmd/config.go
+++ b/simapp/v2/simdv2/cmd/config.go
@@ -2,8 +2,13 @@ package cmd
 
 import (
 	"strings"
+	"time"
 
+	cmtcfg "github.com/cometbft/cometbft/config"
+
+	"cosmossdk.io/core/transaction"
 	serverv2 "cosmossdk.io/server/v2"
+	"cosmossdk.io/server/v2/cometbft"
 
 	clientconfig "github.com/cosmos/cosmos-sdk/client/config"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
@@ -67,4 +72,33 @@ func initServerConfig() serverv2.ServerConfig {
 	serverCfg.MinGasPrices = "0stake"
 
 	return serverCfg
+}
+
+// initCometConfig helps to override default comet config template and configs.
+func initCometConfig() cometbft.CfgOption {
+	cfg := cmtcfg.DefaultConfig()
+
+	// display only warn logs by default except for p2p and state
+	cfg.LogLevel = "*:warn,p2p:info,state:info"
+	// increase block timeout
+	cfg.Consensus.TimeoutCommit = 5 * time.Second
+	// overwrite default pprof listen address
+	cfg.RPC.PprofListenAddress = "localhost:6060"
+
+	return cometbft.OverwriteDefaultConfigTomlConfig(cfg)
+}
+
+func initCometOptions[T transaction.Tx]() cometbft.ServerOptions[T] {
+	serverOptions := cometbft.DefaultServerOptions[T]()
+
+	// TOOD mempool interface doesn't match!
+
+	// overwrite app mempool, using max-txs option
+	// if maxTxs := cast.ToInt(cfg.Get(cometbft.FlagMempoolMaxTxs)); maxTxs >= 0 {
+	// 	serverOptions.Mempool = mempool.NewSenderNonceMempool(
+	// 		mempool.SenderNonceMaxTxOpt(maxTxs),
+	// 	)
+	// }
+
+	return serverOptions
 }


### PR DESCRIPTION
# Description

Closes: https://github.com/cosmos/cosmos-sdk/issues/21733

- [x] Wires mempool config
- [x] Make mempool and snapshots options able to get config
- [x] Demonstrate how to override config.toml config  and set good defaults

Note, that the sdkmempool interface vs the cometbft server mempool interface differs.
Meaning, we cannot use directly the SDK mempool in the new cometbft server.

### types/mempool

```go
type Mempool interface {
	// Insert attempts to insert a Tx into the app-side mempool returning
	// an error upon failure.
	Insert(context.Context, sdk.Tx) error

	// Select returns an Iterator over the app-side mempool. If txs are specified,
	// then they shall be incorporated into the Iterator. The Iterator is not thread-safe to use.
	Select(context.Context, [][]byte) Iterator

	// SelectBy use callback to iterate over the mempool, it's thread-safe to use.
	SelectBy(context.Context, [][]byte, func(sdk.Tx) bool)

	// CountTx returns the number of transactions currently in the mempool.
	CountTx() int

	// Remove attempts to remove a transaction from the mempool, returning an error
	// upon failure.
	Remove(sdk.Tx) error
}
```

### server/v2/cometbft/mempool

```go
// Mempool defines the required methods of an application's mempool.
type Mempool[T transaction.Tx] interface {
	// Insert attempts to insert a Tx into the app-side mempool returning
	// an error upon failure.
	Insert(context.Context, T) error

	// Select returns an Iterator over the app-side mempool. If txs are specified,
	// then they shall be incorporated into the Iterator. The Iterator must be
	// closed by the caller.
	Select(context.Context, []T) Iterator[T]

	// Remove attempts to remove a transaction from the mempool, returning an error
	// upon failure.
	Remove([]T) error
}
```

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title, you can find examples of the prefixes below:
    <!-- * `feat`: A new feature
    * `fix`: A bug fix
    * `docs`: Documentation only changes
    * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
    * `refactor`: A code change that neither fixes a bug nor adds a feature
    * `perf`: A code change that improves performance
    * `test`: Adding missing tests or correcting existing tests
    * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
    * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
    * `chore`: Other changes that don't modify src or test files
    * `revert`: Reverts a previous commit -->
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

Please see [Pull Request Reviewer section in the contributing guide](../CONTRIBUTING.md#reviewer) for more information on how to review a pull request.

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new configuration option for mempool functionality, enhancing application configurability.
	- Added functions to customize default CometBFT configuration, including logging levels and timeout settings.

- **Refactor**
	- Updated server options to allow dynamic processing of configuration settings.

These changes improve the flexibility and configurability of the application, allowing users to tailor settings to their needs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->