### PR TITLE
fix: multiple typos of different importance

### DIFF
--- a/docs/rfc/rfc-001-tx-validation.md
+++ b/docs/rfc/rfc-001-tx-validation.md
@@ -22,4 +22,4 @@ We can and will still support the `ValidateBasic` function for users and provide
 
 ### Consequences
 
-The consequence of updating the transaction flow is that transaction that may have failed before with the `ValidateBasic` flow will now be included in a block and fees charged. 
+The consequence of updating the transaction flow is that transaction that may have failed before with the `ValidateBasic` flow will now be included in a block and the fees charged. 

--- a/types/bech32/legacybech32/pk_test.go
+++ b/types/bech32/legacybech32/pk_test.go
@@ -11,7 +11,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
-func TestBeach32ifPbKey(t *testing.T) {
+func TestBech32ifPbKey(t *testing.T) {
 	require := require.New(t)
 	path := *hd.NewFundraiserParams(0, sdk.CoinType, 0)
 	priv, err := ledger.NewPrivKeySecp256k1Unsafe(path)

--- a/x/auth/ante/sigverify.go
+++ b/x/auth/ante/sigverify.go
@@ -638,7 +638,7 @@ func GetSignerAcc(ctx sdk.Context, ak AccountKeeper, addr sdk.AccAddress) (sdk.A
 }
 
 // CountSubKeys counts the total number of keys for a multi-sig public key.
-// A non-multisig, i.e. a regular signature, it naturally a count of 1. If it is a multisig,
+// A non-multisig, i.e. a regular signature, it naturally has a count of 1. If it is a multisig,
 // then it recursively calls it on its pubkeys.
 func CountSubKeys(pub cryptotypes.PubKey) int {
 	if pub == nil {

--- a/x/auth/client/cli/query.go
+++ b/x/auth/client/cli/query.go
@@ -68,7 +68,7 @@ for. Each module documents its respective events under 'xx_events.md'.
 	cmd.Flags().Int(flags.FlagPage, querytypes.DefaultPage, "Query a specific page of paginated results")
 	cmd.Flags().Int(flags.FlagLimit, querytypes.DefaultLimit, "Query number of transactions results per page returned")
 	cmd.Flags().String(FlagQuery, "", "The transactions events query per Tendermint's query semantics")
-	cmd.Flags().String(FlagOrderBy, "", "The ordering semantics (asc|dsc)")
+	cmd.Flags().String(FlagOrderBy, "", "The ordering semantics (asc|desc)")
 	_ = cmd.MarkFlagRequired(FlagQuery)
 
 	return cmd

--- a/x/evidence/module.go
+++ b/x/evidence/module.go
@@ -172,7 +172,7 @@ func (am AppModule) RegisterStoreDecoder(sdr simtypes.StoreDecoderRegistry) {
 	sdr[types.StoreKey] = simtypes.NewStoreDecoderFuncFromCollectionsSchema(am.keeper.Schema)
 }
 
-// WeightedOperations returns the all the gov module operations with their respective weights.
+// WeightedOperations returns all the gov module operations with their respective weights.
 func (am AppModule) WeightedOperations(simState module.SimulationState) []simtypes.WeightedOperation {
 	return nil
 }

--- a/x/evidence/types/expected_keepers.go
+++ b/x/evidence/types/expected_keepers.go
@@ -48,7 +48,7 @@ type (
 		GetAllBalances(ctx sdk.Context, addr sdk.AccAddress) sdk.Coins
 	}
 
-	Cometinfo interface {
+	CometInfo interface {
 		comet.BlockInfoService
 	}
 )

--- a/x/feegrant/keeper/grpc_query_test.go
+++ b/x/feegrant/keeper/grpc_query_test.go
@@ -161,7 +161,7 @@ func (suite *KeeperTestSuite) TestFeeAllowances() {
 				suite.Require().Equal(len(resp.Allowances), 3)
 				for i, addr := range suite.addrs[1:4] {
 					resp.Allowances[i].Granter = suite.addrs[0].String()
-					resp.Allowances[i].Granter = addr.String()
+					resp.Allowances[i].Grantee = suite.addrs[0].String()
 				}
 			},
 		},

--- a/x/gov/migrations/v3/store_test.go
+++ b/x/gov/migrations/v3/store_test.go
@@ -35,7 +35,6 @@ func TestMigrateStore(t *testing.T) {
 	require.NoError(t, err)
 	prop2, err := v1beta1.NewProposal(v1beta1.NewTextProposal("my title 2", "my desc 2"), 2, propTime, propTime)
 	require.NoError(t, err)
-	require.NoError(t, err)
 	prop2Bz, err := cdc.Marshal(&prop2)
 	require.NoError(t, err)
 

--- a/x/protocolpool/README.md
+++ b/x/protocolpool/README.md
@@ -54,7 +54,7 @@ CommunityPoolSpend can be called by the module authority (default governance mod
 ### CreateContinuousFund
 
 CreateContinuousFund is a message used to initiate a continuous fund for a specific recipient. The proposed percentage of funds will be distributed only on withdraw request for the recipient. The fund distribution continues until expiry time is reached or continuous fund request is canceled.
-NOTE:  This feature is designed to work with the SDK's default bond denom. 
+NOTE: This feature is designed to work with the SDK's default bond denom. 
 
 ```protobuf
   // CreateContinuousFund defines a method to distribute a percentage of funds to an address continuously.


### PR DESCRIPTION
# Description


docs/rfc/rfc-001-tx-validation.md
`add - the `

types/bech32/legacybech32/pk_test.go 
`TestBeach32ifPbKey` - `TestBech32ifPbKey`

x/auth/ante/sigverify.go
`asc|dsc` - `asc|desc`

x/evidence/module.go
`the all the` - `the all `

x/evidence/types/expected_keepers.go
`Cometinfo` - `CometInfo`

x/feegrant/keeper/grpc_query_test.go
`correct property assignment in TestFeeAllowances`

x/gov/migrations/v3/store_test.go
`require.NoError(t, err)` - deleted duplicate

x/protocolpool/README.md
`NOTE:  This` - deleted double space

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected flag description for transaction query ordering to display "asc|desc" instead of "asc|dsc".
  * Fixed test logic to properly validate grantee fields in fee allowance tests.
  * Removed redundant error check in governance proposal migration tests.
  * Corrected test function name typo in Bech32 key tests.

* **Documentation**
  * Improved wording and grammar in multiple comments and documentation files for clarity.
  * Corrected interface name capitalization in evidence module documentation.
  * Minor whitespace and wording adjustments in RFC and module documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->