### PR TITLE
fix: correct panic messages and enforce sealing check in SetStreamingManager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@ Every module contains its own CHANGELOG.md. Please refer to the module you are i
 
 ### Improvements
 
+* (baseapp) [#23951](https://github.com/cosmos/cosmos-sdk/pull/23951) Corrected panic messages in `SetCMS` and `SetCheckTxHandler`, and enforced `sealed` check in `SetStreamingManager` for consistency with other setters.
 * [#23470](https://github.com/cosmos/cosmos-sdk/pull/23470) Converge to use of one single sign mode type and signer data:
   * Use api's signmode throughout the SDK to align with `cosmossdk.io/tx`. This allows developer not to juggle between sign mode types
   * Deprecate `authsigning.SignerData` in favor of txsigning.SignerData and replace its usage

--- a/baseapp/options.go
+++ b/baseapp/options.go
@@ -182,7 +182,7 @@ func (app *BaseApp) SetDB(db corestore.KVStoreWithBatch) {
 
 func (app *BaseApp) SetCMS(cms storetypes.CommitMultiStore) {
 	if app.sealed {
-		panic("SetEndBlocker() on sealed BaseApp")
+		panic("SetCMS() on sealed BaseApp")
 	}
 
 	app.cms = cms
@@ -375,7 +375,7 @@ func (app *BaseApp) SetPrepareProposal(handler sdk.PrepareProposalHandler) {
 // SetCheckTxHandler sets the checkTx function for the BaseApp.
 func (app *BaseApp) SetCheckTxHandler(handler sdk.CheckTxHandler) {
 	if app.sealed {
-		panic("SetCheckTx() on sealed BaseApp")
+		panic("SetCheckTxHandler() on sealed BaseApp")
 	}
 
 	app.checkTxHandler = handler
@@ -408,6 +408,9 @@ func (app *BaseApp) SetStoreMetrics(gatherer metrics.StoreMetrics) {
 
 // SetStreamingManager sets the streaming manager for the BaseApp.
 func (app *BaseApp) SetStreamingManager(manager storetypes.StreamingManager) {
+	if app.sealed {
+		panic("SetStreamingManager() on sealed BaseApp")
+	}
 	app.streamingManager = manager
 }
 


### PR DESCRIPTION
- Updated panic messages in `SetCMS` and `SetCheckTxHandler` to correctly reflect function names.  
- Added a missing `if app.sealed` check in `SetStreamingManager` to prevent modifications after sealing.  

### **Why?**  
- Ensures panic messages match function names, making debugging more straightforward.  
- Aligns `SetStreamingManager` with the behavior of other setter methods that enforce sealing checks.  

---

## Author Checklist  

I have...  

* [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title (`fix`)  
* [ ] confirmed `!` in the type prefix if API or client breaking change  
* [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))  
* [ ] provided a link to the relevant issue or specification  
* [x] reviewed "Files changed" and left comments if necessary  
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)  
* [ ] added a changelog entry to `CHANGELOG.md`  
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)  
* [x] confirmed all CI checks have passed  

## Reviewers Checklist  

I have...  

* [x] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title  
* [x] confirmed all author checklist items have been addressed  
* [x] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated panic messages to accurately reflect method names when the BaseApp is sealed, ensuring clearer error notifications during unauthorized operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->