### PR TITLE
docs: add link to official developer docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,6 @@ The IBC module for the Cosmos SDK has its own [cosmos/ibc-go repository](https:/
 ## Disambiguation
 
 This Cosmos SDK project is not related to the [React-Cosmos](https://github.com/react-cosmos/react-cosmos) project (yet). Many thanks to Evan Coury and Ovidiu (@skidding) for this Github organization name. As per our agreement, this disambiguation notice will stay here.
+
+## Documentation
+- Developer docs: https://docs.cosmos.network/

--- a/README.md
+++ b/README.md
@@ -66,5 +66,3 @@ The IBC module for the Cosmos SDK has its own [cosmos/ibc-go repository](https:/
 
 This Cosmos SDK project is not related to the [React-Cosmos](https://github.com/react-cosmos/react-cosmos) project (yet). Many thanks to Evan Coury and Ovidiu (@skidding) for this Github organization name. As per our agreement, this disambiguation notice will stay here.
 
-## Documentation
-- Developer docs: https://docs.cosmos.network/


### PR DESCRIPTION
Adds a direct link to https://docs.cosmos.network/ to improve discoverability. No code changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new Documentation subsection under Disambiguation in the README.
  * Included a direct link to the developer documentation: https://docs.cosmos.network/
  * Improves discoverability of technical resources for developers.
  * No functional or API changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->