### PR TITLE
chore: fix `TimeoutCommit` confusion

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -15,11 +15,12 @@ For a full list of changes, see the [Changelog](https://github.com/cosmos/cosmos
 #### Deprecation of `TimeoutCommit`
 
 CometBFT v2 has deprecated the use of `TimeoutCommit` for a new field, `NextBlockDelay`, that is part of the
-`FinalizeBlockResponse` ABCI message that is returned to CometBFT via the SDK baseapp.  More information from 
+`FinalizeBlockResponse` ABCI message that is returned to CometBFT via the SDK baseapp.  More information from
 the CometBFT repo can be found [here](https://github.com/cometbft/cometbft/blob/88ef3d267de491db98a654be0af6d791e8724ed0/spec/abci/abci%2B%2B_methods.md?plain=1#L689).
 
-For SDK application developers and node runners, this means that the `timeout_commit` value in the `config.toml` file 
-is now **ignored**.  
+For SDK application developers and node runners, this means that the `timeout_commit` value in the `config.toml` file
+is still used if `NextBlockDelay` is 0 (its default value).  This means that when upgrading to Cosmos SDK v0.54.x, if 
+the existing `timout_commit` values that validators have been using will be maintained and have the same behavior.
 
-For similar behavior, there is a new `baseapp` option, `SetNextBlockDelay` which can be passed to your application upon
+For setting the field in your application, there is a new `baseapp` option, `SetNextBlockDelay` which can be passed to your application upon
 initialization in `app.go`.  

--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -868,7 +868,6 @@ func (app *BaseApp) internalFinalizeBlock(ctx context.Context, req *abci.Finaliz
 		TxResults:             txResults,
 		ValidatorUpdates:      endBlock.ValidatorUpdates,
 		ConsensusParamUpdates: &cp,
-		NextBlockDelay:        app.nextBlockDelay,
 	}, nil
 }
 
@@ -877,7 +876,7 @@ func (app *BaseApp) internalFinalizeBlock(ctx context.Context, req *abci.Finaliz
 // by the transactions in the proposal, finally followed by the application's
 // EndBlock (if defined).
 //
-// For each raw transaction, i.e., a byte slice, BaseApp will only execute it if
+// For each raw transaction, i.e. a byte slice, BaseApp will only execute it if
 // it adheres to the sdk.Tx interface. Otherwise, the raw transaction will be
 // skipped. This is to support compatibility with proposers injecting vote
 // extensions into the proposal, which should not themselves be executed in cases

--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -877,7 +877,7 @@ func (app *BaseApp) internalFinalizeBlock(ctx context.Context, req *abci.Finaliz
 // by the transactions in the proposal, finally followed by the application's
 // EndBlock (if defined).
 //
-// For each raw transaction, i.e. a byte slice, BaseApp will only execute it if
+// For each raw transaction, i.e., a byte slice, BaseApp will only execute it if
 // it adheres to the sdk.Tx interface. Otherwise, the raw transaction will be
 // skipped. This is to support compatibility with proposers injecting vote
 // extensions into the proposal, which should not themselves be executed in cases

--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -868,6 +868,7 @@ func (app *BaseApp) internalFinalizeBlock(ctx context.Context, req *abci.Finaliz
 		TxResults:             txResults,
 		ValidatorUpdates:      endBlock.ValidatorUpdates,
 		ConsensusParamUpdates: &cp,
+		NextBlockDelay:        app.nextBlockDelay,
 	}, nil
 }
 

--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -180,7 +180,7 @@ func NewBaseApp(
 		logger:           logger.With(log.ModuleKey, "baseapp"),
 		name:             name,
 		db:               db,
-		cms:              store.NewCommitMultiStore(db, logger, storemetrics.NewNoOpMetrics()), // by default we use a no-op metric gather in store
+		cms:              store.NewCommitMultiStore(db, logger, storemetrics.NewNoOpMetrics()), // by default, we use a no-op metric gather in store
 		storeLoader:      DefaultStoreLoader,
 		grpcQueryRouter:  NewGRPCQueryRouter(),
 		msgServiceRouter: NewMsgServiceRouter(),

--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"strconv"
 	"sync"
+	"time"
 
 	"github.com/cockroachdb/errors"
 	cmtproto "github.com/cometbft/cometbft/api/cometbft/types/v2"
@@ -161,6 +162,12 @@ type BaseApp struct {
 	//
 	// SAFETY: it's safe to do if validators validate the total gas wanted in the `ProcessProposal`, which is the case in the default handler.
 	disableBlockGasMeter bool
+
+	// nextBlockDelay is the delay to wait until the next block after ABCI has committed.
+	// This gives the application more time to receive precommits.  This is the same as TimeoutCommit,
+	// but can new be set from the application.  This value defaults to 0, and CometBFT will use the
+	// legacy value set in config.toml if it is 0.
+	nextBlockDelay time.Duration
 }
 
 // NewBaseApp returns a reference to an initialized BaseApp. It accepts a
@@ -181,6 +188,7 @@ func NewBaseApp(
 		fauxMerkleMode:   false,
 		sigverifyTx:      true,
 		gasConfig:        config.GasConfig{QueryGasLimit: math.MaxUint64},
+		nextBlockDelay:   0, // default to 0 so that the legacy CometBFT config.toml value is used
 	}
 
 	for _, option := range options {

--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -8,7 +8,6 @@ import (
 	"slices"
 	"strconv"
 	"sync"
-	"time"
 
 	"github.com/cockroachdb/errors"
 	cmtproto "github.com/cometbft/cometbft/api/cometbft/types/v2"
@@ -56,10 +55,6 @@ const (
 	execModeVoteExtension       = sdk.ExecModeVoteExtension       // Extend or verify a pre-commit vote
 	execModeVerifyVoteExtension = sdk.ExecModeVerifyVoteExtension // Verify a vote extension
 	execModeFinalize            = sdk.ExecModeFinalize            // Finalize a block proposal
-
-	// defaultNextBlockDelay is chosen following documentation in CometBFT:
-	// https://github.com/cometbft/cometbft/blob/88ef3d267de491db98a654be0af6d791e8724ed0/spec/abci/abci%2B%2B_methods.md?plain=1#L689
-	defaultNextBlockDelay = time.Second
 )
 
 var _ servertypes.ABCI = (*BaseApp)(nil)
@@ -112,10 +107,6 @@ type BaseApp struct {
 
 	// flag for sealing options and parameters to a BaseApp
 	sealed bool
-
-	// nextBlockDelay is the delay to wait until the next block after ABCI has committed.
-	// This gives the application more time to receive precommits.
-	nextBlockDelay time.Duration
 
 	// block height at which to halt the chain and gracefully shutdown
 	haltHeight uint64
@@ -182,7 +173,7 @@ func NewBaseApp(
 		logger:           logger.With(log.ModuleKey, "baseapp"),
 		name:             name,
 		db:               db,
-		cms:              store.NewCommitMultiStore(db, logger, storemetrics.NewNoOpMetrics()), // by default, we use a no-op metric gather in store
+		cms:              store.NewCommitMultiStore(db, logger, storemetrics.NewNoOpMetrics()), // by default we use a no-op metric gather in store
 		storeLoader:      DefaultStoreLoader,
 		grpcQueryRouter:  NewGRPCQueryRouter(),
 		msgServiceRouter: NewMsgServiceRouter(),
@@ -190,7 +181,6 @@ func NewBaseApp(
 		fauxMerkleMode:   false,
 		sigverifyTx:      true,
 		gasConfig:        config.GasConfig{QueryGasLimit: math.MaxUint64},
-		nextBlockDelay:   defaultNextBlockDelay,
 	}
 
 	for _, option := range options {

--- a/baseapp/options.go
+++ b/baseapp/options.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"time"
 
 	dbm "github.com/cosmos/cosmos-db"
 
@@ -22,6 +23,20 @@ import (
 
 // File for storing in-package BaseApp optional functions,
 // for options that need access to non-exported fields of the BaseApp
+
+// SetNextBlockDelay sets the next block delay for the baseapp.
+//
+// The application is initialized with a default value of 0.
+//
+// More information on this value and how it affects CometBFT can be found here:
+// https://github.com/cometbft/cometbft/blob/88ef3d267de491db98a654be0af6d791e8724ed0/spec/abci/abci%2B%2B_methods.md?plain=1#L689
+func (app *BaseApp) SetNextBlockDelay(delay time.Duration) {
+	if app.sealed {
+		panic("SetNextBlockDelay() on sealed BaseApp")
+	}
+
+	app.nextBlockDelay = delay
+}
 
 // SetPruning sets a pruning option on the multistore associated with the app
 func SetPruning(opts pruningtypes.PruningOptions) func(*BaseApp) {

--- a/baseapp/options.go
+++ b/baseapp/options.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io"
 	"math"
-	"time"
 
 	dbm "github.com/cosmos/cosmos-db"
 
@@ -332,20 +331,6 @@ func (app *BaseApp) SetMempool(mempool mempool.Mempool) {
 		panic("SetMempool() on sealed BaseApp")
 	}
 	app.mempool = mempool
-}
-
-// SetNextBlockDelay sets the next block delay for the baseapp.
-//
-// The application is initialized with a default value of 1s.
-//
-// More information on this value and how it affects CometBFT can be found here:
-// https://github.com/cometbft/cometbft/blob/88ef3d267de491db98a654be0af6d791e8724ed0/spec/abci/abci%2B%2B_methods.md?plain=1#L689
-func (app *BaseApp) SetNextBlockDelay(delay time.Duration) {
-	if app.sealed {
-		panic("SetNextBlockDelay() on sealed BaseApp")
-	}
-
-	app.nextBlockDelay = delay
 }
 
 // SetProcessProposal sets the process proposal function for the BaseApp.

--- a/depinject/provider_desc_test.go
+++ b/depinject/provider_desc_test.go
@@ -45,7 +45,7 @@ func StructInAndOut(_ float32, _ StructIn, _ byte) (int16, StructOut, int32, err
 	return int16(0), StructOut{}, int32(0), nil
 }
 
-func BadErrorPosition() (error, int) { return nil, 0 } //nolint:stylecheck,staticcheck // Deliberately has error as first of multiple arguments.
+func BadErrorPosition() (error, int) { return nil, 0 } //nolint:staticcheck // Deliberately has error as first of multiple arguments.
 
 func BadOptionalFn(_ BadOptional) int { return 0 }
 

--- a/server/util.go
+++ b/server/util.go
@@ -265,8 +265,8 @@ func interceptConfigs(rootViper *viper.Viper, customAppTemplate string, customCo
 		defaultCometCfg := cmtcfg.DefaultConfig()
 		// The SDK is opinionated about those comet values, so we set them here.
 		// We verify first that the user has not changed them for not overriding them.
-		if conf.Consensus.TimeoutCommit == defaultCometCfg.Consensus.TimeoutCommit {
-			conf.Consensus.TimeoutCommit = 5 * time.Second
+		if conf.Consensus.TimeoutCommit == defaultCometCfg.Consensus.TimeoutCommit { // nolint: staticcheck // we are continuing to use this value for backwards compatibility
+			conf.Consensus.TimeoutCommit = 5 * time.Second // nolint: staticcheck // we are continuing to use this value for backwards compatibility
 		}
 		if conf.RPC.PprofListenAddress == defaultCometCfg.RPC.PprofListenAddress {
 			conf.RPC.PprofListenAddress = "localhost:6060"

--- a/server/util.go
+++ b/server/util.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"strings"
 	"syscall"
+	"time"
 
 	cmtcmd "github.com/cometbft/cometbft/v2/cmd/cometbft/commands"
 	cmtcfg "github.com/cometbft/cometbft/v2/config"
@@ -262,6 +263,11 @@ func interceptConfigs(rootViper *viper.Viper, customAppTemplate string, customCo
 		}
 
 		defaultCometCfg := cmtcfg.DefaultConfig()
+		// The SDK is opinionated about those comet values, so we set them here.
+		// We verify first that the user has not changed them for not overriding them.
+		if conf.Consensus.TimeoutCommit == defaultCometCfg.Consensus.TimeoutCommit {
+			conf.Consensus.TimeoutCommit = 5 * time.Second
+		}
 		if conf.RPC.PprofListenAddress == defaultCometCfg.RPC.PprofListenAddress {
 			conf.RPC.PprofListenAddress = "localhost:6060"
 		}

--- a/simapp/simd/cmd/testnet.go
+++ b/simapp/simd/cmd/testnet.go
@@ -51,11 +51,8 @@ var (
 	flagAPIAddress        = "api.address"
 	flagPrintMnemonic     = "print-mnemonic"
 	flagStakingDenom      = "staking-denom"
-	// flagCommitTimeout is a deprecated flag whose value will not be used.
-	//
-	// Deprecated: set NextBlockDelay on the app with baseapp.SetNextBlockDelay()
-	flagCommitTimeout = "commit-timeout"
-	flagSingleHost    = "single-host"
+	flagCommitTimeout     = "commit-timeout"
+	flagSingleHost        = "single-host"
 )
 
 type initArgs struct {
@@ -74,18 +71,17 @@ type initArgs struct {
 }
 
 type startArgs struct {
-	algo          string
-	apiAddress    string
-	chainID       string
-	enableLogging bool
-	grpcAddress   string
-	minGasPrices  string
-	numValidators int
-	outputDir     string
-	printMnemonic bool
-	rpcAddress    string
-	// Deprecated: use baseapp.SetNextBlockDelay() instead.
-	timeoutCommit time.Duration
+	algo           string
+	apiAddress     string
+	chainID        string
+	enableLogging  bool
+	grpcAddress    string
+	minGasPrices   string
+	numValidators  int
+	outputDir      string
+	printMnemonic  bool
+	rpcAddress     string
+	nextBlockDelay time.Duration
 }
 
 func addTestnetFlagsToCmd(cmd *cobra.Command) {
@@ -174,7 +170,7 @@ Example:
 	cmd.Flags().String(flagStartingIPAddress, "192.168.0.1", "Starting IP address (192.168.0.1 results in persistent peers list ID0@192.168.0.1:46656, ID1@192.168.0.2:46656, ...)")
 	cmd.Flags().String(flagListenIPAddress, "0.0.0.0", "TCP or UNIX socket IP address for the RPC server to listen on")
 	cmd.Flags().String(flags.FlagKeyringBackend, flags.DefaultKeyringBackend, "Select keyring's backend (os|file|test)")
-	cmd.Flags().Duration(flagCommitTimeout, 5*time.Second, "Time to wait after a block commit before starting on the new height")
+	cmd.Flags().Duration(flagCommitTimeout, 5*time.Second, "Time to wait after a block commit before starting on the new height - DEPRECATED - use --next")
 	cmd.Flags().Bool(flagSingleHost, false, "Cluster runs on a single host machine with different ports")
 	cmd.Flags().String(flagStakingDenom, sdk.DefaultBondDenom, "Default staking token denominator")
 
@@ -205,6 +201,7 @@ Example:
 			args.apiAddress, _ = cmd.Flags().GetString(flagAPIAddress)
 			args.grpcAddress, _ = cmd.Flags().GetString(flagGRPCAddress)
 			args.printMnemonic, _ = cmd.Flags().GetBool(flagPrintMnemonic)
+			args.nextBlockDelay, _ = cmd.Flags().GetDuration(flagCommitTimeout)
 
 			return startTestnet(cmd, args)
 		},
@@ -454,9 +451,14 @@ func initGenFiles(
 }
 
 func collectGenFiles(
-	clientCtx client.Context, nodeConfig *cmtconfig.Config, chainID string,
-	nodeIDs []string, valPubKeys []cryptotypes.PubKey, numValidators int,
-	outputDir, nodeDirPrefix, nodeDaemonHome string, genBalIterator banktypes.GenesisBalancesIterator,
+	clientCtx client.Context,
+	nodeConfig *cmtconfig.Config,
+	chainID string,
+	nodeIDs []string,
+	valPubKeys []cryptotypes.PubKey,
+	numValidators int,
+	outputDir, nodeDirPrefix, nodeDaemonHome string,
+	genBalIterator banktypes.GenesisBalancesIterator,
 	rpcPortStart, p2pPortStart int,
 	singleMachine bool,
 ) error {
@@ -570,7 +572,7 @@ func startTestnet(cmd *cobra.Command, args startArgs) error {
 	networkConfig.APIAddress = args.apiAddress
 	networkConfig.GRPCAddress = args.grpcAddress
 	networkConfig.PrintMnemonic = args.printMnemonic
-	networkConfig.TimeoutCommit = args.timeoutCommit
+	networkConfig.TimeoutCommit = args.nextBlockDelay
 	networkLogger := network.NewCLILogger(cmd)
 
 	baseDir := fmt.Sprintf("%s/%s", args.outputDir, networkConfig.ChainID)

--- a/simapp/simd/cmd/testnet.go
+++ b/simapp/simd/cmd/testnet.go
@@ -171,7 +171,7 @@ Example:
 	cmd.Flags().String(flagStartingIPAddress, "192.168.0.1", "Starting IP address (192.168.0.1 results in persistent peers list ID0@192.168.0.1:46656, ID1@192.168.0.2:46656, ...)")
 	cmd.Flags().String(flagListenIPAddress, "0.0.0.0", "TCP or UNIX socket IP address for the RPC server to listen on")
 	cmd.Flags().String(flags.FlagKeyringBackend, flags.DefaultKeyringBackend, "Select keyring's backend (os|file|test)")
-	cmd.Flags().Duration(flagCommitTimeout, 5*time.Second, "Time to wait after a block commit before starting on the new height - DEPRECATED - use --next")
+	cmd.Flags().Duration(flagCommitTimeout, 5*time.Second, "Time to wait after a block commit before starting on the new height")
 	cmd.Flags().Bool(flagSingleHost, false, "Cluster runs on a single host machine with different ports")
 	cmd.Flags().String(flagStakingDenom, sdk.DefaultBondDenom, "Default staking token denominator")
 

--- a/simapp/simd/cmd/testnet.go
+++ b/simapp/simd/cmd/testnet.go
@@ -156,7 +156,7 @@ Example:
 			args.algo, _ = cmd.Flags().GetString(flags.FlagKeyType)
 			args.bondTokenDenom, _ = cmd.Flags().GetString(flagStakingDenom)
 			args.singleMachine, _ = cmd.Flags().GetBool(flagSingleHost)
-			config.Consensus.TimeoutCommit, err = cmd.Flags().GetDuration(flagCommitTimeout)
+			config.Consensus.TimeoutCommit, err = cmd.Flags().GetDuration(flagCommitTimeout) // nolint: staticcheck // we are continuing to use this value for backwards compatibility
 			if err != nil {
 				return err
 			}

--- a/simapp/simd/cmd/testnet.go
+++ b/simapp/simd/cmd/testnet.go
@@ -71,17 +71,17 @@ type initArgs struct {
 }
 
 type startArgs struct {
-	algo           string
-	apiAddress     string
-	chainID        string
-	enableLogging  bool
-	grpcAddress    string
-	minGasPrices   string
-	numValidators  int
-	outputDir      string
-	printMnemonic  bool
-	rpcAddress     string
-	nextBlockDelay time.Duration
+	algo          string
+	apiAddress    string
+	chainID       string
+	enableLogging bool
+	grpcAddress   string
+	minGasPrices  string
+	numValidators int
+	outputDir     string
+	printMnemonic bool
+	rpcAddress    string
+	timeoutCommit time.Duration
 }
 
 func addTestnetFlagsToCmd(cmd *cobra.Command) {
@@ -156,6 +156,7 @@ Example:
 			args.algo, _ = cmd.Flags().GetString(flags.FlagKeyType)
 			args.bondTokenDenom, _ = cmd.Flags().GetString(flagStakingDenom)
 			args.singleMachine, _ = cmd.Flags().GetBool(flagSingleHost)
+			config.Consensus.TimeoutCommit, err = cmd.Flags().GetDuration(flagCommitTimeout)
 			if err != nil {
 				return err
 			}
@@ -201,7 +202,7 @@ Example:
 			args.apiAddress, _ = cmd.Flags().GetString(flagAPIAddress)
 			args.grpcAddress, _ = cmd.Flags().GetString(flagGRPCAddress)
 			args.printMnemonic, _ = cmd.Flags().GetBool(flagPrintMnemonic)
-			args.nextBlockDelay, _ = cmd.Flags().GetDuration(flagCommitTimeout)
+			args.timeoutCommit, _ = cmd.Flags().GetDuration(flagCommitTimeout)
 
 			return startTestnet(cmd, args)
 		},
@@ -572,7 +573,7 @@ func startTestnet(cmd *cobra.Command, args startArgs) error {
 	networkConfig.APIAddress = args.apiAddress
 	networkConfig.GRPCAddress = args.grpcAddress
 	networkConfig.PrintMnemonic = args.printMnemonic
-	networkConfig.TimeoutCommit = args.nextBlockDelay
+	networkConfig.TimeoutCommit = args.timeoutCommit
 	networkLogger := network.NewCLILogger(cmd)
 
 	baseDir := fmt.Sprintf("%s/%s", args.outputDir, networkConfig.ChainID)

--- a/tests/systemtests/upgrade_test.go
+++ b/tests/systemtests/upgrade_test.go
@@ -19,7 +19,7 @@ import (
 
 const (
 	testSeed            = "scene learn remember glide apple expand quality spawn property shoe lamp carry upset blossom draft reject aim file trash miss script joy only measure"
-	upgradeHeight int64 = 45
+	upgradeHeight int64 = 22
 	upgradeName         = "v053-to-v054" // must match UpgradeName in simapp/upgrades.go
 )
 
@@ -28,7 +28,7 @@ func TestChainUpgrade(t *testing.T) {
 	// start a legacy chain with some state
 	// when a chain upgrade proposal is executed
 	// then the chain upgrades successfully
-	systest.Sut.ResetChain(t)
+	systest.Sut.StopChain()
 
 	currentBranchBinary := systest.Sut.ExecBinary()
 	currentInitializer := systest.Sut.TestnetInitializer()
@@ -67,10 +67,8 @@ func TestChainUpgrade(t *testing.T) {
 	raw := cli.CustomQuery("q", "gov", "proposal", proposalID)
 	t.Log(raw)
 
-	// generous timeout as this could run faster or slower based on HW or in CI
-	systest.Sut.AwaitBlockHeight(t, upgradeHeight-1, 2*time.Minute)
+	systest.Sut.AwaitBlockHeight(t, upgradeHeight-1, 60*time.Second)
 	t.Logf("current_height: %d\n", systest.Sut.CurrentHeight())
-
 	raw = cli.CustomQuery("q", "gov", "proposal", proposalID)
 	proposalStatus := gjson.Get(raw, "proposal.status").String()
 	require.Equal(t, "PROPOSAL_STATUS_PASSED", proposalStatus, raw)
@@ -84,7 +82,7 @@ func TestChainUpgrade(t *testing.T) {
 	systest.Sut.SetTestnetInitializer(currentInitializer)
 	systest.Sut.StartChain(t)
 
-	require.True(t, upgradeHeight+1 <= systest.Sut.CurrentHeight())
+	require.Equal(t, upgradeHeight+1, systest.Sut.CurrentHeight())
 
 	regex, err := regexp.Compile("DBG this is a debug level message to test that verbose logging mode has properly been enabled during a chain upgrade")
 	require.NoError(t, err)

--- a/tests/systemtests/upgrade_test.go
+++ b/tests/systemtests/upgrade_test.go
@@ -82,7 +82,7 @@ func TestChainUpgrade(t *testing.T) {
 	systest.Sut.SetTestnetInitializer(currentInitializer)
 	systest.Sut.StartChain(t)
 
-	require.Equal(t, upgradeHeight+1, systest.Sut.CurrentHeight())
+	require.True(t, upgradeHeight+1 < systest.Sut.CurrentHeight())
 
 	regex, err := regexp.Compile("DBG this is a debug level message to test that verbose logging mode has properly been enabled during a chain upgrade")
 	require.NoError(t, err)

--- a/testutil/network/network.go
+++ b/testutil/network/network.go
@@ -381,7 +381,7 @@ func New(l Logger, baseDir string, cfg Config) (*Network, error) {
 
 		ctx := server.NewDefaultContext()
 		cmtCfg := ctx.Config
-		cmtCfg.Consensus.TimeoutCommit = cfg.TimeoutCommit
+		cmtCfg.Consensus.TimeoutCommit = cfg.TimeoutCommit // nolint: staticcheck // we are continuing to use this value for backwards compatibility
 
 		// Only allow the first validator to expose an RPC, API and gRPC
 		// server/client due to CometBFT in-process constraints.

--- a/testutil/network/network.go
+++ b/testutil/network/network.go
@@ -381,6 +381,7 @@ func New(l Logger, baseDir string, cfg Config) (*Network, error) {
 
 		ctx := server.NewDefaultContext()
 		cmtCfg := ctx.Config
+		cmtCfg.Consensus.TimeoutCommit = cfg.TimeoutCommit
 
 		// Only allow the first validator to expose an RPC, API and gRPC
 		// server/client due to CometBFT in-process constraints.

--- a/x/group/client/cli/tx.go
+++ b/x/group/client/cli/tx.go
@@ -15,7 +15,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/tx"
 	"github.com/cosmos/cosmos-sdk/version"
-	"github.com/cosmos/cosmos-sdk/x/group" //nolint:staticcheck // deprecated and to be removed
+	"github.com/cosmos/cosmos-sdk/x/group" // nolint: staticcheck // to be removed
 	"github.com/cosmos/cosmos-sdk/x/group/internal/math"
 )
 

--- a/x/group/client/cli/util.go
+++ b/x/group/client/cli/util.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/cosmos/cosmos-sdk/x/group" //nolint:staticcheck // deprecated and to be removed
+	"github.com/cosmos/cosmos-sdk/x/group" // nolint: staticcheck // to be removed
 )
 
 // parseDecisionPolicy reads and parses the decision policy.

--- a/x/group/keeper/genesis.go
+++ b/x/group/keeper/genesis.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/types"
-	"github.com/cosmos/cosmos-sdk/x/group" //nolint:staticcheck // deprecated and to be removed
+	"github.com/cosmos/cosmos-sdk/x/group" // nolint: staticcheck // to be removed
 )
 
 // InitGenesis initializes the group module's genesis state.

--- a/x/group/keeper/grpc_query.go
+++ b/x/group/keeper/grpc_query.go
@@ -11,7 +11,7 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/query"
-	"github.com/cosmos/cosmos-sdk/x/group" //nolint:staticcheck // deprecated and to be removed
+	"github.com/cosmos/cosmos-sdk/x/group" // nolint: staticcheck // to be removed
 	"github.com/cosmos/cosmos-sdk/x/group/errors"
 	"github.com/cosmos/cosmos-sdk/x/group/internal/orm"
 )

--- a/x/group/keeper/keeper.go
+++ b/x/group/keeper/keeper.go
@@ -13,7 +13,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/cosmos/cosmos-sdk/x/group" //nolint:staticcheck // deprecated and to be removed
+	"github.com/cosmos/cosmos-sdk/x/group" // nolint: staticcheck // to be removed
 	"github.com/cosmos/cosmos-sdk/x/group/errors"
 	"github.com/cosmos/cosmos-sdk/x/group/internal/orm"
 )

--- a/x/group/keeper/msg_server.go
+++ b/x/group/keeper/msg_server.go
@@ -15,7 +15,7 @@ import (
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
-	"github.com/cosmos/cosmos-sdk/x/group" //nolint:staticcheck // deprecated and to be removed
+	"github.com/cosmos/cosmos-sdk/x/group" // nolint: staticcheck // to be removed
 	"github.com/cosmos/cosmos-sdk/x/group/errors"
 	"github.com/cosmos/cosmos-sdk/x/group/internal/math"
 	"github.com/cosmos/cosmos-sdk/x/group/internal/orm"

--- a/x/group/keeper/msg_server_priv_test.go
+++ b/x/group/keeper/msg_server_priv_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/testutil"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
-	"github.com/cosmos/cosmos-sdk/x/group" //nolint:staticcheck // deprecated and to be removed
+	"github.com/cosmos/cosmos-sdk/x/group" // nolint: staticcheck // to be removed
 	"github.com/cosmos/cosmos-sdk/x/group/internal/math"
 )
 

--- a/x/group/keeper/proposal_executor.go
+++ b/x/group/keeper/proposal_executor.go
@@ -10,7 +10,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-	"github.com/cosmos/cosmos-sdk/x/group" //nolint:staticcheck // deprecated and to be removed
+	"github.com/cosmos/cosmos-sdk/x/group" // nolint: staticcheck // to be removed
 	"github.com/cosmos/cosmos-sdk/x/group/errors"
 )
 

--- a/x/group/keeper/tally.go
+++ b/x/group/keeper/tally.go
@@ -5,7 +5,7 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-	"github.com/cosmos/cosmos-sdk/x/group" //nolint:staticcheck // deprecated and to be removed
+	"github.com/cosmos/cosmos-sdk/x/group" // nolint: staticcheck // to be removed
 	"github.com/cosmos/cosmos-sdk/x/group/errors"
 	"github.com/cosmos/cosmos-sdk/x/group/internal/orm"
 )


### PR DESCRIPTION
- Set defaultNextBlockDelay to 0 
- the side effect of this is that the default `config.toml` value used before by validators will be picked up and used

This allows developers to set `NextBlockDelay` if they desire in the new way, but keeps the legacy behavior from flags and from the configs.