### PR TITLE
docs: fix events subscription docs link

### DIFF
--- a/systemtests/system.go
+++ b/systemtests/system.go
@@ -842,7 +842,7 @@ type (
 )
 
 // Subscribe to receive events for a topic. Does not block.
-// For query syntax See https://docs.cosmos.network/master/core/events.html#subscribing-to-events
+// For query syntax See https://docs.cosmos.network/main/learn/advanced/events#subscribing-to-events
 func (l *EventListener) Subscribe(query string, cb EventConsumer) func() {
 	ctx, done := context.WithCancel(context.Background())
 	l.t.Cleanup(done)
@@ -864,7 +864,7 @@ func (l *EventListener) Subscribe(query string, cb EventConsumer) func() {
 }
 
 // AwaitQuery blocks and waits for a single result or timeout. This can be used with `broadcast-mode=async`.
-// For query syntax See https://docs.cosmos.network/master/core/events.html#subscribing-to-events
+// For query syntax See https://docs.cosmos.network/main/learn/advanced/events#subscribing-to-events
 func (l *EventListener) AwaitQuery(query string, optMaxWaitTime ...time.Duration) *ctypes.ResultEvent {
 	c, result := CaptureSingleEventConsumer()
 	maxWaitTime := DefaultWaitTime


### PR DESCRIPTION
# Description

Replaces dead URL `https://docs.cosmos.network/master/core/events.html#subscribing-to-events`
with the current working URL `https://docs.cosmos.network/main/learn/advanced/events#subscribing-to-events`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated documentation links for event subscription methods to reflect the latest URLs. No changes to functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->