### PR TITLE
fix: update go module link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -236,7 +236,7 @@ Within the Cosmos SDK we have two forms of documenting decisions, Request For Co
 
 ## Dependencies
 
-We use [Go Modules](https://github.com/golang/go/wiki/Modules) to manage
+We use [Go Modules](https://go.dev/wiki/Modules) to manage
 dependency versions.
 
 The main branch of every Cosmos repository should just build with `go get`,
@@ -300,7 +300,7 @@ For example, in vscode your `.vscode/settings.json` should look like:
 
 User-facing repos should adhere to the trunk based development branching model: https://trunkbaseddevelopment.com. User branches should start with a user name, example: `{moniker}/{issue#}-branch-name`.
 
-The Cosmos SDK repository is a [multi Go module](https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository) repository. It means that we have more than one Go module in a single repository.
+The Cosmos SDK repository is a [multi Go module](https://go.dev/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository) repository. It means that we have more than one Go module in a single repository.
 
 The Cosmos SDK utilizes [semantic versioning](https://semver.org/).
 


### PR DESCRIPTION
# Description

The `Go module` link `https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository` in `CONTRIBUTING.md` is no longer work now

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the `CONTRIBUTING.md` file to clarify the contribution process.
	- Revised the table of contents for improved navigation.
	- Enhanced sections on dependencies, development procedures, and pull request processes.
	- Introduced a draft PR stage for early feedback and outlined responsibilities for pull request owners and reviewers.
	- Structured the concept and feature approval process into distinct stages with defined timelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->