### PR TITLE
fix(tools/cosmovisor): do not download all binaires with autodownload

### DIFF
--- a/tools/cosmovisor/CHANGELOG.md
+++ b/tools/cosmovisor/CHANGELOG.md
@@ -41,6 +41,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### Bug Fixes
 
 * [#23652](https://github.com/cosmos/cosmos-sdk/pull/23652) Fix issue with wrong directory placement when using `prepare-upgrade` for non archive.
+* [#23653](https://github.com/cosmos/cosmos-sdk/pull/23653) Remove duplicate binary downloads during auto-download process
 
 ## v1.7.0 - 2024-11-18
 

--- a/tools/cosmovisor/upgrade.go
+++ b/tools/cosmovisor/upgrade.go
@@ -44,10 +44,6 @@ func UpgradeBinary(logger log.Logger, cfg *Config, p upgradetypes.Plan) error {
 		return fmt.Errorf("cannot parse upgrade info: %w", err)
 	}
 
-	if err := upgradeInfo.ValidateFull(cfg.Name); err != nil {
-		return fmt.Errorf("invalid binaries: %w", err)
-	}
-
 	url, err := GetBinaryURL(upgradeInfo.Binaries)
 	if err != nil {
 		return err


### PR DESCRIPTION
# Description

As described in https://github.com/cosmos/cosmos-sdk/issues/19871, `cosmovisor` will currently try to download binaries for all platforms and architectures. This is bad for several reasons:

1) wastes time, space, and bandwidth
2) increases chance of failure since it has to do more
3) fails if any of checksums are incorrect for any architecture 

This logic was responsible for some issues during the @zeta-chain v27 upgrade since we had messed up one of the checksums in the upgrade proposal.

The only place that this validation should take place is during the proposal submission process.

## Author Checklist


I have...

* [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title, you can find examples of the prefixes below:
    <!-- * `feat`: A new feature
    * `fix`: A bug fix
    * `docs`: Documentation only changes
    * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
    * `refactor`: A code change that neither fixes a bug nor adds a feature
    * `perf`: A code change that improves performance
    * `test`: Adding missing tests or correcting existing tests
    * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
    * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
    * `chore`: Other changes that don't modify src or test files
    * `revert`: Reverts a previous commit -->
* [x] confirmed `!` in the type prefix if API or client breaking change
* [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [x] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
    - will add after https://github.com/cosmos/cosmos-sdk/pull/23652 is merged to avoid conflicts
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

Please see [Pull Request Reviewer section in the contributing guide](../CONTRIBUTING.md#reviewer) for more information on how to review a pull request.

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced the auto-download process by eliminating duplicate binary downloads.
  
- **Refactor**
  - Simplified the binary upgrade workflow by removing an extra validation check.
  - Maintained essential safeguards such as download error handling and ensuring the correct setup of the binary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->