### PR TITLE
docs: fixed typo in threshold and quorums section of onchain multi-sig guide in user guide section of sdk docs

### DIFF
--- a/docs/user/run-node/08-onchain-multisig.md
+++ b/docs/user/run-node/08-onchain-multisig.md
@@ -14,7 +14,7 @@ features.
 The previous implementation only allowed for m-of-n multisig accounts, where m is the number of signatures required to
 authorize a transaction and n is the total number of signers. The new implementation allows for more flexibility by
 introducing threshold and quorum values. The quorum is the minimum voting power to make a proposal valid, while the
-threshol is the minimum of voting power of YES votes to pass a proposal.
+threshold is the minimum of voting power of YES votes to pass a proposal.
 
 ### Revote
 


### PR DESCRIPTION
![Screenshot from 2024-10-25 10-27-15](https://github.com/user-attachments/assets/f47993c7-70d2-4f15-b598-45c386de2114)
