### PR TITLE
chore(x/consensus,x/epochs,x/circuit): use `cosmossdk.io/core/codec` instead of `github.com/cosmos/cosmos-sdk/codec`

### DIFF
--- a/x/circuit/module.go
+++ b/x/circuit/module.go
@@ -11,6 +11,7 @@ import (
 	"cosmossdk.io/collections"
 	"cosmossdk.io/core/appmodule"
 	appmodulev2 "cosmossdk.io/core/appmodule/v2"
+	"cosmossdk.io/core/codec"
 	"cosmossdk.io/core/registry"
 	"cosmossdk.io/core/transaction"
 	"cosmossdk.io/schema"
@@ -19,7 +20,6 @@ import (
 	"cosmossdk.io/x/circuit/types"
 
 	"github.com/cosmos/cosmos-sdk/client"
-	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/types/module"
 )
 
@@ -81,7 +81,11 @@ func (AppModule) ConsensusVersion() uint64 { return ConsensusVersion }
 
 // DefaultGenesis returns default genesis state as raw bytes for the circuit module.
 func (am AppModule) DefaultGenesis() json.RawMessage {
-	return am.cdc.MustMarshalJSON(types.DefaultGenesisState())
+	data, err := am.cdc.MarshalJSON(types.DefaultGenesisState())
+	if err != nil {
+		panic(err)
+	}
+	return data
 }
 
 // ValidateGenesis performs genesis state validation for the circuit module.

--- a/x/consensus/module.go
+++ b/x/consensus/module.go
@@ -9,13 +9,13 @@ import (
 
 	"cosmossdk.io/collections"
 	"cosmossdk.io/core/appmodule"
+	"cosmossdk.io/core/codec"
 	"cosmossdk.io/core/registry"
 	"cosmossdk.io/schema"
 	"cosmossdk.io/x/consensus/keeper"
 	"cosmossdk.io/x/consensus/types"
 
 	"github.com/cosmos/cosmos-sdk/client"
-	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/types/module"
 )
 

--- a/x/epochs/module.go
+++ b/x/epochs/module.go
@@ -10,6 +10,7 @@ import (
 
 	"cosmossdk.io/collections"
 	"cosmossdk.io/core/appmodule"
+	"cosmossdk.io/core/codec"
 	"cosmossdk.io/core/registry"
 	"cosmossdk.io/schema"
 	"cosmossdk.io/x/epochs/keeper"
@@ -17,7 +18,6 @@ import (
 	"cosmossdk.io/x/epochs/types"
 
 	"github.com/cosmos/cosmos-sdk/client"
-	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
 )
@@ -75,7 +75,11 @@ func (am AppModule) RegisterServices(registrar grpc.ServiceRegistrar) error {
 
 // DefaultGenesis returns the epochs module's default genesis state.
 func (am AppModule) DefaultGenesis() json.RawMessage {
-	return am.cdc.MustMarshalJSON(types.DefaultGenesis())
+	data, err := am.cdc.MarshalJSON(types.DefaultGenesis())
+	if err != nil {
+		panic(err)
+	}
+	return data
 }
 
 // ValidateGenesis performs genesis state validation for the epochs module.


### PR DESCRIPTION
# Description

Partially addresses: #23253

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Dependencies**
  - Updated codec imports from Cosmos SDK to Cosmossdk core library across multiple modules

- **Error Handling**
  - Improved JSON marshaling error handling in `DefaultGenesis` methods
  - Added explicit error checking during default genesis state generation

- **Maintenance**
  - Refactored codec-related code to use newer library dependencies
  - Ensured consistent error management in module initialization processes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->