### PR TITLE
docs(swagger): regenerate Swagger API spec to match current protos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Improvements
 
+* (docs) [#25918](https://github.com/cosmos/cosmos-sdk/issues/25918) Regenerate Swagger API spec to reflect current proto state, including `authority` field on consensus params and removal of stale module-config definitions.
+
 ### Bug Fixes
 
 ### Deprecated

--- a/client/docs/swagger-ui/swagger.yaml
+++ b/client/docs/swagger-ui/swagger.yaml
@@ -6747,6 +6747,11 @@ paths:
                     description: >-
                       ABCIParams configure functionality specific to the
                       Application Blockchain Interface.
+                  authority:
+                    type: object
+                    properties:
+                      authority:
+                        type: string
               appHash:
                 type: string
                 format: byte
@@ -7197,6 +7202,11 @@ paths:
                     description: >-
                       ABCIParams configure functionality specific to the
                       Application Blockchain Interface.
+                  authority:
+                    type: object
+                    properties:
+                      authority:
+                        type: string
               appHash:
                 type: string
                 format: byte
@@ -11950,6 +11960,11 @@ paths:
                     description: >-
                       ABCIParams configure functionality specific to the
                       Application Blockchain Interface.
+                  authority:
+                    type: object
+                    properties:
+                      authority:
+                        type: string
             description: >-
               QueryParamsResponse defines the response type for querying
               x/consensus parameters.
@@ -30352,485 +30367,6 @@ paths:
       tags:
         - Query
 definitions:
-  cosmos.app.v1alpha1.Config:
-    type: object
-    properties:
-      modules:
-        type: array
-        items:
-          type: object
-          properties:
-            name:
-              type: string
-              description: >-
-                name is the unique name of the module within the app. It should
-                be a name
-
-                that persists between different versions of a module so that
-                modules
-
-                can be smoothly upgraded to new versions.
-
-
-                For example, for the module cosmos.bank.module.v1.Module, we may
-                chose
-
-                to simply name the module "bank" in the app. When we upgrade to
-
-                cosmos.bank.module.v2.Module, the app-specific name "bank" stays
-                the same
-
-                and the framework knows that the v2 module should receive all
-                the same state
-
-                that the v1 module had. Note: modules should provide info on
-                which versions
-
-                they can migrate from in the ModuleDescriptor.can_migrate_from
-                field.
-            config:
-              description: >-
-                config is the config object for the module. Module config
-                messages should
-
-                define a ModuleDescriptor using the
-                cosmos.app.v1alpha1.is_module extension.
-              type: object
-              properties:
-                '@type':
-                  type: string
-                  description: >-
-                    A URL/resource name that uniquely identifies the type of the
-                    serialized
-
-                    protocol buffer message. This string must contain at least
-
-                    one "/" character. The last segment of the URL's path must
-                    represent
-
-                    the fully qualified name of the type (as in
-
-                    `path/google.protobuf.Duration`). The name should be in a
-                    canonical form
-
-                    (e.g., leading "." is not accepted).
-
-
-                    In practice, teams usually precompile into the binary all
-                    types that they
-
-                    expect it to use in the context of Any. However, for URLs
-                    which use the
-
-                    scheme `http`, `https`, or no scheme, one can optionally set
-                    up a type
-
-                    server that maps type URLs to message definitions as
-                    follows:
-
-
-                    * If no scheme is provided, `https` is assumed.
-
-                    * An HTTP GET on the URL must yield a
-                    [google.protobuf.Type][]
-                      value in binary format, or produce an error.
-                    * Applications are allowed to cache lookup results based on
-                    the
-                      URL, or have them precompiled into a binary to avoid any
-                      lookup. Therefore, binary compatibility needs to be preserved
-                      on changes to types. (Use versioned type names to manage
-                      breaking changes.)
-
-                    Note: this functionality is not currently available in the
-                    official
-
-                    protobuf release, and it is not used for type URLs beginning
-                    with
-
-                    type.googleapis.com. As of May 2023, there are no widely
-                    used type server
-
-                    implementations and no plans to implement one.
-
-
-                    Schemes other than `http`, `https` (or the empty scheme)
-                    might be
-
-                    used with implementation specific semantics.
-              additionalProperties: {}
-            golangBindings:
-              type: array
-              items:
-                type: object
-                properties:
-                  interfaceType:
-                    type: string
-                    title: >-
-                      interface_type is the interface type which will be bound
-                      to a specific implementation type
-                  implementation:
-                    type: string
-                    title: >-
-                      implementation is the implementing type which will be
-                      supplied when an input of type interface is requested
-                description: >-
-                  GolangBinding is an explicit interface type to implementing
-                  type binding for dependency injection.
-              description: >-
-                golang_bindings specifies explicit interface to implementation
-                type bindings which
-
-                depinject uses to resolve interface inputs to provider
-                functions.  The scope of this
-
-                field's configuration is module specific.
-          description: ModuleConfig is a module configuration for an app.
-        description: modules are the module configurations for the app.
-      golangBindings:
-        type: array
-        items:
-          type: object
-          properties:
-            interfaceType:
-              type: string
-              title: >-
-                interface_type is the interface type which will be bound to a
-                specific implementation type
-            implementation:
-              type: string
-              title: >-
-                implementation is the implementing type which will be supplied
-                when an input of type interface is requested
-          description: >-
-            GolangBinding is an explicit interface type to implementing type
-            binding for dependency injection.
-        description: >-
-          golang_bindings specifies explicit interface to implementation type
-          bindings which
-
-          depinject uses to resolve interface inputs to provider functions.  The
-          scope of this
-
-          field's configuration is global (not module specific).
-    description: >-
-      Config represents the configuration for a Cosmos SDK ABCI app.
-
-      It is intended that all state machine logic including the version of
-
-      baseapp and tx handlers (and possibly even Tendermint) that an app needs
-
-      can be described in a config object. For compatibility, the framework
-      should
-
-      allow a mixture of declarative and imperative app wiring, however, apps
-
-      that strive for the maximum ease of maintainability should be able to
-      describe
-
-      their state machine with a config object alone.
-  cosmos.app.v1alpha1.GolangBinding:
-    type: object
-    properties:
-      interfaceType:
-        type: string
-        title: >-
-          interface_type is the interface type which will be bound to a specific
-          implementation type
-      implementation:
-        type: string
-        title: >-
-          implementation is the implementing type which will be supplied when an
-          input of type interface is requested
-    description: >-
-      GolangBinding is an explicit interface type to implementing type binding
-      for dependency injection.
-  cosmos.app.v1alpha1.ModuleConfig:
-    type: object
-    properties:
-      name:
-        type: string
-        description: >-
-          name is the unique name of the module within the app. It should be a
-          name
-
-          that persists between different versions of a module so that modules
-
-          can be smoothly upgraded to new versions.
-
-
-          For example, for the module cosmos.bank.module.v1.Module, we may chose
-
-          to simply name the module "bank" in the app. When we upgrade to
-
-          cosmos.bank.module.v2.Module, the app-specific name "bank" stays the
-          same
-
-          and the framework knows that the v2 module should receive all the same
-          state
-
-          that the v1 module had. Note: modules should provide info on which
-          versions
-
-          they can migrate from in the ModuleDescriptor.can_migrate_from field.
-      config:
-        description: >-
-          config is the config object for the module. Module config messages
-          should
-
-          define a ModuleDescriptor using the cosmos.app.v1alpha1.is_module
-          extension.
-        type: object
-        properties:
-          '@type':
-            type: string
-            description: >-
-              A URL/resource name that uniquely identifies the type of the
-              serialized
-
-              protocol buffer message. This string must contain at least
-
-              one "/" character. The last segment of the URL's path must
-              represent
-
-              the fully qualified name of the type (as in
-
-              `path/google.protobuf.Duration`). The name should be in a
-              canonical form
-
-              (e.g., leading "." is not accepted).
-
-
-              In practice, teams usually precompile into the binary all types
-              that they
-
-              expect it to use in the context of Any. However, for URLs which
-              use the
-
-              scheme `http`, `https`, or no scheme, one can optionally set up a
-              type
-
-              server that maps type URLs to message definitions as follows:
-
-
-              * If no scheme is provided, `https` is assumed.
-
-              * An HTTP GET on the URL must yield a [google.protobuf.Type][]
-                value in binary format, or produce an error.
-              * Applications are allowed to cache lookup results based on the
-                URL, or have them precompiled into a binary to avoid any
-                lookup. Therefore, binary compatibility needs to be preserved
-                on changes to types. (Use versioned type names to manage
-                breaking changes.)
-
-              Note: this functionality is not currently available in the
-              official
-
-              protobuf release, and it is not used for type URLs beginning with
-
-              type.googleapis.com. As of May 2023, there are no widely used type
-              server
-
-              implementations and no plans to implement one.
-
-
-              Schemes other than `http`, `https` (or the empty scheme) might be
-
-              used with implementation specific semantics.
-        additionalProperties: {}
-      golangBindings:
-        type: array
-        items:
-          type: object
-          properties:
-            interfaceType:
-              type: string
-              title: >-
-                interface_type is the interface type which will be bound to a
-                specific implementation type
-            implementation:
-              type: string
-              title: >-
-                implementation is the implementing type which will be supplied
-                when an input of type interface is requested
-          description: >-
-            GolangBinding is an explicit interface type to implementing type
-            binding for dependency injection.
-        description: >-
-          golang_bindings specifies explicit interface to implementation type
-          bindings which
-
-          depinject uses to resolve interface inputs to provider functions.  The
-          scope of this
-
-          field's configuration is module specific.
-    description: ModuleConfig is a module configuration for an app.
-  cosmos.app.v1alpha1.QueryConfigResponse:
-    type: object
-    properties:
-      config:
-        description: config is the current app config.
-        type: object
-        properties:
-          modules:
-            type: array
-            items:
-              type: object
-              properties:
-                name:
-                  type: string
-                  description: >-
-                    name is the unique name of the module within the app. It
-                    should be a name
-
-                    that persists between different versions of a module so that
-                    modules
-
-                    can be smoothly upgraded to new versions.
-
-
-                    For example, for the module cosmos.bank.module.v1.Module, we
-                    may chose
-
-                    to simply name the module "bank" in the app. When we upgrade
-                    to
-
-                    cosmos.bank.module.v2.Module, the app-specific name "bank"
-                    stays the same
-
-                    and the framework knows that the v2 module should receive
-                    all the same state
-
-                    that the v1 module had. Note: modules should provide info on
-                    which versions
-
-                    they can migrate from in the
-                    ModuleDescriptor.can_migrate_from field.
-                config:
-                  description: >-
-                    config is the config object for the module. Module config
-                    messages should
-
-                    define a ModuleDescriptor using the
-                    cosmos.app.v1alpha1.is_module extension.
-                  type: object
-                  properties:
-                    '@type':
-                      type: string
-                      description: >-
-                        A URL/resource name that uniquely identifies the type of
-                        the serialized
-
-                        protocol buffer message. This string must contain at
-                        least
-
-                        one "/" character. The last segment of the URL's path
-                        must represent
-
-                        the fully qualified name of the type (as in
-
-                        `path/google.protobuf.Duration`). The name should be in
-                        a canonical form
-
-                        (e.g., leading "." is not accepted).
-
-
-                        In practice, teams usually precompile into the binary
-                        all types that they
-
-                        expect it to use in the context of Any. However, for
-                        URLs which use the
-
-                        scheme `http`, `https`, or no scheme, one can optionally
-                        set up a type
-
-                        server that maps type URLs to message definitions as
-                        follows:
-
-
-                        * If no scheme is provided, `https` is assumed.
-
-                        * An HTTP GET on the URL must yield a
-                        [google.protobuf.Type][]
-                          value in binary format, or produce an error.
-                        * Applications are allowed to cache lookup results based
-                        on the
-                          URL, or have them precompiled into a binary to avoid any
-                          lookup. Therefore, binary compatibility needs to be preserved
-                          on changes to types. (Use versioned type names to manage
-                          breaking changes.)
-
-                        Note: this functionality is not currently available in
-                        the official
-
-                        protobuf release, and it is not used for type URLs
-                        beginning with
-
-                        type.googleapis.com. As of May 2023, there are no widely
-                        used type server
-
-                        implementations and no plans to implement one.
-
-
-                        Schemes other than `http`, `https` (or the empty scheme)
-                        might be
-
-                        used with implementation specific semantics.
-                  additionalProperties: {}
-                golangBindings:
-                  type: array
-                  items:
-                    type: object
-                    properties:
-                      interfaceType:
-                        type: string
-                        title: >-
-                          interface_type is the interface type which will be
-                          bound to a specific implementation type
-                      implementation:
-                        type: string
-                        title: >-
-                          implementation is the implementing type which will be
-                          supplied when an input of type interface is requested
-                    description: >-
-                      GolangBinding is an explicit interface type to
-                      implementing type binding for dependency injection.
-                  description: >-
-                    golang_bindings specifies explicit interface to
-                    implementation type bindings which
-
-                    depinject uses to resolve interface inputs to provider
-                    functions.  The scope of this
-
-                    field's configuration is module specific.
-              description: ModuleConfig is a module configuration for an app.
-            description: modules are the module configurations for the app.
-          golangBindings:
-            type: array
-            items:
-              type: object
-              properties:
-                interfaceType:
-                  type: string
-                  title: >-
-                    interface_type is the interface type which will be bound to
-                    a specific implementation type
-                implementation:
-                  type: string
-                  title: >-
-                    implementation is the implementing type which will be
-                    supplied when an input of type interface is requested
-              description: >-
-                GolangBinding is an explicit interface type to implementing type
-                binding for dependency injection.
-            description: >-
-              golang_bindings specifies explicit interface to implementation
-              type bindings which
-
-              depinject uses to resolve interface inputs to provider functions. 
-              The scope of this
-
-              field's configuration is global (not module specific).
-    description: QueryConfigResponse is the Query/Config response type.
   google.protobuf.Any:
     type: object
     properties:
@@ -36390,6 +35926,11 @@ definitions:
             description: >-
               ABCIParams configure functionality specific to the Application
               Blockchain Interface.
+          authority:
+            type: object
+            properties:
+              authority:
+                type: string
       appHash:
         type: string
         format: byte
@@ -37883,6 +37424,11 @@ definitions:
             description: >-
               ABCIParams configure functionality specific to the Application
               Blockchain Interface.
+          authority:
+            type: object
+            properties:
+              authority:
+                type: string
       appHash:
         type: string
         format: byte
@@ -38989,6 +38535,11 @@ definitions:
     description: >-
       ABCIParams configure functionality specific to the Application Blockchain
       Interface.
+  tendermint.types.AuthorityParams:
+    type: object
+    properties:
+      authority:
+        type: string
   tendermint.types.Block:
     type: object
     properties:
@@ -39831,6 +39382,11 @@ definitions:
         description: >-
           ABCIParams configure functionality specific to the Application
           Blockchain Interface.
+      authority:
+        type: object
+        properties:
+          authority:
+            type: string
     description: |-
       ConsensusParams contains consensus critical parameters that determine the
       validity of blocks.
@@ -41922,6 +41478,11 @@ definitions:
             description: >-
               ABCIParams configure functionality specific to the Application
               Blockchain Interface.
+          authority:
+            type: object
+            properties:
+              authority:
+                type: string
     description: >-
       QueryParamsResponse defines the response type for querying x/consensus
       parameters.


### PR DESCRIPTION
## Description

Closes #25918.

The committed `client/docs/swagger-ui/swagger.yaml` on `main` had drifted from the output of `make proto-swagger-gen`. Running the existing generator reproducibly produces a diff of **+40 / -479** lines against the file in tree.

This PR commits exactly the regenerator's output. No manual edits to the YAML, and no changes to `client/docs/config.json`, `proto/buf.gen.swagger.yaml`, or `scripts/protoc-swagger-gen.sh`.

### Notable differences vs. the in-tree file

- Adds the `authority` field on consensus params response objects on each affected path. This brings the spec in line with the `AuthorityParams` addition shipped in #25607.
- Removes stale top-level `definitions:` entries for module-config protos (e.g. `cosmos.app.v1alpha1.Config` and `*.module.v1.Module` types). These are not referenced by any of the query/service swagger files included in `client/docs/config.json`, so the current generator no longer emits them.

### Reproducing

```sh
make proto-swagger-gen
git diff --stat client/docs/swagger-ui/swagger.yaml
# client/docs/swagger-ui/swagger.yaml | 519 +++--------
```

Generated with `ghcr.io/cosmos/proto-builder:0.18.1` (the version pinned in the Makefile on `main`).

### Scope

- Targets `main` only. On `release/v0.53.x`, regenerating produces no diff against the in-tree file, so no backport is needed for that branch.
- I did not touch `release/v0.50.x`; happy to open a follow-up if maintainers want that branch refreshed too.

---

#### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] confirmed `!` in the type prefix if API or client breaking change *(N/A — generated docs only)*
- [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
- [x] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary *(diff is 100% generator output)*
- [x] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing) *(N/A — no code change)*
- [x] added a changelog entry to `CHANGELOG.md`
- [x] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc) *(this PR is the doc update)*
- [x] confirmed all CI checks have passed