### PR TITLE
fix: improve error message in network test setup

### DIFF
--- a/simapp/testutil_network_test.go
+++ b/simapp/testutil_network_test.go
@@ -25,7 +25,7 @@ func (s *IntegrationTestSuite) SetupSuite() {
 	s.Require().NoError(err)
 
 	h, err := s.network.WaitForHeight(1)
-	s.Require().NoError(err, "stalled at height %d", h)
+	s.Require().NoError(err, "failed to reach height 1; got %d", h)
 }
 
 func (s *IntegrationTestSuite) TearDownSuite() {


### PR DESCRIPTION
Fix misleading error message in IntegrationTestSuite.SetupSuite()

The previous error message "stalled at height %d" was confusing because
if WaitForHeight(1) succeeds, the height h would be 1, not the height
where the network stalled. 

Changed the error message to "failed to reach height 1; got %d" which
more accurately describes the failure scenario - when the network fails
to reach the expected height 1, it shows the current height h where
the failure occurred.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the clarity of an error message displayed when a certain height is not reached during testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->