### PR TITLE
fix(x/auth/tx)!: reject deprecated Pagination in GetTxsEvent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,10 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (x/auth/tx) [#26517](https://github.com/cosmos/cosmos-sdk/pull/26517) Return a decode error instead of panicking when a transaction's `SignerInfos` and `Signatures` counts disagree in `GetSignaturesV2`, or a multisig's `ModeInfos` and sub-signature counts disagree in `ModeInfoAndSigToSignatureData`.
 * (x/auth/ante) [#26573](https://github.com/cosmos/cosmos-sdk/pull/26573) Reject tx with extra SignerInfos in SetPubKeyDecorator.
 
+### Client Breaking
+
+* (x/auth/tx) [#26399](https://github.com/cosmos/cosmos-sdk/pull/26399) `GetTxsEvent` now returns `InvalidArgument` when the deprecated `GetTxsEventRequest.pagination` field is populated, instead of silently ignoring it. Use the top-level `page`, `limit`, and `order_by` request fields instead.
+
 ### Deprecated
 
 ## [v0.54.2](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.54.2) - 2026-04-15

--- a/x/auth/tx/service.go
+++ b/x/auth/tx/service.go
@@ -48,9 +48,19 @@ func (s txServer) GetTxsEvent(_ context.Context, req *txtypes.GetTxsEventRequest
 		return nil, status.Error(codes.InvalidArgument, "request cannot be nil")
 	}
 
-	orderBy := parseOrderBy(req.OrderBy)
+	// Reject any populated Pagination field. It was deprecated in v0.46 and the
+	// top-level page / limit / order_by request fields supersede it. Silently
+	// translating it would force the SDK to maintain a compatibility shim
+	// indefinitely; returning an explicit error makes the migration visible to
+	// clients. See #25886.
+	if req.Pagination != nil && (req.Pagination.Limit != 0 || req.Pagination.Offset != 0 || req.Pagination.Key != nil || req.Pagination.CountTotal || req.Pagination.Reverse) {
+		return nil, status.Error(
+			codes.InvalidArgument,
+			"GetTxsEventRequest.pagination is deprecated and no longer honored; use the top-level page, limit, and order_by fields instead",
+		)
+	}
 
-	result, err := QueryTxsByEvents(s.clientCtx, int(req.Page), int(req.Limit), req.Query, orderBy)
+	result, err := QueryTxsByEvents(s.clientCtx, int(req.Page), int(req.Limit), req.Query, parseOrderBy(req.OrderBy))
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}

--- a/x/auth/tx/service_test.go
+++ b/x/auth/tx/service_test.go
@@ -1,0 +1,80 @@
+package tx_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	"github.com/cosmos/cosmos-sdk/types/query"
+	txtypes "github.com/cosmos/cosmos-sdk/types/tx"
+	"github.com/cosmos/cosmos-sdk/x/auth/tx"
+)
+
+// TestGetTxsEvent_RejectsDeprecatedPagination ensures that a request which
+// populates the deprecated `pagination` field is rejected with InvalidArgument
+// rather than silently translated. The top-level page / limit / order_by
+// fields supersede `pagination`; keeping a compatibility shim would force the
+// SDK to maintain a translation layer indefinitely. See #25886.
+func TestGetTxsEvent_RejectsDeprecatedPagination(t *testing.T) {
+	srv := tx.NewTxServer(client.Context{}, nil, codectypes.NewInterfaceRegistry())
+
+	cases := []struct {
+		name string
+		pag  *query.PageRequest
+	}{
+		{"limit set", &query.PageRequest{Limit: 100}},
+		{"offset set", &query.PageRequest{Offset: 50}},
+		{"key set", &query.PageRequest{Key: []byte("k")}},
+		{"reverse set", &query.PageRequest{Reverse: true}},
+		{"count_total set", &query.PageRequest{CountTotal: true}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := srv.GetTxsEvent(context.Background(), &txtypes.GetTxsEventRequest{
+				Query:      "tx.height=1",
+				Pagination: tc.pag,
+			})
+			require.Error(t, err)
+			st, ok := status.FromError(err)
+			require.True(t, ok, "expected gRPC status error, got %T", err)
+			require.Equal(t, codes.InvalidArgument, st.Code())
+			require.Contains(t, st.Message(), "pagination is deprecated")
+		})
+	}
+}
+
+// TestGetTxsEvent_EmptyPaginationAccepted ensures that an unset or fully-zero
+// Pagination field does not trigger the rejection above, so clients that
+// auto-construct request structs with a zero-value Pagination still work.
+func TestGetTxsEvent_EmptyPaginationAccepted(t *testing.T) {
+	srv := tx.NewTxServer(client.Context{}, nil, codectypes.NewInterfaceRegistry())
+
+	// Nil pagination — must not trip the InvalidArgument guard. The call
+	// itself will fail later trying to reach a real node (clientCtx has no
+	// client), but the error must NOT be the InvalidArgument from the guard.
+	_, err := srv.GetTxsEvent(context.Background(), &txtypes.GetTxsEventRequest{
+		Query: "tx.height=1",
+	})
+	if err != nil {
+		st, _ := status.FromError(err)
+		require.NotEqual(t, codes.InvalidArgument, st.Code(),
+			"nil pagination must not be rejected: %v", err)
+	}
+
+	// Zero-value pagination — same expectation.
+	_, err = srv.GetTxsEvent(context.Background(), &txtypes.GetTxsEventRequest{
+		Query:      "tx.height=1",
+		Pagination: &query.PageRequest{},
+	})
+	if err != nil {
+		st, _ := status.FromError(err)
+		require.NotEqual(t, codes.InvalidArgument, st.Code(),
+			"zero pagination must not be rejected: %v", err)
+	}
+}


### PR DESCRIPTION
## Description

Closes #25886.

`GetTxsEvent` only reads the top-level `page`, `limit`, and `order_by` fields on `GetTxsEventRequest` and silently drops `req.pagination`. REST clients hitting the gRPC-gateway endpoint typically populate `pagination.limit`, `pagination.offset`, and `pagination.reverse` (as in the report's URLs against `/cosmos/tx/v1beta1/txs`), so each request collapsed to `DefaultLimit=100` ascending results regardless of the values supplied. That is the most likely explanation for the reporter seeing the same address turn up by hash / `tx.height` but not by `transfer.recipient` once the matching set exceeds 100 — they were always reading page 1 in ascending order and never reaching the missing tx.

This change rejects any request that populates a non-zero `req.Pagination` field with `InvalidArgument`, rather than silently ignoring it. Maintaining a translation shim would require keeping that logic correct indefinitely; an explicit error makes the migration visible to clients and tells them exactly which fields to use instead.

- Nil or zero-value `PageRequest{}` is accepted unchanged — clients that auto-construct request structs are unaffected.
- Any non-zero `pagination` field (Limit, Offset, Key, Reverse, CountTotal) triggers the error.
- Clients should use the top-level `page`, `limit`, and `order_by` fields instead.

## Testing

New `x/auth/tx/service_test.go` covers:

- each non-zero pagination field individually rejected with `InvalidArgument`
- nil pagination accepted
- zero-value `PageRequest{}` accepted

```
go test -race ./x/auth/tx/...
ok  	github.com/cosmos/cosmos-sdk/x/auth/tx	2.075s
```

## Author Checklist

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] confirmed `!` in the title — this is a client breaking change
- [x] targeted the correct branch (main)
- [x] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] included the necessary unit tests
