### PR TITLE
module: improve cosmossdk.io/client/v2 v2.11.0 uses old

### DIFF
--- a/types/module/module.go
+++ b/types/module/module.go
@@ -736,7 +736,15 @@ func (m Manager) RunMigrations(ctx context.Context, cfg Configurator, fromVM Ver
 			}
 		} else {
 			sdkCtx.Logger().Info(fmt.Sprintf("adding a new module: %s", moduleName))
-			if module, ok := m.Modules[moduleName].(HasGenesis); ok {
+			if module, ok := m.Modules[moduleName].(appmodule.HasGenesis); ok {
+				source, err := genesis.SourceFromRawJSON(module.(HasGenesisBasics).DefaultGenesis(c.cdc))
+				if err != nil {
+					return nil, err
+				}
+				if err := module.InitGenesis(sdkCtx, source); err != nil {
+					return nil, err
+				}
+			} else if module, ok := m.Modules[moduleName].(HasGenesis); ok {
 				module.InitGenesis(sdkCtx, c.cdc, module.DefaultGenesis(c.cdc))
 			}
 			if module, ok := m.Modules[moduleName].(HasABCIGenesis); ok {


### PR DESCRIPTION
## Summary

cosmossdk.io/client/v2 v2.11.0 uses old "github.com/cosmos/cosmos-sdk/x/tx" import. — modified `types/module/module.go`.

Refs #26295

## Changes

- types/module/module.go (+9, -1)

## Rationale

Applied fix for cosmossdk.io/client/v2 v2.11.0 uses old "github.com/cosmos/cosmos-sdk/x/tx" impo in `module.go`, where the affected behavior originates.

## Scope

1 file(s) modified. Changes isolated to listed files.

## Risk

limited to types/module/module.go.

## Validation

Basic lint and formatting checks passed.