### PR TITLE
Fix typo and cleanup unused error formatting

### DIFF
--- a/crypto/keyring/errors.go
+++ b/crypto/keyring/errors.go
@@ -14,7 +14,7 @@ var (
 	// ErrOverwriteKey is raised when a key cannot be overwritten
 	ErrOverwriteKey = errors.New("cannot overwrite key")
 	// ErrKeyAlreadyExists is raised when creating a key that already exists
-	ErrKeyAlreadyExists = errors.Newf("key already exists")
+	ErrKeyAlreadyExists = errors.New("key already exists")
 	// ErrInvalidSignMode is raised when trying to sign with an invalid method
 	ErrInvalidSignMode = errors.New("invalid sign mode, expected LEGACY_AMINO_JSON or TEXTUAL")
 	// ErrMaxPassPhraseAttempts is raised when the maxPassphraseEntryAttempts is reached

--- a/crypto/keyring/keyring.go
+++ b/crypto/keyring/keyring.go
@@ -890,7 +890,7 @@ func (ks keystore) writeOfflineKey(name string, pk types.PubKey) (*Record, error
 	return k, ks.writeRecord(k)
 }
 
-// writeMultisigKey investigate where thisf function is called maybe remove it
+// writeMultisigKey investigate where this function is called maybe remove it
 func (ks keystore) writeMultisigKey(name string, pk types.PubKey) (*Record, error) {
 	k, err := NewMultiRecord(name, pk)
 	if err != nil {


### PR DESCRIPTION
# Description

- Removed unnecessary use of errors.Newf in ErrKeyAlreadyExists definition; replaced with errors.New for consistency.

- Fixed typo in comment for writeMultisigKey function (thisf → this).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Corrected a typo in a code comment to improve readability.

- **Chores**
  - Simplified internal error creation for consistency. No impact on user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->