### PR TITLE
chore: Remove unused KVStoreKey field from DeterministicTestSuite in auth keeper tests

### DIFF
--- a/x/auth/keeper/deterministic_test.go
+++ b/x/auth/keeper/deterministic_test.go
@@ -31,7 +31,6 @@ type DeterministicTestSuite struct {
 
 	accountNumberLanes uint64
 
-	key           *storetypes.KVStoreKey
 	storeService  corestore.KVStoreService
 	ctx           sdk.Context
 	queryClient   types.QueryClient
@@ -82,7 +81,6 @@ func (suite *DeterministicTestSuite) SetupTest() {
 	types.RegisterQueryServer(queryHelper, keeper.NewQueryServer(suite.accountKeeper))
 	suite.queryClient = types.NewQueryClient(queryHelper)
 
-	suite.key = key
 	suite.storeService = storeService
 	suite.maccPerms = maccPerms
 	suite.accountNumberLanes = 1


### PR DESCRIPTION
Delete key *storetypes.KVStoreKey from DeterministicTestSuite and remove suite.key = key in SetupTest as the raw key is not reused anywhere in this suite. The tests rely on storeService for keeper construction, making the key field redundant. Verified no linter errors.