### PR TITLE
fix incorrect error message in server util test

### DIFF
--- a/server/util_test.go
+++ b/server/util_test.go
@@ -95,7 +95,7 @@ func TestInterceptConfigsPreRunHandlerCreatesConfigFilesWhenMissing(t *testing.T
 	}
 
 	if s.Size() == 0 {
-		t.Fatal("config.toml created as empty file")
+		t.Fatal("app.toml created as empty file")
 	}
 
 	// Test that the config for use in server/start.go is created


### PR DESCRIPTION
# Description

Fix misleading error message in TestInterceptConfigsPreRunHandlerCreatesConfigFilesWhenMissing.
The test was checking if app.toml file is empty but the error message incorrectly 
referenced "config.toml created as empty file" instead of "app.toml created as empty file".

This was a copy-paste error where the config.toml validation logic was duplicated 
for app.toml validation but the error message wasn't updated accordingly.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated a test assertion message to reference the correct configuration file, improving the clarity and accuracy of test diagnostics.
  * Enhances developer experience by making test failures easier to interpret.
  * No impact on application behavior or user-facing functionality.
  * Build and runtime behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->