### PR TITLE
refactor(authz/cli): standardize msg pointer usage in tx CLI handlers

### DIFF
--- a/x/authz/client/cli/tx.go
+++ b/x/authz/client/cli/tx.go
@@ -198,11 +198,12 @@ Examples:
 				return err
 			}
 
-			msg, err := authz.NewMsgGrant(clientCtx.GetFromAddress(), grantee, authorization, expire)
+			msgGrant, err := authz.NewMsgGrant(clientCtx.GetFromAddress(), grantee, authorization, expire)
 			if err != nil {
 				return err
 			}
 
+			var msg sdk.Msg = msgGrant
 			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
 		},
 	}
@@ -253,9 +254,10 @@ Example:
 
 			granter := clientCtx.GetFromAddress()
 			msgAuthorized := args[1]
-			msg := authz.NewMsgRevoke(granter, grantee, msgAuthorized)
+			msgVal := authz.NewMsgRevoke(granter, grantee, msgAuthorized)
 
-			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), &msg)
+			var msg sdk.Msg = &msgVal
+			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
 		},
 	}
 	flags.AddTxFlagsToCmd(cmd)
@@ -290,9 +292,10 @@ Example:
 			if err != nil {
 				return err
 			}
-			msg := authz.NewMsgExec(grantee, theTx.GetMsgs())
+			execVal := authz.NewMsgExec(grantee, theTx.GetMsgs())
 
-			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), &msg)
+			var msg sdk.Msg = &execVal
+			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
 		},
 	}
 


### PR DESCRIPTION
Pass an sdk.Msg interface variable holding a pointer to the concrete message in all three commands: NewCmdGrantAuthorization, NewCmdRevokeAuthorization, and NewCmdExecAuthorization.
Remove mixed value vs pointer usage when calling tx.GenerateOrBroadcastTxCLI for consistency and readability.
No functional changes intended; verified build for x/authz succeeds.