### PR TITLE
docs(server): fix `comet bootstrap-state` command example

### DIFF
--- a/server/cmt_cmds.go
+++ b/server/cmt_cmds.go
@@ -368,7 +368,7 @@ func BootstrapStateCmd[T types.Application](appCreator types.AppCreator[T]) *cob
 		Use:     "bootstrap-state",
 		Short:   "Bootstrap CometBFT state at an arbitrary block height using a light client",
 		Args:    cobra.NoArgs,
-		Example: fmt.Sprintf("%s comet bootstrap-state --height 1000000", version.AppName),
+		Example: "bootstrap-state --height 1000000",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			serverCtx := GetServerContextFromCmd(cmd)
 			logger := log.NewLogger(cmd.OutOrStdout())

--- a/server/cmt_cmds.go
+++ b/server/cmt_cmds.go
@@ -368,7 +368,7 @@ func BootstrapStateCmd[T types.Application](appCreator types.AppCreator[T]) *cob
 		Use:     "bootstrap-state",
 		Short:   "Bootstrap CometBFT state at an arbitrary block height using a light client",
 		Args:    cobra.NoArgs,
-		Example: fmt.Sprintf("%s bootstrap-state --height 1000000", version.AppName),
+		Example: fmt.Sprintf("%s comet bootstrap-state --height 1000000", version.AppName),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			serverCtx := GetServerContextFromCmd(cmd)
 			logger := log.NewLogger(cmd.OutOrStdout())


### PR DESCRIPTION
# Description

Fix another example `simd comet boostrap-state` 😃

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated command usage example for the bootstrap state command, simplifying the format for easier understanding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->