### PR TITLE
chore: fix flaky offline test

### DIFF
--- a/tests/e2e/auth/suite.go
+++ b/tests/e2e/auth/suite.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/testutil/network"
 	"github.com/cosmos/cosmos-sdk/testutil/testdata"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
 	"github.com/cosmos/cosmos-sdk/types/tx"
 	"github.com/cosmos/cosmos-sdk/types/tx/signing"
 	authcli "github.com/cosmos/cosmos-sdk/x/auth/client/cli"
@@ -1232,6 +1233,7 @@ func TestGetBroadcastCommandWithoutOfflineFlag(t *testing.T) {
 	require.NoError(t, err)
 	clientCtx := client.Context{}
 	clientCtx = clientCtx.WithTxConfig(txCfg)
+	clientCtx = clientCtx.WithCodec(moduletestutil.MakeTestEncodingConfig().Codec)
 
 	ctx := context.Background()
 	ctx = context.WithValue(ctx, client.ClientContextKey, &clientCtx)

--- a/tests/integration/auth/client/cli/suite_test.go
+++ b/tests/integration/auth/client/cli/suite_test.go
@@ -845,12 +845,14 @@ func (s *CLITestSuite) TestGetBroadcastCommandWithoutOfflineFlag() {
 	txCfg := s.clientCtx.TxConfig
 	clientCtx := client.Context{}
 	clientCtx = clientCtx.WithTxConfig(txCfg)
+	clientCtx = clientCtx.WithCodec(s.clientCtx.Codec)
 
 	ctx := context.Background()
 	ctx = context.WithValue(ctx, client.ClientContextKey, &clientCtx)
 
 	cmd := authcli.GetBroadcastCommand()
 	_, out := testutil.ApplyMockIO(cmd)
+	clientCtx = clientCtx.WithOutput(out)
 
 	// Create new file with tx
 	builder := txCfg.NewTxBuilder()
@@ -868,9 +870,8 @@ func (s *CLITestSuite) TestGetBroadcastCommandWithoutOfflineFlag() {
 
 	cmd.SetArgs([]string{txFile.Name()})
 	err = cmd.ExecuteContext(ctx)
-	s.Require().Error(err)
-	s.Require().Contains(err.Error(), "connect: connection refused")
-	s.Require().Contains(out.String(), "connect: connection refused")
+	s.Require().NoError(err)
+	s.Require().Contains(out.String(), "no signatures supplied")
 }
 
 // TestTxWithoutPublicKey makes sure sending a proto tx message without the


### PR DESCRIPTION
The test would always panic locally because the context was not being set (explicitly) as can be seen in the test.