### PR TITLE
store: fix incorrect error throw usage

### DIFF
--- a/store/internal/kv/kv.pb.go
+++ b/store/internal/kv/kv.pb.go
@@ -4,6 +4,7 @@
 package kv
 
 import (
+	"errors"
 	fmt "fmt"
 	_ "github.com/cosmos/gogoproto/gogoproto"
 	proto "github.com/cosmos/gogoproto/proto"
@@ -304,7 +305,7 @@ func (m *Pairs) Unmarshal(dAtA []byte) error {
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
-			return fmt.Errorf("proto: Pairs: wiretype end group for non-group")
+			return errors.New("proto: Pairs: wiretype end group for non-group")
 		}
 		if fieldNum <= 0 {
 			return fmt.Errorf("proto: Pairs: illegal tag %d (wire type %d)", fieldNum, wire)
@@ -388,7 +389,7 @@ func (m *Pair) Unmarshal(dAtA []byte) error {
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
-			return fmt.Errorf("proto: Pair: wiretype end group for non-group")
+			return errors.New("proto: Pair: wiretype end group for non-group")
 		}
 		if fieldNum <= 0 {
 			return fmt.Errorf("proto: Pair: illegal tag %d (wire type %d)", fieldNum, wire)
@@ -563,7 +564,7 @@ func skipKv(dAtA []byte) (n int, err error) {
 }
 
 var (
-	ErrInvalidLengthKv        = fmt.Errorf("proto: negative length found during unmarshaling")
-	ErrIntOverflowKv          = fmt.Errorf("proto: integer overflow")
-	ErrUnexpectedEndOfGroupKv = fmt.Errorf("proto: unexpected end of group")
+	ErrInvalidLengthKv        = errors.New("proto: negative length found during unmarshaling")
+	ErrIntOverflowKv          = errors.New("proto: integer overflow")
+	ErrUnexpectedEndOfGroupKv = errors.New("proto: unexpected end of group")
 )

--- a/store/snapshots/types/snapshot.pb.go
+++ b/store/snapshots/types/snapshot.pb.go
@@ -4,6 +4,7 @@
 package types
 
 import (
+	"errors"
 	fmt "fmt"
 	_ "github.com/cosmos/cosmos-proto"
 	_ "github.com/cosmos/gogoproto/gogoproto"
@@ -1076,7 +1077,7 @@ func (m *Snapshot) Unmarshal(dAtA []byte) error {
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
-			return fmt.Errorf("proto: Snapshot: wiretype end group for non-group")
+			return errors.New("proto: Snapshot: wiretype end group for non-group")
 		}
 		if fieldNum <= 0 {
 			return fmt.Errorf("proto: Snapshot: illegal tag %d (wire type %d)", fieldNum, wire)
@@ -1250,7 +1251,7 @@ func (m *Metadata) Unmarshal(dAtA []byte) error {
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
-			return fmt.Errorf("proto: Metadata: wiretype end group for non-group")
+			return errors.New("proto: Metadata: wiretype end group for non-group")
 		}
 		if fieldNum <= 0 {
 			return fmt.Errorf("proto: Metadata: illegal tag %d (wire type %d)", fieldNum, wire)
@@ -1332,7 +1333,7 @@ func (m *SnapshotItem) Unmarshal(dAtA []byte) error {
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
-			return fmt.Errorf("proto: SnapshotItem: wiretype end group for non-group")
+			return errors.New("proto: SnapshotItem: wiretype end group for non-group")
 		}
 		if fieldNum <= 0 {
 			return fmt.Errorf("proto: SnapshotItem: illegal tag %d (wire type %d)", fieldNum, wire)
@@ -1522,7 +1523,7 @@ func (m *SnapshotStoreItem) Unmarshal(dAtA []byte) error {
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
-			return fmt.Errorf("proto: SnapshotStoreItem: wiretype end group for non-group")
+			return errors.New("proto: SnapshotStoreItem: wiretype end group for non-group")
 		}
 		if fieldNum <= 0 {
 			return fmt.Errorf("proto: SnapshotStoreItem: illegal tag %d (wire type %d)", fieldNum, wire)
@@ -1604,7 +1605,7 @@ func (m *SnapshotIAVLItem) Unmarshal(dAtA []byte) error {
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
-			return fmt.Errorf("proto: SnapshotIAVLItem: wiretype end group for non-group")
+			return errors.New("proto: SnapshotIAVLItem: wiretype end group for non-group")
 		}
 		if fieldNum <= 0 {
 			return fmt.Errorf("proto: SnapshotIAVLItem: illegal tag %d (wire type %d)", fieldNum, wire)
@@ -1760,7 +1761,7 @@ func (m *SnapshotExtensionMeta) Unmarshal(dAtA []byte) error {
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
-			return fmt.Errorf("proto: SnapshotExtensionMeta: wiretype end group for non-group")
+			return errors.New("proto: SnapshotExtensionMeta: wiretype end group for non-group")
 		}
 		if fieldNum <= 0 {
 			return fmt.Errorf("proto: SnapshotExtensionMeta: illegal tag %d (wire type %d)", fieldNum, wire)
@@ -1861,7 +1862,7 @@ func (m *SnapshotExtensionPayload) Unmarshal(dAtA []byte) error {
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
-			return fmt.Errorf("proto: SnapshotExtensionPayload: wiretype end group for non-group")
+			return errors.New("proto: SnapshotExtensionPayload: wiretype end group for non-group")
 		}
 		if fieldNum <= 0 {
 			return fmt.Errorf("proto: SnapshotExtensionPayload: illegal tag %d (wire type %d)", fieldNum, wire)
@@ -2002,7 +2003,7 @@ func skipSnapshot(dAtA []byte) (n int, err error) {
 }
 
 var (
-	ErrInvalidLengthSnapshot        = fmt.Errorf("proto: negative length found during unmarshaling")
-	ErrIntOverflowSnapshot          = fmt.Errorf("proto: integer overflow")
-	ErrUnexpectedEndOfGroupSnapshot = fmt.Errorf("proto: unexpected end of group")
+	ErrInvalidLengthSnapshot        = errors.New("proto: negative length found during unmarshaling")
+	ErrIntOverflowSnapshot          = errors.New("proto: integer overflow")
+	ErrUnexpectedEndOfGroupSnapshot = errors.New("proto: unexpected end of group")
 )


### PR DESCRIPTION
fix incorrect `fmt.Errorf` usage in store