### PR TITLE
fix(metrics): minted_tokens is a gauge, should be a counter

### DIFF
--- a/telemetry/wrapper.go
+++ b/telemetry/wrapper.go
@@ -48,6 +48,20 @@ func ModuleSetGauge(module string, val float32, keys ...string) {
 	)
 }
 
+// ModuleIncrCounter increments a counter metric for a module with a given set of keys.
+// If any global labels are defined, they will be added to the module label.
+func ModuleIncrCounter(module string, val float32, keys ...string) {
+	if !IsTelemetryEnabled() {
+		return
+	}
+
+	metrics.IncrCounterWithLabels(
+		keys,
+		val,
+		append([]metrics.Label{NewLabel(MetricLabelNameModule, module)}, globalLabels...),
+	)
+}
+
 // IncrCounter provides a wrapper functionality for emitting a counter metric with
 // global labels (if any).
 func IncrCounter(val float32, keys ...string) {

--- a/x/mint/keeper/keeper.go
+++ b/x/mint/keeper/keeper.go
@@ -173,7 +173,7 @@ func DefaultMintFn(ic types.InflationCalculationFn, staking types.StakingKeeper,
 		}
 
 		if mintedCoin.Amount.IsInt64() {
-			defer telemetry.ModuleSetGauge(types.ModuleName, float32(mintedCoin.Amount.Int64()), "minted_tokens")
+			defer telemetry.ModuleIncrCounter(types.ModuleName, float32(mintedCoin.Amount.Int64()), "minted_tokens")
 		}
 
 		return env.EventService.EventManager(ctx).EmitKV(


### PR DESCRIPTION
# Description

This PR proposes changing the `minted_tokens` metric from a `gauge` to a `counter`.

Currently, the `minted_tokens` metric is implemented as a `gauge`, which is not the most appropriate metric type for this use case. In the current implementation, the value presented by the exporter is only the last "minted_tokens" value.

By changing it to a `counter`, the metric will instead provide a cumulative measure, increasing as new tokens are minted. This change will improve the accuracy and usefulness of the `minted_tokens` metric in monitoring token minting activity over time.

This change allows us to run queries such as `increase(minted_tokens[1h]) by (module)` (minted tokens in the last hour, broken down by modules).

For more information on metric types, please refer to: https://prometheus.io/docs/concepts/metric_types/

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title, you can find examples of the prefixes below:
    <!-- * `feat`: A new feature
    * `fix`: A bug fix
    * `docs`: Documentation only changes
    * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
    * `refactor`: A code change that neither fixes a bug nor adds a feature
    * `perf`: A code change that improves performance
    * `test`: Adding missing tests or correcting existing tests
    * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
    * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
    * `chore`: Other changes that don't modify src or test files
    * `revert`: Reverts a previous commit -->
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

Please see [Pull Request Reviewer section in the contributing guide](../CONTRIBUTING.md#reviewer) for more information on how to review a pull request.

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage
