### PR TITLE
fix: Update broken Go documentation link in types/errors/README.md

### DIFF
--- a/types/errors/README.md
+++ b/types/errors/README.md
@@ -6,4 +6,4 @@ this package is deprecated, users should use "cosmossdk.io/errors" instead.
 
 Errors is a package that was deprecated but still contains error types. These error types are meant to be used by the Cosmos SDK to define error types. It is recommended that modules define their own error types, even if it is a duplicate of errors in this package. This will allow developers to more easily debug module errors and separate them from Cosmos SDK errors. 
 
-For this package's documentation, please see the [go documentation](https://pkg.go.dev/github.com/cosmos/cosmos-sdk@v0.50/types/errors).
+For this package's documentation, please see the [go documentation](https://pkg.go.dev/github.com/cosmos/cosmos-sdk@v0.50.12/types/errors).


### PR DESCRIPTION
## Description

Screenshot of the broken link error:

![Pasted Graphic 18](https://github.com/user-attachments/assets/8081902a-cceb-4b43-98b3-b37b04440b87)

Fix : 
![image](https://github.com/user-attachments/assets/26cfa3b4-4c67-4914-b8fd-ee471a754bd1)

This PR updates a broken link in `types/errors/README.md` that pointed to an outdated Go documentation reference. The old link was referencing `v0.50`, which is no longer the latest maintained version. It has been updated to `v0.50.12` to ensure users are directed to the most recent documentation.

## Changes
- Updated the Go documentation link from:
https://pkg.go.dev/github.com/cosmos/cosmos-sdk@v0.50/types/errors
to
https://pkg.go.dev/github.com/cosmos/cosmos-sdk@v0.50.12/types/errors





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the reference link for the deprecated errors package to point to version v0.50.12 of the Cosmos SDK documentation for improved precision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->