### PR TITLE
fix: vuln check workflow

### DIFF
--- a/.github/workflows/dependencies-review.yml
+++ b/.github/workflows/dependencies-review.yml
@@ -15,12 +15,12 @@ jobs:
       - name: "Setup Go"
         uses: actions/setup-go@v5
         with:
-          go-version: "1.23"
+          go-version: "1.24"
           check-latest: true
       - name: "Dependency Review"
         uses: actions/dependency-review-action@v4
         with:
-          base-ref: ${{ github.event.pull_request.base.sha || 'release/v0.53.x' }}
+          base-ref: ${{ github.event.pull_request.base.sha || 'main' }}
           head-ref: ${{ github.event.pull_request.head.sha || github.ref }}
           fail-on-severity: high
       - name: "Dependency audit"


### PR DESCRIPTION
was using an older go version and looking at `release/v0.53.x` instead of `main`