### PR TITLE
fix: avoid removing entire file when license footer is missing

### DIFF
--- a/enterprise/scripts/add-license.sh
+++ b/enterprise/scripts/add-license.sh
@@ -47,7 +47,11 @@ remove_license_headers() {
 
     # Remove all lines from any occurrence of "IMPORTANT LICENSE NOTICE"
     # through "Copyright (c) 2026 Cosmos Labs US Inc."
-    sed '/\/\/ IMPORTANT LICENSE NOTICE/,/\/\/ Copyright (c) 2026 Cosmos Labs US Inc\./d' "$file" > "$tmpfile"
+    if grep -qF "// Copyright (c) 2026 Cosmos Labs US Inc." "$file"; then
+        sed '/\/\/ IMPORTANT LICENSE NOTICE/,/\/\/ Copyright (c) 2026 Cosmos Labs US Inc\./d' "$file" > "$tmpfile"
+    else
+        cp "$file" "$tmpfile"
+    fi
 
     # Remove any blank lines at the start of file
     sed -i.bak '1{/^$/d;}' "$tmpfile"


### PR DESCRIPTION
sed range deletion silently truncates files to EOF when the closing copyright marker is absent. Add a grep guard so the range is only applied when both markers are confirmed present; otherwise the file is copied as-is.