### PR TITLE
docs: Update SDK version references from v0.50.0-alpha.0 to v0.53.0-rc.2 in documentation

### DIFF
--- a/docs/docs/learn/advanced/08-events.md
+++ b/docs/docs/learn/advanced/08-events.md
@@ -66,7 +66,7 @@ Internally, the `EventManager` tracks a list of Events for the entire execution 
 (i.e. transaction execution, `BeginBlock`, `EndBlock`).
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/types/events.go#L19-L26
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.2/types/events.go#L18-L25
 ```
 
 The `EventManager` comes with a set of useful methods to manage Events. The method
@@ -74,7 +74,7 @@ that is used most by module and application developers is `EmitTypedEvent` or `E
 an Event in the `EventManager`.
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/types/events.go#L53-L62
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.2/types/events.go#L51-L60
 ```
 
 Module developers should handle Event emission via the `EventManager#EmitTypedEvent` or `EventManager#EmitEvent` in each message
@@ -85,7 +85,7 @@ the [`Context`](./02-context.md), where Event should be already registered, and 
 **Typed events:**
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/x/group/keeper/msg_server.go#L95-L97
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.2/x/group/keeper/msg_server.go#L95-L97
 ```
 
 **Legacy events:**
@@ -125,7 +125,7 @@ The main `eventCategory` you can subscribe to are:
 These Events are triggered from the `state` package after a block is committed. You can get the
 full list of Event categories [on the CometBFT Go documentation](https://pkg.go.dev/github.com/cometbft/cometbft/types#pkg-constants).
 
-The `type` and `attribute` value of the `query` allow you to filter the specific Event you are looking for. For example, a `Mint` transaction triggers an Event of type `EventMint` and has an `Id` and an `Owner` as `attributes` (as defined in the [`events.proto` file of the `NFT` module](https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/proto/cosmos/nft/v1beta1/event.proto#L21-L31)).
+The `type` and `attribute` value of the `query` allow you to filter the specific Event you are looking for. For example, a `Mint` transaction triggers an Event of type `EventMint` and has an `Id` and an `Owner` as `attributes` (as defined in the [`events.proto` file of the `NFT` module](https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.2/proto/cosmos/nft/v1beta1/event.proto#L21-L31)).
 
 Subscribing to this Event would be done like so:
 
@@ -142,7 +142,7 @@ Subscribing to this Event would be done like so:
 
 where `ownerAddress` is an address following the [`AccAddress`](../beginner/03-accounts.md#addresses) format.
 
-The same way can be used to subscribe to [legacy events](https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/x/bank/types/events.go).
+The same way can be used to subscribe to [legacy events](https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.2/x/bank/types/events.go).
 
 ## Default Events
 

--- a/docs/docs/learn/advanced/12-simulation.md
+++ b/docs/docs/learn/advanced/12-simulation.md
@@ -8,7 +8,7 @@ The Cosmos SDK offers a full fledged simulation framework to fuzz test every
 message defined by a module.
 
 On the Cosmos SDK, this functionality is provided by [`SimApp`](https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.2/simapp/app_di.go), which is a
-`Baseapp` application that is used for running the [`simulation`](https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/x/simulation) module.
+`Baseapp` application that is used for running the [`simulation`](https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.2/x/simulation) module.
 This module defines all the simulation logic as well as the operations for
 randomized parameters like accounts, balances etc.
 
@@ -41,7 +41,7 @@ failure type:
 
 Each simulation must receive a set of inputs (_i.e_ flags) such as the number of
 blocks that the simulation is run, seed, block size, etc.
-Check the full list of flags [here](https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/x/simulation/client/cli/flags.go#L35-L59).
+Check the full list of flags [here](https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.2/x/simulation/client/cli/flags.go#L43-L70).
 
 ## Simulator Modes
 
@@ -53,7 +53,7 @@ In addition to the various inputs and commands, the simulator runs in three mode
    This mode is helpful for running simulations on a known state such as a live network export where a new (mostly likely breaking) version of the application needs to be tested.
 3. From a `params.json` file where the initial state is pseudo-randomly generated but the module and simulation parameters can be provided manually.
    This allows for a more controlled and deterministic simulation setup while allowing the state space to still be pseudo-randomly simulated.
-   The list of available parameters are listed [here](https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/x/simulation/client/cli/flags.go#L59-L78).
+   The list of available parameters are listed [here](https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.2/x/simulation/client/cli/flags.go#L72-L90).
 
 :::tip
 These modes are not mutually exclusive. So you can for example run a randomly
@@ -63,7 +63,7 @@ generated genesis state (`1`) with manually generated simulation params (`3`).
 ## Usage
 
 This is a general example of how simulations are run. For more specific examples
-check the Cosmos SDK [Makefile](https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/Makefile#L282-L318).
+check the Cosmos SDK [Makefile](https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.2/Makefile#L285-L320).
 
 ```bash
  $ go test -mod=readonly github.com/cosmos/cosmos-sdk/simapp \
@@ -90,7 +90,7 @@ Here are some suggestions when encountering a simulation failure:
 * Run invariants on every operation with `-SimulateEveryOperation`. _Note_: this
   will slow down your simulation **a lot**.
 * Try adding logs to operations that are not logged. You will have to define a
-  [Logger](https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/x/staking/keeper/keeper.go#L65-L68) on your `Keeper`.
+  [Logger](https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.2/x/staking/keeper/keeper.go#L77-L81) on your `Keeper`.
 
 ## Use simulation in your Cosmos SDK-based application
 


### PR DESCRIPTION
# Description
This PR updates documentation references to point to the latest SDK version v0.53.0-rc.2 instead of v0.50.0-alpha.0. The changes include:

In `docs/docs/learn/advanced/08-events.md:`
- Updated GitHub links for events documentation
- Updated line number references in the links

In `docs/docs/learn/advanced/12-simulation.md:`
- Updated SimApp and simulation module references
- Updated links to flags documentation and parameters
- Updated Makefile and Logger references

No functional changes - purely documentation updates to reflect the current SDK version.
Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.  Your PR will not be merged unless you satisfy
all of these items.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title, you can find examples of the prefixes below:
    <!-- * `feat`: A new feature
    * `fix`: A bug fix
    * `docs`: Documentation only changes
    * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
    * `refactor`: A code change that neither fixes a bug nor adds a feature
    * `perf`: A code change that improves performance
    * `test`: Adding missing tests or correcting existing tests
    * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
    * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
    * `chore`: Other changes that don't modify src or test files
    * `revert`: Reverts a previous commit -->
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated all source code reference links in advanced event and simulation documentation to point to Cosmos SDK version v0.53.0-rc.2. No changes were made to the explanatory content or examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->