### PR TITLE
fix: Fix proposer autovote documentation mismatch

### DIFF
--- a/contrib/proto/group/v1/tx.proto
+++ b/contrib/proto/group/v1/tx.proto
@@ -288,7 +288,7 @@ message MsgSubmitProposal {
   string group_policy_address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
 
   // proposers are the account addresses of the proposers.
-  // Proposers signatures will be counted as yes votes.
+  // When exec is EXEC_TRY, proposers are automatically counted as Yes votes.
   repeated string proposers = 2;
 
   // metadata is any arbitrary metadata attached to the proposal.
@@ -299,7 +299,7 @@ message MsgSubmitProposal {
 
   // exec defines the mode of execution of the proposal,
   // whether it should be executed immediately on creation or not.
-  // If so, proposers signatures are considered as Yes votes.
+  // When exec is EXEC_TRY, proposers are automatically counted as Yes votes.
   Exec exec = 5;
 
   // title is the title of the proposal.

--- a/contrib/x/group/README.md
+++ b/contrib/x/group/README.md
@@ -193,7 +193,7 @@ group members) can execute proposals that have been accepted, and execution fees
 paid by the proposal executor.
 It's also possible to try to execute a proposal immediately on creation or on
 new votes using the `Exec` field of `Msg/SubmitProposal` and `Msg/Vote` requests.
-In the former case, proposers signatures are considered as yes votes.
+For `Msg/SubmitProposal`, when exec is EXEC_TRY, proposers are automatically counted as Yes votes.
 In these cases, if the proposal can't be executed (i.e. it didn't pass the
 decision policy's rules), it will still be opened for new votes and
 could be tallied and executed later on.
@@ -448,7 +448,7 @@ It's expected to fail if:
 ### Msg/SubmitProposal
 
 A new proposal can be created with the `MsgSubmitProposal`, which has a group policy account address, a list of proposers addresses, a list of messages to execute if the proposal is accepted and some optional metadata.
-An optional `Exec` value can be provided to try to execute the proposal immediately after proposal creation. Proposers signatures are considered as yes votes in this case.
+An optional `Exec` value can be provided to try to execute the proposal immediately after proposal creation. When exec is EXEC_TRY, proposers are automatically counted as Yes votes.
 
 ```go reference
 https://github.com/cosmos/cosmos-sdk/tree/release/v0.50.x/proto/cosmos/group/v1/tx.proto#L281-L315

--- a/contrib/x/group/client/cli/tx.go
+++ b/contrib/x/group/client/cli/tx.go
@@ -653,7 +653,7 @@ metadata example:
 		},
 	}
 
-	cmd.Flags().String(FlagExec, "", "Set to 1 or 'try' to try to execute proposal immediately after creation (proposers signatures are considered as Yes votes)")
+	cmd.Flags().String(FlagExec, "", "Set to 1 or 'try' to try to execute proposal immediately after creation (when exec is EXEC_TRY, proposers are automatically counted as Yes votes)")
 	flags.AddTxFlagsToCmd(cmd)
 
 	return cmd

--- a/contrib/x/group/keeper/msg_server.go
+++ b/contrib/x/group/keeper/msg_server.go
@@ -626,9 +626,9 @@ func (k Keeper) SubmitProposal(goCtx context.Context, msg *group.MsgSubmitPropos
 		return nil, err
 	}
 
-	// Try to execute proposal immediately
+	// Try to execute proposal immediately. Autovote occurs only when exec is EXEC_TRY.
 	if msg.Exec == group.Exec_EXEC_TRY {
-		// Consider proposers as Yes votes
+		// Proposers are automatically counted as Yes votes
 		for _, proposer := range msg.Proposers {
 			ctx.GasMeter().ConsumeGas(gasCostPerIteration, "vote on proposal")
 			_, err = k.Vote(ctx, &group.MsgVote{

--- a/contrib/x/group/tx.pb.go
+++ b/contrib/x/group/tx.pb.go
@@ -965,7 +965,7 @@ type MsgSubmitProposal struct {
 	// group_policy_address is the account address of group policy.
 	GroupPolicyAddress string `protobuf:"bytes,1,opt,name=group_policy_address,json=groupPolicyAddress,proto3" json:"group_policy_address,omitempty"`
 	// proposers are the account addresses of the proposers.
-	// Proposers signatures will be counted as yes votes.
+	// When exec is EXEC_TRY, proposers are automatically counted as Yes votes.
 	Proposers []string `protobuf:"bytes,2,rep,name=proposers,proto3" json:"proposers,omitempty"`
 	// metadata is any arbitrary metadata attached to the proposal.
 	Metadata string `protobuf:"bytes,3,opt,name=metadata,proto3" json:"metadata,omitempty"`
@@ -973,7 +973,7 @@ type MsgSubmitProposal struct {
 	Messages []*any.Any `protobuf:"bytes,4,rep,name=messages,proto3" json:"messages,omitempty"`
 	// exec defines the mode of execution of the proposal,
 	// whether it should be executed immediately on creation or not.
-	// If so, proposers signatures are considered as Yes votes.
+	// When exec is EXEC_TRY, proposers are automatically counted as Yes votes.
 	Exec Exec `protobuf:"varint,5,opt,name=exec,proto3,enum=cosmos.group.v1.Exec" json:"exec,omitempty"`
 	// title is the title of the proposal.
 	Title string `protobuf:"bytes,6,opt,name=title,proto3" json:"title,omitempty"`


### PR DESCRIPTION
### Summary

Updates Proposers-related docs so it’s clear that proposers are counted as Yes votes only when `Exec == EXEC_TRY`. Docs-only change; no behavior changes.

### Changes

**Proto (`contrib/proto/group/v1/tx.proto`):**
- proposers: "When exec is EXEC_TRY, proposers are automatically counted as Yes votes."
- exec: same wording

**Go (`contrib/x/group/tx.pb.go`):**
- Mirrors proto comments in generated code

**Keeper (`contrib/x/group/keeper/msg_server.go`):**
- Adds: "Autovote occurs only when exec is EXEC_TRY."
- Clarifies proposer autovote comment

**CLI (`contrib/x/group/client/cli/tx.go`):**
- Flag help: "when exec is EXEC_TRY, proposers are automatically counted as Yes votes"

**README (`contrib/x/group/README.md`):**
- Uses "For Msg/SubmitProposal, when exec is EXEC_TRY, proposers are automatically counted as Yes votes"
- Aligns Msg/SubmitProposal section with the above wording