### PR TITLE
fix(x/auth/tx): propagate signing options from codec to NewTxConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (x/gov) [#26353](https://github.com/cosmos/cosmos-sdk/pull/26353) Fix leading comma in `proposal_messages` event attribute emitted by `SubmitProposal`.
 * (telemetry) [#26390](https://github.com/cosmos/cosmos-sdk/pull/26390) Fix env var for otel telemetry initialization.
 * (x/staking) [#26408](https://github.com/cosmos/cosmos-sdk/pull/26408) Fix `MsgBeginRedelegate` failure when redelegating all shares from an unbonded source validator that is removed after unbonding.
+* (x/auth/tx) [#26422](https://github.com/cosmos/cosmos-sdk/pull/26422) Reuse the signing context from the codec's `InterfaceRegistry` when `ConfigOptions.SigningOptions` is unset so that `CustomGetSigners` registered via `NewInterfaceRegistryWithOptions` are honored by `NewTxConfig` / `NewTxConfigWithOptions`.
 
 ### Deprecated
 

--- a/x/auth/tx/config.go
+++ b/x/auth/tx/config.go
@@ -187,17 +187,31 @@ func NewTxConfigWithOptions(protoCodec codec.Codec, configOptions ConfigOptions)
 	var err error
 	if configOptions.SigningContext == nil {
 		if configOptions.SigningOptions == nil {
-			configOptions.SigningOptions, err = NewDefaultSigningOptions()
+			// Reuse the SigningContext from the codec's interface registry.
+			// This propagates SigningOptions (including CustomGetSigners) that
+			// were applied via NewInterfaceRegistryWithOptions; building a
+			// fresh context from NewDefaultSigningOptions would drop them. See
+			// https://github.com/cosmos/cosmos-sdk/issues/22200.
+			if ir := protoCodec.InterfaceRegistry(); ir != nil {
+				configOptions.SigningContext = ir.SigningContext()
+			} else {
+				configOptions.SigningOptions, err = NewDefaultSigningOptions()
+				if err != nil {
+					return nil, err
+				}
+				configOptions.SigningContext, err = txsigning.NewContext(*configOptions.SigningOptions)
+				if err != nil {
+					return nil, err
+				}
+			}
+		} else {
+			if configOptions.SigningOptions.FileResolver == nil {
+				configOptions.SigningOptions.FileResolver = protoCodec.InterfaceRegistry()
+			}
+			configOptions.SigningContext, err = txsigning.NewContext(*configOptions.SigningOptions)
 			if err != nil {
 				return nil, err
 			}
-		}
-		if configOptions.SigningOptions.FileResolver == nil {
-			configOptions.SigningOptions.FileResolver = protoCodec.InterfaceRegistry()
-		}
-		configOptions.SigningContext, err = txsigning.NewContext(*configOptions.SigningOptions)
-		if err != nil {
-			return nil, err
 		}
 	}
 	txConfig.signingContext = configOptions.SigningContext

--- a/x/auth/tx/config_test.go
+++ b/x/auth/tx/config_test.go
@@ -70,3 +70,29 @@ func TestNewTxConfigPropagatesCustomGetSigners(t *testing.T) {
 	// fresh context from defaults and the lookup below failed.
 	require.Same(t, interfaceRegistry.SigningContext(), txConfig.SigningContext())
 }
+
+// TestNewTxConfigWithExplicitSigningOptions covers the branch where the caller
+// supplies SigningOptions directly. The function must build a fresh signing
+// context from those options (not reuse the codec's interface-registry
+// context) and must default FileResolver to the interface registry when
+// unset.
+func TestNewTxConfigWithExplicitSigningOptions(t *testing.T) {
+	interfaceRegistry := types.NewInterfaceRegistry()
+	protoCodec := codec.NewProtoCodec(interfaceRegistry)
+
+	signingOpts := &txsigning.Options{
+		AddressCodec:          address.NewBech32Codec("cosmos"),
+		ValidatorAddressCodec: address.NewBech32Codec("cosmosvaloper"),
+	}
+
+	txConfig, err := tx.NewTxConfigWithOptions(protoCodec, tx.ConfigOptions{
+		SigningOptions: signingOpts,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, txConfig.SigningContext())
+	// A new context was built from the supplied SigningOptions, so it must not
+	// be the interface registry's own signing context.
+	require.NotSame(t, interfaceRegistry.SigningContext(), txConfig.SigningContext())
+	// FileResolver default came from the interface registry.
+	require.NotNil(t, signingOpts.FileResolver)
+}

--- a/x/auth/tx/config_test.go
+++ b/x/auth/tx/config_test.go
@@ -3,10 +3,14 @@ package tx_test
 import (
 	"testing"
 
+	gogoproto "github.com/cosmos/gogoproto/proto"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	protov2 "google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
 
 	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/codec/address"
 	"github.com/cosmos/cosmos-sdk/codec/testutil"
 	"github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/cosmos/cosmos-sdk/std"
@@ -14,6 +18,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/auth/tx"
 	txtestutil "github.com/cosmos/cosmos-sdk/x/auth/tx/testutil"
+	txsigning "github.com/cosmos/cosmos-sdk/x/tx/signing"
 )
 
 func TestGenerator(t *testing.T) {
@@ -33,4 +38,35 @@ func TestConfigOptions(t *testing.T) {
 	require.NotNil(t, txConfig)
 	handler := txConfig.SignModeHandler()
 	require.NotNil(t, handler)
+}
+
+// TestNewTxConfigPropagatesCustomGetSigners verifies that when the codec's
+// interface registry was built with CustomGetSigners, those custom signer
+// functions are reachable through txConfig.SigningContext(). Regression test
+// for https://github.com/cosmos/cosmos-sdk/issues/22200.
+func TestNewTxConfigPropagatesCustomGetSigners(t *testing.T) {
+	addrBytes := []byte("test-signer-addr-bytes")
+	customSigner := func(_ protov2.Message) ([][]byte, error) {
+		return [][]byte{addrBytes}, nil
+	}
+
+	signingOpts := txsigning.Options{
+		AddressCodec:          address.NewBech32Codec("cosmos"),
+		ValidatorAddressCodec: address.NewBech32Codec("cosmosvaloper"),
+	}
+	signingOpts.DefineCustomGetSigners(protoreflect.FullName(gogoproto.MessageName(&testdata.TestMsg{})), customSigner)
+
+	interfaceRegistry, err := types.NewInterfaceRegistryWithOptions(types.InterfaceRegistryOptions{
+		ProtoFiles:     gogoproto.HybridResolver,
+		SigningOptions: signingOpts,
+	})
+	require.NoError(t, err)
+	protoCodec := codec.NewProtoCodec(interfaceRegistry)
+
+	txConfig := tx.NewTxConfig(protoCodec, tx.DefaultSignModes)
+
+	// Sanity: txConfig must reuse the interface registry's signing context so
+	// custom signers carry through. With the pre-fix code, NewTxConfig built a
+	// fresh context from defaults and the lookup below failed.
+	require.Same(t, interfaceRegistry.SigningContext(), txConfig.SigningContext())
 }


### PR DESCRIPTION
## Summary

`NewTxConfig` built a fresh `SigningContext` from `NewDefaultSigningOptions` whenever the caller did not pass `ConfigOptions.SigningOptions`, dropping any `CustomGetSigners` that had been applied to the codec's `InterfaceRegistry` via `NewInterfaceRegistryWithOptions`. `txConfig.SigningContext().Validate()` then failed for messages relying on custom getters with:

\`\`\`
no cosmos.msg.v1.signer option found for message <msg name>; use DefineCustomGetSigners to specify a custom getter
\`\`\`

Reuse the `InterfaceRegistry`'s `SigningContext` when neither `SigningOptions` nor `SigningContext` were supplied, so options applied at registry construction time carry through to `txConfig` consumers without forcing them to switch to `NewTxConfigWithOptions`.

Closes #22200

## Test plan

- [x] Added regression test \`TestNewTxConfigPropagatesCustomGetSigners\` that builds an InterfaceRegistry with a CustomGetSigners entry, runs it through \`NewTxConfig\`, and asserts \`txConfig.SigningContext()\` is the same context as \`interfaceRegistry.SigningContext()\`. With the pre-fix code the assertion fails because a fresh context was built from defaults.
- [x] Full \`x/auth/tx\` suite passes locally.