### PR TITLE
fix(crypto/keyring): correct method comment documentation in legacy_info.go

### DIFF
--- a/crypto/keyring/legacy_info.go
+++ b/crypto/keyring/legacy_info.go
@@ -52,32 +52,32 @@ func (i legacyLocalInfo) GetType() KeyType {
 	return TypeLocal
 }
 
-// GetType implements Info interface
+// GetName implements Info interface
 func (i legacyLocalInfo) GetName() string {
 	return i.Name
 }
 
-// GetType implements Info interface
+// GetPubKey implements Info interface
 func (i legacyLocalInfo) GetPubKey() cryptotypes.PubKey {
 	return i.PubKey
 }
 
-// GetType implements Info interface
+// GetAddress implements Info interface
 func (i legacyLocalInfo) GetAddress() sdk.AccAddress {
 	return i.PubKey.Address().Bytes()
 }
 
-// GetPrivKeyArmor
+// GetPrivKeyArmor returns the armored private key
 func (i legacyLocalInfo) GetPrivKeyArmor() string {
 	return i.PrivKeyArmor
 }
 
-// GetType implements Info interface
+// GetAlgo implements Info interface
 func (i legacyLocalInfo) GetAlgo() hd.PubKeyType {
 	return i.Algo
 }
 
-// GetType implements Info interface
+// GetPath implements Info interface
 func (i legacyLocalInfo) GetPath() (*hd.BIP44Params, error) {
 	return nil, fmt.Errorf("BIP44 Paths are not available for this type")
 }
@@ -111,7 +111,7 @@ func (i legacyLedgerInfo) GetAddress() sdk.AccAddress {
 	return i.PubKey.Address().Bytes()
 }
 
-// GetPath implements Info interface
+// GetAlgo implements Info interface
 func (i legacyLedgerInfo) GetAlgo() hd.PubKeyType {
 	return i.Algo
 }


### PR DESCRIPTION
Fix incorrect method comment documentation in legacy_info.go

Corrects copy-paste errors where method comments incorrectly stated
"GetType implements Info interface" for various methods. All comments
now accurately reflect which interface method each function implements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified and corrected method comments across legacy keyring info implementations to accurately describe behavior and align references.
  * Enhanced a comment to explicitly note that an armored private key is returned where applicable.
  * Standardized phrasing for algorithm and path accessors for consistency.
  * No functional changes: APIs, behavior, and outputs remain unchanged for all users.
  * Improves readability and maintainability for developers without impacting end-user workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->