### PR TITLE
chore(baseapp): deprecate invariants

### DIFF
--- a/types/invariant.go
+++ b/types/invariant.go
@@ -6,17 +6,25 @@ import "fmt"
 // The invariant returns a descriptive message about what happened
 // and a boolean indicating whether the invariant has been broken.
 // The simulator will then halt and print the logs.
+//
+// Deprecated: the Invariant type is deprecated and will be removed once x/crisis is removed.
 type Invariant func(ctx Context) (string, bool)
 
 // Invariants defines a group of invariants
+//
+// Deprecated: the Invariants type is deprecated and will be removed once x/crisis is removed.
 type Invariants []Invariant
 
 // expected interface for registering invariants
+//
+// Deprecated: the InvariantRegistry type is deprecated and will be removed once x/crisis is removed.
 type InvariantRegistry interface {
 	RegisterRoute(moduleName, route string, invar Invariant)
 }
 
 // FormatInvariant returns a standardized invariant message.
+//
+// Deprecated: the FormatInvariant type is deprecated and will be removed once x/crisis is removed.
 func FormatInvariant(module, name, msg string) string {
 	return fmt.Sprintf("%s: %s invariant\n%s\n", module, name, msg)
 }

--- a/types/module/module.go
+++ b/types/module/module.go
@@ -210,7 +210,7 @@ type AppModule interface {
 // Deprecated: this will be removed in the next Cosmos SDK release.
 type HasInvariants interface {
 	// RegisterInvariants registers module invariants.
-	RegisterInvariants(sdk.InvariantRegistry)
+	RegisterInvariants(sdk.InvariantRegistry) // nolint: staticcheck // deprecated interface
 }
 
 // HasServices is the interface for modules to register services.
@@ -268,6 +268,8 @@ func (GenesisOnlyAppModule) IsOnePerModuleType() {}
 func (GenesisOnlyAppModule) IsAppModule() {}
 
 // RegisterInvariants is a placeholder function register no invariants
+//
+// Deprecated: this function will be removed when x/crisis and invariants are removed from the cosmos SDK.
 func (GenesisOnlyAppModule) RegisterInvariants(_ sdk.InvariantRegistry) {}
 
 // ConsensusVersion implements AppModule/ConsensusVersion.


### PR DESCRIPTION
we needed to fully deprecate this type as its usage is already deprecated in x/crisis