### PR TITLE
chore: remove dead String() methods in keys parse command

### DIFF
--- a/client/keys/parse.go
+++ b/client/keys/parse.go
@@ -32,10 +32,6 @@ type hexOutput struct {
 	Bytes string `json:"bytes"`
 }
 
-func (ho hexOutput) String() string {
-	return fmt.Sprintf("Human readable part: %v\nBytes (hex): %s", ho.Human, ho.Bytes)
-}
-
 func newHexOutput(human string, bs []byte) hexOutput {
 	return hexOutput{Human: human, Bytes: fmt.Sprintf("%X", bs)}
 }
@@ -60,15 +56,7 @@ func newBech32Output(config *sdk.Config, bs []byte) bech32Output {
 	return out
 }
 
-func (bo bech32Output) String() string {
-	out := make([]string, len(bo.Formats))
-
-	for i, format := range bo.Formats {
-		out[i] = fmt.Sprintf("  - %s", format)
-	}
-
-	return fmt.Sprintf("Bech32 Formats:\n%s", strings.Join(out, "\n"))
-}
+//
 
 // ParseKeyStringCommand parses an address from hex to bech32 and vice versa.
 func ParseKeyStringCommand() *cobra.Command {
@@ -130,7 +118,7 @@ func runFromHex(config *sdk.Config, w io.Writer, hexstr, output string) bool {
 	return true
 }
 
-func displayParseKeyInfo(w io.Writer, stringer fmt.Stringer, output string) {
+func displayParseKeyInfo(w io.Writer, value any, output string) {
 	var (
 		err error
 		out []byte
@@ -138,10 +126,10 @@ func displayParseKeyInfo(w io.Writer, stringer fmt.Stringer, output string) {
 
 	switch output {
 	case flags.OutputFormatText:
-		out, err = yaml.Marshal(&stringer)
+		out, err = yaml.Marshal(&value)
 
 	case flags.OutputFormatJSON:
-		out, err = json.Marshal(&stringer)
+		out, err = json.Marshal(&value)
 	}
 
 	if err != nil {


### PR DESCRIPTION
Remove dead String() methods in client/keys/parse.go and adjust displayParseKeyInfo to marshal plain values instead of fmt.Stringer. These String() methods were never invoked because CLI output uses YAML/JSON marshalling, which doesn’t call fmt.Stringer, so the methods were effectively dead code.
