### PR TITLE
fix: Correct field name typo in Cosmovisor test data

### DIFF
--- a/tools/cosmovisor/testdata/upgrade-files/f2-bad-type-2.json
+++ b/tools/cosmovisor/testdata/upgrade-files/f2-bad-type-2.json
@@ -1,1 +1,1 @@
-{"name": "upgrade1", "heigh": "123"}
+{"name": "upgrade1", "height": "123"}

--- a/tools/cosmovisor/testdata/upgrade-files/f2-bad-type.json
+++ b/tools/cosmovisor/testdata/upgrade-files/f2-bad-type.json
@@ -1,1 +1,1 @@
-{"name": "upgrade1", "info": 123, "heigh": 123}
+{"name": "upgrade1", "info": 123, "height": 123}


### PR DESCRIPTION
Fix typo in **f2-bad-type.json** and **f2-bad-type-2.json** files:
- Changed "heigh" to "height" in JSON field name

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected a misspelled property in the JSON configuration, ensuring that the key now properly reflects the intended attribute for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->