### PR TITLE
docs: update release notes for v0.53.1 patch release

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,17 +1,15 @@
-# Cosmos SDK v0.53.0 Release Notes
+# Cosmos SDK v0.53.1 Release Notes
 
 💬 [**Release Discussion**](https://github.com/orgs/cosmos/discussions/58)
 
 ## 🚀 Highlights
 
-Announcing Cosmos SDK v0.53
+Announcing Cosmos SDK v0.53.1
 
-We are pleased to announce the release of Cosmos SDK v0.53! We’re excited to be delivering a new version of the Cosmos SDK that provides key features and updates while minimizing breaking changes so you can focus on what matters most: building.
+This release is a patch update that includes feedback from early users of Cosmos SDK v0.53.0.
 
-Upgrading to this version of the Cosmos SDK from any `v0.50.x` release will **require a coordinated chain upgrade**.
-
-For more upgrade information, check out our [upgrading guide](https://github.com/cosmos/cosmos-sdk/blob/v0.53.0/UPGRADING.md)
+Upgrading to this version of the Cosmos SDK from any `v0.53.x` is trivial and does not require a chain upgrade.
 
 ## 📝 Changelog
 
-Check out the [changelog](https://github.com/cosmos/cosmos-sdk/blob/v0.53.0/CHANGELOG.md) for an exhaustive list of changes, or [compare changes](https://github.com/cosmos/cosmos-sdk/compare/v0.50.12...v0.53.0) from the last release.
+Check out the [changelog](https://github.com/cosmos/cosmos-sdk/blob/v0.53.1/CHANGELOG.md) for an exhaustive list of changes, or [compare changes](https://github.com/cosmos/cosmos-sdk/compare/v0.53.0...v0.53.1) from the last release.


### PR DESCRIPTION
Description:
Updated RELEASE_NOTES.md to reflect the v0.53.1 patch release:
Changed version references from v0.53.0 to v0.53.1
Updated release description to indicate this is a patch update with early user feedback
Removed chain upgrade requirement notice since v0.53.1 is a trivial update
Updated changelog and comparison links to point to v0.53.1 resources
This patch release incorporates feedback from early adopters of v0.53.0 without introducing any breaking changes.
Closes: #XXXX
The description is concise but captures all the key changes you made to the release notes while maintaining a professional developer tone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release notes to announce Cosmos SDK patch version 0.53.1.
  * Clarified upgrade instructions for users upgrading from previous 0.53.x versions.
  * Updated changelog and comparison links to reflect the new release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->