### PR TITLE
chore: Add Codecov

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -189,7 +189,6 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           files: ./00profile.out,./01profile.out,./02profile.out,./03profile.out,./tests/integration-profile.out,./tests/e2e-profile.out
-          flags: unittests,integration,e2e
           fail_ci_if_error: false
           verbose: true
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/codecov.yml
+++ b/codecov.yml
@@ -45,24 +45,6 @@ ignore:
   - "**/mock*.go"            # Mock files
   - "**/*.pb.gateway.go"     # Gateway files
 
-# Flags for different test suites to track coverage separately
-flags:
-  unittests:
-    paths:
-      - "!tests/integration/"
-      - "!tests/e2e/"
-    carryforward: true
-
-  integration:
-    paths:
-      - "tests/integration/"
-    carryforward: true
-
-  e2e:
-    paths:
-      - "tests/e2e/"
-    carryforward: true
-
 # How to handle multiple coverage reports
 # The workflow uploads: 00profile.out, 01profile.out, 02profile.out, 03profile.out,
 # integration-profile.out, e2e-profile.out


### PR DESCRIPTION
# Description

Adds codecov to the test workflow in CI. 

Previously the coverage files which are generated via the CI tests were uploaded to sonar cloud. We never ended up using sonarcloud and now the coverage files are just downloaded in the repo-analysis step, but nothing is done with them.

I've added a codecov integration so that we can once again have coverage data. Also added potential for CI failure based on 0.5% or more difference in project and patch coverage. Testing all of this out on #25340 so that we can see it working. Needs to be run on main to set the baseline.