### PR TITLE
docs: fix typos

### DIFF
--- a/docs/architecture/adr-031-msg-service.md
+++ b/docs/architecture/adr-031-msg-service.md
@@ -179,7 +179,7 @@ This design changes how a module functionality is exposed and accessed. It depre
 
 This also allows us to change how we perform functional tests. Instead of mocking AppModules and Router, we will mock a client (server will stay hidden). More specifically: we will never mock `moduleA.MsgServer` in `moduleB`, but rather `moduleA.MsgClient`. One can think about it as working with external services (eg DBs, or online servers...). We assume that the transmission between clients and servers is correctly handled by generated Protocol Buffers.
 
-Finally, closing a module to client API opens desirable OCAP patterns discussed in ADR-033. Since server implementation and interface is hidden, nobody can hold "keepers"/servers and will be forced to relay on the client interface, which will drive developers for correct encapsulation and software engineering patterns.
+Finally, closing a module to client API opens desirable OCAP patterns discussed in ADR-033. Since server implementation and interface is hidden, nobody can hold "keepers"/servers and will be forced to rely on the client interface, which will drive developers for correct encapsulation and software engineering patterns.
 
 ### Pros
 

--- a/docs/architecture/adr-045-check-delivertx-middlewares.md
+++ b/docs/architecture/adr-045-check-delivertx-middlewares.md
@@ -282,7 +282,7 @@ This ADR does not introduce any state-machine-, client- or CLI-breaking changes.
 
 ### Positive
 
-* Allow custom logic to be run before an after `Msg` execution. This enables the [tips](https://github.com/cosmos/cosmos-sdk/issues/9406) and [gas refund](https://github.com/cosmos/cosmos-sdk/issues/2150) uses cases, and possibly other ones.
+* Allow custom logic to be run before and after `Msg` execution. This enables the [tips](https://github.com/cosmos/cosmos-sdk/issues/9406) and [gas refund](https://github.com/cosmos/cosmos-sdk/issues/2150) uses cases, and possibly other ones.
 * Make BaseApp more lightweight, and defer complex logic to small modular components.
 * Separate paths for `{Check,Deliver,Simulate}Tx` with different returns types. This allows for improved readability (replace `if sdkCtx.IsRecheckTx() && !simulate {...}` with separate methods) and more flexibility (e.g. returning a `priority` in `ResponseCheckTx`).
 

--- a/docs/architecture/adr-054-semver-compatible-modules.md
+++ b/docs/architecture/adr-054-semver-compatible-modules.md
@@ -300,7 +300,7 @@ Currently, two generated structs for the same protobuf type cannot exist in the 
 build flags (see https://developers.google.com/protocol-buffers/docs/reference/go/faq#fix-namespace-conflict).
 A relatively simple mitigation to this issue would be to set up the protobuf code to not register protobuf types
 globally if they are generated in an `internal/` package. This will require modules to register their types manually
-with the app-level level protobuf registry, this is similar to what modules already do with the `InterfaceRegistry`
+with the app-level protobuf registry, this is similar to what modules already do with the `InterfaceRegistry`
 and amino codec.
 
 If modules _only_ do ADR 033 message passing then a naive and non-performant solution for


### PR DESCRIPTION
docs/architecture/adr-031-msg-service.md
  relay on -> rely on
docs/architecture/adr-045-check-delivertx-middlewares.md
  an -> and
docs/architecture/adr-054-semver-compatible-modules.md
  app-level level -> app-level 