### PR TITLE
fix: Change otel env var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### Bug Fixes
 
 * (x/gov) [#26353](https://github.com/cosmos/cosmos-sdk/pull/26353) Fix leading comma in `proposal_messages` event attribute emitted by `SubmitProposal`.
+* (telemetry) [#26390](https://github.com/cosmos/cosmos-sdk/pull/26390) Fix env var for otel telemetry initialization.
 
 ### Deprecated
 

--- a/telemetry/README.md
+++ b/telemetry/README.md
@@ -71,8 +71,8 @@ extensions:
 For a full list of configurable options see: https://github.com/open-telemetry/opentelemetry-configuration/blob/main/examples/kitchen-sink.yaml.
 NOTE: the go implementation may not support all options, so check the go [otelconf](https://pkg.go.dev/go.opentelemetry.io/contrib/otelconf) documentation carefully to see what is actually supported.
 
-3. set the `OTEL_EXPERIMENTAL_CONFIG_FILE` environment variable to the path of the configuration file:
-   `export OTEL_EXPERIMENTAL_CONFIG_FILE=path/to/config.yaml`
+3. set the `OTEL_CONFIG_FILE` environment variable to the path of the configuration file:
+   `export OTEL_CONFIG_FILE=path/to/config.yaml`
 4. start your application or tests
 5. view the data in Grafana LGTM at http://localhost:3000/. The Drilldown views are suggested for getting started.
 
@@ -90,7 +90,7 @@ While manual OpenTelemetry initialization is still supported, this package provi
 point of initialization such that end users can just use the official
 OpenTelemetry declarative configuration
 spec: https://opentelemetry.io/docs/languages/sdk-configuration/declarative-configuration/
-End users only need to set the `OTEL_EXPERIMENTAL_CONFIG_FILE` environment variable to the path of
+End users only need to set the `OTEL_CONFIG_FILE` environment variable to the path of
 an OpenTelemetry configuration file, or fill out the otel.yaml file in the node's config directory and that's it.
 All the documentation necessary is provided in the OpenTelemetry documentation.
 

--- a/telemetry/config.go
+++ b/telemetry/config.go
@@ -27,7 +27,7 @@ import (
 const (
 	OtelFileName = "otel.yaml"
 
-	otelConfigEnvVar = "OTEL_EXPERIMENTAL_CONFIG_FILE"
+	otelConfigEnvVar = "OTEL_CONFIG_FILE"
 )
 
 var (
@@ -64,7 +64,7 @@ func init() {
 // Note that a late initialization of the open telemetry SDK causes meters/tracers to utilize a delegate, which incurs
 // an atomic load.
 // In our benchmarks, we saw only a few nanoseconds incurred from this atomic operation.
-// If you wish to avoid this overhead entirely, you may set the OTEL_EXPERIMENTAL_CONFIG_FILE environment variable,'
+// If you wish to avoid this overhead entirely, you may set the OTEL_CONFIG_FILE environment variable,'
 // and the OpenTelemetry SDK will be instantiated via init.
 // This will eliminate the atomic operation overhead.
 func InitializeOpenTelemetry(filePath string) error {


### PR DESCRIPTION
# Description

Fixes otel env var initialization via otelconf.

In [this](https://github.com/open-telemetry/opentelemetry-go-contrib/commit/cf9c17c920880f55acf355a6b8479d8b1beb36a6) patch they changed the production env var and deprecated the old one--it returns an error now.

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->
