### PR TITLE
fix(store/v2): `chunk.Close` is called twice

### DIFF
--- a/store/v2/snapshots/store.go
+++ b/store/v2/snapshots/store.go
@@ -172,14 +172,15 @@ func (s *Store) Load(height uint64, format uint32) (*types.Snapshot, <-chan io.R
 				_ = pw.CloseWithError(err)
 				return
 			}
-			defer chunk.Close()
-			_, err = io.Copy(pw, chunk)
-			if err != nil {
-				_ = pw.CloseWithError(err)
-				return
-			}
-			chunk.Close()
-			pw.Close()
+			func() {
+				defer chunk.Close()
+				_, err = io.Copy(pw, chunk)
+				if err != nil {
+					_ = pw.CloseWithError(err)
+					return
+				}
+				pw.Close()
+			}()
 		}
 	}()
 


### PR DESCRIPTION
Similar to #23146 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved resource management in snapshot loading process
	- Enhanced goroutine handling to prevent potential timing-related issues

<!-- end of auto-generated comment: release notes by coderabbit.ai -->