### PR TITLE
docs: fix dead CometBFT State Sync Links in Snapshots README

### DIFF
--- a/store/snapshots/README.md
+++ b/store/snapshots/README.md
@@ -11,8 +11,8 @@ This document describes the Cosmos SDK implementation of the ABCI state sync
 interface, for more information on CometBFT state sync in general see:
 
 * [CometBFT State Sync for Developers](https://medium.com/cometbft/cometbft-core-state-sync-for-developers-70a96ba3ee35)
-* [ABCI State Sync Spec](https://docs.cometbft.com/v0.37/spec/p2p/messages/state-sync)
-* [ABCI State Sync Method/Type Reference](https://docs.cometbft.com/v0.37/spec/p2p/messages/state-sync)
+* [ABCI State Sync Spec](https://docs.cometbft.com/v0.37/core/state-sync)
+* [ABCI State Sync Method/Type Reference](https://docs.cometbft.com/v0.37/core/state-sync)
 
 ## Overview
 


### PR DESCRIPTION


---

### Description

- Updated outdated and broken CometBFT State Sync documentation links in `store/snapshots/README.md` to point to the correct, working URLs.
- Ensured all references now lead to valid documentation pages.

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated links to the latest locations for the ABCI state sync specification and reference in the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->