### PR TITLE
fix: correct variable names in findEndIndex comment

### DIFF
--- a/store/cachekv/store.go
+++ b/store/cachekv/store.go
@@ -268,7 +268,7 @@ func findEndIndex(strL []string, endQ string) int {
 		}
 		if midStr < endQ {
 			left = mid + 1
-		} else { // midStrL > startQ
+		} else { // midStr > endQ
 			right = mid - 1
 		}
 	}


### PR DESCRIPTION
# Description

Fixed incorrect variable names in the comment of findEndIndex function in store/cachekv/store.go. 
Changed "midStrL > startQ" to "midStr > endQ" to match the actual variables used in the code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated a comment in the binary search logic to accurately describe the comparison being performed. No changes to functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->