### PR TITLE
Fix typos in documentation files

### DIFF
--- a/docs/architecture/adr-059-test-scopes.md
+++ b/docs/architecture/adr-059-test-scopes.md
@@ -242,7 +242,7 @@ demonstrated in [PR#12706](https://github.com/cosmos/cosmos-sdk/pull/12706).
 
 It may be useful if test suites could be run in integration mode (with mocked tendermint) or
 with e2e fixtures (with real tendermint and many nodes). Integration fixtures could be used
-for quicker runs, e2e fixures could be used for more battle hardening.
+for quicker runs, e2e fixtures could be used for more battle hardening.
 
 A PoC `x/gov` was completed in PR [#12847](https://github.com/cosmos/cosmos-sdk/pull/12847)
 is in progress for unit tests demonstrating BDD [Rejected].

--- a/docs/architecture/adr-062-collections-state-layer.md
+++ b/docs/architecture/adr-062-collections-state-layer.md
@@ -74,7 +74,7 @@ Collections types, in fact, delegate the duty of serialisation of keys and value
 which is relevant for swapping serialisation frameworks and enhancing performance.
 `Collections` already comes in with default `ValueEncoders`, specifically for: protobuf objects, special SDK types (sdk.Int, sdk.Dec).
 
-`KeyEncoders` take care of converting keys to bytes, `collections` already comes in with some default `KeyEncoders` for some privimite golang types
+`KeyEncoders` take care of converting keys to bytes, `collections` already comes in with some default `KeyEncoders` for some primitive golang types
 (uint64, string, time.Time, ...) and some widely used sdk types (sdk.Acc/Val/ConsAddress, sdk.Int/Dec, ...).
 These default implementations also offer safety around proper lexicographic ordering and namespace-collision.
 

--- a/docs/architecture/adr-064-abci-2.0.md
+++ b/docs/architecture/adr-064-abci-2.0.md
@@ -120,7 +120,7 @@ Recall, an implementation of `ExtendVoteHandler` does NOT need to be determinist
 however, given a set of vote extensions, `VerifyVoteExtensionHandler` must be
 deterministic, otherwise the chain may suffer from liveness faults. In addition,
 recall CometBFT proceeds in rounds for each height, so if a decision cannot be
-made about about a block proposal at a given height, CometBFT will proceed to the
+made about a block proposal at a given height, CometBFT will proceed to the
 next round and thus will execute `ExtendVote` and `VerifyVoteExtension` again for
 the new round for each validator until 2/3 valid pre-commits can be obtained.
 

--- a/docs/architecture/adr-076-tx-malleability.md
+++ b/docs/architecture/adr-076-tx-malleability.md
@@ -128,7 +128,7 @@ Unfortunately, the vast majority of unaddressed malleability risks affect `SIGN_
 sign mode is still commonly used.
 It is recommended that the following improvements be made to Amino JSON signing:
 
-* hashes of `TxBody` and `AuthInfo` should be added to `AminoSignDoc` so that encoding-level malleablity is addressed
+* hashes of `TxBody` and `AuthInfo` should be added to `AminoSignDoc` so that encoding-level malleability is addressed
 * when constructing `AminoSignDoc`, [protoreflect](https://pkg.go.dev/google.golang.org/protobuf/reflect/protoreflect) API should be used to ensure that there no fields in `TxBody` or `AuthInfo` which do not have a mapping in `AminoSignDoc` have been set
 * fields present in `TxBody` or `AuthInfo` that are not present in `AminoSignDoc` (such as extension options) should
 be added to `AminoSignDoc` if possible

--- a/docs/docs/build/building-modules/16-testing.md
+++ b/docs/docs/build/building-modules/16-testing.md
@@ -6,8 +6,8 @@ sidebar_position: 1
 
 The Cosmos SDK contains different types of [tests](https://martinfowler.com/articles/practical-test-pyramid.html).
 These tests have different goals and are used at different stages of the development cycle.
-We advice, as a general rule, to use tests at all stages of the development cycle.
-It is adviced, as a chain developer, to test your application and modules in a similar way than the SDK.
+We advise, as a general rule, to use tests at all stages of the development cycle.
+It is advised, as a chain developer, to test your application and modules in a similar way than the SDK.
 
 The rationale behind testing can be found in [ADR-59](https://docs.cosmos.network/main/build/architecture/adr-059-test-scopes).
 
@@ -59,7 +59,7 @@ In the SDK, we locate our integration tests under [`/tests/integrations`](https:
 
 The goal of these integration tests is to test how a component interacts with other dependencies. Compared to unit tests, integration tests do not mock dependencies. Instead, they use the direct dependencies of the component. This differs as well from end-to-end tests, which test the component with a full application.
 
-Integration tests interact with the tested module via the defined `Msg` and `Query` services. The result of the test can be verified by checking the state of the application, by checking the emitted events or the response. It is adviced to combine two of these methods to verify the result of the test.
+Integration tests interact with the tested module via the defined `Msg` and `Query` services. The result of the test can be verified by checking the state of the application, by checking the emitted events or the response. It is advised to combine two of these methods to verify the result of the test.
 
 The SDK provides small helpers for quickly setting up an integration tests. These helpers can be found at <https://github.com/cosmos/cosmos-sdk/blob/main/testutil/integration>.
 


### PR DESCRIPTION
adr-059-test-scopes.md
fixures → fixtures

adr-062-collections-state-layer.md
primivite →  primitive

adr-064-abci-2.0.md
about about → about 


adr-076-tx-malleability.md
mallebility →  malleability

16-testing.md
adviced → advised 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected various typographical and grammatical errors in multiple documentation files to improve clarity and accuracy. No technical or functional content was changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->