### PR TITLE
fix(server/v2): avoid server stop get call before start for multi components

### DIFF
--- a/server/v2/api/grpcgateway/server.go
+++ b/server/v2/api/grpcgateway/server.go
@@ -75,7 +75,13 @@ func New[T transaction.Tx](
 
 	s.logger = logger.With(log.ModuleKey, s.Name())
 	s.config = serverCfg
+	mux := http.NewServeMux()
+	mux.Handle("/", s.GRPCGatewayRouter)
 
+	s.server = &http.Server{
+		Addr:    s.config.Address,
+		Handler: mux,
+	}
 	return s, nil
 }
 
@@ -108,14 +114,6 @@ func (s *Server[T]) Start(ctx context.Context) error {
 	if !s.config.Enable {
 		s.logger.Info(fmt.Sprintf("%s server is disabled via config", s.Name()))
 		return nil
-	}
-
-	mux := http.NewServeMux()
-	mux.Handle("/", s.GRPCGatewayRouter)
-
-	s.server = &http.Server{
-		Addr:    s.config.Address,
-		Handler: mux,
 	}
 
 	s.logger.Info("starting gRPC-Gateway server...", "address", s.config.Address)

--- a/server/v2/api/rest/server.go
+++ b/server/v2/api/rest/server.go
@@ -46,10 +46,7 @@ func New[T transaction.Tx](
 		}
 	}
 	srv.config = serverCfg
-	srv.httpServer = &http.Server{
-		Addr:    srv.config.Address,
-		Handler: srv.router,
-	}
+	srv.init()
 	return srv, nil
 }
 
@@ -59,6 +56,13 @@ func New[T transaction.Tx](
 func NewWithConfigOptions[T transaction.Tx](opts ...CfgOption) *Server[T] {
 	return &Server[T]{
 		cfgOptions: opts,
+	}
+}
+
+func (s *Server[T]) init() {
+	s.httpServer = &http.Server{
+		Addr:    s.config.Address,
+		Handler: s.router,
 	}
 }
 
@@ -87,12 +91,7 @@ func (s *Server[T]) Stop(ctx context.Context) error {
 	}
 
 	s.logger.Info("stopping HTTP server")
-	defer func() {
-		s.httpServer = &http.Server{
-			Addr:    s.config.Address,
-			Handler: s.router,
-		}
-	}()
+	defer s.init()
 	return s.httpServer.Shutdown(ctx)
 }
 

--- a/server/v2/api/rest/server.go
+++ b/server/v2/api/rest/server.go
@@ -46,7 +46,10 @@ func New[T transaction.Tx](
 		}
 	}
 	srv.config = serverCfg
-
+	srv.httpServer = &http.Server{
+		Addr:    srv.config.Address,
+		Handler: srv.router,
+	}
 	return srv, nil
 }
 
@@ -67,11 +70,6 @@ func (s *Server[T]) Start(ctx context.Context) error {
 	if !s.config.Enable {
 		s.logger.Info(fmt.Sprintf("%s server is disabled via config", s.Name()))
 		return nil
-	}
-
-	s.httpServer = &http.Server{
-		Addr:    s.config.Address,
-		Handler: s.router,
 	}
 
 	s.logger.Info("starting HTTP server", "address", s.config.Address)

--- a/server/v2/api/rest/server.go
+++ b/server/v2/api/rest/server.go
@@ -46,7 +46,10 @@ func New[T transaction.Tx](
 		}
 	}
 	srv.config = serverCfg
-	srv.init()
+	srv.httpServer = &http.Server{
+		Addr:    srv.config.Address,
+		Handler: srv.router,
+	}
 	return srv, nil
 }
 
@@ -56,13 +59,6 @@ func New[T transaction.Tx](
 func NewWithConfigOptions[T transaction.Tx](opts ...CfgOption) *Server[T] {
 	return &Server[T]{
 		cfgOptions: opts,
-	}
-}
-
-func (s *Server[T]) init() {
-	s.httpServer = &http.Server{
-		Addr:    s.config.Address,
-		Handler: s.router,
 	}
 }
 
@@ -91,7 +87,6 @@ func (s *Server[T]) Stop(ctx context.Context) error {
 	}
 
 	s.logger.Info("stopping HTTP server")
-	defer s.init()
 	return s.httpServer.Shutdown(ctx)
 }
 

--- a/server/v2/api/rest/server.go
+++ b/server/v2/api/rest/server.go
@@ -87,6 +87,12 @@ func (s *Server[T]) Stop(ctx context.Context) error {
 	}
 
 	s.logger.Info("stopping HTTP server")
+	defer func() {
+		s.httpServer = &http.Server{
+			Addr:    s.config.Address,
+			Handler: s.router,
+		}
+	}()
 	return s.httpServer.Shutdown(ctx)
 }
 

--- a/server/v2/api/telemetry/server.go
+++ b/server/v2/api/telemetry/server.go
@@ -52,22 +52,18 @@ func New[T transaction.Tx](cfg server.ConfigMap, logger log.Logger, enableTeleme
 		return nil, fmt.Errorf("failed to initialize metrics: %w", err)
 	}
 	srv.metrics = metrics
-	srv.init()
-	return srv, nil
-}
-
-func (s *Server[T]) init() {
 	mux := http.NewServeMux()
 	// /metrics is the default standard path for Prometheus metrics.
-	mux.HandleFunc("/metrics", s.metricsHandler)
+	mux.HandleFunc("/metrics", srv.metricsHandler)
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "/metrics", http.StatusMovedPermanently)
 	})
 
-	s.server = &http.Server{
-		Addr:    s.config.Address,
+	srv.server = &http.Server{
+		Addr:    srv.config.Address,
 		Handler: mux,
 	}
+	return srv, nil
 }
 
 // Name returns the server name.
@@ -102,7 +98,6 @@ func (s *Server[T]) Stop(ctx context.Context) error {
 		return nil
 	}
 
-	defer s.init()
 	s.logger.Info("stopping telemetry server...", "address", s.config.Address)
 	return s.server.Shutdown(ctx)
 }

--- a/systemtests/system.go
+++ b/systemtests/system.go
@@ -735,6 +735,7 @@ func (s *SystemUnderTest) AddFullnode(t *testing.T, beforeStart ...func(nodeNumb
 		if tomlFile == "app.toml" && IsV2() {
 			file := filepath.Join(WorkDir, s.nodePath(nodeNumber), "config", tomlFile)
 			EditToml(file, func(doc *tomledit.Document) {
+				SetValue(doc, fmt.Sprintf("%s:%d", node.IP, DefaultApiPort+nodeNumber), "grpc-gateway", "address")
 				SetValue(doc, fmt.Sprintf("%s:%d", node.IP, DefaultRestPort+nodeNumber), "rest", "address")
 			})
 		}


### PR DESCRIPTION
* init httpServer early to avoid nil httpServer when stop
* since not easy to reproduce though in system test, for more [info](https://go.dev/play/p/XZbUk4XpRmC)

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x1050bd0f0]

goroutine 1 [running]:
net/http.(*Server).Shutdown(0x10851b518?, {0x108560af8?, 0x14003124720?})
	net/http/server.go:3050 +0x30
cosmossdk.io/server/v2/api/rest.(*Server[...]).Stop(0xd, {0x108560af8?, 0x14003124720})
	cosmossdk.io/server/v2@v2.0.0-20240718121635-a877e3e8048a/api/rest/server.go:93 +0xe4
cosmossdk.io/server/v2.(*Server[...]).Stop(0x1085be3c0, {0x108560af8, 0x14003124720})
	cosmossdk.io/server/v2@v2.0.0-20240718121635-a877e3e8048a/server.go:119 +0x21c
cosmossdk.io/server/v2.createStartCommand[...].func1.2.1()
	cosmossdk.io/server/v2@v2.0.0-20240718121635-a877e3e8048a/commands.go:103 +0xdc
cosmossdk.io/server/v2.createStartCommand[...].func1.2()
	cosmossdk.io/server/v2@v2.0.0-20240718121635-a877e3e8048a/co
```
# Description

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title, you can find examples of the prefixes below:
    <!-- * `feat`: A new feature
    * `fix`: A bug fix
    * `docs`: Documentation only changes
    * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
    * `refactor`: A code change that neither fixes a bug nor adds a feature
    * `perf`: A code change that improves performance
    * `test`: Adding missing tests or correcting existing tests
    * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
    * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
    * `chore`: Other changes that don't modify src or test files
    * `revert`: Reverts a previous commit -->
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

Please see [Pull Request Reviewer section in the contributing guide](../CONTRIBUTING.md#reviewer) for more information on how to review a pull request.

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced initialization process for full nodes to ensure proper configuration for gRPC gateway communication.
	- Improved server initialization for telemetry, encapsulating setup logic within a dedicated method.
	- Streamlined server initialization for the gRPC gateway, centralizing server setup in the creation method.

- **Bug Fixes**
	- Streamlined server lifecycle management with improved initialization and stopping procedures for the HTTP server.

- **Documentation**
	- Minor adjustments to comments and formatting for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->