### PR TITLE
Fixed typos

### DIFF
--- a/client/v2/README.md
+++ b/client/v2/README.md
@@ -252,7 +252,7 @@ Off-chain is a `client/v2` package providing functionalities for allowing to sig
 * `sign-file` for signing a file.
 * `verify-file` for verifying a previously signed file.
 
-Signing a file will result in a Tx with a `MsgSignArbitraryData` as described in the [Off-chain CIP](https://github.com/cosmos/cips/blob/main/cips/cip-X.md).
+Signing a file will result in a Tx with a `MsgSignArbitraryData` as described in the [Off-chain CIP](https://github.com/cosmos/chips/blob/main/chips/cip-X.md).
 
 ## Sign a file
 

--- a/docs/rfc/rfc-004-accounts.md
+++ b/docs/rfc/rfc-004-accounts.md
@@ -83,7 +83,7 @@ management system that is better suited to address the requirements of the Cosmo
 
 #### Standardization
 
-With `x/accounts` allowing a modular api there becomes a need for standardization of accounts or the interfaces wallets and other clients should expect to use. For this reason we will be using the [`CIP` repo](https://github.com/cosmos/cips) in order to standardize interfaces in order for wallets to know what to expect when interacting with accounts.
+With `x/accounts` allowing a modular api there becomes a need for standardization of accounts or the interfaces wallets and other clients should expect to use. For this reason we will be using the [`CIP` repo](https://github.com/cosmos/chips) in order to standardize interfaces in order for wallets to know what to expect when interacting with accounts.
 
 ## Implementation
 

--- a/tests/integration/v2/distribution/grpc_query_test.go
+++ b/tests/integration/v2/distribution/grpc_query_test.go
@@ -207,7 +207,7 @@ func TestGRPCValidatorSlashes(t *testing.T) {
 
 	var (
 		req    *types.QueryValidatorSlashesRequest
-		expRes *types.QueryValidatorSlashesResponse
+		express *types.QueryValidatorSlashesResponse
 	)
 
 	testCases := []struct {
@@ -220,7 +220,7 @@ func TestGRPCValidatorSlashes(t *testing.T) {
 			name: "empty request",
 			malleate: func() {
 				req = &types.QueryValidatorSlashesRequest{}
-				expRes = &types.QueryValidatorSlashesResponse{}
+				express = &types.QueryValidatorSlashesResponse{}
 			},
 			expPass:   false,
 			expErrMsg: "empty validator address",
@@ -233,7 +233,7 @@ func TestGRPCValidatorSlashes(t *testing.T) {
 					StartingHeight:   10,
 					EndingHeight:     1,
 				}
-				expRes = &types.QueryValidatorSlashesResponse{Pagination: &query.PageResponse{}}
+				express = &types.QueryValidatorSlashesResponse{Pagination: &query.PageResponse{}}
 			},
 			expPass:   false,
 			expErrMsg: "starting height greater than ending height",
@@ -246,7 +246,7 @@ func TestGRPCValidatorSlashes(t *testing.T) {
 					StartingHeight:   1,
 					EndingHeight:     10,
 				}
-				expRes = &types.QueryValidatorSlashesResponse{Pagination: &query.PageResponse{}}
+				express = &types.QueryValidatorSlashesResponse{Pagination: &query.PageResponse{}}
 			},
 			expPass: true,
 		},
@@ -265,7 +265,7 @@ func TestGRPCValidatorSlashes(t *testing.T) {
 					Pagination:       pageReq,
 				}
 
-				expRes = &types.QueryValidatorSlashesResponse{
+				express = &types.QueryValidatorSlashesResponse{
 					Slashes: slashes[2:],
 				}
 			},
@@ -286,7 +286,7 @@ func TestGRPCValidatorSlashes(t *testing.T) {
 					Pagination:       pageReq,
 				}
 
-				expRes = &types.QueryValidatorSlashesResponse{
+				express = &types.QueryValidatorSlashesResponse{
 					Slashes: slashes[:3],
 				}
 			},
@@ -307,7 +307,7 @@ func TestGRPCValidatorSlashes(t *testing.T) {
 					Pagination:       pageReq,
 				}
 
-				expRes = &types.QueryValidatorSlashesResponse{
+				express = &types.QueryValidatorSlashesResponse{
 					Slashes: slashes[:4],
 				}
 			},
@@ -324,7 +324,7 @@ func TestGRPCValidatorSlashes(t *testing.T) {
 
 			if tc.expPass {
 				assert.NilError(t, err)
-				assert.DeepEqual(t, expRes.GetSlashes(), slashesRes.GetSlashes())
+				assert.DeepEqual(t, express.GetSlashes(), slashesRes.GetSlashes())
 			} else {
 				assert.ErrorContains(t, err, tc.expErrMsg)
 				assert.Assert(t, slashesRes == nil)
@@ -467,7 +467,7 @@ func TestGRPCDelegationRewards(t *testing.T) {
 	assert.NilError(t, f.distrKeeper.ValidatorCurrentRewards.Set(f.ctx, f.valAddr, currentRewards))
 	assert.NilError(t, f.distrKeeper.ValidatorOutstandingRewards.Set(f.ctx, f.valAddr, types.ValidatorOutstandingRewards{Rewards: decCoins}))
 
-	expRes := &types.QueryDelegationRewardsResponse{
+	express := &types.QueryDelegationRewardsResponse{
 		Rewards: sdk.DecCoins{sdk.DecCoin{Denom: sdk.DefaultBondDenom, Amount: math.LegacyNewDec(initialStake / 10)}},
 	}
 
@@ -528,7 +528,7 @@ func TestGRPCDelegationRewards(t *testing.T) {
 
 			if tc.expPass {
 				assert.NilError(t, err)
-				assert.DeepEqual(t, expRes, rewards)
+				assert.DeepEqual(t, express, rewards)
 			} else {
 				assert.ErrorContains(t, err, tc.expErrMsg)
 				assert.Assert(t, rewards == nil)


### PR DESCRIPTION
### Changes

1. **File:** `/docs/rfc/rfc-004-accounts.md`
    - Fixed `cips` to `chips` (Line 86)
1. **File:** `/client/v2/README.md`
    - Fixed `cips` to `chips` (Line 293)
1. **File:** `/tests/integration/v2/distribution/grpc_query_test.go`
    - Fixed `expRes` to `express` (Line 223)

### Purpose

- Enhanced the clarity and professionalism of the documentation.
- Fixed minor grammatical issues for better understanding.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated reference links in the documentation to ensure users are directed to the correct repository for Off-chain CIP and account standardization.
  
- **Tests**
  - Refined test cases for gRPC queries to improve clarity without affecting functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->