### PR TITLE
docs(x/genutil): fix `genesis migrate` command examples

### DIFF
--- a/x/genutil/client/cli/migrate.go
+++ b/x/genutil/client/cli/migrate.go
@@ -29,7 +29,7 @@ func MigrateGenesisCmd(migrations types.MigrationMap) *cobra.Command {
 		Use:     "migrate <target-version> <genesis-file>",
 		Short:   "Migrate genesis to a specified target version",
 		Long:    "Migrate the source genesis into the target version and print to STDOUT",
-		Example: fmt.Sprintf("%s migrate v0.47 /path/to/genesis.json --chain-id=cosmoshub-3 --genesis-time=2019-04-22T17:00:00Z", version.AppName),
+		Example: fmt.Sprintf("%s genesis migrate v0.47 /path/to/genesis.json --chain-id=cosmoshub-3 --genesis-time=2019-04-22T17:00:00Z", version.AppName),
 		Args:    cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return MigrateHandler(cmd, args, migrations)


### PR DESCRIPTION
# Description

Found another wrong command example: `simd genesis migrate`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated command usage example for the migration command to include the "genesis" prefix for clarity. 

- **Bug Fixes**
	- Corrected command structure in documentation to ensure accurate usage guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->