### PR TITLE
fix: typo corrections in docs and UML diagrams

### DIFF
--- a/docs/docs/build/building-modules/16-testing.md
+++ b/docs/docs/build/building-modules/16-testing.md
@@ -6,7 +6,7 @@ sidebar_position: 1
 
 The Cosmos SDK contains different types of [tests](https://martinfowler.com/articles/practical-test-pyramid.html).
 These tests have different goals and are used at different stages of the development cycle.
-We advice, as a general rule, to use tests at all stages of the development cycle.
+We advise, as a general rule, to use tests at all stages of the development cycle.
 It is advised, as a chain developer, to test your application and modules in a similar way than the SDK.
 
 The rationale behind testing can be found in [ADR-59](https://docs.cosmos.network/main/build/architecture/adr-059-test-scopes).

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -24,7 +24,7 @@ const config = {
   organizationName: "cosmos",
   projectName: "cosmos-sdk",
 
-  // Even if you don't use internalization, you can use this field to set useful
+  // Even if you don't use internationalization, you can use this field to set useful
   // metadata like html lang. For example, if your site is Chinese, you may want
   // to replace "en" with "zh-Hans".
   i18n: {

--- a/docs/static/uml/puml/begin_redelegation_sequence.puml
+++ b/docs/static/uml/puml/begin_redelegation_sequence.puml
@@ -5,7 +5,7 @@ title: Redelegation
 
 msgServer -> keeper : BeginRedelegation(delAddr, valSrcAddr, valDstAddr, sharesAmount)
 participant  "keeper (staking)" as keeper
-keeper -> keeper : get number of sharew
+keeper -> keeper : get number of shares
 note left: If the delegator has more shares than the total shares in the validator\n(due to rounding errors), then just withdraw the max number of shares.
 keeper -> keeper : check the redelegation uses correct denom
 

--- a/docs/static/uml/puml/unbond_sequence.puml
+++ b/docs/static/uml/puml/unbond_sequence.puml
@@ -28,7 +28,7 @@ group Unbond(delAddr, valAddr, shares)
 
     alt complete unbonding, all shares removed
         keeper -> store : remove delegation object
-    else there are still shares delegated (not a complete undbonding)
+    else there are still shares delegated (not a complete unbonding)
         keeper -> store : update delegation object
         keeper -> keeper : AfterDelegationModified hook
     end


### PR DESCRIPTION
docs/docs/build/building-modules/16-testing.md
advice → advise

docs/docusaurus.config.js
internalization → internationalization

docs/static/uml/puml/begin_redelegation_sequence.puml
sharew → shares

docs/static/uml/puml/unbond_sequence.puml
unbonding → unbonding)