### PR TITLE
docs: update version references from v0.47.0-rc1 to v0.52.0-rc.2

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1177,8 +1177,8 @@ The `simapp` package **should not be imported in your own app**. Instead, you sh
 #### App Wiring
 
 SimApp's `app_di.go` is using [App Wiring](https://docs.cosmos.network/main/build/building-apps/app-go-di), the dependency injection framework of the Cosmos SDK.
-This means that modules are injected directly into SimApp thanks to a [configuration file](https://github.com/cosmos/cosmos-sdk/blob/v0.47.0-rc1/simapp/app_config.go).
-The previous behavior, without the dependency injection framework, is still present in [`app.go`](https://github.com/cosmos/cosmos-sdk/blob/v0.47.0-rc1/simapp/app.go) and is not going anywhere.
+This means that modules are injected directly into SimApp thanks to a [configuration file](https://github.com/cosmos/cosmos-sdk/blob/v0.52.0-rc.2/simapp/app_config.go).
+The previous behavior, without the dependency injection framework, is still present in [`app.go`](https://github.com/cosmos/cosmos-sdk/blob/v0.52.0-rc.2/simapp/app.go) and is not going anywhere.
 
 If you are using a `app.go` without dependency injection, add the following lines to your `app.go` in order to provide newer gRPC services:
 

--- a/depinject/README.md
+++ b/depinject/README.md
@@ -75,7 +75,7 @@ Provider functions serve as the basis for the dependency tree. They are analysed
 
 `depinject` supports the use of interface types as inputs to provider functions, which helps decouple dependencies between modules. This approach is particularly useful for managing complex systems with multiple modules, such as the Cosmos SDK, where dependencies need to be flexible and maintainable.
 
-For example, `x/bank` expects an [AccountKeeper](https://pkg.go.dev/cosmossdk.io/x/bank/types#AccountKeeper) interface as [input to ProvideModule](https://github.com/cosmos/cosmos-sdk/blob/v0.47.0-rc1/x/bank/module.go#L208-L260). `SimApp` uses the implementation in `x/auth`, but the modular design allows for easy changes to the implementation if needed.
+For example, `x/bank` expects an [AccountKeeper](https://pkg.go.dev/cosmossdk.io/x/bank/types#AccountKeeper) interface as [input to ProvideModule](https://github.com/cosmos/cosmos-sdk/blob/v0.52.0-rc.2/x/bank/module.go#L208-L260). `SimApp` uses the implementation in `x/auth`, but the modular design allows for easy changes to the implementation if needed.
 
 Consider the following example:
 


### PR DESCRIPTION
Updated version references in documentation files from `v0.47.0-rc1` to `v0.52.0-rc.2` in:
- `UPGRADING.md`
- `depinject/README.md`

Changes include updating GitHub repository links in:
- `simapp/app_config.go` references
- 1simapp/app.go` references
- `x/bank/module.go` references

This ensures documentation consistency with the latest SDK version `v0.52.0-rc.2.`