### PR TITLE
docs: update CheckTx handler docs to match SDK API

### DIFF
--- a/docs/docs/build/abci/04-checktx.md
+++ b/docs/docs/build/abci/04-checktx.md
@@ -20,17 +20,15 @@ https://github.com/cosmos/cosmos-sdk/blob/31c604762a434c7b676b6a89897ecbd7c4653a
 
 ## CheckTx Handler
 
-`CheckTxHandler` allows users to extend the logic of `CheckTx`. `CheckTxHandler` is called by passing context and the transaction bytes received through ABCI. It is required that the handler returns deterministic results given the same transaction bytes. 
-
-:::note
-we return the raw decoded transaction here to avoid decoding it twice.
-:::
+`CheckTxHandler` allows applications to extend the logic of `CheckTx`. It is invoked with the ABCI request and a `RunTx` function that executes the standard `CheckTx` pipeline (ante handlers, gas accounting and mempool interaction). The implementation of `CheckTxHandler` MUST be deterministic for a given `RequestCheckTx`.
 
 ```go
-type CheckTxHandler func(ctx sdk.Context, tx []byte) (Tx, error)
+type CheckTxHandler func(RunTx, *abci.RequestCheckTx) (*abci.ResponseCheckTx, error)
 ```
 
-Setting a custom `CheckTxHandler` is optional. It can be done from your app.go file:
+The provided `RunTx` function does not override ante handlers and does not allow changing the execution mode; it simply runs the transaction through the normal `CheckTx` path and returns the result that can be used to construct a `ResponseCheckTx`.
+
+Setting a custom `CheckTxHandler` is optional. It can be done from your `app.go` file by setting the handler on `BaseApp`:
 
 ```go
 func NewSimApp(
@@ -41,10 +39,16 @@ func NewSimApp(
 	appOpts servertypes.AppOptions,
 	baseAppOptions ...func(*baseapp.BaseApp),
 ) *SimApp {
-  ...
-  // Create ChecktxHandler
-  checktxHandler := abci.NewCustomCheckTxHandler(...)
-  app.SetCheckTxHandler(checktxHandler)
-  ...
+	 ...
+	 checkTxOpt := func(app *baseapp.BaseApp) {
+	 	app.SetCheckTxHandler(func(runTx sdk.RunTx, req *abci.RequestCheckTx) (*abci.ResponseCheckTx, error) {
+	 		// custom pre- or post-processing logic can be added here
+	 		return runTx(req.Tx, nil)
+	 	})
+	 }
+	 baseAppOptions = append(baseAppOptions, checkTxOpt)
+	 ...
 }
 ```
+
+When `RequestCheckTx.Type` is `abci.CheckTxType_New`, the transaction is evaluated for admission into the mempool; when it is `abci.CheckTxType_Recheck`, the existing mempool transaction is re-evaluated and may be removed if it no longer passes validation. Successful `CheckTx` executions update an internal CheckTx state, which is reset when a block is committed.


### PR DESCRIPTION
# Description

- Align CheckTxHandler signature in docs with sdk.CheckTxHandler from types/abci.go.
- Remove outdated note about returning decoded Tx and the non-existent abci.NewCustomCheckTxHandler helper.
- Document how RunTx is used inside CheckTxHandler without overriding ante handlers or exec mode.
- Clarify RequestCheckTx types (New vs Recheck) and mention CheckTx state reset on block commit.
