### PR TITLE
feat(math): add safe arithmetic methods to Uint type and fix bugs

### DIFF
--- a/math/uint.go
+++ b/math/uint.go
@@ -97,35 +97,101 @@ func (u Uint) LT(u2 Uint) bool { return lt(u.i, u2.i) }
 func (u Uint) LTE(u2 Uint) bool { return !u.GT(u2) }
 
 // Add adds Uint from another
-func (u Uint) Add(u2 Uint) Uint { return NewUintFromBigInt(new(big.Int).Add(u.i, u2.i)) }
+func (u Uint) Add(u2 Uint) Uint {
+	res, err := u.SafeAdd(u2)
+	if err != nil {
+		panic(err)
+	}
+	return res
+}
+
+// SafeAdd adds two Uints and returns an error if the result overflows 256 bits.
+func (u Uint) SafeAdd(u2 Uint) (Uint, error) {
+	res := new(big.Int).Add(u.i, u2.i)
+	if err := UintOverflow(res); err != nil {
+		return Uint{}, fmt.Errorf("unsigned integer overflow: %w", err)
+	}
+	return Uint{res}, nil
+}
 
 // AddUint64 convert uint64 and add it to Uint
 func (u Uint) AddUint64(u2 uint64) Uint { return u.Add(NewUint(u2)) }
 
-// Sub adds Uint from another
-func (u Uint) Sub(u2 Uint) Uint { return NewUintFromBigInt(new(big.Int).Sub(u.i, u2.i)) }
+// Sub subtracts u2 from u. Panics on underflow.
+func (u Uint) Sub(u2 Uint) Uint {
+	res, err := u.SafeSub(u2)
+	if err != nil {
+		panic(err)
+	}
+	return res
+}
 
-// SubUint64 adds Uint from another
+// SafeSub subtracts u2 from u and returns an error if the result is negative (underflow).
+func (u Uint) SafeSub(u2 Uint) (Uint, error) {
+	res := new(big.Int).Sub(u.i, u2.i)
+	if res.Sign() < 0 {
+		return Uint{}, errors.New("unsigned integer underflow")
+	}
+	return Uint{res}, nil
+}
+
+// SubUint64 subtracts a uint64 from Uint
 func (u Uint) SubUint64(u2 uint64) Uint { return u.Sub(NewUint(u2)) }
 
 // Mul multiplies two Uints
 func (u Uint) Mul(u2 Uint) (res Uint) {
-	return NewUintFromBigInt(new(big.Int).Mul(u.i, u2.i))
+	r, err := u.SafeMul(u2)
+	if err != nil {
+		panic(err)
+	}
+	return r
 }
 
-// MulUint64 multiplies two Uints
+// SafeMul multiplies two Uints and returns an error if the result overflows 256 bits.
+func (u Uint) SafeMul(u2 Uint) (Uint, error) {
+	res := new(big.Int).Mul(u.i, u2.i)
+	if err := UintOverflow(res); err != nil {
+		return Uint{}, fmt.Errorf("unsigned integer overflow: %w", err)
+	}
+	return Uint{res}, nil
+}
+
+// MulUint64 multiplies Uint with uint64
 func (u Uint) MulUint64(u2 uint64) (res Uint) { return u.Mul(NewUint(u2)) }
 
-// Quo divides Uint with Uint
-func (u Uint) Quo(u2 Uint) (res Uint) { return NewUintFromBigInt(div(u.i, u2.i)) }
+// Quo divides Uint with Uint. Panics on division by zero.
+func (u Uint) Quo(u2 Uint) (res Uint) {
+	r, err := u.SafeQuo(u2)
+	if err != nil {
+		panic(err)
+	}
+	return r
+}
+
+// SafeQuo divides Uint by u2 and returns an error if u2 is zero.
+func (u Uint) SafeQuo(u2 Uint) (Uint, error) {
+	if u2.IsZero() {
+		return Uint{}, errors.New("unsigned integer division by zero")
+	}
+	return Uint{div(u.i, u2.i)}, nil
+}
 
 // Mod returns remainder after dividing with Uint
 // Panics if u2 is zero
 func (u Uint) Mod(u2 Uint) Uint {
-	if u2.IsZero() {
-		panic("division-by-zero")
+	r, err := u.SafeMod(u2)
+	if err != nil {
+		panic(err)
 	}
-	return Uint{mod(u.i, u2.i)}
+	return r
+}
+
+// SafeMod returns the remainder of dividing u by u2, and returns an error if u2 is zero.
+func (u Uint) SafeMod(u2 Uint) (Uint, error) {
+	if u2.IsZero() {
+		return Uint{}, errors.New("unsigned integer division by zero")
+	}
+	return Uint{mod(u.i, u2.i)}, nil
 }
 
 // Incr increments the Uint by one.

--- a/math/uint_safe_ops_test.go
+++ b/math/uint_safe_ops_test.go
@@ -1,0 +1,330 @@
+package math_test
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	sdkmath "cosmossdk.io/math"
+)
+
+func TestUintSafeAdd(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		a, b    sdkmath.Uint
+		want    sdkmath.Uint
+		wantErr bool
+	}{
+		{
+			name: "zero plus zero",
+			a:    sdkmath.ZeroUint(),
+			b:    sdkmath.ZeroUint(),
+			want: sdkmath.ZeroUint(),
+		},
+		{
+			name: "zero plus one",
+			a:    sdkmath.ZeroUint(),
+			b:    sdkmath.OneUint(),
+			want: sdkmath.OneUint(),
+		},
+		{
+			name: "normal addition",
+			a:    sdkmath.NewUint(100),
+			b:    sdkmath.NewUint(200),
+			want: sdkmath.NewUint(300),
+		},
+		{
+			name: "large values",
+			a:    sdkmath.NewUint(1<<63 - 1),
+			b:    sdkmath.NewUint(1<<63 - 1),
+			want: sdkmath.NewUintFromBigInt(new(big.Int).Add(new(big.Int).SetUint64(1<<63-1), new(big.Int).SetUint64(1<<63-1))),
+		},
+		{
+			name:    "overflow beyond 256 bits",
+			a:       sdkmath.NewUintFromBigInt(new(big.Int).Sub(new(big.Int).Exp(big.NewInt(2), big.NewInt(256), nil), big.NewInt(1))),
+			b:       sdkmath.OneUint(),
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			res, err := tc.a.SafeAdd(tc.b)
+			if tc.wantErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "overflow")
+			} else {
+				require.NoError(t, err)
+				require.True(t, res.Equal(tc.want), "expected %s, got %s", tc.want, res)
+			}
+		})
+	}
+}
+
+func TestUintSafeSub(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		a, b    sdkmath.Uint
+		want    sdkmath.Uint
+		wantErr bool
+	}{
+		{
+			name: "zero minus zero",
+			a:    sdkmath.ZeroUint(),
+			b:    sdkmath.ZeroUint(),
+			want: sdkmath.ZeroUint(),
+		},
+		{
+			name: "normal subtraction",
+			a:    sdkmath.NewUint(500),
+			b:    sdkmath.NewUint(200),
+			want: sdkmath.NewUint(300),
+		},
+		{
+			name:    "underflow",
+			a:       sdkmath.NewUint(5),
+			b:       sdkmath.NewUint(10),
+			wantErr: true,
+		},
+		{
+			name:    "zero minus one",
+			a:       sdkmath.ZeroUint(),
+			b:       sdkmath.OneUint(),
+			wantErr: true,
+		},
+		{
+			name: "equal values",
+			a:    sdkmath.NewUint(42),
+			b:    sdkmath.NewUint(42),
+			want: sdkmath.ZeroUint(),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			res, err := tc.a.SafeSub(tc.b)
+			if tc.wantErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "underflow")
+			} else {
+				require.NoError(t, err)
+				require.True(t, res.Equal(tc.want), "expected %s, got %s", tc.want, res)
+			}
+		})
+	}
+}
+
+func TestUintSafeMul(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		a, b    sdkmath.Uint
+		want    sdkmath.Uint
+		wantErr bool
+	}{
+		{
+			name: "zero times anything",
+			a:    sdkmath.ZeroUint(),
+			b:    sdkmath.NewUint(999),
+			want: sdkmath.ZeroUint(),
+		},
+		{
+			name: "one times value",
+			a:    sdkmath.OneUint(),
+			b:    sdkmath.NewUint(12345),
+			want: sdkmath.NewUint(12345),
+		},
+		{
+			name: "normal multiplication",
+			a:    sdkmath.NewUint(100),
+			b:    sdkmath.NewUint(200),
+			want: sdkmath.NewUint(20000),
+		},
+		{
+			name:    "overflow beyond 256 bits",
+			a:       sdkmath.NewUintFromBigInt(new(big.Int).Exp(big.NewInt(2), big.NewInt(200), nil)),
+			b:       sdkmath.NewUintFromBigInt(new(big.Int).Exp(big.NewInt(2), big.NewInt(200), nil)),
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			res, err := tc.a.SafeMul(tc.b)
+			if tc.wantErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "overflow")
+			} else {
+				require.NoError(t, err)
+				require.True(t, res.Equal(tc.want), "expected %s, got %s", tc.want, res)
+			}
+		})
+	}
+}
+
+func TestUintSafeQuo(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		a, b    sdkmath.Uint
+		want    sdkmath.Uint
+		wantErr bool
+	}{
+		{
+			name:    "division by zero",
+			a:       sdkmath.NewUint(100),
+			b:       sdkmath.ZeroUint(),
+			wantErr: true,
+		},
+		{
+			name: "normal division",
+			a:    sdkmath.NewUint(100),
+			b:    sdkmath.NewUint(3),
+			want: sdkmath.NewUint(33),
+		},
+		{
+			name: "exact division",
+			a:    sdkmath.NewUint(100),
+			b:    sdkmath.NewUint(10),
+			want: sdkmath.NewUint(10),
+		},
+		{
+			name: "zero divided by non-zero",
+			a:    sdkmath.ZeroUint(),
+			b:    sdkmath.NewUint(5),
+			want: sdkmath.ZeroUint(),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			res, err := tc.a.SafeQuo(tc.b)
+			if tc.wantErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "division by zero")
+			} else {
+				require.NoError(t, err)
+				require.True(t, res.Equal(tc.want), "expected %s, got %s", tc.want, res)
+			}
+		})
+	}
+}
+
+func TestUintSafeMod(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		a, b    sdkmath.Uint
+		want    sdkmath.Uint
+		wantErr bool
+	}{
+		{
+			name:    "mod by zero",
+			a:       sdkmath.NewUint(100),
+			b:       sdkmath.ZeroUint(),
+			wantErr: true,
+		},
+		{
+			name: "normal mod",
+			a:    sdkmath.NewUint(10),
+			b:    sdkmath.NewUint(3),
+			want: sdkmath.OneUint(),
+		},
+		{
+			name: "exact divisor",
+			a:    sdkmath.NewUint(10),
+			b:    sdkmath.NewUint(5),
+			want: sdkmath.ZeroUint(),
+		},
+		{
+			name: "mod of zero",
+			a:    sdkmath.ZeroUint(),
+			b:    sdkmath.NewUint(7),
+			want: sdkmath.ZeroUint(),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			res, err := tc.a.SafeMod(tc.b)
+			if tc.wantErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "division by zero")
+			} else {
+				require.NoError(t, err)
+				require.True(t, res.Equal(tc.want), "expected %s, got %s", tc.want, res)
+			}
+		})
+	}
+}
+
+// TestUintSafeMethodsDoNotMutate verifies that safe methods do not mutate the receiver.
+func TestUintSafeMethodsDoNotMutate(t *testing.T) {
+	t.Parallel()
+
+	original := sdkmath.NewUint(100)
+	other := sdkmath.NewUint(50)
+
+	// Store original value
+	origVal := original.Uint64()
+
+	_, _ = original.SafeAdd(other)
+	require.Equal(t, origVal, original.Uint64(), "SafeAdd mutated receiver")
+
+	_, _ = original.SafeSub(other)
+	require.Equal(t, origVal, original.Uint64(), "SafeSub mutated receiver")
+
+	_, _ = original.SafeMul(other)
+	require.Equal(t, origVal, original.Uint64(), "SafeMul mutated receiver")
+
+	_, _ = original.SafeQuo(other)
+	require.Equal(t, origVal, original.Uint64(), "SafeQuo mutated receiver")
+
+	_, _ = original.SafeMod(other)
+	require.Equal(t, origVal, original.Uint64(), "SafeMod mutated receiver")
+}
+
+// TestUintAddPanicsOnOverflow ensures Add still panics on overflow (backwards compat).
+func TestUintAddPanicsOnOverflow(t *testing.T) {
+	t.Parallel()
+	uintMax := sdkmath.NewUintFromBigInt(new(big.Int).Sub(new(big.Int).Exp(big.NewInt(2), big.NewInt(256), nil), big.NewInt(1)))
+	require.Panics(t, func() { uintMax.Add(sdkmath.OneUint()) })
+}
+
+// TestUintSubPanicsOnUnderflow ensures Sub still panics on underflow (backwards compat).
+func TestUintSubPanicsOnUnderflow(t *testing.T) {
+	t.Parallel()
+	require.Panics(t, func() { sdkmath.ZeroUint().Sub(sdkmath.OneUint()) })
+}
+
+// TestUintMulPanicsOnOverflow ensures Mul still panics on overflow (backwards compat).
+func TestUintMulPanicsOnOverflow(t *testing.T) {
+	t.Parallel()
+	large := sdkmath.NewUintFromBigInt(new(big.Int).Exp(big.NewInt(2), big.NewInt(200), nil))
+	require.Panics(t, func() { large.Mul(large) })
+}
+
+// TestUintQuoPanicsOnDivByZero ensures Quo still panics on div-by-zero (backwards compat).
+func TestUintQuoPanicsOnDivByZero(t *testing.T) {
+	t.Parallel()
+	require.Panics(t, func() { sdkmath.OneUint().Quo(sdkmath.ZeroUint()) })
+}
+
+// TestUintModPanicsOnDivByZero ensures Mod still panics on div-by-zero (backwards compat).
+func TestUintModPanicsOnDivByZero(t *testing.T) {
+	t.Parallel()
+	require.Panics(t, func() { sdkmath.OneUint().Mod(sdkmath.ZeroUint()) })
+}

--- a/x/feegrant/keeper/keeper.go
+++ b/x/feegrant/keeper/keeper.go
@@ -10,10 +10,8 @@ import (
 	"cosmossdk.io/core/store"
 	errorsmod "cosmossdk.io/errors"
 	"cosmossdk.io/log/v2"
-	storetypes "cosmossdk.io/store/types"
 
 	"github.com/cosmos/cosmos-sdk/codec"
-	"github.com/cosmos/cosmos-sdk/runtime"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/cosmos-sdk/x/auth/ante"
@@ -214,10 +212,6 @@ func (k Keeper) getGrant(ctx context.Context, granter, grantee sdk.AccAddress) (
 // Callback to get all data, returns true to stop, false to keep reading
 // Calling this without pagination is very expensive and only designed for export genesis
 func (k Keeper) IterateAllFeeAllowances(ctx context.Context, cb func(grant feegrant.Grant) bool) error {
-	store := k.storeService.OpenKVStore(ctx)
-	iter := storetypes.KVStorePrefixIterator(runtime.KVStoreAdapter(store), feegrant.FeeAllowanceKeyPrefix)
-	defer iter.Close()
-
 	err := k.FeeAllowance.Walk(ctx, nil, func(key collections.Pair[sdk.AccAddress, sdk.AccAddress], grant feegrant.Grant) (stop bool, err error) {
 		return cb(grant), nil
 	})

--- a/x/feegrant/keeper/msg_server.go
+++ b/x/feegrant/keeper/msg_server.go
@@ -66,7 +66,7 @@ func (k msgServer) GrantAllowance(goCtx context.Context, msg *feegrant.MsgGrantA
 
 // RevokeAllowance revokes a fee allowance between a granter and grantee.
 func (k msgServer) RevokeAllowance(goCtx context.Context, msg *feegrant.MsgRevokeAllowance) (*feegrant.MsgRevokeAllowanceResponse, error) {
-	if msg.Grantee == msg.Granter {
+	if strings.EqualFold(msg.Grantee, msg.Granter) {
 		return nil, errorsmod.Wrap(sdkerrors.ErrInvalidAddress, "addresses must be different")
 	}
 


### PR DESCRIPTION
Add SafeAdd, SafeSub, SafeMul, SafeQuo, SafeMod methods to math.Uint that return errors instead of panicking on overflow/underflow/division-by-zero, matching the existing pattern from math.Int (SafeAdd, SafeSub, SafeMul, etc.).

Refactor existing panicking methods (Add, Sub, Mul, Quo, Mod) to delegate to the safe variants for consistency and to reduce code duplication.

Also fixes:
- x/feegrant: Remove dead code in IterateAllFeeAllowances (unused KVStore iterator that was opened but never used alongside the collections.Walk)
- x/feegrant: Use strings.EqualFold in RevokeAllowance for consistent case-insensitive self-grant check (matching GrantAllowance behavior)

Includes comprehensive test coverage for all new safe methods.

# Description

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->
