### PR TITLE
refactor(tools): use binary.LittleEndian.PutUint64 to simplify code

### DIFF
--- a/tools/benchmark/generator/gen.go
+++ b/tools/benchmark/generator/gen.go
@@ -321,14 +321,7 @@ func (g *Generator) Close() error {
 
 func encodeUint64(x uint64) []byte {
 	var b [8]byte
-	b[0] = byte(x)
-	b[1] = byte(x >> 8)
-	b[2] = byte(x >> 16)
-	b[3] = byte(x >> 24)
-	b[4] = byte(x >> 32)
-	b[5] = byte(x >> 40)
-	b[6] = byte(x >> 48)
-	b[7] = byte(x >> 56)
+	binary.LittleEndian.PutUint64(b[:], x)
 	return b[:]
 }
 


### PR DESCRIPTION
# Description

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the benchmarking generator’s uint64 encoding to use the system’s native byte order.

* **Behavior Changes**
  * Benchmark outputs may differ across platforms with different endianness due to the encoding change.

* **Tests**
  * No changes to public APIs; behavior remains consistent within a given platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->