### PR TITLE
fix!: Update genutils genesis function to preserve consensus params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### Breaking Changes
 
 * (modules) [#26421](https://github.com/cosmos/cosmos-sdk/pull/26421) Remove the `x/protocolpool` module and its API/proto surface from the SDK. Applications upgrading from v0.54 should include `protocolpool` in deleted store upgrades.
-* (genutils) [#XXXXX](https://github.com/cosmos/cosmos-sdk/pull/XXXXX) Consolidate ExportGenesisFileWithTime arguments to preserve consensus params.
+* (genutils) [#26468](https://github.com/cosmos/cosmos-sdk/pull/26468) Consolidate ExportGenesisFileWithTime arguments to preserve consensus params.
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### Breaking Changes
 
 * (modules) [#26421](https://github.com/cosmos/cosmos-sdk/pull/26421) Remove the `x/protocolpool` module and its API/proto surface from the SDK. Applications upgrading from v0.54 should include `protocolpool` in deleted store upgrades.
+* (genutils) [#XXXXX](https://github.com/cosmos/cosmos-sdk/pull/XXXXX) Consolidate ExportGenesisFileWithTime arguments to preserve consensus params.
 
 ### Features
 

--- a/enterprise/group/simapp/simd/cmd/testnet.go
+++ b/enterprise/group/simapp/simd/cmd/testnet.go
@@ -502,7 +502,15 @@ func collectGenFiles(
 		}
 
 		genFile := nodeConfig.GenesisFile()
-		if err := genutil.ExportGenesisFileWithTime(genFile, chainID, nil, appState, genTime); err != nil {
+		// overwrite each validator's genesis file to have a canonical genesis
+		// time and the collected app state, preserving any custom
+		// ConsensusParams loaded from the existing genesis (e.g. opt-in
+		// validator key types like ml_dsa_65).
+		appGenesis.AppState = appState
+		if appGenesis.Consensus != nil {
+			appGenesis.Consensus.Validators = nil
+		}
+		if err := genutil.ExportGenesisFileWithTime(genFile, appGenesis, genTime); err != nil {
 			return err
 		}
 	}

--- a/enterprise/poa/examples/migrate-from-pos/simd/cmd/testnet.go
+++ b/enterprise/poa/examples/migrate-from-pos/simd/cmd/testnet.go
@@ -512,8 +512,15 @@ func collectGenFiles(
 
 		genFile := nodeConfig.GenesisFile()
 
-		// overwrite each validator's genesis file to have a canonical genesis time
-		if err := genutil.ExportGenesisFileWithTime(genFile, chainID, nil, appState, genTime); err != nil {
+		// overwrite each validator's genesis file to have a canonical genesis
+		// time and the collected app state, preserving any custom
+		// ConsensusParams loaded from the existing genesis (e.g. opt-in
+		// validator key types like ml_dsa_65).
+		appGenesis.AppState = appState
+		if appGenesis.Consensus != nil {
+			appGenesis.Consensus.Validators = nil
+		}
+		if err := genutil.ExportGenesisFileWithTime(genFile, appGenesis, genTime); err != nil {
 			return err
 		}
 	}

--- a/enterprise/poa/simapp/simd/cmd/testnet.go
+++ b/enterprise/poa/simapp/simd/cmd/testnet.go
@@ -512,8 +512,15 @@ func collectGenFiles(
 
 		genFile := nodeConfig.GenesisFile()
 
-		// overwrite each validator's genesis file to have a canonical genesis time
-		if err := genutil.ExportGenesisFileWithTime(genFile, chainID, nil, appState, genTime); err != nil {
+		// overwrite each validator's genesis file to have a canonical genesis
+		// time and the collected app state, preserving any custom
+		// ConsensusParams loaded from the existing genesis (e.g. opt-in
+		// validator key types like ml_dsa_65).
+		appGenesis.AppState = appState
+		if appGenesis.Consensus != nil {
+			appGenesis.Consensus.Validators = nil
+		}
+		if err := genutil.ExportGenesisFileWithTime(genFile, appGenesis, genTime); err != nil {
 			return err
 		}
 	}

--- a/simapp/simd/cmd/testnet.go
+++ b/simapp/simd/cmd/testnet.go
@@ -513,8 +513,15 @@ func collectGenFiles(
 
 		genFile := nodeConfig.GenesisFile()
 
-		// overwrite each validator's genesis file to have a canonical genesis time
-		if err := genutil.ExportGenesisFileWithTime(genFile, chainID, nil, appState, genTime); err != nil {
+		// overwrite each validator's genesis file to have a canonical genesis
+		// time and the collected app state, preserving any custom
+		// ConsensusParams loaded from the existing genesis (e.g. opt-in
+		// validator key types like ml_dsa_65).
+		appGenesis.AppState = appState
+		if appGenesis.Consensus != nil {
+			appGenesis.Consensus.Validators = nil
+		}
+		if err := genutil.ExportGenesisFileWithTime(genFile, appGenesis, genTime); err != nil {
 			return err
 		}
 	}

--- a/x/genutil/utils.go
+++ b/x/genutil/utils.go
@@ -2,7 +2,6 @@ package genutil
 
 import (
 	"crypto/sha256"
-	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -16,7 +15,6 @@ import (
 	"github.com/cometbft/cometbft/crypto/secp256k1"
 	"github.com/cometbft/cometbft/p2p"
 	"github.com/cometbft/cometbft/privval"
-	cmttypes "github.com/cometbft/cometbft/types"
 	"github.com/cosmos/go-bip39"
 
 	cryptocodec "github.com/cosmos/cosmos-sdk/crypto/codec"
@@ -34,18 +32,13 @@ func ExportGenesisFile(genesis *types.AppGenesis, genFile string) error {
 	return genesis.SaveAs(genFile)
 }
 
-// ExportGenesisFileWithTime creates and writes the genesis configuration to disk.
-// An error is returned if building or writing the configuration to file fails.
-func ExportGenesisFileWithTime(genFile, chainID string, validators []cmttypes.GenesisValidator, appState json.RawMessage, genTime time.Time) error {
-	appGenesis := types.NewAppGenesisWithVersion(chainID, appState)
+// ExportGenesisFileWithTime overwrites the genesis file at genFile with
+// appGenesis, applying genTime as the genesis time. All other fields on
+// appGenesis (validators, consensus params, app state, app hash, initial
+// height, etc.) are preserved as the caller set them.
+func ExportGenesisFileWithTime(genFile string, appGenesis *types.AppGenesis, genTime time.Time) error {
 	appGenesis.GenesisTime = genTime
-	appGenesis.Consensus.Validators = validators
-
-	if err := appGenesis.ValidateAndComplete(); err != nil {
-		return err
-	}
-
-	return appGenesis.SaveAs(genFile)
+	return ExportGenesisFile(appGenesis, genFile)
 }
 
 // InitializeNodeValidatorFiles creates private validator and p2p configuration files.

--- a/x/genutil/utils_test.go
+++ b/x/genutil/utils_test.go
@@ -11,6 +11,8 @@ import (
 	tmed25519 "github.com/cometbft/cometbft/crypto/ed25519"
 	"github.com/cometbft/cometbft/privval"
 	"github.com/stretchr/testify/require"
+
+	"github.com/cosmos/cosmos-sdk/x/genutil/types"
 )
 
 func TestExportGenesisFileWithTime(t *testing.T) {
@@ -18,7 +20,8 @@ func TestExportGenesisFileWithTime(t *testing.T) {
 
 	fname := filepath.Join(t.TempDir(), "genesis.json")
 
-	require.NoError(t, ExportGenesisFileWithTime(fname, "test", nil, json.RawMessage(`{"account_owner": "Bob"}`), time.Now()))
+	appGenesis := types.NewAppGenesisWithVersion("test", json.RawMessage(`{"account_owner": "Bob"}`))
+	require.NoError(t, ExportGenesisFileWithTime(fname, appGenesis, time.Now()))
 }
 
 func TestInitializeNodeValidatorFilesFromMnemonic(t *testing.T) {


### PR DESCRIPTION
# Description

Updates the genutils function used in testnet command in order to preserve consensus params on export. This should avoid situations in which non-default keyed validators are inconsistent with exported networks.

I've chosen to consolidate the arguments to the function into just `AppGenesis` in order to avoid passing in each relevant argument directly. This is a minor breaking change.
