### PR TITLE
fix(client): don't marshal zero-ed fields

### DIFF
--- a/client/tx/factory.go
+++ b/client/tx/factory.go
@@ -450,7 +450,7 @@ func (f Factory) BuildSimTx(msgs ...sdk.Msg) ([]byte, error) {
 		return nil, err
 	}
 
-	encoder := f.txConfig.TxEncoder()
+	encoder := f.txConfig.TxEncoder() // DITTO
 	if encoder == nil {
 		return nil, errors.New("cannot simulate tx: tx encoder is nil")
 	}

--- a/client/v2/tx/encoder.go
+++ b/client/v2/tx/encoder.go
@@ -22,6 +22,11 @@ var (
 		Indent:         "",
 		UseProtoNames:  true,
 		UseEnumNumbers: false,
+		// Do not emit unpopulated fields.
+		// It helps the client to be compatible accross SDK versions.
+		// Unknown fields will still be rejected by the SDK (node).
+		// However, the client should stay as compatible as possible.
+		EmitUnpopulated: false,
 	}
 
 	// textMarshalOptions

--- a/codec/codec.go
+++ b/codec/codec.go
@@ -41,7 +41,7 @@ type (
 
 		// mustEmbedCodec requires that all implementations of Codec embed an official implementation from the codec
 		// package. This allows new methods to be added to the Codec interface without breaking backwards compatibility.
-		mustEmbedCodec()
+		// mustEmbedCodec()
 	}
 
 	BinaryCodec interface {

--- a/codec/json.go
+++ b/codec/json.go
@@ -32,3 +32,25 @@ func ProtoMarshalJSON(msg proto.Message, resolver jsonpb.AnyResolver) ([]byte, e
 
 	return buf.Bytes(), nil
 }
+
+// ProtoMarshalJSONSkipEmpty provides an auxiliary function to return Proto3 JSON
+// encoded bytes of a message with empty fields omitted.
+// It is especially useful for encoding messages to be sent over the wire.
+func ProtoMarshalJSONSkipEmpty(msg proto.Message, resolver jsonpb.AnyResolver) ([]byte, error) {
+	jm := defaultJM
+	jm.EmitDefaults = false
+	if resolver != nil {
+		jm = &jsonpb.Marshaler{OrigName: true, EmitDefaults: false, AnyResolver: resolver}
+	}
+	err := types.UnpackInterfaces(msg, types.ProtoJSONPacker{JSONPBMarshaler: jm})
+	if err != nil {
+		return nil, err
+	}
+
+	buf := new(bytes.Buffer)
+	if err := jm.Marshal(buf, msg); err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}

--- a/codec/proto_codec.go
+++ b/codec/proto_codec.go
@@ -21,15 +21,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec/types"
 )
 
-// ProtoCodecMarshaler defines an interface for codecs that utilize Protobuf for both
-// binary and JSON encoding.
-// Deprecated: Use Codec instead.
-type ProtoCodecMarshaler interface {
-	Codec
-}
-
-// ProtoCodec defines a codec that utilizes Protobuf for both binary and JSON
-// encoding.
+// ProtoCodec defines a codec that utilizes Protobuf for both binary and JSON encoding.
 type ProtoCodec struct {
 	interfaceRegistry types.InterfaceRegistry
 }


### PR DESCRIPTION
# Description

Due to the new additions of two new fields in the tx body: unordered and timeout, v0.52 clients aren't compatible with lower version anymore.

While always checking unknown fields is crucial, the client library of the SDK doesn't need to marshal all fields of the tx.
Meaning, a tx where unordered and/or timeout are set, will fail in 0.50 with a v0.52 client, when you don't make use of that feature, you should still be able to use the v0.52 client.

This PR fixes that by overriding the json encoder.

HOWEVER, there's two way to do it, and we need to pick one:

- Loosen the codec.Codec constraint (SDK currently only can implement a codec.Codec -- introduced in https://github.com/cosmos/cosmos-sdk/pull/15600)
- Move that codec directly to the codec package and use it in client.

This PR took option 1, but maybe option 2 is better?
When we migrate to client/v2/tx that won't be required, as we use the other proto marshaller.

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title, you can find examples of the prefixes below:
    <!-- * `feat`: A new feature
    * `fix`: A bug fix
    * `docs`: Documentation only changes
    * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
    * `refactor`: A code change that neither fixes a bug nor adds a feature
    * `perf`: A code change that improves performance
    * `test`: Adding missing tests or correcting existing tests
    * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
    * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
    * `chore`: Other changes that don't modify src or test files
    * `revert`: Reverts a previous commit -->
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

Please see [Pull Request Reviewer section in the contributing guide](../CONTRIBUTING.md#reviewer) for more information on how to review a pull request.

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage
