### PR TITLE
fix(server): Fix pruning height calculation

### DIFF
--- a/store/pruning/manager.go
+++ b/store/pruning/manager.go
@@ -3,6 +3,7 @@ package pruning
 import (
 	"encoding/binary"
 	"fmt"
+	"slices"
 	"sort"
 	"sync"
 
@@ -16,17 +17,18 @@ import (
 // determining when to prune old heights of the store
 // based on the strategy described by the pruning options.
 type Manager struct {
-	db               dbm.DB
-	logger           log.Logger
-	opts             types.PruningOptions
-	snapshotInterval uint64
+	db     dbm.DB
+	logger log.Logger
+	opts   types.PruningOptions
 	// Snapshots are taken in a separate goroutine from the regular execution
-	// and can be delivered asynchrounously via HandleSnapshotHeight.
-	// Therefore, we sync access to pruneSnapshotHeights with this mutex.
+	// and can be delivered asynchronously via HandleSnapshotHeight.
+	// Therefore, we sync access to pruneSnapshotHeights, snapshotInterval and initFromDB with this mutex.
 	pruneSnapshotHeightsMx sync.RWMutex
 	// These are the heights that are multiples of snapshotInterval and kept for state sync snapshots.
 	// The heights are added to be pruned when a snapshot is complete.
 	pruneSnapshotHeights []int64
+	snapshotInterval     uint64
+	initFromDB           bool
 }
 
 // NegativeHeightsError is returned when a negative height is provided to the manager.
@@ -51,7 +53,7 @@ func NewManager(db dbm.DB, logger log.Logger) *Manager {
 		db:                   db,
 		logger:               logger,
 		opts:                 types.NewPruningOptions(types.PruningNothing),
-		pruneSnapshotHeights: []int64{0},
+		pruneSnapshotHeights: []int64{0}, // init with 0 block height
 	}
 }
 
@@ -74,28 +76,52 @@ func (m *Manager) HandleSnapshotHeight(height int64) {
 		return
 	}
 
+	if m.snapshotInterval == 0 || uint64(height)%m.snapshotInterval != 0 {
+		// ensure that we keep only heights that match the current snap interval
+		return
+	}
+
 	m.pruneSnapshotHeightsMx.Lock()
 	defer m.pruneSnapshotHeightsMx.Unlock()
 
 	m.logger.Debug("HandleSnapshotHeight", "height", height)
 	m.pruneSnapshotHeights = append(m.pruneSnapshotHeights, height)
 	sort.Slice(m.pruneSnapshotHeights, func(i, j int) bool { return m.pruneSnapshotHeights[i] < m.pruneSnapshotHeights[j] })
+
+	if m.initFromDB && len(m.pruneSnapshotHeights) > 2 { // received 2 fresh snap heights as base level
+		m.pruneSnapshotHeights = m.pruneSnapshotHeights[1:] // drop db state element
+		m.initFromDB = false
+	}
+
 	k := 1
 	for ; k < len(m.pruneSnapshotHeights); k++ {
+		// any one missing in the sequence means they are still in flight
 		if m.pruneSnapshotHeights[k] != m.pruneSnapshotHeights[k-1]+int64(m.snapshotInterval) {
 			break
 		}
 	}
+	// compact the heights list when in-flight snapshots have landed
 	m.pruneSnapshotHeights = m.pruneSnapshotHeights[k-1:]
 
-	// flush the updates to disk so that they are not lost if crash happens.
-	if err := m.db.SetSync(pruneSnapshotHeightsKey, int64SliceToBytes(m.pruneSnapshotHeights)); err != nil {
+	if n := len(m.pruneSnapshotHeights); n > 100 {
+		m.logger.Warn("Snapshot heights state in pruning manager grows unexpected ", "total", height)
+	}
+
+	// flush the max height to disk so that they are not lost if crash happens.
+	if err := m.db.SetSync(pruneSnapshotHeightsKey, int64SliceToBytes(slices.Max(m.pruneSnapshotHeights))); err != nil {
 		panic(err)
 	}
 }
 
 // SetSnapshotInterval sets the interval at which the snapshots are taken.
 func (m *Manager) SetSnapshotInterval(snapshotInterval uint64) {
+	m.pruneSnapshotHeightsMx.Lock()
+	defer m.pruneSnapshotHeightsMx.Unlock()
+
+	if m.snapshotInterval != 0 && snapshotInterval != m.snapshotInterval {
+		// interval is modified, we can not predict in flight snapshots anymore
+		m.pruneSnapshotHeights = make([]int64, 0, 1)
+	}
 	m.snapshotInterval = snapshotInterval
 }
 
@@ -123,13 +149,17 @@ func (m *Manager) GetPruningHeight(height int64) int64 {
 		return pruneHeight
 	}
 
-	if len(m.pruneSnapshotHeights) == 0 { // the length should be greater than zero
+	if len(m.pruneSnapshotHeights) == 0 { // do not prune before an initial snapshot
 		return 0
 	}
 
 	// the snapshot `m.pruneSnapshotHeights[0]` is already operated,
-	// so we can prune upto `m.pruneSnapshotHeights[0] + int64(m.snapshotInterval) - 1`
-	snHeight := m.pruneSnapshotHeights[0] + int64(m.snapshotInterval) - 1
+	snHeight := m.pruneSnapshotHeights[0] - 1
+	if m.pruneSnapshotHeights[0]%int64(m.snapshotInterval) == 0 { // ensure non legacy data
+		// it is safe to prune up to `m.pruneSnapshotHeights[0] + int64(m.snapshotInterval) - 1`
+		// before hitting any in-flight snapshot
+		snHeight += int64(m.snapshotInterval)
+	}
 	return min(snHeight, pruneHeight)
 }
 
@@ -139,17 +169,20 @@ func (m *Manager) LoadSnapshotHeights(db dbm.DB) error {
 		return nil
 	}
 
+	// loading list for backwards compatibility
 	loadedPruneSnapshotHeights, err := loadPruningSnapshotHeights(db)
 	if err != nil {
 		return err
 	}
 
-	if len(loadedPruneSnapshotHeights) > 0 {
-		m.pruneSnapshotHeightsMx.Lock()
-		defer m.pruneSnapshotHeightsMx.Unlock()
-		m.pruneSnapshotHeights = loadedPruneSnapshotHeights
+	if len(loadedPruneSnapshotHeights) == 0 {
+		return nil
 	}
-
+	m.pruneSnapshotHeightsMx.Lock()
+	defer m.pruneSnapshotHeightsMx.Unlock()
+	// restore max only as there are no in-flight snapshots after a restart
+	m.pruneSnapshotHeights = []int64{slices.Max(loadedPruneSnapshotHeights)}
+	m.initFromDB = true
 	return nil
 }
 
@@ -177,7 +210,7 @@ func loadPruningSnapshotHeights(db dbm.DB) ([]int64, error) {
 	return pruneSnapshotHeights, nil
 }
 
-func int64SliceToBytes(slice []int64) []byte {
+func int64SliceToBytes(slice ...int64) []byte {
 	bz := make([]byte, 0, len(slice)*8)
 	for _, ph := range slice {
 		buf := make([]byte, 8)

--- a/store/pruning/manager_test.go
+++ b/store/pruning/manager_test.go
@@ -204,6 +204,7 @@ func TestHandleSnapshotHeight_DbErr_Panic(t *testing.T) {
 	dbMock.EXPECT().SetSync(gomock.Any(), gomock.Any()).Return(errors.New(dbErr)).Times(1)
 
 	manager := pruning.NewManager(dbMock, log.NewNopLogger())
+	manager.SetSnapshotInterval(1)
 	manager.SetOptions(types.NewPruningOptions(types.PruningEverything))
 	require.NotNil(t, manager)
 
@@ -282,7 +283,7 @@ func TestLoadPruningSnapshotHeights(t *testing.T) {
 			db := db.NewMemDB()
 
 			if tc.getFlushedPruningSnapshotHeights != nil {
-				err = db.Set(pruning.PruneSnapshotHeightsKey, pruning.Int64SliceToBytes(tc.getFlushedPruningSnapshotHeights()))
+				err = db.Set(pruning.PruneSnapshotHeightsKey, pruning.Int64SliceToBytes(tc.getFlushedPruningSnapshotHeights()...))
 				require.NoError(t, err)
 			}
 

--- a/store/rootmulti/store_test.go
+++ b/store/rootmulti/store_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	dbm "github.com/cosmos/cosmos-db"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"cosmossdk.io/errors"
@@ -633,6 +634,113 @@ func TestMultiStore_PruningRestart(t *testing.T) {
 	}
 
 	require.Eventually(t, isPruned, 1*time.Second, 10*time.Millisecond, "expected error when loading pruned heights")
+}
+
+func TestMultiStore_PruningWithIntervalUpdates(t *testing.T) {
+	// scenarios
+	// snap height in sync - interval not changed
+	// snap height out of order - interval not changed
+	// snap height in flight - interval not changed
+
+	// snap height in sync - interval modified
+	// snap height out of order - interval modified
+	// snap height in flight - interval modified
+
+	const (
+		initialSnapshotInterval uint64 = 10
+		initialPruneInterval    uint64 = 10
+	)
+
+	specs := map[string]struct {
+		do             func(t *testing.T, ms *Store, commitSnapN func(n int, snapshotInterval uint64) int64)
+		expPruneHeight int64
+	}{
+		" snap height sequential - constant interval": {
+			do: func(t *testing.T, ms *Store, commitSnapN func(n int, snapshotInterval uint64) int64) {
+				t.Helper()
+				commitSnapN(20, initialSnapshotInterval)
+			},
+			expPruneHeight: 14, // 20 - 5 (keep) -1
+		},
+		" snap out of order - constant interval": {
+			do: func(t *testing.T, ms *Store, commitSnapN func(n int, snapshotInterval uint64) int64) {
+				t.Helper()
+				commitSnapN(20, initialSnapshotInterval)
+				ms.pruningManager.HandleSnapshotHeight(10)
+			},
+			expPruneHeight: 14, // 20 - 5 (keep) -1
+		},
+		" snap height sequential - snap interval increased": {
+			do: func(t *testing.T, ms *Store, commitSnapN func(n int, snapshotInterval uint64) int64) {
+				t.Helper()
+				commitSnapN(10, initialSnapshotInterval)
+				currHeight := commitSnapN(10, 20)
+				assert.Equal(t, int64(14), ms.pruningManager.GetPruningHeight(currHeight)) // 20 - 5 (keep) -1
+				commitSnapN(10, 20)
+			},
+			expPruneHeight: 24, // 30 -5 (keep) -1
+		},
+		" snap out of order - snap interval increased": {
+			do: func(t *testing.T, ms *Store, commitSnapN func(n int, snapshotInterval uint64) int64) {
+				t.Helper()
+				commitSnapN(10, initialSnapshotInterval)
+				commitSnapN(30, 20)
+				ms.pruningManager.HandleSnapshotHeight(10)
+			},
+			expPruneHeight: 34, // 40 - 5 (keep) - 1
+		},
+		" snap height sequential - snap interval decreased": {
+			do: func(t *testing.T, ms *Store, commitSnapN func(n int, snapshotInterval uint64) int64) {
+				t.Helper()
+				commitSnapN(10, initialSnapshotInterval)
+				commitSnapN(10, 6)
+			},
+			expPruneHeight: 14, // 20 -5 (keep) -1
+		},
+		" snap out of order - snap interval decreased": {
+			do: func(t *testing.T, ms *Store, commitSnapN func(n int, snapshotInterval uint64) int64) {
+				t.Helper()
+				commitSnapN(10, initialSnapshotInterval)
+				commitSnapN(10, 6)
+				ms.pruningManager.HandleSnapshotHeight(10)
+			},
+			expPruneHeight: 14, // 20 -5 (keep) -1
+		},
+	}
+	for name, spec := range specs {
+		t.Run(name, func(t *testing.T) {
+			db := dbm.NewMemDB()
+			ms := newMultiStoreWithMounts(db, pruningtypes.NewCustomPruningOptions(5, initialPruneInterval))
+			ms.SetSnapshotInterval(initialSnapshotInterval)
+			require.NoError(t, ms.LoadLatestVersion())
+
+			commitSnapN := func(n int, snapshotInterval uint64) int64 {
+				ms.SetSnapshotInterval(snapshotInterval)
+				for range n {
+					height := ms.Commit().Version
+					if height != 0 && snapshotInterval != 0 && uint64(height)%snapshotInterval == 0 {
+						ms.pruningManager.HandleSnapshotHeight(height)
+					}
+				}
+				return ms.LatestVersion()
+			}
+			spec.do(t, ms, commitSnapN)
+			actualHeightToPrune := ms.pruningManager.GetPruningHeight(ms.LatestVersion())
+			require.Equal(t, spec.expPruneHeight, actualHeightToPrune)
+
+			// Ensure async pruning is done
+			isPruned := func() bool {
+				ms.Commit() // to flush the batch with the pruned heights
+				for v := int64(1); v <= actualHeightToPrune; v++ {
+					if _, err := ms.CacheMultiStoreWithVersion(v); err == nil {
+						return false
+					}
+				}
+				return true
+			}
+			require.Eventually(t, isPruned, 1*time.Second, 10*time.Millisecond, "expected error when loading pruned heights")
+		})
+	}
 }
 
 // TestUnevenStoresHeightCheck tests if loading root store correctly errors when


### PR DESCRIPTION
# Description

Closes: #23638

Fixes the pruning height calculation when the interval is updated. See scenario 1 + 2 in the linked issue. Big thanks to  @RogerKSI for reporting this!


With this patch the height calculation after a restart takes the new snapshot interval into account but there is still a possibility for pruning an in-flight snapshot although this should be very unlikely.
The scenario is: after a restart the first snapshot must come after the 2nd and 3rd into `HandleSnapshotHeight`. 

I have been thinking fixes for this scenario as well but I came only up with a solution where the snapshot manager announces a snapshot to the pruning manager in the first step so that we can know what is currently in flight. This requires more changes that should be discussed first.

The old code does not have the same problem as it simply stuck with the loaded values and stopped pruning when the interval was changed. (see scenario 2 in the issue)


---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title, you can find examples of the prefixes below:
    <!-- * `feat`: A new feature
    * `fix`: A bug fix
    * `docs`: Documentation only changes
    * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
    * `refactor`: A code change that neither fixes a bug nor adds a feature
    * `perf`: A code change that improves performance
    * `test`: Adding missing tests or correcting existing tests
    * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
    * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
    * `chore`: Other changes that don't modify src or test files
    * `revert`: Reverts a previous commit -->
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

Please see [Pull Request Reviewer section in the contributing guide](../CONTRIBUTING.md#reviewer) for more information on how to review a pull request.

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced snapshot management to ensure only valid snapshots are processed, with improved consistency in pruning behavior.
  
- **Tests**
  - Expanded testing scenarios to verify proper handling of snapshot intervals and pruning adjustments, including validations under asynchronous conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->