### PR TITLE
Fix typo in x/slashing/README.md

### DIFF
--- a/x/slashing/README.md
+++ b/x/slashing/README.md
@@ -331,7 +331,7 @@ onValidatorBonded(address sdk.ValAddress)
       IndexOffset         : 0,
       JailedUntil         : time.Unix(0, 0),
       Tombstone           : false,
-      MissedBloskCounter  : 0
+      MissedBlockCounter  : 0
     } else {
       signingInfo.StartHeight = CurrentHeight
     }

--- a/x/slashing/README.md
+++ b/x/slashing/README.md
@@ -331,7 +331,7 @@ onValidatorBonded(address sdk.ValAddress)
       IndexOffset         : 0,
       JailedUntil         : time.Unix(0, 0),
       Tombstone           : false,
-      MissedBlockCounter  : 0
+      MissedBlocksCounter  : 0
     } else {
       signingInfo.StartHeight = CurrentHeight
     }


### PR DESCRIPTION
This pull request corrects a spelling error in the documentation. The term `MissedBloskCounter` has been updated to `MissedBlocksCounter` to ensure accuracy and clarity in the documentation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Corrected a typo in the `ValidatorSigningInfo` structure documentation
	- Updated `MissedBloskCounter` to `MissedBlocksCounter` for improved clarity and accuracy

<!-- end of auto-generated comment: release notes by coderabbit.ai -->