### PR TITLE
docs: fix runtime doc dead link to app-go-di.md

### DIFF
--- a/docs/build/building-apps/00-runtime.md
+++ b/docs/build/building-apps/00-runtime.md
@@ -134,7 +134,7 @@ An application only needs to call `AppBuilder.Build` to create a fully configure
 https://github.com/cosmos/cosmos-sdk/blob/v0.52.0-beta.2/runtime/builder.go#L36-L80
 ```
 
-More information on building applications can be found in the [next section](./02-app-go-di.md).
+More information on building applications can be found in the [next section](./01-app-go-di.md).
 
 ## Best Practices
 


### PR DESCRIPTION
app-go-di file name is `01-app-go-di.md`, not `02-app-go-di.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated documentation reference link for the runtime package section
  - Corrected navigation path in the "More information on building applications" paragraph

<!-- end of auto-generated comment: release notes by coderabbit.ai -->