### PR TITLE
fix(x/tx): add feePayer as signer

### DIFF
--- a/x/tx/decode/decode.go
+++ b/x/tx/decode/decode.go
@@ -167,6 +167,18 @@ func (d *Decoder) Decode(txBytes []byte) (*DecodedTx, error) {
 		}
 	}
 
+	// If a fee payer is specified in the AuthInfo, it must be added to the list of signers
+	if authInfo.Fee.Payer != "" {
+		feeAddr, err := d.signingCtx.AddressCodec().StringToBytes(authInfo.Fee.Payer)
+		if err != nil {
+			return nil, errorsmod.Wrap(ErrTxDecode, err.Error())
+		}
+
+		if _, seen := seenSigners[string(feeAddr)]; !seen {
+			signers = append(signers, feeAddr)
+		}
+	}
+
 	return &DecodedTx{
 		Messages:                     msgs,
 		DynamicMessages:              dynamicMsgs,


### PR DESCRIPTION
# Description

Currently anyone can set a feePayer and the fees'll be deducted from its balance without the need of his sign.

For example:
```bash
# feePayer account at start
./simd q bank balances cosmos18hhvznfuq073tyhp2dcfqfulh773pmn4f6643l

balances:
- amount: "5000000000"
  denom: stake
pagination:
  total: "1"
  
# Send without feePayers signature
./simd tx bank send alice cosmos108jsm625z3ejy63uef2ke7t67h6nukt4ty93nr 10000stake --fees 1000000stake --fee-payer cosmos18hhvznfuq073tyhp2dcfqfulh773pmn4f6643l

# feePayer account after send
./simd q bank balances cosmos18hhvznfuq073tyhp2dcfqfulh773pmn4f6643l

balances:
- amount: "4999000000"
  denom: stake
pagination:
  total: "1"
```

Also currently is not possible to do the double sign of this tx to set feePayers signature:
```bash
# Generate tx
./simd tx bank send alice cosmos108jsm625z3ejy63uef2ke7t67h6nukt4ty93nr 10000stake --fees 1000000stake --fee-payer cosmos18hhvznfuq073tyhp2dcfqfulh773pmn4f6643l --generate-only > unsigned_tx.json

# Sign with alice
./simd tx sign unsigned_tx.json --from alice --sign-mode amino-json --output-document alice_signed.json

# Sign with feePayer
./simd tx sign alice_signed.json --from cosmos18hhvznfuq073tyhp2dcfqfulh773pmn4f6643l --sign-mode amino-json --output-document fully_signed.json
.
.
.
tx intended signer does not match the given signer: bob
```
 After this fix, the tx will fail when trying to send without feePayers signature

```bash
./simd tx bank send alice cosmos108jsm625z3ejy63uef2ke7t67h6nukt4ty93nr 10000stake --fees 1000000stake --fee-payer cosmos18hhvznfuq073tyhp2dcfqfulh773pmn4f6643l
.
.
.
raw_log: 'invalid number of signatures: got 1 signatures and 2 signers: unauthorized'
timestamp: ""
tx: null
txhash: 211F611829A9590C65002E98601BDD66343E164A341E8FEA94765BBB7B512FB0
```
<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title, you can find examples of the prefixes below:
    <!-- * `feat`: A new feature
    * `fix`: A bug fix
    * `docs`: Documentation only changes
    * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
    * `refactor`: A code change that neither fixes a bug nor adds a feature
    * `perf`: A code change that improves performance
    * `test`: Adding missing tests or correcting existing tests
    * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
    * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
    * `chore`: Other changes that don't modify src or test files
    * `revert`: Reverts a previous commit -->
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

Please see [Pull Request Reviewer section in the contributing guide](../CONTRIBUTING.md#reviewer) for more information on how to review a pull request.

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage
