### PR TITLE
 x/staking: remove unused WithChainID call in simulation test

### DIFF
--- a/x/staking/simulation/operations_test.go
+++ b/x/staking/simulation/operations_test.go
@@ -124,8 +124,6 @@ func (s *SimTestSuite) SetupTest() {
 func (s *SimTestSuite) TestWeightedOperations() {
 	require := s.Require()
 
-	s.ctx.WithChainID("test-chain")
-
 	cdc := s.encCfg.Codec
 	appParams := make(simtypes.AppParams)
 


### PR DESCRIPTION
# Description

Remove unused `s.ctx.WithChainID("test-chain")` call that doesn't assign result back to context variable, making it a no-op.