### PR TITLE
perf(staking): optimize endblock by reducing bech32 conversions

### DIFF
--- a/x/staking/CHANGELOG.md
+++ b/x/staking/CHANGELOG.md
@@ -31,6 +31,10 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * [#21315](https://github.com/cosmos/cosmos-sdk/pull/21315), [#22556](https://github.com/cosmos/cosmos-sdk/pull/22556) Create metadata type and add metadata field in validator details proto
     * Add parsing of `metadata-profile-pic-uri` in `create-validator` JSON.
     * Add cli flag: `metadata-profile-pic-uri` to `edit-validator` cmd.
+    
+### Improvements
+
+* Optimize validator endblock by reducing bech32 conversions, resulting in significant performance improvement
 
 ### API Breaking Changes
 


### PR DESCRIPTION
This change significantly improves the performance of staking endblock operations by:
1. Eliminating unnecessary Bech32 address conversions in getLastValidatorsByAddr and sortNoLongerBonded
2. Using string(byte[]) directly instead of codec.BytesToString
3. Updating error messages with more helpful context
4. Using AddRaw for better performance on integer addition

These optimizations are especially important for chains with many validators, reducing the time spent in EndBlock which is a critical part of block processing. It speedsup Osmosis state machine processing time by 2%

Backport of commit cccdbd9892ad621645901d003ab6b2c696afe2e3

I am unlikely to do follow-on commits to this PR, if its not desired please feel free to take over or close. Its bothered me a bit that this has been this slow. There is other slow-ness in this area of the code, but this was a very easy state compat win.

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title, you can find examples of the prefixes below:
    <!-- * `feat`: A new feature
    * `fix`: A bug fix
    * `docs`: Documentation only changes
    * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
    * `refactor`: A code change that neither fixes a bug nor adds a feature
    * `perf`: A code change that improves performance
    * `test`: Adding missing tests or correcting existing tests
    * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
    * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
    * `chore`: Other changes that don't modify src or test files
    * `revert`: Reverts a previous commit -->
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

Please see [Pull Request Reviewer section in the contributing guide](../CONTRIBUTING.md#reviewer) for more information on how to review a pull request.

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Introduced a new "Improvements" section in the changelog highlighting enhanced validator processing performance.
- **Refactor**
  - Streamlined internal error reporting and processing logic for improved reliability and efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->