### PR TITLE
fix: resolve critical bugs and improve code reliability

### DIFF
--- a/codec/codec.go
+++ b/codec/codec.go
@@ -59,7 +59,7 @@ type (
 		// MustUnmarshal calls Unmarshal and panics if error is returned.
 		MustUnmarshal(bz []byte, ptr proto.Message)
 
-		// Unmarshal parses the data encoded with UnmarshalLengthPrefixed method and stores
+		// UnmarshalLengthPrefixed parses the data encoded with MarshalLengthPrefixed method and stores
 		// the result in the value pointed to by v.
 		UnmarshalLengthPrefixed(bz []byte, ptr proto.Message) error
 		// MustUnmarshalLengthPrefixed calls UnmarshalLengthPrefixed and panics if error

--- a/codec/collections.go
+++ b/codec/collections.go
@@ -172,6 +172,8 @@ func (c collInterfaceValue[T]) Stringify(value T) string {
 }
 
 func (c collInterfaceValue[T]) ValueType() string {
-	var t T
-	return fmt.Sprintf("%T", t)
+	// We use reflection to get the type name of the interface.
+	// Using `var t T; fmt.Sprintf("%T", t)` would return "<nil>".
+	var p *T
+	return reflect.TypeOf(p).Elem().String()
 }

--- a/codec/proto_codec.go
+++ b/codec/proto_codec.go
@@ -175,7 +175,7 @@ func (pc *ProtoCodec) MarshalAminoJSON(msg gogoproto.Message) ([]byte, error) {
 
 	var protoMsg protoreflect.ProtoMessage
 	typ, err := protoregistry.GlobalTypes.FindMessageByURL(fmt.Sprintf("/%s", gogoproto.MessageName(msg)))
-	if typ != nil && err != nil {
+	if err == nil && typ != nil {
 		protoMsg = typ.New().Interface()
 	} else {
 		desc, err := pc.interfaceRegistry.FindDescriptorByName(protoreflect.FullName(gogoproto.MessageName(msg)))

--- a/codec/types/interface_registry.go
+++ b/codec/types/interface_registry.go
@@ -100,12 +100,12 @@ type UnpackInterfacesMessage interface {
 	//		// where X is an Any field on MyStruct
 	//		err := unpacker.UnpackAny(s.X, &x)
 	//		if err != nil {
-	//			return nil
+	//			return err
 	//		}
 	//		// where Y is a field on MyStruct that implements UnpackInterfacesMessage itself
 	//		err = s.Y.UnpackInterfaces(unpacker)
 	//		if err != nil {
-	//			return nil
+	//			return err
 	//		}
 	//		return nil
 	//	 }

--- a/collections/colltest/codec.go
+++ b/collections/colltest/codec.go
@@ -157,7 +157,12 @@ func (m mockValueCodec[T]) getTypeName(value T) string {
 		return m.valueType
 	}
 	typ := reflect.TypeOf(value)
+	// If the type is a pointer, we get the type it points to.
+	if typ.Kind() == reflect.Ptr {
+		typ = typ.Elem()
+	}
 	name := fmt.Sprintf("%s.%s", typ.PkgPath(), typ.Name())
+	// Store the base type (not pointer) so that `reflect.New` in Decode works correctly.
 	m.seenTypes[name] = typ
 	return name
 }

--- a/collections/indexes/helpers_test.go
+++ b/collections/indexes/helpers_test.go
@@ -69,7 +69,7 @@ func TestHelpers(t *testing.T) {
 	err = ScanValues(ctx, indexedMap, iter, func(v Amount) bool {
 		require.Equal(t, Amount(200), v)
 		numCalled++
-		require.Equal(t, numCalled, 1)
+		require.Equal(t, 1, numCalled)
 		return true // says to stop
 	})
 	require.NoError(t, err)
@@ -82,7 +82,7 @@ func TestHelpers(t *testing.T) {
 		require.Equal(t, Amount(200), kv.Value)
 		require.Equal(t, collections.Join("address1", "osmo"), kv.Key)
 		numCalled++
-		require.Equal(t, numCalled, 1)
+		require.Equal(t, 1, numCalled)
 		return true // says to stop
 	})
 	require.NoError(t, err)

--- a/collections/indexes/reverse_pair.go
+++ b/collections/indexes/reverse_pair.go
@@ -48,7 +48,10 @@ func NewReversePair[Value, K1, K2 any](
 	pairCodec codec.KeyCodec[collections.Pair[K1, K2]],
 	options ...func(*reversePairOptions),
 ) *ReversePair[K1, K2, Value] {
-	pkc := pairCodec.(pairKeyCodec[K1, K2])
+	pkc, ok := pairCodec.(pairKeyCodec[K1, K2])
+	if !ok {
+		panic("NewReversePair requires a collections.PairKeyCodec to be able to access the sub-codecs of the pair")
+	}
 	o := new(reversePairOptions)
 	for _, option := range options {
 		option(o)


### PR DESCRIPTION
Codec fixes:
- Fix logical error in MarshalAminoJSON: correct condition check for protoregistry.GlobalTypes.FindMessageByURL
- Fix ValueType() for interface codec: use reflection to get proper type names instead of '<nil>'
- Fix typo in UnpackInterfaces example: return err instead of nil on error
- Fix documentation for UnmarshalLengthPrefixed: correct method reference

Collections fixes:
- Fix MockValueCodec pointer handling: always work with base types, not pointers
- Fix unsafe type assertion in NewReversePair: add proper error checking
- Fix test argument order in require.Equal: follow testify conventions

Tests pass: All collections and codec tests successful