### PR TITLE
docs: fix possessive "it's" → "its" in code comments

### DIFF
--- a/crypto/keys/bls12_381/key_cgo.go
+++ b/crypto/keys/bls12_381/key_cgo.go
@@ -163,7 +163,7 @@ func (pubKey PubKey) Equals(other cryptotypes.PubKey) bool {
 	return pubKey.Type() == other.Type() && bytes.Equal(pubKey.Bytes(), other.Bytes())
 }
 
-// String returns Hex representation of a pubkey with it's type
+// String returns Hex representation of a pubkey with its type
 func (pubKey PubKey) String() string {
 	return fmt.Sprintf("PubKeyBLS12_381{%X}", pubKey.Key)
 }

--- a/crypto/keys/ed25519/ed25519.go
+++ b/crypto/keys/ed25519/ed25519.go
@@ -186,7 +186,7 @@ func (pubKey *PubKey) VerifySignature(msg, sig []byte) bool {
 	return ed25519consensus.Verify(pubKey.Key, msg, sig)
 }
 
-// String returns Hex representation of a pubkey with it's type
+// String returns Hex representation of a pubkey with its type
 func (pubKey *PubKey) String() string {
 	return fmt.Sprintf("PubKeyEd25519{%X}", pubKey.Key)
 }

--- a/x/auth/types/codec.go
+++ b/x/auth/types/codec.go
@@ -26,7 +26,7 @@ func RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
 }
 
 // RegisterInterfaces associates protoName with AccountI interface
-// and creates a registry of it's concrete implementations
+// and creates a registry of its concrete implementations
 func RegisterInterfaces(registry types.InterfaceRegistry) {
 	registry.RegisterInterface(
 		"cosmos.auth.v1beta1.AccountI",

--- a/x/auth/vesting/types/codec.go
+++ b/x/auth/vesting/types/codec.go
@@ -25,7 +25,7 @@ func RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
 }
 
 // RegisterInterfaces associates protoName with AccountI and VestingAccount
-// Interfaces and creates a registry of it's concrete implementations
+// Interfaces and creates a registry of its concrete implementations
 func RegisterInterfaces(registry types.InterfaceRegistry) {
 	registry.RegisterInterface(
 		"cosmos.vesting.v1beta1.VestingAccount",

--- a/x/feegrant/periodic_fee.go
+++ b/x/feegrant/periodic_fee.go
@@ -17,7 +17,7 @@ var _ FeeAllowanceI = (*PeriodicAllowance)(nil)
 // Keeper.UseGrantedFees and the return values should match how it is handled there.
 //
 // If it returns an error, the fee payment is rejected, otherwise it is accepted.
-// The FeeAllowance implementation is expected to update it's internal state
+// The FeeAllowance implementation is expected to update its internal state
 // and will be saved again after an acceptance.
 //
 // If remove is true (regardless of the error), the FeeAllowance will be deleted from storage

--- a/x/upgrade/exported/exported.go
+++ b/x/upgrade/exported/exported.go
@@ -1,7 +1,7 @@
 package exported
 
 // ProtocolVersionSetter defines the interface fulfilled by BaseApp
-// which allows setting it's appVersion field.
+// which allows setting its appVersion field.
 type ProtocolVersionSetter interface {
 	SetProtocolVersion(uint64)
 }


### PR DESCRIPTION
# Description

Corrects six godoc comments that used the contraction `it's` ("it is") where the possessive `its` was intended. Comments only — no code changes.

Files touched:
- `crypto/keys/bls12_381/key_cgo.go`
- `crypto/keys/ed25519/ed25519.go`
- `x/auth/types/codec.go`
- `x/auth/vesting/types/codec.go`
- `x/feegrant/periodic_fee.go`
- `x/upgrade/exported/exported.go`

No CHANGELOG entry — documentation-only change, not user-facing.