### PR TITLE
fix: Correct telemetry.IncrCounter type mismatch in bank keeper

### DIFF
--- a/x/bank/keeper/send.go
+++ b/x/bank/keeper/send.go
@@ -198,7 +198,7 @@ func (k BaseSendKeeper) InputOutputCoins(ctx context.Context, input types.Input,
 		// such as delegated fee messages.
 		accExists := k.ak.HasAccount(ctx, updatedAddressBz)
 		if !accExists {
-			defer telemetry.IncrCounter(1, "new", "account") //nolint:staticcheck // TODO: switch to OpenTelemetry
+			defer telemetry.IncrCounter(float32(1), "new", "account") //nolint:staticcheck // TODO: switch to OpenTelemetry
 			k.ak.SetAccount(ctx, k.ak.NewAccountWithAddress(ctx, updatedAddressBz))
 		}
 	}
@@ -261,7 +261,7 @@ func (k BaseSendKeeper) ensureAccountCreated(ctx context.Context, toAddr sdk.Acc
 	// such as delegated fee messages.
 	accExists := k.ak.HasAccount(ctx, toAddr)
 	if !accExists {
-		defer telemetry.IncrCounter(1, "new", "account") //nolint:staticcheck // TODO: switch to OpenTelemetry
+		defer telemetry.IncrCounter(float32(1), "new", "account") //nolint:staticcheck // TODO: switch to OpenTelemetry
 		k.ak.SetAccount(ctx, k.ak.NewAccountWithAddress(ctx, toAddr))
 	}
 }


### PR DESCRIPTION
# Description

Fix type mismatch in telemetry.IncrCounter calls. The function expects float32 but code was passing integer literals. Changed telemetry.IncrCounter(1, "new", "account") to telemetry.IncrCounter(float32(1), "new", "account") for proper type compatibility.