### PR TITLE
fix(docs): fix some inconsistent function names in comment

### DIFF
--- a/x/tx/signing/aminojson/options.go
+++ b/x/tx/signing/aminojson/options.go
@@ -27,7 +27,7 @@ func getMessageAminoName(msg protoreflect.Message) (string, bool) {
 	return "", false
 }
 
-// getMessageAminoName returns the amino name of a message if it has been set by the `amino.name` option.
+// getMessageAminoNameAny returns the amino name of a message if it has been set by the `amino.name` option.
 // If the message does not have an amino name, then it returns the msg url.
 func getMessageAminoNameAny(msg protoreflect.Message) string {
 	messageOptions := msg.Descriptor().Options()

--- a/x/upgrade/plan/info_test.go
+++ b/x/upgrade/plan/info_test.go
@@ -24,7 +24,7 @@ func TestInfoTestSuite(t *testing.T) {
 	suite.Run(t, new(InfoTestSuite))
 }
 
-// saveSrcTestFile saves a TestFile in this test's Home/src directory.
+// saveTestFile saves a TestFile in this test's Home/src directory.
 // The full path to the saved file is returned.
 func (s *InfoTestSuite) saveTestFile(f *TestFile) string {
 	fullName, err := f.SaveIn(s.Home)


### PR DESCRIPTION
# Description

fix some inconsistent function names in comment

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->
