### PR TITLE
fix(store): correct unsafe bytes to string conversion in store/internal/conv

### DIFF
--- a/store/internal/conv/string.go
+++ b/store/internal/conv/string.go
@@ -15,5 +15,5 @@ func UnsafeStrToBytes(s string) []byte {
 // to be used generally, but for a specific pattern to delete keys
 // from a map.
 func UnsafeBytesToStr(b []byte) string {
-	return *(*string)(unsafe.Pointer(&b))
+	return unsafe.String(unsafe.SliceData(b), len(b))
 }


### PR DESCRIPTION


# Description

The previous implementation of UnsafeBytesToStr was incorrectly taking the address of the slice header (&b) instead of the slice data, which could lead to memory corruption and segmentation faults. This fix aligns the implementation with the 
correct pattern used elsewhere in the codebase (internal/conv and x/nft/internal/conv) by using unsafe.String(unsafe.SliceData(b), len(b)).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of byte slice to string conversions for better efficiency. No changes to the user-facing interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->