### PR TITLE
refactor: export `HasRegisterServices`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ Every module contains its own CHANGELOG.md. Please refer to the module you are i
 ### Improvements
 
 * (codec) [#22988](https://github.com/cosmos/cosmos-sdk/pull/22988) Improve edge case handling for recursion limits.
+* (module) [#23488](https://github.com/cosmos/cosmos-sdk/pull/23488) Remove CoreAppModuleAdaptor which is no longer used and add HasRegisterServices public interface.
 
 ### Bug Fixes
 

--- a/runtime/app.go
+++ b/runtime/app.go
@@ -5,16 +5,14 @@ import (
 	"fmt"
 	"slices"
 
-	abci "github.com/cometbft/cometbft/api/cometbft/abci/v1"
-	cmtcrypto "github.com/cometbft/cometbft/crypto"
-	cmted25519 "github.com/cometbft/cometbft/crypto/ed25519"
-	"google.golang.org/grpc"
-
 	runtimev1alpha1 "cosmossdk.io/api/cosmos/app/runtime/v1alpha1"
 	"cosmossdk.io/core/appmodule"
 	"cosmossdk.io/core/registry"
 	"cosmossdk.io/log"
 	storetypes "cosmossdk.io/store/types"
+	abci "github.com/cometbft/cometbft/api/cometbft/abci/v1"
+	cmtcrypto "github.com/cometbft/cometbft/crypto"
+	cmted25519 "github.com/cometbft/cometbft/crypto/ed25519"
 
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/client"
@@ -265,12 +263,6 @@ func (a *App) UnsafeFindStoreKey(storeKey string) storetypes.StoreKey {
 	}
 
 	return a.storeKeys[i]
-}
-
-// hasServicesV1 is the interface for registering service in baseapp Cosmos SDK.
-// This API is part of core/appmodule but commented out for dependencies.
-type hasServicesV1 interface {
-	RegisterServices(grpc.ServiceRegistrar) error
 }
 
 // ValidatorKeyProvider returns a function that generates a private key for use by comet.

--- a/runtime/app.go
+++ b/runtime/app.go
@@ -5,14 +5,15 @@ import (
 	"fmt"
 	"slices"
 
+	abci "github.com/cometbft/cometbft/api/cometbft/abci/v1"
+	cmtcrypto "github.com/cometbft/cometbft/crypto"
+	cmted25519 "github.com/cometbft/cometbft/crypto/ed25519"
+
 	runtimev1alpha1 "cosmossdk.io/api/cosmos/app/runtime/v1alpha1"
 	"cosmossdk.io/core/appmodule"
 	"cosmossdk.io/core/registry"
 	"cosmossdk.io/log"
 	storetypes "cosmossdk.io/store/types"
-	abci "github.com/cometbft/cometbft/api/cometbft/abci/v1"
-	cmtcrypto "github.com/cometbft/cometbft/crypto"
-	cmted25519 "github.com/cometbft/cometbft/crypto/ed25519"
 
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/client"

--- a/runtime/app.go
+++ b/runtime/app.go
@@ -80,8 +80,8 @@ func (a *App) RegisterModules(modules ...module.AppModule) error {
 
 		if mod, ok := appModule.(module.HasServices); ok {
 			mod.RegisterServices(a.configurator)
-		} else if module, ok := appModule.(hasServicesV1); ok {
-			if err := module.RegisterServices(a.configurator); err != nil {
+		} else if mod, ok := appModule.(module.HasRegisterServices); ok {
+			if err := mod.RegisterServices(a.configurator); err != nil {
 				return err
 			}
 		}

--- a/testutil/mock/types_module_module.go
+++ b/testutil/mock/types_module_module.go
@@ -276,56 +276,56 @@ func (mr *MockHasServicesMockRecorder) RegisterServices(arg0 any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterServices", reflect.TypeOf((*MockHasServices)(nil).RegisterServices), arg0)
 }
 
-// MockhasServicesV1 is a mock of hasServicesV1 interface.
-type MockhasServicesV1 struct {
+// MockHasRegisterServices is a mock of HasRegisterServices interface.
+type MockHasRegisterServices struct {
 	ctrl     *gomock.Controller
-	recorder *MockhasServicesV1MockRecorder
+	recorder *MockHasRegisterServicesMockRecorder
 	isgomock struct{}
 }
 
-// MockhasServicesV1MockRecorder is the mock recorder for MockhasServicesV1.
-type MockhasServicesV1MockRecorder struct {
-	mock *MockhasServicesV1
+// MockHasRegisterServicesMockRecorder is the mock recorder for MockHasRegisterServices.
+type MockHasRegisterServicesMockRecorder struct {
+	mock *MockHasRegisterServices
 }
 
-// NewMockhasServicesV1 creates a new mock instance.
-func NewMockhasServicesV1(ctrl *gomock.Controller) *MockhasServicesV1 {
-	mock := &MockhasServicesV1{ctrl: ctrl}
-	mock.recorder = &MockhasServicesV1MockRecorder{mock}
+// NewMockHasRegisterServices creates a new mock instance.
+func NewMockHasRegisterServices(ctrl *gomock.Controller) *MockHasRegisterServices {
+	mock := &MockHasRegisterServices{ctrl: ctrl}
+	mock.recorder = &MockHasRegisterServicesMockRecorder{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockhasServicesV1) EXPECT() *MockhasServicesV1MockRecorder {
+func (m *MockHasRegisterServices) EXPECT() *MockHasRegisterServicesMockRecorder {
 	return m.recorder
 }
 
 // IsAppModule mocks base method.
-func (m *MockhasServicesV1) IsAppModule() {
+func (m *MockHasRegisterServices) IsAppModule() {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "IsAppModule")
 }
 
 // IsAppModule indicates an expected call of IsAppModule.
-func (mr *MockhasServicesV1MockRecorder) IsAppModule() *gomock.Call {
+func (mr *MockHasRegisterServicesMockRecorder) IsAppModule() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsAppModule", reflect.TypeOf((*MockhasServicesV1)(nil).IsAppModule))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsAppModule", reflect.TypeOf((*MockHasRegisterServices)(nil).IsAppModule))
 }
 
 // IsOnePerModuleType mocks base method.
-func (m *MockhasServicesV1) IsOnePerModuleType() {
+func (m *MockHasRegisterServices) IsOnePerModuleType() {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "IsOnePerModuleType")
 }
 
 // IsOnePerModuleType indicates an expected call of IsOnePerModuleType.
-func (mr *MockhasServicesV1MockRecorder) IsOnePerModuleType() *gomock.Call {
+func (mr *MockHasRegisterServicesMockRecorder) IsOnePerModuleType() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsOnePerModuleType", reflect.TypeOf((*MockhasServicesV1)(nil).IsOnePerModuleType))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsOnePerModuleType", reflect.TypeOf((*MockHasRegisterServices)(nil).IsOnePerModuleType))
 }
 
 // RegisterServices mocks base method.
-func (m *MockhasServicesV1) RegisterServices(arg0 grpc.ServiceRegistrar) error {
+func (m *MockHasRegisterServices) RegisterServices(arg0 grpc.ServiceRegistrar) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RegisterServices", arg0)
 	ret0, _ := ret[0].(error)
@@ -333,9 +333,9 @@ func (m *MockhasServicesV1) RegisterServices(arg0 grpc.ServiceRegistrar) error {
 }
 
 // RegisterServices indicates an expected call of RegisterServices.
-func (mr *MockhasServicesV1MockRecorder) RegisterServices(arg0 any) *gomock.Call {
+func (mr *MockHasRegisterServicesMockRecorder) RegisterServices(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterServices", reflect.TypeOf((*MockhasServicesV1)(nil).RegisterServices), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterServices", reflect.TypeOf((*MockHasRegisterServices)(nil).RegisterServices), arg0)
 }
 
 // MockHasABCIEndBlock is a mock of HasABCIEndBlock interface.

--- a/types/module/core_module_test.go
+++ b/types/module/core_module_test.go
@@ -1,4 +1,4 @@
-package module
+package module_test
 
 import (
 	"context"
@@ -14,34 +14,35 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/client"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
 )
 
 var (
 	_ appmodule.AppModule = coreAppModuleAdaptor{}
 
-	_ HasAminoCodec                   = coreAppModuleAdaptor{}
-	_ HasGRPCGateway                  = coreAppModuleAdaptor{}
+	_ module.HasAminoCodec            = coreAppModuleAdaptor{}
+	_ module.HasGRPCGateway           = coreAppModuleAdaptor{}
 	_ appmodule.HasRegisterInterfaces = coreAppModuleAdaptor{}
-	_ HasABCIGenesis                  = coreAppModuleAdaptor{}
-	_ HasServices                     = coreAppModuleAdaptor{}
+	_ module.HasABCIGenesis           = coreAppModuleAdaptor{}
+	_ module.HasServices              = coreAppModuleAdaptor{}
 )
 
-// CoreAppModuleAdaptor wraps the core API module as an AppModule that this version of the SDK can use.
-func CoreAppModuleAdaptor(name string, module appmodule.AppModule) AppModule {
+// coreAppModuleAdaptor wraps the core API module as an AppModule that this version of the SDK can use.
+func newCoreAppModuleAdaptor(name string, module appmodule.AppModule) module.AppModule {
 	return coreAppModuleAdaptor{
-		name:   name,
-		module: module,
+		name:      name,
+		appModule: module,
 	}
 }
 
 type coreAppModuleAdaptor struct {
-	name   string
-	module appmodule.AppModule
+	name      string
+	appModule appmodule.AppModule
 }
 
 // DefaultGenesis implements HasGenesis
 func (c coreAppModuleAdaptor) DefaultGenesis() json.RawMessage {
-	if mod, ok := c.module.(appmodule.HasGenesisAuto); ok {
+	if mod, ok := c.appModule.(appmodule.HasGenesisAuto); ok {
 		target := genesis.RawJSONTarget{}
 		err := mod.DefaultGenesis(target.Target())
 		if err != nil {
@@ -56,11 +57,11 @@ func (c coreAppModuleAdaptor) DefaultGenesis() json.RawMessage {
 		return res
 	}
 
-	if mod, ok := c.module.(HasGenesisBasics); ok {
+	if mod, ok := c.appModule.(module.HasGenesisBasics); ok {
 		return mod.DefaultGenesis()
 	}
 
-	if mod, ok := c.module.(HasGenesis); ok {
+	if mod, ok := c.appModule.(module.HasGenesis); ok {
 		return mod.DefaultGenesis()
 	}
 
@@ -69,7 +70,7 @@ func (c coreAppModuleAdaptor) DefaultGenesis() json.RawMessage {
 
 // ValidateGenesis implements HasGenesis
 func (c coreAppModuleAdaptor) ValidateGenesis(bz json.RawMessage) error {
-	if mod, ok := c.module.(appmodule.HasGenesisAuto); ok {
+	if mod, ok := c.appModule.(appmodule.HasGenesisAuto); ok {
 		source, err := genesis.SourceFromRawJSON(bz)
 		if err != nil {
 			return err
@@ -80,11 +81,11 @@ func (c coreAppModuleAdaptor) ValidateGenesis(bz json.RawMessage) error {
 		}
 	}
 
-	if mod, ok := c.module.(HasGenesisBasics); ok {
+	if mod, ok := c.appModule.(module.HasGenesisBasics); ok {
 		return mod.ValidateGenesis(bz)
 	}
 
-	if mod, ok := c.module.(HasGenesis); ok {
+	if mod, ok := c.appModule.(module.HasGenesis); ok {
 		return mod.ValidateGenesis(bz)
 	}
 
@@ -93,7 +94,7 @@ func (c coreAppModuleAdaptor) ValidateGenesis(bz json.RawMessage) error {
 
 // ExportGenesis implements HasGenesis
 func (c coreAppModuleAdaptor) ExportGenesis(ctx context.Context) (json.RawMessage, error) {
-	if module, ok := c.module.(appmodule.HasGenesisAuto); ok {
+	if module, ok := c.appModule.(appmodule.HasGenesisAuto); ok {
 		ctx := sdk.UnwrapSDKContext(ctx).WithGasMeter(storetypes.NewInfiniteGasMeter()) // avoid race conditions
 		target := genesis.RawJSONTarget{}
 		err := module.ExportGenesis(ctx, target.Target())
@@ -109,11 +110,11 @@ func (c coreAppModuleAdaptor) ExportGenesis(ctx context.Context) (json.RawMessag
 		return rawJSON, nil
 	}
 
-	if mod, ok := c.module.(HasABCIGenesis); ok {
+	if mod, ok := c.appModule.(module.HasABCIGenesis); ok {
 		return mod.ExportGenesis(ctx)
 	}
 
-	if mod, ok := c.module.(HasGenesis); ok {
+	if mod, ok := c.appModule.(module.HasGenesis); ok {
 		eg, err := mod.ExportGenesis(ctx)
 		if err != nil {
 			return nil, err
@@ -126,8 +127,8 @@ func (c coreAppModuleAdaptor) ExportGenesis(ctx context.Context) (json.RawMessag
 }
 
 // InitGenesis implements HasGenesis
-func (c coreAppModuleAdaptor) InitGenesis(ctx context.Context, bz json.RawMessage) ([]ValidatorUpdate, error) {
-	if module, ok := c.module.(appmodule.HasGenesisAuto); ok {
+func (c coreAppModuleAdaptor) InitGenesis(ctx context.Context, bz json.RawMessage) ([]module.ValidatorUpdate, error) {
+	if module, ok := c.appModule.(appmodule.HasGenesisAuto); ok {
 		// core API genesis
 		source, err := genesis.SourceFromRawJSON(bz)
 		if err != nil {
@@ -139,11 +140,11 @@ func (c coreAppModuleAdaptor) InitGenesis(ctx context.Context, bz json.RawMessag
 		}
 	}
 
-	if mod, ok := c.module.(HasABCIGenesis); ok {
+	if mod, ok := c.appModule.(module.HasABCIGenesis); ok {
 		return mod.InitGenesis(ctx, bz)
 	}
 
-	if mod, ok := c.module.(HasGenesis); ok {
+	if mod, ok := c.appModule.(module.HasGenesis); ok {
 		if err := mod.InitGenesis(ctx, bz); err != nil {
 			return nil, err
 		}
@@ -159,7 +160,7 @@ func (c coreAppModuleAdaptor) Name() string {
 }
 
 func (c coreAppModuleAdaptor) GetQueryCmd() *cobra.Command {
-	if mod, ok := c.module.(interface {
+	if mod, ok := c.appModule.(interface {
 		GetQueryCmd() *cobra.Command
 	}); ok {
 		return mod.GetQueryCmd()
@@ -169,7 +170,7 @@ func (c coreAppModuleAdaptor) GetQueryCmd() *cobra.Command {
 }
 
 func (c coreAppModuleAdaptor) GetTxCmd() *cobra.Command {
-	if mod, ok := c.module.(interface {
+	if mod, ok := c.appModule.(interface {
 		GetTxCmd() *cobra.Command
 	}); ok {
 		return mod.GetTxCmd()
@@ -180,7 +181,7 @@ func (c coreAppModuleAdaptor) GetTxCmd() *cobra.Command {
 
 // RegisterGRPCGatewayRoutes implements HasGRPCGateway
 func (c coreAppModuleAdaptor) RegisterGRPCGatewayRoutes(ctx client.Context, mux *runtime.ServeMux) {
-	if mod, ok := c.module.(interface {
+	if mod, ok := c.appModule.(interface {
 		RegisterGRPCGatewayRoutes(context client.Context, mux *runtime.ServeMux)
 	}); ok {
 		mod.RegisterGRPCGatewayRoutes(ctx, mux)
@@ -189,7 +190,7 @@ func (c coreAppModuleAdaptor) RegisterGRPCGatewayRoutes(ctx client.Context, mux 
 
 // RegisterInterfaces implements HasRegisterInterfaces
 func (c coreAppModuleAdaptor) RegisterInterfaces(reg registry.InterfaceRegistrar) {
-	if mod, ok := c.module.(interface {
+	if mod, ok := c.appModule.(interface {
 		RegisterInterfaces(registry.InterfaceRegistrar)
 	}); ok {
 		mod.RegisterInterfaces(reg)
@@ -198,7 +199,7 @@ func (c coreAppModuleAdaptor) RegisterInterfaces(reg registry.InterfaceRegistrar
 
 // RegisterLegacyAminoCodec implements HasAminoCodec
 func (c coreAppModuleAdaptor) RegisterLegacyAminoCodec(amino registry.AminoRegistrar) {
-	if mod, ok := c.module.(interface {
+	if mod, ok := c.appModule.(interface {
 		RegisterLegacyAminoCodec(amino registry.AminoRegistrar)
 	}); ok {
 		mod.RegisterLegacyAminoCodec(amino)
@@ -206,15 +207,15 @@ func (c coreAppModuleAdaptor) RegisterLegacyAminoCodec(amino registry.AminoRegis
 }
 
 // RegisterServices implements HasServices
-func (c coreAppModuleAdaptor) RegisterServices(cfg Configurator) {
-	if module, ok := c.module.(hasServicesV1); ok {
+func (c coreAppModuleAdaptor) RegisterServices(cfg module.Configurator) {
+	if module, ok := c.appModule.(module.HasRegisterServices); ok {
 		err := module.RegisterServices(cfg)
 		if err != nil {
 			panic(err)
 		}
 	}
 
-	if module, ok := c.module.(appmodule.HasMigrations); ok {
+	if module, ok := c.appModule.(appmodule.HasMigrations); ok {
 		err := module.RegisterMigrations(cfg)
 		if err != nil {
 			panic(err)

--- a/types/module/core_module_test.go
+++ b/types/module/core_module_test.go
@@ -27,7 +27,6 @@ var (
 	_ module.HasServices              = coreAppModuleAdaptor{}
 )
 
-// coreAppModuleAdaptor wraps the core API module as an AppModule that this version of the SDK can use.
 func newCoreAppModuleAdaptor(name string, module appmodule.AppModule) module.AppModule {
 	return coreAppModuleAdaptor{
 		name:      name,
@@ -35,6 +34,8 @@ func newCoreAppModuleAdaptor(name string, module appmodule.AppModule) module.App
 	}
 }
 
+// coreAppModuleAdaptor wraps the core API module as an AppModule that this version of the SDK can use.
+// This is only used for testing purposes.
 type coreAppModuleAdaptor struct {
 	name      string
 	appModule appmodule.AppModule

--- a/types/module/module.go
+++ b/types/module/module.go
@@ -90,15 +90,16 @@ type HasInvariants interface {
 	RegisterInvariants(sdk.InvariantRegistry)
 }
 
-// HasServices is the interface for modules to register services.
+// HasServices is the interface for modules to register legacy services using the deprecated Configurator type.
+// Deprecated: use HasRegisterServices and its interface in your modules instea.
 type HasServices interface {
 	// RegisterServices allows a module to register services.
 	RegisterServices(Configurator)
 }
 
-// hasServicesV1 is the interface for registering service in baseapp Cosmos SDK.
+// HasRegisterServices is the interface for registering service in baseapp Cosmos SDK.
 // This API is part of core/appmodule but commented out for dependencies.
-type hasServicesV1 interface {
+type HasRegisterServices interface {
 	appmodulev2.AppModule
 
 	RegisterServices(grpc.ServiceRegistrar) error
@@ -406,7 +407,7 @@ func (m *Manager) RegisterServices(cfg Configurator) error {
 			module.RegisterServices(cfg)
 		}
 
-		if module, ok := module.(hasServicesV1); ok {
+		if module, ok := module.(HasRegisterServices); ok {
 			err := module.RegisterServices(cfg)
 			if err != nil {
 				return err

--- a/types/module/module_test.go
+++ b/types/module/module_test.go
@@ -41,7 +41,7 @@ func TestAssertNoForgottenModules(t *testing.T) {
 	mockAppModule1.EXPECT().Name().Times(2).Return("module1")
 	mm := module.NewManager(
 		mockAppModule1,
-		module.CoreAppModuleAdaptor("module3", mockAppModule3),
+		newCoreAppModuleAdaptor("module3", mockAppModule3),
 	)
 	require.NotNil(t, mm)
 	require.Equal(t, 2, len(mm.Modules))
@@ -71,7 +71,7 @@ func TestManagerOrderSetters(t *testing.T) {
 
 	mockAppModule1.EXPECT().Name().Times(2).Return("module1")
 	mockAppModule2.EXPECT().Name().Times(2).Return("module2")
-	mm := module.NewManager(mockAppModule1, mockAppModule2, module.CoreAppModuleAdaptor("module3", mockAppModule3))
+	mm := module.NewManager(mockAppModule1, mockAppModule2, newCoreAppModuleAdaptor("module3", mockAppModule3))
 	require.NotNil(t, mm)
 	require.Equal(t, 3, len(mm.Modules))
 
@@ -114,7 +114,7 @@ func TestManager_RegisterQueryServices(t *testing.T) {
 	mockAppModule1.EXPECT().Name().Times(2).Return("module1")
 	mockAppModule2.EXPECT().Name().Times(2).Return("module2")
 	// TODO: This is not working for Core API modules yet
-	mm := module.NewManager(mockAppModule1, mockAppModule2, module.CoreAppModuleAdaptor("mockAppModule3", mockAppModule3))
+	mm := module.NewManager(mockAppModule1, mockAppModule2, newCoreAppModuleAdaptor("mockAppModule3", mockAppModule3))
 	require.NotNil(t, mm)
 	require.Equal(t, 3, len(mm.Modules))
 
@@ -146,7 +146,7 @@ func TestManager_InitGenesis(t *testing.T) {
 	mockAppModule3 := mock.NewMockCoreAppModule(mockCtrl)
 	mockAppModule1.EXPECT().Name().Times(2).Return("module1")
 	mockAppModule2.EXPECT().Name().Times(4).Return("module2")
-	mm := module.NewManager(mockAppModule1, mockAppModule2, module.CoreAppModuleAdaptor("module3", mockAppModule3))
+	mm := module.NewManager(mockAppModule1, mockAppModule2, newCoreAppModuleAdaptor("module3", mockAppModule3))
 	require.NotNil(t, mm)
 	require.Equal(t, 3, len(mm.Modules))
 
@@ -178,7 +178,7 @@ func TestManager_InitGenesis(t *testing.T) {
 
 	// happy path
 
-	mm2 := module.NewManager(mockAppModuleABCI1, mockAppModule2, module.CoreAppModuleAdaptor("module3", mockAppModule3))
+	mm2 := module.NewManager(mockAppModuleABCI1, mockAppModule2, newCoreAppModuleAdaptor("module3", mockAppModule3))
 	mockAppModuleABCI1.EXPECT().InitGenesis(gomock.Eq(ctx), gomock.Eq(genesisData["module1"])).Times(1).Return([]module.ValidatorUpdate{{}}, nil)
 	mockAppModule2.EXPECT().InitGenesis(gomock.Eq(ctx), gomock.Eq(genesisData["module2"])).Times(1)
 	mockAppModule3.EXPECT().InitGenesis(gomock.Eq(ctx), gomock.Any()).Times(1).Return(nil)
@@ -195,7 +195,7 @@ func TestManager_ExportGenesis(t *testing.T) {
 	mockCoreAppModule := MockCoreAppModule{}
 	mockAppModule1.EXPECT().Name().Times(2).Return("module1")
 	mockAppModule2.EXPECT().Name().Times(2).Return("module2")
-	mm := module.NewManager(mockAppModule1, mockAppModule2, module.CoreAppModuleAdaptor("mockCoreAppModule", mockCoreAppModule))
+	mm := module.NewManager(mockAppModule1, mockAppModule2, newCoreAppModuleAdaptor("mockCoreAppModule", mockCoreAppModule))
 	require.NotNil(t, mm)
 	require.Equal(t, 3, len(mm.Modules))
 


### PR DESCRIPTION
move `hasServicesV1` to `HasRegisterServices` and use where needed.  
- also move the CoreAppModuleAdaptor type to just be used in testing. We don't need to export this

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Updated module service registration interfaces
	- Renamed `hasServicesV1` to `HasRegisterServices`
	- Deprecated older service registration methods
	- Updated type assertions and mock implementations for module interfaces
	- Renamed `CoreAppModuleAdaptor` to `newCoreAppModuleAdaptor`

- **Documentation**
	- Added deprecation notices for legacy service registration approaches
	- Updated CHANGELOG with new interface details and version information

The changes primarily focus on modernizing the module service registration process and improving interface clarity in the SDK.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->