### PR TITLE
Fix GitHub Markdown compatibility for notes

### DIFF
--- a/docs/learn/beginner/00-app-anatomy.md
+++ b/docs/learn/beginner/00-app-anatomy.md
@@ -4,9 +4,9 @@ sidebar_position: 1
 
 # Anatomy of a Cosmos SDK Application
 
-:::note Synopsis
-This document describes the core parts of a Cosmos SDK application, represented throughout the document as a placeholder application named `app`.
-:::
+> **Synopsis**
+>  
+> This document describes the core parts of a Cosmos SDK application, represented throughout the document as a placeholder application named `app`.
 
 ## Node Client
 
@@ -47,9 +47,8 @@ Once the main binary is built, the node can be started by running the [`start` c
 2. Initialize the state-machine with the latest known state, extracted from the `db` stored in the `~/.app/data` folder. At this point, the state-machine is at height `appBlockHeight`.
 3. Create and start a new CometBFT instance. Among other things, the node performs a handshake with its peers. It gets the latest `blockHeight` from them and replays blocks to sync to this height if it is greater than the local `appBlockHeight`. The node starts from genesis and CometBFT sends an `InitChain` message via the ABCI to the `app`, which triggers the [`InitChainer`](#initchainer).
 
-:::note
-When starting a CometBFT instance, the genesis file is the `0` height and the state within the genesis file is committed at block height `1`. When querying the state of the node, querying block height 0 will return an error.
-::: 
+> When starting a CometBFT instance, the genesis file is the `0` height and the state within the genesis file is committed at block height `1`.  
+> When querying the state of the node, querying block height `0` will return an error.
 
 ## Core Application File
 


### PR DESCRIPTION
# docs: Replace unsupported :::note syntax with GitHub-compatible Markdown

## Description

This PR replaces unsupported `:::note` syntax with GitHub-compatible Markdown to improve rendering on GitHub. Specifically:  
- Converted `:::note` blocks into blockquotes (`>`) for better readability.  
---

## Before
<img width="1060" alt="image" src="https://github.com/user-attachments/assets/ed7b9035-21bd-4f24-91c1-5526a3c91f0c" />

## After 
<img width="1022" alt="image" src="https://github.com/user-attachments/assets/d749ef88-ad66-44d7-863c-0b3065c8d1f7" />

