### PR TITLE
fix(types): correct SafeSub documentation comment

### DIFF
--- a/types/coin.go
+++ b/types/coin.go
@@ -141,7 +141,7 @@ func (coin Coin) Sub(coinB Coin) Coin {
 }
 
 // SafeSub safely subtracts the amounts of two coins. It returns an error if the coins differ
-// in denom or subtraction results in negative coin denom.
+// in denom or subtraction results in negative coin amount.
 func (coin Coin) SafeSub(coinB Coin) (Coin, error) {
 	if coin.Denom != coinB.Denom {
 		return Coin{}, fmt.Errorf("invalid coin denoms: %s, %s", coin.Denom, coinB.Denom)


### PR DESCRIPTION
# Description
Fixed incorrect documentation in `SafeSub` function that stated the function returns an error when "subtraction results in negative coin denom" instead of the correct "negative coin amount".

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->
