### PR TITLE
perf(crypto): enable x86_64 assembly for secp256k1 field and scalar operations

### DIFF
--- a/crypto/keys/secp256k1/internal/secp256k1/secp256.go
+++ b/crypto/keys/secp256k1/internal/secp256k1/secp256.go
@@ -16,6 +16,9 @@ package secp256k1
 #  define HAVE___INT128
 #  define USE_FIELD_5X52
 #  define USE_SCALAR_4X64
+#  if defined(__x86_64__)
+#    define USE_ASM_X86_64
+#  endif
 #else
 #  define USE_FIELD_10X26
 #  define USE_SCALAR_8X32


### PR DESCRIPTION
# Description

Enable hand-written x86_64 assembly optimizations in the vendored libsecp256k1 CGo wrapper by defining
  USE_ASM_X86_64 on x86_64 targets.

  The vendored libsecp256k1 includes hand-tuned x86_64 assembly implementations for the hottest inner
  loops of elliptic curve operations, but the CGo build never activated them. Instead, the C compiler's
  uint128_t fallback was used, which produces slower code for these tightly scheduled multiply-accumulate
  chains.

  This enables assembly paths for five functions:
  - secp256k1_fe_mul_inner — field element multiplication
  - secp256k1_fe_sqr_inner — field element squaring
  - secp256k1_scalar_reduce_512 — 512→256 bit scalar reduction
  - secp256k1_scalar_mul_512 — 4×64-limb scalar multiplication
  - secp256k1_scalar_sqr_512 — scalar squaring

  These are called on every ECDSA signature verification (every transaction). The assembly uses only
  baseline x86_64 instructions (mul, adc, shrd) — no AVX or extended ISA required.

  The #if defined(__x86_64__) guard ensures zero impact on ARM64 or other architectures, where the existing uint128_t C path continues to be used.
