### PR TITLE
chore: fix proto building warning

### DIFF
--- a/.github/workflows/proto-registry.yml
+++ b/.github/workflows/proto-registry.yml
@@ -17,7 +17,7 @@
 #     name: "Push to buf.build/cosmos/cosmos-sdk"
 #     steps:
 #       - uses: actions/checkout@v4
-#       - uses: bufbuild/buf-setup-action@v1.29.0
+#       - uses: bufbuild/buf-setup-action@v1.50.0
 #       - run: buf push proto --tag ${{ github.ref_type == 'tag' && github.ref_name || github.sha }} # https://github.com/bufbuild/buf-push-action/issues/20
 
 ## TODO at each module tag to their own buf repository

--- a/.github/workflows/proto.yml
+++ b/.github/workflows/proto.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
-      - uses: bufbuild/buf-setup-action@v1.38.0
+      - uses: bufbuild/buf-setup-action@v1.50.0
       - uses: bufbuild/buf-lint-action@v1
         with:
           input: "proto"
@@ -24,7 +24,7 @@ jobs:
     runs-on: depot-ubuntu-22.04-4
     steps:
       - uses: actions/checkout@v4
-      - uses: bufbuild/buf-setup-action@v1.38.0
+      - uses: bufbuild/buf-setup-action@v1.50.0
       - uses: bufbuild/buf-breaking-action@v1
         with:
           input: "proto"

--- a/client/v2/internal/buf.yaml
+++ b/client/v2/internal/buf.yaml
@@ -4,7 +4,7 @@ deps:
   - buf.build/cosmos/cosmos-proto
 lint:
   use:
-    - DEFAULT
+    - STANDARD
   except:
     - PACKAGE_VERSION_SUFFIX
 breaking:

--- a/depinject/internal/appconfig/buf.yaml
+++ b/depinject/internal/appconfig/buf.yaml
@@ -3,7 +3,7 @@ deps:
   - buf.build/cosmos/cosmos-sdk
 lint:
   use:
-    - DEFAULT
+    - STANDARD
   except:
     - PACKAGE_VERSION_SUFFIX
 breaking:

--- a/depinject/internal/appconfiggogo/buf.yaml
+++ b/depinject/internal/appconfiggogo/buf.yaml
@@ -3,7 +3,7 @@ deps:
   - buf.build/cosmos/cosmos-sdk
 lint:
   use:
-    - DEFAULT
+    - STANDARD
   except:
     - PACKAGE_VERSION_SUFFIX
 breaking:

--- a/proto/buf.yaml
+++ b/proto/buf.yaml
@@ -10,7 +10,7 @@ breaking:
     - FILE
 lint:
   use:
-    - DEFAULT
+    - STANDARD
     - COMMENTS
     - FILE_LOWER_SNAKE_CASE
   except:

--- a/tests/integration/tx/internal/buf.yaml
+++ b/tests/integration/tx/internal/buf.yaml
@@ -5,7 +5,7 @@ deps:
   - buf.build/cosmos/gogo-proto
 lint:
   use:
-    - DEFAULT
+    - STANDARD
   except:
     - PACKAGE_VERSION_SUFFIX
 breaking:

--- a/x/tx/internal/testpb/buf.yaml
+++ b/x/tx/internal/testpb/buf.yaml
@@ -5,7 +5,7 @@ deps:
   - buf.build/cosmos/gogo-proto
 lint:
   use:
-    - DEFAULT
+    - STANDARD
   except:
     - PACKAGE_VERSION_SUFFIX
 breaking:

--- a/x/tx/signing/aminojson/internal/buf.yaml
+++ b/x/tx/signing/aminojson/internal/buf.yaml
@@ -5,7 +5,7 @@ deps:
   - buf.build/cosmos/cosmos-proto
 lint:
   use:
-    - DEFAULT
+    - STANDARD
   except:
     - PACKAGE_VERSION_SUFFIX
 breaking:

--- a/x/tx/signing/textual/internal/textualpb/buf.yaml
+++ b/x/tx/signing/textual/internal/textualpb/buf.yaml
@@ -6,7 +6,7 @@ deps:
   - buf.build/protocolbuffers/wellknowntypes:v23.4
 lint:
   use:
-    - DEFAULT
+    - STANDARD
   except:
     - PACKAGE_VERSION_SUFFIX
 breaking:


### PR DESCRIPTION
removes this warning:

```
**WARN    Category DEFAULT referenced in your buf.yaml is deprecated. It has been replaced by category STANDARD.

        The concept of a default rule has been introduced. A default rule is a rule that will be run
        if no rules are explicitly configured in your buf.yaml. Run buf config ls-lint-rules or
        buf config ls-breaking-rules to see which rules are defaults. With this introduction, having a category
        also named DEFAULT is confusing, as while it happens that all the rules in the DEFAULT category
        are also default rules, the name has become overloaded.

        As with all buf changes, this change is backwards-compatible: DEFAULT will continue to work.
        We recommend replacing DEFAULT in your buf.yaml, but no action is immediately necessary.
**
```