### PR TITLE
chore(client): use command's configured output

### DIFF
--- a/client/cmd.go
+++ b/client/cmd.go
@@ -345,7 +345,7 @@ func GetClientQueryContext(cmd *cobra.Command) (Context, error) {
 // - client.Context field pre-populated & flag not set: uses pre-populated value
 // - client.Context field pre-populated & flag set: uses set flag value
 func GetClientTxContext(cmd *cobra.Command) (Context, error) {
-	ctx := GetClientContextFromCmd(cmd)
+	ctx := GetClientContextFromCmd(cmd).WithOutput(cmd.OutOrStdout())
 	return readTxCommandFlags(ctx, cmd.Flags())
 }
 

--- a/client/cmd_test.go
+++ b/client/cmd_test.go
@@ -1,6 +1,7 @@
 package client_test
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"testing"
@@ -136,4 +137,29 @@ func TestSetCmdClientContextHandler(t *testing.T) {
 			require.Equal(t, tc.expectedContext, clientCtx)
 		})
 	}
+}
+
+func TestContext_usesCobraCommandOutput(t *testing.T) {
+	var initCtx client.Context
+
+	cmd := &cobra.Command{
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return client.SetCmdClientContextHandler(initCtx, cmd)
+		},
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cctx, err := client.GetClientTxContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			return cctx.PrintString("hello")
+		},
+	}
+
+	var outBuf bytes.Buffer
+	cmd.SetOutput(&outBuf)
+
+	require.NoError(t, cmd.Execute())
+
+	require.Equal(t, "hello", outBuf.String())
 }


### PR DESCRIPTION

# Description

I have some external tests that invoke some of the SDK's cobra commands. Those tests often involve creating the command, calling cmd.SetOutput, executing the command, and then inspecting its output.

This change updates the client context to prefer cmd.Output if set (which should only happen in tests), falling back to stdout otherwise; so it should not change any existing client-facing behavior, but it does otherwise make command output testable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced command context to include output capabilities, improving how outputs are handled in the application.
  
- **Tests**
	- Introduced a new test to verify command output when using the updated context, ensuring reliability in output handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->