### PR TITLE
docs: fix typos and improve documentation clarity

### DIFF
--- a/docs/architecture/adr-006-secret-store-replacement.md
+++ b/docs/architecture/adr-006-secret-store-replacement.md
@@ -21,7 +21,7 @@ We are seeking solution that provides a common abstraction layer to the many dif
 
 We recommend replacing the current Keybase backend based on LevelDB with [Keyring](https://github.com/99designs/keyring) by 99 designs. This application is designed to provide a common abstraction and uniform interface between many secret stores and is used by AWS Vault application by 99-designs application.
 
-This appears to fulfill the requirement of protecting both key material and metadata from rouge software on a user’s machine.
+This appears to fulfill the requirement of protecting both key material and metadata from rogue software on a user’s machine.
 
 ## Status
 

--- a/docs/architecture/adr-010-modular-antehandler.md
+++ b/docs/architecture/adr-010-modular-antehandler.md
@@ -142,7 +142,7 @@ type ModuleManager struct {
 }
 
 func (mm ModuleManager) GetAnteHandler() AnteHandler {
-    retun Chainer(mm.AnteHandlerOrder)
+    return Chainer(mm.AnteHandlerOrder)
 }
 ```
 

--- a/docs/architecture/adr-028-public-key-addresses.md
+++ b/docs/architecture/adr-028-public-key-addresses.md
@@ -319,7 +319,7 @@ Algorithm for complex / composed keys:
 
 Module addresses: Should module addresses have different size to differentiate it?
 
-* we will need to set a pre-image prefix for module addresse to kept them in 32-byte space: `hash(hash('module') + module_key)`
+* we will need to set a pre-image prefix for module addresses to kept them in 32-byte space: `hash(hash('module') + module_key)`
 * Aaron observation: we already need to deal with variable length (to not break secp256k1 keys).
 
 Discussion about arithmetic hash function for ZKP

--- a/docs/architecture/adr-042-group-module.md
+++ b/docs/architecture/adr-042-group-module.md
@@ -22,7 +22,7 @@ The legacy amino multi-signature mechanism of the Cosmos SDK has certain limitat
 * It requires `legacy_amino` sign mode ([#8141](https://github.com/cosmos/cosmos-sdk/issues/8141)).
 
 While the group module is not meant to be a total replacement for the current multi-signature accounts, it provides a solution to the limitations described above, with a more flexible key management system where keys can be added, updated or removed, as well as configurable thresholds.
-It's meant to be used with other access control modules such as [`x/feegrant`](./adr-029-fee-grant-module.md) ans [`x/authz`](adr-030-authz-module.md) to simplify key management for individuals and organizations.
+It's meant to be used with other access control modules such as [`x/feegrant`](./adr-029-fee-grant-module.md) and [`x/authz`](adr-030-authz-module.md) to simplify key management for individuals and organizations.
 
 The proof of concept of the group module can be found in https://github.com/regen-network/regen-ledger/tree/master/proto/regen/group/v1alpha1 and https://github.com/regen-network/regen-ledger/tree/master/x/group.
 

--- a/docs/architecture/adr-043-nft-module.md
+++ b/docs/architecture/adr-043-nft-module.md
@@ -156,7 +156,7 @@ message MsgSend {
   string class_id = 1;
   string id       = 2;
   string sender   = 3;
-  string reveiver = 4;
+  string receiver = 4;
 }
 message MsgSendResponse {}
 ```

--- a/docs/architecture/adr-059-test-scopes.md
+++ b/docs/architecture/adr-059-test-scopes.md
@@ -148,7 +148,7 @@ to a production environment as is practical. Presently these tests are located a
 [tests/e2e](https://github.com/cosmos/cosmos-sdk/tree/main/tests/e2e) and rely on [testutil/network](https://github.com/cosmos/cosmos-sdk/tree/main/testutil/network) to start up an in-process Tendermint node.
 
 An application should be built as minimally as possible to exercise the desired functionality.
-The SDK uses an application will only the required modules for the tests. The application developer is adviced to use its own application for e2e tests.
+The SDK uses an application will only the required modules for the tests. The application developer is advised to use its own application for e2e tests.
 
 #### Limitations
 

--- a/docs/docs/learn/advanced/01-transactions.md
+++ b/docs/docs/learn/advanced/01-transactions.md
@@ -76,7 +76,7 @@ The Cosmos SDK also provides a couple of other sign modes for particular use cas
 
 #### `SIGN_MODE_DIRECT_AUX`
 
-`SIGN_MODE_DIRECT_AUX` is a sign mode released in the Cosmos SDK v0.46 which targets transactions with multiple signers. Whereas `SIGN_MODE_DIRECT` expects each signer to sign over both `TxBody` and `AuthInfo` (which includes all other signers' signer infos, i.e. their account sequence, public key and mode info), `SIGN_MODE_DIRECT_AUX` allows N-1 signers to only sign over `TxBody` and _their own_ signer info. Morever, each auxiliary signer (i.e. a signer using `SIGN_MODE_DIRECT_AUX`) doesn't
+`SIGN_MODE_DIRECT_AUX` is a sign mode released in the Cosmos SDK v0.46 which targets transactions with multiple signers. Whereas `SIGN_MODE_DIRECT` expects each signer to sign over both `TxBody` and `AuthInfo` (which includes all other signers' signer infos, i.e. their account sequence, public key and mode info), `SIGN_MODE_DIRECT_AUX` allows N-1 signers to only sign over `TxBody` and _their own_ signer info. Moreover, each auxiliary signer (i.e. a signer using `SIGN_MODE_DIRECT_AUX`) doesn't
 need to sign over the fees:
 
 ```protobuf reference

--- a/docs/docs/learn/advanced/05-encoding.md
+++ b/docs/docs/learn/advanced/05-encoding.md
@@ -57,7 +57,7 @@ Modules are encouraged to utilize Protobuf encoding for their respective types. 
 
 In addition to [following official Protocol Buffer guidelines](https://developers.google.com/protocol-buffers/docs/proto3#simple), we recommend using these annotations in .proto files when dealing with interfaces:
 
-* use `cosmos_proto.accepts_interface` to annote `Any` fields that accept interfaces
+* use `cosmos_proto.accepts_interface` to annotate `Any` fields that accept interfaces
     * pass the same fully qualified name as `protoName` to `InterfaceRegistry.RegisterInterface`
     * example: `(cosmos_proto.accepts_interface) = "cosmos.gov.v1beta1.Content"` (and not just `Content`)
 * annotate interface implementations with `cosmos_proto.implements_interface`

--- a/types/tx/tx.pb.go
+++ b/types/tx/tx.pb.go
@@ -266,7 +266,7 @@ type SignDocDirectAux struct {
 	AccountNumber uint64 `protobuf:"varint,4,opt,name=account_number,json=accountNumber,proto3" json:"account_number,omitempty"`
 	// sequence is the sequence number of the signing account.
 	Sequence uint64 `protobuf:"varint,5,opt,name=sequence,proto3" json:"sequence,omitempty"`
-	// tips have been depreacted and should not be used
+	// tips have been deprecated and should not be used
 	Tip *Tip `protobuf:"bytes,6,opt,name=tip,proto3" json:"tip,omitempty"` // Deprecated: Do not use.
 }
 
@@ -818,7 +818,7 @@ func (m *ModeInfo_Multi) GetModeInfos() []*ModeInfo {
 
 // Fee includes the amount of coins paid in fees and the maximum
 // gas to be used by the transaction. The ratio yields an effective "gasprice",
-// which must be above some miminum to be accepted into the mempool.
+// which must be above some minimum to be accepted into the mempool.
 type Fee struct {
 	// amount is the amount of coins to be paid as a fee
 	Amount github_com_cosmos_cosmos_sdk_types.Coins `protobuf:"bytes,1,rep,name=amount,proto3,castrepeated=github.com/cosmos/cosmos-sdk/types.Coins" json:"amount"`


### PR DESCRIPTION


**Description:**  
This pull request addresses several minor typos and improves the clarity of documentation across multiple files.  
- Corrects spelling mistakes (e.g., "rouge" → "rogue", "adviced" → "advised", "annote" → "annotate", etc.)
- Fixes variable and field names (e.g., "reciever" → "receiver", "address" → "addresses")



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected multiple typographical errors across various architecture decision records and advanced documentation sections for improved clarity and accuracy.
  * Fixed a misspelled field name in the NFT module documentation to accurately reflect the intended recipient field.
  * No functional or logic changes were made; all updates are editorial.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->