### PR TITLE
docs: fix broken links in Introduction.md and cosmovisor README

### DIFF
--- a/api/tendermint/types/params.pulsar.go
+++ b/api/tendermint/types/params.pulsar.go
@@ -3633,7 +3633,7 @@ type EvidenceParams struct {
 	//
 	// It should correspond with an app's "unbonding period" or other similar
 	// mechanism for handling [Nothing-At-Stake
-	// attacks](https://github.com/ethereum/wiki/wiki/Proof-of-Stake-FAQ#what-is-the-nothing-at-stake-problem-and-how-can-it-be-fixed).
+	// attacks](https://ethereum.org/developers/docs/consensus-mechanisms/pos/faqs/#what-is-proof-of-stake).
 	MaxAgeDuration *durationpb.Duration `protobuf:"bytes,2,opt,name=max_age_duration,json=maxAgeDuration,proto3" json:"max_age_duration,omitempty"`
 	// This sets the maximum size of total evidence in bytes that can be committed in a single block.
 	// and should fall comfortably under the max block bytes.

--- a/docs/docs/Introduction.md
+++ b/docs/docs/Introduction.md
@@ -32,6 +32,6 @@ Check out the docs for the various parts of the Cosmos stack.
 
 ## Help & Support
 
-* [**GitHub Discussions**](https://github.com/orgs/cosmos/discussions) - Ask questions and discuss SDK development on GitHub.
+* [**GitHub Discussions**](https://github.com/cosmos/cosmos-sdk/discussions) - Ask questions and discuss SDK development on GitHub.
 * [**Discord**](https://discord.gg/cosmosnetwork) - Chat with Cosmos developers on Discord.
 * [**Found an issue?**](https://github.com/cosmos/cosmos-sdk/edit/main/docs/README.md) - Help us improve this page by suggesting edits on GitHub.

--- a/tools/cosmovisor/README.md
+++ b/tools/cosmovisor/README.md
@@ -376,7 +376,7 @@ Update app to the latest version (e.g. v0.50.0).
 
 :::note
 
-Migration plans are defined using the `x/upgrade` module and described in [In-Place Store Migrations](https://github.com/cosmos/cosmos-sdk/blob/main/docs/learn/advanced/15-upgrade.md). Migrations can perform any deterministic state change.
+Migration plans are defined using the `x/upgrade` module and described in [In-Place Store Migrations](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/learn/advanced/15-upgrade.md). Migrations can perform any deterministic state change.
 
 The migration plan to upgrade the simapp from v0.47 to v0.50 is defined in `simapp/upgrade.go`.
 


### PR DESCRIPTION
# Description

This PR updates documentation links to point to valid locations:

- Fixed the **GitHub Discussions** link in `docs/docs/Introduction.md`  
  from the organization-level discussions page (404) to the `cosmos-sdk` repository discussions page.  

- Fixed the **In-Place Store Migrations** link in `tools/cosmovisor/README.md`  
  to the correct path under `docs/learn/advanced/15-upgrade.md`.  

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

