### PR TITLE
chore(simdv2): allow overriding the --home flag

### DIFF
--- a/simapp/v2/simdv2/cmd/commands.go
+++ b/simapp/v2/simdv2/cmd/commands.go
@@ -37,7 +37,7 @@ import (
 )
 
 func newApp[T transaction.Tx](logger log.Logger, viper *viper.Viper) serverv2.AppI[T] {
-	viper.Set(serverv2.FlagHome, simapp.DefaultNodeHome)
+	viper.SetDefault(serverv2.FlagHome, simapp.DefaultNodeHome)
 	return serverv2.AppI[T](simapp.NewSimApp[T](logger, viper))
 }
 
@@ -165,7 +165,7 @@ func appExport[T transaction.Tx](
 
 	// overwrite the FlagInvCheckPeriod
 	viper.Set(server.FlagInvCheckPeriod, 1)
-	viper.Set(serverv2.FlagHome, simapp.DefaultNodeHome)
+	viper.SetDefault(serverv2.FlagHome, simapp.DefaultNodeHome)
 
 	var simApp *simapp.SimApp[T]
 	if height != -1 {


### PR DESCRIPTION
There were two calls to viper.Set(serverv2.FlagHome, simapp.DefaultNodeHome); these calls invalidated any provided --home command line arguments. When testing multiple simapp instances in the same process, it is necessary to provide separate home directories.

Changing the calls from .Set to .SetDefault retains the previous behavior of using DefaultNodeHome when no --home flag is provided, but it still respects --home when the flag is indeed provided.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of the default home directory for application configuration to ensure consistent initialization.
	- Enhanced error handling for context validation in command initialization.

- **Refactor**
	- Updated method for setting the home directory to utilize default values, streamlining configuration management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->