### PR TITLE
docs(CONTRIBUTING.md): mergify.io link fix

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,7 +117,7 @@ PRs must have a category prefix that is based on the type of changes being made 
 [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.
 Additionally, each PR should only address a single issue.
 
-Pull requests are merged automatically using [`A:automerge` action](https://mergify.io/features/auto-merge).
+Pull requests are merged automatically using [`A:automerge` action](https://docs.mergify.com/workflow/automerge/).
 
 NOTE: when merging, GitHub will squash commits and rebase on top of the main.
 


### PR DESCRIPTION
Hello team, I found that the link to mergify.io in the document is incorrect while I was reviewing it. I have made the correction. Please check it out.