### PR TITLE
chore: normalize Go version to 1.25.5

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module cosmossdk.io/api
 
-go 1.24.0
+go 1.25.5
 
 require (
 	github.com/cosmos/cosmos-proto v1.0.0-beta.5

--- a/collections/go.mod
+++ b/collections/go.mod
@@ -1,6 +1,6 @@
 module cosmossdk.io/collections
 
-go 1.23.2
+go 1.25.5
 
 require (
 	cosmossdk.io/schema v1.1.0

--- a/core/go.mod
+++ b/core/go.mod
@@ -1,6 +1,6 @@
 module cosmossdk.io/core
 
-go 1.24.0
+go 1.25.5
 
 require (
 	cosmossdk.io/api v0.9.2

--- a/depinject/go.mod
+++ b/depinject/go.mod
@@ -1,6 +1,6 @@
 module cosmossdk.io/depinject
 
-go 1.23.2
+go 1.25.5
 
 require (
 	github.com/cosmos/cosmos-proto v1.0.0-beta.5

--- a/errors/go.mod
+++ b/errors/go.mod
@@ -1,6 +1,6 @@
 module cosmossdk.io/errors
 
-go 1.24.0
+go 1.25.5
 
 require (
 	github.com/pkg/errors v0.9.1

--- a/log/go.mod
+++ b/log/go.mod
@@ -1,6 +1,6 @@
 module cosmossdk.io/log/v2
 
-go 1.24.0
+go 1.25.5
 
 require (
 	github.com/bytedance/sonic v1.15.0

--- a/math/go.mod
+++ b/math/go.mod
@@ -1,6 +1,6 @@
 module cosmossdk.io/math
 
-go 1.23.0
+go 1.25.5
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/store/go.mod
+++ b/store/go.mod
@@ -1,6 +1,6 @@
 module cosmossdk.io/store
 
-go 1.24.0
+go 1.25.5
 
 replace (
 	cosmossdk.io/log/v2 => ../log

--- a/tools/benchmark/go.mod
+++ b/tools/benchmark/go.mod
@@ -1,6 +1,6 @@
 module cosmossdk.io/tools/benchmark
 
-go 1.25.0
+go 1.25.5
 
 require (
 	cosmossdk.io/api v0.9.2

--- a/tools/confix/go.mod
+++ b/tools/confix/go.mod
@@ -1,6 +1,6 @@
 module cosmossdk.io/tools/confix
 
-go 1.25.0
+go 1.25.5
 
 require (
 	github.com/cosmos/cosmos-sdk v0.54.0-beta.0

--- a/tools/cosmovisor/go.mod
+++ b/tools/cosmovisor/go.mod
@@ -1,6 +1,6 @@
 module cosmossdk.io/tools/cosmovisor
 
-go 1.25.0
+go 1.25.5
 
 require (
 	cosmossdk.io/log v1.6.1

--- a/x/tx/go.mod
+++ b/x/tx/go.mod
@@ -1,6 +1,6 @@
 module cosmossdk.io/x/tx
 
-go 1.24.0
+go 1.25.5
 
 require (
 	cosmossdk.io/api v0.9.2


### PR DESCRIPTION
Align all module go.mod files to Go 1.25.5 to eliminate version drift across the monorepo
