### PR TITLE
docs: fix typo in post.sh script - correct 'advaced' to 'advanced'

### DIFF
--- a/docs/post.sh
+++ b/docs/post.sh
@@ -6,7 +6,7 @@ rm -rf docs/build/tooling/02-confix.md
 rm -rf docs/build/tooling/03-hubl.md
 rm -rf docs/build/packages/01-depinject.md
 rm -rf docs/build/packages/02-collections.md
-rm -rf docs/learn/advaced-concepts/17-autocli.md
+rm -rf docs/learn/advanced-concepts/17-autocli.md
 rm -rf docs/build/architecture
 rm -rf docs/build/spec
 rm -rf docs/build/rfc


### PR DESCRIPTION
## Summary
This PR fixes a spelling error in the documentation build script.

## Changes
- Fixed typo in `docs/post.sh` line 9
- Changed "advaced-concepts" to "advanced-concepts"
- Corrected file path reference for autocli documentation removal

## Type of Change
- [x] Build script fix
- [x] Typo correction

## Impact
- Ensures correct file path targeting in build cleanup process
- Improves script reliability and maintainability

## Testing
- [x] Verified the corrected path exists in the documentation structure
- [x] Script syntax remains valid

## Checklist
- [x] The change is minimal and focused
- [x] File path is correctly spelled
- [x] No breaking changes to build process