### PR TITLE
chore: fix for Spurious Javadoc @param tags

### DIFF
--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/java/org/bitcoin/NativeSecp256k1.java
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/java/org/bitcoin/NativeSecp256k1.java
@@ -79,7 +79,7 @@ public class NativeSecp256k1 {
      * libsecp256k1 Create an ECDSA signature.
      *
      * @param data Message hash, 32 bytes
-     * @param key Secret key, 32 bytes
+     * @param sec Secret key, 32 bytes
      *
      * Return values
      * @param sig byte array of signature


### PR DESCRIPTION
To fix this problem, the Javadoc must accurately reference the real parameter names. We should either (1) rename the method parameter `sec` to `key` to match the Javadoc, or (2) update the Javadoc `@param` tag from `key` to `sec`. Renaming the parameter could affect callers if source or reflection tooling depends on parameter names, so the safer fix that does not change existing functionality is to adjust the Javadoc only.

Concretely, in `crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/src/java/org/bitcoin/NativeSecp256k1.java`, in the Javadoc for `public static byte[] sign(byte[] data, byte[] sec)`, change the line `* @param key Secret key, 32 bytes` to `* @param sec Secret key, 32 bytes`. No code logic, imports, or method signatures need to change; only this single Javadoc line should be edited.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._