### PR TITLE
refactor(store): keep `batch.Close` error handle logic consistance

### DIFF
--- a/store/rootmulti/store.go
+++ b/store/rootmulti/store.go
@@ -1147,7 +1147,9 @@ func (rs *Store) flushMetadata(db corestore.KVStoreWithBatch, version int64, cIn
 	rs.logger.Debug("flushing metadata", "height", version)
 	batch := db.NewBatch()
 	defer func() {
-		_ = batch.Close()
+		if err := batch.Close(); err != nil {
+			rs.logger.Error("error on batch close", "err", err)
+		}
 	}()
 
 	if cInfo != nil {

--- a/store/rootmulti/store.go
+++ b/store/rootmulti/store.go
@@ -1148,7 +1148,7 @@ func (rs *Store) flushMetadata(db corestore.KVStoreWithBatch, version int64, cIn
 	batch := db.NewBatch()
 	defer func() {
 		if err := batch.Close(); err != nil {
-			rs.logger.Error("error on batch close", "err", err)
+			rs.logger.Error("call flushMetadata error on batch close", "err", err)
 		}
 	}()
 

--- a/store/v2/commitment/metadata.go
+++ b/store/v2/commitment/metadata.go
@@ -2,6 +2,7 @@ package commitment
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 
 	corestore "cosmossdk.io/core/store"
@@ -158,10 +159,7 @@ func (m *MetadataStore) deleteRemovedStoreKeys(version uint64, removeStore func(
 
 	batch := m.kv.NewBatch()
 	defer func() {
-		cErr := batch.Close()
-		if err == nil {
-			err = cErr
-		}
+		err = errors.Join(err, batch.Close())
 	}()
 	for _, storeKey := range removedStoreKeys {
 		if err := removeStore(storeKey, version); err != nil {

--- a/store/v2/commitment/metadata.go
+++ b/store/v2/commitment/metadata.go
@@ -158,8 +158,9 @@ func (m *MetadataStore) deleteRemovedStoreKeys(version uint64, removeStore func(
 
 	batch := m.kv.NewBatch()
 	defer func() {
-		if berr := batch.Close(); berr != nil {
-			err = berr
+		cErr := batch.Close()
+		if err == nil {
+			err = cErr
 		}
 	}()
 	for _, storeKey := range removedStoreKeys {


### PR DESCRIPTION
# Description

This PR includes two changes:

1. The error handling logic of `batch.Close()` in `func deleteRemovedStoreKeys` is different from others, which maybe lose the original error info. Let's keep them consistance.
2. Log error info when `batch.Close()` is error in `func flushMetadata`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling during batch closure in the metadata flushing process to prevent silent failures.
	- Enhanced error reporting in the metadata handling process to preserve original error context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->