### PR TITLE
docs: fix typo

### DIFF
--- a/x/bank/simulation/genesis.go
+++ b/x/bank/simulation/genesis.go
@@ -50,7 +50,7 @@ func RandomGenesisSendEnabled(r *rand.Rand, bondDenom string) []types.SendEnable
 	//   P(sef)  = 18.0% = SendEnabled entry that does not equal the default   = P(stc') + P(sfc) = .045 + .135 = .180
 	//
 	//   P(t)    = 81.0% = Bond denom is sendable      = P(a'c) + P(st)  = .360 + .450 = .810
-	//   P(f)    = 19.0% = Bond demon is NOT sendable  = P(a'c') + P(sf) = .040 + .150 = .190
+	//   P(f)    = 19.0% = Bond denom is NOT sendable  = P(a'c') + P(sf) = .040 + .150 = .190
 
 	return rv
 }

--- a/x/bank/types/genesis.go
+++ b/x/bank/types/genesis.go
@@ -112,7 +112,7 @@ func GetGenesisStateFromAppState(cdc codec.JSONCodec, appState map[string]json.R
 // Params.SendEnabled slice is empty, this is a noop.
 //
 // If the main SendEnabled slice already has entries, the Params.SendEnabled
-// entries are added. In case of the same demon in both, preference is given to
+// entries are added. In case of the same denom in both, preference is given to
 // the existing (main GenesisState field) entry.
 func (gs *GenesisState) MigrateSendEnabled() {
 	gs.SendEnabled = gs.GetAllSendEnabled()

--- a/x/tx/signing/aminojson/aminojson_test.go
+++ b/x/tx/signing/aminojson/aminojson_test.go
@@ -24,7 +24,7 @@ func TestAminoJsonSignMode(t *testing.T) {
 		Msg: &bankv1beta1.MsgSend{
 			FromAddress: "foo",
 			ToAddress:   "bar",
-			Amount:      []*basev1beta1.Coin{{Denom: "demon", Amount: "100"}},
+			Amount:      []*basev1beta1.Coin{{Denom: "denom", Amount: "100"}},
 		},
 		AccNum:        1,
 		AccSeq:        2,

--- a/x/tx/signing/aminojson/fuzz_test.go
+++ b/x/tx/signing/aminojson/fuzz_test.go
@@ -29,7 +29,7 @@ func FuzzSignModeGetSignBytes(f *testing.F) {
 		Msg: &bankv1beta1.MsgSend{
 			FromAddress: "foo",
 			ToAddress:   "bar",
-			Amount:      []*basev1beta1.Coin{{Denom: "demon", Amount: "100"}},
+			Amount:      []*basev1beta1.Coin{{Denom: "denom", Amount: "100"}},
 		},
 		AccNum:        1,
 		AccSeq:        2,


### PR DESCRIPTION
# Description

demon -> denom


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected typographical errors in comments and test cases, changing "demon" to "denom" for clarity and accuracy.
	- Ensured consistency in terminology used for coin denominations across documentation and tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->