### PR TITLE
fix: skip Parse call when Proto is nil in duration_test.go

### DIFF
--- a/x/tx/signing/textual/duration_test.go
+++ b/x/tx/signing/textual/duration_test.go
@@ -44,6 +44,11 @@ func TestDurationJSON(t *testing.T) {
 				require.Equal(t, tc.Text, screens[0].Content)
 			}
 
+			// Skip Parse if tc.Proto is nil or screens is empty
+			if tc.Proto == nil {
+				return
+			}
+
 			val, err := rend.Parse(context.Background(), screens)
 			if tc.Error {
 				require.Error(t, err)


### PR DESCRIPTION
# Description

Fixed a logical error in duration_test.go where Parse was called with an empty screens slice when tc.Proto was nil. This would cause an error since the Parse method expects exactly one screen. Added a check to skip the Parse call when tc.Proto is nil, preventing the error
