### PR TITLE
[DO NOT MERGE] example test for calc failure

### DIFF
--- a/x/accounts/defaults/lockup/utils_test.go
+++ b/x/accounts/defaults/lockup/utils_test.go
@@ -78,7 +78,8 @@ func newMockContext(t *testing.T) (context.Context, store.KVStoreService) {
 				return &stakingtypes.MsgDelegateResponse{}, nil
 			case "/cosmos.staking.v1beta1.MsgUndelegate":
 				return &stakingtypes.MsgUndelegateResponse{
-					Amount: sdk.NewCoin("test", math.NewInt(1)),
+					CompletionTime: time.Now().Add(stakingtypes.DefaultUnbondingTime),
+					Amount:         msg.(*stakingtypes.MsgUndelegate).Amount,
 				}, nil
 			case "/cosmos.distribution.v1beta1.MsgWithdrawDelegatorReward":
 				return &distrtypes.MsgWithdrawDelegatorRewardResponse{}, nil


### PR DESCRIPTION
🚧  Test example. Do not merge
# Description

example:  withdraw without calling `UpdateUndelegationEntry`
4 locked 6 liquid, 7 were staked but are unbonded meanwhile: current balance 10 stake

expected are 0 tokens withdrawable as they are locked forever
