### PR TITLE
refactor: use b.Loop() to simplify the code and improve performance

### DIFF
--- a/codec/types/any_test.go
+++ b/codec/types/any_test.go
@@ -56,9 +56,9 @@ func TestNewAnyWithCustomTypeURLWithErrorNoAllocation(t *testing.T) {
 var sink any
 
 func BenchmarkNewAnyWithCustomTypeURLWithErrorReturned(b *testing.B) {
-	b.ResetTimer()
+
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		any, err := types.NewAnyWithValue(eom)
 		if err == nil {
 			b.Fatal("err wasn't returned")

--- a/contrib/x/nft/internal/conv/string_test.go
+++ b/contrib/x/nft/internal/conv/string_test.go
@@ -52,7 +52,7 @@ func (s *StringSuite) TestUnsafeBytesToStr() {
 }
 
 func BenchmarkUnsafeStrToBytes(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for i := 0; b.Loop(); i++ {
 		UnsafeStrToBytes(strconv.Itoa(i))
 	}
 }

--- a/internal/conv/string_test.go
+++ b/internal/conv/string_test.go
@@ -52,7 +52,7 @@ func (s *StringSuite) TestUnsafeBytesToStr() {
 }
 
 func BenchmarkUnsafeStrToBytes(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for i := 0; b.Loop(); i++ {
 		UnsafeStrToBytes(strconv.Itoa(i))
 	}
 }


### PR DESCRIPTION
# Description

New pr for https://github.com/cosmos/cosmos-sdk/pull/25417

I carefully reviewed the related code and checked the Go official issues, and found that not all bloops can be modified. 

(More details:  https://github.com/golang/go/issues/75599)

 I’ve already made all the possible modifications that could improve performance.

Here is the benchmark result:


Before:

```shell
go test -run=^$ -bench=. ./internal/conv -timeout=1h  
goos: darwin
goarch: arm64
pkg: github.com/cosmos/cosmos-sdk/internal/conv
cpu: Apple M4
BenchmarkUnsafeStrToBytes-10    	98926561	        12.33 ns/op
PASS
ok  	github.com/cosmos/cosmos-sdk/internal/conv	2.164s
```

After:

```shell
 go test -run=^$ -bench=. ./internal/conv -timeout=1h  
goos: darwin
goarch: arm64
pkg: github.com/cosmos/cosmos-sdk/internal/conv
cpu: Apple M4
BenchmarkUnsafeStrToBytes-10    	90407384	        13.13 ns/op
PASS
ok  	github.com/cosmos/cosmos-sdk/internal/conv	1.692s
```
---

Before:

```shell
go test -run=^$ -bench=. ./codec/types -timeout=1h  
goos: darwin
goarch: arm64
pkg: github.com/cosmos/cosmos-sdk/codec/types
cpu: Apple M4
BenchmarkNewAnyWithCustomTypeURLWithErrorReturned-10    	171646992	         7.043 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/cosmos/cosmos-sdk/codec/types	2.427s

```

After:

```shell
go test -run=^$ -bench=. ./codec/types -timeout=1h  
goos: darwin
goarch: arm64
pkg: github.com/cosmos/cosmos-sdk/codec/types
cpu: Apple M4
BenchmarkNewAnyWithCustomTypeURLWithErrorReturned-10    	164805310	         7.246 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/cosmos/cosmos-sdk/codec/types	1.794s
```
---


Before:

```shell
 go test -run=^$ -bench=. ./contrib/x/nft/internal/conv -timeout=1h 
goos: darwin
goarch: arm64
pkg: github.com/cosmos/cosmos-sdk/contrib/x/nft/internal/conv
cpu: Apple M4
BenchmarkUnsafeStrToBytes-10    	100081984	        11.89 ns/op
PASS
ok  	github.com/cosmos/cosmos-sdk/contrib/x/nft/internal/conv	2.230s

```

After:


```shell
go test -run=^$ -bench=. ./contrib/x/nft/internal/conv -timeout=1h  
goos: darwin
goarch: arm64
pkg: github.com/cosmos/cosmos-sdk/contrib/x/nft/internal/conv
cpu: Apple M4
BenchmarkUnsafeStrToBytes-10    	90153356	        13.12 ns/op
PASS
ok  	github.com/cosmos/cosmos-sdk/contrib/x/nft/internal/conv	1.651s

```

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->
