### PR TITLE
docs: redirect the modules introduce doc

### DIFF
--- a/docs/Introduction.md
+++ b/docs/Introduction.md
@@ -21,7 +21,7 @@ Get familiar with the SDK and explore its main concepts.
 * [**Core Concepts**](learn/advanced/00-baseapp.md) -  Read about the core concepts like baseapp, the store, or the server.
 * [**Building Modules**](build/building-modules/00-intro.md) -  Discover how to build modules for the Cosmos SDK.
 * [**Running a Node**](https://docs.cosmos.network/main/user/run-node/keyring) - Running and interacting with nodes using the CLI and API.
-* [**Modules**](./build/modules/README.md) - Explore existing modules to build your application with.
+* [**Modules**](./build/building-modules/00-intro.md) - Explore existing modules to build your application with.
 
 ## Explore the Stack
 


### PR DESCRIPTION
# Description
 redirect the modules introduce doc


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the link in the "Modules" section of the Cosmos SDK documentation for improved navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->