### PR TITLE
simapp: add nil-check for CircuitKeeper in NewAnteHandler to prevent panic

### DIFF
--- a/simapp/ante.go
+++ b/simapp/ante.go
@@ -30,6 +30,11 @@ func NewAnteHandler(options HandlerOptions) (sdk.AnteHandler, error) {
 		return nil, errors.New("sign mode handler is required for ante builder")
 	}
 
+	// Inserted: ensure CircuitKeeper is provided to avoid a panic at runtime.
+	if options.CircuitKeeper == nil {
+		return nil, errors.New("circuit keeper is required for ante builder")
+	}
+
 	anteDecorators := []sdk.AnteDecorator{
 		ante.NewSetUpContextDecorator(), // outermost AnteDecorator. SetUpContext must be called first
 		circuitante.NewCircuitBreakerDecorator(options.CircuitKeeper),

--- a/simapp/ante_test.go
+++ b/simapp/ante_test.go
@@ -1,0 +1,95 @@
+package simapp
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	storeaddress "cosmossdk.io/core/address"
+	signingv1beta1 "cosmossdk.io/api/cosmos/tx/signing/v1beta1"
+	txsigning "cosmossdk.io/x/tx/signing"
+
+	"github.com/stretchr/testify/require"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/auth/ante"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+)
+
+// dummy implementations for required interfaces used only for constructing the ante handler chain.
+
+type dummyAddressCodec struct{}
+
+func (d dummyAddressCodec) StringToBytes(text string) ([]byte, error) { return nil, errors.New("not implemented") }
+func (d dummyAddressCodec) BytesToString(bz []byte) (string, error)   { return "", errors.New("not implemented") }
+
+type dummyAccountKeeper struct{}
+
+func (d dummyAccountKeeper) GetParams(ctx context.Context) (params authtypes.Params) { return authtypes.Params{} }
+func (d dummyAccountKeeper) GetAccount(ctx context.Context, addr sdk.AccAddress) sdk.AccountI {
+	return nil
+}
+func (d dummyAccountKeeper) SetAccount(ctx context.Context, acc sdk.AccountI)                 {}
+func (d dummyAccountKeeper) GetModuleAddress(moduleName string) sdk.AccAddress               { return nil }
+func (d dummyAccountKeeper) AddressCodec() storeaddress.Codec                               { return dummyAddressCodec{} }
+func (d dummyAccountKeeper) UnorderedTransactionsEnabled() bool                             { return false }
+func (d dummyAccountKeeper) RemoveExpiredUnorderedNonces(ctx sdk.Context) error             { return nil }
+func (d dummyAccountKeeper) TryAddUnorderedNonce(ctx sdk.Context, sender []byte, t time.Time) error {
+	return nil
+}
+
+type dummyBankKeeper struct{}
+
+func (d dummyBankKeeper) IsSendEnabledCoins(ctx context.Context, coins ...sdk.Coin) error { return nil }
+func (d dummyBankKeeper) SendCoins(ctx context.Context, from, to sdk.AccAddress, amt sdk.Coins) error {
+	return nil
+}
+func (d dummyBankKeeper) SendCoinsFromAccountToModule(ctx context.Context, senderAddr sdk.AccAddress, recipientModule string, amt sdk.Coins) error {
+	return nil
+}
+
+type dummyFeegrantKeeper struct{}
+
+func (d dummyFeegrantKeeper) UseGrantedFees(ctx context.Context, granter, grantee sdk.AccAddress, fee sdk.Coins, msgs []sdk.Msg) error {
+	return nil
+}
+
+type dummyCircuitBreaker struct{}
+
+func (d dummyCircuitBreaker) IsAllowed(ctx context.Context, typeURL string) (bool, error) { return true, nil }
+
+type dummySignModeHandler struct{}
+
+func (d dummySignModeHandler) Mode() signingv1beta1.SignMode { return signingv1beta1.SignMode_SIGN_MODE_DIRECT }
+func (d dummySignModeHandler) GetSignBytes(_ context.Context, _ txsigning.SignerData, _ txsigning.TxData) ([]byte, error) {
+	return nil, nil
+}
+
+func makeBaseHandlerOptions() ante.HandlerOptions {
+	return ante.HandlerOptions{
+		AccountKeeper:   dummyAccountKeeper{},
+		BankKeeper:      dummyBankKeeper{},
+		FeegrantKeeper:  dummyFeegrantKeeper{},
+		SignModeHandler: txsigning.NewHandlerMap(dummySignModeHandler{}),
+		SigGasConsumer:  ante.DefaultSigVerificationGasConsumer,
+	}
+}
+
+func TestNewAnteHandler_CircuitKeeperNil(t *testing.T) {
+	_, err := NewAnteHandler(HandlerOptions{
+		HandlerOptions: makeBaseHandlerOptions(),
+		CircuitKeeper:  nil,
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "circuit keeper is required for ante builder")
+}
+
+func TestNewAnteHandler_CircuitKeeperProvided(t *testing.T) {
+	h, err := NewAnteHandler(HandlerOptions{
+		HandlerOptions: makeBaseHandlerOptions(),
+		CircuitKeeper:  dummyCircuitBreaker{},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, h)
+}


### PR DESCRIPTION
Add nil check for options.CircuitKeeper in simapp/NewAnteHandler
Fail fast with a clear error instead of panicking during IsAllowed(...)
Aligns with existing required dependency checks (AccountKeeper, BankKeeper, SignModeHandler)
No behavior change for SimApp, which passes &app.CircuitKeeper

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Added a safety check during initialization to ensure the required circuit component is configured, preventing rare startup crashes.
  - Provides a clear error message if the circuit feature is missing, improving diagnostics and reliability.
  - Enhances stability of the transaction processing pipeline with no changes to normal behavior when properly configured.
  - Reduces risk of runtime panics related to misconfiguration, resulting in a smoother startup experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->