### PR TITLE
fix(cosmovisor): fix cosmovisor: wrong check for upgrade height

### DIFF
--- a/tools/cosmovisor/scanner.go
+++ b/tools/cosmovisor/scanner.go
@@ -164,6 +164,9 @@ func (fw *fileWatcher) CheckUpdate(currentUpgrade upgradetypes.Plan) bool {
 
 	// file exist but too early in height
 	currentHeight, err := fw.checkHeight()
+	if err != nil && !errors.Is(err, errUntestAble) {
+		panic(fmt.Errorf("failed to check current block height: %w", err))
+	}
 	if (err != nil || currentHeight < info.Height) && !errors.Is(err, errUntestAble) { // ignore this check for tests
 		return false
 	}


### PR DESCRIPTION
## Summary

cosmovisor: wrong check for upgrade height — modified `tools/cosmovisor/scanner.go`.

Refs #26091

## Changes

- tools/cosmovisor/scanner.go (+3)

## Rationale

Applied fix for cosmovisor: wrong check for upgrade height in `scanner.go`, where the affected behavior originates.

## Scope

1 file(s) modified. Changes isolated to listed files.

## Risk

limited to tools/cosmovisor/scanner.go.

## Validation

Basic lint and formatting checks passed.