### PR TITLE
fix: Implement kvStoreAdapter CacheWrap/CacheWrapWithTrace/GetStoreType

### DIFF
--- a/runtime/store.go
+++ b/runtime/store.go
@@ -5,6 +5,8 @@ import (
 	"io"
 
 	"cosmossdk.io/core/store"
+	"cosmossdk.io/store/cachekv"
+	"cosmossdk.io/store/tracekv"
 	storetypes "cosmossdk.io/store/types"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -106,16 +108,19 @@ type kvStoreAdapter struct {
 	store store.KVStore
 }
 
-func (kvStoreAdapter) CacheWrap() storetypes.CacheWrap {
-	panic("unimplemented")
+func (s kvStoreAdapter) CacheWrap() storetypes.CacheWrap {
+	return cachekv.NewStore(s)
 }
 
-func (kvStoreAdapter) CacheWrapWithTrace(w io.Writer, tc storetypes.TraceContext) storetypes.CacheWrap {
-	panic("unimplemented")
+func (s kvStoreAdapter) CacheWrapWithTrace(w io.Writer, tc storetypes.TraceContext) storetypes.CacheWrap {
+	return cachekv.NewStore(tracekv.NewStore(s, w, tc))
 }
 
-func (kvStoreAdapter) GetStoreType() storetypes.StoreType {
-	panic("unimplemented")
+func (s kvStoreAdapter) GetStoreType() storetypes.StoreType {
+	if ck, ok := s.store.(coreKVStore); ok {
+		return ck.kvStore.GetStoreType()
+	}
+	return storetypes.StoreTypePersistent
 }
 
 func (s kvStoreAdapter) Delete(key []byte) {


### PR DESCRIPTION
# Description

Previously, kvStoreAdapter left CacheWrap, CacheWrapWithTrace, and GetStoreType unimplemented, which could lead to runtime panics when callers used common layers like prefix.Store (delegating GetStoreType to the parent) or attempted to cache-wrap an adapted store. This change implements these methods safely: CacheWrap returns a cachekv store over the adapter, CacheWrapWithTrace wraps the adapter with tracekv and then cachekv, and GetStoreType attempts to delegate to the underlying store when the core store is a coreKVStore wrapper, falling back to StoreTypePersistent otherwise. This preserves correct store typing where possible, aligns with wrapping semantics used across the SDK, and removes a class of latent runtime panics without altering module-level behavior.
