### PR TITLE
docs: update docs

### DIFF
--- a/server/util_test.go
+++ b/server/util_test.go
@@ -260,11 +260,9 @@ func TestInterceptConfigsPreRunHandlerReadsEnvVars(t *testing.T) {
 	}
 }
 
-/*
- The following tests are here to check the precedence of each
- of the configuration sources. A common setup functionality is used
- to avoid duplication of code between tests.
-*/
+// The following tests are here to check the precedence of each
+// of the configuration sources. A common setup functionality is used
+// to avoid duplication of code between tests.
 
 var (
 	TestAddrExpected    = "tcp://127.126.125.124:12345" // expected to be used in test

--- a/store/internal/proofs/create.go
+++ b/store/internal/proofs/create.go
@@ -14,10 +14,8 @@ var (
 	ErrEmptyKeyInData = errors.New("data contains empty key")
 )
 
-/*
-CreateMembershipProof will produce a CommitmentProof that the given key (and queries value) exists in the map.
-If the key doesn't exist in the tree, this will return an error.
-*/
+// CreateMembershipProof will produce a CommitmentProof that the given key (and queries value) exists in the map.
+// If the key doesn't exist in the tree, this will return an error.
 func CreateMembershipProof(data map[string][]byte, key []byte) (*ics23.CommitmentProof, error) {
 	if len(key) == 0 {
 		return nil, ErrEmptyKey
@@ -34,10 +32,8 @@ func CreateMembershipProof(data map[string][]byte, key []byte) (*ics23.Commitmen
 	return proof, nil
 }
 
-/*
-CreateNonMembershipProof will produce a CommitmentProof that the given key doesn't exist in the map.
-If the key exists in the tree, this will return an error.
-*/
+// CreateNonMembershipProof will produce a CommitmentProof that the given key doesn't exist in the map.
+// If the key exists in the tree, this will return an error.
 func CreateNonMembershipProof(data map[string][]byte, key []byte) (*ics23.CommitmentProof, error) {
 	if len(key) == 0 {
 		return nil, ErrEmptyKey

--- a/types/context.go
+++ b/types/context.go
@@ -30,14 +30,12 @@ const (
 	ExecModeFinalize
 )
 
-/*
-Context is an immutable object contains all information needed to
-process a request.
-
-It contains a context.Context object inside if you want to use that,
-but please do not over-use it. We try to keep all data structured
-and standard additions here would be better just to add to the Context struct
-*/
+// Context is an immutable object contains all information needed to
+// process a request.
+//
+// It contains a context.Context object inside if you want to use that,
+// but please do not over-use it. We try to keep all data structured
+// and standard additions here would be better just to add to the Context struct
 type Context struct {
 	baseCtx              context.Context
 	ms                   storetypes.MultiStore


### PR DESCRIPTION
When reading the code, I found two styles of method comments, which were unified into "//"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved testing for configuration handling to ensure correct behavior across various scenarios.
	- Enhanced error handling for permission issues during configuration file access.
  
- **Documentation**
	- Updated comments for clarity in multiple functions and structures, enhancing readability.
	- Marked several fields and methods as deprecated in the `Context` struct, guiding users towards updated practices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->