### PR TITLE
chore(x/auth): use `cosmossdk.io/core/codec` instead of `github.com/cosmos/cosmos-sdk/codec`

### DIFF
--- a/x/group/internal/orm/auto_uint64.go
+++ b/x/group/internal/orm/auto_uint64.go
@@ -4,10 +4,9 @@ import (
 	"github.com/cosmos/gogoproto/proto"
 
 	"cosmossdk.io/core/address"
+	"cosmossdk.io/core/codec"
 	storetypes "cosmossdk.io/core/store"
 	"cosmossdk.io/errors"
-
-	"github.com/cosmos/cosmos-sdk/codec"
 )
 
 var (

--- a/x/group/internal/orm/example_test.go
+++ b/x/group/internal/orm/example_test.go
@@ -1,7 +1,8 @@
 package orm
 
 import (
-	"github.com/cosmos/cosmos-sdk/codec"
+	"cosmossdk.io/core/codec"
+
 	"github.com/cosmos/cosmos-sdk/codec/address"
 	"github.com/cosmos/cosmos-sdk/testutil/testdata"
 )

--- a/x/group/internal/orm/primary_key.go
+++ b/x/group/internal/orm/primary_key.go
@@ -4,9 +4,8 @@ import (
 	"github.com/cosmos/gogoproto/proto"
 
 	"cosmossdk.io/core/address"
+	"cosmossdk.io/core/codec"
 	storetypes "cosmossdk.io/core/store"
-
-	"github.com/cosmos/cosmos-sdk/codec"
 )
 
 var (

--- a/x/group/internal/orm/table.go
+++ b/x/group/internal/orm/table.go
@@ -7,13 +7,13 @@ import (
 	"github.com/cosmos/gogoproto/proto"
 
 	"cosmossdk.io/core/address"
+	"cosmossdk.io/core/codec"
 	storetypes "cosmossdk.io/core/store"
 	errorsmod "cosmossdk.io/errors"
 	"cosmossdk.io/store/types"
 	"cosmossdk.io/x/group/errors"
 	"cosmossdk.io/x/group/internal/orm/prefixstore"
 
-	"github.com/cosmos/cosmos-sdk/codec"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
 


### PR DESCRIPTION
# Description