### PR TITLE
chore: fix typos and improve variable naming consistency

### DIFF
--- a/tests/integration/gov/keeper/grpc_query_test.go
+++ b/tests/integration/gov/keeper/grpc_query_test.go
@@ -211,10 +211,10 @@ func TestLegacyGRPCQueryTally(t *testing.T) {
 
 				expRes = &v1beta1.QueryTallyResultResponse{
 					Tally: v1beta1.TallyResult{
-						Yes:        math.LegacyNewInt(3 * 5 * 1000000),
-						No:         math.LegacyNewInt(0),
-						Abstain:    math.LegacyNewInt(0),
-						NoWithVeto: math.LegacyNewInt(0),
+						Yes:        math.NewInt(3 * 5 * 1000000),
+						No:         math.NewInt(0),
+						Abstain:    math.NewInt(0),
+						NoWithVeto: math.NewInt(0),
 					},
 				}
 			},

--- a/tests/integration/gov/keeper/grpc_query_test.go
+++ b/tests/integration/gov/keeper/grpc_query_test.go
@@ -211,10 +211,10 @@ func TestLegacyGRPCQueryTally(t *testing.T) {
 
 				expRes = &v1beta1.QueryTallyResultResponse{
 					Tally: v1beta1.TallyResult{
-						Yes:        math.NewInt(3 * 5 * 1000000),
-						No:         math.NewInt(0),
-						Abstain:    math.NewInt(0),
-						NoWithVeto: math.NewInt(0),
+						Yes:        math.LegacyNewInt(3 * 5 * 1000000),
+						No:         math.LegacyNewInt(0),
+						Abstain:    math.LegacyNewInt(0),
+						NoWithVeto: math.LegacyNewInt(0),
 					},
 				}
 			},

--- a/types/tx/signing/signature.go
+++ b/types/tx/signing/signature.go
@@ -40,17 +40,17 @@ func SignatureDataToProto(data SignatureData) *SignatureDescriptor_Data {
 			},
 		}
 	case *MultiSignatureData:
-		descDatas := make([]*SignatureDescriptor_Data, len(data.Signatures))
+		descriptorDataList := make([]*SignatureDescriptor_Data, len(data.Signatures))
 
 		for j, d := range data.Signatures {
-			descDatas[j] = SignatureDataToProto(d)
+			descriptorDataList[j] = SignatureDataToProto(d)
 		}
 
 		return &SignatureDescriptor_Data{
 			Sum: &SignatureDescriptor_Data_Multi_{
 				Multi: &SignatureDescriptor_Data_Multi{
 					Bitarray:   data.BitArray,
-					Signatures: descDatas,
+					Signatures: descriptorDataList,
 				},
 			},
 		}
@@ -71,15 +71,15 @@ func SignatureDataFromProto(descData *SignatureDescriptor_Data) SignatureData {
 		}
 	case *SignatureDescriptor_Data_Multi_:
 		multi := descData.Multi
-		datas := make([]SignatureData, len(multi.Signatures))
+		signatureDataList := make([]SignatureData, len(multi.Signatures))
 
 		for j, d := range multi.Signatures {
-			datas[j] = SignatureDataFromProto(d)
+			signatureDataList[j] = SignatureDataFromProto(d)
 		}
 
 		return &MultiSignatureData{
 			BitArray:   multi.Bitarray,
-			Signatures: datas,
+			Signatures: signatureDataList,
 		}
 	default:
 		panic(fmt.Errorf("unexpected case %+v", descData))

--- a/x/bank/keeper/keeper_test.go
+++ b/x/bank/keeper/keeper_test.go
@@ -2497,7 +2497,7 @@ func (suite *KeeperTestSuite) TestGetAllBalances() {
 		sdk.NewInt64Coin("ten", 40000000), sdk.NewInt64Coin("eleven", 4545), sdk.NewInt64Coin("twelve", 41212),
 		sdk.NewInt64Coin("thirteen", 41333), sdk.NewInt64Coin("fourteen", 401414), sdk.NewInt64Coin("fifteen", 47),
 		sdk.NewInt64Coin("sixteen", 400016), sdk.NewInt64Coin("seventeen", 404), sdk.NewInt64Coin("eighteen", 4454),
-		sdk.NewInt64Coin("ninteen", 41298), sdk.NewInt64Coin("twenty", 456789),
+		sdk.NewInt64Coin("nineteen", 41298), sdk.NewInt64Coin("twenty", 456789),
 	)
 
 	bals := []struct {
@@ -2592,11 +2592,11 @@ func (suite *KeeperTestSuite) TestGetAccountsBalances() {
 		sdk.NewInt64Coin("ten", 40000000), sdk.NewInt64Coin("eleven", 4545), sdk.NewInt64Coin("twelve", 41212),
 		sdk.NewInt64Coin("thirteen", 41333), sdk.NewInt64Coin("fourteen", 401414), sdk.NewInt64Coin("fifteen", 47),
 		sdk.NewInt64Coin("sixteen", 400016), sdk.NewInt64Coin("seventeen", 404), sdk.NewInt64Coin("eighteen", 4454),
-		sdk.NewInt64Coin("ninteen", 41298), sdk.NewInt64Coin("twenty", 456789),
+		sdk.NewInt64Coin("nineteen", 41298), sdk.NewInt64Coin("twenty", 456789),
 	)
 	balC := sdk.NewCoins(sdk.NewInt64Coin("one", 222), sdk.NewInt64Coin("two", 234))
 	balD := sdk.Coins(nil)
-	balE := sdk.NewCoins(sdk.NewInt64Coin("banana", 99), sdk.NewInt64Coin("six", 789))
+	balanceE := sdk.NewCoins(sdk.NewInt64Coin("banana", 99), sdk.NewInt64Coin("six", 789))
 	balF := sdk.NewCoins(
 		sdk.NewInt64Coin("one", 37), sdk.NewInt64Coin("two", 3), sdk.NewInt64Coin("three", 399),
 		sdk.NewInt64Coin("four", 3456), sdk.NewInt64Coin("five", 321),
@@ -2613,7 +2613,7 @@ func (suite *KeeperTestSuite) TestGetAccountsBalances() {
 		{Addr: addrB, Coins: balB},
 		{Addr: addrC, Coins: balC},
 		{Addr: addrD, Coins: balD},
-		{Addr: addrE, Coins: balE},
+		{Addr: addrE, Coins: balanceE},
 		{Addr: addrF, Coins: balF},
 		{Addr: addrG, Coins: balG},
 	}

--- a/x/bank/simulation/operations_test.go
+++ b/x/bank/simulation/operations_test.go
@@ -164,13 +164,13 @@ func (suite *SimTestSuite) TestSimulateMsgMultiSend() {
 
 func (suite *SimTestSuite) TestSimulateModuleAccountMsgSend() {
 	const (
-		accCount       = 1
+		accountCount   = 1
 		moduleAccCount = 1
 	)
 
 	s := rand.NewSource(1)
 	r := rand.New(s)
-	accounts := suite.getTestingAccounts(r, accCount)
+	accounts := suite.getTestingAccounts(r, accountCount)
 
 	_, err := suite.app.FinalizeBlock(&abci.FinalizeBlockRequest{
 		Height: suite.app.LastBlockHeight() + 1,
@@ -198,13 +198,13 @@ func (suite *SimTestSuite) TestSimulateModuleAccountMsgSend() {
 
 func (suite *SimTestSuite) TestSimulateMsgMultiSendToModuleAccount() {
 	const (
-		accCount  = 2
-		mAccCount = 2
+		accountCount = 2
+		mAccCount    = 2
 	)
 
 	s := rand.NewSource(1)
 	r := rand.New(s)
-	accounts := suite.getTestingAccounts(r, accCount)
+	accounts := suite.getTestingAccounts(r, accountCount)
 
 	_, err := suite.app.FinalizeBlock(&abci.FinalizeBlockRequest{
 		Height: suite.app.LastBlockHeight() + 1,

--- a/x/genutil/client/cli/genaccount_test.go
+++ b/x/genutil/client/cli/genaccount_test.go
@@ -62,7 +62,7 @@ func TestAddGenesisAccountCmd(t *testing.T) {
 		},
 		{
 			name:        "with keyring",
-			addr:        "ser",
+			addr:        "user",
 			denom:       "1000atom",
 			withKeyring: true,
 			expectErr:   false,

--- a/x/genutil/collect.go
+++ b/x/genutil/collect.go
@@ -96,16 +96,16 @@ func CollectTxs(cdc codec.JSONCodec, txJSONDecoder sdk.TxDecoder, moniker, genTx
 	// addresses and IPs (and port) validator server info
 	var addressesIPs []string
 
-	for _, fo := range fos {
-		if fo.IsDir() {
+	for _, fileEntry := range fos {
+		if fileEntry.IsDir() {
 			continue
 		}
-		if !strings.HasSuffix(fo.Name(), ".json") {
+		if !strings.HasSuffix(fileEntry.Name(), ".json") {
 			continue
 		}
 
 		// get the genTx
-		jsonRawTx, err := os.ReadFile(filepath.Join(genTxsDir, fo.Name()))
+		jsonRawTx, err := os.ReadFile(filepath.Join(genTxsDir, fileEntry.Name()))
 		if err != nil {
 			return appGenTxs, persistentPeers, err
 		}

--- a/x/group/internal/math/dec_test.go
+++ b/x/group/internal/math/dec_test.go
@@ -116,11 +116,11 @@ var genFloatAndDec *rapid.Generator[floatAndDec] = rapid.Custom(func(t *rapid.T)
 
 // Property: n == NewDecFromInt64(n).Int64()
 func testDecInt64(t *rapid.T) {
-	nIn := rapid.Int64().Draw(t, "n")
-	nOut, err := NewDecFromInt64(nIn).Int64()
+	inputInt := rapid.Int64().Draw(t, "n")
+	outputInt, err := NewDecFromInt64(inputInt).Int64()
 
 	require.NoError(t, err)
-	require.Equal(t, nIn, nOut)
+	require.Equal(t, inputInt, outputInt)
 }
 
 // Property: 0 + a == a


### PR DESCRIPTION
This PR fixes minor typos and improves variable naming consistency across tests and core modules to enhance readability and maintainability.

### Changes
- **gov keeper tests**: replaced deprecated `math.NewInt` with `math.LegacyNewInt`.
- **signing**: clarified local variable names (`descDatas` → `descriptorDataList`, `datas` → `signatureDataList`).
- **bank keeper tests**: fixed typo (`ninteen` → `nineteen`) and improved variable name (`balE` → `balanceE`).
- **bank simulation tests**: renamed constants for clarity (`accCount` → `accountCount`).
- **genutil CLI tests**: corrected test address string (`ser` → `user`).
- **genutil collect**: renamed loop variable (`fo` → `fileEntry`) for readability.
- **group math tests**: renamed variables for clarity (`nIn/nOut` → `inputInt/outputInt`).

### Impact
- Improves readability and consistency.
- No changes to runtime logic, consensus, or APIs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Tests
  * Improved clarity and correctness across multiple test suites (governance tallies, bank balances, simulation operations, genesis account CLI, decimal math).
* Refactor
  * Renamed internal variables to enhance readability in signing and genesis utilities; no functional changes.
* Chores
  * Minor typo fixes and test data adjustments.

No user-facing behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->