### PR TITLE
perf(collections): optimize empty slice check in NoValue.Decode

### DIFF
--- a/collections/keyset.go
+++ b/collections/keyset.go
@@ -137,7 +137,7 @@ func (NoValue) Encode(_ NoValue) ([]byte, error) {
 }
 
 func (NoValue) Decode(b []byte) (NoValue, error) {
-	if !bytes.Equal(b, []byte{}) {
+	if len(b) != 0 {
 		return NoValue{}, fmt.Errorf("%w: invalid value, wanted an empty non-nil byte slice, got: %x", ErrEncoding, b)
 	}
 	return NoValue{}, nil


### PR DESCRIPTION
# Description

Replace bytes.Equal(b, []byte{}) with len(b) != 0 for better performance.The len() check is the idiomatic Go way to test for empty slices and avoids unnecessary allocation of []byte{} and function call overhead.

This is a micro-optimization that eliminates allocation in a potentially hot path while maintaining identical semantics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined empty-input handling in decoding logic for key set collections by replacing byte comparison with a length check, improving clarity and potential micro-performance. No changes to behavior or public APIs; existing workflows continue to function as before. This is an internal improvement with no user-facing impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->