### PR TITLE
fix(sims): Use liveness matrix for val sign status in sims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,8 +54,8 @@ Every module contains its own CHANGELOG.md. Please refer to the module you are i
 * (sims) [#21613](https://github.com/cosmos/cosmos-sdk/pull/21613) Add sims2 framework and factory methods for simpler message factories in modules
 
 ### Bug Fixes
-
-* (sims) [21906](https://github.com/cosmos/cosmos-sdk/pull/21906) Skip sims test when running dry on validators
+* (sims) [#21952](https://github.com/cosmos/cosmos-sdk/pull/21952) Use liveness matrix for validator sign status in sims
+* (sims) [#21906](https://github.com/cosmos/cosmos-sdk/pull/21906) Skip sims test when running dry on validators
 * (cli) [#21919](https://github.com/cosmos/cosmos-sdk/pull/21919) Query address-by-acc-num by account_id instead of id.
 
 ### API Breaking Changes

--- a/x/simulation/mock_cometbft.go
+++ b/x/simulation/mock_cometbft.go
@@ -151,10 +151,13 @@ func RandomRequestFinalizeBlock(
 			signed = false
 		}
 
+		var commitStatus cmtproto.BlockIDFlag
 		if signed {
 			event("begin_block", "signing", "signed")
+			commitStatus = cmtproto.BlockIDFlagCommit
 		} else {
 			event("begin_block", "signing", "missed")
+			commitStatus = cmtproto.BlockIDFlagAbsent
 		}
 
 		voteInfos[i] = abci.VoteInfo{
@@ -162,7 +165,7 @@ func RandomRequestFinalizeBlock(
 				Address: SumTruncated(mVal.val.PubKeyBytes),
 				Power:   mVal.val.Power,
 			},
-			BlockIdFlag: cmtproto.BlockIDFlagCommit,
+			BlockIdFlag: commitStatus,
 		}
 	}
 


### PR DESCRIPTION
# Description

Closes: #17912

Use liveness matrix for validator sign status in sims

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated changelog to reflect changes in the "sims" and "cli" modules, including new handling for validator sign status and query updates.

- **Bug Fixes**
	- Improved accuracy of voting information by dynamically reflecting the signing status of blocks in the simulation module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->