### PR TITLE
fix: multiple typos of different importance

### DIFF
--- a/store/cachekv/benchmark_test.go
+++ b/store/cachekv/benchmark_test.go
@@ -72,7 +72,7 @@ type CacheStack struct {
 	cacheStores []types.CacheKVStore
 }
 
-// CurrentContext returns the top context of cached stack,
+// CurrentStore returns the top context of cached stack,
 // if the stack is empty, returns the initial context.
 func (cs *CacheStack) CurrentStore() types.CacheKVStore {
 	l := len(cs.cacheStores)

--- a/store/iavl/store.go
+++ b/store/iavl/store.go
@@ -291,7 +291,7 @@ func (st *Store) Import(version int64) (*iavl.Importer, error) {
 	return tree.Import(version)
 }
 
-// Handle gatest the latest height, if height is 0
+// Handle gets the latest height, if height is 0
 func getHeight(tree Tree, req *types.RequestQuery) int64 {
 	height := req.Height
 	if height == 0 {

--- a/testutil/ioutil.go
+++ b/testutil/ioutil.go
@@ -73,7 +73,7 @@ func TempFile(tb testing.TB) *os.File {
 	return fp
 }
 
-// GetTempDir returns a writable temporary director for the test to use.
+// GetTempDir returns a writable temporary directory for the test to use.
 func GetTempDir(tb testing.TB) string {
 	tb.Helper()
 	// os.MkDir() is used instead of testing.T.TempDir()

--- a/tools/confix/README.md
+++ b/tools/confix/README.md
@@ -34,7 +34,7 @@ rootCmd.AddCommand(
 )
 ```
 
-The `ConfigCommand` function builds the `config` root command and is defined in the `confixCmd` package (`cosmossdk.io/tools/confix/cmd`).
+The `ConfixCommand` function builds the `config` root command and is defined in the `confixCmd` package (`cosmossdk.io/tools/confix/cmd`).
 An implementation example can be found in `simapp`.
 
 The command will be available as `simd config`.

--- a/tools/confix/README.md
+++ b/tools/confix/README.md
@@ -34,7 +34,7 @@ rootCmd.AddCommand(
 )
 ```
 
-The `ConfixCommand` function builds the `config` root command and is defined in the `confixCmd` package (`cosmossdk.io/tools/confix/cmd`).
+The `ConfigCommand` function builds the `config` root command and is defined in the `confixCmd` package (`cosmossdk.io/tools/confix/cmd`).
 An implementation example can be found in `simapp`.
 
 The command will be available as `simd config`.

--- a/types/handler.go
+++ b/types/handler.go
@@ -18,7 +18,7 @@ type PostDecorator interface {
 	PostHandle(ctx Context, tx Tx, simulate, success bool, next PostHandler) (newCtx Context, err error)
 }
 
-// ChainAnteDecorators ChainDecorator chains AnteDecorators together with each AnteDecorator
+// ChainAnteDecorators chains AnteDecorators together with each AnteDecorator
 // wrapping over the decorators further along chain and returns a single AnteHandler.
 //
 // NOTE: The first element is outermost decorator, while the last element is innermost

--- a/x/auth/ante/validator_tx_fee.go
+++ b/x/auth/ante/validator_tx_fee.go
@@ -11,7 +11,7 @@ import (
 )
 
 // checkTxFeeWithValidatorMinGasPrices implements the default fee logic, where the minimum price per
-// unit of gas is fixed and set by each validator, can the tx priority is computed from the gas price.
+// unit of gas is fixed and set by each validator, and the tx priority is computed from the gas price.
 func checkTxFeeWithValidatorMinGasPrices(ctx sdk.Context, tx sdk.Tx) (sdk.Coins, int64, error) {
 	feeTx, ok := tx.(sdk.FeeTx)
 	if !ok {

--- a/x/auth/vesting/README.md
+++ b/x/auth/vesting/README.md
@@ -41,7 +41,7 @@ For all vesting accounts, the owner of the vesting account is able to delegate a
 
 ## Note
 
-Vesting accounts can be initialized with some vesting and non-vesting coins. The non-vesting coins would be immediately transferable. DelayedVesting ContinuousVesting, PeriodicVesting and PermenantVesting accounts can be created with normal messages after genesis. Other types of vesting accounts must be created at genesis, or as part of a manual network upgrade. The current specification only allows for _unconditional_ vesting (ie. there is no possibility of reaching `ET` and
+Vesting accounts can be initialized with some vesting and non-vesting coins. The non-vesting coins would be immediately transferable. DelayedVesting ContinuousVesting, PeriodicVesting and PermanentVesting accounts can be created with normal messages after genesis. Other types of vesting accounts must be created at genesis, or as part of a manual network upgrade. The current specification only allows for _unconditional_ vesting (ie. there is no possibility of reaching `ET` and
 having coins fail to vest).
 
 ## Vesting Account Types

--- a/x/authz/authorizations.go
+++ b/x/authz/authorizations.go
@@ -29,7 +29,7 @@ type Authorization interface {
 // AcceptResponse instruments the controller of an authz message if the request is accepted
 // and if it should be updated or deleted.
 type AcceptResponse struct {
-	// If Accept=true, the controller can accept and authorization and handle the update.
+	// If Accept=true, the controller can accept an authorization and handle the update.
 	Accept bool
 	// If Delete=true, the controller must delete the authorization object and release
 	// storage resources.

--- a/x/group/internal/orm/auto_uint64.go
+++ b/x/group/internal/orm/auto_uint64.go
@@ -82,7 +82,7 @@ func (a AutoUInt64Table) GetOne(store storetypes.KVStore, rowID uint64, dest pro
 }
 
 // PrefixScan returns an Iterator over a domain of keys in ascending order. End is exclusive.
-// Start is an MultiKeyIndex key or prefix. It must be less than end, or the Iterator is invalid and error is returned.
+// Start is a MultiKeyIndex key or prefix. It must be less than end, or the Iterator is invalid and error is returned.
 // Iterator must be closed by caller.
 // To iterate over entire domain, use PrefixScan(1, math.MaxUint64)
 //
@@ -103,7 +103,7 @@ func (a AutoUInt64Table) PrefixScan(store storetypes.KVStore, start, end uint64)
 }
 
 // ReversePrefixScan returns an Iterator over a domain of keys in descending order. End is exclusive.
-// Start is an MultiKeyIndex key or prefix. It must be less than end, or the Iterator is invalid  and error is returned.
+// Start is a MultiKeyIndex key or prefix. It must be less than end, or the Iterator is invalid  and error is returned.
 // Iterator must be closed by caller.
 // To iterate over entire domain, use PrefixScan(1, math.MaxUint64)
 //

--- a/x/group/internal/orm/index.go
+++ b/x/group/internal/orm/index.go
@@ -117,7 +117,7 @@ func (i MultiKeyIndex) GetPaginated(store types.KVStore, searchKey any, pageRequ
 }
 
 // PrefixScan returns an Iterator over a domain of keys in ascending order. End is exclusive.
-// Start is an MultiKeyIndex key or prefix. It must be less than end, or the Iterator is invalid and error is returned.
+// Start is a MultiKeyIndex key or prefix. It must be less than end, or the Iterator is invalid and error is returned.
 // Iterator must be closed by caller.
 // To iterate over entire domain, use PrefixScan(nil, nil)
 //
@@ -145,7 +145,7 @@ func (i MultiKeyIndex) PrefixScan(store types.KVStore, startI, endI any) (Iterat
 }
 
 // ReversePrefixScan returns an Iterator over a domain of keys in descending order. End is exclusive.
-// Start is an MultiKeyIndex key or prefix. It must be less than end, or the Iterator is invalid and error is returned.
+// Start is a MultiKeyIndex key or prefix. It must be less than end, or the Iterator is invalid and error is returned.
 // Iterator must be closed by caller.
 // To iterate over entire domain, use PrefixScan(nil, nil)
 //


### PR DESCRIPTION
# Description


store/cachekv/benchmark_test.go
`CurrentContext` - `CurrentStore`

store/iavl/store.go
`gatest` - `gets`

testutil/ioutil.go
`director` - `directory`

types/handler.go
`ChainAnteDecorators ChainDecorator` -- Removed redundant

x/auth/ante/validator_tx_fee.go
`can the tx priority` - `and the tx priority`

x/auth/vesting/README.md
`PermenantVesting` - `PermanentVesting`

x/authz/authorizations.go
`accept and authorization` - `accept an authorization`

x/group/internal/orm/auto_uint64.go
x/group/internal/orm/index.go
`an MultiKeyIndex `- `a MultiKeyIndex`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected various typographical and grammatical errors in code comments and documentation to improve clarity and accuracy. No changes to functionality or user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->