### PR TITLE
feat(staking): deferred key rotation until H+2 after abci validator updates

### DIFF
--- a/tests/integration/staking/keeper/cons_key_rotation_test.go
+++ b/tests/integration/staking/keeper/cons_key_rotation_test.go
@@ -260,7 +260,7 @@ func bondConsKeyRotationValidator(t *testing.T, f *fixture, consPk cryptotypes.P
 	_, err = f.stakingKeeper.Delegate(f.sdkCtx, addrs[0], f.stakingKeeper.TokensFromConsensusPower(f.sdkCtx, 100), types.Unbonded, v, true)
 	assert.NilError(t, err)
 
-	applyValidatorSetUpdates(t, f.sdkCtx, f.stakingKeeper, -1)
+	applyValidatorSetUpdates(t, f.sdkCtx, f.stakingKeeper, 1)
 
 	return valAddr, addrs[0]
 }

--- a/tests/integration/staking/keeper/cons_key_rotation_test.go
+++ b/tests/integration/staking/keeper/cons_key_rotation_test.go
@@ -16,10 +16,10 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/staking/types"
 )
 
-// Covers msg-server queuing plus end-blocker application: the fee transfer,
-// all four store indexes, the deferred swap of the validators stored
-// ConsensusPubkey, and the two ABCI updates CometBFT needs to retire the old
-// key at zero power and instate the new key at the current power.
+// Covers msg-server queuing plus the EndBlocker's two-phase drain: the fee
+// transfer, all four store indexes, the queue entry at the correct apply
+// height, the pre-apply read-back of the unchanged ConsensusPubkey, and the
+// post-apply swap of the validator's ConsensusPubkey and byConsAddr index.
 func TestRotateConsPubKey_MsgServerQueuesAndEndBlockerApplies(t *testing.T) {
 	t.Parallel()
 	f := initFixture(t)
@@ -42,6 +42,7 @@ func TestRotateConsPubKey_MsgServerQueuesAndEndBlockerApplies(t *testing.T) {
 	powerBefore := valBefore.ConsensusPower(powerReduction)
 	assert.Assert(t, powerBefore > 0)
 
+	writeHeight := f.sdkCtx.BlockHeight()
 	_, err = msgServer.RotateConsPubKey(f.sdkCtx, &types.MsgRotateConsPubKey{
 		ValidatorAddress: valAddr.String(),
 		NewPubkey:        newPubKeyAny(t, newPk),
@@ -74,16 +75,36 @@ func TestRotateConsPubKey_MsgServerQueuesAndEndBlockerApplies(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Assert(t, hasRotated)
 
-	// validators stored ConsensusPubkey is unchanged until the end blocker runs
+	// validators stored ConsensusPubkey is unchanged before the apply height.
+	// The deferred design keeps the SDK view aligned with CometBFT's active
+	// key, which only switches at writeHeight + ConsensusUpdateDelay.
 	preEndBlocker, err := f.stakingKeeper.GetValidator(f.sdkCtx, valAddr)
 	assert.NilError(t, err)
 	preConsAddr, err := preEndBlocker.GetConsAddr()
 	assert.NilError(t, err)
 	assert.DeepEqual(t, oldConsAddr.Bytes(), preConsAddr)
 
-	// advance one block at the current block time so the end blocker applies
-	// the rotation but does not yet prune (maturity is in the future)
+	// advance one block at the current block time. With the deferred apply
+	// design the EndBlocker emit pass runs but the SDK-side state swap does
+	// not yet land (applyHeight = writeHeight + 2 has not been reached).
 	advanceBlock(t, f, f.sdkCtx.BlockHeader().Time)
+
+	stillOld, err := f.stakingKeeper.GetValidator(f.sdkCtx, valAddr)
+	assert.NilError(t, err)
+	stillOldConsAddr, err := stillOld.GetConsAddr()
+	assert.NilError(t, err)
+	assert.DeepEqual(t, oldConsAddr.Bytes(), stillOldConsAddr)
+	byOld, err := f.stakingKeeper.GetValidatorByConsAddr(f.sdkCtx, oldConsAddr)
+	assert.NilError(t, err)
+	assert.Equal(t, valAddr.String(), byOld.OperatorAddress)
+
+	// at the apply height (writeHeight + 2), the drain pass swaps state.
+	// invoke the EndBlocker pass directly at the apply height because the
+	// integration fixture's EndBlocker runs with the captured initial block
+	// height and does not advance with FinalizeBlock.
+	applyCtx := f.sdkCtx.WithBlockHeight(writeHeight + types.ConsensusUpdateDelay)
+	_, err = f.stakingKeeper.ProcessConsKeyRotations(applyCtx, powerReduction)
+	assert.NilError(t, err)
 
 	// old by-cons-addr index is gone
 	_, err = f.stakingKeeper.GetValidatorByConsAddr(f.sdkCtx, oldConsAddr)
@@ -103,9 +124,9 @@ func TestRotateConsPubKey_MsgServerQueuesAndEndBlockerApplies(t *testing.T) {
 	assert.DeepEqual(t, newConsAddr.Bytes(), storedConsAddr)
 	assert.Equal(t, powerBefore, stored.ConsensusPower(powerReduction))
 
-	// the per-validator pending index intentionally persists past the end
-	// blocker so that further rotations are gated until the end blocker
-	// prunes it after maturity
+	// the per-validator pending index intentionally persists past the apply
+	// so that further rotations are gated until the end blocker prunes it
+	// after maturity
 	hasPendingAfter, err := f.stakingKeeper.HasConsKeyRotationInUnbondingWindow(f.sdkCtx, valAddr)
 	assert.NilError(t, err)
 	assert.Assert(t, hasPendingAfter)
@@ -134,8 +155,8 @@ func TestRotateConsPubKey_PruneClearsRotationStateAfterUnbonding(t *testing.T) {
 	assert.NilError(t, err)
 	maturity := f.sdkCtx.BlockHeader().Time.Add(unbondingTime)
 
-	// first block at current time: applies the rotation, maturity is in
-	// the future so no pruning happens
+	// first block at current time: maturity is in the future so no pruning
+	// happens
 	advanceBlock(t, f, f.sdkCtx.BlockHeader().Time)
 
 	has, err := f.stakingKeeper.HasConsKeyRotationQueueEntry(f.sdkCtx, maturity, valAddr)
@@ -164,6 +185,7 @@ func TestRotateConsPubKey_SecondRotationAfterPruningSucceeds(t *testing.T) {
 	t.Parallel()
 	f := initFixture(t)
 	msgServer := keeper.NewMsgServerImpl(f.stakingKeeper)
+	powerReduction := f.stakingKeeper.PowerReduction(f.sdkCtx)
 
 	pkA := ed25519.GenPrivKey().PubKey()
 	pkB := ed25519.GenPrivKey().PubKey()
@@ -171,6 +193,7 @@ func TestRotateConsPubKey_SecondRotationAfterPruningSucceeds(t *testing.T) {
 	valAddr, _ := bondConsKeyRotationValidator(t, f, pkA)
 
 	// first rotation A -> B
+	writeHeight := f.sdkCtx.BlockHeight()
 	_, err := msgServer.RotateConsPubKey(f.sdkCtx, &types.MsgRotateConsPubKey{
 		ValidatorAddress: valAddr.String(),
 		NewPubkey:        newPubKeyAny(t, pkB),
@@ -185,6 +208,14 @@ func TestRotateConsPubKey_SecondRotationAfterPruningSucceeds(t *testing.T) {
 	})
 	assert.ErrorContains(t, err, types.ErrExceedingMaxConsPubKeyRotations.Error())
 
+	// drive the SDK-side state swap at writeHeight + ConsensusUpdateDelay so
+	// the validators stored ConsensusPubkey becomes pkB and the byConsAddr
+	// index moves accordingly. The integration fixture's EndBlocker keeps the
+	// captured block height, so the drain pass is invoked here directly.
+	applyCtx := f.sdkCtx.WithBlockHeight(writeHeight + types.ConsensusUpdateDelay)
+	_, err = f.stakingKeeper.ProcessConsKeyRotations(applyCtx, powerReduction)
+	assert.NilError(t, err)
+
 	// advance past maturity and let the end blocker prune
 	unbondingTime, err := f.stakingKeeper.UnbondingTime(f.sdkCtx)
 	assert.NilError(t, err)
@@ -192,12 +223,18 @@ func TestRotateConsPubKey_SecondRotationAfterPruningSucceeds(t *testing.T) {
 
 	// second rotation back to pkA (the original key) succeeds: the rotation
 	// history was cleared by pruning
+	writeHeight = f.sdkCtx.BlockHeight()
 	_, err = msgServer.RotateConsPubKey(f.sdkCtx, &types.MsgRotateConsPubKey{
 		ValidatorAddress: valAddr.String(),
 		NewPubkey:        newPubKeyAny(t, pkA),
 	})
 	assert.NilError(t, err)
 	advanceBlock(t, f, f.sdkCtx.BlockHeader().Time)
+
+	// drive the drain again for this second rotation
+	applyCtx = f.sdkCtx.WithBlockHeight(writeHeight + types.ConsensusUpdateDelay)
+	_, err = f.stakingKeeper.ProcessConsKeyRotations(applyCtx, powerReduction)
+	assert.NilError(t, err)
 
 	stored, err := f.stakingKeeper.GetValidator(f.sdkCtx, valAddr)
 	assert.NilError(t, err)
@@ -223,7 +260,7 @@ func bondConsKeyRotationValidator(t *testing.T, f *fixture, consPk cryptotypes.P
 	_, err = f.stakingKeeper.Delegate(f.sdkCtx, addrs[0], f.stakingKeeper.TokensFromConsensusPower(f.sdkCtx, 100), types.Unbonded, v, true)
 	assert.NilError(t, err)
 
-	applyValidatorSetUpdates(t, f.sdkCtx, f.stakingKeeper, 1)
+	applyValidatorSetUpdates(t, f.sdkCtx, f.stakingKeeper, -1)
 
 	return valAddr, addrs[0]
 }
@@ -236,8 +273,8 @@ func newPubKeyAny(t *testing.T, pk cryptotypes.PubKey) *codectypes.Any {
 }
 
 // advanceBlock advances the chain by one block at blockTime, driving the
-// staking end blocker through the real ABCI flow so that pending consensus
-// key rotations are applied and any matured rotation entries are pruned.
+// staking end blocker through the real ABCI flow so that any matured rotation
+// entries are pruned.
 func advanceBlock(t *testing.T, f *fixture, blockTime time.Time) {
 	t.Helper()
 	_, err := f.app.FinalizeBlock(&cmtabcitypes.RequestFinalizeBlock{

--- a/x/staking/keeper/genesis.go
+++ b/x/staking/keeper/genesis.go
@@ -198,6 +198,10 @@ func (k Keeper) InitGenesis(ctx context.Context, data *types.GenesisState) (res 
 				panic(fmt.Sprintf("validator %s not found", lv.Address))
 			}
 
+			// TODO: when cons key rotation queues become part of GenesisState,
+			// route this through PendingConsKeyRotations / EffectiveKeyForABCIUpdate
+			// so a rotation in flight at the upgrade boundary emits under the
+			// new cons key.
 			update := validator.ABCIValidatorUpdate(k.PowerReduction(ctx))
 			update.Power = lv.Power // keep the next-val-set offset, use the last power for the first block
 			res = append(res, update)

--- a/x/staking/keeper/rotation.go
+++ b/x/staking/keeper/rotation.go
@@ -139,7 +139,8 @@ func (k Keeper) ApplyConsKeyRotations(ctx context.Context) (err error) {
 	// deleted mid-iteration.
 	var entries []matured
 	for ; iterator.Valid(); iterator.Next() {
-		_, valAddr, err := types.ParseConsKeyRotationApplyQueueKey(iterator.Key())
+		keyCopy := append([]byte(nil), iterator.Key()...)
+		_, valAddr, err := types.ParseConsKeyRotationApplyQueueKey(keyCopy)
 		if err != nil {
 			return err
 		}
@@ -147,7 +148,6 @@ func (k Keeper) ApplyConsKeyRotations(ctx context.Context) (err error) {
 		if uerr := k.cdc.UnmarshalInterface(iterator.Value(), &newPubKey); uerr != nil {
 			return uerr
 		}
-		keyCopy := append([]byte(nil), iterator.Key()...)
 		entries = append(entries, matured{key: keyCopy, valAddr: valAddr, newPubKey: newPubKey})
 	}
 

--- a/x/staking/keeper/rotation.go
+++ b/x/staking/keeper/rotation.go
@@ -1,9 +1,9 @@
 package keeper
 
 import (
-	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	abci "github.com/cometbft/cometbft/abci/types"
@@ -11,6 +11,7 @@ import (
 	"cosmossdk.io/math"
 
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	cryptocodec "github.com/cosmos/cosmos-sdk/crypto/codec"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	storetypes "github.com/cosmos/cosmos-sdk/store/v2/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -37,17 +38,13 @@ func (k Keeper) HasConsKeyRotationQueueEntry(ctx context.Context, maturity time.
 	return k.storeService.OpenKVStore(ctx).Has(types.GetConsKeyRotationQueueKey(maturity, valAddr))
 }
 
-// SetConsKeyRotation writes to indexes that track a pending consensus key
-// rotation. The new pubkey is written to the unapplied queue so the end
-// blocker can perform the rotation in this block.
+// SetConsKeyRotation writes the indexes that track a pending consensus key
+// rotation.
 func (k Keeper) SetConsKeyRotation(ctx context.Context, valAddr sdk.ValAddress, oldPubKey, newPubKey cryptotypes.PubKey) error {
-	sdkCtx := sdk.UnwrapSDKContext(ctx)
-
-	unbondingTime, err := k.UnbondingTime(ctx)
+	maturesAt, err := k.rotationMaturityTime(ctx)
 	if err != nil {
 		return err
 	}
-	maturity := sdkCtx.BlockHeader().Time.Add(unbondingTime)
 
 	oldConsAddr := sdk.ConsAddress(oldPubKey.Address())
 	newConsAddr := sdk.ConsAddress(newPubKey.Address())
@@ -57,10 +54,12 @@ func (k Keeper) SetConsKeyRotation(ctx context.Context, valAddr sdk.ValAddress, 
 	// add to queue keyed by time so that we can iterate rotations happening by
 	// time and quickly remove ones that have matured (fallen out of the
 	// current unbonding period).
-	if err := store.Set(types.GetConsKeyRotationQueueKey(maturity, valAddr), oldConsAddr); err != nil {
+	if err := store.Set(types.GetConsKeyRotationQueueKey(maturesAt, valAddr), oldConsAddr); err != nil {
 		return err
 	}
 
+	// mark this validator has having rotated (used to block future rotation
+	// for this validator within the current unbonding period).
 	if err := store.Set(types.GetValidatorConsKeyRotationKey(valAddr), []byte{}); err != nil {
 		return err
 	}
@@ -81,98 +80,243 @@ func (k Keeper) SetConsKeyRotation(ctx context.Context, valAddr sdk.ValAddress, 
 	if err != nil {
 		return err
 	}
-	return store.Set(types.GetUnappliedConsKeyRotationKey(valAddr), newPubKeyBz)
+
+	// add the rotation to the apply queue, so the end blocker can:
+	// 1. iterate the queue and emit validator power updates for rotations that
+	//    are behind their apply height.
+	// 2. iterate the queue and update staking state for validators who should
+	//    have their rotations applied to sdk state (at apply height).
+	applyHeight := rotationApplyHeight(ctx)
+	return store.Set(types.GetConsKeyRotationApplyQueueKey(applyHeight, valAddr), newPubKeyBz)
 }
 
-// ApplyPendingConsKeyRotations applies every rotation queued by the msg server
-// and returns the validator updates needed to retire each old key at zero
-// power and instate each new key at the validator's current power.
-func (k Keeper) ApplyPendingConsKeyRotations(ctx context.Context, powerReduction math.Int) ([]abci.ValidatorUpdate, error) {
-	var totalUpdates abci.ValidatorUpdates
-
-	store := k.storeService.OpenKVStore(ctx)
-	err := k.IterateUnappliedConsKeyRotations(ctx, func(valAddr sdk.ValAddress, newPubKey cryptotypes.PubKey) error {
-		validator, err := k.GetValidator(ctx, valAddr)
-		if err != nil {
-			return err
-		}
-
-		// handles updating state with the validators new consensus key and
-		// creating abci updates to pass to comet
-		updates, err := k.ApplyConsKeyRotation(ctx, validator, newPubKey, powerReduction)
-		if err != nil {
-			return err
-		}
-		totalUpdates = append(totalUpdates, updates...)
-
-		// the new cons addr is now the validator's live cons addr; further
-		// rotations targeting it are blocked by the by cons addr lookup,
-		// so release its rotation lock entry. The old cons addr entry
-		// stays until the rotation matures.
-		if err := store.Delete(types.GetRotationLockedConsAddrIndexKey(sdk.ConsAddress(newPubKey.Address()))); err != nil {
-			return err
-		}
-
-		return store.Delete(types.GetUnappliedConsKeyRotationKey(valAddr))
-	})
-	if err != nil {
+// ProcessConsKeyRotations performs the two passes over the height-keyed apply
+// queue called once per EndBlock from ApplyAndReturnValidatorSetUpdates:
+//
+//   - Drain (mature): for every entry with applyHeight <= currentHeight, apply
+//     the SDK-side state swap (validator.ConsensusPubkey and byConsAddr index),
+//     delete the queue entry, and release the new-addr rotation lock. The
+//     old-addr lock persists until unbonding-window pruning.
+//   - Emit (new this block): for every entry with applyHeight ==
+//     currentHeight + ConsensusUpdateDelay, build and append the
+//     (old@0, new@power) ValidatorUpdate pair. The entry is not deleted here;
+//     it remains until its applyHeight matures.
+//
+// The drain pass runs first so that subsequent transition emits in the same
+// EndBlock read the post-swap ConsensusPubkey.
+func (k Keeper) ProcessConsKeyRotations(ctx context.Context, powerReduction math.Int) ([]abci.ValidatorUpdate, error) {
+	if err := k.ApplyConsKeyRotations(ctx); err != nil {
 		return nil, err
 	}
-
-	return totalUpdates, nil
+	return k.ConsKeyRotationUpdates(ctx, powerReduction)
 }
 
-// ApplyConsKeyRotation switches the validator's consensus pubkey to newPubKey
-// in x/staking state. The validator record is updated, the old by cons address
-// index entry is deleted, and the new by cons address index entry is written.
-func (k Keeper) ApplyConsKeyRotation(ctx context.Context, validator types.Validator, newPubKey cryptotypes.PubKey, powerReduction math.Int) (abci.ValidatorUpdates, error) {
-	// we will have two validator updates for every consensus key rotation
-	// since a key rotation to comet looks like a validator becoming 0 power
-	// (the old cons addr) and a new validator coming online with the new cons
-	// addr that has the same power as the old validator.
-	updates := make([]abci.ValidatorUpdate, 2)
+// ApplyConsKeyRotations iterates every apply queue entry whose applyHeight has
+// been reached, performs the state swap, and clears the queue entry plus the
+// new addr rotation lock.
+func (k Keeper) ApplyConsKeyRotations(ctx context.Context) (err error) {
+	store := k.storeService.OpenKVStore(ctx)
 
-	// create a validator update that will mark its current cons addr as 0
-	// power
-	updates[0] = validator.ABCIValidatorUpdateZero()
+	// iterate (-, currentHeight+1) which covers every applyHeight <= currentHeight
+	currentHeight := sdk.UnwrapSDKContext(ctx).BlockHeight()
+	iterator, err := store.Iterator(
+		types.ConsKeyRotationApplyQueueKey,
+		storetypes.PrefixEndBytes(types.GetConsKeyRotationApplyQueueHeightPrefix(currentHeight)),
+	)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		err = errors.Join(err, iterator.Close())
+	}()
 
-	// capture the old cons addr before the in-memory swap below, so that we
-	// can delete the old by cons addr index entry further down
+	type matured struct {
+		key       []byte
+		valAddr   sdk.ValAddress
+		newPubKey cryptotypes.PubKey
+	}
+	// collect first; SDK store iterators do not promise safety when keys are
+	// deleted mid-iteration.
+	var entries []matured
+	for ; iterator.Valid(); iterator.Next() {
+		_, valAddr, err := types.ParseConsKeyRotationApplyQueueKey(iterator.Key())
+		if err != nil {
+			return err
+		}
+		var newPubKey cryptotypes.PubKey
+		if uerr := k.cdc.UnmarshalInterface(iterator.Value(), &newPubKey); uerr != nil {
+			return uerr
+		}
+		keyCopy := append([]byte(nil), iterator.Key()...)
+		entries = append(entries, matured{key: keyCopy, valAddr: valAddr, newPubKey: newPubKey})
+	}
+
+	for _, e := range entries {
+		if aerr := k.ApplyConsKeyRotation(ctx, e.valAddr, e.newPubKey); aerr != nil {
+			return aerr
+		}
+
+		// the new cons addr is now the validator's live cons addr. further
+		// rotations targeting it are blocked by the by cons addr lookup, so
+		// release its rotation lock entry. The old cons addr entry stays
+		// until the rotation matures.
+		if derr := store.Delete(types.GetRotationLockedConsAddrIndexKey(sdk.ConsAddress(e.newPubKey.Address()))); derr != nil {
+			return derr
+		}
+
+		// delete the entry from the apply queue
+		if derr := store.Delete(e.key); derr != nil {
+			return derr
+		}
+	}
+	return nil
+}
+
+// ApplyConsKeyRotation swaps the validator's ConsensusPubkey to newPubKey
+// and updates the byConsAddr index. Returns nil silently if the validator no
+// longer exists.
+func (k Keeper) ApplyConsKeyRotation(ctx context.Context, valAddr sdk.ValAddress, newPubKey cryptotypes.PubKey) error {
+	validator, err := k.GetValidator(ctx, valAddr)
+	if err != nil {
+		// this could happen if the validator is removed (unbonds) between when
+		// the rotation was enqueued, and now when we are actually applying it
+		// (since there is a 2 block delay between enqueue and apply).
+		if errors.Is(err, types.ErrNoValidatorFound) {
+			return nil
+		}
+		return err
+	}
+
 	oldConsAddr, err := validator.GetConsAddr()
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	// update the validator in memory to use the new cons addr
 	newAny, err := codectypes.NewAnyWithValue(newPubKey)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	validator.ConsensusPubkey = newAny
 
-	// create a validator update that will mark its new cons addr with the same
-	// power as its previous cons addr
-	updates[1] = validator.ABCIValidatorUpdate(powerReduction)
-
-	// set the validator in the store (keyed by operator address, which didnt
-	// change) to the updated validator with the new cons addr
 	if err := k.SetValidator(ctx, validator); err != nil {
-		return nil, err
+		return err
 	}
 
-	// remove the store entry for the previous cons addr pointing to the
-	// validator
 	store := k.storeService.OpenKVStore(ctx)
 	if err := store.Delete(types.GetValidatorByConsAddrKey(oldConsAddr)); err != nil {
+		return err
+	}
+	return k.SetValidatorByConsAddr(ctx, validator)
+}
+
+// ConsKeyRotationUpdates returns power updates for each validator
+// rotating their consensus keys.
+func (k Keeper) ConsKeyRotationUpdates(ctx context.Context, powerReduction math.Int) (updates []abci.ValidatorUpdate, err error) {
+	store := k.storeService.OpenKVStore(ctx)
+
+	// iterate all entries in the apply queue that are equal to applyHeight
+	applyHeight := rotationApplyHeight(ctx)
+	prefix := types.GetConsKeyRotationApplyQueueHeightPrefix(applyHeight)
+	iterator, err := store.Iterator(prefix, storetypes.PrefixEndBytes(prefix))
+	if err != nil {
 		return nil, err
 	}
+	defer func() {
+		err = errors.Join(err, iterator.Close())
+	}()
 
-	// create a new store entry for the new cons addr pointing to the validator
-	if err := k.SetValidatorByConsAddr(ctx, validator); err != nil {
-		return nil, err
+	for ; iterator.Valid(); iterator.Next() {
+		_, valAddr, err := types.ParseConsKeyRotationApplyQueueKey(iterator.Key())
+		if err != nil {
+			return nil, err
+		}
+		validator, err := k.GetValidator(ctx, valAddr)
+		if err != nil {
+			return nil, err
+		}
+		var newPubKey cryptotypes.PubKey
+		if err := k.cdc.UnmarshalInterface(iterator.Value(), &newPubKey); err != nil {
+			return nil, err
+		}
+		pair, err := k.ConsKeyRotationUpdate(validator, newPubKey, powerReduction)
+		if err != nil {
+			return nil, err
+		}
+		updates = append(updates, pair...)
 	}
-
 	return updates, nil
+}
+
+// ConsKeyRotationUpdate builds the (old@0, new@power) ABCI ValidatorUpdate
+// pair that announces a cons key rotation to CometBFT. It does not mutate
+// state.
+func (k Keeper) ConsKeyRotationUpdate(validator types.Validator, newPubKey cryptotypes.PubKey, powerReduction math.Int) (abci.ValidatorUpdates, error) {
+	oldTmProtoPk, err := validator.CmtConsPublicKey()
+	if err != nil {
+		return nil, fmt.Errorf("converting validators existing cons key to tm proto: %w", err)
+	}
+	newTmProtoPk, err := cryptocodec.ToCmtProtoPublicKey(newPubKey)
+	if err != nil {
+		return nil, fmt.Errorf("converting validators new cons key to tm proto: %w", err)
+	}
+
+	return []abci.ValidatorUpdate{
+		{
+			PubKey: oldTmProtoPk,
+			Power:  0,
+		},
+		{
+			PubKey: newTmProtoPk,
+			Power:  validator.ConsensusPower(powerReduction),
+		},
+	}, nil
+}
+
+type PendingRotations map[string]cryptotypes.PubKey
+
+func (pr PendingRotations) EffectiveKeyForABCIUpdate(valAddr sdk.ValAddress, validator types.Validator) (cryptotypes.PubKey, error) {
+	// if this validator has a pending rotation, use the pk that they are
+	// rotating to
+	if pk, ok := pr[string(valAddr)]; ok {
+		return pk, nil
+	}
+
+	// the validator is not in the pending rotation set, use their current
+	// consensus key
+	return validator.ConsPubKey()
+}
+
+// PendingConsKeyRotations scans the apply queue once and returns every
+// rotation still in flight, keyed by string(valAddr). It is intended to be
+// called once per EndBlock after ProcessConsKeyRotations so the bonded loop
+// can substitute the new cons key on per-validator emits via an O(1) map
+// lookup instead of repeated store reads.
+func (k Keeper) PendingConsKeyRotations(ctx context.Context) (rotations PendingRotations, err error) {
+	store := k.storeService.OpenKVStore(ctx)
+	iterator, err := store.Iterator(
+		types.ConsKeyRotationApplyQueueKey,
+		storetypes.PrefixEndBytes(types.ConsKeyRotationApplyQueueKey),
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		err = errors.Join(err, iterator.Close())
+	}()
+
+	rotations = make(map[string]cryptotypes.PubKey)
+	for ; iterator.Valid(); iterator.Next() {
+		_, valAddr, err := types.ParseConsKeyRotationApplyQueueKey(iterator.Key())
+		if err != nil {
+			return nil, err
+		}
+		var newPubKey cryptotypes.PubKey
+		if err := k.cdc.UnmarshalInterface(iterator.Value(), &newPubKey); err != nil {
+			return nil, err
+		}
+		rotations[string(valAddr)] = newPubKey
+	}
+	return rotations, nil
 }
 
 // PruneMaturedConsKeyRotations removes every rotation whose unbonding window
@@ -214,9 +358,9 @@ func (k Keeper) maturedConsKeyRotationKeys(ctx context.Context, blockTime time.T
 
 	// TODO: migrate ValidatorSigningInfo from oldConsAddr to newConsAddr
 	for ; iterator.Valid(); iterator.Next() {
-		maturity, valAddr, perr := types.ParseConsKeyRotationQueueKey(iterator.Key())
-		if perr != nil {
-			return nil, perr
+		maturity, valAddr, err := types.ParseConsKeyRotationQueueKey(iterator.Key())
+		if err != nil {
+			return nil, err
 		}
 		oldConsAddr := sdk.ConsAddress(iterator.Value())
 
@@ -229,51 +373,19 @@ func (k Keeper) maturedConsKeyRotationKeys(ctx context.Context, blockTime time.T
 	return keys, nil
 }
 
-// IterateUnappliedConsKeyRotations walks every rotation queued by the msg
-// server that the end blocker has not yet applied, in valAddr sorted order. It
-// is safe to delete store keys within the supplied callback.
-func (k Keeper) IterateUnappliedConsKeyRotations(
-	ctx context.Context,
-	cb func(valAddr sdk.ValAddress, newPubKey cryptotypes.PubKey) error,
-) error {
-	rotations, err := k.unappliedConsKeyRotations(ctx)
-	if err != nil {
-		return err
-	}
-	for _, r := range rotations {
-		if err := cb(r.valAddr, r.newPubKey); err != nil {
-			return err
-		}
-	}
-	return nil
+// rotationApplyHeight returns the height that a rotation should be applied at
+// given the current context.
+func rotationApplyHeight(ctx context.Context) int64 {
+	return sdk.UnwrapSDKContext(ctx).BlockHeight() + types.ConsensusUpdateDelay
 }
 
-type unappliedConsKeyRotation struct {
-	valAddr   sdk.ValAddress
-	newPubKey cryptotypes.PubKey
-}
-
-// unappliedConsKeyRotations returns every rotation queued by the msg server
-// that the end blocker has not yet applied.
-func (k Keeper) unappliedConsKeyRotations(ctx context.Context) (rotations []unappliedConsKeyRotation, err error) {
-	store := k.storeService.OpenKVStore(ctx)
-	iterator, err := store.Iterator(types.UnappliedConsKeyRotationKey, storetypes.PrefixEndBytes(types.UnappliedConsKeyRotationKey))
+// rotationMaturityTime returns the time that a rotation will mature at given
+// the current context.
+func (k Keeper) rotationMaturityTime(ctx context.Context) (time.Time, error) {
+	sdkCtx := sdk.UnwrapSDKContext(ctx)
+	unbondingTime, err := k.UnbondingTime(ctx)
 	if err != nil {
-		return nil, err
+		return time.Time{}, err
 	}
-	defer func() {
-		err = errors.Join(err, iterator.Close())
-	}()
-
-	for ; iterator.Valid(); iterator.Next() {
-		key := iterator.Key()
-		valAddr := sdk.ValAddress(bytes.Clone(key[len(types.UnappliedConsKeyRotationKey)+1:]))
-
-		var newPubKey cryptotypes.PubKey
-		if err := k.cdc.UnmarshalInterface(iterator.Value(), &newPubKey); err != nil {
-			return nil, err
-		}
-		rotations = append(rotations, unappliedConsKeyRotation{valAddr: valAddr, newPubKey: newPubKey})
-	}
-	return rotations, nil
+	return sdkCtx.BlockHeader().Time.Add(unbondingTime), nil
 }

--- a/x/staking/keeper/rotation.go
+++ b/x/staking/keeper/rotation.go
@@ -232,6 +232,12 @@ func (k Keeper) ConsKeyRotationUpdates(ctx context.Context, powerReduction math.
 		}
 		validator, err := k.GetValidator(ctx, valAddr)
 		if err != nil {
+			// the validator may have been removed earlier in the same block
+			// (e.g., evidence-driven tombstoning). ApplyConsKeyRotation also
+			// no-ops in this case, so skip emitting an update for it.
+			if errors.Is(err, types.ErrNoValidatorFound) {
+				continue
+			}
 			return nil, err
 		}
 		var newPubKey cryptotypes.PubKey

--- a/x/staking/keeper/rotation_test.go
+++ b/x/staking/keeper/rotation_test.go
@@ -1,7 +1,6 @@
 package keeper_test
 
 import (
-	"errors"
 	"testing"
 	"time"
 
@@ -13,140 +12,265 @@ import (
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 )
 
-func (s *KeeperTestSuite) TestApplyConsKeyRotation() {
+// bondedValidator stores and bonds a validator with the given consensus
+// pubkey, returns the validator record together with its operator address.
+func (s *KeeperTestSuite) bondedValidator(pk cryptotypes.PubKey) (stakingtypes.Validator, sdk.ValAddress) {
 	require := s.Require()
-
-	createValidator := func() (stakingtypes.Validator, sdk.ValAddress, cryptotypes.PubKey) {
-		pk := ed25519.GenPrivKey().PubKey()
-		valAddr := sdk.ValAddress(pk.Address())
-		v, err := stakingtypes.NewValidator(valAddr.String(), pk, stakingtypes.Description{Moniker: "v"})
-		require.NoError(err)
-		v.Status = stakingtypes.Bonded
-		v.Tokens = sdk.TokensFromConsensusPower(10, sdk.DefaultPowerReduction)
-		v.DelegatorShares = math.LegacyNewDecFromInt(v.Tokens)
-		require.NoError(s.stakingKeeper.SetValidator(s.ctx, v))
-		require.NoError(s.stakingKeeper.SetValidatorByConsAddr(s.ctx, v))
-		return v, valAddr, pk
-	}
-
-	testCases := []struct {
-		name  string
-		setup func() (validator stakingtypes.Validator, valAddr sdk.ValAddress, oldPk, newPk cryptotypes.PubKey)
-	}{
-		{
-			name: "successful rotation",
-			setup: func() (stakingtypes.Validator, sdk.ValAddress, cryptotypes.PubKey, cryptotypes.PubKey) {
-				v, valAddr, oldPk := createValidator()
-				return v, valAddr, oldPk, ed25519.GenPrivKey().PubKey()
-			},
-		},
-		{
-			name: "rotate to same key is a no-op",
-			setup: func() (stakingtypes.Validator, sdk.ValAddress, cryptotypes.PubKey, cryptotypes.PubKey) {
-				v, valAddr, oldPk := createValidator()
-				return v, valAddr, oldPk, oldPk
-			},
-		},
-	}
-
-	for _, tc := range testCases {
-		s.T().Run(tc.name, func(t *testing.T) {
-			s.SetupTest()
-
-			validator, valAddr, oldPk, newPk := tc.setup()
-
-			updates, err := s.stakingKeeper.ApplyConsKeyRotation(s.ctx, validator, newPk, sdk.DefaultPowerReduction)
-			require.NoError(err)
-			require.Len(updates, 2)
-			require.Equal(int64(0), updates[0].Power)
-			require.Equal(int64(10), updates[1].Power)
-
-			// validator's stored ConsensusPubkey must now resolve to newPk
-			stored, err := s.stakingKeeper.GetValidator(s.ctx, valAddr)
-			require.NoError(err)
-			gotConsAddr, err := stored.GetConsAddr()
-			require.NoError(err)
-			require.Equal(sdk.ConsAddress(newPk.Address()).Bytes(), gotConsAddr)
-
-			// new by cons address lookup resolves to this validator
-			byNew, err := s.stakingKeeper.GetValidatorByConsAddr(s.ctx, sdk.ConsAddress(newPk.Address()))
-			require.NoError(err)
-			require.Equal(valAddr.String(), byNew.OperatorAddress)
-
-			// old by cons address lookup is gone unless the rotation was a no-op
-			if !oldPk.Equals(newPk) {
-				_, err = s.stakingKeeper.GetValidatorByConsAddr(s.ctx, sdk.ConsAddress(oldPk.Address()))
-				require.Error(err)
-			}
-		})
-	}
+	valAddr := sdk.ValAddress(pk.Address())
+	v, err := stakingtypes.NewValidator(valAddr.String(), pk, stakingtypes.Description{Moniker: "v"})
+	require.NoError(err)
+	v.Status = stakingtypes.Bonded
+	v.Tokens = sdk.TokensFromConsensusPower(10, sdk.DefaultPowerReduction)
+	v.DelegatorShares = math.LegacyNewDecFromInt(v.Tokens)
+	require.NoError(s.stakingKeeper.SetValidator(s.ctx, v))
+	require.NoError(s.stakingKeeper.SetValidatorByConsAddr(s.ctx, v))
+	return v, valAddr
 }
 
-func (s *KeeperTestSuite) TestIterateUnappliedConsKeyRotations() {
+func (s *KeeperTestSuite) TestConsKeyRotationUpdates() {
 	require := s.Require()
 
-	type entry struct {
-		valAddr sdk.ValAddress
-		newPk   cryptotypes.PubKey
-	}
+	s.T().Run("emits old at zero power and new at full power without mutating state", func(t *testing.T) {
+		s.SetupTest()
 
-	errStop := errors.New("stop")
+		oldPk := ed25519.GenPrivKey().PubKey()
+		newPk := ed25519.GenPrivKey().PubKey()
+		validator, valAddr := s.bondedValidator(oldPk)
 
-	testCases := []struct {
-		name      string
-		seedCount int
-		stopAfter int // 0 = no stop
-		expectLen int
-		expectErr error
-	}{
-		{name: "empty store", seedCount: 0, expectLen: 0},
-		{name: "single entry", seedCount: 1, expectLen: 1},
-		{name: "three entries", seedCount: 3, expectLen: 3},
-		{name: "stop with error after first of three", seedCount: 3, stopAfter: 1, expectLen: 1, expectErr: errStop},
-	}
+		updates, err := s.stakingKeeper.ConsKeyRotationUpdate(validator, newPk, sdk.DefaultPowerReduction)
+		require.NoError(err)
+		require.Len(updates, 2)
+		require.Equal(int64(0), updates[0].Power)
+		require.Equal(int64(10), updates[1].Power)
 
-	for _, tc := range testCases {
-		s.T().Run(tc.name, func(t *testing.T) {
-			s.SetupTest()
+		// state must not have been touched
+		stored, err := s.stakingKeeper.GetValidator(s.ctx, valAddr)
+		require.NoError(err)
+		gotConsAddr, err := stored.GetConsAddr()
+		require.NoError(err)
+		require.Equal(sdk.ConsAddress(oldPk.Address()).Bytes(), gotConsAddr)
 
-			seeded := make([]entry, tc.seedCount)
-			for i := range seeded {
-				seeded[i] = entry{
-					valAddr: sdk.ValAddress(ed25519.GenPrivKey().PubKey().Address()),
-					newPk:   ed25519.GenPrivKey().PubKey(),
-				}
-				oldPk := ed25519.GenPrivKey().PubKey()
-				require.NoError(s.stakingKeeper.SetConsKeyRotation(s.ctx, seeded[i].valAddr, oldPk, seeded[i].newPk))
-			}
+		_, err = s.stakingKeeper.GetValidatorByConsAddr(s.ctx, sdk.ConsAddress(newPk.Address()))
+		require.Error(err)
+	})
+}
 
-			var observed []entry
-			err := s.stakingKeeper.IterateUnappliedConsKeyRotations(s.ctx, func(valAddr sdk.ValAddress, newPk cryptotypes.PubKey) error {
-				observed = append(observed, entry{valAddr, newPk})
-				if tc.stopAfter > 0 && len(observed) >= tc.stopAfter {
-					return errStop
-				}
-				return nil
-			})
-			if tc.expectErr != nil {
-				require.ErrorIs(err, tc.expectErr)
-			} else {
-				require.NoError(err)
-			}
-			require.Len(observed, tc.expectLen)
+func (s *KeeperTestSuite) TestApplyConsKeyRotationState() {
+	require := s.Require()
 
-			// each observed entry must round trip to one of the seeded entries
-			for _, got := range observed {
-				found := false
-				for _, want := range seeded {
-					if got.valAddr.Equals(want.valAddr) && got.newPk.Equals(want.newPk) {
-						found = true
-						break
-					}
-				}
-				require.True(found, "observed entry not in seeded set: %s", got.valAddr)
-			}
-		})
-	}
+	s.T().Run("swaps stored ConsensusPubkey and byConsAddr index", func(t *testing.T) {
+		s.SetupTest()
+
+		oldPk := ed25519.GenPrivKey().PubKey()
+		newPk := ed25519.GenPrivKey().PubKey()
+		_, valAddr := s.bondedValidator(oldPk)
+
+		require.NoError(s.stakingKeeper.ApplyConsKeyRotation(s.ctx, valAddr, newPk))
+
+		stored, err := s.stakingKeeper.GetValidator(s.ctx, valAddr)
+		require.NoError(err)
+		gotConsAddr, err := stored.GetConsAddr()
+		require.NoError(err)
+		require.Equal(sdk.ConsAddress(newPk.Address()).Bytes(), gotConsAddr)
+
+		byNew, err := s.stakingKeeper.GetValidatorByConsAddr(s.ctx, sdk.ConsAddress(newPk.Address()))
+		require.NoError(err)
+		require.Equal(valAddr.String(), byNew.OperatorAddress)
+
+		_, err = s.stakingKeeper.GetValidatorByConsAddr(s.ctx, sdk.ConsAddress(oldPk.Address()))
+		require.Error(err)
+	})
+
+	s.T().Run("returns nil when validator no longer exists", func(t *testing.T) {
+		s.SetupTest()
+
+		missing := sdk.ValAddress(ed25519.GenPrivKey().PubKey().Address())
+		newPk := ed25519.GenPrivKey().PubKey()
+		require.NoError(s.stakingKeeper.ApplyConsKeyRotation(s.ctx, missing, newPk))
+	})
+
+	s.T().Run("preserves jailed flag and status across the swap", func(t *testing.T) {
+		s.SetupTest()
+
+		oldPk := ed25519.GenPrivKey().PubKey()
+		newPk := ed25519.GenPrivKey().PubKey()
+		v, valAddr := s.bondedValidator(oldPk)
+		v.Jailed = true
+		v.Status = stakingtypes.Unbonding
+		require.NoError(s.stakingKeeper.SetValidator(s.ctx, v))
+
+		require.NoError(s.stakingKeeper.ApplyConsKeyRotation(s.ctx, valAddr, newPk))
+
+		stored, err := s.stakingKeeper.GetValidator(s.ctx, valAddr)
+		require.NoError(err)
+		require.True(stored.Jailed)
+		require.Equal(stakingtypes.Unbonding, stored.Status)
+	})
+}
+
+func (s *KeeperTestSuite) TestPendingConsKeyRotations() {
+	require := s.Require()
+
+	s.T().Run("empty queue returns empty map", func(t *testing.T) {
+		s.SetupTest()
+
+		got, err := s.stakingKeeper.PendingConsKeyRotations(s.ctx)
+		require.NoError(err)
+		require.Empty(got)
+	})
+
+	s.T().Run("entry in flight is returned keyed by valAddr", func(t *testing.T) {
+		s.SetupTest()
+
+		oldPk := ed25519.GenPrivKey().PubKey()
+		newPk := ed25519.GenPrivKey().PubKey()
+		_, valAddr := s.bondedValidator(oldPk)
+
+		s.ctx = s.ctx.WithBlockHeight(100)
+		require.NoError(s.stakingKeeper.SetConsKeyRotation(s.ctx, valAddr, oldPk, newPk))
+
+		got, err := s.stakingKeeper.PendingConsKeyRotations(s.ctx)
+		require.NoError(err)
+		require.Len(got, 1)
+		pk, ok := got[string(valAddr)]
+		require.True(ok)
+		require.True(pk.Equals(newPk))
+	})
+
+	s.T().Run("drained entry is no longer returned", func(t *testing.T) {
+		s.SetupTest()
+
+		oldPk := ed25519.GenPrivKey().PubKey()
+		newPk := ed25519.GenPrivKey().PubKey()
+		_, valAddr := s.bondedValidator(oldPk)
+
+		s.ctx = s.ctx.WithBlockHeight(100)
+		require.NoError(s.stakingKeeper.SetConsKeyRotation(s.ctx, valAddr, oldPk, newPk))
+
+		s.ctx = s.ctx.WithBlockHeight(100 + stakingtypes.ConsensusUpdateDelay)
+		_, err := s.stakingKeeper.ProcessConsKeyRotations(s.ctx, sdk.DefaultPowerReduction)
+		require.NoError(err)
+
+		got, err := s.stakingKeeper.PendingConsKeyRotations(s.ctx)
+		require.NoError(err)
+		require.Empty(got)
+	})
+}
+
+func (s *KeeperTestSuite) TestProcessConsKeyRotations() {
+	require := s.Require()
+
+	s.T().Run("at write height emits rotation pair, drain is no-op", func(t *testing.T) {
+		s.SetupTest()
+
+		oldPk := ed25519.GenPrivKey().PubKey()
+		newPk := ed25519.GenPrivKey().PubKey()
+		_, valAddr := s.bondedValidator(oldPk)
+
+		s.ctx = s.ctx.WithBlockHeight(100)
+		require.NoError(s.stakingKeeper.SetConsKeyRotation(s.ctx, valAddr, oldPk, newPk))
+
+		updates, err := s.stakingKeeper.ProcessConsKeyRotations(s.ctx, sdk.DefaultPowerReduction)
+		require.NoError(err)
+		require.Len(updates, 2)
+		require.Equal(int64(0), updates[0].Power)
+		require.Equal(int64(10), updates[1].Power)
+
+		// state is still unchanged: drain has not yet matured
+		stored, err := s.stakingKeeper.GetValidator(s.ctx, valAddr)
+		require.NoError(err)
+		gotConsAddr, err := stored.GetConsAddr()
+		require.NoError(err)
+		require.Equal(sdk.ConsAddress(oldPk.Address()).Bytes(), gotConsAddr)
+	})
+
+	s.T().Run("between write and apply heights both passes are no-ops", func(t *testing.T) {
+		s.SetupTest()
+
+		oldPk := ed25519.GenPrivKey().PubKey()
+		newPk := ed25519.GenPrivKey().PubKey()
+		_, valAddr := s.bondedValidator(oldPk)
+
+		s.ctx = s.ctx.WithBlockHeight(100)
+		require.NoError(s.stakingKeeper.SetConsKeyRotation(s.ctx, valAddr, oldPk, newPk))
+
+		s.ctx = s.ctx.WithBlockHeight(100 + stakingtypes.ConsensusUpdateDelay - 1)
+		updates, err := s.stakingKeeper.ProcessConsKeyRotations(s.ctx, sdk.DefaultPowerReduction)
+		require.NoError(err)
+		require.Empty(updates)
+
+		stored, err := s.stakingKeeper.GetValidator(s.ctx, valAddr)
+		require.NoError(err)
+		gotConsAddr, err := stored.GetConsAddr()
+		require.NoError(err)
+		require.Equal(sdk.ConsAddress(oldPk.Address()).Bytes(), gotConsAddr)
+	})
+
+	s.T().Run("at apply height drain swaps state and emit is no-op", func(t *testing.T) {
+		s.SetupTest()
+
+		oldPk := ed25519.GenPrivKey().PubKey()
+		newPk := ed25519.GenPrivKey().PubKey()
+		_, valAddr := s.bondedValidator(oldPk)
+
+		s.ctx = s.ctx.WithBlockHeight(100)
+		require.NoError(s.stakingKeeper.SetConsKeyRotation(s.ctx, valAddr, oldPk, newPk))
+
+		s.ctx = s.ctx.WithBlockHeight(100 + stakingtypes.ConsensusUpdateDelay)
+		updates, err := s.stakingKeeper.ProcessConsKeyRotations(s.ctx, sdk.DefaultPowerReduction)
+		require.NoError(err)
+		require.Empty(updates)
+
+		// swap is now visible in state
+		stored, err := s.stakingKeeper.GetValidator(s.ctx, valAddr)
+		require.NoError(err)
+		gotConsAddr, err := stored.GetConsAddr()
+		require.NoError(err)
+		require.Equal(sdk.ConsAddress(newPk.Address()).Bytes(), gotConsAddr)
+
+		byNew, err := s.stakingKeeper.GetValidatorByConsAddr(s.ctx, sdk.ConsAddress(newPk.Address()))
+		require.NoError(err)
+		require.Equal(valAddr.String(), byNew.OperatorAddress)
+
+		_, err = s.stakingKeeper.GetValidatorByConsAddr(s.ctx, sdk.ConsAddress(oldPk.Address()))
+		require.Error(err)
+
+		// the new addr rotation lock is released; old addr lock remains
+		hasNew, err := s.stakingKeeper.IsConsAddrLockedByRotation(s.ctx, sdk.ConsAddress(newPk.Address()))
+		require.NoError(err)
+		require.False(hasNew)
+		hasOld, err := s.stakingKeeper.IsConsAddrLockedByRotation(s.ctx, sdk.ConsAddress(oldPk.Address()))
+		require.NoError(err)
+		require.True(hasOld)
+	})
+
+	s.T().Run("drain skips removed validator and still clears queue and lock", func(t *testing.T) {
+		s.SetupTest()
+
+		oldPk := ed25519.GenPrivKey().PubKey()
+		newPk := ed25519.GenPrivKey().PubKey()
+		v, valAddr := s.bondedValidator(oldPk)
+
+		s.ctx = s.ctx.WithBlockHeight(100)
+		require.NoError(s.stakingKeeper.SetConsKeyRotation(s.ctx, valAddr, oldPk, newPk))
+
+		// drop the validator before the apply height. RemoveValidator only
+		// works on unbonded records, so flip the status before deleting.
+		v.Status = stakingtypes.Unbonded
+		v.Tokens = math.ZeroInt()
+		v.DelegatorShares = math.LegacyZeroDec()
+		require.NoError(s.stakingKeeper.SetValidator(s.ctx, v))
+		require.NoError(s.stakingKeeper.RemoveValidator(s.ctx, valAddr))
+
+		s.ctx = s.ctx.WithBlockHeight(100 + stakingtypes.ConsensusUpdateDelay)
+		updates, err := s.stakingKeeper.ProcessConsKeyRotations(s.ctx, sdk.DefaultPowerReduction)
+		require.NoError(err)
+		require.Empty(updates)
+
+		hasNew, err := s.stakingKeeper.IsConsAddrLockedByRotation(s.ctx, sdk.ConsAddress(newPk.Address()))
+		require.NoError(err)
+		require.False(hasNew)
+	})
 }
 
 func (s *KeeperTestSuite) TestPruneMaturedConsKeyRotations() {

--- a/x/staking/keeper/rotation_test.go
+++ b/x/staking/keeper/rotation_test.go
@@ -244,6 +244,30 @@ func (s *KeeperTestSuite) TestProcessConsKeyRotations() {
 		require.True(hasOld)
 	})
 
+	s.T().Run("emit skips removed validator", func(t *testing.T) {
+		s.SetupTest()
+
+		oldPk := ed25519.GenPrivKey().PubKey()
+		newPk := ed25519.GenPrivKey().PubKey()
+		v, valAddr := s.bondedValidator(oldPk)
+
+		s.ctx = s.ctx.WithBlockHeight(100)
+		require.NoError(s.stakingKeeper.SetConsKeyRotation(s.ctx, valAddr, oldPk, newPk))
+
+		// drop the validator in the same block, after the rotation is queued
+		// but before emit runs. RemoveValidator only works on unbonded records.
+		v.Status = stakingtypes.Unbonded
+		v.Tokens = math.ZeroInt()
+		v.DelegatorShares = math.LegacyZeroDec()
+		require.NoError(s.stakingKeeper.SetValidator(s.ctx, v))
+		require.NoError(s.stakingKeeper.RemoveValidator(s.ctx, valAddr))
+
+		// still at the write height, so emit runs against the queued entry
+		updates, err := s.stakingKeeper.ProcessConsKeyRotations(s.ctx, sdk.DefaultPowerReduction)
+		require.NoError(err)
+		require.Empty(updates)
+	})
+
 	s.T().Run("drain skips removed validator and still clears queue and lock", func(t *testing.T) {
 		s.SetupTest()
 

--- a/x/staking/keeper/val_state_change.go
+++ b/x/staking/keeper/val_state_change.go
@@ -144,6 +144,25 @@ func (k Keeper) ApplyAndReturnValidatorSetUpdates(ctx context.Context) (updates 
 	totalPower := math.ZeroInt()
 	amtFromBondedToNotBonded, amtFromNotBondedToBonded := math.ZeroInt(), math.ZeroInt()
 
+	// process cons key rotations first so:
+	// 1. the (old_key@0, new_key@power) pair is emitted before any other
+	//    update for this validator in this block. comet applies in slice order,
+	//    so a later main loop emit's power wins.
+	// 2. drain's swap of validator.ConsensusPubkey is visible to subsequent
+	//    reads in this EndBlock.
+	rotationUpdates, err := k.ProcessConsKeyRotations(ctx, powerReduction)
+	if err != nil {
+		return nil, err
+	}
+	updates = append(updates, rotationUpdates...)
+
+	// load the set of in-flight rotations once so the bonded loop emits below
+	// can substitute the new cons key.
+	pendingRotations, err := k.PendingConsKeyRotations(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	// Retrieve the last validator set.
 	// The persistent set is updated later in this function.
 	// (see LastValidatorPowerKey).
@@ -205,7 +224,11 @@ func (k Keeper) ApplyAndReturnValidatorSetUpdates(ctx context.Context) (updates 
 
 		// update the validator set if power has changed
 		if !found || oldPower != newPower {
-			updates = append(updates, validator.ABCIValidatorUpdate(powerReduction))
+			pk, err := pendingRotations.EffectiveKeyForABCIUpdate(valAddr, validator)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get effective key for validator %X: %w", valAddr, err)
+			}
+			updates = append(updates, validator.ABCIValidatorUpdateWithPubKey(powerReduction, pk))
 
 			if err = k.SetLastValidatorPower(ctx, valAddr, newPower); err != nil {
 				return nil, err
@@ -241,19 +264,12 @@ func (k Keeper) ApplyAndReturnValidatorSetUpdates(ctx context.Context) (updates 
 			return nil, err
 		}
 
-		updates = append(updates, validator.ABCIValidatorUpdateZero())
+		pk, err := pendingRotations.EffectiveKeyForABCIUpdate(sdk.ValAddress(valAddrBytes), validator)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get effective key for validator %X: %w", sdk.ValAddress(valAddrBytes), err)
+		}
+		updates = append(updates, validator.ABCIValidatorUpdateZeroWithPubKey(pk))
 	}
-
-	// apply pending consensus key rotations. each rotation emits a zero
-	// power update for the old key followed by a current power update for
-	// the new key. an old key that already received a power change earlier
-	// in this updates list is correctly retired because cometbft applies
-	// updates in order.
-	rotationUpdates, err := k.ApplyPendingConsKeyRotations(ctx, powerReduction)
-	if err != nil {
-		return nil, err
-	}
-	updates = append(updates, rotationUpdates...)
 
 	// Update the pools based on the recent updates in the validator set:
 	// - The tokens from the non-bonded candidates that enter the new validator set need to be transferred

--- a/x/staking/keeper/val_state_change_test.go
+++ b/x/staking/keeper/val_state_change_test.go
@@ -1,27 +1,35 @@
 package keeper_test
 
 import (
+	"testing"
+
+	abci "github.com/cometbft/cometbft/abci/types"
+	cmtprotocrypto "github.com/cometbft/cometbft/proto/tendermint/crypto"
+	"go.uber.org/mock/gomock"
+
 	"cosmossdk.io/math"
 
 	cryptocodec "github.com/cosmos/cosmos-sdk/crypto/codec"
 	"github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
+	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 )
 
 // TestApplyAndReturnValidatorSetUpdatesWithKeyRotation exercises the EndBlocker
-// path where the validator set update loop has already appended an update for
-// the validator's old consensus key (because its power changed) and then a
-// queued key rotation runs. The new key must end up at the validator's current
-// power, not at a delta against the prior update.
+// path where a queued cons key rotation runs in the same block as a power
+// change for the same validator. With the deferred-apply design, the rotation
+// (old@0, new@power) pair is emitted first, and any subsequent main-loop emit
+// for the validator is routed through the new cons key so CometBFT's set ends
+// up at new@power after applying updates in order.
 func (s *KeeperTestSuite) TestApplyAndReturnValidatorSetUpdatesWithKeyRotation() {
 	require := s.Require()
 
 	powerReduction := s.stakingKeeper.PowerReduction(s.ctx)
 
 	// set up a bonded validator with 10 consensus power. LastValidatorPower
-	// is intentionally not seeded, so the main loop will append an update
-	// for the old key with the validator's current power.
+	// is intentionally not seeded, so the main loop will discover a power
+	// change and append an update.
 	oldPk := ed25519.GenPrivKey().PubKey()
 	valAddr := sdk.ValAddress(oldPk.Address())
 	v, err := stakingtypes.NewValidator(valAddr.String(), oldPk, stakingtypes.Description{Moniker: "v"})
@@ -41,9 +49,11 @@ func (s *KeeperTestSuite) TestApplyAndReturnValidatorSetUpdatesWithKeyRotation()
 	require.NoError(err)
 
 	// expected list, in order:
-	//   [0] old @ 10  (from the main loop discovering a power change)
-	//   [1] old @ 0   (from the rotation retiring the old key)
-	//   [2] new @ 10  (from the rotation instating the new key)
+	//   [0] old @ 0   (rotation retiring the old key, emitted first)
+	//   [1] new @ 10  (rotation instating the new key)
+	//   [2] new @ 10  (main-loop power-change emit, routed through the new
+	//                  cons key by effectiveConsKeyForUpdate because the
+	//                  rotation applyHeight is within the emit window)
 	require.Len(updates, 3)
 
 	oldCmtPk, err := cryptocodec.ToCmtProtoPublicKey(oldPk)
@@ -52,13 +62,19 @@ func (s *KeeperTestSuite) TestApplyAndReturnValidatorSetUpdatesWithKeyRotation()
 	require.NoError(err)
 
 	require.Equal(oldCmtPk, updates[0].PubKey)
-	require.Equal(int64(10), updates[0].Power)
+	require.Equal(int64(0), updates[0].Power)
 
-	require.Equal(oldCmtPk, updates[1].PubKey)
-	require.Equal(int64(0), updates[1].Power)
+	require.Equal(newCmtPk, updates[1].PubKey)
+	require.Equal(int64(10), updates[1].Power)
 
 	require.Equal(newCmtPk, updates[2].PubKey)
 	require.Equal(int64(10), updates[2].Power)
+
+	// the main-loop emit must not reference the old cons key — that is the
+	// regression the routing helper prevents.
+	for i, u := range updates[1:] {
+		require.NotEqual(oldCmtPk, u.PubKey, "post-rotation emit %d still references old cons key", i+1)
+	}
 
 	// simulate cometbft applying the updates in order, last write wins per
 	// key. the final state must have the old key removed and the new key at
@@ -77,4 +93,296 @@ func (s *KeeperTestSuite) TestApplyAndReturnValidatorSetUpdatesWithKeyRotation()
 
 	require.Equal(int64(0), finalPower[string(oldBz)])
 	require.Equal(int64(10), finalPower[string(newBz)])
+}
+
+func (s *KeeperTestSuite) TestApplyAndReturnValidatorSetUpdates_RotationEmitSequence() {
+	require := s.Require()
+
+	s.T().Run("baseline rotation only", func(t *testing.T) {
+		s.SetupTest()
+		const H = int64(10)
+		oldPk := ed25519.GenPrivKey().PubKey()
+		newPk := ed25519.GenPrivKey().PubKey()
+
+		s.ctx = s.ctx.WithBlockHeight(H)
+		valAddr := s.bondedValidatorAtPower(oldPk, 10)
+		require.NoError(s.stakingKeeper.SetConsKeyRotation(s.ctx, valAddr, oldPk, newPk))
+
+		// H EndBlock: only the rotation pair is emitted. LastValidatorPower
+		// equals the live power, so the main loop adds nothing.
+		updates, err := s.stakingKeeper.ApplyAndReturnValidatorSetUpdates(s.ctx)
+		require.NoError(err)
+		require.Len(updates, 2)
+		require.Equal(cmtPk(t, oldPk), updates[0].PubKey)
+		require.Equal(int64(0), updates[0].Power)
+		require.Equal(cmtPk(t, newPk), updates[1].PubKey)
+		require.Equal(int64(10), updates[1].Power)
+
+		// H+1 EndBlock: nothing happens; drain and emit passes both no-op.
+		s.ctx = s.ctx.WithBlockHeight(H + 1)
+		updates, err = s.stakingKeeper.ApplyAndReturnValidatorSetUpdates(s.ctx)
+		require.NoError(err)
+		require.Empty(updates)
+
+		// H+2 EndBlock: drain swaps state, emit pass no-op.
+		s.ctx = s.ctx.WithBlockHeight(H + 2)
+		updates, err = s.stakingKeeper.ApplyAndReturnValidatorSetUpdates(s.ctx)
+		require.NoError(err)
+		require.Empty(updates)
+
+		stored, err := s.stakingKeeper.GetValidator(s.ctx, valAddr)
+		require.NoError(err)
+		got, err := stored.GetConsAddr()
+		require.NoError(err)
+		require.Equal(sdk.ConsAddress(newPk.Address()).Bytes(), got)
+	})
+
+	s.T().Run("jail at H emits rotation pair plus zero power on new key", func(t *testing.T) {
+		s.SetupTest()
+		// bonded -> unbonding transition during EndBlock moves tokens between
+		// the bonded and not-bonded module accounts; stub the bank side so
+		// the keeper logic can run end to end.
+		s.bankKeeper.EXPECT().SendCoinsFromModuleToModule(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+		const H = int64(10)
+		oldPk := ed25519.GenPrivKey().PubKey()
+		newPk := ed25519.GenPrivKey().PubKey()
+
+		s.ctx = s.ctx.WithBlockHeight(H)
+		valAddr := s.bondedValidatorAtPower(oldPk, 10)
+		require.NoError(s.stakingKeeper.SetConsKeyRotation(s.ctx, valAddr, oldPk, newPk))
+		// jailing resolves via OLD cons addr — the deferred swap has not run.
+		require.NoError(s.stakingKeeper.Jail(s.ctx, sdk.ConsAddress(oldPk.Address())))
+
+		updates, err := s.stakingKeeper.ApplyAndReturnValidatorSetUpdates(s.ctx)
+		require.NoError(err)
+		require.Len(updates, 3)
+		// rotation pair first
+		require.Equal(cmtPk(t, oldPk), updates[0].PubKey)
+		require.Equal(int64(0), updates[0].Power)
+		require.Equal(cmtPk(t, newPk), updates[1].PubKey)
+		require.Equal(int64(10), updates[1].Power)
+		// jail emit, routed through the helper, references NEW
+		require.Equal(cmtPk(t, newPk), updates[2].PubKey)
+		require.Equal(int64(0), updates[2].Power)
+
+		// CometBFT's view at H+2: validator absent under both keys.
+		set := applyCometSet(t, updates)
+		require.NotContains(set, string(mustMarshal(t, cmtPk(t, oldPk))))
+		require.NotContains(set, string(mustMarshal(t, cmtPk(t, newPk))))
+
+		_ = valAddr
+	})
+
+	s.T().Run("jail at H+1 emits zero power on new key", func(t *testing.T) {
+		s.SetupTest()
+		s.bankKeeper.EXPECT().SendCoinsFromModuleToModule(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+		const H = int64(10)
+		oldPk := ed25519.GenPrivKey().PubKey()
+		newPk := ed25519.GenPrivKey().PubKey()
+
+		s.ctx = s.ctx.WithBlockHeight(H)
+		valAddr := s.bondedValidatorAtPower(oldPk, 10)
+		require.NoError(s.stakingKeeper.SetConsKeyRotation(s.ctx, valAddr, oldPk, newPk))
+
+		// H EndBlock: emit rotation pair, no state swap yet.
+		hUpdates, err := s.stakingKeeper.ApplyAndReturnValidatorSetUpdates(s.ctx)
+		require.NoError(err)
+		require.Len(hUpdates, 2)
+
+		// H+1: slashing routes jail via VoteInfo's OLD cons addr. The
+		// byConsAddr index for OLD still resolves because the swap is deferred.
+		s.ctx = s.ctx.WithBlockHeight(H + 1)
+		require.NoError(s.stakingKeeper.Jail(s.ctx, sdk.ConsAddress(oldPk.Address())))
+		updates, err := s.stakingKeeper.ApplyAndReturnValidatorSetUpdates(s.ctx)
+		require.NoError(err)
+		require.Len(updates, 1)
+		// the jail emit must reference NEW so CometBFT's H+3 set (which has
+		// the new key from H's rotation pair) sees the zero power update.
+		require.Equal(cmtPk(t, newPk), updates[0].PubKey)
+		require.Equal(int64(0), updates[0].Power)
+
+		// H+2: drain runs; validator is already jailed, but the swap on the
+		// operator record still applies. No new emits.
+		s.ctx = s.ctx.WithBlockHeight(H + 2)
+		updates, err = s.stakingKeeper.ApplyAndReturnValidatorSetUpdates(s.ctx)
+		require.NoError(err)
+		require.Empty(updates)
+	})
+
+	s.T().Run("power change at H+1 emits new key at the new power", func(t *testing.T) {
+		s.SetupTest()
+		const H = int64(10)
+		oldPk := ed25519.GenPrivKey().PubKey()
+		newPk := ed25519.GenPrivKey().PubKey()
+
+		s.ctx = s.ctx.WithBlockHeight(H)
+		valAddr := s.bondedValidatorAtPower(oldPk, 10)
+		require.NoError(s.stakingKeeper.SetConsKeyRotation(s.ctx, valAddr, oldPk, newPk))
+
+		// H EndBlock: emit rotation pair.
+		hUpdates, err := s.stakingKeeper.ApplyAndReturnValidatorSetUpdates(s.ctx)
+		require.NoError(err)
+		require.Len(hUpdates, 2)
+
+		// H+1: validator's power moves from 10 to 25 (e.g. delegation).
+		s.ctx = s.ctx.WithBlockHeight(H + 1)
+		s.setValidatorPower(valAddr, 25)
+		updates, err := s.stakingKeeper.ApplyAndReturnValidatorSetUpdates(s.ctx)
+		require.NoError(err)
+		require.Len(updates, 1)
+		require.Equal(cmtPk(t, newPk), updates[0].PubKey) // routed via helper
+		require.Equal(int64(25), updates[0].Power)
+	})
+
+	s.T().Run("power change at H emits rotation pair plus new key at new power", func(t *testing.T) {
+		s.SetupTest()
+		const H = int64(10)
+		oldPk := ed25519.GenPrivKey().PubKey()
+		newPk := ed25519.GenPrivKey().PubKey()
+
+		s.ctx = s.ctx.WithBlockHeight(H)
+		valAddr := s.bondedValidatorAtPower(oldPk, 10)
+		require.NoError(s.stakingKeeper.SetConsKeyRotation(s.ctx, valAddr, oldPk, newPk))
+		s.setValidatorPower(valAddr, 25)
+
+		updates, err := s.stakingKeeper.ApplyAndReturnValidatorSetUpdates(s.ctx)
+		require.NoError(err)
+		require.Len(updates, 3)
+		require.Equal(cmtPk(t, oldPk), updates[0].PubKey)
+		require.Equal(int64(0), updates[0].Power)
+		// rotation emit reads validator's current state (already power 25)
+		require.Equal(cmtPk(t, newPk), updates[1].PubKey)
+		require.Equal(int64(25), updates[1].Power)
+		// main loop emit, routed via helper
+		require.Equal(cmtPk(t, newPk), updates[2].PubKey)
+		require.Equal(int64(25), updates[2].Power)
+
+		// no post-rotation emit references OLD
+		for i, u := range updates[1:] {
+			require.NotEqual(cmtPk(t, oldPk), u.PubKey, "update %d still references old key", i+1)
+		}
+	})
+
+	s.T().Run("two validators rotate at H", func(t *testing.T) {
+		s.SetupTest()
+		const H = int64(10)
+		oldPk1 := ed25519.GenPrivKey().PubKey()
+		newPk1 := ed25519.GenPrivKey().PubKey()
+		oldPk2 := ed25519.GenPrivKey().PubKey()
+		newPk2 := ed25519.GenPrivKey().PubKey()
+
+		s.ctx = s.ctx.WithBlockHeight(H)
+		valAddr1 := s.bondedValidatorAtPower(oldPk1, 10)
+		valAddr2 := s.bondedValidatorAtPower(oldPk2, 10)
+		require.NoError(s.stakingKeeper.SetConsKeyRotation(s.ctx, valAddr1, oldPk1, newPk1))
+		require.NoError(s.stakingKeeper.SetConsKeyRotation(s.ctx, valAddr2, oldPk2, newPk2))
+
+		// H EndBlock: two rotation pairs (4 updates total). Iteration order
+		// across the apply queue is deterministic but not asserted here;
+		// applyCometSet collapses to the final per-key powers.
+		updates, err := s.stakingKeeper.ApplyAndReturnValidatorSetUpdates(s.ctx)
+		require.NoError(err)
+		require.Len(updates, 4)
+		set := applyCometSet(t, updates)
+		require.Equal(int64(10), set[string(mustMarshal(t, cmtPk(t, newPk1)))])
+		require.Equal(int64(10), set[string(mustMarshal(t, cmtPk(t, newPk2)))])
+		require.NotContains(set, string(mustMarshal(t, cmtPk(t, oldPk1))))
+		require.NotContains(set, string(mustMarshal(t, cmtPk(t, oldPk2))))
+
+		// H+2 EndBlock: both rotations drain, no further emits.
+		s.ctx = s.ctx.WithBlockHeight(H + 2)
+		updates, err = s.stakingKeeper.ApplyAndReturnValidatorSetUpdates(s.ctx)
+		require.NoError(err)
+		require.Empty(updates)
+
+		// both validators now hold their new cons keys.
+		stored1, err := s.stakingKeeper.GetValidator(s.ctx, valAddr1)
+		require.NoError(err)
+		got1, err := stored1.GetConsAddr()
+		require.NoError(err)
+		require.Equal(sdk.ConsAddress(newPk1.Address()).Bytes(), got1)
+
+		stored2, err := s.stakingKeeper.GetValidator(s.ctx, valAddr2)
+		require.NoError(err)
+		got2, err := stored2.GetConsAddr()
+		require.NoError(err)
+		require.Equal(sdk.ConsAddress(newPk2.Address()).Bytes(), got2)
+	})
+}
+
+// bondedValidatorAtPower stores a bonded validator with the given consensus
+// pubkey and seeds every index ApplyAndReturnValidatorSetUpdates reads:
+// the operator-keyed validator record, the byConsAddr index, the power
+// index, and LastValidatorPower. With LastValidatorPower seeded, the main
+// loop will not emit a power-change update unless the test mutates the
+// validator's tokens.
+func (s *KeeperTestSuite) bondedValidatorAtPower(pk cryptotypes.PubKey, power int64) sdk.ValAddress {
+	require := s.Require()
+	valAddr := sdk.ValAddress(pk.Address())
+	v, err := stakingtypes.NewValidator(valAddr.String(), pk, stakingtypes.Description{Moniker: "v"})
+	require.NoError(err)
+	v.Status = stakingtypes.Bonded
+	v.Tokens = sdk.TokensFromConsensusPower(power, sdk.DefaultPowerReduction)
+	v.DelegatorShares = math.LegacyNewDecFromInt(v.Tokens)
+	require.NoError(s.stakingKeeper.SetValidator(s.ctx, v))
+	require.NoError(s.stakingKeeper.SetValidatorByConsAddr(s.ctx, v))
+	require.NoError(s.stakingKeeper.SetNewValidatorByPowerIndex(s.ctx, v))
+	require.NoError(s.stakingKeeper.SetLastValidatorPower(s.ctx, valAddr, power))
+	return valAddr
+}
+
+// setValidatorPower mutates the bonded validator's tokens to the given
+// consensus power and refreshes the by-power index, leaving LastValidatorPower
+// untouched so the next EndBlock observes a power change.
+func (s *KeeperTestSuite) setValidatorPower(valAddr sdk.ValAddress, power int64) {
+	require := s.Require()
+	v, err := s.stakingKeeper.GetValidator(s.ctx, valAddr)
+	require.NoError(err)
+	require.NoError(s.stakingKeeper.DeleteValidatorByPowerIndex(s.ctx, v))
+	v.Tokens = sdk.TokensFromConsensusPower(power, sdk.DefaultPowerReduction)
+	v.DelegatorShares = math.LegacyNewDecFromInt(v.Tokens)
+	require.NoError(s.stakingKeeper.SetValidator(s.ctx, v))
+	require.NoError(s.stakingKeeper.SetValidatorByPowerIndex(s.ctx, v))
+}
+
+// cmtPk converts a cryptotypes.PubKey to its cmtproto form for direct
+// comparison against abci.ValidatorUpdate.PubKey.
+func cmtPk(t *testing.T, pk cryptotypes.PubKey) cmtprotocrypto.PublicKey {
+	t.Helper()
+	out, err := cryptocodec.ToCmtProtoPublicKey(pk)
+	if err != nil {
+		t.Fatalf("ToCmtProtoPublicKey: %v", err)
+	}
+	return out
+}
+
+// applyCometSet folds a ValidatorUpdate slice into the per-key power map
+// CometBFT would derive from it: later updates overwrite earlier ones for
+// the same pubkey, and a zero-power update removes the entry. Use this for
+// assertions where the slice order is not the load-bearing property.
+func applyCometSet(t *testing.T, updates []abci.ValidatorUpdate) map[string]int64 {
+	t.Helper()
+	set := map[string]int64{}
+	for _, u := range updates {
+		bz, err := u.PubKey.Marshal()
+		if err != nil {
+			t.Fatalf("PubKey.Marshal: %v", err)
+		}
+		if u.Power == 0 {
+			delete(set, string(bz))
+		} else {
+			set[string(bz)] = u.Power
+		}
+	}
+	return set
+}
+
+// mustMarshal returns the wire form of a cmt proto pubkey for use as a map key.
+func mustMarshal(t *testing.T, pk cmtprotocrypto.PublicKey) []byte {
+	t.Helper()
+	bz, err := pk.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	return bz
 }

--- a/x/staking/keeper/validator_test.go
+++ b/x/staking/keeper/validator_test.go
@@ -46,7 +46,9 @@ func (s *KeeperTestSuite) TestValidator() {
 	updates := s.applyValidatorSetUpdates(ctx, keeper, 1)
 	validator, err := keeper.GetValidator(ctx, valAddr)
 	require.NoError(err)
-	require.Equal(validator.ABCIValidatorUpdate(keeper.PowerReduction(ctx)), updates[0])
+	pk, err := validator.ConsPubKey()
+	require.NoError(err)
+	require.Equal(validator.ABCIValidatorUpdateWithPubKey(keeper.PowerReduction(ctx), pk), updates[0])
 
 	// after the save the validator should be bonded
 	require.Equal(stakingtypes.Bonded, validator.Status)
@@ -274,8 +276,12 @@ func (s *KeeperTestSuite) TestApplyAndReturnValidatorSetUpdatesPowerDecrease() {
 
 	// CometBFT updates should reflect power change
 	updates := s.applyValidatorSetUpdates(ctx, keeper, 2)
-	require.Equal(validators[0].ABCIValidatorUpdate(keeper.PowerReduction(ctx)), updates[0])
-	require.Equal(validators[1].ABCIValidatorUpdate(keeper.PowerReduction(ctx)), updates[1])
+	pk0, err := validators[0].ConsPubKey()
+	require.NoError(err)
+	require.Equal(validators[0].ABCIValidatorUpdateWithPubKey(keeper.PowerReduction(ctx), pk0), updates[0])
+	pk1, err := validators[1].ConsPubKey()
+	require.NoError(err)
+	require.Equal(validators[1].ABCIValidatorUpdateWithPubKey(keeper.PowerReduction(ctx), pk1), updates[1])
 }
 
 func (s *KeeperTestSuite) TestUpdateValidatorCommission() {

--- a/x/staking/types/keys.go
+++ b/x/staking/types/keys.go
@@ -87,14 +87,27 @@ var (
 	// removed when the rotation is applied in the end blocker.
 	RotationLockedConsAddrIndexKey = []byte{0x93} // prefix for the rotation-locked consensus address lookup
 
-	// UnappliedConsKeyRotationKey is the drain queue of rotations that the
-	// msg server has accepted but the end blocker has not yet performed.
-	// Each entry holds the new pubkey to apply. The end blocker iterates
-	// this prefix once per block, applies each rotation, and deletes the
-	// entry. The other three rotation stores remain so the rotation can be
-	// tracked through the rest of the unbonding period.
-	UnappliedConsKeyRotationKey = []byte{0x94} // prefix for unapplied consensus key rotations, keyed by valAddr
+	// ConsKeyRotationApplyQueueKey is the prefix for the height-keyed queue
+	// of cons key rotations whose ValidatorUpdates have been (or will be)
+	// emitted to CometBFT at the height the entry was written, and whose
+	// SDK-side state mutation will be applied when currentHeight reaches
+	// applyHeight = writeHeight + ConsensusUpdateDelay.
+	//
+	// Key format: 0x94 || BigEndian(applyHeight uint64) || lengthPrefix(valAddr)
+	// Value:      marshaled cryptotypes.PubKey (the new consensus pubkey)
+	ConsKeyRotationApplyQueueKey = []byte{0x94}
 )
+
+// ConsensusUpdateDelay is CometBFT's two-block validator-update delay.
+// ValidatorUpdates returned from EndBlock at height H first take effect at
+// height H+ConsensusUpdateDelay. We schedule SDK-side cons key state swaps to
+// match this so that validator.ConsensusPubkey always equals the key CometBFT
+// is actually using.
+//
+// Pinned by CometBFT (state/execution.go in v0.39.3:
+// lastHeightValsChanged = header.Height + 1 + 1; state/state.go documents
+// the invariant).
+const ConsensusUpdateDelay int64 = 2
 
 // UnbondingType defines the type of unbonding operation
 type UnbondingType int
@@ -513,8 +526,39 @@ func GetRotationLockedConsAddrIndexKey(consAddr sdk.ConsAddress) []byte {
 	return append(RotationLockedConsAddrIndexKey, address.MustLengthPrefix(consAddr)...)
 }
 
-// GetUnappliedConsKeyRotationKey returns the key for a rotation that the
-// msg server has queued and the end blocker has not yet applied.
-func GetUnappliedConsKeyRotationKey(valAddr sdk.ValAddress) []byte {
-	return append(UnappliedConsKeyRotationKey, address.MustLengthPrefix(valAddr)...)
+// GetConsKeyRotationApplyQueueKey returns the queue key for a rotation whose
+// SDK-side state swap will be performed when the chain reaches applyHeight.
+func GetConsKeyRotationApplyQueueKey(applyHeight int64, valAddr sdk.ValAddress) []byte {
+	prefix := GetConsKeyRotationApplyQueueHeightPrefix(applyHeight)
+	valBz := address.MustLengthPrefix(valAddr)
+	key := make([]byte, len(prefix)+len(valBz))
+	copy(key, prefix)
+	copy(key[len(prefix):], valBz)
+	return key
+}
+
+// GetConsKeyRotationApplyQueueHeightPrefix returns the iteration prefix for
+// every entry in the apply queue at the given applyHeight.
+func GetConsKeyRotationApplyQueueHeightPrefix(applyHeight int64) []byte {
+	heightBz := sdk.Uint64ToBigEndian(uint64(applyHeight))
+	prefix := make([]byte, len(ConsKeyRotationApplyQueueKey)+len(heightBz))
+	copy(prefix, ConsKeyRotationApplyQueueKey)
+	copy(prefix[len(ConsKeyRotationApplyQueueKey):], heightBz)
+	return prefix
+}
+
+// ParseConsKeyRotationApplyQueueKey extracts the applyHeight and validator
+// address from an apply queue key.
+func ParseConsKeyRotationApplyQueueKey(bz []byte) (int64, sdk.ValAddress, error) {
+	prefixLen := len(ConsKeyRotationApplyQueueKey)
+	if prefix := bz[:prefixLen]; !bytes.Equal(prefix, ConsKeyRotationApplyQueueKey) {
+		return 0, nil, fmt.Errorf("invalid prefix; expected: %X, got: %X", ConsKeyRotationApplyQueueKey, prefix)
+	}
+
+	kv.AssertKeyAtLeastLength(bz, prefixLen+8+1)
+	applyHeight := int64(sdk.BigEndianToUint64(bz[prefixLen : prefixLen+8]))
+
+	valAddrLen := int(bz[prefixLen+8])
+	kv.AssertKeyAtLeastLength(bz, prefixLen+8+1+valAddrLen)
+	return applyHeight, sdk.ValAddress(bz[prefixLen+8+1 : prefixLen+8+1+valAddrLen]), nil
 }

--- a/x/staking/types/keys_test.go
+++ b/x/staking/types/keys_test.go
@@ -262,18 +262,70 @@ func TestGetRotationLockedConsAddrIndexKey(t *testing.T) {
 	}
 }
 
-func TestGetUnappliedConsKeyRotationKey(t *testing.T) {
+func TestGetConsKeyRotationApplyQueueKey(t *testing.T) {
 	tests := []struct {
-		valAddr sdk.ValAddress
-		wantHex string
+		name        string
+		applyHeight int64
+		valAddr     sdk.ValAddress
 	}{
-		{sdk.ValAddress(keysAddr1), "941463d771218209d8bd03c482f69dfba57310f08609"},
-		{sdk.ValAddress(keysAddr2), "94145ef3b5f25c54946d4a89fc0d09d2f126614540f2"},
-		{sdk.ValAddress(keysAddr3), "94143ab62f0d93849be495e21e3e9013a517038f45bd"},
+		{"zero height keysAddr1", 0, sdk.ValAddress(keysAddr1)},
+		{"small height keysAddr2", 42, sdk.ValAddress(keysAddr2)},
+		{"large height keysAddr3", math2.MaxInt64, sdk.ValAddress(keysAddr3)},
 	}
-	for i, tt := range tests {
-		got := hex.EncodeToString(types.GetUnappliedConsKeyRotationKey(tt.valAddr))
-		require.Equal(t, tt.wantHex, got, "Keys did not match on test case %d", i)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bz := types.GetConsKeyRotationApplyQueueKey(tt.applyHeight, tt.valAddr)
+			gotHeight, gotValAddr, err := types.ParseConsKeyRotationApplyQueueKey(bz)
+			require.NoError(t, err)
+			require.Equal(t, tt.applyHeight, gotHeight)
+			require.Equal(t, tt.valAddr, gotValAddr)
+		})
+	}
+}
+
+func TestGetConsKeyRotationApplyQueueKeyOrder(t *testing.T) {
+	valAddr := sdk.ValAddress(keysAddr1)
+	endKey := types.GetConsKeyRotationApplyQueueKey(100, valAddr)
+
+	keyA := types.GetConsKeyRotationApplyQueueKey(50, valAddr)
+	keyB := types.GetConsKeyRotationApplyQueueKey(99, valAddr)
+	keyC := types.GetConsKeyRotationApplyQueueKey(101, valAddr)
+
+	require.Equal(t, -1, bytes.Compare(keyA, endKey))
+	require.Equal(t, -1, bytes.Compare(keyB, endKey))
+	require.Equal(t, 1, bytes.Compare(keyC, endKey))
+}
+
+func TestGetConsKeyRotationApplyQueueHeightPrefix(t *testing.T) {
+	prefix := types.GetConsKeyRotationApplyQueueHeightPrefix(42)
+	full := types.GetConsKeyRotationApplyQueueKey(42, sdk.ValAddress(keysAddr1))
+	require.True(t, bytes.HasPrefix(full, prefix))
+	require.Equal(t, len(types.ConsKeyRotationApplyQueueKey)+8, len(prefix))
+}
+
+func TestParseConsKeyRotationApplyQueueKey_Errors(t *testing.T) {
+	valAddr := sdk.ValAddress(keysAddr1)
+	tests := []struct {
+		name           string
+		buildKey       func() []byte
+		expErrContains string
+	}{
+		{
+			name: "wrong prefix",
+			buildKey: func() []byte {
+				bz := types.GetConsKeyRotationApplyQueueKey(1, valAddr)
+				bz[0] = 0xff
+				return bz
+			},
+			expErrContains: "invalid prefix",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, err := types.ParseConsKeyRotationApplyQueueKey(tt.buildKey())
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tt.expErrContains)
+		})
 	}
 }
 

--- a/x/staking/types/validator.go
+++ b/x/staking/types/validator.go
@@ -271,10 +271,38 @@ func (v Validator) ABCIValidatorUpdate(r math.Int) abci.ValidatorUpdate {
 	}
 }
 
+// ABCIValidatorUpdateWithPubKey returns an abci.ValidatorUpdate from a validator with a
+// custom pub key and the full validator power
+func (v Validator) ABCIValidatorUpdateWithPubKey(r math.Int, pk cryptotypes.PubKey) abci.ValidatorUpdate {
+	tmProtoPk, err := cryptocodec.ToCmtProtoPublicKey(pk)
+	if err != nil {
+		panic(err)
+	}
+
+	return abci.ValidatorUpdate{
+		PubKey: tmProtoPk,
+		Power:  v.ConsensusPower(r),
+	}
+}
+
 // ABCIValidatorUpdateZero returns an abci.ValidatorUpdate from a staking validator type
 // with zero power used for validator updates.
 func (v Validator) ABCIValidatorUpdateZero() abci.ValidatorUpdate {
 	tmProtoPk, err := v.TmConsPublicKey()
+	if err != nil {
+		panic(err)
+	}
+
+	return abci.ValidatorUpdate{
+		PubKey: tmProtoPk,
+		Power:  0,
+	}
+}
+
+// ABCIValidatorUpdateZeroWithPubKey returns an abci.ValidatorUpdate from a validator with a
+// custom pub key and zero validator power.
+func (v Validator) ABCIValidatorUpdateZeroWithPubKey(pk cryptotypes.PubKey) abci.ValidatorUpdate {
+	tmProtoPk, err := cryptocodec.ToCmtProtoPublicKey(pk)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
# Description

Closes a gap with the previous key rotation implementation (and the one in the parent branch) where x/staking state would update validators with their new cons keys at the same height (`H`) that validator updates were provided to comet to inform it to set the prev key to 0 power and update new keys power. However, these changes will not actually become visible in comets validator set until `H+2`. This creates a mismatch between what comet and the sdk think a validators consensus key is at an equivalent height. 

The previous implementation handles some of the issues that would be brought up by this but not all of them, by having fallbacks in a few methods when looking up state that is stored by validator cons addr. This was largely done for evidence handling that could be reported on the previous cons addr within the unbending period (something our implantation will address next). However this doesnt cover all of the `H+1` cons addr mismatch bases and it requires modifying a few different modules in order to make sure every module knows that there is a mismatch between comet and the sdk state at this one height. 

This was very tedious to reason about and was difficult to tell if the previous impl got everything right and updated everywhere that required updating, so I took a different approach and am delaying the switch of the consensus key in state until 2 blocks after we initially process it in the end blocker and send the abci updates to comet. This adds on one new complexity that the previous implantation didnt have, where we now have to ensure abci updates to a validator that is in progress of a key rotation are emitted on the key that the validator is rotating to (since those will be applied at `H+3`), not the old key which is about to be set to 0 power.

Closes: STACK-2833

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->
