### PR TITLE
fix: error checking in unknownproto regression test

### DIFF
--- a/codec/unknownproto/regression_test.go
+++ b/codec/unknownproto/regression_test.go
@@ -2,6 +2,7 @@ package unknownproto_test
 
 import (
 	"encoding/hex"
+	"errors"
 	"io"
 	"testing"
 
@@ -18,8 +19,6 @@ func TestBadBytesPassedIntoDecoder(t *testing.T) {
 	decoder := cfg.TxConfig.TxDecoder()
 	tx, err := decoder(data)
 
-	// TODO: When issue https://github.com/cosmos/cosmos-sdk/issues/7846
-	// is addressed, we'll remove this .Contains check.
-	require.Contains(t, err.Error(), io.ErrUnexpectedEOF.Error())
+	require.True(t, errors.Is(err, io.ErrUnexpectedEOF))
 	require.Nil(t, tx)
 }


### PR DESCRIPTION
# Description

Replace string-based error checking with errors.Is() for proper error chain validation in TestBadBytesPassedIntoDecoder.

- Add errors package import
- Replace require.Contains() with require.True(errors.Is())
- Remove TODO comment as issue is resolved