### PR TITLE
docs(server): update README example to pass params to InterceptConfigsPreRunHandler

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -34,7 +34,12 @@ var (
 				return err
 			}
 
-			return server.InterceptConfigsPreRunHandler(cmd)
+			return server.InterceptConfigsPreRunHandler(
+				cmd,
+				"",                 // custom app.toml template (optional)
+				nil,                // custom app config struct (optional)
+				cmtcfg.DefaultConfig(), // base CometBFT config
+			)
 		},
 	}
     // add root sub-commands ...


### PR DESCRIPTION
# Description

The README example called InterceptConfigsPreRunHandler with no arguments, which no longer matches its current signature and would not compile if copied. This change updates the example to pass the template, config, and cmtcfg.DefaultConfig(), aligning with actual usage in simapp and tests. 
