### PR TITLE
simulation: guard against nil simState in GenerateGenesisStates

### DIFF
--- a/types/module/simulation.go
+++ b/types/module/simulation.go
@@ -124,6 +124,9 @@ func (sm *SimulationManager) RegisterStoreDecoders() {
 // GenerateGenesisStates generates a randomized GenesisState for each of the
 // registered modules
 func (sm *SimulationManager) GenerateGenesisStates(simState *SimulationState) {
+	if simState == nil {
+		return
+	}
 	for _, module := range sm.Modules {
 		module.GenerateGenesisState(simState)
 	}


### PR DESCRIPTION
**Summary**:

Adds a defensive nil check for simState in GenerateGenesisStates to prevent potential nil dereference during simulation.


---


**Context**:

GenerateGenesisStates assumes a non-nil simState, but under certain edge cases (e.g. misconfigured or partial simulation setup), this value may be nil, leading to a panic.

This change ensures the function exits safely when simState is not initialized.


---


**Changes**:

	•	Added early return if simState == nil in GenerateGenesisStates

Scope
	•	Limited to simulation code (types/module/simulation.go)
	•	No impact on consensus or production logic


---


**Rationale**:

This is a defensive safeguard to improve robustness of simulation tooling and prevent unexpected crashes.

---


**Risk**:

Low:
	•	No existing behavior is modified when simState is valid
	•	Only affects edge cases where simState is nil

---



**Validation**:
	•	Code compiles successfully
	•	Change is isolated and does not affect core execution paths