### PR TITLE
fix: correct various typos across codebase

### DIFF
--- a/client/broadcast_test.go
+++ b/client/broadcast_test.go
@@ -20,7 +20,7 @@ func CreateContextWithErrorAndMode(err error, mode string) Context {
 	}
 }
 
-// Test the correct code is returned when
+// Test the correct code is returned when broadcasting transactions with specific mempool errors
 func TestBroadcastError(t *testing.T) {
 	errors := map[error]uint32{
 		mempool.ErrTxInCache:       sdkerrors.ErrTxInMempoolCache.ABCICode(),

--- a/client/query.go
+++ b/client/query.go
@@ -60,7 +60,7 @@ func (ctx Context) GetFromAddress() sdk.AccAddress {
 	return ctx.FromAddress
 }
 
-// GetFeePayerAddress returns the fee granter address from the context
+// GetFeePayerAddress returns the fee payer address from the context
 func (ctx Context) GetFeePayerAddress() sdk.AccAddress {
 	return ctx.FeePayer
 }

--- a/client/v2/CHANGELOG.md
+++ b/client/v2/CHANGELOG.md
@@ -38,7 +38,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Bug Fixes
 
-* [#24722](https://github.com/cosmos/cosmos-sdk/pull/24722) Fix msg parsing in when no pulsar file is present.
+* [#24722](https://github.com/cosmos/cosmos-sdk/pull/24722) Fix msg parsing when no pulsar file is present.
 
 ## [v2.0.0-beta.9](https://github.com/cosmos/cosmos-sdk/tree/client/v2.0.0-beta.9) - 2025-04-24
 

--- a/client/v2/README.md
+++ b/client/v2/README.md
@@ -92,7 +92,7 @@ The keyring is then converted to the `client/v2/autocli/keyring` interface.
 If no keyring is provided, the `autocli` generated command will not be able to sign transactions, but will still be able to query the chain.
 
 :::tip
-The Cosmos SDK keyring and Hubl keyring both implement the `client/v2/autocli/keyring` interface, thanks to the following wrapper:
+The Cosmos SDK keyring implements the `client/v2/autocli/keyring` interface, thanks to the following wrapper:
 
 ```go
 keyring.NewAutoCLIKeyring(kb)
@@ -255,8 +255,4 @@ https://github.com/cosmos/cosmos-sdk/blob/client/v2.0.0-beta.1/client/grpc/cmtse
 
 ## Summary
 
-`autocli` let you generate CLI to your Cosmos SDK-based applications without any cobra boilerplate. It allows you to easily generate CLI commands and flags from your protobuf messages, and provides many options for customising the behavior of your CLI application.
-
-To further enhance your CLI experience with Cosmos SDK-based blockchains, you can use `hubl`. `hubl` is a tool that allows you to query any Cosmos SDK-based blockchain using the new AutoCLI feature of the Cosmos SDK. With `hubl`, you can easily configure a new chain and query modules with just a few simple commands.
-
-For more information on `hubl`, including how to configure a new chain and query a module, see the [Hubl documentation](https://docs.cosmos.network/main/tooling/hubl).
+`autocli` lets you generate CLI for your Cosmos SDK-based applications without any cobra boilerplate. It allows you to easily generate CLI commands and flags from your protobuf messages, and provides many options for customising the behavior of your CLI application.

--- a/codec/codec.go
+++ b/codec/codec.go
@@ -12,7 +12,7 @@ type (
 	// Codec defines a functionality for serializing other objects.
 	// Users can define a custom Protobuf-based serialization.
 	// Note, Amino can still be used without any dependency on Protobuf.
-	// SDK provides to Codec implementations:
+	// SDK provides two Codec implementations:
 	//
 	// 1. AminoCodec: Provides full Amino serialization compatibility.
 	// 2. ProtoCodec: Provides full Protobuf serialization compatibility.

--- a/codec/types/any_test.go
+++ b/codec/types/any_test.go
@@ -28,7 +28,7 @@ var eom = &errOnMarshal{}
 // Ensure that returning an error doesn't suddenly allocate and waste bytes.
 // See https://github.com/cosmos/cosmos-sdk/issues/8537
 func TestNewAnyWithCustomTypeURLWithErrorNoAllocation(t *testing.T) {
-	// This tests continues to fail inconsistently.
+	// This test continues to fail inconsistently.
 	//
 	// Example: https://github.com/cosmos/cosmos-sdk/pull/9246/checks?check_run_id=2643313958#step:6:118
 	// Ref: https://github.com/cosmos/cosmos-sdk/issues/9010

--- a/docs/docs/learn/beginner/02-query-lifecycle.md
+++ b/docs/docs/learn/beginner/02-query-lifecycle.md
@@ -47,7 +47,7 @@ One such tool is [grpcurl](https://github.com/fullstorydev/grpcurl), and a gRPC 
 
 ```bash
 grpcurl \
-    -plaintext                                           # We want results in plain test
+    -plaintext                                           # We want results in plain text
     -import-path ./proto \                               # Import these .proto files
     -proto ./proto/cosmos/staking/v1beta1/query.proto \  # Look into this .proto file for the Query protobuf service
     -d '{"address":"$MY_DELEGATOR"}' \                   # Query arguments


### PR DESCRIPTION
# Description

client/broadcast_test.go 
`Test the correct code is returned when` - not a complete comment

client/query.go
`granter` - `payer`

client/v2/CHANGELOG.md
`parsing in when` - delete extra in

client/v2/README.md
`deleted references to hubl`

codec/codec.go
`SDK provides to Codec` - `SDK provides two Codec`

codec/types/any_test.go
`tests` - `test`

docs/docs/learn/beginner/02-query-lifecycle.md
test - text

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved clarity and accuracy in various code comments and documentation.
  * Corrected typos and updated descriptions in test comments, method comments, changelog, and user guides.
  * Simplified and clarified README content for better usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->