### PR TITLE
ledger(mock): return compressed pubkey from GetAddressPubKeySECP256K1

### DIFF
--- a/crypto/ledger/ledger_mock.go
+++ b/crypto/ledger/ledger_mock.go
@@ -83,7 +83,7 @@ func (mock LedgerSECP256K1Mock) GetAddressPubKeySECP256K1(derivationPath []uint3
 	// Generate the bech32 addr using existing cmtcrypto/etc.
 	pub := &csecp256k1.PubKey{Key: compressedPublicKey}
 	addr := sdk.AccAddress(pub.Address()).String()
-	return pk, addr, err
+	return compressedPublicKey, addr, err
 }
 
 func (mock LedgerSECP256K1Mock) SignSECP256K1(derivationPath []uint32, message []byte, p2 byte) ([]byte, error) {


### PR DESCRIPTION
# Description

Align mock behavior with the SECP256K1 interface contract and function comment by returning the 33-byte compressed public key instead of the 65-byte uncompressed key. This makes the mock consistent with production expectations while remaining backward-compatible with callers that re-compress the key.