### PR TITLE
refactor: use b.Loop() to simplify the code and improve performance

### DIFF
--- a/internal/conv/string_test.go
+++ b/internal/conv/string_test.go
@@ -52,7 +52,7 @@ func (s *StringSuite) TestUnsafeBytesToStr() {
 }
 
 func BenchmarkUnsafeStrToBytes(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for i := 0; b.Loop(); i++ {
 		UnsafeStrToBytes(strconv.Itoa(i))
 	}
 }


### PR DESCRIPTION
# Description

Inspired by https://github.com/cosmos/cosmos-sdk/pull/25379

These changes use b.Loop() to simplify the code and improve performance
Before:

```shell
go test -run=^$ -bench=. ./internal/conv -timeout=1h  
goos: darwin
goarch: arm64
pkg: github.com/cosmos/cosmos-sdk/internal/conv
cpu: Apple M4
BenchmarkUnsafeStrToBytes-10    	98926561	        12.33 ns/op
PASS
ok  	github.com/cosmos/cosmos-sdk/internal/conv	2.164s
```

After:

```shell
 go test -run=^$ -bench=. ./internal/conv -timeout=1h  
goos: darwin
goarch: arm64
pkg: github.com/cosmos/cosmos-sdk/internal/conv
cpu: Apple M4
BenchmarkUnsafeStrToBytes-10    	90407384	        13.13 ns/op
PASS
ok  	github.com/cosmos/cosmos-sdk/internal/conv	1.692s
```