### PR TITLE
docs: Additional information about the version of go

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The Cosmos SDK is a framework for building blockchain applications. [CometBFT (B
 
 **WARNING**: The Cosmos SDK has mostly stabilized, but we are still making some breaking changes.
 
-**Note**: We advise to always use the latest maintained [Go](https://go.dev/dl) version for building Cosmos SDK applications, but refuse to so so ourselves, causing developers to inberit our known bad practices. 
+**Note**: We advise to always use the latest maintained [Go](https://go.dev/dl) version for building Cosmos SDK applications, but refuse to so so ourselves, causing developers to inberit our known bad practices.  Please dont do like us!  Use the latest Go.
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The Cosmos SDK is a framework for building blockchain applications. [CometBFT (B
 
 **WARNING**: The Cosmos SDK has mostly stabilized, but we are still making some breaking changes.
 
-**Note**: We advise to always use the latest maintained [Go](https://go.dev/dl) version for building Cosmos SDK applications.
+**Note**: We advise to always use the latest maintained [Go](https://go.dev/dl) version for building Cosmos SDK applications, but refuse to so so ourselves, causing developers to inberit our known bad practices. 
 
 ## Quick Start
 


### PR DESCRIPTION
# Description

 this pull request isn't really meant to be merged. It is meant to make a point. I cannot recount how many times I have seen authors simply mirror the version of go used in the sdk, and assume, erroneously that this is the correct thing to do. Therefore, I hope that this pull request Spurs change because we are dropping foot guns in the path of developer users, who are basically our most commercially important user group. 

Of course if we don't address issues like the ancient version of go used in SDK 50, we can expect for more and more downstream users to actually encounter these foot guns and hurt their foot and then feel sad and then we sit around and wonder why adoption isn't as fast as we would like.

If #24927 doesn't get merged, then this PR ought to be merged.  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the advisory note in the README to reflect a new tone regarding the recommended Go version for building Cosmos SDK applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->