### PR TITLE
fix: correct require.Equal argument order in deref_test

### DIFF
--- a/x/params/types/deref_test.go
+++ b/x/params/types/deref_test.go
@@ -23,5 +23,5 @@ func TestKeyTableUnfurlsPointers(t *testing.T) {
 		vfn: validator,
 		ty:  reflect.ValueOf("").Type(),
 	}
-	require.Equal(t, got.ty, want.ty)
+	require.Equal(t, want.ty, got.ty)
 }


### PR DESCRIPTION
# Description

Closes: #XXXX

The test was calling `require.Equal(t, got.ty, want.ty)` with arguments in the wrong order. The `testify/require.Equal` function expects `(expected, actual)` format, but it was receiving `(got, want)` which is reversed.
While the test still passes (since equality is symmetric), this causes misleading error messages when the test fails, making debugging harder.
