### PR TITLE
Typo fix grpc_test.go

### DIFF
--- a/tests/systemtests/grpc_test.go
+++ b/tests/systemtests/grpc_test.go
@@ -33,7 +33,7 @@ func TestGRPC(t *testing.T) {
 	require.Greater(t, len(services), 0)
 	require.Contains(t, services, "cosmos.staking.v1beta1.Query")
 
-	// test query invokation
+	// test query invocation
 	rf, formatter, err := grpcurl.RequestParserAndFormatter(grpcurl.FormatText, descSource, os.Stdin, grpcurl.FormatOptions{})
 	require.NoError(t, err)
 


### PR DESCRIPTION
## Pull Request Title
fix: typo correction in grpc_test.go ("invokation" to "invocation")

### Description
This pull request addresses a typo in the `grpc_test.go` file where "invokation" was used instead of the correct spelling, "invocation."

### Changes Made
- Corrected the typo "invokation" to "invocation" in the test comment.

### Related Issues
- N/A

### Additional Notes
- This fix ensures that the comments in the code follow standard spelling conventions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Corrected spelling of "invocation" in a test comment
	- No functional changes to the test code

<!-- end of auto-generated comment: release notes by coderabbit.ai -->