### PR TITLE
fix(errors): improve error string output with codespace and code

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -88,7 +88,7 @@ func New(codespace string, code uint32, desc string) *Error {
 }
 
 func (e Error) Error() string {
-	return e.desc
+	return fmt.Sprintf("[%s:%d] %s", e.codespace, e.code, e.desc)
 }
 
 func (e Error) ABCICode() uint32 {

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -5,11 +5,11 @@ import (
 )
 
 func TestABCIError(t *testing.T) {
-	if err := ABCIError(testCodespace, ErrTxDecode.ABCICode(), "custom"); err.Error() != "custom: tx parse error" {
-		t.Errorf("expected error message: custom: tx parse error, got: %v", err.Error())
+	if err := ABCIError(testCodespace, ErrTxDecode.ABCICode(), "custom"); err.Error() != "custom: [testtesttest:2] tx parse error" {
+		t.Errorf("expected error message: custom: [testtesttest:2] tx parse error, got: %v", err.Error())
 	}
-	if err := ABCIError("unknown", 1, "custom"); err.Error() != "custom: unknown" {
-		t.Errorf("expected error message: custom: unknown, got: %v", err.Error())
+	if err := ABCIError("unknown", 1, "custom"); err.Error() != "custom: [unknown:1] unknown" {
+		t.Errorf("expected error message: custom: [unknown:1] unknown, got: %v", err.Error())
 	}
 }
 

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestABCIError(t *testing.T) {
-	if err := ABCIError(testCodespace, 2, "custom"); err.Error() != "custom: tx parse error" {
+	if err := ABCIError(testCodespace, ErrTxDecode.ABCICode(), "custom"); err.Error() != "custom: tx parse error" {
 		t.Errorf("expected error message: custom: tx parse error, got: %v", err.Error())
 	}
 	if err := ABCIError("unknown", 1, "custom"); err.Error() != "custom: unknown" {


### PR DESCRIPTION
- Improved the `Error()` method in `errors.go` to include the `codespace` and `code` in the error string for better debugging and tracing:
```go
func (e Error) Error() string {
    return fmt.Sprintf("[%s:%d] %s", e.codespace, e.code, e.desc)
}
```
- Updated `errors_test.go` to replace hardcoded code values with usage of `ErrTxDecode.ABCICode()` for better test robustness.

## Author Checklist

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title (`fix`)
- [x] targeted the correct branch (main or release)
- [x] provided a link to the relevant issue or specification
- [x] reviewed "Files changed"
- [x] added/updated tests if necessary
- [x] added a changelog entry to `CHANGELOG.md`
- [x] updated documentation or inline comments if necessary
- [x] confirmed all CI checks have passed

## Reviewers Checklist

- [x] confirmed the correct type prefix in the PR title
- [x] confirmed all author checklist items addressed
- [x] reviewed logic, API changes, documentation, tests, and coverage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced error messages now provide additional context by including error identifiers and related codes alongside descriptive details.
- **Bug Fixes**
	- Updated test cases to reflect the new error message format, ensuring accuracy in error handling assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->