### PR TITLE
fix(types/address): replace unsafe AssertNil with explicit error handling in Hash function

### DIFF
--- a/types/address/hash.go
+++ b/types/address/hash.go
@@ -8,8 +8,6 @@ import (
 
 	"github.com/cometbft/cometbft/v2/crypto"
 
-	"cosmossdk.io/errors"
-
 	"github.com/cosmos/cosmos-sdk/internal/conv"
 )
 
@@ -28,14 +26,23 @@ func Hash(typ string, key []byte) []byte {
 	hasher := sha256.New()
 	_, err := hasher.Write(conv.UnsafeStrToBytes(typ))
 	// the error is always nil, it's here only to satisfy the io.Writer interface
-	errors.AssertNil(err)
+	if err != nil {
+		// This should never happen with sha256.New(), but handle it gracefully
+		panic(fmt.Sprintf("failed to write type to hasher: %v", err))
+	}
 	th := hasher.Sum(nil)
 
 	hasher.Reset()
 	_, err = hasher.Write(th)
-	errors.AssertNil(err)
+	if err != nil {
+		// This should never happen with sha256.New(), but handle it gracefully
+		panic(fmt.Sprintf("failed to write hash to hasher: %v", err))
+	}
 	_, err = hasher.Write(key)
-	errors.AssertNil(err)
+	if err != nil {
+		// This should never happen with sha256.New(), but handle it gracefully
+		panic(fmt.Sprintf("failed to write key to hasher: %v", err))
+	}
 	return hasher.Sum(nil)
 }
 


### PR DESCRIPTION
# Description

Replace the use of errors.AssertNil() with explicit error handling in the Hash function to improve security and robustness in cryptographic operations.

**Changes:**
- Remove dependency on cosmossdk.io/errors package in hash.go
- Replace AssertNil() calls with explicit error checking and panic with descriptive messages


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal error handling in address hashing with explicit checks and clearer panic messages, improving diagnostics during unexpected failures.
  * No changes to public APIs or expected behavior; end users should see no impact in normal use.
  * Enhances transparency of low-level errors during development and debugging.
  * No configuration changes or actions required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->