### PR TITLE
chore(x/slashing,x/protocolpool): use `cosmossdk.io/core/codec` instead of `github.com/cosmos/cosmos-sdk/codec`

### DIFF
--- a/x/protocolpool/module.go
+++ b/x/protocolpool/module.go
@@ -9,11 +9,11 @@ import (
 	"google.golang.org/grpc"
 
 	"cosmossdk.io/core/appmodule"
+	"cosmossdk.io/core/codec"
 	"cosmossdk.io/core/registry"
 	"cosmossdk.io/x/protocolpool/keeper"
 	"cosmossdk.io/x/protocolpool/types"
 
-	"cosmossdk.io/core/codec"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/types/module"
 )

--- a/x/protocolpool/module.go
+++ b/x/protocolpool/module.go
@@ -13,8 +13,8 @@ import (
 	"cosmossdk.io/x/protocolpool/keeper"
 	"cosmossdk.io/x/protocolpool/types"
 
+	"cosmossdk.io/core/codec"
 	"github.com/cosmos/cosmos-sdk/client"
-	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/types/module"
 )
 
@@ -80,7 +80,11 @@ func (am AppModule) RegisterServices(registrar grpc.ServiceRegistrar) error {
 
 // DefaultGenesis returns default genesis state as raw bytes for the protocolpool module.
 func (am AppModule) DefaultGenesis() json.RawMessage {
-	return am.cdc.MustMarshalJSON(types.DefaultGenesisState())
+	data, err := am.cdc.MarshalJSON(types.DefaultGenesisState())
+	if err != nil {
+		panic(err)
+	}
+	return data
 }
 
 // ValidateGenesis performs genesis state validation for the protocolpool module.

--- a/x/slashing/migrations/v4/migrate.go
+++ b/x/slashing/migrations/v4/migrate.go
@@ -7,11 +7,11 @@ import (
 	gogotypes "github.com/cosmos/gogoproto/types"
 
 	"cosmossdk.io/core/address"
+	"cosmossdk.io/core/codec"
 	"cosmossdk.io/errors"
 	storetypes "cosmossdk.io/store/types"
 	"cosmossdk.io/x/slashing/types"
 
-	"cosmossdk.io/core/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 

--- a/x/slashing/migrations/v4/migrate.go
+++ b/x/slashing/migrations/v4/migrate.go
@@ -11,7 +11,7 @@ import (
 	storetypes "cosmossdk.io/store/types"
 	"cosmossdk.io/x/slashing/types"
 
-	"github.com/cosmos/cosmos-sdk/codec"
+	"cosmossdk.io/core/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -74,7 +74,9 @@ func iterateValidatorSigningInfos(
 	for ; iter.Valid(); iter.Next() {
 		addr := ValidatorSigningInfoAddress(iter.Key())
 		var info types.ValidatorSigningInfo
-		cdc.MustUnmarshal(iter.Value(), &info)
+		if err := cdc.Unmarshal(iter.Value(), &info); err != nil {
+			panic(err)
+		}
 
 		if cb(addr, info) {
 			break
@@ -97,7 +99,9 @@ func iterateValidatorMissedBlockBitArray(
 			continue
 		}
 
-		cdc.MustUnmarshal(bz, &missed)
+		if err := cdc.Unmarshal(bz, &missed); err != nil {
+			panic(err)
+		}
 		if cb(i, missed.Value) {
 			break
 		}


### PR DESCRIPTION
# Description

Partially addresses #23253

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated codec import paths from `github.com/cosmos/cosmos-sdk/codec` to `cosmossdk.io/core/codec`
	- Improved error handling in JSON marshaling and unmarshaling processes
	- Enhanced error checking in migration functions for protocol pool and slashing modules

- **Chores**
	- Replaced `MustMarshalJSON` and `MustUnmarshal` with explicit error handling approaches
	- Maintained existing method signatures while improving error management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->