### PR TITLE
Update Changelog Link in UPGRADING.md

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -10,7 +10,7 @@ Note, always read the **App Wiring Changes** section for more information on app
 
 **The only major feature in Cosmos SDK v0.54.x is the upgrade from CometBFT v0.x.x to CometBFT v2.**
 
-For a full list of changes, see the [Changelog](https://github.com/cosmos/cosmos-sdk/blob/release/v0.54.x/CHANGELOG.md).
+For a full list of changes, see the [Changelog](https://github.com/cosmos/cosmos-sdk/blob/main/CHANGELOG.md).
 
 #### Deprecation of `TimeoutCommit`
 


### PR DESCRIPTION
Old Link: https://github.com/cosmos/cosmos-sdk/blob/release/v0.54.x/CHANGELOG.md
New Link: https://github.com/cosmos/cosmos-sdk/blob/main/CHANGELOG.

The link to the changelog was updated to point to the main branch, ensuring that users have access to the most current and comprehensive list of changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the upgrade guide to reference the main branch for the full changelog link in the Cosmos SDK v0.54.x documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->