### PR TITLE
docs(x/circuit): fix `circuit` command examples

### DIFF
--- a/x/circuit/autocli.go
+++ b/x/circuit/autocli.go
@@ -43,7 +43,7 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 "SOME_MSGS" =     1,
 "ALL_MSGS" =      2,
 "SUPER_ADMIN" =   3,`,
-					Example: fmt.Sprintf(`%s circuit authorize [address] '{"level":1,"limit_type_urls":["/cosmos.bank.v1beta1.MsgSend, /cosmos.bank.v1beta1.MsgMultiSend"]}'"`, version.AppName),
+					Example: fmt.Sprintf(`%s tx circuit authorize [address] '{"level":1,"limit_type_urls":["/cosmos.bank.v1beta1.MsgSend, /cosmos.bank.v1beta1.MsgMultiSend"]}'"`, version.AppName),
 					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
 						{ProtoField: "grantee"},
 						{ProtoField: "permissions"}, // TODO(@julienrbrt) Support flattening msg for setting each field as a positional arg
@@ -53,7 +53,7 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					RpcMethod: "TripCircuitBreaker",
 					Use:       "disable <msg_type_urls>",
 					Short:     "Disable a message from being executed",
-					Example:   fmt.Sprintf(`%s circuit disable "/cosmos.bank.v1beta1.MsgSend /cosmos.bank.v1beta1.MsgMultiSend"`, version.AppName),
+					Example:   fmt.Sprintf(`%s tx circuit disable "/cosmos.bank.v1beta1.MsgSend /cosmos.bank.v1beta1.MsgMultiSend"`, version.AppName),
 					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
 						{ProtoField: "msg_type_urls", Varargs: true},
 					},
@@ -62,7 +62,7 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					RpcMethod: "ResetCircuitBreaker",
 					Use:       "reset <msg_type_urls>",
 					Short:     "Enable a message to be executed",
-					Example:   fmt.Sprintf(`%s circuit reset "/cosmos.bank.v1beta1.MsgSend /cosmos.bank.v1beta1.MsgMultiSend"`, version.AppName),
+					Example:   fmt.Sprintf(`%s tx circuit reset "/cosmos.bank.v1beta1.MsgSend /cosmos.bank.v1beta1.MsgMultiSend"`, version.AppName),
 					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
 						{ProtoField: "msg_type_urls", Varargs: true},
 					},


### PR DESCRIPTION
# Description

This PR fixes the examples of `x/circuit` tx subcommands


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated command usage examples for several RPC methods to reflect a new execution format.
		- Changed command prefix from "circuit" to "tx" for `AuthorizeCircuitBreaker`, `TripCircuitBreaker`, and `ResetCircuitBreaker`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->