### PR TITLE
fix(db): Fix pebbleDB integration

### DIFF
--- a/simapp/v2/sim_runner.go
+++ b/simapp/v2/sim_runner.go
@@ -135,10 +135,11 @@ func SetupTestInstance[T Tx, V SimulationApp[T]](
 	appFactory AppFactory[T, V],
 	appConfigFactory AppConfigFactory,
 	randSource simsxv2.RandSource,
+	dbBackend string,
 ) TestInstance[T] {
 	tb.Helper()
 	vp := viper.New()
-	vp.Set("store.app-db-backend", "memdb")
+	vp.Set("store.app-db-backend", dbBackend)
 	vp.Set("home", tb.TempDir())
 
 	depInjCfg := depinject.Configs(
@@ -251,7 +252,7 @@ func RunWithRandSource[T Tx, V SimulationApp[T]](
 	require.NotEmpty(tb, initialBlockHeight, "initial block height must not be 0")
 
 	setupFn := func(ctx context.Context, r *rand.Rand) (TestInstance[T], ChainState[T], []simtypes.Account) {
-		testInstance := SetupTestInstance[T, V](tb, appFactory, appConfigFactory, randSource)
+		testInstance := SetupTestInstance[T, V](tb, appFactory, appConfigFactory, randSource, tCfg.DBBackend)
 		accounts, genesisAppState, chainID, genesisTimestamp := prepareInitialGenesisState(
 			testInstance.App,
 			r,

--- a/simapp/v2/sim_test.go
+++ b/simapp/v2/sim_test.go
@@ -96,7 +96,7 @@ func TestAppSimulationAfterImport(t *testing.T) {
 		chainID := SimAppChainID + "_2"
 
 		importGenesisChainStateFactory := func(ctx context.Context, r *rand.Rand) (TestInstance[Tx], ChainState[Tx], []simtypes.Account) {
-			testInstance := SetupTestInstance(tb, appFactory, AppConfig, ti.RandSource)
+			testInstance := SetupTestInstance(tb, appFactory, AppConfig, ti.RandSource, cfg.DBBackend)
 			newCs := testInstance.InitializeChain(
 				tb,
 				ctx,
@@ -136,7 +136,7 @@ func TestAppImportExport(t *testing.T) {
 		chainID := SimAppChainID
 		tb.Log("importing genesis...\n")
 
-		newTestInstance := SetupTestInstance(tb, appFactory, AppConfig, ti.RandSource)
+		newTestInstance := SetupTestInstance(tb, appFactory, AppConfig, ti.RandSource, cfg.DBBackend)
 		newTestInstance.InitializeChain(
 			tb,
 			context.Background(),

--- a/store/v2/CHANGELOG.md
+++ b/store/v2/CHANGELOG.md
@@ -29,6 +29,9 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 * [#23013](https://github.com/cosmos/cosmos-sdk/pull/23013) Support memDB for sims
 
+### Bug Fixes
+
+* [#23552](https://github.com/cosmos/cosmos-sdk/pull/23552) Fix pebbleDB integration
 
 ## [v2.0.0-beta.2](https://github.com/cosmos/cosmos-sdk/releases/tag/store/v2.0.0-beta.2)
 

--- a/store/v2/db/pebbledb.go
+++ b/store/v2/db/pebbledb.go
@@ -72,7 +72,7 @@ func (db *PebbleDB) Get(key []byte) ([]byte, error) {
 		return nil, fmt.Errorf("failed to perform PebbleDB read: %w", err)
 	}
 
-	return bz, closer.Close()
+	return slices.Clone(bz), closer.Close()
 }
 
 func (db *PebbleDB) Has(key []byte) (bool, error) {

--- a/x/simulation/client/cli/flags.go
+++ b/x/simulation/client/cli/flags.go
@@ -46,7 +46,7 @@ func GetSimulatorFlags() {
 	flag.IntVar(&FlagBlockSizeValue, "BlockSize", 200, "operations per block")
 	flag.BoolVar(&FlagLeanValue, "Lean", false, "lean simulation log output")
 	flag.BoolVar(&FlagCommitValue, "Commit", true, "have the simulation commit")
-	flag.StringVar(&FlagDBBackendValue, "DBBackend", "goleveldb", "custom db backend type: goleveldb, memdb")
+	flag.StringVar(&FlagDBBackendValue, "DBBackend", "memdb", "custom db backend type: goleveldb, pebbledb, memdb")
 
 	// simulation flags
 	flag.BoolVar(&FlagEnabledValue, "Enabled", false, "enable the simulation")


### PR DESCRIPTION
# Description

Closes: #23133

The loaded data became invalid when the closer was called. From the pebble Godocs:

> // The caller should not modify the contents of the returned slice, but it is
// safe to modify the contents of the argument after Get returns. The returned
// slice will remain valid until the returned Closer is closed. On success, the
// caller MUST call closer.Close() or a memory leak will occur.

Note to reviewer:

I was not able to create an integration test to replicate the behaviour within reasonable time. Instead, I used the sims to trigger a failure. Therefore this PR also contains some minor modifications to the sims tests to replicate this.

```shell
# in `simapp/v2` run
go test -failfast -count=1 -mod=readonly -tags='sims'  . -run TestAppStateDeterminism -NumBlocks=45 -DBBackend=pebbledb
```


---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title, you can find examples of the prefixes below:
    <!-- * `feat`: A new feature
    * `fix`: A bug fix
    * `docs`: Documentation only changes
    * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
    * `refactor`: A code change that neither fixes a bug nor adds a feature
    * `perf`: A code change that improves performance
    * `test`: Adding missing tests or correcting existing tests
    * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
    * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
    * `chore`: Other changes that don't modify src or test files
    * `revert`: Reverts a previous commit -->
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

Please see [Pull Request Reviewer section in the contributing guide](../CONTRIBUTING.md#reviewer) for more information on how to review a pull request.

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced simulation setup with configurable database backend
	- Added support for dynamic database backend selection

- **Bug Fixes**
	- Fixed PebbleDB integration by ensuring data slice integrity
	- Improved data handling in database methods to prevent unintended modifications

- **Improvements**
	- Updated default simulation database backend to memDB
	- Expanded database backend configuration options
<!-- end of auto-generated comment: release notes by coderabbit.ai -->