### PR TITLE
refactor(client): change flag for unordered tx timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Improvements
 
+* (client) [#24561](https://github.com/cosmos/cosmos-sdk/pull/24561) TimeoutTimestamp flag has been changed to TimeoutDuration, which now sets the timeout timestamp of unordered transactions to the current time + duration passed.
 * (telemetry) [#24541](https://github.com/cosmos/cosmos-sdk/pull/24541) Telemetry now includes a pre_blocker metric key. x/upgrade should migrate to this key in v0.54.0.
 * (x/auth) [#24541](https://github.com/cosmos/cosmos-sdk/pull/24541) x/auth's PreBlocker now emits telemetry under the pre_blocker metric key.
 * (x/bank) [#24431](https://github.com/cosmos/cosmos-sdk/pull/24431) Reduce the number of `ValidateDenom` calls in `bank.SendCoins` and `Coin`.

--- a/client/flags/flags.go
+++ b/client/flags/flags.go
@@ -74,7 +74,7 @@ const (
 	FlagOffset           = "offset"
 	FlagCountTotal       = "count-total"
 	FlagTimeoutHeight    = "timeout-height"
-	FlagTimeoutTimestamp = "timeout-timestamp"
+	TimeoutDuration      = "timeout-duration"
 	FlagUnordered        = "unordered"
 	FlagKeyAlgorithm     = "algo"
 	FlagKeyType          = "key-type"
@@ -137,9 +137,9 @@ func AddTxFlagsToCmd(cmd *cobra.Command) {
 	f.Bool(FlagOffline, false, "Offline mode (does not allow any online functionality)")
 	f.BoolP(FlagSkipConfirmation, "y", false, "Skip tx broadcasting prompt confirmation")
 	f.String(FlagSignMode, "", "Choose sign mode (direct|amino-json|direct-aux|textual), this is an advanced feature")
-	f.Uint64(FlagTimeoutHeight, 0, "DEPRECATED: Please use --timeout-timestamp instead. Set a block timeout height to prevent the tx from being committed past a certain height")
-	f.Duration(FlagTimeoutTimestamp, 0, "TimeoutTimestamp is the duration the transaction will be considered valid in the mempool. If the transaction is still in the mempool, and the block time has passed the time of submission + TimeoutTimestamp, the transaction will be rejected.")
-	f.Bool(FlagUnordered, false, "Enable unordered transaction delivery; must be used in conjunction with --timeout-timestamp")
+	f.Uint64(FlagTimeoutHeight, 0, "DEPRECATED: Please use --timeout-duration instead. Set a block timeout height to prevent the tx from being committed past a certain height")
+	f.Duration(TimeoutDuration, 0, "TimeoutDuration is the duration the transaction will be considered valid in the mempool. If the transaction is still in the mempool, and the block time has passed the time of submission + TimeoutTimestamp, the transaction will be rejected.")
+	f.Bool(FlagUnordered, false, "Enable unordered transaction delivery; must be used in conjunction with --timeout-duration")
 	f.String(FlagFeePayer, "", "Fee payer pays fees for the transaction instead of deducting from the signer")
 	f.String(FlagFeeGranter, "", "Fee granter grants fees for the transaction")
 	f.String(FlagTip, "", "Tip is the amount that is going to be transferred to the fee payer on the target chain. This flag is only valid when used with --aux, and is ignored if the target chain didn't enable the TipDecorator")
@@ -149,8 +149,8 @@ func AddTxFlagsToCmd(cmd *cobra.Command) {
 	f.String(FlagGas, "", fmt.Sprintf("gas limit to set per-transaction; set to %q to calculate sufficient gas automatically. Note: %q option doesn't always report accurate results. Set a valid coin value to adjust the result. Can be used instead of %q. (default %d)",
 		GasFlagAuto, GasFlagAuto, FlagFees, DefaultGasLimit))
 
-	cmd.MarkFlagsMutuallyExclusive(FlagTimeoutHeight, FlagTimeoutTimestamp)
-	cmd.MarkFlagsRequiredTogether(FlagUnordered, FlagTimeoutTimestamp)
+	cmd.MarkFlagsMutuallyExclusive(FlagTimeoutHeight, TimeoutDuration)
+	cmd.MarkFlagsRequiredTogether(FlagUnordered, TimeoutDuration)
 
 	AddKeyringFlags(f)
 }

--- a/client/flags/flags.go
+++ b/client/flags/flags.go
@@ -138,7 +138,7 @@ func AddTxFlagsToCmd(cmd *cobra.Command) {
 	f.BoolP(FlagSkipConfirmation, "y", false, "Skip tx broadcasting prompt confirmation")
 	f.String(FlagSignMode, "", "Choose sign mode (direct|amino-json|direct-aux|textual), this is an advanced feature")
 	f.Uint64(FlagTimeoutHeight, 0, "DEPRECATED: Please use --timeout-timestamp instead. Set a block timeout height to prevent the tx from being committed past a certain height")
-	f.Int64(FlagTimeoutTimestamp, 0, "Set a block timeout timestamp to prevent the tx from being committed past a certain time")
+	f.Duration(FlagTimeoutTimestamp, 0, "TimeoutTimestamp is the duration the transaction will be considered valid in the mempool. If the transaction is still in the mempool, and the block time has passed the time of submission + TimeoutTimestamp, the transaction will be rejected.")
 	f.Bool(FlagUnordered, false, "Enable unordered transaction delivery; must be used in conjunction with --timeout-timestamp")
 	f.String(FlagFeePayer, "", "Fee payer pays fees for the transaction instead of deducting from the signer")
 	f.String(FlagFeeGranter, "", "Fee granter grants fees for the transaction")

--- a/client/flags/flags.go
+++ b/client/flags/flags.go
@@ -138,7 +138,7 @@ func AddTxFlagsToCmd(cmd *cobra.Command) {
 	f.BoolP(FlagSkipConfirmation, "y", false, "Skip tx broadcasting prompt confirmation")
 	f.String(FlagSignMode, "", "Choose sign mode (direct|amino-json|direct-aux|textual), this is an advanced feature")
 	f.Uint64(FlagTimeoutHeight, 0, "DEPRECATED: Please use --timeout-duration instead. Set a block timeout height to prevent the tx from being committed past a certain height")
-	f.Duration(TimeoutDuration, 0, "TimeoutDuration is the duration the transaction will be considered valid in the mempool. If the transaction is still in the mempool, and the block time has passed the time of submission + TimeoutTimestamp, the transaction will be rejected.")
+	f.Duration(TimeoutDuration, 0, "TimeoutDuration is the duration the transaction will be considered valid in the mempool. The transaction's unordered nonce will be set to the time of transaction creation + the duration value passed. If the transaction is still in the mempool, and the block time has passed the time of submission + TimeoutTimestamp, the transaction will be rejected.")
 	f.Bool(FlagUnordered, false, "Enable unordered transaction delivery; must be used in conjunction with --timeout-duration")
 	f.String(FlagFeePayer, "", "Fee payer pays fees for the transaction instead of deducting from the signer")
 	f.String(FlagFeeGranter, "", "Fee granter grants fees for the transaction")

--- a/client/tx/factory.go
+++ b/client/tx/factory.go
@@ -88,8 +88,8 @@ func NewFactoryCLI(clientCtx client.Context, flagSet *pflag.FlagSet) (Factory, e
 
 	gasAdj := clientCtx.Viper.GetFloat64(flags.FlagGasAdjustment)
 	memo := clientCtx.Viper.GetString(flags.FlagNote)
-	timestampUnix := clientCtx.Viper.GetInt64(flags.FlagTimeoutTimestamp)
-	timeoutTimestamp := time.Unix(timestampUnix, 0)
+	timeout := clientCtx.Viper.GetDuration(flags.FlagTimeoutTimestamp)
+	timeoutTimestamp := time.Now().Add(timeout)
 	timeoutHeight := clientCtx.Viper.GetUint64(flags.FlagTimeoutHeight)
 	unordered := clientCtx.Viper.GetBool(flags.FlagUnordered)
 

--- a/client/tx/factory.go
+++ b/client/tx/factory.go
@@ -89,7 +89,10 @@ func NewFactoryCLI(clientCtx client.Context, flagSet *pflag.FlagSet) (Factory, e
 	gasAdj := clientCtx.Viper.GetFloat64(flags.FlagGasAdjustment)
 	memo := clientCtx.Viper.GetString(flags.FlagNote)
 	timeout := clientCtx.Viper.GetDuration(flags.FlagTimeoutTimestamp)
-	timeoutTimestamp := time.Now().Add(timeout)
+	var timeoutTimestamp time.Time
+	if timeout > 0 {
+		timeoutTimestamp = time.Now().Add(timeout)
+	}
 	timeoutHeight := clientCtx.Viper.GetUint64(flags.FlagTimeoutHeight)
 	unordered := clientCtx.Viper.GetBool(flags.FlagUnordered)
 

--- a/client/tx/factory.go
+++ b/client/tx/factory.go
@@ -88,7 +88,7 @@ func NewFactoryCLI(clientCtx client.Context, flagSet *pflag.FlagSet) (Factory, e
 
 	gasAdj := clientCtx.Viper.GetFloat64(flags.FlagGasAdjustment)
 	memo := clientCtx.Viper.GetString(flags.FlagNote)
-	timeout := clientCtx.Viper.GetDuration(flags.FlagTimeoutTimestamp)
+	timeout := clientCtx.Viper.GetDuration(flags.TimeoutDuration)
 	var timeoutTimestamp time.Time
 	if timeout > 0 {
 		timeoutTimestamp = time.Now().Add(timeout)

--- a/docs/docs/learn/beginner/01-tx-lifecycle.md
+++ b/docs/docs/learn/beginner/01-tx-lifecycle.md
@@ -39,7 +39,15 @@ Additionally, there are several [flags](../advanced/07-cli.md) users can use to 
 
 The ultimate value of the fees paid is equal to the gas multiplied by the gas prices. In other words, `fees = ceil(gas * gasPrices)`. Thus, since fees can be calculated using gas prices and vice versa, the users specify only one of the two.
 
-Later, validators decide whether or not to include the transaction in their block by comparing the given or calculated `gas-prices` to their local `min-gas-prices`. `Tx` is rejected if its `gas-prices` is not high enough, so users are incentivized to pay more.
+Later, validators decide whether to include the transaction in their block by comparing the given or calculated `gas-prices` to their local `min-gas-prices`. `Tx` is rejected if its `gas-prices` is not high enough, so users are incentivized to pay more.
+
+#### Unordered Transactions
+
+With Cosmos SDK v0.53.0, users may send unordered transactions to chains that have this feature enabled.
+The following flags allow a user to build an unordered transaction from the CLI.
+
+* `--unordered` specifies that this transaction should be unordered.
+* `--timeout-duration` specifies the amount of time the unordered transaction should be valid in the mempool. The transaction's unordered nonce will be set to the time of transaction creation + timeout duration.
 
 #### CLI Example
 

--- a/systemtests/cli.go
+++ b/systemtests/cli.go
@@ -195,6 +195,7 @@ func (c CLIWrapper) RunAndWait(args ...string) string {
 // RunCommandWithArgs use for run cli command, not tx
 func (c CLIWrapper) RunCommandWithArgs(args ...string) string {
 	c.t.Helper()
+	args = c.WithKeyringFlags(args...)
 	execOutput, _ := c.run(args)
 	return execOutput
 }

--- a/tests/systemtests/Makefile
+++ b/tests/systemtests/Makefile
@@ -5,7 +5,7 @@ WAIT_TIME ?= 45s
 all: test format
 
 test:
-	go test -mod=readonly -failfast -timeout=15m -tags='system_test' ./... --wait-time=$(WAIT_TIME) --verbose -run=TestUnorderedTXDuplicate
+	go test -mod=readonly -failfast -timeout=15m -tags='system_test' ./... --wait-time=$(WAIT_TIME) --verbose
 
 format:
 	find . -name '*.go' -type f -not -path "./vendor*" -not -path "*.git*" -not -path "./client/lcd/statik/statik.go" | xargs gofumpt -w

--- a/tests/systemtests/Makefile
+++ b/tests/systemtests/Makefile
@@ -5,7 +5,7 @@ WAIT_TIME ?= 45s
 all: test format
 
 test:
-	go test -mod=readonly -failfast -timeout=15m -tags='system_test' ./... --wait-time=$(WAIT_TIME) --verbose
+	go test -mod=readonly -failfast -timeout=15m -tags='system_test' ./... --wait-time=$(WAIT_TIME) --verbose -run=TestUnorderedTXDuplicate
 
 format:
 	find . -name '*.go' -type f -not -path "./vendor*" -not -path "*.git*" -not -path "./client/lcd/statik/statik.go" | xargs gofumpt -w

--- a/tests/systemtests/unordered_tx_test.go
+++ b/tests/systemtests/unordered_tx_test.go
@@ -32,7 +32,7 @@ func TestUnorderedTXDuplicate(t *testing.T) {
 	systest.Sut.StartChain(t)
 
 	// send tokens
-	cmd := []string{"tx", "bank", "send", account1Addr, account2Addr, "5000stake", "--from=" + account1Addr, "--fees=1stake", "--timeout-timestamp=1m", "--unordered", "--sequence=1", "--note=1"}
+	cmd := []string{"tx", "bank", "send", account1Addr, account2Addr, "5000stake", "--from=" + account1Addr, "--fees=1stake", "--timeout-timestamp=8m", "--unordered", "--sequence=1", "--note=1"}
 	rsp1 := cli.Run(cmd...)
 	systest.RequireTxSuccess(t, rsp1)
 
@@ -85,7 +85,7 @@ func TestTxBackwardsCompatability(t *testing.T) {
 	code := gjson.Get(response, "code").Int()
 	require.Equal(t, int64(0), code)
 
-	bankSendCmdArgs = []string{"tx", "bank", "send", senderAddr, valAddr, fmt.Sprintf("%d%s", transferAmount, denom), "--chain-id=" + v50CLI.ChainID(), "--fees=10stake", "--sign-mode=direct", "--unordered", "--timeout-timestamp=5m"}
+	bankSendCmdArgs = []string{"tx", "bank", "send", senderAddr, valAddr, fmt.Sprintf("%d%s", transferAmount, denom), "--chain-id=" + v50CLI.ChainID(), "--fees=10stake", "--sign-mode=direct", "--unordered", "--timeout-timestamp=8m"}
 	res, ok = v53CLI.RunOnly(bankSendCmdArgs...)
 	require.True(t, ok)
 

--- a/tests/systemtests/unordered_tx_test.go
+++ b/tests/systemtests/unordered_tx_test.go
@@ -32,7 +32,7 @@ func TestUnorderedTXDuplicate(t *testing.T) {
 	systest.Sut.StartChain(t)
 
 	// send tokens
-	cmd := []string{"tx", "bank", "send", account1Addr, account2Addr, "5000stake", "--from=" + account1Addr, "--fees=1stake", "--timeout-timestamp=5m", "--unordered", "--note=1", "--chain-id=testing", "--generate-only"}
+	cmd := []string{"tx", "bank", "send", account1Addr, account2Addr, "5000stake", "--from=" + account1Addr, "--fees=1stake", "--timeout-duration=5m", "--unordered", "--note=1", "--chain-id=testing", "--generate-only"}
 	rsp1 := cli.RunCommandWithArgs(cmd...)
 	txFile := testutil.TempFile(t)
 	_, err := txFile.WriteString(rsp1)
@@ -92,7 +92,7 @@ func TestTxBackwardsCompatability(t *testing.T) {
 	code := gjson.Get(response, "code").Int()
 	require.Equal(t, int64(0), code)
 
-	bankSendCmdArgs = []string{"tx", "bank", "send", senderAddr, valAddr, fmt.Sprintf("%d%s", transferAmount, denom), "--chain-id=" + v50CLI.ChainID(), "--fees=10stake", "--sign-mode=direct", "--unordered", "--timeout-timestamp=8m"}
+	bankSendCmdArgs = []string{"tx", "bank", "send", senderAddr, valAddr, fmt.Sprintf("%d%s", transferAmount, denom), "--chain-id=" + v50CLI.ChainID(), "--fees=10stake", "--sign-mode=direct", "--unordered", "--timeout-duration=8m"}
 	res, ok = v53CLI.RunOnly(bankSendCmdArgs...)
 	require.True(t, ok)
 

--- a/tests/systemtests/unordered_tx_test.go
+++ b/tests/systemtests/unordered_tx_test.go
@@ -31,9 +31,8 @@ func TestUnorderedTXDuplicate(t *testing.T) {
 
 	systest.Sut.StartChain(t)
 
-	timeoutTimestamp := time.Now().Add(time.Minute)
 	// send tokens
-	cmd := []string{"tx", "bank", "send", account1Addr, account2Addr, "5000stake", "--from=" + account1Addr, "--fees=1stake", fmt.Sprintf("--timeout-timestamp=%v", timeoutTimestamp.Unix()), "--unordered", "--sequence=1", "--note=1"}
+	cmd := []string{"tx", "bank", "send", account1Addr, account2Addr, "5000stake", "--from=" + account1Addr, "--fees=1stake", "--timeout-timestamp=1m", "--unordered", "--sequence=1", "--note=1"}
 	rsp1 := cli.Run(cmd...)
 	systest.RequireTxSuccess(t, rsp1)
 
@@ -86,7 +85,7 @@ func TestTxBackwardsCompatability(t *testing.T) {
 	code := gjson.Get(response, "code").Int()
 	require.Equal(t, int64(0), code)
 
-	bankSendCmdArgs = []string{"tx", "bank", "send", senderAddr, valAddr, fmt.Sprintf("%d%s", transferAmount, denom), "--chain-id=" + v50CLI.ChainID(), "--fees=10stake", "--sign-mode=direct", "--unordered", "--timeout-timestamp=10000"}
+	bankSendCmdArgs = []string{"tx", "bank", "send", senderAddr, valAddr, fmt.Sprintf("%d%s", transferAmount, denom), "--chain-id=" + v50CLI.ChainID(), "--fees=10stake", "--sign-mode=direct", "--unordered", "--timeout-timestamp=5m"}
 	res, ok = v53CLI.RunOnly(bankSendCmdArgs...)
 	require.True(t, ok)
 

--- a/tests/systemtests/unordered_tx_test.go
+++ b/tests/systemtests/unordered_tx_test.go
@@ -7,11 +7,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cosmos/cosmos-sdk/testutil"
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
 
 	systest "cosmossdk.io/systemtests"
+
+	"github.com/cosmos/cosmos-sdk/testutil"
 )
 
 func TestUnorderedTXDuplicate(t *testing.T) {
@@ -41,7 +42,8 @@ func TestUnorderedTXDuplicate(t *testing.T) {
 	signCmd := []string{"tx", "sign", txFile.Name(), "--from=" + account1Addr, "--chain-id=testing"}
 	rsp1 = cli.RunCommandWithArgs(signCmd...)
 	signedFile := testutil.TempFile(t)
-	signedFile.WriteString(rsp1)
+	_, err = signedFile.WriteString(rsp1)
+	require.NoError(t, err)
 
 	cmd = []string{"tx", "broadcast", signedFile.Name(), "--chain-id=testing"}
 	rsp1 = cli.RunCommandWithArgs(cmd...)

--- a/tests/systemtests/unordered_tx_test.go
+++ b/tests/systemtests/unordered_tx_test.go
@@ -34,14 +34,13 @@ func TestUnorderedTXDuplicate(t *testing.T) {
 
 	// send tokens
 	cmd := []string{"tx", "bank", "send", account1Addr, account2Addr, "5000stake", "--from=" + account1Addr, "--fees=1stake", "--timeout-timestamp=5m", "--unordered", "--sequence=1", "--note=1", "--chain-id=testing", "--generate-only"}
-	rsp1 := cli.Run(cmd...)
+	rsp1, _ := cli.RunOnly(cmd...)
 	txFile := testutil.TempFile(t)
 	_, err := txFile.WriteString(rsp1)
 	require.NoError(t, err)
 
 	signCmd := []string{"tx", "sign", txFile.Name(), "--from=", account1Addr, "--chain-id=testing"}
-	rsp1 = cli.Run(signCmd...)
-
+	rsp1, _ = cli.RunOnly(signCmd...)
 	signedFile := testutil.TempFile(t)
 	signedFile.WriteString(rsp1)
 
@@ -57,9 +56,10 @@ func TestUnorderedTXDuplicate(t *testing.T) {
 		require.Equal(t, int64(19), code.Int()) // 19 == already in mempool.
 		return false                            // always abort
 	}
-	rsp1 = cli.Run(signCmd...)
+	rsp1, _ = cli.RunOnly(signCmd...)
 	signedFileDuplicate := testutil.TempFile(t)
 	signedFileDuplicate.WriteString(rsp1)
+
 	cmd = []string{"tx", "broadcast", signedFileDuplicate.Name(), "--chain-id=testing"}
 	rsp2 := cli.WithRunErrorMatcher(assertDuplicateErr).Run(cmd...)
 	systest.RequireTxFailure(t, rsp2)


### PR DESCRIPTION
# Description

- changes flag behavior for timeouts to take a duration, which simply gets added to the current time. 
- change flag name to `timeout-duration` to better reflect the above change

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.  Your PR will not be merged unless you satisfy
all of these items.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title, you can find examples of the prefixes below:
    <!-- * `feat`: A new feature
    * `fix`: A bug fix
    * `docs`: Documentation only changes
    * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
    * `refactor`: A code change that neither fixes a bug nor adds a feature
    * `perf`: A code change that improves performance
    * `test`: Adding missing tests or correcting existing tests
    * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
    * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
    * `chore`: Other changes that don't modify src or test files
    * `revert`: Reverts a previous commit -->
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Replaced the transaction timeout flag with a new duration-based flag, allowing users to specify how long a transaction remains valid in the mempool.
  - Updated command-line help messages and error handling to reflect the new timeout flag.
- **Bug Fixes**
  - Improved error reporting for duplicate unordered transactions in system tests.
- **Tests**
  - Refactored system tests to use the new timeout duration flag and streamlined transaction creation, signing, and broadcasting steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->