### PR TITLE
chore: group together ABCI methods inside baseapp

### DIFF
--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -95,14 +95,14 @@ func (app *BaseApp) InitChain(req *abci.RequestInitChain) (*abci.ResponseInitCha
 			}))
 	}()
 
-	if app.initChainer == nil {
+	if app.abciHandlers.InitChainer == nil {
 		return &abci.ResponseInitChain{}, nil
 	}
 
 	// add block gas meter for any genesis transactions (allow infinite gas)
 	app.finalizeBlockState.SetContext(app.finalizeBlockState.Context().WithBlockGasMeter(storetypes.NewInfiniteGasMeter()))
 
-	res, err := app.initChainer(app.finalizeBlockState.Context(), req)
+	res, err := app.abciHandlers.InitChainer(app.finalizeBlockState.Context(), req)
 	if err != nil {
 		return nil, err
 	}
@@ -351,7 +351,7 @@ func (app *BaseApp) CheckTx(req *abci.RequestCheckTx) (*abci.ResponseCheckTx, er
 		return nil, fmt.Errorf("unknown RequestCheckTx type: %s", req.Type)
 	}
 
-	if app.checkTxHandler == nil {
+	if app.abciHandlers.CheckTxHandler == nil {
 		gInfo, result, anteEvents, err := app.runTx(mode, req.Tx, nil)
 		if err != nil {
 			return sdkerrors.ResponseCheckTxWithEvents(err, gInfo.GasWanted, gInfo.GasUsed, anteEvents, app.trace), nil
@@ -371,7 +371,7 @@ func (app *BaseApp) CheckTx(req *abci.RequestCheckTx) (*abci.ResponseCheckTx, er
 		return app.runTx(mode, txBytes, tx)
 	}
 
-	return app.checkTxHandler(runTx, req)
+	return app.abciHandlers.CheckTxHandler(runTx, req)
 }
 
 // PrepareProposal implements the PrepareProposal ABCI method and returns a
@@ -388,7 +388,7 @@ func (app *BaseApp) CheckTx(req *abci.RequestCheckTx) (*abci.ResponseCheckTx, er
 // Ref: https://github.com/cosmos/cosmos-sdk/blob/main/docs/architecture/adr-060-abci-1.0.md
 // Ref: https://github.com/cometbft/cometbft/blob/main/spec/abci/abci%2B%2B_basic_concepts.md
 func (app *BaseApp) PrepareProposal(req *abci.RequestPrepareProposal) (resp *abci.ResponsePrepareProposal, err error) {
-	if app.prepareProposal == nil {
+	if app.abciHandlers.PrepareProposalHandler == nil {
 		return nil, errors.New("PrepareProposal handler not set")
 	}
 
@@ -441,7 +441,7 @@ func (app *BaseApp) PrepareProposal(req *abci.RequestPrepareProposal) (resp *abc
 		}
 	}()
 
-	resp, err = app.prepareProposal(app.prepareProposalState.Context(), req)
+	resp, err = app.abciHandlers.PrepareProposalHandler(app.prepareProposalState.Context(), req)
 	if err != nil {
 		app.logger.Error("failed to prepare proposal", "height", req.Height, "time", req.Time, "err", err)
 		return &abci.ResponsePrepareProposal{Txs: req.Txs}, nil
@@ -466,7 +466,7 @@ func (app *BaseApp) PrepareProposal(req *abci.RequestPrepareProposal) (resp *abc
 // Ref: https://github.com/cosmos/cosmos-sdk/blob/main/docs/architecture/adr-060-abci-1.0.md
 // Ref: https://github.com/cometbft/cometbft/blob/main/spec/abci/abci%2B%2B_basic_concepts.md
 func (app *BaseApp) ProcessProposal(req *abci.RequestProcessProposal) (resp *abci.ResponseProcessProposal, err error) {
-	if app.processProposal == nil {
+	if app.abciHandlers.ProcessProposalHandler == nil {
 		return nil, errors.New("ProcessProposal handler not set")
 	}
 
@@ -530,7 +530,7 @@ func (app *BaseApp) ProcessProposal(req *abci.RequestProcessProposal) (resp *abc
 		}
 	}()
 
-	resp, err = app.processProposal(app.processProposalState.Context(), req)
+	resp, err = app.abciHandlers.ProcessProposalHandler(app.processProposalState.Context(), req)
 	if err != nil {
 		app.logger.Error("failed to process proposal", "height", req.Height, "time", req.Time, "hash", fmt.Sprintf("%X", req.Hash), "err", err)
 		return &abci.ResponseProcessProposal{Status: abci.ResponseProcessProposal_REJECT}, nil
@@ -577,7 +577,7 @@ func (app *BaseApp) ExtendVote(_ context.Context, req *abci.RequestExtendVote) (
 		ctx = sdk.NewContext(ms, emptyHeader, false, app.logger).WithStreamingManager(app.streamingManager)
 	}
 
-	if app.extendVote == nil {
+	if app.abciHandlers.ExtendVoteHandler == nil {
 		return nil, errors.New("application ExtendVote handler not set")
 	}
 
@@ -619,7 +619,7 @@ func (app *BaseApp) ExtendVote(_ context.Context, req *abci.RequestExtendVote) (
 		}
 	}()
 
-	resp, err = app.extendVote(ctx, req)
+	resp, err = app.abciHandlers.ExtendVoteHandler(ctx, req)
 	if err != nil {
 		app.logger.Error("failed to extend vote", "height", req.Height, "hash", fmt.Sprintf("%X", req.Hash), "err", err)
 		return &abci.ResponseExtendVote{VoteExtension: []byte{}}, nil
@@ -635,7 +635,7 @@ func (app *BaseApp) ExtendVote(_ context.Context, req *abci.RequestExtendVote) (
 // phase. The response MUST be deterministic. An error is returned if vote
 // extensions are not enabled or if verifyVoteExt fails or panics.
 func (app *BaseApp) VerifyVoteExtension(req *abci.RequestVerifyVoteExtension) (resp *abci.ResponseVerifyVoteExtension, err error) {
-	if app.verifyVoteExt == nil {
+	if app.abciHandlers.VerifyVoteExtensionHandler == nil {
 		return nil, errors.New("application VerifyVoteExtension handler not set")
 	}
 
@@ -689,7 +689,7 @@ func (app *BaseApp) VerifyVoteExtension(req *abci.RequestVerifyVoteExtension) (r
 			Hash:    req.Hash,
 		})
 
-	resp, err = app.verifyVoteExt(ctx, req)
+	resp, err = app.abciHandlers.VerifyVoteExtensionHandler(ctx, req)
 	if err != nil {
 		app.logger.Error("failed to verify vote extension", "height", req.Height, "err", err)
 		return &abci.ResponseVerifyVoteExtension{Status: abci.ResponseVerifyVoteExtension_REJECT}, nil
@@ -937,8 +937,8 @@ func (app *BaseApp) Commit() (*abci.ResponseCommit, error) {
 	header := app.finalizeBlockState.Context().BlockHeader()
 	retainHeight := app.GetBlockRetentionHeight(header.Height)
 
-	if app.precommiter != nil {
-		app.precommiter(app.finalizeBlockState.Context())
+	if app.abciHandlers.Precommiter != nil {
+		app.abciHandlers.Precommiter(app.finalizeBlockState.Context())
 	}
 
 	rms, ok := app.cms.(*rootmulti.Store)
@@ -973,8 +973,8 @@ func (app *BaseApp) Commit() (*abci.ResponseCommit, error) {
 
 	app.finalizeBlockState = nil
 
-	if app.prepareCheckStater != nil {
-		app.prepareCheckStater(app.checkState.Context())
+	if app.abciHandlers.PrepareCheckStater != nil {
+		app.abciHandlers.PrepareCheckStater(app.checkState.Context())
 	}
 
 	// The SnapshotIfApplicable method will create the snapshot by starting the goroutine

--- a/baseapp/options.go
+++ b/baseapp/options.go
@@ -180,11 +180,11 @@ func (app *BaseApp) SetInitChainer(initChainer sdk.InitChainer) {
 		panic("SetInitChainer() on sealed BaseApp")
 	}
 
-	app.initChainer = initChainer
+	app.abciHandlers.InitChainer = initChainer
 }
 
 func (app *BaseApp) PreBlocker() sdk.PreBlocker {
-	return app.preBlocker
+	return app.abciHandlers.PreBlocker
 }
 
 func (app *BaseApp) SetPreBlocker(preBlocker sdk.PreBlocker) {
@@ -192,7 +192,7 @@ func (app *BaseApp) SetPreBlocker(preBlocker sdk.PreBlocker) {
 		panic("SetPreBlocker() on sealed BaseApp")
 	}
 
-	app.preBlocker = preBlocker
+	app.abciHandlers.PreBlocker = preBlocker
 }
 
 func (app *BaseApp) SetBeginBlocker(beginBlocker sdk.BeginBlocker) {
@@ -200,7 +200,7 @@ func (app *BaseApp) SetBeginBlocker(beginBlocker sdk.BeginBlocker) {
 		panic("SetBeginBlocker() on sealed BaseApp")
 	}
 
-	app.beginBlocker = beginBlocker
+	app.abciHandlers.BeginBlocker = beginBlocker
 }
 
 func (app *BaseApp) SetEndBlocker(endBlocker sdk.EndBlocker) {
@@ -208,7 +208,7 @@ func (app *BaseApp) SetEndBlocker(endBlocker sdk.EndBlocker) {
 		panic("SetEndBlocker() on sealed BaseApp")
 	}
 
-	app.endBlocker = endBlocker
+	app.abciHandlers.EndBlocker = endBlocker
 }
 
 func (app *BaseApp) SetPrepareCheckStater(prepareCheckStater sdk.PrepareCheckStater) {
@@ -216,7 +216,7 @@ func (app *BaseApp) SetPrepareCheckStater(prepareCheckStater sdk.PrepareCheckSta
 		panic("SetPrepareCheckStater() on sealed BaseApp")
 	}
 
-	app.prepareCheckStater = prepareCheckStater
+	app.abciHandlers.PrepareCheckStater = prepareCheckStater
 }
 
 func (app *BaseApp) SetPrecommiter(precommiter sdk.Precommiter) {
@@ -224,7 +224,7 @@ func (app *BaseApp) SetPrecommiter(precommiter sdk.Precommiter) {
 		panic("SetPrecommiter() on sealed BaseApp")
 	}
 
-	app.precommiter = precommiter
+	app.abciHandlers.Precommiter = precommiter
 }
 
 func (app *BaseApp) SetAnteHandler(ah sdk.AnteHandler) {
@@ -338,7 +338,7 @@ func (app *BaseApp) SetProcessProposal(handler sdk.ProcessProposalHandler) {
 	if app.sealed {
 		panic("SetProcessProposal() on sealed BaseApp")
 	}
-	app.processProposal = handler
+	app.abciHandlers.ProcessProposalHandler = handler
 }
 
 // SetPrepareProposal sets the prepare proposal function for the BaseApp.
@@ -347,16 +347,16 @@ func (app *BaseApp) SetPrepareProposal(handler sdk.PrepareProposalHandler) {
 		panic("SetPrepareProposal() on sealed BaseApp")
 	}
 
-	app.prepareProposal = handler
+	app.abciHandlers.PrepareProposalHandler = handler
 }
 
-// SetCheckTx sets the checkTx function for the BaseApp.
+// SetCheckTxHandler sets the checkTx function for the BaseApp.
 func (app *BaseApp) SetCheckTxHandler(handler sdk.CheckTxHandler) {
 	if app.sealed {
 		panic("SetCheckTxHandler() on sealed BaseApp")
 	}
 
-	app.checkTxHandler = handler
+	app.abciHandlers.CheckTxHandler = handler
 }
 
 func (app *BaseApp) SetExtendVoteHandler(handler sdk.ExtendVoteHandler) {
@@ -364,7 +364,7 @@ func (app *BaseApp) SetExtendVoteHandler(handler sdk.ExtendVoteHandler) {
 		panic("SetExtendVoteHandler() on sealed BaseApp")
 	}
 
-	app.extendVote = handler
+	app.abciHandlers.ExtendVoteHandler = handler
 }
 
 func (app *BaseApp) SetVerifyVoteExtensionHandler(handler sdk.VerifyVoteExtensionHandler) {
@@ -372,7 +372,7 @@ func (app *BaseApp) SetVerifyVoteExtensionHandler(handler sdk.VerifyVoteExtensio
 		panic("SetVerifyVoteExtensionHandler() on sealed BaseApp")
 	}
 
-	app.verifyVoteExt = handler
+	app.abciHandlers.VerifyVoteExtensionHandler = handler
 }
 
 // SetStoreMetrics sets the prepare proposal function for the BaseApp.

--- a/types/abci.go
+++ b/types/abci.go
@@ -4,6 +4,21 @@ import (
 	abci "github.com/cometbft/cometbft/abci/types"
 )
 
+// ABCIHandlers aggregates all ABCI handlers needed for an application.
+type ABCIHandlers struct {
+	InitChainer
+	CheckTxHandler
+	PreBlocker
+	BeginBlocker
+	EndBlocker
+	ProcessProposalHandler
+	PrepareProposalHandler
+	ExtendVoteHandler
+	VerifyVoteExtensionHandler
+	PrepareCheckStater
+	Precommiter
+}
+
 // InitChainer initializes application state at genesis
 type InitChainer func(ctx Context, req *abci.RequestInitChain) (*abci.ResponseInitChain, error)
 
@@ -13,9 +28,6 @@ type PrepareCheckStater func(ctx Context)
 
 // Precommiter runs code during commit immediately before the `deliverState` is written to the `rootMultiStore`.
 type Precommiter func(ctx Context)
-
-// PeerFilter responds to p2p filtering queries from Tendermint
-type PeerFilter func(info string) *abci.ResponseQuery
 
 // ProcessProposalHandler defines a function type alias for processing a proposer
 type ProcessProposalHandler func(Context, *abci.RequestProcessProposal) (*abci.ResponseProcessProposal, error)
@@ -81,3 +93,6 @@ func (r ResponsePreBlock) IsConsensusParamsChanged() bool {
 }
 
 type RunTx = func(txBytes []byte, tx Tx) (gInfo GasInfo, result *Result, anteEvents []abci.Event, err error)
+
+// PeerFilter responds to p2p filtering queries from Tendermint
+type PeerFilter func(info string) *abci.ResponseQuery


### PR DESCRIPTION
baseapp is so bloated and it would be good if we can start sectioning off the different structs and methods it owns into isolated components.  This is a basic way of doing this by grouping all of the ABCI methods that is fully backwards compat

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Consolidated multiple ABCI handler fields into a single structured field for improved organization and maintainability.
  - Updated all relevant methods and setter/getter functions to use the new centralized handler structure.
  - No changes to application logic or user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->