### PR TITLE
chore: set txs for block query limit to num of txs in block

### DIFF
--- a/tests/e2e/tx/service_test.go
+++ b/tests/e2e/tx/service_test.go
@@ -742,8 +742,10 @@ func (s *E2ETestSuite) TestGetBlockWithTxs_LimitCappedToBlockTxCount() {
 		Pagination: &query.PageRequest{Offset: 0, Limit: 50_000_000},
 	})
 	s.Require().NoError(err)
-	s.Require().Len(grpcRes.Txs, 1)
-	s.Require().Equal(uint64(1), grpcRes.Pagination.Total)
+	// The block has 2 txs; the limit should be capped to the block's tx count
+	// rather than query.DefaultLimit.
+	s.Require().Len(grpcRes.Txs, 2)
+	s.Require().Equal(uint64(2), grpcRes.Pagination.Total)
 }
 
 func (s *E2ETestSuite) TestGetBlockWithTxs_GRPCGateway() {

--- a/tests/e2e/tx/service_test.go
+++ b/tests/e2e/tx/service_test.go
@@ -733,6 +733,19 @@ func (s *E2ETestSuite) TestGetBlockWithTxs_GRPC() {
 	}
 }
 
+func (s *E2ETestSuite) TestGetBlockWithTxs_LimitCappedToBlockTxCount() {
+	// When the requested limit exceeds the number of txs in the block,
+	// the response should contain exactly the block's tx count, not be
+	// capped at query.DefaultLimit.
+	grpcRes, err := s.queryClient.GetBlockWithTxs(context.Background(), &tx.GetBlockWithTxsRequest{
+		Height:     s.txHeight,
+		Pagination: &query.PageRequest{Offset: 0, Limit: 50_000_000},
+	})
+	s.Require().NoError(err)
+	s.Require().Len(grpcRes.Txs, 1)
+	s.Require().Equal(uint64(1), grpcRes.Pagination.Total)
+}
+
 func (s *E2ETestSuite) TestGetBlockWithTxs_GRPCGateway() {
 	val := s.network.Validators[0]
 	testCases := []struct {

--- a/x/auth/tx/service.go
+++ b/x/auth/tx/service.go
@@ -173,13 +173,13 @@ func (s txServer) GetBlockWithTxs(ctx context.Context, req *txtypes.GetBlockWith
 		limit = query.DefaultLimit
 	}
 
-	// if the custom limit is greater than the default limit, adjust it back down
-	if limit > query.DefaultLimit {
-		limit = query.DefaultLimit
-	}
-
 	blockTxs := block.Data.Txs
 	blockTxsLn := uint64(len(blockTxs))
+
+	if limit > blockTxsLn {
+		limit = blockTxsLn
+	}
+
 	txs := make([]*txtypes.Tx, 0, limit)
 	if offset >= blockTxsLn && blockTxsLn != 0 {
 		return nil, sdkerrors.ErrInvalidRequest.Wrapf("out of range: cannot paginate %d txs with offset %d and limit %d", blockTxsLn, offset, limit)


### PR DESCRIPTION
Set to number of txs in block instead of arbitrary amount