### PR TITLE
chore: fix typos and improve wording in comments and identifiers

### DIFF
--- a/internal/testutil/cmd.go
+++ b/internal/testutil/cmd.go
@@ -24,7 +24,7 @@ func ResetArgs(t *testing.T, cmd *cobra.Command) {
 	if !cmd.Flags().Parsed() {
 		return
 	}
-	// If flags have already been parsed, we should reset the values of flags that haven't been set
+	// If flags have already been parsed, we should reset the values of flags that haven't been changed
 	cmd.Flags().Visit(func(pf *pflag.Flag) {
 		// if the flag hasn't been changed, there is no need to reset the args
 		if !pf.Changed {

--- a/log/logger.go
+++ b/log/logger.go
@@ -202,7 +202,7 @@ func (l zeroLogWrapper) WithContext(keyVals ...interface{}) any {
 }
 
 // Impl returns the underlying zerolog logger.
-// It can be used to used zerolog structured API directly instead of the wrapper.
+// It can be used to use zerolog structured API directly instead of the wrapper.
 func (l zeroLogWrapper) Impl() interface{} {
 	return l.Logger
 }

--- a/log/options.go
+++ b/log/options.go
@@ -70,7 +70,7 @@ func OutputJSONOption() Option {
 	}
 }
 
-// ColorOption add option to enable/disable coloring
+// ColorOption adds an option to enable/disable coloring
 // of the logs when console writer is in use
 func ColorOption(val bool) Option {
 	return func(cfg *Config) {
@@ -79,7 +79,7 @@ func ColorOption(val bool) Option {
 }
 
 // TimeFormatOption configures timestamp format of the logger
-// timestamps disabled if empty.
+// timestamps are disabled if empty.
 // it is responsibility of the caller to provider correct values
 // Supported formats:
 //   - time.Layout
@@ -100,14 +100,14 @@ func TimeFormatOption(format string) Option {
 	}
 }
 
-// TraceOption add option to enable/disable print of stacktrace on error log
+// TraceOption adds an option to enable/disable print of stacktrace on error log
 func TraceOption(val bool) Option {
 	return func(cfg *Config) {
 		cfg.StackTrace = val
 	}
 }
 
-// HooksOption append hooks to the Logger hooks
+// HooksOption appends hooks to the Logger hooks
 func HooksOption(hooks ...zerolog.Hook) Option {
 	return func(cfg *Config) {
 		cfg.Hooks = append(cfg.Hooks, hooks...)

--- a/math/doc.go
+++ b/math/doc.go
@@ -1,6 +1,6 @@
 /*
 Package math implements custom Cosmos SDK math types used for arithmetic
 operations. Signed and unsigned integer types utilize Golang's standard library
-big integers types, having a maximum bit length of 256 bits.
+big integer types, having a maximum bit length of 256 bits.
 */
 package math

--- a/math/int.go
+++ b/math/int.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 )
 
-// MaxBitLen defines the maximum bit length supported bit Int and Uint types.
+// MaxBitLen defines the maximum bit length supported by Int and Uint types.
 const MaxBitLen = 256
 
 // maxWordLen defines the maximum word length supported by Int and Uint types.
@@ -102,7 +102,7 @@ func (i Int) BigInt() *big.Int {
 	return new(big.Int).Set(i.i)
 }
 
-// BigIntMut converts Int to big.Int, mutative the input
+// BigIntMut converts Int to big.Int, mutating the input
 func (i Int) BigIntMut() *big.Int {
 	if i.IsNil() {
 		return nil
@@ -144,7 +144,7 @@ func NewIntFromBigInt(i *big.Int) Int {
 
 // NewIntFromBigIntMut constructs Int from big.Int. If the provided big.Int is nil,
 // it returns an empty instance. This function panics if the bit length is > 256.
-// Note, this function mutate the argument.
+// Note, this function mutates the argument.
 func NewIntFromBigIntMut(i *big.Int) Int {
 	if i == nil {
 		return Int{}

--- a/math/uint.go
+++ b/math/uint.go
@@ -21,7 +21,7 @@ func (u Uint) BigInt() *big.Int {
 	return new(big.Int).Set(u.i)
 }
 
-// BigIntMut converts Uint to big.Int, mutative the input
+// BigIntMut converts Uint to big.Int, mutating the input
 func (u Uint) BigIntMut() *big.Int {
 	if u.IsNil() {
 		return nil

--- a/math/uint_test.go
+++ b/math/uint_test.go
@@ -17,7 +17,7 @@ type uintTestSuite struct {
 	suite.Suite
 }
 
-func TestUnitTestSuite(t *testing.T) {
+func TestUintTestSuite(t *testing.T) {
 	suite.Run(t, new(uintTestSuite))
 }
 

--- a/runtime/app.go
+++ b/runtime/app.go
@@ -92,7 +92,7 @@ func (a *App) RegisterModules(modules ...module.AppModule) error {
 
 // RegisterStores registers the provided store keys.
 // This method should only be used for registering extra stores
-// which is necessary for modules that not registered using the app config.
+// which is necessary for modules that are not registered using the app config.
 // To be used in combination of RegisterModules.
 func (a *App) RegisterStores(keys ...storetypes.StoreKey) error {
 	a.storeKeys = append(a.storeKeys, keys...)

--- a/runtime/events.go
+++ b/runtime/events.go
@@ -50,7 +50,7 @@ func (e Events) EmitKV(_ context.Context, eventType string, attrs ...event.Attri
 	return nil
 }
 
-// EmitNonConsensus emits an typed event that is defined in the protobuf file.
+// EmitNonConsensus emits a typed event that is defined in the protobuf file.
 // In the future these events will be added to consensus.
 func (e Events) EmitNonConsensus(_ context.Context, event protoiface.MessageV1) error {
 	return e.EmitTypedEvent(event)

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -82,7 +82,7 @@ type BaseConfig struct {
 	// which informs CometBFT what to index. If empty, all events will be indexed.
 	IndexEvents []string `mapstructure:"index-events"`
 
-	// IavlCacheSize set the size of the iavl tree cache.
+	// IAVLCacheSize set the size of the iavl tree cache.
 	IAVLCacheSize uint64 `mapstructure:"iavl-cache-size"`
 
 	// IAVLDisableFastNode enables or disables the fast sync node.

--- a/server/config/toml.go
+++ b/server/config/toml.go
@@ -74,7 +74,7 @@ inter-block-cache = {{ .BaseConfig.InterBlockCache }}
 # ["message.sender", "message.recipient"]
 index-events = [{{ range .BaseConfig.IndexEvents }}{{ printf "%q, " . }}{{end}}]
 
-# IavlCacheSize set the size of the iavl tree cache (in number of nodes).
+# IAVLCacheSize set the size of the iavl tree cache (in number of nodes).
 iavl-cache-size = {{ .BaseConfig.IAVLCacheSize }}
 
 # IAVLDisableFastNode enables or disables the fast node feature of IAVL. 

--- a/server/grpc/reflection/v2alpha1/reflection.go
+++ b/server/grpc/reflection/v2alpha1/reflection.go
@@ -75,7 +75,7 @@ func newReflectionServiceServer(grpcSrv *grpc.Server, conf Config) (reflectionSe
 	// set deliver descriptor
 	txDescriptor, err := newTxDescriptor(conf.InterfaceRegistry)
 	if err != nil {
-		return reflectionServiceServer{}, fmt.Errorf("unable to create deliver descriptor: %w", err)
+		return reflectionServiceServer{}, fmt.Errorf("unable to create transaction descriptor: %w", err)
 	}
 	authnDescriptor := newAuthnDescriptor(conf.SigningModes)
 	desc := &AppDescriptor{

--- a/server/grpc/server_test.go
+++ b/server/grpc/server_test.go
@@ -185,7 +185,7 @@ func (s *IntegrationTestSuite) TestGRPCServer_BroadcastTx() {
 }
 
 // Test and enforce that we upfront reject any connections to baseapp containing
-// invalid initial x-cosmos-block-height that aren't positive  and in the range [0, max(int64)]
+// invalid initial x-cosmos-block-height that aren't positive and in the range [0, max(int64)]
 // See issue https://github.com/cosmos/cosmos-sdk/issues/7662.
 func (s *IntegrationTestSuite) TestGRPCServerInvalidHeaderHeights() {
 	t := s.T()
@@ -199,7 +199,7 @@ func (s *IntegrationTestSuite) TestGRPCServerInvalidHeaderHeights() {
 		{"9223372036854775808", "value out of range"}, // > max(int64) by 1
 		{"-10", "height < 0"},
 		{"18446744073709551615", "value out of range"}, // max uint64, which is  > max(int64)
-		{"-9223372036854775809", "value out of range"}, // Out of the range of for negative int64
+		{"-9223372036854775809", "value out of range"}, // Out of the range for negative int64
 	}
 	for _, tt := range invalidHeightStrs {
 		t.Run(tt.value, func(t *testing.T) {

--- a/server/start.go
+++ b/server/start.go
@@ -130,7 +130,7 @@ type StartCmdOptions struct {
 	PostSetupStandalone func(svrCtx *Context, clientCtx client.Context, ctx context.Context, g *errgroup.Group) error
 	// AddFlags add custom flags to start cmd
 	AddFlags func(cmd *cobra.Command)
-	// StartCommandHanlder can be used to customize the start command handler
+	// StartCommandHandler can be used to customize the start command handler
 	StartCommandHandler func(svrCtx *Context, clientCtx client.Context, appCreator types.AppCreator, inProcessConsensus bool, opts StartCmdOptions) error
 }
 

--- a/server/util.go
+++ b/server/util.go
@@ -264,7 +264,7 @@ func interceptConfigs(rootViper *viper.Viper, customAppTemplate string, customCo
 
 		defaultCometCfg := cmtcfg.DefaultConfig()
 		// The SDK is opinionated about those comet values, so we set them here.
-		// We verify first that the user has not changed them for not overriding them.
+		// We verify first that the user has not changed them to avoid overriding them.
 		if conf.Consensus.TimeoutCommit == defaultCometCfg.Consensus.TimeoutCommit { // nolint: staticcheck // we are continuing to use this value for backwards compatibility
 			conf.Consensus.TimeoutCommit = 5 * time.Second // nolint: staticcheck // we are continuing to use this value for backwards compatibility
 		}


### PR DESCRIPTION
internal/testutil/cmd.go: updated comment to use “changed” instead of “set.”

log/logger.go: fixed “used to used” → “used to use.”

log/options.go: corrected grammar in option descriptions (“add” → “adds,” “append” → “appends,” etc.).

math/doc.go: fixed pluralization (“big integers types” → “big integer types”).

math/int.go, math/uint.go: changed “mutative” → “mutating,” improved phrasing.

math/uint_test.go: renamed test function TestUnitTestSuite → TestUintTestSuite.

runtime/app.go: corrected “that not” → “that are not.”

runtime/events.go: fixed “an typed” → “a typed.”

server/config/config.go, server/config/toml.go: standardized IAVLCacheSize casing in comments.

server/grpc/reflection/v2alpha1/reflection.go: updated wording for error message (“deliver descriptor” → “transaction descriptor”).

server/grpc/server_test.go: fixed grammar in comment (“of for” → “for”).

server/start.go: fixed typo in StartCommandHandler name.

server/util.go: improved comment to clarify intent (“for not overriding” → “to avoid overriding”).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Renamed public configuration field to IAVLCacheSize; external config key remains unchanged.

* **Style**
  * Improved error message wording during transaction reflection initialization.

* **Documentation**
  * Numerous grammar and typo fixes across comments and option descriptions; no behavioral changes.

* **Tests**
  * Renamed a test suite entry point; no changes to test logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->