### PR TITLE
ci: bump go to 1.26.4 and source CI Go version from go.mod

### DIFF
--- a/.github/workflows/build-simd-nightlies.yml
+++ b/.github/workflows/build-simd-nightlies.yml
@@ -36,7 +36,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.3"
+          go-version-file: "go.mod"
           cache: true
 
       - name: Install aarch64 cross-compiler

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,8 +23,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.3"
-          check-latest: true
+          go-version-file: "go.mod"
       - name: install aarch64-gcc
         if: matrix.go-arch == 'arm64'
         run: sudo apt-get install gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu
@@ -59,8 +58,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.3"
-          check-latest: true
+          go-version-file: "go.mod"
           cache: true
           cache-dependency-path: enterprise/poa/go.sum
       - uses: technote-space/get-diff-action@v6.1.2

--- a/.github/workflows/dependencies-review.yml
+++ b/.github/workflows/dependencies-review.yml
@@ -15,7 +15,7 @@ jobs:
       - name: "Setup Go"
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26.3"
+          go-version: "1.26"
           check-latest: true
       - name: "Dependency Review"
         uses: actions/dependency-review-action@v5

--- a/.github/workflows/dependencies-review.yml
+++ b/.github/workflows/dependencies-review.yml
@@ -15,8 +15,7 @@ jobs:
       - name: "Setup Go"
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26"
-          check-latest: true
+          go-version-file: "go.mod"
       - name: "Dependency Review"
         uses: actions/dependency-review-action@v5
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,8 +17,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.3"
-          check-latest: true
+          go-version-file: "go.mod"
       - uses: technote-space/get-diff-action@v6.1.2
         id: git_diff
         with:

--- a/.github/workflows/pr-go-mod-tidy-mocks.yml
+++ b/.github/workflows/pr-go-mod-tidy-mocks.yml
@@ -20,8 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26.3"
-          check-latest: true
+          go-version-file: "go.mod"
       - name: Run go mod tidy
         run: ./scripts/go-mod-tidy-all.sh
       - name: Check for diffs
@@ -40,8 +39,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26.3"
-          check-latest: true
+          go-version-file: "go.mod"
       - name: Generate mocks
         run: make mocks
       - name: Check for diffs

--- a/.github/workflows/sims-054.yml
+++ b/.github/workflows/sims-054.yml
@@ -23,8 +23,7 @@ jobs:
           ref: "release/v0.54.x"
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.3"
-          check-latest: true
+          go-version-file: "go.mod"
       - run: make build
 
   install-runsim:
@@ -35,8 +34,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.3"
-          check-latest: true
+          go-version-file: "go.mod"
       - name: Install runsim
         run: go install github.com/cosmos/tools/cmd/runsim@v1.0.0
       - uses: actions/cache@v5
@@ -54,8 +52,7 @@ jobs:
           ref: "release/v0.54.x"
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.3"
-          check-latest: true
+          go-version-file: "go.mod"
       - uses: actions/cache@v5
         with:
           path: ~/go/bin
@@ -73,8 +70,7 @@ jobs:
           ref: "release/v0.54.x"
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.3"
-          check-latest: true
+          go-version-file: "go.mod"
       - uses: actions/cache@v5
         with:
           path: ~/go/bin
@@ -92,8 +88,7 @@ jobs:
           ref: "release/v0.54.x"
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.3"
-          check-latest: true
+          go-version-file: "go.mod"
       - uses: actions/cache@v5
         with:
           path: ~/go/bin

--- a/.github/workflows/sims-nightly.yml
+++ b/.github/workflows/sims-nightly.yml
@@ -21,8 +21,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.3"
-          check-latest: true
+          go-version-file: "go.mod"
       - name: test-sim-multi-seed-long
         env:
           GOMEMLIMIT: 14GiB # reserve 2 GiB as buffer for GC to avoid OOM
@@ -36,8 +35,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.3"
-          check-latest: true
+          go-version-file: "go.mod"
       - name: test-sim-import-export
         env:
           GOMEMLIMIT: 14GiB # reserve 2 GiB as buffer for GC to avoid OOM

--- a/.github/workflows/sims.yml
+++ b/.github/workflows/sims.yml
@@ -21,8 +21,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.3"
-          check-latest: true
+          go-version-file: "go.mod"
       - run: make build
 
   test-sim-import-export:
@@ -33,8 +32,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.3"
-          check-latest: true
+          go-version-file: "go.mod"
       - name: test-sim-import-export
         run: |
           make test-sim-import-export
@@ -47,8 +45,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.3"
-          check-latest: true
+          go-version-file: "go.mod"
       - name: test-sim-after-import
         run: |
           make test-sim-after-import
@@ -61,8 +58,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.3"
-          check-latest: true
+          go-version-file: "go.mod"
       - name: test-sim-nondeterminism-streaming
         run: |
           make test-sim-nondeterminism-streaming
@@ -75,8 +71,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.3"
-          check-latest: true
+          go-version-file: "go.mod"
       - name: test-sim-blockstm
         run: |
           make test-sim-blockstm
@@ -89,8 +84,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.3"
-          check-latest: true
+          go-version-file: "go.mod"
       - name: test-sim-multi-seed-short
         run: |
           make test-sim-multi-seed-short

--- a/.github/workflows/systemtests.yml
+++ b/.github/workflows/systemtests.yml
@@ -26,8 +26,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.3"
-          check-latest: true
+          go-version-file: "go.mod"
           cache: true
           cache-dependency-path: |
             ./go.sum
@@ -60,8 +59,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.3"
-          check-latest: true
+          go-version-file: "go.mod"
           cache: true
           cache-dependency-path: go.sum
 
@@ -82,8 +80,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.3"
-          check-latest: true
+          go-version-file: "go.mod"
           cache: true
           cache-dependency-path: enterprise/poa/go.sum
       - uses: technote-space/get-diff-action@v6.1.2
@@ -105,8 +102,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.3"
-          check-latest: true
+          go-version-file: "go.mod"
           cache: true
           cache-dependency-path: enterprise/group/go.sum
       - uses: technote-space/get-diff-action@v6.1.2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,8 +21,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.3"
-          check-latest: true
+          go-version-file: "go.mod"
       - name: Create a file with all core Cosmos SDK pkgs
         run: go list ./... > pkgs.txt
       - name: Split pkgs into 4 files
@@ -55,8 +54,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.3"
-          check-latest: true
+          go-version-file: "go.mod"
           cache: true
           cache-dependency-path: go.sum
       - uses: technote-space/get-diff-action@v6.1.2
@@ -89,8 +87,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.3"
-          check-latest: true
+          go-version-file: "go.mod"
           cache: true
           cache-dependency-path: go.sum
       - uses: technote-space/get-diff-action@v6.1.2
@@ -120,8 +117,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.3"
-          check-latest: true
+          go-version-file: "go.mod"
           cache: true
           cache-dependency-path: go.sum
       - uses: technote-space/get-diff-action@v6.1.2
@@ -274,8 +270,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.3"
-          check-latest: true
+          go-version-file: "go.mod"
           cache: true
           cache-dependency-path: go.sum
       - uses: technote-space/get-diff-action@v6.1.2
@@ -307,8 +302,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.3"
-          check-latest: true
+          go-version-file: "go.mod"
           cache: true
           cache-dependency-path: client/v2/go.sum
       - uses: technote-space/get-diff-action@v6.1.2
@@ -335,8 +329,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.3"
-          check-latest: true
+          go-version-file: "go.mod"
           cache: true
           cache-dependency-path: core/go.sum
       - uses: technote-space/get-diff-action@v6.1.2
@@ -363,8 +356,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.3"
-          check-latest: false
+          go-version-file: "go.mod"
           cache: true
           cache-dependency-path: depinject/go.sum
       - uses: technote-space/get-diff-action@v6.1.2
@@ -391,8 +383,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.3"
-          check-latest: true
+          go-version-file: "go.mod"
           cache: true
           cache-dependency-path: errors/go.sum
       - uses: technote-space/get-diff-action@v6.1.2
@@ -419,8 +410,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.3"
-          check-latest: true
+          go-version-file: "go.mod"
           cache: true
           cache-dependency-path: math/go.sum
       - uses: technote-space/get-diff-action@v6.1.2
@@ -447,8 +437,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.3"
-          check-latest: true
+          go-version-file: "go.mod"
           cache: true
           cache-dependency-path: collections/go.sum
       - uses: technote-space/get-diff-action@v6.1.2
@@ -475,8 +464,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.3"
-          check-latest: true
+          go-version-file: "go.mod"
           cache: true
           cache-dependency-path: tools/cosmovisor/go.sum
       - uses: technote-space/get-diff-action@v6.1.2
@@ -503,8 +491,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.3"
-          check-latest: true
+          go-version-file: "go.mod"
           cache: true
           cache-dependency-path: tools/confix/go.sum
       - uses: technote-space/get-diff-action@v6.1.2
@@ -531,8 +518,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.3"
-          check-latest: true
+          go-version-file: "go.mod"
           cache: true
           cache-dependency-path: store/go.sum
       - uses: technote-space/get-diff-action@v6.1.2
@@ -560,8 +546,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.3"
-          check-latest: true
+          go-version-file: "go.mod"
           cache: true
           cache-dependency-path: log/go.sum
       - uses: technote-space/get-diff-action@v6.1.2
@@ -592,8 +577,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.3"
-          check-latest: true
+          go-version-file: "go.mod"
           cache: true
           cache-dependency-path: enterprise/poa/go.sum
       - uses: technote-space/get-diff-action@v6.1.2

--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module cosmossdk.io/api
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/cosmos/cosmos-proto v1.0.0-beta.5

--- a/client/v2/go.mod
+++ b/client/v2/go.mod
@@ -1,6 +1,6 @@
 module cosmossdk.io/client/v2
 
-go 1.26.3
+go 1.26.4
 
 require (
 	cosmossdk.io/api v1.0.0

--- a/collections/go.mod
+++ b/collections/go.mod
@@ -1,6 +1,6 @@
 module cosmossdk.io/collections
 
-go 1.26.3
+go 1.26.4
 
 require (
 	cosmossdk.io/schema v1.1.0

--- a/core/go.mod
+++ b/core/go.mod
@@ -1,6 +1,6 @@
 module cosmossdk.io/core
 
-go 1.26.3
+go 1.26.4
 
 require (
 	cosmossdk.io/api v1.0.0

--- a/depinject/go.mod
+++ b/depinject/go.mod
@@ -1,6 +1,6 @@
 module cosmossdk.io/depinject
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/cosmos/cosmos-proto v1.0.0-beta.5

--- a/enterprise/group/go.mod
+++ b/enterprise/group/go.mod
@@ -1,6 +1,6 @@
 module github.com/cosmos/cosmos-sdk/enterprise/group
 
-go 1.26.3
+go 1.26.4
 
 require (
 	cosmossdk.io/api v1.0.0

--- a/enterprise/group/simapp/go.mod
+++ b/enterprise/group/simapp/go.mod
@@ -1,6 +1,6 @@
 module github.com/cosmos/cosmos-sdk/enterprise/group/simapp
 
-go 1.26.3
+go 1.26.4
 
 require (
 	cosmossdk.io/api v1.0.0

--- a/enterprise/group/tests/systemtests/go.mod
+++ b/enterprise/group/tests/systemtests/go.mod
@@ -1,6 +1,6 @@
 module github.com/cosmos/cosmos-sdk/enterprise/group/tests/systemtests
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/cosmos/cosmos-sdk/tools/systemtests v0.0.0-00010101000000-000000000000

--- a/enterprise/poa/examples/migrate-from-pos/go.mod
+++ b/enterprise/poa/examples/migrate-from-pos/go.mod
@@ -1,6 +1,6 @@
 module github.com/cosmos/cosmos-sdk/enterprise/poa/examples/migrate-from-pos
 
-go 1.26.3
+go 1.26.4
 
 require (
 	cosmossdk.io/api v1.0.0

--- a/enterprise/poa/go.mod
+++ b/enterprise/poa/go.mod
@@ -1,6 +1,6 @@
 module github.com/cosmos/cosmos-sdk/enterprise/poa
 
-go 1.26.3
+go 1.26.4
 
 require (
 	cosmossdk.io/api v1.0.0

--- a/enterprise/poa/simapp/go.mod
+++ b/enterprise/poa/simapp/go.mod
@@ -1,6 +1,6 @@
 module github.com/cosmos/cosmos-sdk/enterprise/poa/simapp
 
-go 1.26.3
+go 1.26.4
 
 require (
 	cosmossdk.io/api v1.0.0

--- a/enterprise/poa/tests/systemtests/go.mod
+++ b/enterprise/poa/tests/systemtests/go.mod
@@ -1,6 +1,6 @@
 module github.com/cosmos/cosmos-sdk/enterprise/poa/tests/systemtests
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/cosmos/cosmos-sdk v0.54.0

--- a/errors/go.mod
+++ b/errors/go.mod
@@ -1,6 +1,6 @@
 module cosmossdk.io/errors
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/pkg/errors v0.9.1

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-go 1.26.3
+go 1.26.4
 
 module github.com/cosmos/cosmos-sdk
 

--- a/log/go.mod
+++ b/log/go.mod
@@ -1,6 +1,6 @@
 module cosmossdk.io/log/v2
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/bytedance/sonic v1.15.1

--- a/math/go.mod
+++ b/math/go.mod
@@ -1,6 +1,6 @@
 module cosmossdk.io/math
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/simapp/go.mod
+++ b/simapp/go.mod
@@ -1,6 +1,6 @@
 module cosmossdk.io/simapp
 
-go 1.26.3
+go 1.26.4
 
 require (
 	cosmossdk.io/api v1.0.0

--- a/store/go.mod
+++ b/store/go.mod
@@ -1,6 +1,6 @@
 module github.com/cosmos/cosmos-sdk/store/v2
 
-go 1.26.3
+go 1.26.4
 
 require (
 	cosmossdk.io/errors v1.1.0

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -1,6 +1,6 @@
 module github.com/cosmos/cosmos-sdk/tests
 
-go 1.26.3
+go 1.26.4
 
 require (
 	cosmossdk.io/api v1.0.0

--- a/tests/systemtests/go.mod
+++ b/tests/systemtests/go.mod
@@ -1,6 +1,6 @@
 module cosmossdk.io/tests/systemtests
 
-go 1.26.3
+go 1.26.4
 
 // always use latest versions in tests
 replace github.com/cosmos/cosmos-sdk => ../..

--- a/tools/confix/go.mod
+++ b/tools/confix/go.mod
@@ -1,6 +1,6 @@
 module cosmossdk.io/tools/confix
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/cosmos/cosmos-sdk v0.54.0

--- a/tools/cosmovisor/go.mod
+++ b/tools/cosmovisor/go.mod
@@ -1,6 +1,6 @@
 module cosmossdk.io/tools/cosmovisor
 
-go 1.26.3
+go 1.26.4
 
 require (
 	cosmossdk.io/log/v2 v2.1.0

--- a/tools/systemtests/go.mod
+++ b/tools/systemtests/go.mod
@@ -1,4 +1,4 @@
-go 1.26.3
+go 1.26.4
 
 module github.com/cosmos/cosmos-sdk/tools/systemtests
 


### PR DESCRIPTION
# Description

clear GO-2026-5037 and GO-2026-5039 that was fixed in go1.26.4 and avoid future patches

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->
