### PR TITLE
test(crisis): remove redundant keyring account creation in msg_server_test

### DIFF
--- a/x/crisis/keeper/msg_server_test.go
+++ b/x/crisis/keeper/msg_server_test.go
@@ -53,8 +53,6 @@ func (s *KeeperTestSuite) TestMsgVerifyInvariant() {
 
 	encCfg := moduletestutil.MakeTestEncodingConfig(crisis.AppModuleBasic{})
 	kr := keyring.NewInMemory(encCfg.Codec)
-	testutil.CreateKeyringAccounts(s.T(), kr, 1)
-
 	sender := testutil.CreateKeyringAccounts(s.T(), kr, 1)[0]
 
 	s.supplyKeeper.EXPECT().SendCoinsFromAccountToModule(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(2)


### PR DESCRIPTION
Remove an unnecessary CreateKeyringAccounts invocation in x/crisis/keeper/msg_server_test.go that didn’t use its result. Use a single call to create the sender account, avoiding potential duplicate key errors (deterministic key names like key-0). No functional changes to test logic.