### PR TITLE
Fix grammatical errors and improve text clarity in ADR documentation

### DIFF
--- a/docs/architecture/adr-048-consensus-fees.md
+++ b/docs/architecture/adr-048-consensus-fees.md
@@ -76,7 +76,7 @@ This mechanism can be easily composed with prioritization mechanisms:
 
 ### `min-gas-prices`
 
-Deprecate the current per-validator `min-gas-prices` configuration, since it would confusing for it to work together with the consensus gas price.
+Deprecate the current per-validator `min-gas-prices` configuration, since it would be confusing for it to work together with the consensus gas price.
 
 ### Adjust For Block Load
 
@@ -126,7 +126,7 @@ class TierParams:
   priority: int           # priority in tendermint mempool
   initial_gas_price: Coin
   parent_gas_target: int
-  change_speed: Decimal   # 0 means don't adjust for block load.
+  change_speed: Decimal   # 0 means doesn't adjust for block load.
 
 class Params:
     'protocol parameters'
@@ -173,9 +173,9 @@ def end_block():
 
 ### Dos attack protection
 
-To fully saturate the blocks and prevent other transactions from executing, attacker need to use transactions of highest tier, the cost would be significantly higher than the default tier.
+To fully saturate the blocks and prevent other transactions from executing, an attacker needs to use transactions of highest tier, the cost would be significantly higher than the default tier.
 
-If attacker spam with lower tier transactions, user can mitigate by sending higher tier transactions.
+If an attacker spams with lower tier transactions, users can mitigate by sending higher tier transactions.
 
 ## Consequences
 
@@ -189,7 +189,7 @@ If attacker spam with lower tier transactions, user can mitigate by sending high
 
 * The default tier keeps the same predictable gas price experience for client.
 * The higher tier's gas price can adapt to block load.
-* No priority conflict with custom priority based on transaction types, since this proposal only occupy three priority levels.
+* No priority conflict with custom priority based on transaction types, since this proposal only occupies three priority levels.
 * Possibility to compose different priority rules with tiers
 
 ### Negative

--- a/docs/architecture/adr-049-state-sync-hooks.md
+++ b/docs/architecture/adr-049-state-sync-hooks.md
@@ -109,14 +109,14 @@ On top of the existing `Snapshotter` interface for the `multistore`, we add `Ext
 
 ```go
 // ExtensionPayloadReader read extension payloads,
-// it returns io.EOF when reached either end of stream or the extension boundaries.
+// it returns io.EOF when it reaches either end of stream or the extension boundaries.
 type ExtensionPayloadReader = func() ([]byte, error)
 
 // ExtensionPayloadWriter is a helper to write extension payloads to underlying stream.
 type ExtensionPayloadWriter = func([]byte) error
 
 // ExtensionSnapshotter is an extension Snapshotter that is appended to the snapshot stream.
-// ExtensionSnapshotter has an unique name and manages it's own internal formats.
+// ExtensionSnapshotter has a unique name and manages it's own internal formats.
 type ExtensionSnapshotter interface {
 	// SnapshotName returns the name of snapshotter, it should be unique in the manager.
 	SnapshotName() string
@@ -131,7 +131,7 @@ type ExtensionSnapshotter interface {
 	SnapshotExtension(height uint64, payloadWriter ExtensionPayloadWriter) error
 
 	// RestoreExtension restores an extension state snapshot,
-	// the payload reader returns `io.EOF` when reached the extension boundaries.
+	// the payload reader returns `io.EOF` when it reaches the extension boundaries.
 	RestoreExtension(height uint64, format uint32, payloadReader ExtensionPayloadReader) error
 
 }
@@ -144,7 +144,7 @@ As a result of this implementation, we are able to create snapshots of binary ch
 
 ### Backwards Compatibility
 
-This ADR introduces new proto message types, adds an `extensions` field in snapshot `Manager`, and add new `ExtensionSnapshotter` interface, so this is not backwards compatible if we have extensions.
+This ADR introduces new proto message types, adds an `extensions` field in snapshot `Manager`, and adds a new `ExtensionSnapshotter` interface, so this is not backwards compatible if we have extensions.
 
 But for applications that do not have the state data outside of the IAVL tree for any module, the snapshot stream is backwards-compatible.
 

--- a/docs/architecture/adr-050-sign-mode-textual-annex1.md
+++ b/docs/architecture/adr-050-sign-mode-textual-annex1.md
@@ -10,7 +10,7 @@
 
 ## Status
 
-Accepted. Implementation started. Small value renderers details still need to be polished.
+Accepted. Implementation started. Small value renderer details still need to be polished.
 
 ## Abstract
 
@@ -51,7 +51,7 @@ Value Renderers describe how values of different Protobuf types should be encode
 
 ### `coins`
 
-* an array of `coin` is display as the concatenation of each `coin` encoded as the specification above, then joined together with the delimiter `", "` (a comma and a space, no quotes around).
+* an array of `coin` is displayed as the concatenation of each `coin` encoded as the specification above, then joined together with the delimiter `", "` (a comma and a space, no quotes around).
 * the list of coins is ordered by unicode code point of the display denom: `A-Z` < `a-z`. For example, the string `aAbBcC` would be sorted `ABCabc`.
     * if the coins list had 0 items in it then it'll be rendered as `zero`
 
@@ -172,7 +172,7 @@ Vote object
 
 ### Enums
 
-* Show the enum variant name as string.
+* Show the enum variant name as a string.
 
 #### Examples
 
@@ -268,7 +268,7 @@ Examples:
 
 ### bytes
 
-* Bytes of length shorter or equal to 35 are rendered in hexadecimal, all capital letters, without the `0x` prefix.
+* Bytes of length shorter than or equal to 35 are rendered in hexadecimal, all capital letters, without the `0x` prefix.
 * Bytes of length greater than 35 are hashed using SHA256. The rendered text is `SHA-256=`, followed by the 32-byte hash, in hexadecimal, all capital letters, without the `0x` prefix.
 * The hexadecimal string is finally separated into groups of 4 digits, with a space `' '` as separator. If the bytes length is odd, the 2 remaining hexadecimal characters are at the end.
 
@@ -278,7 +278,7 @@ The number 35 was chosen because it is the longest length where the hashed-and-p
 * byte arrays starting from length 36 will be hashed to 32 bytes, which is 64 hex characters plus 15 spaces, and with the `SHA-256=` prefix, it takes 87 characters.
 Also, secp256k1 public keys have length 33, so their Textual representation is not their hashed value, which we would like to avoid.
 
-Note: Data longer than 35 bytes are not rendered in a way that can be inverted. See ADR-050's [section about invertibility](./adr-050-sign-mode-textual.md#invertible-rendering) for a discussion.
+Note: Data longer than 35 bytes is not rendered in a way that can be inverted. See ADR-050's [section about invertibility](./adr-050-sign-mode-textual.md#invertible-rendering) for a discussion.
 
 #### Examples
 

--- a/docs/architecture/adr-050-sign-mode-textual.md
+++ b/docs/architecture/adr-050-sign-mode-textual.md
@@ -18,7 +18,7 @@
 
 ## Status
 
-Accepted. Implementation started. Small value renderers details still need to be polished.
+Accepted. Implementation started. Small value renderer details still need to be polished.
 
 Spec version: 0.
 
@@ -30,7 +30,7 @@ This ADR specifies SIGN_MODE_TEXTUAL, a new string-based sign mode that is targe
 
 Protobuf-based SIGN_MODE_DIRECT was introduced in [ADR-020](./adr-020-protobuf-transaction-encoding.md) and is intended to replace SIGN_MODE_LEGACY_AMINO_JSON in most situations, such as mobile wallets and CLI keyrings. However, the [Ledger](https://www.ledger.com/) hardware wallet is still using SIGN_MODE_LEGACY_AMINO_JSON for displaying the sign bytes to the user. Hardware wallets cannot transition to SIGN_MODE_DIRECT as:
 
-* SIGN_MODE_DIRECT is binary-based and thus not suitable for display to end-users. Technically, hardware wallets could simply display the sign bytes to the user. But this would be considered as blind signing, and is a security concern.
+* SIGN_MODE_DIRECT is binary-based and thus not suitable for display to end-users. Technically, hardware wallets could simply display the sign bytes to the user. But this would be considered blind signing, and is a security concern.
 * hardware cannot decode the protobuf sign bytes due to memory constraints, as the Protobuf definitions would need to be embedded on the hardware device.
 
 In an effort to remove Amino from the SDK, a new sign mode needs to be created for hardware devices. [Initial discussions](https://github.com/cosmos/cosmos-sdk/issues/6513) propose a text-based sign mode, which this ADR formally specifies.
@@ -106,7 +106,7 @@ will be rejected.
 
 For security, transaction signatures should have three properties:
 
-1. Given the transaction, signatures, and chain state, it must be possible to validate that the signatures matches the transaction,
+1. Given the transaction, signatures, and chain state, it must be possible to validate that the signatures match the transaction,
 to verify that the signers must have known their respective secret keys.
 
 2. It must be computationally infeasible to find a substantially different transaction for which the given signatures are valid, given the same chain state.
@@ -180,7 +180,7 @@ indent_key = 3
 expert_key = 4
 ```
 
-Defining the sign_doc as directly an array of screens has also been considered. However, given the possibility of future iterations of this specification, using a single-keyed struct has been chosen over the former proposal, as structs allow for easier backwards-compatibility.
+Defining the sign_doc directly as an array of screens has also been considered. However, given the possibility of future iterations of this specification, using a single-keyed struct has been chosen over the former proposal, as structs allow for easier backwards-compatibility.
 
 ## Details
 
@@ -190,7 +190,7 @@ and expert screens are marked with a leading `*`.
 
 ### Encoding of the Transaction Envelope
 
-We define "transaction envelope" as all data in a transaction that is not in the `TxBody.Messages` field. Transaction envelope includes fee, signer infos and memo, but don't include `Msg`s. `//` denotes comments and are not shown on the Ledger device.
+We define "transaction envelope" as all data in a transaction that is not in the `TxBody.Messages` field. Transaction envelope includes fee, signer infos and memo, but doesn't include `Msg`s. `//` denotes comments and are not shown on the Ledger device.
 
 ```
 Chain ID: <string>
@@ -346,8 +346,8 @@ SIGN_MODE_TEXTUAL is purely additive, and doesn't break any backwards compatibil
 
 ### Negative
 
-* Some fields are still encoded in non-human-readable ways, such as public keys in hexadecimal.
-* New ledger app needs to be released, still unclear
+* Some fields are still encoded in non-human-readable ways, such as public keys encoded in hexadecimal.
+* New ledger app needs to be released, but the timeline is still unclear
 
 ### Neutral
 

--- a/docs/architecture/adr-053-go-module-refactoring.md
+++ b/docs/architecture/adr-053-go-module-refactoring.md
@@ -67,7 +67,7 @@ before `v1.0.0` is tagged and should make use of `internal` packages to limit
 the exposed API surface
 * the new go module's API may deviate from the existing code where there are
 clear improvements to be made or to remove legacy dependencies (for instance on
-amino or gogo proto), as long the old package attempts
+amino or gogo proto), as long as the old package attempts
 to avoid API breakage with aliases and wrappers
 * care should be taken when simply trying to turn an existing package into a
 new go module: https://github.com/golang/go/wiki/Modules#is-it-possible-to-add-a-module-to-a-multi-module-repository.
@@ -79,13 +79,13 @@ if necessary), rather than trying to make an old package a new module.
 ### Backwards Compatibility
 
 If the above guidelines are followed to use aliases or wrapper types pointing
-in existing APIs that point back to the new go modules, there should be no or
+to existing APIs that point back to the new go modules, there should be no or
 very limited breaking changes to existing APIs.
 
 ### Positive
 
 * standalone pieces of software will reach `v1.0.0` sooner
-* new features to specific functionality will be released sooner 
+* new features for specific functionality will be released sooner 
 
 ### Negative
 

--- a/docs/architecture/adr-054-semver-compatible-modules.md
+++ b/docs/architecture/adr-054-semver-compatible-modules.md
@@ -25,7 +25,7 @@ movement to splitting SDK modules into [standalone go modules](https://github.co
 Both of these will ideally allow the ecosystem to move faster because we won't
 be waiting for all dependencies to update synchronously. For instance, we could
 have 3 versions of the core SDK compatible with the latest 2 releases of
-CosmWasm as well as 4 different versions of staking . This sort of setup would
+CosmWasm as well as 4 different versions of staking. This sort of setup would
 allow early adopters to aggressively integrate new versions, while allowing
 more conservative users to be selective about which versions they're ready for.
 
@@ -169,7 +169,7 @@ Imagine that we solve the first two problems but now have a scenario where
 `bar/v2` wants the option to use `MsgDoSomething.condition` which only `foo/v2`
 supports. If `bar/v2` works with `foo` `v1` and sets `condition` to some non-nil
 value, then `foo` will silently ignore this field resulting in a silent logic
-possibly dangerous logic error. If `bar/v2` were able to check whether `foo` was
+a possibly dangerous logic error. If `bar/v2` were able to check whether `foo` was
 on `v1` or `v2` and dynamically, it could choose to only use `condition` when
 `foo/v2` is available. Even if `bar/v2` were able to perform this check, however,
 how do we know that it is always performing the check properly. Without
@@ -535,7 +535,7 @@ One risk of ADR 033 is that dependencies are called at runtime which are not pre
 Also we want modules to have a way to define a minimum dependency API revision that they require. Therefore, all
 modules should declare their set of dependencies upfront. These dependencies could be defined when a module is
 instantiated, but ideally we know what the dependencies are before instantiation and can statically look at an app
-config and determine whether the set of modules. For example, if `bar` requires `foo` revision `>= 1`, then we
+config and determine whether the set of modules is compatible. For example, if `bar` requires `foo` revision `>= 1`, then we
 should be able to know this when creating an app config with two versions of `bar` and `foo`.
 
 We propose defining these dependencies in the proto options of the module config object itself.

--- a/docs/architecture/adr-055-orm.md
+++ b/docs/architecture/adr-055-orm.md
@@ -50,7 +50,7 @@ API and supports:
 
 Almost all the information needed to decode state directly is specified in .proto files. Each table definition specifies
 an ID which is unique per .proto file and each index within a table is unique within that table. Clients then only need
-to know the name of a module and the prefix ORM data for a specific .proto file within that module in order to decode
+to know the name of a module and the ORM data prefix for a specific .proto file within that module in order to decode
 state data directly. This additional information will be exposed directly through app configs which will be explained
 in a future ADR related to app wiring.
 
@@ -60,7 +60,7 @@ be stored in the key value store as `Key: '0', Value: {"b":1}` (with more effici
 Also, the generated code from https://github.com/cosmos/cosmos-proto does optimizations around the
 `google.golang.org/protobuf/reflect/protoreflect` API to improve performance.
 
-A code generator is included with the ORM which creates type safe wrappers around the ORM's dynamic `Table`
+A code generator is included with the ORM which creates type-safe wrappers around the ORM's dynamic `Table`
 implementation and is the recommended way for modules to use the ORM.
 
 The ORM tests provide a simplified bank module demonstration which illustrates:
@@ -106,7 +106,7 @@ Further discussions will happen within the Cosmos SDK Framework Working Group. C
 
 ## References
 
-* https://github.com/iov-one/weave/tree/master/orm).
+* https://github.com/iov-one/weave/tree/master/orm
 * https://github.com/regen-network/regen-ledger/tree/157181f955823149e1825263a317ad8e16096da4/orm
 * https://github.com/cosmos/cosmos-sdk/tree/35d3312c3be306591fcba39892223f1244c8d108/x/group/internal/orm
 * https://github.com/cosmos/cosmos-sdk/discussions/9156


### PR DESCRIPTION
# Description
Corrects grammar, punctuation, and word usage issues across multiple ADR files including ADR-048 through ADR-055. Changes include fixing verb agreement, adding missing articles, correcting prepositions, and improving sentence structure for better readability and professional presentation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Numerous grammar and wording improvements across ADRs 048, 050 (and Annex 1), 053, 054, and 055 for clarity and consistency.
  - Clarified examples and notes in SIGN_MODE_TEXTUAL, including renderer details, transaction envelope wording, and Ledger display comments.
  - Refined descriptions around DoS protection, consequences, enums, bytes length, and coins rendering for better readability.
  - Updated state sync hooks documentation: the snapshot extension interface now documents support for declaring default/supported formats and writing payloads during snapshots.
  - Minor semantic clarification on module compatibility phrasing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->