### PR TITLE
docs: fix CosmosSDK protos path

### DIFF
--- a/store/streaming/abci/README.md
+++ b/store/streaming/abci/README.md
@@ -27,7 +27,7 @@ To generate the stubs the local client implementation can call, run the followin
 make proto-gen
 ```
 
-For other languages you'll need to [download](https://github.com/cosmos/cosmos-sdk/blob/main/third_party/proto/README.md)
+For other languages you'll need to [download](https://github.com/cosmos/cosmos-sdk/blob/main/proto/README.md)
 the CosmosSDK protos into your project and compile. For language specific compilation instructions visit
 [https://github.com/grpc](https://github.com/grpc) and look in the `examples` folder of your
 language of choice `https://github.com/grpc/grpc-{language}/tree/master/examples` and [https://grpc.io](https://grpc.io)


### PR DESCRIPTION
# Description
Updated the path of CosmosSDK protos as changed in [#15142](https://github.com/cosmos/cosmos-sdk/pull/15142)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the documentation link for downloading CosmosSDK protobuf files to point to the correct location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->