### PR TITLE
Fix invalid proto semicolon lines

### DIFF
--- a/proto/cosmos/gov/v1/genesis.proto
+++ b/proto/cosmos/gov/v1/genesis.proto
@@ -28,7 +28,6 @@ message GenesisState {
   TallyParams tally_params = 7 [deprecated = true];
   // params defines all the paramaters of x/gov module.
   Params params = 8 [(cosmos_proto.field_added_in) = "cosmos-sdk 0.47"];
-  ;
   // The constitution allows builders to lay a foundation and define purpose.
   // This is an immutable string set in genesis.
   // There are no amendments, to go outside of scope, just fork.

--- a/proto/cosmos/gov/v1/gov.proto
+++ b/proto/cosmos/gov/v1/gov.proto
@@ -85,11 +85,9 @@ message Proposal {
 
   // title is the title of the proposal
   string title = 11 [(cosmos_proto.field_added_in) = "cosmos-sdk 0.47"];
-  ;
 
   // summary is a short summary of the proposal
   string summary = 12 [(cosmos_proto.field_added_in) = "cosmos-sdk 0.47"];
-  ;
 
   // proposer is the address of the proposal sumbitter
   string proposer = 13


### PR DESCRIPTION
# Description

This removes 3 dead semi-colon lines in 2 `cosmos/gov/v1` proto files. These aren't valid lines and throw errors in some downstream tools depending on the strictness of their settings (e.g. Telescope).


Closes: [no issue but can open for documentation if needed]

`cosmos/gov/v1/gov.proto` has 2 lines removed
`cosmos/gov/v1/genesis.proto` has 1 line removed

Neither of these have functional changes.