### PR TITLE
enhance codebase clarity through systematic terminology corrections

### DIFF
--- a/baseapp/abci_utils_test.go
+++ b/baseapp/abci_utils_test.go
@@ -657,7 +657,7 @@ func (s *ABCIUtilsTestSuite) TestDefaultProposalHandler_PriorityNonceMempoolTxSe
 			expectedTxs: []int{9},
 		},
 		"no txs added": {
-			// Becasuse the first tx was deemed valid but too big, the next expected valid sequence is tx[0].seq (3), so
+			// Because the first tx was deemed valid but too big, the next expected valid sequence is tx[0].seq (3), so
 			// the rest of the txs fail because they have a seq of 4.
 			ctx:      s.ctx,
 			txInputs: []testTx{testTxs[12], testTxs[13], testTxs[14]},

--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -121,7 +121,7 @@ type BaseApp struct {
 	// ResponseCommit.RetainHeight value during ABCI Commit. A value of 0 indicates
 	// that no blocks should be pruned.
 	//
-	// Note: CometBFT block pruning is dependant on this parameter in conjunction
+	// Note: CometBFT block pruning is dependent on this parameter in conjunction
 	// with the unbonding (safety threshold) period, state pruning and state sync
 	// snapshot parameters to determine the correct minimum value of
 	// ResponseCommit.RetainHeight.

--- a/baseapp/test_helpers.go
+++ b/baseapp/test_helpers.go
@@ -52,7 +52,7 @@ func (app *BaseApp) SimTxFinalizeBlock(txEncoder sdk.TxEncoder, tx sdk.Tx) (sdk.
 }
 
 // SimWriteState is an entrypoint for simulations only. They are not executed during the normal ABCI finalize
-// block step but later. Therefor an extra call to the root multi-store (app.cms) is required to write the changes.
+// block step but later. Therefore an extra call to the root multi-store (app.cms) is required to write the changes.
 func (app *BaseApp) SimWriteState() {
 	app.stateManager.GetState(execModeFinalize).MultiStore.Write()
 }

--- a/docs/architecture/adr-037-gov-split-vote.md
+++ b/docs/architecture/adr-037-gov-split-vote.md
@@ -2,7 +2,7 @@
 
 ## Changelog
 
-* 2020/10/28: Intial draft
+* 2020/10/28: Initial draft
 
 ## Status
 

--- a/docs/architecture/adr-063-core-module-api.md
+++ b/docs/architecture/adr-063-core-module-api.md
@@ -199,7 +199,7 @@ func NewKeeper(logger log.Logger) Keeper {
 
 Modules will provide their core services to the runtime module via extension interfaces built on top of the
 `cosmossdk.io/core/appmodule.AppModule` tag interface. This tag interface requires only two empty methods which
-allow `depinject` to identify implementors as `depinject.OnePerModule` types and as app module implementations:
+allow `depinject` to identify implementers as `depinject.OnePerModule` types and as app module implementations:
 
 ```go
 type AppModule interface {

--- a/docs/rfc/PROCESS.md
+++ b/docs/rfc/PROCESS.md
@@ -53,7 +53,7 @@ DRAFT -> PROPOSED -> LAST CALL yyyy-mm-dd -> ACCEPTED | REJECTED -> SUPERSEDED b
 * `LAST CALL <date for the last call>`: [optional] clear notify that we are close to accept updates. Changing a status to `LAST CALL` means that social consensus (of Cosmos SDK maintainers) has been reached and we still want to give it a time to let the community react or analyze.
 * `ACCEPTED`: ADR which will represent a currently implemented or to be implemented architecture design.
 * `REJECTED`: ADR can go from PROPOSED or ACCEPTED to rejected if the consensus among project stakeholders will decide so.
-* `SUPERSEEDED by ADR-xxx`: ADR which has been superseded by a new ADR.
+* `SUPERSEDED by ADR-xxx`: ADR which has been superseded by a new ADR.
 * `ABANDONED`: the ADR is no longer pursued by the original authors.
 
 ## Language used in RFC

--- a/docs/rfc/rfc-001-tx-validation.md
+++ b/docs/rfc/rfc-001-tx-validation.md
@@ -6,7 +6,7 @@
 
 ## Background
 
-Transation Validation is crucial to a functioning state machine. Within the Cosmos SDK there are two validation flows, one is outside the message server and the other within. The flow outside of the message server is the `ValidateBasic` function. It is called in the antehandler on both `CheckTx` and `DeliverTx`. There is an overhead and sometimes duplication of validation within these two flows. This extra validation provides an additional check before entering the mempool.
+Transaction Validation is crucial to a functioning state machine. Within the Cosmos SDK there are two validation flows, one is outside the message server and the other within. The flow outside of the message server is the `ValidateBasic` function. It is called in the antehandler on both `CheckTx` and `DeliverTx`. There is an overhead and sometimes duplication of validation within these two flows. This extra validation provides an additional check before entering the mempool.
 
 With the deprecation of [`GetSigners`](https://github.com/cosmos/cosmos-sdk/issues/11275) we have the optionality to remove [sdk.Msg](https://github.com/cosmos/cosmos-sdk/blob/16a5404f8e00ddcf8857c8a55dca2f7c109c29bc/types/tx_msg.go#L16) and the `ValidateBasic` function. 
 
@@ -16,7 +16,7 @@ With the separation of CometBFT and Cosmos-SDK, there is a lack of control of wh
 
 The acceptance of this RFC would move validation within `ValidateBasic` to the message server in modules, update tutorials and docs to remove mention of using `ValidateBasic` in favour of handling all validation for a message where it is executed.
 
-We can and will still support the `Validatebasic` function for users and provide an extension interface of the function once `sdk.Msg` is depreacted. 
+We can and will still support the `Validatebasic` function for users and provide an extension interface of the function once `sdk.Msg` is deprecated. 
 
 > Note: This is how messages are handled in VMs like Ethereum and CosmWasm. 
 

--- a/docs/rfc/rfc-template.md
+++ b/docs/rfc/rfc-template.md
@@ -32,7 +32,7 @@
 > path and fall into the same pitfalls that we've since matured from. Abandoned ideas are a way to recognize that path 
 > and explain the pitfalls and why they were abandoned.
 
-## Descision
+## Decision
 
 > This section describes alternative designs to the chosen design. This section
 > is important and if an adr does not have any alternatives then it should be

--- a/types/address_test.go
+++ b/types/address_test.go
@@ -428,7 +428,7 @@ func (s *addressTestSuite) TestCustomAddressVerifier() {
 		return fmt.Errorf("incorrect address length %d", n)
 	})
 
-	// Verifiy that the custom logic rejects this 10 byte address
+	// Verify that the custom logic rejects this 10 byte address
 	err = types.VerifyAddressFormat(addr)
 	s.Require().NotNil(err)
 	_, err = types.AccAddressFromBech32(accBech)

--- a/types/denom.go
+++ b/types/denom.go
@@ -47,7 +47,7 @@ func GetDenomUnit(denom string) (math.LegacyDec, bool) {
 	return unit, true
 }
 
-// SetBaseDenom allow overwritting the base denom
+// SetBaseDenom allow overwriting the base denom
 // if the denom has registered before, otherwise return error
 func SetBaseDenom(denom string) error {
 	_, ok := denomUnits[denom]

--- a/x/auth/migrations/legacytx/stdtx.go
+++ b/x/auth/migrations/legacytx/stdtx.go
@@ -20,7 +20,7 @@ var (
 
 // StdFee includes the amount of coins paid in fees and the maximum
 // gas to be used by the transaction. The ratio yields an effective "gasprice",
-// which must be above some miminum to be accepted into the mempool.
+// which must be above some minimum to be accepted into the mempool.
 // [Deprecated]
 type StdFee struct {
 	Amount  sdk.Coins `json:"amount" yaml:"amount"`

--- a/x/group/config.go
+++ b/x/group/config.go
@@ -2,7 +2,7 @@ package group
 
 import "time"
 
-// Config is a config struct used for intialising the group module to avoid using globals.
+// Config is a config struct used for initialising the group module to avoid using globals.
 type Config struct {
 	// MaxExecutionPeriod defines the max duration after a proposal's voting
 	// period ends that members can send a MsgExec to execute the proposal.

--- a/x/upgrade/keeper/keeper.go
+++ b/x/upgrade/keeper/keeper.go
@@ -487,7 +487,7 @@ func (k Keeper) ApplyUpgrade(ctx context.Context, plan types.Plan) error {
 		return err
 	}
 
-	// incremement the protocol version and set it in state and baseapp
+	// increment the protocol version and set it in state and baseapp
 	nextProtocolVersion, err := k.getProtocolVersion(ctx)
 	if err != nil {
 		return err


### PR DESCRIPTION
# Description

meticulously addresses terminology inconsistencies across the codebase:

- `Becasuse ` → `Because` in baseapp/abci_utils_test.go
- `dependant` → `dependent` in baseapp/baseapp.go
- `Therefor` → `Therefore` (capitalization fix) in baseapp/test_helpers.go
- `Intial` → `Initial` in docs/architecture/adr-037-gov-split-vote.md
- `implementors` → `implementers` in docs/architecture/adr-063-core-module-api.md
- `SUPERSEEDED` formatting standardized in docs/rfc/PROCESS.md
- `Transation` → `Transaction` /  `depreacted` → `deprecated` in docs/rfc/rfc-001-tx-validation.md
- `Descision` → `Decision` in docs/rfc/rfc-template.md
-  `Verifiy` → `Verify` in types/address_test.go
- `overwritting` → `overwriting` in types/denom.go
- `miminum` → `minimum` (capitalization fix) in x/auth/migrations/legacytx/stdtx.go
- `intialising` → `initialising` in x/group/config.go
- `incremement` → `increment` in x/upgrade/keeper/keeper.go


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected multiple typographical and spelling errors in user-facing documentation and comments to improve clarity and accuracy.

* **Style**
  * Fixed minor comment typos throughout the codebase for consistency and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->