### PR TITLE
Fixing Typographical Errors in Documentation

### DIFF
--- a/codec/testutil/codec.go
+++ b/codec/testutil/codec.go
@@ -58,7 +58,7 @@ func (o CodecOptions) NewCodec() *codec.ProtoCodec {
 	return codec.NewProtoCodec(o.NewInterfaceRegistry())
 }
 
-// GetAddressCodec returns the address codec. If not address codec was provided it'll create a new one based on the
+// GetAddressCodec returns the address codec. If no address codec was provided it'll create a new one based on the
 // bech32 prefix.
 func (o CodecOptions) GetAddressCodec() coreaddress.Codec {
 	if o.AddressCodec != nil {

--- a/contrib/githooks/pre-commit
+++ b/contrib/githooks/pre-commit
@@ -23,7 +23,7 @@ f_check_cmds() {
 f_check_cmds
 
 if [[ $STAGED_GO_FILES != "" ]]; then
-  f_echo_stderr "[pre-commit] fmt'ing staged files..."
+  f_echo_stderr "[pre-commit] formatting staged files..."
   for file in $STAGED_GO_FILES; do
     if [[ $file =~ vendor/ ]] || [[ $file =~ tests/mocks/ ]] || [[ $file =~ \.pb\.go ]]; then
       continue

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/include/secp256k1.h
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/include/secp256k1.h
@@ -534,7 +534,7 @@ SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_privkey_tweak_mul(
  *          uniformly random 32-byte arrays, or equal to zero. 1 otherwise.
  * Args:    ctx:    pointer to a context object initialized for validation
  *                 (cannot be NULL).
- * In/Out:  pubkey: pointer to a public key obkect.
+ * In/Out:  pubkey: pointer to a public key object.
  * In:      tweak:  pointer to a 32-byte tweak.
  */
 SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_pubkey_tweak_mul(

--- a/crypto/types/multisig/multisignature.go
+++ b/crypto/types/multisig/multisignature.go
@@ -36,7 +36,7 @@ func getIndex(pk types.PubKey, keys []types.PubKey) int {
 }
 
 // AddSignature adds a signature to the multisig, at the corresponding index. The index must
-// represent the pubkey index in the LegacyAmingPubKey structure, which verifies this signature.
+// represent the pubkey index in the LegacyAminoPubKey structure, which verifies this signature.
 // If the signature already exists, replace it.
 func AddSignature(mSig *signing.MultiSignatureData, sig signing.SignatureData, index int) {
 	newSigIndex := mSig.BitArray.NumTrueBitsBefore(index)


### PR DESCRIPTION
changed made: 

If not address - If no address

fmt'ing - formatting 

obkect - object

LegacyAmingPubKey - LegacyAminoPubKey 