### PR TITLE
refactor: Use require.InDelta for stable float64 comparisons

### DIFF
--- a/math/max_min_test.go
+++ b/math/max_min_test.go
@@ -13,7 +13,7 @@ func TestMax(t *testing.T) {
 	require.Equal(t, -11_000_000, minInt, "invalid min for int")
 
 	maxf64 := Max(10.1, -10.1, 20.8, 1_000_000.9, 10.5, 8.4, -11_000_000.9, 20.7)
-	require.Equal(t, 1_000_000.9, maxf64, "invalid max for float64")
+	require.InDelta(t, 1_000_000.9, maxf64, 1e-9, "invalid max for float64")
 	minf64 := Min(10.1, -10.1, 20.8, 1_000_000.9, 10.5, 8.4, -11_000_000.9, 20.7)
-	require.Equal(t, -11_000_000.9, minf64, "invalid min for float64")
+	require.InDelta(t, -11_000_000.9, minf64, 1e-9, "invalid min for float64")
 }


### PR DESCRIPTION
# Description

Replaced direct `float64` comparisons with `require.InDelta` to prevent potential precision issues in tests.
This ensures more stable and reliable test results.

---

## Author Checklist

I have...

* [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in 
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [x] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [x] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [x] confirmed all CI checks have passed

## Reviewers Checklist

I have...

* [x] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [x] confirmed all author checklist items have been addressed
* [x] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
	- Enhanced floating-point validations in numerical tests by allowing a small tolerance for minor precision differences, ensuring more robust and reliable comparisons in the system’s mathematical functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->