### PR TITLE
fix: Small visualization fix by removing unclosed code block in ADR 063

### DIFF
--- a/docs/architecture/adr-063-core-module-api.md
+++ b/docs/architecture/adr-063-core-module-api.md
@@ -192,8 +192,6 @@ func NewKeeper(logger log.Logger) Keeper {
 }
 ```
 
-```
-
 ### Core `AppModule` extension interfaces
 
 


### PR DESCRIPTION
# Description

While going through [ADR 063](https://docs.cosmos.network/v0.53/build/architecture/adr-063-core-module-api), I noticed there is a visualization problem because there was an unclosed code block before the section about `AppModule` extension interfaces. :v:

<img width="1029" height="720" alt="image" src="https://github.com/user-attachments/assets/27af602b-2f55-4f1e-a8ee-acba46a7b31d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected a formatting issue in the ADR-063 Core Module API document by removing an extra closing code fence and a stray blank line.
  * Improves readability and proper rendering of the NewKeeper code snippet and subsequent section header.
  * No functional or API changes; user-facing behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->