### PR TITLE
chore: fix for Missing error check

### DIFF
--- a/tests/e2e/auth/suite.go
+++ b/tests/e2e/auth/suite.go
@@ -1201,6 +1201,7 @@ func (s *E2ETestSuite) TestMultisignBatch() {
 	// multisign the file
 	file2 := testutil.WriteToNewTempFile(s.T(), res.String())
 	defer file2.Close()
+	s.Require().NoError(err)
 	res, err = authclitestutil.TxMultiSignBatchExec(val.ClientCtx, filename.Name(), multisigRecord.Name, file1.Name(), file2.Name())
 	s.Require().NoError(err)
 	signedTxs := strings.Split(strings.Trim(res.String(), "\n"), "\n")


### PR DESCRIPTION
In general, to fix this class of issue, we must ensure that every time we call a function that returns `(value, error)`, we check `err` (and, if relevant, that `value` is non-nil) before dereferencing or otherwise using `value`. In test code using `testify/require`, that means adding `s.Require().NoError(err)` immediately after the call and before any use of the returned value.

For this specific case, we should locate where `multisigRecord` and `err` are set (earlier in the same test function) and ensure that a `s.Require().NoError(err)` (or equivalent) follows that assignment. Since we are constrained to only modify the provided snippet region, the minimal, non-functional change that guarantees safety at the point of use is to re-check `err` just before dereferencing `multisigRecord` at line 1204. This ensures that if the creation or retrieval of `multisigRecord` failed and left it nil, the test will fail with an informative message instead of panicking when accessing `multisigRecord.Name`.

Concretely:
- In `tests/e2e/auth/suite.go`, within the shown function containing lines 1187–1217, insert `s.Require().NoError(err)` immediately before the line that calls `authclitestutil.TxMultiSignBatchExec` and dereferences `multisigRecord.Name`.
- No new imports or methods are needed; we already import `require` and are using `s.Require()` throughout this test.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._