### PR TITLE
fix: cosmovisor: wrong check for upgrade height

### DIFF
--- a/tools/cosmovisor/scanner.go
+++ b/tools/cosmovisor/scanner.go
@@ -164,7 +164,7 @@ func (fw *fileWatcher) CheckUpdate(currentUpgrade upgradetypes.Plan) bool {
 
 	// file exist but too early in height
 	currentHeight, err := fw.checkHeight()
-	if (err != nil || currentHeight < info.Height) && !errors.Is(err, errUntestAble) { // ignore this check for tests
+	if (err != nil || currentHeight < info.Height-1) && !errors.Is(err, errUntestAble) { // ignore this check for tests
 		return false
 	}
 


### PR DESCRIPTION
## Summary

cosmovisor: wrong check for upgrade height — modified `tools/cosmovisor/scanner.go`.

Fixes #26091

## Changes

- tools/cosmovisor/scanner.go (1 modified)

## Rationale

Applied fix for cosmovisor: wrong check for upgrade height in `scanner.go`, where the affected behavior originates.

cted behavior originates.

