### PR TITLE
Fix incorrect comment for QueryAllBalancesRequest in query.proto

### DIFF
--- a/proto/cosmos/bank/v1beta1/query.proto
+++ b/proto/cosmos/bank/v1beta1/query.proto
@@ -144,7 +144,7 @@ message QueryBalanceResponse {
   cosmos.base.v1beta1.Coin balance = 1;
 }
 
-// QueryBalanceRequest is the request type for the Query/AllBalances RPC method.
+// QueryAllBalancesRequest is the request type for the Query/AllBalances RPC method.
 message QueryAllBalancesRequest {
   option (gogoproto.equal)           = false;
   option (gogoproto.goproto_getters) = false;


### PR DESCRIPTION
# Description
This PR resolves  #24944 by correcting the misleading comment in the query.proto file.
Closes: #24944 

Changes Made:
-  Updated the comment above QueryAllBalancesRequest to accurately describe its role in the Query/AllBalances RPC method.

-  Replaced QueryBalanceRequest with QueryAllBalancesRequest in the comment to reflect the correct message type.