### PR TITLE
docs: fix typos in documentation files

### DIFF
--- a/proto/cosmos/gov/v1/genesis.proto
+++ b/proto/cosmos/gov/v1/genesis.proto
@@ -18,15 +18,15 @@ message GenesisState {
   // proposals defines all the proposals present at genesis.
   repeated Proposal proposals = 4;
   // Deprecated: Prefer to use `params` instead.
-  // deposit_params defines all the paramaters of related to deposit.
+  // deposit_params defines all the parameters of related to deposit.
   DepositParams deposit_params = 5 [deprecated = true];
   // Deprecated: Prefer to use `params` instead.
-  // voting_params defines all the paramaters of related to voting.
+  // voting_params defines all the parameters of related to voting.
   VotingParams voting_params = 6 [deprecated = true];
   // Deprecated: Prefer to use `params` instead.
-  // tally_params defines all the paramaters of related to tally.
+  // tally_params defines all the parameters of related to tally.
   TallyParams tally_params = 7 [deprecated = true];
-  // params defines all the paramaters of x/gov module.
+  // params defines all the parameters of x/gov module.
   Params params = 8 [(cosmos_proto.field_added_in) = "cosmos-sdk 0.47"];
   // The constitution allows builders to lay a foundation and define purpose.
   // This is an immutable string set in genesis.

--- a/proto/cosmos/msg/textual/v1/textual.proto
+++ b/proto/cosmos/msg/textual/v1/textual.proto
@@ -9,7 +9,7 @@ extend google.protobuf.MessageOptions {
   // algorithm used to generate the custom textual representation of the
   // protobuf message where this annotation is applied. We recommend to use a
   // short, versioned name as this identifier, e.g. "replace_with_username_v1".
-  // We also recommand providing a human-readable description as protobuf
+  // We also recommend providing a human-readable description as protobuf
   // comments on this annotation, for example a short specification or a link
   // to the relevant documentation.
   //

--- a/proto/cosmos/staking/v1beta1/staking.proto
+++ b/proto/cosmos/staking/v1beta1/staking.proto
@@ -131,7 +131,7 @@ message Validator {
   // strictly positive if this validator's unbonding has been stopped by external modules
   int64 unbonding_on_hold_ref_count = 12;
 
-  // list of unbonding ids, each uniquely identifing an unbonding of this validator
+  // list of unbonding ids, each uniquely identifying an unbonding of this validator
   repeated uint64 unbonding_ids = 13;
 }
 
@@ -376,7 +376,7 @@ message Pool {
   ];
 }
 
-// Infraction indicates the infraction a validator commited.
+// Infraction indicates the infraction a validator committed.
 enum Infraction {
   // UNSPECIFIED defines an empty infraction.
   INFRACTION_UNSPECIFIED = 0;

--- a/proto/cosmos/tx/v1beta1/tx.proto
+++ b/proto/cosmos/tx/v1beta1/tx.proto
@@ -88,7 +88,7 @@ message SignDocDirectAux {
   // sequence is the sequence number of the signing account.
   uint64 sequence = 5;
 
-  // tips have been depreacted and should not be used
+  // tips have been deprecated and should not be used
   Tip tip = 6 [deprecated = true];
 }
 
@@ -220,7 +220,7 @@ message ModeInfo {
 
 // Fee includes the amount of coins paid in fees and the maximum
 // gas to be used by the transaction. The ratio yields an effective "gasprice",
-// which must be above some miminum to be accepted into the mempool.
+// which must be above some mininum to be accepted into the mempool.
 message Fee {
   // amount is the amount of coins to be paid as a fee
   repeated cosmos.base.v1beta1.Coin amount = 1 [


### PR DESCRIPTION
Corrected `paramaters` → `parameters` x4
Corrected `recommand` → `recommend`
Corrected `identifing` → `identifying`
Corrected `commited` → `committed`
Corrected `depreacted` → `deprecated`
Corrected `miminum ` → `mininum`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected multiple spelling and typographical errors in comments and documentation across several modules to improve clarity and accuracy. No changes were made to features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->