### PR TITLE
chore: drop legacy // +build comment

### DIFF
--- a/crypto/keys/secp256k1/internal/secp256k1/secp256_test.go
+++ b/crypto/keys/secp256k1/internal/secp256k1/secp256_test.go
@@ -3,7 +3,6 @@
 // the LICENSE file.
 
 //go:build !gofuzz && cgo
-// +build !gofuzz,cgo
 
 package secp256k1
 


### PR DESCRIPTION
# Description

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->


From Go 1.17, the preferred syntax for build constraints is `//go:build`,
which replaces the old `// +build` form. The old style is now considered
deprecated but still supported for backward compatibility.

This change removes the obsolete `// +build xxx` line, keeping only the
modern `//go:build xxx` directive.

More info: https://github.com/golang/go/issues/41184 and https://go.dev/doc/go1.17#build-lines

Design Doc / Proposal：
https://go.dev/design/draft-gobuild



