### PR TITLE
fix: only overwrite context chainID when necessary

### DIFF
--- a/types/context.go
+++ b/types/context.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	abci "github.com/cometbft/cometbft/api/cometbft/abci/v1"
@@ -162,7 +163,10 @@ func (c Context) WithBlockHeader(header cmtproto.Header) Context {
 	c.header = header
 
 	// when calling withBlockheader on a new context, chainID in the struct will be empty
-	c.chainID = header.ChainID
+	if strings.TrimSpace(c.chainID) == "" {
+		c.chainID = header.ChainID
+	}
+
 	return c
 }
 


### PR DESCRIPTION
# Description

Fixes some weird test failure behaviour in ibc-go. Without the change in this PR we have to reorder context API calls in test file. See diff. With this change we no longer need to modify the test code.

```diff
diff --git a/modules/core/02-client/types/height_test.go b/modules/core/02-client/types/height_test.go
index f9638c6b4..68fccb50a 100644
--- a/modules/core/02-client/types/height_test.go
+++ b/modules/core/02-client/types/height_test.go
@@ -147,14 +147,14 @@ func (suite *TypesTestSuite) TestSelfHeight() {
        ctx := suite.chainA.GetContext()

        // Test default revision
-       ctx = ctx.WithBlockHeight(10)
        ctx = ctx.WithChainID("gaiamainnet")
+       ctx = ctx.WithBlockHeight(10)
        height := types.GetSelfHeight(ctx)
        suite.Require().Equal(types.NewHeight(0, 10), height, "default self height failed")

        // Test successful revision format
-       ctx = ctx.WithBlockHeight(18)
        ctx = ctx.WithChainID("gaiamainnet-3")
+       ctx = ctx.WithBlockHeight(18)
        height = types.GetSelfHeight(ctx)
        suite.Require().Equal(types.NewHeight(3, 18), height, "valid self height failed")
 }
(END)
```
<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title, you can find examples of the prefixes below:
    <!-- * `feat`: A new feature
    * `fix`: A bug fix
    * `docs`: Documentation only changes
    * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
    * `refactor`: A code change that neither fixes a bug nor adds a feature
    * `perf`: A code change that improves performance
    * `test`: Adding missing tests or correcting existing tests
    * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
    * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
    * `chore`: Other changes that don't modify src or test files
    * `revert`: Reverts a previous commit -->
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

Please see [Pull Request Reviewer section in the contributing guide](../CONTRIBUTING.md#reviewer) for more information on how to review a pull request.

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved validation for the `chainID` field to prevent overwriting existing values if they are already set or contain only whitespace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->