### PR TITLE
ci: update goreleaser action to v6

### DIFF
--- a/.github/workflows/release-confix.yml
+++ b/.github/workflows/release-confix.yml
@@ -28,7 +28,7 @@ jobs:
           git tag -d ${{ env.RELEASE_VERSION }} || echo "No such a tag exists before"
           git tag ${{ env.RELEASE_VERSION }} HEAD
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v3
+        uses: goreleaser/goreleaser-action@v6
         with:
           # stick to version v0.179.0(https://github.com/cosmos/cosmos-sdk/issues/11125)
           version: v0.179.0

--- a/.github/workflows/release-cosmovisor.yml
+++ b/.github/workflows/release-cosmovisor.yml
@@ -28,7 +28,7 @@ jobs:
           git tag -d ${{ env.RELEASE_VERSION }} || echo "No such a tag exists before"
           git tag ${{ env.RELEASE_VERSION }} HEAD
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v3
+        uses: goreleaser/goreleaser-action@v6
         with:
           # stick to version v0.179.0(https://github.com/cosmos/cosmos-sdk/issues/11125)
           version: v0.179.0

--- a/.github/workflows/release-simd.yml
+++ b/.github/workflows/release-simd.yml
@@ -28,7 +28,7 @@ jobs:
           git tag -d ${{ env.RELEASE_VERSION }} || echo "No such a tag exists before"
           git tag ${{ env.RELEASE_VERSION }} HEAD
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v3
+        uses: goreleaser/goreleaser-action@v6
         with:
           # stick to version v0.179.0(https://github.com/cosmos/cosmos-sdk/issues/11125)
           version: v0.179.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Unshallow
         run: git fetch --prune --unshallow
       - name: Create release
-        uses: goreleaser/goreleaser-action@v3
+        uses: goreleaser/goreleaser-action@v6
         with:
           args: release --clean --release-notes ./RELEASE_NOTES.md
         env:


### PR DESCRIPTION


### Description
- **What**: Upgrade `goreleaser/goreleaser-action` to `v6` across release workflows.
- **Why**: Stay on supported major with maintenance/security updates; no behavior changes.
