### PR TITLE
chore!: refactor EventManagerI to remove interface

### DIFF
--- a/runtime/events.go
+++ b/runtime/events.go
@@ -24,7 +24,7 @@ func (es EventService) EventManager(ctx context.Context) event.Manager {
 var _ event.Manager = (*Events)(nil)
 
 type Events struct {
-	sdk.EventManagerI
+	*sdk.EventManager
 }
 
 func NewEventManager(ctx context.Context) event.Manager {

--- a/types/context.go
+++ b/types/context.go
@@ -58,7 +58,7 @@ type Context struct {
 	execMode             ExecMode
 	minGasPrice          DecCoins
 	consParams           cmtproto.ConsensusParams
-	eventManager         EventManagerI
+	eventManager         *EventManager
 	priority             int64 // The tx priority, only relevant in CheckTx
 	kvGasConfig          storetypes.GasConfig
 	transientKVGasConfig storetypes.GasConfig
@@ -101,7 +101,7 @@ func (c Context) IsReCheckTx() bool                             { return c.reche
 func (c Context) IsSigverifyTx() bool                           { return c.sigverifyTx }
 func (c Context) ExecMode() ExecMode                            { return c.execMode }
 func (c Context) MinGasPrices() DecCoins                        { return c.minGasPrice }
-func (c Context) EventManager() EventManagerI                   { return c.eventManager }
+func (c Context) EventManager() *EventManager                   { return c.eventManager }
 func (c Context) Priority() int64                               { return c.priority }
 func (c Context) KVGasConfig() storetypes.GasConfig             { return c.kvGasConfig }
 func (c Context) TransientKVGasConfig() storetypes.GasConfig    { return c.transientKVGasConfig }
@@ -309,7 +309,7 @@ func (c Context) WithConsensusParams(params cmtproto.ConsensusParams) Context {
 }
 
 // WithEventManager returns a Context with an updated event manager
-func (c Context) WithEventManager(em EventManagerI) Context {
+func (c Context) WithEventManager(em *EventManager) Context {
 	c.eventManager = em
 	return c
 }

--- a/types/events.go
+++ b/types/events.go
@@ -15,21 +15,9 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 )
 
-type EventManagerI interface {
-	Events() Events
-	ABCIEvents() []abci.Event
-	EmitTypedEvent(tev proto.Message) error
-	EmitTypedEvents(tevs ...proto.Message) error
-	EmitEvent(event Event)
-	EmitEvents(events Events)
-	OverrideEvents(events Events)
-}
-
 // ----------------------------------------------------------------------------
 // Event Manager
 // ----------------------------------------------------------------------------
-
-var _ EventManagerI = (*EventManager)(nil)
 
 // EventManager implements a simple wrapper around a slice of Event objects that
 // can be emitted from.


### PR DESCRIPTION
The interface is unused, and causes breaking changes whenever we want to modify the methods. The regular EventManager object is used across most of the SDK, and overriding the default implementation is not trivial, as the context holds a pointer to the object, which gets initialized in RunTx: https://github.com/cosmos/cosmos-sdk/blob/c69f963352fe0ee5b690cdfd354a6a395b18cb5d/baseapp/baseapp.go#L902

Replacing EventManagerI up the tx execution stack is not trivial, so we should just remove this, as it makes maintaining the existing object much easier.

Closes: STACK-2305