### PR TITLE
chore: add a logged warning for merged proto registry when creating baseapp

### DIFF
--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -3,6 +3,7 @@ package baseapp
 import (
 	"context"
 	"fmt"
+	"github.com/cosmos/cosmos-sdk/types/msgservice"
 	"maps"
 	"math"
 	"slices"
@@ -250,6 +251,19 @@ func NewBaseApp(
 	// Initialize with an empty interface registry to avoid nil pointer dereference.
 	// Unless SetInterfaceRegistry is called with an interface registry with proper address codecs baseapp will panic.
 	app.cdc = codec.NewProtoCodec(codectypes.NewInterfaceRegistry())
+
+	protoFiles, err := proto.MergedRegistry()
+	if err != nil {
+		logger.Warn("error creating merged proto registry", err)
+
+	} else {
+		err = msgservice.ValidateProtoAnnotations(protoFiles)
+		if err != nil {
+			// Once we switch to using protoreflect-based antehandlers, we might
+			// want to panic here instead of logging a warning.
+			logger.Warn("error validating merged proto registry annotations", err)
+		}
+	}
 
 	return app
 }

--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -3,7 +3,6 @@ package baseapp
 import (
 	"context"
 	"fmt"
-	"github.com/cosmos/cosmos-sdk/types/msgservice"
 	"maps"
 	"math"
 	"slices"
@@ -34,6 +33,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/cosmos-sdk/types/mempool"
+	"github.com/cosmos/cosmos-sdk/types/msgservice"
 )
 
 type (
@@ -255,7 +255,6 @@ func NewBaseApp(
 	protoFiles, err := proto.MergedRegistry()
 	if err != nil {
 		logger.Warn("error creating merged proto registry", err)
-
 	} else {
 		err = msgservice.ValidateProtoAnnotations(protoFiles)
 		if err != nil {


### PR DESCRIPTION
`proto.MergedRegistry()` is called `runtime` when initializing an application, and is now called in `client/v2` when building the autocli.

This call may fail because users have not imported some file which has an `init()` needed to register protos or some unknown error.

Right now, this will just fail loudly, resulting in panics when initializing certain nodes (fixed https://github.com/cosmos/cosmos-sdk/pull/24449).  

This PR just adds a warning logger when _all_ (depinject or non-depinject) are created so that developers have access to whatever these errors may be