### PR TITLE
chore:fix typos in err msg

### DIFF
--- a/client/grpc/cmtservice/service.go
+++ b/client/grpc/cmtservice/service.go
@@ -87,7 +87,7 @@ func (s queryServer) GetBlockByHeight(ctx context.Context, req *GetBlockByHeight
 	}
 
 	if req.Height > blockHeight {
-		return nil, status.Error(codes.InvalidArgument, "requested block height is bigger then the chain length")
+		return nil, status.Error(codes.InvalidArgument, "requested block height is bigger than the chain length")
 	}
 
 	protoBlockID, protoBlock, err := GetProtoBlock(ctx, s.clientCtx, &req.Height)
@@ -137,7 +137,7 @@ func (s queryServer) GetValidatorSetByHeight(ctx context.Context, req *GetValida
 	}
 
 	if req.Height > blockHeight {
-		return nil, status.Error(codes.InvalidArgument, "requested block height is bigger then the chain length")
+		return nil, status.Error(codes.InvalidArgument, "requested block height is bigger than the chain length")
 	}
 
 	r, err := ValidatorsOutput(ctx, s.clientCtx, &req.Height, page, limit)

--- a/docs/architecture/adr-028-public-key-addresses.md
+++ b/docs/architecture/adr-028-public-key-addresses.md
@@ -307,7 +307,7 @@ Hashing algorithm
 Algorithm:
 
 * Alan recommends to hash the prefix: `address(pub_key) = hash(hash(key_type) + pub_key)[:32]`, main benefits:
-    * we are free to user arbitrary long prefix names
+    * we are free to use arbitrary long prefix names
     * we still don’t risk collisions
     * switch tables
 * discussion about penalization -> about adding prefix post hash

--- a/docs/architecture/adr-028-public-key-addresses.md
+++ b/docs/architecture/adr-028-public-key-addresses.md
@@ -307,7 +307,7 @@ Hashing algorithm
 Algorithm:
 
 * Alan recommends to hash the prefix: `address(pub_key) = hash(hash(key_type) + pub_key)[:32]`, main benefits:
-    * we are free to use arbitrary long prefix names
+    * we are free to user arbitrary long prefix names
     * we still don’t risk collisions
     * switch tables
 * discussion about penalization -> about adding prefix post hash

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -159,9 +159,9 @@ func (s *errorsTestSuite) TestIsOf() {
 
 	require.True(IsOf(errW, ErrLogic))
 	require.True(IsOf(errW, err, ErrLogic))
-	require.True(IsOf(errW, nil, errW), "error should much itself")
+	require.True(IsOf(errW, nil, errW), "error should match itself")
 	err2 := errors.New("other error")
-	require.True(IsOf(err2, nil, err2), "error should much itself")
+	require.True(IsOf(err2, nil, err2), "error should match itself")
 }
 
 type customError struct{}

--- a/x/gov/types/v1/params.go
+++ b/x/gov/types/v1/params.go
@@ -192,13 +192,13 @@ func (p Params) ValidateBasic() error {
 
 	minInitialDepositRatio, err := sdkmath.LegacyNewDecFromStr(p.MinInitialDepositRatio)
 	if err != nil {
-		return fmt.Errorf("invalid mininum initial deposit ratio of proposal: %w", err)
+		return fmt.Errorf("invalid minimum initial deposit ratio of proposal: %w", err)
 	}
 	if minInitialDepositRatio.IsNegative() {
-		return fmt.Errorf("mininum initial deposit ratio of proposal must be positive: %s", minInitialDepositRatio)
+		return fmt.Errorf("minimum initial deposit ratio of proposal must be positive: %s", minInitialDepositRatio)
 	}
 	if minInitialDepositRatio.GT(sdkmath.LegacyOneDec()) {
-		return fmt.Errorf("mininum initial deposit ratio of proposal is too large: %s", minInitialDepositRatio)
+		return fmt.Errorf("minimum initial deposit ratio of proposal is too large: %s", minInitialDepositRatio)
 	}
 
 	proposalCancelRate, err := sdkmath.LegacyNewDecFromStr(p.ProposalCancelRatio)

--- a/x/nft/keeper/nft_batch_test.go
+++ b/x/nft/keeper/nft_batch_test.go
@@ -58,7 +58,7 @@ func (s *TestSuite) TestBatchMint() {
 			true,
 		},
 		{
-			"faild with repeated nft",
+			"failed with repeated nft",
 			func(tokens []nft.NFT) {
 				s.saveClass(tokens)
 			},
@@ -70,7 +70,7 @@ func (s *TestSuite) TestBatchMint() {
 			false,
 		},
 		{
-			"faild with not exist class",
+			"failed with not exist class",
 			func(tokens []nft.NFT) {
 				// do nothing
 			},
@@ -82,7 +82,7 @@ func (s *TestSuite) TestBatchMint() {
 			false,
 		},
 		{
-			"faild with exist nft",
+			"failed with exist nft",
 			func(tokens []nft.NFT) {
 				s.saveClass(tokens)
 				idx := rand.Intn(len(tokens))


### PR DESCRIPTION
client/grpc/cmtservice/service.go
   then -> than
errors/errors_test.go
   much ->match
x/gov/types/v1/params.go
   mininum -> minimum
x/nft/keeper/nft_batch_test.go
   faild -> failed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Corrected grammar in user-facing error messages for block/validator height checks (“then” → “than”) to improve clarity.
  - Fixed typos in governance parameter validation messages (“mininum” → “minimum”) for clearer feedback during validation.

- Tests
  - Updated test descriptions and assertion messages to fix typos (“faild” → “failed”, “much” → “match”) for clearer test output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->