### PR TITLE
docs(keys): remove unsupported `--dry-run` flag description for `keys migrate`

### DIFF
--- a/client/keys/migrate.go
+++ b/client/keys/migrate.go
@@ -18,8 +18,6 @@ Otherwise, we try to deserialize it using Amino into LegacyInfo. If this attempt
 LegacyInfo to Protobuf serialization format and overwrite the keyring entry. If any error occurred, it will be 
 outputted in CLI and migration will be continued until all keys in the keyring DB are exhausted.
 See https://github.com/cosmos/cosmos-sdk/pull/9695 for more details.
-
-It is recommended to run in 'dry-run' mode first to verify all key migration material.
 `,
 		Args: cobra.NoArgs,
 		RunE: runMigrateCmd,


### PR DESCRIPTION
# Description

`--dry-run` flag of `simd keys migrate` has been removed from #9695, this recommendation and error message `unknown flag: --dry-run` will confuse users

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a `MigrateCommand` for seamless migration of key information from a legacy keybase to an OS secret store.
	- Expanded command description to clarify the migration process from Amino to Protocol Buffers format.

- **Bug Fixes**
	- Improved error handling during key migration, ensuring all keys are processed even if some fail to migrate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->