### PR TITLE
refactor: replace Split in loops with more efficient SplitSeq

### DIFF
--- a/client/rpc/tx.go
+++ b/client/rpc/tx.go
@@ -215,8 +215,8 @@ func parseHashFromInput(in []byte) ([]byte, error) {
 	}
 
 	// Try to find the txhash from yaml output.
-	lines := strings.Split(string(in), "\n")
-	for _, line := range lines {
+	lines := strings.SplitSeq(string(in), "\n")
+	for line := range lines {
 		if strings.HasPrefix(line, "txhash:") {
 			hash := strings.TrimSpace(line[len("txhash:"):])
 			return hex.DecodeString(hash)

--- a/x/auth/client/cli/tx_multisign.go
+++ b/x/auth/client/cli/tx_multisign.go
@@ -399,9 +399,9 @@ func readSignaturesFromFile(ctx client.Context, filename string) (sigs []signing
 	}
 
 	newString := strings.TrimSuffix(string(bz), "\n")
-	lines := strings.Split(newString, "\n")
+	lines := strings.SplitSeq(newString, "\n")
 
-	for _, bz := range lines {
+	for bz := range lines {
 		sig, err := ctx.TxConfig.UnmarshalSignatureJSON([]byte(bz))
 		if err != nil {
 			return nil, err

--- a/x/gov/client/utils/utils.go
+++ b/x/gov/client/utils/utils.go
@@ -29,7 +29,7 @@ func NormalizeVoteOption(option string) string {
 // NormalizeWeightedVoteOptions - normalize vote options param string
 func NormalizeWeightedVoteOptions(options string) string {
 	newOptions := []string{}
-	for _, option := range strings.Split(options, ",") {
+	for option := range strings.SplitSeq(options, ",") {
 		fields := strings.Split(option, "=")
 		fields[0] = NormalizeVoteOption(fields[0])
 		if len(fields) < 2 {

--- a/x/gov/types/v1/vote.go
+++ b/x/gov/types/v1/vote.go
@@ -112,7 +112,7 @@ func VoteOptionFromString(str string) (VoteOption, error) {
 // if the string is invalid.
 func WeightedVoteOptionsFromString(str string) (WeightedVoteOptions, error) {
 	options := WeightedVoteOptions{}
-	for _, option := range strings.Split(str, ",") {
+	for option := range strings.SplitSeq(str, ",") {
 		fields := strings.Split(option, "=")
 		option, err := VoteOptionFromString(fields[0])
 		if err != nil {

--- a/x/gov/types/v1beta1/vote.go
+++ b/x/gov/types/v1beta1/vote.go
@@ -87,7 +87,7 @@ func VoteOptionFromString(str string) (VoteOption, error) {
 // if the string is invalid.
 func WeightedVoteOptionsFromString(str string) (WeightedVoteOptions, error) {
 	options := WeightedVoteOptions{}
-	for _, option := range strings.Split(str, ",") {
+	for option := range strings.SplitSeq(str, ",") {
 		fields := strings.Split(option, "=")
 		option, err := VoteOptionFromString(fields[0])
 		if err != nil {


### PR DESCRIPTION
# Description

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->


strings.SplitSeq (introduced in Go 1.23)  returns a lazy sequence (strings.Seq), allowing gopher to iterate over tokens one by one without creating an intermediate slice.

It significantly reduces memory allocations and can improve performance for long strings.

More info: https://github.com/golang/go/issues/61901