### PR TITLE
 refactor: use b.Loop() in benchmark tests for better performance

### DIFF
--- a/types/coin_benchmark_test.go
+++ b/types/coin_benchmark_test.go
@@ -29,7 +29,7 @@ func BenchmarkCoinsAdditionIntersect(b *testing.B) {
 
 			b.ResetTimer()
 
-			for i := 0; i < b.N; i++ {
+			for b.Loop() {
 				coinsA.Add(coinsB...)
 			}
 		}
@@ -61,7 +61,7 @@ func BenchmarkCoinsAdditionNoIntersect(b *testing.B) {
 
 			b.ResetTimer()
 
-			for i := 0; i < b.N; i++ {
+			for b.Loop() {
 				coinsA.Add(coinsB...)
 			}
 		}
@@ -101,7 +101,7 @@ func BenchmarkSumOfCoinAdds(b *testing.B) {
 
 			b.ResetTimer()
 
-			for i := 0; i < b.N; i++ {
+			for b.Loop() {
 				sumFn(addCoins)
 			}
 		}

--- a/x/auth/ante/sigverify_benchmark_test.go
+++ b/x/auth/ante/sigverify_benchmark_test.go
@@ -28,7 +28,7 @@ func BenchmarkSig(b *testing.B) {
 
 	b.Run("secp256k1", func(b *testing.B) {
 		b.ReportAllocs()
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			ok := pkK.VerifySignature(msg, sigK)
 			require.True(ok)
 		}
@@ -36,7 +36,7 @@ func BenchmarkSig(b *testing.B) {
 
 	b.Run("secp256r1", func(b *testing.B) {
 		b.ReportAllocs()
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			ok := pkR.VerifySignature(msg, sigR)
 			require.True(ok)
 		}

--- a/x/tx/signing/textual/bench_test.go
+++ b/x/tx/signing/textual/bench_test.go
@@ -29,10 +29,9 @@ var intValues = []protoreflect.Value{
 func BenchmarkIntValueRendererFormat(b *testing.B) {
 	ctx := context.Background()
 	ivr := textual.NewIntValueRenderer(fieldDescriptorFromName("UINT64"))
-	b.ResetTimer()
 	b.ReportAllocs()
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		for _, value := range intValues {
 			if _, err := ivr.Format(ctx, value); err != nil {
 				b.Fatal(err)
@@ -56,10 +55,9 @@ var decimalValues = []protoreflect.Value{
 func BenchmarkDecimalValueRendererFormat(b *testing.B) {
 	ctx := context.Background()
 	dvr := textual.NewDecValueRenderer()
-	b.ResetTimer()
 	b.ReportAllocs()
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		for _, value := range decimalValues {
 			if _, err := dvr.Format(ctx, value); err != nil {
 				b.Fatal(err)
@@ -83,10 +81,9 @@ var byteValues = []protoreflect.Value{
 func BenchmarkBytesValueRendererFormat(b *testing.B) {
 	ctx := context.Background()
 	bvr := textual.NewBytesValueRenderer()
-	b.ResetTimer()
 	b.ReportAllocs()
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		for _, value := range byteValues {
 			if _, err := bvr.Format(ctx, value); err != nil {
 				b.Fatal(err)
@@ -129,9 +126,8 @@ func BenchmarkMessageValueRenderer_parseRepeated(b *testing.B) {
 	}
 
 	b.ReportAllocs()
-	b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		for _, rs := range rsL {
 			sink, _ = rs.rend.Parse(ctx, rs.screens)
 		}


### PR DESCRIPTION
# Description

BEFORE:
BenchmarkParseCoin-10 275319 4029 ns/op 2081 B/op 63 allocs/op
BenchmarkCoinsAdditionIntersect/A_1,B_1-10 5409805 297.8 ns/op 168 B/op 5 allocs/op
BenchmarkSig/secp256k1-10 8157 154376 ns/op 744 B/op 15 allocs/op
BenchmarkSig/secp256r1-10 18703 61438 ns/op 1296 B/op 24 allocs/op
BenchmarkIntValueRendererFormat-10 995870 1115 ns/op 784 B/op 19 allocs/op

AFTER:
BenchmarkParseCoin-10 270021 3902 ns/op 2081 B/op 63 allocs/op
BenchmarkCoinsAdditionIntersect/A_1,B_1-10 5444228 230.1 ns/op 168 B/op 5 allocs/op
BenchmarkSig/secp256k1-10 8332 147734 ns/op 744 B/op 15 allocs/op
BenchmarkSig/secp256r1-10 19350 60703 ns/op 1296 B/op 24 allocs/op
BenchmarkIntValueRendererFormat-10 1037956 1155 ns/op 784 B/op 19 allocs/op

reopen #25408 