### PR TITLE
fix(x/staking): handle redelegation when unbonded source is removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 * (x/gov) [#26353](https://github.com/cosmos/cosmos-sdk/pull/26353) Fix leading comma in `proposal_messages` event attribute emitted by `SubmitProposal`.
 * (telemetry) [#26390](https://github.com/cosmos/cosmos-sdk/pull/26390) Fix env var for otel telemetry initialization.
+* (x/staking) [#26408](https://github.com/cosmos/cosmos-sdk/pull/26408) Fix `MsgBeginRedelegate` failure when redelegating all shares from an unbonded source validator that is removed after unbonding.
 
 ### Deprecated
 

--- a/x/staking/app_test.go
+++ b/x/staking/app_test.go
@@ -28,8 +28,11 @@ var (
 	addr1 = sdk.AccAddress(priv1.PubKey().Address())
 	priv2 = secp256k1.GenPrivKey()
 	addr2 = sdk.AccAddress(priv2.PubKey().Address())
+	priv3 = secp256k1.GenPrivKey()
+	addr3 = sdk.AccAddress(priv3.PubKey().Address())
 
 	valKey          = ed25519.GenPrivKey()
+	valKey2         = ed25519.GenPrivKey()
 	commissionRates = types.NewCommissionRates(math.LegacyZeroDec(), math.LegacyZeroDec(), math.LegacyZeroDec())
 )
 
@@ -131,4 +134,116 @@ func TestStakingMsgs(t *testing.T) {
 
 	// balance should be the same because bonding not yet complete
 	require.True(t, sdk.Coins{genCoin.Sub(bondCoin)}.Equal(bankKeeper.GetAllBalances(ctxCheck, addr2)))
+}
+
+func TestBeginRedelegateAllSharesFromUnbondedSourceNoMocks(t *testing.T) {
+	genTokens := sdk.TokensFromConsensusPower(100, sdk.DefaultPowerReduction)
+	valTokens := sdk.TokensFromConsensusPower(10, sdk.DefaultPowerReduction)
+	bobTokens := sdk.TokensFromConsensusPower(5, sdk.DefaultPowerReduction)
+	genCoin := sdk.NewCoin(sdk.DefaultBondDenom, genTokens)
+
+	acc1 := &authtypes.BaseAccount{Address: addr1.String()}
+	acc2 := &authtypes.BaseAccount{Address: addr2.String()}
+	acc3 := &authtypes.BaseAccount{Address: addr3.String()}
+	accs := []simtestutil.GenesisAccount{
+		{GenesisAccount: acc1, Coins: sdk.Coins{genCoin}},
+		{GenesisAccount: acc2, Coins: sdk.Coins{genCoin}},
+		{GenesisAccount: acc3, Coins: sdk.Coins{genCoin}},
+	}
+
+	var (
+		bankKeeper    bankKeeper.Keeper
+		stakingKeeper *stakingKeeper.Keeper
+	)
+
+	startupCfg := simtestutil.DefaultStartUpConfig()
+	startupCfg.GenesisAccounts = accs
+
+	app, err := simtestutil.SetupWithConfiguration(
+		depinject.Configs(
+			testutil.AppConfig,
+			depinject.Supply(log.NewNopLogger()),
+		),
+		startupCfg, &bankKeeper, &stakingKeeper)
+	require.NoError(t, err)
+
+	txConfig := moduletestutil.MakeTestTxConfig()
+	nextHeight := func() int64 { return app.LastBlockHeight() + 1 }
+
+	// Create destination validator (addr1).
+	createDstMsg, err := types.NewMsgCreateValidator(
+		sdk.ValAddress(addr1).String(), valKey.PubKey(), sdk.NewCoin(sdk.DefaultBondDenom, valTokens),
+		types.NewDescription("dst", "", "", "", ""), commissionRates, math.OneInt(),
+	)
+	require.NoError(t, err)
+	_, _, err = simtestutil.SignCheckDeliver(
+		t, txConfig, app.BaseApp, cmtproto.Header{Height: nextHeight()}, []sdk.Msg{createDstMsg},
+		"", []uint64{0}, []uint64{0}, true, true, priv1,
+	)
+	require.NoError(t, err)
+	_, err = app.FinalizeBlock(&abci.RequestFinalizeBlock{Height: nextHeight()})
+	require.NoError(t, err)
+
+	// Create source validator (addr2).
+	createSrcMsg, err := types.NewMsgCreateValidator(
+		sdk.ValAddress(addr2).String(), valKey2.PubKey(), sdk.NewCoin(sdk.DefaultBondDenom, valTokens),
+		types.NewDescription("src", "", "", "", ""), commissionRates, math.OneInt(),
+	)
+	require.NoError(t, err)
+	_, _, err = simtestutil.SignCheckDeliver(
+		t, txConfig, app.BaseApp, cmtproto.Header{Height: nextHeight()}, []sdk.Msg{createSrcMsg},
+		"", []uint64{1}, []uint64{0}, true, true, priv2,
+	)
+	require.NoError(t, err)
+	_, err = app.FinalizeBlock(&abci.RequestFinalizeBlock{Height: nextHeight()})
+	require.NoError(t, err)
+
+	// Bob delegates to source validator.
+	delegateMsg := types.NewMsgDelegate(addr3.String(), sdk.ValAddress(addr2).String(), sdk.NewCoin(sdk.DefaultBondDenom, bobTokens))
+	_, _, err = simtestutil.SignCheckDeliver(
+		t, txConfig, app.BaseApp, cmtproto.Header{Height: nextHeight()}, []sdk.Msg{delegateMsg},
+		"", []uint64{2}, []uint64{0}, true, true, priv3,
+	)
+	require.NoError(t, err)
+	_, err = app.FinalizeBlock(&abci.RequestFinalizeBlock{Height: nextHeight()})
+	require.NoError(t, err)
+
+	// Source operator undelegates all self-delegation so Bob becomes sole delegator.
+	undelegateSelfMsg := types.NewMsgUndelegate(addr2.String(), sdk.ValAddress(addr2).String(), sdk.NewCoin(sdk.DefaultBondDenom, valTokens))
+	_, _, err = simtestutil.SignCheckDeliver(
+		t, txConfig, app.BaseApp, cmtproto.Header{Height: nextHeight()}, []sdk.Msg{undelegateSelfMsg},
+		"", []uint64{1}, []uint64{1}, true, true, priv2,
+	)
+	require.NoError(t, err)
+	_, err = app.FinalizeBlock(&abci.RequestFinalizeBlock{Height: nextHeight()})
+	require.NoError(t, err)
+
+	// Force transition source validator from unbonding to unbonded.
+	ctx := app.NewContext(false)
+	srcVal, err := stakingKeeper.GetValidator(ctx, sdk.ValAddress(addr2))
+	require.NoError(t, err)
+	_, err = stakingKeeper.UnbondingToUnbonded(ctx, srcVal)
+	require.NoError(t, err)
+
+	// Bob redelegates 100% of remaining shares from source to destination.
+	beginRedelegateMsg := types.NewMsgBeginRedelegate(
+		addr3.String(), sdk.ValAddress(addr2).String(), sdk.ValAddress(addr1).String(), sdk.NewCoin(sdk.DefaultBondDenom, bobTokens),
+	)
+	_, _, err = simtestutil.SignCheckDeliver(
+		t, txConfig, app.BaseApp, cmtproto.Header{Height: nextHeight()}, []sdk.Msg{beginRedelegateMsg},
+		"", []uint64{2}, []uint64{1}, true, true, priv3,
+	)
+	require.NoError(t, err)
+
+	// This path should be complete-now: no redelegation entry, source validator removed.
+	ctx = app.NewContext(true)
+	_, err = stakingKeeper.GetValidator(ctx, sdk.ValAddress(addr2))
+	require.ErrorIs(t, err, types.ErrNoValidatorFound)
+	_, err = stakingKeeper.GetDelegation(ctx, addr3, sdk.ValAddress(addr2))
+	require.ErrorIs(t, err, types.ErrNoDelegation)
+	dstDel, err := stakingKeeper.GetDelegation(ctx, addr3, sdk.ValAddress(addr1))
+	require.NoError(t, err)
+	require.Equal(t, bobTokens.String(), dstDel.Shares.RoundInt().String())
+	_, err = stakingKeeper.GetRedelegation(ctx, addr3, sdk.ValAddress(addr2), sdk.ValAddress(addr1))
+	require.ErrorIs(t, err, types.ErrNoRedelegation)
 }

--- a/x/staking/app_test.go
+++ b/x/staking/app_test.go
@@ -136,7 +136,7 @@ func TestStakingMsgs(t *testing.T) {
 	require.True(t, sdk.Coins{genCoin.Sub(bondCoin)}.Equal(bankKeeper.GetAllBalances(ctxCheck, addr2)))
 }
 
-func TestBeginRedelegateAllSharesFromUnbondedSourceNoMocks(t *testing.T) {
+func TestBeginRedelegateAllSharesFromUnbondedSource(t *testing.T) {
 	genTokens := sdk.TokensFromConsensusPower(100, sdk.DefaultPowerReduction)
 	valTokens := sdk.TokensFromConsensusPower(10, sdk.DefaultPowerReduction)
 	bobTokens := sdk.TokensFromConsensusPower(5, sdk.DefaultPowerReduction)

--- a/x/staking/app_test.go
+++ b/x/staking/app_test.go
@@ -2,6 +2,7 @@ package staking_test
 
 import (
 	"testing"
+	"time"
 
 	abci "github.com/cometbft/cometbft/abci/types"
 	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
@@ -218,11 +219,16 @@ func TestBeginRedelegateAllSharesFromUnbondedSource(t *testing.T) {
 	_, err = app.FinalizeBlock(&abci.RequestFinalizeBlock{Height: nextHeight()})
 	require.NoError(t, err)
 
-	// Force transition source validator from unbonding to unbonded.
-	ctx := app.NewContext(false)
-	srcVal, err := stakingKeeper.GetValidator(ctx, sdk.ValAddress(addr2))
+	// Advance block time past unbonding period to trigger unbonding->unbonded via normal block flow.
+	ctx := app.NewContext(true)
+	unbondingTime, err := stakingKeeper.UnbondingTime(ctx)
 	require.NoError(t, err)
-	_, err = stakingKeeper.UnbondingToUnbonded(ctx, srcVal)
+	_, err = app.FinalizeBlock(&abci.RequestFinalizeBlock{
+		Height: nextHeight(),
+		Time:   ctx.BlockTime().Add(unbondingTime).Add(time.Second),
+	})
+	require.NoError(t, err)
+	_, err = app.Commit()
 	require.NoError(t, err)
 
 	// Bob redelegates 100% of remaining shares from source to destination.
@@ -243,7 +249,7 @@ func TestBeginRedelegateAllSharesFromUnbondedSource(t *testing.T) {
 	require.ErrorIs(t, err, types.ErrNoDelegation)
 	dstDel, err := stakingKeeper.GetDelegation(ctx, addr3, sdk.ValAddress(addr1))
 	require.NoError(t, err)
-	require.Equal(t, bobTokens.String(), dstDel.Shares.RoundInt().String())
+	require.Equal(t, bobTokens, dstDel.Shares.RoundInt())
 	_, err = stakingKeeper.GetRedelegation(ctx, addr3, sdk.ValAddress(addr2), sdk.ValAddress(addr1))
 	require.ErrorIs(t, err, types.ErrNoRedelegation)
 }

--- a/x/staking/keeper/delegation.go
+++ b/x/staking/keeper/delegation.go
@@ -1073,8 +1073,13 @@ func (k Keeper) getBeginInfo(
 	ctx context.Context, valSrcAddr sdk.ValAddress,
 ) (completionTime time.Time, height int64, completeNow bool, err error) {
 	validator, err := k.GetValidator(ctx, valSrcAddr)
-	if err != nil && errors.Is(err, types.ErrNoValidatorFound) {
+	if err != nil && !errors.Is(err, types.ErrNoValidatorFound) {
 		return time.Time{}, 0, false, err
+	}
+	if errors.Is(err, types.ErrNoValidatorFound) {
+		// The source validator may have been removed by Unbond when it was already
+		// unbonded and this redelegation consumed its final remaining shares.
+		return time.Time{}, 0, true, nil
 	}
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
 	unbondingTime, err := k.UnbondingTime(ctx)
@@ -1082,9 +1087,8 @@ func (k Keeper) getBeginInfo(
 		return time.Time{}, 0, false, err
 	}
 
-	// TODO: When would the validator not be found?
 	switch {
-	case errors.Is(err, types.ErrNoValidatorFound) || validator.IsBonded():
+	case validator.IsBonded():
 		// the longest wait - just unbonding period from now
 		completionTime = sdkCtx.BlockHeader().Time.Add(unbondingTime)
 		height = sdkCtx.BlockHeight()

--- a/x/staking/keeper/delegation_test.go
+++ b/x/staking/keeper/delegation_test.go
@@ -1053,6 +1053,79 @@ func (s *KeeperTestSuite) TestRedelegateFromUnbondedValidator() {
 	require.ErrorIs(err, stakingtypes.ErrNoRedelegation, "%v", red)
 }
 
+func (s *KeeperTestSuite) TestRedelegateAllSharesFromUnbondedValidator() {
+	ctx, keeper := s.ctx, s.stakingKeeper
+	require := s.Require()
+
+	addrDels, addrVals := createValAddrs(2)
+
+	// create a validator with a self-delegation
+	validator := testutil.NewValidator(s.T(), addrVals[0], PKs[0])
+	require.NoError(keeper.SetValidatorByConsAddr(ctx, validator))
+
+	valTokens := keeper.TokensFromConsensusPower(ctx, 10)
+	validator, issuedShares := validator.AddTokensFromDel(valTokens)
+	require.Equal(valTokens, issuedShares.RoundInt())
+	s.bankKeeper.EXPECT().SendCoinsFromModuleToModule(gomock.Any(), stakingtypes.NotBondedPoolName, stakingtypes.BondedPoolName, gomock.Any())
+	validator = stakingkeeper.TestingUpdateValidator(keeper, ctx, validator, true)
+	val0AccAddr := sdk.AccAddress(addrVals[0].Bytes())
+	selfDelegation := stakingtypes.NewDelegation(val0AccAddr.String(), addrVals[0].String(), issuedShares)
+	require.NoError(keeper.SetDelegation(ctx, selfDelegation))
+
+	// create a second delegation to this validator (the redelegating delegator)
+	require.NoError(keeper.DeleteValidatorByPowerIndex(ctx, validator))
+	delTokens := keeper.TokensFromConsensusPower(ctx, 10)
+	validator, issuedShares = validator.AddTokensFromDel(delTokens)
+	require.Equal(delTokens, issuedShares.RoundInt())
+	stakingkeeper.TestingUpdateValidator(keeper, ctx, validator, true)
+	delegation := stakingtypes.NewDelegation(addrDels[1].String(), addrVals[0].String(), issuedShares)
+	require.NoError(keeper.SetDelegation(ctx, delegation))
+
+	// create a second validator (redelegation destination)
+	validator2 := testutil.NewValidator(s.T(), addrVals[1], PKs[1])
+	validator2, issuedShares = validator2.AddTokensFromDel(valTokens)
+	require.Equal(valTokens, issuedShares.RoundInt())
+	s.bankKeeper.EXPECT().SendCoinsFromModuleToModule(gomock.Any(), stakingtypes.NotBondedPoolName, stakingtypes.BondedPoolName, gomock.Any())
+	_ = stakingkeeper.TestingUpdateValidator(keeper, ctx, validator2, true)
+
+	ctx = ctx.WithBlockHeight(10)
+	ctx = ctx.WithBlockTime(time.Unix(333, 0))
+
+	// remove all self-delegation to move validator into unbonding
+	s.bankKeeper.EXPECT().SendCoinsFromModuleToModule(gomock.Any(), stakingtypes.BondedPoolName, stakingtypes.NotBondedPoolName, gomock.Any())
+	_, amount, err := keeper.Undelegate(ctx, val0AccAddr, addrVals[0], math.LegacyNewDecFromInt(delTokens))
+	require.NoError(err)
+	require.Equal(amount, delTokens)
+
+	// end block
+	s.bankKeeper.EXPECT().SendCoinsFromModuleToModule(gomock.Any(), stakingtypes.BondedPoolName, stakingtypes.NotBondedPoolName, gomock.Any())
+	s.applyValidatorSetUpdates(ctx, keeper, 1)
+
+	validator, err = keeper.GetValidator(ctx, addrVals[0])
+	require.NoError(err)
+	require.Equal(ctx.BlockHeight(), validator.UnbondingHeight)
+
+	// transition validator to unbonded
+	_, err = keeper.UnbondingToUnbonded(ctx, validator)
+	require.NoError(err)
+
+	// redelegate 100% of the only remaining delegation from the unbonded validator
+	s.bankKeeper.EXPECT().SendCoinsFromModuleToModule(gomock.Any(), stakingtypes.NotBondedPoolName, stakingtypes.BondedPoolName, gomock.Any())
+	_, err = keeper.BeginRedelegation(ctx, addrDels[1], addrVals[0], addrVals[1], math.LegacyNewDecFromInt(delTokens))
+	require.NoError(err)
+
+	// source validator and source delegation should be fully removed
+	_, err = keeper.GetValidator(ctx, addrVals[0])
+	require.ErrorIs(err, stakingtypes.ErrNoValidatorFound)
+	_, err = keeper.GetDelegation(ctx, addrDels[1], addrVals[0])
+	require.ErrorIs(err, stakingtypes.ErrNoDelegation)
+
+	// delegation should exist on destination validator
+	dstDel, err := keeper.GetDelegation(ctx, addrDels[1], addrVals[1])
+	require.NoError(err)
+	require.Equal(delTokens, dstDel.Shares.RoundInt())
+}
+
 func (s *KeeperTestSuite) TestUnbondingDelegationAddEntry() {
 	require := s.Require()
 


### PR DESCRIPTION
## Summary
- handle `ErrNoValidatorFound` in staking redelegation begin-info as an immediate-completion path when the source validator was already unbonded and removed after its final shares were consumed
- add a keeper-level regression test covering 100% redelegation from an unbonded source validator
- add an app-level no-mocks regression test reproducing the same flow through full message execution

## Test plan
- [x] `go test ./x/staking/keeper -run TestRedelegateAllSharesFromUnbondedValidator`
- [x] `go test ./x/staking -run TestBeginRedelegateAllSharesFromUnbondedSourceNoMocks`

Made with [Cursor](https://cursor.com)