### PR TITLE
docs: update collections api example code link

### DIFF
--- a/docs/architecture/adr-062-collections-state-layer.md
+++ b/docs/architecture/adr-062-collections-state-layer.md
@@ -78,7 +78,7 @@ These default implementations also offer safety around proper lexicographic orde
 
 Examples of the collections API can be found here:
 - introduction: https://github.com/NibiruChain/collections/tree/main/examples
-- usage in nibiru: [x/oracle](https://github.com/NibiruChain/nibiru/blob/master/x/oracle/keeper/keeper.go#L32), [x/epoch](https://github.com/NibiruChain/nibiru/blob/4566d9f6d22807abbd78c01454664d64f6e108e0/x/epochs/keeper/epoch.go)
+- usage in nibiru: [x/oracle](https://github.com/NibiruChain/nibiru/blob/v2.0.0-rc.14/x/oracle/keeper/keeper.go#L37~L50), [x/epoch](https://github.com/NibiruChain/nibiru/blob/4566d9f6d22807abbd78c01454664d64f6e108e0/x/epochs/keeper/epoch.go)
 - cosmos-sdk's x/staking migrated: https://github.com/testinginprod/cosmos-sdk/pull/22
 
 


### PR DESCRIPTION
I find another invalid link, similar to #23230

The old link `https://github.com/NibiruChain/nibiru/blob/master/x/oracle/keeper/keeper.go#L32`  isn't correct and doesn't use versioned/tagged link, this PR updates it to the correct one

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated usage references in architecture decision record (ADR) document
	- Updated GitHub source code links for `x/oracle` module to point to specific version tag
	- Maintained existing references for `x/epoch` module

<!-- end of auto-generated comment: release notes by coderabbit.ai -->