### PR TITLE
Feat/cachemultistore snapshot

### DIFF
--- a/store/cachekv/store.go
+++ b/store/cachekv/store.go
@@ -171,6 +171,38 @@ func (store *Store) CacheWrapWithTrace(w io.Writer, tc types.TraceContext) types
 	return NewStore(tracekv.NewStore(store, w, tc))
 }
 
+// Copy creates a deep copy of the Store object
+func (store *Store) Copy() types.CacheKVStore {
+	store.mtx.Lock()
+	defer store.mtx.Unlock()
+
+	// Copy cache
+	cacheCopy := make(map[string]*cValue, len(store.cache))
+	for key, val := range store.cache {
+		newVal := *val // Create a copy of the cValue
+		cacheCopy[key] = &newVal
+	}
+
+	// Copy unsortedCache
+	unsortedCacheCopy := make(map[string]struct{}, len(store.unsortedCache))
+	for key := range store.unsortedCache {
+		unsortedCacheCopy[key] = struct{}{}
+	}
+
+	// Copy sortedCache
+	sortedCacheCopy := store.sortedCache.Copy()
+
+	// Create new Store with copied values
+	newStore := &Store{
+		cache:         cacheCopy,
+		unsortedCache: unsortedCacheCopy,
+		sortedCache:   sortedCacheCopy,
+		parent:        store.parent,
+	}
+
+	return newStore
+}
+
 //----------------------------------------
 // Iteration
 

--- a/store/cachekv/store.go
+++ b/store/cachekv/store.go
@@ -171,38 +171,6 @@ func (store *Store) CacheWrapWithTrace(w io.Writer, tc types.TraceContext) types
 	return NewStore(tracekv.NewStore(store, w, tc))
 }
 
-// Copy creates a deep copy of the Store object
-func (store *Store) Copy() types.CacheKVStore {
-	store.mtx.Lock()
-	defer store.mtx.Unlock()
-
-	// Copy cache
-	cacheCopy := make(map[string]*cValue, len(store.cache))
-	for key, val := range store.cache {
-		newVal := *val // Create a copy of the cValue
-		cacheCopy[key] = &newVal
-	}
-
-	// Copy unsortedCache
-	unsortedCacheCopy := make(map[string]struct{}, len(store.unsortedCache))
-	for key := range store.unsortedCache {
-		unsortedCacheCopy[key] = struct{}{}
-	}
-
-	// Copy sortedCache
-	sortedCacheCopy := store.sortedCache.Copy()
-
-	// Create new Store with copied values
-	newStore := &Store{
-		cache:         cacheCopy,
-		unsortedCache: unsortedCacheCopy,
-		sortedCache:   sortedCacheCopy,
-		parent:        store.parent,
-	}
-
-	return newStore
-}
-
 // Clone creates a copy-on-write snapshot of the Store.
 func (store *Store) Clone() types.BranchStore {
 	store.mtx.Lock()

--- a/store/cachemulti/store.go
+++ b/store/cachemulti/store.go
@@ -167,3 +167,29 @@ func (cms Store) GetKVStore(key types.StoreKey) types.KVStore {
 	}
 	return store.(types.KVStore)
 }
+
+// Copy creates a deep copy of the Store object
+func (cms Store) Copy() types.CacheMultiStore {
+	// Deep copy the db field
+	newDB := cms.db.Copy()
+
+	// Deep copy the cachekv stores map
+	newStores := make(map[types.StoreKey]types.CacheWrap, len(cms.stores))
+	for key, store := range cms.stores {
+		store, ok := store.(*cachekv.Store)
+		if ok {
+			newStores[key] = store.Copy()
+		}
+	}
+
+	// Create new Store with copied values
+	newStore := Store{
+		db:           newDB,
+		stores:       newStores,
+		keys:         cms.keys,
+		traceWriter:  cms.traceWriter,
+		traceContext: cms.traceContext,
+	}
+
+	return newStore
+}

--- a/store/cachemulti/store.go
+++ b/store/cachemulti/store.go
@@ -168,32 +168,6 @@ func (cms Store) GetKVStore(key types.StoreKey) types.KVStore {
 	return store.(types.KVStore)
 }
 
-// Copy creates a deep copy of the Store object
-func (cms Store) Copy() types.CacheMultiStore {
-	// Deep copy the db field
-	newDB := cms.db.Copy()
-
-	// Deep copy the cachekv stores map
-	newStores := make(map[types.StoreKey]types.CacheWrap, len(cms.stores))
-	for key, store := range cms.stores {
-		store, ok := store.(*cachekv.Store)
-		if ok {
-			newStores[key] = store.Copy()
-		}
-	}
-
-	// Create new Store with copied values
-	newStore := Store{
-		db:           newDB,
-		stores:       newStores,
-		keys:         cms.keys,
-		traceWriter:  cms.traceWriter,
-		traceContext: cms.traceContext,
-	}
-
-	return newStore
-}
-
 // Clone creates a copy-on-write snapshot of the multistore.
 func (cms Store) Clone() Store {
 	newDB := cms.db.(types.BranchStore).Clone().(types.CacheKVStore)

--- a/store/types/store.go
+++ b/store/types/store.go
@@ -150,7 +150,6 @@ type MultiStore interface {
 type CacheMultiStore interface {
 	MultiStore
 	Write() // Writes operations to underlying KVStore
-	Copy() CacheMultiStore
 }
 
 // CommitMultiStore is an interface for a MultiStore without cache capabilities.
@@ -275,7 +274,7 @@ type CacheKVStore interface {
 
 	// Writes operations to underlying KVStore
 	Write()
-	Copy() CacheKVStore
+	Discard()
 }
 
 // CommitKVStore is an interface for MultiStore.

--- a/store/types/store.go
+++ b/store/types/store.go
@@ -295,6 +295,9 @@ type CacheWrap interface {
 	// Write syncs with the underlying store.
 	Write()
 
+	// Discard clears the pending write set without applying it to the parent store.
+	Discard()
+
 	// CacheWrap recursively wraps again.
 	CacheWrap() CacheWrap
 
@@ -308,6 +311,15 @@ type CacheWrapper interface {
 
 	// CacheWrapWithTrace branches a store with tracing enabled.
 	CacheWrapWithTrace(w io.Writer, tc TraceContext) CacheWrap
+}
+
+// BranchStore represents a cache store that can be cloned and restored.
+type BranchStore interface {
+	// Clone returns a copy-on-write snapshot of the store.
+	Clone() BranchStore
+
+	// Restore replaces the store's contents with that of the given snapshot.
+	Restore(BranchStore)
 }
 
 func (cid CommitID) IsZero() bool {

--- a/store/types/store.go
+++ b/store/types/store.go
@@ -150,6 +150,9 @@ type MultiStore interface {
 type CacheMultiStore interface {
 	MultiStore
 	Write() // Writes operations to underlying KVStore
+
+	// Clone returns a sibling store of CacheMultiStore
+	Clone() CacheMultiStore
 }
 
 // CommitMultiStore is an interface for a MultiStore without cache capabilities.
@@ -274,7 +277,8 @@ type CacheKVStore interface {
 
 	// Writes operations to underlying KVStore
 	Write()
-	Discard()
+	// Clone creates a new Store object with same parent
+	Clone() CacheKVStore
 }
 
 // CommitKVStore is an interface for MultiStore.
@@ -294,9 +298,6 @@ type CacheWrap interface {
 	// Write syncs with the underlying store.
 	Write()
 
-	// Discard clears the pending write set without applying it to the parent store.
-	Discard()
-
 	// CacheWrap recursively wraps again.
 	CacheWrap() CacheWrap
 
@@ -310,15 +311,6 @@ type CacheWrapper interface {
 
 	// CacheWrapWithTrace branches a store with tracing enabled.
 	CacheWrapWithTrace(w io.Writer, tc TraceContext) CacheWrap
-}
-
-// BranchStore represents a cache store that can be cloned and restored.
-type BranchStore interface {
-	// Clone returns a copy-on-write snapshot of the store.
-	Clone() BranchStore
-
-	// Restore replaces the store's contents with that of the given snapshot.
-	Restore(BranchStore)
 }
 
 func (cid CommitID) IsZero() bool {

--- a/store/types/store.go
+++ b/store/types/store.go
@@ -150,6 +150,7 @@ type MultiStore interface {
 type CacheMultiStore interface {
 	MultiStore
 	Write() // Writes operations to underlying KVStore
+	Copy() CacheMultiStore
 }
 
 // CommitMultiStore is an interface for a MultiStore without cache capabilities.
@@ -274,6 +275,7 @@ type CacheKVStore interface {
 
 	// Writes operations to underlying KVStore
 	Write()
+	Copy() CacheKVStore
 }
 
 // CommitKVStore is an interface for MultiStore.


### PR DESCRIPTION
# Description

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->
        
        
- **Idea:** Introduce a mechanism to **redirect those writes to an grand parent store** effectively applying the ChangeSet on demand.
- **Impact**
    1. If a revert occurs and the snapshot becomes the active `cacheCtx.MultiStore`, any changes can still be correctly committed back to the original store.
    2. Until a `Commit()` is performed, nothing is ever written to the origin store within the StateDB. Therefore, there is no risk of the snapshot’s reverted cache store ever overwriting the state.