### PR TITLE
feat(x/distribution): panic on negative community pool

### DIFF
--- a/x/distribution/types/fee_pool.go
+++ b/x/distribution/types/fee_pool.go
@@ -20,8 +20,8 @@ func (f FeePool) ValidateGenesis() error {
 		return fmt.Errorf("negative DecimalPool in distribution fee pool, is %v", f.DecimalPool)
 	}
 
-	if f.CommunityPool.IsAnyNegative() { // TODO(@julienrbrt) in v0.53, panic if the community pool is set
-		return fmt.Errorf("negative CommunityPool in distribution fee pool, is %v", f.CommunityPool)
+	if f.CommunityPool.IsAnyNegative() {
+		panic(fmt.Sprintf("negative CommunityPool in distribution fee pool, is %v", f.CommunityPool))
 	}
 
 	return nil


### PR DESCRIPTION
Previously, the ValidateGenesis function would return an error when encountering
a negative CommunityPool value. This change makes it panic instead, as specified
in the TODO comment. This is a breaking change that will be introduced in v0.53.

This change helps maintain the invariant that the community pool should never
be negative, making it easier to catch and debug issues earlier in the
development process.