### PR TITLE
chore: use errors.New to replace fmt.Errorf with no parameters

### DIFF
--- a/x/tx/internal/testpb/signers.pulsar.go
+++ b/x/tx/internal/testpb/signers.pulsar.go
@@ -3,6 +3,7 @@ package testpb
 
 import (
 	_ "cosmossdk.io/api/cosmos/msg/v1"
+	"errors"
 	fmt "fmt"
 	_ "github.com/cosmos/cosmos-proto"
 	runtime "github.com/cosmos/cosmos-proto/runtime"
@@ -115,7 +116,7 @@ func (x *fastReflection_SimpleSigner) Has(fd protoreflect.FieldDescriptor) bool 
 		return x.Signer != ""
 	default:
 		if fd.IsExtension() {
-			panic(fmt.Errorf("proto3 declared messages do not support extensions: SimpleSigner"))
+			panic(errors.New("proto3 declared messages do not support extensions: SimpleSigner"))
 		}
 		panic(fmt.Errorf("message SimpleSigner does not contain field %s", fd.FullName()))
 	}


### PR DESCRIPTION
use errors.New to replace fmt.Errorf with no parameters

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new Protobuf message type `SimpleSigner` with a string field.
	- Added multiple new message types with nested and repeated fields, enhancing data structure capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->