### PR TITLE
docs: fix incorrect capitalization of Google Docs

### DIFF
--- a/docs/rfc/README.md
+++ b/docs/rfc/README.md
@@ -10,7 +10,7 @@ immediate decision is required.
 
 The purpose of an RFC is to serve as a historical record of a high-level
 discussion that might otherwise only be recorded in an ad-hoc way (for example,
-via gists or Google docs) that are difficult to discover for someone after the
+via gists or Google Docs) that are difficult to discover for someone after the
 fact. An RFC _may_ give rise to more specific architectural _decisions_ for
 the Cosmos SDK, but those decisions must be recorded separately in
 [Architecture Decision Records (ADR)](../architecture).


### PR DESCRIPTION
# Description

noticed that in a few places the product name was written as *Google docs* with a lowercase "d".
updated it to the correct form - *Google Docs*. This aligns with the official product naming.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected capitalization of “Google Docs” in existing documentation for consistency and polish.
  * No content, meaning, or guidance was changed—this is a purely editorial update.
  * No impact on features, settings, or workflows; users can continue using the product as before.
  * Improves readability and professional tone across the referenced documentation section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->