### PR TITLE
test(baseapp): pin gRPC Query / FinalizeBlock concurrency safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### Improvements
 
 * (docs) [#25918](https://github.com/cosmos/cosmos-sdk/issues/25918) Regenerate Swagger API spec to reflect current proto state, including `authority` field on consensus params and removal of stale module-config definitions.
+* (baseapp) [#22368](https://github.com/cosmos/cosmos-sdk/issues/22368) Add `-race`-mode regression test (`TestABCI_Race_GRPC_Query_During_Commit`) covering concurrent `BaseApp.Query` and `FinalizeBlock`/`Commit`. Pins down the state-management mutex work added in #24655 and follow-ups so the data race reported against v0.50.x cannot regress silently.
 
 ### Bug Fixes
 

--- a/baseapp/abci_test.go
+++ b/baseapp/abci_test.go
@@ -2654,6 +2654,60 @@ func TestFinalizeBlockDeferResponseHandle(t *testing.T) {
 	require.NotEmpty(t, err)
 }
 
+// TestABCI_Race_GRPC_Query_During_Commit reproduces the scenario reported in
+// #22368: a gRPC-style query goroutine calling BaseApp.Query while another
+// goroutine drives FinalizeBlock/Commit in a tight loop. With prior racy
+// state-management code (before the state.Manager / state.State RW-mutex
+// work in #24655 and follow-ups), `go test -race` would flag a DATA RACE on
+// fields touched by Commit and read by CreateQueryContext. This test guards
+// against any regression.
+func TestABCI_Race_GRPC_Query_During_Commit(t *testing.T) {
+	suite := NewBaseAppSuite(t, baseapp.SetChainID("test-chain-id"))
+	app := suite.baseApp
+
+	_, err := app.InitChain(&abci.RequestInitChain{
+		ChainId:         "test-chain-id",
+		ConsensusParams: &cmtproto.ConsensusParams{Block: &cmtproto.BlockParams{MaxGas: 5_000_000}},
+		InitialHeight:   1,
+	})
+	require.NoError(t, err)
+	_, err = app.Commit()
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var queries atomic.Uint64
+
+	queryLoop := func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+				// height=0 forces app.Query to read app.LastBlockHeight()
+				// and CreateQueryContext to walk both check + finalize
+				// states. Path is intentionally invalid; we only care
+				// about the state-access path executing without races.
+				_, _ = app.Query(ctx, &abci.RequestQuery{Path: "/store/main/key", Data: []byte("k"), Height: 0})
+				queries.Add(1)
+			}
+		}
+	}
+
+	for i := 0; i < 16; i++ {
+		go queryLoop()
+	}
+
+	for i := 0; i < 200; i++ {
+		_, err = app.FinalizeBlock(&abci.RequestFinalizeBlock{Height: app.LastBlockHeight() + 1})
+		require.NoError(t, err)
+		_, err = app.Commit()
+		require.NoError(t, err)
+	}
+
+	cancel()
+	require.Greater(t, queries.Load(), uint64(0), "no concurrent queries ran")
+}
+
 func TestABCI_Race_Commit_Query(t *testing.T) {
 	suite := NewBaseAppSuite(t, baseapp.SetChainID("test-chain-id"))
 	app := suite.baseApp


### PR DESCRIPTION
## Description

Refs #22368.

When the issue was reported against v0.50.10, \`BaseApp.CreateQueryContext\` reached into the BaseApp's check / finalize states without coordinating with \`Commit\`, so \`go test -race\` flagged a DATA RACE on the underlying state fields. The state-management mutex work landed in #24655 and the subsequent \`state.Manager\` / \`state.State\` RW-mutex refactor closed those races on \`main\`, but **no test held the line** — a regression that loosened the mutex coverage would slip through CI silently.

This PR adds \`TestABCI_Race_GRPC_Query_During_Commit\` to pin the invariant down: 16 goroutines drive \`BaseApp.Query\` (the gRPC-style entry point that walks \`CreateQueryContext\`) while the main goroutine drives 200 rounds of \`FinalizeBlock\` + \`Commit\`. Test passes cleanly under \`-race\` today, and reverting any of the existing \`state.Manager.stateMut\` / \`state.State.mtx\` lock-takes makes it fail.

### Why a regression test rather than a code fix
I could not reproduce the original race on current \`main\` — the prior mutex work resolved it. The companion regression test is the smallest landable artifact that prevents the same data race from re-appearing.

Maintainers — once this lands, I'm happy to leave a note on #22368 confirming the race no longer reproduces and asking whether it can be closed (or downgraded to \"add regression coverage\" and closed by this PR).

### Test
- \`go test -race -count=1 -run TestABCI_Race_GRPC_Query_During_Commit ./baseapp/...\` → PASS
- Existing \`TestABCI_Race_Commit_Query\` still passes (covers the \`CreateQueryContextWithCheckHeader\` direct path; the new test covers the higher-level \`BaseApp.Query\` path including the \`LastBlockHeight\` lookup at \`abci.go:178\`)

---

#### Author Checklist

I have...

* [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title (\`test\`)
* [x] confirmed no \`!\` in the type prefix — test-only change, no API surface affected
* [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [x] provided a link to the relevant issue
* [x] included the necessary unit/integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing) — this PR _is_ the test
* [x] added a changelog entry to \`CHANGELOG.md\`
* [x] included comments for [documenting Go code](https://blog.golang.org/godoc) — godoc on the new test explains the scenario and history
* [ ] updated the relevant documentation or specification — n/a
* [ ] confirmed all CI checks have passed — pending