### PR TITLE
Upgrade GitHub Action to download-artifact@v5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,7 +70,7 @@ jobs:
             **/go.sum
             **/Makefile
             Makefile
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           name: "${{ github.sha }}-${{ matrix.part }}"
       - name: test & coverage report creation
@@ -159,27 +159,27 @@ jobs:
             go.sum
             **/go.mod
             **/go.sum
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         if: env.GIT_DIFF
         with:
           name: "${{ github.sha }}-00-coverage"
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         if: env.GIT_DIFF
         with:
           name: "${{ github.sha }}-01-coverage"
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         if: env.GIT_DIFF
         with:
           name: "${{ github.sha }}-02-coverage"
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         if: env.GIT_DIFF
         with:
           name: "${{ github.sha }}-03-coverage"
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         if: env.GIT_DIFF
         with:
           name: "${{ github.sha }}-integration-coverage"
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         if: env.GIT_DIFF
         with:
           name: "${{ github.sha }}-e2e-coverage"


### PR DESCRIPTION
Version v5 introduces major improvements in performance, artifact handling, and compatibility with recent workflow updates.
 Release notes:https://github.com/actions/download-artifact/releases/tag/v5.0.0

Change:
uses: actions/download-artifact@v4 -> uses: actions/download-artifact@v5
