### PR TITLE
docs: remove invalid symbols

### DIFF
--- a/client/v2/README.md
+++ b/client/v2/README.md
@@ -350,6 +350,6 @@ The `encoding` flag lets you choose how the contents of the file should be encod
 To verify a file only the key name used and the previously signed file are needed.
 
 ```text
-➜ simd off-chain verify-file alice signedFile.json
+simd off-chain verify-file alice signedFile.json
 Verification OK!
 ```


### PR DESCRIPTION
remove invalid symbols to make the command work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated README.md for the `verify-file` command example
	- Removed unnecessary leading dash in command line instruction
	- Improved formatting of off-chain file verification documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->