### PR TITLE
chore(ci): upgrade checkout to v6

### DIFF
--- a/.github/workflows/proto-registry.yml
+++ b/.github/workflows/proto-registry.yml
@@ -16,7 +16,7 @@
 #     runs-on: depot-ubuntu-22.04-4
 #     name: "Push to buf.build/cosmos/cosmos-sdk"
 #     steps:
-#       - uses: actions/checkout@v5
+#       - uses: actions/checkout@v6
 #       - uses: bufbuild/buf-setup-action@v1.50.0
 #       - run: buf push proto --tag ${{ github.ref_type == 'tag' && github.ref_name || github.sha }} # https://github.com/bufbuild/buf-push-action/issues/20
 


### PR DESCRIPTION
Bumps `actions/checkout` from v5 to v6. Workflow-only change, no impact on functionality.

https://github.com/actions/checkout/releases/tag/v6.0.0

Follow: https://github.com/cosmos/cosmos-sdk/pull/25593