### PR TITLE
chore(x/feegrant): use `cosmossdk.io/core/codec` instead of `github.com/cosmos/cosmos-sdk/codec`

### DIFF
--- a/x/feegrant/migrations/v2/store.go
+++ b/x/feegrant/migrations/v2/store.go
@@ -4,11 +4,11 @@ import (
 	"context"
 
 	"cosmossdk.io/core/appmodule"
+	"cosmossdk.io/core/codec"
 	"cosmossdk.io/core/store"
 	"cosmossdk.io/store/prefix"
 	"cosmossdk.io/x/feegrant"
 
-	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/runtime"
 )
 

--- a/x/feegrant/module/module.go
+++ b/x/feegrant/module/module.go
@@ -10,13 +10,13 @@ import (
 	"google.golang.org/grpc"
 
 	"cosmossdk.io/core/appmodule"
+	"cosmossdk.io/core/codec"
 	"cosmossdk.io/core/registry"
 	"cosmossdk.io/errors"
 	"cosmossdk.io/x/feegrant"
 	"cosmossdk.io/x/feegrant/client/cli"
 	"cosmossdk.io/x/feegrant/keeper"
 
-	"cosmossdk.io/core/codec"
 	sdkclient "github.com/cosmos/cosmos-sdk/client"
 	cdctypes "github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/cosmos/cosmos-sdk/types/module"

--- a/x/feegrant/module/module.go
+++ b/x/feegrant/module/module.go
@@ -16,8 +16,8 @@ import (
 	"cosmossdk.io/x/feegrant/client/cli"
 	"cosmossdk.io/x/feegrant/keeper"
 
+	"cosmossdk.io/core/codec"
 	sdkclient "github.com/cosmos/cosmos-sdk/client"
-	"github.com/cosmos/cosmos-sdk/codec"
 	cdctypes "github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 )
@@ -103,7 +103,11 @@ func (am AppModule) RegisterMigrations(mr appmodule.MigrationRegistrar) error {
 
 // DefaultGenesis returns default genesis state as raw bytes for the feegrant module.
 func (am AppModule) DefaultGenesis() json.RawMessage {
-	return am.cdc.MustMarshalJSON(feegrant.DefaultGenesisState())
+	data, err := am.cdc.MarshalJSON(feegrant.DefaultGenesisState())
+	if err != nil {
+		panic(err)
+	}
+	return data
 }
 
 // ValidateGenesis performs genesis state validation for the feegrant module.

--- a/x/feegrant/simulation/decoder.go
+++ b/x/feegrant/simulation/decoder.go
@@ -6,6 +6,7 @@ import (
 
 	"cosmossdk.io/core/codec"
 	"cosmossdk.io/x/feegrant"
+
 	"github.com/cosmos/cosmos-sdk/types/kv"
 )
 

--- a/x/feegrant/simulation/decoder.go
+++ b/x/feegrant/simulation/decoder.go
@@ -4,9 +4,8 @@ import (
 	"bytes"
 	"fmt"
 
+	"cosmossdk.io/core/codec"
 	"cosmossdk.io/x/feegrant"
-
-	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/types/kv"
 )
 
@@ -17,8 +16,12 @@ func NewDecodeStore(cdc codec.Codec) func(kvA, kvB kv.Pair) string {
 		switch {
 		case bytes.Equal(kvA.Key[:1], feegrant.FeeAllowanceKeyPrefix):
 			var grantA, grantB feegrant.Grant
-			cdc.MustUnmarshal(kvA.Value, &grantA)
-			cdc.MustUnmarshal(kvB.Value, &grantB)
+			if err := cdc.Unmarshal(kvA.Value, &grantA); err != nil {
+				panic(err)
+			}
+			if err := cdc.Unmarshal(kvB.Value, &grantB); err != nil {
+				panic(err)
+			}
 			return fmt.Sprintf("%v\n%v", grantA, grantB)
 		default:
 			panic(fmt.Sprintf("invalid feegrant key %X", kvA.Key))


### PR DESCRIPTION
# Description

Partially addresses: #23253

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated codec dependency from `cosmos-sdk/codec` to `cosmossdk.io/core/codec`
	- Improved error handling in `DefaultGenesis` method and `NewDecodeStore` function
	- Replaced `MustMarshalJSON` and `MustUnmarshal` with methods that allow explicit error management

- **Chores**
	- Updated import statements to use new codec package

<!-- end of auto-generated comment: release notes by coderabbit.ai -->