### PR TITLE
Fixed typos and minor grammar issues across multiple files.

### DIFF
--- a/client/grpc/cmtservice/service.go
+++ b/client/grpc/cmtservice/service.go
@@ -87,7 +87,7 @@ func (s queryServer) GetBlockByHeight(ctx context.Context, req *GetBlockByHeight
 	}
 
 	if req.Height > blockHeight {
-		return nil, status.Error(codes.InvalidArgument, "requested block height is bigger then the chain length")
+		return nil, status.Error(codes.InvalidArgument, "requested block height is bigger than the chain length")
 	}
 
 	protoBlockID, protoBlock, err := GetProtoBlock(ctx, s.clientCtx, &req.Height)
@@ -137,7 +137,7 @@ func (s queryServer) GetValidatorSetByHeight(ctx context.Context, req *GetValida
 	}
 
 	if req.Height > blockHeight {
-		return nil, status.Error(codes.InvalidArgument, "requested block height is bigger then the chain length")
+		return nil, status.Error(codes.InvalidArgument, "requested block height is bigger than the chain length")
 	}
 
 	r, err := ValidatorsOutput(ctx, s.clientCtx, &req.Height, page, limit)

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,7 +23,7 @@ It is built using the following stack:
 ## Docs Build Workflow
 
 The docs are built and deployed automatically on GitHub Pages by a [GitHub Action workflow](../.github/workflows/build-docs.yml).
-The workflow is triggered on every push to the `main` and `release/v**` branches, every time documentations or specs are modified.
+The workflow is triggered on every push to the `main` and `release/v**` branches, every time documentation or specs are modified.
 
 ### How It Works
 

--- a/docs/docs/build/build.md
+++ b/docs/docs/build/build.md
@@ -6,7 +6,7 @@ sidebar_position: 0
 
 * [Building Apps](./building-apps/00-app-go.md) - The documentation in this section will guide you through the process of developing your dApp using the Cosmos SDK framework.
 * [Modules](../../../x/README.md) - Information about the various modules available in the Cosmos SDK: Auth, Authz, Bank, Circuit, Consensus, Distribution, Epochs, Evidence, Feegrant, Governance, Group, Mint, NFT, Protocolpool, Slashing, Staking, Upgrade, Genutil.
-* [Migrations](./migrations/01-intro.md) - See what has been updated in each release the process of the transition between versions.
+* [Migrations](./migrations/01-intro.md) - See what has been updated in each release and the process of the transition between versions.
 * [Packages](./packages/README.md) - Explore a curated collection of pre-built modules and functionalities, streamlining the development process.
 * [Tooling](./tooling/README.md) - A suite of utilities designed to enhance the development workflow, optimizing the efficiency of Cosmos SDK-based projects.
 * [ADR's](./architecture/README.md) - Provides a structured repository of key decisions made during the development process, which have been documented and offers rationale behind key decisions being made.

--- a/docs/spec/SPEC_STANDARD.md
+++ b/docs/spec/SPEC_STANDARD.md
@@ -45,7 +45,7 @@ The section may have any or all of the following subsections, as appropriate to 
 * *API* - A detailed description of the feature's API.
 * *Technical Details* - All technical details including syntax, diagrams, semantics, protocols, data structures, algorithms, and pseudocode as appropriate. The technical specification should be detailed enough such that separate correct implementations of the specification without knowledge of each other are compatible.
 * *Backwards Compatibility* - A discussion of compatibility (or lack thereof) with previous feature or protocol versions.
-* *Known Issues* - A list of known issues. This subsection is specially important for specifications of already in-use features.
+* *Known Issues* - A list of known issues. This subsection is especially important for specifications of already in-use features.
 * *Example Implementation* - A concrete example implementation or description of an expected implementation to serve as the primary reference for implementers.
 
 ### History

--- a/docs/spec/addresses/bech32.md
+++ b/docs/spec/addresses/bech32.md
@@ -14,8 +14,8 @@ In the Cosmos network, keys and addresses may refer to a number of different rol
 
 ## Encoding
 
-While all user facing interfaces to Cosmos software should exposed Bech32 interfaces, many internal interfaces encode binary value in hex or base64 encoded form.
+While all user facing interfaces to Cosmos software should expose Bech32 interfaces, many internal interfaces encode binary value in hex or base64 encoded form.
 
-To convert between other binary representation of addresses and keys, it is important to first apply the Amino encoding process before Bech32 encoding.
+To convert between other binary representations of addresses and keys, it is important to first apply the Amino encoding process before Bech32 encoding.
 
 A complete implementation of the Amino serialization format is unnecessary in most cases. Simply prepending bytes from this [table](https://github.com/cometbft/cometbft/blob/main/spec/blockchain/encoding.md) to the byte string payload before Bech32 encoding will be sufficient for compatible representation.

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -192,7 +192,7 @@ func Wrap(err error, description string) error {
 		return nil
 	}
 
-	// If this error does not carry the stacktrace information yet, attach
+	// If this error does not carry the stack trace information yet, attach
 	// one. This should be done only once per error at the lowest frame
 	// possible (most inner wrap).
 	if stackTrace(err) == nil {


### PR DESCRIPTION
client/grpc/cmtservice/service.go - then -> than in error messages.

docs/README.md - documentations -> documentation.

docs/docs/build/build.md - added missing conjunction and.

docs/spec/SPEC_STANDARD.md - specially -> especially.

docs/spec/addresses/bech32.md - exposed -> expose, representation -> representations.

errors/errors.go - stacktrace -> stack trace.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected multiple grammatical and typographical errors across various documentation files to improve clarity and readability.

* **Style**
  * Fixed minor grammar issues in user-facing error messages and code comments for improved accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->