### PR TITLE
refactor(tools): echo the binary path after build tools

### DIFF
--- a/tools/confix/Makefile
+++ b/tools/confix/Makefile
@@ -4,9 +4,11 @@ all: confix condiff test
 
 confix:
 	go build -mod=readonly ./cmd/confix
+	@echo "confix binary has been successfully built in tools/confix/confix"
 
 condiff:
 	go build -mod=readonly ./cmd/condiff
+	@echo "condiff binary has been successfully built in tools/confix/condiff"
 
 test:
 	go test -mod=readonly -race ./...

--- a/tools/cosmovisor/Makefile
+++ b/tools/cosmovisor/Makefile
@@ -4,6 +4,7 @@ all: cosmovisor test
 
 cosmovisor:
 	go build -mod=readonly ./cmd/cosmovisor
+	@echo "cosmovisor binary has been successfully built in tools/cosmovisor/cosmovisor"
 
 test:
 	go test -mod=readonly -race ./...

--- a/tools/hubl/Makefile
+++ b/tools/hubl/Makefile
@@ -4,6 +4,7 @@ all: hubl test
 
 hubl:
 	go build -mod=readonly ./cmd/hubl
+	@echo "hubl binary has been successfully built in tools/hubl/hubl"
 
 test:
 	go test -mod=readonly -race ./...


### PR DESCRIPTION
# Description

The first time I ran `make cosmovisor`, it took me some time to locate the `cosmovisor` binary(neither in `build/` nor something like `out/`).

It would be better to display the location where the built binary is so that we can conveniently run it for test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added confirmation messages after successful builds for the `confix`, `condiff`, `cosmovisor`, and `hubl` binaries, enhancing user feedback during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->