### PR TITLE
fix(server): Fix pruning height calculation 

### DIFF
--- a/store/pruning/manager_test.go
+++ b/store/pruning/manager_test.go
@@ -110,6 +110,7 @@ func TestStrategies(t *testing.T) {
 			for curHeight := int64(0); curHeight < 110000; curHeight++ {
 				if tc.snapshotInterval != 0 {
 					if curHeight > int64(tc.snapshotInterval) && curHeight%int64(tc.snapshotInterval) == int64(tc.snapshotInterval)-1 {
+						manager.AnnounceSnapshotHeight(curHeight - int64(tc.snapshotInterval) + 1)
 						manager.HandleSnapshotHeight(curHeight - int64(tc.snapshotInterval) + 1)
 						snHeight = curHeight
 					}
@@ -204,6 +205,7 @@ func TestHandleSnapshotHeight_DbErr_Panic(t *testing.T) {
 	dbMock.EXPECT().SetSync(gomock.Any(), gomock.Any()).Return(errors.New(dbErr)).Times(1)
 
 	manager := pruning.NewManager(dbMock, log.NewNopLogger())
+	manager.SetSnapshotInterval(1)
 	manager.SetOptions(types.NewPruningOptions(types.PruningEverything))
 	require.NotNil(t, manager)
 
@@ -282,7 +284,7 @@ func TestLoadPruningSnapshotHeights(t *testing.T) {
 			db := db.NewMemDB()
 
 			if tc.getFlushedPruningSnapshotHeights != nil {
-				err = db.Set(pruning.PruneSnapshotHeightsKey, pruning.Int64SliceToBytes(tc.getFlushedPruningSnapshotHeights()))
+				err = db.Set(pruning.PruneSnapshotHeightsKey, pruning.Int64SliceToBytes(tc.getFlushedPruningSnapshotHeights()...))
 				require.NoError(t, err)
 			}
 

--- a/store/rootmulti/store.go
+++ b/store/rootmulti/store.go
@@ -357,6 +357,10 @@ func (rs *Store) PruneSnapshotHeight(height int64) {
 	rs.pruningManager.HandleSnapshotHeight(height)
 }
 
+func (rs *Store) AnnounceSnapshotHeight(height int64) {
+	rs.pruningManager.AnnounceSnapshotHeight(height)
+}
+
 // SetInterBlockCache sets the Store's internal inter-block (persistent) cache.
 // When this is defined, all CommitKVStores will be wrapped with their respective
 // inter-block cache.

--- a/store/rootmulti/store_test.go
+++ b/store/rootmulti/store_test.go
@@ -4,10 +4,13 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"fmt"
+	"math/rand"
+	"sync"
 	"testing"
 	"time"
 
 	dbm "github.com/cosmos/cosmos-db"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"cosmossdk.io/errors"
@@ -633,6 +636,121 @@ func TestMultiStore_PruningRestart(t *testing.T) {
 	}
 
 	require.Eventually(t, isPruned, 1*time.Second, 10*time.Millisecond, "expected error when loading pruned heights")
+}
+
+func TestMultiStore_PruningWithIntervalUpdates(t *testing.T) {
+	// scenarios
+	// snap height in sync - interval not changed
+	// snap height out of order - interval not changed
+	// snap height in flight - interval not changed
+
+	// snap height in sync - interval modified
+	// snap height out of order - interval modified
+	// snap height in flight - interval modified
+
+	const (
+		initialSnapshotInterval uint64 = 10
+		initialPruneInterval    uint64 = 10
+	)
+
+	specs := map[string]struct {
+		do             func(t *testing.T, ms *Store, commitSnapN func(n int, snapshotInterval uint64) int64)
+		expPruneHeight int64
+	}{
+		" snap height sequential - constant interval": {
+			do: func(t *testing.T, ms *Store, commitSnapN func(n int, snapshotInterval uint64) int64) {
+				t.Helper()
+				commitSnapN(20, initialSnapshotInterval)
+			},
+			expPruneHeight: 14, // 20 - 5 (keep) -1
+		},
+		" snap out of order - constant interval": {
+			do: func(t *testing.T, ms *Store, commitSnapN func(n int, snapshotInterval uint64) int64) {
+				t.Helper()
+				commitSnapN(20, initialSnapshotInterval)
+				ms.pruningManager.HandleSnapshotHeight(10)
+			},
+			expPruneHeight: 14, // 20 - 5 (keep) -1
+		},
+		" snap height sequential - snap interval increased": {
+			do: func(t *testing.T, ms *Store, commitSnapN func(n int, snapshotInterval uint64) int64) {
+				t.Helper()
+				commitSnapN(10, initialSnapshotInterval)
+				currHeight := commitSnapN(10, 20)
+				assert.Equal(t, int64(14), ms.pruningManager.GetPruningHeight(currHeight)) // 20 - 5 (keep) -1
+				commitSnapN(10, 20)
+			},
+			expPruneHeight: 24, // 30 -5 (keep) -1
+		},
+		" snap out of order - snap interval increased": {
+			do: func(t *testing.T, ms *Store, commitSnapN func(n int, snapshotInterval uint64) int64) {
+				t.Helper()
+				commitSnapN(10, initialSnapshotInterval)
+				commitSnapN(30, 20)
+				ms.pruningManager.HandleSnapshotHeight(10)
+			},
+			expPruneHeight: 29, // 10 (legacy state not cleared) + 20 - 1
+		},
+		" snap height sequential - snap interval decreased": {
+			do: func(t *testing.T, ms *Store, commitSnapN func(n int, snapshotInterval uint64) int64) {
+				t.Helper()
+				commitSnapN(10, initialSnapshotInterval)
+				commitSnapN(10, 6)
+			},
+			expPruneHeight: 14, // 20 -5 (keep) -1
+		},
+		" snap out of order - snap interval decreased": {
+			do: func(t *testing.T, ms *Store, commitSnapN func(n int, snapshotInterval uint64) int64) {
+				t.Helper()
+				commitSnapN(10, initialSnapshotInterval)
+				commitSnapN(10, 6)
+				ms.pruningManager.HandleSnapshotHeight(10)
+			},
+			expPruneHeight: 14, // 20 -5 (keep) -1
+		},
+	}
+	for name, spec := range specs {
+		t.Run(name, func(t *testing.T) {
+			db := dbm.NewMemDB()
+			ms := newMultiStoreWithMounts(db, pruningtypes.NewCustomPruningOptions(5, initialPruneInterval))
+			ms.SetSnapshotInterval(initialSnapshotInterval)
+			require.NoError(t, ms.LoadLatestVersion())
+			rnd := rand.New(rand.NewSource(1))
+			commitSnapN := func(n int, snapshotInterval uint64) int64 {
+				ms.SetSnapshotInterval(snapshotInterval)
+				var wg sync.WaitGroup
+				for range n {
+					height := ms.Commit().Version
+					if height != 0 && snapshotInterval != 0 && uint64(height)%snapshotInterval == 0 {
+						ms.pruningManager.AnnounceSnapshotHeight(height)
+						wg.Add(1)
+						go func() { // random completion order
+							time.Sleep(time.Duration(rnd.Int31n(int32(time.Millisecond))))
+							ms.pruningManager.HandleSnapshotHeight(height)
+							wg.Done()
+						}()
+					}
+				}
+				wg.Wait()
+				return ms.LatestVersion()
+			}
+			spec.do(t, ms, commitSnapN)
+			actualHeightToPrune := ms.pruningManager.GetPruningHeight(ms.LatestVersion())
+			require.Equal(t, spec.expPruneHeight, actualHeightToPrune)
+
+			// Ensure async pruning is done
+			isPruned := func() bool {
+				ms.Commit() // to flush the batch with the pruned heights
+				for v := int64(1); v <= actualHeightToPrune; v++ {
+					if _, err := ms.CacheMultiStoreWithVersion(v); err == nil {
+						return false
+					}
+				}
+				return true
+			}
+			require.Eventually(t, isPruned, 1*time.Second, 10*time.Millisecond, "expected error when loading pruned heights")
+		})
+	}
 }
 
 // TestUnevenStoresHeightCheck tests if loading root store correctly errors when

--- a/store/snapshots/manager.go
+++ b/store/snapshots/manager.go
@@ -165,6 +165,7 @@ func (m *Manager) Create(height uint64) (*types.Snapshot, error) {
 		return nil, errorsmod.Wrap(storetypes.ErrLogic, "no snapshot store configured")
 	}
 
+	m.multistore.AnnounceSnapshotHeight(int64(height))
 	defer m.multistore.PruneSnapshotHeight(int64(height))
 
 	err := m.begin(opSnapshot)

--- a/store/snapshots/manager_test.go
+++ b/store/snapshots/manager_test.go
@@ -68,8 +68,9 @@ func TestManager_Take(t *testing.T) {
 		{7, 8, 9},
 	}
 	snapshotter := &mockSnapshotter{
-		items:         items,
-		prunedHeights: make(map[int64]struct{}),
+		items:            items,
+		announcedHeights: make(map[int64]struct{}),
+		prunedHeights:    make(map[int64]struct{}),
 	}
 	extSnapshotter := newExtSnapshotter(10)
 
@@ -138,7 +139,8 @@ func TestManager_Prune(t *testing.T) {
 func TestManager_Restore(t *testing.T) {
 	store := setupStore(t)
 	target := &mockSnapshotter{
-		prunedHeights: make(map[int64]struct{}),
+		announcedHeights: make(map[int64]struct{}),
+		prunedHeights:    make(map[int64]struct{}),
 	}
 	extSnapshotter := newExtSnapshotter(0)
 	manager := snapshots.NewManager(store, opts, target, nil, log.NewNopLogger())

--- a/store/snapshots/types/snapshotter.go
+++ b/store/snapshots/types/snapshotter.go
@@ -11,6 +11,9 @@ type Snapshotter interface {
 	// Snapshot writes snapshot items into the protobuf writer.
 	Snapshot(height uint64, protoWriter protoio.Writer) error
 
+	// AnnounceSnapshotHeight informs the underlying system of a snapshot being initiated at a given height.
+	AnnounceSnapshotHeight(height int64)
+
 	// PruneSnapshotHeight prunes the given height according to the prune strategy.
 	// If PruneNothing, this is a no-op.
 	// If other strategy, this height is persisted until it is


### PR DESCRIPTION
Better alternative to #24489

Closes: #23638

With the `AnnounceSnapshotHeigh` method new snapshots are tracked while in-flight so that their height is not pruned accidentally.

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.  Your PR will not be merged unless you satisfy
all of these items.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title, you can find examples of the prefixes below:
    <!-- * `feat`: A new feature
    * `fix`: A bug fix
    * `docs`: Documentation only changes
    * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
    * `refactor`: A code change that neither fixes a bug nor adds a feature
    * `perf`: A code change that improves performance
    * `test`: Adding missing tests or correcting existing tests
    * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
    * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
    * `chore`: Other changes that don't modify src or test files
    * `revert`: Reverts a previous commit -->
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] confirmed all CI checks have passed

