### PR TITLE
chore: fix issue with collecting supported versions

### DIFF
--- a/tools/confix/cmd/migrate.go
+++ b/tools/confix/cmd/migrate.go
@@ -61,7 +61,12 @@ In case of any error in updating the file, no output is written.`,
 			targetVersion := args[0]
 			plan, ok := confix.Migrations[targetVersion]
 			if !ok {
-				return fmt.Errorf("unknown version %q, supported versions are: %q", targetVersion, slices.Collect(maps.Keys(confix.Migrations)))
+				var supportedVersions []string
+				for version := range confix.Migrations {
+					supportedVersions = append(supportedVersions, version)
+				}
+			return fmt.Errorf("unknown version %q, supported versions are: %v", targetVersion, supportedVersions)
+				}
 			}
 
 			rawFile, err := confix.LoadConfig(configPath)


### PR DESCRIPTION
# Description

I replaced the incorrect usage of `slices.Collect(maps.Keys(confix.Migrations))` with a more standard approach of explicitly building the slice using a `for` loop. This resolves the issue and ensures the code properly handles the keys from the map in accordance with Go's best practices for working with maps and slices.

---

## Author Checklist

* [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title, you can find examples of the prefixes below:
    <!-- * `feat`: A new feature
    * `fix`: A bug fix
    * `docs`: Documentation only changes
    * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
    * `refactor`: A code change that neither fixes a bug nor adds a feature
    * `perf`: A code change that improves performance
    * `test`: Adding missing tests or correcting existing tests
    * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
    * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
    * `chore`: Other changes that don't modify src or test files
    * `revert`: Reverts a previous commit -->
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [x] reviewed "Files changed" and left comments if necessary
* [x] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [x] confirmed all CI checks have passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the error message during migration so that when an unsupported version is specified, it now displays a clear, straightforward list of supported versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->