### PR TITLE
chore: fix potential nil panic in `Logger` methods

### DIFF
--- a/log/slog/logger.go
+++ b/log/slog/logger.go
@@ -24,27 +24,27 @@ func NewCustomLogger(log *slog.Logger) Logger {
 	return Logger{log: log}
 }
 
-func (l Logger) Info(msg string, keyVals ...any) {
+func (l *Logger) Info(msg string, keyVals ...any) {
 	l.log.Info(msg, keyVals...)
 }
 
-func (l Logger) Warn(msg string, keyVals ...any) {
+func (l *Logger) Warn(msg string, keyVals ...any) {
 	l.log.Warn(msg, keyVals...)
 }
 
-func (l Logger) Error(msg string, keyVals ...any) {
+func (l *Logger) Error(msg string, keyVals ...any) {
 	l.log.Error(msg, keyVals...)
 }
 
-func (l Logger) Debug(msg string, keyVals ...any) {
+func (l *Logger) Debug(msg string, keyVals ...any) {
 	l.log.Debug(msg, keyVals...)
 }
 
-func (l Logger) With(keyVals ...any) log.Logger {
+func (l *Logger) With(keyVals ...any) log.Logger {
 	return Logger{log: l.log.With(keyVals...)}
 }
 
 // Impl returns l's underlying [*slog.Logger].
-func (l Logger) Impl() any {
+func (l *Logger) Impl() any {
 	return l.log
 }


### PR DESCRIPTION
# Description

`Logger` methods were accepting the struct **by value**, which could lead to unintended copies and potential `nil` pointer dereferences if `Logger{log: nil}` was ever used.  

To fix this, I updated `Info`, `Warn`, `Error`, `Debug`, and `With` to receive `Logger` **by pointer**.
This ensures the logger instance is properly referenced and avoids unnecessary copies.  

This change improves stability and prevents subtle runtime errors.

---

## Author Checklist

I have...

* [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title, you can find examples of the prefixes below:
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [x] confirmed all CI checks have passed

## Reviewers Checklist

* [x] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [x] confirmed all author checklist items have been addressed
* [x] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage
