### PR TITLE
Secure upgrade info directory permissions (0700)

### DIFF
--- a/x/upgrade/keeper/keeper.go
+++ b/x/upgrade/keeper/keeper.go
@@ -546,7 +546,8 @@ func (k Keeper) DumpUpgradeInfoToDisk(height int64, p types.Plan) error {
 // GetUpgradeInfoPath returns the upgrade info file path
 func (k Keeper) GetUpgradeInfoPath() (string, error) {
 	upgradeInfoFileDir := filepath.Join(k.homePath, "data")
-	if err := os.MkdirAll(upgradeInfoFileDir, os.ModePerm); err != nil {
+	// Use restrictive permissions to avoid world-writable/executable directory (security hardening)
+    if err := os.MkdirAll(upgradeInfoFileDir, 0o700); err != nil {
 		return "", fmt.Errorf("could not create directory %q: %w", upgradeInfoFileDir, err)
 	}
 


### PR DESCRIPTION

Tighten permissions for the upgrade info directory to prevent world access.

### Change
- Replace `os.ModePerm` (0777) with `0o700` when creating `data` directory in `x/upgrade/keeper/keeper.go`.

### Rationale
- Prevents world-writable/executable directory, reducing risk of symlink attacks and metadata leakage.
- The file itself is already `0600`; the directory should match that security posture.


