### PR TITLE
chore: run systems tests on DI and direct applications

### DIFF
--- a/.github/workflows/systemtests.yml
+++ b/.github/workflows/systemtests.yml
@@ -15,8 +15,10 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test-system:
+  setup:
     runs-on: depot-ubuntu-22.04-4
+    outputs:
+      git_diff: ${{ steps.git_diff.outputs.diff }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -39,11 +41,23 @@ jobs:
             **/go.sum
             **/Makefile
             Makefile
-      - name: system tests
-        if: env.GIT_DIFF
+
+  test-system:
+    needs: setup
+    if: needs.setup.outputs.git_diff
+    runs-on: depot-ubuntu-22.04-4
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run system tests
         run: |
           make test-system
-      - name: system tests (legacy)
-        if: env.GIT_DIFF
+
+  test-system-legacy:
+    needs: setup
+    if: needs.setup.outputs.git_diff
+    runs-on: depot-ubuntu-22.04-4
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run legacy system tests
         run: |
           COSMOS_BUILD_OPTIONS=legacy make test-system

--- a/.github/workflows/systemtests.yml
+++ b/.github/workflows/systemtests.yml
@@ -43,3 +43,7 @@ jobs:
         if: env.GIT_DIFF
         run: |
           make test-system
+      - name: system tests (legacy)
+        if: env.GIT_DIFF
+        run: |
+          COSMOS_BUILD_OPTIONS=legacy make test-system


### PR DESCRIPTION
run two parallel jobs
- system test (app built from app_di)
- system test legacy (app built from app.go declarative build)