### PR TITLE
fix: typos and improve phrasing

### DIFF
--- a/store/v2/db/pebbledb.go
+++ b/store/v2/db/pebbledb.go
@@ -18,7 +18,7 @@ import (
 var _ corestore.KVStoreWithBatch = (*PebbleDB)(nil)
 
 // PebbleDB implements `corestore.KVStoreWithBatch` using PebbleDB as the underlying storage engine.
-// It is used for only store v2 migration, since some clients use PebbleDB as
+// It is used only for store v2 migration, since some clients use PebbleDB as
 // the IAVL v0/v1 backend.
 type PebbleDB struct {
 	storage *pebble.DB

--- a/x/auth/types/genesis.go
+++ b/x/auth/types/genesis.go
@@ -131,7 +131,7 @@ func ValidateGenAccounts(accounts GenesisAccounts) error {
 		// check for duplicated accounts
 		addrStr := acc.GetAddress().String()
 		if _, ok := addrMap[addrStr]; ok {
-			return fmt.Errorf("duplicate account found in genesis state; address: %s", addrStr)
+			return fmt.Errorf("duplicates account found in genesis state; address: %s", addrStr)
 		}
 
 		addrMap[addrStr] = true


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
Corrected ` used for only store` to `used only for store`
Corrected `duplicate` to `duplicates` (in the context of the code, it might be more logical to use the word `duplicates` in the plural, since we are talking about multiple accounts)

Please review the changes and let me know if any additional changes are needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated comment documentation for `PebbleDB` with minor grammatical improvement
	- Modified error message in `ValidateGenAccounts` function to use "duplicates" instead of "duplicate"

These changes are purely textual and do not impact the functional behavior of the code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->