### PR TITLE
chore: lint fixes

### DIFF
--- a/baseapp/abci_test.go
+++ b/baseapp/abci_test.go
@@ -1336,7 +1336,6 @@ func TestABCI_GetBlockRetentionHeight(t *testing.T) {
 	}
 
 	for name, tc := range testCases {
-		tc := tc
 
 		tc.bapp.SetParamStore(&paramStore{db: dbm.NewMemDB()})
 		_, err = tc.bapp.InitChain(&abci.RequestInitChain{

--- a/client/cmd_test.go
+++ b/client/cmd_test.go
@@ -125,8 +125,6 @@ func TestSetCmdClientContextHandler(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			cmd := newCmd()
 			_ = testutil.ApplyMockIODiscardOutErr(cmd)

--- a/client/flags/flags_test.go
+++ b/client/flags/flags_test.go
@@ -22,7 +22,6 @@ func TestParseGasSetting(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 
 		t.Run(tc.name, func(t *testing.T) {
 			gs, err := flags.ParseGasSetting(tc.input)

--- a/client/tx/aux_builder_test.go
+++ b/client/tx/aux_builder_test.go
@@ -213,7 +213,7 @@ func TestAuxTxBuilder(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
-		tc := tc
+
 		t.Run(tc.name, func(t *testing.T) {
 			b = tx.NewAuxTxBuilder()
 			err := tc.malleate()

--- a/client/tx/aux_builder_test.go
+++ b/client/tx/aux_builder_test.go
@@ -213,7 +213,6 @@ func TestAuxTxBuilder(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
-
 		t.Run(tc.name, func(t *testing.T) {
 			b = tx.NewAuxTxBuilder()
 			err := tc.malleate()

--- a/codec/amino_codec_test.go
+++ b/codec/amino_codec_test.go
@@ -71,7 +71,6 @@ func TestAminoCodecMarshalJSONIndent(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 
 		t.Run(tc.name, func(t *testing.T) {
 			cdc := codec.NewAminoCodec(createTestCodec())

--- a/codec/codec_common_test.go
+++ b/codec/codec_common_test.go
@@ -121,7 +121,6 @@ func testMarshaling(t *testing.T, cdc interface {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		m1 := mustMarshaler{cdc.Marshal, cdc.MustMarshal, cdc.Unmarshal, cdc.MustUnmarshal}
 		m2 := mustMarshaler{cdc.MarshalLengthPrefixed, cdc.MustMarshalLengthPrefixed, cdc.UnmarshalLengthPrefixed, cdc.MustUnmarshalLengthPrefixed}
 		m3 := mustMarshaler{

--- a/crypto/keyring/keyring_test.go
+++ b/crypto/keyring/keyring_test.go
@@ -2002,7 +2002,7 @@ func TestRenameKey(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
+
 		kr := newKeyring(t, "testKeyring")
 		t.Run(tc.name, func(t *testing.T) {
 			tc.run(kr)

--- a/crypto/types/compact_bit_array_test.go
+++ b/crypto/types/compact_bit_array_test.go
@@ -58,7 +58,6 @@ func TestBitArrayEqual(t *testing.T) {
 		{name: "different should not be equal", b1: big1, b2: big2, eq: false},
 	}
 	for _, tc := range cases {
-
 		t.Run(tc.name, func(t *testing.T) {
 			eq := tc.b1.Equal(tc.b2)
 			require.Equal(t, tc.eq, eq)
@@ -102,7 +101,6 @@ func TestJSONMarshalUnmarshal(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-
 		t.Run(tc.bA.String(), func(t *testing.T) {
 			bz, err := json.Marshal(tc.bA)
 			require.NoError(t, err)
@@ -162,7 +160,6 @@ func TestCompactMarshalUnmarshal(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-
 		t.Run(tc.bA.String(), func(t *testing.T) {
 			bz := tc.bA.CompactMarshal()
 

--- a/crypto/types/compact_bit_array_test.go
+++ b/crypto/types/compact_bit_array_test.go
@@ -58,7 +58,7 @@ func TestBitArrayEqual(t *testing.T) {
 		{name: "different should not be equal", b1: big1, b2: big2, eq: false},
 	}
 	for _, tc := range cases {
-		tc := tc
+
 		t.Run(tc.name, func(t *testing.T) {
 			eq := tc.b1.Equal(tc.b2)
 			require.Equal(t, tc.eq, eq)
@@ -102,7 +102,7 @@ func TestJSONMarshalUnmarshal(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
+
 		t.Run(tc.bA.String(), func(t *testing.T) {
 			bz, err := json.Marshal(tc.bA)
 			require.NoError(t, err)
@@ -162,7 +162,7 @@ func TestCompactMarshalUnmarshal(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
+
 		t.Run(tc.bA.String(), func(t *testing.T) {
 			bz := tc.bA.CompactMarshal()
 
@@ -209,7 +209,7 @@ func TestCompactBitArrayNumOfTrueBitsBefore(t *testing.T) {
 		{`"______________xx"`, []int{14, 15}, []int{0, 1}},
 	}
 	for tcIndex, tc := range testCases {
-		tc := tc
+
 		tcIndex := tcIndex
 		t.Run(tc.marshalledBA, func(t *testing.T) {
 			var bA *CompactBitArray

--- a/simapp/app_test.go
+++ b/simapp/app_test.go
@@ -132,8 +132,10 @@ func TestRunMigrations(t *testing.T) {
 	}
 
 	// Initialize the chain
-	app.InitChain(&abci.RequestInitChain{})
-	app.Commit()
+	_, err := app.InitChain(&abci.RequestInitChain{})
+	require.NoError(t, err)
+	_, err = app.Commit()
+	require.NoError(t, err)
 
 	testCases := []struct {
 		name         string

--- a/simapp/sim_test.go
+++ b/simapp/sim_test.go
@@ -296,10 +296,11 @@ func TestAppSimulationAfterImport(t *testing.T) {
 	newApp := NewSimApp(log.NewNopLogger(), newDB, nil, true, appOptions, fauxMerkleModeOpt, baseapp.SetChainID(SimAppChainID))
 	require.Equal(t, "SimApp", newApp.Name())
 
-	newApp.InitChain(&abci.RequestInitChain{
+	_, err = newApp.InitChain(&abci.RequestInitChain{
 		AppStateBytes: exported.AppState,
 		ChainId:       SimAppChainID,
 	})
+	require.NoError(t, err)
 
 	_, _, err = simulation.SimulateFromSeed(
 		t,

--- a/simapp/simd/cmd/testnet.go
+++ b/simapp/simd/cmd/testnet.go
@@ -18,10 +18,6 @@ import (
 	"cosmossdk.io/math/unsafe"
 	"cosmossdk.io/simapp"
 
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
-	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
-	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
-
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/tx"
@@ -35,8 +31,11 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	"github.com/cosmos/cosmos-sdk/version"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/cosmos/cosmos-sdk/x/genutil"
 	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 )
 
 var (

--- a/store/iavl/store_test.go
+++ b/store/iavl/store_test.go
@@ -639,7 +639,6 @@ func TestSetInitialVersion(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 
 		t.Run(tc.name, func(t *testing.T) {
 			db := dbm.NewMemDB()

--- a/store/pruning/manager_test.go
+++ b/store/pruning/manager_test.go
@@ -75,7 +75,7 @@ func TestStrategies(t *testing.T) {
 	}
 
 	for name, tc := range testcases {
-		tc := tc // Local copy to avoid shadowing.
+		// Local copy to avoid shadowing.
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/store/pruning/manager_test.go
+++ b/store/pruning/manager_test.go
@@ -75,7 +75,6 @@ func TestStrategies(t *testing.T) {
 	}
 
 	for name, tc := range testcases {
-		// Local copy to avoid shadowing.
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/store/types/iterator_test.go
+++ b/store/types/iterator_test.go
@@ -84,7 +84,7 @@ func TestPaginatedIterator(t *testing.T) {
 			reverse: true,
 		},
 	} {
-		tc := tc
+
 		t.Run(tc.desc, func(t *testing.T) {
 			var iter types.Iterator
 			if tc.reverse {

--- a/store/types/iterator_test.go
+++ b/store/types/iterator_test.go
@@ -84,7 +84,6 @@ func TestPaginatedIterator(t *testing.T) {
 			reverse: true,
 		},
 	} {
-
 		t.Run(tc.desc, func(t *testing.T) {
 			var iter types.Iterator
 			if tc.reverse {

--- a/store/types/store_test.go
+++ b/store/types/store_test.go
@@ -53,7 +53,6 @@ func TestStoreUpgrades(t *testing.T) {
 	}
 
 	for name, tc := range cases {
-
 		t.Run(name, func(t *testing.T) {
 			for _, r := range tc.expectAdd {
 				assert.Equal(t, tc.upgrades.IsAdded(r.key), true)

--- a/store/types/store_test.go
+++ b/store/types/store_test.go
@@ -53,7 +53,7 @@ func TestStoreUpgrades(t *testing.T) {
 	}
 
 	for name, tc := range cases {
-		tc := tc
+
 		t.Run(name, func(t *testing.T) {
 			for _, r := range tc.expectAdd {
 				assert.Equal(t, tc.upgrades.IsAdded(r.key), true)

--- a/types/coin_test.go
+++ b/types/coin_test.go
@@ -168,7 +168,6 @@ func (s *coinTestSuite) TestAddCoin() {
 	}
 
 	for tcIndex, tc := range cases {
-		tc := tc
 		if tc.shouldPanic {
 			s.Require().Panics(func() { tc.inputOne.Add(tc.inputTwo) })
 		} else {
@@ -208,7 +207,6 @@ func (s *coinTestSuite) TestSubCoin() {
 	}
 
 	for tcIndex, tc := range cases {
-		tc := tc
 		if tc.shouldPanic {
 			s.Require().Panics(func() { tc.inputOne.Sub(tc.inputTwo) })
 		} else {
@@ -264,7 +262,7 @@ func (s *coinTestSuite) TestMulIntCoins() {
 
 	assert := s.Assert()
 	for i, tc := range testCases {
-		tc := tc
+
 		if tc.shouldPanic {
 			assert.Panics(func() { tc.input.MulInt(tc.multiplier) })
 		} else {
@@ -291,7 +289,7 @@ func (s *coinTestSuite) TestQuoIntCoins() {
 
 	assert := s.Assert()
 	for i, tc := range testCases {
-		tc := tc
+
 		if tc.shouldPanic {
 			assert.Panics(func() { tc.input.QuoInt(tc.divisor) })
 		} else {
@@ -316,7 +314,7 @@ func (s *coinTestSuite) TestIsGTECoin() {
 	}
 
 	for tcIndex, tc := range cases {
-		tc := tc
+
 		if tc.panics {
 			s.Require().Panics(func() { tc.inputOne.IsGTE(tc.inputTwo) })
 		} else {
@@ -340,7 +338,7 @@ func (s *coinTestSuite) TestIsLTECoin() {
 	}
 
 	for tcIndex, tc := range cases {
-		tc := tc
+
 		if tc.panics {
 			s.Require().Panics(func() { tc.inputOne.IsLTE(tc.inputTwo) })
 		} else {
@@ -366,7 +364,7 @@ func (s *coinTestSuite) TestIsLTCoin() {
 	}
 
 	for tcIndex, tc := range cases {
-		tc := tc
+
 		if tc.panics {
 			s.Require().Panics(func() { tc.inputOne.IsLT(tc.inputTwo) })
 		} else {
@@ -634,7 +632,7 @@ func (s *coinTestSuite) TestSubCoins() {
 
 	assert := s.Assert()
 	for i, tc := range testCases {
-		tc := tc
+
 		if tc.shouldPanic {
 			assert.Panics(func() { tc.inputOne.Sub(tc.inputTwo...) })
 		} else {
@@ -659,7 +657,7 @@ func (s *coinTestSuite) TestSafeSubCoin() {
 	}
 
 	for _, tc := range cases {
-		tc := tc
+
 		res, err := tc.inputOne.SafeSub(tc.inputTwo)
 		if err != nil {
 			s.Require().Contains(err.Error(), tc.expErrMsg)
@@ -1290,7 +1288,7 @@ func (s *coinTestSuite) TestCoinValidate() {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
+
 		t := s.T()
 		t.Run(tc.name, func(t *testing.T) {
 			err := tc.coin.Validate()

--- a/types/coin_test.go
+++ b/types/coin_test.go
@@ -262,7 +262,6 @@ func (s *coinTestSuite) TestMulIntCoins() {
 
 	assert := s.Assert()
 	for i, tc := range testCases {
-
 		if tc.shouldPanic {
 			assert.Panics(func() { tc.input.MulInt(tc.multiplier) })
 		} else {
@@ -289,7 +288,6 @@ func (s *coinTestSuite) TestQuoIntCoins() {
 
 	assert := s.Assert()
 	for i, tc := range testCases {
-
 		if tc.shouldPanic {
 			assert.Panics(func() { tc.input.QuoInt(tc.divisor) })
 		} else {
@@ -314,7 +312,6 @@ func (s *coinTestSuite) TestIsGTECoin() {
 	}
 
 	for tcIndex, tc := range cases {
-
 		if tc.panics {
 			s.Require().Panics(func() { tc.inputOne.IsGTE(tc.inputTwo) })
 		} else {
@@ -338,7 +335,6 @@ func (s *coinTestSuite) TestIsLTECoin() {
 	}
 
 	for tcIndex, tc := range cases {
-
 		if tc.panics {
 			s.Require().Panics(func() { tc.inputOne.IsLTE(tc.inputTwo) })
 		} else {
@@ -364,7 +360,6 @@ func (s *coinTestSuite) TestIsLTCoin() {
 	}
 
 	for tcIndex, tc := range cases {
-
 		if tc.panics {
 			s.Require().Panics(func() { tc.inputOne.IsLT(tc.inputTwo) })
 		} else {
@@ -632,7 +627,6 @@ func (s *coinTestSuite) TestSubCoins() {
 
 	assert := s.Assert()
 	for i, tc := range testCases {
-
 		if tc.shouldPanic {
 			assert.Panics(func() { tc.inputOne.Sub(tc.inputTwo...) })
 		} else {

--- a/types/context_test.go
+++ b/types/context_test.go
@@ -213,7 +213,7 @@ func (s *contextTestSuite) TestContextHeaderClone() {
 	}
 
 	for name, tc := range cases {
-		tc := tc
+
 		s.T().Run(name, func(t *testing.T) {
 			ctx := types.NewContext(nil, tc.h, false, nil)
 			s.Require().Equal(tc.h.Height, ctx.BlockHeight())

--- a/types/context_test.go
+++ b/types/context_test.go
@@ -213,7 +213,6 @@ func (s *contextTestSuite) TestContextHeaderClone() {
 	}
 
 	for name, tc := range cases {
-
 		s.T().Run(name, func(t *testing.T) {
 			ctx := types.NewContext(nil, tc.h, false, nil)
 			s.Require().Equal(tc.h.Height, ctx.BlockHeight())

--- a/types/dec_coin_test.go
+++ b/types/dec_coin_test.go
@@ -211,7 +211,6 @@ func (s *decCoinTestSuite) TestIsValid() {
 	}
 
 	for _, tc := range tests {
-
 		if tc.expectPass {
 			s.Require().True(tc.coin.IsValid(), tc.msg)
 		} else {
@@ -246,7 +245,6 @@ func (s *decCoinTestSuite) TestSubDecCoin() {
 	decCoin := sdk.NewDecCoin("mytoken", math.NewInt(10))
 
 	for _, tc := range tests {
-
 		if tc.expectPass {
 			equal := tc.coin.Sub(decCoin)
 			s.Require().Equal(equal, decCoin, tc.msg)
@@ -282,7 +280,6 @@ func (s *decCoinTestSuite) TestSubDecCoins() {
 	decCoins := sdk.NewDecCoinsFromCoins(sdk.NewCoin("btc", math.NewInt(10)), sdk.NewCoin("eth", math.NewInt(15)), sdk.NewCoin("mytoken", math.NewInt(5)))
 
 	for _, tc := range tests {
-
 		if tc.expectPass {
 			equal := tc.coins.Sub(decCoins)
 			s.Require().Equal(equal, decCoins, tc.msg)
@@ -524,7 +521,6 @@ func (s *decCoinTestSuite) TestDecCoinsQuoDecTruncate() {
 	}
 
 	for i, tc := range testCases {
-
 		if tc.panics {
 			s.Require().Panics(func() { tc.coins.QuoDecTruncate(tc.input) })
 		} else {
@@ -561,7 +557,6 @@ func (s *decCoinTestSuite) TestNewDecCoinsWithIsValid() {
 	}
 
 	for _, tc := range tests {
-
 		if tc.expectPass {
 			s.Require().True(tc.coin.IsValid(), tc.msg)
 		} else {
@@ -588,7 +583,6 @@ func (s *decCoinTestSuite) TestNewDecCoinsWithZeroCoins() {
 	}
 
 	for _, tc := range tests {
-
 		s.Require().Equal(sdk.NewDecCoinsFromCoins(tc.coins...).Len(), tc.expectLength)
 	}
 }
@@ -620,7 +614,6 @@ func (s *decCoinTestSuite) TestDecCoins_AddDecCoinWithIsValid() {
 	}
 
 	for _, tc := range tests {
-
 		if tc.expectPass {
 			s.Require().True(tc.coin.IsValid(), tc.msg)
 		} else {
@@ -676,7 +669,6 @@ func (s *decCoinTestSuite) TestDecCoins_GetDenomByIndex() {
 	}
 
 	for i, tc := range testCases {
-
 		s.T().Run(tc.name, func(t *testing.T) {
 			if tc.expectedErr {
 				s.Require().Panics(func() { tc.input.GetDenomByIndex(tc.index) }, "Test should have panicked")
@@ -718,7 +710,6 @@ func (s *decCoinTestSuite) TestDecCoins_IsAllPositive() {
 	}
 
 	for i, tc := range testCases {
-
 		s.T().Run(tc.name, func(t *testing.T) {
 			if tc.expectedResult {
 				s.Require().True(tc.input.IsAllPositive(), "Test case #%d: %s", i, tc.name)
@@ -788,7 +779,6 @@ func (s *decCoinTestSuite) TestDecCoin_IsGTE() {
 	}
 
 	for i, tc := range testCases {
-
 		s.T().Run(tc.name, func(t *testing.T) {
 			if tc.expectedPanic {
 				s.Require().Panics(func() { tc.coin.IsGTE(tc.otherCoin) }, "Test case #%d: %s", i, tc.name)
@@ -832,7 +822,6 @@ func (s *decCoinTestSuite) TestDecCoins_IsZero() {
 	}
 
 	for i, tc := range testCases {
-
 		s.T().Run(tc.name, func(t *testing.T) {
 			if tc.expectedResult {
 				s.Require().True(tc.coins.IsZero(), "Test case #%d: %s", i, tc.name)
@@ -887,7 +876,6 @@ func (s *decCoinTestSuite) TestDecCoins_MulDec() {
 	}
 
 	for i, tc := range testCases {
-
 		s.T().Run(tc.name, func(t *testing.T) {
 			res := tc.coins.MulDec(tc.multiplier)
 			s.Require().Equal(tc.expectedResult, res, "Test case #%d: %s", i, tc.name)
@@ -936,7 +924,6 @@ func (s *decCoinTestSuite) TestDecCoins_MulDecTruncate() {
 	}
 
 	for i, tc := range testCases {
-
 		s.T().Run(tc.name, func(t *testing.T) {
 			if tc.expectedPanic {
 				s.Require().Panics(func() { tc.coins.MulDecTruncate(tc.multiplier) }, "Test case #%d: %s", i, tc.name)
@@ -989,7 +976,6 @@ func (s *decCoinTestSuite) TestDecCoins_QuoDec() {
 	}
 
 	for i, tc := range testCases {
-
 		s.T().Run(tc.name, func(t *testing.T) {
 			if tc.panics {
 				s.Require().Panics(func() { tc.coins.QuoDec(tc.input) }, "Test case #%d: %s", i, tc.name)

--- a/types/dec_coin_test.go
+++ b/types/dec_coin_test.go
@@ -211,7 +211,7 @@ func (s *decCoinTestSuite) TestIsValid() {
 	}
 
 	for _, tc := range tests {
-		tc := tc
+
 		if tc.expectPass {
 			s.Require().True(tc.coin.IsValid(), tc.msg)
 		} else {
@@ -246,7 +246,7 @@ func (s *decCoinTestSuite) TestSubDecCoin() {
 	decCoin := sdk.NewDecCoin("mytoken", math.NewInt(10))
 
 	for _, tc := range tests {
-		tc := tc
+
 		if tc.expectPass {
 			equal := tc.coin.Sub(decCoin)
 			s.Require().Equal(equal, decCoin, tc.msg)
@@ -282,7 +282,7 @@ func (s *decCoinTestSuite) TestSubDecCoins() {
 	decCoins := sdk.NewDecCoinsFromCoins(sdk.NewCoin("btc", math.NewInt(10)), sdk.NewCoin("eth", math.NewInt(15)), sdk.NewCoin("mytoken", math.NewInt(5)))
 
 	for _, tc := range tests {
-		tc := tc
+
 		if tc.expectPass {
 			equal := tc.coins.Sub(decCoins)
 			s.Require().Equal(equal, decCoins, tc.msg)
@@ -524,7 +524,7 @@ func (s *decCoinTestSuite) TestDecCoinsQuoDecTruncate() {
 	}
 
 	for i, tc := range testCases {
-		tc := tc
+
 		if tc.panics {
 			s.Require().Panics(func() { tc.coins.QuoDecTruncate(tc.input) })
 		} else {
@@ -561,7 +561,7 @@ func (s *decCoinTestSuite) TestNewDecCoinsWithIsValid() {
 	}
 
 	for _, tc := range tests {
-		tc := tc
+
 		if tc.expectPass {
 			s.Require().True(tc.coin.IsValid(), tc.msg)
 		} else {
@@ -588,7 +588,7 @@ func (s *decCoinTestSuite) TestNewDecCoinsWithZeroCoins() {
 	}
 
 	for _, tc := range tests {
-		tc := tc
+
 		s.Require().Equal(sdk.NewDecCoinsFromCoins(tc.coins...).Len(), tc.expectLength)
 	}
 }
@@ -620,7 +620,7 @@ func (s *decCoinTestSuite) TestDecCoins_AddDecCoinWithIsValid() {
 	}
 
 	for _, tc := range tests {
-		tc := tc
+
 		if tc.expectPass {
 			s.Require().True(tc.coin.IsValid(), tc.msg)
 		} else {
@@ -676,7 +676,7 @@ func (s *decCoinTestSuite) TestDecCoins_GetDenomByIndex() {
 	}
 
 	for i, tc := range testCases {
-		tc := tc
+
 		s.T().Run(tc.name, func(t *testing.T) {
 			if tc.expectedErr {
 				s.Require().Panics(func() { tc.input.GetDenomByIndex(tc.index) }, "Test should have panicked")
@@ -718,7 +718,7 @@ func (s *decCoinTestSuite) TestDecCoins_IsAllPositive() {
 	}
 
 	for i, tc := range testCases {
-		tc := tc
+
 		s.T().Run(tc.name, func(t *testing.T) {
 			if tc.expectedResult {
 				s.Require().True(tc.input.IsAllPositive(), "Test case #%d: %s", i, tc.name)
@@ -788,7 +788,7 @@ func (s *decCoinTestSuite) TestDecCoin_IsGTE() {
 	}
 
 	for i, tc := range testCases {
-		tc := tc
+
 		s.T().Run(tc.name, func(t *testing.T) {
 			if tc.expectedPanic {
 				s.Require().Panics(func() { tc.coin.IsGTE(tc.otherCoin) }, "Test case #%d: %s", i, tc.name)
@@ -832,7 +832,7 @@ func (s *decCoinTestSuite) TestDecCoins_IsZero() {
 	}
 
 	for i, tc := range testCases {
-		tc := tc
+
 		s.T().Run(tc.name, func(t *testing.T) {
 			if tc.expectedResult {
 				s.Require().True(tc.coins.IsZero(), "Test case #%d: %s", i, tc.name)
@@ -887,7 +887,7 @@ func (s *decCoinTestSuite) TestDecCoins_MulDec() {
 	}
 
 	for i, tc := range testCases {
-		tc := tc
+
 		s.T().Run(tc.name, func(t *testing.T) {
 			res := tc.coins.MulDec(tc.multiplier)
 			s.Require().Equal(tc.expectedResult, res, "Test case #%d: %s", i, tc.name)
@@ -936,7 +936,7 @@ func (s *decCoinTestSuite) TestDecCoins_MulDecTruncate() {
 	}
 
 	for i, tc := range testCases {
-		tc := tc
+
 		s.T().Run(tc.name, func(t *testing.T) {
 			if tc.expectedPanic {
 				s.Require().Panics(func() { tc.coins.MulDecTruncate(tc.multiplier) }, "Test case #%d: %s", i, tc.name)
@@ -989,7 +989,7 @@ func (s *decCoinTestSuite) TestDecCoins_QuoDec() {
 	}
 
 	for i, tc := range testCases {
-		tc := tc
+
 		s.T().Run(tc.name, func(t *testing.T) {
 			if tc.panics {
 				s.Require().Panics(func() { tc.coins.QuoDec(tc.input) }, "Test case #%d: %s", i, tc.name)

--- a/types/events_test.go
+++ b/types/events_test.go
@@ -268,7 +268,7 @@ func (s *eventsTestSuite) TestMarkEventsToIndex() {
 	}
 
 	for name, tc := range testCases {
-		tc := tc
+
 		s.T().Run(name, func(_ *testing.T) {
 			s.Require().Equal(tc.expected, sdk.MarkEventsToIndex(tc.events, tc.indexSet))
 		})

--- a/types/events_test.go
+++ b/types/events_test.go
@@ -268,7 +268,6 @@ func (s *eventsTestSuite) TestMarkEventsToIndex() {
 	}
 
 	for name, tc := range testCases {
-
 		s.T().Run(name, func(_ *testing.T) {
 			s.Require().Equal(tc.expected, sdk.MarkEventsToIndex(tc.events, tc.indexSet))
 		})

--- a/types/tx/direct_aux_test.go
+++ b/types/tx/direct_aux_test.go
@@ -33,7 +33,7 @@ func TestSignDocDirectAux(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
-		tc := tc
+
 		t.Run(tc.name, func(t *testing.T) {
 			err := tc.sd.ValidateBasic()
 
@@ -68,7 +68,7 @@ func TestAuxSignerData(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
-		tc := tc
+
 		t.Run(tc.name, func(t *testing.T) {
 			err := tc.sd.ValidateBasic()
 

--- a/types/tx/direct_aux_test.go
+++ b/types/tx/direct_aux_test.go
@@ -33,7 +33,6 @@ func TestSignDocDirectAux(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
-
 		t.Run(tc.name, func(t *testing.T) {
 			err := tc.sd.ValidateBasic()
 
@@ -68,7 +67,6 @@ func TestAuxSignerData(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
-
 		t.Run(tc.name, func(t *testing.T) {
 			err := tc.sd.ValidateBasic()
 

--- a/types/utils_test.go
+++ b/types/utils_test.go
@@ -33,7 +33,6 @@ func (s *utilsTestSuite) TestTimeFormatAndParse() {
 		{"2011-01-10T23:10:05.758230235Z", "2011-01-10T23:10:05.758230235", true},
 	}
 	for _, tc := range cases {
-		tc := tc
 		timeFromRFC, err := time.Parse(time.RFC3339Nano, tc.RFC3339NanoStr)
 		s.Require().Nil(err)
 		timeFromSDKFormat, err := time.Parse(sdk.SortableTimeFormat, tc.SDKSortableTimeStr)
@@ -116,8 +115,6 @@ func (s *utilsTestSuite) TestParseTime() {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
-
 		s.Run(tc.name, func() {
 			tm, err := sdk.ParseTime(tc.input)
 			if tc.expectErr {

--- a/x/auth/ante/basic_test.go
+++ b/x/auth/ante/basic_test.go
@@ -214,7 +214,6 @@ func TestTxHeightTimeoutDecorator(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 
 		t.Run(tc.name, func(t *testing.T) {
 			suite.txBuilder = suite.clientCtx.TxConfig.NewTxBuilder()

--- a/x/auth/keeper/msg_server_test.go
+++ b/x/auth/keeper/msg_server_test.go
@@ -97,7 +97,6 @@ func (s *KeeperTestSuite) TestUpdateParams() {
 	}
 
 	for _, tc := range testCases {
-
 		s.Run(tc.name, func() {
 			_, err := s.msgServer.UpdateParams(s.ctx, tc.req)
 			if tc.expectErr {

--- a/x/auth/keeper/msg_server_test.go
+++ b/x/auth/keeper/msg_server_test.go
@@ -97,7 +97,7 @@ func (s *KeeperTestSuite) TestUpdateParams() {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
+
 		s.Run(tc.name, func() {
 			_, err := s.msgServer.UpdateParams(s.ctx, tc.req)
 			if tc.expectErr {

--- a/x/auth/migrations/legacytx/stdtx_test.go
+++ b/x/auth/migrations/legacytx/stdtx_test.go
@@ -90,7 +90,6 @@ func TestStdSignBytes(t *testing.T) {
 		FileResolver: proto.HybridResolver,
 	})
 	for i, tc := range tests {
-
 		t.Run(tc.name, func(t *testing.T) {
 			anyMsgs := make([]*anypb.Any, len(tc.args.msgs))
 			for j, msg := range tc.args.msgs {

--- a/x/auth/migrations/legacytx/stdtx_test.go
+++ b/x/auth/migrations/legacytx/stdtx_test.go
@@ -90,7 +90,7 @@ func TestStdSignBytes(t *testing.T) {
 		FileResolver: proto.HybridResolver,
 	})
 	for i, tc := range tests {
-		tc := tc
+
 		t.Run(tc.name, func(t *testing.T) {
 			anyMsgs := make([]*anypb.Any, len(tc.args.msgs))
 			for j, msg := range tc.args.msgs {

--- a/x/auth/tx/aux_test.go
+++ b/x/auth/tx/aux_test.go
@@ -98,7 +98,7 @@ func TestBuilderWithAux(t *testing.T) {
 		{"happy case", func() {}, false},
 	}
 	for _, tc := range testcases {
-		tc := tc
+
 		t.Run(tc.name, func(t *testing.T) {
 			txBuilder, txSig = makeTxBuilder(t)
 

--- a/x/auth/tx/aux_test.go
+++ b/x/auth/tx/aux_test.go
@@ -98,7 +98,6 @@ func TestBuilderWithAux(t *testing.T) {
 		{"happy case", func() {}, false},
 	}
 	for _, tc := range testcases {
-
 		t.Run(tc.name, func(t *testing.T) {
 			txBuilder, txSig = makeTxBuilder(t)
 

--- a/x/authz/authorization_grant_test.go
+++ b/x/authz/authorization_grant_test.go
@@ -34,7 +34,6 @@ func TestNewGrant(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.title, func(t *testing.T) {
 			_, err := NewGrant(tc.blockTime, tc.a, tc.expire)
 			expecError(require.New(t), tc.err, err)

--- a/x/authz/client/cli/tx_test.go
+++ b/x/authz/client/cli/tx_test.go
@@ -592,7 +592,7 @@ func (s *CLITestSuite) TestCmdRevokeAuthorizations() {
 		},
 	}
 	for _, tc := range testCases {
-		tc := tc
+
 		s.Run(tc.name, func() {
 			cmd := cli.NewCmdRevokeAuthorization(addresscodec.NewBech32Codec("cosmos"))
 
@@ -727,7 +727,7 @@ func (s *CLITestSuite) TestNewExecGenericAuthorized() {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
+
 		s.Run(tc.name, func() {
 			cmd := cli.NewCmdExecAuthorization()
 
@@ -812,7 +812,7 @@ func (s *CLITestSuite) TestNewExecGrantAuthorized() {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
+
 		s.Run(tc.name, func() {
 			cmd := cli.NewCmdExecAuthorization()
 			clientCtx := s.clientCtx

--- a/x/authz/client/cli/tx_test.go
+++ b/x/authz/client/cli/tx_test.go
@@ -592,7 +592,6 @@ func (s *CLITestSuite) TestCmdRevokeAuthorizations() {
 		},
 	}
 	for _, tc := range testCases {
-
 		s.Run(tc.name, func() {
 			cmd := cli.NewCmdRevokeAuthorization(addresscodec.NewBech32Codec("cosmos"))
 
@@ -727,7 +726,6 @@ func (s *CLITestSuite) TestNewExecGenericAuthorized() {
 	}
 
 	for _, tc := range testCases {
-
 		s.Run(tc.name, func() {
 			cmd := cli.NewCmdExecAuthorization()
 
@@ -812,7 +810,6 @@ func (s *CLITestSuite) TestNewExecGrantAuthorized() {
 	}
 
 	for _, tc := range testCases {
-
 		s.Run(tc.name, func() {
 			cmd := cli.NewCmdExecAuthorization()
 			clientCtx := s.clientCtx

--- a/x/authz/keeper/grpc_query_test.go
+++ b/x/authz/keeper/grpc_query_test.go
@@ -183,7 +183,6 @@ func (suite *TestSuite) TestGRPCQueryGranterGrants() {
 	}
 
 	for _, tc := range testCases {
-
 		suite.Run(fmt.Sprintf("Case %s", tc.msg), func() {
 			tc.preRun()
 			result, err := queryClient.GranterGrants(gocontext.Background(), &tc.request)

--- a/x/authz/keeper/grpc_query_test.go
+++ b/x/authz/keeper/grpc_query_test.go
@@ -183,7 +183,7 @@ func (suite *TestSuite) TestGRPCQueryGranterGrants() {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
+
 		suite.Run(fmt.Sprintf("Case %s", tc.msg), func() {
 			tc.preRun()
 			result, err := queryClient.GranterGrants(gocontext.Background(), &tc.request)

--- a/x/bank/client/cli/tx_test.go
+++ b/x/bank/client/cli/tx_test.go
@@ -111,7 +111,6 @@ func (s *CLITestSuite) TestSendTxCmd() {
 	}
 
 	for _, tc := range testCases {
-
 		s.Run(tc.name, func() {
 			args := append([]string{tc.from.String(), tc.to.String(), tc.amount.String()}, tc.extraArgs...)
 
@@ -224,7 +223,6 @@ func (s *CLITestSuite) TestMultiSendTxCmd() {
 	}
 
 	for _, tc := range testCases {
-
 		s.Run(tc.name, func() {
 			ctx := svrcmd.CreateExecuteContext(context.Background())
 

--- a/x/bank/client/cli/tx_test.go
+++ b/x/bank/client/cli/tx_test.go
@@ -111,7 +111,7 @@ func (s *CLITestSuite) TestSendTxCmd() {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
+
 		s.Run(tc.name, func() {
 			args := append([]string{tc.from.String(), tc.to.String(), tc.amount.String()}, tc.extraArgs...)
 
@@ -224,7 +224,7 @@ func (s *CLITestSuite) TestMultiSendTxCmd() {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
+
 		s.Run(tc.name, func() {
 			ctx := svrcmd.CreateExecuteContext(context.Background())
 

--- a/x/bank/keeper/genesis_test.go
+++ b/x/bank/keeper/genesis_test.go
@@ -113,7 +113,6 @@ func (suite *KeeperTestSuite) TestTotalSupply() {
 	}
 
 	for _, tc := range testcases {
-
 		suite.Run(tc.name, func() {
 			if tc.expPanic {
 				suite.PanicsWithError(tc.expPanicMsg, func() { suite.bankKeeper.InitGenesis(suite.ctx, tc.genesis) })

--- a/x/bank/keeper/genesis_test.go
+++ b/x/bank/keeper/genesis_test.go
@@ -113,7 +113,7 @@ func (suite *KeeperTestSuite) TestTotalSupply() {
 	}
 
 	for _, tc := range testcases {
-		tc := tc
+
 		suite.Run(tc.name, func() {
 			if tc.expPanic {
 				suite.PanicsWithError(tc.expPanicMsg, func() { suite.bankKeeper.InitGenesis(suite.ctx, tc.genesis) })

--- a/x/bank/keeper/grpc_query_test.go
+++ b/x/bank/keeper/grpc_query_test.go
@@ -78,7 +78,6 @@ func (suite *KeeperTestSuite) TestQueryBalance() {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 
 		suite.Run(tc.name, func() {
 			res, err := queryClient.Balance(gocontext.Background(), tc.req)

--- a/x/bank/types/balance_test.go
+++ b/x/bank/types/balance_test.go
@@ -103,7 +103,6 @@ func TestBalanceValidate(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-
 		t.Run(tc.name, func(t *testing.T) {
 			err := tc.balance.Validate()
 

--- a/x/bank/types/balance_test.go
+++ b/x/bank/types/balance_test.go
@@ -103,7 +103,7 @@ func TestBalanceValidate(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
+
 		t.Run(tc.name, func(t *testing.T) {
 			err := tc.balance.Validate()
 

--- a/x/bank/types/genesis_test.go
+++ b/x/bank/types/genesis_test.go
@@ -146,7 +146,6 @@ func TestGenesisStateValidate(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-
 		t.Run(tc.name, func(tt *testing.T) {
 			err := tc.genesisState.Validate()
 

--- a/x/bank/types/genesis_test.go
+++ b/x/bank/types/genesis_test.go
@@ -146,7 +146,7 @@ func TestGenesisStateValidate(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
+
 		t.Run(tc.name, func(tt *testing.T) {
 			err := tc.genesisState.Validate()
 

--- a/x/bank/types/metadata_test.go
+++ b/x/bank/types/metadata_test.go
@@ -216,7 +216,6 @@ func TestMetadataValidate(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-
 		t.Run(tc.name, func(t *testing.T) {
 			err := tc.metadata.Validate()
 
@@ -258,7 +257,6 @@ func TestMarshalJSONMetaData(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-
 		t.Run(tc.name, func(t *testing.T) {
 			bz, err := cdc.MarshalJSON(tc.input)
 			require.NoError(t, err)

--- a/x/bank/types/metadata_test.go
+++ b/x/bank/types/metadata_test.go
@@ -216,7 +216,7 @@ func TestMetadataValidate(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
+
 		t.Run(tc.name, func(t *testing.T) {
 			err := tc.metadata.Validate()
 
@@ -258,7 +258,7 @@ func TestMarshalJSONMetaData(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
+
 		t.Run(tc.name, func(t *testing.T) {
 			bz, err := cdc.MarshalJSON(tc.input)
 			require.NoError(t, err)

--- a/x/consensus/keeper/keeper_test.go
+++ b/x/consensus/keeper/keeper_test.go
@@ -292,7 +292,6 @@ func (s *KeeperTestSuite) TestUpdateParams() {
 	}
 
 	for _, tc := range testCases {
-
 		s.Run(tc.name, func() {
 			s.SetupTest()
 			_, err := s.consensusParamsKeeper.UpdateParams(s.ctx, tc.input)

--- a/x/consensus/keeper/keeper_test.go
+++ b/x/consensus/keeper/keeper_test.go
@@ -292,7 +292,7 @@ func (s *KeeperTestSuite) TestUpdateParams() {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
+
 		s.Run(tc.name, func() {
 			s.SetupTest()
 			_, err := s.consensusParamsKeeper.UpdateParams(s.ctx, tc.input)

--- a/x/evidence/keeper/msg_server_test.go
+++ b/x/evidence/keeper/msg_server_test.go
@@ -66,7 +66,7 @@ func (s *KeeperTestSuite) TestSubmitEvidence() {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
+
 		s.Run(tc.name, func() {
 			_, err := s.msgServer.SubmitEvidence(s.ctx, tc.req)
 			if tc.expErr {

--- a/x/evidence/keeper/msg_server_test.go
+++ b/x/evidence/keeper/msg_server_test.go
@@ -66,7 +66,6 @@ func (s *KeeperTestSuite) TestSubmitEvidence() {
 	}
 
 	for _, tc := range testCases {
-
 		s.Run(tc.name, func() {
 			_, err := s.msgServer.SubmitEvidence(s.ctx, tc.req)
 			if tc.expErr {

--- a/x/evidence/types/evidence_test.go
+++ b/x/evidence/types/evidence_test.go
@@ -65,7 +65,6 @@ func TestEquivocationValidateBasic(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-
 		t.Run(tc.name, func(t *testing.T) {
 			require.Equal(t, tc.expectErr, tc.e.ValidateBasic() != nil)
 		})

--- a/x/evidence/types/evidence_test.go
+++ b/x/evidence/types/evidence_test.go
@@ -65,7 +65,7 @@ func TestEquivocationValidateBasic(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
+
 		t.Run(tc.name, func(t *testing.T) {
 			require.Equal(t, tc.expectErr, tc.e.ValidateBasic() != nil)
 		})

--- a/x/feegrant/client/cli/tx_test.go
+++ b/x/feegrant/client/cli/tx_test.go
@@ -412,7 +412,6 @@ func (s *CLITestSuite) TestNewCmdFeeGrant() {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 
 		s.Run(tc.name, func() {
 			cmd := cli.NewCmdFeeGrant(codecaddress.NewBech32Codec("cosmos"))

--- a/x/feegrant/grant_test.go
+++ b/x/feegrant/grant_test.go
@@ -80,7 +80,7 @@ func TestGrant(t *testing.T) {
 	}
 
 	for name, tc := range cases {
-		tc := tc
+
 		t.Run(name, func(t *testing.T) {
 			grant, err := feegrant.NewGrant(tc.granter, tc.grantee, &feegrant.BasicAllowance{
 				SpendLimit: tc.limit,

--- a/x/feegrant/grant_test.go
+++ b/x/feegrant/grant_test.go
@@ -80,7 +80,6 @@ func TestGrant(t *testing.T) {
 	}
 
 	for name, tc := range cases {
-
 		t.Run(name, func(t *testing.T) {
 			grant, err := feegrant.NewGrant(tc.granter, tc.grantee, &feegrant.BasicAllowance{
 				SpendLimit: tc.limit,

--- a/x/feegrant/keeper/genesis_test.go
+++ b/x/feegrant/keeper/genesis_test.go
@@ -130,7 +130,6 @@ func TestInitGenesis(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-
 		t.Run(tc.name, func(t *testing.T) {
 			f := initFixture(t)
 			if !tc.invalidAddr {

--- a/x/feegrant/keeper/genesis_test.go
+++ b/x/feegrant/keeper/genesis_test.go
@@ -130,7 +130,7 @@ func TestInitGenesis(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
+
 		t.Run(tc.name, func(t *testing.T) {
 			f := initFixture(t)
 			if !tc.invalidAddr {

--- a/x/feegrant/keeper/keeper_test.go
+++ b/x/feegrant/keeper/keeper_test.go
@@ -159,7 +159,6 @@ func (suite *KeeperTestSuite) TestKeeperCrud() {
 	}
 
 	for name, tc := range cases {
-
 		suite.Run(name, func() {
 			allow, _ := suite.feegrantKeeper.GetAllowance(suite.ctx, tc.granter, tc.grantee)
 
@@ -253,7 +252,6 @@ func (suite *KeeperTestSuite) TestUseGrantedFee() {
 	}
 
 	for name, tc := range cases {
-
 		suite.Run(name, func() {
 			err := suite.feegrantKeeper.GrantAllowance(suite.ctx, tc.granter, tc.grantee, future)
 			suite.Require().NoError(err)
@@ -389,7 +387,6 @@ func (suite *KeeperTestSuite) TestPruneGrants() {
 	}
 
 	for _, tc := range testCases {
-
 		suite.Run(tc.name, func() {
 			if tc.preRun != nil {
 				tc.preRun()

--- a/x/feegrant/keeper/keeper_test.go
+++ b/x/feegrant/keeper/keeper_test.go
@@ -159,7 +159,7 @@ func (suite *KeeperTestSuite) TestKeeperCrud() {
 	}
 
 	for name, tc := range cases {
-		tc := tc
+
 		suite.Run(name, func() {
 			allow, _ := suite.feegrantKeeper.GetAllowance(suite.ctx, tc.granter, tc.grantee)
 
@@ -253,7 +253,7 @@ func (suite *KeeperTestSuite) TestUseGrantedFee() {
 	}
 
 	for name, tc := range cases {
-		tc := tc
+
 		suite.Run(name, func() {
 			err := suite.feegrantKeeper.GrantAllowance(suite.ctx, tc.granter, tc.grantee, future)
 			suite.Require().NoError(err)
@@ -389,7 +389,7 @@ func (suite *KeeperTestSuite) TestPruneGrants() {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
+
 		suite.Run(tc.name, func() {
 			if tc.preRun != nil {
 				tc.preRun()

--- a/x/genutil/client/cli/gentx_test.go
+++ b/x/genutil/client/cli/gentx_test.go
@@ -113,7 +113,6 @@ func (s *CLITestSuite) TestGenTxCmd() {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 
 		dir := s.T().TempDir()
 		genTxFile := filepath.Join(dir, "myTx")

--- a/x/genutil/client/cli/migrate_test.go
+++ b/x/genutil/client/cli/migrate_test.go
@@ -53,7 +53,7 @@ func TestMigrateGenesis(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
+
 		t.Run(tc.name, func(t *testing.T) {
 			genesisFile := testutil.WriteToNewTempFile(t, tc.genesis)
 			jsonOutput, err := clitestutil.ExecTestCLICmd(

--- a/x/genutil/client/cli/migrate_test.go
+++ b/x/genutil/client/cli/migrate_test.go
@@ -53,7 +53,6 @@ func TestMigrateGenesis(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-
 		t.Run(tc.name, func(t *testing.T) {
 			genesisFile := testutil.WriteToNewTempFile(t, tc.genesis)
 			jsonOutput, err := clitestutil.ExecTestCLICmd(

--- a/x/genutil/client/cli/validate_genesis_test.go
+++ b/x/genutil/client/cli/validate_genesis_test.go
@@ -80,7 +80,6 @@ func TestValidateGenesis(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 
 		t.Run(tc.name, func(t *testing.T) {
 			genesisFile := testutil.WriteToNewTempFile(t, tc.genesis)

--- a/x/gov/client/cli/tx_test.go
+++ b/x/gov/client/cli/tx_test.go
@@ -155,7 +155,6 @@ func (s *CLITestSuite) TestNewCmdSubmitProposal() {
 	}
 
 	for _, tc := range testCases {
-
 		s.Run(tc.name, func() {
 			cmd := cli.NewCmdSubmitProposal()
 
@@ -248,7 +247,6 @@ func (s *CLITestSuite) TestNewCmdSubmitLegacyProposal() {
 	}
 
 	for _, tc := range testCases {
-
 		s.Run(tc.name, func() {
 			cmd := cli.NewCmdSubmitLegacyProposal()
 
@@ -312,7 +310,6 @@ func (s *CLITestSuite) TestNewCmdDeposit() {
 	}
 
 	for _, tc := range testCases {
-
 		s.Run(tc.name, func() {
 			cmd := cli.NewCmdDeposit()
 
@@ -390,7 +387,6 @@ func (s *CLITestSuite) TestNewCmdVote() {
 	}
 
 	for _, tc := range testCases {
-
 		s.Run(tc.name, func() {
 			cmd := cli.NewCmdVote()
 			out, err := clitestutil.ExecTestCLICmd(s.clientCtx, cmd, tc.args)
@@ -491,7 +487,6 @@ func (s *CLITestSuite) TestNewCmdWeightedVote() {
 	}
 
 	for _, tc := range testCases {
-
 		s.Run(tc.name, func() {
 			cmd := cli.NewCmdWeightedVote()
 			out, err := clitestutil.ExecTestCLICmd(s.clientCtx, cmd, tc.args)

--- a/x/gov/client/cli/tx_test.go
+++ b/x/gov/client/cli/tx_test.go
@@ -155,7 +155,6 @@ func (s *CLITestSuite) TestNewCmdSubmitProposal() {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 
 		s.Run(tc.name, func() {
 			cmd := cli.NewCmdSubmitProposal()
@@ -249,7 +248,6 @@ func (s *CLITestSuite) TestNewCmdSubmitLegacyProposal() {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 
 		s.Run(tc.name, func() {
 			cmd := cli.NewCmdSubmitLegacyProposal()
@@ -314,7 +312,6 @@ func (s *CLITestSuite) TestNewCmdDeposit() {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 
 		s.Run(tc.name, func() {
 			cmd := cli.NewCmdDeposit()
@@ -393,7 +390,7 @@ func (s *CLITestSuite) TestNewCmdVote() {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
+
 		s.Run(tc.name, func() {
 			cmd := cli.NewCmdVote()
 			out, err := clitestutil.ExecTestCLICmd(s.clientCtx, cmd, tc.args)
@@ -494,7 +491,7 @@ func (s *CLITestSuite) TestNewCmdWeightedVote() {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
+
 		s.Run(tc.name, func() {
 			cmd := cli.NewCmdWeightedVote()
 			out, err := clitestutil.ExecTestCLICmd(s.clientCtx, cmd, tc.args)

--- a/x/gov/client/utils/query_test.go
+++ b/x/gov/client/utils/query_test.go
@@ -140,7 +140,6 @@ func TestGetPaginatedVotes(t *testing.T) {
 			},
 		},
 	} {
-		tc := tc
 
 		t.Run(tc.description, func(t *testing.T) {
 			marshaled := make([]cmttypes.Tx, len(tc.msgs))

--- a/x/gov/keeper/msg_server_test.go
+++ b/x/gov/keeper/msg_server_test.go
@@ -1688,7 +1688,6 @@ func (suite *KeeperTestSuite) TestMsgUpdateParams() {
 	}
 
 	for _, tc := range testCases {
-
 		suite.Run(tc.name, func() {
 			msg := tc.input()
 			exec := func(updateParams *v1.MsgUpdateParams) error {

--- a/x/gov/keeper/msg_server_test.go
+++ b/x/gov/keeper/msg_server_test.go
@@ -1688,7 +1688,7 @@ func (suite *KeeperTestSuite) TestMsgUpdateParams() {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
+
 		suite.Run(tc.name, func() {
 			msg := tc.input()
 			exec := func(updateParams *v1.MsgUpdateParams) error {

--- a/x/gov/migrations/v3/convert_test.go
+++ b/x/gov/migrations/v3/convert_test.go
@@ -49,7 +49,7 @@ func TestConvertToLegacyProposal(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			tc := tc
+
 			proposal.FinalTallyResult = &tc.tallyResult
 			v1beta1Proposal, err := v3.ConvertToLegacyProposal(proposal)
 			if tc.expErr {

--- a/x/gov/migrations/v3/convert_test.go
+++ b/x/gov/migrations/v3/convert_test.go
@@ -49,7 +49,6 @@ func TestConvertToLegacyProposal(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-
 			proposal.FinalTallyResult = &tc.tallyResult
 			v1beta1Proposal, err := v3.ConvertToLegacyProposal(proposal)
 			if tc.expErr {

--- a/x/gov/types/v1/genesis_test.go
+++ b/x/gov/types/v1/genesis_test.go
@@ -173,7 +173,6 @@ func TestValidateGenesis(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-
 		t.Run(tc.name, func(t *testing.T) {
 			err := v1.ValidateGenesis(tc.genesisState())
 			if tc.expErrMsg != "" {

--- a/x/gov/types/v1/genesis_test.go
+++ b/x/gov/types/v1/genesis_test.go
@@ -173,7 +173,7 @@ func TestValidateGenesis(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
+
 		t.Run(tc.name, func(t *testing.T) {
 			err := v1.ValidateGenesis(tc.genesisState())
 			if tc.expErrMsg != "" {

--- a/x/group/client/cli/tx_test.go
+++ b/x/group/client/cli/tx_test.go
@@ -207,7 +207,6 @@ func (s *CLITestSuite) TestTxCreateGroup() {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 
 		s.Run(tc.name, func() {
 			ctx := svrcmd.CreateExecuteContext(context.Background())
@@ -335,7 +334,6 @@ func (s *CLITestSuite) TestTxUpdateGroupAdmin() {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 
 		s.Run(tc.name, func() {
 			ctx := svrcmd.CreateExecuteContext(context.Background())
@@ -430,7 +428,6 @@ func (s *CLITestSuite) TestTxUpdateGroupMetadata() {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 
 		s.Run(tc.name, func() {
 			ctx := svrcmd.CreateExecuteContext(context.Background())
@@ -545,7 +542,6 @@ func (s *CLITestSuite) TestTxUpdateGroupMembers() {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 
 		s.Run(tc.name, func() {
 			ctx := svrcmd.CreateExecuteContext(context.Background())

--- a/x/group/genesis_test.go
+++ b/x/group/genesis_test.go
@@ -735,7 +735,6 @@ func TestGenesisStateValidate(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-
 		t.Run(tc.name, func(t *testing.T) {
 			err := tc.genesisState.Validate()
 			if tc.expErr {

--- a/x/group/genesis_test.go
+++ b/x/group/genesis_test.go
@@ -735,7 +735,7 @@ func TestGenesisStateValidate(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		tc := tc
+
 		t.Run(tc.name, func(t *testing.T) {
 			err := tc.genesisState.Validate()
 			if tc.expErr {

--- a/x/mint/keeper/msg_server_test.go
+++ b/x/mint/keeper/msg_server_test.go
@@ -60,7 +60,7 @@ func (s *IntegrationTestSuite) TestUpdateParams() {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
+
 		s.Run(tc.name, func() {
 			_, err := s.msgServer.UpdateParams(s.ctx, tc.request)
 			if tc.expectErr {

--- a/x/mint/keeper/msg_server_test.go
+++ b/x/mint/keeper/msg_server_test.go
@@ -60,7 +60,6 @@ func (s *IntegrationTestSuite) TestUpdateParams() {
 	}
 
 	for _, tc := range testCases {
-
 		s.Run(tc.name, func() {
 			_, err := s.msgServer.UpdateParams(s.ctx, tc.request)
 			if tc.expectErr {

--- a/x/slashing/keeper/msg_server_test.go
+++ b/x/slashing/keeper/msg_server_test.go
@@ -132,7 +132,7 @@ func (s *KeeperTestSuite) TestUpdateParams() {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
+
 		s.Run(tc.name, func() {
 			_, err := s.msgServer.UpdateParams(s.ctx, tc.request)
 			if tc.expectErr {
@@ -318,7 +318,7 @@ func (s *KeeperTestSuite) TestUnjail() {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
+
 		s.Run(tc.name, func() {
 			req := tc.malleate()
 			_, err := s.msgServer.Unjail(s.ctx, req)

--- a/x/slashing/keeper/msg_server_test.go
+++ b/x/slashing/keeper/msg_server_test.go
@@ -132,7 +132,6 @@ func (s *KeeperTestSuite) TestUpdateParams() {
 	}
 
 	for _, tc := range testCases {
-
 		s.Run(tc.name, func() {
 			_, err := s.msgServer.UpdateParams(s.ctx, tc.request)
 			if tc.expectErr {
@@ -318,7 +317,6 @@ func (s *KeeperTestSuite) TestUnjail() {
 	}
 
 	for _, tc := range testCases {
-
 		s.Run(tc.name, func() {
 			req := tc.malleate()
 			_, err := s.msgServer.Unjail(s.ctx, req)

--- a/x/staking/client/cli/tx_test.go
+++ b/x/staking/client/cli/tx_test.go
@@ -145,7 +145,7 @@ func (s *CLITestSuite) TestPrepareConfigForTxCreateValidator() {
 	}
 
 	for _, tc := range tests {
-		tc := tc
+
 		s.Run(tc.name, func() {
 			fs, _ := cli.CreateValidatorMsgFlagSet(ip)
 			fs.String(flags.FlagName, "", "name of private key with which to sign the gentx")
@@ -292,7 +292,7 @@ func (s *CLITestSuite) TestNewCreateValidatorCmd() {
 		},
 	}
 	for _, tc := range testCases {
-		tc := tc
+
 		s.Run(tc.name, func() {
 			out, err := clitestutil.ExecTestCLICmd(s.clientCtx, cmd, tc.args)
 			if tc.expectErrMsg != "" {
@@ -415,7 +415,6 @@ func (s *CLITestSuite) TestNewEditValidatorCmd() {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 
 		s.Run(tc.name, func() {
 			out, err := clitestutil.ExecTestCLICmd(s.clientCtx, cmd, tc.args)

--- a/x/staking/client/cli/tx_test.go
+++ b/x/staking/client/cli/tx_test.go
@@ -145,7 +145,6 @@ func (s *CLITestSuite) TestPrepareConfigForTxCreateValidator() {
 	}
 
 	for _, tc := range tests {
-
 		s.Run(tc.name, func() {
 			fs, _ := cli.CreateValidatorMsgFlagSet(ip)
 			fs.String(flags.FlagName, "", "name of private key with which to sign the gentx")
@@ -292,7 +291,6 @@ func (s *CLITestSuite) TestNewCreateValidatorCmd() {
 		},
 	}
 	for _, tc := range testCases {
-
 		s.Run(tc.name, func() {
 			out, err := clitestutil.ExecTestCLICmd(s.clientCtx, cmd, tc.args)
 			if tc.expectErrMsg != "" {
@@ -415,7 +413,6 @@ func (s *CLITestSuite) TestNewEditValidatorCmd() {
 	}
 
 	for _, tc := range testCases {
-
 		s.Run(tc.name, func() {
 			out, err := clitestutil.ExecTestCLICmd(s.clientCtx, cmd, tc.args)
 			if tc.expectErrMsg != "" {

--- a/x/staking/keeper/msg_server_test.go
+++ b/x/staking/keeper/msg_server_test.go
@@ -227,7 +227,6 @@ func (s *KeeperTestSuite) TestMsgCreateValidator() {
 		},
 	}
 	for _, tc := range testCases {
-
 		s.T().Run(tc.name, func(t *testing.T) {
 			_, err := msgServer.CreateValidator(ctx, tc.input)
 			if tc.expErr {
@@ -403,7 +402,6 @@ func (s *KeeperTestSuite) TestMsgEditValidator() {
 		},
 	}
 	for _, tc := range testCases {
-
 		s.T().Run(tc.name, func(t *testing.T) {
 			_, err := msgServer.EditValidator(tc.ctx, tc.input)
 			if tc.expErr {
@@ -521,7 +519,6 @@ func (s *KeeperTestSuite) TestMsgDelegate() {
 	}
 
 	for _, tc := range testCases {
-
 		s.T().Run(tc.name, func(t *testing.T) {
 			_, err := msgServer.Delegate(ctx, tc.input)
 			if tc.expErr {
@@ -689,7 +686,6 @@ func (s *KeeperTestSuite) TestMsgBeginRedelegate() {
 	}
 
 	for _, tc := range testCases {
-
 		s.T().Run(tc.name, func(t *testing.T) {
 			_, err := msgServer.BeginRedelegate(ctx, tc.input)
 			if tc.expErr {
@@ -813,7 +809,6 @@ func (s *KeeperTestSuite) TestMsgUndelegate() {
 	}
 
 	for _, tc := range testCases {
-
 		s.T().Run(tc.name, func(t *testing.T) {
 			_, err := msgServer.Undelegate(ctx, tc.input)
 			if tc.expErr {
@@ -975,7 +970,6 @@ func (s *KeeperTestSuite) TestMsgCancelUnbondingDelegation() {
 	}
 
 	for _, tc := range testCases {
-
 		s.T().Run(tc.name, func(t *testing.T) {
 			_, err := msgServer.CancelUnbondingDelegation(ctx, tc.input)
 			if tc.expErr {
@@ -1114,7 +1108,6 @@ func (s *KeeperTestSuite) TestMsgUpdateParams() {
 	}
 
 	for _, tc := range testCases {
-
 		s.T().Run(tc.name, func(t *testing.T) {
 			_, err := msgServer.UpdateParams(ctx, tc.input)
 			if tc.expErr {

--- a/x/staking/keeper/msg_server_test.go
+++ b/x/staking/keeper/msg_server_test.go
@@ -227,7 +227,7 @@ func (s *KeeperTestSuite) TestMsgCreateValidator() {
 		},
 	}
 	for _, tc := range testCases {
-		tc := tc
+
 		s.T().Run(tc.name, func(t *testing.T) {
 			_, err := msgServer.CreateValidator(ctx, tc.input)
 			if tc.expErr {
@@ -403,7 +403,7 @@ func (s *KeeperTestSuite) TestMsgEditValidator() {
 		},
 	}
 	for _, tc := range testCases {
-		tc := tc
+
 		s.T().Run(tc.name, func(t *testing.T) {
 			_, err := msgServer.EditValidator(tc.ctx, tc.input)
 			if tc.expErr {
@@ -521,7 +521,7 @@ func (s *KeeperTestSuite) TestMsgDelegate() {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
+
 		s.T().Run(tc.name, func(t *testing.T) {
 			_, err := msgServer.Delegate(ctx, tc.input)
 			if tc.expErr {
@@ -689,7 +689,7 @@ func (s *KeeperTestSuite) TestMsgBeginRedelegate() {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
+
 		s.T().Run(tc.name, func(t *testing.T) {
 			_, err := msgServer.BeginRedelegate(ctx, tc.input)
 			if tc.expErr {
@@ -813,7 +813,7 @@ func (s *KeeperTestSuite) TestMsgUndelegate() {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
+
 		s.T().Run(tc.name, func(t *testing.T) {
 			_, err := msgServer.Undelegate(ctx, tc.input)
 			if tc.expErr {
@@ -975,7 +975,7 @@ func (s *KeeperTestSuite) TestMsgCancelUnbondingDelegation() {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
+
 		s.T().Run(tc.name, func(t *testing.T) {
 			_, err := msgServer.CancelUnbondingDelegation(ctx, tc.input)
 			if tc.expErr {
@@ -1114,7 +1114,7 @@ func (s *KeeperTestSuite) TestMsgUpdateParams() {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
+
 		s.T().Run(tc.name, func(t *testing.T) {
 			_, err := msgServer.UpdateParams(ctx, tc.input)
 			if tc.expErr {

--- a/x/staking/types/authz_test.go
+++ b/x/staking/types/authz_test.go
@@ -353,7 +353,6 @@ func TestAuthzAuthorizations(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-
 		t.Run(tc.msg, func(t *testing.T) {
 			delAuth, err := stakingtypes.NewStakeAuthorization(tc.allowed, tc.denied, tc.msgType, tc.limit)
 			require.NoError(t, err)

--- a/x/staking/types/authz_test.go
+++ b/x/staking/types/authz_test.go
@@ -353,7 +353,7 @@ func TestAuthzAuthorizations(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
+
 		t.Run(tc.msg, func(t *testing.T) {
 			delAuth, err := stakingtypes.NewStakeAuthorization(tc.allowed, tc.denied, tc.msgType, tc.limit)
 			require.NoError(t, err)

--- a/x/upgrade/keeper/keeper_test.go
+++ b/x/upgrade/keeper/keeper_test.go
@@ -169,7 +169,6 @@ func (s *KeeperTestSuite) TestScheduleUpgrade() {
 	}
 
 	for _, tc := range cases {
-		tc := tc
 
 		s.Run(tc.name, func() {
 			// reset suite

--- a/x/upgrade/types/plan_test.go
+++ b/x/upgrade/types/plan_test.go
@@ -42,7 +42,7 @@ func TestPlanString(t *testing.T) {
 	}
 
 	for name, tc := range cases {
-		tc := tc // copy to local variable for scopelint
+		// copy to local variable for scopelint
 		t.Run(name, func(t *testing.T) {
 			s := tc.p.String()
 			require.Equal(t, tc.expect, s)
@@ -93,7 +93,7 @@ func TestPlanValid(t *testing.T) {
 	}
 
 	for name, tc := range cases {
-		tc := tc // copy to local variable for scopelint
+		// copy to local variable for scopelint
 		t.Run(name, func(t *testing.T) {
 			err := tc.p.ValidateBasic()
 			if tc.valid {
@@ -142,7 +142,7 @@ func TestShouldExecute(t *testing.T) {
 	}
 
 	for name, tc := range cases {
-		tc := tc // copy to local variable for scopelint
+		// copy to local variable for scopelint
 		t.Run(name, func(t *testing.T) {
 			should := tc.p.ShouldExecute(tc.ctxHeight)
 			assert.Equal(t, tc.expected, should)

--- a/x/upgrade/types/plan_test.go
+++ b/x/upgrade/types/plan_test.go
@@ -42,7 +42,6 @@ func TestPlanString(t *testing.T) {
 	}
 
 	for name, tc := range cases {
-		// copy to local variable for scopelint
 		t.Run(name, func(t *testing.T) {
 			s := tc.p.String()
 			require.Equal(t, tc.expect, s)
@@ -93,7 +92,6 @@ func TestPlanValid(t *testing.T) {
 	}
 
 	for name, tc := range cases {
-		// copy to local variable for scopelint
 		t.Run(name, func(t *testing.T) {
 			err := tc.p.ValidateBasic()
 			if tc.valid {
@@ -142,7 +140,6 @@ func TestShouldExecute(t *testing.T) {
 	}
 
 	for name, tc := range cases {
-		// copy to local variable for scopelint
 		t.Run(name, func(t *testing.T) {
 			should := tc.p.ShouldExecute(tc.ctxHeight)
 			assert.Equal(t, tc.expected, should)

--- a/x/upgrade/types/storeloader_test.go
+++ b/x/upgrade/types/storeloader_test.go
@@ -106,7 +106,6 @@ func TestSetLoader(t *testing.T) {
 	v := []byte("value")
 
 	for name, tc := range cases {
-
 		t.Run(name, func(t *testing.T) {
 			// prepare a db with some data
 			db := dbm.NewMemDB()

--- a/x/upgrade/types/storeloader_test.go
+++ b/x/upgrade/types/storeloader_test.go
@@ -106,7 +106,7 @@ func TestSetLoader(t *testing.T) {
 	v := []byte("value")
 
 	for name, tc := range cases {
-		tc := tc
+
 		t.Run(name, func(t *testing.T) {
 			// prepare a db with some data
 			db := dbm.NewMemDB()


### PR DESCRIPTION
We currently have some PRs that are failing lints (idk why they are getting picked up), but this PR goes ahead and makes some fixes.  Most of the fixes are in tests due to the `tc := tc` copy not being needed or are formatting and error checking