### PR TITLE
fix(x/upgrade/plan): accept Windows .exe daemon in archive layouts

### DIFF
--- a/x/upgrade/plan/downloader.go
+++ b/x/upgrade/plan/downloader.go
@@ -47,26 +47,36 @@ func DownloadUpgrade(dstRoot, url, daemonName string) error {
 // The archive is unpacked and saved in dstDir.
 // If the archive contains /{daemonName} and not /bin/{daemonName}, then /{daemonName} will be moved to /bin/{daemonName}.
 // If this returns nil, the download was successful, and {dstDir}/bin/{daemonName} is a regular executable file.
+//
+// Windows-archive layouts that ship the daemon as {daemonName}.exe are also
+// accepted: the .exe variant is moved/renamed to /bin/{daemonName} so the
+// rest of the upgrade pipeline can treat it identically.
 func downloadUpgradeAsArchive(dstDir, url, daemonName string) error {
 	err := getter.Get(dstDir, url)
 	if err != nil {
 		return err
 	}
 
-	// If bin/{daemonName} exists, we're done.
 	dstDirBinFile := filepath.Join(dstDir, "bin", daemonName)
-	err = EnsureBinary(dstDirBinFile)
-	if err == nil {
-		return nil
+	// Probe the four locations a daemon binary can land in after unpacking:
+	// {bin/,/}{daemonName,daemonName.exe}. The .exe variants exist because
+	// Windows releases (e.g. windows/amd64) cannot drop the extension, and
+	// ValidateFull downloads every arch listed in the upgrade plan.
+	candidates := []string{
+		dstDirBinFile,
+		filepath.Join(dstDir, daemonName),
+		dstDirBinFile + ".exe",
+		filepath.Join(dstDir, daemonName+".exe"),
 	}
-
-	// Otherwise, check for a root {daemonName} file and move it to the bin/ directory if found.
-	dstDirFile := filepath.Join(dstDir, daemonName)
-	err = EnsureBinary(dstDirFile)
-	if err == nil {
-		err = os.Rename(dstDirFile, dstDirBinFile)
-		if err != nil {
-			return fmt.Errorf("could not move %s to the bin directory: %w", daemonName, err)
+	for _, src := range candidates {
+		if err = EnsureBinary(src); err != nil {
+			continue
+		}
+		if src == dstDirBinFile {
+			return nil
+		}
+		if err = os.Rename(src, dstDirBinFile); err != nil {
+			return fmt.Errorf("could not move %s to the bin directory: %w", filepath.Base(src), err)
 		}
 		return nil
 	}

--- a/x/upgrade/plan/downloader_test.go
+++ b/x/upgrade/plan/downloader_test.go
@@ -208,6 +208,36 @@ func (s *DownloaderTestSuite) TestDownloadUpgrade() {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "result does not contain a bin/not-expected or not-expected file")
 	})
+
+	// Windows release archives ship the daemon as {name}.exe. Without
+	// canonicalizing the extension, ValidateFull rejects every windows/*
+	// binary listed in an upgrade plan even though it's a valid release.
+	// Regression coverage for https://github.com/cosmos/cosmos-sdk/issues/19871.
+	winName := "win-daemon"
+	winExeAtRoot := NewTestFile(winName+".exe", "#!/usr/bin\necho 'I am a windows daemon'\n")
+	winExeInBin := NewTestFile("bin"+winName+".exe", "#!/usr/bin\necho 'I am a windows daemon in bin'\n")
+	winExeAtRootZip := s.saveSrcTestZip(winName+"-root.zip", NewTestZip(winExeAtRoot))
+	winExeInBinZip := s.saveSrcTestZip(winName+"-bin.zip", NewTestZip(winExeInBin))
+
+	s.T().Run("url returns archive with windows .exe at root", func(t *testing.T) {
+		dstRoot := getDstDir(t.Name())
+		url := makeFileURL(t, winExeAtRootZip)
+		err := DownloadUpgrade(dstRoot, url, winName)
+		require.NoError(t, err)
+		expectedFile := filepath.Join(dstRoot, "bin", winName)
+		requireFileExistsAndIsExecutable(t, expectedFile)
+		requireFileEquals(t, expectedFile, winExeAtRoot)
+	})
+
+	s.T().Run("url returns archive with windows .exe in bin", func(t *testing.T) {
+		dstRoot := getDstDir(t.Name())
+		url := makeFileURL(t, winExeInBinZip)
+		err := DownloadUpgrade(dstRoot, url, winName)
+		require.NoError(t, err)
+		expectedFile := filepath.Join(dstRoot, "bin", winName)
+		requireFileExistsAndIsExecutable(t, expectedFile)
+		requireFileEquals(t, expectedFile, winExeInBin)
+	})
 }
 
 func (s *DownloaderTestSuite) TestEnsureBinary() {


### PR DESCRIPTION
## Summary

\`downloadUpgradeAsArchive\` only looked for \`{daemonName}\` and \`bin/{daemonName}\` inside an unpacked release archive, so Windows releases that ship the binary as \`{daemonName}.exe\` were rejected. This made \`plan.Info.ValidateFull\` fail for any upgrade plan that listed a \`windows/*\` binary — including normal multi-arch GoReleaser output — with errors like:

\`\`\`
url \"...windows_x86_64.tar.gz?checksum=sha256:...\" result does not contain a bin/<daemon> or <daemon> file
\`\`\`

The caller never opts out of the Windows entry because \`ValidateFull\` walks every os/arch declared in the plan.

This change probes the four locations a daemon binary can land in after unpacking — \`bin/{name}\`, \`{name}\`, \`bin/{name}.exe\`, \`{name}.exe\` — and renames the matched file to \`bin/{daemonName}\` so the rest of the upgrade pipeline keeps treating it as a single canonical path. No platform-specific runtime check is added; the extension probing is purely about accepting a layout, not running it.

Closes #19871

## Test plan

- [x] Added two regression cases to \`TestDownloadUpgrade\`: a Windows-style archive with \`{name}.exe\` at root and one with \`bin/{name}.exe\`. Both must produce a canonical \`bin/{daemon}\` executable. With the pre-fix code both fail with the message above.
- [x] Existing downloader tests pass; ran \`go test ./x/upgrade/plan/...\`.