### PR TITLE
refactor(store/v2): join `batch.Close` error with `original err`

### DIFF
--- a/store/v2/commitment/metadata.go
+++ b/store/v2/commitment/metadata.go
@@ -82,10 +82,7 @@ func (m *MetadataStore) flushCommitInfo(version uint64, cInfo *proof.CommitInfo)
 
 	batch := m.kv.NewBatch()
 	defer func() {
-		cErr := batch.Close()
-		if err == nil {
-			err = cErr
-		}
+		err = errors.Join(err, batch.Close())
 	}()
 	cInfoKey := []byte(fmt.Sprintf(commitInfoKeyFmt, version))
 	value, err := cInfo.Marshal()
@@ -114,10 +111,7 @@ func (m *MetadataStore) flushCommitInfo(version uint64, cInfo *proof.CommitInfo)
 func (m *MetadataStore) flushRemovedStoreKeys(version uint64, storeKeys []string) (err error) {
 	batch := m.kv.NewBatch()
 	defer func() {
-		cErr := batch.Close()
-		if err == nil {
-			err = cErr
-		}
+		err = errors.Join(err, batch.Close())
 	}()
 
 	for _, storeKey := range storeKeys {

--- a/store/v2/migration/manager.go
+++ b/store/v2/migration/manager.go
@@ -185,10 +185,7 @@ func (m *Manager) writeChangeset() error {
 		// yet not in the for-loop which can leave resource lingering.
 		err = func() (err error) {
 			defer func() {
-				cErr := batch.Close()
-				if err == nil {
-					err = cErr
-				}
+				err = errors.Join(err, batch.Close())
 			}()
 
 			if err := batch.Set(csKey, csBytes); err != nil {

--- a/store/v2/storage/pebbledb/db.go
+++ b/store/v2/storage/pebbledb/db.go
@@ -212,10 +212,7 @@ func (db *Database) Prune(version uint64) (err error) {
 
 	batch := db.storage.NewBatch()
 	defer func() {
-		cErr := batch.Close()
-		if err == nil {
-			err = cErr
-		}
+		err = errors.Join(err, batch.Close())
 	}()
 
 	var (
@@ -339,10 +336,7 @@ func (db *Database) ReverseIterator(storeKey []byte, version uint64, start, end 
 func (db *Database) PruneStoreKeys(storeKeys []string, version uint64) (err error) {
 	batch := db.storage.NewBatch()
 	defer func() {
-		cErr := batch.Close()
-		if err == nil {
-			err = cErr
-		}
+		err = errors.Join(err, batch.Close())
 	}()
 
 	for _, storeKey := range storeKeys {
@@ -444,10 +438,7 @@ func getMVCCSlice(db *pebble.DB, storeKey, key []byte, version uint64) ([]byte, 
 func (db *Database) deleteRemovedStoreKeys(version uint64) (err error) {
 	batch := db.storage.NewBatch()
 	defer func() {
-		cErr := batch.Close()
-		if err == nil {
-			err = cErr
-		}
+		err = errors.Join(err, batch.Close())
 	}()
 
 	end := encoding.BuildPrefixWithVersion(removedStoreKeyPrefix, version+1)


### PR DESCRIPTION
# Description

> We should errors.Join them then to not lose any error.

Based on the [comment](https://github.com/cosmos/cosmos-sdk/pull/21812#discussion_r1774698204) from @julienrbrt in #21812.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling across various methods to improve reliability during batch operations.
	- Improved logic for managing changesets during the migration process.

- **Bug Fixes**
	- Streamlined batch processing and key management in the database, ensuring better performance and accuracy.

- **Documentation**
	- Updated method signatures to reflect improvements in error handling and operational logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->