### PR TITLE
Use Sleep Instead Of Timer In String Tests

### DIFF
--- a/store/internal/conv/string_test.go
+++ b/store/internal/conv/string_test.go
@@ -25,9 +25,7 @@ func (s *StringSuite) TestUnsafeStrToBytes() {
 	for i := 0; i < 5; i++ {
 		b := unsafeConvertStr()
 		runtime.GC()
-		timer := time.NewTimer(2 * time.Millisecond)
-		<-timer.C
-		timer.Stop()
+		time.Sleep(2 * time.Millisecond)
 		b2 := append(b, 'd')
 		s.Equal("abc", string(b))
 		s.Equal("abcd", string(b2))
@@ -44,9 +42,7 @@ func (s *StringSuite) TestUnsafeBytesToStr() {
 	for i := 0; i < 5; i++ {
 		str := unsafeConvertBytes()
 		runtime.GC()
-		timer := time.NewTimer(2 * time.Millisecond)
-		<-timer.C
-		timer.Stop()
+		time.Sleep(2 * time.Millisecond)
 		s.Equal("abc", str)
 	}
 }


### PR DESCRIPTION
Replace short-lived timers with time.Sleep in unsafe string conversion tests to avoid redundant allocations while keeping the GC delay.