### PR TITLE
docs: update cometbft links to v1.x

### DIFF
--- a/docs/architecture/adr-064-abci-2.0.md
+++ b/docs/architecture/adr-064-abci-2.0.md
@@ -401,7 +401,7 @@ in both `BeginBlock` and `EndBlock` events.
 
 ### Upgrading
 
-CometBFT defines a consensus parameter, [`VoteExtensionsEnableHeight`](https://github.com/cometbft/cometbft/blob/v0.38.0-alpha.1/spec/abci/abci%2B%2B_app_requirements.md#abciparamsvoteextensionsenableheight),
+CometBFT defines a consensus parameter, [`VoteExtensionsEnableHeight`](https://github.com/cometbft/cometbft/blob/v1.x/spec/abci/abci%2B%2B_app_requirements.md#featureparamsvoteextensionsenableheight),
 which specifies the height at which vote extensions are enabled and **required**.
 If the value is set to zero, which is the default, then vote extensions are
 disabled and an application is not required to implement and use vote extensions.

--- a/docs/docs/build/abci/03-vote-extensions.md
+++ b/docs/docs/build/abci/03-vote-extensions.md
@@ -18,14 +18,14 @@ An application can set this handler in `app.go` via the `baseapp.SetExtendVoteHa
 `BaseApp` option function. The `sdk.ExtendVoteHandler`, if defined, is called during
 the `ExtendVote` ABCI method. Note, if an application decides to implement
 `baseapp.ExtendVoteHandler`, it MUST return a non-nil `VoteExtension`. However, the vote
-extension can be empty. See [here](https://github.com/cometbft/cometbft/blob/v0.38.0-rc1/spec/abci/abci++_methods.md#extendvote)
+extension can be empty. See [here](https://github.com/cometbft/cometbft/blob/v1.x/spec/abci/abci++_methods.md#extendvote)
 for more details.
 
 There are many decentralized censorship-resistant use cases for vote extensions.
 For example, a validator may want to submit prices for a price oracle or encryption
 shares for an encrypted transaction mempool. Note, an application should be careful
 to consider the size of the vote extensions as they could increase latency in block
-production. See [here](https://github.com/cometbft/cometbft/blob/v0.38.0-rc1/docs/qa/CometBFT-QA-38.md#vote-extensions-testbed)
+production. See [here](https://github.com/cometbft/cometbft/blob/v1.x/docs/references/qa/CometBFT-QA-38.md#vote-extensions-testbed)
 for more details.
 
 Click [here](https://docs.cosmos.network/main/build/abci/vote-extensions) if you would like a walkthrough of how to implement vote extensions.
@@ -46,7 +46,7 @@ An application can set this handler in `app.go` via the `baseapp.SetVerifyVoteEx
 during the `VerifyVoteExtension` ABCI method. If an application defines a vote
 extension handler, it should also define a verification handler. Note, not all
 validators will share the same view of what vote extensions they verify depending
-on how votes are propagated. See [here](https://github.com/cometbft/cometbft/blob/v0.38.0-rc1/spec/abci/abci++_methods.md#verifyvoteextension)
+on how votes are propagated. See [here](https://github.com/cometbft/cometbft/blob/v1.x/spec/abci/abci++_methods.md#verifyvoteextension)
 for more details.
 
 Additionally, please keep in mind that performance can be degraded if vote extensions are too big (https://docs.cometbft.com/v0.38/qa/cometbft-qa-38#vote-extensions-testbed), so we highly recommend a size validation in `ValidateVoteExtensions`.

--- a/docs/docs/build/building-apps/02-app-mempool.md
+++ b/docs/docs/build/building-apps/02-app-mempool.md
@@ -10,7 +10,7 @@ This section describes how the app-side mempool can be used and replaced.
 
 Since `v0.47` the application has its own mempool to allow much more granular
 block building than previous versions. This change was enabled by
-[ABCI 1.0](https://github.com/cometbft/cometbft/blob/v0.37.0/spec/abci).
+[ABCI 1.0](https://github.com/cometbft/cometbft/blob/v1.x/spec/abci).
 Notably it introduces the `PrepareProposal` and `ProcessProposal` steps of ABCI++.
 
 :::note Pre-requisite Readings

--- a/docs/docs/build/building-apps/04-vote-extensions.md
+++ b/docs/docs/build/building-apps/04-vote-extensions.md
@@ -23,14 +23,14 @@ An application can set this handler in `app.go` via the `baseapp.SetExtendVoteHa
 `BaseApp` option function. The `sdk.ExtendVoteHandler`, if defined, is called during
 the `ExtendVote` ABCI method. Note, if an application decides to implement
 `baseapp.ExtendVoteHandler`, it MUST return a non-nil `VoteExtension`. However, the vote
-extension can be empty. See [here](https://github.com/cometbft/cometbft/blob/v0.38.0-rc1/spec/abci/abci++_methods.md#extendvote)
+extension can be empty. See [here](https://github.com/cometbft/cometbft/blob/v1.x/spec/abci/abci++_methods.md#extendvote)
 for more details.
 
 There are many decentralized censorship-resistant use cases for vote extensions.
 For example, a validator may want to submit prices for a price oracle or encryption
 shares for an encrypted transaction mempool. Note, an application should be careful
 to consider the size of the vote extensions as they could increase latency in block
-production. See [here](https://github.com/cometbft/cometbft/blob/v0.38.0-rc1/docs/qa/CometBFT-QA-38.md#vote-extensions-testbed)
+production. See [here](https://github.com/cometbft/cometbft/blob/v1.x/docs/references/qa/CometBFT-QA-38.md#vote-extensions-testbed)
 for more details.
 
 ## Verify Vote Extension
@@ -48,7 +48,7 @@ An application can set this handler in `app.go` via the `baseapp.SetVerifyVoteEx
 during the `VerifyVoteExtension` ABCI method. If an application defines a vote
 extension handler, it should also define a verification handler. Note, not all
 validators will share the same view of what vote extensions they verify depending
-on how votes are propagated. See [here](https://github.com/cometbft/cometbft/blob/v0.38.0-rc1/spec/abci/abci++_methods.md#verifyvoteextension)
+on how votes are propagated. See [here](https://github.com/cometbft/cometbft/blob/v1.x/spec/abci/abci++_methods.md#verifyvoteextension)
 for more details.
 
 ## Vote Extension Propagation

--- a/docs/docs/learn/advanced/00-baseapp.md
+++ b/docs/docs/learn/advanced/00-baseapp.md
@@ -99,7 +99,7 @@ Finally, a few more important parameters:
 * `minGasPrices`: This parameter defines the minimum gas prices accepted by the node. This is a
   **local** parameter, meaning each full-node can set a different `minGasPrices`. It is used in the
   `AnteHandler` during [`CheckTx`](#checktx), mainly as a spam protection mechanism. The transaction
-  enters the [mempool](https://github.com/cometbft/cometbft/blob/v0.37.x/spec/abci/abci++_basic_concepts.md#mempool-methods)
+  enters the [mempool](https://github.com/cometbft/cometbft/blob/v1.x/spec/abci/abci++_basic_concepts.md#mempool-methods)
   only if the gas prices of the transaction are greater than one of the minimum gas price in
   `minGasPrices` (e.g. if `minGasPrices == 1uatom,1photon`, the `gas-price` of the transaction must be
   greater than `1uatom` OR `1photon`).
@@ -230,7 +230,7 @@ Just like the `msgServiceRouter`, the `grpcQueryRouter` is initialized with all 
 
 ## Main ABCI 2.0 Messages
 
-The [Application-Blockchain Interface](https://github.com/cometbft/cometbft/blob/v0.37.x/spec/abci/abci++_basic_concepts.md) (ABCI) is a generic interface that connects a state-machine with a consensus engine to form a functional full-node. It can be wrapped in any language, and needs to be implemented by each application-specific blockchain built on top of an ABCI-compatible consensus engine like CometBFT.
+The [Application-Blockchain Interface](https://github.com/cometbft/cometbft/blob/v1.x/spec/abci/abci++_basic_concepts.md) (ABCI) is a generic interface that connects a state-machine with a consensus engine to form a functional full-node. It can be wrapped in any language, and needs to be implemented by each application-specific blockchain built on top of an ABCI-compatible consensus engine like CometBFT.
 
 The consensus engine handles two main tasks:
 
@@ -264,7 +264,7 @@ Note that, unlike `CheckTx()`, `PrepareProposal` process `sdk.Msg`s, so it can d
 
 It's important to note that `PrepareProposal` complements the `ProcessProposal` method which is executed after this method. The combination of these two methods means that it is possible to guarantee that no invalid transactions are ever committed. Furthermore, such a setup can give rise to other interesting use cases such as Oracles, threshold decryption and more.
 
-`PrepareProposal` returns a response to the underlying consensus engine of type [`abci.ResponsePrepareProposal`](https://github.com/cometbft/cometbft/blob/v0.37.x/spec/abci/abci++_methods.md#processproposal). The response contains:
+`PrepareProposal` returns a response to the underlying consensus engine of type [`abci.ResponsePrepareProposal`](https://github.com/cometbft/cometbft/blob/v1.x/spec/abci/abci++_methods.md#processproposal). The response contains:
 
 *   `Code (uint32)`: Response Code. `0` if successful.
 *   `Data ([]byte)`: Result bytes, if any.
@@ -291,7 +291,7 @@ CometBFT calls it when it receives a proposal and the CometBFT algorithm has not
 
 However, developers must exercise greater caution when using these methods. Incorrectly coding these methods could affect liveness as CometBFT is unable to receive 2/3 valid precommits to finalize a block.
 
-`ProcessProposal` returns a response to the underlying consensus engine of type [`abci.ResponseProcessProposal`](https://github.com/cometbft/cometbft/blob/v0.37.x/spec/abci/abci++_methods.md#processproposal). The response contains:
+`ProcessProposal` returns a response to the underlying consensus engine of type [`abci.ResponseProcessProposal`](https://github.com/cometbft/cometbft/blob/v1.x/spec/abci/abci++_methods.md#processproposal). The response contains:
 
 *   `Code (uint32)`: Response Code. `0` if successful.
 *   `Data ([]byte)`: Result bytes, if any.
@@ -338,7 +338,7 @@ be rejected. In any case, the sender's account will not actually pay the fees un
 is actually included in a block, because `checkState` never gets committed to the main state. The
 `checkState` is reset to the latest state of the main state each time a blocks gets [committed](#commit).
 
-`CheckTx` returns a response to the underlying consensus engine of type [`abci.ResponseCheckTx`](https://github.com/cometbft/cometbft/blob/v0.37.x/spec/abci/abci++_methods.md#checktx).
+`CheckTx` returns a response to the underlying consensus engine of type [`abci.ResponseCheckTx`](https://github.com/cometbft/cometbft/blob/v1.x/spec/abci/abci++_methods.md#checktx).
 The response contains:
 
 * `Code (uint32)`: Response Code. `0` if successful.
@@ -426,9 +426,9 @@ Note, when `PostHandler`s fail, the state from `runMsgs` is also reverted, effec
 
 ### InitChain
 
-The [`InitChain` ABCI message](https://github.com/cometbft/cometbft/blob/v0.37.x/spec/abci/abci++_basic_concepts.md#method-overview) is sent from the underlying CometBFT engine when the chain is first started. It is mainly used to **initialize** parameters and state like:
+The [`InitChain` ABCI message](https://github.com/cometbft/cometbft/blob/v1.x/spec/abci/abci++_basic_concepts.md#method-overview) is sent from the underlying CometBFT engine when the chain is first started. It is mainly used to **initialize** parameters and state like:
 
-* [Consensus Parameters](https://github.com/cometbft/cometbft/blob/v0.37.x/spec/abci/abci++_app_requirements.md#consensus-parameters) via `setConsensusParams`.
+* [Consensus Parameters](https://github.com/cometbft/cometbft/blob/v1.x/spec/abci/abci++_app_requirements.md#consensus-parameters) via `setConsensusParams`.
 * [`checkState` and `finalizeBlockState`](#state-updates) via `setState`.
 * The [block gas meter](../beginner/04-gas-fees.md#block-gas-meter), with infinite gas to process genesis transactions.
 
@@ -437,7 +437,7 @@ Finally, the `InitChain(req abci.RequestInitChain)` method of `BaseApp` calls th
 
 ### FinalizeBlock
 
-The [`FinalizeBlock` ABCI message](https://github.com/cometbft/cometbft/blob/v0.38.x/spec/abci/abci++_basic_concepts.md#method-overview) is sent from the underlying CometBFT engine when a block proposal created by the correct proposer is received. The previous `BeginBlock, DeliverTx and Endblock` calls are private methods on the BaseApp struct. In ABCI++, `FinalizeBlock` also returns the `app_hash` in its response, which represents the application state after processing all transactions in the block.
+The [`FinalizeBlock` ABCI message](https://github.com/cometbft/cometbft/blob/v1.x/spec/abci/abci++_basic_concepts.md#method-overview) is sent from the underlying CometBFT engine when a block proposal created by the correct proposer is received. The previous `BeginBlock, DeliverTx and Endblock` calls are private methods on the BaseApp struct. In ABCI++, `FinalizeBlock` also returns the `app_hash` in its response, which represents the application state after processing all transactions in the block.
 
 
 ```go reference 
@@ -460,7 +460,7 @@ https://github.com/cosmos/cosmos-sdk/blob/v0.53.0/baseapp/abci.go#L869
 
 * Initialize the [block gas meter](../beginner/04-gas-fees.md#block-gas-meter) with the `maxGas` limit. The `gas` consumed within the block cannot go above `maxGas`. This parameter is defined in the application's consensus parameters.
 * Run the application's [`beginBlocker()`](../beginner/00-app-anatomy.md#beginblocker-and-endblocker), which mainly runs the [`BeginBlocker()`](../../build/building-modules/06-beginblock-endblock.md#beginblock) method of each of the modules.
-* Set the [`VoteInfos`](https://github.com/cometbft/cometbft/blob/v0.37.x/spec/abci/abci++_methods.md#voteinfo) of the application, i.e. the list of validators whose _precommit_ for the previous block was included by the proposer of the current block. This information is carried into the [`Context`](./02-context.md) so that it can be used during transaction execution and EndBlock.
+* Set the [`VoteInfos`](https://github.com/cometbft/cometbft/blob/v1.x/spec/abci/abci++_methods.md#voteinfo) of the application, i.e. the list of validators whose _precommit_ for the previous block was included by the proposer of the current block. This information is carried into the [`Context`](./02-context.md) so that it can be used during transaction execution and EndBlock.
 
 #### Transaction Execution
 
@@ -485,7 +485,7 @@ https://github.com/cosmos/cosmos-sdk/blob/v0.53.0/store/types/gas.go#L230-L241
 
 At any point, if `GasConsumed > GasWanted`, the function returns with `Code != 0` and the execution fails.
 
-Each transactions returns a response to the underlying consensus engine of type [`abci.ExecTxResult`](https://github.com/cometbft/cometbft/blob/v0.38.0-rc1/spec/abci/abci%2B%2B_methods.md#exectxresult). The response contains:
+Each transactions returns a response to the underlying consensus engine of type [`abci.ExecTxResult`](https://github.com/cometbft/cometbft/blob/v1.x/spec/abci/abci%2B%2B_methods.md#exectxresult). The response contains:
 
 * `Code (uint32)`: Response Code. `0` if successful.
 * `Data ([]byte)`: Result bytes, if any.
@@ -508,7 +508,7 @@ At the end of `FinalizeBlock`, the application returns a `ResponseFinalizeBlock`
 
 ### Commit
 
-The [`Commit` ABCI message](https://github.com/cometbft/cometbft/blob/v0.37.x/spec/abci/abci++_basic_concepts.md#method-overview) is sent from the underlying CometBFT engine after the full-node has received _precommits_ from 2/3+ of validators (weighted by voting power). On the `BaseApp` end, the `Commit(res abci.ResponseCommit)` function is implemented to commit all the valid state transitions that occurred during `FinalizeBlock` and to reset state for the next block.
+The [`Commit` ABCI message](https://github.com/cometbft/cometbft/blob/v1.x/spec/abci/abci++_basic_concepts.md#method-overview) is sent from the underlying CometBFT engine after the full-node has received _precommits_ from 2/3+ of validators (weighted by voting power). On the `BaseApp` end, the `Commit(res abci.ResponseCommit)` function is implemented to commit all the valid state transitions that occurred during `FinalizeBlock` and to reset state for the next block.
 
 To commit state-transitions, the `Commit` function calls the `Write()` function on `finalizeBlockState.ms`, where `finalizeBlockState.ms` is a branched multistore of the main store `app.cms`. Then, the `Commit` function sets `checkState` to the latest header (obtained from `finalizeBlockState.ctx.BlockHeader`) and `finalizeBlockState` to `nil`.
 
@@ -516,11 +516,11 @@ Finally, the `app_hash` that was returned in `ResponseFinalizeBlock` is now used
 
 ### Info
 
-The [`Info` ABCI message](https://github.com/cometbft/cometbft/blob/v0.37.x/spec/abci/abci++_basic_concepts.md#info-methods) is a simple query from the underlying consensus engine, notably used to sync the latter with the application during a handshake that happens on startup. When called, the `Info(res abci.ResponseInfo)` function from `BaseApp` will return the application's name, version and the hash of the last commit of `app.cms`.
+The [`Info` ABCI message](https://github.com/cometbft/cometbft/blob/v1.x/spec/abci/abci++_basic_concepts.md#info-methods) is a simple query from the underlying consensus engine, notably used to sync the latter with the application during a handshake that happens on startup. When called, the `Info(res abci.ResponseInfo)` function from `BaseApp` will return the application's name, version and the hash of the last commit of `app.cms`.
 
 ### Query
 
-The [`Query` ABCI message](https://github.com/cometbft/cometbft/blob/v0.37.x/spec/abci/abci++_basic_concepts.md#info-methods) is used to serve queries received from the underlying consensus engine, including queries received via RPC like CometBFT RPC. It used to be the main entrypoint to build interfaces with the application, but with the introduction of [gRPC queries](../../build/building-modules/04-query-services.md) in Cosmos SDK v0.40, its usage is more limited. The application must respect a few rules when implementing the `Query` method, which are outlined [here](https://github.com/cometbft/cometbft/blob/v0.37.x/spec/abci/abci++_app_requirements.md#query).
+The [`Query` ABCI message](https://github.com/cometbft/cometbft/blob/v1.x/spec/abci/abci++_basic_concepts.md#info-methods) is used to serve queries received from the underlying consensus engine, including queries received via RPC like CometBFT RPC. It used to be the main entrypoint to build interfaces with the application, but with the introduction of [gRPC queries](../../build/building-modules/04-query-services.md) in Cosmos SDK v0.40, its usage is more limited. The application must respect a few rules when implementing the `Query` method, which are outlined [here](https://github.com/cometbft/cometbft/blob/v1.x/spec/abci/abci++_app_requirements.md#query).
 
 Each CometBFT `query` comes with a `path`, which is a `string` which denotes what to query. If the `path` matches a gRPC fully-qualified service method, then `BaseApp` will defer the query to the `grpcQueryRouter` and let it handle it like explained [above](#grpc-query-router). Otherwise, the `path` represents a query that is not (yet) handled by the gRPC router. `BaseApp` splits the `path` string with the `/` delimiter. By convention, the first element of the split string (`split[0]`) contains the category of `query` (`app`, `p2p`, `store` or `custom` ). The `BaseApp` implementation of the `Query(req abci.RequestQuery)` method is a simple dispatcher serving these 4 main categories of queries:
 

--- a/docs/docs/learn/advanced/03-node.md
+++ b/docs/docs/learn/advanced/03-node.md
@@ -32,7 +32,7 @@ https://github.com/cosmos/cosmos-sdk/blob/v0.53.0/types/config.go#L14-L29
 * Prepare and execute the `executor`.
   
 ```go reference
-https://github.com/cometbft/cometbft/blob/v0.37.0/libs/cli/setup.go#L74-L78
+https://github.com/cometbft/cometbft/blob/v1.x/libs/cli/setup.go#L74-L78
 ```
 
 See an example of `main` function from the `simapp` application, the Cosmos SDK's application for demo purposes:
@@ -81,7 +81,7 @@ Then, the instance of `app` is used to instantiate a new CometBFT node:
 https://github.com/cosmos/cosmos-sdk/blob/v0.53.0/server/start.go#L361-L400
 ```
 
-The CometBFT node can be created with `app` because the latter satisfies the [`abci.Application` interface](https://github.com/cometbft/cometbft/blob/v0.37.0/abci/types/application.go#L9-L35) (given that `app` extends [`baseapp`](./00-baseapp.md)). As part of the `node.New` method, CometBFT makes sure that the height of the application (i.e. number of blocks since genesis) is equal to the height of the CometBFT node. The difference between these two heights should always be negative or null. If it is strictly negative, `node.New` will replay blocks until the height of the application reaches the height of the CometBFT node. Finally, if the height of the application is `0`, the CometBFT node will call [`InitChain`](./00-baseapp.md#initchain) on the application to initialize the state from the genesis file.
+The CometBFT node can be created with `app` because the latter satisfies the [`abci.Application` interface](https://github.com/cometbft/cometbft/blob/v1.x/abci/types/application.go#L9-L35) (given that `app` extends [`baseapp`](./00-baseapp.md)). As part of the `node.New` method, CometBFT makes sure that the height of the application (i.e. number of blocks since genesis) is equal to the height of the CometBFT node. The difference between these two heights should always be negative or null. If it is strictly negative, `node.New` will replay blocks until the height of the application reaches the height of the CometBFT node. Finally, if the height of the application is `0`, the CometBFT node will call [`InitChain`](./00-baseapp.md#initchain) on the application to initialize the state from the genesis file.
 
 Once the CometBFT node is instantiated and in sync with the application, the node can be started:
 

--- a/docs/docs/learn/advanced/08-events.md
+++ b/docs/docs/learn/advanced/08-events.md
@@ -20,7 +20,7 @@ Events are implemented in the Cosmos SDK as an alias of the ABCI `Event` type an
 take the form of: `{eventType}.{attributeKey}={attributeValue}`.
 
 ```protobuf reference
-https://github.com/cometbft/cometbft/blob/v0.37.0/proto/tendermint/abci/types.proto#L334-L343
+https://github.com/cometbft/cometbft/blob/v1.x/proto/tendermint/abci/types.proto#L385-L394
 ```
 
 An Event contains:

--- a/docs/spec/_ics/ics-030-signed-messages.md
+++ b/docs/spec/_ics/ics-030-signed-messages.md
@@ -87,7 +87,7 @@ to the Cosmos chain identifier. The user-agent should **refuse** signing if the
 `@chain_id` field does not match the currently active chain! The `@type` field
 must equal the constant `"message"`. The `@type` field corresponds to the type of
 structure the user will be signing in an application. For now, a user is only
-allowed to sign bytes of valid ASCII text ([see here](https://github.com/cometbft/cometbft/blob/v0.37.0/libs/strings/string.go#L35-L64)).
+allowed to sign bytes of valid ASCII text ([see here](https://github.com/cometbft/cometbft/blob/v1.x/internal/strings/string.go#L57-L67)).
 However, this will change and evolve to support additional application-specific
 structures that are human-readable and machine-verifiable ([see Future Adaptations](#future-adaptations)).
 


### PR DESCRIPTION
# Description

Closes: #24717

This PR migrates all cometbft repository links in the docs from the deprecated `v0.37.x` and `v0.38.x` branches (and related pre-release tags) to `v1.x`, the current upstream convention.

PR #24719 was a partial fix that touched only one of the affected files and was closed without merging. This PR completes the migration across every file listed in the issue.

## Files updated (8)

- `docs/docs/learn/advanced/03-node.md`
- `docs/docs/learn/advanced/00-baseapp.md`
- `docs/docs/learn/advanced/08-events.md`
- `docs/spec/_ics/ics-030-signed-messages.md`
- `docs/docs/build/building-apps/02-app-mempool.md`
- `docs/architecture/adr-064-abci-2.0.md`
- `docs/docs/build/abci/03-vote-extensions.md`
- `docs/docs/build/building-apps/04-vote-extensions.md`

## Notes on non-trivial migrations

A handful of links could not be migrated by a pure version-string swap because the upstream content moved or was renamed. Each new target was verified to exist on `v1.x` and to be the semantic equivalent of the original:

- `libs/strings/string.go` was internalized in cometbft v1 (see [`.changelog/v1.0.0/breaking-changes/1485-libs-strings-internalize.md`](https://github.com/cometbft/cometbft/blob/v1.x/.changelog/v1.0.0/breaking-changes/1485-libs-strings-internalize.md)). The link in `ics-030-signed-messages.md` now points at `internal/strings/string.go` with the line range updated to the `IsASCIIText` function.
- `docs/qa/CometBFT-QA-38.md` was relocated to `docs/references/qa/CometBFT-QA-38.md` in `v1.x`. The `#vote-extensions-testbed` anchor still resolves.
- The consensus parameter `ABCIParams.VoteExtensionsEnableHeight` was renamed to `FeatureParams.VoteExtensionsEnableHeight` in cometbft v1. The anchor in `adr-064-abci-2.0.md` was updated to `#featureparamsvoteextensionsenableheight` accordingly.
- The line range in `08-events.md` (`proto/tendermint/abci/types.proto`) was shifted from `L334-L343` to `L385-L394` to match the current location of the `Event` message definition.

No links had to be skipped. Every `cometbft/cometbft/blob/v0.37*` and `cometbft/cometbft/blob/v0.38*` link in the in-scope files has been migrated and the corresponding `v1.x` URL was checked for HTTP 200.

Out-of-scope links (intentionally untouched):

- `https://docs.cometbft.com/v0.38/...` references (e.g. in `03-vote-extensions.md`) — these point at the cometbft docs site, not the `cometbft/cometbft` repo, and the issue is scoped to repo links.

## Scope

Pure URL migration. No prose, formatting, or whitespace changes; no go.mod or version bumps; no code changes.

---

## Author Checklist

I have...

* [x] included the correct type prefix in the PR title (`docs:`)
* [x] confirmed `!` in the type prefix is not needed (no API or client breaking change)
* [x] targeted the correct branch (`main`)
* [x] provided a link to the relevant issue (#24717)
* [x] reviewed "Files changed" and confirmed only URL substitutions are present
* [ ] included the necessary unit and integration tests — N/A, docs-only change
* [ ] added a changelog entry to `CHANGELOG.md` — N/A per `AGENTS.md` ("user-facing or notable changes"); link migration is neither
* [x] updated the relevant documentation
* [ ] confirmed all CI checks have passed — will monitor after open
