### PR TITLE
test(x/upgrade): add TestDueAt for Plan.DueAt()

### DIFF
--- a/x/upgrade/types/plan_test.go
+++ b/x/upgrade/types/plan_test.go
@@ -145,3 +145,29 @@ func TestShouldExecute(t *testing.T) {
 		})
 	}
 }
+
+func TestDueAt(t *testing.T) {
+	cases := map[string]struct {
+		p        types.Plan
+		expected string
+	}{
+		"positive height": {
+			p:        types.Plan{Name: "do-good", Height: 1234},
+			expected: "height: 1234",
+		},
+		"zero height": {
+			p:        types.Plan{Name: "do-good", Height: 0},
+			expected: "height: 0",
+		},
+		"large height": {
+			p:        types.Plan{Name: "do-good", Height: 9223372036854775807},
+			expected: "height: 9223372036854775807",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, tc.p.DueAt())
+		})
+	}
+}


### PR DESCRIPTION
# Description

`Plan.DueAt()` in `x/upgrade/types/plan.go` returns `fmt.Sprintf("height: %d", p.Height)`. Its sibling methods `ValidateBasic` and `ShouldExecute` are covered by table tests in `plan_test.go`, but `DueAt` itself had no direct coverage.

This PR adds a small table test covering three cases:
- typical positive height (`1234`)
- zero value (`0`)
- `math.MaxInt64` boundary (`9223372036854775807`)

Test-only change. No CHANGELOG entry — not user-facing.

Note: I do not have Go installed locally; CI will run the test.