### PR TITLE
chore: add note in `x/staking` about reserved keys from LSM modules

### DIFF
--- a/x/staking/types/keys.go
+++ b/x/staking/types/keys.go
@@ -56,6 +56,9 @@ var (
 	ParamsKey = []byte{0x51} // prefix for parameters for module x/staking
 
 	DelegationByValIndexKey = []byte{0x71} // key for delegations by a validator
+
+	// NOTE: keys in range 0x81–0x87 were previously used in liquid staking forks of the staking module.
+	// Module developers MUST NOT use these keys and MUST consider them "reserved".
 )
 
 // UnbondingType defines the type of unbonding operation


### PR DESCRIPTION
Closes GAIA-127

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added comments clarifying that certain key byte ranges are reserved due to previous use in liquid staking forks. No functional changes were made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->