### PR TITLE
fix: isolate CheckTx and simulation state from DeliverTx commits (backport #25529)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 * (baseapp) [#23879](https://github.com/cosmos/cosmos-sdk/pull/23879) Ensure finalize block response is not empty in the defer check of FinalizeBlock to avoid panic by nil pointer.
 * (query) [#23884](https://github.com/cosmos/cosmos-sdk/pull/23884) Fix NPE in query pagination.
+* (baseapp) [#25530](https://github.com/cosmos/cosmos-sdk/pull/25530) isolate CheckTx and simulation state from DeliverTx commits by loading the last committed snapshot and keeping the simulation context in sync.
 
 ## [v0.50.14](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.50.14) - 2025-07-08
 

--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -105,6 +105,9 @@ type BaseApp struct {
 	// - checkState: Used for CheckTx, which is set based on the previous block's
 	// state. This state is never committed.
 	//
+	// - simulationState: Mirrors the last committed state for simulations. It shares
+	// the same root snapshot as CheckTx but is never written back.
+	//
 	// - prepareProposalState: Used for PrepareProposal, which is set based on the
 	// previous block's state. This state is never committed. In case of multiple
 	// consensus rounds, the state is always reset to the previous block's state.
@@ -116,6 +119,7 @@ type BaseApp struct {
 	// - finalizeBlockState: Used for FinalizeBlock, which is set based on the
 	// previous block's state. This state is committed.
 	checkState           *state
+	simulationState      *state
 	prepareProposalState *state
 	processProposalState *state
 	finalizeBlockState   *state
@@ -478,6 +482,19 @@ func (app *BaseApp) IsSealed() bool { return app.sealed }
 // multi-store branch, and provided header.
 func (app *BaseApp) setState(mode execMode, h cmtproto.Header) {
 	ms := app.cms.CacheMultiStore()
+	if mode == execModeCheck {
+		// Load the last committed version so CheckTx (and by extension simulations)
+		// operate on the same state that DeliverTx committed in the previous block.
+		// Ref: https://github.com/cosmos/cosmos-sdk/issues/20685
+		//
+		// Using the versioned cache also unwraps any inter-block cache layers,
+		// preventing simulation runs from polluting the global inter-block cache
+		// with transient writes.
+		// Ref: https://github.com/cosmos/cosmos-sdk/issues/23891
+		if versionedCache, err := app.cms.CacheMultiStoreWithVersion(h.Height); err == nil {
+			ms = versionedCache
+		}
+	}
 	headerInfo := header.Info{
 		Height:  h.Height,
 		Time:    h.Time,
@@ -493,8 +510,14 @@ func (app *BaseApp) setState(mode execMode, h cmtproto.Header) {
 
 	switch mode {
 	case execModeCheck:
-		baseState.SetContext(baseState.Context().WithIsCheckTx(true).WithMinGasPrices(app.minGasPrices))
-		app.checkState = baseState
+		// Simulations never persist state, so they can reuse the base snapshot
+		// that was branched off the last committed height.
+		app.simulationState = baseState
+
+		// Branch again for CheckTx so AnteHandler writes do not leak back into
+		// the shared simulation snapshot.
+		checkMs := ms.CacheMultiStore()
+		app.checkState = &state{ctx: baseState.Context().WithIsCheckTx(true).WithMinGasPrices(app.minGasPrices).WithMultiStore(checkMs), ms: checkMs}
 
 	case execModePrepareProposal:
 		app.prepareProposalState = baseState
@@ -640,7 +663,14 @@ func (app *BaseApp) getState(mode execMode) *state {
 
 	case execModeProcessProposal:
 		return app.processProposalState
+	case execModeSimulate:
+		// Keep the simulation context aligned with the CheckTx context while
+		// preserving its own store branch.
+		if app.checkState != nil && app.simulationState != nil {
+			app.simulationState.SetContext(app.checkState.Context().WithMultiStore(app.simulationState.ms))
+		}
 
+		return app.simulationState
 	default:
 		return app.checkState
 	}


### PR DESCRIPTION
# Description

Isolate CheckTx and simulation state from DeliverTx commits by loading the last committed snapshot and keeping the simulation context in sync

Closes: #20685 #23891 