### PR TITLE
fix: remove redundant newline and optimize string formatting

### DIFF
--- a/systemtests/cli.go
+++ b/systemtests/cli.go
@@ -211,7 +211,7 @@ func (c CLIWrapper) AwaitTxCommitted(submitResp string, timeout ...time.Duration
 		txResult = c.WithRunErrorsIgnored().CustomQuery("q", "tx", txHash.String())
 		if code := gjson.Get(txResult, "code"); code.Exists() {
 			if code.Int() != 0 { // 0 = success code
-				c.t.Logf("+++ got error response code: %s\n", txResult)
+				c.t.Logf("+++ got error response code: %s", txResult)
 			}
 			return txResult, true
 		}
@@ -512,7 +512,7 @@ func expErrWithMsg(t assert.TestingT, err error, args []interface{}, expMsg stri
 	}
 	var found bool
 	for _, v := range args {
-		if strings.Contains(fmt.Sprintf("%s", v), expMsg) {
+		if strings.Contains(fmt.Sprint(v), expMsg) {
 			found = true
 			break
 		}


### PR DESCRIPTION
This PR makes minor improvements to the CLI test wrapper by:
- Removing a redundant `\n` in a log message (`Logf` already appends a newline).
- Replacing `fmt.Sprintf("%s", v)` with `fmt.Sprint(v)`, which is a more concise and idiomatic way to convert values to strings.


Closes: #XXXX

---

## Author Checklist

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

---

## Reviewers Checklist

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Refined log message formatting for more consistent and clear output.
  - Updated string conversion methods to enhance error message representation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->