### PR TITLE
docs: Update `More Info` link of `SECURITY.md`

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -57,13 +57,8 @@ If you follow these guidelines when reporting an issue to us, we commit to:
 
 ### More information
 
-* See [TIMELINE.md] for an example timeline of a disclosure.
-* See [DISCLOSURE.md] to see more into the inner workings of the disclosure
-  process.
 * See [EXAMPLES.md] for some of the examples that we are interested in for the
   bug bounty program.
 
 [h1]: https://hackerone.com/cosmos
-[TIMELINE.md]: https://github.com/cosmos/security/blob/main/TIMELINE.md
-[DISCLOSURE.md]: https://github.com/cosmos/security/blob/main/DISCLOSURE.md
-[EXAMPLES.md]: https://github.com/cosmos/security/blob/main/EXAMPLES.md
+[EXAMPLES.md]: https://github.com/interchainio/security/blob/main/resources/CLASSIFICATION_MATRIX.md#real-world-examples


### PR DESCRIPTION
# Description

Since [cosmos/security](https://github.com/cosmos/security) has moved to [interchainio/security](https://github.com/interchainio/security), some links are not valid now.

The link to `Example` could be found in the new repo, others couldn't, so I deleted them...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the Coordinated Vulnerability Disclosure Policy for enhanced clarity on reporting security vulnerabilities.
	- Added a warning against opening public issues for security concerns.
	- Specified reporting methods and clarified that reports to `security@interchain.io` are not eligible for bounty rewards.
	- Updated the link for `EXAMPLES.md` to a new resource related to real-world examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->