### PR TITLE
fix(systemtests): properly cancel context in EventListener cleanup

### DIFF
--- a/systemtests/system.go
+++ b/systemtests/system.go
@@ -877,8 +877,11 @@ func (l *EventListener) Subscribe(query string, cb EventConsumer) func() {
 	eventsChan, err := l.client.Subscribe(ctx, "testing", query)
 	require.NoError(l.t, err)
 	cleanup := func() {
-		ctx, _ := context.WithTimeout(ctx, DefaultWaitTime) //nolint:govet // used in cleanup only
-		go l.client.Unsubscribe(ctx, "testing", query)      //nolint:errcheck // used by tests only
+		ctx, cancel := context.WithTimeout(ctx, DefaultWaitTime)
+		go func() {
+			defer cancel()
+			l.client.Unsubscribe(ctx, "testing", query) //nolint:errcheck // used by tests only
+		}()
 		done()
 	}
 	go func() {


### PR DESCRIPTION
Fixes a context leak in `EventListener.Subscribe` cleanup function where the cancel function from `context.WithTimeout` was ignored.

The cleanup function now properly calls `cancel()` after unsubscribing, preventing the timeout timer from leaking. This brings the code in line with the pattern used elsewhere in the codebase (e.g., `system.go:294` and `client/rpc/tx.go:131`).

- Removed `//nolint:govet` comment that was suppressing the warning
- Wrapped the `Unsubscribe` call in a goroutine with `defer cancel()`
- Maintains async behavior while properly releasing resources