### PR TITLE
fix(schema): fix `make lint-fix` reports error

### DIFF
--- a/schema/appdata/mux.go
+++ b/schema/appdata/mux.go
@@ -138,8 +138,8 @@ func ListenerMux(listeners ...Listener) Listener {
 	}
 
 	mux.onBatch = func(batch PacketBatch) error {
-		for _, listener := range listeners {
-			err := batch.apply(&listener)
+		for i := range listeners {
+			err := batch.apply(&listeners[i])
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
# Description

Fixes the error reported by running `make lint-fix`

```shell
appdata/mux.go:142:23: G601: Implicit memory aliasing in for loop. (gosec)
                        err := batch.apply(&listener)
                                           ^
linting module cosmossdk.io/schema/testing [2025-01-14T08:44:51+00:00]
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved internal listener handling mechanism in the application's event processing logic
	- Optimized slice iteration method to ensure accurate listener referencing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->