### PR TITLE
test: fix failing `runtime/v2` test

### DIFF
--- a/runtime/v2/services_test.go
+++ b/runtime/v2/services_test.go
@@ -39,8 +39,11 @@ func TestRegisterServices(t *testing.T) {
 		},
 	}
 
-	mockModule.On("RegisterMsgHandlers", app.msgRouterBuilder).Once()
-	mockModule.On("RegisterQueryHandlers", app.queryRouterBuilder).Once()
+	msgWrapper := newStfRouterWrapper(app.msgRouterBuilder)
+	queryWrapper := newStfRouterWrapper(app.queryRouterBuilder)
+
+	mockModule.On("RegisterMsgHandlers", &msgWrapper).Once()
+	mockModule.On("RegisterQueryHandlers", &queryWrapper).Once()
 
 	err := mm.RegisterServices(app)
 


### PR DESCRIPTION
Fixes a test that must have been failing once the `stfRouterWrapper` type was added to wrap `RouterBuilder`s.

The incorrect type was being expected in the Mock statement

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Updated the mock expectations in the service registration tests to enhance validation of interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->