### PR TITLE
fix(server/v2): respect context cancellation in start command

### DIFF
--- a/server/v2/commands.go
+++ b/server/v2/commands.go
@@ -125,7 +125,7 @@ func createStartCommand[T transaction.Tx](
 					cancelFn()
 					cmd.Printf("caught %s signal\n", sig.String())
 				case <-ctx.Done():
-					// If the root context is cancelled (which is likely to happen in tests involving cobra commands),
+					// If the root context is canceled (which is likely to happen in tests involving cobra commands),
 					// don't block waiting for the OS signal before stopping the server.
 					cancelFn()
 				}


### PR DESCRIPTION
When running external tests that involve starting a v2 server, the only way to get the command to shut down was through sending an interrupt or termination signal, which is not possible to do independently through many concurrent serer commands within the same process.

Respect the root context being cancelled, as a signal that the server needs to be stopped.

Unfortunately there are no existing unit tests in the server/v2 package with running a start command, that can be expanded to cover this behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved signal handling for graceful shutdown, enhancing server responsiveness during cancellation.

- **Bug Fixes**
	- Addressed potential blocking issues during shutdown by implementing a more efficient control flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->