### PR TITLE
chore: update all uses of v50 in doc references

### DIFF
--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -245,4 +245,4 @@ Modules that do not depend on the Cosmos SDK can be released at any time from th
 
 Branches that go modules are released from:
 
-* Store v1 is released from `release/v0.50.x` branch.
+* Store v1 is released from `release/v0.53.x` branch.

--- a/depinject/README.md
+++ b/depinject/README.md
@@ -75,7 +75,7 @@ Provider functions serve as the basis for the dependency tree. They are analysed
 
 `depinject` supports the use of interface types as inputs to provider functions, which helps decouple dependencies between modules. This approach is particularly useful for managing complex systems with multiple modules, such as the Cosmos SDK, where dependencies need to be flexible and maintainable.
 
-For example, `x/bank` expects an [AccountKeeper](https://pkg.go.dev/cosmossdk.io/x/bank/types#AccountKeeper) interface as [input to ProvideModule](https://github.com/cosmos/cosmos-sdk/tree/release/v0.50.x/x/bank/module.go#L208-L260). `SimApp` uses the implementation in `x/auth`, but the modular design allows for easy changes to the implementation if needed.
+For example, `x/bank` expects an [AccountKeeper](https://pkg.go.dev/cosmossdk.io/x/bank/types#AccountKeeper) interface as [input to ProvideModule](https://github.com/cosmos/cosmos-sdk/tree/release/v0.53.x/x/bank/module.go#L208-L260). `SimApp` uses the implementation in `x/auth`, but the modular design allows for easy changes to the implementation if needed.
 
 Consider the following example:
 

--- a/depinject/appconfig/README.md
+++ b/depinject/appconfig/README.md
@@ -201,7 +201,7 @@ satisfy this dependency graph which allows staking and slashing to depend on eac
 In order to test and debug the module configuration, we need to build an app config, generally defined in a YAML file.
 This configuration should be passed first to `appconfig.LoadYAML` to get an `depinject.Config` instance.Then the
 `depinject.Config` can be passed to `depinject.Inject` and we can try to resolve dependencies in the app config.
-Alternatively, the `depinject.Config` can be created via [pure Go code](https://github.com/cosmos/cosmos-sdk/tree/release/v0.50.x/simapp/app_config.go).
+Alternatively, the `depinject.Config` can be created via [pure Go code](https://github.com/cosmos/cosmos-sdk/tree/release/v0.53.x/simapp/app_config.go).
 
 Ex:
 

--- a/docs/docs/build/building-apps/00-app-go.md
+++ b/docs/docs/build/building-apps/00-app-go.md
@@ -10,5 +10,5 @@ For now please instead read the [tutorials](https://tutorials.cosmos.network) fo
 ## Complete `app.go`
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/simapp/app.go
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/simapp/app.go
 ```

--- a/docs/docs/build/building-apps/04-vote-extensions.md
+++ b/docs/docs/build/building-apps/04-vote-extensions.md
@@ -40,7 +40,7 @@ other validators when validating their pre-commits. For a given vote extension,
 this process MUST be deterministic. The Cosmos SDK defines `sdk.VerifyVoteExtensionHandler`:
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/types/abci.go#L26-L27
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/types/abci.go#L26-L27
 ```
 
 An application can set this handler in `app.go` via the `baseapp.SetVerifyVoteExtensionHandler`

--- a/docs/docs/build/building-modules/01-module-manager.md
+++ b/docs/docs/build/building-modules/01-module-manager.md
@@ -61,7 +61,7 @@ Use `module.CoreAppModuleBasicAdaptor` instead for creating an `AppModuleBasic` 
 The `AppModuleBasic` interface defines the independent methods modules need to implement.
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/types/module/module.go#L56-L66
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/types/module/module.go#L56-L66
 ```
 
 * `RegisterLegacyAminoCodec(*codec.LegacyAmino)`: Registers the `amino` codec for the module, which is used to marshal and unmarshal structs to/from `[]byte` in order to persist them in the module's `KVStore`.
@@ -73,7 +73,7 @@ All the `AppModuleBasic` of an application are managed by the [`BasicManager`](#
 ### `HasName`
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/types/module/module.go#L71-L73
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/types/module/module.go#L71-L73
 ```
 
 * `HasName` is an interface that has a method `Name()`. This method returns the name of the module as a `string`.
@@ -87,7 +87,7 @@ For easily creating an `AppModule` that only has genesis functionalities, use `m
 #### `module.HasGenesisBasics`
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/types/module/module.go#L76-L79
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/types/module/module.go#L76-L79
 ```
 
 Let us go through the methods:
@@ -139,7 +139,7 @@ Previously the `module.AppModule` interface was containing all the methods that 
 :::
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/types/module/module.go#L195-L199
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/types/module/module.go#L195-L199
 ```
 
 ### `HasInvariants`
@@ -147,7 +147,7 @@ https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/types/module/module.go
 This interface defines one method. It allows to checks if a module can register invariants.
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/types/module/module.go#L202-L205
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/types/module/module.go#L202-L205
 ```
 
 * `RegisterInvariants(sdk.InvariantRegistry)`: Registers the [`invariants`](./07-invariants.md) of the module. If an invariant deviates from its predicted value, the [`InvariantRegistry`](./07-invariants.md#registry) triggers appropriate logic (most often the chain will be halted).
@@ -165,7 +165,7 @@ https://github.com/cosmos/cosmos-sdk/blob/6afece6/core/appmodule/module.go#L22-L
 #### `module.HasServices`
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/types/module/module.go#L208-L211
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/types/module/module.go#L208-L211
 ```
 
 * `RegisterServices(Configurator)`: Allows a module to register services.
@@ -175,7 +175,7 @@ https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/types/module/module.go
 This interface defines one method for checking a module consensus version.
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/types/module/module.go#L214-L220
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/types/module/module.go#L214-L220
 ```
 
 * `ConsensusVersion() uint64`: Returns the consensus version of the module.
@@ -189,7 +189,7 @@ The `HasPreBlocker` is an extension interface from `appmodule.AppModule`. All mo
 The `HasBeginBlocker` is an extension interface from `appmodule.AppModule`. All modules that have an `BeginBlock` method implement this interface.
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/core/appmodule/module.go#L56-L63
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/core/appmodule/module.go#L56-L63
 ```
 
 * `BeginBlock(context.Context) error`: This method gives module developers the option to implement logic that is automatically triggered at the beginning of each block.
@@ -199,7 +199,7 @@ https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/core/appmodule/module.
 The `HasEndBlocker` is an extension interface from `appmodule.AppModule`. All modules that have an `EndBlock` method implement this interface. If a module need to return validator set updates (staking), they can use `HasABCIEndBlock`
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/core/appmodule/module.go#L66-L72
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/core/appmodule/module.go#L66-L72
 ```
 
 * `EndBlock(context.Context) error`: This method gives module developers the option to implement logic that is automatically triggered at the end of each block.
@@ -209,7 +209,7 @@ https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/core/appmodule/module.
 The `HasABCIEndBlock` is an extension interface from `module.AppModule`. All modules that have an `EndBlock` which return validator set updates implement this interface.
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/types/module/module.go#L222-L225
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/types/module/module.go#L222-L225
 ```
 
 * `EndBlock(context.Context) ([]abci.ValidatorUpdate, error)`: This method gives module developers the option to inform the underlying consensus engine of validator set changes (e.g. the `staking` module).
@@ -219,7 +219,7 @@ https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/types/module/module.go
 `HasPrecommit` is an extension interface from `appmodule.AppModule`. All modules that have a `Precommit` method implement this interface.
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/core/appmodule/module.go#L49-L52
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/core/appmodule/module.go#L49-L52
 ```
 
 * `Precommit(context.Context)`: This method gives module developers the option to implement logic that is automatically triggered during [`Commit'](../../learn/advanced/00-baseapp.md#commit) of each block using the [`finalizeblockstate`](../../learn/advanced/00-baseapp.md#state-updates) of the block to be committed. Implement empty if no logic needs to be triggered during `Commit` of each block for this module.
@@ -229,7 +229,7 @@ https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/core/appmodule/module.
 `HasPrepareCheckState` is an extension interface from `appmodule.AppModule`. All modules that have a `PrepareCheckState` method implement this interface.
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/core/appmodule/module.go#L49-L52
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/core/appmodule/module.go#L49-L52
 ```
 
 * `PrepareCheckState(context.Context)`: This method gives module developers the option to implement logic that is automatically triggered during [`Commit'](../../learn/advanced/00-baseapp.md#commit) of each block using the [`checkState`](../../learn/advanced/00-baseapp.md#state-updates) of the next block. Implement empty if no logic needs to be triggered during `Commit` of each block for this module.
@@ -265,7 +265,7 @@ Module managers are used to manage collections of `AppModuleBasic` and `AppModul
 The `BasicManager` is a structure that lists all the `AppModuleBasic` of an application:
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/types/module/module.go#L82
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/types/module/module.go#L82
 ```
 
 It implements the following methods:
@@ -285,7 +285,7 @@ It implements the following methods:
 The `Manager` is a structure that holds all the `AppModule` of an application, and defines the order of execution between several key components of these modules:
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/types/module/module.go#L267-L276
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/types/module/module.go#L267-L276
 ```
 
 The module manager is used throughout the application whenever an action on a collection of modules is required. It implements the following methods:
@@ -314,15 +314,15 @@ The module manager is used throughout the application whenever an action on a co
 Here's an example of a concrete integration within an `simapp`:
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/simapp/app.go#L411-L434
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/simapp/app.go#L411-L434
 ```
 
 This is the same example from `runtime` (the package that powers app di):
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/runtime/module.go#L61
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/runtime/module.go#L61
 ```
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/runtime/module.go#L82
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/runtime/module.go#L82
 ```

--- a/docs/docs/build/building-modules/02-messages-and-queries.md
+++ b/docs/docs/build/building-modules/02-messages-and-queries.md
@@ -34,7 +34,7 @@ Each `Msg` service method must have exactly one argument, which must implement t
 See an example of a `Msg` service definition from `x/bank` module:
 
 ```protobuf reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/proto/cosmos/bank/v1beta1/tx.proto#L13-L36
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/proto/cosmos/bank/v1beta1/tx.proto#L13-L36
 ```
 
 ### `sdk.Msg` Interface
@@ -98,7 +98,7 @@ Queries should be defined using [Protobuf services](https://developers.google.co
 Here's an example of such a `Query` service definition:
 
 ```protobuf reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/proto/cosmos/auth/v1beta1/query.proto#L14-L89
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/proto/cosmos/auth/v1beta1/query.proto#L14-L89
 ```
 
 As `proto.Message`s, generated `Response` types implement by default `String()` method of [`fmt.Stringer`](https://pkg.go.dev/fmt#Stringer).
@@ -133,5 +133,5 @@ Store queries query directly for store keys. They use `clientCtx.QueryABCI(req a
 See following examples:
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/baseapp/abci.go#L864-L894
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/baseapp/abci.go#L864-L894
 ```

--- a/docs/docs/build/building-modules/03-msg-services.md
+++ b/docs/docs/build/building-modules/03-msg-services.md
@@ -24,19 +24,19 @@ As further described in [ADR 031](../architecture/adr-031-msg-service.md), this 
 Protobuf generates a `MsgServer` interface based on a definition of `Msg` service. It is the role of the module developer to implement this interface, by implementing the state transition logic that should happen upon receival of each `sdk.Msg`. As an example, here is the generated `MsgServer` interface for `x/bank`, which exposes two `sdk.Msg`s:
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/x/bank/types/tx.pb.go#L550-L568
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/x/bank/types/tx.pb.go#L550-L568
 ```
 
 When possible, the existing module's [`Keeper`](./06-keeper.md) should implement `MsgServer`, otherwise a `msgServer` struct that embeds the `Keeper` can be created, typically in `./keeper/msg_server.go`:
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/x/bank/keeper/msg_server.go#L17-L19
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/x/bank/keeper/msg_server.go#L17-L19
 ```
 
 `msgServer` methods can retrieve the `context.Context` from the `context.Context` parameter method using the `sdk.UnwrapSDKContext`:
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/x/bank/keeper/msg_server.go#L56
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/x/bank/keeper/msg_server.go#L56
 ```
 
 `sdk.Msg` processing usually follows these 3 steps:
@@ -95,13 +95,13 @@ These events are relayed back to the underlying consensus engine and can be used
 The invoked `msgServer` method returns a `proto.Message` response and an `error`. These return values are then wrapped into an `*sdk.Result` or an `error` using `sdk.WrapServiceResult(ctx context.Context, res proto.Message, err error)`:
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/baseapp/msg_service_router.go#L160
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/baseapp/msg_service_router.go#L160
 ```
 
 This method takes care of marshaling the `res` parameter to protobuf and attaching any events on the `ctx.EventManager()` to the `sdk.Result`.
 
 ```protobuf reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/proto/cosmos/base/abci/v1beta1/abci.proto#L93-L113
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/proto/cosmos/base/abci/v1beta1/abci.proto#L93-L113
 ```
 
 This diagram shows a typical structure of a Protobuf `Msg` service, and how the message propagates through the module.
@@ -115,5 +115,5 @@ New [telemetry metrics](../../learn/advanced/09-telemetry.md) can be created fro
 This is an example from the `x/auth/vesting` module:
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/x/auth/vesting/msg_server.go#L76-L88
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/x/auth/vesting/msg_server.go#L76-L88
 ```

--- a/docs/docs/build/building-modules/04-query-services.md
+++ b/docs/docs/build/building-modules/04-query-services.md
@@ -34,7 +34,7 @@ These custom queries methods should be implemented by a module's keeper, typical
 Here's an example implementation for the bank module:
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/x/bank/keeper/grpc_query.go
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/x/bank/keeper/grpc_query.go
 ```
 
 ### Calling queries from the State Machine

--- a/docs/docs/build/building-modules/06-beginblock-endblock.md
+++ b/docs/docs/build/building-modules/06-beginblock-endblock.md
@@ -35,13 +35,13 @@ It is possible for developers to define the order of execution between the `Begi
 See an example implementation of `BeginBlocker` from the `distribution` module:
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/x/distribution/abci.go#L14-L38
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/x/distribution/abci.go#L14-L38
 ```
 
 and an example implementation of `EndBlocker` from the `staking` module:
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/x/staking/keeper/abci.go#L22-L27
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/x/staking/keeper/abci.go#L22-L27
 ```
 
 <!-- TODO: leaving this here to update docs with core api changes  -->

--- a/docs/docs/build/building-modules/06-keeper.md
+++ b/docs/docs/build/building-modules/06-keeper.md
@@ -41,7 +41,7 @@ type Keeper struct {
 For example, here is the type definition of the `keeper` from the `staking` module:
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/x/staking/keeper/keeper.go#L23-L31
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/x/staking/keeper/keeper.go#L23-L31
 ```
 
 Let us go through the different parameters:
@@ -81,12 +81,12 @@ and the method will go through the following steps:
 2. Marshal `value` to `[]byte` using the codec `cdc`.
 3. Set the encoded value in the store at location `key` using the `Set(key []byte, value []byte)` method of the store.
 
-For more, see an example of `keeper`'s [methods implementation from the `staking` module](https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/x/staking/keeper/keeper.go).
+For more, see an example of `keeper`'s [methods implementation from the `staking` module](https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/x/staking/keeper/keeper.go).
 
 The [module `KVStore`](../../learn/advanced/04-store.md#kvstore-and-commitkvstore-interfaces) also provides an `Iterator()` method which returns an `Iterator` object to iterate over a domain of keys.
 
 This is an example from the `auth` module to iterate accounts:
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/x/auth/keeper/account.go
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/x/auth/keeper/account.go
 ```

--- a/docs/docs/build/building-modules/07-invariants.md
+++ b/docs/docs/build/building-modules/07-invariants.md
@@ -19,7 +19,7 @@ An invariant is a property of the application that should always be true. In the
 An `Invariant` is a function that checks for a particular invariant within a module. Module `Invariant`s must follow the `Invariant` type:
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/types/invariant.go#L9
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/types/invariant.go#L9
 ```
 
 The `string` return value is the invariant message, which can be used when printing logs, and the `bool` return value is the actual result of the invariant check.
@@ -58,10 +58,10 @@ func AllInvariants(k Keeper) sdk.Invariant {
 Finally, module developers need to implement the `RegisterInvariants` method as part of the [`AppModule` interface](./01-module-manager.md#appmodule). Indeed, the `RegisterInvariants` method of the module, implemented in the `module/module.go` file, typically only defers the call to a `RegisterInvariants` method implemented in the `keeper/invariants.go` file. The `RegisterInvariants` method registers a route for each `Invariant` function in the [`InvariantRegistry`](#invariant-registry):
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/x/staking/keeper/invariants.go#L12-L22
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/x/staking/keeper/invariants.go#L12-L22
 ```
 
-For more, see an example of [`Invariant`s implementation from the `staking` module](https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/x/staking/keeper/invariants.go).
+For more, see an example of [`Invariant`s implementation from the `staking` module](https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/x/staking/keeper/invariants.go).
 
 ## Invariant Registry
 
@@ -70,13 +70,13 @@ The `InvariantRegistry` is a registry where the `Invariant`s of all the modules 
 At its core, the `InvariantRegistry` is defined in the Cosmos SDK as an interface:
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/types/invariant.go#L14-L17
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/types/invariant.go#L14-L17
 ```
 
 Typically, this interface is implemented in the `keeper` of a specific module. The most used implementation of an `InvariantRegistry` can be found in the `crisis` module:
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/x/crisis/keeper/keeper.go#L48-L50
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/x/crisis/keeper/keeper.go#L48-L50
 ```
 
 The `InvariantRegistry` is therefore typically instantiated by instantiating the `keeper` of the `crisis` module in the [application's constructor function](../../learn/beginner/00-app-anatomy.md#constructor-function).
@@ -84,7 +84,7 @@ The `InvariantRegistry` is therefore typically instantiated by instantiating the
 `Invariant`s can be checked manually via [`message`s](./02-messages-and-queries.md), but most often they are checked automatically at the end of each block. Here is an example from the `crisis` module:
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/x/crisis/abci.go#L13-L23
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/x/crisis/abci.go#L13-L23
 ```
 
 In both cases, if one of the `Invariant`s returns false, the `InvariantRegistry` can trigger special logic (e.g. have the application panic and print the `Invariant`s message in the log).

--- a/docs/docs/build/building-modules/08-genesis.md
+++ b/docs/docs/build/building-modules/08-genesis.md
@@ -22,7 +22,7 @@ The subset of the genesis state defined from a given module is generally defined
 See an example of `GenesisState` protobuf message definition from the `auth` module:
 
 ```protobuf reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/proto/cosmos/auth/v1beta1/genesis.proto
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/proto/cosmos/auth/v1beta1/genesis.proto
 ```
 
 Next we present the main genesis-related methods that need to be implemented by module developers in order for their module to be used in Cosmos SDK applications.
@@ -32,7 +32,7 @@ Next we present the main genesis-related methods that need to be implemented by 
 The `DefaultGenesis()` method is a simple method that calls the constructor function for `GenesisState` with the default value for each parameter. See an example from the `auth` module:
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/x/auth/module.go#L63-L67
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/x/auth/module.go#L63-L67
 ```
 
 ### `ValidateGenesis`
@@ -40,7 +40,7 @@ https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/x/auth/module.go#L63-L
 The `ValidateGenesis(data GenesisState)` method is called to verify that the provided `genesisState` is correct. It should perform validity checks on each of the parameters listed in `GenesisState`. See an example from the `auth` module:
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/x/auth/types/genesis.go#L62-L75
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/x/auth/types/genesis.go#L62-L75
 ```
 
 ## Other Genesis Methods
@@ -56,7 +56,7 @@ The [module manager](./01-module-manager.md#manager) of the application is respo
 See an example of `InitGenesis` from the `auth` module:
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/x/auth/keeper/genesis.go#L8-L35
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/x/auth/keeper/genesis.go#L8-L35
 ```
 
 ### `ExportGenesis`
@@ -66,7 +66,7 @@ The `ExportGenesis` method is executed whenever an export of the state is made. 
 See an example of `ExportGenesis` from the `auth` module.
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/x/auth/keeper/genesis.go#L37-L49
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/x/auth/keeper/genesis.go#L37-L49
 ```
 
 ### GenesisTxHandler
@@ -74,5 +74,5 @@ https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/x/auth/keeper/genesis.
 `GenesisTxHandler` is a way for modules to submit state transitions prior to the first block. This is used by `x/genutil` to submit the genesis transactions for the validators to be added to staking. 
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/core/genesis/txhandler.go#L3-L6
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/core/genesis/txhandler.go#L3-L6
 ```

--- a/docs/docs/build/building-modules/09-module-interfaces.md
+++ b/docs/docs/build/building-modules/09-module-interfaces.md
@@ -27,7 +27,7 @@ Transaction commands typically have their own `tx.go` file that lives within the
 Here is an example from the `x/bank` module:
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/x/bank/client/cli/tx.go#L37-L76
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/x/bank/client/cli/tx.go#L37-L76
 ```
 
 In the example, `NewSendTxCmd()` creates and returns the transaction command for a transaction that wraps and delivers `MsgSend`. `MsgSend` is the message used to send tokens from one account to another.
@@ -49,13 +49,13 @@ In general, the getter function does the following:
 Each module can implement `NewTxCmd()`, which aggregates all of the transaction commands of the module. Here is an example from the `x/bank` module:
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/x/bank/client/cli/tx.go#L20-L35
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/x/bank/client/cli/tx.go#L20-L35
 ```
 
 Each module then can also implement a `GetTxCmd()` method that simply returns `NewTxCmd()`. This allows the root command to easily aggregate all of the transaction commands for each module. Here is an example:
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/x/bank/module.go#L84-L86
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/x/bank/module.go#L84-L86
 ```
 
 ### Query Commands
@@ -68,7 +68,7 @@ This section is being rewritten. Refer to [AutoCLI](https://docs.cosmos.network/
 [Queries](./02-messages-and-queries.md#queries) allow users to gather information about the application or network state; they are routed by the application and processed by the module in which they are defined. Query commands typically have their own `query.go` file in the module's `./client/cli` folder. Like transaction commands, they are specified in getter functions. Here is an example of a query command from the `x/auth` module:
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/x/auth/client/cli/query.go#L86-L128
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/x/auth/client/cli/query.go#L86-L128
 ```
 
 In the example, `GetAccountCmd()` creates and returns a query command that returns the state of an account based on the provided account address.
@@ -90,13 +90,13 @@ In general, the getter function does the following:
 Each module must implement `GetQueryCmd()`, which aggregates all of the query commands of the module. Here is an example from the `x/auth` module:
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/x/auth/client/cli/query.go#L33-L53
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/x/auth/client/cli/query.go#L33-L53
 ```
 
 Each module must also implement the `GetQueryCmd()` method for `AppModuleBasic` that returns the `GetQueryCmd()` function. This allows for the root command to easily aggregate all of the query commands for each module. Here is an example:
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/x/bank/module.go#L84-L87
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/x/bank/module.go#L84-L87
 ```
 
 ### Flags
@@ -124,7 +124,7 @@ For more detailed information on creating flags, visit the [Cobra Documentation]
 As mentioned in [transaction commands](#transaction-commands), there is a set of flags that all transaction commands must add. This is done with the `AddTxFlagsToCmd` method defined in the Cosmos SDK's `./client/flags` package.
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/client/flags/flags.go#L108-L138
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/client/flags/flags.go#L108-L138
 ```
 
 Since `AddTxFlagsToCmd(cmd *cobra.Command)` includes all of the basic flags required for a transaction command, module developers may choose not to add any of their own (specifying arguments instead may often be more appropriate).
@@ -132,7 +132,7 @@ Since `AddTxFlagsToCmd(cmd *cobra.Command)` includes all of the basic flags requ
 Similarly, there is a `AddQueryFlagsToCmd(cmd *cobra.Command)` to add common flags to a module query command.
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/client/flags/flags.go#L95-L106```
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/client/flags/flags.go#L95-L106```
 -->
 
 ## gRPC
@@ -146,7 +146,7 @@ In order to do that, modules must implement `RegisterGRPCGatewayRoutes(clientCtx
 Here's an example from the `x/auth` module:
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/x/auth/module.go#L71-L76
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/x/auth/module.go#L71-L76
 ```
 
 ## gRPC-gateway REST
@@ -156,7 +156,7 @@ Applications need to support web services that use HTTP requests (e.g. a web wal
 Modules that want to expose REST queries should add `google.api.http` annotations to their `rpc` methods, such as in the example below from the `x/auth` module:
 
 ```protobuf reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/proto/cosmos/auth/v1beta1/query.proto#L14-L89
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/proto/cosmos/auth/v1beta1/query.proto#L14-L89
 ```
 
 gRPC gateway is started in-process along with the application and CometBFT. It can be enabled or disabled by setting gRPC Configuration `enable` in [`app.toml`](../run-node/01-run-node.md#configuring-the-node-using-apptoml-and-configtoml).

--- a/docs/docs/build/building-modules/12-errors.md
+++ b/docs/docs/build/building-modules/12-errors.md
@@ -21,7 +21,7 @@ Registration of errors is handled via the [`errors` package](https://github.com/
 Example:
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/x/distribution/types/errors.go
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/x/distribution/types/errors.go
 ```
 
 Each custom module error must provide the codespace, which is typically the module name
@@ -43,7 +43,7 @@ execution.
 Example:
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/x/bank/keeper/keeper.go#L141-L182
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/x/bank/keeper/keeper.go#L141-L182
 ```
 
 Regardless if an error is wrapped or not, the Cosmos SDK's `errors` package provides a function to determine if

--- a/docs/docs/build/building-modules/13-upgrade.md
+++ b/docs/docs/build/building-modules/13-upgrade.md
@@ -46,7 +46,7 @@ func (am AppModule) RegisterServices(cfg module.Configurator) {
 Since these migrations are functions that need access to a Keeper's store, use a wrapper around the keepers called `Migrator` as shown in this example:
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/x/bank/keeper/migrations.go
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/x/bank/keeper/migrations.go
 ```
 
 ## Writing Migration Scripts
@@ -60,4 +60,4 @@ func (m Migrator) Migrate1to2(ctx sdk.Context) error {
 }
 ```
 
-To see example code of changes that were implemented in a migration of balance keys, check out [migrateBalanceKeys](https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/x/bank/migrations/v2/store.go#L55-L76). For context, this code introduced migrations of the bank store that updated addresses to be prefixed by their length in bytes as outlined in [ADR-028](../architecture/adr-028-public-key-addresses.md).
+To see example code of changes that were implemented in a migration of balance keys, check out [migrateBalanceKeys](https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/x/bank/migrations/v2/store.go#L55-L76). For context, this code introduced migrations of the bank store that updated addresses to be prefixed by their length in bytes as outlined in [ADR-028](../architecture/adr-028-public-key-addresses.md).

--- a/docs/docs/build/building-modules/15-depinject.md
+++ b/docs/docs/build/building-modules/15-depinject.md
@@ -30,7 +30,7 @@ A chain developer can then use the module by following these two steps:
 The module available configuration is defined in a Protobuf file, located at `{moduleName}/module/v1/module.proto`.
 
 ```protobuf reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/proto/cosmos/group/module/v1/module.proto
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/proto/cosmos/group/module/v1/module.proto
 ```
 
 * `go_import` must point to the Go package of the custom module.
@@ -39,16 +39,16 @@ https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/proto/cosmos/group/mod
   Taking `group` as example, a chain developer is able to decide, thanks to `uint64 max_metadata_len`, what the maximum metadata length allowed for a group proposal is.
 
   ```go reference
-  https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/simapp/app_config.go#L228-L234
+  https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/simapp/app_config.go#L228-L234
   ```
 
-That message is generated using [`pulsar`](https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/scripts/protocgen-pulsar.sh) (by running `make proto-gen`).
-In the case of the `group` module, this file is generated here: https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/api/cosmos/group/module/v1/module.pulsar.go.
+That message is generated using [`pulsar`](https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/scripts/protocgen-pulsar.sh) (by running `make proto-gen`).
+In the case of the `group` module, this file is generated here: https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/api/cosmos/group/module/v1/module.pulsar.go.
 
 The part that is relevant for the module configuration is:
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/api/cosmos/group/module/v1/module.pulsar.go#L515-L527
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/api/cosmos/group/module/v1/module.pulsar.go#L515-L527
 ```
 
 :::note
@@ -67,14 +67,14 @@ All methods, structs and their fields must be public for `depinject`.
 1. Import the module configuration generated package:
 
     ```go reference
-    https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/x/group/module/module.go#L12-L14
+    https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/x/group/module/module.go#L12-L14
     ```
 
     Define an `init()` function for defining the `providers` of the module configuration:  
     This registers the module configuration message and the wiring of the module.
 
     ```go reference
-    https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/x/group/module/module.go#L194-L199
+    https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/x/group/module/module.go#L194-L199
     ```
 
 2. Ensure that the module implements the `appmodule.AppModule` interface:
@@ -92,20 +92,20 @@ All methods, structs and their fields must be public for `depinject`.
     :::
 
     ```go reference
-    https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/x/group/module/module.go#L201-L211
+    https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/x/group/module/module.go#L201-L211
     ```
 
 4. Define the module outputs with a public struct that inherits `depinject.Out`:
    The module outputs are the dependencies that the module provides to other modules. It is usually the module itself and its keeper.
 
     ```go reference
-    https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/x/group/module/module.go#L213-L218
+    https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/x/group/module/module.go#L213-L218
     ```
 
 5. Create a function named `ProvideModule` (as called in 1.) and use the inputs for instantiating the module outputs.
 
   ```go reference
-  https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/x/group/module/module.go#L220-L235
+  https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/x/group/module/module.go#L220-L235
   ```
 
 The `ProvideModule` function should return an instance of `cosmossdk.io/core/appmodule.AppModule` which implements
@@ -114,7 +114,7 @@ one or more app module extension interfaces for initializing the module.
 Following is the complete app wiring configuration for `group`:
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/x/group/module/module.go#L194-L235
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/x/group/module/module.go#L194-L235
 ```
 
 The module is now ready to be used with `depinject` by a chain developer.

--- a/docs/docs/build/building-modules/16-testing.md
+++ b/docs/docs/build/building-modules/16-testing.md
@@ -19,37 +19,37 @@ All packages and modules should have unit test coverage. Modules should have the
 The SDK uses `mockgen` to generate mocks for keepers:
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/scripts/mockgen.sh#L3-L6
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/scripts/mockgen.sh#L3-L6
 ```
 
 You can read more about mockgen [here](https://go.uber.org/mock).
 
 ### Example
 
-As an example, we will walkthrough the [keeper tests](https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/x/gov/keeper/keeper_test.go) of the `x/gov` module.
+As an example, we will walkthrough the [keeper tests](https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/x/gov/keeper/keeper_test.go) of the `x/gov` module.
 
 The `x/gov` module has a `Keeper` type, which requires a few external dependencies (ie. imports outside `x/gov` to work properly).
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/x/gov/keeper/keeper.go#L22-L24
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/x/gov/keeper/keeper.go#L22-L24
 ```
 
 In order to only test `x/gov`, we mock the [expected keepers](https://docs.cosmos.network/v0.46/building-modules/keeper.html#type-definition) and instantiate the `Keeper` with the mocked dependencies. Note that we may need to configure the mocked dependencies to return the expected values:
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/x/gov/keeper/common_test.go#L67-L81
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/x/gov/keeper/common_test.go#L67-L81
 ```
 
 This allows us to test the `x/gov` module without having to import other modules.
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/x/gov/keeper/keeper_test.go#L3-L42
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/x/gov/keeper/keeper_test.go#L3-L42
 ```
 
 We can test then create unit tests using the newly created `Keeper` instance.
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/x/gov/keeper/keeper_test.go#L83-L107
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/x/gov/keeper/keeper_test.go#L83-L107
 ```
 
 ## Integration Tests
@@ -81,7 +81,7 @@ Each query is tested using 2 methods:
 Here's an example of regression tests:
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/tests/integration/bank/keeper/deterministic_test.go#L134-L151
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/tests/integration/bank/keeper/deterministic_test.go#L134-L151
 ```
 
 ## Simulations
@@ -89,17 +89,17 @@ https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/tests/integration/bank
 Simulations uses as well a minimal application, built with [`depinject`](../packages/01-depinject.md):
 
 :::note
-You can as well use the `AppConfig` `configurator` for creating an `AppConfig` [inline](https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/x/slashing/app_test.go#L54-L62). There is no difference between those two ways, use whichever you prefer.
+You can as well use the `AppConfig` `configurator` for creating an `AppConfig` [inline](https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/x/slashing/app_test.go#L54-L62). There is no difference between those two ways, use whichever you prefer.
 :::
 
 Following is an example for `x/gov/` simulations:
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/x/gov/simulation/operations_test.go#L406-L430
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/x/gov/simulation/operations_test.go#L406-L430
 ```
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/x/gov/simulation/operations_test.go#L90-L132
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/x/gov/simulation/operations_test.go#L90-L132
 ```
 
 ## End-to-end Tests

--- a/docs/docs/build/tooling/00-protobuf.md
+++ b/docs/docs/build/tooling/00-protobuf.md
@@ -11,13 +11,13 @@ To generate the proto file, the Cosmos SDK uses a docker image, this image is pr
 Below is the example of the Cosmos SDK's commands for generating, linting, and formatting protobuf files that can be reused in any applications makefile. 
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/Makefile#L411-L432
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/Makefile#L411-L432
 ```
 
 The script used to generate the protobuf files can be found in the `scripts/` directory. 
 
 ```shell reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/scripts/protocgen.sh
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/scripts/protocgen.sh
 ```
 
 ## Buf

--- a/docs/docs/learn/advanced/00-baseapp.md
+++ b/docs/docs/learn/advanced/00-baseapp.md
@@ -50,7 +50,7 @@ management logic.
 The `BaseApp` type holds many important parameters for any Cosmos SDK based application.
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/baseapp/baseapp.go#L58-L182
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/baseapp/baseapp.go#L58-L182
 ```
 
 Let us go through the most important components.
@@ -118,7 +118,7 @@ func NewBaseApp(
 ```
 
 The `BaseApp` constructor function is pretty straightforward. The only thing worth noting is the
-possibility to provide additional [`options`](https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/baseapp/options.go)
+possibility to provide additional [`options`](https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/baseapp/options.go)
 to the `BaseApp`, which will execute them in order. The `options` are generally `setter` functions
 for important parameters, like `SetPruning()` to set pruning options or `SetMinGasPrices()` to set
 the node's `min-gas-prices`.
@@ -218,7 +218,7 @@ When messages and queries are received by the application, they must be routed t
 
 [`sdk.Msg`s](../../build/building-modules/02-messages-and-queries.md#messages) need to be routed after they are extracted from transactions, which are sent from the underlying CometBFT engine via the [`CheckTx`](#checktx) and [`FinalizeBlock`](#finalizeblock) ABCI messages. To do so, `BaseApp` holds a `msgServiceRouter` which maps fully-qualified service methods (`string`, defined in each module's Protobuf  `Msg` service) to the appropriate module's `MsgServer` implementation.
 
-The [default `msgServiceRouter` included in `BaseApp`](https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/baseapp/msg_service_router.go) is stateless. However, some applications may want to make use of more stateful routing mechanisms such as allowing governance to disable certain routes or point them to new modules for upgrade purposes. For this reason, the `sdk.Context` is also passed into each [route handler inside `msgServiceRouter`](https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/baseapp/msg_service_router.go#L31-L32). For a stateless router that doesn't want to make use of this, you can just ignore the `ctx`.
+The [default `msgServiceRouter` included in `BaseApp`](https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/baseapp/msg_service_router.go) is stateless. However, some applications may want to make use of more stateful routing mechanisms such as allowing governance to disable certain routes or point them to new modules for upgrade purposes. For this reason, the `sdk.Context` is also passed into each [route handler inside `msgServiceRouter`](https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/baseapp/msg_service_router.go#L31-L32). For a stateless router that doesn't want to make use of this, you can just ignore the `ctx`.
 
 The application's `msgServiceRouter` is initialized with all the routes using the application's [module manager](../../build/building-modules/01-module-manager.md#manager) (via the `RegisterServices` method), which itself is initialized with all the application's modules in the application's [constructor](../beginner/00-app-anatomy.md#constructor-function).
 
@@ -349,7 +349,7 @@ The response contains:
 * `GasUsed (int64)`: Amount of gas consumed by transaction. During `CheckTx`, this value is computed by multiplying the standard cost of a transaction byte by the size of the raw transaction. Next is an example:
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/x/auth/ante/basic.go#L102
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/x/auth/ante/basic.go#L102
 ```
 
 * `Events ([]cmn.KVPair)`: Key-Value tags for filtering and indexing transactions (eg. by account). See [`event`s](./08-events.md) for more.
@@ -377,7 +377,7 @@ After that, `RunTx()` calls `ValidateBasic()`, when available and for backward c
 Then, the [`anteHandler`](#antehandler) of the application is run (if it exists). In preparation of this step, both the `checkState`/`finalizeBlockState`'s `context` and `context`'s `CacheMultiStore` are branched using the `cacheTxContext()` function.
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/baseapp/baseapp.go#L663-L680
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/baseapp/baseapp.go#L663-L680
 ```
 
 This allows `RunTx` not to commit the changes made to the state during the execution of `anteHandler` if it ends up failing. It also prevents the module implementing the `anteHandler` from writing to state, which is an important part of the [object-capabilities](./10-ocap.md) of the Cosmos SDK.
@@ -389,7 +389,7 @@ Finally, the [`RunMsgs()`](#runmsgs) function is called to process the `sdk.Msg`
 The `AnteHandler` is a special handler that implements the `AnteHandler` interface and is used to authenticate the transaction before the transaction's internal messages are processed.
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/types/handler.go#L6-L8
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/types/handler.go#L6-L8
 ```
 
 The `AnteHandler` is theoretically optional, but still a very important component of public blockchain networks. It serves 3 primary purposes:
@@ -398,7 +398,7 @@ The `AnteHandler` is theoretically optional, but still a very important componen
 * Perform preliminary _stateful_ validity checks like ensuring signatures are valid or that the sender has enough funds to pay for fees.
 * Play a role in the incentivisation of stakeholders via the collection of transaction fees.
 
-`BaseApp` holds an `anteHandler` as parameter that is initialized in the [application's constructor](../beginner/00-app-anatomy.md#application-constructor). The most widely used `anteHandler` is the [`auth` module](https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/x/auth/ante/ante.go).
+`BaseApp` holds an `anteHandler` as parameter that is initialized in the [application's constructor](../beginner/00-app-anatomy.md#application-constructor). The most widely used `anteHandler` is the [`auth` module](https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/x/auth/ante/ante.go).
 
 Click [here](../beginner/04-gas-fees.md#antehandler) for more on the `anteHandler`.
 
@@ -417,7 +417,7 @@ Like `AnteHandler`s, `PostHandler`s are theoretically optional.
 Other use cases like unused gas refund can also be enabled by `PostHandler`s.
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/x/auth/posthandler/post.go#L1-L15
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/x/auth/posthandler/post.go#L1-L15
 ```
 
 Note, when `PostHandler`s fail, the state from `runMsgs` is also reverted, effectively making the transaction fail.
@@ -441,7 +441,7 @@ The [`FinalizeBlock` ABCI message](https://github.com/cometbft/cometbft/blob/v0.
 
 
 ```go reference 
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/baseapp/abci.go#L623
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/baseapp/abci.go#L623
 ```
 
 #### PreBlock 
@@ -453,7 +453,7 @@ https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/baseapp/abci.go#L623
 * Initialize [`finalizeBlockState`](#state-updates) with the latest header using the `req abci.RequestFinalizeBlock` passed as parameter via the `setState` function.
 
   ```go reference
-  https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/baseapp/baseapp.go#L682-L706
+  https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/baseapp/baseapp.go#L682-L706
   ```
   
   This function also resets the [main gas meter](../beginner/04-gas-fees.md#main-gas-meter).
@@ -469,7 +469,7 @@ When the underlying consensus engine receives a block proposal, each transaction
 Before the first transaction of a given block is processed, a [volatile state](#state-updates) called `finalizeBlockState` is initialized during FinalizeBlock. This state is updated each time a transaction is processed via `FinalizeBlock`, and committed to the [main state](#main-state) when the block is [committed](#commit), after what it is set to `nil`.
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/baseapp/baseapp.go#LL708-L743
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/baseapp/baseapp.go#LL708-L743
 ```
 
 Transaction execution within `FinalizeBlock` performs the **exact same steps as `CheckTx`**, with a little caveat at step 3 and the addition of a fifth step:
@@ -480,7 +480,7 @@ Transaction execution within `FinalizeBlock` performs the **exact same steps as 
 During the additional fifth step outlined in (2), each read/write to the store increases the value of `GasConsumed`. You can find the default cost of each operation:
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/store/types/gas.go#L230-L241
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/store/types/gas.go#L230-L241
 ```
 
 At any point, if `GasConsumed > GasWanted`, the function returns with `Code != 0` and the execution fails.
@@ -501,7 +501,7 @@ Each transactions returns a response to the underlying consensus engine of type 
 EndBlock is run after transaction execution completes. It allows developers to have logic be executed at the end of each block. In the Cosmos SDK, the bulk EndBlock() method is to run the application's EndBlocker(), which mainly runs the EndBlocker() method of each of the application's modules.
 
 ```go reference 
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/baseapp/baseapp.go#L747-L769
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/baseapp/baseapp.go#L747-L769
 ```
 
 ### Commit
@@ -533,7 +533,7 @@ Each CometBFT `query` comes with a `path`, which is a `string` which denotes wha
 In the Cosmos-SDK this is implemented as a NoOp:
 
 ``` go reference 
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/baseapp/abci_utils.go#L274-L281
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/baseapp/abci_utils.go#L274-L281
 ```
 
 ### VerifyVoteExtension
@@ -543,5 +543,5 @@ https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/baseapp/abci_utils.go#
 In the Cosmos-SDK this is implemented as a NoOp:
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/baseapp/abci_utils.go#L282-L288
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/baseapp/abci_utils.go#L282-L288
 ```

--- a/docs/docs/learn/advanced/03-node.md
+++ b/docs/docs/learn/advanced/03-node.md
@@ -24,7 +24,7 @@ In general, developers will implement the `main.go` function with the following 
 * Then, the `config` is retrieved and config parameters are set. This mainly involves setting the Bech32 prefixes for [addresses](../beginner/03-accounts.md#addresses).
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/types/config.go#L14-L29
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/types/config.go#L14-L29
 ```
 
 * Using [cobra](https://github.com/spf13/cobra), the root command of the full-node client is created. After that, all the custom commands of the application are added using the `AddCommand()` method of `rootCmd`.
@@ -38,7 +38,7 @@ https://github.com/cometbft/cometbft/blob/v0.37.0/libs/cli/setup.go#L74-L78
 See an example of `main` function from the `simapp` application, the Cosmos SDK's application for demo purposes:
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/simapp/simd/main.go
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/simapp/simd/main.go
 ```
 
 ## `start` command
@@ -60,25 +60,25 @@ The flow of the `start` command is pretty straightforward. First, it retrieves t
 With the `db`, the `start` command creates a new instance of the application using an `appCreator` function:
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/server/start.go#L220
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/server/start.go#L220
 ```
 
 Note that an `appCreator` is a function that fulfills the `AppCreator` signature:
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/server/types/app.go#L68
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/server/types/app.go#L68
 ```
 
 In practice, the [constructor of the application](../beginner/00-app-anatomy.md#constructor-function) is passed as the `appCreator`.
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/simapp/simd/cmd/root_v2.go#L294-L308
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/simapp/simd/cmd/root_v2.go#L294-L308
 ```
 
 Then, the instance of `app` is used to instantiate a new CometBFT node:
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/server/start.go#L341-L378
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/server/start.go#L341-L378
 ```
 
 The CometBFT node can be created with `app` because the latter satisfies the [`abci.Application` interface](https://github.com/cometbft/cometbft/blob/v0.37.0/abci/types/application.go#L9-L35) (given that `app` extends [`baseapp`](./00-baseapp.md)). As part of the `node.New` method, CometBFT makes sure that the height of the application (i.e. number of blocks since genesis) is equal to the height of the CometBFT node. The difference between these two heights should always be negative or null. If it is strictly negative, `node.New` will replay blocks until the height of the application reaches the height of the CometBFT node. Finally, if the height of the application is `0`, the CometBFT node will call [`InitChain`](./00-baseapp.md#initchain) on the application to initialize the state from the genesis file.
@@ -86,7 +86,7 @@ The CometBFT node can be created with `app` because the latter satisfies the [`a
 Once the CometBFT node is instantiated and in sync with the application, the node can be started:
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/server/start.go#L350-L352
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/server/start.go#L350-L352
 ```
 
 Upon starting, the node will bootstrap its RPC and P2P server and start dialing peers. During handshake with its peers, if the node realizes they are ahead, it will query all the blocks sequentially in order to catch up. Then, it will wait for new block proposals and block signatures from validators in order to make progress.

--- a/docs/docs/learn/advanced/04-store.md
+++ b/docs/docs/learn/advanced/04-store.md
@@ -63,13 +63,13 @@ The Cosmos SDK comes with a large set of stores to persist the state of applicat
 At its very core, a Cosmos SDK `store` is an object that holds a `CacheWrapper` and has a `GetStoreType()` method:
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/store/types/store.go#L15-L18
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/store/types/store.go#L15-L18
 ```
 
 The `GetStoreType` is a simple method that returns the type of store, whereas a `CacheWrapper` is a simple interface that implements store read caching and write branching through `Write` method:
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/store/types/store.go#L287-L320
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/store/types/store.go#L287-L320
 ```
 
 Branching and cache is used ubiquitously in the Cosmos SDK and required to be implemented on every store type. A storage branch creates an isolated, ephemeral branch of a store that can be passed around and updated without affecting the main underlying store. This is used to trigger temporary state-transitions that may be reverted later should an error occur. Read more about it in [context](./02-context.md#Store-branching)
@@ -79,13 +79,13 @@ Branching and cache is used ubiquitously in the Cosmos SDK and required to be im
 A commit store is a store that has the ability to commit changes made to the underlying tree or db. The Cosmos SDK differentiates simple stores from commit stores by extending the basic store interfaces with a `Committer`:
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/store/types/store.go#L32-L37
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/store/types/store.go#L32-L37
 ```
 
 The `Committer` is an interface that defines methods to persist changes to disk:
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/store/types/store.go#L20-L30
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/store/types/store.go#L20-L30
 ```
 
 The `CommitID` is a deterministic commit of the state tree. Its hash is returned to the underlying consensus engine and stored in the block header. Note that commit store interfaces exist for various purposes, one of which is to make sure not every object can commit the store. As part of the [object-capabilities model](./10-ocap.md) of the Cosmos SDK, only `baseapp` should have the ability to commit stores. For example, this is the reason why the `ctx.KVStore()` method by which modules typically access stores returns a `KVStore` and not a `CommitKVStore`.
@@ -99,7 +99,7 @@ The Cosmos SDK comes with many types of stores, the most used being [`CommitMult
 Each Cosmos SDK application holds a multistore at its root to persist its state. The multistore is a store of `KVStores` that follows the `Multistore` interface:
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/store/types/store.go#L123-L155
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/store/types/store.go#L123-L155
 ```
 
 If tracing is enabled, then branching the multistore will firstly wrap all the underlying `KVStore` in [`TraceKv.Store`](#tracekv-store).
@@ -109,23 +109,23 @@ If tracing is enabled, then branching the multistore will firstly wrap all the u
 The main type of `Multistore` used in the Cosmos SDK is `CommitMultiStore`, which is an extension of the `Multistore` interface:
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/store/types/store.go#L164-L227
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/store/types/store.go#L164-L227
 ```
 
 As for concrete implementation, the [`rootMulti.Store`] is the go-to implementation of the `CommitMultiStore` interface.
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/store/rootmulti/store.go#L53-L77
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/store/rootmulti/store.go#L53-L77
 ```
 
 The `rootMulti.Store` is a base-layer multistore built around a `db` on top of which multiple `KVStores` can be mounted, and is the default multistore store used in [`baseapp`](./00-baseapp.md).
 
 ### CacheMultiStore
 
-Whenever the `rootMulti.Store` needs to be branched, a [`cachemulti.Store`](https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/store/cachemulti/store.go) is used.
+Whenever the `rootMulti.Store` needs to be branched, a [`cachemulti.Store`](https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/store/cachemulti/store.go) is used.
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/store/cachemulti/store.go#L19-L33
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/store/cachemulti/store.go#L19-L33
 ```
 
 `cachemulti.Store` branches all substores (creates a virtual store for each substore) in its constructor and hold them in `Store.stores`. Moreover caches all read queries. `Store.GetKVStore()` returns the store from `Store.stores`, and `Store.Write()` recursively calls `CacheWrap.Write()` on all the substores.
@@ -141,13 +141,13 @@ Individual `KVStore`s are used by modules to manage a subset of the global state
 `CommitKVStore`s are declared by proxy of their respective `key` and mounted on the application's [multistore](#multistore) in the [main application file](../beginner/00-app-anatomy.md#core-application-file). In the same file, the `key` is also passed to the module's `keeper` that is responsible for managing the store.
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/store/types/store.go#L229-L266
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/store/types/store.go#L229-L266
 ```
 
 Apart from the traditional `Get` and `Set` methods, that a `KVStore` must implement via the `BasicKVStore` interface; a `KVStore` must provide an `Iterator(start, end)` method which returns an `Iterator` object. It is used to iterate over a range of keys, typically keys that share a common prefix. Below is an example from the bank's module keeper, used to iterate over all account balances:
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/x/bank/keeper/view.go#L125-L140
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/x/bank/keeper/view.go#L125-L140
 ```
 
 ### `IAVL` Store
@@ -155,7 +155,7 @@ https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/x/bank/keeper/view.go#
 The default implementation of `KVStore` and `CommitKVStore` used in `baseapp` is the `iavl.Store`.
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/store/iavl/store.go#L35-L40
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/store/iavl/store.go#L35-L40
 ```
 
 `iavl` stores are based around an [IAVL Tree](https://github.com/cosmos/iavl), a self-balancing binary tree which guarantees that:
@@ -171,7 +171,7 @@ The documentation on the IAVL Tree is located [here](https://github.com/cosmos/i
 `dbadapter.Store` is an adapter for `dbm.DB` making it fulfilling the `KVStore` interface.
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/store/dbadapter/store.go#L13-L16
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/store/dbadapter/store.go#L13-L16
 ```
 
 `dbadapter.Store` embeds `dbm.DB`, meaning most of the `KVStore` interface functions are implemented. The other functions (mostly miscellaneous) are manually implemented. This store is primarily used within [Transient Stores](#transient-store)
@@ -181,7 +181,7 @@ https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/store/dbadapter/store.
 `Transient.Store` is a base-layer `KVStore` which is automatically discarded at the end of the block.
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/store/transient/store.go#L16-L19
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/store/transient/store.go#L16-L19
 ```
 
 `Transient.Store` is a `dbadapter.Store` with a `dbm.NewMemDB()`. All `KVStore` methods are reused. When `Store.Commit()` is called, a new `dbadapter.Store` is assigned, discarding previous reference and making it garbage collected.
@@ -189,13 +189,13 @@ https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/store/transient/store.
 This type of store is useful to persist information that is only relevant per-block. One example would be to store parameter changes (i.e. a bool set to `true` if a parameter changed in a block).
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/x/params/types/subspace.go#L21-L31
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/x/params/types/subspace.go#L21-L31
 ```
 
 Transient stores are typically accessed via the [`context`](./02-context.md) via the `TransientStore()` method:
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/types/context.go#L340-L343
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/types/context.go#L340-L343
 ```
 
 ## KVStore Wrappers
@@ -205,7 +205,7 @@ https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/types/context.go#L340-
 `cachekv.Store` is a wrapper `KVStore` which provides buffered writing / cached reading functionalities over the underlying `KVStore`.
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/store/cachekv/store.go#L26-L36
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/store/cachekv/store.go#L26-L36
 ```
 
 This is the type used whenever an IAVL Store needs to be branched to create an isolated store (typically when we need to mutate a state that might be reverted later).
@@ -224,29 +224,29 @@ This is the type used whenever an IAVL Store needs to be branched to create an i
 
 ### `GasKv` Store
 
-Cosmos SDK applications use [`gas`](../beginner/04-gas-fees.md) to track resources usage and prevent spam. [`GasKv.Store`](https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/store/gaskv/store.go) is a `KVStore` wrapper that enables automatic gas consumption each time a read or write to the store is made. It is the solution of choice to track storage usage in Cosmos SDK applications.
+Cosmos SDK applications use [`gas`](../beginner/04-gas-fees.md) to track resources usage and prevent spam. [`GasKv.Store`](https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/store/gaskv/store.go) is a `KVStore` wrapper that enables automatic gas consumption each time a read or write to the store is made. It is the solution of choice to track storage usage in Cosmos SDK applications.
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/store/gaskv/store.go#L11-L17
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/store/gaskv/store.go#L11-L17
 ```
 
 When methods of the parent `KVStore` are called, `GasKv.Store` automatically consumes appropriate amount of gas depending on the `Store.gasConfig`:
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/store/types/gas.go#L219-L228
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/store/types/gas.go#L219-L228
 ```
 
 By default, all `KVStores` are wrapped in `GasKv.Stores` when retrieved. This is done in the `KVStore()` method of the [`context`](./02-context.md):
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/types/context.go#L335-L338
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/types/context.go#L335-L338
 ```
 
 In this case, the gas configuration set in the `context` is used. The gas configuration can be set using the `WithKVGasConfig` method of the `context`.
 Otherwise it uses the following default:
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/store/types/gas.go#L230-L241
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/store/types/gas.go#L230-L241
 ```
 
 ### `TraceKv` Store
@@ -254,7 +254,7 @@ https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/store/types/gas.go#L23
 `tracekv.Store` is a wrapper `KVStore` which provides operation tracing functionalities over the underlying `KVStore`. It is applied automatically by the Cosmos SDK on all `KVStore` if tracing is enabled on the parent `MultiStore`.
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/store/tracekv/store.go#L20-L43
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/store/tracekv/store.go#L20-L43
 ```
 
 When each `KVStore` methods are called, `tracekv.Store` automatically logs `traceOperation` to the `Store.writer`. `traceOperation.Metadata` is filled with `Store.context` when it is not nil. `TraceContext` is a `map[string]interface{}`.
@@ -264,7 +264,7 @@ When each `KVStore` methods are called, `tracekv.Store` automatically logs `trac
 `prefix.Store` is a wrapper `KVStore` which provides automatic key-prefixing functionalities over the underlying `KVStore`.
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/store/prefix/store.go#L15-L21
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/store/prefix/store.go#L15-L21
 ```
 
 When `Store.{Get, Set}()` is called, the store forwards the call to its parent, with the key prefixed with the `Store.prefix`.
@@ -275,10 +275,10 @@ When `Store.Iterator()` is called, it does not simply prefix the `Store.prefix`,
 
 `listenkv.Store` is a wrapper `KVStore` which provides state listening capabilities over the underlying `KVStore`.
 It is applied automatically by the Cosmos SDK on any `KVStore` whose `StoreKey` is specified during state streaming configuration.
-Additional information about state streaming configuration can be found in the [store/streaming/README.md](https://github.com/cosmos/cosmos-sdk/tree/v0.50.0-alpha.0/store/streaming).
+Additional information about state streaming configuration can be found in the [store/streaming/README.md](https://github.com/cosmos/cosmos-sdk/tree/v0.53.0-rc.4/store/streaming).
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/store/listenkv/store.go#L11-L18
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/store/listenkv/store.go#L11-L18
 ```
 
 When `KVStore.Set` or `KVStore.Delete` methods are called, `listenkv.Store` automatically writes the operations to the set of `Store.listeners`.

--- a/docs/docs/learn/advanced/07-cli.md
+++ b/docs/docs/learn/advanced/07-cli.md
@@ -43,7 +43,7 @@ The `main.go` file needs to have a `main()` function that creates a root command
 The `main()` function finally creates an executor and [execute](https://pkg.go.dev/github.com/spf13/cobra#Command.Execute) the root command. See an example of `main()` function from the `simapp` application:
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/simapp/simd/main.go#L12-L24
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/simapp/simd/main.go#L12-L24
 ```
 
 The rest of the document will detail what needs to be implemented for each step and include smaller portions of code from the `simapp` CLI files.
@@ -57,16 +57,16 @@ Every application CLI first constructs a root command, then adds functionality b
 The root command (called `rootCmd`) is what the user first types into the command line to indicate which application they wish to interact with. The string used to invoke the command (the "Use" field) is typically the name of the application suffixed with `-d`, e.g. `simd` or `gaiad`. The root command typically includes the following commands to support basic functionality in the application.
 
 * **Status** command from the Cosmos SDK rpc client tools, which prints information about the status of the connected [`Node`](./03-node.md). The Status of a node includes `NodeInfo`,`SyncInfo` and `ValidatorInfo`.
-* **Keys** [commands](https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/client/keys) from the Cosmos SDK client tools, which includes a collection of subcommands for using the key functions in the Cosmos SDK crypto tools, including adding a new key and saving it to the keyring, listing all public keys stored in the keyring, and deleting a key. For example, users can type `simd keys add <name>` to add a new key and save an encrypted copy to the keyring, using the flag `--recover` to recover a private key from a seed phrase or the flag `--multisig` to group multiple keys together to create a multisig key. For full details on the `add` key command, see the code [here](https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/client/keys/add.go). For more details about usage of `--keyring-backend` for storage of key credentials look at the [keyring docs](../../user/run-node/00-keyring.md).
+* **Keys** [commands](https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/client/keys) from the Cosmos SDK client tools, which includes a collection of subcommands for using the key functions in the Cosmos SDK crypto tools, including adding a new key and saving it to the keyring, listing all public keys stored in the keyring, and deleting a key. For example, users can type `simd keys add <name>` to add a new key and save an encrypted copy to the keyring, using the flag `--recover` to recover a private key from a seed phrase or the flag `--multisig` to group multiple keys together to create a multisig key. For full details on the `add` key command, see the code [here](https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/client/keys/add.go). For more details about usage of `--keyring-backend` for storage of key credentials look at the [keyring docs](../../user/run-node/00-keyring.md).
 * **Server** commands from the Cosmos SDK server package. These commands are responsible for providing the mechanisms necessary to start an ABCI CometBFT application and provides the CLI framework (based on [cobra](https://github.com/spf13/cobra)) necessary to fully bootstrap an application. The package exposes two core functions: `StartCmd` and `ExportCmd` which creates commands to start the application and export state respectively.
-Learn more [here](https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/server).
+Learn more [here](https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/server).
 * [**Transaction**](#transaction-commands) commands.
 * [**Query**](#query-commands) commands.
 
 Next is an example `rootCmd` function from the `simapp` application. It instantiates the root command, adds a [*persistent* flag](#flags) and `PreRun` function to be run before every execution, and adds all of the necessary subcommands.
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/simapp/simd/cmd/root_v2.go#L47-L130
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/simapp/simd/cmd/root_v2.go#L47-L130
 ```
 
 :::tip
@@ -80,13 +80,13 @@ By default app uses CometBFT app config template from Cosmos SDK, which can be o
 Here's an example code to override default `app.toml` template.
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/simapp/simd/cmd/root_v2.go#L144-L199
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/simapp/simd/cmd/root_v2.go#L144-L199
 ```
 
-The `initAppConfig()` also allows overriding the default Cosmos SDK's [server config](https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/server/config/config.go#L235). One example is the `min-gas-prices` config, which defines the minimum gas prices a validator is willing to accept for processing a transaction. By default, the Cosmos SDK sets this parameter to `""` (empty string), which forces all validators to tweak their own `app.toml` and set a non-empty value, or else the node will halt on startup. This might not be the best UX for validators, so the chain developer can set a default `app.toml` value for validators inside this `initAppConfig()` function.
+The `initAppConfig()` also allows overriding the default Cosmos SDK's [server config](https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/server/config/config.go#L235). One example is the `min-gas-prices` config, which defines the minimum gas prices a validator is willing to accept for processing a transaction. By default, the Cosmos SDK sets this parameter to `""` (empty string), which forces all validators to tweak their own `app.toml` and set a non-empty value, or else the node will halt on startup. This might not be the best UX for validators, so the chain developer can set a default `app.toml` value for validators inside this `initAppConfig()` function.
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/simapp/simd/cmd/root_v2.go#L164-L180
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/simapp/simd/cmd/root_v2.go#L164-L180
 ```
 
 The root-level `status` and `keys` subcommands are common across most applications and do not interact with application state. The bulk of an application's functionality - what users can actually *do* with it - is enabled by its `tx` and `query` commands.
@@ -96,7 +96,7 @@ The root-level `status` and `keys` subcommands are common across most applicatio
 [Transactions](./01-transactions.md) are objects wrapping [`Msg`s](../../build/building-modules/02-messages-and-queries.md#messages) that trigger state changes. To enable the creation of transactions using the CLI interface, a function `txCommand` is generally added to the `rootCmd`:
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/simapp/simd/cmd/root_v2.go#L222-L229
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/simapp/simd/cmd/root_v2.go#L222-L229
 ```
 
 This `txCommand` function adds all the transaction available to end-users for the application. This typically includes:
@@ -108,7 +108,7 @@ This `txCommand` function adds all the transaction available to end-users for th
 Here is an example of a `txCommand` aggregating these subcommands from the `simapp` application:
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/simapp/simd/cmd/root_v2.go#L270-L292
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/simapp/simd/cmd/root_v2.go#L270-L292
 ```
 
 :::tip
@@ -121,7 +121,7 @@ Read more about [AutoCLI](https://docs.cosmos.network/main/core/autocli) in its 
 [**Queries**](../../build/building-modules/02-messages-and-queries.md#queries) are objects that allow users to retrieve information about the application's state. To enable the creation of queries using the CLI interface, a function `queryCommand` is generally added to the `rootCmd`:
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/simapp/simd/cmd/root_v2.go#L222-L229
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/simapp/simd/cmd/root_v2.go#L222-L229
 ```
 
 This `queryCommand` function adds all the queries available to end-users for the application. This typically includes:
@@ -135,7 +135,7 @@ This `queryCommand` function adds all the queries available to end-users for the
 Here is an example of a `queryCommand` aggregating subcommands from the `simapp` application:
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/simapp/simd/cmd/root_v2.go#L249-L268
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/simapp/simd/cmd/root_v2.go#L249-L268
 ```
 
 :::tip
@@ -179,7 +179,7 @@ It is vital that the root command of an application uses `PersistentPreRun()` co
 Here is an example of an `PersistentPreRun()` function from `simapp`:
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/blob/v0.50.0-alpha.0/simapp/simd/cmd/root_v2.go#L81-L120
+https://github.com/cosmos/cosmos-sdk/blob/v0.53.0-rc.4/simapp/simd/cmd/root_v2.go#L81-L120
 ```
 
 The `SetCmdClientContextHandler` call reads persistent flags via `ReadPersistentCommandFlags` which creates a `client.Context` and sets that on the root command's `Context`.

--- a/x/auth/tx/README.md
+++ b/x/auth/tx/README.md
@@ -35,19 +35,19 @@ This package represents the Cosmos SDK implementation of the `client.TxConfig`, 
 The interface defines a set of methods for creating a `client.TxBuilder`.
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/tree/release/v0.50.x/client/tx_config.go#L25-L31
+https://github.com/cosmos/cosmos-sdk/tree/release/v0.53.x/client/tx_config.go#L25-L31
 ```
 
 The default implementation of `client.TxConfig` is instantiated by `NewTxConfig` in `x/auth/tx` module.
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/tree/release/v0.50.x/x/auth/tx/config.go#L22-L28
+https://github.com/cosmos/cosmos-sdk/tree/release/v0.53.x/x/auth/tx/config.go#L22-L28
 ```
 
 ### `TxBuilder`
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/tree/release/v0.50.x/client/tx_config.go#L33-L50
+https://github.com/cosmos/cosmos-sdk/tree/release/v0.53.x/client/tx_config.go#L33-L50
 ```
 
 The [`client.TxBuilder`](https://docs.cosmos.network/main/core/transactions#transaction-generation) interface is as well implemented by `x/auth/tx`.

--- a/x/auth/vesting/README.md
+++ b/x/auth/vesting/README.md
@@ -73,25 +73,25 @@ type VestingAccount interface {
 ### BaseVestingAccount
 
 ```protobuf reference
-https://github.com/cosmos/cosmos-sdk/tree/release/v0.50.x/proto/cosmos/vesting/v1beta1/vesting.proto#L11-L35
+https://github.com/cosmos/cosmos-sdk/tree/release/v0.53.x/proto/cosmos/vesting/v1beta1/vesting.proto#L11-L35
 ```
 
 ### ContinuousVestingAccount
 
 ```protobuf reference
-https://github.com/cosmos/cosmos-sdk/tree/release/v0.50.x/proto/cosmos/vesting/v1beta1/vesting.proto#L37-L46
+https://github.com/cosmos/cosmos-sdk/tree/release/v0.53.x/proto/cosmos/vesting/v1beta1/vesting.proto#L37-L46
 ```
 
 ### DelayedVestingAccount
 
 ```protobuf reference
-https://github.com/cosmos/cosmos-sdk/tree/release/v0.50.x/proto/cosmos/vesting/v1beta1/vesting.proto#L48-L57
+https://github.com/cosmos/cosmos-sdk/tree/release/v0.53.x/proto/cosmos/vesting/v1beta1/vesting.proto#L48-L57
 ```
 
 ### Period
 
 ```protobuf reference
-https://github.com/cosmos/cosmos-sdk/tree/release/v0.50.x/proto/cosmos/vesting/v1beta1/vesting.proto#L59-L69
+https://github.com/cosmos/cosmos-sdk/tree/release/v0.53.x/proto/cosmos/vesting/v1beta1/vesting.proto#L59-L69
 ```
 
 ```go
@@ -103,7 +103,7 @@ type Periods []Period
 ### PeriodicVestingAccount
 
 ```protobuf reference
-https://github.com/cosmos/cosmos-sdk/tree/release/v0.50.x/proto/cosmos/vesting/v1beta1/vesting.proto#L71-L81
+https://github.com/cosmos/cosmos-sdk/tree/release/v0.53.x/proto/cosmos/vesting/v1beta1/vesting.proto#L71-L81
 ```
 
 In order to facilitate less ad-hoc type checking and assertions and to support flexibility in account balance usage, the existing `x/bank` `ViewKeeper` interface is updated to contain the following:
@@ -123,7 +123,7 @@ type ViewKeeper interface {
 ### PermanentLockedAccount
 
 ```protobuf reference
-https://github.com/cosmos/cosmos-sdk/tree/release/v0.50.x/proto/cosmos/vesting/v1beta1/vesting.proto#L83-L94
+https://github.com/cosmos/cosmos-sdk/tree/release/v0.53.x/proto/cosmos/vesting/v1beta1/vesting.proto#L83-L94
 ```
 
 ## Vesting Account Specification

--- a/x/evidence/README.md
+++ b/x/evidence/README.md
@@ -219,7 +219,7 @@ The Cosmos SDK handles two types of evidence inside the ABCI `BeginBlock`:
 The evidence module handles these two evidence types the same way. First, the Cosmos SDK converts the CometBFT concrete evidence type to an SDK `Evidence` interface using `Equivocation` as the concrete type.
 
 ```protobuf reference
-https://github.com/cosmos/cosmos-sdk/tree/release/v0.50.x/proto/cosmos/evidence/v1beta1/evidence.proto#L12-L32
+https://github.com/cosmos/cosmos-sdk/tree/release/v0.53.x/proto/cosmos/evidence/v1beta1/evidence.proto#L12-L32
 ```
 
 For some `Equivocation` submitted in `block` to be valid, it must satisfy:
@@ -243,7 +243,7 @@ validator to ever re-enter the validator set.
 The `Equivocation` evidence is handled as follows:
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/tree/release/v0.50.x/x/evidence/keeper/infraction.go#L26-L140
+https://github.com/cosmos/cosmos-sdk/tree/release/v0.53.x/x/evidence/keeper/infraction.go#L26-L140
 ```
 
 **Note:** The slashing, jailing, and tombstoning calls are delegated through the `x/slashing` module

--- a/x/group/README.md
+++ b/x/group/README.md
@@ -101,7 +101,7 @@ custom decision policies, as long as they adhere to the `DecisionPolicy`
 interface:
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/tree/release/v0.50.x/x/group/types.go#L27-L45
+https://github.com/cosmos/cosmos-sdk/tree/release/v0.53.x/x/group/types.go#L27-L45
 ```
 
 #### Threshold decision policy
@@ -337,7 +337,7 @@ The metadata has a maximum length that is chosen by the app developer, and
 passed into the group keeper as a config.
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/tree/release/v0.50.x/proto/cosmos/group/v1/tx.proto#L67-L80
+https://github.com/cosmos/cosmos-sdk/tree/release/v0.53.x/proto/cosmos/group/v1/tx.proto#L67-L80
 ```
 
 It's expected to fail if
@@ -350,7 +350,7 @@ It's expected to fail if
 Group members can be updated with the `UpdateGroupMembers`.
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/tree/release/v0.50.x/proto/cosmos/group/v1/tx.proto#L88-L102
+https://github.com/cosmos/cosmos-sdk/tree/release/v0.53.x/proto/cosmos/group/v1/tx.proto#L88-L102
 ```
 
 In the list of `MemberUpdates`, an existing member can be removed by setting its weight to 0.
@@ -365,7 +365,7 @@ It's expected to fail if:
 The `UpdateGroupAdmin` can be used to update a group admin.
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/tree/release/v0.50.x/proto/cosmos/group/v1/tx.proto#L107-L120
+https://github.com/cosmos/cosmos-sdk/tree/release/v0.53.x/proto/cosmos/group/v1/tx.proto#L107-L120
 ```
 
 It's expected to fail if the signer is not the admin of the group.
@@ -375,7 +375,7 @@ It's expected to fail if the signer is not the admin of the group.
 The `UpdateGroupMetadata` can be used to update a group metadata.
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/tree/release/v0.50.x/proto/cosmos/group/v1/tx.proto#L125-L138
+https://github.com/cosmos/cosmos-sdk/tree/release/v0.53.x/proto/cosmos/group/v1/tx.proto#L125-L138
 ```
 
 It's expected to fail if:
@@ -388,7 +388,7 @@ It's expected to fail if:
 A new group policy can be created with the `MsgCreateGroupPolicy`, which has an admin address, a group id, a decision policy and some optional metadata.
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/tree/release/v0.50.x/proto/cosmos/group/v1/tx.proto#L147-L165
+https://github.com/cosmos/cosmos-sdk/tree/release/v0.53.x/proto/cosmos/group/v1/tx.proto#L147-L165
 ```
 
 It's expected to fail if:
@@ -402,7 +402,7 @@ It's expected to fail if:
 A new group with policy can be created with the `MsgCreateGroupWithPolicy`, which has an admin address, a list of members, a decision policy, a `group_policy_as_admin` field to optionally set group and group policy admin with group policy address and some optional metadata for group and group policy.
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/tree/release/v0.50.x/proto/cosmos/group/v1/tx.proto#L191-L215
+https://github.com/cosmos/cosmos-sdk/tree/release/v0.53.x/proto/cosmos/group/v1/tx.proto#L191-L215
 ```
 
 It's expected to fail for the same reasons as `Msg/CreateGroup` and `Msg/CreateGroupPolicy`.
@@ -412,7 +412,7 @@ It's expected to fail for the same reasons as `Msg/CreateGroup` and `Msg/CreateG
 The `UpdateGroupPolicyAdmin` can be used to update a group policy admin.
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/tree/release/v0.50.x/proto/cosmos/group/v1/tx.proto#L173-L186
+https://github.com/cosmos/cosmos-sdk/tree/release/v0.53.x/proto/cosmos/group/v1/tx.proto#L173-L186
 ```
 
 It's expected to fail if the signer is not the admin of the group policy.
@@ -422,7 +422,7 @@ It's expected to fail if the signer is not the admin of the group policy.
 The `UpdateGroupPolicyDecisionPolicy` can be used to update a decision policy.
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/tree/release/v0.50.x/proto/cosmos/group/v1/tx.proto#L226-L241
+https://github.com/cosmos/cosmos-sdk/tree/release/v0.53.x/proto/cosmos/group/v1/tx.proto#L226-L241
 ```
 
 It's expected to fail if:
@@ -435,7 +435,7 @@ It's expected to fail if:
 The `UpdateGroupPolicyMetadata` can be used to update a group policy metadata.
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/tree/release/v0.50.x/proto/cosmos/group/v1/tx.proto#L246-L259
+https://github.com/cosmos/cosmos-sdk/tree/release/v0.53.x/proto/cosmos/group/v1/tx.proto#L246-L259
 ```
 
 It's expected to fail if:
@@ -449,7 +449,7 @@ A new proposal can be created with the `MsgSubmitProposal`, which has a group po
 An optional `Exec` value can be provided to try to execute the proposal immediately after proposal creation. Proposers signatures are considered as yes votes in this case.
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/tree/release/v0.50.x/proto/cosmos/group/v1/tx.proto#L281-L315
+https://github.com/cosmos/cosmos-sdk/tree/release/v0.53.x/proto/cosmos/group/v1/tx.proto#L281-L315
 ```
 
 It's expected to fail if:
@@ -462,7 +462,7 @@ It's expected to fail if:
 A proposal can be withdrawn using `MsgWithdrawProposal` which has an `address` (can be either a proposer or the group policy admin) and a `proposal_id` (which has to be withdrawn).
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/tree/release/v0.50.x/proto/cosmos/group/v1/tx.proto#L323-L333
+https://github.com/cosmos/cosmos-sdk/tree/release/v0.53.x/proto/cosmos/group/v1/tx.proto#L323-L333
 ```
 
 It's expected to fail if:
@@ -476,7 +476,7 @@ A new vote can be created with the `MsgVote`, given a proposal id, a voter addre
 An optional `Exec` value can be provided to try to execute the proposal immediately after voting.
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/tree/release/v0.50.x/proto/cosmos/group/v1/tx.proto#L338-L358
+https://github.com/cosmos/cosmos-sdk/tree/release/v0.53.x/proto/cosmos/group/v1/tx.proto#L338-L358
 ```
 
 It's expected to fail if:
@@ -489,7 +489,7 @@ It's expected to fail if:
 A proposal can be executed with the `MsgExec`.
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/tree/release/v0.50.x/proto/cosmos/group/v1/tx.proto#L363-L373
+https://github.com/cosmos/cosmos-sdk/tree/release/v0.53.x/proto/cosmos/group/v1/tx.proto#L363-L373
 ```
 
 The messages that are part of this proposal won't be executed if:
@@ -502,7 +502,7 @@ The messages that are part of this proposal won't be executed if:
 The `MsgLeaveGroup` allows group member to leave a group.
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/tree/release/v0.50.x/proto/cosmos/group/v1/tx.proto#L381-L391
+https://github.com/cosmos/cosmos-sdk/tree/release/v0.53.x/proto/cosmos/group/v1/tx.proto#L381-L391
 ```
 
 It's expected to fail if:

--- a/x/group/internal/orm/README.md
+++ b/x/group/internal/orm/README.md
@@ -21,7 +21,7 @@ The orm package provides a framework for creating relational database tables wit
 A table can be built given a `codec.ProtoMarshaler` model type, a prefix to access the underlying prefix store used to store table data as well as a `Codec` for marshalling/unmarshalling.
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/tree/release/v0.50.x/x/group/internal/orm/table.go#L30-L36
+https://github.com/cosmos/cosmos-sdk/tree/release/v0.53.x/x/group/internal/orm/table.go#L30-L36
 ```
 
 In the prefix store, entities should be stored by an unique identifier called `RowID` which can be based either on an `uint64` auto-increment counter, string or dynamic size bytes.
@@ -42,7 +42,7 @@ The `table` struct is private, so that we only have custom tables built on top o
 `AutoUInt64Table` is a table type with an auto incrementing `uint64` ID.
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/tree/release/v0.50.x/x/group/internal/orm/auto_uint64.go#L15-L18
+https://github.com/cosmos/cosmos-sdk/tree/release/v0.53.x/x/group/internal/orm/auto_uint64.go#L15-L18
 ```
 
 It's based on the `Sequence` struct which is a persistent unique key generator based on a counter encoded using 8 byte big endian.
@@ -56,7 +56,7 @@ It's based on the `Sequence` struct which is a persistent unique key generator b
 The model provided for creating a `PrimaryKeyTable` should implement the `PrimaryKeyed` interface:
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/tree/release/v0.50.x/x/group/internal/orm/primary_key.go#L30-L44
+https://github.com/cosmos/cosmos-sdk/tree/release/v0.53.x/x/group/internal/orm/primary_key.go#L30-L44
 ```
 
 `PrimaryKeyFields()` method returns the list of key parts for a given object.
@@ -75,7 +75,7 @@ Key parts, except the last part, follow these rules:
 Secondary indexes can be used on `Indexable` [tables](01_table.md). Indeed, those tables implement the `Indexable` interface that provides a set of functions that can be called by indexes to register and interact with the tables, like callback functions that are called on entries creation, update or deletion to create, update or remove corresponding entries in the table secondary indexes.
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/tree/release/v0.50.x/x/group/internal/orm/types.go#L88-L93
+https://github.com/cosmos/cosmos-sdk/tree/release/v0.53.x/x/group/internal/orm/types.go#L88-L93
 ```
 
 ### MultiKeyIndex
@@ -83,17 +83,17 @@ https://github.com/cosmos/cosmos-sdk/tree/release/v0.50.x/x/group/internal/orm/t
 A `MultiKeyIndex` is an index where multiple entries can point to the same underlying object.
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/tree/release/v0.50.x/x/group/internal/orm/index.go#L26-L32
+https://github.com/cosmos/cosmos-sdk/tree/release/v0.53.x/x/group/internal/orm/index.go#L26-L32
 ```
 
 Internally, it uses an `Indexer` that manages the persistence of the index based on searchable keys and create/update/delete operations.
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/tree/release/v0.50.x/x/group/internal/orm/index.go#L15-L20
+https://github.com/cosmos/cosmos-sdk/tree/release/v0.53.x/x/group/internal/orm/index.go#L15-L20
 ```
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/tree/release/v0.50.x/x/group/internal/orm/indexer.go#L15-L19
+https://github.com/cosmos/cosmos-sdk/tree/release/v0.53.x/x/group/internal/orm/indexer.go#L15-L19
 ```
 
 The currently used implementation of an `indexer`, `Indexer`, relies on an `IndexerFunc` that should be provided when instantiating the index. Based on the source object, this function returns one or multiple index keys as `[]interface{}`. Such secondary index keys should be bytes, string or `uint64` in order to be handled properly by the [key codec](01_table.md#key-codec) which defines specific encoding for those types.
@@ -112,19 +112,19 @@ Both [tables](01_table.md) and [secondary indexes](02_secondary_index.md) suppor
 An `Iterator` allows iteration through a sequence of key value pairs.
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/tree/release/v0.50.x/x/group/internal/orm/types.go#L77-L85
+https://github.com/cosmos/cosmos-sdk/tree/release/v0.53.x/x/group/internal/orm/types.go#L77-L85
 ```
 
 Tables rely on a `typeSafeIterator` that is used by `PrefixScan` and `ReversePrefixScan` `table` methods to iterate through a range of `RowID`s.
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/tree/release/v0.50.x/x/group/internal/orm/table.go#L287-L291
+https://github.com/cosmos/cosmos-sdk/tree/release/v0.53.x/x/group/internal/orm/table.go#L287-L291
 ```
 
 Secondary indexes rely on an `indexIterator` that can strip the `RowID` from the full index key in order to get the underlying value in the table prefix store.
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/tree/release/v0.50.x/x/group/internal/orm/index.go#L233-L239
+https://github.com/cosmos/cosmos-sdk/tree/release/v0.53.x/x/group/internal/orm/index.go#L233-L239
 ```
 
 Under the hood, both use a prefix store `Iterator` (alias for tm-db `Iterator`).
@@ -135,7 +135,7 @@ The `Paginate` function does pagination given an [`Iterator`](#iterator) and a `
 It unmarshals the results into the provided dest interface that should be a pointer to a slice of models.
 
 ```go reference
-https://github.com/cosmos/cosmos-sdk/tree/release/v0.50.x/x/group/internal/orm/iterator.go#L102-L220
+https://github.com/cosmos/cosmos-sdk/tree/release/v0.53.x/x/group/internal/orm/iterator.go#L102-L220
 ```
 
 Secondary indexes have a `GetPaginated` method that returns an `Iterator` for the given searched secondary index key, starting from the `query.PageRequest` key if provided. It's important to note that this `query.PageRequest` key should be a `RowID` (that could have been returned by a previous paginated request). The returned `Iterator` can then be used with the `Paginate` function and the same `query.PageRequest`.


### PR DESCRIPTION
Closes SDK-286

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated all documentation reference links to point to Cosmos SDK version v0.53.x or v0.53.0-rc.4, replacing previous references to v0.50.x or v0.50.0-alpha.0.
  - No changes were made to explanatory text, code snippets, or logic—only the referenced source code URLs were updated to reflect the newer SDK release.
  - Documentation remains functionally unchanged aside from versioned link updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->