### PR TITLE
docs: The quotation marks are incorrect.

### DIFF
--- a/store/cachekv/README.md
+++ b/store/cachekv/README.md
@@ -31,7 +31,7 @@ The Store struct wraps the underlying `KVStore` (`parent`) with additional data 
 
 ### `cache`
 
-The main mapping of key-value pairs stored in cache. This map contains both keys that are cached from read operations as well as ‘dirty’ keys which map to a value that is potentially different than what is in the underlying `KVStore`.
+The main mapping of key-value pairs stored in cache. This map contains both keys that are cached from read operations as well as `dirty` keys which map to a value that is potentially different than what is in the underlying `KVStore`.
 
 Values that are mapped to in `cache` are wrapped in a `cValue` struct, which contains the value and a boolean flag (`dirty`) representing whether the value has been written since the last write-back to `parent`.
 


### PR DESCRIPTION
The quotation marks are incorrect.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the formatting of technical terms in the documentation for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->