### PR TITLE
fix(client): get desired config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ Every module contains its own CHANGELOG.md. Please refer to the module you are i
 
 * (sims) [#21906](https://github.com/cosmos/cosmos-sdk/pull/21906) Skip sims test when running dry on validators
 * (cli) [#21919](https://github.com/cosmos/cosmos-sdk/pull/21919) Query address-by-acc-num by account_id instead of id.
+* (client) [#22261](https://github.com/cosmos/cosmos-sdk/pull/22261) Explicitly set the client configuration file.
 
 ### API Breaking Changes
 

--- a/client/config/toml.go
+++ b/client/config/toml.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"text/template"
 
@@ -75,9 +76,14 @@ func writeConfigFile(configFilePath string, config interface{}) error {
 
 // getClientConfig reads values from client.toml file and unmarshalls them into ClientConfig
 func getClientConfig(configPath string, v *viper.Viper) (*Config, error) {
+	const (
+		confName = "client"
+		confType = "toml"
+	)
 	v.AddConfigPath(configPath)
 	v.SetConfigName("client")
 	v.SetConfigType("toml")
+	v.SetConfigFile(fmt.Sprintf("%s/%s.%s", configPath, confName, confType))
 
 	if err := v.ReadInConfig(); err != nil {
 		return nil, err

--- a/client/config/toml.go
+++ b/client/config/toml.go
@@ -81,8 +81,8 @@ func getClientConfig(configPath string, v *viper.Viper) (*Config, error) {
 		confType = "toml"
 	)
 	v.AddConfigPath(configPath)
-	v.SetConfigName("client")
-	v.SetConfigType("toml")
+	v.SetConfigName(confName)
+	v.SetConfigType(confType)
 	v.SetConfigFile(fmt.Sprintf("%s/%s.%s", configPath, confName, confType))
 
 	if err := v.ReadInConfig(); err != nil {


### PR DESCRIPTION
# Description

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

When calling the `conf, err := getClientConfig(configPath, ctx.Viper)` on the client configuration, the current code calls the following functions on the `Viper` instance:

```
	v.AddConfigPath(configPath)
	v.SetConfigName("client")
	v.SetConfigType("toml")

	if err := v.ReadInConfig(); err != nil {
		return nil, err
	}
```

However, if having a custom home directory specified, this will result in picking up an incorrect configuration.
This happens because the logic in place does the following:

- [`v.AddConfigPath(configPath)` adds the specified configPath to a slice](https://github.com/spf13/viper/blob/b9733f03ad014259d08f405c13e3d7f469fa1a8e/viper.go#L576-L585)
- [`v.SetConfigName("client")` sets the `v.configName` to the value provided, AND sets the **v.configFile = ""**](https://github.com/spf13/viper/blob/b9733f03ad014259d08f405c13e3d7f469fa1a8e/viper.go#L2176-L2181) THIS IS THE ISSUE
- [ `v.SetConfigType("toml")` does the same for the `v.configTyoe`](https://github.com/spf13/viper/blob/b9733f03ad014259d08f405c13e3d7f469fa1a8e/viper.go#L2187)
- [`v.ReadInConfig()` calls the `getConfigFile`](https://github.com/spf13/viper/blob/b9733f03ad014259d08f405c13e3d7f469fa1a8e/viper.go#L1636). This function [checks for `v.configFile == ""` (WHICH is TRUE)](https://github.com/spf13/viper/blob/b9733f03ad014259d08f405c13e3d7f469fa1a8e/viper.go#L2226) and calls a `findConfigFile` function that searches for the config file in the slice of config paths.

This logic can result in using an incorrect configuration file.

To ensure the desired configuration file is used (using the provided `configPath`), this PR adds the call to the `SetConfigFile` function, which explicitly sets the `v.configFile` value.


---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title, you can find examples of the prefixes below:
    <!-- * `feat`: A new feature
    * `fix`: A bug fix
    * `docs`: Documentation only changes
    * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
    * `refactor`: A code change that neither fixes a bug nor adds a feature
    * `perf`: A code change that improves performance
    * `test`: Adding missing tests or correcting existing tests
    * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
    * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
    * `chore`: Other changes that don't modify src or test files
    * `revert`: Reverts a previous commit -->
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

Please see [Pull Request Reviewer section in the contributing guide](../CONTRIBUTING.md#reviewer) for more information on how to review a pull request.

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced simulation of nested messages.
	- Added a Linux-only backend for crypto/keyring module.
	- Enabled importing hex keys via standard input.
	- Explicitly set the client configuration file.
  
- **Bug Fixes**
	- Resolved issues with querying addresses.
	- Improved handling of client configurations.
	- Skipped certain tests under specific conditions.

- **Documentation**
	- Updated changelog for clarity and ease of navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->