### PR TITLE
fix(cosmovisor): switch to staged upgrade binary on startup

### DIFF
--- a/tools/cosmovisor/CHANGELOG.md
+++ b/tools/cosmovisor/CHANGELOG.md
@@ -44,6 +44,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 * [#23683](https://github.com/cosmos/cosmos-sdk/pull/23683) Replace `SigInt` with `SigTerm` to gracefully shutdown the process.
 * [#26526](https://github.com/cosmos/cosmos-sdk/pull/26526) Buffer the `cmdDone` and `psChan` channels in `WaitForUpgradeOrExit` so the `cmd.Wait` / `Process.Wait` goroutines do not leak on the upgrade and shutdown-grace-timeout paths.
+* [#25861](https://github.com/cosmos/cosmos-sdk/issues/25861) Check for a pending upgrade on startup and switch the `current` symlink to the staged binary before launching the daemon, so a node restarting after the upgrade height resumes on the new binary instead of crash-looping on the old one.
 
 ## v1.7.1 - 2025-01-12
 

--- a/tools/cosmovisor/process.go
+++ b/tools/cosmovisor/process.go
@@ -182,10 +182,68 @@ pollLoop:
 	}
 }
 
+// CheckPendingUpgrade inspects the live `data/upgrade-info.json` written by
+// `x/upgrade` and, if it points at a different upgrade than the one currently
+// linked under `current/`, switches the symlink to the staged binary before
+// the daemon is launched.
+//
+// This is the recovery path for the case where a node restarts after an
+// upgrade height has been reached but before cosmovisor's running-process
+// watcher had a chance to swap the binary (e.g. a crash, an OOM kill, or a
+// manual restart during the upgrade window). Without this pre-startup check,
+// cosmovisor would re-launch the pre-upgrade binary, which then panics again
+// the moment it reaches the upgrade height.
+//
+// If the upgrade binary is not staged, the call is a no-op and the existing
+// file-watcher / auto-download path remains responsible for resolving the
+// upgrade once the daemon is running.
+func (l Launcher) CheckPendingUpgrade() error {
+	bz, err := os.ReadFile(l.cfg.UpgradeInfoFilePath())
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("reading %s: %w", l.cfg.UpgradeInfoFilePath(), err)
+	}
+
+	var pending upgradetypes.Plan
+	if err := json.Unmarshal(bz, &pending); err != nil {
+		return fmt.Errorf("parsing %s: %w", l.cfg.UpgradeInfoFilePath(), err)
+	}
+	if pending.Name == "" {
+		return nil
+	}
+
+	if current, err := l.cfg.UpgradeInfo(); err == nil && current.Name == pending.Name {
+		return nil
+	}
+
+	if err := plan.EnsureBinary(l.cfg.UpgradeBin(pending.Name)); err != nil {
+		l.logger.Info(
+			"pending upgrade detected on startup but upgrade binary is not staged; deferring to file watcher",
+			"upgrade", pending.Name,
+			"height", pending.Height,
+			"error", err,
+		)
+		return nil
+	}
+
+	l.logger.Info(
+		"pending upgrade detected on startup, switching to upgrade binary",
+		"upgrade", pending.Name,
+		"height", pending.Height,
+	)
+	return l.cfg.SetCurrentUpgrade(pending)
+}
+
 // Run launches the app in a subprocess and returns when the subprocess (app)
 // exits (either when it dies, or *after* a successful upgrade.) and the upgrade is finished.
 // Returns true if the upgrade request was detected and the upgrade process started.
 func (l Launcher) Run(args []string, stdin io.Reader, stdout, stderr io.Writer) (bool, error) {
+	if err := l.CheckPendingUpgrade(); err != nil {
+		return false, fmt.Errorf("pre-startup upgrade check failed: %w", err)
+	}
+
 	bin, err := l.cfg.CurrentBin()
 	if err != nil {
 		return false, fmt.Errorf("error creating symlink to genesis: %w", err)

--- a/tools/cosmovisor/process_pending_upgrade_test.go
+++ b/tools/cosmovisor/process_pending_upgrade_test.go
@@ -1,0 +1,116 @@
+//go:build linux || darwin
+
+package cosmovisor_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"cosmossdk.io/log/v2"
+	"cosmossdk.io/tools/cosmovisor"
+
+	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+)
+
+func writePendingUpgrade(t *testing.T, cfg *cosmovisor.Config, p upgradetypes.Plan) {
+	t.Helper()
+	bz, err := json.Marshal(p)
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(filepath.Dir(cfg.UpgradeInfoFilePath()), 0o755))
+	require.NoError(t, os.WriteFile(cfg.UpgradeInfoFilePath(), bz, 0o600))
+}
+
+func newPendingUpgradeLauncher(t *testing.T) (*cosmovisor.Config, cosmovisor.Launcher) {
+	t.Helper()
+	cfg := prepareConfig(
+		t,
+		fmt.Sprintf("%s/%s", workDir, "testdata/validate"),
+		cosmovisor.Config{Name: "dummyd", PollInterval: 15},
+	)
+	logger := log.NewTestLogger(t).With(log.ModuleKey, "cosmovisor")
+	launcher, err := cosmovisor.NewLauncher(logger, cfg)
+	require.NoError(t, err)
+	return cfg, launcher
+}
+
+func TestCheckPendingUpgrade_NoFile(t *testing.T) {
+	cfg, launcher := newPendingUpgradeLauncher(t)
+
+	require.NoError(t, launcher.CheckPendingUpgrade())
+
+	currentBin, err := cfg.CurrentBin()
+	require.NoError(t, err)
+	rPath, err := filepath.EvalSymlinks(cfg.GenesisBin())
+	require.NoError(t, err)
+	require.Equal(t, rPath, currentBin)
+}
+
+func TestCheckPendingUpgrade_StagedBinarySwitches(t *testing.T) {
+	cfg, launcher := newPendingUpgradeLauncher(t)
+
+	writePendingUpgrade(t, cfg, upgradetypes.Plan{Name: "chain2", Height: 49})
+	require.NoError(t, launcher.CheckPendingUpgrade())
+
+	currentBin, err := cfg.CurrentBin()
+	require.NoError(t, err)
+	rPath, err := filepath.EvalSymlinks(cfg.UpgradeBin("chain2"))
+	require.NoError(t, err)
+	require.Equal(t, rPath, currentBin)
+}
+
+func TestCheckPendingUpgrade_AlreadyCurrentIsNoop(t *testing.T) {
+	cfg, launcher := newPendingUpgradeLauncher(t)
+
+	require.NoError(t, cfg.SetCurrentUpgrade(upgradetypes.Plan{Name: "chain2", Height: 49}))
+	writePendingUpgrade(t, cfg, upgradetypes.Plan{Name: "chain2", Height: 49})
+
+	require.NoError(t, launcher.CheckPendingUpgrade())
+
+	currentBin, err := cfg.CurrentBin()
+	require.NoError(t, err)
+	rPath, err := filepath.EvalSymlinks(cfg.UpgradeBin("chain2"))
+	require.NoError(t, err)
+	require.Equal(t, rPath, currentBin)
+}
+
+func TestCheckPendingUpgrade_MissingBinaryDefersToWatcher(t *testing.T) {
+	cfg, launcher := newPendingUpgradeLauncher(t)
+
+	writePendingUpgrade(t, cfg, upgradetypes.Plan{Name: "not-staged-yet", Height: 100})
+
+	require.NoError(t, launcher.CheckPendingUpgrade())
+
+	currentBin, err := cfg.CurrentBin()
+	require.NoError(t, err)
+	rPath, err := filepath.EvalSymlinks(cfg.GenesisBin())
+	require.NoError(t, err)
+	require.Equal(t, rPath, currentBin)
+}
+
+func TestCheckPendingUpgrade_MalformedFileErrors(t *testing.T) {
+	cfg, launcher := newPendingUpgradeLauncher(t)
+
+	require.NoError(t, os.MkdirAll(filepath.Dir(cfg.UpgradeInfoFilePath()), 0o755))
+	require.NoError(t, os.WriteFile(cfg.UpgradeInfoFilePath(), []byte("not json"), 0o600))
+
+	require.Error(t, launcher.CheckPendingUpgrade())
+}
+
+func TestCheckPendingUpgrade_EmptyNameIsNoop(t *testing.T) {
+	cfg, launcher := newPendingUpgradeLauncher(t)
+
+	writePendingUpgrade(t, cfg, upgradetypes.Plan{})
+
+	require.NoError(t, launcher.CheckPendingUpgrade())
+
+	currentBin, err := cfg.CurrentBin()
+	require.NoError(t, err)
+	rPath, err := filepath.EvalSymlinks(cfg.GenesisBin())
+	require.NoError(t, err)
+	require.Equal(t, rPath, currentBin)
+}

--- a/tools/cosmovisor/process_test.go
+++ b/tools/cosmovisor/process_test.go
@@ -4,6 +4,7 @@ package cosmovisor_test
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io/fs"
 	"os"
@@ -567,4 +568,56 @@ func (b *buffer) Reset() {
 	b.m.Lock()
 	defer b.m.Unlock()
 	b.b.Reset()
+}
+
+// TestLaunchProcess_CheckPendingUpgradeFiresInsideRun pins that
+// Launcher.Run consults Launcher.CheckPendingUpgrade before launching the
+// subprocess. Pre-stages a data/upgrade-info.json pointing at chain2 while
+// the current symlink still points at genesis (the crash-restart scenario
+// the pre-startup check exists to recover from). If Run were to skip
+// CheckPendingUpgrade, the genesis "Genesis ..." script would launch and
+// the stdout assertion below would fail.
+func TestLaunchProcess_CheckPendingUpgradeFiresInsideRun(t *testing.T) {
+	cfg := prepareConfig(
+		t,
+		fmt.Sprintf("%s/%s", workDir, "testdata/validate"),
+		cosmovisor.Config{
+			Name:             "dummyd",
+			PollInterval:     15,
+			UnsafeSkipBackup: true,
+		},
+	)
+
+	// Sanity-check the precondition: current link starts on genesis.
+	currentBin, err := cfg.CurrentBin()
+	require.NoError(t, err)
+	rPath, err := filepath.EvalSymlinks(cfg.GenesisBin())
+	require.NoError(t, err)
+	require.Equal(t, rPath, currentBin)
+
+	bz, err := json.Marshal(upgradetypes.Plan{Name: "chain2", Height: 49})
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(filepath.Dir(cfg.UpgradeInfoFilePath()), 0o755))
+	require.NoError(t, os.WriteFile(cfg.UpgradeInfoFilePath(), bz, 0o600))
+
+	logger := log.NewTestLogger(t).With(log.ModuleKey, "cosmosvisor")
+	launcher, err := cosmovisor.NewLauncher(logger, cfg)
+	require.NoError(t, err)
+
+	stdin, _ := os.Open(os.DevNull)
+	stdout, stderr := newBuffer(), newBuffer()
+
+	doUpgrade, err := launcher.Run([]string{"second", "run", "--verbose"}, stdin, stdout, stderr)
+	require.NoError(t, err)
+	require.False(t, doUpgrade)
+	require.Empty(t, stderr.String())
+	require.Equal(t, "Chain 2 is live!\nArgs: second run --verbose\nFinished successfully\n", stdout.String())
+
+	// Current link now points at the upgrade binary — observable proof
+	// that CheckPendingUpgrade executed inside Run before subprocess launch.
+	currentBin, err = cfg.CurrentBin()
+	require.NoError(t, err)
+	rPath, err = filepath.EvalSymlinks(cfg.UpgradeBin("chain2"))
+	require.NoError(t, err)
+	require.Equal(t, rPath, currentBin)
 }


### PR DESCRIPTION
## Description

Closes #25861.

`cosmovisor` only learns about a pending upgrade through its running-process file watcher (`WaitForUpgradeOrExit`). If the node restarts after the upgrade height has been reached but before the watcher had a chance to swap the binary — a crash, an OOM kill, or a manual restart during the upgrade window — cosmovisor re-launches whatever the `current` symlink points at, which is still the pre-upgrade binary. That binary then panics at the upgrade height and the loop repeats.

This PR adds a small pre-startup check that reads the live `data/upgrade-info.json` written by `x/upgrade` and, if it names an upgrade that differs from the one currently linked under `current/`, switches the symlink to the staged binary before the daemon is launched.

### Behaviour

- No `upgrade-info.json` ⇒ no-op (genesis / steady-state startup).
- Pending plan matches the upgrade already linked under `current/` ⇒ no-op.
- Pending plan names a different upgrade and the binary is staged in `cosmovisor/upgrades/<name>/bin/` ⇒ symlink is repointed before launch.
- Pending plan names a different upgrade and the binary is **not** staged ⇒ logged and left alone; the existing file-watcher / auto-download path remains in charge once the daemon is running.

The change is purely additive — the `Launcher.Run` path that today launches whatever `current` points at is untouched except for the new pre-check; behaviour is unchanged in every case that already worked.

## Testing

New unit tests in `tools/cosmovisor/process_pending_upgrade_test.go` cover all six branches:

- `TestCheckPendingUpgrade_NoFile`
- `TestCheckPendingUpgrade_StagedBinarySwitches`
- `TestCheckPendingUpgrade_AlreadyCurrentIsNoop`
- `TestCheckPendingUpgrade_MissingBinaryDefersToWatcher`
- `TestCheckPendingUpgrade_MalformedFileErrors`
- `TestCheckPendingUpgrade_EmptyNameIsNoop`

```
go test ./tools/cosmovisor/...
ok  cosmossdk.io/tools/cosmovisor                       34.281s
ok  cosmossdk.io/tools/cosmovisor/cmd/cosmovisor         1.371s
```

## Relation to prior work

PR #25864 attempted the same fix and was closed only for unsigned commits (no review feedback). This PR re-implements the pre-startup check independently, with broader test coverage of the no-op / fallback branches that the issue's analysis section called out.

---

## Author Checklist

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title (`fix:`)
- [x] confirmed `!` in the title is not needed (no API or client breaking change)
- [x] targeted the correct branch (`main`)
- [x] provided a link to the relevant issue (#25861)
- [x] reviewed \"Files changed\"
- [x] included the necessary unit tests
- [x] added a changelog entry to `tools/cosmovisor/CHANGELOG.md`
- [x] N/A — no user-facing documentation change (cosmovisor recovers transparently)
- [x] will monitor CI checks after open