### PR TITLE
feat: implement EarliestStoreHeight in node gRPC Status endpoint

### DIFF
--- a/client/grpc/node/service.go
+++ b/client/grpc/node/service.go
@@ -52,14 +52,20 @@ func (s queryServer) Status(ctx context.Context, _ *StatusRequest) (*StatusRespo
 
 	blockTime := sdkCtx.BlockTime()
 
+	var earliestHeight uint64
+	if s.clientCtx.Client != nil {
+		if node, err := s.clientCtx.GetNode(); err == nil {
+			if status, err := node.Status(ctx); err == nil {
+				earliestHeight = uint64(status.SyncInfo.EarliestBlockHeight)
+			}
+		}
+	}
+
 	return &StatusResponse{
-		// TODO: Get earliest version from store.
-		//
-		// Ref: ...
-		// EarliestStoreHeight: sdkCtx.MultiStore(),
-		Height:        uint64(sdkCtx.BlockHeight()),
-		Timestamp:     &blockTime,
-		AppHash:       sdkCtx.BlockHeader().AppHash,
-		ValidatorHash: sdkCtx.BlockHeader().NextValidatorsHash,
+		EarliestStoreHeight: earliestHeight,
+		Height:              uint64(sdkCtx.BlockHeight()),
+		Timestamp:           &blockTime,
+		AppHash:             sdkCtx.BlockHeader().AppHash,
+		ValidatorHash:       sdkCtx.BlockHeader().NextValidatorsHash,
 	}, nil
 }


### PR DESCRIPTION
## Summary
Resolves a TODO that has been present since April 2023 when the Status endpoint was first added (#15597).

## Implementation
Uses `clientCtx.GetNode().Status()` to retrieve CometBFT's earliest block height from the BlockStore, following the same pattern as the cmtservice.

## Discussion Points
The proto comment states "earliest block height available in the store" which could mean:
1. CometBFT BlockStore (this implementation) - earliest block with transaction data
2. State store - earliest block with queryable application state  

These should typically be the same but could diverge with different pruning configurations.

## Testing Needed
- [ ] Add unit tests for Status endpoint
- [ ] Test on pruned nodes
- [ ] Verify behavior matches expectations

## Changes
- Modified `client/grpc/node/service.go` to populate `EarliestStoreHeight` field
- Removed the TODO comment