### PR TITLE
chore: remove redundant zero capacity from map initialization

### DIFF
--- a/x/bank/types/send_authorization.go
+++ b/x/bank/types/send_authorization.go
@@ -72,7 +72,7 @@ func (a SendAuthorization) ValidateBasic() error {
 		return sdkerrors.ErrInvalidCoins.Wrapf("spend limit must be positive")
 	}
 
-	found := make(map[string]bool, 0)
+	found := make(map[string]bool)
 	for i := range a.AllowList {
 		if found[a.AllowList[i]] {
 			return ErrDuplicateEntry


### PR DESCRIPTION
# Description

Remove unnecessary zero capacity parameter from make(map[string]bool, 0) in send_authorization.go. The zero capacity is the default value and specifying it explicitly is redundant

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - No user-facing features added in this release.

- Refactor
  - Simplified internal initialization within authorization validation for cleaner, more idiomatic code. Behavior, duplicate detection, and outcomes remain unchanged.

- Chores
  - Minor code cleanup with no impact on public APIs or configuration.

- Impact
  - No changes to functionality or user experience. No action required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->