### PR TITLE
docs: multiple typos in adr documentation

### DIFF
--- a/docs/architecture/adr-008-dCERT-group.md
+++ b/docs/architecture/adr-008-dCERT-group.md
@@ -68,9 +68,9 @@ following specifications:
    send a transaction accepting their admission at which point the validity of
    their admission is to be confirmed.
     * A sequence number is assigned when a member is added to dCERT group.
-     If a member leaves the dCERT group and then enters back, a new sequence number
+     If a member leaves the dCERT group and then re-enters, a new sequence number
      is assigned.  
-* Addresses which control the greatest amount of preferred-representation are
+* Addresses that control the greatest amount of preferred-representation are
    eligible to join the dCERT group (up the _maximum number of dCERT members_).
    If the dCERT group is already full and new member is admitted, the existing
    dCERT member with the lowest amount of votes is kicked from the dCERT group.
@@ -93,7 +93,7 @@ following specifications:
 
 All members of the dCERT group must stake tokens _specifically_ to maintain
 eligibility as a dCERT member. These tokens can be staked directly by the vying
-dCERT member or out of the good will of a 3rd party (who shall gain no on-chain
+dCERT member or out of the goodwill of a 3rd party (who shall gain no on-chain
 benefits for doing so). This staking mechanism should use the existing global
 unbonding time of tokens staked for network validator security. A dCERT member
 can _only be_ a member if it has the required tokens staked under this
@@ -101,7 +101,7 @@ mechanism. If those tokens are unbonded then the dCERT member must be
 automatically kicked from the group.  
 
 Slashing of a particular dCERT member due to soft-contract breach should be
-performed by governance on a per member basis based on the magnitude of the
+performed by governance on a per-member basis based on the magnitude of the
 breach.  The process flow is anticipated to be that a dCERT member is suspended
 by the dCERT group prior to being slashed by governance.  
 
@@ -109,11 +109,11 @@ Membership suspension by the dCERT group takes place through a voting procedure
 by the dCERT group members. After this suspension has taken place, a governance
 proposal to slash the dCERT member must be submitted, if the proposal is not
 approved by the time the rescinding member has completed unbonding their
-tokens, then the tokens are no longer staked and unable to be slashed.
+tokens, then the tokens are no longer staked and are unable to be slashed.
 
 Additionally in the case of an emergency situation of a colluding and malicious
 dCERT group, the community needs the capability to disband the entire dCERT
-group and likely fully slash them. This could be achieved though a special new
+group and likely fully slash them. This could be achieved through a special new
 proposal type (implemented as a general governance proposal) which would halt
 the functionality of the dCERT group until the proposal was concluded. This
 special proposal type would likely need to also have a fairly large wager which
@@ -144,7 +144,7 @@ required.
 
 Note also, that if there was a problem with governance voting (for instance a
 capability to vote many times) then governance would be broken and should be
-halted with this mechanism, it would be then up to the validator set to
+halted with this mechanism, it would then be up to the validator set to
 coordinate and hard-fork upgrade to a patched version of the software where
 governance is re-enabled (and fixed). If the dCERT group abuses this privilege
 they should all be severely slashed.
@@ -157,8 +157,8 @@ Proposed
 
 ### Positive
 
-* Potential to reduces the number of parties to coordinate with during an emergency
-* Reduction in possibility of disclosing sensitive information to malicious parties
+* Potential to reduce the number of parties to coordinate with during an emergency
+* Reduction in the possibility of disclosing sensitive information to malicious parties
 
 ### Negative
 

--- a/docs/architecture/adr-009-evidence-module.md
+++ b/docs/architecture/adr-009-evidence-module.md
@@ -11,9 +11,9 @@ Accepted
 
 ## Context
 
-In order to support building highly secure, robust and interoperable blockchain
+In order to support building a highly secure, robust and interoperable blockchain
 applications, it is vital for the Cosmos SDK to expose a mechanism in which arbitrary
-evidence can be submitted, evaluated and verified resulting in some agreed upon
+evidence can be submitted, evaluated and verified resulting in some agreed-upon
 penalty for any misbehavior committed by a validator, such as equivocation (double-voting),
 signing when unbonded, signing an incorrect state transition (in the future), etc.
 Furthermore, such a mechanism is paramount for any
@@ -31,7 +31,7 @@ functionality:
   custom evidence messages, message handlers, and methods to slash and penalize
   accordingly for misbehavior.
 * Support the ability to route evidence messages to handlers in any module to
-  determine the validity of submitted misbehavior.
+  determine the validity of the submitted misbehavior.
 * Support the ability, through governance, to modify slashing penalties of any
   evidence type.
 * Querier implementation to support querying params, evidence types, params, and
@@ -49,7 +49,7 @@ an infraction time. We want the `Evidence` type to remain as flexible as possibl
 When submitting evidence to the `x/evidence` module, the concrete type must provide
 the validator's consensus address, which should be known by the `x/slashing`
 module (assuming the infraction is valid), the height at which the infraction
-occurred and the validator's power at same height in which the infraction occurred.
+occurred and the validator's power was at the same height as the infraction occurred.
 
 ```go
 type Evidence interface {
@@ -161,7 +161,7 @@ type GenesisState struct {
 ### Positive
 
 * Allows the state machine to process misbehavior submitted on-chain and penalize
-  validators based on agreed upon slashing parameters.
+  validators based on agreed-upon slashing parameters.
 * Allows evidence types to be defined and handled by any module. This further allows
   slashing and jailing to be defined by more complex mechanisms.
 * Does not solely rely on Tendermint to submit evidence.

--- a/docs/architecture/adr-010-modular-antehandler.md
+++ b/docs/architecture/adr-010-modular-antehandler.md
@@ -13,7 +13,7 @@ SUPERSEDED by ADR-045
 
 The current AnteHandler design allows users to either use the default AnteHandler provided in `x/auth` or to build their own AnteHandler from scratch. Ideally AnteHandler functionality is split into multiple, modular functions that can be chained together along with custom ante-functions so that users do not have to rewrite common antehandler logic when they want to implement custom behavior.
 
-For example, let's say a user wants to implement some custom signature verification logic. In the current codebase, the user would have to write their own Antehandler from scratch largely reimplementing much of the same code and then set their own custom, monolithic antehandler in the baseapp. Instead, we would like to allow users to specify custom behavior when necessary and combine them with default ante-handler functionality in a way that is as modular and flexible as possible.
+For example, let's say a user wants to implement some custom signature verification logic. In the current codebase, the user would have to write their own Antehandler from scratch largely reimplementing much of the same code and then set their own custom, monolithic antehandler in the baseapp. Instead, we would like to allow users to specify custom behavior when necessary and combine it with default ante-handler functionality in a way that is as modular and flexible as possible.
 
 ## Proposals
 
@@ -157,7 +157,7 @@ app.SetAnteHandler(mm.GetAnteHandler())
 
 #### Custom Workflow
 
-This is an example workflow for a user that wants to implement custom antehandler logic. In this example, the user wants to implement custom signature verification and change the order of antehandler so that validate memo runs before signature verification.
+This is an example workflow for a user who wants to implement custom antehandler logic. In this example, the user wants to implement custom signature verification and change the order of antehandler so that validate memo runs before signature verification.
 
 ##### User Code
 
@@ -177,7 +177,7 @@ moduleManager.SetAnteHandlerOrder([]AnteHandler(ValidateMemo, CustomSigVerify, D
 Pros:
 
 1. Allows for ante functionality to be as modular as possible.
-2. For users that do not need custom ante-functionality, there is little difference between how antehandlers work and how BeginBlock and EndBlock work in ModuleManager.
+2. For users who do not need custom ante-functionality, there is little difference between how antehandlers work and how BeginBlock and EndBlock work in ModuleManager.
 3. Still easy to understand
 
 Cons:
@@ -186,13 +186,13 @@ Cons:
 
 ### Simple Decorators
 
-This approach takes inspiration from Weave's decorator design while trying to minimize the number of breaking changes to the Cosmos SDK and maximizing simplicity. Like Weave decorators, this approach allows one `AnteDecorator` to wrap the next AnteHandler to do pre- and post-processing on the result. This is useful since decorators can do defer/cleanups after an AnteHandler returns as well as perform some setup beforehand. Unlike Weave decorators, these `AnteDecorator` functions can only wrap over the AnteHandler rather than the entire handler execution path. This is deliberate as we want decorators from different modules to perform authentication/validation on a `tx`. However, we do not want decorators being capable of wrapping and modifying the results of a `MsgHandler`.
+This approach takes inspiration from Weave's decorator design while trying to minimize the number of breaking changes to the Cosmos SDK and maximize simplicity. Like Weave decorators, this approach allows one `AnteDecorator` to wrap the next AnteHandler to do pre- and post-processing on the result. This is useful since decorators can do defer/cleanups after an AnteHandler returns as well as perform some setup beforehand. Unlike Weave decorators, these `AnteDecorator` functions can only wrap over the AnteHandler rather than the entire handler execution path. This is deliberate as we want decorators from different modules to perform authentication/validation on a `tx`. However, we do not want decorators to be capable of wrapping and modifying the results of a `MsgHandler`.
 
-In addition, this approach will not break any core Cosmos SDK API's. Since we preserve the notion of an AnteHandler and still set a single AnteHandler in baseapp, the decorator is simply an additional approach available for users that desire more customization. The API of modules (namely `x/auth`) may break with this approach, but the core API remains untouched.
+In addition, this approach will not break any core Cosmos SDK API's. Since we preserve the notion of an AnteHandler and still set a single AnteHandler in baseapp, the decorator is simply an additional approach available for users who desire more customization. The API of modules (namely `x/auth`) may break with this approach, but the core API remains untouched.
 
 Allow Decorator interface that can be chained together to create a Cosmos SDK AnteHandler.
 
-This allows users to choose between implementing an AnteHandler by themselves and setting it in the baseapp, or use the decorator pattern to chain their custom decorators with the Cosmos SDK provided decorators in the order they wish.
+This allows users to choose between implementing an AnteHandler by themselves and setting it in the baseapp, or using the decorator pattern to chain their custom decorators with the Cosmos SDK provided decorators in the order they wish.
 
 ```go
 // An AnteDecorator wraps an AnteHandler, and can do pre- and post-processing on the next AnteHandler

--- a/docs/architecture/adr-011-generalize-genesis-accounts.md
+++ b/docs/architecture/adr-011-generalize-genesis-accounts.md
@@ -125,7 +125,7 @@ func ValidateGenesis(data GenesisState) error {
         }
         addrMap[addrStr] = true
 
-        // check account specific validation
+        // check account-specific validation
         if err := acc.Validate(); err != nil {
             return fmt.Errorf("invalid account found in genesis state; address: %s, error: %s", addrStr, err.Error())
         }

--- a/docs/architecture/adr-012-state-accessors.md
+++ b/docs/architecture/adr-012-state-accessors.md
@@ -19,8 +19,8 @@ state is defined as a `StoreKey`, which gives full access on the entire Merkle t
 send the access right to a specific key-value pair (or a set of key-value pairs) to another module safely.
 
 Finally, because the getter/setter functions are defined as methods of a module's `Keeper`, the reviewers
-have to consider the whole Merkle tree space when they reviewing a function accessing any part of the state.
-There is no static way to know which part of the state that the function is accessing (and which is not).
+have to consider the whole Merkle tree space when they review a function accessing any part of the state.
+There is no static way to know which part of the state the function is accessing (and which is not).
 
 ## Decision
 
@@ -125,8 +125,8 @@ Where the `key` argument in core method is typed.
 
 Some of the properties of the accessor types are:
 
-* State access happens only when a function which takes a `Context` as an argument is invoked
-* Accessor type structs give rights to access the state only that the struct is referring, no other
+* State access happens only when a function that takes a `Context` as an argument is invoked
+* Accessor type structs give rights to access only the state that the struct is referring to, no other
 * Marshalling/Unmarshalling happens implicitly within the core methods
 
 ## Status

--- a/docs/architecture/adr-013-metrics.md
+++ b/docs/architecture/adr-013-metrics.md
@@ -16,7 +16,7 @@ performing. We aim to expose metrics from modules and other core parts of the Co
 In addition, we should aim to support multiple configurable sinks that an operator may choose from.
 By default, when telemetry is enabled, the application should track and expose metrics that are
 stored in-memory. The operator may choose to enable additional sinks, where we support only
-[Prometheus](https://prometheus.io/) for now, as it's battle-tested, simple to setup, open source,
+[Prometheus](https://prometheus.io/) for now, as it's battle-tested, simple to set up, open source,
 and is rich with ecosystem tooling.
 
 We must also aim to integrate metrics into the Cosmos SDK in the most seamless way possible such that
@@ -148,7 +148,7 @@ func (k BaseKeeper) MintCoins(ctx sdk.Context, moduleName string, amt sdk.Coins)
 
 ### Positive
 
-* Exposure into the performance and behavior of an application
+* Exposure to the performance and behavior of an application
 
 ### Negative
 

--- a/docs/architecture/adr-014-proportional-slashing.md
+++ b/docs/architecture/adr-014-proportional-slashing.md
@@ -8,13 +8,13 @@
 
 ## Context
 
-In Proof of Stake-based chains, centralization of consensus power amongst a small set of validators can cause harm to the network due to increased risk of censorship, liveness failure, fork attacks, etc.  However, while this centralization causes a negative externality to the network, it is not directly felt by the delegators contributing towards delegating towards already large validators.  We would like a way to pass on the negative externality cost of centralization onto those large validators and their delegators.
+In Proof-of-Stake-based chains, centralization of consensus power among a small set of validators can cause harm to the network due to an increased risk of censorship, liveness failure, and fork attacks, etc.  However, while this centralization causes a negative externality to the network, it is not directly felt by the delegators who contribute to delegating to already large validators.  We would like a way to pass on the negative externality cost of centralization onto those large validators and their delegators.
 
 ## Decision
 
 ### Design
 
-To solve this problem, we will implement a procedure called Proportional Slashing.  The desire is that the larger a validator is, the more they should be slashed.  The first naive attempt is to make a validator's slash percent proportional to their share of consensus voting power.
+To solve this problem, we will implement a procedure called Proportional Slashing.  The desire is that the larger a validator is, the more it should be slashed.  The first naive attempt is to make a validator's slash percent proportional to their share of consensus voting power.
 
 ```text
 slash_amount = k * power // power is the faulting validator's voting power and k is some on-chain constant
@@ -28,7 +28,7 @@ slash_amount = k * (power_1 + power_2 + ... + power_n) // where power_i is the v
 
 Now, if someone splits a validator of 10% into two validators of 5% each which both fault, then they both fault in the same time frame, they both will get slashed at the sum 10% amount.
 
-However in practice, we likely don't want a linear relation between amount of stake at fault, and the percentage of stake to slash. In particular, solely 5% of stake double signing effectively did nothing to majorly threaten security, whereas 30% of stake being at fault clearly merits a large slashing factor, due to being very close to the point at which Tendermint security is threatened. A linear relation would require a factor of 6 gap between these two, whereas the difference in risk posed to the network is much larger. We propose using S-curves (formally [logistic functions](https://en.wikipedia.org/wiki/Logistic_function) to solve this). S-Curves capture the desired criterion quite well. They allow the slashing factor to be minimal for small values, and then grow very rapidly near some threshold point where the risk posed becomes notable.
+However in practice, we likely don't want a linear relation between the amount of stake at fault, and the percentage of stake to slash. In particular, solely 5% of stake double signing effectively did nothing to majorly threaten security, whereas 30% of stake being at fault clearly merits a large slashing factor, due to being very close to the point at which Tendermint security is threatened. A linear relation would require a factor of 6 gap between these two, whereas the difference in risk posed to the network is much larger. We propose using S-curves (formally [logistic functions](https://en.wikipedia.org/wiki/Logistic_function) to solve this). S-Curves capture the desired criterion quite well. They allow the slashing factor to be minimal for small values, and then grow very rapidly near some threshold point where the risk posed becomes notable.
 
 #### Parameterization
 
@@ -82,4 +82,4 @@ Proposed
 
 ### Negative
 
-* More computationally expensive than current implementation.  Will require more data about "recent slashing events" to be stored on chain.
+* More computationally expensive than the current implementation.  Will require more data about "recent slashing events" to be stored on chain.

--- a/docs/architecture/adr-016-validator-consensus-key-rotation.md
+++ b/docs/architecture/adr-016-validator-consensus-key-rotation.md
@@ -7,7 +7,7 @@
 
 ## Context
 
-Validator consensus key rotation feature has been discussed and requested for a long time, for the sake of safer validator key management policy (e.g. https://github.com/tendermint/tendermint/issues/1136). So, we suggest one of the simplest form of validator consensus key rotation implementation mostly onto Cosmos SDK.
+Validator consensus key rotation feature has been discussed and requested for a long time, for the sake of safer validator key management policy (e.g. https://github.com/tendermint/tendermint/issues/1136). So, we suggest one of the simplest forms of validator consensus key rotation implementation mostly onto Cosmos SDK.
 
 We don't need to make any update on consensus logic in Tendermint because Tendermint does not have any mapping information of consensus key and validator operator key, meaning that from Tendermint's point of view, a consensus key rotation of a validator is simply a replacement of a consensus key to another.
 
@@ -40,13 +40,13 @@ Also, it should be noted that this ADR includes only the simplest form of consen
     * a validator should pay `KeyRotationFee` to rotate the consensus key which is calculated as below
     * `KeyRotationFee` = (max(`VotingPowerPercentage` *100, 1)* `InitialKeyRotationFee`) * 2^(number of rotations in `ConsPubKeyRotationHistory` in recent unbonding period)
 * evidence module
-    * evidence module can search corresponding consensus key for any height from slashing keeper so that it can decide which consensus key is supposed to be used for the given height.
+    * evidence module can search corresponding consensus key for any height from the slashing keeper so that it can decide which consensus key is supposed to be used for the given height.
 * abci.ValidatorUpdate
-    * tendermint already has ability to change a consensus key by ABCI communication(`ValidatorUpdate`).
+    * tendermint already has the ability to change a consensus key by ABCI communication(`ValidatorUpdate`).
     * validator consensus key update can be done via creating new + delete old by change the power to zero.
     * therefore, we expect we do not even need to change Tendermint codebase at all to implement this feature.
 * new genesis parameters in `staking` module
-    * `MaxConsPubKeyRotations` : maximum number of rotation can be executed by a validator in recent unbonding period. default value 10 is suggested(11th key rotation will be rejected)
+    * `MaxConsPubKeyRotations` : maximum number of rotations can be executed by a validator in recent unbonding period. default value 10 is suggested(11th key rotation will be rejected)
     * `InitialKeyRotationFee` : the initial key rotation fee when no key rotation has happened in recent unbonding period. default value 1atom is suggested(1atom fee for the first key rotation in recent unbonding period)
 
 ### Workflow


### PR DESCRIPTION
nothing fancy, just typos