### PR TITLE
fix(x/gov): remove leading comma in proposal_messages event attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Bug Fixes
 
+* (x/gov) [#26352](https://github.com/cosmos/cosmos-sdk/pull/26352) Fix leading comma in `proposal_messages` event attribute emitted by `SubmitProposal`.
+
 ### Deprecated
 
 ## [v0.54.2](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.54.2) - 2026-04-15

--- a/x/gov/keeper/proposal.go
+++ b/x/gov/keeper/proposal.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"cosmossdk.io/collections"
@@ -35,13 +36,12 @@ func (k Keeper) SubmitProposal(ctx context.Context, messages []sdk.Msg, metadata
 		return v1.Proposal{}, err
 	}
 
-	// Will hold a comma-separated string of all Msg type URLs.
-	msgsStr := ""
+	msgTypeURLs := make([]string, 0, len(messages))
 
 	// Loop through all messages and confirm that each has a handler and the gov module account
 	// as the only signer
 	for _, msg := range messages {
-		msgsStr += fmt.Sprintf(",%s", sdk.MsgTypeURL(msg))
+		msgTypeURLs = append(msgTypeURLs, sdk.MsgTypeURL(msg))
 
 		// perform a basic validation of the message
 		if m, ok := msg.(sdk.HasValidateBasic); ok {
@@ -124,7 +124,7 @@ func (k Keeper) SubmitProposal(ctx context.Context, messages []sdk.Msg, metadata
 			types.EventTypeSubmitProposal,
 			sdk.NewAttribute(types.AttributeKeyProposalID, fmt.Sprintf("%d", proposalID)),
 			sdk.NewAttribute(types.AttributeKeyProposalProposer, proposer.String()),
-			sdk.NewAttribute(types.AttributeKeyProposalMessages, msgsStr),
+			sdk.NewAttribute(types.AttributeKeyProposalMessages, strings.Join(msgTypeURLs, ",")),
 		),
 	)
 

--- a/x/gov/keeper/proposal_test.go
+++ b/x/gov/keeper/proposal_test.go
@@ -173,6 +173,33 @@ func (suite *KeeperTestSuite) TestSubmitProposal() {
 	}
 }
 
+// TestSubmitProposal_EmitsMessagesWithoutLeadingComma is a regression test for
+// https://github.com/cosmos/cosmos-sdk/issues/26045 — the proposal_messages
+// event attribute previously contained a leading comma because each type URL
+// was prepended with one inside the loop.
+func (suite *KeeperTestSuite) TestSubmitProposal_EmitsMessagesWithoutLeadingComma() {
+	suite.reset()
+
+	govAcct := suite.govKeeper.GetGovernanceAccount(suite.ctx).GetAddress().String()
+	tp := v1beta1.TextProposal{Title: "title", Description: "description"}
+	prop, err := v1.NewLegacyContent(&tp, govAcct)
+	suite.Require().NoError(err)
+
+	msgs := []sdk.Msg{prop, prop}
+	_, err = suite.govKeeper.SubmitProposal(suite.ctx, msgs, "", "title", "summary", suite.addrs[0], false)
+	suite.Require().NoError(err)
+
+	attrs, ok := suite.ctx.EventManager().Events().GetAttributes(types.AttributeKeyProposalMessages)
+	suite.Require().True(ok, "proposal_messages attribute should be emitted")
+	suite.Require().NotEmpty(attrs)
+
+	value := attrs[0].Value
+	suite.Require().False(strings.HasPrefix(value, ","), "proposal_messages must not start with a leading comma, got %q", value)
+
+	expected := strings.Join([]string{sdk.MsgTypeURL(prop), sdk.MsgTypeURL(prop)}, ",")
+	suite.Require().Equal(expected, value)
+}
+
 func (suite *KeeperTestSuite) TestCancelProposal() {
 	govAcct := suite.govKeeper.GetGovernanceAccount(suite.ctx).GetAddress().String()
 	tp := v1beta1.TextProposal{Title: "title", Description: "description"}


### PR DESCRIPTION
# Description

Closes: #26045

The `proposal_messages` event attribute was being built by prepending a comma to each message type URL inside the loop in `x/gov/keeper/proposal.go`:

```go
msgsStr += fmt.Sprintf(",%s", sdk.MsgTypeURL(msg))
```

For a proposal with two messages, this emitted `",/cosmos.bank.v1beta1.MsgSend,/cosmos.staking.v1beta1.MsgDelegate"` instead of `"/cosmos.bank.v1beta1.MsgSend,/cosmos.staking.v1beta1.MsgDelegate"`. The leading comma broke downstream consumers that parse the attribute by splitting on commas (the first element comes back empty).

## Changes

- Replace the manual `msgsStr` accumulator with a `[]string` collected via `append`, then emit the joined value with `strings.Join(msgTypeURLs, ",")`.
- Add `TestSubmitProposal_EmitsMessagesWithoutLeadingComma` regression test that submits a proposal with two messages and asserts the emitted attribute has no leading comma and equals the expected joined value.

I noted the issue thread mentioned checking `CancelProposal` for the same pattern — confirmed it does not emit a `proposal_messages` event (it only logs), so no changes needed there.

A CHANGELOG entry will be added in a follow-up commit once this PR has a number.