### PR TITLE
fix: Inconsintances and typos in doc comments

### DIFF
--- a/crypto/keyring/legacy_info.go
+++ b/crypto/keyring/legacy_info.go
@@ -52,32 +52,32 @@ func (i legacyLocalInfo) GetType() KeyType {
 	return TypeLocal
 }
 
-// GetType implements Info interface
+// GetName implements Info interface
 func (i legacyLocalInfo) GetName() string {
 	return i.Name
 }
 
-// GetType implements Info interface
+// GetPubKey implements Info interface
 func (i legacyLocalInfo) GetPubKey() cryptotypes.PubKey {
 	return i.PubKey
 }
 
-// GetType implements Info interface
+// GetAddress implements Info interface
 func (i legacyLocalInfo) GetAddress() sdk.AccAddress {
 	return i.PubKey.Address().Bytes()
 }
 
-// GetPrivKeyArmor
+// GetPrivKeyArmor returns the armored private key
 func (i legacyLocalInfo) GetPrivKeyArmor() string {
 	return i.PrivKeyArmor
 }
 
-// GetType implements Info interface
+// GetAlgo implements Info interface
 func (i legacyLocalInfo) GetAlgo() hd.PubKeyType {
 	return i.Algo
 }
 
-// GetType implements Info interface
+// GetPath implements Info interface
 func (i legacyLocalInfo) GetPath() (*hd.BIP44Params, error) {
 	return nil, fmt.Errorf("BIP44 Paths are not available for this type")
 }
@@ -111,7 +111,7 @@ func (i legacyLedgerInfo) GetAddress() sdk.AccAddress {
 	return i.PubKey.Address().Bytes()
 }
 
-// GetPath implements Info interface
+// GetAlgo implements Info interface
 func (i legacyLedgerInfo) GetAlgo() hd.PubKeyType {
 	return i.Algo
 }

--- a/crypto/keyring/migration_test.go
+++ b/crypto/keyring/migration_test.go
@@ -246,7 +246,7 @@ func newLegacyLocalInfo(name string, pub cryptotypes.PubKey, privArmor string, a
 	}
 }
 
-// newLegacyOfflineInfo creates a new legacyLedgerInfo instance
+// newLegacyLedgerInfo creates a new legacyLedgerInfo instance
 func newLegacyLedgerInfo(name string, pub cryptotypes.PubKey, path hd.BIP44Params, algo hd.PubKeyType) LegacyInfo {
 	return &legacyLedgerInfo{
 		Name:   name,

--- a/crypto/keys/ed25519/ed25519.go
+++ b/crypto/keys/ed25519/ed25519.go
@@ -186,7 +186,7 @@ func (pubKey *PubKey) VerifySignature(msg, sig []byte) bool {
 	return ed25519consensus.Verify(pubKey.Key, msg, sig)
 }
 
-// String returns Hex representation of a pubkey with it's type
+// String returns Hex representation of a pubkey with its type
 func (pubKey *PubKey) String() string {
 	return fmt.Sprintf("PubKeyEd25519{%X}", pubKey.Key)
 }

--- a/crypto/types/compact_bit_array.go
+++ b/crypto/types/compact_bit_array.go
@@ -83,7 +83,7 @@ func (bA *CompactBitArray) SetIndex(i int, v bool) bool {
 }
 
 // NumTrueBitsBefore returns the number of bits set to true before the
-// given index. e.g. if bA = _XX__XX, NumOfTrueBitsBefore(4) = 2, since
+// given index. e.g. if bA = _XX__XX, NumTrueBitsBefore(4) = 2, since
 // there are two bits set to true before index 4.
 func (bA *CompactBitArray) NumTrueBitsBefore(index int) int {
 	onesCount := 0

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -159,9 +159,9 @@ func (s *errorsTestSuite) TestIsOf() {
 
 	require.True(IsOf(errW, ErrLogic))
 	require.True(IsOf(errW, err, ErrLogic))
-	require.True(IsOf(errW, nil, errW), "error should much itself")
+	require.True(IsOf(errW, nil, errW), "error should match itself")
 	err2 := errors.New("other error")
-	require.True(IsOf(err2, nil, err2), "error should much itself")
+	require.True(IsOf(err2, nil, err2), "error should match itself")
 }
 
 type customError struct{}

--- a/log/options.go
+++ b/log/options.go
@@ -6,7 +6,8 @@ import (
 	"github.com/rs/zerolog"
 )
 
-// defaultConfig has all the options disabled, except Color and TimeFormat
+// defaultConfig provides a base configuration with maximum verbosity (TraceLevel)
+// and minimal formatting options enabled (Color and TimeFormat)
 var defaultConfig = Config{
 	Level:      zerolog.TraceLevel, // this is the default level that zerolog initializes new Logger's with
 	Filter:     nil,


### PR DESCRIPTION
reopen #25302 with more impact!!!!
fixed deprecated names
write unfinished comment
fix typos
and correct misleading comment

I know 6 commits but not all of them are usual typos