### PR TITLE
chore: add inline documentation re. partial HistoricalInfo headers

### DIFF
--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -780,6 +780,10 @@ func (app *BaseApp) internalFinalizeBlock(goCtx context.Context, req *abci.Reque
 		))
 	}
 
+	// NOTE: Header populated here is intentionally partial; it omits Version, LastBlockID,
+	// LastCommitHash, DataHash, ValidatorsHash, ConsensusHash, LastResultsHash, and EvidenceHash.
+	// As a result, the HistoricalInfo headers stored by x/staking are unreliable and cannot reproduce
+	// the correct Header hash. Please use req.Hash instead.
 	header := cmtproto.Header{
 		ChainID:            app.chainID,
 		Height:             req.Height,

--- a/x/staking/keeper/historical_info.go
+++ b/x/staking/keeper/historical_info.go
@@ -82,7 +82,10 @@ func (k Keeper) GetAllHistoricalInfo(ctx context.Context) ([]types.HistoricalInf
 }
 
 // TrackHistoricalInfo saves the latest historical-info and deletes the oldest
-// heights that are below pruning height
+// heights that are below pruning height.
+// NOTE: HistoricalInfo headers are partial and omit fields such as: Version, LastBlockID,
+// LastCommitHash, DataHash, ValidatorsHash, ConsensusHash, LastResultsHash, and EvidenceHash.
+// As a result hashing the Header will not produce the correct result.
 func (k Keeper) TrackHistoricalInfo(ctx context.Context) error {
 	entryNum, err := k.HistoricalEntries(ctx)
 	if err != nil {


### PR DESCRIPTION
# Description

Adds documentation detailing partial HistoricalInfo headers to both baseapp and x/staking.

Closes: #25316

