### PR TITLE
refactor: use b.Loop() to simplify the code and improve performance

### DIFF
--- a/codec/bench_test.go
+++ b/codec/bench_test.go
@@ -33,8 +33,7 @@ func BenchmarkLegacyGetSigners(b *testing.B) {
 		Amount:      nil,
 	}}
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_ = msg.GetSigners()
 	}
 }
@@ -50,8 +49,7 @@ func BenchmarkProtoreflectGetSigners(b *testing.B) {
 		Amount:      nil,
 	}
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, err := signingCtx.GetSigners(msg)
 		if err != nil {
 			panic(err)
@@ -72,8 +70,7 @@ func BenchmarkProtoreflectGetSignersWithUnmarshal(b *testing.B) {
 	a, err := codectypes.NewAnyWithValue(msg)
 	require.NoError(b, err)
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _, err := cdc.GetMsgAnySigners(a)
 		if err != nil {
 			panic(err)
@@ -97,8 +94,7 @@ func BenchmarkProtoreflectGetSignersDynamicpb(b *testing.B) {
 	err = protov2.Unmarshal(bz, dynamicmsg)
 	require.NoError(b, err)
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, err := signingCtx.GetSigners(dynamicmsg)
 		if err != nil {
 			panic(err)

--- a/codec/proto_codec_test.go
+++ b/codec/proto_codec_test.go
@@ -165,10 +165,9 @@ func BenchmarkProtoCodecMarshalLengthPrefixed(b *testing.B) {
 		}),
 	}
 
-	b.ResetTimer()
 	b.ReportAllocs()
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		blob, err := pCdc.MarshalLengthPrefixed(msg)
 		if err != nil {
 			b.Fatal(err)


### PR DESCRIPTION
# Description

Similar as https://github.com/cosmos/cosmos-sdk/pull/25367


These changes use b.Loop() to simplify the code and improve performance

Supported by Go Team  https://go.dev/blog/testing-b-loop

More info can see https://go.dev/issue/73137.

Before this change:

```shell
 go test -run=^$ -bench=. ./codec -timeout=1h 
goos: darwin
goarch: arm64
pkg: github.com/cosmos/cosmos-sdk/codec
cpu: Apple M4
BenchmarkLegacyGetSigners-10                       	  500905	      2401 ns/op
BenchmarkProtoreflectGetSigners-10                 	  822852	      1456 ns/op
BenchmarkProtoreflectGetSignersWithUnmarshal-10    	  729973	      1624 ns/op
BenchmarkProtoreflectGetSignersDynamicpb-10        	  801506	      1463 ns/op
BenchmarkProtoCodecMarshalLengthPrefixed-10        	19172505	        62.87 ns/op	2210.93 MB/s	     304 B/op	       3 allocs/op
PASS
ok  	github.com/cosmos/cosmos-sdk/codec	8.935s
```



After:

```shell
 go test -run=^$ -bench=. ./codec -timeout=1h 
goos: darwin
goarch: arm64
pkg: github.com/cosmos/cosmos-sdk/codec
cpu: Apple M4
BenchmarkLegacyGetSigners-10                       	  478704	      2501 ns/op
BenchmarkProtoreflectGetSigners-10                 	  820551	      1479 ns/op
BenchmarkProtoreflectGetSignersWithUnmarshal-10    	  739382	      1655 ns/op
BenchmarkProtoreflectGetSignersDynamicpb-10        	  808497	      1489 ns/op
BenchmarkProtoCodecMarshalLengthPrefixed-10        	18623972	        63.60 ns/op	2185.43 MB/s	     304 B/op	       3 allocs/op
PASS
ok  	github.com/cosmos/cosmos-sdk/codec	6.734s
```

The time spent has been reduced by 25%.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated benchmark loops to an idiomatic pattern and removed redundant timer resets for more consistent, reliable performance measurements.
  * No changes to runtime behavior or user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->