### PR TITLE
refactor(simdv2): allow non-comet server components

### DIFF
--- a/simapp/v2/simdv2/cmd/commands.go
+++ b/simapp/v2/simdv2/cmd/commands.go
@@ -17,7 +17,6 @@ import (
 	"cosmossdk.io/server/v2/api/grpc"
 	"cosmossdk.io/server/v2/api/rest"
 	"cosmossdk.io/server/v2/api/telemetry"
-	"cosmossdk.io/server/v2/cometbft"
 	serverstore "cosmossdk.io/server/v2/store"
 	"cosmossdk.io/simapp/v2"
 	confixcmd "cosmossdk.io/tools/confix/cmd"
@@ -43,8 +42,8 @@ func newApp[T transaction.Tx](logger log.Logger, viper *viper.Viper) serverv2.Ap
 
 func initRootCmd[T transaction.Tx](
 	rootCmd *cobra.Command,
-	txConfig client.TxConfig,
 	moduleManager *runtimev2.MM[T],
+	consensusComponent serverv2.ServerComponent[T],
 ) {
 	cfg := sdk.GetConfig()
 	cfg.Seal()
@@ -70,11 +69,7 @@ func initRootCmd[T transaction.Tx](
 		rootCmd,
 		newApp,
 		initServerConfig(),
-		cometbft.New(
-			&genericTxDecoder[T]{txConfig},
-			initCometOptions[T](),
-			initCometConfig(),
-		),
+		consensusComponent,
 		grpc.New[T](),
 		serverstore.New[T](),
 		telemetry.New[T](),

--- a/simapp/v2/simdv2/cmd/root_test.go
+++ b/simapp/v2/simdv2/cmd/root_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestInitCmd(t *testing.T) {
-	rootCmd := cmd.NewRootCmd[transaction.Tx]()
+	rootCmd := cmd.NewCometBFTRootCmd[transaction.Tx]()
 	rootCmd.SetArgs([]string{
 		"init",        // Test the init cmd
 		"simapp-test", // Moniker
@@ -29,7 +29,7 @@ func TestInitCmd(t *testing.T) {
 func TestHomeFlagRegistration(t *testing.T) {
 	homeDir := "/tmp/foo"
 
-	rootCmd := cmd.NewRootCmd[transaction.Tx]()
+	rootCmd := cmd.NewCometBFTRootCmd[transaction.Tx]()
 	rootCmd.SetArgs([]string{
 		"query",
 		fmt.Sprintf("--%s", flags.FlagHome),

--- a/simapp/v2/simdv2/cmd/testnet_test.go
+++ b/simapp/v2/simdv2/cmd/testnet_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestInitTestFilesCmd(t *testing.T) {
-	rootCmd := cmd.NewRootCmd[transaction.Tx]()
+	rootCmd := cmd.NewCometBFTRootCmd[transaction.Tx]()
 	rootCmd.SetArgs([]string{
 		"testnet", // Test the testnet init-files command
 		"init-files",

--- a/simapp/v2/simdv2/main.go
+++ b/simapp/v2/simdv2/main.go
@@ -12,7 +12,7 @@ import (
 )
 
 func main() {
-	rootCmd := cmd.NewRootCmd[transaction.Tx]()
+	rootCmd := cmd.NewCometBFTRootCmd[transaction.Tx]()
 	if err := serverv2.Execute(rootCmd, clientv2helpers.EnvPrefix, simapp.DefaultNodeHome); err != nil {
 		fmt.Fprintln(rootCmd.OutOrStderr(), err)
 		os.Exit(1)


### PR DESCRIPTION
This renames NewRootCmd to NewCometBFTRootCmd, to make it clear that it uses CometBFT for the consensus layer. Callers who want to use a different consensus-providing server component can instead call NewRootCmdWithConsensusComponent, passing in a callback to be evaluated with a client context in order to produce the component.

This pattern is working for Gordian-Cosmos integration.

I'm not especially tied to the new function names. I'm also open to more clear naming for "consensus component" which occurs a few times.

/cc @kocubinski as this may overlap or conflict with #22267.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new command structure with the `NewCometBFTRootCmd` function for improved consensus component integration.
	- Added `NewRootCmdWithConsensusComponent` function for flexible command creation.

- **Bug Fixes**
	- Updated command initialization across multiple components to ensure consistent behavior with the new consensus structure.

- **Tests**
	- Modified test cases to utilize the new command structure, ensuring compatibility with recent changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->