### PR TITLE
feat(blockstm): reduce conflicts on Has() reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (blockstm) [#25909](https://github.com/cosmos/cosmos-sdk/pull/25909) Cache pre-state to optimize value-based validation.
 * (deps) [#26388](https://github.com/cosmos/cosmos-sdk/pull/26388) Bump CometBFT version to v0.39.3.
 * (crypto) [#26436](https://github.com/cosmos/cosmos-sdk/pull/26436) Add ML-DSA-65 (FIPS 204) post-quantum validator consensus key type, with SDK key wrappers, Amino + interface-registry registration, multisig support, and a `hd.MlDsa65Type` constant.
+* (blockstm) [#26467](https://github.com/cosmos/cosmos-sdk/pull/26467) Track existence for `Has()` reads to reduce false conflicts.
 
 ### Improvements
 

--- a/internal/blockstm/executor.go
+++ b/internal/blockstm/executor.go
@@ -3,7 +3,6 @@ package blockstm
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"go.opentelemetry.io/otel/metric"
 )
@@ -71,7 +70,7 @@ func (e *Executor) Run() error {
 }
 
 func (e *Executor) TryExecute(version TxnVersion) (TxnVersion, TaskKind) {
-	start := time.Now()
+	start := instNow()
 	e.scheduler.executedTxns.Add(1)
 	view := e.execute(version.Index)
 

--- a/internal/blockstm/metrics.go
+++ b/internal/blockstm/metrics.go
@@ -200,6 +200,15 @@ func (i *instrument) Start(cfg map[string]any) error {
 	return nil
 }
 
+// instNow returns time.Now() when instrumentation is active, zero time otherwise.
+// Gating the syscall here saves the per-call overhead when inst is nil.
+func instNow() time.Time {
+	if inst == nil {
+		return time.Time{}
+	}
+	return time.Now()
+}
+
 // measureSince records the duration in milliseconds since start on the given histogram.
 // Safe to call when inst is nil.
 func measureSince(ctx context.Context, get func() metric.Int64Histogram, start time.Time) {

--- a/internal/blockstm/mvdata.go
+++ b/internal/blockstm/mvdata.go
@@ -261,7 +261,7 @@ func (d *GMVData[V]) Iterator(
 
 // ValidateReadSet validates the read descriptors,
 // returns true if valid.
-func (d *GMVData[V]) ValidateReadSet(ctx context.Context, txn TxnIndex, rs *ReadSet) bool {
+func (d *GMVData[V]) ValidateReadSet(ctx context.Context, txn TxnIndex, rs *ReadSet, storage Storage) bool {
 	for _, desc := range rs.Reads {
 		_, version, estimate := d.Read(ctx, desc.Key, txn)
 		if estimate {
@@ -271,6 +271,27 @@ func (d *GMVData[V]) ValidateReadSet(ctx context.Context, txn TxnIndex, rs *Read
 		if version != desc.Version {
 			// previously read entry from data, now NOT_FOUND,
 			// or read some entry, but not the same version as before
+			return false
+		}
+	}
+
+	for _, desc := range rs.HasReads {
+		value, version, estimate := d.Read(ctx, desc.Key, txn)
+		if estimate {
+			return false
+		}
+		if version.Valid() {
+			if (!d.isZero(value)) != desc.Exists {
+				return false
+			}
+			continue
+		}
+		// No MVData entry. Storage is immutable, so FromStorage reads are still valid.
+		// Otherwise the original MVData writer was aborted and we must re-check storage.
+		if desc.FromStorage {
+			continue
+		}
+		if storage.(GStorage[V]).Has(desc.Key) != desc.Exists {
 			return false
 		}
 	}

--- a/internal/blockstm/mvdata.go
+++ b/internal/blockstm/mvdata.go
@@ -274,6 +274,7 @@ func (d *GMVData[V]) ValidateReadSet(ctx context.Context, txn TxnIndex, rs *Read
 		}
 	}
 
+	gs := storage.(GStorage[V])
 	for _, desc := range rs.HasReads {
 		value, version, estimate := d.Read(ctx, desc.Key, txn)
 		if estimate {
@@ -290,7 +291,7 @@ func (d *GMVData[V]) ValidateReadSet(ctx context.Context, txn TxnIndex, rs *Read
 		if desc.FromStorage {
 			continue
 		}
-		if storage.(GStorage[V]).Has(desc.Key) != desc.Exists {
+		if gs == nil || gs.Has(desc.Key) != desc.Exists {
 			return false
 		}
 	}

--- a/internal/blockstm/mvdata.go
+++ b/internal/blockstm/mvdata.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"sync/atomic"
-	"time"
 
 	"go.opentelemetry.io/otel/metric"
 
@@ -77,7 +76,7 @@ func (d *GMVData[V]) getIndexOrDefault(ctx context.Context, key Key) *BitmapInde
 
 // Consolidate returns wroteNewLocation
 func (d *GMVData[V]) Consolidate(ctx context.Context, version TxnVersion, writeSet *GMemDB[V]) bool {
-	start := time.Now()
+	start := instNow()
 	defer measureSince(ctx, func() metric.Int64Histogram { return inst.MVDataConsolidate }, start)
 
 	if writeSet == nil || writeSet.Len() == 0 {
@@ -201,7 +200,7 @@ func (d *GMVData[V]) deleteIndex(ctx context.Context, key Key, txn TxnIndex) {
 // If the key is found but value is an estimate, returns `(value, version, true)`.
 // If the key is found, returns `(value, version, false)`, `value` can be zero value which means deleted.
 func (d *GMVData[V]) Read(ctx context.Context, key Key, txn TxnIndex) (V, TxnVersion, bool) {
-	start := time.Now()
+	start := instNow()
 	defer measureSince(ctx, func() metric.Int64Histogram { return inst.MVDataRead }, start)
 	var zero V
 	if txn == 0 {

--- a/internal/blockstm/mvdata.go
+++ b/internal/blockstm/mvdata.go
@@ -274,25 +274,27 @@ func (d *GMVData[V]) ValidateReadSet(ctx context.Context, txn TxnIndex, rs *Read
 		}
 	}
 
-	gs := storage.(GStorage[V])
-	for _, desc := range rs.HasReads {
-		value, version, estimate := d.Read(ctx, desc.Key, txn)
-		if estimate {
-			return false
-		}
-		if version.Valid() {
-			if (!d.isZero(value)) != desc.Exists {
+	if len(rs.HasReads) > 0 {
+		gs, _ := storage.(GStorage[V])
+		for _, desc := range rs.HasReads {
+			value, version, estimate := d.Read(ctx, desc.Key, txn)
+			if estimate {
 				return false
 			}
-			continue
-		}
-		// No MVData entry. Storage is immutable, so FromStorage reads are still valid.
-		// Otherwise the original MVData writer was aborted and we must re-check storage.
-		if desc.FromStorage {
-			continue
-		}
-		if gs == nil || gs.Has(desc.Key) != desc.Exists {
-			return false
+			if version.Valid() {
+				if (!d.isZero(value)) != desc.Exists {
+					return false
+				}
+				continue
+			}
+			// No MVData entry. Storage is immutable, so FromStorage reads are still valid.
+			// Otherwise the original MVData writer was aborted and we must re-check storage.
+			if desc.FromStorage {
+				continue
+			}
+			if gs == nil || gs.Has(desc.Key) != desc.Exists {
+				return false
+			}
 		}
 	}
 

--- a/internal/blockstm/mvdata_test.go
+++ b/internal/blockstm/mvdata_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 
 	"github.com/test-go/testify/require"
+
+	storetypes "github.com/cosmos/cosmos-sdk/store/v2/types"
 )
 
 func TestEmptyMVData(t *testing.T) {
@@ -89,6 +91,88 @@ func TestReadErrConversion(t *testing.T) {
 	var readErr ErrReadError
 	require.True(t, errors.As(err, &readErr))
 	require.Equal(t, TxnIndex(1), readErr.BlockingTxn)
+}
+
+type panickingStorage struct{}
+
+func (panickingStorage) GetStoreType() storetypes.StoreType              { panic("not allowed") }
+func (panickingStorage) Get([]byte) []byte                               { panic("not allowed") }
+func (panickingStorage) Has([]byte) bool                                 { panic("validation re-probed storage") }
+func (panickingStorage) Iterator(_, _ []byte) storetypes.Iterator        { panic("not allowed") }
+func (panickingStorage) ReverseIterator(_, _ []byte) storetypes.Iterator { panic("not allowed") }
+
+func TestHasReadValidation(t *testing.T) {
+	ctx := context.Background()
+	k := []byte("k")
+
+	cases := []struct {
+		name    string
+		setup   func(*MVData, *MemDB)
+		desc    HasDescriptor
+		storage Storage // nil → use the populated MemDB
+		valid   bool
+	}{
+		{
+			name: "mvdata_version_flip_preserves_existence",
+			setup: func(d *MVData, _ *MemDB) {
+				d.Consolidate(ctx, TxnVersion{1, 0}, KV(k, []byte("v1")))
+				d.Consolidate(ctx, TxnVersion{2, 0}, KV(k, []byte("v2")))
+			},
+			desc:  HasDescriptor{Key: k, Exists: true},
+			valid: true,
+		},
+		{
+			name: "mvdata_delete_flips_existence",
+			setup: func(d *MVData, _ *MemDB) {
+				d.Consolidate(ctx, TxnVersion{1, 0}, KV(k, []byte("v")))
+				d.Consolidate(ctx, TxnVersion{2, 0}, KV(k, nil))
+			},
+			desc:  HasDescriptor{Key: k, Exists: true},
+			valid: false,
+		},
+		{
+			name:  "storage_fallback_matches",
+			setup: func(_ *MVData, s *MemDB) { s.Set(k, []byte("pre")) },
+			desc:  HasDescriptor{Key: k, Exists: true},
+			valid: true,
+		},
+		{
+			name:  "storage_fallback_mismatch",
+			setup: func(_ *MVData, s *MemDB) { s.Set(k, []byte("pre")) },
+			desc:  HasDescriptor{Key: k, Exists: false},
+			valid: false,
+		},
+		{
+			name:    "from_storage_skips_probe",
+			desc:    HasDescriptor{Key: k, Exists: true, FromStorage: true},
+			storage: panickingStorage{},
+			valid:   true,
+		},
+		{
+			name: "estimate_invalidates",
+			setup: func(d *MVData, _ *MemDB) {
+				d.Consolidate(ctx, TxnVersion{1, 0}, KV(k, []byte("v")))
+				d.ConvertWritesToEstimates(1)
+			},
+			desc:  HasDescriptor{Key: k, Exists: true},
+			valid: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			data := NewMVData(10)
+			memdb := NewMemDB()
+			if tc.setup != nil {
+				tc.setup(data, memdb)
+			}
+			storage := Storage(memdb)
+			if tc.storage != nil {
+				storage = tc.storage
+			}
+			rs := &ReadSet{HasReads: []HasDescriptor{tc.desc}}
+			require.Equal(t, tc.valid, data.ValidateReadSet(ctx, 3, rs, storage))
+		})
+	}
 }
 
 func TestSnapshot(t *testing.T) {

--- a/internal/blockstm/mvmemory.go
+++ b/internal/blockstm/mvmemory.go
@@ -85,7 +85,7 @@ func (mv *MVMemory) ValidateReadSet(ctx context.Context, txn TxnIndex) bool {
 	// Invariant: at least one `Record` call has been made for `txn`
 	rs := *mv.lastReadSet[txn].Load()
 	for store, readSet := range rs {
-		if !mv.data[store].ValidateReadSet(ctx, txn, readSet) {
+		if !mv.data[store].ValidateReadSet(ctx, txn, readSet, mv.storage[store]) {
 			return false
 		}
 	}

--- a/internal/blockstm/mvview.go
+++ b/internal/blockstm/mvview.go
@@ -80,8 +80,8 @@ func (s *GMVMemoryView[V]) WriteCount() int {
 	return s.writeSet.Len()
 }
 
-// Callers must not mutate key after the call: Get and Has store it by
-// reference in the read set.
+// Get reads key from MVData or storage. Callers must not mutate key after the
+// call: Get and Has store it by reference in the read set.
 func (s *GMVMemoryView[V]) Get(key []byte) V {
 	start := instNow()
 	if s.writeSet != nil {
@@ -116,7 +116,7 @@ func (s *GMVMemoryView[V]) Get(key []byte) V {
 	}
 }
 
-// See Get for the key-aliasing contract.
+// Has reports whether key exists. See Get for the key-aliasing contract.
 func (s *GMVMemoryView[V]) Has(key []byte) bool {
 	start := instNow()
 	if s.writeSet != nil {

--- a/internal/blockstm/mvview.go
+++ b/internal/blockstm/mvview.go
@@ -143,7 +143,8 @@ func (s *GMVMemoryView[V]) Has(key []byte) bool {
 			exists = !s.mvData.isZero(value)
 			measureSince(s.ctx, func() metric.Int64Histogram { return inst.MVViewReadMVData }, start)
 		} else {
-			// Probe storage existence directly to avoid loading the full value.
+			// Existence probe; on miss GCachedStorage.Has loads via Get to
+			// warm the cache for subsequent Has/Get on the same key.
 			exists = s.storage.Has(key)
 			fromStorage = true
 			measureSince(s.ctx, func() metric.Int64Histogram { return inst.MVViewReadStorage }, start)

--- a/internal/blockstm/mvview.go
+++ b/internal/blockstm/mvview.go
@@ -2,7 +2,6 @@ package blockstm
 
 import (
 	"context"
-	"time"
 
 	"go.opentelemetry.io/otel/metric"
 
@@ -84,7 +83,7 @@ func (s *GMVMemoryView[V]) WriteCount() int {
 // Callers must not mutate key after the call: Get and Has store it by
 // reference in the read set.
 func (s *GMVMemoryView[V]) Get(key []byte) V {
-	start := time.Now()
+	start := instNow()
 	if s.writeSet != nil {
 		if value, found := s.writeSet.OverlayGet(key); found {
 			// value written by this txn
@@ -97,7 +96,7 @@ func (s *GMVMemoryView[V]) Get(key []byte) V {
 	for {
 		value, version, estimate := s.mvData.Read(s.ctx, key, s.txn)
 		if estimate {
-			estimateStart := time.Now()
+			estimateStart := instNow()
 			// read ESTIMATE mark, wait for the blocking txn to finish
 			s.waitFor(version.Index)
 			measureSince(s.ctx, func() metric.Int64Histogram { return inst.MVViewEstimateWait }, estimateStart)
@@ -119,7 +118,7 @@ func (s *GMVMemoryView[V]) Get(key []byte) V {
 
 // See Get for the key-aliasing contract.
 func (s *GMVMemoryView[V]) Has(key []byte) bool {
-	start := time.Now()
+	start := instNow()
 	if s.writeSet != nil {
 		if value, found := s.writeSet.OverlayGet(key); found {
 			measureSince(s.ctx, func() metric.Int64Histogram { return inst.MVViewReadWriteSet }, start)
@@ -130,7 +129,7 @@ func (s *GMVMemoryView[V]) Has(key []byte) bool {
 	for {
 		value, version, estimate := s.mvData.Read(s.ctx, key, s.txn)
 		if estimate {
-			estimateStart := time.Now()
+			estimateStart := instNow()
 			s.waitFor(version.Index)
 			measureSince(s.ctx, func() metric.Int64Histogram { return inst.MVViewEstimateWait }, estimateStart)
 			continue
@@ -156,7 +155,7 @@ func (s *GMVMemoryView[V]) Has(key []byte) bool {
 }
 
 func (s *GMVMemoryView[V]) Set(key []byte, value V) {
-	start := time.Now()
+	start := instNow()
 	defer measureSince(s.ctx, func() metric.Int64Histogram { return inst.MVViewWrite }, start)
 	if s.mvData.isZero(value) {
 		panic("nil value is not allowed")
@@ -166,7 +165,7 @@ func (s *GMVMemoryView[V]) Set(key []byte, value V) {
 }
 
 func (s *GMVMemoryView[V]) Delete(key []byte) {
-	start := time.Now()
+	start := instNow()
 	defer measureSince(s.ctx, func() metric.Int64Histogram { return inst.MVViewDelete }, start)
 	var empty V
 	s.init()
@@ -182,7 +181,7 @@ func (s *GMVMemoryView[V]) ReverseIterator(start, end []byte) storetypes.GIterat
 }
 
 func (s *GMVMemoryView[V]) iterator(opts IteratorOptions) storetypes.GIterator[V] {
-	iterStart := time.Now()
+	iterStart := instNow()
 	mvIter := s.mvData.Iterator(opts, s.txn, s.waitFor)
 
 	var parentIter, wsIter storetypes.GIterator[V]

--- a/internal/blockstm/mvview.go
+++ b/internal/blockstm/mvview.go
@@ -81,6 +81,8 @@ func (s *GMVMemoryView[V]) WriteCount() int {
 	return s.writeSet.Len()
 }
 
+// Callers must not mutate key after the call: Get and Has store it by
+// reference in the read set.
 func (s *GMVMemoryView[V]) Get(key []byte) V {
 	start := time.Now()
 	if s.writeSet != nil {
@@ -115,8 +117,42 @@ func (s *GMVMemoryView[V]) Get(key []byte) V {
 	}
 }
 
+// See Get for the key-aliasing contract.
 func (s *GMVMemoryView[V]) Has(key []byte) bool {
-	return !s.mvData.isZero(s.Get(key))
+	start := time.Now()
+	if s.writeSet != nil {
+		if value, found := s.writeSet.OverlayGet(key); found {
+			measureSince(s.ctx, func() metric.Int64Histogram { return inst.MVViewReadWriteSet }, start)
+			return !s.mvData.isZero(value)
+		}
+	}
+
+	for {
+		value, version, estimate := s.mvData.Read(s.ctx, key, s.txn)
+		if estimate {
+			estimateStart := time.Now()
+			s.waitFor(version.Index)
+			measureSince(s.ctx, func() metric.Int64Histogram { return inst.MVViewEstimateWait }, estimateStart)
+			continue
+		}
+
+		var (
+			exists      bool
+			fromStorage bool
+		)
+		if version.Valid() {
+			exists = !s.mvData.isZero(value)
+			measureSince(s.ctx, func() metric.Int64Histogram { return inst.MVViewReadMVData }, start)
+		} else {
+			// Probe storage existence directly to avoid loading the full value.
+			exists = s.storage.Has(key)
+			fromStorage = true
+			measureSince(s.ctx, func() metric.Int64Histogram { return inst.MVViewReadStorage }, start)
+		}
+
+		s.readSet.HasReads = append(s.readSet.HasReads, HasDescriptor{Key: key, Exists: exists, FromStorage: fromStorage})
+		return exists
+	}
 }
 
 func (s *GMVMemoryView[V]) Set(key []byte, value V) {

--- a/internal/blockstm/mvview_test.go
+++ b/internal/blockstm/mvview_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/test-go/testify/require"
 
@@ -35,6 +36,133 @@ func TestMVMemoryViewDelete(t *testing.T) {
 	view = mview.GetKVStore(StoreKeyAuth)
 	require.Nil(t, view.Get(Key("a")))
 	require.False(t, view.Has(Key("a")))
+}
+
+func TestMVMemoryViewHasStoragePath(t *testing.T) {
+	ctx := context.Background()
+	stores := map[storetypes.StoreKey]int{StoreKeyAuth: 0}
+
+	parent := NewMultiMemDB(stores)
+	parent.GetKVStore(StoreKeyAuth).Set([]byte("present"), []byte("v"))
+
+	counted := &countingStorage[[]byte]{GStorage: parent.GetKVStore(StoreKeyAuth)}
+	storages := []Storage{NewGCachedStorage[[]byte](counted, storetypes.BytesIsZero)}
+	mv := NewMVMemory(4, stores, storages, NewScheduler(4))
+
+	mview := mv.View(ctx, 0)
+	view := mview.GetKVStore(StoreKeyAuth)
+	require.True(t, view.Has([]byte("present")))
+	require.False(t, view.Has([]byte("missing")))
+
+	require.EqualValues(t, 2, counted.gets.Load()+counted.hasOps.Load(),
+		"Has() should consult underlying storage once per distinct key")
+
+	rs := (*mview.ReadSet())[0]
+	require.Empty(t, rs.Reads, "Has() must not emit value-versioned descriptors")
+	require.Equal(t, []HasDescriptor{
+		{Key: []byte("present"), Exists: true, FromStorage: true},
+		{Key: []byte("missing"), Exists: false, FromStorage: true},
+	}, rs.HasReads)
+}
+
+func TestMVMemoryViewHasConflictReduction(t *testing.T) {
+	key := []byte("k")
+	cases := []struct {
+		name      string
+		mutate    func(storetypes.KVStore)
+		wantValid bool
+	}{
+		{"same_existence_revalidates", func(s storetypes.KVStore) { s.Set(key, []byte("v0-new")) }, true},
+		{"existence_flip_invalidates", func(s storetypes.KVStore) { s.Delete(key) }, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			stores := map[storetypes.StoreKey]int{StoreKeyAuth: 0}
+			storage := NewMultiMemDB(stores)
+			storage.GetKVStore(StoreKeyAuth).Set(key, []byte("v0"))
+
+			mv := NewMVMemory(4, stores, MultiStoreToCachedStorage(storage, stores), NewScheduler(4))
+
+			// Txn 2 observes Has(key)==true via storage.
+			view2 := mv.View(ctx, 2)
+			require.True(t, view2.GetKVStore(StoreKeyAuth).Has(key))
+			mv.Record(TxnVersion{2, 0}, view2)
+
+			// Txn 0 mutates the same key; existence may or may not flip.
+			view0 := mv.View(ctx, 0)
+			tc.mutate(view0.GetKVStore(StoreKeyAuth))
+			mv.Record(TxnVersion{0, 0}, view0)
+
+			require.Equal(t, tc.wantValid, mv.ValidateReadSet(ctx, 2))
+		})
+	}
+}
+
+func TestReadSetKeyAliasing(t *testing.T) {
+	ctx := context.Background()
+	stores := map[storetypes.StoreKey]int{StoreKeyAuth: 0}
+	storage := NewMultiMemDB(stores)
+	mv := NewMVMemory(4, stores, MultiStoreToCachedStorage(storage, stores), NewScheduler(4))
+
+	mview := mv.View(ctx, 0)
+	view := mview.GetKVStore(StoreKeyAuth)
+
+	getKey := []byte("get-key")
+	hasKey := []byte("has-key")
+	_ = view.Get(getKey)
+	_ = view.Has(hasKey)
+
+	rs := (*mview.ReadSet())[0]
+	require.True(t, &rs.Reads[0].Key[0] == &getKey[0],
+		"Get should store the caller's key slice without copying")
+	require.True(t, &rs.HasReads[0].Key[0] == &hasKey[0],
+		"Has should store the caller's key slice without copying")
+}
+
+func TestMVMemoryViewHasWaitsOnEstimate(t *testing.T) {
+	ctx := context.Background()
+	key := []byte("k")
+	stores := map[storetypes.StoreKey]int{StoreKeyAuth: 0}
+	storage := NewMultiMemDB(stores)
+	scheduler := NewScheduler(4)
+	mv := NewMVMemory(4, stores, MultiStoreToCachedStorage(storage, stores), scheduler)
+
+	// Txn 0 wrote key then was re-marked ESTIMATE (mimics block-stm aborting a writer).
+	view0 := mv.View(ctx, 0)
+	view0.GetKVStore(StoreKeyAuth).Set(key, []byte("v"))
+	mv.Record(TxnVersion{0, 0}, view0)
+	mv.ConvertWritesToEstimates(0)
+
+	existsCh := make(chan bool, 1)
+	go func() {
+		scheduler.TryIncarnate(2)
+		view2 := mv.View(ctx, 2)
+		exists := view2.GetKVStore(StoreKeyAuth).Has(key)
+		mv.Record(TxnVersion{2, 0}, view2)
+		existsCh <- exists
+	}()
+
+	select {
+	case <-existsCh:
+		t.Fatal("Has() should block on Txn 0's ESTIMATE")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	// Txn 0 re-executes with a delete; existence flips to false.
+	view0 = mv.View(ctx, 0)
+	view0.GetKVStore(StoreKeyAuth).Delete(key)
+	mv.Record(TxnVersion{0, 1}, view0)
+	scheduler.TryIncarnate(0)
+	scheduler.FinishExecution(TxnVersion{0, 1}, false)
+
+	select {
+	case exists := <-existsCh:
+		require.False(t, exists, "Has() should observe Txn 0's delete after wake-up")
+	case <-time.After(time.Second):
+		t.Fatal("Has() did not wake up after Txn 0 finished")
+	}
+	require.True(t, mv.ValidateReadSet(ctx, 2))
 }
 
 func TestMVMemoryViewIteration(t *testing.T) {

--- a/internal/blockstm/storage.go
+++ b/internal/blockstm/storage.go
@@ -64,8 +64,9 @@ func (s *GCachedStorage[V]) Get(key []byte) V {
 	return v
 }
 
-// Has returns whether key exists in the underlying storage.
-// Misses populate the value cache via Get so subsequent Has/Get calls hit the cache.
+// Has returns whether key exists. Cache misses load the value via Get to
+// warm the cache; stores with a cheaper Has trade that for fewer re-loads
+// on subsequent Has/Get.
 func (s *GCachedStorage[V]) Has(key []byte) bool {
 	if e, ok := s.cache.Load(string(key)); ok {
 		return !s.isZero(e.(cacheEntry[V]).v)

--- a/internal/blockstm/storage.go
+++ b/internal/blockstm/storage.go
@@ -31,6 +31,7 @@ type GStorage[V any] interface {
 	Storage
 
 	Get(key []byte) V
+	Has(key []byte) bool
 
 	Iterator(start, end []byte) storetypes.GIterator[V]
 	ReverseIterator(start, end []byte) storetypes.GIterator[V]
@@ -42,14 +43,15 @@ type GStorage[V any] interface {
 // it'll bypass cache when doing iteration.
 type GCachedStorage[V any] struct {
 	GStorage[V]
-	cache sync.Map
+	cache  sync.Map
+	isZero func(V) bool
 }
 
 // cacheEntry boxes V so a cached zero-value any never reaches sync.Map as a nil interface.
 type cacheEntry[V any] struct{ v V }
 
-func NewGCachedStorage[V any](storage GStorage[V]) *GCachedStorage[V] {
-	return &GCachedStorage[V]{GStorage: storage}
+func NewGCachedStorage[V any](storage GStorage[V], isZero func(V) bool) *GCachedStorage[V] {
+	return &GCachedStorage[V]{GStorage: storage, isZero: isZero}
 }
 
 func (s *GCachedStorage[V]) Get(key []byte) V {
@@ -62,6 +64,17 @@ func (s *GCachedStorage[V]) Get(key []byte) V {
 	return v
 }
 
+// Has returns whether key exists in the underlying storage.
+// Misses populate the value cache via Get so subsequent Has/Get calls hit the cache.
+func (s *GCachedStorage[V]) Has(key []byte) bool {
+	if e, ok := s.cache.Load(string(key)); ok {
+		return !s.isZero(e.(cacheEntry[V]).v)
+	}
+	v := s.GStorage.Get(key)
+	s.cache.Store(string(key), cacheEntry[V]{v: v})
+	return !s.isZero(v)
+}
+
 // MultiStoreToCachedStorage convert MultiStore to an array of GStorage, wrap each store with a cache.
 func MultiStoreToCachedStorage(ms MultiStore, stores map[storetypes.StoreKey]int) []Storage {
 	storage := make([]Storage, len(stores))
@@ -69,9 +82,9 @@ func MultiStoreToCachedStorage(ms MultiStore, stores map[storetypes.StoreKey]int
 		store := ms.GetStore(key)
 		switch v := store.(type) {
 		case storetypes.KVStore:
-			storage[i] = NewGCachedStorage(v)
+			storage[i] = NewGCachedStorage[[]byte](v, storetypes.BytesIsZero)
 		case storetypes.ObjKVStore:
-			storage[i] = NewGCachedStorage(v)
+			storage[i] = NewGCachedStorage[any](v, storetypes.AnyIsZero)
 		default:
 			panic("unsupported store type")
 		}

--- a/internal/blockstm/storage_test.go
+++ b/internal/blockstm/storage_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	storetypes "github.com/cosmos/cosmos-sdk/store/v2/types"
 )
 
 // TestGCachedStorage covers hit/miss memoization for both V=[]byte and V=any,
@@ -13,34 +15,46 @@ func TestGCachedStorage(t *testing.T) {
 	t.Run("KV", func(t *testing.T) {
 		parent := NewMemDB()
 		parent.Set([]byte("k"), []byte("v"))
-		assertCache(t, parent, []byte("v"), nil)
+		assertCache(t, parent, storetypes.BytesIsZero, []byte("v"), nil)
 	})
 
 	t.Run("ObjKV", func(t *testing.T) {
 		parent := NewObjMemDB()
 		parent.Set([]byte("k"), "v")
-		assertCache(t, parent, "v", nil)
+		assertCache[any](t, parent, storetypes.AnyIsZero, "v", nil)
 	})
 }
 
-func assertCache[V any](t *testing.T, parent GStorage[V], hitValue, missValue V) {
+func assertCache[V any](t *testing.T, parent GStorage[V], isZero func(V) bool, hitValue, missValue V) {
 	t.Helper()
 	counted := &countingStorage[V]{GStorage: parent}
-	cached := NewGCachedStorage(counted)
+	cached := NewGCachedStorage(counted, isZero)
 
 	for i := 0; i < 3; i++ {
 		require.Equal(t, hitValue, cached.Get([]byte("k")))
 		require.Equal(t, missValue, cached.Get([]byte("missing")))
 	}
 	require.EqualValues(t, 2, counted.gets.Load(), "each distinct key reads parent exactly once")
+
+	// Has uses the populated cache; no extra parent probes.
+	require.True(t, cached.Has([]byte("k")))
+	require.False(t, cached.Has([]byte("missing")))
+	require.EqualValues(t, 2, counted.gets.Load()+counted.hasOps.Load(),
+		"Has should reuse the Get cache without extra parent probes")
 }
 
 type countingStorage[V any] struct {
 	GStorage[V]
-	gets atomic.Int64
+	gets   atomic.Int64
+	hasOps atomic.Int64
 }
 
 func (c *countingStorage[V]) Get(key []byte) V {
 	c.gets.Add(1)
 	return c.GStorage.Get(key)
+}
+
+func (c *countingStorage[V]) Has(key []byte) bool {
+	c.hasOps.Add(1)
+	return c.GStorage.Has(key)
 }

--- a/internal/blockstm/tree/btree.go
+++ b/internal/blockstm/tree/btree.go
@@ -3,7 +3,6 @@ package tree
 import (
 	"context"
 	"sync/atomic"
-	"time"
 
 	"github.com/cosmos/btree"
 	"go.opentelemetry.io/otel/metric"
@@ -27,12 +26,12 @@ func NewBTree[T any](less func(a, b T) bool, degree int) *BTree[T] {
 }
 
 func (bt *BTree[T]) Get(ctx context.Context, item T) (result T, ok bool) {
-	defer measureSince(ctx, func() metric.Int64Histogram { return treeInst.Get }, time.Now())
+	defer measureSince(ctx, func() metric.Int64Histogram { return treeInst.Get }, treeNow())
 	return bt.Load().Get(item)
 }
 
 func (bt *BTree[T]) GetOrDefault(ctx context.Context, item T, fillDefaults func(*T)) T {
-	defer measureSince(ctx, func() metric.Int64Histogram { return treeInst.GetOrDefault }, time.Now())
+	defer measureSince(ctx, func() metric.Int64Histogram { return treeInst.GetOrDefault }, treeNow())
 	for {
 		t := bt.Load()
 		result, ok := t.Get(item)
@@ -50,7 +49,7 @@ func (bt *BTree[T]) GetOrDefault(ctx context.Context, item T, fillDefaults func(
 }
 
 func (bt *BTree[T]) Set(ctx context.Context, item T) (prev T, ok bool) {
-	defer measureSince(ctx, func() metric.Int64Histogram { return treeInst.Set }, time.Now())
+	defer measureSince(ctx, func() metric.Int64Histogram { return treeInst.Set }, treeNow())
 	for {
 		t := bt.Load()
 		c := t.Copy()
@@ -63,7 +62,7 @@ func (bt *BTree[T]) Set(ctx context.Context, item T) (prev T, ok bool) {
 }
 
 func (bt *BTree[T]) Delete(ctx context.Context, item T) (prev T, ok bool) {
-	defer measureSince(ctx, func() metric.Int64Histogram { return treeInst.Delete }, time.Now())
+	defer measureSince(ctx, func() metric.Int64Histogram { return treeInst.Delete }, treeNow())
 	for {
 		t := bt.Load()
 		c := t.Copy()
@@ -76,7 +75,7 @@ func (bt *BTree[T]) Delete(ctx context.Context, item T) (prev T, ok bool) {
 }
 
 func (bt *BTree[T]) Scan(ctx context.Context, iter func(item T) bool) {
-	defer measureSince(ctx, func() metric.Int64Histogram { return treeInst.Scan }, time.Now())
+	defer measureSince(ctx, func() metric.Int64Histogram { return treeInst.Scan }, treeNow())
 	bt.Load().Scan(iter)
 }
 
@@ -90,7 +89,7 @@ func (bt *BTree[T]) Iter() btree.IterG[T] {
 
 // ReverseSeek returns the first item that is less than or equal to the pivot
 func (bt *BTree[T]) ReverseSeek(ctx context.Context, pivot T) (result T, ok bool) {
-	defer measureSince(ctx, func() metric.Int64Histogram { return treeInst.ReverseSeek }, time.Now())
+	defer measureSince(ctx, func() metric.Int64Histogram { return treeInst.ReverseSeek }, treeNow())
 	bt.Load().Descend(pivot, func(item T) bool {
 		result = item
 		ok = true

--- a/internal/blockstm/tree/metrics.go
+++ b/internal/blockstm/tree/metrics.go
@@ -93,6 +93,14 @@ func (i *treeInstrument) Start(cfg map[string]any) error {
 	return nil
 }
 
+// treeNow returns time.Now() when tree instrumentation is active, zero time otherwise.
+func treeNow() time.Time {
+	if treeInst == nil {
+		return time.Time{}
+	}
+	return time.Now()
+}
+
 func measureSince(ctx context.Context, get func() metric.Int64Histogram, start time.Time) {
 	if treeInst == nil {
 		return

--- a/internal/blockstm/types.go
+++ b/internal/blockstm/types.go
@@ -30,6 +30,15 @@ type ReadDescriptor struct {
 	Version TxnVersion
 }
 
+// HasDescriptor records a Has() observation. Validation checks Exists, not version.
+// FromStorage marks reads served from immutable pre-state, so validation can skip
+// re-probing storage when MVData still has no entry for the key.
+type HasDescriptor struct {
+	Key         Key
+	Exists      bool
+	FromStorage bool
+}
+
 type IteratorOptions struct {
 	// [Start, End) is the range of the iterator
 	Start     Key
@@ -49,6 +58,7 @@ type IteratorDescriptor struct {
 
 type ReadSet struct {
 	Reads     []ReadDescriptor
+	HasReads  []HasDescriptor
 	Iterators []IteratorDescriptor
 }
 
@@ -70,7 +80,7 @@ type MVStore interface {
 	ClearEstimates(txn TxnIndex)
 	ConsolidateEmpty(context.Context, TxnIndex)
 
-	ValidateReadSet(context.Context, TxnIndex, *ReadSet) bool
+	ValidateReadSet(context.Context, TxnIndex, *ReadSet, Storage) bool
 	SnapshotToStore(context.Context, storetypes.Store)
 }
 


### PR DESCRIPTION
# Description

- `Has()` previously went through `Get()` and recorded a value-versioned `ReadDescriptor`, a concurrent value-only write would falsely invalidate the reader. Track `Has()` reads as `HasDescriptor{Key, Exists, FromStorage}` so validation checks only the existence bit.
- Add `Has()` to `GStorage` so the storage path probes existence without loading the value. `FromStorage` marks observations derived from immutable pre-state so validation can skip the storage re-probe when MVData has no entry.

Updates: https://github.com/cosmos/cosmos-sdk/issues/25777

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->


```
benchstat main.txt opt.txt
goos: darwin
goarch: arm64
pkg: github.com/cosmos/cosmos-sdk/internal/blockstm
cpu: Apple M4 Max
                                                │   main.txt    │               opt.txt               │
                                                │    sec/op     │    sec/op     vs base               │
BlockSTM/random-10000/100-sequential-16            869.4m ±  1%   873.1m ±  1%        ~ (p=0.240 n=6)
BlockSTM/random-10000/100-worker-1-16              251.4m ±  0%   202.7m ± 27%        ~ (p=0.065 n=6)
BlockSTM/random-10000/100-worker-5-16              12.47m ±  0%   12.43m ±  5%        ~ (p=1.000 n=6)
BlockSTM/random-10000/100-worker-10-16             14.59m ±  2%   14.18m ±  4%        ~ (p=0.240 n=6)
BlockSTM/random-10000/100-worker-15-16             18.77m ±  2%   17.31m ±  1%   -7.74% (p=0.002 n=6)
BlockSTM/random-10000/100-worker-20-16             18.78m ±  1%   18.07m ±  8%        ~ (p=0.065 n=6)
BlockSTM/has-hit-10000/100-sequential-16           190.7m ±  1%   190.4m ±  1%        ~ (p=0.818 n=6)
BlockSTM/has-hit-10000/100-worker-1-16            215.44m ±  1%   80.49m ±  1%  -62.64% (p=0.002 n=6)
BlockSTM/has-hit-10000/100-worker-5-16             48.55m ±  0%   21.61m ±  7%  -55.49% (p=0.002 n=6)
BlockSTM/has-hit-10000/100-worker-10-16            66.17m ± 25%   15.94m ±  2%  -75.91% (p=0.002 n=6)
BlockSTM/has-hit-10000/100-worker-15-16           111.93m ± 40%   15.40m ±  2%  -86.24% (p=0.002 n=6)
BlockSTM/has-hit-10000/100-worker-20-16            94.79m ± 46%   15.17m ± 11%  -84.00% (p=0.002 n=6)
BlockSTM/has-miss-10000/100-sequential-16          11.25m ±  1%   11.61m ±  2%   +3.18% (p=0.002 n=6)
BlockSTM/has-miss-10000/100-worker-1-16           212.02m ±  1%   77.01m ±  3%  -63.68% (p=0.002 n=6)
BlockSTM/has-miss-10000/100-worker-5-16            47.10m ±  0%   19.57m ±  4%  -58.44% (p=0.002 n=6)
BlockSTM/has-miss-10000/100-worker-10-16           70.97m ± 39%   14.28m ± 10%  -79.88% (p=0.002 n=6)
BlockSTM/has-miss-10000/100-worker-15-16           86.05m ± 10%   15.25m ±  3%  -82.28% (p=0.002 n=6)
BlockSTM/has-miss-10000/100-worker-20-16           82.92m ± 26%   15.39m ±  3%  -81.44% (p=0.002 n=6)
BlockSTM/no-conflict-10000-sequential-16           869.7m ±  1%   870.4m ±  0%        ~ (p=1.000 n=6)
BlockSTM/no-conflict-10000-worker-1-16             348.5m ±  1%   345.4m ±  2%        ~ (p=0.065 n=6)
BlockSTM/no-conflict-10000-worker-5-16             34.46m ±  2%   41.68m ± 12%  +20.92% (p=0.002 n=6)
BlockSTM/no-conflict-10000-worker-10-16            33.88m ±  0%   39.84m ±  4%  +17.59% (p=0.002 n=6)
BlockSTM/no-conflict-10000-worker-15-16            37.21m ±  1%   42.23m ±  2%  +13.49% (p=0.002 n=6)
BlockSTM/no-conflict-10000-worker-20-16            39.97m ±  2%   43.81m ±  2%   +9.61% (p=0.002 n=6)
BlockSTM/worst-case-10000-sequential-16            859.3m ±  0%   865.5m ±  3%   +0.72% (p=0.002 n=6)
BlockSTM/worst-case-10000-worker-1-16              169.2m ±  0%   127.1m ± 14%  -24.90% (p=0.002 n=6)
BlockSTM/worst-case-10000-worker-5-16              69.24m ±  0%   59.91m ±  0%  -13.48% (p=0.002 n=6)
BlockSTM/worst-case-10000-worker-10-16             65.24m ±  0%   56.48m ±  0%  -13.42% (p=0.002 n=6)
BlockSTM/worst-case-10000-worker-15-16             68.36m ±  1%   59.15m ±  0%  -13.47% (p=0.002 n=6)
BlockSTM/worst-case-10000-worker-20-16             67.98m ±  0%   59.00m ±  1%  -13.22% (p=0.002 n=6)
BlockSTM/iterate-10000/100-sequential-16           875.5m ±  0%   874.0m ±  0%   -0.17% (p=0.002 n=6)
BlockSTM/iterate-10000/100-worker-1-16             505.9m ±  0%   350.4m ±  0%  -30.73% (p=0.002 n=6)
BlockSTM/iterate-10000/100-worker-5-16             34.16m ±  1%   31.36m ±  1%   -8.21% (p=0.002 n=6)
BlockSTM/iterate-10000/100-worker-10-16            41.16m ±  2%   38.61m ±  1%   -6.19% (p=0.002 n=6)
BlockSTM/iterate-10000/100-worker-15-16            40.84m ±  3%   38.33m ±  0%   -6.13% (p=0.002 n=6)
BlockSTM/iterate-10000/100-worker-20-16            42.92m ±  0%   40.25m ±  1%   -6.22% (p=0.002 n=6)
BlockSTM/iterate-10000/100-prepop-sequential-16    875.2m ±  0%   874.8m ±  0%        ~ (p=0.240 n=6)
BlockSTM/iterate-10000/100-prepop-worker-1-16      506.3m ±  0%   352.2m ±  1%  -30.44% (p=0.002 n=6)
BlockSTM/iterate-10000/100-prepop-worker-5-16      34.28m ±  0%   31.36m ±  1%   -8.50% (p=0.002 n=6)
BlockSTM/iterate-10000/100-prepop-worker-10-16     41.04m ±  1%   38.65m ±  0%   -5.80% (p=0.002 n=6)
BlockSTM/iterate-10000/100-prepop-worker-15-16     40.72m ±  1%   38.38m ±  2%   -5.74% (p=0.002 n=6)
BlockSTM/iterate-10000/100-prepop-worker-20-16     42.86m ±  1%   40.30m ±  0%   -5.97% (p=0.002 n=6)
BlockSTM/iterate-newkeys-2000-sequential-16        929.5µ ±  0%   930.1µ ±  0%        ~ (p=0.240 n=6)
BlockSTM/iterate-newkeys-2000-worker-1-16          10.26m ±  0%   10.06m ±  1%   -1.94% (p=0.002 n=6)
BlockSTM/iterate-newkeys-2000-worker-5-16          3.988m ±  1%   3.934m ±  0%   -1.34% (p=0.004 n=6)
BlockSTM/iterate-newkeys-2000-worker-10-16         3.879m ±  2%   3.855m ±  0%   -0.60% (p=0.002 n=6)
BlockSTM/iterate-newkeys-2000-worker-15-16         4.511m ±  2%   4.498m ±  1%        ~ (p=0.485 n=6)
BlockSTM/iterate-newkeys-2000-worker-20-16         6.919m ±  4%   6.869m ±  4%        ~ (p=0.310 n=6)
geomean                                            58.97m         42.35m        -28.19%

                                                │  main.txt  │              opt.txt               │
                                                │  exec/txn  │  exec/txn   vs base                │
BlockSTM/random-10000/100-sequential-16           1.000 ± 0%   1.000 ± 0%       ~ (p=1.000 n=6) ¹
BlockSTM/has-hit-10000/100-sequential-16          1.000 ± 0%   1.000 ± 0%       ~ (p=1.000 n=6) ¹
BlockSTM/has-miss-10000/100-sequential-16         1.000 ± 0%   1.000 ± 0%       ~ (p=1.000 n=6) ¹
BlockSTM/no-conflict-10000-sequential-16          1.000 ± 0%   1.000 ± 0%       ~ (p=1.000 n=6) ¹
BlockSTM/worst-case-10000-sequential-16           1.000 ± 0%   1.000 ± 0%       ~ (p=1.000 n=6) ¹
BlockSTM/iterate-10000/100-sequential-16          1.000 ± 0%   1.000 ± 0%       ~ (p=1.000 n=6) ¹
BlockSTM/iterate-10000/100-prepop-sequential-16   1.000 ± 0%   1.000 ± 0%       ~ (p=1.000 n=6) ¹
BlockSTM/iterate-newkeys-2000-sequential-16       1.000 ± 0%   1.000 ± 0%       ~ (p=1.000 n=6) ¹
geomean                                           1.000        1.000       +0.00%
¹ all samples are equal

                                                │   main.txt   │              opt.txt               │
                                                │   val/txn    │  val/txn    vs base                │
BlockSTM/random-10000/100-sequential-16           0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
BlockSTM/has-hit-10000/100-sequential-16          0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
BlockSTM/has-miss-10000/100-sequential-16         0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
BlockSTM/no-conflict-10000-sequential-16          0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
BlockSTM/worst-case-10000-sequential-16           0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
BlockSTM/iterate-10000/100-sequential-16          0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
BlockSTM/iterate-10000/100-prepop-sequential-16   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
BlockSTM/iterate-newkeys-2000-sequential-16       0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
geomean                                                      ²               +0.00%               ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                                                │    main.txt    │                opt.txt                │
                                                │      B/op      │     B/op      vs base                 │
BlockSTM/random-10000/100-sequential-16           9.395Mi ± 0%     9.395Mi ± 0%        ~ (p=1.000 n=6)
BlockSTM/random-10000/100-worker-1-16             25.67Mi ± 0%     25.72Mi ± 2%   +0.19% (p=0.002 n=6)
BlockSTM/random-10000/100-worker-5-16             25.06Mi ± 0%     25.71Mi ± 0%   +2.59% (p=0.002 n=6)
BlockSTM/random-10000/100-worker-10-16            38.99Mi ± 2%     42.78Mi ± 8%   +9.73% (p=0.002 n=6)
BlockSTM/random-10000/100-worker-15-16            63.16Mi ± 1%     64.60Mi ± 0%   +2.29% (p=0.002 n=6)
BlockSTM/random-10000/100-worker-20-16            64.07Mi ± 0%     65.29Mi ± 0%   +1.91% (p=0.002 n=6)
BlockSTM/has-hit-10000/100-sequential-16            0.000 ± 0%       0.000 ± 0%        ~ (p=1.000 n=6) ¹
BlockSTM/has-hit-10000/100-worker-1-16            125.1Mi ± 0%     100.4Mi ± 0%  -19.76% (p=0.002 n=6)
BlockSTM/has-hit-10000/100-worker-5-16            125.2Mi ± 0%     100.7Mi ± 0%  -19.62% (p=0.002 n=6)
BlockSTM/has-hit-10000/100-worker-10-16           125.5Mi ± 0%     101.3Mi ± 0%  -19.29% (p=0.002 n=6)
BlockSTM/has-hit-10000/100-worker-15-16           125.8Mi ± 0%     101.4Mi ± 0%  -19.33% (p=0.002 n=6)
BlockSTM/has-hit-10000/100-worker-20-16           125.7Mi ± 0%     101.5Mi ± 0%  -19.30% (p=0.002 n=6)
BlockSTM/has-miss-10000/100-sequential-16           0.000 ± 0%       0.000 ± 0%        ~ (p=1.000 n=6) ¹
BlockSTM/has-miss-10000/100-worker-1-16           124.9Mi ± 0%     100.2Mi ± 0%  -19.80% (p=0.002 n=6)
BlockSTM/has-miss-10000/100-worker-5-16           124.9Mi ± 0%     100.3Mi ± 0%  -19.75% (p=0.002 n=6)
BlockSTM/has-miss-10000/100-worker-10-16          125.1Mi ± 0%     100.5Mi ± 0%  -19.61% (p=0.002 n=6)
BlockSTM/has-miss-10000/100-worker-15-16          125.2Mi ± 0%     100.6Mi ± 0%  -19.63% (p=0.002 n=6)
BlockSTM/has-miss-10000/100-worker-20-16          125.2Mi ± 0%     100.6Mi ± 0%  -19.63% (p=0.002 n=6)
BlockSTM/no-conflict-10000-sequential-16          10.29Mi ± 0%     10.29Mi ± 0%        ~ (p=0.567 n=6)
BlockSTM/no-conflict-10000-worker-1-16            72.25Mi ± 0%     72.86Mi ± 0%   +0.85% (p=0.002 n=6)
BlockSTM/no-conflict-10000-worker-5-16            89.32Mi ± 1%     95.87Mi ± 2%   +7.33% (p=0.002 n=6)
BlockSTM/no-conflict-10000-worker-10-16           141.2Mi ± 0%     145.8Mi ± 1%   +3.25% (p=0.002 n=6)
BlockSTM/no-conflict-10000-worker-15-16           166.0Mi ± 1%     168.5Mi ± 3%   +1.45% (p=0.026 n=6)
BlockSTM/no-conflict-10000-worker-20-16           161.8Mi ± 2%     168.9Mi ± 3%   +4.39% (p=0.004 n=6)
BlockSTM/worst-case-10000-sequential-16           9.155Mi ± 0%     9.155Mi ± 0%        ~ (p=1.000 n=6)
BlockSTM/worst-case-10000-worker-1-16             22.99Mi ± 0%     23.13Mi ± 1%   +0.62% (p=0.002 n=6)
BlockSTM/worst-case-10000-worker-5-16             58.94Mi ± 0%     60.44Mi ± 0%   +2.54% (p=0.002 n=6)
BlockSTM/worst-case-10000-worker-10-16            60.93Mi ± 0%     62.25Mi ± 0%   +2.18% (p=0.002 n=6)
BlockSTM/worst-case-10000-worker-15-16            62.91Mi ± 0%     64.08Mi ± 0%   +1.85% (p=0.002 n=6)
BlockSTM/worst-case-10000-worker-20-16            63.10Mi ± 0%     64.27Mi ± 0%   +1.85% (p=0.002 n=6)
BlockSTM/iterate-10000/100-sequential-16          16.02Mi ± 0%     16.02Mi ± 0%        ~ (p=1.000 n=6) ¹
BlockSTM/iterate-10000/100-worker-1-16            67.30Mi ± 0%     66.02Mi ± 0%   -1.90% (p=0.002 n=6)
BlockSTM/iterate-10000/100-worker-5-16            81.22Mi ± 0%     83.09Mi ± 0%   +2.29% (p=0.002 n=6)
BlockSTM/iterate-10000/100-worker-10-16           126.5Mi ± 0%     128.5Mi ± 0%   +1.57% (p=0.002 n=6)
BlockSTM/iterate-10000/100-worker-15-16           142.5Mi ± 1%     144.5Mi ± 0%   +1.39% (p=0.002 n=6)
BlockSTM/iterate-10000/100-worker-20-16           155.5Mi ± 1%     157.0Mi ± 1%   +0.98% (p=0.041 n=6)
BlockSTM/iterate-10000/100-prepop-sequential-16   16.01Mi ± 0%     16.01Mi ± 0%        ~ (p=0.080 n=6)
BlockSTM/iterate-10000/100-prepop-worker-1-16     67.24Mi ± 0%     65.98Mi ± 0%   -1.87% (p=0.002 n=6)
BlockSTM/iterate-10000/100-prepop-worker-5-16     81.69Mi ± 0%     83.10Mi ± 0%   +1.73% (p=0.002 n=6)
BlockSTM/iterate-10000/100-prepop-worker-10-16    126.1Mi ± 0%     128.8Mi ± 0%   +2.10% (p=0.002 n=6)
BlockSTM/iterate-10000/100-prepop-worker-15-16    142.4Mi ± 0%     144.4Mi ± 1%   +1.40% (p=0.002 n=6)
BlockSTM/iterate-10000/100-prepop-worker-20-16    154.8Mi ± 1%     157.0Mi ± 2%        ~ (p=0.093 n=6)
BlockSTM/iterate-newkeys-2000-sequential-16       1.217Mi ± 0%     1.217Mi ± 0%        ~ (p=0.470 n=6)
BlockSTM/iterate-newkeys-2000-worker-1-16         14.63Mi ± 0%     14.69Mi ± 0%   +0.42% (p=0.002 n=6)
BlockSTM/iterate-newkeys-2000-worker-5-16         16.81Mi ± 0%     16.94Mi ± 0%   +0.77% (p=0.002 n=6)
BlockSTM/iterate-newkeys-2000-worker-10-16        21.55Mi ± 0%     21.73Mi ± 0%   +0.80% (p=0.002 n=6)
BlockSTM/iterate-newkeys-2000-worker-15-16        28.05Mi ± 0%     28.35Mi ± 0%   +1.05% (p=0.002 n=6)
BlockSTM/iterate-newkeys-2000-worker-20-16        39.06Mi ± 3%     38.81Mi ± 5%        ~ (p=0.589 n=6)
geomean                                                        ²                  -3.37%               ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                                                │   main.txt    │               opt.txt               │
                                                │   allocs/op   │  allocs/op   vs base                │
BlockSTM/random-10000/100-sequential-16           220.0k ± 0%     220.0k ± 0%       ~ (p=1.000 n=6) ¹
BlockSTM/random-10000/100-worker-1-16             390.0k ± 0%     381.0k ± 2%  -2.31% (p=0.004 n=6)
BlockSTM/random-10000/100-worker-5-16             369.7k ± 0%     369.8k ± 0%       ~ (p=0.558 n=6)
BlockSTM/random-10000/100-worker-10-16            522.9k ± 2%     554.8k ± 6%  +6.10% (p=0.002 n=6)
BlockSTM/random-10000/100-worker-15-16            788.8k ± 1%     791.4k ± 0%       ~ (p=0.065 n=6)
BlockSTM/random-10000/100-worker-20-16            799.9k ± 0%     800.0k ± 0%       ~ (p=0.485 n=6)
BlockSTM/has-hit-10000/100-sequential-16           0.000 ± 0%      0.000 ± 0%       ~ (p=1.000 n=6) ¹
BlockSTM/has-hit-10000/100-worker-1-16            204.0k ± 0%     204.0k ± 0%       ~ (p=0.855 n=6)
BlockSTM/has-hit-10000/100-worker-5-16            210.0k ± 0%     215.8k ± 0%  +2.79% (p=0.002 n=6)
BlockSTM/has-hit-10000/100-worker-10-16           221.2k ± 0%     241.6k ± 0%  +9.23% (p=0.002 n=6)
BlockSTM/has-hit-10000/100-worker-15-16           230.2k ± 2%     246.8k ± 1%  +7.20% (p=0.002 n=6)
BlockSTM/has-hit-10000/100-worker-20-16           229.9k ± 2%     248.0k ± 1%  +7.88% (p=0.002 n=6)
BlockSTM/has-miss-10000/100-sequential-16          0.000 ± 0%      0.000 ± 0%       ~ (p=1.000 n=6) ¹
BlockSTM/has-miss-10000/100-worker-1-16           194.0k ± 0%     194.0k ± 0%       ~ (p=0.416 n=6)
BlockSTM/has-miss-10000/100-worker-5-16           196.2k ± 0%     198.2k ± 0%  +1.02% (p=0.002 n=6)
BlockSTM/has-miss-10000/100-worker-10-16          201.2k ± 0%     208.8k ± 0%  +3.81% (p=0.002 n=6)
BlockSTM/has-miss-10000/100-worker-15-16          205.8k ± 0%     211.9k ± 0%  +2.92% (p=0.002 n=6)
BlockSTM/has-miss-10000/100-worker-20-16          206.1k ± 1%     211.9k ± 0%  +2.81% (p=0.002 n=6)
BlockSTM/no-conflict-10000-sequential-16          220.6k ± 0%     220.6k ± 0%       ~ (p=1.000 n=6) ¹
BlockSTM/no-conflict-10000-worker-1-16            1.036M ± 0%     1.036M ± 0%       ~ (p=0.102 n=6)
BlockSTM/no-conflict-10000-worker-5-16            1.225M ± 1%     1.292M ± 2%  +5.46% (p=0.002 n=6)
BlockSTM/no-conflict-10000-worker-10-16           1.811M ± 0%     1.856M ± 1%  +2.48% (p=0.002 n=6)
BlockSTM/no-conflict-10000-worker-15-16           2.123M ± 1%     2.139M ± 3%       ~ (p=0.132 n=6)
BlockSTM/no-conflict-10000-worker-20-16           2.076M ± 2%     2.149M ± 3%  +3.52% (p=0.009 n=6)
BlockSTM/worst-case-10000-sequential-16           220.0k ± 0%     220.0k ± 0%       ~ (p=1.000 n=6) ¹
BlockSTM/worst-case-10000-worker-1-16             350.2k ± 0%     342.7k ± 1%  -2.14% (p=0.002 n=6)
BlockSTM/worst-case-10000-worker-5-16             749.9k ± 0%     752.9k ± 0%  +0.41% (p=0.002 n=6)
BlockSTM/worst-case-10000-worker-10-16            771.9k ± 0%     772.9k ± 0%       ~ (p=0.093 n=6)
BlockSTM/worst-case-10000-worker-15-16            794.8k ± 0%     793.5k ± 0%  -0.16% (p=0.002 n=6)
BlockSTM/worst-case-10000-worker-20-16            796.9k ± 0%     795.6k ± 0%  -0.16% (p=0.002 n=6)
BlockSTM/iterate-10000/100-sequential-16          292.6k ± 0%     292.6k ± 0%       ~ (p=1.000 n=6) ¹
BlockSTM/iterate-10000/100-worker-1-16            746.6k ± 0%     716.5k ± 0%  -4.03% (p=0.002 n=6)
BlockSTM/iterate-10000/100-worker-5-16            843.8k ± 0%     853.9k ± 0%  +1.21% (p=0.002 n=6)
BlockSTM/iterate-10000/100-worker-10-16           1.282M ± 0%     1.290M ± 0%  +0.65% (p=0.002 n=6)
BlockSTM/iterate-10000/100-worker-15-16           1.442M ± 1%     1.449M ± 0%       ~ (p=0.132 n=6)
BlockSTM/iterate-10000/100-worker-20-16           1.568M ± 1%     1.569M ± 1%       ~ (p=0.818 n=6)
BlockSTM/iterate-10000/100-prepop-sequential-16   292.5k ± 0%     292.5k ± 0%       ~ (p=1.000 n=6) ¹
BlockSTM/iterate-10000/100-prepop-worker-1-16     746.4k ± 0%     716.4k ± 0%  -4.02% (p=0.002 n=6)
BlockSTM/iterate-10000/100-prepop-worker-5-16     848.2k ± 0%     854.1k ± 0%  +0.70% (p=0.002 n=6)
BlockSTM/iterate-10000/100-prepop-worker-10-16    1.278M ± 0%     1.293M ± 0%  +1.18% (p=0.002 n=6)
BlockSTM/iterate-10000/100-prepop-worker-15-16    1.441M ± 0%     1.448M ± 1%  +0.49% (p=0.002 n=6)
BlockSTM/iterate-10000/100-prepop-worker-20-16    1.562M ± 0%     1.569M ± 2%       ~ (p=0.485 n=6)
BlockSTM/iterate-newkeys-2000-sequential-16       13.74k ± 0%     13.74k ± 0%       ~ (p=1.000 n=6) ¹
BlockSTM/iterate-newkeys-2000-worker-1-16         137.2k ± 0%     137.2k ± 0%       ~ (p=1.000 n=6) ¹
BlockSTM/iterate-newkeys-2000-worker-5-16         161.6k ± 0%     162.4k ± 0%  +0.48% (p=0.002 n=6)
BlockSTM/iterate-newkeys-2000-worker-10-16        215.3k ± 0%     216.6k ± 0%  +0.60% (p=0.002 n=6)
BlockSTM/iterate-newkeys-2000-worker-15-16        291.5k ± 0%     294.4k ± 0%  +1.01% (p=0.002 n=6)
BlockSTM/iterate-newkeys-2000-worker-20-16        387.7k ± 3%     384.3k ± 6%       ~ (p=0.180 n=6)
geomean                                                       ²                +1.02%               ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```