### PR TITLE
feat(baseapp): emit gen-tx events on finalize-state EventManager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### Improvements
 
 * (docs) [#25918](https://github.com/cosmos/cosmos-sdk/issues/25918) Regenerate Swagger API spec to reflect current proto state, including `authority` field on consensus params and removal of stale module-config definitions.
+* (baseapp) [#25984](https://github.com/cosmos/cosmos-sdk/issues/25984) `BaseApp.ExecuteGenesisTx` now re-emits the genesis transaction's events on the finalize-block state's `EventManager`, so indexers, ABCI listeners and other post-genesis hooks that observe events can see gen-tx events instead of having them silently dropped.
 
 ### Bug Fixes
 

--- a/baseapp/abci_test.go
+++ b/baseapp/abci_test.go
@@ -2701,3 +2701,65 @@ func TestABCI_Race_Commit_Query(t *testing.T) {
 
 	require.Equal(t, int64(1001), app.GetContextForCheckTx(nil).BlockHeight())
 }
+
+// TestABCI_ExecuteGenesisTx_PropagatesEvents pins down the fix from #25984:
+// BaseApp.ExecuteGenesisTx must re-emit the genesis transaction's events on
+// the finalize-block state's EventManager. Without that, gen-tx events are
+// confined to the per-tx result and dropped (ResponseInitChain has no
+// top-level events field), which breaks indexers that rely on events alone
+// to track chain state at genesis.
+func TestABCI_ExecuteGenesisTx_PropagatesEvents(t *testing.T) {
+	var (
+		txBytes []byte
+		appRef  *baseapp.BaseApp
+	)
+
+	initChainerOpt := func(bapp *baseapp.BaseApp) {
+		bapp.SetInitChainer(func(_ sdk.Context, _ *abci.RequestInitChain) (*abci.ResponseInitChain, error) {
+			require.NoError(t, appRef.ExecuteGenesisTx(txBytes))
+			return &abci.ResponseInitChain{}, nil
+		})
+	}
+
+	suite := NewBaseAppSuite(t, baseapp.SetChainID("test-chain-id"), initChainerOpt)
+	appRef = suite.baseApp
+
+	deliverKey := []byte("genesis-counter")
+	baseapptestutil.RegisterCounterServer(
+		suite.baseApp.MsgServiceRouter(),
+		CounterServerImpl{t, capKey1, deliverKey},
+	)
+
+	// Build a tx whose handler emits a known event.
+	tx := newTxCounter(t, suite.txConfig, 0, 0)
+	var err error
+	txBytes, err = suite.txConfig.TxEncoder()(tx)
+	require.NoError(t, err)
+
+	_, err = suite.baseApp.InitChain(&abci.RequestInitChain{
+		ChainId:         "test-chain-id",
+		ConsensusParams: &cmtproto.ConsensusParams{},
+		AppStateBytes:   []byte("{}"),
+	})
+	require.NoError(t, err)
+
+	events := getFinalizeBlockStateCtx(suite.baseApp).EventManager().Events()
+
+	var sawCounterEvent bool
+	for _, ev := range events {
+		if ev.Type != sdk.EventTypeMessage {
+			continue
+		}
+		for _, attr := range ev.Attributes {
+			if attr.Key == "update_counter" && attr.Value == "0" {
+				sawCounterEvent = true
+				break
+			}
+		}
+		if sawCounterEvent {
+			break
+		}
+	}
+	require.True(t, sawCounterEvent,
+		"genesis-tx event was not propagated to the finalize-state EventManager; events=%+v", events)
+}

--- a/baseapp/genesis.go
+++ b/baseapp/genesis.go
@@ -6,17 +6,37 @@ import (
 	"github.com/cometbft/cometbft/abci/types"
 
 	"cosmossdk.io/core/genesis"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 var _ genesis.TxHandler = (*BaseApp)(nil)
 
 // ExecuteGenesisTx implements genesis.GenesisState from
-// cosmossdk.io/core/genesis to set initial state in genesis
+// cosmossdk.io/core/genesis to set initial state in genesis.
+//
+// On success the events produced by the genesis transaction's message
+// handlers are re-published on the finalize-block state's EventManager so
+// that subscribers running during InitChain (event indexers, ABCI listeners
+// and any custom post-genesis hook that walks the manager) can observe
+// them. Without this, gen-tx events are confined to the per-tx result and
+// silently dropped because ResponseInitChain has no top-level events
+// field. Refs #25984.
 func (ba *BaseApp) ExecuteGenesisTx(tx []byte) error {
 	res := ba.deliverTx(tx, nil, nil, -1, nil)
 
 	if res.Code != types.CodeTypeOK {
 		return errors.New(res.Log)
+	}
+
+	if len(res.Events) > 0 {
+		if finalizeState := ba.stateManager.GetState(execModeFinalize); finalizeState != nil {
+			events := make(sdk.Events, len(res.Events))
+			for i, ev := range res.Events {
+				events[i] = sdk.Event(ev)
+			}
+			finalizeState.Context().EventManager().EmitEvents(events)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
## Description

Closes #25984.

\`BaseApp.ExecuteGenesisTx\` previously discarded the \`abci.Event\`s returned by the genesis transaction's message handlers. The events lived only on the per-tx \`ExecTxResult\`, and since \`ResponseInitChain\` has no top-level events field, anything that walks the \`EventManager\` during InitChain — event indexers, ABCI listeners, custom post-genesis hooks — saw nothing for gen-txs.

This PR re-emits those events on the finalize-block state's \`EventManager\` after the tx succeeds, so subscribers running inside InitChain (and the first \`FinalizeBlock\`, which carries InitChain's state) can observe them.

\`genesis.TxHandler\` stays unchanged so module callers do not need to migrate.

### Test
- New \`TestABCI_ExecuteGenesisTx_PropagatesEvents\` in \`baseapp/abci_test.go\` registers a handler that emits a known event, runs the tx through an \`InitChainer\` that calls \`ExecuteGenesisTx\`, and asserts the event is visible on the finalize-state \`EventManager\` after \`InitChain\` returns. Reverting the new emit block makes the test fail.
- Full \`TestABCI_\` suite passes locally.

---

#### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [x] confirmed \`!\` in the type prefix if API or client breaking change — no breaking change
* [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [x] provided a link to the relevant issue or specification
* [ ] reviewed "Files changed" and left comments if necessary — n/a
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing) — added in this PR
* [x] added a changelog entry to \`CHANGELOG.md\`
* [ ] included comments for [documenting Go code](https://blog.golang.org/godoc) — godoc on \`ExecuteGenesisTx\` updated
* [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc) — n/a
* [ ] confirmed all CI checks have passed — pending