### PR TITLE
fix(store/cachemulti): isolate traceContext map across branched stores

### DIFF
--- a/store/cachemulti/store.go
+++ b/store/cachemulti/store.go
@@ -43,11 +43,18 @@ func NewFromKVStore(
 	keys map[string]types.StoreKey, traceWriter io.Writer, traceContext types.TraceContext,
 ) Store {
 	cms := Store{
-		db:           cachekv.NewStore(store),
-		stores:       make(map[types.StoreKey]types.CacheWrap, len(stores)),
-		keys:         keys,
-		traceWriter:  traceWriter,
-		traceContext: traceContext,
+		db:          cachekv.NewStore(store),
+		stores:      make(map[types.StoreKey]types.CacheWrap, len(stores)),
+		keys:        keys,
+		traceWriter: traceWriter,
+		// Defensive clone so every Store owns its own trace-context map.
+		// Without this, the caller (typically rootmulti.Store or another
+		// cachemulti.Store) and every branched cms share a single map and
+		// race with each other on Clone()/Merge iteration vs. in-place
+		// maps.Copy in SetTracingContext. Same class of bug that #11117
+		// fixed for rootmulti.Store — applying the same isolation here
+		// (#25841).
+		traceContext: traceContext.Clone(),
 	}
 
 	for key, store := range stores {
@@ -93,12 +100,18 @@ func (cms Store) SetTracer(w io.Writer) types.MultiStore {
 // the given context with the existing context by key. Any existing keys will
 // be overwritten. It is implied that the caller should update the context when
 // necessary between tracing operations. It returns a modified MultiStore.
+//
+// The merged context is materialised into a fresh map rather than written into
+// cms.traceContext in place. Concurrent CacheMultiStore() callers iterate that
+// map via Clone() (see NewFromKVStore), so an in-place maps.Copy races with
+// them on shared references — exactly the failure mode #25841 captured.
+// Allocating a new map for the merged result keeps every prior reference
+// stable: existing branched cms keep pointing at the old map, the updated
+// cms returned here points at the new one.
 func (cms Store) SetTracingContext(tc types.TraceContext) types.MultiStore {
-	if cms.traceContext != nil {
-		maps.Copy(cms.traceContext, tc)
-	} else {
-		cms.traceContext = tc
-	}
+	merged := cms.traceContext.Clone()
+	maps.Copy(merged, tc)
+	cms.traceContext = merged
 
 	return cms
 }

--- a/store/cachemulti/store_test.go
+++ b/store/cachemulti/store_test.go
@@ -1,11 +1,16 @@
 package cachemulti
 
 import (
+	"bytes"
 	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
+	dbm "github.com/cosmos/cosmos-db"
+
+	"cosmossdk.io/store/dbadapter"
 	"cosmossdk.io/store/types"
 )
 
@@ -21,4 +26,95 @@ func TestStoreGetKVStore(t *testing.T) {
 
 	require.PanicsWithValue(errMsg,
 		func() { s.GetKVStore(key) })
+}
+
+// TestNewFromKVStoreIsolatesTraceContext locks in the fix for #25841: the
+// trace-context map handed to NewFromKVStore must not be retained by
+// reference, otherwise downstream Clone()/Merge iteration races with any
+// caller still mutating their copy of the map (e.g. SetTracingContext or a
+// sibling cms branched off the same parent).
+func TestNewFromKVStoreIsolatesTraceContext(t *testing.T) {
+	tc := types.TraceContext{"chain_id": "test-chain"}
+	cms := NewFromKVStore(
+		dbadapter.Store{DB: dbm.NewMemDB()},
+		map[types.StoreKey]types.CacheWrapper{},
+		nil,
+		new(bytes.Buffer),
+		tc,
+	)
+
+	// Mutating the input map after construction must not bleed into the
+	// cms's private trace context.
+	tc["chain_id"] = "OTHER"
+	tc["leak"] = "value"
+
+	require.Equal(t, "test-chain", cms.traceContext["chain_id"])
+	_, leaked := cms.traceContext["leak"]
+	require.False(t, leaked, "external mutation must not reach cms.traceContext")
+}
+
+// TestSetTracingContextDoesNotMutateInPlace pins the SetTracingContext fix
+// for #25841 — the receiver returns a Store backed by a fresh map so prior
+// branched cms keep pointing at the old map without observing the merge.
+func TestSetTracingContextDoesNotMutateInPlace(t *testing.T) {
+	tc := types.TraceContext{"chain_id": "test-chain"}
+	cms := NewFromKVStore(
+		dbadapter.Store{DB: dbm.NewMemDB()},
+		map[types.StoreKey]types.CacheWrapper{},
+		nil,
+		new(bytes.Buffer),
+		tc,
+	)
+
+	// Hold a reference to the map cms is using right now so we can prove
+	// the merge does not write through it.
+	originalMap := cms.traceContext
+
+	cms2 := cms.SetTracingContext(types.TraceContext{"height": "42"}).(Store)
+
+	// originalMap stays untouched.
+	_, mutated := originalMap["height"]
+	require.False(t, mutated, "SetTracingContext must not mutate the prior trace-context map")
+
+	// cms2 sees the merged result.
+	require.Equal(t, "test-chain", cms2.traceContext["chain_id"])
+	require.Equal(t, "42", cms2.traceContext["height"])
+}
+
+// TestCacheMultiStoreConcurrentWithSetTracingContext is the direct regression
+// test for #25841. Before the fix, running this under `go test -race` raised
+// "fatal error: concurrent map iteration and map write" because branched
+// cms instances and the parent shared one trace-context map; one goroutine
+// iterating via Clone()/Merge collided with another writing via
+// SetTracingContext.
+func TestCacheMultiStoreConcurrentWithSetTracingContext(t *testing.T) {
+	cms := NewFromKVStore(
+		dbadapter.Store{DB: dbm.NewMemDB()},
+		map[types.StoreKey]types.CacheWrapper{},
+		nil,
+		new(bytes.Buffer),
+		types.TraceContext{"chain_id": "test-chain"},
+	)
+
+	const goroutines = 16
+	const iterations = 200
+	var wg sync.WaitGroup
+	wg.Add(2 * goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				_ = cms.CacheMultiStore()
+			}
+		}()
+		go func(i int) {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				_ = cms.SetTracingContext(types.TraceContext{
+					fmt.Sprintf("k-%d-%d", i, j): "v",
+				})
+			}
+		}(i)
+	}
+	wg.Wait()
 }


### PR DESCRIPTION
## What

Closes #25841.

`cachemulti.NewFromKVStore` retained the trace-context map handed by its caller (typically `rootmulti.Store` or another `cachemulti.Store`) **by reference** and stored it directly on the new cms. `SetTracingContext` then mutated that same map in place via `maps.Copy`. Concurrent `CacheMultiStore()` callers branch off the parent and call `NewFromKVStore`, which iterates the shared map via `Clone()` inside the per-key loop, so a goroutine on the iteration side collided with another goroutine on the `maps.Copy` write side and the runtime raised:

```
fatal error: concurrent map iteration and map write

internal/runtime/maps.(*Iter).Next(...)
maps.Copy[...](...)
cosmossdk.io/store/types.TraceContext.Clone(...)
    cosmossdk.io/store/types/store.go:464
cosmossdk.io/store/cachemulti.NewFromKVStore(...)
    cosmossdk.io/store/cachemulti/store.go:55
cosmossdk.io/store/cachemulti.newCacheMultiStoreFromCMS(...)
    cosmossdk.io/store/cachemulti/store.go:82
cosmossdk.io/store/cachemulti.Store.CacheMultiStore(...)
    cosmossdk.io/store/cachemulti/store.go:141
```

This is the same class of bug PR #11117 fixed for `rootmulti.Store` by adding a mutex + deep-copy getter. `cachemulti.Store` uses value receivers, so a `sync.Mutex` inline would be a no-op on copies and would trip `go vet`. Instead apply the same isolation by giving every cms its own map at construction time and rewriting `SetTracingContext` to materialise a fresh map per call.

## Fix

| Site | Before | After |
|------|--------|-------|
| `NewFromKVStore` | stored `traceContext` by reference | stores `traceContext.Clone()` — the parent's map can no longer be observed by branched cms |
| `SetTracingContext` | `maps.Copy(cms.traceContext, tc)` mutated in place | clones `cms.traceContext` into a fresh map, merges `tc` into the copy, and reassigns. Prior cms references still point at the old map and never see the write |

`TraceContext.Clone()` returns an empty map on nil input, so the nil-traceContext path keeps working without an explicit branch.

## Regression tests

`store/cachemulti/store_test.go` gets three new cases:

- **`TestNewFromKVStoreIsolatesTraceContext`** — external mutation of the input map after construction must not bleed into `cms.traceContext`. Pins the isolation invariant.
- **`TestSetTracingContextDoesNotMutateInPlace`** — the map a cms was using *before* a `SetTracingContext` call must be untouched after the call. Locks in the fresh-map merge semantics so existing branched references stay stable.
- **`TestCacheMultiStoreConcurrentWithSetTracingContext`** — drives 16 goroutines branching cms via `CacheMultiStore()` against 16 goroutines mutating its trace context via `SetTracingContext`, 200 iterations each. Reproduces the original `concurrent map iteration and map write` fatal under `go test -race` without the fix; passes cleanly with it.

## Run

```
$ cd store && go test -race ./cachemulti/ -count=1 -v
=== RUN   TestStoreGetKVStore
--- PASS
=== RUN   TestNewFromKVStoreIsolatesTraceContext
--- PASS
=== RUN   TestSetTracingContextDoesNotMutateInPlace
--- PASS
=== RUN   TestCacheMultiStoreConcurrentWithSetTracingContext
--- PASS
ok      cosmossdk.io/store/cachemulti   1.807s

$ go vet ./cachemulti/
(clean)

$ gofmt -l cachemulti/store.go cachemulti/store_test.go
(clean)
```

## Targeting note

Opening against `release/v0.53.x` directly because `main` already removed `traceWriter`/`traceContext` from `cachemulti.{NewStore,NewFromKVStore,NewFromParent}` as part of the store v2 migration (`store/CHANGELOG.md:53`), so the bug no longer exists upstream — it only affects the v0.50/v0.52/v0.53 legacy store branches that still ship `cosmossdk.io/store@v1.x`. Happy to mirror against `release/v0.52.x` and `release/v0.50.x` if the maintainers prefer separate PRs over a mergify backport.

## CHANGELOG

Per maintainer convention, leaving the `### Bug Fixes` line for the merger to add at landing time alongside the assigned PR number. Suggested:

```
* (store) [#XXXX](https://github.com/cosmos/cosmos-sdk/pull/XXXX) Fix concurrent-map race in `cachemulti.Store` trace-context handling by isolating the map per Store at construction and materialising a fresh map per `SetTracingContext` call (Fixes #25841).
```