### PR TITLE
docs: fixed broken links

### DIFF
--- a/docs/docs/Introduction.md
+++ b/docs/docs/Introduction.md
@@ -27,8 +27,8 @@ Get familiar with the SDK and explore its main concepts.
 
 Check out the docs for the various parts of the Cosmos stack.
 
-* [**Cosmos Hub**](https://hub.cosmos.network) - The first of thousands of interconnected blockchains on the Cosmos Network.
-* [**CometBFT**](https://docs.cometbft.com) - The leading BFT engine for building blockchains, powering Cosmos SDK.
+* [**Cosmos Hub**](https://hub.cosmos.network/main) - The first of thousands of interconnected blockchains on the Cosmos Network.
+* [**CometBFT**](https://docs.cometbft.com/v1.0/) - The leading BFT engine for building blockchains, powering Cosmos SDK.
 
 ## Help & Support
 

--- a/docs/docs/learn/intro/00-overview.md
+++ b/docs/docs/learn/intro/00-overview.md
@@ -35,7 +35,7 @@ The Cosmos SDK is the most advanced framework for building custom modular applic
 * Previously the default consensus engine available within the Cosmos SDK is [CometBFT](https://github.com/cometbft/cometbft). CometBFT is the most mature BFT consensus engine in existence. It is widely used across the industry and is considered the gold standard consensus engine for building Proof-of-Stake systems.
 * The Cosmos SDK is open-source and designed to make it easy to build blockchains out of composable [modules](../../build/modules). As the ecosystem of open-source Cosmos SDK modules grows, it will become increasingly easier to build complex decentralized platforms with it.
 * The Cosmos SDK is inspired by capabilities-based security, and informed by years of wrestling with blockchain state-machines. This makes the Cosmos SDK a very secure environment to build blockchains.
-* Most importantly, the Cosmos SDK has already been used to build many application-specific blockchains that are already in production. Among others, we can cite [Cosmos Hub](https://hub.cosmos.network), [IRIS Hub](https://irisnet.org), [Binance Chain](https://docs.binance.org/), [Terra](https://terra.money/) or [Kava](https://www.kava.io/). [Many more](https://cosmos.network/ecosystem) are building on the Cosmos SDK.
+* Most importantly, the Cosmos SDK has already been used to build many application-specific blockchains that are already in production. Among others, we can cite [Cosmos Hub](https://hub.cosmos.network/main), [IRIS Hub](https://irisnet.org), [Binance Chain](https://docs.binance.org/), [Terra](https://terra.money/) or [Kava](https://www.kava.io/). [Many more](https://cosmos.network/ecosystem) are building on the Cosmos SDK.
 
 ## Getting started with the Cosmos SDK
 

--- a/docs/docs/learn/intro/00-overview.md
+++ b/docs/docs/learn/intro/00-overview.md
@@ -7,7 +7,7 @@ sidebar_position: 1
 The [Cosmos SDK](https://github.com/cosmos/cosmos-sdk) is an open-source toolkit for building multi-asset public Proof-of-Stake (PoS) <df value="blockchain">blockchains</df>, like the Cosmos Hub, as well as permissioned Proof-of-Authority (PoA) blockchains. Blockchains built with the Cosmos SDK are generally referred to as **application-specific blockchains**.
 
 The goal of the Cosmos SDK is to allow developers to easily create custom blockchains from scratch that can natively interoperate with other blockchains. 
-We further this modular approach by allowing developers to plug and play with different consensus engines this can range from the [CometBFT](https://github.com/cometbft/cometbft) or [Rollkit](https://rollkit.dev/). 
+We further this modular approach by allowing developers to plug and play with different consensus engines this can range from the [CometBFT](https://github.com/cometbft/cometbft) or [Rollkit](https://ev.xyz/). 
 
 SDK-based blockchains have the choice to use the predefined modules or to build their own modules. What this means is that developers can build a blockchain that is tailored to their specific use case, without having to worry about the low-level details of building a blockchain from scratch. Predefined modules include staking, governance, and token issuance, among others.
 

--- a/docs/docs/user/run-node/00-keyring.md
+++ b/docs/docs/user/run-node/00-keyring.md
@@ -25,7 +25,7 @@ private keys storage, and user sessions according to the user's password policie
 is a list of the most popular operating systems and their respective password managers:
 
 * macOS: [Keychain](https://support.apple.com/en-gb/guide/keychain-access/welcome/mac)
-* Windows: [Credentials Management API](https://docs.microsoft.com/en-us/windows/win32/secauthn/credentials-management)
+* Windows: [Credentials Management API](https://learn.microsoft.com/en-us/windows/win32/secauthn/credentials-management)
 * GNU/Linux:
     * [libsecret](https://gitlab.gnome.org/GNOME/libsecret)
     * [kwallet](https://api.kde.org/frameworks/kwallet/html/index.html)

--- a/docs/docs/user/run-node/01-run-node.md
+++ b/docs/docs/user/run-node/01-run-node.md
@@ -50,7 +50,7 @@ The `~/.simapp` folder has the following structure:
 
 ## Updating Some Default Settings
 
-If you want to change any field values in configuration files (for ex: genesis.json) you can use `jq` ([installation](https://stedolan.github.io/jq/download/) & [docs](https://stedolan.github.io/jq/manual/#Assignment)) & `sed` commands to do that. A few examples are listed here.
+If you want to change any field values in configuration files (for ex: genesis.json) you can use `jq` ([installation](https://jqlang.org/download/) & [docs](https://jqlang.org/manual/)) & `sed` commands to do that. A few examples are listed here.
 
 ```bash
 # to change the chain-id

--- a/docs/docs/user/run-node/02-interact-node.md
+++ b/docs/docs/user/run-node/02-interact-node.md
@@ -244,7 +244,7 @@ func main() {
 
 ### CosmJS
 
-CosmJS documentation can be found at [https://cosmos.github.io/cosmjs](https://cosmos.github.io/cosmjs). As of January 2021, CosmJS documentation is still a work in progress.
+CosmJS documentation can be found at [https://github.com/cosmos/cosmjs](https://github.com/cosmos/cosmjs). As of January 2021, CosmJS documentation is still a work in progress.
 
 ## Using the REST Endpoints
 
@@ -286,4 +286,4 @@ Assuming the state at that block has not yet been pruned by the node, this query
 
 ### Cross-Origin Resource Sharing (CORS)
 
-[CORS policies](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) are not enabled by default to help with security. If you would like to use the rest-server in a public environment we recommend you provide a reverse proxy, this can be done with [nginx](https://www.nginx.com/). For testing and development purposes there is an `enabled-unsafe-cors` field inside [`app.toml`](../../user/run-node/01-run-node.md#configuring-the-node-using-apptoml-and-configtoml).
+[CORS policies](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CORS) are not enabled by default to help with security. If you would like to use the rest-server in a public environment we recommend you provide a reverse proxy, this can be done with [nginx](https://nginx.org/). For testing and development purposes there is an `enabled-unsafe-cors` field inside [`app.toml`](../../user/run-node/01-run-node.md#configuring-the-node-using-apptoml-and-configtoml).

--- a/docs/docs/user/run-node/03-txs.md
+++ b/docs/docs/user/run-node/03-txs.md
@@ -426,4 +426,4 @@ curl -X POST \
 
 ## Using CosmJS (JavaScript & TypeScript)
 
-CosmJS aims to build client libraries in JavaScript that can be embedded in web applications. Please see [https://cosmos.github.io/cosmjs](https://cosmos.github.io/cosmjs) for more information. As of January 2021, CosmJS documentation is still a work in progress.
+CosmJS aims to build client libraries in JavaScript that can be embedded in web applications. Please see [https://github.com/cosmos/cosmjs](https://github.com/cosmos/cosmjs) for more information. As of January 2021, CosmJS documentation is still a work in progress.


### PR DESCRIPTION
# Description

Fixed as many broken links as i can find

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Refreshed external links across Introduction, Learn overview, and Run Node guides.
  - Updated Cosmos Hub and CometBFT URLs.
  - Replaced Rollkit link with ev.xyz.
  - Pointed Windows Credentials API to learn.microsoft.com.
  - Switched jq references to jqlang.org.
  - Updated CosmJS links to the GitHub repository.
  - Revised CORS reference path on MDN and changed nginx link to nginx.org.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->