### PR TITLE
fix: bound compact bit array index by elems length

### DIFF
--- a/crypto/types/compact_bit_array.go
+++ b/crypto/types/compact_bit_array.go
@@ -55,7 +55,7 @@ func (bA *CompactBitArray) GetIndex(i int) bool {
 	if bA == nil {
 		return false
 	}
-	if i < 0 || i >= bA.Count() {
+	if i < 0 || i >= bA.Count() || i>>3 >= len(bA.Elems) {
 		return false
 	}
 
@@ -69,7 +69,7 @@ func (bA *CompactBitArray) SetIndex(i int, v bool) bool {
 		return false
 	}
 
-	if i < 0 || i >= bA.Count() {
+	if i < 0 || i >= bA.Count() || i>>3 >= len(bA.Elems) {
 		return false
 	}
 

--- a/crypto/types/compact_bit_array_test.go
+++ b/crypto/types/compact_bit_array_test.go
@@ -245,6 +245,23 @@ func TestCompactBitArrayGetSetIndex(t *testing.T) {
 	}
 }
 
+func TestGetSetIndexNeverCrashesOnInconsistentExtraBits(t *testing.T) {
+	// A CompactBitArray decoded from untrusted proto can have ExtraBitsStored
+	// inconsistent with len(Elems). Count() trusts ExtraBitsStored, so an index
+	// can pass the Count() guard yet fall outside Elems.
+	bA := &CompactBitArray{ExtraBitsStored: 9, Elems: []byte{0xff}}
+	require.Equal(t, 9, bA.Count())
+	for i := 0; i < bA.Count(); i++ {
+		require.NotPanics(t, func() { bA.GetIndex(i) })
+		require.NotPanics(t, func() { bA.SetIndex(i, true) })
+	}
+	// Indices backed by a real byte still resolve normally.
+	require.True(t, bA.GetIndex(0))
+	// Indices past the backing slice are rejected instead of panicking.
+	require.False(t, bA.GetIndex(8))
+	require.False(t, bA.SetIndex(8, true))
+}
+
 func BenchmarkNumTrueBitsBefore(b *testing.B) {
 	ba, _ := randCompactBitArray(100)
 


### PR DESCRIPTION
Repro: submit a multisig tx whose `CompactBitArray` has `Elems` shorter than its `ExtraBitsStored` implies, e.g. `Elems=[0xff]`, `ExtraBitsStored=9` against a 9-key multisig.
Cause: `GetIndex`/`SetIndex` bound the index only against `Count()`, which is `(len(Elems)-1)*8 + ExtraBitsStored`. `ExtraBitsStored` is an untrusted `uint32` decoded from the tx bit array, so a crafted value pushes `Count()` past `len(Elems)*8`; an index then clears the `Count()` guard but reads `Elems[i>>3]` out of range and panics during multisig verification (`x/auth/ante/sigverify.go`, `crypto/keys/multisig`).
Fix: also bound `i>>3` against `len(Elems)` in both accessors, alongside the existing negative-index guard from #9164.
