### PR TITLE
chore(ci): bump codeql go version

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -46,7 +46,7 @@ jobs:
       if: matrix.language == 'go'
       uses: actions/setup-go@v6
       with:
-        go-version: '1.x'
+        go-version: '1.25.7'
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v4


### PR DESCRIPTION
# Description

Fixes https://github.com/cosmos/cosmos-sdk/pull/25875#issuecomment-3860900471.

We updated to go 1.25.7 ,but CodeQL was configure with version 1.x, which didnt auto update the patch release.

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->
