### PR TITLE
chore(x/distribution): use `cosmossdk.io/core/codec` instead of `github.com/cosmos/cosmos-sdk/codec`

### DIFF
--- a/x/distribution/migrations/v4/migrate.go
+++ b/x/distribution/migrations/v4/migrate.go
@@ -7,9 +7,9 @@ import (
 	gogotypes "github.com/cosmos/gogoproto/types"
 
 	"cosmossdk.io/core/appmodule"
+	"cosmossdk.io/core/codec"
 	"cosmossdk.io/core/store"
 
-	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -46,6 +46,9 @@ func GetPreviousProposerConsAddr(ctx context.Context, storeService store.KVStore
 // SetPreviousProposerConsAddr set the proposer public key for this block.
 func SetPreviousProposerConsAddr(ctx context.Context, storeService store.KVStoreService, cdc codec.BinaryCodec, consAddr sdk.ConsAddress) error {
 	kvStore := storeService.OpenKVStore(ctx)
-	bz := cdc.MustMarshal(&gogotypes.BytesValue{Value: consAddr})
+	bz, err := cdc.Marshal(&gogotypes.BytesValue{Value: consAddr})
+	if err != nil {
+		panic(err)
+	}
 	return kvStore.Set(OldProposerKey, bz)
 }

--- a/x/distribution/module.go
+++ b/x/distribution/module.go
@@ -11,6 +11,7 @@ import (
 
 	"cosmossdk.io/collections"
 	"cosmossdk.io/core/appmodule"
+	"cosmossdk.io/core/codec"
 	"cosmossdk.io/core/registry"
 	"cosmossdk.io/schema"
 	"cosmossdk.io/x/distribution/client/cli"
@@ -19,7 +20,6 @@ import (
 	"cosmossdk.io/x/distribution/types"
 
 	sdkclient "github.com/cosmos/cosmos-sdk/client"
-	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/simsx"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
@@ -115,7 +115,11 @@ func (am AppModule) RegisterMigrations(mr appmodule.MigrationRegistrar) error {
 
 // DefaultGenesis returns default genesis state as raw bytes for the distribution module.
 func (am AppModule) DefaultGenesis() json.RawMessage {
-	return am.cdc.MustMarshalJSON(types.DefaultGenesisState())
+	data, err := am.cdc.MarshalJSON(types.DefaultGenesisState())
+	if err != nil {
+		panic(err)
+	}
+	return data
 }
 
 // ValidateGenesis performs genesis state validation for the distribution module.

--- a/x/distribution/simulation/decoder.go
+++ b/x/distribution/simulation/decoder.go
@@ -4,9 +4,9 @@ import (
 	"bytes"
 	"fmt"
 
+	"cosmossdk.io/core/codec"
 	"cosmossdk.io/x/distribution/types"
 
-	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/kv"
 )
@@ -18,14 +18,22 @@ func NewDecodeStore(cdc codec.Codec) func(kvA, kvB kv.Pair) string {
 		switch {
 		case bytes.Equal(kvA.Key[:1], types.FeePoolKey):
 			var feePoolA, feePoolB types.FeePool
-			cdc.MustUnmarshal(kvA.Value, &feePoolA)
-			cdc.MustUnmarshal(kvB.Value, &feePoolB)
+			if err := cdc.Unmarshal(kvA.Value, &feePoolA); err != nil {
+				panic(err)
+			}
+			if err := cdc.Unmarshal(kvB.Value, &feePoolB); err != nil {
+				panic(err)
+			}
 			return fmt.Sprintf("%v\n%v", feePoolA, feePoolB)
 
 		case bytes.Equal(kvA.Key[:1], types.ValidatorOutstandingRewardsPrefix):
 			var rewardsA, rewardsB types.ValidatorOutstandingRewards
-			cdc.MustUnmarshal(kvA.Value, &rewardsA)
-			cdc.MustUnmarshal(kvB.Value, &rewardsB)
+			if err := cdc.Unmarshal(kvA.Value, &rewardsA); err != nil {
+				panic(err)
+			}
+			if err := cdc.Unmarshal(kvB.Value, &rewardsB); err != nil {
+				panic(err)
+			}
 			return fmt.Sprintf("%v\n%v", rewardsA, rewardsB)
 
 		case bytes.Equal(kvA.Key[:1], types.DelegatorWithdrawAddrPrefix):
@@ -33,32 +41,52 @@ func NewDecodeStore(cdc codec.Codec) func(kvA, kvB kv.Pair) string {
 
 		case bytes.Equal(kvA.Key[:1], types.DelegatorStartingInfoPrefix):
 			var infoA, infoB types.DelegatorStartingInfo
-			cdc.MustUnmarshal(kvA.Value, &infoA)
-			cdc.MustUnmarshal(kvB.Value, &infoB)
+			if err := cdc.Unmarshal(kvA.Value, &infoA); err != nil {
+				panic(err)
+			}
+			if err := cdc.Unmarshal(kvB.Value, &infoB); err != nil {
+				panic(err)
+			}
 			return fmt.Sprintf("%v\n%v", infoA, infoB)
 
 		case bytes.Equal(kvA.Key[:1], types.ValidatorHistoricalRewardsPrefix):
 			var rewardsA, rewardsB types.ValidatorHistoricalRewards
-			cdc.MustUnmarshal(kvA.Value, &rewardsA)
-			cdc.MustUnmarshal(kvB.Value, &rewardsB)
+			if err := cdc.Unmarshal(kvA.Value, &rewardsA); err != nil {
+				panic(err)
+			}
+			if err := cdc.Unmarshal(kvB.Value, &rewardsB); err != nil {
+				panic(err)
+			}
 			return fmt.Sprintf("%v\n%v", rewardsA, rewardsB)
 
 		case bytes.Equal(kvA.Key[:1], types.ValidatorCurrentRewardsPrefix):
 			var rewardsA, rewardsB types.ValidatorCurrentRewards
-			cdc.MustUnmarshal(kvA.Value, &rewardsA)
-			cdc.MustUnmarshal(kvB.Value, &rewardsB)
+			if err := cdc.Unmarshal(kvA.Value, &rewardsA); err != nil {
+				panic(err)
+			}
+			if err := cdc.Unmarshal(kvB.Value, &rewardsB); err != nil {
+				panic(err)
+			}
 			return fmt.Sprintf("%v\n%v", rewardsA, rewardsB)
 
 		case bytes.Equal(kvA.Key[:1], types.ValidatorAccumulatedCommissionPrefix):
 			var commissionA, commissionB types.ValidatorAccumulatedCommission
-			cdc.MustUnmarshal(kvA.Value, &commissionA)
-			cdc.MustUnmarshal(kvB.Value, &commissionB)
+			if err := cdc.Unmarshal(kvA.Value, &commissionA); err != nil {
+				panic(err)
+			}
+			if err := cdc.Unmarshal(kvB.Value, &commissionB); err != nil {
+				panic(err)
+			}
 			return fmt.Sprintf("%v\n%v", commissionA, commissionB)
 
 		case bytes.Equal(kvA.Key[:1], types.ValidatorSlashEventPrefix):
 			var eventA, eventB types.ValidatorSlashEvent
-			cdc.MustUnmarshal(kvA.Value, &eventA)
-			cdc.MustUnmarshal(kvB.Value, &eventB)
+			if err := cdc.Unmarshal(kvA.Value, &eventA); err != nil {
+				panic(err)
+			}
+			if err := cdc.Unmarshal(kvB.Value, &eventB); err != nil {
+				panic(err)
+			}
 			return fmt.Sprintf("%v\n%v", eventA, eventB)
 
 		default:


### PR DESCRIPTION
# Description

Partially addresses: #23253

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Dependency Updates**
  - Updated codec library from Cosmos SDK to cosmossdk.io/core

- **Error Handling Improvements**
  - Enhanced marshaling and unmarshaling error handling across distribution module
  - Added explicit error checks and panic mechanisms for codec operations

- **Migration Changes**
  - Updated import statements and method implementations in migration files
  - Improved robustness of JSON and binary encoding processes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->