### PR TITLE
docs: correct terminology spelling in bank and params module documentation

### DIFF
--- a/x/bank/README.md
+++ b/x/bank/README.md
@@ -1002,7 +1002,7 @@ Example Output:
 
 ### SendEnabled
 
-The `SendEnabled` enpoints allows users to query the SendEnabled entries of the `bank` module.
+The `SendEnabled` endpoints allows users to query the SendEnabled entries of the `bank` module.
 
 Any denominations NOT returned, use the `Params.DefaultSendEnabled` value.
 

--- a/x/params/README.md
+++ b/x/params/README.md
@@ -76,4 +76,4 @@ Modules often define parameters as a proto message. The generated struct can imp
 * `KeyTable.RegisterParamSet()`: registers all parameters in the struct
 * `Subspace.{Get, Set}ParamSet()`: Get to & Set from the struct
 
-The implementor should be a pointer in order to use `GetParamSet()`.
+The implementer should be a pointer in order to use `GetParamSet()`.


### PR DESCRIPTION
# Description
- Fix typo in x/bank/README.md: "enpoints" → "endpoints"
- Fix typo in x/params/README.md: "implementor" → "implementer"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed minor typographical errors in the documentation for the bank and params modules to improve clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->