### PR TITLE
feat: mark safe gov and distribution queries

### DIFF
--- a/proto/cosmos/distribution/v1beta1/query.proto
+++ b/proto/cosmos/distribution/v1beta1/query.proto
@@ -7,6 +7,7 @@ import "google/api/annotations.proto";
 import "cosmos/base/v1beta1/coin.proto";
 import "cosmos/distribution/v1beta1/distribution.proto";
 import "cosmos_proto/cosmos.proto";
+import "cosmos/query/v1/query.proto";
 import "amino/amino.proto";
 
 option go_package = "github.com/cosmos/cosmos-sdk/x/distribution/types";
@@ -15,7 +16,8 @@ option go_package = "github.com/cosmos/cosmos-sdk/x/distribution/types";
 service Query {
   // Params queries params of the distribution module.
   rpc Params(QueryParamsRequest) returns (QueryParamsResponse) {
-    option (google.api.http).get = "/cosmos/distribution/v1beta1/params";
+    option (cosmos.query.v1.module_query_safe) = true;
+    option (google.api.http).get               = "/cosmos/distribution/v1beta1/params";
   }
 
   // ValidatorDistributionInfo queries validator commission and self-delegation rewards for validator
@@ -27,19 +29,22 @@ service Query {
   // ValidatorOutstandingRewards queries rewards of a validator address.
   rpc ValidatorOutstandingRewards(QueryValidatorOutstandingRewardsRequest)
       returns (QueryValidatorOutstandingRewardsResponse) {
-    option (google.api.http).get = "/cosmos/distribution/v1beta1/validators/"
-                                   "{validator_address}/outstanding_rewards";
+    option (cosmos.query.v1.module_query_safe) = true;
+    option (google.api.http).get               = "/cosmos/distribution/v1beta1/validators/"
+                                                 "{validator_address}/outstanding_rewards";
   }
 
   // ValidatorCommission queries accumulated commission for a validator.
   rpc ValidatorCommission(QueryValidatorCommissionRequest) returns (QueryValidatorCommissionResponse) {
-    option (google.api.http).get = "/cosmos/distribution/v1beta1/validators/"
-                                   "{validator_address}/commission";
+    option (cosmos.query.v1.module_query_safe) = true;
+    option (google.api.http).get               = "/cosmos/distribution/v1beta1/validators/"
+                                                 "{validator_address}/commission";
   }
 
   // ValidatorSlashes queries slash events of a validator.
   rpc ValidatorSlashes(QueryValidatorSlashesRequest) returns (QueryValidatorSlashesResponse) {
-    option (google.api.http).get = "/cosmos/distribution/v1beta1/validators/{validator_address}/slashes";
+    option (cosmos.query.v1.module_query_safe) = true;
+    option (google.api.http).get               = "/cosmos/distribution/v1beta1/validators/{validator_address}/slashes";
   }
 
   // DelegationRewards queries the total rewards accrued by a delegation.
@@ -56,37 +61,43 @@ service Query {
 
   // DelegatorValidators queries the validators of a delegator.
   rpc DelegatorValidators(QueryDelegatorValidatorsRequest) returns (QueryDelegatorValidatorsResponse) {
-    option (google.api.http).get = "/cosmos/distribution/v1beta1/delegators/"
-                                   "{delegator_address}/validators";
+    option (cosmos.query.v1.module_query_safe) = true;
+    option (google.api.http).get               = "/cosmos/distribution/v1beta1/delegators/"
+                                                 "{delegator_address}/validators";
   }
 
   // DelegatorWithdrawAddress queries withdraw address of a delegator.
   rpc DelegatorWithdrawAddress(QueryDelegatorWithdrawAddressRequest) returns (QueryDelegatorWithdrawAddressResponse) {
-    option (google.api.http).get = "/cosmos/distribution/v1beta1/delegators/"
-                                   "{delegator_address}/withdraw_address";
+    option (cosmos.query.v1.module_query_safe) = true;
+    option (google.api.http).get               = "/cosmos/distribution/v1beta1/delegators/"
+                                                 "{delegator_address}/withdraw_address";
   }
 
   // CommunityPool queries the community pool coins.
   //
   rpc CommunityPool(QueryCommunityPoolRequest) returns (QueryCommunityPoolResponse) {
-    option (google.api.http).get = "/cosmos/distribution/v1beta1/community_pool";
+    option (cosmos.query.v1.module_query_safe) = true;
+    option (google.api.http).get               = "/cosmos/distribution/v1beta1/community_pool";
   }
 
   // ValidatorHistoricalRewards queries historical rewards for a validator at a specific period.
   rpc ValidatorHistoricalRewards(QueryValidatorHistoricalRewardsRequest)
       returns (QueryValidatorHistoricalRewardsResponse) {
-    option (google.api.http).get = "/cosmos/distribution/v1beta1/validators/"
-                                   "{validator_address}/historical_rewards/{period}";
+    option (cosmos.query.v1.module_query_safe) = true;
+    option (google.api.http).get               = "/cosmos/distribution/v1beta1/validators/"
+                                                 "{validator_address}/historical_rewards/{period}";
   }
 
   // ValidatorCurrentRewards queries current rewards for a validator.
   rpc ValidatorCurrentRewards(QueryValidatorCurrentRewardsRequest) returns (QueryValidatorCurrentRewardsResponse) {
-    option (google.api.http).get = "/cosmos/distribution/v1beta1/validators/"
-                                   "{validator_address}/current_rewards";
+    option (cosmos.query.v1.module_query_safe) = true;
+    option (google.api.http).get               = "/cosmos/distribution/v1beta1/validators/"
+                                                 "{validator_address}/current_rewards";
   }
 
   // DelegatorStartingInfo queries the starting info for a delegator.
   rpc DelegatorStartingInfo(QueryDelegatorStartingInfoRequest) returns (QueryDelegatorStartingInfoResponse) {
+    option (cosmos.query.v1.module_query_safe) = true;
     option (google.api.http).get =
         "/cosmos/distribution/v1beta1/delegators/{delegator_address}/starting_info/{validator_address}";
   }

--- a/proto/cosmos/gov/v1/query.proto
+++ b/proto/cosmos/gov/v1/query.proto
@@ -5,6 +5,7 @@ import "cosmos/base/query/v1beta1/pagination.proto";
 import "google/api/annotations.proto";
 import "cosmos/gov/v1/gov.proto";
 import "cosmos_proto/cosmos.proto";
+import "cosmos/query/v1/query.proto";
 
 option go_package = "github.com/cosmos/cosmos-sdk/x/gov/types/v1";
 
@@ -12,42 +13,50 @@ option go_package = "github.com/cosmos/cosmos-sdk/x/gov/types/v1";
 service Query {
   // Constitution queries the chain's constitution.
   rpc Constitution(QueryConstitutionRequest) returns (QueryConstitutionResponse) {
-    option (google.api.http).get = "/cosmos/gov/v1/constitution";
+    option (cosmos.query.v1.module_query_safe) = true;
+    option (google.api.http).get               = "/cosmos/gov/v1/constitution";
   }
 
   // Proposal queries proposal details based on ProposalID.
   rpc Proposal(QueryProposalRequest) returns (QueryProposalResponse) {
-    option (google.api.http).get = "/cosmos/gov/v1/proposals/{proposal_id}";
+    option (cosmos.query.v1.module_query_safe) = true;
+    option (google.api.http).get               = "/cosmos/gov/v1/proposals/{proposal_id}";
   }
 
   // Proposals queries all proposals based on given status.
   rpc Proposals(QueryProposalsRequest) returns (QueryProposalsResponse) {
-    option (google.api.http).get = "/cosmos/gov/v1/proposals";
+    option (cosmos.query.v1.module_query_safe) = true;
+    option (google.api.http).get               = "/cosmos/gov/v1/proposals";
   }
 
   // Vote queries voted information based on proposalID, voterAddr.
   rpc Vote(QueryVoteRequest) returns (QueryVoteResponse) {
-    option (google.api.http).get = "/cosmos/gov/v1/proposals/{proposal_id}/votes/{voter}";
+    option (cosmos.query.v1.module_query_safe) = true;
+    option (google.api.http).get               = "/cosmos/gov/v1/proposals/{proposal_id}/votes/{voter}";
   }
 
   // Votes queries votes of a given proposal.
   rpc Votes(QueryVotesRequest) returns (QueryVotesResponse) {
-    option (google.api.http).get = "/cosmos/gov/v1/proposals/{proposal_id}/votes";
+    option (cosmos.query.v1.module_query_safe) = true;
+    option (google.api.http).get               = "/cosmos/gov/v1/proposals/{proposal_id}/votes";
   }
 
   // Params queries all parameters of the gov module.
   rpc Params(QueryParamsRequest) returns (QueryParamsResponse) {
-    option (google.api.http).get = "/cosmos/gov/v1/params/{params_type}";
+    option (cosmos.query.v1.module_query_safe) = true;
+    option (google.api.http).get               = "/cosmos/gov/v1/params/{params_type}";
   }
 
   // Deposit queries single deposit information based on proposalID, depositAddr.
   rpc Deposit(QueryDepositRequest) returns (QueryDepositResponse) {
-    option (google.api.http).get = "/cosmos/gov/v1/proposals/{proposal_id}/deposits/{depositor}";
+    option (cosmos.query.v1.module_query_safe) = true;
+    option (google.api.http).get               = "/cosmos/gov/v1/proposals/{proposal_id}/deposits/{depositor}";
   }
 
   // Deposits queries all deposits of a single proposal.
   rpc Deposits(QueryDepositsRequest) returns (QueryDepositsResponse) {
-    option (google.api.http).get = "/cosmos/gov/v1/proposals/{proposal_id}/deposits";
+    option (cosmos.query.v1.module_query_safe) = true;
+    option (google.api.http).get               = "/cosmos/gov/v1/proposals/{proposal_id}/deposits";
   }
 
   // TallyResult queries the tally of a proposal vote.


### PR DESCRIPTION
# Description

Closes: #20219

This marks the safe `x/gov` and `x/distribution` gRPC queries with `module_query_safe` so they can be called from module query contexts such as Interchain Accounts.

I left a few queries unmarked because their current code paths are not safe for this annotation:

- `x/distribution` reward queries that call `IncrementValidatorPeriod`
- `x/gov` `TallyResult`, which calls `Tally` for voting-period proposals

The rest of the annotated queries use read-only keeper paths.

Validation:

- `make proto-lint`
- `go test -count=1 ./x/gov/keeper ./x/distribution/keeper`
- `git diff --check`