### PR TITLE
chore: Revert "fix: use the gogoproto merge registry as a file resolver instead of the interface registry (#24330)"

### DIFF
--- a/client/v2/CHANGELOG.md
+++ b/client/v2/CHANGELOG.md
@@ -46,7 +46,6 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Bug Fixes
 
-* (cli) [#24330](https://github.com/cosmos/cosmos-sdk/pull/24330) Use the gogoproto merge registry as a file resolver instead of the interface registry.
 * [#21853](https://github.com/cosmos/cosmos-sdk/pull/21853) Fix `*big.Int` unmarshalling in txs.
 
 ## [v2.0.0-beta.8] - 2025-01-29

--- a/client/v2/autocli/app.go
+++ b/client/v2/autocli/app.go
@@ -1,7 +1,6 @@
 package autocli
 
 import (
-	"github.com/cosmos/gogoproto/proto"
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/reflect/protoregistry"
@@ -62,14 +61,10 @@ type AppOptions struct {
 //	rootCmd := initRootCmd()
 //	err = autoCliOpts.EnhanceRootCommand(rootCmd)
 func (appOptions AppOptions) EnhanceRootCommand(rootCmd *cobra.Command) error {
-	mergedFiles, err := proto.MergedRegistry()
-	if err != nil {
-		return err
-	}
 	builder := &Builder{
 		Builder: flag.Builder{
 			TypeResolver:          protoregistry.GlobalTypes,
-			FileResolver:          mergedFiles,
+			FileResolver:          appOptions.ClientCtx.InterfaceRegistry,
 			AddressCodec:          appOptions.AddressCodec,
 			ValidatorAddressCodec: appOptions.ValidatorAddressCodec,
 			ConsensusAddressCodec: appOptions.ConsensusAddressCodec,


### PR DESCRIPTION


This reverts commit 6555c98d09713c2e10685de32ab135f9033b66b5.
