### PR TITLE
fix: correct grammar in test files and comments

### DIFF
--- a/contrib/x/circuit/keeper/msg_server_test.go
+++ b/contrib/x/circuit/keeper/msg_server_test.go
@@ -278,7 +278,7 @@ func TestResetCircuitBreaker(t *testing.T) {
 		lastEvent(ft.ctx),
 	)
 
-	// user tries to reset a message they dont have permission to reset
+	// user tries to reset a message they don't have permission to reset
 	url = "cosmos.staking.v1beta1.MsgCreateValidator"
 	// give restricted perms to a user
 	someMsgs := &types.Permissions{Level: types.Permissions_LEVEL_SOME_MSGS, LimitTypeUrls: []string{url2}}

--- a/tests/e2e/staking/suite.go
+++ b/tests/e2e/staking/suite.go
@@ -139,7 +139,7 @@ func (s *E2ETestSuite) TestBlockResults() {
 	require.NoError(err)
 	require.NoError(s.network.WaitForNextBlock())
 
-	// Create a HTTP rpc client.
+	// Create an HTTP rpc client.
 	rpcClient, err := http.New(val.RPCAddress, "/websocket")
 	require.NoError(err)
 

--- a/testutil/network/util.go
+++ b/testutil/network/util.go
@@ -81,7 +81,7 @@ func startInProcess(cfg Config, val *Validator) error {
 		val.RPCClient = local.New(tmNode)
 	}
 
-	// We'll need a RPC client if the validator exposes a gRPC or REST endpoint.
+	// We'll need an RPC client if the validator exposes a gRPC or REST endpoint.
 	if val.APIAddress != "" || val.AppConfig.GRPC.Enable {
 		val.ClientCtx = val.ClientCtx.
 			WithClient(val.RPCClient)

--- a/x/auth/ante/ante_test.go
+++ b/x/auth/ante/ante_test.go
@@ -136,7 +136,7 @@ func TestAnteHandlerSigErrors(t *testing.T) {
 			sdkerrors.ErrNoSignatures,
 		},
 		{
-			"num sigs dont match GetSigners",
+			"num sigs don't match GetSigners",
 			func(suite *AnteTestSuite) TestCaseArgs {
 				privs, accNums, accSeqs := []cryptotypes.PrivKey{priv0}, []uint64{0}, []uint64{0}
 


### PR DESCRIPTION
## Description
Fixed grammatical errors in test files and comments for improved readability.

⚠️ **Note:** These are comment-only changes in test files. No production code logic is affected. This is a minor documentation improvement to the repository.

## Changes
- Fixed `a HTTP` → `an HTTP` in e2e test comment
- Fixed `a RPC` → `an RPC` in network utility comment
- Fixed `dont` → `don't` in test assertion messages

## Files Modified
- tests/e2e/staking/suite.go (comment only)
- testutil/network/util.go (comment only)
- x/auth/ante/ante_test.go (test assertion message)
- contrib/x/circuit/keeper/msg_server_test.go (comment only)

## Impact
- No functional changes to code logic
- No changes to production code
- Test readability improvement only