### PR TITLE
chore: restore `TxWithTimeoutHeight` 

### DIFF
--- a/x/auth/signing/sig_verifiable_tx.go
+++ b/x/auth/signing/sig_verifiable_tx.go
@@ -22,6 +22,7 @@ type Tx interface {
 
 	types.TxWithMemo
 	types.FeeTx
+	types.TxWithTimeoutHeight
 	types.TxWithUnordered
 	types.HasValidateBasic
 }


### PR DESCRIPTION
restore this interface as it was removed and some clients rely on it