### PR TITLE
perf(client): optimize CheckCometError with structured error matching

### DIFF
--- a/client/broadcast_test.go
+++ b/client/broadcast_test.go
@@ -64,3 +64,27 @@ func TestBroadcastCancellation(t *testing.T) {
 		require.ErrorIs(t, err, context.Canceled)
 	}
 }
+
+func BenchmarkCheckCometErrorCompare(b *testing.B) {
+	txBytes := []byte{0xA, 0xB}
+
+	errs := []error{
+		mempool.ErrTxInCache,
+		mempool.ErrTxTooLarge{},
+		mempool.ErrMempoolIsFull{},
+	}
+
+	for _, err := range errs {
+		errName := fmt.Sprintf("%T", err)
+
+		b.Run(errName, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if CheckCometError(err, txBytes) == nil {
+					b.FailNow()
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
```
goos: linux
goarch: amd64
pkg: github.com/cosmos/cosmos-sdk/client
cpu: Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
                                                       │   old.txt    │       new.txt       │
                                                       │    sec/op    │    sec/op     vs base   │
CheckCometErrorCompare/Old_*errors.errorString-12        1.238µ ± 18%
CheckCometErrorCompare/Old_mempool.ErrTxTooLarge-12      1.679µ ±  8%
CheckCometErrorCompare/Old_mempool.ErrMempoolIsFull-12   1.911µ ±  8%
CheckCometErrorCompare/New_*errors.errorString-12                       1.175µ ± 10%
CheckCometErrorCompare/New_mempool.ErrTxTooLarge-12                     1.633µ ±  8%
CheckCometErrorCompare/New_mempool.ErrMempoolIsFull-12                  1.923µ ± 16%
geomean                                                  1.583µ         1.545µ        ? ¹ ²
¹ benchmark set differs from baseline; geomeans may not be comparable
² ratios must be >0 to compute geomean

                                                       │  old.txt   │      new.txt      │
                                                       │    B/op    │    B/op     vs base   │
CheckCometErrorCompare/Old_*errors.errorString-12        464.0 ± 0%
CheckCometErrorCompare/Old_mempool.ErrTxTooLarge-12      560.0 ± 0%
CheckCometErrorCompare/Old_mempool.ErrMempoolIsFull-12   544.0 ± 0%
CheckCometErrorCompare/New_*errors.errorString-12                     464.0 ± 0%
CheckCometErrorCompare/New_mempool.ErrTxTooLarge-12                   464.0 ± 0%
CheckCometErrorCompare/New_mempool.ErrMempoolIsFull-12                464.0 ± 0%
geomean                                                  520.9        464.0       ? ¹ ²
¹ benchmark set differs from baseline; geomeans may not be comparable
² ratios must be >0 to compute geomean

                                                       │  old.txt   │      new.txt      │
                                                       │ allocs/op  │ allocs/op   vs base   │
CheckCometErrorCompare/Old_*errors.errorString-12        7.000 ± 0%
CheckCometErrorCompare/Old_mempool.ErrTxTooLarge-12      9.000 ± 0%
CheckCometErrorCompare/Old_mempool.ErrMempoolIsFull-12   8.000 ± 0%
CheckCometErrorCompare/New_*errors.errorString-12                     7.000 ± 0%
CheckCometErrorCompare/New_mempool.ErrTxTooLarge-12                   7.000 ± 0%
CheckCometErrorCompare/New_mempool.ErrMempoolIsFull-12                7.000 ± 0%
geomean                                                  7.958        7.000       ? ¹ ²

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved error handling for transaction broadcasting, making error detection more robust and reliable.

* **Tests**
  * Added a benchmark to measure performance and reliability of the updated error handling logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->