### PR TITLE
fix: wrong cosmos-proto field

### DIFF
--- a/proto/cosmos/staking/v1beta1/genesis.proto
+++ b/proto/cosmos/staking/v1beta1/genesis.proto
@@ -48,7 +48,7 @@ message LastValidatorPower {
   option (gogoproto.goproto_getters) = false;
 
   // address is the address of the validator.
-  string address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+  string address = 1 [(cosmos_proto.scalar_type) = "cosmos.AddressString"];
 
   // power defines the power of the validator.
   int64 power = 2;


### PR DESCRIPTION
# Description

replaced `cosmos_proto.scalar` with `cosmos_proto.scalar_type` in `LastValidatorPower` - the old one doesn’t exist.
