### PR TITLE
refactor(mock): implement String and GetSigners in KVStoreTx

### DIFF
--- a/server/mock/tx.go
+++ b/server/mock/tx.go
@@ -73,7 +73,9 @@ func (msg *KVStoreTx) Equals(key cryptotypes.PubKey) bool {
 
 // dummy implementation of proto.Message
 func (msg *KVStoreTx) Reset()         {}
-func (msg *KVStoreTx) String() string { return "TODO" }
+func (msg *KVStoreTx) String() string {
+	return fmt.Sprintf("KVStoreTx{key=%s, value=%s, address=%s}", msg.key, msg.value, msg.address)
+}
 func (msg *KVStoreTx) ProtoMessage()  {}
 
 var (
@@ -116,7 +118,7 @@ func (msg *KVStoreTx) ValidateBasic() error {
 }
 
 func (msg *KVStoreTx) GetSigners() ([][]byte, error) {
-	return nil, nil
+	return [][]byte{msg.address.Bytes()}, nil
 }
 
 func (msg *KVStoreTx) GetPubKeys() ([]cryptotypes.PubKey, error) { panic("GetPubKeys not implemented") }

--- a/server/mock/tx.go
+++ b/server/mock/tx.go
@@ -118,6 +118,9 @@ func (msg *KVStoreTx) ValidateBasic() error {
 }
 
 func (msg *KVStoreTx) GetSigners() ([][]byte, error) {
+	if msg.address == nil {
+		return [][]byte{}, nil
+	}
 	return [][]byte{msg.address.Bytes()}, nil
 }
 


### PR DESCRIPTION
This PR improves the KVStoreTx mock implementation by replacing placeholder logic with functional code:

- Implements the String() method to return a structured representation of the transaction.

- Implements the GetSigners() method to correctly return the address of the transaction signer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the display of transaction information for better clarity.
  - Corrected signer address handling to ensure accurate address representation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->