### PR TITLE
ci: add pre-commit config to enforce make lint-fix

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+  - repo: local
+    hooks:
+      - id: lint-fix
+        name: make lint-fix
+        entry: make lint-fix
+        language: system
+        pass_filenames: false
+        always_run: true


### PR DESCRIPTION
## Summary

- Adds `.pre-commit-config.yaml` with a single local hook that runs `make lint-fix` before every commit
- Catches gci import ordering, gofumpt, and staticcheck issues locally before they hit CI
- Zero new dependencies — uses the existing `make lint-fix` target

## Usage

```bash
# Install once
pre-commit install

# Run manually on all files
pre-commit run --all-files
```

## Why

Several recent PRs and commits have had lint failures caught by CI that a pre-commit hook would have caught locally, requiring extra fix-up commits. This hook closes that loop.

Issue: N/A