### PR TITLE
docs: fix autocli for non module commands example code link

### DIFF
--- a/client/v2/README.md
+++ b/client/v2/README.md
@@ -252,7 +252,7 @@ It is possible to use `AutoCLI` for non module commands. The trick is still to i
 For example, here is how the SDK does it for `cometbft` gRPC commands:
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/main/client/grpc/cmtservice/autocli.go#L52-L71
+https://github.com/cosmos/cosmos-sdk/blob/release/v0.52.x/client/grpc/cmtservice/autocli.go#L52-L71
 ```
 
 #### Conventions for the `Use` field in Cobra


### PR DESCRIPTION
# Description

Use the versioned release link instead of using the main branch