### PR TITLE
perf(x/tx): optimize CBOR text encoding to reduce allocations

### DIFF
--- a/x/tx/signing/textual/internal/cbor/cbor.go
+++ b/x/tx/signing/textual/internal/cbor/cbor.go
@@ -98,7 +98,7 @@ func (s Text) Encode(w io.Writer) error {
 	if err != nil {
 		return err
 	}
-	_, err = w.Write([]byte(string(s)))
+	_, err = io.WriteString(w, string(s))
 	return err
 }
 


### PR DESCRIPTION
Optimizes Text.Encode() in the CBOR encoder by replacing w.Write([]byte(string(s))) with io.WriteString(w, string(s)) to eliminate unnecessary byte slice allocations.