### PR TITLE
docs: fix typos in documentation and error messages

### DIFF
--- a/crypto/keyring/errors.go
+++ b/crypto/keyring/errors.go
@@ -15,7 +15,7 @@ var (
 	ErrOverwriteKey = errors.New("cannot overwrite key")
 	// ErrKeyAlreadyExists is raised when creating a key that already exists
 	ErrKeyAlreadyExists = errors.Newf("key already exists")
-	// ErrInvalidSignMode is raised when trying to sign with an invaled method
+	// ErrInvalidSignMode is raised when trying to sign with an invalid method
 	ErrInvalidSignMode = errors.New("invalid sign mode, expected LEGACY_AMINO_JSON or TEXTUAL")
 	// ErrMaxPassPhraseAttempts is raised when the maxPassphraseEntryAttempts is reached
 	ErrMaxPassPhraseAttempts = errors.New("too many failed passphrase attempts")

--- a/x/staking/README.md
+++ b/x/staking/README.md
@@ -464,7 +464,7 @@ When a Validator is slashed, the following occurs:
 
 * The total `slashAmount` is calculated as the `slashFactor` (a chain parameter) \* `TokensFromConsensusPower`,
   the total number of tokens bonded to the validator at the time of the infraction.
-* Every unbonding delegation and pseudo-unbonding redelegation such that the infraction occured before the unbonding or
+* Every unbonding delegation and pseudo-unbonding redelegation such that the infraction occurred before the unbonding or
   redelegation began from the validator are slashed by the `slashFactor` percentage of the initialBalance.
 * Each amount slashed from redelegations and unbonding delegations is subtracted from the
   total slash amount.
@@ -472,7 +472,7 @@ When a Validator is slashed, the following occurs:
   `NonBondedPool` depending on the validator's status. This reduces the total supply of tokens.
 
 In the case of a slash due to any infraction that requires evidence to submitted (for example double-sign), the slash
-occurs at the block where the evidence is included, not at the block where the infraction occured.
+occurs at the block where the evidence is included, not at the block where the infraction occurred.
 Put otherwise, validators are not slashed retroactively, only when they are caught.
 
 #### Slash Unbonding Delegation


### PR DESCRIPTION


**Description:**  
This pull request corrects several typographical errors in documentation and error messages:
- Fixed "occured" to "occurred" in `x/staking/README.md`
- Fixed "invaled" to "invalid" in `crypto/keyring/errors.go`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected typographical errors in comments and documentation to improve clarity and accuracy. No functional changes were made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->