### PR TITLE
docs: Spelling error.

### DIFF
--- a/client/tx/tx.go
+++ b/client/tx/tx.go
@@ -241,10 +241,10 @@ func checkMultipleSigners(tx authsigning.Tx) error {
 	return nil
 }
 
-// Sign signs a given tx with a named key. The bytes signed over are canconical.
+// Sign signs a given tx with a named key. The bytes signed over are canonical.
 // The resulting signature will be added to the transaction builder overwriting the previous
 // ones if overwrite=true (otherwise, the signature will be appended).
-// Signing a transaction with mutltiple signers in the DIRECT mode is not supported and will
+// Signing a transaction with multiple signers in the DIRECT mode is not supported and will
 // return an error.
 // An error is returned upon failure.
 func Sign(ctx client.Context, txf Factory, name string, txBuilder client.TxBuilder, overwriteSig bool) error {


### PR DESCRIPTION
Spelling error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected spelling errors in comments related to the `Sign` function for clarity.
	- Clarified comments regarding signing transactions with multiple signers in DIRECT mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->