### PR TITLE
fix(baseapp): `startTime` of `telemetry metric` should be calculated before `defer`

### DIFF
--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -180,7 +180,6 @@ func (app *BaseApp) Query(_ context.Context, req *abci.QueryRequest) (resp *abci
 
 	telemetry.IncrCounter(1, "query", "count")
 	telemetry.IncrCounter(1, "query", req.Path)
-	
 	start := telemetry.Now()
 	defer telemetry.MeasureSince(start, req.Path)
 

--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -180,7 +180,9 @@ func (app *BaseApp) Query(_ context.Context, req *abci.QueryRequest) (resp *abci
 
 	telemetry.IncrCounter(1, "query", "count")
 	telemetry.IncrCounter(1, "query", req.Path)
-	defer telemetry.MeasureSince(telemetry.Now(), req.Path)
+	
+	start := telemetry.Now()
+	defer telemetry.MeasureSince(start, req.Path)
 
 	if req.Path == QueryPathBroadcastTx {
 		return queryResult(errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "can't route a broadcast tx message"), app.trace), nil


### PR DESCRIPTION
# Description

Similar to the changes in #21963 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the timing of telemetry measurement initiation for enhanced performance tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->