### PR TITLE
feat(gov): support decode proposals from removed module with legacy msg 

### DIFF
--- a/x/gov/keeper/keeper.go
+++ b/x/gov/keeper/keeper.go
@@ -251,3 +251,8 @@ func (k Keeper) assertSummaryLength(summary string) error {
 	}
 	return nil
 }
+
+// LegacyCodec returns the legacy codec (for testing).
+func (k Keeper) LegacyCodec() codec.Codec {
+	return k.legacyCdc
+}

--- a/x/gov/keeper/keeper_test.go
+++ b/x/gov/keeper/keeper_test.go
@@ -153,6 +153,23 @@ func TestGetGovGovernanceAndModuleAccountAddress(t *testing.T) {
 	require.Equal(t, mAddr, govKeeper.ModuleAccountAddress())
 }
 
+type dummyCodec struct{ codec.Codec }
+
+func TestWithLegacyCodec(t *testing.T) {
+	k := &keeper.Keeper{}
+
+	// Should set legacyCdc field
+	legacy := &dummyCodec{}
+	opt := keeper.WithLegacyCodec(legacy)
+	opt(k)
+	require.Equal(t, legacy, k.LegacyCodec())
+
+	// Should panic if nil is passed
+	require.PanicsWithValue(t, "legacyCdc cannot be nil", func() {
+		keeper.WithLegacyCodec(nil)(k)
+	})
+}
+
 func TestKeeperTestSuite(t *testing.T) {
 	suite.Run(t, new(KeeperTestSuite))
 }


### PR DESCRIPTION
# Description

* add [WithLegacyCodec](https://github.com/MANTRA-Chain/mantrachain/pull/407/commits/f301bc2cc5404f0384a19575f2f637034e1d26ed#diff-0f1d2976054440336a576d47a44a37b80cdf6701dd9113012bce0e3c425819b7R601) to support query with `cosmos/gov/v1beta1/proposals` api that contains legacy msg
* ideally [RegisterLegacyInterfaces](https://github.com/MANTRA-Chain/mantrachain/pull/407/commits/c7c88c07945032856e84e74b85d619888ddf0cde#diff-5cbdb414f6d2bee3ccf72887696ccebf55e1bd3756f435969cffd386353e5c84R51) in client side should work the same way as `cosmos/tx/v1beta1/txs` api

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->
