### PR TITLE
chore(sims): Complete sims integration for app v2

### DIFF
--- a/scripts/build/simulations.mk
+++ b/scripts/build/simulations.mk
@@ -21,12 +21,6 @@ test-sim-nondeterminism-streaming:
 	# @cd ${CURRENT_DIR}/simapp && go test -failfast -mod=readonly -timeout=30m -tags='sims' -run TestAppStateDeterminism \
 	# 	-NumBlocks=100 -BlockSize=200 -EnableStreaming=true
 
-test-sim-custom-genesis-fast:
-	# @echo "Running custom genesis simulation..."
-	# @echo "By default, ${HOME}/.simapp/config/genesis.json will be used."
-	# @cd ${CURRENT_DIR}/simapp && go test -failfast -mod=readonly -timeout=30m -tags='sims' -run TestFullAppSimulation -Genesis=${HOME}/.simapp/config/genesis.json \
-	# 	-NumBlocks=100 -BlockSize=200 -Seed=99  -SigverifyTx=false
-
 test-sim-import-export:
 	 @echo "Running application import/export simulation. This may take several minutes..."
 	 @cd ${CURRENT_DIR}/simapp/v2 && go test -failfast -mod=readonly -timeout 20m -tags='sims' -run TestAppImportExport \
@@ -37,11 +31,6 @@ test-sim-after-import:
 	 @cd ${CURRENT_DIR}/simapp/v2 && go test -failfast -mod=readonly -timeout 30m -tags='sims' -run TestAppSimulationAfterImport \
 	 	-NumBlocks=50
 
-test-sim-custom-genesis-multi-seed:
-	# @echo "Running multi-seed custom genesis simulation..."
-	# @echo "By default, ${HOME}/.simapp/config/genesis.json will be used."
-	# @cd ${CURRENT_DIR}/simapp/v2 && go test -failfast -mod=readonly -timeout 30m -tags='sims' -run TestFullAppSimulation -Genesis=${HOME}/.simapp/config/genesis.json \
-	# 	-NumBlocks=400
 
 test-sim-multi-seed-long:
 	 @echo "Running long multi-seed application simulation. This may take awhile!"
@@ -56,10 +45,8 @@ test-sim-multi-seed-short:
 .PHONY: \
 test-sim-nondeterminism \
 test-sim-nondeterminism-streaming \
-test-sim-custom-genesis-fast \
 test-sim-import-export \
 test-sim-after-import \
-test-sim-custom-genesis-multi-seed \
 test-sim-multi-seed-short \
 test-sim-multi-seed-long \
 

--- a/scripts/build/simulations.mk
+++ b/scripts/build/simulations.mk
@@ -1,25 +1,9 @@
-# TODO: This should be ported to work with SimApp v2.
 
 #? test-sim-nondeterminism: Run non-determinism test for simapp
 test-sim-nondeterminism:
 	 @echo "Running non-determinism test..."
 	 @cd ${CURRENT_DIR}/simapp/v2 && go test -failfast -mod=readonly -timeout=30m -tags='sims' -run TestAppStateDeterminism \
 	   	-NumBlocks=100 -BlockSize=200
-
-
-# Requires an exported plugin. See store/streaming/README.md for documentation.
-#
-# example:
-#   export COSMOS_SDK_ABCI_V1=<path-to-plugin-binary>
-#   make test-sim-nondeterminism-streaming
-#
-# Using the built-in examples:
-#   export COSMOS_SDK_ABCI_V1=<path-to-sdk>/store/streaming/abci/examples/file/file
-#   make test-sim-nondeterminism-streaming
-test-sim-nondeterminism-streaming:
-	# @echo "Running non-determinism-streaming test..."
-	# @cd ${CURRENT_DIR}/simapp && go test -failfast -mod=readonly -timeout=30m -tags='sims' -run TestAppStateDeterminism \
-	# 	-NumBlocks=100 -BlockSize=200 -EnableStreaming=true
 
 test-sim-import-export:
 	 @echo "Running application import/export simulation. This may take several minutes..."
@@ -44,7 +28,6 @@ test-sim-multi-seed-short:
 
 .PHONY: \
 test-sim-nondeterminism \
-test-sim-nondeterminism-streaming \
 test-sim-import-export \
 test-sim-after-import \
 test-sim-multi-seed-short \

--- a/server/v2/appmanager/CHANGELOG.md
+++ b/server/v2/appmanager/CHANGELOG.md
@@ -22,8 +22,6 @@ Each entry must include the Github issue reference in the following format:
 
 ## [Unreleased]
 
-* [#23013](https://github.com/cosmos/cosmos-sdk/pull/23013) Add TransactionFuzzer as entrypoint for sims
-
 
 ## [v1.0.0-beta.2](https://github.com/cosmos/cosmos-sdk/releases/tag/server/v2/appmanager%2Fv1.0.0-beta.2)
 

--- a/server/v2/appmanager/CHANGELOG.md
+++ b/server/v2/appmanager/CHANGELOG.md
@@ -22,6 +22,9 @@ Each entry must include the Github issue reference in the following format:
 
 ## [Unreleased]
 
+* [#23013](https://github.com/cosmos/cosmos-sdk/pull/23013) Add TransactionFuzzer as entrypoint for sims
+
+
 ## [v1.0.0-beta.2](https://github.com/cosmos/cosmos-sdk/releases/tag/server/v2/appmanager%2Fv1.0.0-beta.2)
 
 * [#23013](https://github.com/cosmos/cosmos-sdk/pull/23013) Introduce `TransactionFuzzer`, an interface for processing and generated state transitions.

--- a/server/v2/cometbft/abci.go
+++ b/server/v2/cometbft/abci.go
@@ -519,7 +519,7 @@ func (c *consensus[T]) FinalizeBlock(
 	events = append(events, resp.EndBlockEvents...)
 
 	// listen to state streaming changes in accordance with the block
-	err = c.streamDeliverBlockChanges(ctx, req.Height, req.Txs, decodedTxs, resp.TxResults, events, stateChanges)
+	err = c.streamDeliverBlockChanges(ctx, req.Height, req.Txs, decodedTxs, *resp, stateChanges)
 	if err != nil {
 		return nil, err
 	}

--- a/server/v2/cometbft/abci.go
+++ b/server/v2/cometbft/abci.go
@@ -18,7 +18,6 @@ import (
 	appmodulev2 "cosmossdk.io/core/appmodule/v2"
 	"cosmossdk.io/core/comet"
 	corecontext "cosmossdk.io/core/context"
-	"cosmossdk.io/core/event"
 	"cosmossdk.io/core/server"
 	"cosmossdk.io/core/store"
 	"cosmossdk.io/core/transaction"
@@ -509,14 +508,6 @@ func (c *consensus[T]) FinalizeBlock(
 	if err != nil {
 		return nil, fmt.Errorf("unable to commit the changeset: %w", err)
 	}
-
-	var events []event.Event
-	events = append(events, resp.PreBlockEvents...)
-	events = append(events, resp.BeginBlockEvents...)
-	for _, tx := range resp.TxResults {
-		events = append(events, tx.Events...)
-	}
-	events = append(events, resp.EndBlockEvents...)
 
 	// listen to state streaming changes in accordance with the block
 	err = c.streamDeliverBlockChanges(ctx, req.Height, req.Txs, decodedTxs, *resp, stateChanges)

--- a/server/v2/cometbft/streaming.go
+++ b/server/v2/cometbft/streaming.go
@@ -2,7 +2,9 @@ package cometbft
 
 import (
 	"context"
+	"cosmossdk.io/core/transaction"
 	"encoding/json"
+	"fmt"
 
 	"cosmossdk.io/core/event"
 	"cosmossdk.io/core/server"
@@ -18,14 +20,69 @@ func (c *consensus[T]) streamDeliverBlockChanges(
 	height int64,
 	txs [][]byte,
 	decodedTxs []T,
-	txResults []server.TxResult,
-	events []event.Event,
+	blockResp server.BlockResponse,
 	stateChanges []store.StateChanges,
 ) error {
+	return StreamOut(ctx, height, txs, decodedTxs, blockResp, stateChanges, c.streamingManager, c.listener, c.cfg.AppTomlConfig.Trace, c.logger.Error)
+}
+
+// StreamOut stream all the changes happened during deliver block.
+func StreamOut[T transaction.Tx](
+	ctx context.Context,
+	height int64,
+	rawTXs [][]byte,
+	decodedTXs []T,
+	blockRsp server.BlockResponse,
+	stateChanges []store.StateChanges,
+	streamingManager streaming.Manager,
+	listener *appdata.Listener,
+	traceErrs bool,
+	logErrFn func(msg string, keyVals ...any),
+) error {
+	var events []event.Event
+	events = append(events, blockRsp.PreBlockEvents...)
+	events = append(events, blockRsp.BeginBlockEvents...)
+	for _, tx := range blockRsp.TxResults {
+		events = append(events, tx.Events...)
+	}
+	events = append(events, blockRsp.EndBlockEvents...)
+	txResults := blockRsp.TxResults
+
+	err := doServeStreamListeners(
+		ctx,
+		height,
+		rawTXs,
+		txResults,
+		traceErrs,
+		streamingManager,
+		events,
+		logErrFn,
+		stateChanges,
+	)
+	if err != nil {
+		return err
+	}
+	return doServeHookListener(listener, height, rawTXs, decodedTXs, events, stateChanges)
+}
+
+func doServeStreamListeners(
+	ctx context.Context,
+	height int64,
+	rawTXs [][]byte,
+	txResults []server.TxResult,
+	traceErrs bool,
+	streamingManager streaming.Manager,
+	events []event.Event,
+	logErrFn func(msg string, keyVals ...any),
+	stateChanges []store.StateChanges,
+) error {
+	if len(streamingManager.Listeners) == 0 {
+		return nil
+	}
 	// convert txresults to streaming txresults
 	streamingTxResults := make([]*streaming.ExecTxResult, len(txResults))
 	for i, txResult := range txResults {
-		space, code, log := errorsmod.ABCIInfo(txResult.Error, c.cfg.AppTomlConfig.Trace)
+		space, code, log := errorsmod.ABCIInfo(txResult.Error, traceErrs)
 
 		events, err := streaming.IntoStreamingEvents(txResult.Events)
 		if err != nil {
@@ -42,31 +99,47 @@ func (c *consensus[T]) streamDeliverBlockChanges(
 		}
 	}
 
-	for _, streamingListener := range c.streamingManager.Listeners {
+	for _, streamingListener := range streamingManager.Listeners {
 		events, err := streaming.IntoStreamingEvents(events)
 		if err != nil {
 			return err
 		}
 		if err := streamingListener.ListenDeliverBlock(ctx, streaming.ListenDeliverBlockRequest{
 			BlockHeight: height,
-			Txs:         txs,
+			Txs:         rawTXs,
 			TxResults:   streamingTxResults,
 			Events:      events,
 		}); err != nil {
-			c.logger.Error("ListenDeliverBlock listening hook failed", "height", height, "err", err)
+			if streamingManager.StopNodeOnErr {
+				return fmt.Errorf("listen deliver block: %w", err)
+			}
+			logErrFn("ListenDeliverBlock listening hook failed", "height", height, "err", err)
 		}
 
 		if err := streamingListener.ListenStateChanges(ctx, intoStreamingKVPairs(stateChanges)); err != nil {
-			c.logger.Error("ListenStateChanges listening hook failed", "height", height, "err", err)
+			if streamingManager.StopNodeOnErr {
+				return fmt.Errorf("listen state changes: %w", err)
+			}
+			logErrFn("ListenStateChanges listening hook failed", "height", height, "err", err)
 		}
 	}
+	return nil
+}
 
-	if c.listener == nil {
+func doServeHookListener[T transaction.Tx](
+	listener *appdata.Listener,
+	height int64,
+	rawTXs [][]byte,
+	decodedTXs []T,
+	events []event.Event,
+	stateChanges []store.StateChanges,
+) error {
+	if listener == nil {
 		return nil
 	}
 	// stream the StartBlockData to the listener.
-	if c.listener.StartBlock != nil {
-		if err := c.listener.StartBlock(appdata.StartBlockData{
+	if listener.StartBlock != nil {
+		if err := listener.StartBlock(appdata.StartBlockData{
 			Height:      uint64(height),
 			HeaderBytes: nil, // TODO: https://github.com/cosmos/cosmos-sdk/issues/22009
 			HeaderJSON:  nil, // TODO: https://github.com/cosmos/cosmos-sdk/issues/22009
@@ -75,14 +148,14 @@ func (c *consensus[T]) streamDeliverBlockChanges(
 		}
 	}
 	// stream the TxData to the listener.
-	if c.listener.OnTx != nil {
-		for i, tx := range txs {
-			if err := c.listener.OnTx(appdata.TxData{
+	if listener.OnTx != nil {
+		for i, tx := range rawTXs {
+			if err := listener.OnTx(appdata.TxData{
 				BlockNumber: uint64(height),
 				TxIndex:     int32(i),
 				Bytes:       func() ([]byte, error) { return tx, nil },
 				JSON: func() (json.RawMessage, error) {
-					return json.Marshal(decodedTxs[i])
+					return json.Marshal(decodedTXs[i])
 				},
 			}); err != nil {
 				return err
@@ -90,20 +163,20 @@ func (c *consensus[T]) streamDeliverBlockChanges(
 		}
 	}
 	// stream the EventData to the listener.
-	if c.listener.OnEvent != nil {
-		if err := c.listener.OnEvent(appdata.EventData{Events: events}); err != nil {
+	if listener.OnEvent != nil {
+		if err := listener.OnEvent(appdata.EventData{Events: events}); err != nil {
 			return err
 		}
 	}
 	// stream the KVPairData to the listener.
-	if c.listener.OnKVPair != nil {
-		if err := c.listener.OnKVPair(appdata.KVPairData{Updates: stateChanges}); err != nil {
+	if listener.OnKVPair != nil {
+		if err := listener.OnKVPair(appdata.KVPairData{Updates: stateChanges}); err != nil {
 			return err
 		}
 	}
 	// stream the CommitData to the listener.
-	if c.listener.Commit != nil {
-		if completionCallback, err := c.listener.Commit(appdata.CommitData{}); err != nil {
+	if listener.Commit != nil {
+		if completionCallback, err := listener.Commit(appdata.CommitData{}); err != nil {
 			return err
 		} else if completionCallback != nil {
 			if err := completionCallback(); err != nil {

--- a/server/v2/cometbft/streaming.go
+++ b/server/v2/cometbft/streaming.go
@@ -2,13 +2,13 @@ package cometbft
 
 import (
 	"context"
-	"cosmossdk.io/core/transaction"
 	"encoding/json"
 	"fmt"
 
 	"cosmossdk.io/core/event"
 	"cosmossdk.io/core/server"
 	"cosmossdk.io/core/store"
+	"cosmossdk.io/core/transaction"
 	errorsmod "cosmossdk.io/errors/v2"
 	"cosmossdk.io/schema/appdata"
 	"cosmossdk.io/server/v2/streaming"

--- a/server/v2/stf/CHANGELOG.md
+++ b/server/v2/stf/CHANGELOG.md
@@ -22,6 +22,9 @@ Each entry must include the Github issue reference in the following format:
 
 ## [Unreleased]
 
+* [#23013](https://github.com/cosmos/cosmos-sdk/pull/23013) Add DeliverSims entrypoint for sims
+
+
 ## [v1.0.0-beta.2](https://github.com/cosmos/cosmos-sdk/releases/tag/server/v2/stf%2Fv1.0.0-beta.2)
 
 * [#23013](https://github.com/cosmos/cosmos-sdk/pull/23013) Introduce `DeliverSims`, an interface for state transitions by sims.

--- a/server/v2/stf/CHANGELOG.md
+++ b/server/v2/stf/CHANGELOG.md
@@ -22,8 +22,6 @@ Each entry must include the Github issue reference in the following format:
 
 ## [Unreleased]
 
-* [#23013](https://github.com/cosmos/cosmos-sdk/pull/23013) Add DeliverSims entrypoint for sims
-
 
 ## [v1.0.0-beta.2](https://github.com/cosmos/cosmos-sdk/releases/tag/server/v2/stf%2Fv1.0.0-beta.2)
 

--- a/simapp/v2/go.mod
+++ b/simapp/v2/go.mod
@@ -51,6 +51,8 @@ require (
 	google.golang.org/protobuf v1.36.3
 )
 
+require cosmossdk.io/schema v1.0.0
+
 require (
 	buf.build/gen/go/cometbft/cometbft/protocolbuffers/go v1.36.3-20241120201313-68e42a58b301.1 // indirect
 	buf.build/gen/go/cosmos/gogo-proto/protocolbuffers/go v1.36.3-20240130113600-88ef6483f90f.1 // indirect
@@ -64,7 +66,6 @@ require (
 	cosmossdk.io/core/testing v0.0.1 // indirect
 	cosmossdk.io/errors v1.0.1 // indirect
 	cosmossdk.io/errors/v2 v2.0.0 // indirect
-	cosmossdk.io/schema v1.0.0 // indirect
 	cosmossdk.io/server/v2/stf v1.0.0-beta.2 // indirect
 	cosmossdk.io/store v1.10.0-rc.1.0.20241218084712-ca559989da43 // indirect
 	cosmossdk.io/x/tx v1.0.1 // indirect

--- a/simapp/v2/sim_runner.go
+++ b/simapp/v2/sim_runner.go
@@ -522,12 +522,16 @@ func doMainLoop[T Tx](
 		txTotalCounter += txPerBlockCounter
 		cs.ActiveValidatorSet = cs.ActiveValidatorSet.Update(blockRsp.ValidatorUpdates)
 
+		if len(testInstance.StreamManager.Listeners) == 0 && testInstance.StreamHook == nil {
+			continue
+		}
 		// stream data
 		strmCtx, cancel := context.WithTimeout(rootCtx, time.Second)
+		rawTxs := simsx.Collect(blockReqN.Txs, func(a T) []byte { return a.Bytes() })
 		require.NoError(tb, cometbft.StreamOut[T](
 			strmCtx,
 			int64(blockReqN.Height),
-			[][]byte{},
+			rawTxs,
 			blockReqN.Txs,
 			*blockRsp,
 			changeSet,

--- a/store/CHANGELOG.md
+++ b/store/CHANGELOG.md
@@ -31,10 +31,6 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
-### Improvements
-
-* [#23013](https://github.com/cosmos/cosmos-sdk/pull/23013) Support memDB for sims
-
 
 ## v1.10.0 (December 13, 2024)
 

--- a/store/CHANGELOG.md
+++ b/store/CHANGELOG.md
@@ -31,6 +31,11 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
+### Improvements
+
+* [#23013](https://github.com/cosmos/cosmos-sdk/pull/23013) Support memDB for sims
+
+
 ## v1.10.0 (December 13, 2024)
 
 ### Improvements

--- a/store/v2/CHANGELOG.md
+++ b/store/v2/CHANGELOG.md
@@ -25,6 +25,11 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
+### Improvements
+
+* [#23013](https://github.com/cosmos/cosmos-sdk/pull/23013) Support memDB for sims
+
+
 ## [v2.0.0-beta.2](https://github.com/cosmos/cosmos-sdk/releases/tag/store/v2.0.0-beta.2)
 
 * [#22336](https://github.com/cosmos/cosmos-sdk/pull/22336) Finish migration manager.


### PR DESCRIPTION
# Description

Closes: #23265

* Remove `genesis` sims targets . Background: they are not going to work without the private account keys for signing
* Remove  `streaming` sims targets. Background: there are 2 models of streaming support in the SDK which integrate on the [v2/cometbft](https://github.com/cosmos/cosmos-sdk/pull/22695/files#diff-7b7a7596b7540b60992d38884da7f9e591a2a23c8a7e8af0556330be5c0f3e24) level. Sims are one layer above on the appmanager. While I added support to the v2 sims runner, I don't see much value in providing a setup for the listener side already. There are unit tests in place for the streaming logic.
* Address todos and minor cleanup
* Changelogs

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title, you can find examples of the prefixes below:
    <!-- * `feat`: A new feature
    * `fix`: A bug fix
    * `docs`: Documentation only changes
    * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
    * `refactor`: A code change that neither fixes a bug nor adds a feature
    * `perf`: A code change that improves performance
    * `test`: Adding missing tests or correcting existing tests
    * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
    * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
    * `chore`: Other changes that don't modify src or test files
    * `revert`: Reverts a previous commit -->
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

Please see [Pull Request Reviewer section in the contributing guide](../CONTRIBUTING.md#reviewer) for more information on how to review a pull request.

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Simulation Improvements**
	- Added support for `memDB` in simulations
	- Introduced new entry points for simulations: `TransactionFuzzer` and `DeliverSims`

- **Code Cleanup**
	- Removed commented-out simulation test targets from build scripts
	- Simplified event handling in block finalization process

- **Streaming Enhancements**
	- Updated streaming functionality with improved event processing
	- Added new methods for managing block changes and listener interactions

- **Dependency Updates**
	- Updated module requirements to include `cosmossdk.io/schema` as a direct dependency
<!-- end of auto-generated comment: release notes by coderabbit.ai -->