### PR TITLE
chore(auth): fix typos and improve comments

### DIFF
--- a/x/auth/ante/sigverify.go
+++ b/x/auth/ante/sigverify.go
@@ -35,7 +35,7 @@ var (
 )
 
 func init() {
-	// This decodes a valid hex string into a sepc256k1Pubkey for use in transaction simulation
+	// This decodes a valid hex string into a secp256k1Pubkey for use in transaction simulation
 	bz, _ := hex.DecodeString("035AD6810A47F073553FF30D2FCC7E0D3B1C0B74B61A1AAA2582344037151E143A")
 	copy(key, bz)
 	simSecp256k1Pubkey.Key = key
@@ -100,7 +100,7 @@ func (spkd SetPubKeyDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate b
 		if err != nil {
 			return ctx, err
 		}
-		// account already has pubkey set,no need to reset
+		// account already has pubkey set, no need to reset
 		if acc.GetPubKey() != nil {
 			continue
 		}

--- a/x/auth/ante/validator_tx_fee.go
+++ b/x/auth/ante/validator_tx_fee.go
@@ -50,7 +50,7 @@ func checkTxFeeWithValidatorMinGasPrices(ctx sdk.Context, tx sdk.Tx) (sdk.Coins,
 // getTxPriority returns a naive tx priority based on the amount of the smallest denomination of the gas price
 // provided in a transaction.
 // NOTE: This implementation should be used with a great consideration as it opens potential attack vectors
-// where txs with multiple coins could not be prioritize as expected.
+// where txs with multiple coins could not be prioritized as expected.
 func getTxPriority(fee sdk.Coins, gas int64) int64 {
 	var priority int64
 	for _, c := range fee {

--- a/x/auth/client/tx.go
+++ b/x/auth/client/tx.go
@@ -105,7 +105,7 @@ func ReadTxFromFile(ctx client.Context, filename string) (tx sdk.Tx, err error) 
 	return ctx.TxConfig.TxJSONDecoder()(bytes)
 }
 
-// ReadTxsFromInput reads multiples txs from the given filename(s). Can pass "-" to read from stdin.
+// ReadTxsFromInput reads multiple txs from the given filename(s). Can pass "-" to read from stdin.
 // Unlike ReadTxFromFile, this function does not decode the txs.
 func ReadTxsFromInput(txCfg client.TxConfig, filenames ...string) (scanner *BatchScanner, err error) {
 	if len(filenames) == 0 {

--- a/x/auth/keeper/deterministic_test.go
+++ b/x/auth/keeper/deterministic_test.go
@@ -88,7 +88,7 @@ func (suite *DeterministicTestSuite) SetupTest() {
 	suite.accountNumberLanes = 1
 }
 
-// createAndSetAccount creates a random account and sets to the keeper store.
+// createAndSetAccounts creates random accounts and sets them to the keeper store.
 func (suite *DeterministicTestSuite) createAndSetAccounts(t *rapid.T, count int) []sdk.AccountI {
 	accs := make([]sdk.AccountI, 0, count)
 

--- a/x/auth/keeper/msg_server_test.go
+++ b/x/auth/keeper/msg_server_test.go
@@ -92,7 +92,7 @@ func (s *KeeperTestSuite) TestUpdateParams() {
 				},
 			},
 			expectErr: true,
-			expErrMsg: "invalid SECK256k1 signature verification cost",
+			expErrMsg: "invalid SECP256k1 signature verification cost",
 		},
 	}
 

--- a/x/auth/signing/sign_mode_handler.go
+++ b/x/auth/signing/sign_mode_handler.go
@@ -8,7 +8,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/tx/signing"
 )
 
-// SignModeHandler defines a interface to be implemented by types which will handle
+// SignModeHandler defines an interface to be implemented by types which will handle
 // SignMode's by generating sign bytes from a Tx and SignerData
 type SignModeHandler interface {
 	// DefaultMode is the default mode that is to be used with this handler if no

--- a/x/auth/tx/README.md
+++ b/x/auth/tx/README.md
@@ -116,7 +116,7 @@ The `x/auth/tx` module provides a convenient CLI command for decoding and encodi
 #### `encode`
 
 The `encode` command encodes a transaction created with the `--generate-only` flag or signed with the sign command.
-The transaction is serialized it to Protobuf and returned as base64.
+The transaction is serialized to Protobuf and returned as base64.
 
 ```bash
 $ simd tx encode tx.json
@@ -128,7 +128,7 @@ More information about the `encode` command can be found running `simd tx encode
 
 #### `decode`
 
-The `decode` commands decodes a transaction encoded with the `encode` command.
+The `decode` command decodes a transaction encoded with the `encode` command.
 
 
 ```bash

--- a/x/auth/tx/builder.go
+++ b/x/auth/tx/builder.go
@@ -95,7 +95,7 @@ func (w *wrapper) SetTimeoutTimestamp(timestamp time.Time) {
 	}
 }
 
-func (w *wrapper) GetTimeoutTimeStamp() time.Time {
+func (w *wrapper) GetTimeoutTimestamp() time.Time {
 	t := w.tx.Body.TimeoutTimestamp
 	if t == nil {
 		return time.Time{}

--- a/x/auth/tx/service.go
+++ b/x/auth/tx/service.go
@@ -21,7 +21,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/auth/migrations/legacytx"
 )
 
-// baseAppSimulateFn is the signature of the Baseapp#Simulate function.
+// baseAppSimulateFn is the signature of the BaseApp#Simulate function.
 type baseAppSimulateFn func(txBytes []byte) (sdk.GasInfo, *sdk.Result, error)
 
 // txServer is the server for the protobuf Tx service.

--- a/x/auth/types/account.go
+++ b/x/auth/types/account.go
@@ -159,7 +159,7 @@ func NewModuleAddress(name string) sdk.AccAddress {
 	return address.Module(name)
 }
 
-// NewEmptyModuleAccount creates a empty ModuleAccount from a string
+// NewEmptyModuleAccount creates an empty ModuleAccount from a string
 func NewEmptyModuleAccount(name string, permissions ...string) *ModuleAccount {
 	moduleAddress := NewModuleAddress(name)
 	baseAcc := NewBaseAccountWithAddress(moduleAddress)

--- a/x/auth/types/codec.go
+++ b/x/auth/types/codec.go
@@ -26,7 +26,7 @@ func RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
 }
 
 // RegisterInterfaces associates protoName with AccountI interface
-// and creates a registry of it's concrete implementations
+// and creates a registry of its concrete implementations
 func RegisterInterfaces(registry types.InterfaceRegistry) {
 	registry.RegisterInterface(
 		"cosmos.auth.v1beta1.AccountI",

--- a/x/auth/types/credentials_test.go
+++ b/x/auth/types/credentials_test.go
@@ -13,7 +13,7 @@ import (
 func TestNewModuleCredentials(t *testing.T) {
 	// wrong derivation keys
 	_, err := authtypes.NewModuleCredential("group", []byte{})
-	require.Error(t, err, "derivation keys must be non empty")
+	require.Error(t, err, "derivation keys must be non-empty")
 	_, err = authtypes.NewModuleCredential("group", [][]byte{{0x0, 0x30}, {}}...)
 	require.Error(t, err)
 

--- a/x/auth/types/genesis.go
+++ b/x/auth/types/genesis.go
@@ -91,7 +91,7 @@ func SanitizeGenesisAccounts(genAccs GenesisAccounts) GenesisAccounts {
 		}
 	}
 
-	// dupAccNums a sorted list of the account numbers with duplicates.
+	// dupAccNums is a sorted list of the account numbers with duplicates.
 	var dupAccNums []uint64
 	for num := range dupAccNum {
 		dupAccNums = append(dupAccNums, num)

--- a/x/auth/types/params.go
+++ b/x/auth/types/params.go
@@ -41,7 +41,7 @@ func DefaultParams() Params {
 //	BenchmarkSig/secp256k1     4334   277167 ns/op   4128 B/op   79 allocs/op
 //	BenchmarkSig/secp256r1    10000   108769 ns/op   1672 B/op   33 allocs/op
 //
-// Based on the results above secp256k1 is 2.7x is slower. However we propose to discount it
+// Based on the results above secp256k1 is 2.7x slower. However we propose to discount it
 // because we don't compare the cgo implementation of secp256k1, which is faster.
 func (p Params) SigVerifyCostSecp256r1() uint64 {
 	return p.SigVerifyCostSecp256k1 / 2

--- a/x/auth/types/params_legacy.go
+++ b/x/auth/types/params_legacy.go
@@ -1,6 +1,6 @@
 /*
 NOTE: Usage of x/params to manage parameters is deprecated in favor of x/gov
-controlled execution of MsgUpdateParams messages. These types remains solely
+controlled execution of MsgUpdateParams messages. These types remain solely
 for migration purposes and will be removed in a future release.
 */
 package types

--- a/x/auth/types/params_test.go
+++ b/x/auth/types/params_test.go
@@ -30,7 +30,7 @@ func TestParams_Validate(t *testing.T) {
 		{"invalid ED25519 signature verification cost", types.NewParams(types.DefaultMaxMemoCharacters, types.DefaultTxSigLimit, types.DefaultTxSizeCostPerByte,
 			0, types.DefaultSigVerifyCostSecp256k1), fmt.Errorf("invalid ED25519 signature verification cost: 0")},
 		{"invalid SECK256k1 signature verification cost", types.NewParams(types.DefaultMaxMemoCharacters, types.DefaultTxSigLimit, types.DefaultTxSizeCostPerByte,
-			types.DefaultSigVerifyCostED25519, 0), fmt.Errorf("invalid SECK256k1 signature verification cost: 0")},
+			types.DefaultSigVerifyCostED25519, 0), fmt.Errorf("invalid SECP256k1 signature verification cost: 0")},
 		{"invalid max memo characters", types.NewParams(0, types.DefaultTxSigLimit, types.DefaultTxSizeCostPerByte,
 			types.DefaultSigVerifyCostED25519, types.DefaultSigVerifyCostSecp256k1), fmt.Errorf("invalid max memo characters: 0")},
 		{"invalid tx size cost per byte", types.NewParams(types.DefaultMaxMemoCharacters, types.DefaultTxSigLimit, 0,


### PR DESCRIPTION
Corrected spelling mistakes, fixed grammar, and improved comment clarity across the `x/auth` package.
Also standardized naming conventions (e.g., SECK256k1 → SECP256k1, multiples → multiple).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Corrected spelling of a public transaction timeout accessor; update integrations to use the new, consistently named field/method. No behavioral changes.

- Documentation
  - Improved grammar, capitalization, and clarity across comments and user docs, including clearer CLI encode/decode descriptions.

- Tests
  - Updated expected error message text to fix typos and capitalization for signature verification cost validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->