### PR TITLE
docs(staking): Fix typos, grammar, and incorrect CLI description

### DIFF
--- a/x/staking/README.md
+++ b/x/staking/README.md
@@ -631,11 +631,11 @@ This message is expected to fail if:
 When this message is processed the following actions occur:
 
 * validator's `DelegatorShares` and the delegation's `Shares` are both reduced by the message `SharesAmount`
-* calculate the token worth of the shares remove that amount tokens held within the validator
+* calculate the token worth of the shares and remove that amount of tokens held within the validator
 * with those removed tokens, if the validator is:
     * `Bonded` - add them to an entry in `UnbondingDelegation` (create `UnbondingDelegation` if it doesn't exist) with a completion time a full unbonding period from the current time. Update pool shares to reduce BondedTokens and increase NotBondedTokens by token worth of the shares.
     * `Unbonding` - add them to an entry in `UnbondingDelegation` (create `UnbondingDelegation` if it doesn't exist) with the same completion time as the validator (`UnbondingMinTime`).
-    * `Unbonded` - then send the coins the message `DelegatorAddr`
+    * `Unbonded` - then send the coins to the message `DelegatorAddr`
 * if there are no more `Shares` in the delegation, then the delegation object is removed from the store
     * under this situation if the delegation is the validator's self-delegation then also jail the validator.
 
@@ -698,7 +698,7 @@ This message is expected to fail if:
 When this message is processed the following actions occur:
 
 * the source validator's `DelegatorShares` and the delegations `Shares` are both reduced by the message `SharesAmount`
-* calculate the token worth of the shares remove that amount tokens held within the source validator.
+* calculate the token worth of the shares and remove that amount of tokens held within the source validator.
 * if the source validator is:
     * `Bonded` - add an entry to the `Redelegation` (create `Redelegation` if it doesn't exist) with a completion time a full unbonding period from the current time. Update pool shares to reduce BondedTokens and increase NotBondedTokens by token worth of the shares (this may be effectively reversed in the next step however).
     * `Unbonding` - add an entry to the `Redelegation` (create `Redelegation` if it doesn't exist) with the same completion time as the validator (`UnbondingMinTime`).
@@ -1668,7 +1668,7 @@ simd tx staking unbond cosmosvaloper1gghjut3ccd8ay0zduzj64hwre2fxs9ldmqhffj 100s
 
 ##### cancel unbond
 
-The command `cancel-unbond` allow users to cancel the unbonding delegation entry and delegate back to the original validator.
+The command `cancel-unbond` allows users to cancel the unbonding delegation entry and delegate back to the original validator.
 
 Usage:
 

--- a/x/staking/autocli.go
+++ b/x/staking/autocli.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	autocliv1 "cosmossdk.io/api/cosmos/autocli/v1"
-	_ "cosmossdk.io/api/cosmos/crypto/ed25519" // register to that it shows up in protoregistry.GlobalTypes
+	_ "cosmossdk.io/api/cosmos/crypto/ed25519" // register so that it shows up in protoregistry.GlobalTypes
 	stakingv1beta "cosmossdk.io/api/cosmos/staking/v1beta1"
 
 	"github.com/cosmos/cosmos-sdk/version"
@@ -153,7 +153,7 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 				{
 					RpcMethod:      "BeginRedelegate",
 					Use:            "redelegate [src-validator-addr] [dst-validator-addr] [amount] --from [delegator]",
-					Short:          "Generate multisig signatures for transactions generated offline",
+					Short:          "Redelegate illiquid tokens from one validator to another",
 					Long:           "Redelegate an amount of illiquid staking tokens from one validator to another.",
 					Example:        fmt.Sprintf(`%s tx staking redelegate cosmosvaloper... cosmosvaloper... 100stake --from mykey`, version.AppName),
 					PositionalArgs: []*autocliv1.PositionalArgDescriptor{{ProtoField: "validator_src_address"}, {ProtoField: "validator_dst_address"}, {ProtoField: "amount"}},


### PR DESCRIPTION
x/staking/autocli.go:

- Fixed a significantly misleading `Short` description for the `redelegate` command.  The previous description was incorrect and belonged to a different command's function.
- Corrected a minor typo in a code comment (`to that` -> `so that`).

x/staking/README.md:

- Corrected grammatical errors in the state transition descriptions for `MsgUndelegate` and `MsgBeginRedelegate` for better clarity (e.g., "remove that amount tokens" -> "remove that amount **of** tokens").
 - Fixed subject-verb agreement in the `cancel-unbond` command description (`allow` -> `allows`).


These small fixes ensure that the documentation is accurate and that the CLI help text provides the correct information to users, reducing potential confusion.

Closes: #XXXX *(If this PR closes an open issue, please replace XXXX with the issue number)*