### PR TITLE
docs: fix misleading comment for FlagRecover

### DIFF
--- a/x/genutil/client/cli/init.go
+++ b/x/genutil/client/cli/init.go
@@ -32,7 +32,7 @@ const (
 	// FlagOverwrite defines a flag to overwrite an existing genesis JSON file.
 	FlagOverwrite = "overwrite"
 
-	// FlagRecover defines a flag to initialize the private validator key from a specific seed.
+	// FlagRecover defines a flag to recover the validator key from a BIP39 mnemonic.
 	FlagRecover = "recover"
 
 	// FlagDefaultBondDenom defines the default denom to use in the genesis file.


### PR DESCRIPTION
Corrected the comment for FlagRecover to accurately reflect that it recovers the validator key from a BIP39 mnemonic, not a seed.

# Description

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->
