### PR TITLE
fix(x/slashing): fix logical error in TestSlashingMsgs test

### DIFF
--- a/x/slashing/app_test.go
+++ b/x/slashing/app_test.go
@@ -104,7 +104,7 @@ func TestSlashingMsgs(t *testing.T) {
 	unjailMsg := &types.MsgUnjail{ValidatorAddr: sdk.ValAddress(addr1).String()}
 
 	ctxCheck = app.NewContext(true)
-	_, err = slashingKeeper.GetValidatorSigningInfo(ctxCheck, sdk.ConsAddress(valAddr))
+	_, err = slashingKeeper.GetValidatorSigningInfo(ctxCheck, sdk.ConsAddress(valKey.PubKey().Address()))
 	require.NoError(t, err)
 
 	// unjail should fail with unknown validator


### PR DESCRIPTION
Fix logical inconsistency in TestSlashingMsgs where validator signing info
was being queried for the wrong address.

The test creates a validator using addr1 and valKey, but then attempts
to get signing info for valAddr (which is derived from valKey but not
the same as the created validator's address). This creates a mismatch
between the validator being tested and the address being queried.

Changed GetValidatorSigningInfo call from sdk.ConsAddress(valAddr) to
sdk.ConsAddress(valKey.PubKey().Address()) to ensure the signing info
is queried for the correct validator that was actually created in the test.
