### PR TITLE
Remove outdated help message in the bank module

### DIFF
--- a/x/bank/autocli.go
+++ b/x/bank/autocli.go
@@ -46,12 +46,12 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					Use:       "total-supply",
 					Alias:     []string{"total"},
 					Short:     "Query the total supply of coins of the chain",
-					Long:      "Query total supply of coins that are held by accounts in the chain. To query for the total supply of a specific coin denomination use --denom flag.",
+					Long:      "Query the total supply of coins that are held by accounts in the chain.",
 				},
 				{
 					RpcMethod:      "SupplyOf",
 					Use:            "total-supply-of [denom]",
-					Short:          "Query the supply of a single coin denom",
+					Short:          "Query the total supply of a specific coin denomination.",
 					PositionalArgs: []*autocliv1.PositionalArgDescriptor{{ProtoField: "denom"}},
 				},
 				{


### PR DESCRIPTION
# Description

The outdated message states that it is possible to use the `--denom` comand line parameter to query only for a specific denomination, while in reality a separate `total-supply-of` command shall be used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the help text for two bank module CLI commands to provide clearer and more concise descriptions. No changes to functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->