### PR TITLE
fix(blockstm): remove double-unlock on panic path in Resume()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Bug Fixes
 
+* (blockstm) [#26355](https://github.com/cosmos/cosmos-sdk/pull/26355) fix(blockstm): remove double-unlock on panic path in `Resume()`.
+
 ### Deprecated
 
 ## [v0.54.2](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.54.2) - 2026-04-15

--- a/internal/blockstm/status.go
+++ b/internal/blockstm/status.go
@@ -103,18 +103,6 @@ func (s *StatusEntry) Resume() {
 		return
 	}
 
-	// status must be SUSPENDED and cond != nil
-	if s.status != StatusSuspended || s.cond == nil {
-		s.Unlock()
-		panic(fmt.Sprintf("invalid resume: status=%v", s.status))
-	}
-
-	// status must be SUSPENDED and cond != nil
-	if s.status != StatusSuspended || s.cond == nil {
-		s.Unlock()
-		panic(fmt.Sprintf("invalid resume: status=%v", s.status))
-	}
-
 	s.status = StatusExecuting
 	s.cond.Notify()
 	s.cond = nil


### PR DESCRIPTION
# Description
remove dead duplicate checks that called `s.Unlock()` before panic
while defer `s.Unlock()` was already set, causing double-unlock
Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->
