### PR TITLE
docs: fix typos

### DIFF
--- a/x/auth/autocli.go
+++ b/x/auth/autocli.go
@@ -5,8 +5,8 @@ import (
 
 	authv1beta1 "cosmossdk.io/api/cosmos/auth/v1beta1"
 	autocliv1 "cosmossdk.io/api/cosmos/autocli/v1"
-	_ "cosmossdk.io/api/cosmos/crypto/secp256k1" // register to that it shows up in protoregistry.GlobalTypes
-	_ "cosmossdk.io/api/cosmos/crypto/secp256r1" // register to that it shows up in protoregistry.GlobalTypes
+	_ "cosmossdk.io/api/cosmos/crypto/secp256k1" // register so that it shows up in protoregistry.GlobalTypes
+	_ "cosmossdk.io/api/cosmos/crypto/secp256r1" // register so that it shows up in protoregistry.GlobalTypes
 
 	"github.com/cosmos/cosmos-sdk/version"
 )

--- a/x/auth/tx/aux_test.go
+++ b/x/auth/tx/aux_test.go
@@ -88,7 +88,7 @@ func TestBuilderWithAux(t *testing.T) {
 		malleate func()
 		expErr   bool
 	}{
-		{"address and msg signer mistacher", func() { txBuilder.SetAddress("foobar") }, true},
+		{"address and msg signer mismatch", func() { txBuilder.SetAddress("foobar") }, true},
 		{"memo mismatch", func() { txBuilder.SetMemo("mismatch") }, true},
 		{"timeout height mismatch", func() { txBuilder.SetTimeoutHeight(98) }, true},
 		{"extension options length mismatch", func() { txBuilder.SetExtensionOptions() }, true},

--- a/x/auth/types/params.go
+++ b/x/auth/types/params.go
@@ -41,8 +41,8 @@ func DefaultParams() Params {
 //	BenchmarkSig/secp256k1     4334   277167 ns/op   4128 B/op   79 allocs/op
 //	BenchmarkSig/secp256r1    10000   108769 ns/op   1672 B/op   33 allocs/op
 //
-// Based on the results above secp256k1 is 2.7x is slwer. However we propose to discount it
-// because we are we don't compare the cgo implementation of secp256k1, which is faster.
+// Based on the results above secp256k1 is 2.7x is slower. However we propose to discount it
+// because we don't compare the cgo implementation of secp256k1, which is faster.
 func (p Params) SigVerifyCostSecp256r1() uint64 {
 	return p.SigVerifyCostSecp256k1 / 2
 }

--- a/x/auth/vesting/types/period.go
+++ b/x/auth/vesting/types/period.go
@@ -11,7 +11,7 @@ import (
 // Periods stores all vesting periods passed as part of a PeriodicVestingAccount
 type Periods []Period
 
-// Duration is converts the period Length from seconds to a time.Duration
+// Duration converts the period Length from seconds to a time.Duration
 func (p Period) Duration() time.Duration {
 	return time.Duration(p.Length) * time.Second
 }

--- a/x/auth/vesting/types/vesting_account.go
+++ b/x/auth/vesting/types/vesting_account.go
@@ -87,7 +87,7 @@ func (bva *BaseVestingAccount) TrackDelegation(balance, vestingCoins, amount sdk
 }
 
 // TrackUndelegation tracks an undelegation amount by setting the necessary
-// values by which delegated vesting and delegated vesting need to decrease and
+// values by which delegated vesting and delegated free need to decrease and
 // by which amount the base coins need to increase.
 //
 // NOTE: The undelegation (bond refund) amount may exceed the delegated

--- a/x/auth/vesting/types/vesting_account.go
+++ b/x/auth/vesting/types/vesting_account.go
@@ -233,7 +233,7 @@ func (cva ContinuousVestingAccount) LockedCoins(blockTime time.Time) sdk.Coins {
 }
 
 // TrackDelegation tracks a desired delegation amount by setting the appropriate
-// values for the amount of delegated vesting, delegated free, and reducing the
+// values for the amount of delegated vesting, delegated vesting, and reducing the
 // overall amount of base coins.
 func (cva *ContinuousVestingAccount) TrackDelegation(blockTime time.Time, balance, amount sdk.Coins) {
 	cva.BaseVestingAccount.TrackDelegation(balance, cva.GetVestingCoins(blockTime), amount)

--- a/x/authz/module/module.go
+++ b/x/authz/module/module.go
@@ -196,7 +196,7 @@ func (am AppModule) RegisterStoreDecoder(sdr simtypes.StoreDecoderRegistry) {
 	sdr[keeper.StoreKey] = simulation.NewDecodeStore(am.cdc)
 }
 
-// WeightedOperations returns the all the gov module operations with their respective weights.
+// WeightedOperations returns all the authz module operations with their respective weights.
 // This method is ignored when WeightedOperationsX exists and will be removed in the future
 func (am AppModule) WeightedOperations(simState module.SimulationState) []simtypes.WeightedOperation {
 	return simulation.WeightedOperations(

--- a/x/distribution/simulation/operations_test.go
+++ b/x/distribution/simulation/operations_test.go
@@ -97,7 +97,7 @@ func (suite *SimTestSuite) TestSimulateMsgSetWithdrawAddress() {
 
 // TestSimulateMsgWithdrawDelegatorReward tests the normal scenario of a valid message
 // of type TypeMsgWithdrawDelegatorReward.
-// Abnormal scenarios, where the message is created by an errors, are not tested here.
+// Abnormal scenarios, where the message is created by an error, are not tested here.
 func (suite *SimTestSuite) TestSimulateMsgWithdrawDelegatorReward() {
 	// setup 3 accounts
 	s := rand.NewSource(4)
@@ -143,7 +143,7 @@ func (suite *SimTestSuite) TestSimulateMsgWithdrawDelegatorReward() {
 
 // TestSimulateMsgWithdrawValidatorCommission tests the normal scenario of a valid message
 // of type TypeMsgWithdrawValidatorCommission.
-// Abnormal scenarios, where the message is created by an errors, are not tested here.
+// Abnormal scenarios, where the message is created by an error, are not tested here.
 func (suite *SimTestSuite) TestSimulateMsgWithdrawValidatorCommission() {
 	suite.testSimulateMsgWithdrawValidatorCommission("atoken")
 	suite.testSimulateMsgWithdrawValidatorCommission("tokenxxx")

--- a/x/distribution/types/keys.go
+++ b/x/distribution/types/keys.go
@@ -130,7 +130,7 @@ func GetValidatorCurrentRewardsAddress(key []byte) (valAddr sdk.ValAddress) {
 // GetValidatorAccumulatedCommissionAddress creates the address from a validator's accumulated commission key.
 func GetValidatorAccumulatedCommissionAddress(key []byte) (valAddr sdk.ValAddress) {
 	// key is in the format:
-	// 0x07<valAddrLen (1 Byte)><valAddr_Bytes>: ValidatorCurrentRewards
+	// 0x07<valAddrLen (1 Byte)><valAddr_Bytes>: ValidatorAccumulatedCommission
 
 	// Remove prefix and address length.
 	kv.AssertKeyAtLeastLength(key, 3)


### PR DESCRIPTION
# Description

x/auth/autocli.go
`register so that it`

x/auth/tx/aux_test.go
`mistacher` - `mismatch`

x/auth/types/params.go
`slwer` - `slower`
`because we are we don't` - `because we don't `

x/auth/vesting/types/period.go
`Duration is converts` - `Duration converts`

x/authz/module/module.go
`returns the all the gov` - `returns all the authz`

x/distribution/simulation/operations_test.go
`errors` - `error`

x/distribution/types/keys.go
`ValidatorCurrentRewards` - `ValidatorAccumulatedCommission`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected typos and improved clarity in comments across multiple modules, including authentication, vesting, authorization, and distribution.
  * Fixed test case names and grammatical errors in test descriptions for improved readability.
  * Updated comment descriptions to accurately reflect method behavior and key formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->