### PR TITLE
refactor: use b.Loop() in benchmark tests for better performance

### DIFF
--- a/crypto/armor_test.go
+++ b/crypto/armor_test.go
@@ -186,8 +186,7 @@ func BenchmarkBcryptGenerateFromPassword(b *testing.B) {
 		b.Run(fmt.Sprintf("benchmark-security-param-%d", param), func(b *testing.B) {
 			b.ReportAllocs()
 			saltBytes := cmtcrypto.CRandBytes(16)
-			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
+			for b.Loop() {
 				_, err := bcrypt.GenerateFromPassword(saltBytes, passphrase, param)
 				require.Nil(b, err)
 			}

--- a/store/internal/maps/bench_test.go
+++ b/store/internal/maps/bench_test.go
@@ -4,10 +4,9 @@ import "testing"
 
 func BenchmarkKVPairBytes(b *testing.B) {
 	kvp := NewKVPair(make([]byte, 128), make([]byte, 1e6))
-	b.ResetTimer()
 	b.ReportAllocs()
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		b.SetBytes(int64(len(kvp.Bytes())))
 	}
 }

--- a/x/auth/keeper/keeper_bench_test.go
+++ b/x/auth/keeper/keeper_bench_test.go
@@ -37,7 +37,7 @@ func BenchmarkAccountMapperGetAccountFound(b *testing.B) {
 	}
 
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for i := 0; b.Loop(); i++ {
 		arr := []byte{byte((i & 0xFF0000) >> 16), byte((i & 0xFF00) >> 8), byte(i & 0xFF)}
 		accountKeeper.GetAccount(ctx, sdk.AccAddress(arr))
 	}

--- a/x/bank/types/balance_test.go
+++ b/x/bank/types/balance_test.go
@@ -196,8 +196,7 @@ func benchmarkSanitizeBalances(b *testing.B, nAddresses int) {
 	coins := sdk.Coins{coin}
 	addrs, _ := makeRandomAddressesAndPublicKeys(nAddresses)
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		var balances []bank.Balance
 		for _, addr := range addrs {
 			balances = append(balances, bank.Balance{


### PR DESCRIPTION


BEFORE:
BenchmarkSanitizeBalances500-10           1543     2308112 ns/op    369488 B/op    7017 allocs/op
BenchmarkKVPairBytes-10                  28095      129261 ns/op   7737.34 MB/s  1007623 B/op  1 allocs/op
BenchmarkBcryptGenerateFromPassword-10      13   259145115 ns/op      5246 B/op      8 allocs/op
BenchmarkAccountMapperGetAccountFound-10 1936346      2032 ns/op      1440 B/op     16 allocs/op

AFTER:  
BenchmarkSanitizeBalances500-10           1568     2282725 ns/op    377539 B/op    8017 allocs/op
BenchmarkKVPairBytes-10                  26112      122790 ns/op   8145.10 MB/s  1007624 B/op  1 allocs/op
BenchmarkBcryptGenerateFromPassword-10      13   265506067 ns/op      5245 B/op      8 allocs/op
BenchmarkAccountMapperGetAccountFound-10 1000000      4023 ns/op      1861 B/op     29 allocs/op

