### PR TITLE
fix(auth/ante): correct lowGasPrice calculation in TestEnsureMempoolFees

### DIFF
--- a/x/auth/ante/basic.go
+++ b/x/auth/ante/basic.go
@@ -198,7 +198,7 @@ func NewTxTimeoutHeightDecorator() TxTimeoutHeightDecorator {
 	return TxTimeoutHeightDecorator{}
 }
 
-// AnteHandle implements an AnteHandler decorator for the TxHeightTimeoutDecorator
+// AnteHandle implements an AnteHandler decorator for the TxTimeoutHeightDecorator
 // type where the current block height is checked against the tx's height timeout.
 // If a height timeout is provided (non-zero) and is less than the current block
 // height, then an error is returned.

--- a/x/auth/ante/fee_test.go
+++ b/x/auth/ante/fee_test.go
@@ -100,7 +100,7 @@ func TestEnsureMempoolFees(t *testing.T) {
 	// Set IsCheckTx back to true for testing sufficient mempool fee
 	s.ctx = s.ctx.WithIsCheckTx(true)
 
-	atomPrice = sdk.NewDecCoinFromDec("atom", math.LegacyNewDec(0).Quo(math.LegacyNewDec(100000)))
+	atomPrice = sdk.NewDecCoinFromDec("atom", math.LegacyNewDec(1).Quo(math.LegacyNewDec(100000)))
 	lowGasPrice := []sdk.DecCoin{atomPrice}
 	s.ctx = s.ctx.WithMinGasPrices(lowGasPrice)
 


### PR DESCRIPTION
Fix logical error in TestEnsureMempoolFees test where lowGasPrice was incorrectly calculated.

Problem: math.LegacyNewDec(0).Quo(math.LegacyNewDec(100000)) equals 0, not 0.00001. 
This meant that lowGasPrice was actually 0, which is not a "low" gas price but a zero price.

The test was supposed to verify behavior with a low gas price of 0.00001atom, but due to 
the mathematical error (0 ÷ 100000 = 0), it was actually testing with zero gas price.

Fixed by changing the calculation to math.LegacyNewDec(1).Quo(math.LegacyNewDec(100000)) 
which correctly produces 0.00001.

This ensures the test properly validates the mempool fee logic with actual low gas prices 
rather than zero gas prices.

Also fixed comment that incorrectly referenced TxHeightTimeoutDecorator instead of TxTimeoutHeightDecorator in basic.go