### PR TITLE
fix: mempool error causes state machine failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (x/authz) [#24638](https://github.com/cosmos/cosmos-sdk/pull/24638) Fixed a minor bug where the grant key was cast as a string and dumped directly into the error message leading to an error string possibly containing invalid UTF-8.
 * (client, client/rpc, x/auth/tx) [#24551](https://github.com/cosmos/cosmos-sdk/pull/24551) Handle cancellation properly when supplying context to client methods.
 * (x/epochs) [#24770](https://github.com/cosmos/cosmos-sdk/pull/24770) Fix register of epoch hooks in `InvokeSetHooks`.
+* (baseapp) [#]() Don't take mempool error as state machine execution failure.
 
 ### Deprecated
 

--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -888,8 +888,7 @@ func (app *BaseApp) runTx(mode sdk.ExecMode, txBytes []byte, tx sdk.Tx) (gInfo s
 	case execModeFinalize:
 		err = app.mempool.Remove(tx)
 		if err != nil && !errors.Is(err, mempool.ErrTxNotFound) {
-			return gInfo, nil, anteEvents,
-				fmt.Errorf("failed to remove tx from mempool: %w", err)
+			app.logger.Error("failed to remove tx from mempool", "err", err)
 		}
 	}
 


### PR DESCRIPTION
Solution:
- mempool can be configured differently by different nodes, bringing mempool error into state machine can introduce consensus failure (app hash mismatch).

# Description

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->
