### PR TITLE
chore(x/bank): use `cosmossdk.io/core/codec` instead of `github.com/cosmos/cosmos-sdk/codec`

### DIFF
--- a/x/bank/types/balance.go
+++ b/x/bank/types/balance.go
@@ -7,9 +7,9 @@ import (
 	"sort"
 
 	"cosmossdk.io/core/address"
+	"cosmossdk.io/core/codec"
 	"cosmossdk.io/x/bank/exported"
 
-	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 

--- a/x/bank/types/balance.go
+++ b/x/bank/types/balance.go
@@ -7,9 +7,9 @@ import (
 	"sort"
 
 	"cosmossdk.io/core/address"
-	"cosmossdk.io/core/codec"
 	"cosmossdk.io/x/bank/exported"
 
+	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 

--- a/x/bank/types/genesis.go
+++ b/x/bank/types/genesis.go
@@ -5,7 +5,8 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/cosmos/cosmos-sdk/codec"
+	"cosmossdk.io/core/codec"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -101,7 +102,9 @@ func GetGenesisStateFromAppState(cdc codec.JSONCodec, appState map[string]json.R
 	var genesisState GenesisState
 
 	if appState[ModuleName] != nil {
-		cdc.MustUnmarshalJSON(appState[ModuleName], &genesisState)
+		if err := cdc.UnmarshalJSON(appState[ModuleName], &genesisState); err != nil {
+			panic(err)
+		}
 	}
 
 	return &genesisState

--- a/x/bank/v2/module.go
+++ b/x/bank/v2/module.go
@@ -8,12 +8,11 @@ import (
 	"github.com/spf13/cobra"
 
 	appmodulev2 "cosmossdk.io/core/appmodule/v2"
+	"cosmossdk.io/core/codec"
 	"cosmossdk.io/core/registry"
 	"cosmossdk.io/x/bank/v2/client/cli"
 	"cosmossdk.io/x/bank/v2/keeper"
 	"cosmossdk.io/x/bank/v2/types"
-
-	"github.com/cosmos/cosmos-sdk/codec"
 )
 
 // ConsensusVersion defines the current x/bank/v2 module consensus version.
@@ -58,7 +57,11 @@ func (AppModule) RegisterInterfaces(registrar registry.InterfaceRegistrar) {
 
 // DefaultGenesis returns default genesis state as raw bytes for the bank module.
 func (am AppModule) DefaultGenesis() json.RawMessage {
-	return am.cdc.MustMarshalJSON(types.DefaultGenesisState())
+	data, err := am.cdc.MarshalJSON(types.DefaultGenesisState())
+	if err != nil {
+		panic(err)
+	}
+	return data
 }
 
 // ValidateGenesis performs genesis state validation for the bank module.


### PR DESCRIPTION
# Description

Partially addresses: #23253