### PR TITLE
docs: correct spelling errors across multiple packages

### DIFF
--- a/server/mock/store.go
+++ b/server/mock/store.go
@@ -221,7 +221,7 @@ func (kv kvStore) Prefix(prefix []byte) storetypes.KVStore {
 }
 
 func (kv kvStore) Gas(meter storetypes.GasMeter, config storetypes.GasConfig) storetypes.KVStore {
-	panic("not implmeneted")
+	panic("not implemented")
 }
 
 func (kv kvStore) Iterator(start, end []byte) storetypes.Iterator {

--- a/server/start.go
+++ b/server/start.go
@@ -969,7 +969,7 @@ func testnetify(ctx *Context, testnetAppCreator types.AppCreator, db dbm.DB, tra
 		return nil, err
 	}
 
-	// Modfiy Validators stateDB entry.
+	// Modify Validators stateDB entry.
 	err = stateDB.Set(fmt.Appendf(nil, "validatorsKey:%v", blockStore.Height()), buf)
 	if err != nil {
 		return nil, err

--- a/server/types/abci.go
+++ b/server/types/abci.go
@@ -33,5 +33,5 @@ type ABCI interface {
 	ListSnapshots(*abci.ListSnapshotsRequest) (*abci.ListSnapshotsResponse, error)                // List available snapshots
 	OfferSnapshot(*abci.OfferSnapshotRequest) (*abci.OfferSnapshotResponse, error)                // Offer a snapshot to the application
 	LoadSnapshotChunk(*abci.LoadSnapshotChunkRequest) (*abci.LoadSnapshotChunkResponse, error)    // Load a snapshot chunk
-	ApplySnapshotChunk(*abci.ApplySnapshotChunkRequest) (*abci.ApplySnapshotChunkResponse, error) // Apply a shapshot chunk
+	ApplySnapshotChunk(*abci.ApplySnapshotChunkRequest) (*abci.ApplySnapshotChunkResponse, error) // Apply a snapshot chunk
 }

--- a/tests/e2e/distribution/grpc_query_suite.go
+++ b/tests/e2e/distribution/grpc_query_suite.go
@@ -45,7 +45,7 @@ func (s *GRPCQueryTestSuite) SetupSuite() {
 	s.Require().NoError(s.network.WaitForNextBlock())
 }
 
-// TearDownSuite cleans up the curret test network after _each_ test.
+// TearDownSuite cleans up the current test network after _each_ test.
 func (s *GRPCQueryTestSuite) TearDownSuite() {
 	s.T().Log("tearing down grpc e2e test suite")
 	s.network.Cleanup()

--- a/tests/e2e/distribution/suite.go
+++ b/tests/e2e/distribution/suite.go
@@ -123,7 +123,7 @@ func (s *E2ETestSuite) SetupSuite() {
 	s.Require().NoError(s.network.WaitForNextBlock())
 }
 
-// TearDownSuite cleans up the curret test network after _each_ test.
+// TearDownSuite cleans up the current test network after _each_ test.
 func (s *E2ETestSuite) TearDownSuite() {
 	s.T().Log("tearing down e2e test suite1")
 	s.network.Cleanup()

--- a/tests/e2e/distribution/withdraw_all_suite.go
+++ b/tests/e2e/distribution/withdraw_all_suite.go
@@ -46,7 +46,7 @@ func (s *WithdrawAllTestSuite) SetupSuite() {
 	s.Require().NoError(s.network.WaitForNextBlock())
 }
 
-// TearDownSuite cleans up the curret test network after _each_ test.
+// TearDownSuite cleans up the current test network after _each_ test.
 func (s *WithdrawAllTestSuite) TearDownSuite() {
 	s.T().Log("tearing down withdraw all e2e test suite")
 	s.network.Cleanup()

--- a/tests/integration/staking/keeper/validator_test.go
+++ b/tests/integration/staking/keeper/validator_test.go
@@ -645,7 +645,7 @@ func TestApplyAndReturnValidatorSetUpdatesInserted(t *testing.T) {
 	validators[1] = keeper.TestingUpdateValidator(f.stakingKeeper, f.sdkCtx, validators[1], false)
 	applyValidatorSetUpdates(t, f.sdkCtx, f.stakingKeeper, 2)
 
-	// test validtor added at the beginning
+	// test validator added at the beginning
 	//  tendermintUpdate set: {} -> {c0}
 	assert.NilError(t, f.stakingKeeper.SetValidator(f.sdkCtx, validators[2]))
 	assert.NilError(t, f.stakingKeeper.SetValidatorByPowerIndex(f.sdkCtx, validators[2]))
@@ -655,7 +655,7 @@ func TestApplyAndReturnValidatorSetUpdatesInserted(t *testing.T) {
 	validators[2], _ = f.stakingKeeper.GetValidator(f.sdkCtx, val2bz)
 	assert.DeepEqual(t, validators[2].ABCIValidatorUpdate(f.stakingKeeper.PowerReduction(f.sdkCtx)), updates[0])
 
-	// test validtor added at the beginning
+	// test validator added at the beginning
 	//  tendermintUpdate set: {} -> {c0}
 	assert.NilError(t, f.stakingKeeper.SetValidator(f.sdkCtx, validators[3]))
 	assert.NilError(t, f.stakingKeeper.SetValidatorByPowerIndex(f.sdkCtx, validators[3]))
@@ -665,7 +665,7 @@ func TestApplyAndReturnValidatorSetUpdatesInserted(t *testing.T) {
 	validators[3], _ = f.stakingKeeper.GetValidator(f.sdkCtx, val3bz)
 	assert.DeepEqual(t, validators[3].ABCIValidatorUpdate(f.stakingKeeper.PowerReduction(f.sdkCtx)), updates[0])
 
-	// test validtor added at the end
+	// test validator added at the end
 	//  tendermintUpdate set: {} -> {c0}
 	assert.NilError(t, f.stakingKeeper.SetValidator(f.sdkCtx, validators[4]))
 	assert.NilError(t, f.stakingKeeper.SetValidatorByPowerIndex(f.sdkCtx, validators[4]))

--- a/types/address.go
+++ b/types/address.go
@@ -641,7 +641,7 @@ func (ca ConsAddress) String() string {
 }
 
 // Bech32ifyAddressBytes returns a bech32 representation of address bytes.
-// Returns an empty sting if the byte slice is 0-length. Returns an error if the bech32 conversion
+// Returns an empty string if the byte slice is 0-length. Returns an error if the bech32 conversion
 // fails or the prefix is empty.
 func Bech32ifyAddressBytes(prefix string, bs []byte) (string, error) {
 	if len(bs) == 0 {
@@ -654,7 +654,7 @@ func Bech32ifyAddressBytes(prefix string, bs []byte) (string, error) {
 }
 
 // MustBech32ifyAddressBytes returns a bech32 representation of address bytes.
-// Returns an empty sting if the byte slice is 0-length. It panics if the bech32 conversion
+// Returns an empty string if the byte slice is 0-length. It panics if the bech32 conversion
 // fails or the prefix is empty.
 func MustBech32ifyAddressBytes(prefix string, bs []byte) string {
 	s, err := Bech32ifyAddressBytes(prefix, bs)


### PR DESCRIPTION
server/mock/store.go
`implmeneted` - `implemented`

server/start.go
`Modfiy` - `Modify`

server/types/abci.go
`shapshot` - `snapshot`

tests/e2e/distribution/grpc_query_suite.go
`curret` - `current`

tests/e2e/distribution/suite.go
`curret` - `current`

tests/e2e/distribution/suite.go
`curret` - `current`

tests/integration/staking/keeper/validator_test.go
`validtor` - `validator` х3

types/address.go
`sting` - `string`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Corrected multiple typos in comments and error messages across various files to improve clarity and readability. No changes were made to application logic or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->