### PR TITLE
refactor: Address TODO by resetting prefixIterator on invalid state

### DIFF
--- a/x/accounts/internal/prefixstore/prefixstore.go
+++ b/x/accounts/internal/prefixstore/prefixstore.go
@@ -139,15 +139,14 @@ func (pi *prefixIterator) Next() {
 	}
 
 	if pi.iter.Next(); !pi.iter.Valid() || !bytes.HasPrefix(pi.iter.Key(), pi.prefix) {
-		// TODO: shouldn't pi be set to nil instead?
-		pi.valid = false
+		*pi = prefixIterator{}
 	}
 }
 
 // Implements Iterator
 func (pi *prefixIterator) Key() (key []byte) {
-	if !pi.valid {
-		panic("prefixIterator invalid, cannot call Key()")
+	if pi == nil || !pi.valid {
+		panic("prefixIterator invalid or nil, cannot call Key()")
 	}
 
 	key = pi.iter.Key()
@@ -158,8 +157,8 @@ func (pi *prefixIterator) Key() (key []byte) {
 
 // Implements Iterator
 func (pi *prefixIterator) Value() []byte {
-	if !pi.valid {
-		panic("prefixIterator invalid, cannot call Value()")
+	if pi == nil || !pi.valid {
+		panic("prefixIterator invalid or nil, cannot call Value()")
 	}
 
 	return pi.iter.Value()


### PR DESCRIPTION
- Implemented the TODO to reset the prefixIterator state in the Next method by setting the iterator to a zero value (*pi = prefixIterator{}) when it becomes invalid.
- Updated Key and Value methods to include checks for nil or invalid states, ensuring robust error handling and alignment with the updated iterator behavior.
- This change addresses the previously noted TODO and improves the safety and clarity of handling invalid iterator states.

# Description

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title, you can find examples of the prefixes below:
    <!-- * `feat`: A new feature
    * `fix`: A bug fix
    * `docs`: Documentation only changes
    * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
    * `refactor`: A code change that neither fixes a bug nor adds a feature
    * `perf`: A code change that improves performance
    * `test`: Adding missing tests or correcting existing tests
    * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
    * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
    * `chore`: Other changes that don't modify src or test files
    * `revert`: Reverts a previous commit -->
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

Please see [Pull Request Reviewer section in the contributing guide](../CONTRIBUTING.md#reviewer) for more information on how to review a pull request.

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling and state management for prefix iterator
  - Enhanced robustness of iterator validation process
  - Added additional checks to prevent potential nil pointer dereferencing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->