### PR TITLE
docs: correct spelling errors across multiple packages 

### DIFF
--- a/client/keys/migrate_test.go
+++ b/client/keys/migrate_test.go
@@ -98,7 +98,7 @@ func (s *MigrateTestSuite) Test_runMigrateCmdRecord() {
 	item := design99keyring.Item{
 		Key:         s.appName,
 		Data:        serializedRecord,
-		Description: "SDK kerying version",
+		Description: "SDK keyring version",
 	}
 
 	cmd := MigrateCommand()
@@ -130,7 +130,7 @@ func (s *MigrateTestSuite) Test_runMigrateCmdLegacyMultiInfo() {
 	item := design99keyring.Item{
 		Key:         s.appName,
 		Data:        serializedLegacyMultiInfo,
-		Description: "SDK kerying version",
+		Description: "SDK keyring version",
 	}
 
 	cmd := MigrateCommand()

--- a/crypto/armor.go
+++ b/crypto/armor.go
@@ -170,7 +170,7 @@ func encryptPrivKey(privKey cryptotypes.PrivKey, passphrase string) (saltBytes, 
 		panic(errorsmod.Wrap(err, "error generating cypher from key"))
 	}
 
-	nonce := make([]byte, aead.NonceSize(), aead.NonceSize()+len(privKeyBytes)+aead.Overhead()) // Nonce is fixed to maintain consistency, each key is generated  at every encryption using a random salt.
+	nonce := make([]byte, aead.NonceSize(), aead.NonceSize()+len(privKeyBytes)+aead.Overhead()) // Nonce is fixed to maintain consistency, each key is generated at every encryption using a random salt.
 
 	encBytes = aead.Seal(nil, nonce, privKeyBytes, nil)
 

--- a/crypto/keyring/keyring_test.go
+++ b/crypto/keyring/keyring_test.go
@@ -2013,7 +2013,7 @@ func TestRenameKey(t *testing.T) {
 
 // TestChangeBcrypt tests the compatibility from upstream Bcrypt and our own
 func TestChangeBcrypt(t *testing.T) {
-	pw := []byte("somepasswword!")
+	pw := []byte("somepassword!")
 
 	saltBytes := cmtcrypto.CRandBytes(16)
 	cosmosHash, err := cosmosbcrypt.GenerateFromPassword(saltBytes, pw, 2)

--- a/crypto/keyring/migration_test.go
+++ b/crypto/keyring/migration_test.go
@@ -53,7 +53,7 @@ func (s *MigrationTestSuite) TestMigrateLegacyLocalKey() {
 	item := keyring.Item{
 		Key:         n1,
 		Data:        serializedLegacyLocalInfo,
-		Description: "SDK kerying version",
+		Description: "SDK keyring version",
 	}
 
 	s.Require().NoError(s.ks.SetItem(item))
@@ -71,7 +71,7 @@ func (s *MigrationTestSuite) TestMigrateLegacyLedgerKey() {
 	item := keyring.Item{
 		Key:         n1,
 		Data:        serializedLegacyLedgerInfo,
-		Description: "SDK kerying version",
+		Description: "SDK keyring version",
 	}
 
 	s.Require().NoError(s.ks.SetItem(item))

--- a/crypto/keys/secp256k1/secp256k1_cgo.go
+++ b/crypto/keys/secp256k1/secp256k1_cgo.go
@@ -15,7 +15,7 @@ func (privKey *PrivKey) Sign(msg []byte) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	// we do not need v  in r||s||v:
+	// we do not need v in r||s||v:
 	rs := rsv[:len(rsv)-1]
 	return rs, nil
 }

--- a/crypto/keys/secp256r1/privkey.go
+++ b/crypto/keys/secp256r1/privkey.go
@@ -30,7 +30,7 @@ func (m *PrivKey) Type() string {
 	return name
 }
 
-// Sign hashes and signs the message usign ECDSA. Implements sdk.PrivKey interface.
+// Sign hashes and signs the message using ECDSA. Implements sdk.PrivKey interface.
 func (m *PrivKey) Sign(msg []byte) ([]byte, error) {
 	return m.Secret.Sign(msg)
 }

--- a/crypto/ledger/ledger_test.go
+++ b/crypto/ledger/ledger_test.go
@@ -77,7 +77,7 @@ func TestPublicKeyUnsafeHDPath(t *testing.T) {
 		require.NoError(t, tmp.ValidateKey())
 		(&tmp).AssertIsPrivKeyInner()
 
-		// in this test we are chekcking if the generated keys are correct.
+		// in this test we are checking if the generated keys are correct.
 		require.Equal(t, expectedAnswers[i], priv.PubKey().String(),
 			"Is your device using test mnemonic: %s ?", testdata.TestMnemonic)
 

--- a/crypto/types/multisig/multisignature.go
+++ b/crypto/types/multisig/multisignature.go
@@ -36,7 +36,7 @@ func getIndex(pk types.PubKey, keys []types.PubKey) int {
 }
 
 // AddSignature adds a signature to the multisig, at the corresponding index. The index must
-// represent the pubkey index in the LegacyAmingPubKey structure, which verifies this signature.
+// represent the pubkey index in the LegacyAminoPubKey structure, which verifies this signature.
 // If the signature already exists, replace it.
 func AddSignature(mSig *signing.MultiSignatureData, sig signing.SignatureData, index int) {
 	newSigIndex := mSig.BitArray.NumTrueBitsBefore(index)

--- a/depinject/appconfig/module.go
+++ b/depinject/appconfig/module.go
@@ -18,7 +18,7 @@ var Register = RegisterModule
 // function. All module initialization should be handled by the provided options.
 //
 // Config is a protobuf message type. It should define the cosmos.app.v1alpha.module
-// option and must explicitly specify go_packageto make debugging easier for users.
+// option and must explicitly specify go_package to make debugging easier for users.
 //
 // If you want to customize an existing module, you need to overwrite by calling
 // RegisterModule again with the same config (proto API type) and new Provide or


### PR DESCRIPTION
# Description

`kerying` - `keyring` x2 
`generated  at` -- removed extra space
`somepasswword` - `somepassword`
`kerying` - keyring x2
`v  in` -- removed extra space
`usign` - `using`
`chekcking` - `checking`
`LegacyAmingPubKey` - `LegacyAminoPubKey`
`go_packageto` - `go_package to`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Corrected various typographical errors and improved comment clarity across multiple areas of the application.
* **Tests**
  * Fixed typos in test descriptions and test data to ensure accuracy and readability. 

No changes to application logic or user-facing features were made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->