### PR TITLE
fix: correct spelling and grammar errors in staking comments

### DIFF
--- a/store/cachekv/store_test.go
+++ b/store/cachekv/store_test.go
@@ -76,7 +76,7 @@ func TestCacheKVStoreNested(t *testing.T) {
 	mem := dbadapter.Store{DB: dbm.NewMemDB()}
 	st := cachekv.NewStore(mem)
 
-	// set. check its there on st and not on mem.
+	// set. check it's there on st and not on mem.
 	st.Set(keyFmt(1), valFmt(1))
 	require.Empty(t, mem.Get(keyFmt(1)))
 	require.Equal(t, valFmt(1), st.Get(keyFmt(1)))
@@ -85,13 +85,13 @@ func TestCacheKVStoreNested(t *testing.T) {
 	st2 := cachekv.NewStore(st)
 	require.Equal(t, valFmt(1), st2.Get(keyFmt(1)))
 
-	// update the value on st2, check it only effects st2
+	// update the value on st2, check it only affects st2
 	st2.Set(keyFmt(1), valFmt(3))
 	require.Equal(t, []byte(nil), mem.Get(keyFmt(1)))
 	require.Equal(t, valFmt(1), st.Get(keyFmt(1)))
 	require.Equal(t, valFmt(3), st2.Get(keyFmt(1)))
 
-	// st2 writes to its parent, st. doesnt effect mem
+	// st2 writes to its parent, st. doesn't affect mem
 	st2.Write()
 	require.Equal(t, []byte(nil), mem.Get(keyFmt(1)))
 	require.Equal(t, valFmt(3), st.Get(keyFmt(1)))
@@ -222,41 +222,41 @@ func TestCacheKVMergeIteratorBasics(t *testing.T) {
 	st.Delete(k)
 	assertIterateDomain(t, st, 0)
 
-	// now set it and assert its there
+	// now set it and assert it's there
 	st.Set(k, v)
 	assertIterateDomain(t, st, 1)
 
-	// write it and assert its there
+	// write it and assert it's there
 	st.Write()
 	assertIterateDomain(t, st, 1)
 
-	// remove it in cache and assert its not
+	// remove it in cache and assert it's not
 	st.Delete(k)
 	assertIterateDomain(t, st, 0)
 
-	// write the delete and assert its not there
+	// write the delete and assert it's not there
 	st.Write()
 	assertIterateDomain(t, st, 0)
 
-	// add two keys and assert theyre there
+	// add two keys and assert they're there
 	k1, v1 := keyFmt(1), valFmt(1)
 	st.Set(k, v)
 	st.Set(k1, v1)
 	assertIterateDomain(t, st, 2)
 
-	// write it and assert theyre there
+	// write it and assert they're there
 	st.Write()
 	assertIterateDomain(t, st, 2)
 
-	// remove one in cache and assert its not
+	// remove one in cache and assert it's not
 	st.Delete(k1)
 	assertIterateDomain(t, st, 1)
 
-	// write the delete and assert its not there
+	// write the delete and assert it's not there
 	st.Write()
 	assertIterateDomain(t, st, 1)
 
-	// delete the other key in cache and asserts its empty
+	// delete the other key in cache and assert it's empty
 	st.Delete(k)
 	assertIterateDomain(t, st, 0)
 }

--- a/store/listenkv/store.go
+++ b/store/listenkv/store.go
@@ -64,7 +64,7 @@ func (s *Store) ReverseIterator(start, end []byte) types.Iterator {
 }
 
 // iterator facilitates iteration over a KVStore. It delegates the necessary
-// calls to it's parent KVStore.
+// calls to its parent KVStore.
 func (s *Store) iterator(start, end []byte, ascending bool) types.Iterator {
 	var parent types.Iterator
 

--- a/store/tracekv/store.go
+++ b/store/tracekv/store.go
@@ -91,7 +91,7 @@ func (tkv *Store) ReverseIterator(start, end []byte) types.Iterator {
 }
 
 // iterator facilitates iteration over a KVStore. It delegates the necessary
-// calls to it's parent KVStore.
+// calls to its parent KVStore.
 func (tkv *Store) iterator(start, end []byte, ascending bool) types.Iterator {
 	var parent types.Iterator
 


### PR DESCRIPTION
# Description
This PR corrects spelling and grammar errors in staking comments
Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected grammar and punctuation in comments and docstrings, improving clarity (e.g., “it’s” vs “its”).
  * Clarified iterator-related documentation without altering behavior or APIs.

* **Tests**
  * Updated test comments for readability and accuracy; no changes to assertions or test behavior.

* **Style**
  * Minor comment style cleanups to ensure consistent terminology and punctuation across the codebase.

No functional changes; user-facing behavior and public interfaces remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->