### PR TITLE
fix: more accurate links

### DIFF
--- a/x/gov/README.md
+++ b/x/gov/README.md
@@ -7,7 +7,7 @@ sidebar_position: 1
 ## Abstract
 
 This paper specifies the Governance module of the Cosmos SDK, which was first
-described in the [Cosmos Whitepaper](https://cosmos.network/about/whitepaper) in
+described in the [Cosmos Whitepaper](https://github.com/cosmos/cosmos/blob/master/WHITEPAPER.md) in
 June 2016.
 
 The module enables Cosmos SDK based blockchain to support an on-chain governance

--- a/x/slashing/README.md
+++ b/x/slashing/README.md
@@ -7,7 +7,7 @@ sidebar_position: 1
 ## Abstract
 
 This section specifies the slashing module of the Cosmos SDK, which implements functionality
-first outlined in the [Cosmos Whitepaper](https://cosmos.network/about/whitepaper) in June 2016.
+first outlined in the [Cosmos Whitepaper](https://github.com/cosmos/cosmos/blob/master/WHITEPAPER.md) in June 2016.
 
 The slashing module enables Cosmos SDK-based blockchains to disincentivize any attributable action
 by a protocol-recognized actor with value at stake by penalizing them ("slashing").

--- a/x/staking/README.md
+++ b/x/staking/README.md
@@ -7,7 +7,7 @@ sidebar_position: 1
 ## Abstract
 
 This paper specifies the Staking module of the Cosmos SDK that was first
-described in the [Cosmos Whitepaper](https://cosmos.network/about/whitepaper)
+described in the [Cosmos Whitepaper](https://github.com/cosmos/cosmos/blob/master/WHITEPAPER.md)
 in June 2016.
 
 The module enables Cosmos SDK-based blockchain to support an advanced


### PR DESCRIPTION
Replaces Cosmos Whitepaper links in multiple module READMEs with GitHub repository URL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated references to the Cosmos Whitepaper in the module documentation. The previous links to the Cosmos network website have been replaced with direct GitHub-hosted URLs, ensuring users have access to the most accurate and current version of the document.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->