### PR TITLE
docs: update types/errors package documentation link to v0.52.0-beta.1

### DIFF
--- a/types/errors/README.md
+++ b/types/errors/README.md
@@ -6,4 +6,4 @@ this package is deprecated, users should use "cosmossdk.io/errors" instead.
 
 Errors is a package that was deprecated but still contains error types. These error types are meant to be used by the Cosmos SDK to define error types. It is recommended that modules define their own error types, even if it is a duplicate of errors in this package. This will allow developers to more easily debug module errors and separate them from Cosmos SDK errors. 
 
-For this package's documentation, please see the [go documentation](https://pkg.go.dev/github.com/cosmos/cosmos-sdk@v0.52.0-beta.1/types/errors).
+For this package's documentation, please see the [go documentation](https://pkg.go.dev/github.com/cosmos/cosmos-sdk@v0.50/types/errors).

--- a/types/errors/README.md
+++ b/types/errors/README.md
@@ -6,4 +6,4 @@ this package is deprecated, users should use "cosmossdk.io/errors" instead.
 
 Errors is a package that was deprecated but still contains error types. These error types are meant to be used by the Cosmos SDK to define error types. It is recommended that modules define their own error types, even if it is a duplicate of errors in this package. This will allow developers to more easily debug module errors and separate them from Cosmos SDK errors. 
 
-For this package's documentation, please see the [go documentation](https://pkg.go.dev/github.com/cosmos/cosmos-sdk@v0.47.5/types/errors).
+For this package's documentation, please see the [go documentation](https://pkg.go.dev/github.com/cosmos/cosmos-sdk@v0.52.0-beta.1/types/errors).


### PR DESCRIPTION
# Description

Updates the documentation link in types/errors/README.md from v0.47.5 to v0.52.0-beta.1 to reflect the current version of the SDK. This change ensures that users are directed to the most up-to-date documentation.

Closes: #XXXX

## Author Checklist

I have...

* [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [x] confirmed `!` in the type prefix if API or client breaking change (not needed for docs changes)
* [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [x] provided a link to the relevant issue or specification
* [x] reviewed "Files changed" and left comments if necessary
* [x] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing) (not needed for docs changes)
* [ ] added a changelog entry to `CHANGELOG.md`:
* [x] updated the relevant documentation or specification
* [x] confirmed all CI checks have passed

## Reviewers Checklist

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed 
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated the documentation reference for the deprecated error module to point to version `v0.50` of the Cosmos SDK, ensuring users have access to the latest guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->