### PR TITLE
feat(server/v2): add SimulateWithState to AppManager

### DIFF
--- a/server/v2/appmanager/appmanager.go
+++ b/server/v2/appmanager/appmanager.go
@@ -41,6 +41,10 @@ type AppManager[T transaction.Tx] interface {
 	// Simulate runs validation and execution flow of a Tx.
 	Simulate(ctx context.Context, tx T) (server.TxResult, corestore.WriterMap, error)
 
+	// SimulateWithState runs validation and execution flow of a Tx,
+	// using the provided state instead of loading the latest state from the underlying database.
+	SimulateWithState(ctx context.Context, state corestore.ReaderMap, tx T) (server.TxResult, corestore.WriterMap, error)
+
 	// Query queries the application at the provided version.
 	// CONTRACT: Version must always be provided, if 0, get latest
 	Query(ctx context.Context, version uint64, request transaction.Msg) (transaction.Msg, error)
@@ -189,6 +193,13 @@ func (a appManager[T]) Simulate(ctx context.Context, tx T) (server.TxResult, cor
 	if err != nil {
 		return server.TxResult{}, nil, err
 	}
+	result, cs := a.stf.Simulate(ctx, state, a.config.SimulationGasLimit, tx) // TODO: check if this is done in the antehandler
+	return result, cs, nil
+}
+
+// SimulateWithState runs validation and execution flow of a Tx,
+// using the provided state instead of loading the latest state from the underlying database.
+func (a appManager[T]) SimulateWithState(ctx context.Context, state corestore.ReaderMap, tx T) (server.TxResult, corestore.WriterMap, error) {
 	result, cs := a.stf.Simulate(ctx, state, a.config.SimulationGasLimit, tx) // TODO: check if this is done in the antehandler
 	return result, cs, nil
 }


### PR DESCRIPTION
There is already the QueryWithState method to query against a modified state, but the Simulate analog was missing.

This is useful in particular when a server component receives different transactions at different times, and wants to ensure that subsequent transactions would be valid to apply after the prior transactions.

In other words, the first received transaction can be validated with Simulate; then the returned corestore.WriterMap is used to seed the input to the following call to SimulateWithState; and then the returned corestore.WriterMap is used for all following SimulateWithState calls.

While it is currently impossible for SimulateWithState to return an error, an error value is  in the return signature for symmetry with other AppManager methods and to allow the possibility of returned errors in the future.

There were no existing tests in the server/v2/appmanager package, to be expanded to include test coverage for the new method.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new method for simulating transactions using a specified state, enhancing flexibility in transaction validation.
- **Bug Fixes**
	- No bug fixes were included in this update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->