### PR TITLE
fix(tools/cosmovisor): fix wrong dir `prepare-upgrade` when non archive

### DIFF
--- a/tools/cosmovisor/CHANGELOG.md
+++ b/tools/cosmovisor/CHANGELOG.md
@@ -36,6 +36,12 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
+## v1.7.1 - 2025-01-10
+
+### Bug Fixes
+
+* []() Fix issue with wrong directory placement when using `prepare-upgrade` for non archive.
+
 ## v1.7.0 - 2024-11-18
 
 ### Features

--- a/tools/cosmovisor/CHANGELOG.md
+++ b/tools/cosmovisor/CHANGELOG.md
@@ -36,11 +36,11 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
-## v1.7.1 - 2025-01-10
+## v1.7.1 - 2025-01-12
 
 ### Bug Fixes
 
-* []() Fix issue with wrong directory placement when using `prepare-upgrade` for non archive.
+* [#23652](https://github.com/cosmos/cosmos-sdk/pull/23652) Fix issue with wrong directory placement when using `prepare-upgrade` for non archive.
 
 ## v1.7.0 - 2024-11-18
 

--- a/tools/cosmovisor/cmd/cosmovisor/prepare_upgrade.go
+++ b/tools/cosmovisor/cmd/cosmovisor/prepare_upgrade.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -73,8 +72,7 @@ func prepareUpgradeHandler(cmd *cobra.Command, _ []string) error {
 
 	logger.Info("Downloading upgrade binary", "url", binaryURL)
 
-	upgradeBin := filepath.Join(cfg.UpgradeBin(upgradeInfo.Name), cfg.Name)
-	if err := plan.DownloadUpgrade(filepath.Dir(upgradeBin), binaryURL, cfg.Name); err != nil {
+	if err := plan.DownloadUpgrade(cfg.UpgradeDir(upgradeInfo.Name), binaryURL, cfg.Name); err != nil {
 		return fmt.Errorf("failed to download and verify binary: %w", err)
 	}
 


### PR DESCRIPTION
# Description

Fixes the wrong upgrade directory when using cosmovisor prepare-upgrade with non archives.
It actually worked for archives by luck as DownloadUpgrade[1] is opinionated, the way to get the upgrade directory was simply wrong:

[1]:
```
// This is an opinionated directory structure that corresponds with Cosmovisor requirements.
// If the url is not an archive, it is downloaded and saved to {dstRoot}/bin/{daemonName}.
// If the url is an archive, it is downloaded and unpacked to {dstRoot}.
```

cc @johnletey 

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title, you can find examples of the prefixes below:
    <!-- * `feat`: A new feature
    * `fix`: A bug fix
    * `docs`: Documentation only changes
    * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
    * `refactor`: A code change that neither fixes a bug nor adds a feature
    * `perf`: A code change that improves performance
    * `test`: Adding missing tests or correcting existing tests
    * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
    * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
    * `chore`: Other changes that don't modify src or test files
    * `revert`: Reverts a previous commit -->
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

Please see [Pull Request Reviewer section in the contributing guide](../CONTRIBUTING.md#reviewer) for more information on how to review a pull request.

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the upgrade process to ensure that binaries are placed in the correct location during non-archive upgrades. This improvement enhances the reliability of the upgrade preparation, reducing potential errors.
  - Released as part of the new version update (v1.7.1), offering users a more streamlined upgrade experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->