### PR TITLE
feat(server): add support for SafetyStartDelay to mitigate double-sign risks

### DIFF
--- a/server/start.go
+++ b/server/start.go
@@ -16,7 +16,6 @@ import (
 	cmtcmd "github.com/cometbft/cometbft/cmd/cometbft/commands"
 	cmtcfg "github.com/cometbft/cometbft/config"
 	cmtjson "github.com/cometbft/cometbft/libs/json"
-	"github.com/cometbft/cometbft/libs/tempfile" // Added for ForceSync control
 	"github.com/cometbft/cometbft/node"
 	"github.com/cometbft/cometbft/p2p"
 	pvm "github.com/cometbft/cometbft/privval"
@@ -185,18 +184,21 @@ is performed. Note, when enabled, gRPC will also be automatically enabled.
 			serverCtx := GetServerContextFromCmd(cmd)
 
 			// Logic: Safety Delay is only active when O_SYNC is disabled.
-			if serverCtx.Config.DisableOSSync {
-				serverCtx.Logger.Info("Disabling O_SYNC for atomic file writes (Performance Mode)")
-				tempfile.ForceSync(false)
+			// Use Viper to read config safely (decoupled from CometBFT struct changes)
+			disableOSSync := serverCtx.Viper.GetBool("disable_os_sync")
+
+			if disableOSSync {
+				// We don't call ForceSync here anymore to avoid dependency on CometBFT changes.
+				// CometBFT node initialization will handle the actual O_SYNC toggling.
 
 				// Apply Safety Start Delay only when O_SYNC is disabled
-				if delay := serverCtx.Config.SafetyStartDelay; delay > 0 {
-					serverCtx.Logger.Info("Safety Start Delay active due to disabled O_SYNC", "duration", delay)
-					time.Sleep(delay)
+				// Also read from Viper for safety
+				startDelayStr := serverCtx.Viper.GetString("safety_start_delay")
+				startDelay, err := time.ParseDuration(startDelayStr)
+				if err == nil && startDelay > 0 {
+					serverCtx.Logger.Info("Safety Start Delay active due to disabled O_SYNC", "duration", startDelay)
+					time.Sleep(startDelay)
 				}
-			} else {
-				// Default safe behavior
-				tempfile.ForceSync(true)
 			}
 
 			_, err := GetPruningOptionsFromFlags(serverCtx.Viper)


### PR DESCRIPTION
# Description

## Summary
This ensures safe validator startup whenever O_SYNC durability guarantees are intentionally relaxed.
This PR adds support for the safety_start_delay configuration from CometBFT. When the node is configured to run with disable_os_sync = true (optimized I/O mode), this feature forces the node to wait for a specified duration before starting.
This is a companion PR to CometBFT PR https://github.com/cometbft/cometbft/issues/5515 .

## Problem Statement
Validators operating on low-end hardware often face I/O bottlenecks during block commitment, leading to missed blocks. A proposed solution in CometBFT allows disabling os.O_SYNC (disable_os_sync) to eliminate this bottleneck.
However, disabling O_SYNC introduces a risk of "Amnesia" (double signing) if the node restarts immediately after a power failure, as the local state might not have been persisted to disk.

## Solution
We implement a Safety Start Delay mechanism in the start command.
- It reads disable_os_sync and safety_start_delay directly from the config (via Viper) to maintain loose coupling with CometBFT versions.
- If disable_os_sync is enabled, the node sleeps for safety_start_delay (default 6s) before initializing the app.
- This delay ensures that the network has likely produced a new block, mitigating the risk of double signing due to local data loss.

## Related Issues
- CometBFT Issue: https://github.com/cometbft/cometbft/issues/5514
- CometBFT PR: https://github.com/cometbft/cometbft/issues/5515

## Backward Compatibility
- No Impact on Default Behavior: If disable_os_sync is false (default), the delay logic is skipped entirely.
- Safe Decoupling: This PR does not import new CometBFT packages or call new APIs directly. It relies on configuration values present in config.toml, ensuring compilation and runtime compatibility with older CometBFT versions.

## How to Test
1. Set disable_os_sync = true and safety_start_delay = "6s" in config.toml.
2. Start the node (gaiad start).
3. Observe a "Safety Start Delay active..." log message and a 5-second pause before the node starts.
4. Set disable_os_sync = false.
5. Start the node. It should start immediately without delay.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->
