### PR TITLE
feat(depinject): add UnregisterModule function

### DIFF
--- a/depinject/CHANGELOG.md
+++ b/depinject/CHANGELOG.md
@@ -22,6 +22,8 @@ Each entry must include the Github issue reference in the following format:
 
 ## [Unreleased]
 
+* [#23127](https://github.com/cosmos/cosmos-sdk/pull/23127) feat: add `UnregisterModule` function.
+
 ## 1.1.0
 
 * [#22438](https://github.com/cosmos/cosmos-sdk/pull/22438) Unexported fields on `In` structs are now silently ignored instead of failing.

--- a/depinject/appconfig/module.go
+++ b/depinject/appconfig/module.go
@@ -11,6 +11,15 @@ import (
 
 var Register = RegisterModule
 
+func modouleProtoType(m any) (proto.Message, reflect.Type) {
+	protoM, ok := m.(proto.Message)
+	if !ok {
+		panic(fmt.Errorf("expected module to be a proto.Message, got %T", m))
+	}
+
+	return protoM, reflect.TypeOf(protoM)
+}
+
 // RegisterModule registers a module with the global module registry. The provided
 // protobuf message is used only to uniquely identify the protobuf module config
 // type. The instance of the protobuf message used in the actual configuration
@@ -21,12 +30,7 @@ var Register = RegisterModule
 // cosmos.app.v1alpha.module option and must explicitly specify go_package
 // to make debugging easier for users.
 func RegisterModule(config any, options ...Option) {
-	protoConfig, ok := config.(proto.Message)
-	if !ok {
-		panic(fmt.Errorf("expected config to be a proto.Message, got %T", config))
-	}
-
-	ty := reflect.TypeOf(config)
+	protoConfig, ty := modouleProtoType(config)
 	init := &internal.ModuleInitializer{
 		ConfigProtoMessage: protoConfig,
 		ConfigGoType:       ty,
@@ -39,6 +43,13 @@ func RegisterModule(config any, options ...Option) {
 			return
 		}
 	}
+}
+
+// UnregisterModule from the global module registry. Can be used to overwrite previously
+// registered module.
+func UnregisterModule(config any, options ...Option) {
+	_, ty := modouleProtoType(config)
+	delete(internal.ModuleRegistry, ty)
 }
 
 // Option is a functional option for implementing modules.


### PR DESCRIPTION
# Description

Closes: #XXXX

In order to overwrite a default genesis from the SDK module we have to wrap the `AppModule`. Since the SDK modules are automatically supplied ot depinject in the `init` function, we need to unregister them, before registering the wrapped AppModule.

Use case: the default bank `DenomMetadata` is empty. I want to predefine denoms into it.

The flow is:
1. Create a custom bank module that wraps the sdk bank module
2. Implement `UnergisterModule` function -- this PR
3. Unregister the SDK bank module, and register the wrapped one

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title, you can find examples of the prefixes below:
    <!-- * `feat`: A new feature
    * `fix`: A bug fix
    * `docs`: Documentation only changes
    * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
    * `refactor`: A code change that neither fixes a bug nor adds a feature
    * `perf`: A code change that improves performance
    * `test`: Adding missing tests or correcting existing tests
    * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
    * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
    * `chore`: Other changes that don't modify src or test files
    * `revert`: Reverts a previous commit -->
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

Please see [Pull Request Reviewer section in the contributing guide](../CONTRIBUTING.md#reviewer) for more information on how to review a pull request.

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `UnregisterModule` function to allow removing previously registered modules from the global module registry
  - Introduced type-checking utility for module configurations

- **Documentation**
  - Updated changelog to reflect new functionality and previous version details

Note: This release continues to evolve the `depinject` module with improved module management capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->