### PR TITLE
chore: fix comment

### DIFF
--- a/server/v2/api/telemetry/metrics.go
+++ b/server/v2/api/telemetry/metrics.go
@@ -57,7 +57,7 @@ type GatherResponse struct {
 	ContentType string
 }
 
-// New creates a new instance of Metrics
+// NewMetrics creates a new instance of Metrics
 func NewMetrics(cfg *Config) (*Metrics, error) {
 	if numGlobalLabels := len(cfg.GlobalLabels); numGlobalLabels > 0 {
 		parsedGlobalLabels := make([]metrics.Label, numGlobalLabels)

--- a/server/v2/store/commands.go
+++ b/server/v2/store/commands.go
@@ -16,7 +16,7 @@ import (
 	"cosmossdk.io/store/v2/root"
 )
 
-// QueryBlockResultsCmd implements the default command for a BlockResults query.
+// PrunesCmd implements the default command for pruning app history states.
 func (s *Server[T]) PrunesCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "prune [pruning-method]",

--- a/server/v2/store/server.go
+++ b/server/v2/store/server.go
@@ -19,7 +19,7 @@ var (
 
 const ServerName = "store"
 
-// StoreComponent manages store config and contains prune & snapshot commands
+// Server manages store config and contains prune & snapshot commands
 type Server[T transaction.Tx] struct {
 	config *Config
 	// saving appCreator for only RestoreSnapshotCmd

--- a/server/v2/store/snapshot.go
+++ b/server/v2/store/snapshot.go
@@ -24,7 +24,7 @@ import (
 
 const SnapshotFileName = "_snapshot"
 
-// QueryBlockResultsCmd implements the default command for a BlockResults query.
+// ExportSnapshotCmd exports app state to snapshot store.
 func (s *Server[T]) ExportSnapshotCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "export",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated comments for clarity on function and method purposes, including:
		- `NewMetrics` function name clarification.
		- `PrunesCmd` method now specifies its role in pruning application history states.
		- `Server` type terminology updated for better understanding.
		- `ExportSnapshotCmd` method now clearly states its function in exporting application state to the snapshot store.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->