### PR TITLE
auth: Improve cli tx decoding with fallback to direct txBytes protobuf unmarshaling

### DIFF
--- a/x/auth/client/cli/decode.go
+++ b/x/auth/client/cli/decode.go
@@ -59,7 +59,7 @@ func decodeTxAndGetJSON(clientCtx client.Context, txBytes []byte) ([]byte, error
 	// Fallback to direct unmarshaling
 	var sdkTx sdktx.Tx
 	if err := clientCtx.Codec.Unmarshal(txBytes, &sdkTx); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to directly unmarshal txBytes: %w", err)
 	}
 
 	return clientCtx.Codec.MarshalJSON(&sdkTx)


### PR DESCRIPTION
IIRC before it supported only signBytes.

This mean now `cli tx decode` accepts the output generated by the mempool in https://github.com/cosmos/cosmos-sdk/pull/20802.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced transaction decoding reliability with improved error handling, ensuring more robust conversion of transactions to JSON even when unexpected issues arise.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->