### PR TITLE
fix(crypto): replace recovery id normalization with explicit validation

### DIFF
--- a/crypto/keys/secp256k1/internal/secp256k1/secp256_test.go
+++ b/crypto/keys/secp256k1/internal/secp256k1/secp256_test.go
@@ -160,8 +160,10 @@ func signAndRecoverWithRandomMessages(t *testing.T, keys func() ([]byte, []byte)
 		}
 		compactSigCheck(t, sig)
 
-		// TODO: why do we flip around the recovery id?
-		sig[len(sig)-1] %= 4
+		// Ensure recovery id is in expected range for recoverable signatures.
+		if sig[64] >= 4 {
+			t.Fatalf("unexpected recovery id: %d", sig[64])
+		}
 
 		pubkey2, err := RecoverPubkey(msg, sig)
 		if err != nil {


### PR DESCRIPTION
What it does now: in signAndRecoverWithRandomMessages, after Sign, sig[len(sig)-1] %= 4 is executed. This normalizes V to the range 0..3.

Library expectations: libsecp256k1 operates on recid ∈ {0,1,2,3}. Our Sign gets recid from secp256k1_ecdsa_recoverable_signature_serialize_compact and writes it to sig[64] as 0..3. In RecoverPubkey, the check explicitly prohibits recid >= 4 and returns ErrInvalidRecoveryID.

Conclusion: after Sign, normalization %= 4 is unnecessary and potentially masks deviations if the API ever returns something other than 0..3. Where a random signature is generated manually (randSig), %= 4 is justified to make the pseudo-random recid valid; but after the actual Sign, it is not.

