### PR TITLE
chore: update v0.53.x release notes and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 # Changelog
 
-## UNRELEASED
+## [v0.53.5](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.53.5) - 2025-12-12
 
 ### Features
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,4 @@
-# Cosmos SDK v0.53.4 Release Notes
+# Cosmos SDK v0.53.5 Release Notes
 
 ## 🚀 Highlights
 
@@ -8,4 +8,4 @@ This is fully API and state-compatible with all v0.53.x releases.
 
 ## 📝 Changelog
 
-Check out the [changelog](https://github.com/cosmos/cosmos-sdk/blob/v0.53.4/CHANGELOG.md) for an exhaustive list of changes or [compare changes](https://github.com/cosmos/cosmos-sdk/compare/v0.53.3...v0.53.4) from the last release.
+Check out the [changelog](https://github.com/cosmos/cosmos-sdk/blob/v0.53.5/CHANGELOG.md) for an exhaustive list of changes or [compare changes](https://github.com/cosmos/cosmos-sdk/compare/v0.53.4...v0.53.5) from the last release.


### PR DESCRIPTION
# Description

updates release notes and changelog from previous release v0.53.5, which did not update these things.
