### PR TITLE
chore: restore key testutil

### DIFF
--- a/simapp/simd/cmd/testnet.go
+++ b/simapp/simd/cmd/testnet.go
@@ -314,7 +314,7 @@ func initTestnetFiles(
 			return err
 		}
 
-		addr, secret, err := testutil.GenerateSaveCoinKey(kb, nodeDirName, "", true, algo, sdk.GetConfig().GetFullBIP44Path())
+		addr, secret, err := testutil.GenerateSaveCoinKey(kb, nodeDirName, "", true, algo)
 		if err != nil {
 			_ = os.RemoveAll(args.outputDir)
 			return err

--- a/testutil/key.go
+++ b/testutil/key.go
@@ -8,7 +8,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
-// GenerateCoinKey generates a new key mnemonic along with its addrress.
+// GenerateCoinKey generates a new key mnemonic along with its address.
 func GenerateCoinKey(algo keyring.SignatureAlgo, cdc codec.Codec) (sdk.AccAddress, string, error) {
 	// generate a private key, with mnemonic
 	info, secret, err := keyring.NewInMemory(cdc).NewMnemonic(
@@ -28,7 +28,7 @@ func GenerateCoinKey(algo keyring.SignatureAlgo, cdc codec.Codec) (sdk.AccAddres
 	return addr, secret, nil
 }
 
-// GenerateSaveCoinKey generates a new key mnemonic with its addrress.
+// GenerateSaveCoinKey generates a new key mnemonic with its address.
 // If mnemonic is provided then it's used for key generation.
 // The key is saved in the keyring. The function returns error if overwrite=true and the key
 // already exists.

--- a/testutil/key.go
+++ b/testutil/key.go
@@ -1,14 +1,14 @@
 package testutil
 
 import (
-	"errors"
+	"fmt"
 
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
-// GenerateCoinKey generates a new key mnemonic along with its address.
+// GenerateCoinKey generates a new key mnemonic along with its addrress.
 func GenerateCoinKey(algo keyring.SignatureAlgo, cdc codec.Codec) (sdk.AccAddress, string, error) {
 	// generate a private key, with mnemonic
 	info, secret, err := keyring.NewInMemory(cdc).NewMnemonic(
@@ -28,7 +28,7 @@ func GenerateCoinKey(algo keyring.SignatureAlgo, cdc codec.Codec) (sdk.AccAddres
 	return addr, secret, nil
 }
 
-// GenerateSaveCoinKey generates a new key mnemonic with its address.
+// GenerateSaveCoinKey generates a new key mnemonic with its addrress.
 // If mnemonic is provided then it's used for key generation.
 // The key is saved in the keyring. The function returns error if overwrite=true and the key
 // already exists.
@@ -37,7 +37,6 @@ func GenerateSaveCoinKey(
 	keyName, mnemonic string,
 	overwrite bool,
 	algo keyring.SignatureAlgo,
-	hdPath string,
 ) (sdk.AccAddress, string, error) {
 	exists := false
 	_, err := keybase.Key(keyName)
@@ -47,12 +46,12 @@ func GenerateSaveCoinKey(
 
 	// ensure no overwrite
 	if !overwrite && exists {
-		return sdk.AccAddress{}, "", errors.New("key already exists, overwrite is disabled")
+		return sdk.AccAddress{}, "", fmt.Errorf("key already exists, overwrite is disabled")
 	}
 
 	if exists {
 		if err := keybase.Delete(keyName); err != nil {
-			return sdk.AccAddress{}, "", errors.New("failed to overwrite key")
+			return sdk.AccAddress{}, "", fmt.Errorf("failed to overwrite key")
 		}
 	}
 
@@ -64,9 +63,9 @@ func GenerateSaveCoinKey(
 	// generate or recover a new account
 	if mnemonic != "" {
 		secret = mnemonic
-		record, err = keybase.NewAccount(keyName, mnemonic, keyring.DefaultBIP39Passphrase, hdPath, algo)
+		record, err = keybase.NewAccount(keyName, mnemonic, keyring.DefaultBIP39Passphrase, sdk.GetConfig().GetFullBIP44Path(), algo)
 	} else {
-		record, secret, err = keybase.NewMnemonic(keyName, keyring.English, hdPath, keyring.DefaultBIP39Passphrase, algo)
+		record, secret, err = keybase.NewMnemonic(keyName, keyring.English, sdk.GetConfig().GetFullBIP44Path(), keyring.DefaultBIP39Passphrase, algo)
 	}
 	if err != nil {
 		return sdk.AccAddress{}, "", err

--- a/testutil/key_test.go
+++ b/testutil/key_test.go
@@ -32,7 +32,7 @@ func TestGenerateSaveCoinKey(t *testing.T) {
 	kb, err := keyring.New(t.Name(), "test", t.TempDir(), nil, encCfg.Codec)
 	require.NoError(t, err)
 
-	addr, mnemonic, err := GenerateSaveCoinKey(kb, "keyname", "", false, hd.Secp256k1, types.GetConfig().GetFullBIP44Path())
+	addr, mnemonic, err := GenerateSaveCoinKey(kb, "keyname", "", false, hd.Secp256k1)
 	require.NoError(t, err)
 
 	// Test key was actually saved
@@ -58,15 +58,15 @@ func TestGenerateSaveCoinKeyOverwriteFlag(t *testing.T) {
 	require.NoError(t, err)
 
 	keyname := "justakey"
-	addr1, _, err := GenerateSaveCoinKey(kb, keyname, "", false, hd.Secp256k1, types.GetConfig().GetFullBIP44Path())
+	addr1, _, err := GenerateSaveCoinKey(kb, keyname, "", false, hd.Secp256k1)
 	require.NoError(t, err)
 
 	// Test overwrite with overwrite=false
-	_, _, err = GenerateSaveCoinKey(kb, keyname, "", false, hd.Secp256k1, types.GetConfig().GetFullBIP44Path())
+	_, _, err = GenerateSaveCoinKey(kb, keyname, "", false, hd.Secp256k1)
 	require.Error(t, err)
 
 	// Test overwrite with overwrite=true
-	addr2, _, err := GenerateSaveCoinKey(kb, keyname, "", true, hd.Secp256k1, types.GetConfig().GetFullBIP44Path())
+	addr2, _, err := GenerateSaveCoinKey(kb, keyname, "", true, hd.Secp256k1)
 	require.NoError(t, err)
 
 	require.NotEqual(t, addr1, addr2)

--- a/testutil/network/network.go
+++ b/testutil/network/network.go
@@ -484,7 +484,7 @@ func New(l Logger, baseDir string, cfg Config) (*Network, error) {
 			mnemonic = cfg.Mnemonics[i]
 		}
 
-		addr, secret, err := testutil.GenerateSaveCoinKey(kb, nodeDirName, mnemonic, true, algo, sdk.GetConfig().GetFullBIP44Path())
+		addr, secret, err := testutil.GenerateSaveCoinKey(kb, nodeDirName, mnemonic, true, algo)
 		if err != nil {
 			return nil, err
 		}

--- a/x/auth/signing/sig_verifiable_tx.go
+++ b/x/auth/signing/sig_verifiable_tx.go
@@ -22,6 +22,7 @@ type Tx interface {
 
 	types.TxWithMemo
 	types.FeeTx
+	types.TxWithTimeoutHeight
 	types.TxWithUnordered
 	types.HasValidateBasic
 }


### PR DESCRIPTION
Restores the `testutil.GenerateSaveCoinKey` signature to what it was in `v0.50`.  This change was introduced at some point does not seem necessary to break until we have a good reason:

1. it is a test utility
2. everywhere it was used in our codebase, it still used the global config path, and users can set this if they really need to