### PR TITLE
fix(x/bank/keeper): correct typos in comments and error messages

### DIFF
--- a/x/bank/keeper/grpc_query.go
+++ b/x/bank/keeper/grpc_query.go
@@ -215,7 +215,7 @@ func (k BaseKeeper) DenomMetadata(c context.Context, req *types.QueryDenomMetada
 
 	metadata, found := k.GetDenomMetaData(ctx, req.Denom)
 	if !found {
-		return nil, status.Errorf(codes.NotFound, "client metadata for denom %s", req.Denom)
+		return nil, status.Errorf(codes.NotFound, "no metadata found for denom %s", req.Denom)
 	}
 
 	return &types.QueryDenomMetadataResponse{
@@ -301,7 +301,7 @@ func (k BaseKeeper) SendEnabled(goCtx context.Context, req *types.QuerySendEnabl
 	return resp, nil
 }
 
-// DenomOwnersByQuery is identical to DenomOwner query, but receives denom values via query string.
+// DenomOwnersByQuery is identical to DenomOwners query, but receives denom values via query string.
 func (k BaseKeeper) DenomOwnersByQuery(ctx context.Context, req *types.QueryDenomOwnersByQueryRequest) (*types.QueryDenomOwnersByQueryResponse, error) {
 	if req == nil {
 		return nil, status.Errorf(codes.InvalidArgument, "empty request")

--- a/x/bank/keeper/keeper.go
+++ b/x/bank/keeper/keeper.go
@@ -447,7 +447,7 @@ func (k BaseKeeper) trackDelegation(ctx context.Context, addr sdk.AccAddress, ba
 	return nil
 }
 
-// trackUndelegation trakcs undelegation of the given account if it is a vesting account
+// trackUndelegation tracks undelegation of the given account if it is a vesting account
 func (k BaseKeeper) trackUndelegation(ctx context.Context, addr sdk.AccAddress, amt sdk.Coins) error {
 	acc := k.ak.GetAccount(ctx, addr)
 	if acc == nil {


### PR DESCRIPTION
# Description

- Fixes typo in error message for missing denom metadata query
- Corrects comment typo: "DenomOwner" → "DenomOwners"
- Fixes comment typo: "trakcs" → "tracks" in trackUndelegation function

No functional or logic changes are included in this patch

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated error message to clarify when no metadata is found for a given denomination.

- **Documentation**
  - Corrected comments to improve accuracy and fix typos in method descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->