### PR TITLE
e2e/tests: fix typos, remove debug code & improve test consistency

### DIFF
--- a/tests/e2e/auth/suite.go
+++ b/tests/e2e/auth/suite.go
@@ -698,7 +698,7 @@ func (s *E2ETestSuite) TestCLISendGenerateSignAndBroadcast() {
 	s.Require().NoError(err)
 	s.Require().NoError(s.network.WaitForNextBlock())
 
-	// Ensure destiny account state
+	// Ensure destination account state
 	err = s.network.RetryForBlocks(func() error {
 		resp, err = testutil.GetRequest(fmt.Sprintf("%s/cosmos/bank/v1beta1/balances/%s", val1.APIAddress, addr))
 		s.Require().NoError(err)

--- a/tests/e2e/auth/suite.go
+++ b/tests/e2e/auth/suite.go
@@ -838,7 +838,7 @@ func (s *E2ETestSuite) TestCLIMultisignSortSignatures() {
 	var balRes banktypes.QueryAllBalancesResponse
 	err = val1.ClientCtx.Codec.UnmarshalJSON(resp, &balRes)
 	s.Require().NoError(err)
-	intialCoins := balRes.Balances
+	initialCoins := balRes.Balances
 
 	// Send coins from validator to multisig.
 	sendTokens := sdk.NewInt64Coin(s.cfg.BondDenom, 10)
@@ -854,7 +854,7 @@ func (s *E2ETestSuite) TestCLIMultisignSortSignatures() {
 	s.Require().NoError(err)
 	err = val1.ClientCtx.Codec.UnmarshalJSON(resp, &balRes)
 	s.Require().NoError(err)
-	diff, _ := balRes.Balances.SafeSub(intialCoins...)
+	diff, _ := balRes.Balances.SafeSub(initialCoins...)
 	s.Require().Equal(sendTokens.Amount, diff.AmountOf(s.cfg.BondDenom))
 
 	// Generate multisig transaction.

--- a/tests/e2e/authz/tx.go
+++ b/tests/e2e/authz/tx.go
@@ -531,7 +531,7 @@ func (s *E2ETestSuite) TestNewExecGrantAuthorized() {
 			"",
 		},
 		{
-			"error over grantee doesn't exist on chain",
+			"error due to insufficient funds for grantee",
 			[]string{
 				execMsg.Name(),
 				fmt.Sprintf("--%s=%s", flags.FlagFrom, grantee1.String()),
@@ -541,7 +541,7 @@ func (s *E2ETestSuite) TestNewExecGrantAuthorized() {
 			},
 			0,
 			true,
-			"insufficient funds", // earlier the error was account not found here.
+			"insufficient funds",
 		},
 		{
 			"error over spent",

--- a/tests/e2e/distribution/grpc_query_suite.go
+++ b/tests/e2e/distribution/grpc_query_suite.go
@@ -563,6 +563,5 @@ func doRequest(url string, headers map[string]string) ([]byte, http.Header, erro
 	if err = res.Body.Close(); err != nil {
 		return nil, nil, err
 	}
-	fmt.Printf("headers: %v\n", res.Header)
 	return body, res.Header, nil
 }

--- a/tests/e2e/distribution/suite.go
+++ b/tests/e2e/distribution/suite.go
@@ -125,7 +125,7 @@ func (s *E2ETestSuite) SetupSuite() {
 
 // TearDownSuite cleans up the current test network after _each_ test.
 func (s *E2ETestSuite) TearDownSuite() {
-	s.T().Log("tearing down e2e test suite1")
+	s.T().Log("tearing down e2e test suite")
 	s.network.Cleanup()
 }
 

--- a/tests/e2e/gov/deposits.go
+++ b/tests/e2e/gov/deposits.go
@@ -30,7 +30,7 @@ func NewDepositTestSuite(cfg network.Config) *DepositTestSuite {
 }
 
 func (s *DepositTestSuite) SetupSuite() {
-	s.T().Log("setting up test suite")
+	s.T().Log("setting up e2e test suite")
 
 	var err error
 	s.network, err = network.New(s.T(), s.T().TempDir(), s.cfg)

--- a/tests/e2e/gov/deposits.go
+++ b/tests/e2e/gov/deposits.go
@@ -127,13 +127,13 @@ func (s *DepositTestSuite) TestQueryProposalAfterVotingPeriod() {
 	s.Require().Len(deposits.Deposits, 0)
 }
 
-func (s *DepositTestSuite) queryDeposits(val *network.Validator, proposalID string, exceptErr bool, message string) *v1.QueryDepositsResponse {
+func (s *DepositTestSuite) queryDeposits(val *network.Validator, proposalID string, expectErr bool, message string) *v1.QueryDepositsResponse {
 	s.Require().NoError(s.network.WaitForNextBlock())
 
 	resp, err := testutil.GetRequest(fmt.Sprintf("%s/cosmos/gov/v1/proposals/%s/deposits", val.APIAddress, proposalID))
 	s.Require().NoError(err)
 
-	if exceptErr {
+	if expectErr {
 		s.Require().Contains(string(resp), message)
 		return nil
 	}
@@ -145,13 +145,13 @@ func (s *DepositTestSuite) queryDeposits(val *network.Validator, proposalID stri
 	return &depositsRes
 }
 
-func (s *DepositTestSuite) queryDeposit(val *network.Validator, proposalID string, exceptErr bool, message string) *v1.QueryDepositResponse {
+func (s *DepositTestSuite) queryDeposit(val *network.Validator, proposalID string, expectErr bool, message string) *v1.QueryDepositResponse {
 	s.Require().NoError(s.network.WaitForNextBlock())
 
 	resp, err := testutil.GetRequest(fmt.Sprintf("%s/cosmos/gov/v1/proposals/%s/deposits/%s", val.APIAddress, proposalID, val.Address.String()))
 	s.Require().NoError(err)
 
-	if exceptErr {
+	if expectErr {
 		s.Require().Contains(string(resp), message)
 		return nil
 	}

--- a/tests/e2e/gov/grpc.go
+++ b/tests/e2e/gov/grpc.go
@@ -99,7 +99,7 @@ func (s *E2ETestSuite) TestGetProposalsGRPC() {
 			err = val.ClientCtx.Codec.UnmarshalJSON(resp, &proposals)
 
 			if tc.expErr {
-				s.Require().Empty(proposals.Proposals)
+				s.Require().Error(err)
 			} else {
 				s.Require().NoError(err)
 				s.Require().Len(proposals.Proposals, tc.wantNumProposals)

--- a/tests/e2e/gov/tx.go
+++ b/tests/e2e/gov/tx.go
@@ -221,7 +221,7 @@ func (s *E2ETestSuite) TestNewCmdSubmitLegacyProposal() {
 		{
 			"invalid proposal",
 			[]string{
-				fmt.Sprintf("--%s='Where is the title!?'", cli.FlagDescription),        //nolint:staticcheck // keep deprecated flag for test
+				fmt.Sprintf("--%s=%s", cli.FlagDescription, "Where is the title!?"),        //nolint:staticcheck // keep deprecated flag for test
 				fmt.Sprintf("--%s=%s", cli.FlagProposalType, v1beta1.ProposalTypeText), //nolint:staticcheck // keep deprecated flag for test
 				fmt.Sprintf("--%s=%s", cli.FlagDeposit, sdk.NewCoin(s.cfg.BondDenom, math.NewInt(10000)).String()),
 				fmt.Sprintf("--%s=%s", flags.FlagFrom, val.Address.String()),
@@ -245,8 +245,8 @@ func (s *E2ETestSuite) TestNewCmdSubmitLegacyProposal() {
 		{
 			"valid transaction",
 			[]string{
-				fmt.Sprintf("--%s='Text Proposal'", cli.FlagTitle),
-				fmt.Sprintf("--%s='Where is the title!?'", cli.FlagDescription),        //nolint:staticcheck // keep deprecated flag for test
+				fmt.Sprintf("--%s=%s", cli.FlagTitle, "Text Proposal"),
+				fmt.Sprintf("--%s=%s", cli.FlagDescription, "Where is the title!?"),        //nolint:staticcheck // keep deprecated flag for test
 				fmt.Sprintf("--%s=%s", cli.FlagProposalType, v1beta1.ProposalTypeText), //nolint:staticcheck // keep deprecated flag for test
 				fmt.Sprintf("--%s=%s", cli.FlagDeposit, sdk.NewCoin(s.cfg.BondDenom, math.NewInt(100000)).String()),
 				fmt.Sprintf("--%s=%s", flags.FlagFrom, val.Address.String()),


### PR DESCRIPTION
tests/e2e/auth/suite.go 
  - `intialCoins` → `initialCoins`  
  - comment “Ensure destiny account state” → “Ensure destination account state”  

tests/e2e/distribution/grpc_query_suite.go
  - remove `fmt.Printf("headers: …")`  

tests/e2e/distribution/suite.go
  - log “tearing down e2e test suite1” → “tearing down e2e test suite”  

tests/e2e/gov/deposits.go 
  - log “setting up test suite” → “setting up e2e test suite”  
  - `exceptErr` → `expectErr`  

tests/e2e/gov/grpc.go 
  -  
    ```go
    // before
    if tc.expErr {
      s.Require().Empty(proposals.Proposals)
    }  
    // after
    if tc.expErr {
      s.Require().Error(err)
    }
    ```  

tests/e2e/gov/tx.go 
  - `--Title='Text Proposal'` → `--Title=Text Proposal`  
  - `--Description='Where is the title!?'` → `--Description=Where is the title!?`  
