### PR TITLE
ci: add setup-go to test-system and test-system-legacy jobs

### DIFF
--- a/.github/workflows/systemtests.yml
+++ b/.github/workflows/systemtests.yml
@@ -48,6 +48,13 @@ jobs:
     runs-on: depot-ubuntu-22.04-4
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-tags: true
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: "go.mod"
+          cache: true
+          cache-dependency-path: ./go.sum
       - name: Run system tests
         run: |
           make test-system
@@ -58,6 +65,13 @@ jobs:
     runs-on: depot-ubuntu-22.04-4
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-tags: true
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: "go.mod"
+          cache: true
+          cache-dependency-path: ./go.sum
       - name: Run legacy system tests
         run: |
           COSMOS_BUILD_OPTIONS=legacy make test-system


### PR DESCRIPTION
## Summary

- `test-system` and `test-system-legacy` jobs were running `make test-system` without a `setup-go` step, relying on the runner's ambient Go version
- This causes `go: updates to go.mod needed, disabled by -mod=readonly` build failures when the runner's Go differs from the module requirement
- The `setup` job (diff detection only) had `go-version: "1.23"` hardcoded — but this Go version was never propagated to the actual test jobs
- Added `actions/setup-go@v6` with `go-version-file: "go.mod"` to both jobs, consistent with the approach in #26486 for the main CI workflows
- Also added `fetch-tags: true` to the checkout in both jobs since `make test-system` invokes `build-v50` which checks out a tagged ref

## Impact

This unblocks all open PRs targeting `release/v0.53.x` — including the staking redelegation fix in #26417.

Issue: N/A