### PR TITLE
chore: prep release for systemtest v1.3.0

### DIFF
--- a/systemtests/CHANGELOG.md
+++ b/systemtests/CHANGELOG.md
@@ -36,6 +36,10 @@ Ref: https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.j
 
 ## [Unreleased]
 
+## [v1.3.0] -  2025-07-22
+
+* [#24962](https://github.com/cosmos/cosmos-sdk/pull/24962) Allow chain id to be configured via `--chain-id` flag.
+
 ## [v1.2.0] -  2025-04-24
 
 * SDK v0.53.x support.

--- a/systemtests/CHANGELOG.md
+++ b/systemtests/CHANGELOG.md
@@ -36,7 +36,7 @@ Ref: https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.j
 
 ## [Unreleased]
 
-## [v1.3.0] - 2025-07-22
+## [v1.3.0] - 2025-07-23
 
 * [#24962](https://github.com/cosmos/cosmos-sdk/pull/24962) Allow chain id to be configured via `--chain-id` flag.
 

--- a/systemtests/CHANGELOG.md
+++ b/systemtests/CHANGELOG.md
@@ -36,11 +36,11 @@ Ref: https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.j
 
 ## [Unreleased]
 
-## [v1.3.0] -  2025-07-22
+## [v1.3.0] - 2025-07-22
 
 * [#24962](https://github.com/cosmos/cosmos-sdk/pull/24962) Allow chain id to be configured via `--chain-id` flag.
 
-## [v1.2.0] -  2025-04-24
+## [v1.2.0] - 2025-04-24
 
 * SDK v0.53.x support.
 


### PR DESCRIPTION
# Description

bumping the minor version for this as the PR added "functionality in a backward compatible manner" - ref: https://semver.org/




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a changelog entry for version 1.3.0, highlighting the new option to configure the chain ID using a command-line flag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->