### PR TITLE
chore: create temp fix for faulty vuln report in  CI

### DIFF
--- a/.github/workflows/dependencies-review.yml
+++ b/.github/workflows/dependencies-review.yml
@@ -26,6 +26,15 @@ jobs:
         run: ./scripts/dep-assert.sh
       - name: "Go vulnerability check"
         run: |
-          make vulncheck || echo "::warning file=govulncheck::Vulnerabilities detected, check logs!"
+          make vulncheck | tee govulncheck-output.txt || true
         continue-on-error: true
         # TODO: restore failing vuln check when the comet dependency vuln works https://pkg.go.dev/vuln/GO-2025-3443
+      - name: Comment on PR
+        uses: mshick/add-pr-comment@v2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          message: |
+            ⚠️ **govulncheck found vulnerabilities:**
+            ```
+            $(cat govulncheck-output.txt)
+            ```

--- a/.github/workflows/dependencies-review.yml
+++ b/.github/workflows/dependencies-review.yml
@@ -39,6 +39,6 @@ jobs:
           message: |
             ⚠️ **govulncheck found vulnerabilities:**
              ```
-            ${{ steps.govulncheck.outputs.result }}
+            ${{ steps.govuln.outputs.result }}
             ```
           message-id: govulncheck-warning

--- a/.github/workflows/dependencies-review.yml
+++ b/.github/workflows/dependencies-review.yml
@@ -5,6 +5,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write  # Allow commenting on PRs
 
 jobs:
   dependency-review:

--- a/.github/workflows/dependencies-review.yml
+++ b/.github/workflows/dependencies-review.yml
@@ -28,13 +28,15 @@ jobs:
       - name: "Go vulnerability check"
         id: govuln
         run: |
-          make vulncheck | tee govulncheck-output.txt || true
+          make vulncheck 2>&1 | tee govulncheck-output.txt || true
           echo "govulncheck_output<<EOF" >> $GITHUB_ENV
           cat govulncheck-output.txt >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV
         continue-on-error: true
+      - name: Debug govulncheck Output
+        run: cat govulncheck-output.txt || echo "govulncheck-output.txt is empty!"
       - name: Comment on PR
-        if: steps.govuln.outcome == 'failure'
+        if: env.govulncheck_output != ''
         uses: mshick/add-pr-comment@v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependencies-review.yml
+++ b/.github/workflows/dependencies-review.yml
@@ -20,17 +20,19 @@ jobs:
       - name: "Dependency Review"
         uses: actions/dependency-review-action@v4
         with:
-          base-ref: ${{ github.event.pull_request.base.sha || 'main' }}
+          base-ref: ${{ github.event.pull_request.base.sha || 'release/v0.53.x' }}
           head-ref: ${{ github.event.pull_request.head.sha || github.ref }}
-          fail-on-severity: high # otherwise we fail on ourselves due to https://github.com/advisories/GHSA-qfc5-6r3j-jj22, https://github.com/advisories/GHSA-w44m-8mv2-v78h TODO(@julienrbrt) submit a PR to the action to ignore packages
+          fail-on-severity: high
       - name: "Dependency audit"
         run: ./scripts/dep-assert.sh
       - name: "Go vulnerability check"
         id: govuln
         run: |
-          make vulncheck
+          make vulncheck | tee govulncheck-output.txt || true
+          echo "govulncheck_output<<EOF" >> $GITHUB_ENV
+          cat govulncheck-output.txt >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
         continue-on-error: true
-        # TODO: restore failing vuln check when the comet dependency vuln works https://pkg.go.dev/vuln/GO-2025-3443
       - name: Comment on PR
         if: steps.govuln.outcome == 'failure'
         uses: mshick/add-pr-comment@v2
@@ -38,7 +40,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           message: |
             ⚠️ **govulncheck found vulnerabilities:**
-             ```
-            ${{ steps.govuln.outputs.result }}
+            ```
+            ${{ env.govulncheck_output }}
             ```
           message-id: govulncheck-warning

--- a/.github/workflows/dependencies-review.yml
+++ b/.github/workflows/dependencies-review.yml
@@ -26,16 +26,19 @@ jobs:
       - name: "Dependency audit"
         run: ./scripts/dep-assert.sh
       - name: "Go vulnerability check"
+        id: govuln
         run: |
-          make vulncheck | tee govulncheck-output.txt || true
+          make vulncheck
         continue-on-error: true
         # TODO: restore failing vuln check when the comet dependency vuln works https://pkg.go.dev/vuln/GO-2025-3443
       - name: Comment on PR
+        if: steps.govuln.outcome == 'failure'
         uses: mshick/add-pr-comment@v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           message: |
             ⚠️ **govulncheck found vulnerabilities:**
+             ```
+            ${{ steps.govulncheck.outputs.result }}
             ```
-            $(cat govulncheck-output.txt)
-            ```
+          message-id: govulncheck-warning

--- a/.github/workflows/dependencies-review.yml
+++ b/.github/workflows/dependencies-review.yml
@@ -25,4 +25,7 @@ jobs:
       - name: "Dependency audit"
         run: ./scripts/dep-assert.sh
       - name: "Go vulnerability check"
-        run: make vulncheck
+        run: |
+          make vulncheck || echo "::warning file=govulncheck::Vulnerabilities detected, check logs!"
+        continue-on-error: true
+        # TODO: restore failing vuln check when the comet dependency vuln works https://pkg.go.dev/vuln/GO-2025-3443


### PR DESCRIPTION
This [vuln](https://github.com/cosmos/cosmos-sdk/actions/runs/13915084637/job/38936560326?pr=24023) keeps going off in our CI, but it is for versions of [Comet <= v0.38.16](https://pkg.go.dev/vuln/GO-2025-3443).  We use v0.38.17, but still get this error, so I am turning the check into a warning until we have a fix / move to comet v1.0.1