### PR TITLE
Add blazar project to Cosmos SDK external tooling readme section

### DIFF
--- a/docs/build/tooling/README.md
+++ b/docs/build/tooling/README.md
@@ -20,7 +20,8 @@ This includes tools for development, operating a node, and ease of use of a Cosm
 
 ## External Tools
 
-This section highlights tools that are not maintained by the SDK team, but are useful for Cosmos SDK development.
+This section highlights tools that are not maintained by the SDK team, but are useful for Cosmos SDK operations and development.
 
+* [Blazar](https://github.com/ChorusOne/blazar)
 * [Ignite](https://docs.ignite.com)
 * [Spawn](https://github.com/rollchains/spawn)


### PR DESCRIPTION
# Description

[Blazar](https://github.com/ChorusOne/blazar) is a standalone service designed to interact with the Cosmos SDK node, specifically handling all types of network upgrades.

It serves as an [alternative to Cosmovisor](https://github.com/ChorusOne/blazar?tab=readme-ov-file#comparison-to-cosmovisor) with an extensive feature set, including a user interface (UI), Slack notifications, an optional SQL database for ad-hoc upgrade scheduling, and comprehensive pre- and post-upgrade checks.

You can learn more about Blazar [here](https://github.com/ChorusOne/blazar?tab=readme-ov-file#what-is-blazar).

**Why this Pull Request?**
Blazar provides significant value to the Cosmos ecosystem by simplifying the network upgrade process for validator operators. While Cosmovisor has been a useful tool, it did not fully meet our needs at Chorus One. Consequently, we developed Blazar to address these gaps.

We believe other network operators will find Blazar to be a substantial improvement, enhancing their day-to-day operations.

**Is Blazar actively maintained?**
Yes, Blazar is actively maintained and used for the majority of Cosmos SDK network upgrades at Chorus One. It has been rigorously tested, both through integration and unit tests, and is regularly applied in real-world scenarios, approximately on a weekly basis.
