### PR TITLE
chore: fix typos in test and comment

### DIFF
--- a/codec/amino_codec_test.go
+++ b/codec/amino_codec_test.go
@@ -22,7 +22,7 @@ func createTestCodec() *codec.LegacyAmino {
 	return cdc
 }
 
-func TestAminoMarsharlInterface(t *testing.T) {
+func TestAminoMarshalInterface(t *testing.T) {
 	cdc := codec.NewAminoCodec(createTestCodec())
 	m := interfaceMarshaler{cdc.MarshalInterface, cdc.UnmarshalInterface}
 	testInterfaceMarshaling(require.New(t), m, true)

--- a/codec/codec.go
+++ b/codec/codec.go
@@ -10,7 +10,7 @@ import (
 
 type (
 	// Codec defines a functionality for serializing other objects.
-	// Users can defin a custom Protobuf-based serialization.
+	// Users can define a custom Protobuf-based serialization.
 	// Note, Amino can still be used without any dependency on Protobuf.
 	// SDK provides to Codec implementations:
 	//

--- a/codec/proto_codec_test.go
+++ b/codec/proto_codec_test.go
@@ -36,7 +36,7 @@ func createTestInterfaceRegistry() types.InterfaceRegistry {
 	return interfaceRegistry
 }
 
-func TestProtoMarsharlInterface(t *testing.T) {
+func TestProtoMarshalInterface(t *testing.T) {
 	cdc := codec.NewProtoCodec(createTestInterfaceRegistry())
 	m := interfaceMarshaler{cdc.MarshalInterface, cdc.UnmarshalInterface}
 	testInterfaceMarshaling(require.New(t), m, false)


### PR DESCRIPTION
Renamed test functions:

- TestAminoMarsharlInterface → TestAminoMarshalInterface
- TestProtoMarsharlInterface → TestProtoMarshalInterface

Fixed comment typo:

- defin → define