### PR TITLE
chore: check if fund exists for CancelContinuousFund in `x/protocolpool`

### DIFF
--- a/x/protocolpool/keeper/msg_server.go
+++ b/x/protocolpool/keeper/msg_server.go
@@ -146,6 +146,15 @@ func (k MsgServer) CancelContinuousFund(ctx context.Context, msg *types.MsgCance
 	canceledHeight := sdkCtx.BlockHeight()
 	canceledTime := sdkCtx.BlockTime()
 
+	has, err := k.ContinuousFunds.Has(sdkCtx, recipient)
+	if err != nil {
+		return nil, fmt.Errorf("cannot get continuous fund for recipient %w", err)
+	}
+
+	if !has {
+		return nil, fmt.Errorf("cannot cancel continuous fund for recipient %s - does not exist", msg.Recipient)
+	}
+
 	if err := k.ContinuousFunds.Remove(sdkCtx, recipient); err != nil {
 		return nil, fmt.Errorf("failed to remove continuous fund for recipient %s: %w", msg.Recipient, err)
 	}

--- a/x/protocolpool/keeper/msg_server_test.go
+++ b/x/protocolpool/keeper/msg_server_test.go
@@ -366,7 +366,7 @@ func (suite *KeeperTestSuite) TestCancelContinuousFund() {
 			expErrMsg: "decoding bech32 failed:",
 		},
 		{
-			name: "remove a continuous fund that already was removed - no error",
+			name: "remove a continuous fund that already was removed - error does not exist",
 			msg: &types.MsgCancelContinuousFund{
 				Authority: validAuthority,
 				Recipient: validRecipient.String(),
@@ -377,7 +377,7 @@ func (suite *KeeperTestSuite) TestCancelContinuousFund() {
 				// Ensure the continuous fund is not set so that Remove fails.
 				_ = suite.poolKeeper.ContinuousFunds.Remove(suite.ctx, validRecipient)
 			},
-			expErr: false,
+			expErr: true,
 		},
 		{
 			name: "valid cancel continuous fund",


### PR DESCRIPTION
Audit nit

instead of being a silent no error - we error if the fund you are trying to remove does not exist

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling when attempting to cancel a non-existent continuous fund, ensuring users receive a clear error message if the fund does not exist.

- **Tests**
  - Updated tests to verify that cancelling a non-existent continuous fund now correctly returns an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->