### PR TITLE
test(bank/cli): remove duplicate --broadcast-mode flag in tx tests

### DIFF
--- a/x/bank/client/cli/tx_test.go
+++ b/x/bank/client/cli/tx_test.go
@@ -56,7 +56,6 @@ func (s *CLITestSuite) TestSendTxCmd() {
 	extraArgs := []string{
 		fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastSync),
 		fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
-		fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastSync),
 		fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin("photon", sdkmath.NewInt(10))).String()),
 		fmt.Sprintf("--%s=test-chain", flags.FlagChainID),
 	}
@@ -141,7 +140,6 @@ func (s *CLITestSuite) TestMultiSendTxCmd() {
 	extraArgs := []string{
 		fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastSync),
 		fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
-		fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastSync),
 		fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin("photon", sdkmath.NewInt(10))).String()),
 		fmt.Sprintf("--%s=test-chain", flags.FlagChainID),
 	}


### PR DESCRIPTION
# Description

Removed redundant --broadcast-mode flag from extraArgs in both TestSendTxCmd and TestMultiSendTxCmd.

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Removed duplicate entries of the broadcast mode flag in transaction command tests to streamline test arguments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->