### PR TITLE
feat(x/distribution): panic on negative CommunityPool in ValidateGenesis

### DIFF
--- a/x/distribution/types/fee_pool.go
+++ b/x/distribution/types/fee_pool.go
@@ -20,8 +20,8 @@ func (f FeePool) ValidateGenesis() error {
 		return fmt.Errorf("negative DecimalPool in distribution fee pool, is %v", f.DecimalPool)
 	}
 
-	if f.CommunityPool.IsAnyNegative() { // TODO(@julienrbrt) in v0.53, panic if the community pool is set
-		return fmt.Errorf("negative CommunityPool in distribution fee pool, is %v", f.CommunityPool)
+	if f.CommunityPool.IsAnyNegative() {
+		panic(fmt.Sprintf("negative CommunityPool in distribution fee pool, is %v", f.CommunityPool))
 	}
 
 	return nil


### PR DESCRIPTION
Changes ValidateGenesis to panic instead of returning an error when CommunityPool is negative.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Adjusted fee distribution validation to enforce stricter checks. The system now immediately terminates execution upon detecting an invalid fee pool value, ensuring enhanced stability and integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->