### PR TITLE
Fix error comparison in TestAminoCodecUnpackAnyFails to use require.EqualError

### DIFF
--- a/codec/amino_codec_test.go
+++ b/codec/amino_codec_test.go
@@ -2,7 +2,6 @@ package codec_test
 
 import (
 	"bytes"
-	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -110,5 +109,5 @@ func TestAminoCodecUnpackAnyFails(t *testing.T) {
 	cdc := codec.NewAminoCodec(createTestCodec())
 	err := cdc.UnpackAny(new(types.Any), &testdata.Cat{})
 	require.Error(t, err)
-	require.Equal(t, err, errors.New("AminoCodec can't handle unpack protobuf Any's"))
+	require.EqualError(t, err, "AminoCodec can't handle unpack protobuf Any's")
 }


### PR DESCRIPTION
Previously, the test TestAminoCodecUnpackAnyFails compared errors using require.Equal with errors.New("..."). This approach is incorrect in Go, because each call to errors.New returns a new error instance, and comparing two error instances with == or require.Equal will always fail, even if their messages are identical.

The idiomatic way to check for a specific error message in Go tests is to use require.EqualError, which compares the error's message string directly. This change makes the test more robust and ensures it will pass as long as the error message matches, regardless of the error instance.

This update improves the reliability and correctness of the test, following best practices for error handling in Go.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved error assertion in a test to check for matching error messages instead of comparing error objects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->