### PR TITLE
chore: fix format and redirect wrong path in CODING_GUIDELINES.md & README.md

### DIFF
--- a/CODING_GUIDELINES.md
+++ b/CODING_GUIDELINES.md
@@ -93,7 +93,7 @@ Make sure your code is well tested:
 * Provide unit tests for every unit of your code if possible. Unit tests are expected to comprise 70%-80% of your tests.
 * Describe the test scenarios you are implementing for integration tests.
 * Create integration tests for queries and msgs.
-* Use both test cases and property / fuzzy testing. We use the [rapid](pgregory.net/rapid) Go library for property-based and fuzzy testing.
+* Use both test cases and property / fuzzy testing. We use the [rapid](https://pgregory.net/rapid) Go library for property-based and fuzzy testing.
 * Do not decrease code test coverage. Explain in a PR if test coverage is decreased.
 
 We expect tests to use `require` or `assert` rather than `t.Skip` or `t.Fail`,

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The Cosmos SDK is a framework for building blockchain applications. [CometBFT (B
 
 ## Quick Start
 
-To learn how the Cosmos SDK works from a high-level perspective, see the Cosmos SDK [High-Level Intro](https://docs.cosmos.network/main/intro/overview).
+To learn how the Cosmos SDK works from a high-level perspective, see the Cosmos SDK [High-Level Intro](https://docs.cosmos.network/main/learn/intro/overview).
 
 If you want to get started quickly and learn how to build on top of Cosmos SDK, visit [Cosmos SDK Tutorials](https://tutorials.cosmos.network). You can also fork the tutorial's repository to get started building your own Cosmos SDK application.
 


### PR DESCRIPTION
Hello Team! In Markdown, you need to add http:// or https:// to the link. Otherwise, it will consider it’s a path in the project, not a website address. I changed it to https://pgregory.net/rapid, and now it works. And the latest documentation URL for Cosmos SDK is https://docs.cosmos.network/main/learn/intro/overview , I have made the corresponding changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the URL for the "rapid" Go library in the coding guidelines.
  - Updated the link to the Cosmos SDK High-Level Intro documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->