### PR TITLE
feat(systemtests): setup chain with more args

### DIFF
--- a/systemtests/system.go
+++ b/systemtests/system.go
@@ -47,7 +47,7 @@ var (
 )
 
 type TestnetInitializer interface {
-	Initialize()
+	Initialize(xargs ...string)
 }
 
 // SystemUnderTest blockchain provisioning
@@ -139,12 +139,12 @@ func (s *SystemUnderTest) CommitTimeout() time.Duration {
 	return time.Duration((int64(s.blockTime) * 90) / 100) // leave 10% for all other operations
 }
 
-func (s *SystemUnderTest) SetupChain() {
+func (s *SystemUnderTest) SetupChain(initArgs ...string) {
 	s.Logf("Setup chain: %s\n", s.outputDir)
 	if err := os.RemoveAll(filepath.Join(WorkDir, s.outputDir)); err != nil {
 		panic(err.Error())
 	}
-	s.testnetInitializer.Initialize()
+	s.testnetInitializer.Initialize(initArgs...)
 	s.nodesCount = s.initialNodesCount
 
 	// modify genesis with system test defaults

--- a/systemtests/testnet_init.go
+++ b/systemtests/testnet_init.go
@@ -38,7 +38,7 @@ func NewLegacySingleNodeInitializer(
 	}
 }
 
-func (s LegacySingleNode) Initialize() {
+func (s LegacySingleNode) Initialize(xargs ...string) {
 	args := []string{
 		"testnet",
 		"init-files",
@@ -48,6 +48,7 @@ func (s LegacySingleNode) Initialize() {
 		"--keyring-backend=test",
 		"--minimum-gas-prices=" + s.minGasPrice,
 	}
+	args = append(args, xargs...)
 
 	s.log(fmt.Sprintf("+++ %s %s\n", s.execBinary, strings.Join(args, " ")))
 	out, err := RunShellCmd(s.execBinary, args...)
@@ -107,7 +108,7 @@ func InitializerWithBinary(binary string, sut *SystemUnderTest) TestnetInitializ
 	)
 }
 
-func (s SingleHostTestnetCmdInitializer) Initialize() {
+func (s SingleHostTestnetCmdInitializer) Initialize(xargs ...string) {
 	args := []string{
 		"testnet",
 		"init-files",
@@ -119,6 +120,7 @@ func (s SingleHostTestnetCmdInitializer) Initialize() {
 		"--single-host",
 		"--minimum-gas-prices=" + s.minGasPrice,
 	}
+	args = append(args, xargs...)
 
 	s.log(fmt.Sprintf("+++ %s %s\n", s.execBinary, strings.Join(args, " ")))
 	out, err := RunShellCmd(s.execBinary, args...)
@@ -155,7 +157,7 @@ func NewModifyConfigYamlInitializer(exec string, s *SystemUnderTest) *ModifyConf
 	}
 }
 
-func (s ModifyConfigYamlInitializer) Initialize() {
+func (s ModifyConfigYamlInitializer) Initialize(xargs ...string) {
 	// init with legacy testnet command
 	args := []string{
 		"testnet",
@@ -166,6 +168,7 @@ func (s ModifyConfigYamlInitializer) Initialize() {
 		"--keyring-backend=test",
 		"--minimum-gas-prices=" + s.minGasPrice,
 	}
+	args = append(args, xargs...)
 
 	s.log(fmt.Sprintf("+++ %s %s\n", s.execBinary, strings.Join(args, " ")))
 


### PR DESCRIPTION
# Description

adds the ability to pass in additional flags to the chain's testnet `init-files` command. this allows for custom implementations to alter their setup.
