### PR TITLE
doc: fix link for proto-gen

### DIFF
--- a/server/v2/streaming/plugin.md
+++ b/server/v2/streaming/plugin.md
@@ -29,7 +29,7 @@ To generate the stubs the local client implementation can call, run the followin
 make proto-gen
 ```
 
-For other languages you'll need to [download](https://github.com/cosmos/cosmos-sdk/blob/main/third_party/proto/README.md)
+For other languages you'll need to [download](https://github.com/cosmos/cosmos-sdk/blob/main/proto/README.md#generate)
 the CosmosSDK protos into your project and compile. For language specific compilation instructions visit
 [https://github.com/grpc](https://github.com/grpc) and look in the `examples` folder of your
 language of choice `https://github.com/grpc/grpc-{language}/tree/master/examples` and [https://grpc.io](https://grpc.io)

--- a/store/streaming/abci/README.md
+++ b/store/streaming/abci/README.md
@@ -27,7 +27,7 @@ To generate the stubs the local client implementation can call, run the followin
 make proto-gen
 ```
 
-For other languages you'll need to [download](https://github.com/cosmos/cosmos-sdk/blob/main/third_party/proto/README.md)
+For other languages you'll need to [download](https://github.com/cosmos/cosmos-sdk/blob/main/proto/README.md#generate)
 the CosmosSDK protos into your project and compile. For language specific compilation instructions visit
 [https://github.com/grpc](https://github.com/grpc) and look in the `examples` folder of your
 language of choice `https://github.com/grpc/grpc-{language}/tree/master/examples` and [https://grpc.io](https://grpc.io)


### PR DESCRIPTION
refer to [this](https://github.com/cosmos/cosmos-sdk/commit/7d28f63291c0225c1cf2cbe33408df9cba4c53b7#diff-ae1706c4818260d41095a2f58c105647c1b1debaece2b318c36e14c9a7f5d8fdR20)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated documentation for the ABCI and State Streaming Plugin to clarify the implementation of the `ABCIListener` interface.
	- Enhanced instructions for generating code, including downloading CosmosSDK protos and compiling them.
	- Expanded examples for creating gRPC clients and servers, detailing the `ListenerGRPCPlugin` struct.
	- Improved configuration guidance for `app.toml` settings related to streaming.
	- Clarified testing instructions for exporting plugins and running tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->