### PR TITLE
Remove unsupported formatters from golangci-lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,12 +14,9 @@ linters:
     - errcheck
     - errorlint
     - copyloopvar
-    - gci
     - goconst
     - gocritic
-    - gofumpt
     - gosec
-    - gosimple
     - govet
     - ineffassign
     - misspell
@@ -29,7 +26,6 @@ linters:
     - staticcheck
     - stylecheck
     - thelper
-    - typecheck
     - unconvert
     - unused
 


### PR DESCRIPTION
# Description
Formatters and toilet linters that are not mentioned in the new version must be removed from the include list:

- `gci` (formatter)
- `gofumpt` (formatter)
- `simple` (not present in the new version)
- `type check` (deprecated, no longer contains instructions)
Without these changes, golangci-lint fails with errors. Locally tested per the [official migration guide.](https://golangci-lint.run/product/migration-guide/)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Streamlined internal quality tooling by removing redundant checks and reformatting configuration settings for improved consistency in development processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->