### PR TITLE
docs(CONTRIBUTING.md): PROCESS.md link fix

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -168,8 +168,8 @@ When writing documentation, follow the [Documentation Writing Guidelines](./docs
 
 Within the Cosmos SDK we have two forms of documenting decisions, Request For Comment (RFC) & Architecture Design Record (ADR). They perform two different functions. The process for assessing if something needs an RFC is located in the respective folders: 
 
-* [RFC Process](./docs/rfc/process.md)
-* [ADR Process](./docs/adr/process.md) 
+* [RFC Process](./docs/rfc/PROCESS.md)
+* [ADR Process](./docs/architecture/PROCESS.md) 
 
 
 ## Dependencies


### PR DESCRIPTION
Hello team, I found that the link to process.md in the document doesn't work. I noticed that this is due to a mismatch in English capitalization and path names. I have made the necessary corrections and tested it successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated contributor guidelines to ensure the correct links for proposal reviews and architectural decision records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->