### PR TITLE
docs: fix links

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -66,14 +66,8 @@ If you follow these guidelines when reporting an issue to us, we commit to:
 
 ### More information
 
-* See [TIMELINE.md] for an example timeline of a disclosure.
-* See [DISCLOSURE.md] to see more into the inner workings of the disclosure
-  process.
-* See [EXAMPLES.md] for some of the examples that we are interested in for the
-  bug bounty program.
+* See [README.md] for materials, artifacts, and reference documents related to security.
 
 [gh-private-advisory]: /../../security/advisories/new
 [h1]: https://hackerone.com/cosmos
-[TIMELINE.md]: https://github.com/cosmos/security/blob/main/TIMELINE.md
-[DISCLOSURE.md]: https://github.com/cosmos/security/blob/main/DISCLOSURE.md
-[EXAMPLES.md]: https://github.com/cosmos/security/blob/main/EXAMPLES.md
+[README.md]: https://github.com/interchainio/security


### PR DESCRIPTION
Since https://github.com/cosmos/security
has been moved to 
https://github.com/interchainio/security

Updated the link to the correct repository

Closes: #XXXX

With🖤