### PR TITLE
fix(scripts): add quotes for safe argument handling in pre-commit hook

### DIFF
--- a/contrib/githooks/pre-commit
+++ b/contrib/githooks/pre-commit
@@ -6,7 +6,7 @@ CMDS='git go gofmt goimports misspell'
 STAGED_GO_FILES=$(git diff --cached --name-only -- '*.go')
 
 f_echo_stderr() {
-  echo $@ >&2
+  echo "$@" >&2
 }
 
 f_exit_success() {


### PR DESCRIPTION
# Description
Adds quotes around `$@` in the `f_echo_stderr` function in the pre-commit script, ensuring safe handling of arguments containing spaces or special characters

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of messages with spaces or special characters in pre-commit hook error output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->