### PR TITLE
fix: use proper context in upgrade module gRPC gateway registration

### DIFF
--- a/x/upgrade/module.go
+++ b/x/upgrade/module.go
@@ -66,7 +66,7 @@ func (AppModuleBasic) RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
 
 // RegisterGRPCGatewayRoutes registers the gRPC Gateway routes for the upgrade module.
 func (AppModuleBasic) RegisterGRPCGatewayRoutes(clientCtx client.Context, mux *gwruntime.ServeMux) {
-	if err := types.RegisterQueryHandlerClient(context.Background(), mux, types.NewQueryClient(clientCtx)); err != nil {
+	if err := types.RegisterQueryHandlerClient(clientCtx.GetCmdContextWithFallback(), mux, types.NewQueryClient(clientCtx)); err != nil {
 		panic(err)
 	}
 }


### PR DESCRIPTION

## Summary

Replaces `context.Background()` with `clientCtx.GetCmdContextWithFallback()` in the upgrade module's gRPC Gateway route registration to ensure proper context propagation from CLI commands.

## Context

The `RegisterGRPCGatewayRoutes` function was using `context.Background()` when registering gRPC Gateway handlers, which bypasses CLI context management including cancellation signals and timeouts.

