### PR TITLE
fix(proto): remove extra semicolons in gov v1 proto files

### DIFF
--- a/proto/cosmos/gov/v1/genesis.proto
+++ b/proto/cosmos/gov/v1/genesis.proto
@@ -28,7 +28,6 @@ message GenesisState {
   TallyParams tally_params = 7 [deprecated = true];
   // params defines all the paramaters of x/gov module.
   Params params = 8 [(cosmos_proto.field_added_in) = "cosmos-sdk 0.47"];
-  ;
   // The constitution allows builders to lay a foundation and define purpose.
   // This is an immutable string set in genesis.
   // There are no amendments, to go outside of scope, just fork.

--- a/proto/cosmos/gov/v1/gov.proto
+++ b/proto/cosmos/gov/v1/gov.proto
@@ -85,11 +85,9 @@ message Proposal {
 
   // title is the title of the proposal
   string title = 11 [(cosmos_proto.field_added_in) = "cosmos-sdk 0.47"];
-  ;
 
   // summary is a short summary of the proposal
   string summary = 12 [(cosmos_proto.field_added_in) = "cosmos-sdk 0.47"];
-  ;
 
   // proposer is the address of the proposal sumbitter
   string proposer = 13


### PR DESCRIPTION
Fixes #25364. 

This PR removes extra semicolons in `proto/cosmos/gov/v1/genesis.proto` and `proto/cosmos/gov/v1/gov.proto` which were causing syntax errors in some Protobuf parsers (like the one used by Telescope codegen).