### PR TITLE
feat: add conversion function from comet type to sdk crypto type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### Features
 
 * (server) [#24720](https://github.com/cosmos/cosmos-sdk/pull/24720) add `verbose_log_level` flag for configuring the log level when switching to verbose logging mode during sensitive operations (such as chain upgrades).
+* (crypto) [#24861](https://github.com/cosmos/cosmos-sdk/pull/24861) add `PubKeyFromCometTypeAndBytes` helper function to convert from `comet/v2` PubKeys to the `cryptotypes.Pubkey` interface.
 
 ### Improvements
 

--- a/crypto/keys/convert.go
+++ b/crypto/keys/convert.go
@@ -1,0 +1,48 @@
+package keys
+
+import (
+	"github.com/cometbft/cometbft/v2/crypto/ed25519"
+	"github.com/cometbft/cometbft/v2/crypto/encoding"
+	"github.com/cometbft/cometbft/v2/crypto/secp256k1"
+
+	cosmosed25519 "github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
+	cosmossecp256k1 "github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
+	"github.com/cosmos/cosmos-sdk/crypto/types"
+)
+
+// PubKeyFromTypeAndBytes builds a crypto.PubKey from the given type and bytes.
+// It returns ErrUnsupportedKey if the pubkey type is unsupported or
+// ErrInvalidKeyLen if the key length is invalid.
+func PubKeyFromTypeAndBytes(pkType string, bytes []byte) (types.PubKey, error) {
+	var pubKey types.PubKey
+	switch pkType {
+	case ed25519.KeyType:
+		if len(bytes) != ed25519.PubKeySize {
+			return nil, encoding.ErrInvalidKeyLen{
+				Key:  pkType,
+				Got:  len(bytes),
+				Want: ed25519.PubKeySize,
+			}
+		}
+
+		pk := make([]byte, ed25519.PubKeySize)
+		copy(pk, bytes)
+		pubKey = &cosmosed25519.PubKey{Key: pk}
+
+	case secp256k1.KeyType:
+		if len(bytes) != secp256k1.PubKeySize {
+			return nil, encoding.ErrInvalidKeyLen{
+				Key:  pkType,
+				Got:  len(bytes),
+				Want: secp256k1.PubKeySize,
+			}
+		}
+
+		pk := make([]byte, secp256k1.PubKeySize)
+		copy(pk, bytes)
+		pubKey = &cosmossecp256k1.PubKey{Key: pk}
+	default:
+		return nil, encoding.ErrUnsupportedKey{KeyType: pkType}
+	}
+	return pubKey, nil
+}

--- a/crypto/keys/convert.go
+++ b/crypto/keys/convert.go
@@ -10,10 +10,10 @@ import (
 	"github.com/cosmos/cosmos-sdk/crypto/types"
 )
 
-// PubKeyFromTypeAndBytes builds a crypto.PubKey from the given type and bytes.
+// PubKeyFromCometTypeAndBytes builds a crypto.PubKey from the given comet/v2 type and bytes.
 // It returns ErrUnsupportedKey if the pubkey type is unsupported or
 // ErrInvalidKeyLen if the key length is invalid.
-func PubKeyFromTypeAndBytes(pkType string, bytes []byte) (types.PubKey, error) {
+func PubKeyFromCometTypeAndBytes(pkType string, bytes []byte) (types.PubKey, error) {
 	var pubKey types.PubKey
 	switch pkType {
 	case ed25519.KeyType:

--- a/crypto/keys/convert_test.go
+++ b/crypto/keys/convert_test.go
@@ -13,13 +13,13 @@ import (
 	"github.com/cosmos/cosmos-sdk/crypto/keys"
 )
 
-func TestPubKeyFromTypeAndBytes(t *testing.T) {
+func TestPubKeyFromCometTypeAndBytes(t *testing.T) {
 	// --- ed25519 ---
 	edPriv := ed25519.GenPrivKey()
 	edPub := edPriv.PubKey()
 
 	// valid
-	pk, err := keys.PubKeyFromTypeAndBytes(edPub.Type(), edPub.Bytes())
+	pk, err := keys.PubKeyFromCometTypeAndBytes(edPub.Type(), edPub.Bytes())
 	require.NoError(t, err)
 	require.Equal(t, edPub.Type(), pk.Type())
 	require.Equal(t, edPub.Bytes(), pk.Bytes())
@@ -27,7 +27,7 @@ func TestPubKeyFromTypeAndBytes(t *testing.T) {
 	require.Equal(t, edPub.VerifySignature([]byte("msg"), []byte("sig")), pk.VerifySignature([]byte("msg"), []byte("sig")))
 
 	// invalid length
-	_, err = keys.PubKeyFromTypeAndBytes(edPub.Type(), edPub.Bytes()[:5])
+	_, err = keys.PubKeyFromCometTypeAndBytes(edPub.Type(), edPub.Bytes()[:5])
 	require.Error(t, err)
 	var invLen encoding.ErrInvalidKeyLen
 	require.ErrorAs(t, err, &invLen)
@@ -36,14 +36,14 @@ func TestPubKeyFromTypeAndBytes(t *testing.T) {
 	secpPriv := secp256k1.GenPrivKey()
 	secpPub := secpPriv.PubKey()
 
-	pk, err = keys.PubKeyFromTypeAndBytes(secpPub.Type(), secpPub.Bytes())
+	pk, err = keys.PubKeyFromCometTypeAndBytes(secpPub.Type(), secpPub.Bytes())
 	require.NoError(t, err)
 	require.Equal(t, secpPub.Type(), pk.Type())
 	require.Equal(t, secpPub.Bytes(), pk.Bytes())
 	require.Equal(t, secpPub.Address(), pk.Address())
 	require.Equal(t, secpPub.VerifySignature([]byte("msg"), []byte("sig")), pk.VerifySignature([]byte("msg"), []byte("sig")))
 
-	_, err = keys.PubKeyFromTypeAndBytes(secpPub.Type(), secpPub.Bytes()[:5])
+	_, err = keys.PubKeyFromCometTypeAndBytes(secpPub.Type(), secpPub.Bytes()[:5])
 	require.Error(t, err)
 	require.ErrorAs(t, err, &invLen)
 
@@ -52,19 +52,19 @@ func TestPubKeyFromTypeAndBytes(t *testing.T) {
 		ethPriv := secp256k1eth.GenPrivKey()
 		ethPub := ethPriv.PubKey()
 
-		pk, err = keys.PubKeyFromTypeAndBytes(ethPub.Type(), ethPub.Bytes())
+		pk, err = keys.PubKeyFromCometTypeAndBytes(ethPub.Type(), ethPub.Bytes())
 		require.NoError(t, err)
 		require.Equal(t, ethPub.Type(), pk.Type())
 		require.Equal(t, ethPub.Bytes(), pk.Bytes())
 		require.Equal(t, ethPub.Address(), pk.Address())
 		require.Equal(t, ethPub.VerifySignature([]byte("msg"), []byte("sig")), pk.VerifySignature([]byte("msg"), []byte("sig")))
 
-		_, err = keys.PubKeyFromTypeAndBytes(ethPub.Type(), ethPub.Bytes()[:5])
+		_, err = keys.PubKeyFromCometTypeAndBytes(ethPub.Type(), ethPub.Bytes()[:5])
 		require.Error(t, err)
 		require.ErrorAs(t, err, &invLen)
 	} else {
 		// should error if type known but not enabled
-		_, err := keys.PubKeyFromTypeAndBytes(secp256k1eth.KeyType, []byte{})
+		_, err := keys.PubKeyFromCometTypeAndBytes(secp256k1eth.KeyType, []byte{})
 		require.Error(t, err)
 	}
 
@@ -73,7 +73,7 @@ func TestPubKeyFromTypeAndBytes(t *testing.T) {
 	require.Error(t, err)
 
 	// --- unsupported type ---
-	_, err = keys.PubKeyFromTypeAndBytes("not-a-key", []byte{1, 2, 3})
+	_, err = keys.PubKeyFromCometTypeAndBytes("not-a-key", []byte{1, 2, 3})
 	require.Error(t, err)
 	var unsup encoding.ErrUnsupportedKey
 	require.ErrorAs(t, err, &unsup)

--- a/crypto/keys/convert_test.go
+++ b/crypto/keys/convert_test.go
@@ -68,26 +68,9 @@ func TestPubKeyFromTypeAndBytes(t *testing.T) {
 		require.Error(t, err)
 	}
 
-	// --- bls12381 (optional) ---
-	if bls12381.Enabled {
-		blsPriv, err := bls12381.GenPrivKey()
-		require.NoError(t, err)
-		blsPub := blsPriv.PubKey()
-
-		pk, err = keys.PubKeyFromTypeAndBytes(blsPub.Type(), blsPub.Bytes())
-		require.NoError(t, err)
-		require.Equal(t, blsPub.Type(), pk.Type())
-		require.Equal(t, blsPub.Bytes(), pk.Bytes())
-		require.Equal(t, blsPub.Address(), pk.Address())
-		require.Equal(t, blsPub.VerifySignature([]byte("msg"), []byte("sig")), pk.VerifySignature([]byte("msg"), []byte("sig")))
-
-		_, err = keys.PubKeyFromTypeAndBytes(blsPub.Type(), blsPub.Bytes()[:5])
-		require.Error(t, err)
-		require.ErrorAs(t, err, &invLen)
-	} else {
-		_, err := keys.PubKeyFromTypeAndBytes(bls12381.KeyType, []byte{})
-		require.Error(t, err)
-	}
+	// --- bls keys are not enabled in comet and should fail ---
+	_, err = bls12381.GenPrivKey()
+	require.Error(t, err)
 
 	// --- unsupported type ---
 	_, err = keys.PubKeyFromTypeAndBytes("not-a-key", []byte{1, 2, 3})

--- a/crypto/keys/convert_test.go
+++ b/crypto/keys/convert_test.go
@@ -1,0 +1,97 @@
+package keys_test
+
+import (
+	"testing"
+
+	"github.com/cometbft/cometbft/v2/crypto/bls12381"
+	"github.com/cometbft/cometbft/v2/crypto/ed25519"
+	"github.com/cometbft/cometbft/v2/crypto/encoding"
+	"github.com/cometbft/cometbft/v2/crypto/secp256k1"
+	"github.com/cometbft/cometbft/v2/crypto/secp256k1eth"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cosmos/cosmos-sdk/crypto/keys"
+)
+
+func TestPubKeyFromTypeAndBytes(t *testing.T) {
+	// --- ed25519 ---
+	edPriv := ed25519.GenPrivKey()
+	edPub := edPriv.PubKey()
+
+	// valid
+	pk, err := keys.PubKeyFromTypeAndBytes(edPub.Type(), edPub.Bytes())
+	require.NoError(t, err)
+	require.Equal(t, edPub.Type(), pk.Type())
+	require.Equal(t, edPub.Bytes(), pk.Bytes())
+	require.Equal(t, edPub.Address(), pk.Address())
+	require.Equal(t, edPub.VerifySignature([]byte("msg"), []byte("sig")), pk.VerifySignature([]byte("msg"), []byte("sig")))
+
+	// invalid length
+	_, err = keys.PubKeyFromTypeAndBytes(edPub.Type(), edPub.Bytes()[:5])
+	require.Error(t, err)
+	var invLen encoding.ErrInvalidKeyLen
+	require.ErrorAs(t, err, &invLen)
+
+	// --- secp256k1 ---
+	secpPriv := secp256k1.GenPrivKey()
+	secpPub := secpPriv.PubKey()
+
+	pk, err = keys.PubKeyFromTypeAndBytes(secpPub.Type(), secpPub.Bytes())
+	require.NoError(t, err)
+	require.Equal(t, secpPub.Type(), pk.Type())
+	require.Equal(t, secpPub.Bytes(), pk.Bytes())
+	require.Equal(t, secpPub.Address(), pk.Address())
+	require.Equal(t, secpPub.VerifySignature([]byte("msg"), []byte("sig")), pk.VerifySignature([]byte("msg"), []byte("sig")))
+
+	_, err = keys.PubKeyFromTypeAndBytes(secpPub.Type(), secpPub.Bytes()[:5])
+	require.Error(t, err)
+	require.ErrorAs(t, err, &invLen)
+
+	// --- secp256k1eth (optional) ---
+	if secp256k1eth.Enabled {
+		ethPriv := secp256k1eth.GenPrivKey()
+		ethPub := ethPriv.PubKey()
+
+		pk, err = keys.PubKeyFromTypeAndBytes(ethPub.Type(), ethPub.Bytes())
+		require.NoError(t, err)
+		require.Equal(t, ethPub.Type(), pk.Type())
+		require.Equal(t, ethPub.Bytes(), pk.Bytes())
+		require.Equal(t, ethPub.Address(), pk.Address())
+		require.Equal(t, ethPub.VerifySignature([]byte("msg"), []byte("sig")), pk.VerifySignature([]byte("msg"), []byte("sig")))
+
+		_, err = keys.PubKeyFromTypeAndBytes(ethPub.Type(), ethPub.Bytes()[:5])
+		require.Error(t, err)
+		require.ErrorAs(t, err, &invLen)
+	} else {
+		// should error if type known but not enabled
+		_, err := keys.PubKeyFromTypeAndBytes(secp256k1eth.KeyType, []byte{})
+		require.Error(t, err)
+	}
+
+	// --- bls12381 (optional) ---
+	if bls12381.Enabled {
+		blsPriv, err := bls12381.GenPrivKey()
+		require.NoError(t, err)
+		blsPub := blsPriv.PubKey()
+
+		pk, err = keys.PubKeyFromTypeAndBytes(blsPub.Type(), blsPub.Bytes())
+		require.NoError(t, err)
+		require.Equal(t, blsPub.Type(), pk.Type())
+		require.Equal(t, blsPub.Bytes(), pk.Bytes())
+		require.Equal(t, blsPub.Address(), pk.Address())
+		require.Equal(t, blsPub.VerifySignature([]byte("msg"), []byte("sig")), pk.VerifySignature([]byte("msg"), []byte("sig")))
+
+		_, err = keys.PubKeyFromTypeAndBytes(blsPub.Type(), blsPub.Bytes()[:5])
+		require.Error(t, err)
+		require.ErrorAs(t, err, &invLen)
+	} else {
+		_, err := keys.PubKeyFromTypeAndBytes(bls12381.KeyType, []byte{})
+		require.Error(t, err)
+	}
+
+	// --- unsupported type ---
+	_, err = keys.PubKeyFromTypeAndBytes("not-a-key", []byte{1, 2, 3})
+	require.Error(t, err)
+	var unsup encoding.ErrUnsupportedKey
+	require.ErrorAs(t, err, &unsup)
+}

--- a/crypto/types/types.go
+++ b/crypto/types/types.go
@@ -1,7 +1,10 @@
 package types
 
 import (
+	"github.com/cometbft/cometbft/crypto"
 	cmtcrypto "github.com/cometbft/cometbft/v2/crypto"
+	"github.com/cometbft/cometbft/v2/crypto/bls12381"
+	"github.com/cometbft/cometbft/v2/crypto/secp256k1eth"
 	proto "github.com/cosmos/gogoproto/proto"
 )
 

--- a/crypto/types/types.go
+++ b/crypto/types/types.go
@@ -1,10 +1,7 @@
 package types
 
 import (
-	"github.com/cometbft/cometbft/crypto"
 	cmtcrypto "github.com/cometbft/cometbft/v2/crypto"
-	"github.com/cometbft/cometbft/v2/crypto/bls12381"
-	"github.com/cometbft/cometbft/v2/crypto/secp256k1eth"
 	proto "github.com/cosmos/gogoproto/proto"
 )
 


### PR DESCRIPTION
need to add changelog

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for reconstructing public keys from key type and byte data for Ed25519 and Secp256k1.
- **Tests**
  - Introduced comprehensive tests to verify public key reconstruction, error handling for invalid key types and lengths, and compatibility checks for supported key types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->