### PR TITLE
fix(staking): add missing iterator.Close() in v5 migration

### DIFF
--- a/x/staking/migrations/v5/store.go
+++ b/x/staking/migrations/v5/store.go
@@ -14,6 +14,7 @@ import (
 
 func migrateDelegationsByValidatorIndex(ctx sdk.Context, store storetypes.KVStore, cdc codec.BinaryCodec) error {
 	iterator := storetypes.KVStorePrefixIterator(store, DelegationKey)
+	defer iterator.Close()
 
 	for ; iterator.Valid(); iterator.Next() {
 		key := iterator.Key()


### PR DESCRIPTION
`migrateDelegationsByValidatorIndex` was missing iterator.Close(), added defer to fix the leak。