### PR TITLE
chore: set up backport rule for 53

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -12,14 +12,14 @@ queue_rules:
     merge_method: squash
 
 pull_request_rules:
-  - name: backport patches to v0.52.x branch
+  - name: backport patches to v0.53.x branch
     conditions:
       - base=main
-      - label=backport/v0.52.x
+      - label=backport/v0.53.x
     actions:
       backport:
         branches:
-          - release/v0.52.x
+          - release/v0.53.x
   - name: backport patches to v0.50.x branch
     conditions:
       - base=main


### PR DESCRIPTION
change 52 to 53

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Streamlined the automated patch backporting process to support the new release branch, ensuring that maintenance updates are now directed to the current release cycle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->