### PR TITLE
chore(x/staking): use `cosmossdk.io/core/codec` instead of `github.com/cosmos/cosmos-sdk/codec`

### DIFF
--- a/x/staking/migrations/v5/store.go
+++ b/x/staking/migrations/v5/store.go
@@ -9,7 +9,7 @@ import (
 	"cosmossdk.io/store/prefix"
 	storetypes "cosmossdk.io/store/types"
 
-	"github.com/cosmos/cosmos-sdk/codec"
+	"cosmossdk.io/core/codec"
 )
 
 func migrateDelegationsByValidatorIndex(store storetypes.KVStore) error {

--- a/x/staking/migrations/v5/store.go
+++ b/x/staking/migrations/v5/store.go
@@ -5,11 +5,10 @@ import (
 	"fmt"
 	"strconv"
 
+	"cosmossdk.io/core/codec"
 	"cosmossdk.io/core/log"
 	"cosmossdk.io/store/prefix"
 	storetypes "cosmossdk.io/store/types"
-
-	"cosmossdk.io/core/codec"
 )
 
 func migrateDelegationsByValidatorIndex(store storetypes.KVStore) error {

--- a/x/staking/migrations/v6/store.go
+++ b/x/staking/migrations/v6/store.go
@@ -3,9 +3,8 @@ package v6
 import (
 	"context"
 
-	storetypes "cosmossdk.io/store/types"
-
 	"cosmossdk.io/core/codec"
+	storetypes "cosmossdk.io/store/types"
 )
 
 // MigrateStore performs in-place store migrations from v5 to v6.

--- a/x/staking/migrations/v6/store.go
+++ b/x/staking/migrations/v6/store.go
@@ -5,7 +5,7 @@ import (
 
 	storetypes "cosmossdk.io/store/types"
 
-	"github.com/cosmos/cosmos-sdk/codec"
+	"cosmossdk.io/core/codec"
 )
 
 // MigrateStore performs in-place store migrations from v5 to v6.

--- a/x/staking/module.go
+++ b/x/staking/module.go
@@ -11,6 +11,7 @@ import (
 
 	"cosmossdk.io/collections"
 	"cosmossdk.io/core/appmodule"
+	"cosmossdk.io/core/codec"
 	"cosmossdk.io/core/registry"
 	"cosmossdk.io/depinject"
 	"cosmossdk.io/schema"
@@ -18,7 +19,6 @@ import (
 	"cosmossdk.io/x/staking/keeper"
 	"cosmossdk.io/x/staking/types"
 
-	"cosmossdk.io/core/codec"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/types/module"
 )

--- a/x/staking/module.go
+++ b/x/staking/module.go
@@ -18,8 +18,8 @@ import (
 	"cosmossdk.io/x/staking/keeper"
 	"cosmossdk.io/x/staking/types"
 
+	"cosmossdk.io/core/codec"
 	"github.com/cosmos/cosmos-sdk/client"
-	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/types/module"
 )
 
@@ -119,7 +119,11 @@ func (am AppModule) RegisterMigrations(mr appmodule.MigrationRegistrar) error {
 
 // DefaultGenesis returns default genesis state as raw bytes for the staking module.
 func (am AppModule) DefaultGenesis() json.RawMessage {
-	return am.cdc.MustMarshalJSON(types.DefaultGenesisState())
+	data, err := am.cdc.MarshalJSON(types.DefaultGenesisState())
+	if err != nil {
+		panic(err)
+	}
+	return data
 }
 
 // ValidateGenesis performs genesis state validation for the staking module.
@@ -135,7 +139,9 @@ func (am AppModule) ValidateGenesis(bz json.RawMessage) error {
 // InitGenesis performs genesis initialization for the staking module.
 func (am AppModule) InitGenesis(ctx context.Context, data json.RawMessage) ([]appmodule.ValidatorUpdate, error) {
 	var genesisState types.GenesisState
-	am.cdc.MustUnmarshalJSON(data, &genesisState)
+	if err := am.cdc.UnmarshalJSON(data, &genesisState); err != nil {
+		panic(err)
+	}
 	return am.keeper.InitGenesis(ctx, &genesisState)
 }
 

--- a/x/staking/simulation/decoder.go
+++ b/x/staking/simulation/decoder.go
@@ -7,7 +7,7 @@ import (
 	"cosmossdk.io/math"
 	"cosmossdk.io/x/staking/types"
 
-	"github.com/cosmos/cosmos-sdk/codec"
+	"cosmossdk.io/core/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/kv"
 )
@@ -30,8 +30,12 @@ func NewDecodeStore(cdc codec.Codec) func(kvA, kvB kv.Pair) string {
 		case bytes.Equal(kvA.Key[:1], types.ValidatorsKey):
 			var validatorA, validatorB types.Validator
 
-			cdc.MustUnmarshal(kvA.Value, &validatorA)
-			cdc.MustUnmarshal(kvB.Value, &validatorB)
+			if err := cdc.Unmarshal(kvA.Value, &validatorA); err != nil {
+				panic(err)
+			}
+			if err := cdc.Unmarshal(kvB.Value, &validatorB); err != nil {
+				panic(err)
+			}
 
 			return fmt.Sprintf("%v\n%v", validatorA, validatorB)
 		case bytes.Equal(kvA.Key[:1], types.LastValidatorPowerKey),
@@ -42,45 +46,69 @@ func NewDecodeStore(cdc codec.Codec) func(kvA, kvB kv.Pair) string {
 		case bytes.Equal(kvA.Key[:1], types.DelegationKey):
 			var delegationA, delegationB types.Delegation
 
-			cdc.MustUnmarshal(kvA.Value, &delegationA)
-			cdc.MustUnmarshal(kvB.Value, &delegationB)
+			if err := cdc.Unmarshal(kvA.Value, &delegationA); err != nil {
+				panic(err)
+			}
+			if err := cdc.Unmarshal(kvB.Value, &delegationB); err != nil {
+				panic(err)
+			}
 
 			return fmt.Sprintf("%v\n%v", delegationA, delegationB)
 		case bytes.Equal(kvA.Key[:1], types.UnbondingDelegationKey),
 			bytes.Equal(kvA.Key[:1], types.UnbondingDelegationByValIndexKey):
 			var ubdA, ubdB types.UnbondingDelegation
 
-			cdc.MustUnmarshal(kvA.Value, &ubdA)
-			cdc.MustUnmarshal(kvB.Value, &ubdB)
+			if err := cdc.Unmarshal(kvA.Value, &ubdA); err != nil {
+				panic(err)
+			}
+			if err := cdc.Unmarshal(kvB.Value, &ubdB); err != nil {
+				panic(err)
+			}
 
 			return fmt.Sprintf("%v\n%v", ubdA, ubdB)
 		case bytes.Equal(kvA.Key[:1], types.RedelegationKey),
 			bytes.Equal(kvA.Key[:1], types.RedelegationByValSrcIndexKey):
 			var redA, redB types.Redelegation
 
-			cdc.MustUnmarshal(kvA.Value, &redA)
-			cdc.MustUnmarshal(kvB.Value, &redB)
+			if err := cdc.Unmarshal(kvA.Value, &redA); err != nil {
+				panic(err)
+			}
+			if err := cdc.Unmarshal(kvB.Value, &redB); err != nil {
+				panic(err)
+			}
 
 			return fmt.Sprintf("%v\n%v", redA, redB)
 		case bytes.Equal(kvA.Key[:1], types.ParamsKey):
 			var paramsA, paramsB types.Params
 
-			cdc.MustUnmarshal(kvA.Value, &paramsA)
-			cdc.MustUnmarshal(kvB.Value, &paramsB)
+			if err := cdc.Unmarshal(kvA.Value, &paramsA); err != nil {
+				panic(err)
+			}
+			if err := cdc.Unmarshal(kvB.Value, &paramsB); err != nil {
+				panic(err)
+			}
 
 			return fmt.Sprintf("%v\n%v", paramsA, paramsB)
 		case bytes.Equal(kvA.Key[:1], types.ValidatorConsPubKeyRotationHistoryKey):
 			var historyA, historyB types.ConsPubKeyRotationHistory
 
-			cdc.MustUnmarshal(kvA.Value, &historyA)
-			cdc.MustUnmarshal(kvB.Value, &historyB)
+			if err := cdc.Unmarshal(kvA.Value, &historyA); err != nil {
+				panic(err)
+			}
+			if err := cdc.Unmarshal(kvB.Value, &historyB); err != nil {
+				panic(err)
+			}
 
 			return fmt.Sprintf("%v\n%v", historyA, historyB)
 		case bytes.Equal(kvA.Key[:1], types.ValidatorConsensusKeyRotationRecordQueueKey):
 			var historyA, historyB types.ValAddrsOfRotatedConsKeys
 
-			cdc.MustUnmarshal(kvA.Value, &historyA)
-			cdc.MustUnmarshal(kvB.Value, &historyB)
+			if err := cdc.Unmarshal(kvA.Value, &historyA); err != nil {
+				panic(err)
+			}
+			if err := cdc.Unmarshal(kvB.Value, &historyB); err != nil {
+				panic(err)
+			}
 
 			return fmt.Sprintf("%v\n%v", historyA, historyB)
 		default:

--- a/x/staking/simulation/decoder.go
+++ b/x/staking/simulation/decoder.go
@@ -4,10 +4,10 @@ import (
 	"bytes"
 	"fmt"
 
+	"cosmossdk.io/core/codec"
 	"cosmossdk.io/math"
 	"cosmossdk.io/x/staking/types"
 
-	"cosmossdk.io/core/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/kv"
 )

--- a/x/staking/types/delegation.go
+++ b/x/staking/types/delegation.go
@@ -6,9 +6,9 @@ import (
 	"time"
 
 	"cosmossdk.io/core/address"
+	"cosmossdk.io/core/codec"
 	"cosmossdk.io/math"
 
-	"cosmossdk.io/core/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 

--- a/x/staking/types/delegation.go
+++ b/x/staking/types/delegation.go
@@ -8,7 +8,7 @@ import (
 	"cosmossdk.io/core/address"
 	"cosmossdk.io/math"
 
-	"github.com/cosmos/cosmos-sdk/codec"
+	"cosmossdk.io/core/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -26,7 +26,11 @@ func NewDelegation(delegatorAddr, validatorAddr string, shares math.LegacyDec) D
 
 // MustMarshalDelegation returns the delegation bytes. Panics if fails
 func MustMarshalDelegation(cdc codec.BinaryCodec, delegation Delegation) []byte {
-	return cdc.MustMarshal(&delegation)
+	data, err := cdc.Marshal(&delegation)
+	if err != nil {
+		panic(err)
+	}
+	return data
 }
 
 // MustUnmarshalDelegation return the unmarshaled delegation from bytes.
@@ -143,7 +147,11 @@ func (ubd *UnbondingDelegation) RemoveEntry(i int64) {
 
 // return the unbonding delegation
 func MustMarshalUBD(cdc codec.BinaryCodec, ubd UnbondingDelegation) []byte {
-	return cdc.MustMarshal(&ubd)
+	data, err := cdc.Marshal(&ubd)
+	if err != nil {
+		panic(err)
+	}
+	return data
 }
 
 // unmarshal a unbonding delegation from a store value
@@ -234,7 +242,11 @@ func (red *Redelegation) RemoveEntry(i int64) {
 
 // MustMarshalRED returns the Redelegation bytes. Panics if fails.
 func MustMarshalRED(cdc codec.BinaryCodec, red Redelegation) []byte {
-	return cdc.MustMarshal(&red)
+	data, err := cdc.Marshal(&red)
+	if err != nil {
+		panic(err)
+	}
+	return data
 }
 
 // MustUnmarshalRED unmarshals a redelegation from a store value. Panics if fails.

--- a/x/staking/types/genesis.go
+++ b/x/staking/types/genesis.go
@@ -5,7 +5,7 @@ import (
 
 	gogoprotoany "github.com/cosmos/gogoproto/types/any"
 
-	"github.com/cosmos/cosmos-sdk/codec"
+	"cosmossdk.io/core/codec"
 )
 
 // NewGenesisState creates a new GenesisState instance
@@ -30,7 +30,9 @@ func GetGenesisStateFromAppState(cdc codec.JSONCodec, appState map[string]json.R
 	var genesisState GenesisState
 
 	if appState[ModuleName] != nil {
-		cdc.MustUnmarshalJSON(appState[ModuleName], &genesisState)
+		if err := cdc.UnmarshalJSON(appState[ModuleName], &genesisState); err != nil {
+			panic(err)
+		}
 	}
 
 	return &genesisState

--- a/x/staking/types/validator.go
+++ b/x/staking/types/validator.go
@@ -12,10 +12,10 @@ import (
 
 	"cosmossdk.io/core/address"
 	"cosmossdk.io/core/appmodule"
+	"cosmossdk.io/core/codec"
 	"cosmossdk.io/errors"
 	"cosmossdk.io/math"
 
-	"cosmossdk.io/core/codec"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"

--- a/x/staking/types/validator.go
+++ b/x/staking/types/validator.go
@@ -15,7 +15,7 @@ import (
 	"cosmossdk.io/errors"
 	"cosmossdk.io/math"
 
-	"github.com/cosmos/cosmos-sdk/codec"
+	"cosmossdk.io/core/codec"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -152,7 +152,11 @@ func (v Validators) UnpackInterfaces(c gogoprotoany.AnyUnpacker) error {
 
 // return the redelegation
 func MustMarshalValidator(cdc codec.BinaryCodec, validator *Validator) []byte {
-	return cdc.MustMarshal(validator)
+	data, err := cdc.Marshal(validator)
+	if err != nil {
+		panic(err)
+	}
+	return data
 }
 
 // unmarshal a redelegation from a store value


### PR DESCRIPTION
# Description

Partially addresses #23253

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Dependency Updates**
	- Updated codec import from Cosmos SDK to core codec library across multiple staking module files.

- **Error Handling Improvements**
	- Enhanced marshaling and unmarshaling processes with explicit error checking.
	- Replaced `MustMarshal/Unmarshal` methods with more robust error handling techniques.

- **Code Maintenance**
	- Standardized error management in staking module type definitions and methods.
	- Migrated codec dependencies to new import path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->