### PR TITLE
fix: return compressed pubkey and use HRP for bech32 address

### DIFF
--- a/crypto/ledger/ledger_mock.go
+++ b/crypto/ledger/ledger_mock.go
@@ -80,10 +80,10 @@ func (mock LedgerSECP256K1Mock) GetAddressPubKeySECP256K1(derivationPath []uint3
 	compressedPublicKey := make([]byte, csecp256k1.PubKeySize)
 	copy(compressedPublicKey, cmp.SerializeCompressed())
 
-	// Generate the bech32 addr using existing cmtcrypto/etc.
+	// Generate the bech32 addr using provided hrp
 	pub := &csecp256k1.PubKey{Key: compressedPublicKey}
-	addr := sdk.AccAddress(pub.Address()).String()
-	return pk, addr, err
+	addr := sdk.MustBech32ifyAddressBytes(hrp, sdk.AccAddress(pub.Address()))
+	return compressedPublicKey, addr, err
 }
 
 func (mock LedgerSECP256K1Mock) SignSECP256K1(derivationPath []uint32, message []byte, p2 byte) ([]byte, error) {


### PR DESCRIPTION
# Description

- Change GetAddressPubKeySECP256K1 to return the compressed public key (33 bytes) instead of the uncompressed key, aligning with the SECP256K1 interface contract and the function comment.
- Generate the bech32 address using the provided HRP via sdk.MustBech32ifyAddressBytes(hrp, ...), instead of relying on String() with global config.
- These changes ensure API consistency with real Ledger behavior, prevent downstream assumptions from breaking (consumers expect compressed keys), and correctly respect chain-specific bech32 prefixes passed by callers.