### PR TITLE
refactor: fix lint and use `NextBlockDelay` instead of `TimeoutCommit`

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,227 +1,25 @@
 # Upgrade Reference
 
-This document provides a quick reference for the upgrades from `v0.50.x` to `v0.53.x` of Cosmos SDK.
+This document provides a quick reference for the upgrades from `v0.53.x` to `v0.54.x` of Cosmos SDK.
 
 Note, always read the **App Wiring Changes** section for more information on application wiring updates.
 
-🚨Upgrading to v0.53.x will require a **coordinated** chain upgrade.🚨
+🚨Upgrading to v0.54.x will require a **coordinated** chain upgrade.🚨
 
 ### TLDR;
 
-Unordered transactions, `x/protocolpool`, and `x/epoch` are the major new features added in v0.53.x.
+**The only major feature in Cosmos SDK v0.54.x is the upgrade from CometBFT v0.x.x to CometBFT v2.**
 
-We also added the ability to add a `CheckTx` handler and enabled ed25519 signature verification.
+For a full list of changes, see the [Changelog](https://github.com/cosmos/cosmos-sdk/blob/release/v0.54.x/CHANGELOG.md).
 
-For a full list of changes, see the [Changelog](https://github.com/cosmos/cosmos-sdk/blob/release/v0.53.x/CHANGELOG.md).
+#### Deprecation of `TimeoutCommit`
 
-### Unordered Transactions
+CometBFT v2 has deprecated the use of `TimeoutCommit` for a new field, `NextBlockDelay`, that is part of the
+`FinalizeBlockResponse` ABCI message that is returned to CometBFT via the SDK baseapp.  More information from 
+the CometBFT repo can be found [here](https://github.com/cometbft/cometbft/blob/88ef3d267de491db98a654be0af6d791e8724ed0/spec/abci/abci%2B%2B_methods.md?plain=1#L689).
 
-The Cosmos SDK now supports unordered transactions. _This is an opt-in feature_.
+For SDK application developers and node runners, this means that the `timeout_commit` value in the `config.toml` file 
+is now **ignored**.  
 
-Clients that use this feature may now submit their transactions in a fire-and-forget manner to chains that enabled unordered transactions.
-
-To submit an unordered transaction, clients must set the `unordered` flag to
-`true` and ensure a reasonable `timeout_timestamp` is set. The `timeout_timestamp` is
-used as a TTL for the transaction and provides replay protection. Each transaction's `timeout_timestamp` must be
-unique to the account; however, the difference may be as small as a nanosecond. See [ADR-070](https://github.com/cosmos/cosmos-sdk/blob/main/docs/architecture/adr-070-unordered-transactions.md) for more details.
-
-Note that unordered transactions require sequence values to be zero, and will **FAIL** if a non-zero sequence value is set. 
-Please ensure no sequence value is set when submitting an unordered transaction.
-Services that rely on prior assumptions about sequence values should be updated to handle unordered transactions.
-Services should be aware that when the transaction is unordered, the transaction sequence will always be zero.
-
-#### Enabling Unordered Transactions
-
-To enable unordered transactions, supply the `WithUnorderedTransactions` option to the `x/auth` keeper:
-
-```go
-	app.AccountKeeper = authkeeper.NewAccountKeeper(
-		appCodec,
-		runtime.NewKVStoreService(keys[authtypes.StoreKey]),
-		authtypes.ProtoBaseAccount,
-		maccPerms,
-		authcodec.NewBech32Codec(sdk.Bech32MainPrefix),
-		sdk.Bech32MainPrefix,
-		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
-		authkeeper.WithUnorderedTransactions(true), // new option!
-	)
-```
-
-If using dependency injection, update the auth module config.
-
-```go
-		{
-			Name: authtypes.ModuleName,
-			Config: appconfig.WrapAny(&authmodulev1.Module{
-				Bech32Prefix:             "cosmos",
-				ModuleAccountPermissions: moduleAccPerms,
-				EnableUnorderedTransactions: true, // remove this line if you do not want unordered transactions.
-			}),
-		},
-```
-
-By default, unordered transactions use a transaction timeout duration of 10 minutes and a default gas charge of 2240 gas units.
-To modify these default values, pass in the corresponding options to the new `SigVerifyOptions` field in `x/auth's` `ante.HandlerOptions`.
-
-```go
-options := ante.HandlerOptions{
-    SigVerifyOptions: []ante.SigVerificationDecoratorOption{
-        // change below as needed.
-        ante.WithUnorderedTxGasCost(ante.DefaultUnorderedTxGasCost),
-        ante.WithMaxUnorderedTxTimeoutDuration(ante.DefaultMaxTimoutDuration),
-    },
-}
-```
-
-```go
-anteDecorators := []sdk.AnteDecorator{
-    // ... other decorators ...
-    ante.NewSigVerificationDecorator(options.AccountKeeper, options.SignModeHandler, options.SigVerifyOptions...), // supply new options
-}
-```
-
-### App Wiring Changes
-
-In this section, we describe the required app wiring changes to run a v0.53.x Cosmos SDK application.
-
-**These changes are directly applicable to your application wiring.**
-
-The `x/auth` module now contains a `PreBlocker` that _must_ be set in the module manager's `SetOrderPreBlockers` method.
-
-```go
-app.ModuleManager.SetOrderPreBlockers(
-    upgradetypes.ModuleName,
-    authtypes.ModuleName, // NEW
-)
-```
-
-That's it.
-
-### New Modules
-
-Below are some **optional** new modules you can include in your chain. 
-To see a full example of wiring these modules, please check out the [SimApp](https://github.com/cosmos/cosmos-sdk/blob/release/v0.53.x/simapp/app.go).
-
-#### Epochs
-
-⚠️Adding this module requires a `StoreUpgrade`⚠️
-
-The new, supplemental `x/epochs` module provides Cosmos SDK modules functionality to register and execute custom logic at fixed time-intervals.
-
-Required wiring:
-- Keeper Instantiation
-- StoreKey addition
-- Hooks Registration 
-- App Module Registration
-- entry in SetOrderBeginBlockers
-- entry in SetGenesisModuleOrder
-- entry in SetExportModuleOrder
-
-#### ProtocolPool
-
-:::warning
-
-Using `protocolpool` will cause the following `x/distribution` handlers to return an error:
-
-
-**QueryService**
-
-- `CommunityPool`
-
-**MsgService**
-
-- `CommunityPoolSpend`
-- `FundCommunityPool`
-
-If you have services that rely on this functionality from `x/distribution`, please update them to use the `x/protocolpool` equivalents.
-
-:::
-
-⚠️Adding this module requires a `StoreUpgrade`⚠️
-
-The new, supplemental `x/protocolpool` module provides extended functionality for managing and distributing block reward revenue.
-
-Required wiring:
-- Module Account Permissions
-  - protocolpooltypes.ModuleName (nil)
-  - protocolpooltypes.ProtocolPoolEscrowAccount (nil)
-- Keeper Instantiation
-- StoreKey addition
-- Passing the keeper to the Distribution Keeper
-  - `distrkeeper.WithExternalCommunityPool(app.ProtocolPoolKeeper)`
-- App Module Registration
-- entry in SetOrderBeginBlockers
-- entry in SetOrderEndBlockers
-- entry in SetGenesisModuleOrder
-- entry in SetExportModuleOrder **before `x/bank`**
-
-## Custom Minting Function in `x/mint`
-
-This release introduces the ability to configure a custom mint function in `x/mint`. The minting logic is now abstracted as a `MintFn` with a default implementation that can be overridden.
-
-### What’s New
-
-- **Configurable Mint Function:**  
-  A new `MintFn` abstraction is introduced. By default, the module uses `DefaultMintFn`, but you can supply your own implementation.
-
-- **Deprecated InflationCalculationFn Parameter:**  
-  The `InflationCalculationFn` argument previously provided to `mint.NewAppModule()` is now ignored and must be `nil`. To customize the default minter’s inflation behavior, wrap your custom function with `mintkeeper.DefaultMintFn` and pass it via the `WithMintFn` option:
-  
-```go
-  mintkeeper.WithMintFn(mintkeeper.DefaultMintFn(customInflationFn))
-```  
-
-### How to Upgrade
-
-1. **Using the Default Minting Function**
-
-   No action is needed if you’re happy with the default behavior. Make sure your application wiring initializes the MintKeeper like this:
-
-```go
-   mintKeeper := mintkeeper.NewKeeper(
-       appCodec,
-       storeService,
-       stakingKeeper,
-       accountKeeper,
-       bankKeeper,
-       authtypes.FeeCollectorName,
-       authtypes.NewModuleAddress(govtypes.ModuleName).String(),
-   )
-```
-
-2. **Using a Custom Minting Function**
-    
-    To use a custom minting function, define it as follows and pass it you your mintKeeper when constructing it:
-
-```go
-func myCustomMintFunc(ctx sdk.Context, k *mintkeeper.Keeper) {
-   // do minting...
-}
-
-// ...
-   mintKeeper := mintkeeper.NewKeeper(
-       appCodec,
-       storeService,
-       stakingKeeper,
-       accountKeeper,
-       bankKeeper,
-       authtypes.FeeCollectorName,
-       authtypes.NewModuleAddress(govtypes.ModuleName).String(),
-       mintkeeper.WithMintFn(myCustomMintFunc), // Use custom minting function
-   )
-```
-
-### Misc Changes
-
-#### Testnet's init-files Command
-
-Some changes were made to `testnet`'s `init-files` command to support our new testing framework, `Systemtest`.
-
-##### Flag Changes
-
-- The flag for validator count was changed from `--v` to `--validator-count`(shorthand: `-v`).
-
-##### Flag Additions
-- `--staking-denom` allows changing the default stake denom, `stake`.
-- `--commit-timeout` enables changing the commit timeout of the chain.
-- `--single-host` enables running a multi-node network on a single host. This bumps each subsequent node's network addresses by 1. For example, node1's gRPC address will be 9090, node2's 9091, etc...
+For similar behavior, there is a new `baseapp` option, `SetNextBlockDelay` which can be passed to your application upon
+initialization in `app.go`.  

--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -868,6 +868,7 @@ func (app *BaseApp) internalFinalizeBlock(ctx context.Context, req *abci.Finaliz
 		TxResults:             txResults,
 		ValidatorUpdates:      endBlock.ValidatorUpdates,
 		ConsensusParamUpdates: &cp,
+		NextBlockDelay:        app.nextBlockDelay,
 	}, nil
 }
 
@@ -876,7 +877,7 @@ func (app *BaseApp) internalFinalizeBlock(ctx context.Context, req *abci.Finaliz
 // by the transactions in the proposal, finally followed by the application's
 // EndBlock (if defined).
 //
-// For each raw transaction, i.e. a byte slice, BaseApp will only execute it if
+// For each raw transaction, i.e., a byte slice, BaseApp will only execute it if
 // it adheres to the sdk.Tx interface. Otherwise, the raw transaction will be
 // skipped. This is to support compatibility with proposers injecting vote
 // extensions into the proposal, which should not themselves be executed in cases

--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"strconv"
 	"sync"
+	"time"
 
 	"github.com/cockroachdb/errors"
 	cmtproto "github.com/cometbft/cometbft/api/cometbft/types/v2"
@@ -108,6 +109,10 @@ type BaseApp struct {
 	// flag for sealing options and parameters to a BaseApp
 	sealed bool
 
+	// nextBlockDelay is the delay to wait until the next block after ABCI has committed.
+	// This gives the application more time to receive precommits.
+	nextBlockDelay time.Duration
+
 	// block height at which to halt the chain and gracefully shutdown
 	haltHeight uint64
 
@@ -181,6 +186,7 @@ func NewBaseApp(
 		fauxMerkleMode:   false,
 		sigverifyTx:      true,
 		gasConfig:        config.GasConfig{QueryGasLimit: math.MaxUint64},
+		nextBlockDelay:   time.Second,
 	}
 
 	for _, option := range options {

--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -56,6 +56,10 @@ const (
 	execModeVoteExtension       = sdk.ExecModeVoteExtension       // Extend or verify a pre-commit vote
 	execModeVerifyVoteExtension = sdk.ExecModeVerifyVoteExtension // Verify a vote extension
 	execModeFinalize            = sdk.ExecModeFinalize            // Finalize a block proposal
+
+	// defaultNextBlockDelay is chosen following documentation in CometBFT:
+	// https://github.com/cometbft/cometbft/blob/88ef3d267de491db98a654be0af6d791e8724ed0/spec/abci/abci%2B%2B_methods.md?plain=1#L689
+	defaultNextBlockDelay = time.Second
 )
 
 var _ servertypes.ABCI = (*BaseApp)(nil)
@@ -178,7 +182,7 @@ func NewBaseApp(
 		logger:           logger.With(log.ModuleKey, "baseapp"),
 		name:             name,
 		db:               db,
-		cms:              store.NewCommitMultiStore(db, logger, storemetrics.NewNoOpMetrics()), // by default we use a no-op metric gather in store
+		cms:              store.NewCommitMultiStore(db, logger, storemetrics.NewNoOpMetrics()), // by default, we use a no-op metric gather in store
 		storeLoader:      DefaultStoreLoader,
 		grpcQueryRouter:  NewGRPCQueryRouter(),
 		msgServiceRouter: NewMsgServiceRouter(),
@@ -186,7 +190,7 @@ func NewBaseApp(
 		fauxMerkleMode:   false,
 		sigverifyTx:      true,
 		gasConfig:        config.GasConfig{QueryGasLimit: math.MaxUint64},
-		nextBlockDelay:   time.Second,
+		nextBlockDelay:   defaultNextBlockDelay,
 	}
 
 	for _, option := range options {

--- a/baseapp/options.go
+++ b/baseapp/options.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"time"
 
 	dbm "github.com/cosmos/cosmos-db"
 
@@ -331,6 +332,15 @@ func (app *BaseApp) SetMempool(mempool mempool.Mempool) {
 		panic("SetMempool() on sealed BaseApp")
 	}
 	app.mempool = mempool
+}
+
+// SetNextBlockDelay sets the next block delay for the baseapp.
+func (app *BaseApp) SetNextBlockDelay(delay time.Duration) {
+	if app.sealed {
+		panic("SetNextBlockDelay() on sealed BaseApp")
+	}
+
+	app.nextBlockDelay = delay
 }
 
 // SetProcessProposal sets the process proposal function for the BaseApp.

--- a/baseapp/options.go
+++ b/baseapp/options.go
@@ -336,6 +336,8 @@ func (app *BaseApp) SetMempool(mempool mempool.Mempool) {
 
 // SetNextBlockDelay sets the next block delay for the baseapp.
 //
+// The application is initialized with a default value of 1s.
+//
 // More information on this value and how it affects CometBFT can be found here:
 // https://github.com/cometbft/cometbft/blob/88ef3d267de491db98a654be0af6d791e8724ed0/spec/abci/abci%2B%2B_methods.md?plain=1#L689
 func (app *BaseApp) SetNextBlockDelay(delay time.Duration) {

--- a/baseapp/options.go
+++ b/baseapp/options.go
@@ -335,6 +335,9 @@ func (app *BaseApp) SetMempool(mempool mempool.Mempool) {
 }
 
 // SetNextBlockDelay sets the next block delay for the baseapp.
+//
+// More information on this value and how it affects CometBFT can be found here:
+// https://github.com/cometbft/cometbft/blob/88ef3d267de491db98a654be0af6d791e8724ed0/spec/abci/abci%2B%2B_methods.md?plain=1#L689
 func (app *BaseApp) SetNextBlockDelay(delay time.Duration) {
 	if app.sealed {
 		panic("SetNextBlockDelay() on sealed BaseApp")

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -2,8 +2,9 @@ package config
 
 import (
 	"fmt"
-	"github.com/spf13/viper"
 	"math"
+
+	"github.com/spf13/viper"
 
 	pruningtypes "cosmossdk.io/store/pruning/types"
 

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -2,9 +2,8 @@ package config
 
 import (
 	"fmt"
-	"math"
-
 	"github.com/spf13/viper"
+	"math"
 
 	pruningtypes "cosmossdk.io/store/pruning/types"
 

--- a/server/util.go
+++ b/server/util.go
@@ -12,7 +12,6 @@ import (
 	"path/filepath"
 	"strings"
 	"syscall"
-	"time"
 
 	cmtcmd "github.com/cometbft/cometbft/v2/cmd/cometbft/commands"
 	cmtcfg "github.com/cometbft/cometbft/v2/config"
@@ -263,11 +262,6 @@ func interceptConfigs(rootViper *viper.Viper, customAppTemplate string, customCo
 		}
 
 		defaultCometCfg := cmtcfg.DefaultConfig()
-		// The SDK is opinionated about those comet values, so we set them here.
-		// We verify first that the user has not changed them for not overriding them.
-		if conf.Consensus.TimeoutCommit == defaultCometCfg.Consensus.TimeoutCommit {
-			conf.Consensus.TimeoutCommit = 5 * time.Second
-		}
 		if conf.RPC.PprofListenAddress == defaultCometCfg.RPC.PprofListenAddress {
 			conf.RPC.PprofListenAddress = "localhost:6060"
 		}

--- a/simapp/simd/cmd/testnet.go
+++ b/simapp/simd/cmd/testnet.go
@@ -160,7 +160,6 @@ Example:
 			args.algo, _ = cmd.Flags().GetString(flags.FlagKeyType)
 			args.bondTokenDenom, _ = cmd.Flags().GetString(flagStakingDenom)
 			args.singleMachine, _ = cmd.Flags().GetBool(flagSingleHost)
-			config.Consensus.TimeoutCommit, err = cmd.Flags().GetDuration(flagCommitTimeout)
 			if err != nil {
 				return err
 			}

--- a/simapp/simd/cmd/testnet.go
+++ b/simapp/simd/cmd/testnet.go
@@ -51,8 +51,11 @@ var (
 	flagAPIAddress        = "api.address"
 	flagPrintMnemonic     = "print-mnemonic"
 	flagStakingDenom      = "staking-denom"
-	flagCommitTimeout     = "commit-timeout"
-	flagSingleHost        = "single-host"
+	// flagCommitTimeout is a deprecated flag whose value will not be used.
+	//
+	// Deprecated: set NextBlockDelay on the app with baseapp.SetNextBlockDelay()
+	flagCommitTimeout = "commit-timeout"
+	flagSingleHost    = "single-host"
 )
 
 type initArgs struct {
@@ -81,6 +84,7 @@ type startArgs struct {
 	outputDir     string
 	printMnemonic bool
 	rpcAddress    string
+	// Deprecated: use baseapp.SetNextBlockDelay() instead.
 	timeoutCommit time.Duration
 }
 

--- a/tests/systemtests/upgrade_test.go
+++ b/tests/systemtests/upgrade_test.go
@@ -19,7 +19,7 @@ import (
 
 const (
 	testSeed            = "scene learn remember glide apple expand quality spawn property shoe lamp carry upset blossom draft reject aim file trash miss script joy only measure"
-	upgradeHeight int64 = 35
+	upgradeHeight int64 = 45
 	upgradeName         = "v053-to-v054" // must match UpgradeName in simapp/upgrades.go
 )
 

--- a/tests/systemtests/upgrade_test.go
+++ b/tests/systemtests/upgrade_test.go
@@ -19,7 +19,7 @@ import (
 
 const (
 	testSeed            = "scene learn remember glide apple expand quality spawn property shoe lamp carry upset blossom draft reject aim file trash miss script joy only measure"
-	upgradeHeight int64 = 22
+	upgradeHeight int64 = 35
 	upgradeName         = "v053-to-v054" // must match UpgradeName in simapp/upgrades.go
 )
 
@@ -28,7 +28,7 @@ func TestChainUpgrade(t *testing.T) {
 	// start a legacy chain with some state
 	// when a chain upgrade proposal is executed
 	// then the chain upgrades successfully
-	systest.Sut.StopChain()
+	systest.Sut.ResetChain(t)
 
 	currentBranchBinary := systest.Sut.ExecBinary()
 	currentInitializer := systest.Sut.TestnetInitializer()
@@ -67,8 +67,10 @@ func TestChainUpgrade(t *testing.T) {
 	raw := cli.CustomQuery("q", "gov", "proposal", proposalID)
 	t.Log(raw)
 
-	systest.Sut.AwaitBlockHeight(t, upgradeHeight-1, 60*time.Second)
+	// generous timeout as this could run faster or slower based on HW or in CI
+	systest.Sut.AwaitBlockHeight(t, upgradeHeight-1, 2*time.Minute)
 	t.Logf("current_height: %d\n", systest.Sut.CurrentHeight())
+
 	raw = cli.CustomQuery("q", "gov", "proposal", proposalID)
 	proposalStatus := gjson.Get(raw, "proposal.status").String()
 	require.Equal(t, "PROPOSAL_STATUS_PASSED", proposalStatus, raw)
@@ -82,7 +84,7 @@ func TestChainUpgrade(t *testing.T) {
 	systest.Sut.SetTestnetInitializer(currentInitializer)
 	systest.Sut.StartChain(t)
 
-	require.Equal(t, upgradeHeight+1, systest.Sut.CurrentHeight())
+	require.True(t, upgradeHeight+1 <= systest.Sut.CurrentHeight())
 
 	regex, err := regexp.Compile("DBG this is a debug level message to test that verbose logging mode has properly been enabled during a chain upgrade")
 	require.NoError(t, err)

--- a/testutil/network/network.go
+++ b/testutil/network/network.go
@@ -381,7 +381,6 @@ func New(l Logger, baseDir string, cfg Config) (*Network, error) {
 
 		ctx := server.NewDefaultContext()
 		cmtCfg := ctx.Config
-		cmtCfg.Consensus.TimeoutCommit = cfg.TimeoutCommit
 
 		// Only allow the first validator to expose an RPC, API and gRPC
 		// server/client due to CometBFT in-process constraints.


### PR DESCRIPTION
# Description

- Remove all uses of `TimeoutCommit` in the codebase
- add new `NextBlockDelay` value to `baseapp` that can be set at app instantiation (we could further extend by adding a config field  but assuming this is fine for now)