### PR TITLE
docs: update cometbft db code reference link

### DIFF
--- a/store/prefix/store.go
+++ b/store/prefix/store.go
@@ -81,7 +81,7 @@ func (s Store) Delete(key []byte) {
 }
 
 // Iterator implements KVStore
-// Check https://github.com/cometbft/cometbft/blob/master/libs/db/prefix_db.go#L106
+// Check https://github.com/cometbft/cometbft-db/blob/v1.0.1/prefixdb.go#L109
 func (s Store) Iterator(start, end []byte) types.Iterator {
 	newstart := cloneAppend(s.prefix, start)
 
@@ -98,7 +98,7 @@ func (s Store) Iterator(start, end []byte) types.Iterator {
 }
 
 // ReverseIterator implements KVStore
-// Check https://github.com/cometbft/cometbft/blob/master/libs/db/prefix_db.go#L129
+// Check https://github.com/cometbft/cometbft-db/blob/v1.0.1/prefixdb.go#L132
 func (s Store) ReverseIterator(start, end []byte) types.Iterator {
 	newstart := cloneAppend(s.prefix, start)
 

--- a/store/prefix/store.go
+++ b/store/prefix/store.go
@@ -12,7 +12,7 @@ import (
 
 var _ types.KVStore = Store{}
 
-// Store is similar with cometbft/cometbft/libs/db/prefix_db
+// Store is similar with cometbft/cometbft-db/blob/v1.0.1/prefixdb.go
 // both gives access only to the limited subset of the store
 // for convenience or safety
 type Store struct {
@@ -192,7 +192,7 @@ func (pi *prefixIterator) Error() error {
 	return nil
 }
 
-// copied from github.com/cometbft/cometbft/libs/db/prefix_db.go
+// copied from github.com/cometbft/cometbft-db/blob/v1.0.1/prefixdb.go
 func stripPrefix(key, prefix []byte) []byte {
 	if len(key) < len(prefix) || !bytes.Equal(key[:len(prefix)], prefix) {
 		panic("should not happen")

--- a/x/accounts/internal/prefixstore/prefixstore.go
+++ b/x/accounts/internal/prefixstore/prefixstore.go
@@ -21,7 +21,7 @@ func New(store store.KVStore, prefix []byte) store.KVStore {
 
 var _ store.KVStore = Store{}
 
-// Store is similar with cometbft/cometbft/libs/db/prefix_db
+// Store is similar with cometbft/cometbft-db/blob/v1.0.1/prefixdb.go
 // both gives access only to the limited subset of the store
 // for convenience or safety
 type Store struct {
@@ -180,7 +180,7 @@ func (pi *prefixIterator) Error() error {
 	return nil
 }
 
-// copied from github.com/cometbft/cometbft/libs/db/prefix_db.go
+// copied from github.com/cometbft/cometbft-db/blob/v1.0.1/prefixdb.go
 func stripPrefix(key, prefix []byte) []byte {
 	if len(key) < len(prefix) || !bytes.Equal(key[:len(prefix)], prefix) {
 		panic("should not happen")

--- a/x/accounts/internal/prefixstore/prefixstore.go
+++ b/x/accounts/internal/prefixstore/prefixstore.go
@@ -63,7 +63,7 @@ func (s Store) Set(key, value []byte) error {
 func (s Store) Delete(key []byte) error { return s.parent.Delete(s.key(key)) }
 
 // Implements KVStore
-// Check https://github.com/cometbft/cometbft/blob/master/libs/db/prefix_db.go#L106
+// Check https://github.com/cometbft/cometbft-db/blob/v1.0.1/prefixdb.go#L109
 func (s Store) Iterator(start, end []byte) (store.Iterator, error) {
 	newstart := cloneAppend(s.prefix, start)
 
@@ -83,7 +83,7 @@ func (s Store) Iterator(start, end []byte) (store.Iterator, error) {
 }
 
 // ReverseIterator implements KVStore
-// Check https://github.com/cometbft/cometbft/blob/master/libs/db/prefix_db.go#L129
+// Check https://github.com/cometbft/cometbft-db/blob/v1.0.1/prefixdb.go#L132
 func (s Store) ReverseIterator(start, end []byte) (store.Iterator, error) {
 	newstart := cloneAppend(s.prefix, start)
 

--- a/x/group/internal/orm/prefixstore/prefixstore.go
+++ b/x/group/internal/orm/prefixstore/prefixstore.go
@@ -21,7 +21,7 @@ func New(store store.KVStore, prefix []byte) store.KVStore {
 
 var _ store.KVStore = Store{}
 
-// Store is similar with cometbft/cometbft/libs/db/prefix_db
+// Store is similar with cometbft/cometbft-db/blob/v1.0.1/prefixdb.go
 // both gives access only to the limited subset of the store
 // for convenience or safety
 type Store struct {
@@ -180,7 +180,7 @@ func (pi *prefixIterator) Error() error {
 	return nil
 }
 
-// copied from github.com/cometbft/cometbft/libs/db/prefix_db.go
+// copied from github.com/cometbft/cometbft-db/blob/v1.0.1/prefixdb.go
 func stripPrefix(key, prefix []byte) []byte {
 	if len(key) < len(prefix) || !bytes.Equal(key[:len(prefix)], prefix) {
 		panic("should not happen")

--- a/x/group/internal/orm/prefixstore/prefixstore.go
+++ b/x/group/internal/orm/prefixstore/prefixstore.go
@@ -63,7 +63,7 @@ func (s Store) Set(key, value []byte) error {
 func (s Store) Delete(key []byte) error { return s.parent.Delete(s.key(key)) }
 
 // Implements KVStore
-// Check https://github.com/cometbft/cometbft/blob/master/libs/db/prefix_db.go#L106
+// Check https://github.com/cometbft/cometbft-db/blob/v1.0.1/prefixdb.go#L109
 func (s Store) Iterator(start, end []byte) (store.Iterator, error) {
 	newstart := cloneAppend(s.prefix, start)
 
@@ -83,7 +83,7 @@ func (s Store) Iterator(start, end []byte) (store.Iterator, error) {
 }
 
 // ReverseIterator implements KVStore
-// Check https://github.com/cometbft/cometbft/blob/master/libs/db/prefix_db.go#L129
+// Check https://github.com/cometbft/cometbft-db/blob/v1.0.1/prefixdb.go#L132
 func (s Store) ReverseIterator(start, end []byte) (store.Iterator, error) {
 	newstart := cloneAppend(s.prefix, start)
 


### PR DESCRIPTION
# Description

Since `prefix_db.go` has been removed from `cometbft` to `cometbft-db` at [this commit](https://github.com/cometbft/cometbft/commit/816dfce8fed0b37495b1da7a55cf4e3ba1c0009a#diff-fe9756e57b02b0ce9de32bbce41643c58d2d973182c230978bdced8a76b2f1c2L11), the original link couldn't work now,we should update them

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated comments to reflect new URLs for the `Iterator` and `ReverseIterator` methods in the `Store` and `prefixstore` packages, ensuring accurate references to the `cometbft-db` repository.
  
- **Bug Fixes**
	- No functional changes were made; all existing methods continue to operate as intended without any alterations to their logic or signatures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->