### PR TITLE
refactor(collections): add Copy method to collection types

### DIFF
--- a/collections/indexed_map.go
+++ b/collections/indexed_map.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 
 	"cosmossdk.io/collections/codec"
+	"cosmossdk.io/core/store"
 )
 
 // Indexes represents a type which groups multiple Index
@@ -172,6 +173,16 @@ func (m *IndexedMap[PrimaryKey, Value, Idx]) KeyCodec() codec.KeyCodec[PrimaryKe
 
 func (m *IndexedMap[PrimaryKey, Value, Idx]) ValueCodec() codec.ValueCodec[Value] {
 	return m.m.ValueCodec()
+}
+
+// Copy creates a new IndexedMap with the same configuration but using a different store accessor.
+// This is useful when you need to create a copy of the indexed map that targets a different store.
+func (m *IndexedMap[PrimaryKey, Value, Idx]) Copy(sa func(context.Context) store.KVStore) *IndexedMap[PrimaryKey, Value, Idx] {
+	return &IndexedMap[PrimaryKey, Value, Idx]{
+		Indexes:         m.Indexes,
+		computedIndexes: m.computedIndexes,
+		m:               m.m.Copy(sa),
+	}
 }
 
 func (m *IndexedMap[PrimaryKey, Value, Idx]) ref(ctx context.Context, pk PrimaryKey, value Value) error {

--- a/collections/indexes/multi.go
+++ b/collections/indexes/multi.go
@@ -6,6 +6,7 @@ import (
 
 	"cosmossdk.io/collections"
 	"cosmossdk.io/collections/codec"
+	"cosmossdk.io/core/store"
 )
 
 type multiOptions struct {
@@ -134,8 +135,17 @@ func (m *Multi[ReferenceKey, PrimaryKey, Value]) MatchExact(ctx context.Context,
 	return m.Iterate(ctx, collections.NewPrefixedPairRange[ReferenceKey, PrimaryKey](refKey))
 }
 
-func (m *Multi[K1, K2, Value]) KeyCodec() codec.KeyCodec[collections.Pair[K1, K2]] {
+func (m *Multi[ReferenceKey, PrimaryKey, Value]) KeyCodec() codec.KeyCodec[collections.Pair[ReferenceKey, PrimaryKey]] {
 	return m.refKeys.KeyCodec()
+}
+
+// Copy creates a new Multi index with the same configuration but using a different store accessor.
+// This is useful when you need to create a copy of the index that targets a different store.
+func (m *Multi[ReferenceKey, PrimaryKey, Value]) Copy(sa func(context.Context) store.KVStore) *Multi[ReferenceKey, PrimaryKey, Value] {
+	return &Multi[ReferenceKey, PrimaryKey, Value]{
+		getRefKey: m.getRefKey,
+		refKeys:   m.refKeys.Copy(sa),
+	}
 }
 
 // MultiIterator is just a KeySetIterator with key as Pair[ReferenceKey, PrimaryKey].

--- a/collections/indexes/reverse_pair.go
+++ b/collections/indexes/reverse_pair.go
@@ -5,6 +5,7 @@ import (
 
 	"cosmossdk.io/collections"
 	"cosmossdk.io/collections/codec"
+	"cosmossdk.io/core/store"
 )
 
 type reversePairOptions struct {
@@ -123,6 +124,14 @@ func (i *ReversePair[K1, K2, Value]) IterateRaw(
 
 func (i *ReversePair[K1, K2, Value]) KeyCodec() codec.KeyCodec[collections.Pair[K2, K1]] {
 	return i.refKeys.KeyCodec()
+}
+
+// Copy creates a new ReversePair index with the same configuration but using a different store accessor.
+// This is useful when you need to create a copy of the index that targets a different store.
+func (i *ReversePair[K1, K2, Value]) Copy(sa func(context.Context) store.KVStore) *ReversePair[K1, K2, Value] {
+	return &ReversePair[K1, K2, Value]{
+		refKeys: i.refKeys.Copy(sa),
+	}
 }
 
 // ReversePairIterator is a helper type around a collections.KeySetIterator when used to work

--- a/collections/indexes/unique.go
+++ b/collections/indexes/unique.go
@@ -7,6 +7,7 @@ import (
 
 	"cosmossdk.io/collections"
 	"cosmossdk.io/collections/codec"
+	"cosmossdk.io/core/store"
 )
 
 // Unique identifies an index that imposes uniqueness constraints on the reference key.
@@ -101,6 +102,15 @@ func (i *Unique[ReferenceKey, PrimaryKey, Value]) IterateRaw(ctx context.Context
 		return
 	}
 	return (UniqueIterator[ReferenceKey, PrimaryKey])(iter), nil
+}
+
+// Copy creates a new Unique index with the same configuration but using a different store accessor.
+// This is useful when you need to create a copy of the index that targets a different store.
+func (i *Unique[ReferenceKey, PrimaryKey, Value]) Copy(sa func(context.Context) store.KVStore) *Unique[ReferenceKey, PrimaryKey, Value] {
+	return &Unique[ReferenceKey, PrimaryKey, Value]{
+		getRefKey: i.getRefKey,
+		refKeys:   i.refKeys.Copy(sa),
+	}
 }
 
 // UniqueIterator is an Iterator wrapper, that exposes only the functionality needed to work with Unique keys.

--- a/collections/keyset.go
+++ b/collections/keyset.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"cosmossdk.io/collections/codec"
+	"cosmossdk.io/core/store"
 )
 
 // WithKeySetUncheckedValue changes the behavior of the KeySet when it encounters
@@ -104,6 +105,12 @@ func (k KeySet[K]) Clear(ctx context.Context, ranger Ranger[K]) error {
 
 func (k KeySet[K]) KeyCodec() codec.KeyCodec[K]           { return (Map[K, NoValue])(k).KeyCodec() }
 func (k KeySet[K]) ValueCodec() codec.ValueCodec[NoValue] { return (Map[K, NoValue])(k).ValueCodec() }
+
+// Copy creates a new KeySet with the same configuration but using a different store accessor.
+// This is useful when you need to create a copy of the keyset that targets a different store.
+func (k KeySet[K]) Copy(sa func(context.Context) store.KVStore) KeySet[K] {
+	return (KeySet[K])((Map[K, NoValue])(k).Copy(sa))
+}
 
 // KeySetIterator works like an Iterator, but it does not expose any API to deal with values.
 type KeySetIterator[K any] Iterator[K, NoValue]

--- a/collections/map.go
+++ b/collections/map.go
@@ -288,3 +288,16 @@ func EncodeKeyWithPrefix[K any](prefix []byte, kc codec.KeyCodec[K], key K) ([]b
 	}
 	return keyBytes, nil
 }
+
+// Copy creates a new Map with the same configuration but using a different StoreAccessor.
+// This is useful when you need to create a copy of the map that targets a different store.
+func (m Map[K, V]) Copy(sa func(context.Context) store.KVStore) Map[K, V] {
+	return Map[K, V]{
+		kc:               m.kc,
+		vc:               m.vc,
+		sa:               sa,
+		prefix:           m.prefix,
+		name:             m.name,
+		isSecondaryIndex: m.isSecondaryIndex,
+	}
+}


### PR DESCRIPTION
# Description

refactor(collections): add Copy method to collection types

Added Copy methods to several collection types that were missing them (Map, Unique, Multi, ReversePair, KeySet). This enables developers to create new collection instances that share the same configuration but point to a different store. Makes the collections API more consistent and simplifies code reuse when working with different stores.

---

## Author Checklist

I have...

* [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [x] confirmed `!` in the type prefix if API or client breaking change
* [x] targeted the correct branch
* [x] reviewed "Files changed" and left comments if necessary
* [x] included the necessary unit and integration tests
* [x] added a changelog entry to `CHANGELOG.md`
* [x] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [x] confirmed all CI checks have passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced the ability to duplicate various collection configurations, allowing users to create copies that retain current setups while connecting to alternative storage contexts.
  - Enhanced several data structures to support flexible management across different storage backends, including improvements to multi-index functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->