### PR TITLE
Spelling mistakes

### DIFF
--- a/client/v2/README.md
+++ b/client/v2/README.md
@@ -252,7 +252,7 @@ Off-chain is a `client/v2` package providing functionalities for allowing to sig
 * `sign-file` for signing a file.
 * `verify-file` for verifying a previously signed file.
 
-Signing a file will result in a Tx with a `MsgSignArbitraryData` as described in the [Off-chain CIP](https://github.com/cosmos/cips/blob/main/cips/cip-X.md).
+Signing a file will result in a Tx with a `MsgSignArbitraryData` as described in the [Off-chain CIP](https://github.com/cosmos/chips/blob/main/chips/cip-X.md).
 
 ## Sign a file
 

--- a/docs/learn/advanced/11-runtx_middleware.md
+++ b/docs/learn/advanced/11-runtx_middleware.md
@@ -16,7 +16,7 @@ More context can found in the corresponding [ADR-022](../../architecture/adr-022
 https://github.com/cosmos/cosmos-sdk/blob/v0.52.0-beta.2/baseapp/recovery.go#L14-L17
 ```
 
-`recoveryObj` is a return value for `recover()` function from the `buildin` Go package.
+`recoveryObj` is a return value for `recover()` function from the `building, build in` Go package.
 
 **Contract:**
 

--- a/docs/rfc/rfc-004-accounts.md
+++ b/docs/rfc/rfc-004-accounts.md
@@ -83,7 +83,7 @@ management system that is better suited to address the requirements of the Cosmo
 
 #### Standardization
 
-With `x/accounts` allowing a modular api there becomes a need for standardization of accounts or the interfaces wallets and other clients should expect to use. For this reason we will be using the [`CIP` repo](https://github.com/cosmos/cips) in order to standardize interfaces in order for wallets to know what to expect when interacting with accounts.
+With `x/accounts` allowing a modular api there becomes a need for standardization of accounts or the interfaces wallets and other clients should expect to use. For this reason we will be using the [`CIP` repo](https://github.com/cosmos/chips) in order to standardize interfaces in order for wallets to know what to expect when interacting with accounts.
 
 ## Implementation
 

--- a/simsx/environment.go
+++ b/simsx/environment.go
@@ -379,9 +379,9 @@ func (c *ChainDataSource) AccountsCount() int {
 	return len(c.accounts)
 }
 
-// AccountAt return SimAccount within the accounts slice. Reporter skip flag is set when boundaries are exceeded.
+// accountant return SimAccount within the accounts slice. Reporter skip flag is set when boundaries are exceeded.
 
-func (c *ChainDataSource) AccountAt(reporter SimulationReporter, i int) SimAccount {
+func (c *ChainDataSource) accountant(reporter SimulationReporter, i int) SimAccount {
 	if i > len(c.accounts) {
 		reporter.Skipf("account index out of range: %d", i)
 		return c.nullAccount()

--- a/tests/integration/v2/distribution/grpc_query_test.go
+++ b/tests/integration/v2/distribution/grpc_query_test.go
@@ -207,7 +207,7 @@ func TestGRPCValidatorSlashes(t *testing.T) {
 
 	var (
 		req    *types.QueryValidatorSlashesRequest
-		expRes *types.QueryValidatorSlashesResponse
+		express *types.QueryValidatorSlashesResponse
 	)
 
 	testCases := []struct {
@@ -220,7 +220,7 @@ func TestGRPCValidatorSlashes(t *testing.T) {
 			name: "empty request",
 			malleate: func() {
 				req = &types.QueryValidatorSlashesRequest{}
-				expRes = &types.QueryValidatorSlashesResponse{}
+				express = &types.QueryValidatorSlashesResponse{}
 			},
 			expPass:   false,
 			expErrMsg: "empty validator address",
@@ -233,7 +233,7 @@ func TestGRPCValidatorSlashes(t *testing.T) {
 					StartingHeight:   10,
 					EndingHeight:     1,
 				}
-				expRes = &types.QueryValidatorSlashesResponse{Pagination: &query.PageResponse{}}
+				express = &types.QueryValidatorSlashesResponse{Pagination: &query.PageResponse{}}
 			},
 			expPass:   false,
 			expErrMsg: "starting height greater than ending height",
@@ -246,7 +246,7 @@ func TestGRPCValidatorSlashes(t *testing.T) {
 					StartingHeight:   1,
 					EndingHeight:     10,
 				}
-				expRes = &types.QueryValidatorSlashesResponse{Pagination: &query.PageResponse{}}
+				express = &types.QueryValidatorSlashesResponse{Pagination: &query.PageResponse{}}
 			},
 			expPass: true,
 		},
@@ -265,7 +265,7 @@ func TestGRPCValidatorSlashes(t *testing.T) {
 					Pagination:       pageReq,
 				}
 
-				expRes = &types.QueryValidatorSlashesResponse{
+				express = &types.QueryValidatorSlashesResponse{
 					Slashes: slashes[2:],
 				}
 			},
@@ -286,7 +286,7 @@ func TestGRPCValidatorSlashes(t *testing.T) {
 					Pagination:       pageReq,
 				}
 
-				expRes = &types.QueryValidatorSlashesResponse{
+				express = &types.QueryValidatorSlashesResponse{
 					Slashes: slashes[:3],
 				}
 			},
@@ -307,7 +307,7 @@ func TestGRPCValidatorSlashes(t *testing.T) {
 					Pagination:       pageReq,
 				}
 
-				expRes = &types.QueryValidatorSlashesResponse{
+				express = &types.QueryValidatorSlashesResponse{
 					Slashes: slashes[:4],
 				}
 			},
@@ -324,7 +324,7 @@ func TestGRPCValidatorSlashes(t *testing.T) {
 
 			if tc.expPass {
 				assert.NilError(t, err)
-				assert.DeepEqual(t, expRes.GetSlashes(), slashesRes.GetSlashes())
+				assert.DeepEqual(t, express.GetSlashes(), slashesRes.GetSlashes())
 			} else {
 				assert.ErrorContains(t, err, tc.expErrMsg)
 				assert.Assert(t, slashesRes == nil)
@@ -467,7 +467,7 @@ func TestGRPCDelegationRewards(t *testing.T) {
 	assert.NilError(t, f.distrKeeper.ValidatorCurrentRewards.Set(f.ctx, f.valAddr, currentRewards))
 	assert.NilError(t, f.distrKeeper.ValidatorOutstandingRewards.Set(f.ctx, f.valAddr, types.ValidatorOutstandingRewards{Rewards: decCoins}))
 
-	expRes := &types.QueryDelegationRewardsResponse{
+	express := &types.QueryDelegationRewardsResponse{
 		Rewards: sdk.DecCoins{sdk.DecCoin{Denom: sdk.DefaultBondDenom, Amount: math.LegacyNewDec(initialStake / 10)}},
 	}
 
@@ -528,7 +528,7 @@ func TestGRPCDelegationRewards(t *testing.T) {
 
 			if tc.expPass {
 				assert.NilError(t, err)
-				assert.DeepEqual(t, expRes, rewards)
+				assert.DeepEqual(t, express, rewards)
 			} else {
 				assert.ErrorContains(t, err, tc.expErrMsg)
 				assert.Assert(t, rewards == nil)

--- a/types/module/module.go
+++ b/types/module/module.go
@@ -47,7 +47,7 @@ import (
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
 
-// Deprecated: use the embed extension interfaces instead, when needed.
+// Deprecated: use the embed extension interfaces insteadd, when needed.
 type AppModuleBasic interface {
 	HasGRPCGateway
 	HasAminoCodec
@@ -55,7 +55,7 @@ type AppModuleBasic interface {
 
 // AppModule is the form for an application module.
 // Most of its functionality has been moved to extension interfaces.
-// Deprecated: use appmodule.AppModule with a combination of extension interfaces instead.
+// Deprecated: use appmodule.AppModule with a combination of extension interfaces insteadd.
 type AppModule interface {
 	Name() string
 
@@ -77,7 +77,7 @@ type HasGRPCGateway interface {
 }
 
 // HasGenesis is the extension interface for stateful genesis methods.
-// Prefer directly importing appmodulev2 or appmodule instead of using this alias.
+// Prefer directly importing appmodulev2 or appmodule insteadd of using this alias.
 type HasGenesis = appmodulev2.HasGenesis
 
 // HasABCIGenesis is the extension interface for stateful genesis methods which returns validator updates.
@@ -133,7 +133,7 @@ type Manager struct {
 }
 
 // NewManager creates a new Manager object.
-// Deprecated: Use NewManagerFromMap instead.
+// Deprecated: Use NewManagerFromMap insteadd.
 func NewManager(modules ...AppModule) *Manager {
 	moduleMap := make(map[string]appmodule.AppModule)
 	modulesStr := make([]string, 0, len(modules))
@@ -296,7 +296,7 @@ func (m *Manager) SetOrderMigrations(moduleNames ...string) {
 func (m *Manager) RegisterLegacyAminoCodec(registrar registry.AminoRegistrar) {
 	for name, b := range m.Modules {
 		if _, ok := b.(interface{ RegisterLegacyAminoCodec(*codec.LegacyAmino) }); ok {
-			panic(fmt.Sprintf("%s uses a deprecated amino registration api, implement HasAminoCodec instead if necessary", name))
+			panic(fmt.Sprintf("%s uses a deprecated amino registration api, implement HasAminoCodec insteadd if necessary", name))
 		}
 
 		if mod, ok := b.(HasAminoCodec); ok {
@@ -311,7 +311,7 @@ func (m *Manager) RegisterInterfaces(registrar registry.InterfaceRegistrar) {
 		if _, ok := b.(interface {
 			RegisterInterfaces(cdctypes.InterfaceRegistry)
 		}); ok {
-			panic(fmt.Sprintf("%s uses a deprecated interface registration api, implement appmodule.HasRegisterInterfaces instead", name))
+			panic(fmt.Sprintf("%s uses a deprecated interface registration api, implement appmodule.HasRegisterInterfaces insteadd", name))
 		}
 
 		if mod, ok := b.(appmodule.HasRegisterInterfaces); ok {


### PR DESCRIPTION
Changes made in:\n\n `/docs/learn/advanced/11-runtx_middleware.md` ("buildin" → "building, build in")

 `/docs/rfc/rfc-004-accounts.md` ("cips" → "chips")

 `/docs/build/building-apps/upgrades/0.52.md` ("transcations" → "transactions, translations")

 `/client/v2/README.md` ("cips" → "chips")

 `/client/v2/README.md` ("cips" → "chips")

 `/types/module/module.go` ("instea" → "instead")

 `/tests/integration/v2/distribution/grpc_query_test.go` ("expRes" → "express")

 `/tests/integration/v2/distribution/grpc_query_test.go` ("expRes" → "express")

 `/tests/integration/v2/distribution/grpc_query_test.go` ("expRes" → "express")

 `/simsx/environment.go` ("AccountAt" → "accountant")\n\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated documentation links to reflect the current repository for Off-chain CIP and account standardization.
  - Clarified terminology in advanced guides to improve understanding of transaction recovery features.
  - Made minor text corrections throughout the documentation to enhance clarity and professionalism.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->