### PR TITLE
build(deps): bump Go 1.25.6 to 1.25.7

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.6"
+          go-version: "1.25.7"
           check-latest: true
       - name: install aarch64-gcc
         if: matrix.go-arch == 'arm64'
@@ -59,7 +59,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.6"
+          go-version: "1.25.7"
           check-latest: true
           cache: true
           cache-dependency-path: enterprise/poa/go.sum

--- a/.github/workflows/dependencies-review.yml
+++ b/.github/workflows/dependencies-review.yml
@@ -15,7 +15,7 @@ jobs:
       - name: "Setup Go"
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25.6"
+          go-version: "1.25.7"
           check-latest: true
       - name: "Dependency Review"
         uses: actions/dependency-review-action@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.6"
+          go-version: "1.25.7"
           check-latest: true
       - uses: technote-space/get-diff-action@v6.1.2
         id: git_diff

--- a/.github/workflows/pr-go-mod-tidy-mocks.yml
+++ b/.github/workflows/pr-go-mod-tidy-mocks.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25.6"
+          go-version: "1.25.7"
           check-latest: true
       - name: Run go mod tidy
         run: ./scripts/go-mod-tidy-all.sh
@@ -40,7 +40,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25.6"
+          go-version: "1.25.7"
           check-latest: true
       - name: Generate mocks
         run: make mocks

--- a/.github/workflows/release-confix.yml
+++ b/.github/workflows/release-confix.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.6"
+          go-version: "1.25.7"
           check-latest: true
       # get 'v*.*.*' part from 'confix/v*.*.*' and save to $GITHUB_ENV
       - name: Set env

--- a/.github/workflows/release-cosmovisor.yml
+++ b/.github/workflows/release-cosmovisor.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.6"
+          go-version: "1.25.7"
           check-latest: true
       # get 'v*.*.*' part from 'cosmovisor/v*.*.*' and save to $GITHUB_ENV
       - name: Set env

--- a/.github/workflows/release-simd.yml
+++ b/.github/workflows/release-simd.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.6"
+          go-version: "1.25.7"
           check-latest: true
       # get 'v*.*.*' part from 'simd/v*.*.*' and save to $GITHUB_ENV
       - name: Set env

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25.6"
+          go-version: "1.25.7"
           check-latest: true
       - name: Unshallow
         run: git fetch --prune --unshallow

--- a/.github/workflows/sims-047.yml
+++ b/.github/workflows/sims-047.yml
@@ -21,7 +21,7 @@ jobs:
           ref: "release/v0.47.x"
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.6"
+          go-version: "1.25.7"
           check-latest: true
       - run: make build
 
@@ -33,7 +33,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.6"
+          go-version: "1.25.7"
           check-latest: true
       - name: Install runsim
         run: go install github.com/cosmos/tools/cmd/runsim@v1.0.0
@@ -52,7 +52,7 @@ jobs:
           ref: "release/v0.47.x"
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.6"
+          go-version: "1.25.7"
           check-latest: true
       - uses: actions/cache@v5
         with:
@@ -71,7 +71,7 @@ jobs:
           ref: "release/v0.47.x"
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.6"
+          go-version: "1.25.7"
           check-latest: true
       - uses: actions/cache@v5
         with:
@@ -90,7 +90,7 @@ jobs:
           ref: "release/v0.47.x"
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.6"
+          go-version: "1.25.7"
           check-latest: true
       - uses: actions/cache@v5
         with:

--- a/.github/workflows/sims-050.yml
+++ b/.github/workflows/sims-050.yml
@@ -22,7 +22,7 @@ jobs:
           ref: "release/v0.50.x"
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.6"
+          go-version: "1.25.7"
           check-latest: true
       - run: make build
 
@@ -34,7 +34,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.6"
+          go-version: "1.25.7"
           check-latest: true
       - name: Install runsim
         run: go install github.com/cosmos/tools/cmd/runsim@v1.0.0
@@ -53,7 +53,7 @@ jobs:
           ref: "release/v0.50.x"
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.6"
+          go-version: "1.25.7"
           check-latest: true
       - uses: actions/cache@v5
         with:
@@ -72,7 +72,7 @@ jobs:
           ref: "release/v0.50.x"
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.6"
+          go-version: "1.25.7"
           check-latest: true
       - uses: actions/cache@v5
         with:
@@ -91,7 +91,7 @@ jobs:
           ref: "release/v0.50.x"
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.6"
+          go-version: "1.25.7"
           check-latest: true
       - uses: actions/cache@v5
         with:

--- a/.github/workflows/sims-053.yml
+++ b/.github/workflows/sims-053.yml
@@ -22,7 +22,7 @@ jobs:
           ref: "release/v0.53.x"
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.6"
+          go-version: "1.25.7"
           check-latest: true
       - run: make build
 
@@ -34,7 +34,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.6"
+          go-version: "1.25.7"
           check-latest: true
       - name: Install runsim
         run: go install github.com/cosmos/tools/cmd/runsim@v1.0.0
@@ -53,7 +53,7 @@ jobs:
           ref: "release/v0.53.x"
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.6"
+          go-version: "1.25.7"
           check-latest: true
       - uses: actions/cache@v5
         with:
@@ -72,7 +72,7 @@ jobs:
           ref: "release/v0.53.x"
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.6"
+          go-version: "1.25.7"
           check-latest: true
       - uses: actions/cache@v5
         with:
@@ -91,7 +91,7 @@ jobs:
           ref: "release/v0.53.x"
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.6"
+          go-version: "1.25.7"
           check-latest: true
       - uses: actions/cache@v5
         with:

--- a/.github/workflows/sims-nightly.yml
+++ b/.github/workflows/sims-nightly.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.6"
+          go-version: "1.25.7"
           check-latest: true
       - name: test-sim-multi-seed-long
         env:
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.6"
+          go-version: "1.25.7"
           check-latest: true
       - name: test-sim-import-export
         env:

--- a/.github/workflows/sims.yml
+++ b/.github/workflows/sims.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.6"
+          go-version: "1.25.7"
           check-latest: true
       - run: make build
 
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.6"
+          go-version: "1.25.7"
           check-latest: true
       - name: test-sim-import-export
         run: |
@@ -47,7 +47,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.6"
+          go-version: "1.25.7"
           check-latest: true
       - name: test-sim-after-import
         run: |
@@ -61,7 +61,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.6"
+          go-version: "1.25.7"
           check-latest: true
       - name: test-sim-nondeterminism-streaming
         run: |
@@ -75,7 +75,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.6"
+          go-version: "1.25.7"
           check-latest: true
       - name: test-sim-multi-seed-short
         run: |

--- a/.github/workflows/systemtests.yml
+++ b/.github/workflows/systemtests.yml
@@ -28,7 +28,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.6"
+          go-version: "1.25.7"
           check-latest: true
           cache: true
           cache-dependency-path: |
@@ -94,7 +94,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.6"
+          go-version: "1.25.7"
           check-latest: true
           cache: true
           cache-dependency-path: enterprise/poa/go.sum

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.6"
+          go-version: "1.25.7"
           check-latest: true
       - name: Create a file with all core Cosmos SDK pkgs
         run: go list ./... > pkgs.txt
@@ -55,7 +55,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.6"
+          go-version: "1.25.7"
           check-latest: true
           cache: true
           cache-dependency-path: go.sum
@@ -89,7 +89,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.6"
+          go-version: "1.25.7"
           check-latest: true
           cache: true
           cache-dependency-path: go.sum
@@ -120,7 +120,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.6"
+          go-version: "1.25.7"
           check-latest: true
           cache: true
           cache-dependency-path: go.sum
@@ -274,7 +274,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.6"
+          go-version: "1.25.7"
           check-latest: true
           cache: true
           cache-dependency-path: go.sum
@@ -307,7 +307,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.6"
+          go-version: "1.25.7"
           check-latest: true
           cache: true
           cache-dependency-path: client/v2/go.sum
@@ -335,7 +335,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.6"
+          go-version: "1.25.7"
           check-latest: true
           cache: true
           cache-dependency-path: core/go.sum
@@ -363,7 +363,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.6"
+          go-version: "1.25.7"
           check-latest: false
           cache: true
           cache-dependency-path: depinject/go.sum
@@ -391,7 +391,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.6"
+          go-version: "1.25.7"
           check-latest: true
           cache: true
           cache-dependency-path: errors/go.sum
@@ -419,7 +419,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.6"
+          go-version: "1.25.7"
           check-latest: true
           cache: true
           cache-dependency-path: math/go.sum
@@ -474,7 +474,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.6"
+          go-version: "1.25.7"
           check-latest: true
           cache: true
           cache-dependency-path: collections/go.sum
@@ -502,7 +502,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.6"
+          go-version: "1.25.7"
           check-latest: true
           cache: true
           cache-dependency-path: tools/cosmovisor/go.sum
@@ -530,7 +530,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.6"
+          go-version: "1.25.7"
           check-latest: true
           cache: true
           cache-dependency-path: tools/confix/go.sum
@@ -558,7 +558,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.6"
+          go-version: "1.25.7"
           check-latest: true
           cache: true
           cache-dependency-path: store/go.sum
@@ -586,7 +586,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.6"
+          go-version: "1.25.7"
           check-latest: true
           cache: true
           cache-dependency-path: store/go.sum
@@ -614,7 +614,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.6"
+          go-version: "1.25.7"
           check-latest: true
           cache: true
           cache-dependency-path: log/go.sum
@@ -649,7 +649,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.6"
+          go-version: "1.25.7"
           check-latest: true
           cache: true
           cache-dependency-path: x/tx/go.sum
@@ -677,7 +677,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.6"
+          go-version: "1.25.7"
           check-latest: true
           cache: true
           cache-dependency-path: tools/benchmark/go.sum
@@ -709,7 +709,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.6"
+          go-version: "1.25.7"
           check-latest: true
           cache: true
           cache-dependency-path: enterprise/poa/go.sum

--- a/client/v2/go.mod
+++ b/client/v2/go.mod
@@ -1,6 +1,6 @@
 module cosmossdk.io/client/v2
 
-go 1.25.6
+go 1.25.7
 
 require (
 	cosmossdk.io/api v0.9.2

--- a/enterprise/poa/go.mod
+++ b/enterprise/poa/go.mod
@@ -1,6 +1,6 @@
 module github.com/cosmos/cosmos-sdk/enterprise/poa
 
-go 1.25.6
+go 1.25.7
 
 require (
 	cosmossdk.io/api v0.9.2

--- a/enterprise/poa/simapp/go.mod
+++ b/enterprise/poa/simapp/go.mod
@@ -1,6 +1,6 @@
 module github.com/cosmos/cosmos-sdk/enterprise/poa/simapp
 
-go 1.25.6
+go 1.25.7
 
 require (
 	cosmossdk.io/api v0.9.2

--- a/enterprise/poa/tests/systemtests/go.mod
+++ b/enterprise/poa/tests/systemtests/go.mod
@@ -1,6 +1,6 @@
 module github.com/cosmos/cosmos-sdk/enterprise/poa/tests/systemtests
 
-go 1.25.6
+go 1.25.7
 
 require (
 	cosmossdk.io/systemtests v1.4.0

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-go 1.25.6
+go 1.25.7
 
 module github.com/cosmos/cosmos-sdk
 

--- a/simapp/go.mod
+++ b/simapp/go.mod
@@ -1,6 +1,6 @@
 module cosmossdk.io/simapp
 
-go 1.25.6
+go 1.25.7
 
 require (
 	cosmossdk.io/api v0.9.2

--- a/systemtests/go.mod
+++ b/systemtests/go.mod
@@ -1,6 +1,6 @@
 module cosmossdk.io/systemtests
 
-go 1.25.6
+go 1.25.7
 
 require (
 	cosmossdk.io/math v1.5.3

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -1,6 +1,6 @@
 module github.com/cosmos/cosmos-sdk/tests
 
-go 1.25.6
+go 1.25.7
 
 require (
 	cosmossdk.io/api v0.9.2

--- a/tests/systemtests/go.mod
+++ b/tests/systemtests/go.mod
@@ -1,6 +1,6 @@
 module cosmossdk.io/tests/systemtests
 
-go 1.25.6
+go 1.25.7
 
 replace (
 	// always use latest versions in tests


### PR DESCRIPTION
## Summary

- Bumps Go from 1.25.6 to 1.25.7 across all `go.mod` files and CI workflows
- Fixes negligible vulnerability [GO-2026-4337](https://pkg.go.dev/vuln/GO-2026-4337) (CVE-2025-68121): unexpected session resumption in `crypto/tls` where certificate validation could be bypassed when `Config.ClientCAs` or `RootCAs` are mutated between handshakes (which is not even really a possibility here anyway)
- Go 1.25.7 released Feb 4, 2026

## Context
- solves my issue of `dependency-review` check failing on #25647 