### PR TITLE
Fixed typos and improved clarity in documentation

### DIFF
--- a/client/grpc/reflection/reflection.pb.go
+++ b/client/grpc/reflection/reflection.pb.go
@@ -114,7 +114,7 @@ func (m *ListAllInterfacesResponse) GetInterfaceNames() []string {
 // ListImplementationsRequest is the request type of the ListImplementations
 // RPC.
 type ListImplementationsRequest struct {
-	// interface_name defines the interface to query the implementations for.
+	// interface_name defines the interface to query the implementations.
 	InterfaceName string `protobuf:"bytes,1,opt,name=interface_name,json=interfaceName,proto3" json:"interface_name,omitempty"`
 }
 
@@ -300,12 +300,12 @@ type ReflectionServiceServer interface {
 	ListImplementations(context.Context, *ListImplementationsRequest) (*ListImplementationsResponse, error)
 }
 
-// UnimplementedReflectionServiceServer can be embedded to have forward compatible implementations.
+// UnimplementedReflectionServiceServer can be embedded to have forward-compatible implementations.
 type UnimplementedReflectionServiceServer struct {
 }
 
 func (*UnimplementedReflectionServiceServer) ListAllInterfaces(ctx context.Context, req *ListAllInterfacesRequest) (*ListAllInterfacesResponse, error) {
-	return nil, status.Errorf(codes.Unimplemented, "method ListAllInterfaces not implemented")
+	return nil, status.Errorf(codes.Unimplemented, "method ListAllInterfaces is not implemented")
 }
 func (*UnimplementedReflectionServiceServer) ListImplementations(ctx context.Context, req *ListImplementationsRequest) (*ListImplementationsResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method ListImplementations not implemented")

--- a/client/v2/internal/testpb/msg.proto
+++ b/client/v2/internal/testpb/msg.proto
@@ -21,7 +21,7 @@ service Msg {
 }
 
 message MsgRequest {
-  // u32 is an uint32
+  // u32 is a uint32
   uint32                                u32        = 1;
   uint64                                u64        = 2;
   string                                str        = 3;

--- a/client/v2/tx/types.go
+++ b/client/v2/tx/types.go
@@ -181,7 +181,7 @@ func txParamsFromFlagSet(flags *pflag.FlagSet, keybase keyring2.Keyring, ac addr
 
 	fees, _ := flags.GetString(FlagFees)
 	feePayer, _ := flags.GetString(FlagFeePayer)
-	feeGrater, _ := flags.GetString(FlagFeeGranter)
+	feeGranter, _ := flags.GetString(FlagFeeGranter)
 
 	unordered, _ := flags.GetBool(FlagUnordered)
 
@@ -189,7 +189,7 @@ func txParamsFromFlagSet(flags *pflag.FlagSet, keybase keyring2.Keyring, ac addr
 	if err != nil {
 		return params, err
 	}
-	feeConfig, err := NewFeeConfig(fees, feePayer, feeGrater)
+	feeConfig, err := NewFeeConfig(fees, feePayer, feeGranter)
 	if err != nil {
 		return params, err
 	}

--- a/core/server/doc.go
+++ b/core/server/doc.go
@@ -1,4 +1,4 @@
-// Server Defines types and interfaces which are shared between Consensus, Appmanager and Stf
+// Server Defines types and interfaces which are shared between Consensus, App Manager and Stf
 // This package is not meant to be used directly by modules instead if an advanced user would like
 // to create a custom server or replace a component in the server they will need to use the app package.
 package server

--- a/crypto/keyring/types.go
+++ b/crypto/keyring/types.go
@@ -6,7 +6,7 @@ import (
 )
 
 // Language is a language to create the BIP 39 mnemonic in.
-// Currently, only english is supported though.
+// Currently, only English is supported though.
 // Find a list of all supported languages in the BIP 39 spec (word lists).
 type Language int
 


### PR DESCRIPTION
corrected typos:
u32 is an uint32 - u32 is a uint32
feeGrater - feeGranter
Appmanager - App Manager
english - English

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected article usage in comment for `u32` field in `MsgRequest`.
	- Fixed typo in variable name from `feeGrater` to `feeGranter` in `txParamsFromFlagSet` function.
	- Updated comment formatting for "Appmanager" to "App Manager" in documentation.
	- Corrected capitalization of "english" to "English" in comment for `Language` type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->