### PR TITLE
docs: fix inconsistances in comments

### DIFF
--- a/collections/codec/codec.go
+++ b/collections/codec/codec.go
@@ -22,7 +22,7 @@ type KeyCodec[T any] interface {
 	// the key T. Returns the number of bytes read, the type T
 	// or an error in case of decoding failure.
 	Decode(buffer []byte) (int, T, error)
-	// Size returns the buffer size need to encode key T in binary format.
+	// Size returns the buffer size needed to encode key T in binary format.
 	// The returned value must match what is computed by Encode for all
 	// encodings except the ones involving varints. Varints are expected
 	// to return the maximum varint bytes buffer length, at the risk of

--- a/collections/triple.go
+++ b/collections/triple.go
@@ -324,7 +324,7 @@ func (t tripleKeyCodec[K1, K2, K3]) SchemaCodec() (codec.SchemaCodec[Triple[K1, 
 	}, nil
 }
 
-// NewPrefixUntilTripleRange defines a collection query which ranges until the provided Pair prefix.
+// NewPrefixUntilTripleRange defines a collection query which ranges until the provided Triple prefix.
 // Unstable: this API might change in the future.
 func NewPrefixUntilTripleRange[K1, K2, K3 any](k1 K1) Ranger[Triple[K1, K2, K3]] {
 	key := TriplePrefix[K1, K2, K3](k1)
@@ -353,7 +353,7 @@ func NewSuperPrefixedTripleRange[K1, K2, K3 any](k1 K1, k2 K2) Ranger[Triple[K1,
 	}
 }
 
-// NewPrefixUntilTripleRangeReversed defines a collection query which ranges until the provided Pair prefix
+// NewPrefixUntilTripleRangeReversed defines a collection query which ranges until the provided Triple prefix
 // in reverse order.
 // Unstable: this API might change in the future.
 func NewPrefixUntilTripleRangeReversed[K1, K2, K3 any](k1 K1) Ranger[Triple[K1, K2, K3]] {

--- a/core/appmodule/module.go
+++ b/core/appmodule/module.go
@@ -64,7 +64,7 @@ type ResponsePreBlock interface {
 // custom logic before BeginBlock.
 type HasPreBlocker interface {
 	AppModule
-	// PreBlock is method that will be run before BeginBlock.
+	// PreBlock is a method that will be run before BeginBlock.
 	PreBlock(context.Context) (ResponsePreBlock, error)
 }
 

--- a/core/coins/format.go
+++ b/core/coins/format.go
@@ -18,7 +18,7 @@ const emptyCoins = "zero"
 // a separator ('/', ':', '.', '_' or '-').
 var coinRegex = regexp.MustCompile(`^(\d+(\.\d+)?)([a-zA-Z][a-zA-Z0-9\/\:\._\-]{2,127})$`)
 
-// formatCoin formats a sdk.Coin into a value-rendered string, using the
+// formatCoin formats a basev1beta1.Coin into a value-rendered string, using the
 // given metadata about the denom. It returns the formatted coin string, the
 // display denom, and an optional error.
 func formatCoin(coin *basev1beta1.Coin, metadata *bankv1beta1.Metadata) (string, error) {

--- a/core/comet/service.go
+++ b/core/comet/service.go
@@ -16,8 +16,8 @@ type BlockInfo interface {
 	// ValidatorsHash returns the hash of the validators
 	// For Comet, it is the hash of the next validator set
 	GetValidatorsHash() []byte
-	GetProposerAddress() []byte // ProposerAddress returns the address of the block proposer
-	GetLastCommit() CommitInfo  // DecidedLastCommit returns the last commit info
+	GetProposerAddress() []byte // GetProposerAddress returns the address of the block proposer
+	GetLastCommit() CommitInfo  // GetLastCommit returns the last commit info
 }
 
 // MisbehaviorType is the type of misbehavior for a validator

--- a/crypto/keyring/legacy_info.go
+++ b/crypto/keyring/legacy_info.go
@@ -52,32 +52,32 @@ func (i legacyLocalInfo) GetType() KeyType {
 	return TypeLocal
 }
 
-// GetType implements Info interface
+// GetName implements Info interface
 func (i legacyLocalInfo) GetName() string {
 	return i.Name
 }
 
-// GetType implements Info interface
+// GetPubKey implements Info interface
 func (i legacyLocalInfo) GetPubKey() cryptotypes.PubKey {
 	return i.PubKey
 }
 
-// GetType implements Info interface
+// GetAddress implements Info interface
 func (i legacyLocalInfo) GetAddress() sdk.AccAddress {
 	return i.PubKey.Address().Bytes()
 }
 
-// GetPrivKeyArmor
+// GetPrivKeyArmor returns the armored private key
 func (i legacyLocalInfo) GetPrivKeyArmor() string {
 	return i.PrivKeyArmor
 }
 
-// GetType implements Info interface
+// GetAlgo implements Info interface
 func (i legacyLocalInfo) GetAlgo() hd.PubKeyType {
 	return i.Algo
 }
 
-// GetType implements Info interface
+// GetPath implements Info interface
 func (i legacyLocalInfo) GetPath() (*hd.BIP44Params, error) {
 	return nil, fmt.Errorf("BIP44 Paths are not available for this type")
 }
@@ -111,7 +111,7 @@ func (i legacyLedgerInfo) GetAddress() sdk.AccAddress {
 	return i.PubKey.Address().Bytes()
 }
 
-// GetPath implements Info interface
+// GetAlgo implements Info interface
 func (i legacyLedgerInfo) GetAlgo() hd.PubKeyType {
 	return i.Algo
 }

--- a/crypto/keyring/migration_test.go
+++ b/crypto/keyring/migration_test.go
@@ -246,7 +246,7 @@ func newLegacyLocalInfo(name string, pub cryptotypes.PubKey, privArmor string, a
 	}
 }
 
-// newLegacyOfflineInfo creates a new legacyLedgerInfo instance
+// newLegacyLedgerInfo creates a new legacyLedgerInfo instance
 func newLegacyLedgerInfo(name string, pub cryptotypes.PubKey, path hd.BIP44Params, algo hd.PubKeyType) LegacyInfo {
 	return &legacyLedgerInfo{
 		Name:   name,

--- a/crypto/keys/ed25519/ed25519.go
+++ b/crypto/keys/ed25519/ed25519.go
@@ -186,7 +186,7 @@ func (pubKey *PubKey) VerifySignature(msg, sig []byte) bool {
 	return ed25519consensus.Verify(pubKey.Key, msg, sig)
 }
 
-// String returns Hex representation of a pubkey with it's type
+// String returns Hex representation of a pubkey with its type
 func (pubKey *PubKey) String() string {
 	return fmt.Sprintf("PubKeyEd25519{%X}", pubKey.Key)
 }

--- a/crypto/types/compact_bit_array.go
+++ b/crypto/types/compact_bit_array.go
@@ -83,7 +83,7 @@ func (bA *CompactBitArray) SetIndex(i int, v bool) bool {
 }
 
 // NumTrueBitsBefore returns the number of bits set to true before the
-// given index. e.g. if bA = _XX__XX, NumOfTrueBitsBefore(4) = 2, since
+// given index. e.g. if bA = _XX__XX, NumTrueBitsBefore(4) = 2, since
 // there are two bits set to true before index 4.
 func (bA *CompactBitArray) NumTrueBitsBefore(index int) int {
 	onesCount := 0

--- a/depinject/debug.go
+++ b/depinject/debug.go
@@ -108,9 +108,8 @@ const (
 	debugContainerLog = "debug_container.log"
 )
 
-// Debug is a default debug option which sends log output to stderr, dumps
-// the container in the graphviz DOT and SVG formats to debug_container.dot
-// and debug_container.svg respectively.
+// Debug is a default debug option which writes logs to debug_container.log and
+// dumps the container in the Graphviz DOT format to debug_container.dot.
 func Debug() DebugOption {
 	return DebugOptions(
 		FileLogger(debugContainerLog),
@@ -159,8 +158,8 @@ func DebugCleanup(cleanup func()) DebugOption {
 }
 
 // AutoDebug does the same thing as Debug when there is an error and deletes
-// the debug_container.dot if it exists when there is no error. This is the
-// default debug mode of Run.
+// debug_container.dot and debug_container.log if they exist when there is no
+// error. This is the default debug mode of Run.
 func AutoDebug() DebugOption {
 	return DebugOptions(
 		OnError(Debug()),

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -159,9 +159,9 @@ func (s *errorsTestSuite) TestIsOf() {
 
 	require.True(IsOf(errW, ErrLogic))
 	require.True(IsOf(errW, err, ErrLogic))
-	require.True(IsOf(errW, nil, errW), "error should much itself")
+	require.True(IsOf(errW, nil, errW), "error should match itself")
 	err2 := errors.New("other error")
-	require.True(IsOf(err2, nil, err2), "error should much itself")
+	require.True(IsOf(err2, nil, err2), "error should match itself")
 }
 
 type customError struct{}

--- a/log/options.go
+++ b/log/options.go
@@ -6,7 +6,8 @@ import (
 	"github.com/rs/zerolog"
 )
 
-// defaultConfig has all the options disabled, except Color and TimeFormat
+// defaultConfig provides a base configuration with maximum verbosity (TraceLevel)
+// and minimal formatting options enabled (Color and TimeFormat)
 var defaultConfig = Config{
 	Level:      zerolog.TraceLevel, // this is the default level that zerolog initializes new Logger's with
 	Filter:     nil,


### PR DESCRIPTION
fix all the possible inconsistances in comments.
in debug.go - 
The comment on Debug() mentions DOT and SVG output (debug_container.dot and debug_container.svg), but the code only writes DOT and log (debug_container.dot, debug_container.log). SVG is not generated.
and
The comment mentions deleting only debug_container.dot, but the code deletes both debug_container.dot and debug_container.log.