### PR TITLE
chore(x/genutil): use `cosmossdk.io/core/codec` instead of `github.com/cosmos/cosmos-sdk/codec`

### DIFF
--- a/x/genutil/depinject.go
+++ b/x/genutil/depinject.go
@@ -6,8 +6,8 @@ import (
 	"cosmossdk.io/depinject"
 	"cosmossdk.io/depinject/appconfig"
 
+	"cosmossdk.io/core/codec"
 	"github.com/cosmos/cosmos-sdk/client"
-	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/x/genutil/types"
 )
 

--- a/x/genutil/depinject.go
+++ b/x/genutil/depinject.go
@@ -3,10 +3,10 @@ package genutil
 import (
 	modulev1 "cosmossdk.io/api/cosmos/genutil/module/v1"
 	"cosmossdk.io/core/appmodule"
+	"cosmossdk.io/core/codec"
 	"cosmossdk.io/depinject"
 	"cosmossdk.io/depinject/appconfig"
 
-	"cosmossdk.io/core/codec"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/x/genutil/types"
 )

--- a/x/genutil/module.go
+++ b/x/genutil/module.go
@@ -8,8 +8,8 @@ import (
 	"cosmossdk.io/core/appmodule"
 	appmodulev2 "cosmossdk.io/core/appmodule/v2"
 
+	"cosmossdk.io/core/codec"
 	"github.com/cosmos/cosmos-sdk/client"
-	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	"github.com/cosmos/cosmos-sdk/x/genutil/types"
 )
@@ -62,7 +62,11 @@ func (AppModule) Name() string {
 
 // DefaultGenesis returns default genesis state as raw bytes for the genutil module.
 func (am AppModule) DefaultGenesis() json.RawMessage {
-	return am.cdc.MustMarshalJSON(types.DefaultGenesisState())
+	data, err := am.cdc.MarshalJSON(types.DefaultGenesisState())
+	if err != nil {
+		panic(err)
+	}
+	return data
 }
 
 // ValidateGenesis performs genesis state validation for the genutil module.
@@ -79,7 +83,9 @@ func (am AppModule) ValidateGenesis(bz json.RawMessage) error {
 // InitGenesis is skipped in a server/v2 application as DecodeGenesisJSON takes precedence.
 func (am AppModule) InitGenesis(ctx context.Context, data json.RawMessage) ([]module.ValidatorUpdate, error) {
 	var genesisState types.GenesisState
-	am.cdc.MustUnmarshalJSON(data, &genesisState)
+	if err := am.cdc.UnmarshalJSON(data, &genesisState); err != nil {
+		panic(err)
+	}
 	return InitGenesis(ctx, am.stakingKeeper, am.deliverTx, genesisState, am.txEncodingConfig)
 }
 

--- a/x/genutil/module.go
+++ b/x/genutil/module.go
@@ -7,8 +7,8 @@ import (
 
 	"cosmossdk.io/core/appmodule"
 	appmodulev2 "cosmossdk.io/core/appmodule/v2"
-
 	"cosmossdk.io/core/codec"
+
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	"github.com/cosmos/cosmos-sdk/x/genutil/types"

--- a/x/genutil/types/genesis_state.go
+++ b/x/genutil/types/genesis_state.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"os"
 
+	"cosmossdk.io/core/codec"
 	stakingtypes "cosmossdk.io/x/staking/types"
 
-	"cosmossdk.io/core/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 

--- a/x/genutil/types/genesis_state.go
+++ b/x/genutil/types/genesis_state.go
@@ -7,7 +7,7 @@ import (
 
 	stakingtypes "cosmossdk.io/x/staking/types"
 
-	"github.com/cosmos/cosmos-sdk/codec"
+	"cosmossdk.io/core/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -47,7 +47,9 @@ func NewGenesisStateFromTx(txJSONEncoder sdk.TxEncoder, genTxs []sdk.Tx) *Genesi
 func GetGenesisStateFromAppState(cdc codec.JSONCodec, appState map[string]json.RawMessage) *GenesisState {
 	var genesisState GenesisState
 	if appState[ModuleName] != nil {
-		cdc.MustUnmarshalJSON(appState[ModuleName], &genesisState)
+		if err := cdc.UnmarshalJSON(appState[ModuleName], &genesisState); err != nil {
+			panic(err)
+		}
 	}
 	return &genesisState
 }
@@ -56,7 +58,10 @@ func GetGenesisStateFromAppState(cdc codec.JSONCodec, appState map[string]json.R
 func SetGenesisStateInAppState(
 	cdc codec.JSONCodec, appState map[string]json.RawMessage, genesisState *GenesisState,
 ) map[string]json.RawMessage {
-	genesisStateBz := cdc.MustMarshalJSON(genesisState)
+	genesisStateBz, err := cdc.MarshalJSON(genesisState)
+	if err != nil {
+		panic(err)
+	}
 	appState[ModuleName] = genesisStateBz
 	return appState
 }


### PR DESCRIPTION
# Description

Partially addresses: #23253