### PR TITLE
imp: call msg ValidateBasic on DispatchAction

### DIFF
--- a/x/authz/keeper/keeper.go
+++ b/x/authz/keeper/keeper.go
@@ -158,6 +158,12 @@ func (k Keeper) DispatchActions(ctx context.Context, grantee sdk.AccAddress, msg
 			}
 		}
 
+		if m, ok := msg.(sdk.HasValidateBasic); ok {
+			if err := m.ValidateBasic(); err != nil {
+				return nil, err
+			}
+		}
+
 		handler := k.router.Handler(msg)
 		if handler == nil {
 			return nil, sdkerrors.ErrUnknownRequest.Wrapf("unrecognized message route: %s", sdk.MsgTypeURL(msg))


### PR DESCRIPTION
# Description

Currently, the `DispatchAction` logic does not check whether the message implements the `ValidateBasic` method.
This update adds that check and calls `ValidateBasic`, following the same approach used in the `runTx` function.

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->
