### PR TITLE
chore: server: wrap panic as error in bindFlags to preserve error chain

### DIFF
--- a/server/util.go
+++ b/server/util.go
@@ -71,7 +71,7 @@ func bindFlags(basename string, cmd *cobra.Command, v *viper.Viper) (err error) 
                 err = fmt.Errorf("bindFlags failed: %v", r)
             }
         }
-    }(
+    }()
 
 	cmd.Flags().VisitAll(func(f *pflag.Flag) {
 		// Environment variables can't have dashes in them, so bind them to their equivalent

--- a/server/util.go
+++ b/server/util.go
@@ -63,11 +63,15 @@ func NewContext(v *viper.Viper, config *cmtcfg.Config, logger log.Logger) *Conte
 }
 
 func bindFlags(basename string, cmd *cobra.Command, v *viper.Viper) (err error) {
-	defer func() {
-		if r := recover(); r != nil {
-			err = fmt.Errorf("bindFlags failed: %v", r)
-		}
-	}()
+    defer func() {
+        if r := recover(); r != nil {
+            if e, ok := r.(error); ok {
+                err = fmt.Errorf("bindFlags failed: %w", e)
+            } else {
+                err = fmt.Errorf("bindFlags failed: %v", r)
+            }
+        }
+    }(
 
 	cmd.Flags().VisitAll(func(f *pflag.Flag) {
 		// Environment variables can't have dashes in them, so bind them to their equivalent


### PR DESCRIPTION
# Description
Hi! I tweaked `bindFlags` so that if it catches a panic of type `error`, it keeps it as a proper wrapped error instead of flattening it into plain text. That means you can now use `errors.Is` or `errors.As` to figure out what actually went wrong, instead of parsing strings. If the panic isn’t an `error`, behavior stays the same — it just formats it as text.

Why
Before, `fmt.Errorf("%v", r)` was stripping away all the useful type information. You’d end up with `"bindFlags failed: something"` and no way to check the original error type. Now the chain is preserved, making debugging and logging a lot easier.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved panic recovery in flag processing to preserve underlying errors, providing clearer, more actionable error messages.
  * Error messages now consistently include original failure context instead of generic summaries, aiding faster troubleshooting and support diagnostics.
  * Functional behavior remains unchanged with no impact on existing workflows; only error reporting during failures is enhanced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->