### PR TITLE
chore(x/group,x/nft,x/mint): use `cosmossdk.io/core/codec` instead of `github.com/cosmos/cosmos-sdk/codec`

### DIFF
--- a/x/group/internal/orm/types.go
+++ b/x/group/internal/orm/types.go
@@ -9,12 +9,12 @@ import (
 
 	"github.com/cosmos/gogoproto/proto"
 
+	"cosmossdk.io/core/codec"
 	storetypes "cosmossdk.io/core/store"
 	errorsmod "cosmossdk.io/errors"
 	"cosmossdk.io/x/group/errors"
 	"cosmossdk.io/x/group/internal/orm/prefixstore"
 
-	"github.com/cosmos/cosmos-sdk/codec"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/cosmos-sdk/types/query"
 )

--- a/x/group/keeper/genesis.go
+++ b/x/group/keeper/genesis.go
@@ -7,13 +7,15 @@ import (
 	"cosmossdk.io/errors"
 	"cosmossdk.io/x/group"
 
-	"github.com/cosmos/cosmos-sdk/codec"
+	"cosmossdk.io/core/codec"
 )
 
 // InitGenesis initializes the group module's genesis state.
 func (k Keeper) InitGenesis(ctx context.Context, cdc codec.JSONCodec, data json.RawMessage) error {
 	var genesisState group.GenesisState
-	cdc.MustUnmarshalJSON(data, &genesisState)
+	if err := cdc.UnmarshalJSON(data, &genesisState); err != nil {
+		panic(err)
+	}
 
 	store := k.KVStoreService.OpenKVStore(ctx)
 

--- a/x/group/keeper/genesis.go
+++ b/x/group/keeper/genesis.go
@@ -4,10 +4,9 @@ import (
 	"context"
 	"encoding/json"
 
+	"cosmossdk.io/core/codec"
 	"cosmossdk.io/errors"
 	"cosmossdk.io/x/group"
-
-	"cosmossdk.io/core/codec"
 )
 
 // InitGenesis initializes the group module's genesis state.

--- a/x/group/module/module.go
+++ b/x/group/module/module.go
@@ -16,8 +16,8 @@ import (
 	"cosmossdk.io/x/group/keeper"
 	"cosmossdk.io/x/group/simulation"
 
+	"cosmossdk.io/core/codec"
 	sdkclient "github.com/cosmos/cosmos-sdk/client"
-	"github.com/cosmos/cosmos-sdk/codec"
 	cdctypes "github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/cosmos/cosmos-sdk/simsx"
 	"github.com/cosmos/cosmos-sdk/types/module"
@@ -118,7 +118,11 @@ func (am AppModule) EndBlock(ctx context.Context) error {
 
 // DefaultGenesis returns default genesis state as raw bytes for the group module.
 func (am AppModule) DefaultGenesis() json.RawMessage {
-	return am.cdc.MustMarshalJSON(group.NewGenesisState())
+	data, err := am.cdc.MarshalJSON(group.NewGenesisState())
+	if err != nil {
+		panic(err)
+	}
+	return data
 }
 
 // ValidateGenesis performs genesis state validation for the group module.

--- a/x/group/module/module.go
+++ b/x/group/module/module.go
@@ -10,13 +10,13 @@ import (
 	"google.golang.org/grpc"
 
 	"cosmossdk.io/core/appmodule"
+	"cosmossdk.io/core/codec"
 	"cosmossdk.io/core/registry"
 	"cosmossdk.io/x/group"
 	"cosmossdk.io/x/group/client/cli"
 	"cosmossdk.io/x/group/keeper"
 	"cosmossdk.io/x/group/simulation"
 
-	"cosmossdk.io/core/codec"
 	sdkclient "github.com/cosmos/cosmos-sdk/client"
 	cdctypes "github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/cosmos/cosmos-sdk/simsx"

--- a/x/group/simulation/decoder.go
+++ b/x/group/simulation/decoder.go
@@ -7,7 +7,7 @@ import (
 	"cosmossdk.io/x/group"
 	"cosmossdk.io/x/group/keeper"
 
-	"github.com/cosmos/cosmos-sdk/codec"
+	"cosmossdk.io/core/codec"
 	"github.com/cosmos/cosmos-sdk/types/kv"
 )
 
@@ -19,36 +19,56 @@ func NewDecodeStore(cdc codec.Codec) func(kvA, kvB kv.Pair) string {
 		case bytes.Equal(kvA.Key[:1], []byte{keeper.GroupTablePrefix}):
 			var groupA, groupB group.GroupInfo
 
-			cdc.MustUnmarshal(kvA.Value, &groupA)
-			cdc.MustUnmarshal(kvB.Value, &groupB)
+			if err := cdc.Unmarshal(kvA.Value, &groupA); err != nil {
+				panic(err)
+			}
+			if err := cdc.Unmarshal(kvB.Value, &groupB); err != nil {
+				panic(err)
+			}
 
 			return fmt.Sprintf("%v\n%v", groupA, groupB)
 		case bytes.Equal(kvA.Key[:1], []byte{keeper.GroupMemberTablePrefix}):
 			var memberA, memberB group.GroupMember
 
-			cdc.MustUnmarshal(kvA.Value, &memberA)
-			cdc.MustUnmarshal(kvB.Value, &memberB)
+			if err := cdc.Unmarshal(kvA.Value, &memberA); err != nil {
+				panic(err)
+			}
+			if err := cdc.Unmarshal(kvB.Value, &memberB); err != nil {
+				panic(err)
+			}
 
 			return fmt.Sprintf("%v\n%v", memberA, memberB)
 		case bytes.Equal(kvA.Key[:1], []byte{keeper.GroupPolicyTablePrefix}):
 			var accA, accB group.GroupPolicyInfo
 
-			cdc.MustUnmarshal(kvA.Value, &accA)
-			cdc.MustUnmarshal(kvB.Value, &accB)
+			if err := cdc.Unmarshal(kvA.Value, &accA); err != nil {
+				panic(err)
+			}
+			if err := cdc.Unmarshal(kvB.Value, &accB); err != nil {
+				panic(err)
+			}
 
 			return fmt.Sprintf("%v\n%v", accA, accB)
 		case bytes.Equal(kvA.Key[:1], []byte{keeper.ProposalTablePrefix}):
 			var propA, propB group.Proposal
 
-			cdc.MustUnmarshal(kvA.Value, &propA)
-			cdc.MustUnmarshal(kvB.Value, &propB)
+			if err := cdc.Unmarshal(kvA.Value, &propA); err != nil {
+				panic(err)
+			}
+			if err := cdc.Unmarshal(kvB.Value, &propB); err != nil {
+				panic(err)
+			}
 
 			return fmt.Sprintf("%v\n%v", propA, propB)
 		case bytes.Equal(kvA.Key[:1], []byte{keeper.VoteTablePrefix}):
 			var voteA, voteB group.Vote
 
-			cdc.MustUnmarshal(kvA.Value, &voteA)
-			cdc.MustUnmarshal(kvB.Value, &voteB)
+			if err := cdc.Unmarshal(kvA.Value, &voteA); err != nil {
+				panic(err)
+			}
+			if err := cdc.Unmarshal(kvB.Value, &voteB); err != nil {
+				panic(err)
+			}
 
 			return fmt.Sprintf("%v\n%v", voteA, voteB)
 		default:

--- a/x/group/simulation/decoder.go
+++ b/x/group/simulation/decoder.go
@@ -4,10 +4,10 @@ import (
 	"bytes"
 	"fmt"
 
+	"cosmossdk.io/core/codec"
 	"cosmossdk.io/x/group"
 	"cosmossdk.io/x/group/keeper"
 
-	"cosmossdk.io/core/codec"
 	"github.com/cosmos/cosmos-sdk/types/kv"
 )
 

--- a/x/mint/module.go
+++ b/x/mint/module.go
@@ -10,13 +10,13 @@ import (
 
 	"cosmossdk.io/collections"
 	"cosmossdk.io/core/appmodule"
+	"cosmossdk.io/core/codec"
 	"cosmossdk.io/core/registry"
 	"cosmossdk.io/schema"
 	"cosmossdk.io/x/mint/keeper"
 	"cosmossdk.io/x/mint/simulation"
 	"cosmossdk.io/x/mint/types"
 
-	"cosmossdk.io/core/codec"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/simsx"
 	"github.com/cosmos/cosmos-sdk/types/module"

--- a/x/mint/module.go
+++ b/x/mint/module.go
@@ -16,8 +16,8 @@ import (
 	"cosmossdk.io/x/mint/simulation"
 	"cosmossdk.io/x/mint/types"
 
+	"cosmossdk.io/core/codec"
 	"github.com/cosmos/cosmos-sdk/client"
-	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/simsx"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
@@ -110,7 +110,11 @@ func (am AppModule) RegisterMigrations(mr appmodule.MigrationRegistrar) error {
 
 // DefaultGenesis returns default genesis state as raw bytes for the mint module.
 func (am AppModule) DefaultGenesis() json.RawMessage {
-	return am.cdc.MustMarshalJSON(types.DefaultGenesisState())
+	data, err := am.cdc.MarshalJSON(types.DefaultGenesisState())
+	if err != nil {
+		panic(err)
+	}
+	return data
 }
 
 // ValidateGenesis performs genesis state validation for the mint module.

--- a/x/nft/module/module.go
+++ b/x/nft/module/module.go
@@ -14,8 +14,8 @@ import (
 	"cosmossdk.io/x/nft/keeper"
 	"cosmossdk.io/x/nft/simulation"
 
+	"cosmossdk.io/core/codec"
 	sdkclient "github.com/cosmos/cosmos-sdk/client"
-	"github.com/cosmos/cosmos-sdk/codec"
 	cdctypes "github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/cosmos/cosmos-sdk/simsx"
 	"github.com/cosmos/cosmos-sdk/types/module"
@@ -85,7 +85,11 @@ func (AppModule) RegisterGRPCGatewayRoutes(clientCtx sdkclient.Context, mux *gwr
 
 // DefaultGenesis returns default genesis state as raw bytes for the nft module.
 func (am AppModule) DefaultGenesis() json.RawMessage {
-	return am.cdc.MustMarshalJSON(nft.DefaultGenesisState())
+	data, err := am.cdc.MarshalJSON(nft.DefaultGenesisState())
+	if err != nil {
+		panic(err)
+	}
+	return data
 }
 
 // ValidateGenesis performs genesis state validation for the nft module.

--- a/x/nft/module/module.go
+++ b/x/nft/module/module.go
@@ -8,13 +8,13 @@ import (
 	"google.golang.org/grpc"
 
 	"cosmossdk.io/core/appmodule"
+	"cosmossdk.io/core/codec"
 	"cosmossdk.io/core/registry"
 	"cosmossdk.io/errors"
 	"cosmossdk.io/x/nft"
 	"cosmossdk.io/x/nft/keeper"
 	"cosmossdk.io/x/nft/simulation"
 
-	"cosmossdk.io/core/codec"
 	sdkclient "github.com/cosmos/cosmos-sdk/client"
 	cdctypes "github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/cosmos/cosmos-sdk/simsx"

--- a/x/nft/simulation/decoder.go
+++ b/x/nft/simulation/decoder.go
@@ -4,10 +4,10 @@ import (
 	"bytes"
 	"fmt"
 
+	"cosmossdk.io/core/codec"
 	"cosmossdk.io/x/nft"
 	"cosmossdk.io/x/nft/keeper"
 
-	"cosmossdk.io/core/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/kv"
 )

--- a/x/nft/simulation/decoder.go
+++ b/x/nft/simulation/decoder.go
@@ -7,7 +7,7 @@ import (
 	"cosmossdk.io/x/nft"
 	"cosmossdk.io/x/nft/keeper"
 
-	"github.com/cosmos/cosmos-sdk/codec"
+	"cosmossdk.io/core/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/kv"
 )
@@ -19,13 +19,21 @@ func NewDecodeStore(cdc codec.Codec) func(kvA, kvB kv.Pair) string {
 		switch {
 		case bytes.Equal(kvA.Key[:1], keeper.ClassKey):
 			var classA, classB nft.Class
-			cdc.MustUnmarshal(kvA.Value, &classA)
-			cdc.MustUnmarshal(kvB.Value, &classB)
+			if err := cdc.Unmarshal(kvA.Value, &classA); err != nil {
+				panic(err)
+			}
+			if err := cdc.Unmarshal(kvB.Value, &classB); err != nil {
+				panic(err)
+			}
 			return fmt.Sprintf("%v\n%v", classA, classB)
 		case bytes.Equal(kvA.Key[:1], keeper.NFTKey):
 			var nftA, nftB nft.NFT
-			cdc.MustUnmarshal(kvA.Value, &nftA)
-			cdc.MustUnmarshal(kvB.Value, &nftB)
+			if err := cdc.Unmarshal(kvA.Value, &nftA); err != nil {
+				panic(err)
+			}
+			if err := cdc.Unmarshal(kvB.Value, &nftB); err != nil {
+				panic(err)
+			}
 			return fmt.Sprintf("%v\n%v", nftA, nftB)
 		case bytes.Equal(kvA.Key[:1], keeper.NFTOfClassByOwnerKey):
 			return fmt.Sprintf("%v\n%v", kvA.Value, kvB.Value)


### PR DESCRIPTION
# Description

Partially addresses #23253

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Dependency Updates**
	- Updated codec imports from Cosmos SDK to `cosmossdk.io/core`

- **Error Handling Improvements**
	- Enhanced error management in genesis state marshaling
	- Replaced `MustMarshalJSON` with explicit error checking
	- Improved unmarshalling error reporting in various modules

- **Code Maintenance**
	- Updated method signatures to accommodate new codec interface
	- Refined error handling across multiple packages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->