### PR TITLE
chore(contributing): delete old file path

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,7 +128,7 @@ NOTE: when merging, GitHub will squash commits and rebase on top of the main.
 
 ### Pull Request Templates
 
-There are three PR templates. The [default template](./.github/PULL_REQUEST_TEMPLATE.md) is for types `fix`, `feat`, and `refactor`. We also have a [docs template](./.github/PULL_REQUEST_TEMPLATE/docs.md) for documentation changes. When previewing a PR before it has been opened, you can change the template by adding one of the following parameters to the url:
+There are three PR templates. The [default template](./.github/PULL_REQUEST_TEMPLATE.md) is used for PR types such as `fix`, `feat`,`docs`, and `refactor`, among others. These are just a few examples. For more details, please refer to the default template.
 
 * `template=docs.md`
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,8 +130,6 @@ NOTE: when merging, GitHub will squash commits and rebase on top of the main.
 
 There are three PR templates. The [default template](./.github/PULL_REQUEST_TEMPLATE.md) is used for PR types such as `fix`, `feat`,`docs`, and `refactor`, among others. These are just a few examples. For more details, please refer to the default template.
 
-* `template=docs.md`
-
 ### Pull Request Accountability
 
 #### Owner


### PR DESCRIPTION
https://github.com/cosmos/cosmos-sdk/commit/a39869aa3f7c7aa13811a1edb1917591be3143df#diff-755a0b8325879dc97818215ec547e19581667c7ad05742f62a23933b7dd113f9 
`.github/PULL_REQUEST_TEMPLATE/docs.md` has been deleted 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated the `CONTRIBUTING.md` file to include `docs` as a pull request type and clarified the applicability of the default template for various PR types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->