### PR TITLE
chore: use 5s for default `NextBlockDelay`

### DIFF
--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -57,9 +57,11 @@ const (
 	execModeVerifyVoteExtension = sdk.ExecModeVerifyVoteExtension // Verify a vote extension
 	execModeFinalize            = sdk.ExecModeFinalize            // Finalize a block proposal
 
-	// defaultNextBlockDelay is chosen following documentation in CometBFT:
+	// defaultNextBlockDelay is chosen to be the historical default value in Cosmos SDK for TimeoutCommit
+	//
+	// More information on the change from TimeoutCommit to NextBlockDelay can be found here:
 	// https://github.com/cometbft/cometbft/blob/88ef3d267de491db98a654be0af6d791e8724ed0/spec/abci/abci%2B%2B_methods.md?plain=1#L689
-	defaultNextBlockDelay = time.Second
+	defaultNextBlockDelay = 5 * time.Second
 )
 
 var _ servertypes.ABCI = (*BaseApp)(nil)

--- a/tests/systemtests/upgrade_test.go
+++ b/tests/systemtests/upgrade_test.go
@@ -28,7 +28,7 @@ func TestChainUpgrade(t *testing.T) {
 	// start a legacy chain with some state
 	// when a chain upgrade proposal is executed
 	// then the chain upgrades successfully
-	systest.Sut.ResetChain(t)
+	systest.Sut.StopChain()
 
 	currentBranchBinary := systest.Sut.ExecBinary()
 	currentInitializer := systest.Sut.TestnetInitializer()
@@ -67,10 +67,8 @@ func TestChainUpgrade(t *testing.T) {
 	raw := cli.CustomQuery("q", "gov", "proposal", proposalID)
 	t.Log(raw)
 
-	// generous timeout as this could run faster or slower based on HW or in CI
-	systest.Sut.AwaitBlockHeight(t, upgradeHeight-1, 2*time.Minute)
+	systest.Sut.AwaitBlockHeight(t, upgradeHeight-1, 60*time.Second)
 	t.Logf("current_height: %d\n", systest.Sut.CurrentHeight())
-
 	raw = cli.CustomQuery("q", "gov", "proposal", proposalID)
 	proposalStatus := gjson.Get(raw, "proposal.status").String()
 	require.Equal(t, "PROPOSAL_STATUS_PASSED", proposalStatus, raw)
@@ -84,7 +82,7 @@ func TestChainUpgrade(t *testing.T) {
 	systest.Sut.SetTestnetInitializer(currentInitializer)
 	systest.Sut.StartChain(t)
 
-	require.True(t, upgradeHeight+1 <= systest.Sut.CurrentHeight())
+	require.Equal(t, upgradeHeight+1, systest.Sut.CurrentHeight())
 
 	regex, err := regexp.Compile("DBG this is a debug level message to test that verbose logging mode has properly been enabled during a chain upgrade")
 	require.NoError(t, err)

--- a/tests/systemtests/upgrade_test.go
+++ b/tests/systemtests/upgrade_test.go
@@ -19,7 +19,7 @@ import (
 
 const (
 	testSeed            = "scene learn remember glide apple expand quality spawn property shoe lamp carry upset blossom draft reject aim file trash miss script joy only measure"
-	upgradeHeight int64 = 45
+	upgradeHeight int64 = 22
 	upgradeName         = "v053-to-v054" // must match UpgradeName in simapp/upgrades.go
 )
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the default next block delay to 5 seconds for improved consistency with historical settings.
  - Adjusted the block height for triggering chain upgrades in system tests to occur earlier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->