### PR TITLE
chore: remove obsolete TODO comment in startCmtNode function

### DIFF
--- a/server/start.go
+++ b/server/start.go
@@ -366,7 +366,6 @@ func startInProcess(svrCtx *Context, svrCfg serverconfig.Config, clientCtx clien
 	return g.Wait()
 }
 
-// TODO: Move nodeKey into being created within the function.
 func startCmtNode(
 	ctx context.Context,
 	cfg *cmtcfg.Config,


### PR DESCRIPTION
Remove outdated TODO comment about moving nodeKey creation inside the function.

The TODO comment "Move nodeKey into being created within the function" was added in 
PR #16152 (May 2023) when nodeKey was being passed as a parameter to startCmtNode.

However, the suggested refactoring was completed in PR #16238 (July 2023) when the 
function signature was changed to create nodeKey internally via p2p.LoadOrGenNodeKey().