### PR TITLE
Changed the return value of normalizeBroadcastMode from "unspecified"…

### DIFF
--- a/client/broadcast.go
+++ b/client/broadcast.go
@@ -145,6 +145,6 @@ func normalizeBroadcastMode(mode tx.BroadcastMode) string {
 	case tx.BroadcastMode_BROADCAST_MODE_SYNC:
 		return "sync"
 	default:
-		return "unspecified"
+		return ""
 	}
 }


### PR DESCRIPTION
Changed the return value of normalizeBroadcastMode from "unspecified" to an empty string (""). Since "unspecified" might be an invalid broadcast mode, returning "" allows the caller to handle the default value appropriately and prevents potential misuse of the "unspecified" string.