### PR TITLE
docs: add missing modules `accounts` and `group` in modules list

### DIFF
--- a/x/README.md
+++ b/x/README.md
@@ -6,6 +6,7 @@ sidebar_position: 0
 
 Here are some production-grade modules that can be used in Cosmos SDK applications, along with their respective documentation:
 
+* [Accounts](./accounts/README.md) - Tools and infrastructure for creating advanced smart accounts.
 * [Auth](./auth/README.md) - Authentication of accounts and transactions for Cosmos SDK applications.
 * [Authz](./authz/README.md) - Authorization for accounts to perform actions on behalf of other accounts.
 * [Bank](./bank/README.md) - Token transfer functionalities.
@@ -18,6 +19,7 @@ Here are some production-grade modules that can be used in Cosmos SDK applicatio
 * [Feegrant](./feegrant/README.md) - Grant fee allowances for executing transactions.
 * [Genutil](./genutil/README.md) - Genesis utilities for the Cosmos SDK.
 * [Governance](./gov/README.md) - On-chain proposals and voting.
+* [Group](./group/README.md) - On-chain multisig accounts creation and management.
 * [Mint](./mint/README.md) - Creation of new units of staking token.
 * [NFT](./nft/README.md) - NFT module implemented based on [ADR43](https://docs.cosmos.network/main/build/architecture/adr-043-nft-module).
 * [Params](./params/README.md) - Globally available parameter store.
@@ -28,7 +30,7 @@ Here are some production-grade modules that can be used in Cosmos SDK applicatio
 * [Upgrade](./upgrade/README.md) - Software upgrades handling and coordination.
 * [Validate](./validate/README.md) - Global ante/post handlers and tx validator setup.
 
-To learn more about the process of building modules, visit the [building modules reference documentation](https://docs.cosmos.network/main/building-modules/intro).
+To learn more about the process of building modules, visit the [building modules reference documentation](https://docs.cosmos.network/main/build/building-modules/intro).
 
 ## IBC
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added documentation for new "Accounts" module
  - Added documentation for new "Group" module
  - Updated documentation link for building modules reference

<!-- end of auto-generated comment: release notes by coderabbit.ai -->