### PR TITLE
schema.ModuleCodec() breaks with collections.PairKeyCodec

### DIFF
--- a/collections/pair.go
+++ b/collections/pair.go
@@ -50,6 +50,8 @@ func PairPrefix[K1, K2 any](key K1) Pair[K1, K2] {
 // first part of the key and the KeyCodec of the second part of the key.
 func PairKeyCodec[K1, K2 any](keyCodec1 codec.KeyCodec[K1], keyCodec2 codec.KeyCodec[K2]) codec.KeyCodec[Pair[K1, K2]] {
 	return pairKeyCodec[K1, K2]{
+		key1Name:  "k1",
+		key2Name:  "k2",
 		keyCodec1: keyCodec1,
 		keyCodec2: keyCodec2,
 	}


### PR DESCRIPTION
There is a simple problem with the usage of `collections.PairKeyCodec` which is currently used in `x/auth`, `x/bank` and `x/gov`

When I build the module codec for each collections.Schema using the built in schema.ModuleCodec(opts) function those 3 modules will fail with `invalid key field "" in type "balances": field name cannot be empty, might be missing the named key codec`

The modules do not use collections.NamedPairKeyCodec and actually never set names for each field so we end up with empty field names and such ModuleCodec() fails. So we have two options, either change each module's PairKeyCodec to a NamedPairKeyCodec or, like I did in this mini PR, add default names to PairKeyCodec which isn't ideal but certainly fixes the function panic.

Personally I suggest fixing up the modules themselves but that would require a full new cosmos sdk release while for this simple fix it could be included in a new Collections release