### PR TITLE
fix: correct various typos across codebase

### DIFF
--- a/client/broadcast_test.go
+++ b/client/broadcast_test.go
@@ -20,7 +20,7 @@ func CreateContextWithErrorAndMode(err error, mode string) Context {
 	}
 }
 
-// Test the correct code is returned when
+// Test the correct code is returned when broadcasting transactions with specific mempool errors
 func TestBroadcastError(t *testing.T) {
 	errors := map[error]uint32{
 		mempool.ErrTxInCache:       sdkerrors.ErrTxInMempoolCache.ABCICode(),

--- a/client/query.go
+++ b/client/query.go
@@ -60,7 +60,7 @@ func (ctx Context) GetFromAddress() sdk.AccAddress {
 	return ctx.FromAddress
 }
 
-// GetFeePayerAddress returns the fee granter address from the context
+// GetFeePayerAddress returns the fee payer address from the context
 func (ctx Context) GetFeePayerAddress() sdk.AccAddress {
 	return ctx.FeePayer
 }

--- a/client/v2/CHANGELOG.md
+++ b/client/v2/CHANGELOG.md
@@ -38,7 +38,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Bug Fixes
 
-* [#24722](https://github.com/cosmos/cosmos-sdk/pull/24722) Fix msg parsing in when no pulsar file is present.
+* [#24722](https://github.com/cosmos/cosmos-sdk/pull/24722) Fix msg parsing when no pulsar file is present.
 
 ## [v2.0.0-beta.9](https://github.com/cosmos/cosmos-sdk/tree/client/v2.0.0-beta.9) - 2025-04-24
 

--- a/client/v2/README.md
+++ b/client/v2/README.md
@@ -92,7 +92,7 @@ The keyring is then converted to the `client/v2/autocli/keyring` interface.
 If no keyring is provided, the `autocli` generated command will not be able to sign transactions, but will still be able to query the chain.
 
 :::tip
-The Cosmos SDK keyring and Hubl keyring both implement the `client/v2/autocli/keyring` interface, thanks to the following wrapper:
+The Cosmos SDK keyring implements the `client/v2/autocli/keyring` interface, thanks to the following wrapper:
 
 ```go
 keyring.NewAutoCLIKeyring(kb)
@@ -255,8 +255,4 @@ https://github.com/cosmos/cosmos-sdk/blob/client/v2.0.0-beta.1/client/grpc/cmtse
 
 ## Summary
 
-`autocli` let you generate CLI to your Cosmos SDK-based applications without any cobra boilerplate. It allows you to easily generate CLI commands and flags from your protobuf messages, and provides many options for customising the behavior of your CLI application.
-
-To further enhance your CLI experience with Cosmos SDK-based blockchains, you can use `hubl`. `hubl` is a tool that allows you to query any Cosmos SDK-based blockchain using the new AutoCLI feature of the Cosmos SDK. With `hubl`, you can easily configure a new chain and query modules with just a few simple commands.
-
-For more information on `hubl`, including how to configure a new chain and query a module, see the [Hubl documentation](https://docs.cosmos.network/main/tooling/hubl).
+`autocli` lets you generate CLI for your Cosmos SDK-based applications without any cobra boilerplate. It allows you to easily generate CLI commands and flags from your protobuf messages, and provides many options for customising the behavior of your CLI application.

--- a/codec/codec.go
+++ b/codec/codec.go
@@ -12,7 +12,7 @@ type (
 	// Codec defines a functionality for serializing other objects.
 	// Users can define a custom Protobuf-based serialization.
 	// Note, Amino can still be used without any dependency on Protobuf.
-	// SDK provides to Codec implementations:
+	// SDK provides two Codec implementations:
 	//
 	// 1. AminoCodec: Provides full Amino serialization compatibility.
 	// 2. ProtoCodec: Provides full Protobuf serialization compatibility.

--- a/codec/types/any_test.go
+++ b/codec/types/any_test.go
@@ -28,7 +28,7 @@ var eom = &errOnMarshal{}
 // Ensure that returning an error doesn't suddenly allocate and waste bytes.
 // See https://github.com/cosmos/cosmos-sdk/issues/8537
 func TestNewAnyWithCustomTypeURLWithErrorNoAllocation(t *testing.T) {
-	// This tests continues to fail inconsistently.
+	// This test continues to fail inconsistently.
 	//
 	// Example: https://github.com/cosmos/cosmos-sdk/pull/9246/checks?check_run_id=2643313958#step:6:118
 	// Ref: https://github.com/cosmos/cosmos-sdk/issues/9010

--- a/docs/docs/learn/beginner/02-query-lifecycle.md
+++ b/docs/docs/learn/beginner/02-query-lifecycle.md
@@ -47,7 +47,7 @@ One such tool is [grpcurl](https://github.com/fullstorydev/grpcurl), and a gRPC 
 
 ```bash
 grpcurl \
-    -plaintext                                           # We want results in plain test
+    -plaintext                                           # We want results in plain text
     -import-path ./proto \                               # Import these .proto files
     -proto ./proto/cosmos/staking/v1beta1/query.proto \  # Look into this .proto file for the Query protobuf service
     -d '{"address":"$MY_DELEGATOR"}' \                   # Query arguments

--- a/store/cachekv/benchmark_test.go
+++ b/store/cachekv/benchmark_test.go
@@ -72,7 +72,7 @@ type CacheStack struct {
 	cacheStores []types.CacheKVStore
 }
 
-// CurrentContext returns the top context of cached stack,
+// CurrentStore returns the top context of cached stack,
 // if the stack is empty, returns the initial context.
 func (cs *CacheStack) CurrentStore() types.CacheKVStore {
 	l := len(cs.cacheStores)

--- a/store/iavl/store.go
+++ b/store/iavl/store.go
@@ -291,7 +291,7 @@ func (st *Store) Import(version int64) (*iavl.Importer, error) {
 	return tree.Import(version)
 }
 
-// Handle gatest the latest height, if height is 0
+// Handle gets the latest height, if height is 0
 func getHeight(tree Tree, req *types.RequestQuery) int64 {
 	height := req.Height
 	if height == 0 {

--- a/testutil/ioutil.go
+++ b/testutil/ioutil.go
@@ -73,7 +73,7 @@ func TempFile(tb testing.TB) *os.File {
 	return fp
 }
 
-// GetTempDir returns a writable temporary director for the test to use.
+// GetTempDir returns a writable temporary directory for the test to use.
 func GetTempDir(tb testing.TB) string {
 	tb.Helper()
 	// os.MkDir() is used instead of testing.T.TempDir()

--- a/types/handler.go
+++ b/types/handler.go
@@ -18,7 +18,7 @@ type PostDecorator interface {
 	PostHandle(ctx Context, tx Tx, simulate, success bool, next PostHandler) (newCtx Context, err error)
 }
 
-// ChainAnteDecorators ChainDecorator chains AnteDecorators together with each AnteDecorator
+// ChainAnteDecorators chains AnteDecorators together with each AnteDecorator
 // wrapping over the decorators further along chain and returns a single AnteHandler.
 //
 // NOTE: The first element is outermost decorator, while the last element is innermost

--- a/x/auth/ante/validator_tx_fee.go
+++ b/x/auth/ante/validator_tx_fee.go
@@ -11,7 +11,7 @@ import (
 )
 
 // checkTxFeeWithValidatorMinGasPrices implements the default fee logic, where the minimum price per
-// unit of gas is fixed and set by each validator, can the tx priority is computed from the gas price.
+// unit of gas is fixed and set by each validator, and the tx priority is computed from the gas price.
 func checkTxFeeWithValidatorMinGasPrices(ctx sdk.Context, tx sdk.Tx) (sdk.Coins, int64, error) {
 	feeTx, ok := tx.(sdk.FeeTx)
 	if !ok {

--- a/x/auth/vesting/README.md
+++ b/x/auth/vesting/README.md
@@ -41,7 +41,7 @@ For all vesting accounts, the owner of the vesting account is able to delegate a
 
 ## Note
 
-Vesting accounts can be initialized with some vesting and non-vesting coins. The non-vesting coins would be immediately transferable. DelayedVesting ContinuousVesting, PeriodicVesting and PermenantVesting accounts can be created with normal messages after genesis. Other types of vesting accounts must be created at genesis, or as part of a manual network upgrade. The current specification only allows for _unconditional_ vesting (ie. there is no possibility of reaching `ET` and
+Vesting accounts can be initialized with some vesting and non-vesting coins. The non-vesting coins would be immediately transferable. DelayedVesting ContinuousVesting, PeriodicVesting and PermanentVesting accounts can be created with normal messages after genesis. Other types of vesting accounts must be created at genesis, or as part of a manual network upgrade. The current specification only allows for _unconditional_ vesting (ie. there is no possibility of reaching `ET` and
 having coins fail to vest).
 
 ## Vesting Account Types

--- a/x/authz/authorizations.go
+++ b/x/authz/authorizations.go
@@ -29,7 +29,7 @@ type Authorization interface {
 // AcceptResponse instruments the controller of an authz message if the request is accepted
 // and if it should be updated or deleted.
 type AcceptResponse struct {
-	// If Accept=true, the controller can accept and authorization and handle the update.
+	// If Accept=true, the controller can accept an authorization and handle the update.
 	Accept bool
 	// If Delete=true, the controller must delete the authorization object and release
 	// storage resources.

--- a/x/group/internal/orm/auto_uint64.go
+++ b/x/group/internal/orm/auto_uint64.go
@@ -82,7 +82,7 @@ func (a AutoUInt64Table) GetOne(store storetypes.KVStore, rowID uint64, dest pro
 }
 
 // PrefixScan returns an Iterator over a domain of keys in ascending order. End is exclusive.
-// Start is an MultiKeyIndex key or prefix. It must be less than end, or the Iterator is invalid and error is returned.
+// Start is a MultiKeyIndex key or prefix. It must be less than end, or the Iterator is invalid and error is returned.
 // Iterator must be closed by caller.
 // To iterate over entire domain, use PrefixScan(1, math.MaxUint64)
 //
@@ -103,7 +103,7 @@ func (a AutoUInt64Table) PrefixScan(store storetypes.KVStore, start, end uint64)
 }
 
 // ReversePrefixScan returns an Iterator over a domain of keys in descending order. End is exclusive.
-// Start is an MultiKeyIndex key or prefix. It must be less than end, or the Iterator is invalid  and error is returned.
+// Start is a MultiKeyIndex key or prefix. It must be less than end, or the Iterator is invalid  and error is returned.
 // Iterator must be closed by caller.
 // To iterate over entire domain, use PrefixScan(1, math.MaxUint64)
 //

--- a/x/group/internal/orm/index.go
+++ b/x/group/internal/orm/index.go
@@ -117,7 +117,7 @@ func (i MultiKeyIndex) GetPaginated(store types.KVStore, searchKey any, pageRequ
 }
 
 // PrefixScan returns an Iterator over a domain of keys in ascending order. End is exclusive.
-// Start is an MultiKeyIndex key or prefix. It must be less than end, or the Iterator is invalid and error is returned.
+// Start is a MultiKeyIndex key or prefix. It must be less than end, or the Iterator is invalid and error is returned.
 // Iterator must be closed by caller.
 // To iterate over entire domain, use PrefixScan(nil, nil)
 //
@@ -145,7 +145,7 @@ func (i MultiKeyIndex) PrefixScan(store types.KVStore, startI, endI any) (Iterat
 }
 
 // ReversePrefixScan returns an Iterator over a domain of keys in descending order. End is exclusive.
-// Start is an MultiKeyIndex key or prefix. It must be less than end, or the Iterator is invalid and error is returned.
+// Start is a MultiKeyIndex key or prefix. It must be less than end, or the Iterator is invalid and error is returned.
 // Iterator must be closed by caller.
 // To iterate over entire domain, use PrefixScan(nil, nil)
 //


### PR DESCRIPTION
# Description

client/broadcast_test.go 
`Test the correct code is returned when` - not a complete comment

client/query.go
`granter` - `payer`

client/v2/CHANGELOG.md
`parsing in when` - delete extra in

client/v2/README.md
`deleted references to hubl`

codec/codec.go
`SDK provides to Codec` - `SDK provides two Codec`

codec/types/any_test.go
`tests` - `test`

docs/docs/learn/beginner/02-query-lifecycle.md
test - text

store/cachekv/benchmark_test.go
`CurrentContext` - `CurrentStore`

store/iavl/store.go
`gatest` - `gets`

testutil/ioutil.go
`director` - `directory`

types/handler.go
`ChainAnteDecorators ChainDecorator` -- Removed redundant

x/auth/ante/validator_tx_fee.go
`can the tx priority` - `and the tx priority`

x/auth/vesting/README.md
`PermenantVesting` - `PermanentVesting`

x/authz/authorizations.go
`accept and authorization` - `accept an authorization`

x/group/internal/orm/auto_uint64.go
x/group/internal/orm/index.go
`an MultiKeyIndex `- `a MultiKeyIndex`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected various typos and improved clarity in comments and documentation across multiple modules.
  * Updated changelog and README files for accuracy and conciseness.
  * Enhanced comment descriptions for better understanding of code behavior and test coverage.

* **Style**
  * Improved consistency in comment formatting and terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->