### PR TITLE
refactor: use b.Loop()

### DIFF
--- a/types/bench_test.go
+++ b/types/bench_test.go
@@ -18,7 +18,7 @@ var coinStrs = []string{
 func BenchmarkParseCoin(b *testing.B) {
 	var blankCoin sdk.Coin
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		for _, coinStr := range coinStrs {
 			coin, err := sdk.ParseCoinNormalized(coinStr)
 			if err != nil {
@@ -44,7 +44,7 @@ func BenchmarkUintMarshal(b *testing.B) {
 
 	var scratch [20]byte
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		for _, value := range values {
 			u := sdkmath.NewUint(value)
 			n, err := u.MarshalTo(scratch[:])
@@ -69,7 +69,7 @@ func BenchmarkIntMarshal(b *testing.B) {
 
 	var scratch [20]byte
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		for _, value := range values {
 			in := sdkmath.NewInt(value)
 			n, err := in.MarshalTo(scratch[:])

--- a/types/context_bench_test.go
+++ b/types/context_bench_test.go
@@ -13,8 +13,7 @@ func BenchmarkContext_KVStore(b *testing.B) {
 
 	ctx := testutil.DefaultContext(key, types.NewTransientStoreKey("transient_"+b.Name()))
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_ = ctx.KVStore(key)
 	}
 }
@@ -24,8 +23,7 @@ func BenchmarkContext_TransientStore(b *testing.B) {
 
 	ctx := testutil.DefaultContext(key, types.NewTransientStoreKey("transient_"+b.Name()))
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_ = ctx.TransientStore(key)
 	}
 }
@@ -35,8 +33,7 @@ func BenchmarkContext_CacheContext(b *testing.B) {
 
 	ctx := testutil.DefaultContext(key, types.NewTransientStoreKey("transient_"+b.Name()))
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _ = ctx.CacheContext()
 	}
 }


### PR DESCRIPTION
# Description

Inspired by https://github.com/cosmos/cosmos-sdk/pull/25367

Before:

```shell
go test -run=^$ -bench=. ./types -timeout=1h                         
goos: darwin
goarch: arm64
pkg: github.com/cosmos/cosmos-sdk/types
cpu: Apple M4
BenchmarkCoinsAdditionIntersect/sizes:_A_1,_B_1-10         	 7500938	       156.7 ns/op	     168 B/op	       5 allocs/op
BenchmarkCoinsAdditionIntersect/sizes:_A_5,_B_5-10         	 1227510	       985.9 ns/op	    2000 B/op	      40 allocs/op
BenchmarkCoinsAdditionIntersect/sizes:_A_5,_B_20-10        	  400801	      2996 ns/op	    5616 B/op	     103 allocs/op
BenchmarkCoinsAdditionIntersect/sizes:_A_1,_B_1000-10      	    7449	    161854 ns/op	  253849 B/op	    4018 allocs/op
BenchmarkCoinsAdditionIntersect/sizes:_A_2,_B_1000-10      	    7602	    163277 ns/op	  253978 B/op	    4021 allocs/op
BenchmarkCoinsAdditionNoIntersect/sizes:_A_1,_B_1-10       	 7978852	       145.4 ns/op	     176 B/op	       6 allocs/op
BenchmarkCoinsAdditionNoIntersect/sizes:_A_5,_B_5-10       	 1000000	      1142 ns/op	    2072 B/op	      46 allocs/op
BenchmarkCoinsAdditionNoIntersect/sizes:_A_5,_B_20-10      	  373627	      3246 ns/op	    5496 B/op	     108 allocs/op
BenchmarkCoinsAdditionNoIntersect/sizes:_A_1,_B_1000-10    	    6684	    163536 ns/op	  253858 B/op	    4019 allocs/op
BenchmarkCoinsAdditionNoIntersect/sizes:_A_2,_B_1000-10    	    7196	    162358 ns/op	  253953 B/op	    4023 allocs/op
BenchmarkCoinsAdditionNoIntersect/sizes:_A_1000,_B_2-10    	    7281	    162797 ns/op	  253953 B/op	    4023 allocs/op
BenchmarkSumOfCoinAdds/Fn:_MapCoins,_num_adds:_1000,_coinsPerAdd:_5,_intersecting:_2-10         	    1576	    756258 ns/op	  451527 B/op	    4023 allocs/op
BenchmarkSumOfCoinAdds/Fn:_Coins,_num_adds:_1000,_coinsPerAdd:_5,_intersecting:_2-10            	       4	 257198802 ns/op	381251084 B/op	 6026882 allocs/op
BenchmarkSumOfCoinAdds/Fn:_MapCoins,_num_adds:_10000,_coinsPerAdd:_10,_intersecting:_10-10      	     284	   4239354 ns/op	 8000798 B/op	  199987 allocs/op
BenchmarkSumOfCoinAdds/Fn:_Coins,_num_adds:_10000,_coinsPerAdd:_10,_intersecting:_10-10         	      56	  20827225 ns/op	44555440 B/op	  789926 allocs/op
BenchmarkParseCoin-10                                                                           	  466135	      2541 ns/op	    2081 B/op	      63 allocs/op
BenchmarkUintMarshal-10                                                                         	 2216409	       537.1 ns/op	  13.03 MB/s	     464 B/op	      31 allocs/op
BenchmarkIntMarshal-10                                                                          	 3490920	       344.5 ns/op	  20.32 MB/s	     144 B/op	      12 allocs/op
BenchmarkContext_KVStore-10                                                                     	29799010	        38.97 ns/op
BenchmarkContext_TransientStore-10                                                              	29517632	        38.29 ns/op
BenchmarkContext_CacheContext-10                                                                	 1398974	       843.1 ns/op
PASS
ok  	github.com/cosmos/cosmos-sdk/types	30.276s

```

after refactor:


```shell
go test -run=^$ -bench=. ./types -timeout=1h 
goos: darwin
goarch: arm64
pkg: github.com/cosmos/cosmos-sdk/types
cpu: Apple M4
BenchmarkCoinsAdditionIntersect/sizes:_A_1,_B_1-10         	 7451043	       156.9 ns/op	     168 B/op	       5 allocs/op
BenchmarkCoinsAdditionIntersect/sizes:_A_5,_B_5-10         	 1212171	       987.3 ns/op	    2000 B/op	      40 allocs/op
BenchmarkCoinsAdditionIntersect/sizes:_A_5,_B_20-10        	  397844	      3038 ns/op	    5616 B/op	     103 allocs/op
BenchmarkCoinsAdditionIntersect/sizes:_A_1,_B_1000-10      	    7507	    163296 ns/op	  253850 B/op	    4018 allocs/op
BenchmarkCoinsAdditionIntersect/sizes:_A_2,_B_1000-10      	    7162	    163952 ns/op	  253977 B/op	    4021 allocs/op
BenchmarkCoinsAdditionNoIntersect/sizes:_A_1,_B_1-10       	 8266701	       145.5 ns/op	     176 B/op	       6 allocs/op
BenchmarkCoinsAdditionNoIntersect/sizes:_A_5,_B_5-10       	 1000000	      1148 ns/op	    2072 B/op	      46 allocs/op
BenchmarkCoinsAdditionNoIntersect/sizes:_A_5,_B_20-10      	  373614	      3205 ns/op	    5496 B/op	     108 allocs/op
BenchmarkCoinsAdditionNoIntersect/sizes:_A_1,_B_1000-10    	    7228	    163530 ns/op	  253857 B/op	    4019 allocs/op
BenchmarkCoinsAdditionNoIntersect/sizes:_A_2,_B_1000-10    	    7182	    163601 ns/op	  253953 B/op	    4023 allocs/op
BenchmarkCoinsAdditionNoIntersect/sizes:_A_1000,_B_2-10    	    7425	    163503 ns/op	  253953 B/op	    4023 allocs/op
BenchmarkSumOfCoinAdds/Fn:_MapCoins,_num_adds:_1000,_coinsPerAdd:_5,_intersecting:_2-10         	    1576	    757852 ns/op	  451525 B/op	    4023 allocs/op
BenchmarkSumOfCoinAdds/Fn:_Coins,_num_adds:_1000,_coinsPerAdd:_5,_intersecting:_2-10            	       4	 258382990 ns/op	381153096 B/op	 6026880 allocs/op
BenchmarkSumOfCoinAdds/Fn:_MapCoins,_num_adds:_10000,_coinsPerAdd:_10,_intersecting:_10-10      	     279	   4179920 ns/op	 8000792 B/op	  199987 allocs/op
BenchmarkSumOfCoinAdds/Fn:_Coins,_num_adds:_10000,_coinsPerAdd:_10,_intersecting:_10-10         	      55	  21003712 ns/op	44555430 B/op	  789926 allocs/op
BenchmarkParseCoin-10                                                                           	  472576	      2549 ns/op	    2081 B/op	      63 allocs/op
BenchmarkUintMarshal-10                                                                         	 2201193	       544.7 ns/op	  12.85 MB/s	     464 B/op	      31 allocs/op
BenchmarkIntMarshal-10                                                                          	 2709350	       449.4 ns/op	  15.58 MB/s	     416 B/op	      25 allocs/op
BenchmarkContext_KVStore-10                                                                     	31625830	        38.22 ns/op
BenchmarkContext_TransientStore-10                                                              	31355367	        38.39 ns/op
BenchmarkContext_CacheContext-10                                                                	 1410063	       851.1 ns/op
PASS
ok  	github.com/cosmos/cosmos-sdk/types	28.740s

```
The changes can make the code more concise while also reducing the execution time.


Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->
