### PR TITLE
docs: update version references from v0.47.0-rc1 to v0.50

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1177,8 +1177,8 @@ The `simapp` package **should not be imported in your own app**. Instead, you sh
 #### App Wiring
 
 SimApp's `app_di.go` is using [App Wiring](https://docs.cosmos.network/main/build/building-apps/app-go-di), the dependency injection framework of the Cosmos SDK.
-This means that modules are injected directly into SimApp thanks to a [configuration file](https://github.com/cosmos/cosmos-sdk/blob/v0.47.0-rc1/simapp/app_config.go).
-The previous behavior, without the dependency injection framework, is still present in [`app.go`](https://github.com/cosmos/cosmos-sdk/blob/v0.47.0-rc1/simapp/app.go) and is not going anywhere.
+This means that modules are injected directly into SimApp thanks to a [configuration file](https://github.com/cosmos/cosmos-sdk/blob/v0.50/simapp/app_config.go).
+The previous behavior, without the dependency injection framework, is still present in [`app.go`](https://github.com/cosmos/cosmos-sdk/blob/v0.50/simapp/app.go) and is not going anywhere.
 
 If you are using a `app.go` without dependency injection, add the following lines to your `app.go` in order to provide newer gRPC services:
 

--- a/depinject/README.md
+++ b/depinject/README.md
@@ -75,7 +75,7 @@ Provider functions serve as the basis for the dependency tree. They are analysed
 
 `depinject` supports the use of interface types as inputs to provider functions, which helps decouple dependencies between modules. This approach is particularly useful for managing complex systems with multiple modules, such as the Cosmos SDK, where dependencies need to be flexible and maintainable.
 
-For example, `x/bank` expects an [AccountKeeper](https://pkg.go.dev/cosmossdk.io/x/bank/types#AccountKeeper) interface as [input to ProvideModule](https://github.com/cosmos/cosmos-sdk/blob/v0.47.0-rc1/x/bank/module.go#L208-L260). `SimApp` uses the implementation in `x/auth`, but the modular design allows for easy changes to the implementation if needed.
+For example, `x/bank` expects an [AccountKeeper](https://pkg.go.dev/cosmossdk.io/x/bank/types#AccountKeeper) interface as [input to ProvideModule](https://github.com/cosmos/cosmos-sdk/blob/v0.50/x/bank/module.go#L208-L260). `SimApp` uses the implementation in `x/auth`, but the modular design allows for easy changes to the implementation if needed.
 
 Consider the following example:
 


### PR DESCRIPTION
# Description

Updates links in `UPGRADING.md` and `depinject/README.md` from v0.47.0-rc1 to v0.50 to reflect the latest maintained version of the SDK. This change ensures that users are directed to the most up-to-date documentation and code references.

Closes: #XXXX

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and please add links to any relevant follow up issues._

I have...

* [x] included the correct type prefix in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change (not needed for docs changes)
* [x] targeted the correct branch (see PR Targeting)
* [ ] provided a link to the relevant issue or specification
* [x] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration tests (not needed for docs changes)
* [x] updated the relevant documentation or specification
* [ ] confirmed all CI checks have passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Revised documentation to reference the current stable package version.
	- Updated guidance on dependency injection to reflect the latest version requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->