### PR TITLE
chore: simplify SetDecisionPolicy to pack DecisionPolicy directly into Any

### DIFF
--- a/contrib/x/group/msgs.go
+++ b/contrib/x/group/msgs.go
@@ -1,8 +1,6 @@
 package group
 
 import (
-	"github.com/cosmos/gogoproto/proto"
-
 	"github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
@@ -102,11 +100,7 @@ func NewMsgUpdateGroupPolicyDecisionPolicy(admin, address sdk.AccAddress, decisi
 
 // SetDecisionPolicy sets the decision policy for MsgUpdateGroupPolicyDecisionPolicy.
 func (m *MsgUpdateGroupPolicyDecisionPolicy) SetDecisionPolicy(decisionPolicy DecisionPolicy) error {
-	msg, ok := decisionPolicy.(proto.Message)
-	if !ok {
-		return sdkerrors.ErrInvalidType.Wrapf("can't proto marshal %T", msg)
-	}
-	any, err := types.NewAnyWithValue(msg)
+	any, err := types.NewAnyWithValue(decisionPolicy)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
# Description

- Remove redundant proto.Message cast and unreachable error branch
- Use types.NewAnyWithValue(decisionPolicy) consistently
- Drop unnecessary github.com/cosmos/gogoproto/proto import
- Align with SetDecisionPolicy implementations across the module
