### PR TITLE
docs: delete e2e test

### DIFF
--- a/docs/architecture/adr-059-test-scopes.md
+++ b/docs/architecture/adr-059-test-scopes.md
@@ -139,15 +139,6 @@ Modules not returning simulation operations:
 * Useful error messages not provided on from CI, requiring a developer to run
   the simulation locally to reproduce.
 
-### E2E tests
-
-End to end tests exercise the entire system as we understand it in as close an approximation
-to a production environment as is practical. Presently these tests are located at
-[tests/e2e](https://github.com/cosmos/cosmos-sdk/tree/main/tests/e2e) and rely on [testutil/network](https://github.com/cosmos/cosmos-sdk/tree/main/testutil/network) to start up an in-process Tendermint node.
-
-An application should be built as minimally as possible to exercise the desired functionality.
-The SDK uses an application will only the required modules for the tests. The application developer is advised to use its own application for e2e tests.
-
 #### Limitations
 
 In general the limitations of end to end tests are orchestration and compute cost.


### PR DESCRIPTION
e2e test has been deleted in https://github.com/cosmos/cosmos-sdk/pull/22364

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Revised the `adr-059-test-scopes.md` document to clarify testing paradigms within the SDK.
	- Enhanced definitions and scopes for unit tests, integration tests, and E2E tests.
	- Expanded context with references to previous architectural decisions.
	- Updated decision table and outlined expected outcomes of changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->