### PR TITLE
docs: fix typos in gov module README

### DIFF
--- a/x/gov/README.md
+++ b/x/gov/README.md
@@ -301,7 +301,7 @@ Since this is more of a social feature than a technical feature, we'll now get i
 * What is the purpose of the chain, specifically?
     * best example of this is the Cosmos hub, where different founding groups, have different interpertations of the purpose of the network.
 
-This genesis entry, "constitution" hasn't been designed for existing chains, who should likely just ratify a constitution using their governance system.  Instead, this is for new chains.  It will allow for validators to have a much clearer idea of purpose and the expecations placed on them while operating thier nodes.  Likewise, for community members, the constitution will give them some idea of what to expect from both the "chain team" and the validators, respectively.
+This genesis entry, "constitution" hasn't been designed for existing chains, who should likely just ratify a constitution using their governance system.  Instead, this is for new chains.  It will allow for validators to have a much clearer idea of purpose and the expectations placed on them while operating their nodes.  Likewise, for community members, the constitution will give them some idea of what to expect from both the "chain team" and the validators, respectively.
 
 This constitution is designed to be immutable, and placed only in genesis, though that could change over time by a pull request to the cosmos-sdk that allows for the constitution to be changed by governance.  Communities whishing to make amendments to their original constitution should use the governance mechanism and a "signaling proposal" to do exactly that.
 


### PR DESCRIPTION
## Summary
This PR fixes two spelling errors in the governance module documentation.

## Changes
- Fixed typos in `x/gov/README.md` line 304
- Changed "expecations" to "expectations"
- Changed "thier" to "their"
- Improved readability of the constitution section

## Type of Change
- [x] Documentation fix
- [x] Typo correction

## Context
These typos were found in the governance module's constitution section, which describes validator responsibilities and community expectations. Proper spelling enhances the professional appearance and clarity of this important documentation.

## Testing
- [x] Verified the changes maintain proper context and meaning
- [x] Documentation renders correctly in markdown
- [x] No functional code changes required

## Checklist
- [x] The changes are minimal and focused
- [x] Documentation is grammatically correct
- [x] No breaking changes
- [x] Maintains original meaning and context