### PR TITLE
feat(autocli): replace pulsar types with Go-native structs (Phase 1 of pulsar removal)

### DIFF
--- a/client/cmd.go
+++ b/client/cmd.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	txsigning "github.com/cosmos/cosmos-sdk/x/tx/signing"
 )
 
 // ClientContextKey defines the context key used to retrieve a client.Context from

--- a/client/cmd.go
+++ b/client/cmd.go
@@ -17,7 +17,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	txsigning "github.com/cosmos/cosmos-sdk/x/tx/signing"
 )
 
 // ClientContextKey defines the context key used to retrieve a client.Context from

--- a/client/grpc/cmtservice/autocli.go
+++ b/client/grpc/cmtservice/autocli.go
@@ -1,12 +1,11 @@
 package cmtservice
 
 import (
-	cmtv1beta1 "cosmossdk.io/api/cosmos/base/tendermint/v1beta1"
 	autocli "cosmossdk.io/core/autocli"
 )
 
 var CometBFTAutoCLIDescriptor = &autocli.ServiceCommandDescriptor{
-	Service: cmtv1beta1.Service_ServiceDesc.ServiceName,
+	Service: "cosmos.base.tendermint.v1beta1.Service",
 	RpcCommandOptions: []*autocli.RpcCommandOptions{
 		{
 			RpcMethod: "GetNodeInfo",

--- a/client/grpc/cmtservice/autocli.go
+++ b/client/grpc/cmtservice/autocli.go
@@ -1,13 +1,13 @@
 package cmtservice
 
 import (
-	autocliv1 "cosmossdk.io/api/cosmos/autocli/v1"
 	cmtv1beta1 "cosmossdk.io/api/cosmos/base/tendermint/v1beta1"
+	autocli "cosmossdk.io/core/autocli"
 )
 
-var CometBFTAutoCLIDescriptor = &autocliv1.ServiceCommandDescriptor{
+var CometBFTAutoCLIDescriptor = &autocli.ServiceCommandDescriptor{
 	Service: cmtv1beta1.Service_ServiceDesc.ServiceName,
-	RpcCommandOptions: []*autocliv1.RpcCommandOptions{
+	RpcCommandOptions: []*autocli.RpcCommandOptions{
 		{
 			RpcMethod: "GetNodeInfo",
 			Use:       "node-info",
@@ -28,7 +28,7 @@ var CometBFTAutoCLIDescriptor = &autocliv1.ServiceCommandDescriptor{
 			Use:            "block-by-height [height]",
 			Short:          "Query for a committed block by height",
 			Long:           "Query for a specific committed block using the CometBFT RPC `block_by_height` method",
-			PositionalArgs: []*autocliv1.PositionalArgDescriptor{{ProtoField: "height"}},
+			PositionalArgs: []*autocli.PositionalArgDescriptor{{ProtoField: "height"}},
 		},
 		{
 			RpcMethod: "GetLatestValidatorSet",
@@ -40,7 +40,7 @@ var CometBFTAutoCLIDescriptor = &autocliv1.ServiceCommandDescriptor{
 			RpcMethod:      "GetValidatorSetByHeight",
 			Use:            "validator-set-by-height [height]",
 			Short:          "Query for a validator set by height",
-			PositionalArgs: []*autocliv1.PositionalArgDescriptor{{ProtoField: "height"}},
+			PositionalArgs: []*autocli.PositionalArgDescriptor{{ProtoField: "height"}},
 		},
 		{
 			RpcMethod: "ABCIQuery",
@@ -55,7 +55,7 @@ var CometBFTAutoCLIDescriptor = &autocliv1.ServiceCommandDescriptor{
 			RpcMethod:      "GetBlockResults",
 			Use:            "block-results [height]",
 			Short:          "Query for block results by height",
-			PositionalArgs: []*autocliv1.PositionalArgDescriptor{{ProtoField: "height"}},
+			PositionalArgs: []*autocli.PositionalArgDescriptor{{ProtoField: "height"}},
 		},
 	},
 }
@@ -75,8 +75,8 @@ func (m cometModule) Name() string {
 	return "comet"
 }
 
-func (m cometModule) AutoCLIOptions() *autocliv1.ModuleOptions {
-	return &autocliv1.ModuleOptions{
+func (m cometModule) AutoCLIOptions() *autocli.ModuleOptions {
+	return &autocli.ModuleOptions{
 		Query: CometBFTAutoCLIDescriptor,
 	}
 }

--- a/client/grpc/node/autocli.go
+++ b/client/grpc/node/autocli.go
@@ -1,13 +1,13 @@
 package node
 
 import (
-	autocliv1 "cosmossdk.io/api/cosmos/autocli/v1"
 	nodev1beta1 "cosmossdk.io/api/cosmos/base/node/v1beta1"
+	autocli "cosmossdk.io/core/autocli"
 )
 
-var ServiceAutoCLIDescriptor = &autocliv1.ServiceCommandDescriptor{
+var ServiceAutoCLIDescriptor = &autocli.ServiceCommandDescriptor{
 	Service: nodev1beta1.Service_ServiceDesc.ServiceName,
-	RpcCommandOptions: []*autocliv1.RpcCommandOptions{
+	RpcCommandOptions: []*autocli.RpcCommandOptions{
 		{
 			RpcMethod: "Config",
 			Use:       "config",
@@ -36,8 +36,8 @@ func (m nodeModule) Name() string {
 	return "node"
 }
 
-func (m nodeModule) AutoCLIOptions() *autocliv1.ModuleOptions {
-	return &autocliv1.ModuleOptions{
+func (m nodeModule) AutoCLIOptions() *autocli.ModuleOptions {
+	return &autocli.ModuleOptions{
 		Query: ServiceAutoCLIDescriptor,
 	}
 }

--- a/client/grpc/node/autocli.go
+++ b/client/grpc/node/autocli.go
@@ -1,12 +1,11 @@
 package node
 
 import (
-	nodev1beta1 "cosmossdk.io/api/cosmos/base/node/v1beta1"
 	autocli "cosmossdk.io/core/autocli"
 )
 
 var ServiceAutoCLIDescriptor = &autocli.ServiceCommandDescriptor{
-	Service: nodev1beta1.Service_ServiceDesc.ServiceName,
+	Service: "cosmos.base.node.v1beta1.Service",
 	RpcCommandOptions: []*autocli.RpcCommandOptions{
 		{
 			RpcMethod: "Config",

--- a/client/tx/aux_builder.go
+++ b/client/tx/aux_builder.go
@@ -4,17 +4,15 @@ import (
 	"context"
 	"time"
 
-	"github.com/cosmos/gogoproto/proto"
-	"google.golang.org/protobuf/types/known/anypb"
+	gogoproto "github.com/cosmos/gogoproto/proto"
+	gogotypes "github.com/cosmos/gogoproto/types/any"
 	"google.golang.org/protobuf/types/known/timestamppb"
-
-	txv1beta1 "cosmossdk.io/api/cosmos/tx/v1beta1"
 
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-	"github.com/cosmos/cosmos-sdk/types/tx"
+	txtypes "github.com/cosmos/cosmos-sdk/types/tx"
 	"github.com/cosmos/cosmos-sdk/types/tx/signing"
 	txsigning "github.com/cosmos/cosmos-sdk/x/tx/signing"
 	"github.com/cosmos/cosmos-sdk/x/tx/signing/aminojson"
@@ -27,8 +25,8 @@ type AuxTxBuilder struct {
 	// - b.msgs is used for constructing the AMINO sign bz,
 	// - b.body is used for constructing the DIRECT_AUX sign bz.
 	msgs          []sdk.Msg
-	body          *txv1beta1.TxBody
-	auxSignerData *tx.AuxSignerData
+	body          *txtypes.TxBody
+	auxSignerData *txtypes.AuxSignerData
 }
 
 // NewAuxTxBuilder creates a new client-side builder for constructing an
@@ -40,14 +38,12 @@ func NewAuxTxBuilder() AuxTxBuilder {
 // SetAddress sets the aux signer's bech32 address.
 func (b *AuxTxBuilder) SetAddress(addr string) {
 	b.checkEmptyFields()
-
 	b.auxSignerData.Address = addr
 }
 
 // SetMemo sets a memo in the tx.
 func (b *AuxTxBuilder) SetMemo(memo string) {
 	b.checkEmptyFields()
-
 	b.body.Memo = memo
 	b.auxSignerData.SignDoc.BodyBytes = nil
 }
@@ -55,7 +51,6 @@ func (b *AuxTxBuilder) SetMemo(memo string) {
 // SetTimeoutHeight sets a timeout height in the tx.
 func (b *AuxTxBuilder) SetTimeoutHeight(height uint64) {
 	b.checkEmptyFields()
-
 	b.body.TimeoutHeight = height
 	b.auxSignerData.SignDoc.BodyBytes = nil
 }
@@ -63,56 +58,51 @@ func (b *AuxTxBuilder) SetTimeoutHeight(height uint64) {
 // SetTimeoutTimestamp sets a timeout timestamp in the tx.
 func (b *AuxTxBuilder) SetTimeoutTimestamp(timestamp time.Time) {
 	// Only set TimeoutTimestamp if we have a non-zero time.Time.
-	// Setting timestamppb.New() with a zero/default value time.Time results in a non-zero timestamppb.Timestamp,
-	// which causes the value to show up in the signature - breaking <v0.53.x compatibility.
+	// Setting a zero/default value results in a non-zero Timestamp which
+	// would appear in the signature, breaking <v0.53.x compatibility.
 	if !timestamp.IsZero() && timestamp.Unix() > 0 {
 		b.checkEmptyFields()
-		b.body.TimeoutTimestamp = timestamppb.New(timestamp)
+		b.body.TimeoutTimestamp = &timestamp
 		b.auxSignerData.SignDoc.BodyBytes = nil
 	}
 }
 
 // SetMsgs sets an array of Msgs in the tx.
 func (b *AuxTxBuilder) SetMsgs(msgs ...sdk.Msg) error {
-	anys := make([]*anypb.Any, len(msgs))
+	anys := make([]*gogotypes.Any, len(msgs))
 	for i, msg := range msgs {
 		legacyAny, err := codectypes.NewAnyWithValue(msg)
 		if err != nil {
 			return err
 		}
-		anys[i] = &anypb.Any{
+		anys[i] = &gogotypes.Any{
 			TypeUrl: legacyAny.TypeUrl,
 			Value:   legacyAny.Value,
 		}
 	}
 
 	b.checkEmptyFields()
-
 	b.msgs = msgs
 	b.body.Messages = anys
 	b.auxSignerData.SignDoc.BodyBytes = nil
-
 	return nil
 }
 
 // SetAccountNumber sets the aux signer's account number in the AuxSignerData.
 func (b *AuxTxBuilder) SetAccountNumber(accNum uint64) {
 	b.checkEmptyFields()
-
 	b.auxSignerData.SignDoc.AccountNumber = accNum
 }
 
 // SetChainID sets the chain id in the AuxSignerData.
 func (b *AuxTxBuilder) SetChainID(chainID string) {
 	b.checkEmptyFields()
-
 	b.auxSignerData.SignDoc.ChainId = chainID
 }
 
 // SetSequence sets the aux signer's sequence in the AuxSignerData.
 func (b *AuxTxBuilder) SetSequence(accSeq uint64) {
 	b.checkEmptyFields()
-
 	b.auxSignerData.SignDoc.Sequence = accSeq
 }
 
@@ -125,7 +115,6 @@ func (b *AuxTxBuilder) SetPubKey(pk cryptotypes.PubKey) error {
 
 	b.checkEmptyFields()
 	b.auxSignerData.SignDoc.PublicKey = anyPk
-
 	return nil
 }
 
@@ -146,7 +135,6 @@ func (b *AuxTxBuilder) SetSignMode(mode signing.SignMode) error {
 // SetSignature sets the aux signer's signature in the AuxSignerData.
 func (b *AuxTxBuilder) SetSignature(sig []byte) {
 	b.checkEmptyFields()
-
 	b.auxSignerData.Sig = sig
 }
 
@@ -154,27 +142,21 @@ func (b *AuxTxBuilder) SetSignature(sig []byte) {
 func (b *AuxTxBuilder) SetExtensionOptions(extOpts ...*codectypes.Any) {
 	b.checkEmptyFields()
 
-	anyExtOpts := make([]*anypb.Any, len(extOpts))
+	anyExtOpts := make([]*gogotypes.Any, len(extOpts))
 	for i, extOpt := range extOpts {
-		anyExtOpts[i] = &anypb.Any{
-			TypeUrl: extOpt.TypeUrl,
-			Value:   extOpt.Value,
-		}
+		anyExtOpts[i] = &gogotypes.Any{TypeUrl: extOpt.TypeUrl, Value: extOpt.Value}
 	}
 	b.body.ExtensionOptions = anyExtOpts
 	b.auxSignerData.SignDoc.BodyBytes = nil
 }
 
-// SetNonCriticalExtensionOptions sets the aux signer's signature.
+// SetNonCriticalExtensionOptions sets the aux signer's non-critical extension options.
 func (b *AuxTxBuilder) SetNonCriticalExtensionOptions(extOpts ...*codectypes.Any) {
 	b.checkEmptyFields()
 
-	anyNonCritExtOpts := make([]*anypb.Any, len(extOpts))
+	anyNonCritExtOpts := make([]*gogotypes.Any, len(extOpts))
 	for i, extOpt := range extOpts {
-		anyNonCritExtOpts[i] = &anypb.Any{
-			TypeUrl: extOpt.TypeUrl,
-			Value:   extOpt.Value,
-		}
+		anyNonCritExtOpts[i] = &gogotypes.Any{TypeUrl: extOpt.TypeUrl, Value: extOpt.Value}
 	}
 	b.body.NonCriticalExtensionOptions = anyNonCritExtOpts
 	b.auxSignerData.SignDoc.BodyBytes = nil
@@ -197,7 +179,7 @@ func (b *AuxTxBuilder) GetSignBytes() ([]byte, error) {
 		return nil, sdkerrors.ErrLogic.Wrap("sign doc is nil, call setters on AuxTxBuilder first")
 	}
 
-	bodyBz, err := proto.Marshal(body)
+	bodyBz, err := gogoproto.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
@@ -210,56 +192,55 @@ func (b *AuxTxBuilder) GetSignBytes() ([]byte, error) {
 	var signBz []byte
 	switch b.auxSignerData.Mode {
 	case signing.SignMode_SIGN_MODE_DIRECT_AUX:
-		{
-			signBz, err = proto.Marshal(b.auxSignerData.SignDoc)
-			if err != nil {
-				return nil, err
-			}
+		signBz, err = gogoproto.Marshal(b.auxSignerData.SignDoc)
+		if err != nil {
+			return nil, err
 		}
+
 	case signing.SignMode_SIGN_MODE_LEGACY_AMINO_JSON:
-		{
-			handler := aminojson.NewSignModeHandler(aminojson.SignModeHandlerOptions{
-				FileResolver: proto.HybridResolver,
-			})
+		handler := aminojson.NewSignModeHandler(aminojson.SignModeHandlerOptions{
+			FileResolver: gogoproto.HybridResolver,
+		})
 
-			// Convert pulsar TxBody to Go-native TxBodyData for the signing handler.
-			auxMsgs := make([]txsigning.RawMsg, len(body.Messages))
-			for i, m := range body.Messages {
-				auxMsgs[i] = txsigning.RawMsg{TypeUrl: m.TypeUrl, Value: m.Value}
-			}
-			auxBodyData := &txsigning.TxBodyData{
-				Messages:         auxMsgs,
-				Memo:             body.Memo,
-				TimeoutHeight:    body.TimeoutHeight,
-				TimeoutTimestamp: body.TimeoutTimestamp,
-				Unordered:        body.Unordered,
-				// AuxTxBuilder has no concern with extension options, so we set them to nil.
-				// This preserves pre-PR#16025 behavior where extension options were ignored, this code path:
-				// https://github.com/cosmos/cosmos-sdk/blob/ac3c209326a26b46f65a6cc6f5b5ebf6beb79b38/client/tx/aux_builder.go#L193
-				// https://github.com/cosmos/cosmos-sdk/blob/ac3c209326a26b46f65a6cc6f5b5ebf6beb79b38/x/auth/migrations/legacytx/stdsign.go#L49
-			}
-
-			signBz, err = handler.GetSignBytes(
-				context.Background(),
-				txsigning.SignerData{
-					Address:       b.auxSignerData.Address,
-					ChainID:       b.auxSignerData.SignDoc.ChainId,
-					AccountNumber: b.auxSignerData.SignDoc.AccountNumber,
-					Sequence:      b.auxSignerData.SignDoc.Sequence,
-					PubKey:        nil,
-				},
-				txsigning.TxData{
-					Body: auxBodyData,
-					// Aux signer never signs over fee.
-					// For LEGACY_AMINO_JSON, we use the convention to sign over empty fees.
-					// ref: https://github.com/cosmos/cosmos-sdk/pull/10348
-					AuthInfo: &txsigning.TxAuthInfoData{
-						Fee: txsigning.TxFeeData{},
-					},
-				},
-			)
-			return signBz, err
+		// Convert gogoproto TxBody to Go-native TxBodyData for the signing handler.
+		auxMsgs := make([]txsigning.RawMsg, len(body.Messages))
+		for i, m := range body.Messages {
+			auxMsgs[i] = txsigning.RawMsg{TypeUrl: m.TypeUrl, Value: m.Value}
 		}
+
+		var ts *timestamppb.Timestamp
+		if body.TimeoutTimestamp != nil {
+			ts = timestamppb.New(*body.TimeoutTimestamp)
+		}
+
+		auxBodyData := &txsigning.TxBodyData{
+			Messages:         auxMsgs,
+			Memo:             body.Memo,
+			TimeoutHeight:    body.TimeoutHeight,
+			TimeoutTimestamp: ts,
+			Unordered:        body.Unordered,
+			// AuxTxBuilder has no concern with extension options per legacy behavior.
+			// ref: https://github.com/cosmos/cosmos-sdk/blob/ac3c209326a26b46f65a6cc6f5b5ebf6beb79b38/client/tx/aux_builder.go#L193
+		}
+
+		signBz, err = handler.GetSignBytes(
+			context.Background(),
+			txsigning.SignerData{
+				Address:       b.auxSignerData.Address,
+				ChainID:       b.auxSignerData.SignDoc.ChainId,
+				AccountNumber: b.auxSignerData.SignDoc.AccountNumber,
+				Sequence:      b.auxSignerData.SignDoc.Sequence,
+				PubKey:        nil,
+			},
+			txsigning.TxData{
+				Body: auxBodyData,
+				// Aux signer never signs over fee; use empty fees per convention.
+				// ref: https://github.com/cosmos/cosmos-sdk/pull/10348
+				AuthInfo: &txsigning.TxAuthInfoData{Fee: txsigning.TxFeeData{}},
+			},
+		)
+		return signBz, err
+
 	default:
 		return nil, sdkerrors.ErrInvalidRequest.Wrapf("got unknown sign mode %s", b.auxSignerData.Mode)
 	}
@@ -268,9 +249,9 @@ func (b *AuxTxBuilder) GetSignBytes() ([]byte, error) {
 }
 
 // GetAuxSignerData returns the builder's AuxSignerData.
-func (b *AuxTxBuilder) GetAuxSignerData() (tx.AuxSignerData, error) {
+func (b *AuxTxBuilder) GetAuxSignerData() (txtypes.AuxSignerData, error) {
 	if err := b.auxSignerData.ValidateBasic(); err != nil {
-		return tx.AuxSignerData{}, err
+		return txtypes.AuxSignerData{}, err
 	}
 
 	return *b.auxSignerData, nil
@@ -278,13 +259,13 @@ func (b *AuxTxBuilder) GetAuxSignerData() (tx.AuxSignerData, error) {
 
 func (b *AuxTxBuilder) checkEmptyFields() {
 	if b.body == nil {
-		b.body = &txv1beta1.TxBody{}
+		b.body = &txtypes.TxBody{}
 	}
 
 	if b.auxSignerData == nil {
-		b.auxSignerData = &tx.AuxSignerData{}
+		b.auxSignerData = &txtypes.AuxSignerData{}
 		if b.auxSignerData.SignDoc == nil {
-			b.auxSignerData.SignDoc = &tx.SignDocDirectAux{}
+			b.auxSignerData.SignDoc = &txtypes.SignDocDirectAux{}
 		}
 	}
 }

--- a/client/tx/aux_builder.go
+++ b/client/tx/aux_builder.go
@@ -222,8 +222,13 @@ func (b *AuxTxBuilder) GetSignBytes() ([]byte, error) {
 				FileResolver: proto.HybridResolver,
 			})
 
-			auxBody := &txv1beta1.TxBody{
-				Messages:         body.Messages,
+			// Convert pulsar TxBody to Go-native TxBodyData for the signing handler.
+			auxMsgs := make([]txsigning.RawMsg, len(body.Messages))
+			for i, m := range body.Messages {
+				auxMsgs[i] = txsigning.RawMsg{TypeUrl: m.TypeUrl, Value: m.Value}
+			}
+			auxBodyData := &txsigning.TxBodyData{
+				Messages:         auxMsgs,
 				Memo:             body.Memo,
 				TimeoutHeight:    body.TimeoutHeight,
 				TimeoutTimestamp: body.TimeoutTimestamp,
@@ -232,8 +237,6 @@ func (b *AuxTxBuilder) GetSignBytes() ([]byte, error) {
 				// This preserves pre-PR#16025 behavior where extension options were ignored, this code path:
 				// https://github.com/cosmos/cosmos-sdk/blob/ac3c209326a26b46f65a6cc6f5b5ebf6beb79b38/client/tx/aux_builder.go#L193
 				// https://github.com/cosmos/cosmos-sdk/blob/ac3c209326a26b46f65a6cc6f5b5ebf6beb79b38/x/auth/migrations/legacytx/stdsign.go#L49
-				ExtensionOptions:            nil,
-				NonCriticalExtensionOptions: nil,
 			}
 
 			signBz, err = handler.GetSignBytes(
@@ -246,14 +249,12 @@ func (b *AuxTxBuilder) GetSignBytes() ([]byte, error) {
 					PubKey:        nil,
 				},
 				txsigning.TxData{
-					Body: auxBody,
-					AuthInfo: &txv1beta1.AuthInfo{
-						SignerInfos: nil,
-						// Aux signer never signs over fee.
-						// For LEGACY_AMINO_JSON, we use the convention to sign
-						// over empty fees.
-						// ref: https://github.com/cosmos/cosmos-sdk/pull/10348
-						Fee: &txv1beta1.Fee{},
+					Body: auxBodyData,
+					// Aux signer never signs over fee.
+					// For LEGACY_AMINO_JSON, we use the convention to sign over empty fees.
+					// ref: https://github.com/cosmos/cosmos-sdk/pull/10348
+					AuthInfo: &txsigning.TxAuthInfoData{
+						Fee: txsigning.TxFeeData{},
 					},
 				},
 			)

--- a/client/v2/autocli/app.go
+++ b/client/v2/autocli/app.go
@@ -1,12 +1,12 @@
 package autocli
 
 import (
+	autoclicore "cosmossdk.io/core/autocli"
 	"github.com/cosmos/gogoproto/proto"
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/reflect/protoregistry"
 
-	autocliv1 "cosmossdk.io/api/cosmos/autocli/v1"
 	"cosmossdk.io/client/v2/autocli/flag"
 	"cosmossdk.io/core/address"
 	"cosmossdk.io/core/appmodule"
@@ -35,7 +35,7 @@ type AppOptions struct {
 	// is specified on the module's AppModule implementation. This allows an
 	// app to override module options if they are either not provided by a
 	// module or need to be improved.
-	ModuleOptions map[string]*autocliv1.ModuleOptions `optional:"true"`
+	ModuleOptions map[string]*autoclicore.ModuleOptions `optional:"true"`
 
 	// AddressCodec is the address codec to use for the app.
 	AddressCodec          address.Codec

--- a/client/v2/autocli/app.go
+++ b/client/v2/autocli/app.go
@@ -1,7 +1,6 @@
 package autocli
 
 import (
-	autoclicore "cosmossdk.io/core/autocli"
 	"github.com/cosmos/gogoproto/proto"
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc"
@@ -10,6 +9,7 @@ import (
 	"cosmossdk.io/client/v2/autocli/flag"
 	"cosmossdk.io/core/address"
 	"cosmossdk.io/core/appmodule"
+	autoclicore "cosmossdk.io/core/autocli"
 	"cosmossdk.io/depinject"
 
 	"github.com/cosmos/cosmos-sdk/client"

--- a/client/v2/autocli/common.go
+++ b/client/v2/autocli/common.go
@@ -1,7 +1,6 @@
 package autocli
 
 import (
-	autoclicore "cosmossdk.io/core/autocli"
 	"fmt"
 	"strings"
 
@@ -11,6 +10,7 @@ import (
 
 	"cosmossdk.io/client/v2/internal/flags"
 	"cosmossdk.io/client/v2/internal/util"
+	autoclicore "cosmossdk.io/core/autocli"
 
 	"github.com/cosmos/cosmos-sdk/client"
 )

--- a/client/v2/autocli/common.go
+++ b/client/v2/autocli/common.go
@@ -1,6 +1,7 @@
 package autocli
 
 import (
+	autoclicore "cosmossdk.io/core/autocli"
 	"fmt"
 	"strings"
 
@@ -8,7 +9,6 @@ import (
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"sigs.k8s.io/yaml"
 
-	autocliv1 "cosmossdk.io/api/cosmos/autocli/v1"
 	"cosmossdk.io/client/v2/internal/flags"
 	"cosmossdk.io/client/v2/internal/util"
 
@@ -22,10 +22,10 @@ const (
 	msgCmdType
 )
 
-func (b *Builder) buildMethodCommandCommon(descriptor protoreflect.MethodDescriptor, options *autocliv1.RpcCommandOptions, exec func(cmd *cobra.Command, input protoreflect.Message) error) (*cobra.Command, error) {
+func (b *Builder) buildMethodCommandCommon(descriptor protoreflect.MethodDescriptor, options *autoclicore.RpcCommandOptions, exec func(cmd *cobra.Command, input protoreflect.Message) error) (*cobra.Command, error) {
 	if options == nil {
 		// use the defaults
-		options = &autocliv1.RpcCommandOptions{}
+		options = &autoclicore.RpcCommandOptions{}
 	}
 
 	short := options.Short
@@ -112,7 +112,7 @@ func (b *Builder) enhanceCommandCommon(
 ) error {
 	moduleOptions := appOptions.ModuleOptions
 	if len(moduleOptions) == 0 {
-		moduleOptions = make(map[string]*autocliv1.ModuleOptions)
+		moduleOptions = make(map[string]*autoclicore.ModuleOptions)
 	}
 	for name, module := range appOptions.Modules {
 		if _, ok := moduleOptions[name]; !ok {
@@ -180,7 +180,7 @@ func (b *Builder) enhanceCommandCommon(
 }
 
 // enhanceQuery enhances the provided query command with the autocli commands for a module.
-func enhanceQuery(builder *Builder, moduleName string, cmd *cobra.Command, modOpts *autocliv1.ModuleOptions) error {
+func enhanceQuery(builder *Builder, moduleName string, cmd *cobra.Command, modOpts *autoclicore.ModuleOptions) error {
 	if queryCmdDesc := modOpts.Query; queryCmdDesc != nil {
 		short := queryCmdDesc.Short
 		if short == "" {
@@ -198,7 +198,7 @@ func enhanceQuery(builder *Builder, moduleName string, cmd *cobra.Command, modOp
 }
 
 // enhanceMsg enhances the provided msg command with the autocli commands for a module.
-func enhanceMsg(builder *Builder, moduleName string, cmd *cobra.Command, modOpts *autocliv1.ModuleOptions) error {
+func enhanceMsg(builder *Builder, moduleName string, cmd *cobra.Command, modOpts *autoclicore.ModuleOptions) error {
 	if txCmdDesc := modOpts.Tx; txCmdDesc != nil {
 		short := txCmdDesc.Short
 		if short == "" {
@@ -216,7 +216,7 @@ func enhanceMsg(builder *Builder, moduleName string, cmd *cobra.Command, modOpts
 }
 
 // enhanceCustomCmd enhances the provided custom query or msg command autocli commands for a module.
-func enhanceCustomCmd(builder *Builder, cmd *cobra.Command, cmdType cmdType, modOpts *autocliv1.ModuleOptions) error {
+func enhanceCustomCmd(builder *Builder, cmd *cobra.Command, cmdType cmdType, modOpts *autoclicore.ModuleOptions) error {
 	switch cmdType {
 	case queryCmdType:
 		if modOpts.Query != nil && modOpts.Query.EnhanceCustomCommand {

--- a/client/v2/autocli/common_test.go
+++ b/client/v2/autocli/common_test.go
@@ -13,11 +13,11 @@ import (
 	"google.golang.org/protobuf/reflect/protoregistry"
 	"gotest.tools/v3/assert"
 
-	autocliv1 "cosmossdk.io/api/cosmos/autocli/v1"
 	reflectionv2alpha1 "cosmossdk.io/api/cosmos/base/reflection/v2alpha1"
 	"cosmossdk.io/client/v2/autocli/flag"
 	"cosmossdk.io/client/v2/internal/testpbgogo"
 	testpb "cosmossdk.io/client/v2/internal/testpbpulsar"
+	autoclicore "cosmossdk.io/core/autocli"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
@@ -160,7 +160,7 @@ func TestEnhanceCommand(t *testing.T) {
 		cmdTp := cmdType(i)
 
 		appOptions := AppOptions{
-			ModuleOptions: map[string]*autocliv1.ModuleOptions{
+			ModuleOptions: map[string]*autoclicore.ModuleOptions{
 				"test": {},
 			},
 		}
@@ -171,7 +171,7 @@ func TestEnhanceCommand(t *testing.T) {
 		cmd = &cobra.Command{Use: "test"}
 
 		appOptions = AppOptions{
-			ModuleOptions: map[string]*autocliv1.ModuleOptions{},
+			ModuleOptions: map[string]*autoclicore.ModuleOptions{},
 		}
 		customCommands := map[string]*cobra.Command{
 			"test2": {Use: "test"},
@@ -181,7 +181,7 @@ func TestEnhanceCommand(t *testing.T) {
 
 		cmd = &cobra.Command{Use: "test"}
 		appOptions = AppOptions{
-			ModuleOptions: map[string]*autocliv1.ModuleOptions{
+			ModuleOptions: map[string]*autoclicore.ModuleOptions{
 				"test": {Tx: nil},
 			},
 		}
@@ -196,12 +196,12 @@ func TestErrorBuildCommand(t *testing.T) {
 	b.AddQueryConnFlags = nil
 	b.AddTxConnFlags = nil
 
-	commandDescriptor := &autocliv1.ServiceCommandDescriptor{
+	commandDescriptor := &autoclicore.ServiceCommandDescriptor{
 		Service: testpb.Msg_ServiceDesc.ServiceName,
-		RpcCommandOptions: []*autocliv1.RpcCommandOptions{
+		RpcCommandOptions: []*autoclicore.RpcCommandOptions{
 			{
 				RpcMethod: "Send",
-				PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+				PositionalArgs: []*autoclicore.PositionalArgDescriptor{
 					{
 						ProtoField: "un-existent-proto-field",
 					},
@@ -211,7 +211,7 @@ func TestErrorBuildCommand(t *testing.T) {
 	}
 
 	appOptions := AppOptions{
-		ModuleOptions: map[string]*autocliv1.ModuleOptions{
+		ModuleOptions: map[string]*autoclicore.ModuleOptions{
 			"test": {
 				Query: commandDescriptor,
 				Tx:    commandDescriptor,
@@ -222,8 +222,8 @@ func TestErrorBuildCommand(t *testing.T) {
 	_, err := b.BuildMsgCommand(context.Background(), appOptions, nil)
 	assert.ErrorContains(t, err, "can't find field un-existent-proto-field")
 
-	appOptions.ModuleOptions["test"].Tx = &autocliv1.ServiceCommandDescriptor{Service: "un-existent-service"}
-	appOptions.ModuleOptions["test"].Query = &autocliv1.ServiceCommandDescriptor{Service: "un-existent-service"}
+	appOptions.ModuleOptions["test"].Tx = &autoclicore.ServiceCommandDescriptor{Service: "un-existent-service"}
+	appOptions.ModuleOptions["test"].Query = &autoclicore.ServiceCommandDescriptor{Service: "un-existent-service"}
 	_, err = b.BuildMsgCommand(context.Background(), appOptions, nil)
 	assert.ErrorContains(t, err, "can't find service un-existent-service")
 }

--- a/client/v2/autocli/flag/builder.go
+++ b/client/v2/autocli/flag/builder.go
@@ -1,6 +1,7 @@
 package flag
 
 import (
+	autoclicore "cosmossdk.io/core/autocli"
 	"context"
 	"errors"
 	"fmt"
@@ -15,7 +16,6 @@ import (
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/reflect/protoregistry"
 
-	autocliv1 "cosmossdk.io/api/cosmos/autocli/v1"
 	msgv1 "cosmossdk.io/api/cosmos/msg/v1"
 	"cosmossdk.io/client/v2/internal/flags"
 	"cosmossdk.io/client/v2/internal/util"
@@ -120,12 +120,12 @@ func (b *Builder) DefineScalarFlagType(scalarName string, flagType Type) {
 }
 
 // AddMessageFlags adds flags for each field in the message to the flag set.
-func (b *Builder) AddMessageFlags(ctx *context.Context, flagSet *pflag.FlagSet, messageType protoreflect.MessageType, commandOptions *autocliv1.RpcCommandOptions) (*MessageBinder, error) {
+func (b *Builder) AddMessageFlags(ctx *context.Context, flagSet *pflag.FlagSet, messageType protoreflect.MessageType, commandOptions *autoclicore.RpcCommandOptions) (*MessageBinder, error) {
 	return b.addMessageFlags(ctx, flagSet, messageType, commandOptions, namingOptions{})
 }
 
 // addMessageFlags adds flags for each field in the message to the flag set.
-func (b *Builder) addMessageFlags(ctx *context.Context, flagSet *pflag.FlagSet, messageType protoreflect.MessageType, commandOptions *autocliv1.RpcCommandOptions, options namingOptions) (*MessageBinder, error) {
+func (b *Builder) addMessageFlags(ctx *context.Context, flagSet *pflag.FlagSet, messageType protoreflect.MessageType, commandOptions *autoclicore.RpcCommandOptions, options namingOptions) (*MessageBinder, error) {
 	messageBinder := &MessageBinder{
 		messageType: messageType,
 		// positional args are also parsed using a FlagSet so that we can reuse all the same parsers
@@ -217,10 +217,10 @@ func (b *Builder) addMessageFlags(ctx *context.Context, flagSet *pflag.FlagSet, 
 	// add it as `--from` flag (instead of --field-name flags)
 	if signerFieldName != "" && messageBinder.SignerInfo == (SignerInfo{}) {
 		if commandOptions.FlagOptions == nil {
-			commandOptions.FlagOptions = make(map[string]*autocliv1.FlagOptions)
+			commandOptions.FlagOptions = make(map[string]*autoclicore.FlagOptions)
 		}
 
-		commandOptions.FlagOptions[signerFieldName] = &autocliv1.FlagOptions{
+		commandOptions.FlagOptions[signerFieldName] = &autoclicore.FlagOptions{
 			Name:      flags.FlagFrom,
 			Usage:     "Name or address with which to sign the message",
 			Shorthand: "f",
@@ -234,7 +234,7 @@ func (b *Builder) addMessageFlags(ctx *context.Context, flagSet *pflag.FlagSet, 
 	}
 
 	// define all other fields as flags
-	flagOptsByFlagName := map[string]*autocliv1.FlagOptions{}
+	flagOptsByFlagName := map[string]*autoclicore.autoclicore.FlagOptions{}
 	for i := 0; i < fields.Len(); i++ {
 		field := fields.Get(i)
 		fieldName := string(field.Name())
@@ -311,7 +311,7 @@ func (b *Builder) addFieldBindingToArgs(ctx *context.Context, messageBinder *Mes
 		ctx,
 		messageBinder.positionalFlagSet,
 		field,
-		&autocliv1.FlagOptions{Name: fmt.Sprintf("%d", len(messageBinder.positionalArgs))},
+		&autoclicore.FlagOptions{Name: fmt.Sprintf("%d", len(messageBinder.positionalArgs))},
 		namingOptions{},
 	)
 	if err != nil {
@@ -330,7 +330,7 @@ func (b *Builder) bindPageRequest(ctx *context.Context, flagSet *pflag.FlagSet, 
 		ctx,
 		flagSet,
 		util.ResolveMessageType(b.TypeResolver, field.Message()),
-		&autocliv1.RpcCommandOptions{},
+		&autoclicore.RpcCommandOptions{},
 		namingOptions{Prefix: "page-"},
 	)
 }
@@ -342,9 +342,9 @@ type namingOptions struct {
 }
 
 // addFieldFlag adds a flag for the provided field to the flag set.
-func (b *Builder) addFieldFlag(ctx *context.Context, flagSet *pflag.FlagSet, field protoreflect.FieldDescriptor, opts *autocliv1.FlagOptions, options namingOptions) (name string, hasValue HasValue, err error) {
+func (b *Builder) addFieldFlag(ctx *context.Context, flagSet *pflag.FlagSet, field protoreflect.FieldDescriptor, opts *autoclicore.FlagOptions, options namingOptions) (name string, hasValue HasValue, err error) {
 	if opts == nil {
-		opts = &autocliv1.FlagOptions{}
+		opts = &autoclicore.FlagOptions{}
 	}
 
 	if field.Kind() == protoreflect.MessageKind && field.Message().FullName() == "cosmos.base.query.v1beta1.PageRequest" {

--- a/client/v2/autocli/flag/builder.go
+++ b/client/v2/autocli/flag/builder.go
@@ -1,7 +1,6 @@
 package flag
 
 import (
-	autoclicore "cosmossdk.io/core/autocli"
 	"context"
 	"errors"
 	"fmt"
@@ -16,12 +15,13 @@ import (
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/reflect/protoregistry"
 
-	msgv1 "cosmossdk.io/api/cosmos/msg/v1"
 	"cosmossdk.io/client/v2/internal/flags"
 	"cosmossdk.io/client/v2/internal/util"
 	"cosmossdk.io/core/address"
+	autoclicore "cosmossdk.io/core/autocli"
 
 	"github.com/cosmos/cosmos-sdk/runtime"
+	msgv1 "github.com/cosmos/cosmos-sdk/types/msgservice"
 )
 
 const (
@@ -234,7 +234,7 @@ func (b *Builder) addMessageFlags(ctx *context.Context, flagSet *pflag.FlagSet, 
 	}
 
 	// define all other fields as flags
-	flagOptsByFlagName := map[string]*autoclicore.autoclicore.FlagOptions{}
+	flagOptsByFlagName := map[string]*autoclicore.FlagOptions{}
 	for i := 0; i < fields.Len(); i++ {
 		field := fields.Get(i)
 		fieldName := string(field.Name())
@@ -508,7 +508,7 @@ func GetScalarType(field protoreflect.FieldDescriptor) (string, bool) {
 // GetSignerFieldName gets signer field name of a message.
 // AutoCLI supports only one signer field per message.
 func GetSignerFieldName(descriptor protoreflect.MessageDescriptor) string {
-	signersFields := proto.GetExtension(descriptor.Options(), msgv1.E_Signer).([]string)
+	signersFields := proto.GetExtension(descriptor.Options(), msgv1.E_SignerV2).([]string)
 	if len(signersFields) == 0 {
 		return ""
 	}

--- a/client/v2/autocli/flag/coin.go
+++ b/client/v2/autocli/flag/coin.go
@@ -6,15 +6,17 @@ import (
 	"strings"
 
 	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/reflect/protoregistry"
+	"google.golang.org/protobuf/types/dynamicpb"
 
-	basev1beta1 "cosmossdk.io/api/cosmos/base/v1beta1"
 	"cosmossdk.io/client/v2/internal/coins"
+	coinscore "cosmossdk.io/core/coins"
 )
 
 type coinType struct{}
 
 type coinValue struct {
-	value *basev1beta1.Coin
+	value *coinscore.Coin
 }
 
 func (c coinType) NewValue(*context.Context, *Builder) Value {
@@ -29,22 +31,29 @@ func (c *coinValue) Get(protoreflect.Value) (protoreflect.Value, error) {
 	if c.value == nil {
 		return protoreflect.Value{}, nil
 	}
-	return protoreflect.ValueOfMessage(c.value.ProtoReflect()), nil
+	// Build a dynamic proto message for cosmos.base.v1beta1.Coin using the
+	// global type registry (populated by gogoproto's init()).
+	mt, err := protoregistry.GlobalTypes.FindMessageByName("cosmos.base.v1beta1.Coin")
+	if err != nil {
+		return protoreflect.Value{}, err
+	}
+	dynCoin := dynamicpb.NewMessage(mt.Descriptor())
+	dynCoin.Set(mt.Descriptor().Fields().ByName("denom"), protoreflect.ValueOfString(c.value.Denom))
+	dynCoin.Set(mt.Descriptor().Fields().ByName("amount"), protoreflect.ValueOfString(c.value.Amount))
+	return protoreflect.ValueOfMessage(dynCoin), nil
 }
 
 func (c *coinValue) String() string {
 	if c.value == nil {
 		return ""
 	}
-
-	return c.value.String()
+	return c.value.Amount + c.value.Denom
 }
 
 func (c *coinValue) Set(stringValue string) error {
 	if strings.Contains(stringValue, ",") {
 		return errors.New("coin flag must be a single coin, specific multiple coins with multiple flags or spaces")
 	}
-
 	coin, err := coins.ParseCoin(stringValue)
 	if err != nil {
 		return err

--- a/client/v2/autocli/flag/dec_coin.go
+++ b/client/v2/autocli/flag/dec_coin.go
@@ -6,15 +6,17 @@ import (
 	"strings"
 
 	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/reflect/protoregistry"
+	"google.golang.org/protobuf/types/dynamicpb"
 
-	basev1beta1 "cosmossdk.io/api/cosmos/base/v1beta1"
 	"cosmossdk.io/client/v2/internal/coins"
+	coinscore "cosmossdk.io/core/coins"
 )
 
 type decCoinType struct{}
 
 type decCoinValue struct {
-	value *basev1beta1.DecCoin
+	value *coinscore.DecCoin
 }
 
 func (c decCoinType) NewValue(*context.Context, *Builder) Value {
@@ -29,22 +31,29 @@ func (c *decCoinValue) Get(protoreflect.Value) (protoreflect.Value, error) {
 	if c.value == nil {
 		return protoreflect.Value{}, nil
 	}
-	return protoreflect.ValueOfMessage(c.value.ProtoReflect()), nil
+	// Build a dynamic proto message for cosmos.base.v1beta1.DecCoin using the
+	// global type registry (populated by gogoproto's init()).
+	mt, err := protoregistry.GlobalTypes.FindMessageByName("cosmos.base.v1beta1.DecCoin")
+	if err != nil {
+		return protoreflect.Value{}, err
+	}
+	dynCoin := dynamicpb.NewMessage(mt.Descriptor())
+	dynCoin.Set(mt.Descriptor().Fields().ByName("denom"), protoreflect.ValueOfString(c.value.Denom))
+	dynCoin.Set(mt.Descriptor().Fields().ByName("amount"), protoreflect.ValueOfString(c.value.Amount))
+	return protoreflect.ValueOfMessage(dynCoin), nil
 }
 
 func (c *decCoinValue) String() string {
 	if c.value == nil {
 		return ""
 	}
-
-	return c.value.String()
+	return c.value.Amount + c.value.Denom
 }
 
 func (c *decCoinValue) Set(stringValue string) error {
 	if strings.Contains(stringValue, ",") {
 		return errors.New("coin flag must be a single coin, specific multiple coins with multiple flags or spaces")
 	}
-
 	coin, err := coins.ParseDecCoin(stringValue)
 	if err != nil {
 		return err

--- a/client/v2/autocli/interface.go
+++ b/client/v2/autocli/interface.go
@@ -1,10 +1,10 @@
 package autocli
 
 import (
-	autoclicore "cosmossdk.io/core/autocli"
 	"github.com/spf13/cobra"
 
 	"cosmossdk.io/core/appmodule"
+	autoclicore "cosmossdk.io/core/autocli"
 )
 
 // HasAutoCLIConfig is an AppModule extension interface for declaring autocli module options.

--- a/client/v2/autocli/interface.go
+++ b/client/v2/autocli/interface.go
@@ -1,9 +1,9 @@
 package autocli
 
 import (
+	autoclicore "cosmossdk.io/core/autocli"
 	"github.com/spf13/cobra"
 
-	autocliv1 "cosmossdk.io/api/cosmos/autocli/v1"
 	"cosmossdk.io/core/appmodule"
 )
 
@@ -12,7 +12,7 @@ type HasAutoCLIConfig interface {
 	appmodule.AppModule
 
 	// AutoCLIOptions are the autocli module options for this module.
-	AutoCLIOptions() *autocliv1.ModuleOptions
+	AutoCLIOptions() *autoclicore.ModuleOptions
 }
 
 // HasCustomQueryCommand is an AppModule extension interface for declaring a custom query command.

--- a/client/v2/autocli/keyring/interface.go
+++ b/client/v2/autocli/keyring/interface.go
@@ -1,7 +1,7 @@
 package keyring
 
 import (
-	signingv1beta1 "cosmossdk.io/api/cosmos/tx/signing/v1beta1"
+	txsigning "github.com/cosmos/cosmos-sdk/x/tx/signing"
 
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 )
@@ -19,5 +19,5 @@ type Keyring interface {
 	GetPubKey(name string) (cryptotypes.PubKey, error)
 
 	// Sign signs the given bytes with the key with the given name.
-	Sign(name string, msg []byte, signMode signingv1beta1.SignMode) ([]byte, error)
+	Sign(name string, msg []byte, signMode txsigning.SignMode) ([]byte, error)
 }

--- a/client/v2/autocli/keyring/interface.go
+++ b/client/v2/autocli/keyring/interface.go
@@ -1,9 +1,8 @@
 package keyring
 
 import (
-	txsigning "github.com/cosmos/cosmos-sdk/x/tx/signing"
-
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
+	txsigning "github.com/cosmos/cosmos-sdk/x/tx/signing"
 )
 
 // Keyring is an interface used for signing transactions.

--- a/client/v2/autocli/keyring/keyring.go
+++ b/client/v2/autocli/keyring/keyring.go
@@ -3,9 +3,8 @@ package keyring
 import (
 	"context"
 
-	txsigning "github.com/cosmos/cosmos-sdk/x/tx/signing"
-
 	"github.com/cosmos/cosmos-sdk/crypto/types"
+	txsigning "github.com/cosmos/cosmos-sdk/x/tx/signing"
 )
 
 // KeyringContextKey is the key used to store the keyring in the context.

--- a/client/v2/autocli/keyring/keyring.go
+++ b/client/v2/autocli/keyring/keyring.go
@@ -3,7 +3,7 @@ package keyring
 import (
 	"context"
 
-	signingv1beta1 "cosmossdk.io/api/cosmos/tx/signing/v1beta1"
+	txsigning "github.com/cosmos/cosmos-sdk/x/tx/signing"
 
 	"github.com/cosmos/cosmos-sdk/crypto/types"
 )
@@ -44,6 +44,6 @@ func (k *KeyringImpl) LookupAddressByKeyName(name string) ([]byte, error) {
 }
 
 // Sign implements Keyring.
-func (k *KeyringImpl) Sign(name string, msg []byte, signMode signingv1beta1.SignMode) ([]byte, error) {
+func (k *KeyringImpl) Sign(name string, msg []byte, signMode txsigning.SignMode) ([]byte, error) {
 	return k.k.Sign(name, msg, signMode)
 }

--- a/client/v2/autocli/keyring/no_keyring.go
+++ b/client/v2/autocli/keyring/no_keyring.go
@@ -3,7 +3,7 @@ package keyring
 import (
 	"errors"
 
-	signingv1beta1 "cosmossdk.io/api/cosmos/tx/signing/v1beta1"
+	txsigning "github.com/cosmos/cosmos-sdk/x/tx/signing"
 
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 )
@@ -26,6 +26,6 @@ func (k NoKeyring) GetPubKey(name string) (cryptotypes.PubKey, error) {
 	return nil, errNoKeyring
 }
 
-func (k NoKeyring) Sign(name string, msg []byte, signMode signingv1beta1.SignMode) ([]byte, error) {
+func (k NoKeyring) Sign(name string, msg []byte, signMode txsigning.SignMode) ([]byte, error) {
 	return nil, errNoKeyring
 }

--- a/client/v2/autocli/keyring/no_keyring.go
+++ b/client/v2/autocli/keyring/no_keyring.go
@@ -3,9 +3,8 @@ package keyring
 import (
 	"errors"
 
-	txsigning "github.com/cosmos/cosmos-sdk/x/tx/signing"
-
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
+	txsigning "github.com/cosmos/cosmos-sdk/x/tx/signing"
 )
 
 var _ Keyring = NoKeyring{}

--- a/client/v2/autocli/msg.go
+++ b/client/v2/autocli/msg.go
@@ -1,6 +1,7 @@
 package autocli
 
 import (
+	autoclicore "cosmossdk.io/core/autocli"
 	"context"
 	"fmt"
 
@@ -10,7 +11,6 @@ import (
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/types/dynamicpb"
 
-	autocliv1 "cosmossdk.io/api/cosmos/autocli/v1"
 	"cosmossdk.io/client/v2/autocli/flag"
 	"cosmossdk.io/client/v2/internal/flags"
 	"cosmossdk.io/client/v2/internal/util"
@@ -39,7 +39,7 @@ func (b *Builder) BuildMsgCommand(ctx context.Context, appOptions AppOptions, cu
 // AddMsgServiceCommands adds a sub-command to the provided command for each
 // method in the specified service and returns the command. This can be used in
 // order to add auto-generated commands to an existing command.
-func (b *Builder) AddMsgServiceCommands(cmd *cobra.Command, cmdDescriptor *autocliv1.ServiceCommandDescriptor) error {
+func (b *Builder) AddMsgServiceCommands(cmd *cobra.Command, cmdDescriptor *autoclicore.ServiceCommandDescriptor) error {
 	for cmdName, subCmdDescriptor := range cmdDescriptor.SubCommands {
 		subCmd := findSubCommand(cmd, cmdName)
 		if subCmd == nil {
@@ -72,7 +72,7 @@ func (b *Builder) AddMsgServiceCommands(cmd *cobra.Command, cmdDescriptor *autoc
 	service := descriptor.(protoreflect.ServiceDescriptor)
 	methods := service.Methods()
 
-	rpcOptMap := map[protoreflect.Name]*autocliv1.RpcCommandOptions{}
+	rpcOptMap := map[protoreflect.Name]*autoclicore.autoclicore.RpcCommandOptions{}
 	for _, option := range cmdDescriptor.RpcCommandOptions {
 		methodName := protoreflect.Name(option.RpcMethod)
 		// validate that methods exist
@@ -87,7 +87,7 @@ func (b *Builder) AddMsgServiceCommands(cmd *cobra.Command, cmdDescriptor *autoc
 		methodDescriptor := methods.Get(i)
 		methodOpts, ok := rpcOptMap[methodDescriptor.Name()]
 		if !ok {
-			methodOpts = &autocliv1.RpcCommandOptions{}
+			methodOpts = &autoclicore.RpcCommandOptions{}
 		}
 
 		if methodOpts.Skip {
@@ -116,7 +116,7 @@ func (b *Builder) AddMsgServiceCommands(cmd *cobra.Command, cmdDescriptor *autoc
 }
 
 // BuildMsgMethodCommand returns a command that outputs the JSON representation of the message.
-func (b *Builder) BuildMsgMethodCommand(descriptor protoreflect.MethodDescriptor, options *autocliv1.RpcCommandOptions) (*cobra.Command, error) {
+func (b *Builder) BuildMsgMethodCommand(descriptor protoreflect.MethodDescriptor, options *autoclicore.RpcCommandOptions) (*cobra.Command, error) {
 	execFunc := func(cmd *cobra.Command, input protoreflect.Message) error {
 		clientCtx, err := client.GetClientTxContext(cmd)
 		if err != nil {

--- a/client/v2/autocli/msg.go
+++ b/client/v2/autocli/msg.go
@@ -1,7 +1,6 @@
 package autocli
 
 import (
-	autoclicore "cosmossdk.io/core/autocli"
 	"context"
 	"fmt"
 
@@ -15,6 +14,7 @@ import (
 	"cosmossdk.io/client/v2/internal/flags"
 	"cosmossdk.io/client/v2/internal/util"
 	addresscodec "cosmossdk.io/core/address"
+	autoclicore "cosmossdk.io/core/autocli"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	clienttx "github.com/cosmos/cosmos-sdk/client/tx"
@@ -72,7 +72,7 @@ func (b *Builder) AddMsgServiceCommands(cmd *cobra.Command, cmdDescriptor *autoc
 	service := descriptor.(protoreflect.ServiceDescriptor)
 	methods := service.Methods()
 
-	rpcOptMap := map[protoreflect.Name]*autoclicore.autoclicore.RpcCommandOptions{}
+	rpcOptMap := map[protoreflect.Name]*autoclicore.RpcCommandOptions{}
 	for _, option := range cmdDescriptor.RpcCommandOptions {
 		methodName := protoreflect.Name(option.RpcMethod)
 		// validate that methods exist

--- a/client/v2/autocli/msg_test.go
+++ b/client/v2/autocli/msg_test.go
@@ -13,10 +13,10 @@ import (
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/golden"
 
-	autocliv1 "cosmossdk.io/api/cosmos/autocli/v1"
 	bankv1beta1 "cosmossdk.io/api/cosmos/bank/v1beta1"
 	"cosmossdk.io/client/v2/internal/testpbgogo"
 	testpb "cosmossdk.io/client/v2/internal/testpbpulsar"
+	autoclicore "cosmossdk.io/core/autocli"
 
 	"github.com/cosmos/cosmos-sdk/client"
 )
@@ -28,7 +28,7 @@ var buildModuleMsgCommand = func(moduleName string, f *fixture) (*cobra.Command,
 	return cmd, err
 }
 
-func buildCustomModuleMsgCommand(cmdDescriptor *autocliv1.ServiceCommandDescriptor) func(moduleName string, f *fixture) (*cobra.Command, error) {
+func buildCustomModuleMsgCommand(cmdDescriptor *autoclicore.ServiceCommandDescriptor) func(moduleName string, f *fixture) (*cobra.Command, error) {
 	return func(moduleName string, f *fixture) (*cobra.Command, error) {
 		ctx := context.WithValue(context.Background(), client.ClientContextKey, &f.clientCtx)
 		cmd := topLevelCmd(ctx, moduleName, fmt.Sprintf("Transactions commands for the %s module", moduleName))
@@ -37,14 +37,14 @@ func buildCustomModuleMsgCommand(cmdDescriptor *autocliv1.ServiceCommandDescript
 	}
 }
 
-var bankAutoCLI = &autocliv1.ServiceCommandDescriptor{
+var bankAutoCLI = &autoclicore.ServiceCommandDescriptor{
 	Service: bankv1beta1.Msg_ServiceDesc.ServiceName,
-	RpcCommandOptions: []*autocliv1.RpcCommandOptions{
+	RpcCommandOptions: []*autoclicore.RpcCommandOptions{
 		{
 			RpcMethod:      "Send",
 			Use:            "send [from_key_or_address] [to_address] [amount] [flags]",
 			Short:          "Send coins from one account to another",
-			PositionalArgs: []*autocliv1.PositionalArgDescriptor{{ProtoField: "from_address"}, {ProtoField: "to_address"}, {ProtoField: "amount"}},
+			PositionalArgs: []*autoclicore.PositionalArgDescriptor{{ProtoField: "from_address"}, {ProtoField: "to_address"}, {ProtoField: "amount"}},
 		},
 	},
 	EnhanceCustomCommand: true,
@@ -61,14 +61,14 @@ func TestMsg(t *testing.T) {
 	assert.NilError(t, err)
 	golden.Assert(t, out.String(), "msg-output.golden")
 
-	out, err = runCmd(fixture, buildCustomModuleMsgCommand(&autocliv1.ServiceCommandDescriptor{
+	out, err = runCmd(fixture, buildCustomModuleMsgCommand(&autoclicore.ServiceCommandDescriptor{
 		Service: bankv1beta1.Msg_ServiceDesc.ServiceName,
-		RpcCommandOptions: []*autocliv1.RpcCommandOptions{
+		RpcCommandOptions: []*autoclicore.RpcCommandOptions{
 			{
 				RpcMethod:      "Send",
 				Use:            "send [from_key_or_address] [to_address] [amount] [flags]",
 				Short:          "Send coins from one account to another",
-				PositionalArgs: []*autocliv1.PositionalArgDescriptor{{ProtoField: "from_address"}, {ProtoField: "to_address"}, {ProtoField: "amount"}},
+				PositionalArgs: []*autoclicore.PositionalArgDescriptor{{ProtoField: "from_address"}, {ProtoField: "to_address"}, {ProtoField: "amount"}},
 			},
 		},
 		EnhanceCustomCommand: true,
@@ -80,14 +80,14 @@ func TestMsg(t *testing.T) {
 	assert.NilError(t, err)
 	golden.Assert(t, out.String(), "msg-output.golden")
 
-	out, err = runCmd(fixture, buildCustomModuleMsgCommand(&autocliv1.ServiceCommandDescriptor{
+	out, err = runCmd(fixture, buildCustomModuleMsgCommand(&autoclicore.ServiceCommandDescriptor{
 		Service: bankv1beta1.Msg_ServiceDesc.ServiceName,
-		RpcCommandOptions: []*autocliv1.RpcCommandOptions{
+		RpcCommandOptions: []*autoclicore.RpcCommandOptions{
 			{
 				RpcMethod:      "Send",
 				Use:            "send [from_key_or_address] [to_address] [amount] [flags]",
 				Short:          "Send coins from one account to another",
-				PositionalArgs: []*autocliv1.PositionalArgDescriptor{{ProtoField: "to_address"}, {ProtoField: "amount"}},
+				PositionalArgs: []*autoclicore.PositionalArgDescriptor{{ProtoField: "to_address"}, {ProtoField: "amount"}},
 				// from_address should be automatically added
 			},
 		},
@@ -101,15 +101,15 @@ func TestMsg(t *testing.T) {
 	assert.NilError(t, err)
 	golden.Assert(t, out.String(), "msg-output.golden")
 
-	out, err = runCmd(fixture, buildCustomModuleMsgCommand(&autocliv1.ServiceCommandDescriptor{
+	out, err = runCmd(fixture, buildCustomModuleMsgCommand(&autoclicore.ServiceCommandDescriptor{
 		Service: bankv1beta1.Msg_ServiceDesc.ServiceName,
-		RpcCommandOptions: []*autocliv1.RpcCommandOptions{
+		RpcCommandOptions: []*autoclicore.RpcCommandOptions{
 			{
 				RpcMethod:      "Send",
 				Use:            "send [from_key_or_address] [to_address] [amount] [flags]",
 				Short:          "Send coins from one account to another",
-				PositionalArgs: []*autocliv1.PositionalArgDescriptor{{ProtoField: "to_address"}, {ProtoField: "amount"}},
-				FlagOptions: map[string]*autocliv1.FlagOptions{
+				PositionalArgs: []*autoclicore.PositionalArgDescriptor{{ProtoField: "to_address"}, {ProtoField: "amount"}},
+				FlagOptions: map[string]*autoclicore.FlagOptions{
 					"from_address": {Name: "sender"}, // use a custom flag for signer
 				},
 			},
@@ -129,14 +129,14 @@ func TestMsg(t *testing.T) {
 // There are no protov2 files registered in the global registry for those types.
 func TestMsgGogo(t *testing.T) {
 	fixture := initFixture(t)
-	out, err := runCmd(fixture, buildCustomModuleMsgCommand(&autocliv1.ServiceCommandDescriptor{
+	out, err := runCmd(fixture, buildCustomModuleMsgCommand(&autoclicore.ServiceCommandDescriptor{
 		Service: testpbgogo.MsgGogoOnly_serviceDesc.ServiceName, // using gogoproto only test msg
-		RpcCommandOptions: []*autocliv1.RpcCommandOptions{
+		RpcCommandOptions: []*autoclicore.RpcCommandOptions{
 			{
 				RpcMethod:      "Send",
 				Use:            "send [a_coin] [str] [flags]",
 				Short:          "Send coins from one account to another",
-				PositionalArgs: []*autocliv1.PositionalArgDescriptor{{ProtoField: "a_coin"}, {ProtoField: "str"}},
+				PositionalArgs: []*autoclicore.PositionalArgDescriptor{{ProtoField: "a_coin"}, {ProtoField: "str"}},
 				// an_address should be automatically added
 			},
 		},
@@ -153,12 +153,12 @@ func TestMsgGogo(t *testing.T) {
 func TestMsgWithFlattenFields(t *testing.T) {
 	fixture := initFixture(t)
 
-	out, err := runCmd(fixture, buildCustomModuleMsgCommand(&autocliv1.ServiceCommandDescriptor{
+	out, err := runCmd(fixture, buildCustomModuleMsgCommand(&autoclicore.ServiceCommandDescriptor{
 		Service: bankv1beta1.Msg_ServiceDesc.ServiceName,
-		RpcCommandOptions: []*autocliv1.RpcCommandOptions{
+		RpcCommandOptions: []*autoclicore.RpcCommandOptions{
 			{
 				RpcMethod: "UpdateParams",
-				PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+				PositionalArgs: []*autoclicore.PositionalArgDescriptor{
 					{ProtoField: "authority"},
 					{ProtoField: "params.send_enabled.denom"},
 					{ProtoField: "params.send_enabled.enabled"},
@@ -233,11 +233,11 @@ func TestBuildCustomMsgCommand(t *testing.T) {
 	b := &Builder{}
 	customCommandCalled := false
 	appOptions := AppOptions{
-		ModuleOptions: map[string]*autocliv1.ModuleOptions{
+		ModuleOptions: map[string]*autoclicore.ModuleOptions{
 			"test": {
-				Tx: &autocliv1.ServiceCommandDescriptor{
+				Tx: &autoclicore.ServiceCommandDescriptor{
 					Service:           testpb.Msg_ServiceDesc.ServiceName,
-					RpcCommandOptions: []*autocliv1.RpcCommandOptions{},
+					RpcCommandOptions: []*autoclicore.RpcCommandOptions{},
 				},
 			},
 		},
@@ -260,7 +260,7 @@ func TestNotFoundErrorsMsg(t *testing.T) {
 	b.AddQueryConnFlags = nil
 	b.AddTxConnFlags = nil
 
-	buildModuleMsgCommand := func(moduleName string, cmdDescriptor *autocliv1.ServiceCommandDescriptor) (*cobra.Command, error) {
+	buildModuleMsgCommand := func(moduleName string, cmdDescriptor *autoclicore.ServiceCommandDescriptor) (*cobra.Command, error) {
 		cmd := topLevelCmd(context.Background(), moduleName, fmt.Sprintf("Transactions commands for the %s module", moduleName))
 
 		err := b.AddMsgServiceCommands(cmd, cmdDescriptor)
@@ -268,21 +268,21 @@ func TestNotFoundErrorsMsg(t *testing.T) {
 	}
 
 	// Query non existent service
-	_, err := buildModuleMsgCommand("test", &autocliv1.ServiceCommandDescriptor{Service: "un-existent-service"})
+	_, err := buildModuleMsgCommand("test", &autoclicore.ServiceCommandDescriptor{Service: "un-existent-service"})
 	assert.ErrorContains(t, err, "can't find service un-existent-service")
 
-	_, err = buildModuleMsgCommand("test", &autocliv1.ServiceCommandDescriptor{
+	_, err = buildModuleMsgCommand("test", &autoclicore.ServiceCommandDescriptor{
 		Service:           testpb.Query_ServiceDesc.ServiceName,
-		RpcCommandOptions: []*autocliv1.RpcCommandOptions{{RpcMethod: "un-existent-method"}},
+		RpcCommandOptions: []*autoclicore.RpcCommandOptions{{RpcMethod: "un-existent-method"}},
 	})
 	assert.ErrorContains(t, err, "rpc method \"un-existent-method\" not found")
 
-	_, err = buildModuleMsgCommand("test", &autocliv1.ServiceCommandDescriptor{
+	_, err = buildModuleMsgCommand("test", &autoclicore.ServiceCommandDescriptor{
 		Service: testpb.Msg_ServiceDesc.ServiceName,
-		RpcCommandOptions: []*autocliv1.RpcCommandOptions{
+		RpcCommandOptions: []*autoclicore.RpcCommandOptions{
 			{
 				RpcMethod: "Send",
-				PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+				PositionalArgs: []*autoclicore.PositionalArgDescriptor{
 					{
 						ProtoField: "un-existent-proto-field",
 					},
@@ -292,12 +292,12 @@ func TestNotFoundErrorsMsg(t *testing.T) {
 	})
 	assert.ErrorContains(t, err, "can't find field un-existent-proto-field")
 
-	_, err = buildModuleMsgCommand("test", &autocliv1.ServiceCommandDescriptor{
+	_, err = buildModuleMsgCommand("test", &autoclicore.ServiceCommandDescriptor{
 		Service: testpb.Msg_ServiceDesc.ServiceName,
-		RpcCommandOptions: []*autocliv1.RpcCommandOptions{
+		RpcCommandOptions: []*autoclicore.RpcCommandOptions{
 			{
 				RpcMethod: "Send",
-				FlagOptions: map[string]*autocliv1.FlagOptions{
+				FlagOptions: map[string]*autoclicore.FlagOptions{
 					"un-existent-flag": {},
 				},
 			},

--- a/client/v2/autocli/query.go
+++ b/client/v2/autocli/query.go
@@ -1,7 +1,6 @@
 package autocli
 
 import (
-	autoclicore "cosmossdk.io/core/autocli"
 	"context"
 	"fmt"
 	"io"
@@ -14,6 +13,7 @@ import (
 
 	"cosmossdk.io/client/v2/internal/flags"
 	"cosmossdk.io/client/v2/internal/util"
+	autoclicore "cosmossdk.io/core/autocli"
 	"cosmossdk.io/math"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -70,7 +70,7 @@ func (b *Builder) AddQueryServiceCommands(cmd *cobra.Command, cmdDescriptor *aut
 	service := descriptor.(protoreflect.ServiceDescriptor)
 	methods := service.Methods()
 
-	rpcOptMap := map[protoreflect.Name]*autoclicore.autoclicore.RpcCommandOptions{}
+	rpcOptMap := map[protoreflect.Name]*autoclicore.RpcCommandOptions{}
 	for _, option := range cmdDescriptor.RpcCommandOptions {
 		name := protoreflect.Name(option.RpcMethod)
 		rpcOptMap[name] = option

--- a/client/v2/autocli/query.go
+++ b/client/v2/autocli/query.go
@@ -1,6 +1,7 @@
 package autocli
 
 import (
+	autoclicore "cosmossdk.io/core/autocli"
 	"context"
 	"fmt"
 	"io"
@@ -11,7 +12,6 @@ import (
 	"github.com/spf13/cobra"
 	"google.golang.org/protobuf/reflect/protoreflect"
 
-	autocliv1 "cosmossdk.io/api/cosmos/autocli/v1"
 	"cosmossdk.io/client/v2/internal/flags"
 	"cosmossdk.io/client/v2/internal/util"
 	"cosmossdk.io/math"
@@ -37,7 +37,7 @@ func (b *Builder) BuildQueryCommand(ctx context.Context, appOptions AppOptions, 
 // AddQueryServiceCommands adds a sub-command to the provided command for each
 // method in the specified service and returns the command. This can be used in
 // order to add auto-generated commands to an existing command.
-func (b *Builder) AddQueryServiceCommands(cmd *cobra.Command, cmdDescriptor *autocliv1.ServiceCommandDescriptor) error {
+func (b *Builder) AddQueryServiceCommands(cmd *cobra.Command, cmdDescriptor *autoclicore.ServiceCommandDescriptor) error {
 	for cmdName, subCmdDesc := range cmdDescriptor.SubCommands {
 		subCmd := findSubCommand(cmd, cmdName)
 		if subCmd == nil {
@@ -70,7 +70,7 @@ func (b *Builder) AddQueryServiceCommands(cmd *cobra.Command, cmdDescriptor *aut
 	service := descriptor.(protoreflect.ServiceDescriptor)
 	methods := service.Methods()
 
-	rpcOptMap := map[protoreflect.Name]*autocliv1.RpcCommandOptions{}
+	rpcOptMap := map[protoreflect.Name]*autoclicore.autoclicore.RpcCommandOptions{}
 	for _, option := range cmdDescriptor.RpcCommandOptions {
 		name := protoreflect.Name(option.RpcMethod)
 		rpcOptMap[name] = option
@@ -84,7 +84,7 @@ func (b *Builder) AddQueryServiceCommands(cmd *cobra.Command, cmdDescriptor *aut
 		methodDescriptor := methods.Get(i)
 		methodOpts, ok := rpcOptMap[methodDescriptor.Name()]
 		if !ok {
-			methodOpts = &autocliv1.RpcCommandOptions{}
+			methodOpts = &autoclicore.RpcCommandOptions{}
 		}
 
 		if methodOpts.Skip {
@@ -114,7 +114,7 @@ func (b *Builder) AddQueryServiceCommands(cmd *cobra.Command, cmdDescriptor *aut
 
 // BuildQueryMethodCommand creates a gRPC query command for the given service method. This can be used to auto-generate
 // just a single command for a single service rpc method.
-func (b *Builder) BuildQueryMethodCommand(ctx context.Context, descriptor protoreflect.MethodDescriptor, options *autocliv1.RpcCommandOptions) (*cobra.Command, error) {
+func (b *Builder) BuildQueryMethodCommand(ctx context.Context, descriptor protoreflect.MethodDescriptor, options *autoclicore.RpcCommandOptions) (*cobra.Command, error) {
 	getClientConn := b.GetClientConn
 	serviceDescriptor := descriptor.Parent().(protoreflect.ServiceDescriptor)
 	methodName := fmt.Sprintf("/%s/%s", serviceDescriptor.FullName(), descriptor.Name())

--- a/client/v2/autocli/query_test.go
+++ b/client/v2/autocli/query_test.go
@@ -15,10 +15,10 @@ import (
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/golden"
 
-	autocliv1 "cosmossdk.io/api/cosmos/autocli/v1"
 	queryv1beta1 "cosmossdk.io/api/cosmos/base/query/v1beta1"
 	basev1beta1 "cosmossdk.io/api/cosmos/base/v1beta1"
 	testpb "cosmossdk.io/client/v2/internal/testpbpulsar"
+	autoclicore "cosmossdk.io/core/autocli"
 
 	"github.com/cosmos/cosmos-sdk/client"
 )
@@ -47,9 +47,9 @@ var buildModuleVargasOptional = func(moduleName string, f *fixture) (*cobra.Comm
 	return cmd, err
 }
 
-var testCmdDesc = &autocliv1.ServiceCommandDescriptor{
+var testCmdDesc = &autoclicore.ServiceCommandDescriptor{
 	Service: testpb.Query_ServiceDesc.ServiceName,
-	RpcCommandOptions: []*autocliv1.RpcCommandOptions{
+	RpcCommandOptions: []*autoclicore.RpcCommandOptions{
 		{
 			RpcMethod:  "Echo",
 			Use:        "echo [pos1] [pos2] [pos3...]",
@@ -59,7 +59,7 @@ var testCmdDesc = &autocliv1.ServiceCommandDescriptor{
 			Example:    "echo 1 abc {}",
 			Short:      "echo echos the value provided by the user",
 			Long:       "echo echos the value provided by the user as a proto JSON object with populated with the provided fields and positional arguments",
-			PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+			PositionalArgs: []*autoclicore.PositionalArgDescriptor{
 				{
 					ProtoField: "positional1",
 				},
@@ -71,7 +71,7 @@ var testCmdDesc = &autocliv1.ServiceCommandDescriptor{
 					Varargs:    true,
 				},
 			},
-			FlagOptions: map[string]*autocliv1.FlagOptions{
+			FlagOptions: map[string]*autoclicore.FlagOptions{
 				"u32": {
 					Name:      "uint32",
 					Shorthand: "u",
@@ -116,11 +116,11 @@ var testCmdDesc = &autocliv1.ServiceCommandDescriptor{
 			},
 		},
 	},
-	SubCommands: map[string]*autocliv1.ServiceCommandDescriptor{
+	SubCommands: map[string]*autoclicore.ServiceCommandDescriptor{
 		// we test the sub-command functionality using the same service with different options
 		"deprecatedecho": {
 			Service: testpb.Query_ServiceDesc.ServiceName,
-			RpcCommandOptions: []*autocliv1.RpcCommandOptions{
+			RpcCommandOptions: []*autoclicore.RpcCommandOptions{
 				{
 					RpcMethod:  "Echo",
 					Deprecated: "don't use this",
@@ -129,7 +129,7 @@ var testCmdDesc = &autocliv1.ServiceCommandDescriptor{
 		},
 		"skipecho": {
 			Service: testpb.Query_ServiceDesc.ServiceName,
-			RpcCommandOptions: []*autocliv1.RpcCommandOptions{
+			RpcCommandOptions: []*autoclicore.RpcCommandOptions{
 				{
 					RpcMethod: "Echo",
 					Skip:      true,
@@ -139,9 +139,9 @@ var testCmdDesc = &autocliv1.ServiceCommandDescriptor{
 	},
 }
 
-var testCmdDescOptional = &autocliv1.ServiceCommandDescriptor{
+var testCmdDescOptional = &autoclicore.ServiceCommandDescriptor{
 	Service: testpb.Query_ServiceDesc.ServiceName,
-	RpcCommandOptions: []*autocliv1.RpcCommandOptions{
+	RpcCommandOptions: []*autoclicore.RpcCommandOptions{
 		{
 			RpcMethod:  "Echo",
 			Use:        "echo [pos1] [pos2] [pos3...]",
@@ -151,7 +151,7 @@ var testCmdDescOptional = &autocliv1.ServiceCommandDescriptor{
 			Example:    "echo 1 abc {}",
 			Short:      "echo echos the value provided by the user",
 			Long:       "echo echos the value provided by the user as a proto JSON object with populated with the provided fields and positional arguments",
-			PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+			PositionalArgs: []*autoclicore.PositionalArgDescriptor{
 				{
 					ProtoField: "positional1",
 				},
@@ -164,9 +164,9 @@ var testCmdDescOptional = &autocliv1.ServiceCommandDescriptor{
 	},
 }
 
-var testCmdDescInvalidOptAndVargas = &autocliv1.ServiceCommandDescriptor{
+var testCmdDescInvalidOptAndVargas = &autoclicore.ServiceCommandDescriptor{
 	Service: testpb.Query_ServiceDesc.ServiceName,
-	RpcCommandOptions: []*autocliv1.RpcCommandOptions{
+	RpcCommandOptions: []*autoclicore.RpcCommandOptions{
 		{
 			RpcMethod:  "Echo",
 			Use:        "echo [pos1] [pos2] [pos3...]",
@@ -176,7 +176,7 @@ var testCmdDescInvalidOptAndVargas = &autocliv1.ServiceCommandDescriptor{
 			Example:    "echo 1 abc {}",
 			Short:      "echo echos the value provided by the user",
 			Long:       "echo echos the value provided by the user as a proto JSON object with populated with the provided fields and positional arguments",
-			PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+			PositionalArgs: []*autoclicore.PositionalArgDescriptor{
 				{
 					ProtoField: "positional1",
 				},
@@ -660,7 +660,7 @@ func TestBuildCustomQueryCommand(t *testing.T) {
 	customCommandCalled := false
 
 	appOptions := AppOptions{
-		ModuleOptions: map[string]*autocliv1.ModuleOptions{
+		ModuleOptions: map[string]*autoclicore.ModuleOptions{
 			"test": {
 				Query: testCmdDesc,
 			},
@@ -684,30 +684,30 @@ func TestNotFoundErrorsQuery(t *testing.T) {
 	b.AddQueryConnFlags = nil
 	b.AddTxConnFlags = nil
 
-	buildModuleQueryCommand := func(_ string, cmdDescriptor *autocliv1.ServiceCommandDescriptor) (*cobra.Command, error) {
+	buildModuleQueryCommand := func(_ string, cmdDescriptor *autoclicore.ServiceCommandDescriptor) (*cobra.Command, error) {
 		cmd := topLevelCmd(context.Background(), "query", "Querying subcommands")
 		err := b.AddMsgServiceCommands(cmd, cmdDescriptor)
 		return cmd, err
 	}
 
 	// bad service
-	_, err := buildModuleQueryCommand("test", &autocliv1.ServiceCommandDescriptor{Service: "foo"})
+	_, err := buildModuleQueryCommand("test", &autoclicore.ServiceCommandDescriptor{Service: "foo"})
 	assert.ErrorContains(t, err, "can't find service foo")
 
 	// bad method
-	_, err = buildModuleQueryCommand("test", &autocliv1.ServiceCommandDescriptor{
+	_, err = buildModuleQueryCommand("test", &autoclicore.ServiceCommandDescriptor{
 		Service:           testpb.Query_ServiceDesc.ServiceName,
-		RpcCommandOptions: []*autocliv1.RpcCommandOptions{{RpcMethod: "bar"}},
+		RpcCommandOptions: []*autoclicore.RpcCommandOptions{{RpcMethod: "bar"}},
 	})
 	assert.ErrorContains(t, err, "rpc method \"bar\" not found")
 
 	// bad positional field
-	_, err = buildModuleQueryCommand("test", &autocliv1.ServiceCommandDescriptor{
+	_, err = buildModuleQueryCommand("test", &autoclicore.ServiceCommandDescriptor{
 		Service: testpb.Query_ServiceDesc.ServiceName,
-		RpcCommandOptions: []*autocliv1.RpcCommandOptions{
+		RpcCommandOptions: []*autoclicore.RpcCommandOptions{
 			{
 				RpcMethod: "Echo",
-				PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+				PositionalArgs: []*autoclicore.PositionalArgDescriptor{
 					{
 						ProtoField: "foo",
 					},
@@ -718,12 +718,12 @@ func TestNotFoundErrorsQuery(t *testing.T) {
 	assert.ErrorContains(t, err, "can't find field foo")
 
 	// bad flag field
-	_, err = buildModuleQueryCommand("test", &autocliv1.ServiceCommandDescriptor{
+	_, err = buildModuleQueryCommand("test", &autoclicore.ServiceCommandDescriptor{
 		Service: testpb.Query_ServiceDesc.ServiceName,
-		RpcCommandOptions: []*autocliv1.RpcCommandOptions{
+		RpcCommandOptions: []*autoclicore.RpcCommandOptions{
 			{
 				RpcMethod: "Echo",
-				FlagOptions: map[string]*autocliv1.FlagOptions{
+				FlagOptions: map[string]*autoclicore.FlagOptions{
 					"baz": {},
 				},
 			},

--- a/client/v2/go.mod
+++ b/client/v2/go.mod
@@ -277,3 +277,5 @@ require (
 replace github.com/cosmos/cosmos-sdk => ../..
 
 replace github.com/cometbft/cometbft => github.com/cometbft/cometbft v0.39.0-rc1.0.20260527154549-606b4197148f
+
+replace cosmossdk.io/core => ../../core

--- a/client/v2/internal/coins/format.go
+++ b/client/v2/internal/coins/format.go
@@ -5,7 +5,7 @@ import (
 	"regexp"
 	"strings"
 
-	basev1beta1 "cosmossdk.io/api/cosmos/base/v1beta1"
+	coinscore "cosmossdk.io/core/coins"
 )
 
 // Amount can be a whole number or a decimal number. Denominations can be 3 ~ 128
@@ -13,50 +13,32 @@ import (
 // a separator ('/', ':', '.', '_' or '-').
 var coinRegex = regexp.MustCompile(`^(\d+(\.\d+)?)([a-zA-Z][a-zA-Z0-9\/\:\._\-]{2,127})$`)
 
-// ParseCoin parses a coin from a string. The string must be in the format
-// <amount><denom>, where <amount> is a number and <denom> is a valid denom.
-func ParseCoin(input string) (*basev1beta1.Coin, error) {
+// ParseCoin parses a coin from a string in the format <amount><denom>.
+func ParseCoin(input string) (*coinscore.Coin, error) {
 	amount, denom, err := parseCoin(input)
 	if err != nil {
 		return nil, err
 	}
-
-	return &basev1beta1.Coin{
-		Amount: amount,
-		Denom:  denom,
-	}, nil
+	return &coinscore.Coin{Amount: amount, Denom: denom}, nil
 }
 
-// ParseDecCoin parses a decCoin from a string. The string must be in the format
-// <amount><denom>, where <amount> is a number and <denom> is a valid denom.
-func ParseDecCoin(input string) (*basev1beta1.DecCoin, error) {
+// ParseDecCoin parses a dec coin from a string in the format <amount><denom>.
+func ParseDecCoin(input string) (*coinscore.DecCoin, error) {
 	amount, denom, err := parseCoin(input)
 	if err != nil {
 		return nil, err
 	}
-
-	return &basev1beta1.DecCoin{
-		Amount: amount,
-		Denom:  denom,
-	}, nil
+	return &coinscore.DecCoin{Amount: amount, Denom: denom}, nil
 }
 
-// parseCoin parses a coin string into its amount and denom components.
-// The input string must be in the format <amount><denom>.
-// It returns the amount string, denom string, and any error encountered.
-// Returns an error if the input is empty or doesn't match the expected format.
 func parseCoin(input string) (amount, denom string, err error) {
 	input = strings.TrimSpace(input)
-
 	if input == "" {
 		return "", "", errors.New("empty input when parsing coin")
 	}
-
 	matches := coinRegex.FindStringSubmatch(input)
-
 	if len(matches) == 0 {
 		return "", "", errors.New("invalid input format")
 	}
-
 	return matches[1], matches[3], nil
 }

--- a/contrib/x/circuit/autocli.go
+++ b/contrib/x/circuit/autocli.go
@@ -3,22 +3,22 @@ package circuit
 import (
 	"fmt"
 
-	autocliv1 "cosmossdk.io/api/cosmos/autocli/v1"
+	autocli "cosmossdk.io/core/autocli"
 
 	circuitv1 "github.com/cosmos/cosmos-sdk/contrib/api/cosmos/circuit/v1"
 	"github.com/cosmos/cosmos-sdk/version"
 )
 
-func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
-	return &autocliv1.ModuleOptions{
-		Query: &autocliv1.ServiceCommandDescriptor{
+func (am AppModule) AutoCLIOptions() *autocli.ModuleOptions {
+	return &autocli.ModuleOptions{
+		Query: &autocli.ServiceCommandDescriptor{
 			Service: circuitv1.Query_ServiceDesc.ServiceName,
-			RpcCommandOptions: []*autocliv1.RpcCommandOptions{
+			RpcCommandOptions: []*autocli.RpcCommandOptions{
 				{
 					RpcMethod:      "Account",
 					Use:            "account [address]",
 					Short:          "Query a specific account's permissions",
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{{ProtoField: "address"}},
+					PositionalArgs: []*autocli.PositionalArgDescriptor{{ProtoField: "address"}},
 				},
 				{
 					RpcMethod: "Accounts",
@@ -32,16 +32,16 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 				},
 			},
 		},
-		Tx: &autocliv1.ServiceCommandDescriptor{
+		Tx: &autocli.ServiceCommandDescriptor{
 			Service: circuitv1.Msg_ServiceDesc.ServiceName,
-			RpcCommandOptions: []*autocliv1.RpcCommandOptions{
+			RpcCommandOptions: []*autocli.RpcCommandOptions{
 				{
 					RpcMethod: "AuthorizeCircuitBreaker",
 					Use:       "authorize [grantee] [level] [msg_type_urls] --from [granter]",
 					Short:     "Authorize an account to trip the circuit breaker.",
 					Long:      `Authorize an account to trip the circuit breaker. Level can be: some-msgs, all-msgs or super-admin.`,
 					Example:   fmt.Sprintf(`%s tx circuit authorize [address] super-admin "/cosmos.bank.v1beta1.MsgSend /cosmos.bank.v1beta1.MsgMultiSend"`, version.AppName),
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+					PositionalArgs: []*autocli.PositionalArgDescriptor{
 						{ProtoField: "grantee"},
 						{ProtoField: "permissions.level"},
 						{ProtoField: "permissions.limit_type_urls", Varargs: true},
@@ -52,7 +52,7 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					Use:       "disable [msg_type_urls]",
 					Short:     "Disable a message from being executed",
 					Example:   fmt.Sprintf(`%s circuit disable "/cosmos.bank.v1beta1.MsgSend /cosmos.bank.v1beta1.MsgMultiSend"`, version.AppName),
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+					PositionalArgs: []*autocli.PositionalArgDescriptor{
 						{ProtoField: "msg_type_urls", Varargs: true},
 					},
 				},
@@ -61,7 +61,7 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					Use:       "reset [msg_type_urls]",
 					Short:     "Enable a message to be executed",
 					Example:   fmt.Sprintf(`%s circuit reset "/cosmos.bank.v1beta1.MsgSend /cosmos.bank.v1beta1.MsgMultiSend"`, version.AppName),
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+					PositionalArgs: []*autocli.PositionalArgDescriptor{
 						{ProtoField: "msg_type_urls", Varargs: true},
 					},
 				},

--- a/contrib/x/crisis/autocli.go
+++ b/contrib/x/crisis/autocli.go
@@ -1,22 +1,22 @@
 package crisis
 
 import (
-	autocliv1 "cosmossdk.io/api/cosmos/autocli/v1"
+	autocli "cosmossdk.io/core/autocli"
 
 	crisisv1beta1 "github.com/cosmos/cosmos-sdk/contrib/api/cosmos/crisis/v1beta1"
 )
 
 // AutoCLIOptions implements the autocli.HasAutoCLIConfig interface.
-func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
-	return &autocliv1.ModuleOptions{
-		Tx: &autocliv1.ServiceCommandDescriptor{
+func (am AppModule) AutoCLIOptions() *autocli.ModuleOptions {
+	return &autocli.ModuleOptions{
+		Tx: &autocli.ServiceCommandDescriptor{
 			Service: crisisv1beta1.Msg_ServiceDesc.ServiceName,
-			RpcCommandOptions: []*autocliv1.RpcCommandOptions{
+			RpcCommandOptions: []*autocli.RpcCommandOptions{
 				{
 					RpcMethod: "VerifyInvariant",
 					Use:       "invariant-broken [module-name] [invariant-route] --from mykey",
 					Short:     "Submit proof that an invariant is broken",
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+					PositionalArgs: []*autocli.PositionalArgDescriptor{
 						{ProtoField: "invariant_module_name"},
 						{ProtoField: "invariant_route"},
 					},

--- a/contrib/x/nft/module/autocli.go
+++ b/contrib/x/nft/module/autocli.go
@@ -3,7 +3,7 @@ package module
 import (
 	"fmt"
 
-	autocliv1 "cosmossdk.io/api/cosmos/autocli/v1"
+	autocli "cosmossdk.io/core/autocli"
 
 	nftv1beta1 "github.com/cosmos/cosmos-sdk/contrib/api/cosmos/nft/v1beta1"
 	"github.com/cosmos/cosmos-sdk/contrib/x/nft"
@@ -11,17 +11,17 @@ import (
 )
 
 // AutoCLIOptions implements the autocli.HasAutoCLIConfig interface.
-func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
-	return &autocliv1.ModuleOptions{
-		Query: &autocliv1.ServiceCommandDescriptor{
+func (am AppModule) AutoCLIOptions() *autocli.ModuleOptions {
+	return &autocli.ModuleOptions{
+		Query: &autocli.ServiceCommandDescriptor{
 			Service: nftv1beta1.Query_ServiceDesc.ServiceName,
-			RpcCommandOptions: []*autocliv1.RpcCommandOptions{
+			RpcCommandOptions: []*autocli.RpcCommandOptions{
 				{
 					RpcMethod: "Balance",
 					Use:       "balance [owner] [class-id]",
 					Short:     "Query the number of NFTs of a given class owned by the owner.",
 					Example:   fmt.Sprintf(`%s query %s balance <owner> <class-id>`, version.AppName, nft.ModuleName),
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+					PositionalArgs: []*autocli.PositionalArgDescriptor{
 						{ProtoField: "owner"},
 						{ProtoField: "class_id"},
 					},
@@ -31,7 +31,7 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					Use:       "owner [class-id] [nft-id]",
 					Short:     "Query the owner of the NFT based on its class and id.",
 					Example:   fmt.Sprintf(`%s query %s owner <class-id> <nft-id>`, version.AppName, nft.ModuleName),
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+					PositionalArgs: []*autocli.PositionalArgDescriptor{
 						{ProtoField: "class_id"},
 						{ProtoField: "id"},
 					},
@@ -41,7 +41,7 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					Use:       "supply [class-id]",
 					Short:     "Query the number of nft based on the class.",
 					Example:   fmt.Sprintf(`%s query %s supply <class-id>`, version.AppName, nft.ModuleName),
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+					PositionalArgs: []*autocli.PositionalArgDescriptor{
 						{ProtoField: "class_id"},
 					},
 				},
@@ -50,7 +50,7 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					Use:       "nfts [class-id]",
 					Short:     "Query all NFTs of a given class or owner address.",
 					Example:   fmt.Sprintf(`%s query %s nfts <class-id> --owner=<owner>`, version.AppName, nft.ModuleName),
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+					PositionalArgs: []*autocli.PositionalArgDescriptor{
 						{ProtoField: "class_id"},
 					},
 				},
@@ -59,7 +59,7 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					Use:       "nft [class-id] [nft-id]",
 					Short:     "Query an NFT based on its class and id.",
 					Example:   fmt.Sprintf(`%s query %s nft <class-id> <nft-id>`, version.AppName, nft.ModuleName),
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+					PositionalArgs: []*autocli.PositionalArgDescriptor{
 						{ProtoField: "class_id"},
 						{ProtoField: "id"},
 					},
@@ -69,7 +69,7 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					Use:       "class [class-id]",
 					Short:     "Query an NFT class based on its id",
 					Example:   fmt.Sprintf(`%s query %s class <class-id>`, version.AppName, nft.ModuleName),
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+					PositionalArgs: []*autocli.PositionalArgDescriptor{
 						{ProtoField: "class_id"},
 					},
 				},
@@ -81,14 +81,14 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 				},
 			},
 		},
-		Tx: &autocliv1.ServiceCommandDescriptor{
+		Tx: &autocli.ServiceCommandDescriptor{
 			Service: nftv1beta1.Msg_ServiceDesc.ServiceName,
-			RpcCommandOptions: []*autocliv1.RpcCommandOptions{
+			RpcCommandOptions: []*autocli.RpcCommandOptions{
 				{
 					RpcMethod: "Send",
 					Use:       "send [class-id] [nft-id] [receiver] --from [sender]",
 					Short:     "Transfer ownership of NFT",
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+					PositionalArgs: []*autocli.PositionalArgDescriptor{
 						{ProtoField: "class_id"},
 						{ProtoField: "id"},
 						{ProtoField: "receiver"},

--- a/core/autocli/options.go
+++ b/core/autocli/options.go
@@ -1,127 +1,83 @@
 package autocli
 
+import (
+	gogoproto "github.com/cosmos/gogoproto/proto"
+)
+
+func init() {
+	gogoproto.RegisterType((*ModuleOptions)(nil), "cosmos.autocli.v1.ModuleOptions")
+	gogoproto.RegisterType((*ServiceCommandDescriptor)(nil), "cosmos.autocli.v1.ServiceCommandDescriptor")
+	gogoproto.RegisterType((*RpcCommandOptions)(nil), "cosmos.autocli.v1.RpcCommandOptions")
+	gogoproto.RegisterType((*FlagOptions)(nil), "cosmos.autocli.v1.FlagOptions")
+	gogoproto.RegisterType((*PositionalArgDescriptor)(nil), "cosmos.autocli.v1.PositionalArgDescriptor")
+}
+
 // ModuleOptions describes the CLI options for a Cosmos SDK module.
 type ModuleOptions struct {
-	// Tx describes the tx commands for the module.
-	Tx *ServiceCommandDescriptor
-
-	// Query describes the query commands for the module.
-	Query *ServiceCommandDescriptor
+	Tx    *ServiceCommandDescriptor `protobuf:"bytes,1,opt,name=tx,proto3" json:"tx,omitempty"`
+	Query *ServiceCommandDescriptor `protobuf:"bytes,2,opt,name=query,proto3" json:"query,omitempty"`
 }
+
+func (*ModuleOptions) Reset()         {}
+func (*ModuleOptions) String() string { return "" }
+func (*ModuleOptions) ProtoMessage()  {}
 
 // ServiceCommandDescriptor describes a CLI command based on a protobuf service.
 type ServiceCommandDescriptor struct {
-	// Service is the fully qualified name of the protobuf service to build the
-	// command from. It can be left empty if SubCommands are used instead.
-	Service string
-
-	// RpcCommandOptions are options for commands generated from rpc methods.
-	// If no options are specified for a given rpc method, a command will be
-	// generated for that method with the default options.
-	RpcCommandOptions []*RpcCommandOptions
-
-	// SubCommands is a map of optional sub-commands for this command based on
-	// different protobuf services. The map key is used as the name of the
-	// sub-command.
-	SubCommands map[string]*ServiceCommandDescriptor
-
-	// EnhanceCustomCommand specifies whether to enhance an existing custom
-	// command with the services from gRPC. If false and a custom command
-	// already exists, no commands will be generated for the service.
-	EnhanceCustomCommand bool
-
-	// Short is an optional override for the short description of the auto
-	// generated command.
-	Short string
+	Service              string                               `protobuf:"bytes,1,opt,name=service,proto3" json:"service,omitempty"`
+	RpcCommandOptions    []*RpcCommandOptions                 `protobuf:"bytes,2,rep,name=rpc_command_options,json=rpcCommandOptions,proto3" json:"rpc_command_options,omitempty"`
+	SubCommands          map[string]*ServiceCommandDescriptor `protobuf:"bytes,3,rep,name=sub_commands,json=subCommands,proto3" json:"sub_commands,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
+	EnhanceCustomCommand bool                                 `protobuf:"varint,4,opt,name=enhance_custom_command,json=enhanceCustomCommand,proto3" json:"enhance_custom_command,omitempty"`
+	Short                string                               `protobuf:"bytes,5,opt,name=short,proto3" json:"short,omitempty"`
 }
 
-// RpcCommandOptions specifies options for commands generated from protobuf rpc
-// methods.
+func (*ServiceCommandDescriptor) Reset()         {}
+func (*ServiceCommandDescriptor) String() string { return "" }
+func (*ServiceCommandDescriptor) ProtoMessage()  {}
+
+// RpcCommandOptions specifies options for commands generated from protobuf rpc methods.
 type RpcCommandOptions struct {
-	// RpcMethod is the short name of the protobuf rpc method this command is
-	// generated from.
-	RpcMethod string
-
-	// Use is the one-line usage method. It also allows specifying an alternate
-	// name for the command as the first word of the usage text.
-	Use string
-
-	// Long is the long message shown in the 'help <this-command>' output.
-	Long string
-
-	// Short is the short description shown in the 'help' output.
-	Short string
-
-	// Example is examples of how to use the command.
-	Example string
-
-	// Alias is an array of aliases that can be used instead of the first word
-	// in Use.
-	Alias []string
-
-	// SuggestFor is an array of command names for which this command will be
-	// suggested — similar to aliases but only suggests.
-	SuggestFor []string
-
-	// Deprecated defines, if this command is deprecated and should print this
-	// string when used.
-	Deprecated string
-
-	// Version defines the version for this command.
-	Version string
-
-	// FlagOptions are options for flags generated from rpc request fields.
-	// By default all request fields are configured as flags. They can also be
-	// configured as positional args instead using PositionalArgs.
-	FlagOptions map[string]*FlagOptions
-
-	// PositionalArgs specifies positional arguments for the command.
-	PositionalArgs []*PositionalArgDescriptor
-
-	// Skip specifies whether to skip this rpc method when generating commands.
-	Skip bool
-
-	// GovProposal specifies whether autocli should generate a gov proposal
-	// transaction for this rpc method instead of a plain transaction.
-	GovProposal bool
+	RpcMethod      string                     `protobuf:"bytes,1,opt,name=rpc_method,json=rpcMethod,proto3" json:"rpc_method,omitempty"`
+	Use            string                     `protobuf:"bytes,2,opt,name=use,proto3" json:"use,omitempty"`
+	Long           string                     `protobuf:"bytes,3,opt,name=long,proto3" json:"long,omitempty"`
+	Short          string                     `protobuf:"bytes,4,opt,name=short,proto3" json:"short,omitempty"`
+	Example        string                     `protobuf:"bytes,5,opt,name=example,proto3" json:"example,omitempty"`
+	Alias          []string                   `protobuf:"bytes,6,rep,name=alias,proto3" json:"alias,omitempty"`
+	SuggestFor     []string                   `protobuf:"bytes,7,rep,name=suggest_for,json=suggestFor,proto3" json:"suggest_for,omitempty"`
+	Deprecated     string                     `protobuf:"bytes,8,opt,name=deprecated,proto3" json:"deprecated,omitempty"`
+	Version        string                     `protobuf:"bytes,9,opt,name=version,proto3" json:"version,omitempty"`
+	FlagOptions    map[string]*FlagOptions    `protobuf:"bytes,10,rep,name=flag_options,json=flagOptions,proto3" json:"flag_options,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
+	PositionalArgs []*PositionalArgDescriptor `protobuf:"bytes,11,rep,name=positional_args,json=positionalArgs,proto3" json:"positional_args,omitempty"`
+	Skip           bool                       `protobuf:"varint,12,opt,name=skip,proto3" json:"skip,omitempty"`
+	GovProposal    bool                       `protobuf:"varint,13,opt,name=gov_proposal,json=govProposal,proto3" json:"gov_proposal,omitempty"`
 }
+
+func (*RpcCommandOptions) Reset()         {}
+func (*RpcCommandOptions) String() string { return "" }
+func (*RpcCommandOptions) ProtoMessage()  {}
 
 // FlagOptions are options for flags generated from rpc request fields.
 type FlagOptions struct {
-	// Name is an alternate name to use for the field flag.
-	Name string
-
-	// Shorthand is a one-letter abbreviated flag.
-	Shorthand string
-
-	// Usage is the help message.
-	Usage string
-
-	// DefaultValue is the default value as text.
-	DefaultValue string
-
-	// Deprecated is the usage text to show if this flag is deprecated.
-	Deprecated string
-
-	// ShorthandDeprecated is the usage text to show if the shorthand of this
-	// flag is deprecated.
-	ShorthandDeprecated string
-
-	// Hidden hides the flag from help/usage text.
-	Hidden bool
+	Name                string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	Shorthand           string `protobuf:"bytes,2,opt,name=shorthand,proto3" json:"shorthand,omitempty"`
+	Usage               string `protobuf:"bytes,3,opt,name=usage,proto3" json:"usage,omitempty"`
+	DefaultValue        string `protobuf:"bytes,4,opt,name=default_value,json=defaultValue,proto3" json:"default_value,omitempty"`
+	Deprecated          string `protobuf:"bytes,6,opt,name=deprecated,proto3" json:"deprecated,omitempty"`
+	ShorthandDeprecated string `protobuf:"bytes,7,opt,name=shorthand_deprecated,json=shorthandDeprecated,proto3" json:"shorthand_deprecated,omitempty"`
+	Hidden              bool   `protobuf:"varint,8,opt,name=hidden,proto3" json:"hidden,omitempty"`
 }
+
+func (*FlagOptions) Reset()         {}
+func (*FlagOptions) String() string { return "" }
+func (*FlagOptions) ProtoMessage()  {}
 
 // PositionalArgDescriptor describes a positional argument.
 type PositionalArgDescriptor struct {
-	// ProtoField specifies the proto field to use as the positional arg.
-	ProtoField string
-
-	// Varargs makes a positional parameter a varargs parameter. This can only
-	// be applied to the last positional parameter and the proto field must be
-	// a repeated field. Mutually exclusive with Optional.
-	Varargs bool
-
-	// Optional makes the last positional parameter optional.
-	// Mutually exclusive with Varargs.
-	Optional bool
+	ProtoField string `protobuf:"bytes,1,opt,name=proto_field,json=protoField,proto3" json:"proto_field,omitempty"`
+	Varargs    bool   `protobuf:"varint,2,opt,name=varargs,proto3" json:"varargs,omitempty"`
+	Optional   bool   `protobuf:"varint,3,opt,name=optional,proto3" json:"optional,omitempty"`
 }
+
+func (*PositionalArgDescriptor) Reset()         {}
+func (*PositionalArgDescriptor) String() string { return "" }
+func (*PositionalArgDescriptor) ProtoMessage()  {}

--- a/core/autocli/options.go
+++ b/core/autocli/options.go
@@ -1,0 +1,127 @@
+package autocli
+
+// ModuleOptions describes the CLI options for a Cosmos SDK module.
+type ModuleOptions struct {
+	// Tx describes the tx commands for the module.
+	Tx *ServiceCommandDescriptor
+
+	// Query describes the query commands for the module.
+	Query *ServiceCommandDescriptor
+}
+
+// ServiceCommandDescriptor describes a CLI command based on a protobuf service.
+type ServiceCommandDescriptor struct {
+	// Service is the fully qualified name of the protobuf service to build the
+	// command from. It can be left empty if SubCommands are used instead.
+	Service string
+
+	// RpcCommandOptions are options for commands generated from rpc methods.
+	// If no options are specified for a given rpc method, a command will be
+	// generated for that method with the default options.
+	RpcCommandOptions []*RpcCommandOptions
+
+	// SubCommands is a map of optional sub-commands for this command based on
+	// different protobuf services. The map key is used as the name of the
+	// sub-command.
+	SubCommands map[string]*ServiceCommandDescriptor
+
+	// EnhanceCustomCommand specifies whether to enhance an existing custom
+	// command with the services from gRPC. If false and a custom command
+	// already exists, no commands will be generated for the service.
+	EnhanceCustomCommand bool
+
+	// Short is an optional override for the short description of the auto
+	// generated command.
+	Short string
+}
+
+// RpcCommandOptions specifies options for commands generated from protobuf rpc
+// methods.
+type RpcCommandOptions struct {
+	// RpcMethod is the short name of the protobuf rpc method this command is
+	// generated from.
+	RpcMethod string
+
+	// Use is the one-line usage method. It also allows specifying an alternate
+	// name for the command as the first word of the usage text.
+	Use string
+
+	// Long is the long message shown in the 'help <this-command>' output.
+	Long string
+
+	// Short is the short description shown in the 'help' output.
+	Short string
+
+	// Example is examples of how to use the command.
+	Example string
+
+	// Alias is an array of aliases that can be used instead of the first word
+	// in Use.
+	Alias []string
+
+	// SuggestFor is an array of command names for which this command will be
+	// suggested — similar to aliases but only suggests.
+	SuggestFor []string
+
+	// Deprecated defines, if this command is deprecated and should print this
+	// string when used.
+	Deprecated string
+
+	// Version defines the version for this command.
+	Version string
+
+	// FlagOptions are options for flags generated from rpc request fields.
+	// By default all request fields are configured as flags. They can also be
+	// configured as positional args instead using PositionalArgs.
+	FlagOptions map[string]*FlagOptions
+
+	// PositionalArgs specifies positional arguments for the command.
+	PositionalArgs []*PositionalArgDescriptor
+
+	// Skip specifies whether to skip this rpc method when generating commands.
+	Skip bool
+
+	// GovProposal specifies whether autocli should generate a gov proposal
+	// transaction for this rpc method instead of a plain transaction.
+	GovProposal bool
+}
+
+// FlagOptions are options for flags generated from rpc request fields.
+type FlagOptions struct {
+	// Name is an alternate name to use for the field flag.
+	Name string
+
+	// Shorthand is a one-letter abbreviated flag.
+	Shorthand string
+
+	// Usage is the help message.
+	Usage string
+
+	// DefaultValue is the default value as text.
+	DefaultValue string
+
+	// Deprecated is the usage text to show if this flag is deprecated.
+	Deprecated string
+
+	// ShorthandDeprecated is the usage text to show if the shorthand of this
+	// flag is deprecated.
+	ShorthandDeprecated string
+
+	// Hidden hides the flag from help/usage text.
+	Hidden bool
+}
+
+// PositionalArgDescriptor describes a positional argument.
+type PositionalArgDescriptor struct {
+	// ProtoField specifies the proto field to use as the positional arg.
+	ProtoField string
+
+	// Varargs makes a positional parameter a varargs parameter. This can only
+	// be applied to the last positional parameter and the proto field must be
+	// a repeated field. Mutually exclusive with Optional.
+	Varargs bool
+
+	// Optional makes the last positional parameter optional.
+	// Mutually exclusive with Varargs.
+	Optional bool
+}

--- a/core/coins/format.go
+++ b/core/coins/format.go
@@ -6,8 +6,6 @@ import (
 	"sort"
 	"strings"
 
-	bankv1beta1 "cosmossdk.io/api/cosmos/bank/v1beta1"
-	basev1beta1 "cosmossdk.io/api/cosmos/base/v1beta1"
 	"cosmossdk.io/math"
 )
 
@@ -18,13 +16,38 @@ const emptyCoins = "zero"
 // a separator ('/', ':', '.', '_' or '-').
 var coinRegex = regexp.MustCompile(`^(\d+(\.\d+)?)([a-zA-Z][a-zA-Z0-9\/\:\._\-]{2,127})$`)
 
-// formatCoin formats a sdk.Coin into a value-rendered string, using the
-// given metadata about the denom. It returns the formatted coin string, the
-// display denom, and an optional error.
-func formatCoin(coin *basev1beta1.Coin, metadata *bankv1beta1.Metadata) (string, error) {
+// Coin is a denomination and amount pair used for coin formatting.
+// It mirrors cosmos.base.v1beta1.Coin's Denom/Amount string fields.
+type Coin struct {
+	Denom  string `json:"denom"`
+	Amount string `json:"amount"`
+}
+
+// DecCoin is a denomination and decimal amount pair.
+type DecCoin struct {
+	Denom  string `json:"denom"`
+	Amount string `json:"amount"`
+}
+
+// DenomUnit defines a denomination unit with an exponent.
+type DenomUnit struct {
+	Denom    string   `json:"denom"`
+	Exponent uint32   `json:"exponent"`
+	Aliases  []string `json:"aliases,omitempty"`
+}
+
+// Metadata holds denomination display metadata.
+type Metadata struct {
+	Display    string       `json:"display"`
+	Base       string       `json:"base,omitempty"`
+	DenomUnits []*DenomUnit `json:"denom_units,omitempty"`
+}
+
+// formatCoin formats a Coin into a value-rendered string, using the
+// given metadata about the denom.
+func formatCoin(coin *Coin, metadata *Metadata) (string, error) {
 	coinDenom := coin.Denom
 
-	// Return early if no display denom or display denom is the current coin denom.
 	if metadata == nil || metadata.Display == "" || coinDenom == metadata.Display {
 		vr, err := math.FormatDec(coin.Amount)
 		return vr + " " + coin.Denom, err
@@ -32,7 +55,6 @@ func formatCoin(coin *basev1beta1.Coin, metadata *bankv1beta1.Metadata) (string,
 
 	dispDenom := metadata.Display
 
-	// Find exponents of both denoms.
 	var coinExp, dispExp uint32
 	foundCoinExp, foundDispExp := false, false
 	for _, unit := range metadata.DenomUnits {
@@ -46,7 +68,6 @@ func formatCoin(coin *basev1beta1.Coin, metadata *bankv1beta1.Metadata) (string,
 		}
 	}
 
-	// If we didn't find either exponent, then we return early.
 	if !foundCoinExp || !foundDispExp {
 		vr, err := math.FormatInt(coin.Amount)
 		return vr + " " + coin.Denom, err
@@ -67,12 +88,9 @@ func formatCoin(coin *basev1beta1.Coin, metadata *bankv1beta1.Metadata) (string,
 	return vr + " " + dispDenom, err
 }
 
-// FormatCoins formats Coins into a value-rendered string, which uses
-// `formatCoin` separated by ", " (a comma and a space), and sorted
-// alphabetically by value-rendered denoms. It expects an array of metadata
-// (optionally nil), where each metadata at index `i` MUST match the coin denom
-// at the same index.
-func FormatCoins(coins []*basev1beta1.Coin, metadata []*bankv1beta1.Metadata) (string, error) {
+// FormatCoins formats Coins into a value-rendered string, sorted alphabetically.
+// Each metadata at index i MUST match the coin denom at the same index.
+func FormatCoins(coins []*Coin, metadata []*Metadata) (string, error) {
 	if len(coins) != len(metadata) {
 		return "", fmt.Errorf("formatCoins expect one metadata for each coin; expected %d, got %d", len(coins), len(metadata))
 	}
@@ -85,8 +103,6 @@ func FormatCoins(coins []*basev1beta1.Coin, metadata []*bankv1beta1.Metadata) (s
 			return "", err
 		}
 
-		// If a coin contains a comma, return an error given that the output
-		// could be misinterpreted by the user as 2 different coins.
 		if strings.Contains(formatted[i], ",") {
 			return "", fmt.Errorf("coin %s contains a comma", formatted[i])
 		}
@@ -96,34 +112,41 @@ func FormatCoins(coins []*basev1beta1.Coin, metadata []*bankv1beta1.Metadata) (s
 		return emptyCoins, nil
 	}
 
-	// Sort the formatted coins by display denom.
 	sort.SliceStable(formatted, func(i, j int) bool {
 		denomI := strings.Split(formatted[i], " ")[1]
 		denomJ := strings.Split(formatted[j], " ")[1]
-
 		return denomI < denomJ
 	})
 
 	return strings.Join(formatted, ", "), nil
 }
 
-// ParseCoin parses a coin from a string. The string must be in the format
-// <amount><denom>, where <amount> is a number and <denom> is a valid denom.
-func ParseCoin(input string) (*basev1beta1.Coin, error) {
+// ParseCoin parses a coin from a string in the format <amount><denom>.
+func ParseCoin(input string) (*Coin, error) {
 	input = strings.TrimSpace(input)
-
 	if input == "" {
 		return nil, fmt.Errorf("empty input when parsing coin")
 	}
 
 	matches := coinRegex.FindStringSubmatch(input)
-
 	if len(matches) == 0 {
 		return nil, fmt.Errorf("invalid input format")
 	}
 
-	return &basev1beta1.Coin{
-		Amount: matches[1],
-		Denom:  matches[3],
-	}, nil
+	return &Coin{Amount: matches[1], Denom: matches[3]}, nil
+}
+
+// ParseDecCoin parses a decimal coin from a string in the format <amount><denom>.
+func ParseDecCoin(input string) (*DecCoin, error) {
+	input = strings.TrimSpace(input)
+	if input == "" {
+		return nil, fmt.Errorf("empty input when parsing dec coin")
+	}
+
+	matches := coinRegex.FindStringSubmatch(input)
+	if len(matches) == 0 {
+		return nil, fmt.Errorf("invalid input format")
+	}
+
+	return &DecCoin{Amount: matches[1], Denom: matches[3]}, nil
 }

--- a/core/coins/format_test.go
+++ b/core/coins/format_test.go
@@ -7,25 +7,23 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	bankv1beta1 "cosmossdk.io/api/cosmos/bank/v1beta1"
-	basev1beta1 "cosmossdk.io/api/cosmos/base/v1beta1"
 	"cosmossdk.io/core/coins"
 )
 
 // coinJSONTest is the type of test cases in the coin.json file.
 type coinJSONTest struct {
-	Proto    *basev1beta1.Coin
-	Metadata *bankv1beta1.Metadata
-	Text     string
-	Error    bool
+	Proto    *coins.Coin     `json:"proto"`
+	Metadata *coins.Metadata `json:"metadata"`
+	Text     string          `json:"text"`
+	Error    bool            `json:"error"`
 }
 
 // coinsJSONTest is the type of test cases in the coins.json file.
 type coinsJSONTest struct {
-	Proto    []*basev1beta1.Coin
-	Metadata map[string]*bankv1beta1.Metadata
-	Text     string
-	Error    bool
+	Proto    []*coins.Coin              `json:"proto"`
+	Metadata map[string]*coins.Metadata `json:"metadata"`
+	Text     string                     `json:"text"`
+	Error    bool                       `json:"error"`
 }
 
 func TestFormatCoin(t *testing.T) {
@@ -38,7 +36,7 @@ func TestFormatCoin(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.Text, func(t *testing.T) {
 			if tc.Proto != nil {
-				out, err := coins.FormatCoins([]*basev1beta1.Coin{tc.Proto}, []*bankv1beta1.Metadata{tc.Metadata})
+				out, err := coins.FormatCoins([]*coins.Coin{tc.Proto}, []*coins.Metadata{tc.Metadata})
 
 				if tc.Error {
 					require.Error(t, err)
@@ -62,7 +60,7 @@ func TestFormatCoins(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.Text, func(t *testing.T) {
 			if tc.Proto != nil {
-				metadata := make([]*bankv1beta1.Metadata, len(tc.Proto))
+				metadata := make([]*coins.Metadata, len(tc.Proto))
 				for i, coin := range tc.Proto {
 					metadata[i] = tc.Metadata[coin.Denom]
 				}

--- a/crypto/keyring/autocli.go
+++ b/crypto/keyring/autocli.go
@@ -1,10 +1,9 @@
 package keyring
 
 import (
-	signingv1beta1 "cosmossdk.io/api/cosmos/tx/signing/v1beta1"
-
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	authsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
+	txsigning "github.com/cosmos/cosmos-sdk/x/tx/signing"
 )
 
 // autoCLIKeyring represents the keyring interface used by the AutoCLI.
@@ -20,7 +19,7 @@ type autoCLIKeyring interface {
 	GetPubKey(name string) (cryptotypes.PubKey, error)
 
 	// Sign signs the given bytes with the key with the given name.
-	Sign(name string, msg []byte, signMode signingv1beta1.SignMode) ([]byte, error)
+	Sign(name string, msg []byte, signMode txsigning.SignMode) ([]byte, error)
 }
 
 // NewAutoCLIKeyring wraps the SDK keyring and make it compatible with the AutoCLI keyring interfaces.
@@ -70,7 +69,7 @@ func (a *autoCLIKeyringAdapter) GetPubKey(name string) (cryptotypes.PubKey, erro
 	return record.GetPubKey()
 }
 
-func (a *autoCLIKeyringAdapter) Sign(name string, msg []byte, signMode signingv1beta1.SignMode) ([]byte, error) {
+func (a *autoCLIKeyringAdapter) Sign(name string, msg []byte, signMode txsigning.SignMode) ([]byte, error) {
 	record, err := a.Key(name)
 	if err != nil {
 		return nil, err

--- a/enterprise/group/go.mod
+++ b/enterprise/group/go.mod
@@ -282,3 +282,5 @@ replace (
 )
 
 replace github.com/cometbft/cometbft => github.com/cometbft/cometbft v0.39.0-rc1.0.20260527154549-606b4197148f
+
+replace cosmossdk.io/core => ../../core

--- a/enterprise/group/simapp/app.go
+++ b/enterprise/group/simapp/app.go
@@ -23,7 +23,6 @@ import (
 	dbm "github.com/cosmos/cosmos-db"
 	"github.com/cosmos/gogoproto/proto"
 
-	autocliv1 "cosmossdk.io/api/cosmos/autocli/v1"
 	"cosmossdk.io/client/v2/autocli"
 	clienthelpers "cosmossdk.io/client/v2/helpers"
 	"cosmossdk.io/core/appmodule"
@@ -360,7 +359,7 @@ func NewSimApp(
 		panic(err)
 	}
 
-	autocliv1.RegisterQueryServer(app.GRPCQueryRouter(), runtimeservices.NewAutoCLIQueryService(app.ModuleManager.Modules))
+	autocli.RegisterQueryServer(app.GRPCQueryRouter(), runtimeservices.NewAutoCLIQueryService(app.ModuleManager.Modules))
 
 	overrideModules := map[string]module.AppModuleSimulation{
 		authtypes.ModuleName: auth.NewAppModule(app.encodingConfig.Codec, app.AccountKeeper, authsims.RandomGenesisAccounts),

--- a/enterprise/group/simapp/go.mod
+++ b/enterprise/group/simapp/go.mod
@@ -292,3 +292,5 @@ replace (
 )
 
 replace github.com/cometbft/cometbft => github.com/cometbft/cometbft v0.39.0-rc1.0.20260527154549-606b4197148f
+
+replace cosmossdk.io/core => ../../../core

--- a/enterprise/group/simapp/go.mod
+++ b/enterprise/group/simapp/go.mod
@@ -294,3 +294,5 @@ replace (
 replace github.com/cometbft/cometbft => github.com/cometbft/cometbft v0.39.0-rc1.0.20260527154549-606b4197148f
 
 replace cosmossdk.io/core => ../../../core
+
+replace cosmossdk.io/client/v2 => ../../../client/v2

--- a/enterprise/group/tests/systemtests/go.mod
+++ b/enterprise/group/tests/systemtests/go.mod
@@ -285,3 +285,5 @@ replace (
 )
 
 replace github.com/cometbft/cometbft => github.com/cometbft/cometbft v0.39.0-rc1.0.20260527154549-606b4197148f
+
+replace cosmossdk.io/core => ../../../../core

--- a/enterprise/group/x/group/module/autocli.go
+++ b/enterprise/group/x/group/module/autocli.go
@@ -15,22 +15,22 @@
 package module
 
 import (
-	autocliv1 "cosmossdk.io/api/cosmos/autocli/v1"
+	autocli "cosmossdk.io/core/autocli"
 
 	groupv1 "github.com/cosmos/cosmos-sdk/enterprise/group/x/group"
 )
 
 // AutoCLIOptions implements the autocli.HasAutoCLIConfig interface.
-func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
-	return &autocliv1.ModuleOptions{
-		Query: &autocliv1.ServiceCommandDescriptor{
+func (am AppModule) AutoCLIOptions() *autocli.ModuleOptions {
+	return &autocli.ModuleOptions{
+		Query: &autocli.ServiceCommandDescriptor{
 			Service: groupv1.Query_serviceDesc.ServiceName,
-			RpcCommandOptions: []*autocliv1.RpcCommandOptions{
+			RpcCommandOptions: []*autocli.RpcCommandOptions{
 				{
 					RpcMethod: "GroupInfo",
 					Use:       "group-info [group-id]",
 					Short:     "Query for group info by group id",
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+					PositionalArgs: []*autocli.PositionalArgDescriptor{
 						{ProtoField: "group_id"},
 					},
 				},
@@ -38,7 +38,7 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					RpcMethod: "GroupPolicyInfo",
 					Use:       "group-policy-info [group-policy-account]",
 					Short:     "Query for group policy info by account address of group policy",
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+					PositionalArgs: []*autocli.PositionalArgDescriptor{
 						{ProtoField: "address"},
 					},
 				},
@@ -46,7 +46,7 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					RpcMethod: "GroupMembers",
 					Use:       "group-members [group-id]",
 					Short:     "Query for group members by group id",
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+					PositionalArgs: []*autocli.PositionalArgDescriptor{
 						{ProtoField: "group_id"},
 					},
 				},
@@ -54,7 +54,7 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					RpcMethod: "GroupsByAdmin",
 					Use:       "groups-by-admin [admin]",
 					Short:     "Query for groups by admin account address",
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+					PositionalArgs: []*autocli.PositionalArgDescriptor{
 						{ProtoField: "admin"},
 					},
 				},
@@ -62,7 +62,7 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					RpcMethod: "GroupPoliciesByGroup",
 					Use:       "group-policies-by-group [group-id]",
 					Short:     "Query for group policies by group id",
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+					PositionalArgs: []*autocli.PositionalArgDescriptor{
 						{ProtoField: "group_id"},
 					},
 				},
@@ -70,7 +70,7 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					RpcMethod: "GroupPoliciesByAdmin",
 					Use:       "group-policies-by-admin [admin]",
 					Short:     "Query for group policies by admin account address",
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+					PositionalArgs: []*autocli.PositionalArgDescriptor{
 						{ProtoField: "admin"},
 					},
 				},
@@ -78,7 +78,7 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					RpcMethod: "Proposal",
 					Use:       "proposal [proposal-id]",
 					Short:     "Query for proposal by id",
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+					PositionalArgs: []*autocli.PositionalArgDescriptor{
 						{ProtoField: "proposal_id"},
 					},
 				},
@@ -86,7 +86,7 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					RpcMethod: "ProposalsByGroupPolicy",
 					Use:       "proposals-by-group-policy [group-policy-account]",
 					Short:     "Query for proposals by account address of group policy",
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+					PositionalArgs: []*autocli.PositionalArgDescriptor{
 						{ProtoField: "address"},
 					},
 				},
@@ -94,7 +94,7 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					RpcMethod: "VoteByProposalVoter",
 					Use:       "vote [proposal-id] [voter]",
 					Short:     "Query for vote by proposal id and voter account address",
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+					PositionalArgs: []*autocli.PositionalArgDescriptor{
 						{ProtoField: "proposal_id"},
 						{ProtoField: "voter"},
 					},
@@ -103,7 +103,7 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					RpcMethod: "VotesByProposal",
 					Use:       "votes-by-proposal [proposal-id]",
 					Short:     "Query for votes by proposal id",
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+					PositionalArgs: []*autocli.PositionalArgDescriptor{
 						{ProtoField: "proposal_id"},
 					},
 				},
@@ -111,7 +111,7 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					RpcMethod: "VotesByVoter",
 					Use:       "votes-by-voter [voter]",
 					Short:     "Query for votes by voter account address",
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+					PositionalArgs: []*autocli.PositionalArgDescriptor{
 						{ProtoField: "voter"},
 					},
 				},
@@ -119,7 +119,7 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					RpcMethod: "GroupsByMember",
 					Use:       "groups-by-member [address]",
 					Short:     "Query for groups by member address",
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+					PositionalArgs: []*autocli.PositionalArgDescriptor{
 						{ProtoField: "address"},
 					},
 				},
@@ -127,7 +127,7 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					RpcMethod: "TallyResult",
 					Use:       "tally-result [proposal-id]",
 					Short:     "Query tally result of proposal",
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+					PositionalArgs: []*autocli.PositionalArgDescriptor{
 						{ProtoField: "proposal_id"},
 					},
 				},
@@ -138,15 +138,15 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 				},
 			},
 		},
-		Tx: &autocliv1.ServiceCommandDescriptor{
+		Tx: &autocli.ServiceCommandDescriptor{
 			Service:              groupv1.Msg_serviceDesc.ServiceName,
 			EnhanceCustomCommand: false, // use custom commands only until v0.51
-			RpcCommandOptions: []*autocliv1.RpcCommandOptions{
+			RpcCommandOptions: []*autocli.RpcCommandOptions{
 				{
 					RpcMethod: "UpdateGroupAdmin",
 					Use:       "update-group-admin [admin] [group-id] [new-admin]",
 					Short:     "Update a group's admin",
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+					PositionalArgs: []*autocli.PositionalArgDescriptor{
 						{ProtoField: "admin"}, {ProtoField: "group_id"}, {ProtoField: "new_admin"},
 					},
 				},
@@ -154,7 +154,7 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					RpcMethod: "UpdateGroupMetadata",
 					Use:       "update-group-metadata [admin] [group-id] [metadata]",
 					Short:     "Update a group's metadata",
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+					PositionalArgs: []*autocli.PositionalArgDescriptor{
 						{ProtoField: "admin"}, {ProtoField: "group_id"}, {ProtoField: "metadata"},
 					},
 				},
@@ -162,7 +162,7 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					RpcMethod: "UpdateGroupPolicyAdmin",
 					Use:       "update-group-policy-admin [admin] [group-policy-account] [new-admin]",
 					Short:     "Update a group policy admin",
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+					PositionalArgs: []*autocli.PositionalArgDescriptor{
 						{ProtoField: "admin"}, {ProtoField: "group_policy_address"}, {ProtoField: "new_admin"},
 					},
 				},
@@ -170,7 +170,7 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					RpcMethod: "UpdateGroupPolicyMetadata",
 					Use:       "update-group-policy-metadata [admin] [group-policy-account] [new-metadata]",
 					Short:     "Update a group policy metadata",
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+					PositionalArgs: []*autocli.PositionalArgDescriptor{
 						{ProtoField: "admin"}, {ProtoField: "group_policy_address"}, {ProtoField: "metadata"},
 					},
 				},
@@ -178,7 +178,7 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					RpcMethod: "WithdrawProposal",
 					Use:       "withdraw-proposal [proposal-id] [group-policy-admin-or-proposer]",
 					Short:     "Withdraw a submitted proposal",
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+					PositionalArgs: []*autocli.PositionalArgDescriptor{
 						{ProtoField: "proposal_id"}, {ProtoField: "address"},
 					},
 				},
@@ -197,10 +197,10 @@ Parameters:
 		VOTE_OPTION_NO_WITH_VETO: no-with-veto
 	Metadata: metadata for the vote
 `,
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+					PositionalArgs: []*autocli.PositionalArgDescriptor{
 						{ProtoField: "proposal_id"}, {ProtoField: "voter"}, {ProtoField: "option"}, {ProtoField: "metadata"},
 					},
-					FlagOptions: map[string]*autocliv1.FlagOptions{
+					FlagOptions: map[string]*autocli.FlagOptions{
 						"exec": {Name: "exec", DefaultValue: "", Usage: "Set to 'try' for trying to execute proposal immediately after voting"},
 					},
 				},
@@ -208,7 +208,7 @@ Parameters:
 					RpcMethod: "Exec",
 					Use:       "exec [proposal-id]",
 					Short:     "Execute a proposal",
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+					PositionalArgs: []*autocli.PositionalArgDescriptor{
 						{ProtoField: "proposal_id"},
 					},
 				},
@@ -216,7 +216,7 @@ Parameters:
 					RpcMethod: "LeaveGroup",
 					Use:       "leave-group [member-address] [group-id]",
 					Short:     "Remove member from the group",
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+					PositionalArgs: []*autocli.PositionalArgDescriptor{
 						{ProtoField: "address"}, {ProtoField: "group_id"},
 					},
 				},

--- a/enterprise/poa/examples/migrate-from-pos/app.go
+++ b/enterprise/poa/examples/migrate-from-pos/app.go
@@ -32,7 +32,6 @@ import (
 	"github.com/cosmos/gogoproto/proto"
 	"github.com/spf13/cast"
 
-	autocliv1 "cosmossdk.io/api/cosmos/autocli/v1"
 	"cosmossdk.io/client/v2/autocli"
 	clienthelpers "cosmossdk.io/client/v2/helpers"
 	"cosmossdk.io/core/appmodule"
@@ -393,7 +392,7 @@ func NewSimApp(
 		panic(err)
 	}
 
-	autocliv1.RegisterQueryServer(app.GRPCQueryRouter(), runtimeservices.NewAutoCLIQueryService(app.ModuleManager.Modules))
+	autocli.RegisterQueryServer(app.GRPCQueryRouter(), runtimeservices.NewAutoCLIQueryService(app.ModuleManager.Modules))
 
 	overrideModules := map[string]module.AppModuleSimulation{
 		authtypes.ModuleName: auth.NewAppModule(app.encodingConfig.Codec, app.AccountKeeper, authsims.RandomGenesisAccounts),

--- a/enterprise/poa/examples/migrate-from-pos/go.mod
+++ b/enterprise/poa/examples/migrate-from-pos/go.mod
@@ -347,3 +347,5 @@ replace (
 )
 
 replace github.com/cometbft/cometbft => github.com/cometbft/cometbft v0.39.0-rc1.0.20260527154549-606b4197148f
+
+replace cosmossdk.io/core => ../../../../core

--- a/enterprise/poa/examples/migrate-from-pos/go.mod
+++ b/enterprise/poa/examples/migrate-from-pos/go.mod
@@ -349,3 +349,5 @@ replace (
 replace github.com/cometbft/cometbft => github.com/cometbft/cometbft v0.39.0-rc1.0.20260527154549-606b4197148f
 
 replace cosmossdk.io/core => ../../../../core
+
+replace cosmossdk.io/client/v2 => ../../../../client/v2

--- a/enterprise/poa/go.mod
+++ b/enterprise/poa/go.mod
@@ -282,3 +282,5 @@ replace (
 )
 
 replace github.com/cometbft/cometbft => github.com/cometbft/cometbft v0.39.0-rc1.0.20260527154549-606b4197148f
+
+replace cosmossdk.io/core => ../../core

--- a/enterprise/poa/simapp/app.go
+++ b/enterprise/poa/simapp/app.go
@@ -22,7 +22,6 @@ import (
 	dbm "github.com/cosmos/cosmos-db"
 	"github.com/cosmos/gogoproto/proto"
 
-	autocliv1 "cosmossdk.io/api/cosmos/autocli/v1"
 	"cosmossdk.io/client/v2/autocli"
 	clienthelpers "cosmossdk.io/client/v2/helpers"
 	"cosmossdk.io/core/appmodule"
@@ -299,7 +298,7 @@ func NewSimApp(
 		panic(err)
 	}
 
-	autocliv1.RegisterQueryServer(app.GRPCQueryRouter(), runtimeservices.NewAutoCLIQueryService(app.ModuleManager.Modules))
+	autocli.RegisterQueryServer(app.GRPCQueryRouter(), runtimeservices.NewAutoCLIQueryService(app.ModuleManager.Modules))
 
 	overrideModules := map[string]module.AppModuleSimulation{
 		authtypes.ModuleName: auth.NewAppModule(app.encodingConfig.Codec, app.AccountKeeper, authsims.RandomGenesisAccounts),

--- a/enterprise/poa/simapp/go.mod
+++ b/enterprise/poa/simapp/go.mod
@@ -298,3 +298,5 @@ replace (
 )
 
 replace github.com/cometbft/cometbft => github.com/cometbft/cometbft v0.39.0-rc1.0.20260527154549-606b4197148f
+
+replace cosmossdk.io/core => ../../../core

--- a/enterprise/poa/simapp/go.mod
+++ b/enterprise/poa/simapp/go.mod
@@ -300,3 +300,5 @@ replace (
 replace github.com/cometbft/cometbft => github.com/cometbft/cometbft v0.39.0-rc1.0.20260527154549-606b4197148f
 
 replace cosmossdk.io/core => ../../../core
+
+replace cosmossdk.io/client/v2 => ../../../client/v2

--- a/enterprise/poa/tests/systemtests/go.mod
+++ b/enterprise/poa/tests/systemtests/go.mod
@@ -285,3 +285,5 @@ replace (
 )
 
 replace github.com/cometbft/cometbft => github.com/cometbft/cometbft v0.39.0-rc1.0.20260527154549-606b4197148f
+
+replace cosmossdk.io/core => ../../../../core

--- a/enterprise/poa/x/poa/autocli.go
+++ b/enterprise/poa/x/poa/autocli.go
@@ -15,17 +15,17 @@
 package poa
 
 import (
-	autocliv1 "cosmossdk.io/api/cosmos/autocli/v1"
+	autocli "cosmossdk.io/core/autocli"
 
 	poav1 "github.com/cosmos/cosmos-sdk/enterprise/poa/api/cosmos/poa/v1"
 )
 
 // AutoCLIOptions implements the autocli.HasAutoCLIConfig interface.
-func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
-	return &autocliv1.ModuleOptions{
-		Query: &autocliv1.ServiceCommandDescriptor{
+func (am AppModule) AutoCLIOptions() *autocli.ModuleOptions {
+	return &autocli.ModuleOptions{
+		Query: &autocli.ServiceCommandDescriptor{
 			Service: poav1.Query_ServiceDesc.ServiceName,
-			RpcCommandOptions: []*autocliv1.RpcCommandOptions{
+			RpcCommandOptions: []*autocli.RpcCommandOptions{
 				{
 					RpcMethod: "Params",
 					Use:       "params",
@@ -35,7 +35,7 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					RpcMethod: "Validator",
 					Use:       "validator [address]",
 					Short:     "Query a validator by consensus or operator address",
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+					PositionalArgs: []*autocli.PositionalArgDescriptor{
 						{ProtoField: "address"},
 					},
 				},
@@ -48,7 +48,7 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					RpcMethod: "WithdrawableFees",
 					Use:       "withdrawable-fees [operator-address]",
 					Short:     "Query withdrawable fees for a validator operator",
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+					PositionalArgs: []*autocli.PositionalArgDescriptor{
 						{ProtoField: "operator_address"},
 					},
 				},
@@ -59,7 +59,7 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 				},
 			},
 		},
-		Tx: &autocliv1.ServiceCommandDescriptor{
+		Tx: &autocli.ServiceCommandDescriptor{
 			Service:              poav1.Msg_ServiceDesc.ServiceName,
 			EnhanceCustomCommand: true, // Preserve custom tx commands (CreateValidator has complex pubkey handling)
 		},

--- a/go.mod
+++ b/go.mod
@@ -369,3 +369,5 @@ retract (
 )
 
 replace github.com/cometbft/cometbft => github.com/cometbft/cometbft v0.39.0-rc1.0.20260527154549-606b4197148f
+
+replace cosmossdk.io/core => ./core

--- a/runtime/autocli.go
+++ b/runtime/autocli.go
@@ -2,24 +2,25 @@ package runtime
 
 import (
 	appv1alpha1 "cosmossdk.io/api/cosmos/app/v1alpha1"
-	autocliv1 "cosmossdk.io/api/cosmos/autocli/v1"
 	reflectionv1 "cosmossdk.io/api/cosmos/reflection/v1"
+	"cosmossdk.io/core/autocli"
 )
 
-func (m appModule) AutoCLIOptions() *autocliv1.ModuleOptions {
-	return &autocliv1.ModuleOptions{
-		Query: &autocliv1.ServiceCommandDescriptor{
+func (m appModule) AutoCLIOptions() *autocli.ModuleOptions {
+	return &autocli.ModuleOptions{
+		Query: &autocli.ServiceCommandDescriptor{
 			Service: appv1alpha1.Query_ServiceDesc.ServiceName,
-			RpcCommandOptions: []*autocliv1.RpcCommandOptions{
+			RpcCommandOptions: []*autocli.RpcCommandOptions{
 				{
 					RpcMethod: "Config",
 					Short:     "Query the current app config",
 				},
 			},
-			SubCommands: map[string]*autocliv1.ServiceCommandDescriptor{
+			SubCommands: map[string]*autocli.ServiceCommandDescriptor{
 				"autocli": {
-					Service: autocliv1.Query_ServiceDesc.ServiceName,
-					RpcCommandOptions: []*autocliv1.RpcCommandOptions{
+					// cosmos.autocli.v1.Query
+					Service: "cosmos.autocli.v1.Query",
+					RpcCommandOptions: []*autocli.RpcCommandOptions{
 						{
 							RpcMethod: "AppOptions",
 							Short:     "Query the custom autocli options",
@@ -28,7 +29,7 @@ func (m appModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 				},
 				"reflection": {
 					Service: reflectionv1.ReflectionService_ServiceDesc.ServiceName,
-					RpcCommandOptions: []*autocliv1.RpcCommandOptions{
+					RpcCommandOptions: []*autocli.RpcCommandOptions{
 						{
 							RpcMethod: "FileDescriptors",
 							Short:     "Query the app's protobuf file descriptors",

--- a/runtime/autocli.go
+++ b/runtime/autocli.go
@@ -2,8 +2,9 @@ package runtime
 
 import (
 	appv1alpha1 "cosmossdk.io/api/cosmos/app/v1alpha1"
-	reflectionv1 "cosmossdk.io/api/cosmos/reflection/v1"
 	"cosmossdk.io/core/autocli"
+
+	reflectionpkg "github.com/cosmos/cosmos-sdk/runtime/services/reflection"
 )
 
 func (m appModule) AutoCLIOptions() *autocli.ModuleOptions {
@@ -18,7 +19,6 @@ func (m appModule) AutoCLIOptions() *autocli.ModuleOptions {
 			},
 			SubCommands: map[string]*autocli.ServiceCommandDescriptor{
 				"autocli": {
-					// cosmos.autocli.v1.Query
 					Service: "cosmos.autocli.v1.Query",
 					RpcCommandOptions: []*autocli.RpcCommandOptions{
 						{
@@ -28,7 +28,7 @@ func (m appModule) AutoCLIOptions() *autocli.ModuleOptions {
 					},
 				},
 				"reflection": {
-					Service: reflectionv1.ReflectionService_ServiceDesc.ServiceName,
+					Service: reflectionpkg.ServiceName,
 					RpcCommandOptions: []*autocli.RpcCommandOptions{
 						{
 							RpcMethod: "FileDescriptors",

--- a/runtime/services.go
+++ b/runtime/services.go
@@ -5,11 +5,11 @@ import (
 
 	appv1alpha1 "cosmossdk.io/api/cosmos/app/v1alpha1"
 	autocliv1 "cosmossdk.io/api/cosmos/autocli/v1"
-	reflectionv1 "cosmossdk.io/api/cosmos/reflection/v1"
 	"cosmossdk.io/core/comet"
 	"cosmossdk.io/core/header"
 
 	"github.com/cosmos/cosmos-sdk/runtime/services"
+	reflectionpkg "github.com/cosmos/cosmos-sdk/runtime/services/reflection"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 )
@@ -26,7 +26,7 @@ func (a *App) registerRuntimeServices(cfg module.Configurator) error {
 	if err != nil {
 		return err
 	}
-	reflectionv1.RegisterReflectionServiceServer(cfg.QueryServer(), reflectionSvc)
+	reflectionpkg.RegisterReflectionServiceServer(cfg.QueryServer(), reflectionSvc)
 
 	return nil
 }

--- a/runtime/services.go
+++ b/runtime/services.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	appv1alpha1 "cosmossdk.io/api/cosmos/app/v1alpha1"
-	autocliv1 "cosmossdk.io/api/cosmos/autocli/v1"
 	"cosmossdk.io/core/comet"
 	"cosmossdk.io/core/header"
 
@@ -20,7 +19,7 @@ func (a *App) registerRuntimeServices(cfg module.Configurator) error {
 	if a.appConfig != nil {
 		appv1alpha1.RegisterQueryServer(cfg.QueryServer(), services.NewAppQueryService(a.appConfig))
 	}
-	autocliv1.RegisterQueryServer(cfg.QueryServer(), services.NewAutoCLIQueryService(a.ModuleManager.Modules))
+	services.RegisterAutoCLIQueryServer(cfg.QueryServer(), services.NewAutoCLIQueryService(a.ModuleManager.Modules))
 
 	reflectionSvc, err := services.NewReflectionService()
 	if err != nil {

--- a/runtime/services/autocli.go
+++ b/runtime/services/autocli.go
@@ -10,7 +10,6 @@ import (
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/reflect/protoregistry"
 
-	autocliv1 "cosmossdk.io/api/cosmos/autocli/v1"
 	"cosmossdk.io/core/appmodule"
 	"cosmossdk.io/core/autocli"
 
@@ -20,7 +19,7 @@ import (
 
 // AutoCLIQueryService implements the cosmos.autocli.v1.Query service.
 type AutoCLIQueryService struct {
-	autocliv1.UnimplementedQueryServer
+	UnimplementedAutoCLIQueryServer
 
 	moduleOptions map[string]*autocli.ModuleOptions
 }
@@ -49,8 +48,6 @@ func ExtractAutoCLIOptions(appModules map[string]any) map[string]*autocli.Module
 
 		cfg := &autocliConfigurator{}
 
-		// try to auto-discover options based on the last msg and query
-		// services registered for the module
 		if mod, ok := mod.(module.HasServices); ok {
 			mod.RegisterServices(cfg)
 		}
@@ -62,7 +59,6 @@ func ExtractAutoCLIOptions(appModules map[string]any) map[string]*autocli.Module
 			}
 		}
 
-		// check for errors in the configurator
 		if cfg.Error() != nil {
 			panic(cfg.Error())
 		}
@@ -90,93 +86,11 @@ func ExtractAutoCLIOptions(appModules map[string]any) map[string]*autocli.Module
 	return moduleOptions
 }
 
-func (a AutoCLIQueryService) AppOptions(context.Context, *autocliv1.AppOptionsRequest) (*autocliv1.AppOptionsResponse, error) {
-	return &autocliv1.AppOptionsResponse{
-		ModuleOptions: toProtoModuleOptions(a.moduleOptions),
-	}, nil
+func (a AutoCLIQueryService) AppOptions(_ context.Context, _ *AppOptionsRequest) (*AppOptionsResponse, error) {
+	return &AppOptionsResponse{ModuleOptions: a.moduleOptions}, nil
 }
 
-// toProtoModuleOptions converts Go-native autocli options to the pulsar proto
-// types required by the gRPC AppOptions endpoint. This is the only place in
-// the codebase where that conversion is needed.
-func toProtoModuleOptions(opts map[string]*autocli.ModuleOptions) map[string]*autocliv1.ModuleOptions {
-	result := make(map[string]*autocliv1.ModuleOptions, len(opts))
-	for name, opt := range opts {
-		if opt == nil {
-			continue
-		}
-		result[name] = &autocliv1.ModuleOptions{
-			Tx:    toProtoServiceDesc(opt.Tx),
-			Query: toProtoServiceDesc(opt.Query),
-		}
-	}
-	return result
-}
-
-func toProtoServiceDesc(d *autocli.ServiceCommandDescriptor) *autocliv1.ServiceCommandDescriptor {
-	if d == nil {
-		return nil
-	}
-	proto := &autocliv1.ServiceCommandDescriptor{
-		Service:              d.Service,
-		EnhanceCustomCommand: d.EnhanceCustomCommand,
-		Short:                d.Short,
-	}
-	for _, opt := range d.RpcCommandOptions {
-		proto.RpcCommandOptions = append(proto.RpcCommandOptions, toProtoRpcOpts(opt))
-	}
-	if len(d.SubCommands) > 0 {
-		proto.SubCommands = make(map[string]*autocliv1.ServiceCommandDescriptor, len(d.SubCommands))
-		for k, v := range d.SubCommands {
-			proto.SubCommands[k] = toProtoServiceDesc(v)
-		}
-	}
-	return proto
-}
-
-func toProtoRpcOpts(o *autocli.RpcCommandOptions) *autocliv1.RpcCommandOptions {
-	if o == nil {
-		return nil
-	}
-	proto := &autocliv1.RpcCommandOptions{
-		RpcMethod:   o.RpcMethod,
-		Use:         o.Use,
-		Long:        o.Long,
-		Short:       o.Short,
-		Example:     o.Example,
-		Alias:       o.Alias,
-		SuggestFor:  o.SuggestFor,
-		Deprecated:  o.Deprecated,
-		Version:     o.Version,
-		Skip:        o.Skip,
-		GovProposal: o.GovProposal,
-	}
-	for _, p := range o.PositionalArgs {
-		proto.PositionalArgs = append(proto.PositionalArgs, &autocliv1.PositionalArgDescriptor{
-			ProtoField: p.ProtoField,
-			Varargs:    p.Varargs,
-			Optional:   p.Optional,
-		})
-	}
-	if len(o.FlagOptions) > 0 {
-		proto.FlagOptions = make(map[string]*autocliv1.FlagOptions, len(o.FlagOptions))
-		for k, f := range o.FlagOptions {
-			if f == nil {
-				continue
-			}
-			proto.FlagOptions[k] = &autocliv1.FlagOptions{
-				Name:                f.Name,
-				Shorthand:           f.Shorthand,
-				Usage:               f.Usage,
-				DefaultValue:        f.DefaultValue,
-				Deprecated:          f.Deprecated,
-				ShorthandDeprecated: f.ShorthandDeprecated,
-				Hidden:              f.Hidden,
-			}
-		}
-	}
-	return proto
-}
+var _ AutoCLIQueryServer = &AutoCLIQueryService{}
 
 // autocliConfigurator allows us to call RegisterServices and introspect the services
 type autocliConfigurator struct {
@@ -213,6 +127,7 @@ func (a *autocliConfigurator) RegisterService(sd *grpc.ServiceDesc, ss any) {
 		a.queryServer.RegisterService(sd, ss)
 	}
 }
+
 func (a *autocliConfigurator) Error() error { return nil }
 
 // autocliServiceRegistrar is used to capture the service name for registered services
@@ -223,5 +138,3 @@ type autocliServiceRegistrar struct {
 func (a *autocliServiceRegistrar) RegisterService(sd *grpc.ServiceDesc, _ any) {
 	a.serviceName = sd.ServiceName
 }
-
-var _ autocliv1.QueryServer = &AutoCLIQueryService{}

--- a/runtime/services/autocli.go
+++ b/runtime/services/autocli.go
@@ -13,6 +13,7 @@ import (
 	autocliv1 "cosmossdk.io/api/cosmos/autocli/v1"
 	cosmosmsg "cosmossdk.io/api/cosmos/msg/v1"
 	"cosmossdk.io/core/appmodule"
+	"cosmossdk.io/core/autocli"
 
 	"github.com/cosmos/cosmos-sdk/types/module"
 )
@@ -21,7 +22,7 @@ import (
 type AutoCLIQueryService struct {
 	autocliv1.UnimplementedQueryServer
 
-	moduleOptions map[string]*autocliv1.ModuleOptions
+	moduleOptions map[string]*autocli.ModuleOptions
 }
 
 // NewAutoCLIQueryService returns a AutoCLIQueryService for the provided modules.
@@ -36,11 +37,11 @@ func NewAutoCLIQueryService(appModules map[string]any) *AutoCLIQueryService {
 // Example Usage:
 //
 //	ExtractAutoCLIOptions(ModuleManager.Modules)
-func ExtractAutoCLIOptions(appModules map[string]any) map[string]*autocliv1.ModuleOptions {
-	moduleOptions := map[string]*autocliv1.ModuleOptions{}
+func ExtractAutoCLIOptions(appModules map[string]any) map[string]*autocli.ModuleOptions {
+	moduleOptions := map[string]*autocli.ModuleOptions{}
 	for modName, mod := range appModules {
 		if autoCliMod, ok := mod.(interface {
-			AutoCLIOptions() *autocliv1.ModuleOptions
+			AutoCLIOptions() *autocli.ModuleOptions
 		}); ok {
 			moduleOptions[modName] = autoCliMod.AutoCLIOptions()
 			continue
@@ -67,17 +68,17 @@ func ExtractAutoCLIOptions(appModules map[string]any) map[string]*autocliv1.Modu
 		}
 
 		haveServices := false
-		modOptions := &autocliv1.ModuleOptions{}
+		modOptions := &autocli.ModuleOptions{}
 		if cfg.msgServer.serviceName != "" {
 			haveServices = true
-			modOptions.Tx = &autocliv1.ServiceCommandDescriptor{
+			modOptions.Tx = &autocli.ServiceCommandDescriptor{
 				Service: cfg.msgServer.serviceName,
 			}
 		}
 
 		if cfg.queryServer.serviceName != "" {
 			haveServices = true
-			modOptions.Query = &autocliv1.ServiceCommandDescriptor{
+			modOptions.Query = &autocli.ServiceCommandDescriptor{
 				Service: cfg.queryServer.serviceName,
 			}
 		}
@@ -91,8 +92,90 @@ func ExtractAutoCLIOptions(appModules map[string]any) map[string]*autocliv1.Modu
 
 func (a AutoCLIQueryService) AppOptions(context.Context, *autocliv1.AppOptionsRequest) (*autocliv1.AppOptionsResponse, error) {
 	return &autocliv1.AppOptionsResponse{
-		ModuleOptions: a.moduleOptions,
+		ModuleOptions: toProtoModuleOptions(a.moduleOptions),
 	}, nil
+}
+
+// toProtoModuleOptions converts Go-native autocli options to the pulsar proto
+// types required by the gRPC AppOptions endpoint. This is the only place in
+// the codebase where that conversion is needed.
+func toProtoModuleOptions(opts map[string]*autocli.ModuleOptions) map[string]*autocliv1.ModuleOptions {
+	result := make(map[string]*autocliv1.ModuleOptions, len(opts))
+	for name, opt := range opts {
+		if opt == nil {
+			continue
+		}
+		result[name] = &autocliv1.ModuleOptions{
+			Tx:    toProtoServiceDesc(opt.Tx),
+			Query: toProtoServiceDesc(opt.Query),
+		}
+	}
+	return result
+}
+
+func toProtoServiceDesc(d *autocli.ServiceCommandDescriptor) *autocliv1.ServiceCommandDescriptor {
+	if d == nil {
+		return nil
+	}
+	proto := &autocliv1.ServiceCommandDescriptor{
+		Service:              d.Service,
+		EnhanceCustomCommand: d.EnhanceCustomCommand,
+		Short:                d.Short,
+	}
+	for _, opt := range d.RpcCommandOptions {
+		proto.RpcCommandOptions = append(proto.RpcCommandOptions, toProtoRpcOpts(opt))
+	}
+	if len(d.SubCommands) > 0 {
+		proto.SubCommands = make(map[string]*autocliv1.ServiceCommandDescriptor, len(d.SubCommands))
+		for k, v := range d.SubCommands {
+			proto.SubCommands[k] = toProtoServiceDesc(v)
+		}
+	}
+	return proto
+}
+
+func toProtoRpcOpts(o *autocli.RpcCommandOptions) *autocliv1.RpcCommandOptions {
+	if o == nil {
+		return nil
+	}
+	proto := &autocliv1.RpcCommandOptions{
+		RpcMethod:   o.RpcMethod,
+		Use:         o.Use,
+		Long:        o.Long,
+		Short:       o.Short,
+		Example:     o.Example,
+		Alias:       o.Alias,
+		SuggestFor:  o.SuggestFor,
+		Deprecated:  o.Deprecated,
+		Version:     o.Version,
+		Skip:        o.Skip,
+		GovProposal: o.GovProposal,
+	}
+	for _, p := range o.PositionalArgs {
+		proto.PositionalArgs = append(proto.PositionalArgs, &autocliv1.PositionalArgDescriptor{
+			ProtoField: p.ProtoField,
+			Varargs:    p.Varargs,
+			Optional:   p.Optional,
+		})
+	}
+	if len(o.FlagOptions) > 0 {
+		proto.FlagOptions = make(map[string]*autocliv1.FlagOptions, len(o.FlagOptions))
+		for k, f := range o.FlagOptions {
+			if f == nil {
+				continue
+			}
+			proto.FlagOptions[k] = &autocliv1.FlagOptions{
+				Name:                f.Name,
+				Shorthand:           f.Shorthand,
+				Usage:               f.Usage,
+				DefaultValue:        f.DefaultValue,
+				Deprecated:          f.Deprecated,
+				ShorthandDeprecated: f.ShorthandDeprecated,
+				Hidden:              f.Hidden,
+			}
+		}
+	}
+	return proto
 }
 
 // autocliConfigurator allows us to call RegisterServices and introspect the services

--- a/runtime/services/autocli.go
+++ b/runtime/services/autocli.go
@@ -11,11 +11,11 @@ import (
 	"google.golang.org/protobuf/reflect/protoregistry"
 
 	autocliv1 "cosmossdk.io/api/cosmos/autocli/v1"
-	cosmosmsg "cosmossdk.io/api/cosmos/msg/v1"
 	"cosmossdk.io/core/appmodule"
 	"cosmossdk.io/core/autocli"
 
 	"github.com/cosmos/cosmos-sdk/types/module"
+	cosmosmsg "github.com/cosmos/cosmos-sdk/types/msgservice"
 )
 
 // AutoCLIQueryService implements the cosmos.autocli.v1.Query service.
@@ -207,7 +207,7 @@ func (a *autocliConfigurator) RegisterService(sd *grpc.ServiceDesc, ss any) {
 		return
 	}
 
-	if protobuf.HasExtension(desc.Options(), cosmosmsg.E_Service) {
+	if protobuf.HasExtension(desc.Options(), cosmosmsg.E_ServiceV2) {
 		a.msgServer.RegisterService(sd, ss)
 	} else {
 		a.queryServer.RegisterService(sd, ss)

--- a/runtime/services/autocli_grpc.go
+++ b/runtime/services/autocli_grpc.go
@@ -1,0 +1,87 @@
+package services
+
+import (
+	"context"
+
+	gogoproto "github.com/cosmos/gogoproto/proto"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"cosmossdk.io/core/autocli"
+)
+
+// AutoCLI gRPC service stubs for cosmos.autocli.v1.Query without importing
+// cosmossdk.io/api/cosmos/autocli/v1 (pulsar).
+
+const autoCLIQueryServiceName = "cosmos.autocli.v1.Query"
+
+// AppOptionsRequest is the request type for cosmos.autocli.v1.Query/AppOptions.
+type AppOptionsRequest struct{}
+
+func (*AppOptionsRequest) Reset()         {}
+func (*AppOptionsRequest) String() string { return "AppOptionsRequest{}" }
+func (*AppOptionsRequest) ProtoMessage()  {}
+
+// AppOptionsResponse is the response type for cosmos.autocli.v1.Query/AppOptions.
+type AppOptionsResponse struct {
+	ModuleOptions map[string]*autocli.ModuleOptions `protobuf:"bytes,1,rep,name=module_options,json=moduleOptions,proto3" json:"module_options,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
+}
+
+func (*AppOptionsResponse) Reset()         {}
+func (*AppOptionsResponse) String() string { return "AppOptionsResponse{}" }
+func (*AppOptionsResponse) ProtoMessage()  {}
+
+func init() {
+	gogoproto.RegisterType((*AppOptionsRequest)(nil), "cosmos.autocli.v1.AppOptionsRequest")
+	gogoproto.RegisterType((*AppOptionsResponse)(nil), "cosmos.autocli.v1.AppOptionsResponse")
+}
+
+// AutoCLIQueryServer is the server interface for the autocli query service.
+type AutoCLIQueryServer interface {
+	AppOptions(context.Context, *AppOptionsRequest) (*AppOptionsResponse, error)
+}
+
+// UnimplementedAutoCLIQueryServer must be embedded for forward compatibility.
+type UnimplementedAutoCLIQueryServer struct{}
+
+func (UnimplementedAutoCLIQueryServer) AppOptions(context.Context, *AppOptionsRequest) (*AppOptionsResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method AppOptions not implemented")
+}
+
+// RegisterAutoCLIQueryServer registers the AutoCLI query server with the gRPC registrar.
+func RegisterAutoCLIQueryServer(s grpc.ServiceRegistrar, srv AutoCLIQueryServer) {
+	s.RegisterService(&AutoCLIQuery_ServiceDesc, srv)
+}
+
+// AutoCLIQuery_ServiceDesc is the grpc.ServiceDesc for the autocli query service.
+var AutoCLIQuery_ServiceDesc = grpc.ServiceDesc{
+	ServiceName: autoCLIQueryServiceName,
+	HandlerType: (*AutoCLIQueryServer)(nil),
+	Methods: []grpc.MethodDesc{
+		{
+			MethodName: "AppOptions",
+			Handler:    _AutoCLIQuery_AppOptions_Handler,
+		},
+	},
+	Streams:  []grpc.StreamDesc{},
+	Metadata: "cosmos/autocli/v1/query.proto",
+}
+
+func _AutoCLIQuery_AppOptions_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
+	in := new(AppOptionsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(AutoCLIQueryServer).AppOptions(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/" + autoCLIQueryServiceName + "/AppOptions",
+	}
+	handler := func(ctx context.Context, req any) (any, error) {
+		return srv.(AutoCLIQueryServer).AppOptions(ctx, req.(*AppOptionsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}

--- a/runtime/services/reflection.go
+++ b/runtime/services/reflection.go
@@ -3,31 +3,31 @@ package services
 import (
 	"context"
 
-	"github.com/cosmos/gogoproto/proto"
+	gogoproto "github.com/cosmos/gogoproto/proto"
 	"google.golang.org/protobuf/types/descriptorpb"
 
-	reflectionv1 "cosmossdk.io/api/cosmos/reflection/v1"
+	reflectionpkg "github.com/cosmos/cosmos-sdk/runtime/services/reflection"
 )
 
 // ReflectionService implements the cosmos.reflection.v1 service.
 type ReflectionService struct {
-	reflectionv1.UnimplementedReflectionServiceServer
-	files *descriptorpb.FileDescriptorSet
+	reflectionpkg.UnimplementedServiceServer
+	files []*descriptorpb.FileDescriptorProto
 }
 
 func NewReflectionService() (*ReflectionService, error) {
-	fds, err := proto.MergedGlobalFileDescriptors()
+	fds, err := gogoproto.MergedGlobalFileDescriptors()
 	if err != nil {
 		return nil, err
 	}
 
-	return &ReflectionService{files: fds}, nil
+	return &ReflectionService{files: fds.File}, nil
 }
 
-func (r ReflectionService) FileDescriptors(_ context.Context, _ *reflectionv1.FileDescriptorsRequest) (*reflectionv1.FileDescriptorsResponse, error) {
-	return &reflectionv1.FileDescriptorsResponse{
-		Files: r.files.File,
+func (r ReflectionService) FileDescriptors(_ context.Context, _ *reflectionpkg.FileDescriptorsRequest) (*reflectionpkg.FileDescriptorsResponse, error) {
+	return &reflectionpkg.FileDescriptorsResponse{
+		Files: r.files,
 	}, nil
 }
 
-var _ reflectionv1.ReflectionServiceServer = &ReflectionService{}
+var _ reflectionpkg.ServiceServer = &ReflectionService{}

--- a/runtime/services/reflection/reflection.go
+++ b/runtime/services/reflection/reflection.go
@@ -1,0 +1,91 @@
+// Package reflection provides the cosmos.reflection.v1.ReflectionService gRPC
+// implementation without depending on cosmossdk.io/api/cosmos/reflection/v1.
+package reflection
+
+import (
+	"context"
+	"fmt"
+
+	gogoproto "github.com/cosmos/gogoproto/proto"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/descriptorpb"
+)
+
+// ServiceName is the fully-qualified name of the ReflectionService.
+const ServiceName = "cosmos.reflection.v1.ReflectionService"
+
+// FileDescriptorsRequest is the request type for FileDescriptors.
+// It mirrors cosmos.reflection.v1.FileDescriptorsRequest (empty message).
+type FileDescriptorsRequest struct{}
+
+func (r *FileDescriptorsRequest) Reset()         {}
+func (r *FileDescriptorsRequest) String() string { return "FileDescriptorsRequest{}" }
+func (r *FileDescriptorsRequest) ProtoMessage()  {}
+
+// FileDescriptorsResponse is the response type for FileDescriptors.
+// It mirrors cosmos.reflection.v1.FileDescriptorsResponse.
+type FileDescriptorsResponse struct {
+	Files []*descriptorpb.FileDescriptorProto
+}
+
+func (r *FileDescriptorsResponse) Reset() {}
+func (r *FileDescriptorsResponse) String() string {
+	return fmt.Sprintf("FileDescriptorsResponse{Files: %d}", len(r.Files))
+}
+func (r *FileDescriptorsResponse) ProtoMessage() {}
+
+// ServiceServer is the server API for the cosmos.reflection.v1.ReflectionService.
+type ServiceServer interface {
+	FileDescriptors(context.Context, *FileDescriptorsRequest) (*FileDescriptorsResponse, error)
+}
+
+// UnimplementedServiceServer must be embedded for forward compatibility.
+type UnimplementedServiceServer struct{}
+
+func (UnimplementedServiceServer) FileDescriptors(context.Context, *FileDescriptorsRequest) (*FileDescriptorsResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method FileDescriptors not implemented")
+}
+
+// RegisterReflectionServiceServer registers srv with the gRPC service registrar.
+func RegisterReflectionServiceServer(s grpc.ServiceRegistrar, srv ServiceServer) {
+	s.RegisterService(&ReflectionService_ServiceDesc, srv)
+}
+
+// ReflectionService_ServiceDesc is the grpc.ServiceDesc for ReflectionService.
+var ReflectionService_ServiceDesc = grpc.ServiceDesc{
+	ServiceName: ServiceName,
+	HandlerType: (*ServiceServer)(nil),
+	Methods: []grpc.MethodDesc{
+		{
+			MethodName: "FileDescriptors",
+			Handler:    _ReflectionService_FileDescriptors_Handler,
+		},
+	},
+	Streams:  []grpc.StreamDesc{},
+	Metadata: "cosmos/reflection/v1/reflection.proto",
+}
+
+func _ReflectionService_FileDescriptors_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
+	in := new(FileDescriptorsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ServiceServer).FileDescriptors(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/cosmos.reflection.v1.ReflectionService/FileDescriptors",
+	}
+	handler := func(ctx context.Context, req any) (any, error) {
+		return srv.(ServiceServer).FileDescriptors(ctx, req.(*FileDescriptorsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func init() {
+	gogoproto.RegisterType((*FileDescriptorsRequest)(nil), "cosmos.reflection.v1.FileDescriptorsRequest")
+	gogoproto.RegisterType((*FileDescriptorsResponse)(nil), "cosmos.reflection.v1.FileDescriptorsResponse")
+}

--- a/server/mock/tx.go
+++ b/server/mock/tx.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 
 	protov2 "google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/reflect/protoregistry"
+	"google.golang.org/protobuf/types/dynamicpb"
 
-	bankv1beta1 "cosmossdk.io/api/cosmos/bank/v1beta1"
 	errorsmod "cosmossdk.io/errors"
 
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
@@ -103,7 +105,17 @@ func (msg *KVStoreTx) GetMsgs() []sdk.Msg {
 }
 
 func (msg *KVStoreTx) GetMsgsV2() ([]protov2.Message, error) {
-	return []protov2.Message{&bankv1beta1.MsgSend{FromAddress: msg.address.String()}}, nil // this is a hack for tests
+	// Build a dynamic cosmos.bank.v1beta1.MsgSend without importing the pulsar type.
+	mt, err := protoregistry.GlobalTypes.FindMessageByName("cosmos.bank.v1beta1.MsgSend")
+	if err != nil {
+		return nil, err
+	}
+	dynMsg := dynamicpb.NewMessage(mt.Descriptor())
+	if f := mt.Descriptor().Fields().ByName("from_address"); f != nil {
+		dynMsg.Set(f, dynMsg.NewField(f))
+		dynMsg.Set(f, protoreflect.ValueOfString(msg.address.String()))
+	}
+	return []protov2.Message{dynMsg}, nil
 }
 
 func (msg *KVStoreTx) GetSignBytes() []byte {

--- a/simapp/app.go
+++ b/simapp/app.go
@@ -10,7 +10,6 @@ import (
 	"github.com/cosmos/gogoproto/proto"
 	"github.com/spf13/cast"
 
-	autocliv1 "cosmossdk.io/api/cosmos/autocli/v1"
 	reflectionv1 "cosmossdk.io/api/cosmos/reflection/v1"
 	"cosmossdk.io/client/v2/autocli"
 	clienthelpers "cosmossdk.io/client/v2/helpers"
@@ -563,7 +562,7 @@ func NewSimApp(
 	// Make sure it's called after `app.ModuleManager` and `app.configurator` are set.
 	app.RegisterUpgradeHandlers()
 
-	autocliv1.RegisterQueryServer(app.GRPCQueryRouter(), runtimeservices.NewAutoCLIQueryService(app.ModuleManager.Modules))
+	autocli.RegisterQueryServer(app.GRPCQueryRouter(), runtimeservices.NewAutoCLIQueryService(app.ModuleManager.Modules))
 
 	reflectionSvc, err := runtimeservices.NewReflectionService()
 	if err != nil {

--- a/simapp/app.go
+++ b/simapp/app.go
@@ -10,7 +10,7 @@ import (
 	"github.com/cosmos/gogoproto/proto"
 	"github.com/spf13/cast"
 
-	reflectionv1 "cosmossdk.io/api/cosmos/reflection/v1"
+	reflectionpkg "github.com/cosmos/cosmos-sdk/runtime/services/reflection"
 	"cosmossdk.io/client/v2/autocli"
 	clienthelpers "cosmossdk.io/client/v2/helpers"
 	"cosmossdk.io/core/appmodule"
@@ -568,7 +568,7 @@ func NewSimApp(
 	if err != nil {
 		panic(err)
 	}
-	reflectionv1.RegisterReflectionServiceServer(app.GRPCQueryRouter(), reflectionSvc)
+	reflectionpkg.RegisterReflectionServiceServer(app.GRPCQueryRouter(), reflectionSvc)
 
 	// add test gRPC service for testing gRPC queries in isolation
 	testdata_pulsar.RegisterQueryServer(app.GRPCQueryRouter(), testdata_pulsar.QueryImpl{})

--- a/simapp/go.mod
+++ b/simapp/go.mod
@@ -348,3 +348,5 @@ replace (
 replace github.com/cometbft/cometbft => github.com/cometbft/cometbft v0.39.0-rc1.0.20260527154549-606b4197148f
 
 replace cosmossdk.io/core => ../core
+
+replace cosmossdk.io/client/v2 => ../client/v2

--- a/simapp/go.mod
+++ b/simapp/go.mod
@@ -346,3 +346,5 @@ replace (
 )
 
 replace github.com/cometbft/cometbft => github.com/cometbft/cometbft v0.39.0-rc1.0.20260527154549-606b4197148f
+
+replace cosmossdk.io/core => ../core

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -348,3 +348,5 @@ replace (
 replace github.com/cometbft/cometbft => github.com/cometbft/cometbft v0.39.0-rc1.0.20260527154549-606b4197148f
 
 replace cosmossdk.io/core => ../core
+
+replace cosmossdk.io/client/v2 => ../client/v2

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -346,3 +346,5 @@ replace (
 )
 
 replace github.com/cometbft/cometbft => github.com/cometbft/cometbft v0.39.0-rc1.0.20260527154549-606b4197148f
+
+replace cosmossdk.io/core => ../core

--- a/tests/integration/tx/aminojson/aminojson_test.go
+++ b/tests/integration/tx/aminojson/aminojson_test.go
@@ -30,7 +30,7 @@ import (
 	msgv1 "cosmossdk.io/api/cosmos/msg/v1"
 	slashingapi "cosmossdk.io/api/cosmos/slashing/v1beta1"
 	stakingapi "cosmossdk.io/api/cosmos/staking/v1beta1"
-	txv1beta1 "cosmossdk.io/api/cosmos/tx/v1beta1"
+	txsigning "github.com/cosmos/cosmos-sdk/x/tx/signing"
 	vestingapi "cosmossdk.io/api/cosmos/vesting/v1beta1"
 	"cosmossdk.io/math"
 
@@ -149,8 +149,8 @@ func TestAminoJSON_Equivalence(t *testing.T) {
 					AccNum:        1,
 					AccSeq:        2,
 					SignerAddress: "signerAddress",
-					Fee: &txv1beta1.Fee{
-						Amount: []*v1beta1.Coin{{Denom: "uatom", Amount: "1000"}},
+					Fee: &txsigning.TxFeeData{
+						Amount: []txsigning.TxCoinData{{Denom: "uatom", Amount: "1000"}},
 					},
 				}
 
@@ -469,8 +469,8 @@ func TestAminoJSON_LegacyParity(t *testing.T) {
 				AccNum:        1,
 				AccSeq:        2,
 				SignerAddress: "signerAddress",
-				Fee: &txv1beta1.Fee{
-					Amount: []*v1beta1.Coin{{Denom: "uatom", Amount: "1000"}},
+				Fee: &txsigning.TxFeeData{
+					Amount: []txsigning.TxCoinData{{Denom: "uatom", Amount: "1000"}},
 				},
 			}
 

--- a/tests/systemtests/go.mod
+++ b/tests/systemtests/go.mod
@@ -284,3 +284,5 @@ require (
 )
 
 replace github.com/cometbft/cometbft => github.com/cometbft/cometbft v0.39.0-rc1.0.20260527154549-606b4197148f
+
+replace cosmossdk.io/core => ../../core

--- a/testutil/x/counter/autocli.go
+++ b/testutil/x/counter/autocli.go
@@ -1,16 +1,16 @@
 package counter
 
 import (
-	autocliv1 "cosmossdk.io/api/cosmos/autocli/v1"
 	counterv1 "cosmossdk.io/api/cosmos/counter/v1"
+	autocli "cosmossdk.io/core/autocli"
 )
 
 // AutoCLIOptions implements the autocli.HasAutoCLIConfig interface.
-func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
-	return &autocliv1.ModuleOptions{
-		Query: &autocliv1.ServiceCommandDescriptor{
+func (am AppModule) AutoCLIOptions() *autocli.ModuleOptions {
+	return &autocli.ModuleOptions{
+		Query: &autocli.ServiceCommandDescriptor{
 			Service: counterv1.Query_ServiceDesc.ServiceName,
-			RpcCommandOptions: []*autocliv1.RpcCommandOptions{
+			RpcCommandOptions: []*autocli.RpcCommandOptions{
 				{
 					RpcMethod: "GetCount",
 					Use:       "count",
@@ -18,15 +18,15 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 				},
 			},
 		},
-		Tx: &autocliv1.ServiceCommandDescriptor{
+		Tx: &autocli.ServiceCommandDescriptor{
 			Service: counterv1.Msg_ServiceDesc.ServiceName,
-			RpcCommandOptions: []*autocliv1.RpcCommandOptions{
+			RpcCommandOptions: []*autocli.RpcCommandOptions{
 				{
 					RpcMethod:      "IncreaseCount",
 					Use:            "increase-count <count>",
 					Alias:          []string{"increase-counter", "increase", "inc", "bump"},
 					Short:          "Increase the counter by the specified amount",
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{{ProtoField: "count"}},
+					PositionalArgs: []*autocli.PositionalArgDescriptor{{ProtoField: "count"}},
 				},
 			},
 		},

--- a/tools/confix/go.mod
+++ b/tools/confix/go.mod
@@ -278,3 +278,5 @@ require (
 replace github.com/cosmos/cosmos-sdk => ../..
 
 replace github.com/cometbft/cometbft => github.com/cometbft/cometbft v0.39.0-rc1.0.20260527154549-606b4197148f
+
+replace cosmossdk.io/core => ../../core

--- a/tools/systemtests/go.mod
+++ b/tools/systemtests/go.mod
@@ -287,3 +287,5 @@ replace (
 )
 
 replace github.com/cometbft/cometbft => github.com/cometbft/cometbft v0.39.0-rc1.0.20260527154549-606b4197148f
+
+replace cosmossdk.io/core => ../../core

--- a/types/module/configurator.go
+++ b/types/module/configurator.go
@@ -8,12 +8,12 @@ import (
 	protobuf "google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
 
-	cosmosmsg "cosmossdk.io/api/cosmos/msg/v1"
 	errorsmod "cosmossdk.io/errors"
 
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	cosmosmsg "github.com/cosmos/cosmos-sdk/types/msgservice"
 )
 
 // Configurator provides the hooks to allow modules to configure and register
@@ -66,7 +66,7 @@ func (c *configurator) RegisterService(sd *googlegrpc.ServiceDesc, ss any) {
 		return
 	}
 
-	if protobuf.HasExtension(desc.Options(), cosmosmsg.E_Service) {
+	if protobuf.HasExtension(desc.Options(), cosmosmsg.E_ServiceV2) {
 		c.msgServer.RegisterService(sd, ss)
 	} else {
 		c.queryServer.RegisterService(sd, ss)

--- a/types/msgservice/extensions_v2.go
+++ b/types/msgservice/extensions_v2.go
@@ -1,0 +1,33 @@
+package msgservice
+
+import (
+	"google.golang.org/protobuf/runtime/protoimpl"
+	descriptorpb "google.golang.org/protobuf/types/descriptorpb"
+)
+
+// E_ServiceV2 and E_SignerV2 are protov2-compatible (protoimpl.ExtensionInfo)
+// equivalents of E_Service and E_Signer. Use these with
+// google.golang.org/protobuf/proto.HasExtension / proto.GetExtension.
+//
+// The underlying proto field numbers and semantics are identical to the
+// pulsar-generated cosmossdk.io/api/cosmos/msg/v1 extensions; the file
+// descriptor is registered by the gogoproto msg.pb.go init().
+var (
+	E_ServiceV2 = &protoimpl.ExtensionInfo{
+		ExtendedType:  (*descriptorpb.ServiceOptions)(nil),
+		ExtensionType: (*bool)(nil),
+		Field:         11110000,
+		Name:          "cosmos.msg.v1.service",
+		Tag:           "varint,11110000,opt,name=service",
+		Filename:      "cosmos/msg/v1/msg.proto",
+	}
+
+	E_SignerV2 = &protoimpl.ExtensionInfo{
+		ExtendedType:  (*descriptorpb.MessageOptions)(nil),
+		ExtensionType: (*[]string)(nil),
+		Field:         11110000,
+		Name:          "cosmos.msg.v1.signer",
+		Tag:           "bytes,11110000,rep,name=signer",
+		Filename:      "cosmos/msg/v1/msg.proto",
+	}
+)

--- a/types/msgservice/validate.go
+++ b/types/msgservice/validate.go
@@ -8,8 +8,6 @@ import (
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/reflect/protoregistry"
 
-	msg "cosmossdk.io/api/cosmos/msg/v1"
-
 	"github.com/cosmos/cosmos-sdk/x/tx/signing"
 )
 
@@ -48,7 +46,7 @@ func ValidateProtoAnnotations(protoFiles signing.ProtoFileResolver) error {
 // validateMsgServiceAnnotations validates that the service has the
 // `(cosmos.msg.v1.service) = true` proto annotation.
 func validateMsgServiceAnnotations(sd protoreflect.ServiceDescriptor) error {
-	ext := proto.GetExtension(sd.Options(), msg.E_Service)
+	ext := proto.GetExtension(sd.Options(), E_ServiceV2)
 	isService, ok := ext.(bool)
 	if !ok {
 		return fmt.Errorf("expected bool, got %T", ext)

--- a/x/auth/autocli.go
+++ b/x/auth/autocli.go
@@ -4,19 +4,19 @@ import (
 	"fmt"
 
 	authv1beta1 "cosmossdk.io/api/cosmos/auth/v1beta1"
-	autocliv1 "cosmossdk.io/api/cosmos/autocli/v1"
 	_ "cosmossdk.io/api/cosmos/crypto/secp256k1" // register so that it shows up in protoregistry.GlobalTypes
 	_ "cosmossdk.io/api/cosmos/crypto/secp256r1" // register so that it shows up in protoregistry.GlobalTypes
+	autocli "cosmossdk.io/core/autocli"
 
 	"github.com/cosmos/cosmos-sdk/version"
 )
 
 // AutoCLIOptions implements the autocli.HasAutoCLIConfig interface.
-func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
-	return &autocliv1.ModuleOptions{
-		Query: &autocliv1.ServiceCommandDescriptor{
+func (am AppModule) AutoCLIOptions() *autocli.ModuleOptions {
+	return &autocli.ModuleOptions{
+		Query: &autocli.ServiceCommandDescriptor{
 			Service: authv1beta1.Query_ServiceDesc.ServiceName,
-			RpcCommandOptions: []*autocliv1.RpcCommandOptions{
+			RpcCommandOptions: []*autocli.RpcCommandOptions{
 				{
 					RpcMethod: "Accounts",
 					Use:       "accounts",
@@ -26,19 +26,19 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					RpcMethod:      "Account",
 					Use:            "account [address]",
 					Short:          "Query account by address",
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{{ProtoField: "address"}},
+					PositionalArgs: []*autocli.PositionalArgDescriptor{{ProtoField: "address"}},
 				},
 				{
 					RpcMethod:      "AccountInfo",
 					Use:            "account-info [address]",
 					Short:          "Query account info which is common to all account types.",
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{{ProtoField: "address"}},
+					PositionalArgs: []*autocli.PositionalArgDescriptor{{ProtoField: "address"}},
 				},
 				{
 					RpcMethod:      "AccountAddressByID",
 					Use:            "address-by-acc-num [acc-num]",
 					Short:          "Query account address by account number",
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{{ProtoField: "account_id"}},
+					PositionalArgs: []*autocli.PositionalArgDescriptor{{ProtoField: "account_id"}},
 				},
 				{
 					RpcMethod: "ModuleAccounts",
@@ -50,19 +50,19 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					Use:            "module-account [module-name]",
 					Short:          "Query module account info by module name",
 					Example:        fmt.Sprintf("%s q auth module-account gov", version.AppName),
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{{ProtoField: "name"}},
+					PositionalArgs: []*autocli.PositionalArgDescriptor{{ProtoField: "name"}},
 				},
 				{
 					RpcMethod:      "AddressBytesToString",
 					Use:            "address-bytes-to-string [address-bytes]",
 					Short:          "Transform an address bytes to string",
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{{ProtoField: "address_bytes"}},
+					PositionalArgs: []*autocli.PositionalArgDescriptor{{ProtoField: "address_bytes"}},
 				},
 				{
 					RpcMethod:      "AddressStringToBytes",
 					Use:            "address-string-to-bytes [address-string]",
 					Short:          "Transform an address string to bytes",
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{{ProtoField: "address_string"}},
+					PositionalArgs: []*autocli.PositionalArgDescriptor{{ProtoField: "address_string"}},
 				},
 				{
 					RpcMethod: "Bech32Prefix",
@@ -76,15 +76,15 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 				},
 			},
 		},
-		Tx: &autocliv1.ServiceCommandDescriptor{
+		Tx: &autocli.ServiceCommandDescriptor{
 			Service: authv1beta1.Msg_ServiceDesc.ServiceName,
-			RpcCommandOptions: []*autocliv1.RpcCommandOptions{
+			RpcCommandOptions: []*autocli.RpcCommandOptions{
 				{
 					RpcMethod:      "UpdateParams",
 					Use:            "update-params-proposal [params]",
 					Short:          "Submit a proposal to update auth module params. Note: the entire params must be provided.",
 					Example:        fmt.Sprintf(`%s tx auth update-params-proposal '{ "max_memo_characters": 0, "tx_sig_limit": 0, "tx_size_cost_per_byte": 0, "sig_verify_cost_ed25519": 0, "sig_verify_cost_secp256k1": 0 }'`, version.AppName),
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{{ProtoField: "params"}},
+					PositionalArgs: []*autocli.PositionalArgDescriptor{{ProtoField: "params"}},
 					GovProposal:    true,
 				},
 			},

--- a/x/auth/migrations/legacytx/stdtx_test.go
+++ b/x/auth/migrations/legacytx/stdtx_test.go
@@ -109,14 +109,31 @@ func TestStdSignBytes(t *testing.T) {
 					Sequence:      tc.args.sequence,
 				},
 				txsigning.TxData{
-					Body: &txv1beta1.TxBody{
-						Memo:          tc.args.memo,
-						Messages:      anyMsgs,
-						TimeoutHeight: tc.args.timeoutHeight,
-					},
-					AuthInfo: &txv1beta1.AuthInfo{
-						Fee: tc.args.fee,
-					},
+					Body: func() *txsigning.TxBodyData {
+						rawMsgs := make([]txsigning.RawMsg, len(anyMsgs))
+						for k, m := range anyMsgs {
+							rawMsgs[k] = txsigning.RawMsg{TypeUrl: m.TypeUrl, Value: m.Value}
+						}
+						return &txsigning.TxBodyData{
+							Messages:      rawMsgs,
+							Memo:          tc.args.memo,
+							TimeoutHeight: tc.args.timeoutHeight,
+						}
+					}(),
+					AuthInfo: func() *txsigning.TxAuthInfoData {
+						var coins []txsigning.TxCoinData
+						var payer, granter string
+						var gas uint64
+						if f := tc.args.fee; f != nil {
+							for _, c := range f.Amount {
+								coins = append(coins, txsigning.TxCoinData{Denom: c.Denom, Amount: c.Amount})
+							}
+							payer, granter, gas = f.Payer, f.Granter, f.GasLimit
+						}
+						return &txsigning.TxAuthInfoData{
+							Fee: txsigning.TxFeeData{Amount: coins, Payer: payer, Granter: granter, GasLimit: gas},
+						}
+					}(),
 				},
 			)
 			require.NoError(t, err)

--- a/x/auth/signing/verify.go
+++ b/x/auth/signing/verify.go
@@ -4,53 +4,30 @@ import (
 	"context"
 	"fmt"
 
-	signingv1beta1 "cosmossdk.io/api/cosmos/tx/signing/v1beta1"
-
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	"github.com/cosmos/cosmos-sdk/crypto/types/multisig"
 	"github.com/cosmos/cosmos-sdk/types/tx/signing"
 	txsigning "github.com/cosmos/cosmos-sdk/x/tx/signing"
 )
 
-// APISignModesToInternal converts a protobuf SignMode array to a signing.SignMode array.
-func APISignModesToInternal(modes []signingv1beta1.SignMode) ([]signing.SignMode, error) {
+// APISignModesToInternal converts a txsigning.SignMode slice to a signing.SignMode slice.
+// Both types have identical underlying integer values; conversion is a plain cast.
+func APISignModesToInternal(modes []txsigning.SignMode) ([]signing.SignMode, error) {
 	internalModes := make([]signing.SignMode, len(modes))
 	for i, mode := range modes {
-		internalMode, err := APISignModeToInternal(mode)
-		if err != nil {
-			return nil, err
-		}
-		internalModes[i] = internalMode
+		internalModes[i] = signing.SignMode(mode)
 	}
 	return internalModes, nil
 }
 
-// APISignModeToInternal converts a protobuf SignMode to a signing.SignMode.
-func APISignModeToInternal(mode signingv1beta1.SignMode) (signing.SignMode, error) {
-	switch mode {
-	case signingv1beta1.SignMode_SIGN_MODE_DIRECT:
-		return signing.SignMode_SIGN_MODE_DIRECT, nil
-	case signingv1beta1.SignMode_SIGN_MODE_LEGACY_AMINO_JSON:
-		return signing.SignMode_SIGN_MODE_LEGACY_AMINO_JSON, nil
-	case signingv1beta1.SignMode_SIGN_MODE_DIRECT_AUX:
-		return signing.SignMode_SIGN_MODE_DIRECT_AUX, nil
-	default:
-		return signing.SignMode_SIGN_MODE_UNSPECIFIED, fmt.Errorf("unsupported sign mode %s", mode)
-	}
+// APISignModeToInternal converts a txsigning.SignMode to a signing.SignMode.
+func APISignModeToInternal(mode txsigning.SignMode) (signing.SignMode, error) {
+	return signing.SignMode(mode), nil
 }
 
-// internalSignModeToAPI converts a signing.SignMode to a protobuf SignMode.
-func internalSignModeToAPI(mode signing.SignMode) (signingv1beta1.SignMode, error) {
-	switch mode {
-	case signing.SignMode_SIGN_MODE_DIRECT:
-		return signingv1beta1.SignMode_SIGN_MODE_DIRECT, nil
-	case signing.SignMode_SIGN_MODE_LEGACY_AMINO_JSON:
-		return signingv1beta1.SignMode_SIGN_MODE_LEGACY_AMINO_JSON, nil
-	case signing.SignMode_SIGN_MODE_DIRECT_AUX:
-		return signingv1beta1.SignMode_SIGN_MODE_DIRECT_AUX, nil
-	default:
-		return signingv1beta1.SignMode_SIGN_MODE_UNSPECIFIED, fmt.Errorf("unsupported sign mode %s", mode)
-	}
+// internalSignModeToAPI converts a signing.SignMode to a txsigning.SignMode.
+func internalSignModeToAPI(mode signing.SignMode) (txsigning.SignMode, error) {
+	return txsigning.SignMode(mode), nil
 }
 
 // VerifySignature verifies a transaction signature contained in SignatureData abstracting over different signing

--- a/x/auth/tx/adapter.go
+++ b/x/auth/tx/adapter.go
@@ -1,141 +1,79 @@
 package tx
 
 import (
-	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
-	basev1beta1 "cosmossdk.io/api/cosmos/base/v1beta1"
-	multisigv1beta1 "cosmossdk.io/api/cosmos/crypto/multisig/v1beta1"
-	signingv1beta1 "cosmossdk.io/api/cosmos/tx/signing/v1beta1"
-	txv1beta1 "cosmossdk.io/api/cosmos/tx/v1beta1"
-
-	"github.com/cosmos/cosmos-sdk/types/tx"
 	txsigning "github.com/cosmos/cosmos-sdk/x/tx/signing"
 )
 
-// GetSigningTxData returns an x/tx/signing.TxData representation of a transaction for use in the signing
-// API defined in x/tx.  The reason for all of this conversion is that x/tx depends on the protoreflect API
-// defined in google.golang.org/protobuf while x/auth/tx depends on the legacy proto API defined in
-// github.com/gogo/protobuf and the downstream SDK fork of that library, github.com/cosmos/gogoproto.
-// Therefore we need to convert between the two APIs.
+// GetSigningTxData returns an x/tx/signing.TxData representation of a transaction
+// for use in the signing API defined in x/tx. Converts gogoproto wrapper types into
+// the Go-native signing.TxData without any pulsar dependency.
 func (w *wrapper) GetSigningTxData() txsigning.TxData {
 	body := w.tx.Body
 	authInfo := w.tx.AuthInfo
 
-	msgs := make([]*anypb.Any, len(body.Messages))
-	for i, msg := range body.Messages {
-		msgs[i] = &anypb.Any{
-			TypeUrl: msg.TypeUrl,
-			Value:   msg.Value,
-		}
+	msgs := make([]txsigning.RawMsg, len(body.Messages))
+	for i, m := range body.Messages {
+		msgs[i] = txsigning.RawMsg{TypeUrl: m.TypeUrl, Value: m.Value}
 	}
 
-	extOptions := make([]*anypb.Any, len(body.ExtensionOptions))
-	for i, extOption := range body.ExtensionOptions {
-		extOptions[i] = &anypb.Any{
-			TypeUrl: extOption.TypeUrl,
-			Value:   extOption.Value,
-		}
+	extOpts := make([]txsigning.RawMsg, len(body.ExtensionOptions))
+	for i, e := range body.ExtensionOptions {
+		extOpts[i] = txsigning.RawMsg{TypeUrl: e.TypeUrl, Value: e.Value}
 	}
 
-	nonCriticalExtOptions := make([]*anypb.Any, len(body.NonCriticalExtensionOptions))
-	for i, extOption := range body.NonCriticalExtensionOptions {
-		nonCriticalExtOptions[i] = &anypb.Any{
-			TypeUrl: extOption.TypeUrl,
-			Value:   extOption.Value,
-		}
+	nonCritExtOpts := make([]txsigning.RawMsg, len(body.NonCriticalExtensionOptions))
+	for i, e := range body.NonCriticalExtensionOptions {
+		nonCritExtOpts[i] = txsigning.RawMsg{TypeUrl: e.TypeUrl, Value: e.Value}
 	}
 
-	feeCoins := authInfo.Fee.Amount
-	feeAmount := make([]*basev1beta1.Coin, len(feeCoins))
-	for i, coin := range feeCoins {
-		feeAmount[i] = &basev1beta1.Coin{
-			Denom:  coin.Denom,
-			Amount: coin.Amount.String(),
-		}
-	}
-
-	txSignerInfos := make([]*txv1beta1.SignerInfo, len(authInfo.SignerInfos))
-	for i, signerInfo := range authInfo.SignerInfos {
-		modeInfo := &txv1beta1.ModeInfo{}
-		adaptModeInfo(signerInfo.ModeInfo, modeInfo)
-		txSignerInfo := &txv1beta1.SignerInfo{
-			PublicKey: &anypb.Any{
-				TypeUrl: signerInfo.PublicKey.TypeUrl,
-				Value:   signerInfo.PublicKey.Value,
-			},
-			Sequence: signerInfo.Sequence,
-			ModeInfo: modeInfo,
-		}
-		txSignerInfos[i] = txSignerInfo
-	}
-
-	txAuthInfo := &txv1beta1.AuthInfo{
-		SignerInfos: txSignerInfos,
-		Fee: &txv1beta1.Fee{
-			Amount:   feeAmount,
-			GasLimit: authInfo.Fee.GasLimit,
-			Payer:    authInfo.Fee.Payer,
-			Granter:  authInfo.Fee.Granter,
-		},
-	}
-
-	// Only set TimeoutTimestamp if we have a non-zero time.Time.
-	// Setting timestamppb.New() with a zero/default value time.Time results in a non-zero timestamppb.Timestamp,
-	// which causes the value to show up in the signature - breaking <v0.53.x compatibility.
 	var ts *timestamppb.Timestamp
 	if body.TimeoutTimestamp != nil {
 		ts = timestamppb.New(*body.TimeoutTimestamp)
 	}
 
-	txBody := &txv1beta1.TxBody{
+	txBody := &txsigning.TxBodyData{
 		Messages:                    msgs,
 		Memo:                        body.Memo,
 		TimeoutHeight:               body.TimeoutHeight,
 		Unordered:                   body.Unordered,
 		TimeoutTimestamp:            ts,
-		ExtensionOptions:            extOptions,
-		NonCriticalExtensionOptions: nonCriticalExtOptions,
+		ExtensionOptions:            extOpts,
+		NonCriticalExtensionOptions: nonCritExtOpts,
 	}
-	txData := txsigning.TxData{
+
+	feeCoins := make([]txsigning.TxCoinData, 0)
+	if authInfo.Fee != nil {
+		for _, c := range authInfo.Fee.Amount {
+			feeCoins = append(feeCoins, txsigning.TxCoinData{
+				Denom:  c.Denom,
+				Amount: c.Amount.String(),
+			})
+		}
+	}
+
+	var feePayer, feeGranter string
+	var gasLimit uint64
+	if authInfo.Fee != nil {
+		feePayer = authInfo.Fee.Payer
+		feeGranter = authInfo.Fee.Granter
+		gasLimit = authInfo.Fee.GasLimit
+	}
+
+	txAuthInfo := &txsigning.TxAuthInfoData{
+		Fee: txsigning.TxFeeData{
+			Amount:   feeCoins,
+			GasLimit: gasLimit,
+			Payer:    feePayer,
+			Granter:  feeGranter,
+		},
+	}
+
+	return txsigning.TxData{
+		Body:          txBody,
 		AuthInfo:      txAuthInfo,
 		AuthInfoBytes: w.getAuthInfoBytes(),
-		Body:          txBody,
 		BodyBytes:     w.getBodyBytes(),
-	}
-	return txData
-}
-
-func adaptModeInfo(legacy *tx.ModeInfo, res *txv1beta1.ModeInfo) {
-	// handle nil modeInfo. this is permissible through the code path:
-	// https://github.com/cosmos/cosmos-sdk/blob/4a6a1e3cb8de459891cb0495052589673d14ef51/x/auth/tx/builder.go#L295
-	// -> https://github.com/cosmos/cosmos-sdk/blob/b7841e3a76a38d069c1b9cb3d48368f7a67e9c26/x/auth/tx/sigs.go#L15-L17
-	// when signature.Data is nil.
-	if legacy == nil {
-		return
-	}
-
-	switch mi := legacy.Sum.(type) {
-	case *tx.ModeInfo_Single_:
-		res.Sum = &txv1beta1.ModeInfo_Single_{
-			Single: &txv1beta1.ModeInfo_Single{
-				Mode: signingv1beta1.SignMode(legacy.GetSingle().Mode),
-			},
-		}
-	case *tx.ModeInfo_Multi_:
-		multiModeInfos := legacy.GetMulti().ModeInfos
-		modeInfos := make([]*txv1beta1.ModeInfo, len(multiModeInfos))
-		for _, modeInfo := range multiModeInfos {
-			adaptModeInfo(modeInfo, &txv1beta1.ModeInfo{})
-		}
-		res.Sum = &txv1beta1.ModeInfo_Multi_{
-			Multi: &txv1beta1.ModeInfo_Multi{
-				Bitarray: &multisigv1beta1.CompactBitArray{
-					Elems:           mi.Multi.Bitarray.Elems,
-					ExtraBitsStored: mi.Multi.Bitarray.ExtraBitsStored,
-				},
-				ModeInfos: modeInfos,
-			},
-		}
 	}
 }

--- a/x/auth/tx/testutil/suite.go
+++ b/x/auth/tx/testutil/suite.go
@@ -6,8 +6,6 @@ import (
 
 	"github.com/stretchr/testify/suite"
 
-	signingv1beta1 "cosmossdk.io/api/cosmos/tx/signing/v1beta1"
-
 	"github.com/cosmos/cosmos-sdk/client"
 	kmultisig "github.com/cosmos/cosmos-sdk/crypto/keys/multisig"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
@@ -16,6 +14,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	signingtypes "github.com/cosmos/cosmos-sdk/types/tx/signing"
 	"github.com/cosmos/cosmos-sdk/x/auth/signing"
+	txsigning "github.com/cosmos/cosmos-sdk/x/tx/signing"
 )
 
 // TxConfigTestSuite provides a test suite that can be used to test that a TxConfig implementation is correct.
@@ -101,7 +100,7 @@ func (s *TxConfigTestSuite) TestTxBuilderSetSignatures() {
 	s.Require().Error(txBuilder.GetTx().ValidateBasic())
 
 	signModeHandler := s.TxConfig.SignModeHandler()
-	s.Require().Contains(signModeHandler.SupportedModes(), signingv1beta1.SignMode_SIGN_MODE_DIRECT)
+	s.Require().Contains(signModeHandler.SupportedModes(), txsigning.SignMode_SIGN_MODE_DIRECT)
 	defaultSignMode, err := signing.APISignModeToInternal(s.TxConfig.SignModeHandler().DefaultMode())
 	s.Require().NoError(err)
 

--- a/x/auth/vesting/autocli.go
+++ b/x/auth/vesting/autocli.go
@@ -1,16 +1,16 @@
 package vesting
 
 import (
-	autocliv1 "cosmossdk.io/api/cosmos/autocli/v1"
 	vestingv1beta1 "cosmossdk.io/api/cosmos/vesting/v1beta1"
+	autocli "cosmossdk.io/core/autocli"
 )
 
 // AutoCLIOptions implements the autocli.HasAutoCLIConfig interface.
-func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
-	return &autocliv1.ModuleOptions{
-		Tx: &autocliv1.ServiceCommandDescriptor{
+func (am AppModule) AutoCLIOptions() *autocli.ModuleOptions {
+	return &autocli.ModuleOptions{
+		Tx: &autocli.ServiceCommandDescriptor{
 			Service: vestingv1beta1.Msg_ServiceDesc.ServiceName,
-			RpcCommandOptions: []*autocliv1.RpcCommandOptions{
+			RpcCommandOptions: []*autocli.RpcCommandOptions{
 				{
 					RpcMethod: "CreateVestingAccount",
 					Use:       "create-vesting-account [to_address] [end_time] [amount]",
@@ -20,12 +20,12 @@ account can either be a delayed or continuous vesting account, which is determin
 by the '--delayed' flag. All vesting accounts created will have their start time
 set by the committed block's time. The end_time must be provided as a UNIX epoch
 timestamp.`,
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+					PositionalArgs: []*autocli.PositionalArgDescriptor{
 						{ProtoField: "to_address"},
 						{ProtoField: "end_time"},
 						{ProtoField: "amount", Varargs: true},
 					},
-					FlagOptions: map[string]*autocliv1.FlagOptions{
+					FlagOptions: map[string]*autocli.FlagOptions{
 						"delayed": {Name: "delayed", Usage: "Create a delayed vesting account if true"},
 					},
 				},
@@ -35,7 +35,7 @@ timestamp.`,
 					Short:     "Create a new permanently locked account funded with an allocation of tokens.",
 					Long: `Create a new account funded with an allocation of permanently locked tokens.
 These tokens may be used for staking but are non-transferable. Staking rewards will accrue as liquid and transferable tokens.`,
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+					PositionalArgs: []*autocli.PositionalArgDescriptor{
 						{ProtoField: "to_address"},
 						{ProtoField: "amount", Varargs: true},
 					},

--- a/x/authz/module/autocli.go
+++ b/x/authz/module/autocli.go
@@ -4,25 +4,25 @@ import (
 	"fmt"
 
 	authzv1beta1 "cosmossdk.io/api/cosmos/authz/v1beta1"
-	autocliv1 "cosmossdk.io/api/cosmos/autocli/v1"
+	autocli "cosmossdk.io/core/autocli"
 
 	"github.com/cosmos/cosmos-sdk/version"
 	bank "github.com/cosmos/cosmos-sdk/x/bank/types"
 )
 
 // AutoCLIOptions implements the autocli.HasAutoCLIConfig interface.
-func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
-	return &autocliv1.ModuleOptions{
-		Query: &autocliv1.ServiceCommandDescriptor{
+func (am AppModule) AutoCLIOptions() *autocli.ModuleOptions {
+	return &autocli.ModuleOptions{
+		Query: &autocli.ServiceCommandDescriptor{
 			Service: authzv1beta1.Query_ServiceDesc.ServiceName,
-			RpcCommandOptions: []*autocliv1.RpcCommandOptions{
+			RpcCommandOptions: []*autocli.RpcCommandOptions{
 				{
 					RpcMethod: "Grants",
 					Use:       "grants [granter-addr] [grantee-addr] <msg-type-url>",
 					Short:     "Query grants for a granter-grantee pair and optionally a msg-type-url",
 					Long:      "Query authorization grants for a granter-grantee pair. If msg-type-url is set, it will select grants only for that msg type.",
 					Example:   fmt.Sprintf("%s query authz grants cosmos1skj.. cosmos1skjwj.. %s", version.AppName, bank.SendAuthorization{}.MsgTypeURL()),
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+					PositionalArgs: []*autocli.PositionalArgDescriptor{
 						{ProtoField: "granter"},
 						{ProtoField: "grantee"},
 						{ProtoField: "msg_type_url", Optional: true},
@@ -32,7 +32,7 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					RpcMethod: "GranterGrants",
 					Use:       "grants-by-granter [granter-addr]",
 					Short:     "Query authorization grants granted by granter",
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+					PositionalArgs: []*autocli.PositionalArgDescriptor{
 						{ProtoField: "granter"},
 					},
 				},
@@ -40,22 +40,22 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					RpcMethod: "GranteeGrants",
 					Use:       "grants-by-grantee [grantee-addr]",
 					Short:     "Query authorization grants granted to a grantee",
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+					PositionalArgs: []*autocli.PositionalArgDescriptor{
 						{ProtoField: "grantee"},
 					},
 				},
 			},
 		},
-		Tx: &autocliv1.ServiceCommandDescriptor{
+		Tx: &autocli.ServiceCommandDescriptor{
 			Service:              authzv1beta1.Msg_ServiceDesc.ServiceName,
 			EnhanceCustomCommand: false, // use custom commands only until v0.51
-			RpcCommandOptions: []*autocliv1.RpcCommandOptions{
+			RpcCommandOptions: []*autocli.RpcCommandOptions{
 				{
 					RpcMethod: "Exec",
 					Use:       "exec [msg-json-file] --from [grantee]",
 					Short:     "Execute tx on behalf of granter account",
 					Example:   fmt.Sprintf("$ %s tx authz exec msg.json --from grantee\n $ %[1]s tx bank send [granter] [recipient] [amount] --generate-only | jq .body.messages > msg.json && %[1]s tx authz exec msg.json --from grantee", version.AppName),
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+					PositionalArgs: []*autocli.PositionalArgDescriptor{
 						{ProtoField: "msgs", Varargs: true},
 					},
 				},
@@ -65,7 +65,7 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					Short:     `Revoke authorization from a granter to a grantee`,
 					Example: fmt.Sprintf(`%s tx authz revoke cosmos1skj.. %s --from=cosmos1skj..`,
 						version.AppName, bank.SendAuthorization{}.MsgTypeURL()),
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+					PositionalArgs: []*autocli.PositionalArgDescriptor{
 						{ProtoField: "grantee"},
 						{ProtoField: "msg_type_url"},
 					},

--- a/x/authz/msgs_test.go
+++ b/x/authz/msgs_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/anypb"
 
-	txv1beta1 "cosmossdk.io/api/cosmos/tx/v1beta1"
 	sdkmath "cosmossdk.io/math"
 
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -129,13 +128,13 @@ func TestAminoJSON(t *testing.T) {
 					Sequence:      1,
 				},
 				txsigning.TxData{
-					Body: &txv1beta1.TxBody{
+					Body: &txsigning.TxBodyData{
+						Messages:      []txsigning.RawMsg{{TypeUrl: anyMsg.TypeUrl, Value: anyMsg.Value}},
 						Memo:          "memo",
-						Messages:      []*anypb.Any{anyMsg},
 						TimeoutHeight: 1,
 					},
-					AuthInfo: &txv1beta1.AuthInfo{
-						Fee: &txv1beta1.Fee{},
+					AuthInfo: &txsigning.TxAuthInfoData{
+						Fee: txsigning.TxFeeData{},
 					},
 				},
 			)

--- a/x/bank/autocli.go
+++ b/x/bank/autocli.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strings"
 
-	bankv1beta1 "cosmossdk.io/api/cosmos/bank/v1beta1"
 	autocli "cosmossdk.io/core/autocli"
 
 	"github.com/cosmos/cosmos-sdk/version"
@@ -14,7 +13,7 @@ import (
 func (am AppModule) AutoCLIOptions() *autocli.ModuleOptions {
 	return &autocli.ModuleOptions{
 		Query: &autocli.ServiceCommandDescriptor{
-			Service: bankv1beta1.Query_ServiceDesc.ServiceName,
+			Service: "cosmos.bank.v1beta1.Query",
 			RpcCommandOptions: []*autocli.RpcCommandOptions{
 				{
 					RpcMethod:      "Balance",
@@ -90,7 +89,7 @@ To look up all denoms, do not provide any arguments.`,
 			},
 		},
 		Tx: &autocli.ServiceCommandDescriptor{
-			Service:              bankv1beta1.Msg_ServiceDesc.ServiceName,
+			Service:              "cosmos.bank.v1beta1.Msg",
 			EnhanceCustomCommand: true,
 			RpcCommandOptions: []*autocli.RpcCommandOptions{
 				{

--- a/x/bank/autocli.go
+++ b/x/bank/autocli.go
@@ -4,42 +4,42 @@ import (
 	"fmt"
 	"strings"
 
-	autocliv1 "cosmossdk.io/api/cosmos/autocli/v1"
 	bankv1beta1 "cosmossdk.io/api/cosmos/bank/v1beta1"
+	autocli "cosmossdk.io/core/autocli"
 
 	"github.com/cosmos/cosmos-sdk/version"
 )
 
 // AutoCLIOptions implements the autocli.HasAutoCLIConfig interface.
-func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
-	return &autocliv1.ModuleOptions{
-		Query: &autocliv1.ServiceCommandDescriptor{
+func (am AppModule) AutoCLIOptions() *autocli.ModuleOptions {
+	return &autocli.ModuleOptions{
+		Query: &autocli.ServiceCommandDescriptor{
 			Service: bankv1beta1.Query_ServiceDesc.ServiceName,
-			RpcCommandOptions: []*autocliv1.RpcCommandOptions{
+			RpcCommandOptions: []*autocli.RpcCommandOptions{
 				{
 					RpcMethod:      "Balance",
 					Use:            "balance [address] [denom]",
 					Short:          "Query an account balance by address and denom",
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{{ProtoField: "address"}, {ProtoField: "denom"}},
+					PositionalArgs: []*autocli.PositionalArgDescriptor{{ProtoField: "address"}, {ProtoField: "denom"}},
 				},
 				{
 					RpcMethod:      "AllBalances",
 					Use:            "balances [address]",
 					Short:          "Query for account balances by address",
 					Long:           "Query the total balance of an account or of a specific denomination.",
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{{ProtoField: "address"}},
+					PositionalArgs: []*autocli.PositionalArgDescriptor{{ProtoField: "address"}},
 				},
 				{
 					RpcMethod:      "SpendableBalances",
 					Use:            "spendable-balances [address]",
 					Short:          "Query for account spendable balances by address",
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{{ProtoField: "address"}},
+					PositionalArgs: []*autocli.PositionalArgDescriptor{{ProtoField: "address"}},
 				},
 				{
 					RpcMethod:      "SpendableBalanceByDenom",
 					Use:            "spendable-balance [address] [denom]",
 					Short:          "Query the spendable balance of a single denom for a single account.",
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{{ProtoField: "address"}, {ProtoField: "denom"}},
+					PositionalArgs: []*autocli.PositionalArgDescriptor{{ProtoField: "address"}, {ProtoField: "denom"}},
 				},
 				{
 					RpcMethod: "TotalSupply",
@@ -52,7 +52,7 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					RpcMethod:      "SupplyOf",
 					Use:            "total-supply-of [denom]",
 					Short:          "Query the supply of a single coin denom",
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{{ProtoField: "denom"}},
+					PositionalArgs: []*autocli.PositionalArgDescriptor{{ProtoField: "denom"}},
 				},
 				{
 					RpcMethod: "Params",
@@ -63,7 +63,7 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					RpcMethod:      "DenomMetadata",
 					Use:            "denom-metadata [denom]",
 					Short:          "Query the client metadata of a given coin denomination",
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{{ProtoField: "denom"}},
+					PositionalArgs: []*autocli.PositionalArgDescriptor{{ProtoField: "denom"}},
 				},
 				{
 					RpcMethod: "DenomsMetadata",
@@ -74,7 +74,7 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					RpcMethod:      "DenomOwners",
 					Use:            "denom-owners [denom]",
 					Short:          "Query for all account addresses that own a particular token denomination.",
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{{ProtoField: "denom"}},
+					PositionalArgs: []*autocli.PositionalArgDescriptor{{ProtoField: "denom"}},
 				},
 				{
 					RpcMethod: "SendEnabled",
@@ -85,14 +85,14 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 To look up one or more specific denoms, supply them as arguments to this command.
 To look up all denoms, do not provide any arguments.`,
 					),
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{{ProtoField: "denoms", Varargs: true}},
+					PositionalArgs: []*autocli.PositionalArgDescriptor{{ProtoField: "denoms", Varargs: true}},
 				},
 			},
 		},
-		Tx: &autocliv1.ServiceCommandDescriptor{
+		Tx: &autocli.ServiceCommandDescriptor{
 			Service:              bankv1beta1.Msg_ServiceDesc.ServiceName,
 			EnhanceCustomCommand: true,
-			RpcCommandOptions: []*autocliv1.RpcCommandOptions{
+			RpcCommandOptions: []*autocli.RpcCommandOptions{
 				{
 					RpcMethod: "Send",
 					Use:       "send [from_key_or_address] [to_address] [amount]",
@@ -101,14 +101,14 @@ To look up all denoms, do not provide any arguments.`,
 Note, the '--from' flag is ignored as it is implied from [from_key_or_address].
 When using '--dry-run' a key name cannot be used, only a bech32 address.
 Note: multiple coins can be send by space separated.`,
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{{ProtoField: "from_address"}, {ProtoField: "to_address"}, {ProtoField: "amount", Varargs: true}},
+					PositionalArgs: []*autocli.PositionalArgDescriptor{{ProtoField: "from_address"}, {ProtoField: "to_address"}, {ProtoField: "amount", Varargs: true}},
 				},
 				{
 					RpcMethod:      "UpdateParams",
 					Use:            "update-params-proposal [params]",
 					Short:          "Submit a proposal to update bank module params. Note: the entire params must be provided.",
 					Example:        fmt.Sprintf(`%s tx bank update-params-proposal '{ "default_send_enabled": true }'`, version.AppName),
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{{ProtoField: "params"}},
+					PositionalArgs: []*autocli.PositionalArgDescriptor{{ProtoField: "params"}},
 					GovProposal:    true,
 				},
 				{
@@ -116,8 +116,8 @@ Note: multiple coins can be send by space separated.`,
 					Use:            "set-send-enabled-proposal [send_enabled]",
 					Short:          "Submit a proposal to set/update/delete send enabled entries",
 					Example:        fmt.Sprintf(`%s tx bank set-send-enabled-proposal '{"denom":"stake","enabled":true}'`, version.AppName),
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{{ProtoField: "send_enabled", Varargs: true}},
-					FlagOptions: map[string]*autocliv1.FlagOptions{
+					PositionalArgs: []*autocli.PositionalArgDescriptor{{ProtoField: "send_enabled", Varargs: true}},
+					FlagOptions: map[string]*autocli.FlagOptions{
 						"use_default_for": {Name: "use-default-for", Usage: "Use default for the given denom (delete a send enabled entry)"},
 					},
 					GovProposal: true,

--- a/x/consensus/autocli.go
+++ b/x/consensus/autocli.go
@@ -3,38 +3,38 @@ package consensus
 import (
 	"fmt"
 
-	autocliv1 "cosmossdk.io/api/cosmos/autocli/v1"
 	consensusv1 "cosmossdk.io/api/cosmos/consensus/v1"
+	autocli "cosmossdk.io/core/autocli"
 
 	"github.com/cosmos/cosmos-sdk/client/grpc/cmtservice"
 	"github.com/cosmos/cosmos-sdk/version"
 )
 
 // AutoCLIOptions implements the autocli.HasAutoCLIConfig interface.
-func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
-	return &autocliv1.ModuleOptions{
-		Query: &autocliv1.ServiceCommandDescriptor{
+func (am AppModule) AutoCLIOptions() *autocli.ModuleOptions {
+	return &autocli.ModuleOptions{
+		Query: &autocli.ServiceCommandDescriptor{
 			Service: consensusv1.Query_ServiceDesc.ServiceName,
-			RpcCommandOptions: []*autocliv1.RpcCommandOptions{
+			RpcCommandOptions: []*autocli.RpcCommandOptions{
 				{
 					RpcMethod: "Params",
 					Use:       "params",
 					Short:     "Query the current consensus parameters",
 				},
 			},
-			SubCommands: map[string]*autocliv1.ServiceCommandDescriptor{
+			SubCommands: map[string]*autocli.ServiceCommandDescriptor{
 				"comet": cmtservice.CometBFTAutoCLIDescriptor,
 			},
 		},
-		Tx: &autocliv1.ServiceCommandDescriptor{
+		Tx: &autocli.ServiceCommandDescriptor{
 			Service: consensusv1.Msg_ServiceDesc.ServiceName,
-			RpcCommandOptions: []*autocliv1.RpcCommandOptions{
+			RpcCommandOptions: []*autocli.RpcCommandOptions{
 				{
 					RpcMethod: "UpdateParams",
 					Use:       "update-params-proposal [params]",
 					Short:     "Submit a proposal to update consensus module params. Note: the entire params must be provided.",
 					Example:   fmt.Sprintf(`%s tx consensus update-params-proposal '{ params }'`, version.AppName),
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+					PositionalArgs: []*autocli.PositionalArgDescriptor{
 						{ProtoField: "block"},
 						{ProtoField: "evidence"},
 						{ProtoField: "validator"},

--- a/x/distribution/autocli.go
+++ b/x/distribution/autocli.go
@@ -3,18 +3,18 @@ package distribution
 import (
 	"fmt"
 
-	autocliv1 "cosmossdk.io/api/cosmos/autocli/v1"
 	distributionv1beta1 "cosmossdk.io/api/cosmos/distribution/v1beta1"
+	autocli "cosmossdk.io/core/autocli"
 
 	"github.com/cosmos/cosmos-sdk/version"
 )
 
 // AutoCLIOptions implements the autocli.HasAutoCLIConfig interface.
-func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
-	return &autocliv1.ModuleOptions{
-		Query: &autocliv1.ServiceCommandDescriptor{
+func (am AppModule) AutoCLIOptions() *autocli.ModuleOptions {
+	return &autocli.ModuleOptions{
+		Query: &autocli.ServiceCommandDescriptor{
 			Service: distributionv1beta1.Query_ServiceDesc.ServiceName,
-			RpcCommandOptions: []*autocliv1.RpcCommandOptions{
+			RpcCommandOptions: []*autocli.RpcCommandOptions{
 				{
 					RpcMethod: "Params",
 					Use:       "params",
@@ -26,7 +26,7 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					Short:     "Query validator distribution info",
 					Example:   fmt.Sprintf(`Example: $ %s query distribution validator-distribution-info [validator-address]`, version.AppName),
 
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+					PositionalArgs: []*autocli.PositionalArgDescriptor{
 						{ProtoField: "validator_address"},
 					},
 				},
@@ -35,7 +35,7 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					Use:       "validator-outstanding-rewards [validator]",
 					Short:     "Query distribution outstanding (un-withdrawn) rewards for a validator and all their delegations",
 					Example:   fmt.Sprintf(`$ %s query distribution validator-outstanding-rewards [validator-address]`, version.AppName),
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+					PositionalArgs: []*autocli.PositionalArgDescriptor{
 						{ProtoField: "validator_address"},
 					},
 				},
@@ -44,7 +44,7 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					Use:       "commission [validator]",
 					Short:     "Query distribution validator commission",
 					Example:   fmt.Sprintf(`$ %s query distribution commission [validator-address]`, version.AppName),
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+					PositionalArgs: []*autocli.PositionalArgDescriptor{
 						{ProtoField: "validator_address"},
 					},
 				},
@@ -53,7 +53,7 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					Use:       "slashes [validator] [start-height] [end-height]",
 					Short:     "Query distribution validator slashes",
 					Example:   fmt.Sprintf(`$ %s query distribution slashes [validator-address] 0 100`, version.AppName),
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+					PositionalArgs: []*autocli.PositionalArgDescriptor{
 						{ProtoField: "validator_address"},
 						{ProtoField: "starting_height"},
 						{ProtoField: "ending_height"},
@@ -64,7 +64,7 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					Use:       "rewards-by-validator [delegator-addr] [validator-addr]",
 					Short:     "Query all distribution delegator from a particular validator",
 					Example:   fmt.Sprintf("$ %s query distribution rewards [delegator-address] [validator-address]", version.AppName),
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+					PositionalArgs: []*autocli.PositionalArgDescriptor{
 						{ProtoField: "delegator_address"},
 						{ProtoField: "validator_address"},
 					},
@@ -75,7 +75,7 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					Short:     "Query all distribution delegator rewards",
 					Long:      "Query all rewards earned by a delegator",
 					Example:   fmt.Sprintf("$ %s query distribution rewards [delegator-address]", version.AppName),
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+					PositionalArgs: []*autocli.PositionalArgDescriptor{
 						{ProtoField: "delegator_address"},
 					},
 				},
@@ -90,7 +90,7 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					Use:       "validator-historical-rewards [validator] [period]",
 					Short:     "Query validator historical rewards for a specific period",
 					Example:   fmt.Sprintf(`$ %s query distribution validator-historical-rewards [validator-address] 5`, version.AppName),
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+					PositionalArgs: []*autocli.PositionalArgDescriptor{
 						{ProtoField: "validator_address"},
 						{ProtoField: "period"},
 					},
@@ -100,7 +100,7 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					Use:       "validator-current-rewards [validator]",
 					Short:     "Query validator current rewards",
 					Example:   fmt.Sprintf(`$ %s query distribution validator-current-rewards [validator-address]`, version.AppName),
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+					PositionalArgs: []*autocli.PositionalArgDescriptor{
 						{ProtoField: "validator_address"},
 					},
 				},
@@ -109,22 +109,22 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					Use:       "delegator-starting-info [delegator-address] [validator-address]",
 					Short:     "Query delegator starting info for a delegation",
 					Example:   fmt.Sprintf(`$ %s query distribution delegator-starting-info [delegator-address] [validator-address]`, version.AppName),
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+					PositionalArgs: []*autocli.PositionalArgDescriptor{
 						{ProtoField: "delegator_address"},
 						{ProtoField: "validator_address"},
 					},
 				},
 			},
 		},
-		Tx: &autocliv1.ServiceCommandDescriptor{
+		Tx: &autocli.ServiceCommandDescriptor{
 			Service: distributionv1beta1.Msg_ServiceDesc.ServiceName,
-			RpcCommandOptions: []*autocliv1.RpcCommandOptions{
+			RpcCommandOptions: []*autocli.RpcCommandOptions{
 				{
 					RpcMethod: "SetWithdrawAddress",
 					Use:       "set-withdraw-addr [withdraw-addr]",
 					Short:     "Change the default withdraw address for rewards associated with an address",
 					Example:   fmt.Sprintf("%s tx distribution set-withdraw-addr cosmos1gghjut3ccd8ay0zduzj64hwre2fxs9ld75ru9p --from mykey", version.AppName),
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+					PositionalArgs: []*autocli.PositionalArgDescriptor{
 						{ProtoField: "withdraw_address"},
 					},
 				},
@@ -132,7 +132,7 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					RpcMethod: "WithdrawDelegatorReward",
 					Use:       "withdraw-rewards [validator-addr]",
 					Short:     "Withdraw rewards from a given delegation address",
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+					PositionalArgs: []*autocli.PositionalArgDescriptor{
 						{ProtoField: "validator_address"},
 					},
 				},
@@ -140,7 +140,7 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					RpcMethod: "WithdrawValidatorCommission",
 					Use:       "withdraw-validator-commission [validator-addr]",
 					Short:     "Withdraw commissions from a validator address (must be a validator operator)",
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+					PositionalArgs: []*autocli.PositionalArgDescriptor{
 						{ProtoField: "validator_address"},
 					},
 				},
@@ -149,7 +149,7 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					Use:       "fund-validator-rewards-pool [validator-addr] [amount]",
 					Short:     "Fund the validator rewards pool with the specified amount",
 					Example:   fmt.Sprintf("%s tx distribution fund-validator-rewards-pool cosmosvaloper1x20lytyf6zkcrv5edpkfkn8sz578qg5sqfyqnp 100uatom --from mykey", version.AppName),
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+					PositionalArgs: []*autocli.PositionalArgDescriptor{
 						{ProtoField: "validator_address"},
 						{ProtoField: "amount", Varargs: true},
 					},
@@ -159,7 +159,7 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					Use:       "fund-community-pool [amount]",
 					Short:     "Funds the community pool with the specified amount",
 					Example:   fmt.Sprintf(`$ %s tx distribution fund-community-pool 100uatom --from mykey`, version.AppName),
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+					PositionalArgs: []*autocli.PositionalArgDescriptor{
 						{ProtoField: "amount", Varargs: true},
 					},
 				},
@@ -168,7 +168,7 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					Use:            "update-params-proposal [params]",
 					Short:          "Submit a proposal to update distribution module params. Note: the entire params must be provided.",
 					Example:        fmt.Sprintf(`%s tx distribution update-params-proposal '{ "community_tax": "20000", "base_proposer_reward": "0", "bonus_proposer_reward": "0", "withdraw_addr_enabled": true }'`, version.AppName),
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{{ProtoField: "params"}},
+					PositionalArgs: []*autocli.PositionalArgDescriptor{{ProtoField: "params"}},
 					GovProposal:    true,
 				},
 				{
@@ -176,7 +176,7 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					Use:       "community-pool-spend-proposal [recipient] [amount]",
 					Example:   fmt.Sprintf(`$ %s tx distribution community-pool-spend-proposal [recipient] 100uatom`, version.AppName),
 					Short:     "Submit a proposal to spend from the community pool",
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+					PositionalArgs: []*autocli.PositionalArgDescriptor{
 						{ProtoField: "recipient"},
 						{ProtoField: "amount", Varargs: true},
 					},

--- a/x/epochs/autocli.go
+++ b/x/epochs/autocli.go
@@ -1,16 +1,16 @@
 package epochs
 
 import (
-	autocliv1 "cosmossdk.io/api/cosmos/autocli/v1"
 	epochsv1beta1 "cosmossdk.io/api/cosmos/epochs/v1beta1"
+	autocli "cosmossdk.io/core/autocli"
 )
 
 // AutoCLIOptions implements the autocli.HasAutoCLIConfig interface.
-func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
-	return &autocliv1.ModuleOptions{
-		Query: &autocliv1.ServiceCommandDescriptor{
+func (am AppModule) AutoCLIOptions() *autocli.ModuleOptions {
+	return &autocli.ModuleOptions{
+		Query: &autocli.ServiceCommandDescriptor{
 			Service: epochsv1beta1.Query_ServiceDesc.ServiceName,
-			RpcCommandOptions: []*autocliv1.RpcCommandOptions{
+			RpcCommandOptions: []*autocli.RpcCommandOptions{
 				{
 					RpcMethod: "EpochInfos",
 					Use:       "epoch-infos",
@@ -20,7 +20,7 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					RpcMethod: "CurrentEpoch",
 					Use:       "current-epoch [identifier]",
 					Short:     "Query current epoch by specified identifier",
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+					PositionalArgs: []*autocli.PositionalArgDescriptor{
 						{ProtoField: "identifier"},
 					},
 				},

--- a/x/evidence/autocli.go
+++ b/x/evidence/autocli.go
@@ -3,24 +3,24 @@ package evidence
 import (
 	"fmt"
 
-	autocliv1 "cosmossdk.io/api/cosmos/autocli/v1"
 	evidencev1beta1 "cosmossdk.io/api/cosmos/evidence/v1beta1"
+	autocli "cosmossdk.io/core/autocli"
 
 	"github.com/cosmos/cosmos-sdk/version"
 )
 
 // AutoCLIOptions implements the autocli.HasAutoCLIConfig interface.
-func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
-	return &autocliv1.ModuleOptions{
-		Query: &autocliv1.ServiceCommandDescriptor{
+func (am AppModule) AutoCLIOptions() *autocli.ModuleOptions {
+	return &autocli.ModuleOptions{
+		Query: &autocli.ServiceCommandDescriptor{
 			Service: evidencev1beta1.Query_ServiceDesc.ServiceName,
-			RpcCommandOptions: []*autocliv1.RpcCommandOptions{
+			RpcCommandOptions: []*autocli.RpcCommandOptions{
 				{
 					RpcMethod:      "Evidence",
 					Use:            "evidence [hash]",
 					Short:          "Query for evidence by hash",
 					Example:        fmt.Sprintf("%s query evidence evidence DF0C23E8634E480F84B9D5674A7CDC9816466DEC28A3358F73260F68D28D7660", version.AppName),
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{{ProtoField: "hash"}},
+					PositionalArgs: []*autocli.PositionalArgDescriptor{{ProtoField: "hash"}},
 				},
 				{
 					RpcMethod: "AllEvidence",

--- a/x/feegrant/module/autocli.go
+++ b/x/feegrant/module/autocli.go
@@ -3,24 +3,24 @@ package module
 import (
 	"fmt"
 
-	autocliv1 "cosmossdk.io/api/cosmos/autocli/v1"
 	feegrantv1beta1 "cosmossdk.io/api/cosmos/feegrant/v1beta1"
+	autocli "cosmossdk.io/core/autocli"
 
 	"github.com/cosmos/cosmos-sdk/version"
 )
 
-func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
-	return &autocliv1.ModuleOptions{
-		Query: &autocliv1.ServiceCommandDescriptor{
+func (am AppModule) AutoCLIOptions() *autocli.ModuleOptions {
+	return &autocli.ModuleOptions{
+		Query: &autocli.ServiceCommandDescriptor{
 			Service: feegrantv1beta1.Query_ServiceDesc.ServiceName,
-			RpcCommandOptions: []*autocliv1.RpcCommandOptions{
+			RpcCommandOptions: []*autocli.RpcCommandOptions{
 				{
 					RpcMethod: "Allowance",
 					Use:       "grant [granter] [grantee]",
 					Short:     "Query details of a single grant",
 					Long:      "Query details for a grant. You can find the fee-grant of a granter and grantee.",
 					Example:   fmt.Sprintf(`$ %s query feegrant grant [granter] [grantee]`, version.AppName),
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+					PositionalArgs: []*autocli.PositionalArgDescriptor{
 						{ProtoField: "granter"},
 						{ProtoField: "grantee"},
 					},
@@ -31,7 +31,7 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					Short:     "Query all grants of a grantee",
 					Long:      "Queries all the grants for a grantee address.",
 					Example:   fmt.Sprintf(`$ %s query feegrant grants-by-grantee [grantee]`, version.AppName),
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+					PositionalArgs: []*autocli.PositionalArgDescriptor{
 						{ProtoField: "grantee"},
 					},
 				},
@@ -40,22 +40,22 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					Use:       "grants-by-granter [granter]",
 					Short:     "Query all grants by a granter",
 					Example:   fmt.Sprintf(`$ %s query feegrant grants-by-granter [granter]`, version.AppName),
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+					PositionalArgs: []*autocli.PositionalArgDescriptor{
 						{ProtoField: "granter"},
 					},
 				},
 			},
 		},
-		Tx: &autocliv1.ServiceCommandDescriptor{
+		Tx: &autocli.ServiceCommandDescriptor{
 			Service: feegrantv1beta1.Msg_ServiceDesc.ServiceName,
-			RpcCommandOptions: []*autocliv1.RpcCommandOptions{
+			RpcCommandOptions: []*autocli.RpcCommandOptions{
 				{
 					RpcMethod: "RevokeAllowance",
 					Use:       "revoke [granter] [grantee]",
 					Short:     "Revoke a fee grant",
 					Long:      "Revoke fee grant from a granter to a grantee. Note, the '--from' flag is ignored as it is implied from [granter]",
 					Example:   fmt.Sprintf(`$ %s tx feegrant revoke [granter] [grantee]`, version.AppName),
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+					PositionalArgs: []*autocli.PositionalArgDescriptor{
 						{ProtoField: "granter"},
 						{ProtoField: "grantee"},
 					},

--- a/x/gov/autocli.go
+++ b/x/gov/autocli.go
@@ -3,24 +3,24 @@ package gov
 import (
 	"fmt"
 
-	autocliv1 "cosmossdk.io/api/cosmos/autocli/v1"
 	govv1 "cosmossdk.io/api/cosmos/gov/v1"
+	autocli "cosmossdk.io/core/autocli"
 
 	"github.com/cosmos/cosmos-sdk/version"
 )
 
 // AutoCLIOptions implements the autocli.HasAutoCLIConfig interface.
-func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
-	return &autocliv1.ModuleOptions{
-		Query: &autocliv1.ServiceCommandDescriptor{
+func (am AppModule) AutoCLIOptions() *autocli.ModuleOptions {
+	return &autocli.ModuleOptions{
+		Query: &autocli.ServiceCommandDescriptor{
 			Service: govv1.Query_ServiceDesc.ServiceName,
-			RpcCommandOptions: []*autocliv1.RpcCommandOptions{
+			RpcCommandOptions: []*autocli.RpcCommandOptions{
 				{
 					RpcMethod: "Params",
 					Use:       "params",
 					Short:     "Query the parameters of the governance process",
 					Long:      "Query the parameters of the governance process. Specify specific param types (voting|tallying|deposit) to filter results.",
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+					PositionalArgs: []*autocli.PositionalArgDescriptor{
 						{ProtoField: "params_type", Optional: true},
 					},
 				},
@@ -36,7 +36,7 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					Alias:     []string{"proposer"},
 					Short:     "Query details of a single proposal",
 					Example:   fmt.Sprintf("%s query gov proposal 1", version.AppName),
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+					PositionalArgs: []*autocli.PositionalArgDescriptor{
 						{ProtoField: "proposal_id"},
 					},
 				},
@@ -45,7 +45,7 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					Use:       "vote [proposal-id] [voter-addr]",
 					Short:     "Query details of a single vote",
 					Example:   fmt.Sprintf("%s query gov vote 1 cosmos1...", version.AppName),
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+					PositionalArgs: []*autocli.PositionalArgDescriptor{
 						{ProtoField: "proposal_id"},
 						{ProtoField: "voter"},
 					},
@@ -55,7 +55,7 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					Use:       "votes [proposal-id]",
 					Short:     "Query votes of a single proposal",
 					Example:   fmt.Sprintf("%s query gov votes 1", version.AppName),
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+					PositionalArgs: []*autocli.PositionalArgDescriptor{
 						{ProtoField: "proposal_id"},
 					},
 				},
@@ -63,7 +63,7 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					RpcMethod: "Deposit",
 					Use:       "deposit [proposal-id] [depositor-addr]",
 					Short:     "Query details of a deposit",
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+					PositionalArgs: []*autocli.PositionalArgDescriptor{
 						{ProtoField: "proposal_id"},
 						{ProtoField: "depositor"},
 					},
@@ -72,7 +72,7 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					RpcMethod: "Deposits",
 					Use:       "deposits [proposal-id]",
 					Short:     "Query deposits on a proposal",
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+					PositionalArgs: []*autocli.PositionalArgDescriptor{
 						{ProtoField: "proposal_id"},
 					},
 				},
@@ -81,7 +81,7 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					Use:       "tally [proposal-id]",
 					Short:     "Query the tally of a proposal vote",
 					Example:   fmt.Sprintf("%s query gov tally 1", version.AppName),
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+					PositionalArgs: []*autocli.PositionalArgDescriptor{
 						{ProtoField: "proposal_id"},
 					},
 				},
@@ -93,16 +93,16 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 			},
 			EnhanceCustomCommand: true, // We still have manual commands in gov that we want to keep
 		},
-		Tx: &autocliv1.ServiceCommandDescriptor{
+		Tx: &autocli.ServiceCommandDescriptor{
 			Service: govv1.Msg_ServiceDesc.ServiceName,
-			RpcCommandOptions: []*autocliv1.RpcCommandOptions{
+			RpcCommandOptions: []*autocli.RpcCommandOptions{
 				{
 					RpcMethod: "Deposit",
 					Use:       "deposit [proposal-id] [deposit]",
 					Short:     "Deposit tokens for an active proposal",
 					Long:      fmt.Sprintf(`Submit a deposit for an active proposal. You can find the proposal-id by running "%s query gov proposals"`, version.AppName),
 					Example:   fmt.Sprintf(`$ %s tx gov deposit 1 10stake --from mykey`, version.AppName),
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+					PositionalArgs: []*autocli.PositionalArgDescriptor{
 						{ProtoField: "proposal_id"},
 						{ProtoField: "amount", Varargs: true},
 					},
@@ -112,7 +112,7 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					Use:       "cancel-proposal [proposal-id]",
 					Short:     "Cancel governance proposal before the voting period ends. Must be signed by the proposal creator.",
 					Example:   fmt.Sprintf(`$ %s tx gov cancel-proposal 1 --from mykey`, version.AppName),
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+					PositionalArgs: []*autocli.PositionalArgDescriptor{
 						{ProtoField: "proposal_id"},
 					},
 				},
@@ -122,11 +122,11 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					Short:     "Vote for an active proposal, options: yes/no/no-with-veto/abstain",
 					Long:      fmt.Sprintf(`Submit a vote for an active proposal. Use the --metadata to optionally give a reason. You can find the proposal-id by running "%s query gov proposals"`, version.AppName),
 					Example:   fmt.Sprintf("$ %s tx gov vote 1 yes --from mykey", version.AppName),
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+					PositionalArgs: []*autocli.PositionalArgDescriptor{
 						{ProtoField: "proposal_id"},
 						{ProtoField: "option"},
 					},
-					FlagOptions: map[string]*autocliv1.FlagOptions{
+					FlagOptions: map[string]*autocli.FlagOptions{
 						"metadata": {Name: "metadata", Usage: "Add a description to the vote"},
 					},
 				},
@@ -136,7 +136,7 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					Short:          "Submit a proposal to update gov module params. Note: the entire params must be provided.",
 					Long:           fmt.Sprintf("Submit a proposal to update gov module params. Note: the entire params must be provided.\n See the fields to fill in by running `%s query gov params --output json`", version.AppName),
 					Example:        fmt.Sprintf(`%s tx gov update-params-proposal '{ params }'`, version.AppName),
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{{ProtoField: "params"}},
+					PositionalArgs: []*autocli.PositionalArgDescriptor{{ProtoField: "params"}},
 					GovProposal:    true,
 				},
 			},

--- a/x/mint/autocli.go
+++ b/x/mint/autocli.go
@@ -3,17 +3,17 @@ package mint
 import (
 	"fmt"
 
-	autocliv1 "cosmossdk.io/api/cosmos/autocli/v1"
 	mintv1beta1 "cosmossdk.io/api/cosmos/mint/v1beta1"
+	autocli "cosmossdk.io/core/autocli"
 
 	"github.com/cosmos/cosmos-sdk/version"
 )
 
-func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
-	return &autocliv1.ModuleOptions{
-		Query: &autocliv1.ServiceCommandDescriptor{
+func (am AppModule) AutoCLIOptions() *autocli.ModuleOptions {
+	return &autocli.ModuleOptions{
+		Query: &autocli.ServiceCommandDescriptor{
 			Service: mintv1beta1.Query_ServiceDesc.ServiceName,
-			RpcCommandOptions: []*autocliv1.RpcCommandOptions{
+			RpcCommandOptions: []*autocli.RpcCommandOptions{
 				{
 					RpcMethod: "Params",
 					Use:       "params",
@@ -31,16 +31,16 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 				},
 			},
 		},
-		Tx: &autocliv1.ServiceCommandDescriptor{
+		Tx: &autocli.ServiceCommandDescriptor{
 			Service: mintv1beta1.Msg_ServiceDesc.ServiceName,
-			RpcCommandOptions: []*autocliv1.RpcCommandOptions{
+			RpcCommandOptions: []*autocli.RpcCommandOptions{
 				{
 					RpcMethod:      "UpdateParams",
 					Use:            "update-params-proposal [params]",
 					Short:          "Submit a proposal to update mint module params. Note: the entire params must be provided.",
 					Long:           fmt.Sprintf("Submit a proposal to update mint module params. Note: the entire params must be provided.\n See the fields to fill in by running `%s query mint params --output json`", version.AppName),
 					Example:        fmt.Sprintf(`%s tx mint update-params-proposal '{ "mint_denom": "stake", ... }'`, version.AppName),
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{{ProtoField: "params"}},
+					PositionalArgs: []*autocli.PositionalArgDescriptor{{ProtoField: "params"}},
 					GovProposal:    true,
 				},
 			},

--- a/x/slashing/autocli.go
+++ b/x/slashing/autocli.go
@@ -3,17 +3,17 @@ package slashing
 import (
 	"fmt"
 
-	autocliv1 "cosmossdk.io/api/cosmos/autocli/v1"
 	slashingv1beta "cosmossdk.io/api/cosmos/slashing/v1beta1"
+	autocli "cosmossdk.io/core/autocli"
 
 	"github.com/cosmos/cosmos-sdk/version"
 )
 
-func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
-	return &autocliv1.ModuleOptions{
-		Query: &autocliv1.ServiceCommandDescriptor{
+func (am AppModule) AutoCLIOptions() *autocli.ModuleOptions {
+	return &autocli.ModuleOptions{
+		Query: &autocli.ServiceCommandDescriptor{
 			Service: slashingv1beta.Query_ServiceDesc.ServiceName,
-			RpcCommandOptions: []*autocliv1.RpcCommandOptions{
+			RpcCommandOptions: []*autocli.RpcCommandOptions{
 				{
 					RpcMethod: "Params",
 					Use:       "params",
@@ -25,7 +25,7 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					Short:     "Query a validator's signing information",
 					Long:      "Query a validator's signing information, with a pubkey ('<appd> comet show-validator') or a validator consensus address",
 					Example:   fmt.Sprintf(`%s query slashing signing-info '{"@type":"/cosmos.crypto.ed25519.PubKey","key":"OauFcTKbN5Lx3fJL689cikXBqe+hcp6Y+x0rYUdR9Jk="}'`, version.AppName),
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+					PositionalArgs: []*autocli.PositionalArgDescriptor{
 						{ProtoField: "cons_address"},
 					},
 				},
@@ -36,9 +36,9 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 				},
 			},
 		},
-		Tx: &autocliv1.ServiceCommandDescriptor{
+		Tx: &autocli.ServiceCommandDescriptor{
 			Service: slashingv1beta.Msg_ServiceDesc.ServiceName,
-			RpcCommandOptions: []*autocliv1.RpcCommandOptions{
+			RpcCommandOptions: []*autocli.RpcCommandOptions{
 				{
 					RpcMethod: "Unjail",
 					Use:       "unjail",
@@ -51,7 +51,7 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					Short:          "Submit a proposal to update slashing module params. Note: the entire params must be provided.",
 					Long:           fmt.Sprintf("Submit a proposal to update slashing module params. Note: the entire params must be provided.\n See the fields to fill in by running `%s query slashing params --output json`", version.AppName),
 					Example:        fmt.Sprintf(`%s tx slashing update-params-proposal '{ "signed_blocks_window": "100", ... }'`, version.AppName),
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{{ProtoField: "params"}},
+					PositionalArgs: []*autocli.PositionalArgDescriptor{{ProtoField: "params"}},
 					GovProposal:    true,
 				},
 			},

--- a/x/staking/autocli.go
+++ b/x/staking/autocli.go
@@ -3,18 +3,18 @@ package staking
 import (
 	"fmt"
 
-	autocliv1 "cosmossdk.io/api/cosmos/autocli/v1"
 	_ "cosmossdk.io/api/cosmos/crypto/ed25519" // register so that it shows up in protoregistry.GlobalTypes
 	stakingv1beta "cosmossdk.io/api/cosmos/staking/v1beta1"
+	autocli "cosmossdk.io/core/autocli"
 
 	"github.com/cosmos/cosmos-sdk/version"
 )
 
-func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
-	return &autocliv1.ModuleOptions{
-		Query: &autocliv1.ServiceCommandDescriptor{
+func (am AppModule) AutoCLIOptions() *autocli.ModuleOptions {
+	return &autocli.ModuleOptions{
+		Query: &autocli.ServiceCommandDescriptor{
 			Service: stakingv1beta.Query_ServiceDesc.ServiceName,
-			RpcCommandOptions: []*autocliv1.RpcCommandOptions{
+			RpcCommandOptions: []*autocli.RpcCommandOptions{
 				{
 					RpcMethod: "Validators",
 					Short:     "Query for all validators",
@@ -25,7 +25,7 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					Use:       "validator [validator-addr]",
 					Short:     "Query a validator",
 					Long:      "Query details about an individual validator.",
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+					PositionalArgs: []*autocli.PositionalArgDescriptor{
 						{ProtoField: "validator_addr"},
 					},
 				},
@@ -34,7 +34,7 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					Use:       "delegations-to [validator-addr]",
 					Short:     "Query all delegations made to one validator",
 					Long:      "Query delegations on an individual validator.",
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+					PositionalArgs: []*autocli.PositionalArgDescriptor{
 						{
 							ProtoField: "validator_addr",
 						},
@@ -46,7 +46,7 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					Short:     "Query all unbonding delegations from a validator",
 					Long:      "Query delegations that are unbonding _from_ a validator.",
 					Example:   fmt.Sprintf("$ %s query staking unbonding-delegations-from [val-addr]", version.AppName),
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+					PositionalArgs: []*autocli.PositionalArgDescriptor{
 						{ProtoField: "validator_addr"},
 					},
 				},
@@ -55,7 +55,7 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					Use:       "delegation [delegator-addr] [validator-addr]",
 					Short:     "Query a delegation based on address and validator address",
 					Long:      "Query delegations for an individual delegator on an individual validator",
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+					PositionalArgs: []*autocli.PositionalArgDescriptor{
 						{ProtoField: "delegator_addr"},
 						{ProtoField: "validator_addr"},
 					},
@@ -65,7 +65,7 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					Use:       "unbonding-delegation [delegator-addr] [validator-addr]",
 					Short:     "Query an unbonding-delegation record based on delegator and validator address",
 					Long:      "Query unbonding delegations for an individual delegator on an individual validator.",
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+					PositionalArgs: []*autocli.PositionalArgDescriptor{
 						{ProtoField: "delegator_addr"},
 						{ProtoField: "validator_addr"},
 					},
@@ -75,7 +75,7 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					Use:       "delegations [delegator-addr]",
 					Short:     "Query all delegations made by one delegator",
 					Long:      "Query delegations for an individual delegator on all validators.",
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+					PositionalArgs: []*autocli.PositionalArgDescriptor{
 						{ProtoField: "delegator_addr"},
 					},
 				},
@@ -83,7 +83,7 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					RpcMethod: "DelegatorValidators",
 					Use:       "delegator-validators [delegator-addr]",
 					Short:     "Query all validators info for given delegator address",
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+					PositionalArgs: []*autocli.PositionalArgDescriptor{
 						{ProtoField: "delegator_addr"},
 					},
 				},
@@ -91,7 +91,7 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					RpcMethod: "DelegatorValidator",
 					Use:       "delegator-validator [delegator-addr] [validator-addr]",
 					Short:     "Query validator info for given delegator validator pair",
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+					PositionalArgs: []*autocli.PositionalArgDescriptor{
 						{ProtoField: "delegator_addr"},
 						{ProtoField: "validator_addr"},
 					},
@@ -101,7 +101,7 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					Use:       "unbonding-delegations [delegator-addr]",
 					Short:     "Query all unbonding-delegations records for one delegator",
 					Long:      "Query unbonding delegations for an individual delegator.",
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+					PositionalArgs: []*autocli.PositionalArgDescriptor{
 						{ProtoField: "delegator_addr"},
 					},
 				},
@@ -110,7 +110,7 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					Use:       "redelegation [delegator-addr] [src-validator-addr] [dst-validator-addr]",
 					Short:     "Query a redelegation record based on delegator and a source and destination validator address",
 					Long:      "Query a redelegation record for an individual delegator between a source and destination validator.",
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+					PositionalArgs: []*autocli.PositionalArgDescriptor{
 						{ProtoField: "delegator_addr"},
 						{ProtoField: "src_validator_addr"},
 						{ProtoField: "dst_validator_addr", Optional: true},
@@ -121,7 +121,7 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					Use:       "historical-info [height]",
 					Short:     "Query historical info at given height",
 					Example:   fmt.Sprintf("$ %s query staking historical-info 5", version.AppName),
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+					PositionalArgs: []*autocli.PositionalArgDescriptor{
 						{ProtoField: "height"},
 					},
 				},
@@ -139,16 +139,16 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 				},
 			},
 		},
-		Tx: &autocliv1.ServiceCommandDescriptor{
+		Tx: &autocli.ServiceCommandDescriptor{
 			Service: stakingv1beta.Msg_ServiceDesc.ServiceName,
-			RpcCommandOptions: []*autocliv1.RpcCommandOptions{
+			RpcCommandOptions: []*autocli.RpcCommandOptions{
 				{
 					RpcMethod:      "Delegate",
 					Use:            "delegate [validator-addr] [amount] --from [delegator_address]",
 					Short:          "Delegate liquid tokens to a validator",
 					Long:           "Delegate an amount of liquid coins to a validator from your wallet.",
 					Example:        fmt.Sprintf("%s tx staking delegate cosmosvaloper... 1000stake --from mykey", version.AppName),
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{{ProtoField: "validator_address"}, {ProtoField: "amount"}},
+					PositionalArgs: []*autocli.PositionalArgDescriptor{{ProtoField: "validator_address"}, {ProtoField: "amount"}},
 				},
 				{
 					RpcMethod:      "BeginRedelegate",
@@ -156,7 +156,7 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					Short:          "Generate multisig signatures for transactions generated offline",
 					Long:           "Redelegate an amount of illiquid staking tokens from one validator to another.",
 					Example:        fmt.Sprintf(`%s tx staking redelegate cosmosvaloper... cosmosvaloper... 100stake --from mykey`, version.AppName),
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{{ProtoField: "validator_src_address"}, {ProtoField: "validator_dst_address"}, {ProtoField: "amount"}},
+					PositionalArgs: []*autocli.PositionalArgDescriptor{{ProtoField: "validator_src_address"}, {ProtoField: "validator_dst_address"}, {ProtoField: "amount"}},
 				},
 				{
 					RpcMethod:      "Undelegate",
@@ -164,14 +164,14 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					Short:          "Unbond shares from a validator",
 					Long:           "Unbond an amount of bonded shares from a validator.",
 					Example:        fmt.Sprintf(`%s tx staking unbond cosmosvaloper... 100stake --from mykey`, version.AppName),
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{{ProtoField: "validator_address"}, {ProtoField: "amount"}},
+					PositionalArgs: []*autocli.PositionalArgDescriptor{{ProtoField: "validator_address"}, {ProtoField: "amount"}},
 				},
 				{
 					RpcMethod:      "CancelUnbondingDelegation",
 					Use:            "cancel-unbond [validator-addr] [amount] [creation-height]",
 					Short:          "Cancel unbonding delegation and delegate back to the validator",
 					Example:        fmt.Sprintf(`%s tx staking cancel-unbond cosmosvaloper... 100stake 2 --from mykey`, version.AppName),
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{{ProtoField: "validator_address"}, {ProtoField: "amount"}, {ProtoField: "creation_height"}},
+					PositionalArgs: []*autocli.PositionalArgDescriptor{{ProtoField: "validator_address"}, {ProtoField: "amount"}, {ProtoField: "creation_height"}},
 				},
 				{
 					RpcMethod:      "UpdateParams",
@@ -179,7 +179,7 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					Short:          "Submit a proposal to update staking module params. Note: the entire params must be provided.",
 					Long:           fmt.Sprintf("Submit a proposal to update staking module params. Note: the entire params must be provided.\n See the fields to fill in by running `%s query staking params --output json`", version.AppName),
 					Example:        fmt.Sprintf(`%s tx staking update-params-proposal '{ "unbonding_time": "504h0m0s", ... }'`, version.AppName),
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{{ProtoField: "params"}},
+					PositionalArgs: []*autocli.PositionalArgDescriptor{{ProtoField: "params"}},
 					GovProposal:    true,
 				},
 			},

--- a/x/tx/decode/decode.go
+++ b/x/tx/decode/decode.go
@@ -2,21 +2,26 @@ package decode
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/cosmos/cosmos-proto/anyutil"
+	gogoproto "github.com/cosmos/gogoproto/proto"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/reflect/protoregistry"
+	"google.golang.org/protobuf/types/known/anypb"
 
-	v1beta1 "cosmossdk.io/api/cosmos/tx/v1beta1"
 	errorsmod "cosmossdk.io/errors"
 
+	txtypes "github.com/cosmos/cosmos-sdk/types/tx"
 	"github.com/cosmos/cosmos-sdk/x/tx/signing"
 )
 
 // DecodedTx contains the decoded transaction, its signers, and other flags.
 type DecodedTx struct {
 	Messages                     []proto.Message
-	Tx                           *v1beta1.Tx
-	TxRaw                        *v1beta1.TxRaw
+	Tx                           *txtypes.Tx
+	TxRaw                        *txtypes.TxRaw
 	Signers                      [][]byte
 	TxBodyHasUnknownNonCriticals bool
 }
@@ -42,55 +47,73 @@ func NewDecoder(options Options) (*Decoder, error) {
 	}, nil
 }
 
+// msgDescriptor returns the protoreflect.MessageDescriptor for the named message
+// from the global type registry. The gogoproto init() functions register all SDK
+// proto types into protoregistry.GlobalTypes.
+func msgDescriptor(fullName protoreflect.FullName) (protoreflect.MessageType, error) {
+	mt, err := protoregistry.GlobalTypes.FindMessageByName(fullName)
+	if err != nil {
+		return nil, fmt.Errorf("descriptor for %s not found in global registry: %w", fullName, err)
+	}
+	return mt, nil
+}
+
 // Decode decodes raw protobuf encoded transaction bytes into a DecodedTx.
 func (d *Decoder) Decode(txBytes []byte) (*DecodedTx, error) {
 	// Make sure txBytes follow ADR-027.
-	err := rejectNonADR027TxRaw(txBytes)
+	if err := rejectNonADR027TxRaw(txBytes); err != nil {
+		return nil, errorsmod.Wrap(ErrTxDecode, err.Error())
+	}
+
+	// Get descriptors from the global registry — gogoproto's proto.RegisterType
+	// populates protoregistry.GlobalTypes, so no pulsar import is needed.
+	txRawMT, err := msgDescriptor("cosmos.tx.v1beta1.TxRaw")
+	if err != nil {
+		return nil, errorsmod.Wrap(ErrTxDecode, err.Error())
+	}
+	txBodyMT, err := msgDescriptor("cosmos.tx.v1beta1.TxBody")
+	if err != nil {
+		return nil, errorsmod.Wrap(ErrTxDecode, err.Error())
+	}
+	authInfoMT, err := msgDescriptor("cosmos.tx.v1beta1.AuthInfo")
 	if err != nil {
 		return nil, errorsmod.Wrap(ErrTxDecode, err.Error())
 	}
 
-	var raw v1beta1.TxRaw
+	fileResolver := d.signingCtx.FileResolver()
 
 	// reject all unknown proto fields in the root TxRaw
-	fileResolver := d.signingCtx.FileResolver()
-	err = RejectUnknownFieldsStrict(txBytes, raw.ProtoReflect().Descriptor(), fileResolver)
-	if err != nil {
+	if err = signing.RejectUnknownFieldsStrict(txBytes, txRawMT.Descriptor(), fileResolver); err != nil {
 		return nil, errorsmod.Wrap(ErrTxDecode, err.Error())
 	}
 
-	err = proto.Unmarshal(txBytes, &raw)
-	if err != nil {
+	var raw txtypes.TxRaw
+	if err = gogoproto.Unmarshal(txBytes, &raw); err != nil {
 		return nil, err
 	}
 
-	var body v1beta1.TxBody
+	var body txtypes.TxBody
 
 	// allow non-critical unknown fields in TxBody
-	txBodyHasUnknownNonCriticals, err := RejectUnknownFields(raw.BodyBytes, body.ProtoReflect().Descriptor(), true, fileResolver)
+	txBodyHasUnknownNonCriticals, err := signing.RejectUnknownFields(raw.BodyBytes, txBodyMT.Descriptor(), true, fileResolver)
 	if err != nil {
 		return nil, errorsmod.Wrap(ErrTxDecode, err.Error())
 	}
-
-	err = proto.Unmarshal(raw.BodyBytes, &body)
-	if err != nil {
+	if err = gogoproto.Unmarshal(raw.BodyBytes, &body); err != nil {
 		return nil, errorsmod.Wrap(ErrTxDecode, err.Error())
 	}
 
-	var authInfo v1beta1.AuthInfo
+	var authInfo txtypes.AuthInfo
 
 	// reject all unknown proto fields in AuthInfo
-	err = RejectUnknownFieldsStrict(raw.AuthInfoBytes, authInfo.ProtoReflect().Descriptor(), fileResolver)
-	if err != nil {
+	if err = signing.RejectUnknownFieldsStrict(raw.AuthInfoBytes, authInfoMT.Descriptor(), fileResolver); err != nil {
+		return nil, errorsmod.Wrap(ErrTxDecode, err.Error())
+	}
+	if err = gogoproto.Unmarshal(raw.AuthInfoBytes, &authInfo); err != nil {
 		return nil, errorsmod.Wrap(ErrTxDecode, err.Error())
 	}
 
-	err = proto.Unmarshal(raw.AuthInfoBytes, &authInfo)
-	if err != nil {
-		return nil, errorsmod.Wrap(ErrTxDecode, err.Error())
-	}
-
-	theTx := &v1beta1.Tx{
+	theTx := &txtypes.Tx{
 		Body:       &body,
 		AuthInfo:   &authInfo,
 		Signatures: raw.Signatures,
@@ -99,7 +122,9 @@ func (d *Decoder) Decode(txBytes []byte) (*DecodedTx, error) {
 	var signers [][]byte
 	var msgs []proto.Message
 	seenSigners := map[string]struct{}{}
-	for _, anyMsg := range body.Messages {
+	for _, gogoMsg := range body.Messages {
+		// Convert gogoproto Any to protov2 Any for anyutil.Unpack.
+		anyMsg := &anypb.Any{TypeUrl: gogoMsg.TypeUrl, Value: gogoMsg.Value}
 		msg, signerErr := anyutil.Unpack(anyMsg, fileResolver, d.signingCtx.TypeResolver())
 		if signerErr != nil {
 			return nil, errorsmod.Wrap(ErrTxDecode, signerErr.Error())
@@ -110,12 +135,10 @@ func (d *Decoder) Decode(txBytes []byte) (*DecodedTx, error) {
 			return nil, errorsmod.Wrap(ErrTxDecode, signerErr.Error())
 		}
 		for _, s := range ss {
-			_, seen := seenSigners[string(s)]
-			if seen {
-				continue
+			if _, seen := seenSigners[string(s)]; !seen {
+				signers = append(signers, s)
+				seenSigners[string(s)] = struct{}{}
 			}
-			signers = append(signers, s)
-			seenSigners[string(s)] = struct{}{}
 		}
 	}
 
@@ -125,7 +148,6 @@ func (d *Decoder) Decode(txBytes []byte) (*DecodedTx, error) {
 		if err != nil {
 			return nil, errorsmod.Wrap(ErrTxDecode, err.Error())
 		}
-
 		if _, seen := seenSigners[string(feeAddr)]; !seen {
 			signers = append(signers, feeAddr)
 		}

--- a/x/tx/decode/errors.go
+++ b/x/tx/decode/errors.go
@@ -1,13 +1,17 @@
 package decode
 
-import "cosmossdk.io/errors"
+import (
+	errorsmod "cosmossdk.io/errors"
 
-const (
-	txCodespace = "tx"
+	"github.com/cosmos/cosmos-sdk/x/tx/signing"
 )
 
+const txCodespace = "tx"
+
 var (
-	// ErrTxDecode is returned if we cannot parse a transaction
-	ErrTxDecode     = errors.Register(txCodespace, 1, "tx parse error")
-	ErrUnknownField = errors.Register(txCodespace, 2, "unknown protobuf field")
+	// ErrTxDecode is returned if we cannot parse a transaction.
+	ErrTxDecode = errorsmod.Register(txCodespace, 1, "tx parse error")
+
+	// ErrUnknownField is re-exported from x/tx/signing for backwards compatibility.
+	ErrUnknownField = signing.ErrUnknownField
 )

--- a/x/tx/decode/unknown.go
+++ b/x/tx/decode/unknown.go
@@ -1,197 +1,26 @@
 package decode
 
 import (
-	"errors"
-	"fmt"
-	"strings"
-
 	"google.golang.org/protobuf/encoding/protowire"
-	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protodesc"
 	"google.golang.org/protobuf/reflect/protoreflect"
-	"google.golang.org/protobuf/types/known/anypb"
+
+	"github.com/cosmos/cosmos-sdk/x/tx/signing"
 )
 
-const bit11NonCritical = 1 << 10
-
-var (
-	anyDesc     = (&anypb.Any{}).ProtoReflect().Descriptor()
-	anyFullName = anyDesc.FullName()
-)
-
-// RejectUnknownFieldsStrict operates by the same rules as RejectUnknownFields, but returns an error if any unknown
-// non-critical fields are encountered.
+// RejectUnknownFieldsStrict rejects any bytes bz that contain unknown proto fields.
+// It delegates to x/tx/signing where the implementation now lives.
 func RejectUnknownFieldsStrict(bz []byte, msg protoreflect.MessageDescriptor, resolver protodesc.Resolver) error {
-	_, err := RejectUnknownFields(bz, msg, false, resolver)
-	return err
+	return signing.RejectUnknownFieldsStrict(bz, msg, resolver)
 }
 
-// RejectUnknownFields rejects any bytes bz with an error that has unknown fields for the provided proto.Message type with an
-// option to allow non-critical fields (specified as those fields with bit 11) to pass through. In either case, the
-// hasUnknownNonCriticals will be set to true if non-critical fields were encountered during traversal. This flag can be
-// used to treat a message with non-critical field different in different security contexts (such as transaction signing).
-// This function traverses inside of messages nested via google.protobuf.Any. It does not do any deserialization of the proto.Message.
-// An AnyResolver must be provided for traversing inside google.protobuf.Any's.
-func RejectUnknownFields(bz []byte, desc protoreflect.MessageDescriptor, allowUnknownNonCriticals bool, resolver protodesc.Resolver) (hasUnknownNonCriticals bool, err error) {
-	// recursion limit with same default as https://github.com/protocolbuffers/protobuf-go/blob/v1.35.2/encoding/protowire/wire.go#L28
-	return doRejectUnknownFields(bz, desc, allowUnknownNonCriticals, resolver, 10_000)
+// RejectUnknownFields is like RejectUnknownFieldsStrict but allows non-critical unknown fields.
+func RejectUnknownFields(bz []byte, desc protoreflect.MessageDescriptor, allowUnknownNonCriticals bool, resolver protodesc.Resolver) (bool, error) {
+	return signing.RejectUnknownFields(bz, desc, allowUnknownNonCriticals, resolver)
 }
 
-func doRejectUnknownFields(
-	bz []byte,
-	desc protoreflect.MessageDescriptor,
-	allowUnknownNonCriticals bool,
-	resolver protodesc.Resolver,
-	recursionLimit int,
-) (hasUnknownNonCriticals bool, err error) {
-	if len(bz) == 0 {
-		return hasUnknownNonCriticals, nil
-	}
-	if recursionLimit == 0 {
-		return false, errors.New("recursion limit reached")
-	}
-
-	fields := desc.Fields()
-
-	for len(bz) > 0 {
-		tagNum, wireType, m := protowire.ConsumeTag(bz)
-		if m < 0 {
-			return hasUnknownNonCriticals, errors.New("invalid length")
-		}
-
-		fieldDesc := fields.ByNumber(tagNum)
-		if fieldDesc == nil {
-			isCriticalField := tagNum&bit11NonCritical == 0
-
-			if !isCriticalField {
-				hasUnknownNonCriticals = true
-			}
-
-			if isCriticalField || !allowUnknownNonCriticals {
-				// The tag is critical, so report it.
-				return hasUnknownNonCriticals, ErrUnknownField.Wrapf(
-					"%s: {TagNum: %d, WireType:%q}",
-					desc.FullName(), tagNum, WireTypeToString(wireType))
-			}
-		}
-
-		// Skip over the bytes that store fieldNumber and wireType bytes.
-		bz = bz[m:]
-		n := protowire.ConsumeFieldValue(tagNum, wireType, bz)
-		if n < 0 {
-			err = fmt.Errorf("could not consume field value for tagNum: %d, wireType: %q; %w",
-				tagNum, WireTypeToString(wireType), protowire.ParseError(n))
-			return hasUnknownNonCriticals, err
-		}
-		fieldBytes := bz[:n]
-		bz = bz[n:]
-
-		// An unknown but non-critical field
-		if fieldDesc == nil {
-			continue
-		}
-
-		fieldMessage := fieldDesc.Message()
-		// not message or group kind
-		if fieldMessage == nil {
-			continue
-		}
-		// if a message descriptor is a placeholder resolve it using the injected resolver.
-		// this can happen when a descriptor has been registered in the
-		// "google.golang.org/protobuf" registry but not in "github.com/cosmos/gogoproto".
-		// fixes: https://github.com/cosmos/cosmos-sdk/issues/22574
-		if fieldMessage.IsPlaceholder() {
-			gogoDesc, err := resolver.FindDescriptorByName(fieldMessage.FullName())
-			if err != nil {
-				return hasUnknownNonCriticals, fmt.Errorf("could not resolve placeholder descriptor: %v: %w", fieldMessage, err)
-			}
-			fieldMessage = gogoDesc.(protoreflect.MessageDescriptor)
-		}
-
-		// consume length prefix of nested message
-		_, o := protowire.ConsumeVarint(fieldBytes)
-		if o < 0 {
-			err = fmt.Errorf("could not consume length prefix fieldBytes for nested message: %v: %w",
-				fieldMessage, protowire.ParseError(o))
-			return hasUnknownNonCriticals, err
-		} else if o > len(fieldBytes) {
-			err = fmt.Errorf("length prefix > len(fieldBytes) for nested message: %v", fieldMessage)
-			return hasUnknownNonCriticals, err
-		}
-
-		fieldBytes = fieldBytes[o:]
-
-		var err error
-
-		if fieldMessage.FullName() == anyFullName {
-			// Firstly typecheck types.Any to ensure nothing snuck in.
-			hasUnknownNonCriticalsChild, err := doRejectUnknownFields(fieldBytes, anyDesc, allowUnknownNonCriticals, resolver, recursionLimit-1)
-			hasUnknownNonCriticals = hasUnknownNonCriticals || hasUnknownNonCriticalsChild
-			if err != nil {
-				return hasUnknownNonCriticals, err
-			}
-			var a anypb.Any
-			if err = proto.Unmarshal(fieldBytes, &a); err != nil {
-				return hasUnknownNonCriticals, err
-			}
-
-			msgName := protoreflect.FullName(strings.TrimPrefix(a.TypeUrl, "/"))
-			msgDesc, err := resolver.FindDescriptorByName(msgName)
-			if err != nil {
-				return hasUnknownNonCriticals, err
-			}
-
-			fieldMessage = msgDesc.(protoreflect.MessageDescriptor)
-			fieldBytes = a.Value
-		}
-
-		hasUnknownNonCriticalsChild, err := doRejectUnknownFields(fieldBytes, fieldMessage, allowUnknownNonCriticals, resolver, recursionLimit-1)
-		hasUnknownNonCriticals = hasUnknownNonCriticals || hasUnknownNonCriticalsChild
-		if err != nil {
-			return hasUnknownNonCriticals, err
-		}
-	}
-
-	return hasUnknownNonCriticals, nil
-}
-
-// errUnknownField represents an error indicating that we encountered
-// a field that isn't available in the target proto.Message.
-type errUnknownField struct {
-	Desc     protoreflect.MessageDescriptor
-	TagNum   protowire.Number
-	WireType protowire.Type
-}
-
-// String implements fmt.Stringer.
-func (twt *errUnknownField) String() string {
-	return fmt.Sprintf("errUnknownField %q: {TagNum: %d, WireType:%q}",
-		twt.Desc.FullName(), twt.TagNum, WireTypeToString(twt.WireType))
-}
-
-// Error implements the error interface.
-func (twt *errUnknownField) Error() string {
-	return twt.String()
-}
-
-var _ error = (*errUnknownField)(nil)
-
-// WireTypeToString returns a string representation of the given protowire.Type.
+// WireTypeToString returns a human-readable string for a protobuf wire type.
+// Re-exported from x/tx/signing for backwards compatibility.
 func WireTypeToString(wt protowire.Type) string {
-	switch wt {
-	case 0:
-		return "varint"
-	case 1:
-		return "fixed64"
-	case 2:
-		return "bytes"
-	case 3:
-		return "start_group"
-	case 4:
-		return "end_group"
-	case 5:
-		return "fixed32"
-	default:
-		return fmt.Sprintf("unknown type: %d", wt)
-	}
+	return signing.WireTypeToString(wt)
 }

--- a/x/tx/signing/aminojson/aminojson.go
+++ b/x/tx/signing/aminojson/aminojson.go
@@ -8,8 +8,6 @@ import (
 	gogoproto "github.com/cosmos/gogoproto/proto"
 	"google.golang.org/protobuf/reflect/protoregistry"
 
-	signingv1beta1 "cosmossdk.io/api/cosmos/tx/signing/v1beta1"
-
 	"github.com/cosmos/cosmos-sdk/x/tx/decode"
 	"github.com/cosmos/cosmos-sdk/x/tx/signing"
 	"github.com/cosmos/cosmos-sdk/x/tx/signing/aminojson/internal/aminojsonpb"
@@ -55,8 +53,8 @@ func NewSignModeHandler(options SignModeHandlerOptions) *SignModeHandler {
 }
 
 // Mode implements the Mode method of the SignModeHandler interface.
-func (h SignModeHandler) Mode() signingv1beta1.SignMode {
-	return signingv1beta1.SignMode_SIGN_MODE_LEGACY_AMINO_JSON
+func (h SignModeHandler) Mode() signing.SignMode {
+	return signing.SignMode_SIGN_MODE_LEGACY_AMINO_JSON
 }
 
 // GetSignBytes implements the GetSignBytes method of the SignModeHandler interface.

--- a/x/tx/signing/aminojson/aminojson.go
+++ b/x/tx/signing/aminojson/aminojson.go
@@ -8,8 +8,6 @@ import (
 	"google.golang.org/protobuf/reflect/protoregistry"
 	"google.golang.org/protobuf/types/known/anypb"
 
-	basev1beta1 "cosmossdk.io/api/cosmos/base/v1beta1"
-
 	"github.com/cosmos/cosmos-sdk/x/tx/signing"
 	"github.com/cosmos/cosmos-sdk/x/tx/signing/aminojson/internal/aminojsonpb"
 )
@@ -83,17 +81,13 @@ func (h SignModeHandler) GetSignBytes(_ context.Context, signerData signing.Sign
 
 	f := txData.AuthInfo.Fee
 
-	// Convert []TxCoinData → []*basev1beta1.Coin for the amino sign fee.
-	feeCoins := make([]*basev1beta1.Coin, len(f.Amount))
+	// Convert []TxCoinData to FeeAmount for the amino sign fee.
+	// basev1beta1.Coin construction is hidden inside aminojsonpb.NewAminoSignFee.
+	feeAmounts := make([]aminojsonpb.FeeAmount, len(f.Amount))
 	for i, c := range f.Amount {
-		feeCoins[i] = &basev1beta1.Coin{Denom: c.Denom, Amount: c.Amount}
+		feeAmounts[i] = aminojsonpb.FeeAmount{Denom: c.Denom, Amount: c.Amount}
 	}
-	fee := &aminojsonpb.AminoSignFee{
-		Amount:  feeCoins,
-		Gas:     f.GasLimit,
-		Payer:   f.Payer,
-		Granter: f.Granter,
-	}
+	fee := aminojsonpb.NewAminoSignFee(feeAmounts, f.GasLimit, f.Payer, f.Granter)
 
 	// Convert []RawMsg → []*anypb.Any for the amino sign doc Msgs field.
 	msgs := make([]*anypb.Any, len(body.Messages))

--- a/x/tx/signing/aminojson/aminojson.go
+++ b/x/tx/signing/aminojson/aminojson.go
@@ -2,13 +2,14 @@ package aminojson
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	gogoproto "github.com/cosmos/gogoproto/proto"
 	"google.golang.org/protobuf/reflect/protoregistry"
+	"google.golang.org/protobuf/types/known/anypb"
 
-	"github.com/cosmos/cosmos-sdk/x/tx/decode"
+	basev1beta1 "cosmossdk.io/api/cosmos/base/v1beta1"
+
 	"github.com/cosmos/cosmos-sdk/x/tx/signing"
 	"github.com/cosmos/cosmos-sdk/x/tx/signing/aminojson/internal/aminojsonpb"
 )
@@ -44,7 +45,7 @@ func NewSignModeHandler(options SignModeHandlerOptions) *SignModeHandler {
 		h.encoder = NewEncoder(EncoderOptions{
 			FileResolver: options.FileResolver,
 			TypeResolver: options.TypeResolver,
-			EnumAsString: false, // ensure enum as string is disabled
+			EnumAsString: false,
 		})
 	} else {
 		h.encoder = *options.Encoder
@@ -60,13 +61,19 @@ func (h SignModeHandler) Mode() signing.SignMode {
 // GetSignBytes implements the GetSignBytes method of the SignModeHandler interface.
 func (h SignModeHandler) GetSignBytes(_ context.Context, signerData signing.SignerData, txData signing.TxData) ([]byte, error) {
 	body := txData.Body
-	_, err := decode.RejectUnknownFields(
-		txData.BodyBytes, body.ProtoReflect().Descriptor(), false, h.fileResolver)
+
+	// Get TxBody descriptor from the global registry to run unknown field checks.
+	// gogoproto's init() registers all SDK proto types into protoregistry.GlobalTypes.
+	txBodyMT, err := protoregistry.GlobalTypes.FindMessageByName("cosmos.tx.v1beta1.TxBody")
+	if err != nil {
+		return nil, fmt.Errorf("txbody descriptor not in global registry: %w", err)
+	}
+	_, err = signing.RejectUnknownFields(txData.BodyBytes, txBodyMT.Descriptor(), false, h.fileResolver)
 	if err != nil {
 		return nil, err
 	}
 
-	if (len(body.ExtensionOptions) > 0) || (len(body.NonCriticalExtensionOptions) > 0) {
+	if len(body.ExtensionOptions) > 0 || len(body.NonCriticalExtensionOptions) > 0 {
 		return nil, fmt.Errorf("%s does not support protobuf extension options: invalid request", h.Mode())
 	}
 
@@ -74,19 +81,24 @@ func (h SignModeHandler) GetSignBytes(_ context.Context, signerData signing.Sign
 		return nil, fmt.Errorf("got empty address in %s handler: invalid request", h.Mode())
 	}
 
-	// We set a convention that if the tipper signs with LEGACY_AMINO_JSON, then
-	// they sign over empty fees and 0 gas.
-	var fee *aminojsonpb.AminoSignFee
-
 	f := txData.AuthInfo.Fee
-	if f == nil {
-		return nil, errors.New("fee cannot be nil when tipper is not signer")
+
+	// Convert []TxCoinData → []*basev1beta1.Coin for the amino sign fee.
+	feeCoins := make([]*basev1beta1.Coin, len(f.Amount))
+	for i, c := range f.Amount {
+		feeCoins[i] = &basev1beta1.Coin{Denom: c.Denom, Amount: c.Amount}
 	}
-	fee = &aminojsonpb.AminoSignFee{
-		Amount:  f.Amount,
+	fee := &aminojsonpb.AminoSignFee{
+		Amount:  feeCoins,
 		Gas:     f.GasLimit,
 		Payer:   f.Payer,
 		Granter: f.Granter,
+	}
+
+	// Convert []RawMsg → []*anypb.Any for the amino sign doc Msgs field.
+	msgs := make([]*anypb.Any, len(body.Messages))
+	for i, m := range body.Messages {
+		msgs[i] = &anypb.Any{TypeUrl: m.TypeUrl, Value: m.Value}
 	}
 
 	signDoc := &aminojsonpb.AminoSignDoc{
@@ -95,9 +107,9 @@ func (h SignModeHandler) GetSignBytes(_ context.Context, signerData signing.Sign
 		ChainId:          signerData.ChainID,
 		Sequence:         signerData.Sequence,
 		Memo:             body.Memo,
-		Msgs:             txData.Body.Messages,
-		Unordered:        txData.Body.Unordered,
-		TimeoutTimestamp: txData.Body.TimeoutTimestamp,
+		Msgs:             msgs,
+		Unordered:        body.Unordered,
+		TimeoutTimestamp: body.TimeoutTimestamp,
 		Fee:              fee,
 	}
 

--- a/x/tx/signing/aminojson/aminojson_test.go
+++ b/x/tx/signing/aminojson/aminojson_test.go
@@ -12,15 +12,16 @@ import (
 
 	bankv1beta1 "cosmossdk.io/api/cosmos/bank/v1beta1"
 	basev1beta1 "cosmossdk.io/api/cosmos/base/v1beta1"
-	txv1beta1 "cosmossdk.io/api/cosmos/tx/v1beta1"
 
+	txsigning "github.com/cosmos/cosmos-sdk/x/tx/signing"
 	"github.com/cosmos/cosmos-sdk/x/tx/signing/aminojson"
+	"github.com/cosmos/cosmos-sdk/x/tx/signing/aminojson/internal/aminojsonpb"
 	"github.com/cosmos/cosmos-sdk/x/tx/signing/testutil"
 )
 
 func TestAminoJsonSignMode(t *testing.T) {
-	fee := &txv1beta1.Fee{
-		Amount: []*basev1beta1.Coin{{Denom: "uatom", Amount: "1000"}},
+	fee := &txsigning.TxFeeData{
+		Amount: []txsigning.TxCoinData{{Denom: "uatom", Amount: "1000"}},
 	}
 	handlerOptions := testutil.HandlerArgumentOptions{
 		ChainID: "test-chain",
@@ -84,8 +85,8 @@ func TestAminoJsonSignMode(t *testing.T) {
 }
 
 func TestUnorderedTimeoutCompat(t *testing.T) {
-	fee := &txv1beta1.Fee{
-		Amount: []*basev1beta1.Coin{{Denom: "uatom", Amount: "1000"}},
+	fee := &txsigning.TxFeeData{
+		Amount: []txsigning.TxCoinData{{Denom: "uatom", Amount: "1000"}},
 	}
 
 	now := time.Now()
@@ -156,8 +157,8 @@ func TestUnorderedTimeoutCompat(t *testing.T) {
 }
 
 func TestUnorderedEmpty(t *testing.T) {
-	fee := &txv1beta1.Fee{
-		Amount: []*basev1beta1.Coin{{Denom: "uatom", Amount: "1000"}},
+	fee := &txsigning.TxFeeData{
+		Amount: []txsigning.TxCoinData{{Denom: "uatom", Amount: "1000"}},
 	}
 
 	opts := testutil.HandlerArgumentOptions{
@@ -187,8 +188,8 @@ func TestUnorderedEmpty(t *testing.T) {
 }
 
 func TestUnorderedBusiness(t *testing.T) {
-	fee := &txv1beta1.Fee{
-		Amount: []*basev1beta1.Coin{{Denom: "uatom", Amount: "1000"}},
+	fee := &txsigning.TxFeeData{
+		Amount: []txsigning.TxCoinData{{Denom: "uatom", Amount: "1000"}},
 	}
 
 	timeout := time.Now().Add(3 * time.Hour)
@@ -270,7 +271,7 @@ func TestNullSliceAsEmptyEncoder(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			fee := &txv1beta1.Fee{
+			fee := &aminojsonpb.AminoSignFee{
 				Amount: tc.amount,
 			}
 
@@ -304,8 +305,8 @@ func TestNullSliceAsEmptyEncoderDirect(t *testing.T) {
 	require.NotNil(t, customEncoder)
 
 	// Create a Fee message with an empty list (Fee uses legacy_coins which uses NullSliceAsEmptyEncoder)
-	fee := &txv1beta1.Fee{
-		Amount: []*basev1beta1.Coin{}, // empty slice
+	fee := &aminojsonpb.AminoSignFee{
+		Amount: []*basev1beta1.Coin{},
 	}
 
 	// Marshal using the encoder

--- a/x/tx/signing/aminojson/fuzz_test.go
+++ b/x/tx/signing/aminojson/fuzz_test.go
@@ -9,8 +9,8 @@ import (
 
 	bankv1beta1 "cosmossdk.io/api/cosmos/bank/v1beta1"
 	basev1beta1 "cosmossdk.io/api/cosmos/base/v1beta1"
-	txv1beta1 "cosmossdk.io/api/cosmos/tx/v1beta1"
 
+	txsigning "github.com/cosmos/cosmos-sdk/x/tx/signing"
 	"github.com/cosmos/cosmos-sdk/x/tx/signing/testutil"
 )
 
@@ -20,8 +20,8 @@ func FuzzSignModeGetSignBytes(f *testing.F) {
 	}
 
 	// 1. Create seeds.
-	fee := &txv1beta1.Fee{
-		Amount: []*basev1beta1.Coin{{Denom: "uatom", Amount: "1000"}},
+	fee := &txsigning.TxFeeData{
+		Amount: []txsigning.TxCoinData{{Denom: "uatom", Amount: "1000"}},
 	}
 	seed := &testutil.HandlerArgumentOptions{
 		ChainID: "test-chain",

--- a/x/tx/signing/aminojson/internal/aminojsonpb/fee.go
+++ b/x/tx/signing/aminojson/internal/aminojsonpb/fee.go
@@ -1,0 +1,20 @@
+package aminojsonpb
+
+import v1beta1 "cosmossdk.io/api/cosmos/base/v1beta1"
+
+// FeeAmount is a simple denom/amount string pair used to build AminoSignFee
+// without exposing cosmossdk.io/api/cosmos/base/v1beta1 to callers.
+type FeeAmount struct {
+	Denom  string
+	Amount string
+}
+
+// NewAminoSignFee constructs an AminoSignFee from plain coin data, hiding
+// the basev1beta1.Coin construction inside the internal aminojsonpb package.
+func NewAminoSignFee(coins []FeeAmount, gas uint64, payer, granter string) *AminoSignFee {
+	feeCoins := make([]*v1beta1.Coin, len(coins))
+	for i, c := range coins {
+		feeCoins[i] = &v1beta1.Coin{Denom: c.Denom, Amount: c.Amount}
+	}
+	return &AminoSignFee{Amount: feeCoins, Gas: gas, Payer: payer, Granter: granter}
+}

--- a/x/tx/signing/context.go
+++ b/x/tx/signing/context.go
@@ -12,7 +12,6 @@ import (
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/reflect/protoregistry"
 
-	msgv1 "cosmossdk.io/api/cosmos/msg/v1"
 	"cosmossdk.io/core/address"
 )
 
@@ -131,7 +130,7 @@ type CustomGetSigner struct {
 func (c CustomGetSigner) IsManyPerContainerType() {}
 
 func getSignersFieldNames(descriptor protoreflect.MessageDescriptor) ([]string, error) {
-	signersFields := proto.GetExtension(descriptor.Options(), msgv1.E_Signer).([]string)
+	signersFields := proto.GetExtension(descriptor.Options(), E_Signer).([]string)
 	if len(signersFields) == 0 {
 		return nil, fmt.Errorf("no cosmos.msg.v1.signer option found for message %s; use DefineCustomGetSigners to specify a custom getter", descriptor.FullName())
 	}
@@ -151,7 +150,7 @@ func (c *Context) Validate() error {
 			sd := fd.Services().Get(i)
 
 			// Skip services that are not annotated with the "cosmos.msg.v1.service" option.
-			if ext := proto.GetExtension(sd.Options(), msgv1.E_Service); ext == nil || !ext.(bool) {
+			if ext := proto.GetExtension(sd.Options(), E_Service); ext == nil || !ext.(bool) {
 				continue
 			}
 

--- a/x/tx/signing/direct/direct.go
+++ b/x/tx/signing/direct/direct.go
@@ -3,17 +3,13 @@ package direct
 import (
 	"context"
 
-	"google.golang.org/protobuf/proto"
+	gogoproto "github.com/cosmos/gogoproto/proto"
 
-	txv1beta1 "cosmossdk.io/api/cosmos/tx/v1beta1"
-
+	txtypes "github.com/cosmos/cosmos-sdk/types/tx"
 	"github.com/cosmos/cosmos-sdk/x/tx/signing"
 )
 
-var (
-	_                  signing.SignModeHandler = SignModeHandler{}
-	protov2MarshalOpts                         = proto.MarshalOptions{Deterministic: true}
-)
+var _ signing.SignModeHandler = SignModeHandler{}
 
 // SignModeHandler is the SIGN_MODE_DIRECT implementation of signing.SignModeHandler.
 type SignModeHandler struct{}
@@ -24,8 +20,10 @@ func (h SignModeHandler) Mode() signing.SignMode {
 }
 
 // GetSignBytes implements signing.SignModeHandler.GetSignBytes.
+// SignDoc has only scalar fields (no maps), so gogoproto.Marshal produces
+// the same deterministic bytes as proto.MarshalOptions{Deterministic:true}.
 func (SignModeHandler) GetSignBytes(_ context.Context, signerData signing.SignerData, txData signing.TxData) ([]byte, error) {
-	return protov2MarshalOpts.Marshal(&txv1beta1.SignDoc{
+	return gogoproto.Marshal(&txtypes.SignDoc{
 		BodyBytes:     txData.BodyBytes,
 		AuthInfoBytes: txData.AuthInfoBytes,
 		ChainId:       signerData.ChainID,

--- a/x/tx/signing/direct/direct.go
+++ b/x/tx/signing/direct/direct.go
@@ -5,7 +5,6 @@ import (
 
 	"google.golang.org/protobuf/proto"
 
-	signingv1beta1 "cosmossdk.io/api/cosmos/tx/signing/v1beta1"
 	txv1beta1 "cosmossdk.io/api/cosmos/tx/v1beta1"
 
 	"github.com/cosmos/cosmos-sdk/x/tx/signing"
@@ -20,8 +19,8 @@ var (
 type SignModeHandler struct{}
 
 // Mode implements signing.SignModeHandler.Mode.
-func (h SignModeHandler) Mode() signingv1beta1.SignMode {
-	return signingv1beta1.SignMode_SIGN_MODE_DIRECT
+func (h SignModeHandler) Mode() signing.SignMode {
+	return signing.SignMode_SIGN_MODE_DIRECT
 }
 
 // GetSignBytes implements signing.SignModeHandler.GetSignBytes.

--- a/x/tx/signing/direct/direct_test.go
+++ b/x/tx/signing/direct/direct_test.go
@@ -75,9 +75,10 @@ func TestDirectModeHandler(t *testing.T) {
 	authInfoBz, err := proto.Marshal(authInfo)
 	require.NoError(t, err)
 
+	// SIGN_MODE_DIRECT only uses BodyBytes and AuthInfoBytes; Body/AuthInfo are not accessed.
 	txData := signing.TxData{
-		Body:                       txBody,
-		AuthInfo:                   authInfo,
+		Body:                       &signing.TxBodyData{},
+		AuthInfo:                   &signing.TxAuthInfoData{},
 		BodyBytes:                  bodyBz,
 		AuthInfoBytes:              authInfoBz,
 		BodyHasUnknownNonCriticals: false,

--- a/x/tx/signing/directaux/direct_aux.go
+++ b/x/tx/signing/directaux/direct_aux.go
@@ -9,7 +9,6 @@ import (
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoregistry"
 
-	signingv1beta1 "cosmossdk.io/api/cosmos/tx/signing/v1beta1"
 	txv1beta1 "cosmossdk.io/api/cosmos/tx/v1beta1"
 
 	"github.com/cosmos/cosmos-sdk/x/tx/signing"
@@ -54,8 +53,8 @@ func NewSignModeHandler(options SignModeHandlerOptions) (SignModeHandler, error)
 var _ signing.SignModeHandler = SignModeHandler{}
 
 // Mode implements signing.SignModeHandler.Mode.
-func (h SignModeHandler) Mode() signingv1beta1.SignMode {
-	return signingv1beta1.SignMode_SIGN_MODE_DIRECT_AUX
+func (h SignModeHandler) Mode() signing.SignMode {
+	return signing.SignMode_SIGN_MODE_DIRECT_AUX
 }
 
 // getFirstSigner returns the first signer from the first message in the tx. It replicates behavior in
@@ -93,7 +92,7 @@ func (h SignModeHandler) GetSignBytes(
 	}
 	if feePayer == signerData.Address {
 		return nil, fmt.Errorf("fee payer %s cannot sign with %s: unauthorized",
-			feePayer, signingv1beta1.SignMode_SIGN_MODE_DIRECT_AUX)
+			feePayer, signing.SignMode_SIGN_MODE_DIRECT_AUX)
 	}
 
 	signDocDirectAux := &txv1beta1.SignDocDirectAux{

--- a/x/tx/signing/directaux/direct_aux.go
+++ b/x/tx/signing/directaux/direct_aux.go
@@ -6,11 +6,13 @@ import (
 	"fmt"
 
 	"github.com/cosmos/cosmos-proto/anyutil"
+	gogoproto "github.com/cosmos/gogoproto/proto"
+	gogotypes "github.com/cosmos/gogoproto/types/any"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoregistry"
+	"google.golang.org/protobuf/types/known/anypb"
 
-	txv1beta1 "cosmossdk.io/api/cosmos/tx/v1beta1"
-
+	txtypes "github.com/cosmos/cosmos-sdk/types/tx"
 	"github.com/cosmos/cosmos-sdk/x/tx/signing"
 )
 
@@ -23,30 +25,23 @@ type SignModeHandler struct {
 
 // SignModeHandlerOptions are the options for the SignModeHandler.
 type SignModeHandlerOptions struct {
-	// TypeResolver is the protoregistry.MessageTypeResolver to use for resolving protobuf types when unpacking any messages.
-	TypeResolver protoregistry.MessageTypeResolver
-
-	// SignersContext is the signing.Context to use for getting signers.
+	TypeResolver   protoregistry.MessageTypeResolver
 	SignersContext *signing.Context
 }
 
 // NewSignModeHandler returns a new SignModeHandler.
 func NewSignModeHandler(options SignModeHandlerOptions) (SignModeHandler, error) {
 	h := SignModeHandler{}
-
 	if options.SignersContext == nil {
 		return h, errors.New("signers context is required")
 	}
 	h.signersContext = options.SignersContext
-
 	h.fileResolver = h.signersContext.FileResolver()
-
 	if options.TypeResolver == nil {
 		h.typeResolver = protoregistry.GlobalTypes
 	} else {
 		h.typeResolver = options.TypeResolver
 	}
-
 	return h, nil
 }
 
@@ -57,14 +52,14 @@ func (h SignModeHandler) Mode() signing.SignMode {
 	return signing.SignMode_SIGN_MODE_DIRECT_AUX
 }
 
-// getFirstSigner returns the first signer from the first message in the tx. It replicates behavior in
-// https://github.com/cosmos/cosmos-sdk/blob/4a6a1e3cb8de459891cb0495052589673d14ef51/x/auth/tx/builder.go#L142
 func (h SignModeHandler) getFirstSigner(txData signing.TxData) ([]byte, error) {
 	if len(txData.Body.Messages) == 0 {
 		return nil, errors.New("no signer found")
 	}
-
-	msg, err := anyutil.Unpack(txData.Body.Messages[0], h.fileResolver, h.typeResolver)
+	// Convert RawMsg to *anypb.Any for anyutil.Unpack.
+	rawMsg := txData.Body.Messages[0]
+	anyMsg := &anypb.Any{TypeUrl: rawMsg.TypeUrl, Value: rawMsg.Value}
+	msg, err := anyutil.Unpack(anyMsg, h.fileResolver, h.typeResolver)
 	if err != nil {
 		return nil, err
 	}
@@ -85,9 +80,10 @@ func (h SignModeHandler) GetSignBytes(
 		if err != nil {
 			return nil, err
 		}
-		feePayer, err = h.signersContext.AddressCodec().BytesToString(fp)
-		if err != nil {
-			return nil, err
+		var addrErr error
+		feePayer, addrErr = h.signersContext.AddressCodec().BytesToString(fp)
+		if addrErr != nil {
+			return nil, addrErr
 		}
 	}
 	if feePayer == signerData.Address {
@@ -95,14 +91,24 @@ func (h SignModeHandler) GetSignBytes(
 			feePayer, signing.SignMode_SIGN_MODE_DIRECT_AUX)
 	}
 
-	signDocDirectAux := &txv1beta1.SignDocDirectAux{
+	signDocDirectAux := &txtypes.SignDocDirectAux{
 		BodyBytes:     txData.BodyBytes,
-		PublicKey:     signerData.PubKey,
 		ChainId:       signerData.ChainID,
 		AccountNumber: signerData.AccountNumber,
 		Sequence:      signerData.Sequence,
 	}
 
-	protov2MarshalOpts := proto.MarshalOptions{Deterministic: true}
-	return protov2MarshalOpts.Marshal(signDocDirectAux)
+	// Convert signerData.PubKey (*anypb.Any, protov2) to gogoproto Any for SignDocDirectAux.PublicKey.
+	if signerData.PubKey != nil {
+		signDocDirectAux.PublicKey = &gogotypes.Any{
+			TypeUrl: signerData.PubKey.TypeUrl,
+			Value:   signerData.PubKey.Value,
+		}
+	}
+
+	return gogoproto.Marshal(signDocDirectAux)
 }
+
+// toProtov2Any converts a protov2 Any to a raw byte form for the sign doc.
+// Kept as a reference; actual conversion happens inline above.
+var _ = proto.Marshal // suppress unused import

--- a/x/tx/signing/directaux/direct_aux_test.go
+++ b/x/tx/signing/directaux/direct_aux_test.go
@@ -14,7 +14,6 @@ import (
 	bankv1beta1 "cosmossdk.io/api/cosmos/bank/v1beta1"
 	basev1beta1 "cosmossdk.io/api/cosmos/base/v1beta1"
 	"cosmossdk.io/api/cosmos/crypto/secp256k1"
-	signingv1beta1 "cosmossdk.io/api/cosmos/tx/signing/v1beta1"
 	txv1beta1 "cosmossdk.io/api/cosmos/tx/v1beta1"
 	"cosmossdk.io/core/address"
 
@@ -28,7 +27,7 @@ func TestDirectAuxHandler(t *testing.T) {
 	memo := "sometestmemo"
 	msg, err := anyutil.New(&bankv1beta1.MsgSend{})
 	require.NoError(t, err)
-	accNum, accSeq := uint64(1), uint64(2) // Arbitrary account number/sequence
+	accNum, accSeq := uint64(1), uint64(2)
 
 	pk := &secp256k1.PubKey{
 		Key: make([]byte, 256),
@@ -36,34 +35,31 @@ func TestDirectAuxHandler(t *testing.T) {
 	anyPk, err := anyutil.New(pk)
 	require.NoError(t, err)
 
-	signerInfo := []*txv1beta1.SignerInfo{
-		{
-			PublicKey: anyPk,
-			ModeInfo: &txv1beta1.ModeInfo{
-				Sum: &txv1beta1.ModeInfo_Single_{
-					Single: &txv1beta1.ModeInfo_Single{
-						Mode: signingv1beta1.SignMode_SIGN_MODE_DIRECT_AUX,
-					},
-				},
-			},
-			Sequence: accSeq,
-		},
-	}
-
-	fee := &txv1beta1.Fee{
-		Amount:   []*basev1beta1.Coin{{Denom: "uatom", Amount: "1000"}},
-		GasLimit: 20000,
-		Payer:    feePayerAddr,
-	}
-
-	txBody := &txv1beta1.TxBody{
-		Messages: []*anypb.Any{msg},
+	// Build Go-native TxBodyData for signing.TxData.
+	txBodyData := &signing.TxBodyData{
+		Messages: []signing.RawMsg{{TypeUrl: msg.TypeUrl, Value: msg.Value}},
 		Memo:     memo,
 	}
 
-	authInfo := &txv1beta1.AuthInfo{
-		Fee:         fee,
-		SignerInfos: signerInfo,
+	authInfoData := &signing.TxAuthInfoData{
+		Fee: signing.TxFeeData{
+			Amount:   []signing.TxCoinData{{Denom: "uatom", Amount: "1000"}},
+			GasLimit: 20000,
+			Payer:    feePayerAddr,
+		},
+	}
+
+	// Build pulsar types for proto.Marshal (bytes only, not stored in TxData).
+	txBodyProto := &txv1beta1.TxBody{
+		Messages: []*anypb.Any{msg},
+		Memo:     memo,
+	}
+	authInfoProto := &txv1beta1.AuthInfo{
+		Fee: &txv1beta1.Fee{
+			Amount:   []*basev1beta1.Coin{{Denom: "uatom", Amount: "1000"}},
+			GasLimit: 20000,
+			Payer:    feePayerAddr,
+		},
 	}
 
 	signingData := signing.SignerData{
@@ -74,16 +70,18 @@ func TestDirectAuxHandler(t *testing.T) {
 		PubKey:        anyPk,
 	}
 
-	bodyBz, err := proto.Marshal(txBody)
+	bodyBz, err := proto.Marshal(txBodyProto)
 	require.NoError(t, err)
-	authInfoBz, err := proto.Marshal(authInfo)
+	authInfoBz, err := proto.Marshal(authInfoProto)
 	require.NoError(t, err)
+
 	txData := signing.TxData{
-		Body:          txBody,
-		AuthInfo:      authInfo,
+		Body:          txBodyData,
+		AuthInfo:      authInfoData,
 		AuthInfoBytes: authInfoBz,
 		BodyBytes:     bodyBz,
 	}
+
 	signersCtx, err := signing.NewContext(signing.Options{
 		AddressCodec:          dummyAddressCodec{},
 		ValidatorAddressCodec: dummyAddressCodec{},
@@ -103,34 +101,39 @@ func TestDirectAuxHandler(t *testing.T) {
 	}
 	_, err = modeHandler.GetSignBytes(context.Background(), feePayerSigningData, txData)
 	require.EqualError(t, err, fmt.Sprintf("fee payer %s cannot sign with %s: unauthorized",
-		feePayerAddr, signingv1beta1.SignMode_SIGN_MODE_DIRECT_AUX))
+		feePayerAddr, signing.SignMode_SIGN_MODE_DIRECT_AUX))
 
 	t.Log("verifying fee payer fallback to GetSigners cannot use SIGN_MODE_DIRECT_AUX")
-	feeWithNoPayer := &txv1beta1.Fee{
-		Amount:   []*basev1beta1.Coin{{Denom: "uatom", Amount: "1000"}},
-		GasLimit: 20000,
+	authInfoDataWithNoFeePayer := &signing.TxAuthInfoData{
+		Fee: signing.TxFeeData{
+			Amount:   []signing.TxCoinData{{Denom: "uatom", Amount: "1000"}},
+			GasLimit: 20000,
+		},
 	}
-	authInfoWithNoFeePayer := &txv1beta1.AuthInfo{
-		Fee:         feeWithNoPayer,
-		SignerInfos: signerInfo,
+	authInfoWithNoFeePayerProto := &txv1beta1.AuthInfo{
+		Fee: &txv1beta1.Fee{
+			Amount:   []*basev1beta1.Coin{{Denom: "uatom", Amount: "1000"}},
+			GasLimit: 20000,
+		},
 	}
-	authInfoWithNoFeePayerBz, err := proto.Marshal(authInfoWithNoFeePayer)
+	authInfoWithNoFeePayerBz, err := proto.Marshal(authInfoWithNoFeePayerProto)
 	require.NoError(t, err)
 	txDataWithNoFeePayer := signing.TxData{
-		Body:          txBody,
+		Body:          txBodyData,
 		BodyBytes:     bodyBz,
-		AuthInfo:      authInfoWithNoFeePayer,
+		AuthInfo:      authInfoDataWithNoFeePayer,
 		AuthInfoBytes: authInfoWithNoFeePayerBz,
 	}
 	_, err = modeHandler.GetSignBytes(context.Background(), signingData, txDataWithNoFeePayer)
 	require.EqualError(t, err, fmt.Sprintf("fee payer %s cannot sign with %s: unauthorized", "",
-		signingv1beta1.SignMode_SIGN_MODE_DIRECT_AUX))
+		signing.SignMode_SIGN_MODE_DIRECT_AUX))
 
 	t.Log("verify GetSignBytes with generating sign bytes by marshaling signDocDirectAux")
 	signBytes, err := modeHandler.GetSignBytes(context.Background(), signingData, txData)
 	require.NoError(t, err)
 	require.NotNil(t, signBytes)
 
+	// Build expected bytes using the pulsar SignDocDirectAux for comparison.
 	signDocDirectAux := &txv1beta1.SignDocDirectAux{
 		BodyBytes:     bodyBz,
 		PublicKey:     anyPk,

--- a/x/tx/signing/handler_map.go
+++ b/x/tx/signing/handler_map.go
@@ -3,16 +3,14 @@ package signing
 import (
 	"context"
 	"fmt"
-
-	signingv1beta1 "cosmossdk.io/api/cosmos/tx/signing/v1beta1"
 )
 
 // HandlerMap aggregates several sign mode handlers together for convenient generation of sign bytes
 // based on sign mode.
 type HandlerMap struct {
-	signModeHandlers map[signingv1beta1.SignMode]SignModeHandler
-	defaultMode      signingv1beta1.SignMode
-	modes            []signingv1beta1.SignMode
+	signModeHandlers map[SignMode]SignModeHandler
+	defaultMode      SignMode
+	modes            []SignMode
 }
 
 // NewHandlerMap constructs a new sign mode handler map. The first handler is used as the default.
@@ -21,7 +19,7 @@ func NewHandlerMap(handlers ...SignModeHandler) *HandlerMap {
 		panic("no handlers")
 	}
 	res := &HandlerMap{
-		signModeHandlers: map[signingv1beta1.SignMode]SignModeHandler{},
+		signModeHandlers: map[SignMode]SignModeHandler{},
 	}
 
 	for i, handler := range handlers {
@@ -40,17 +38,17 @@ func NewHandlerMap(handlers ...SignModeHandler) *HandlerMap {
 }
 
 // SupportedModes lists the modes supported by this handler map.
-func (h *HandlerMap) SupportedModes() []signingv1beta1.SignMode {
+func (h *HandlerMap) SupportedModes() []SignMode {
 	return h.modes
 }
 
 // DefaultMode returns the default mode for this handler map.
-func (h *HandlerMap) DefaultMode() signingv1beta1.SignMode {
+func (h *HandlerMap) DefaultMode() SignMode {
 	return h.defaultMode
 }
 
 // GetSignBytes returns the sign bytes for the transaction for the requested mode.
-func (h *HandlerMap) GetSignBytes(ctx context.Context, signMode signingv1beta1.SignMode, signerData SignerData, txData TxData) ([]byte, error) {
+func (h *HandlerMap) GetSignBytes(ctx context.Context, signMode SignMode, signerData SignerData, txData TxData) ([]byte, error) {
 	handler, ok := h.signModeHandlers[signMode]
 	if !ok {
 		return nil, fmt.Errorf("unsupported sign mode %s", signMode)

--- a/x/tx/signing/handler_map_test.go
+++ b/x/tx/signing/handler_map_test.go
@@ -6,8 +6,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	signingv1beta1 "cosmossdk.io/api/cosmos/tx/signing/v1beta1"
-
 	"github.com/cosmos/cosmos-sdk/x/tx/signing"
 )
 
@@ -18,8 +16,8 @@ var (
 
 type directHandler struct{}
 
-func (s directHandler) Mode() signingv1beta1.SignMode {
-	return signingv1beta1.SignMode_SIGN_MODE_DIRECT
+func (s directHandler) Mode() signing.SignMode {
+	return signing.SignMode_SIGN_MODE_DIRECT
 }
 
 func (s directHandler) GetSignBytes(_ context.Context, _ signing.SignerData, _ signing.TxData) ([]byte, error) {
@@ -28,8 +26,8 @@ func (s directHandler) GetSignBytes(_ context.Context, _ signing.SignerData, _ s
 
 type aminoJSONHandler struct{}
 
-func (s aminoJSONHandler) Mode() signingv1beta1.SignMode {
-	return signingv1beta1.SignMode_SIGN_MODE_LEGACY_AMINO_JSON
+func (s aminoJSONHandler) Mode() signing.SignMode {
+	return signing.SignMode_SIGN_MODE_LEGACY_AMINO_JSON
 }
 
 func (s aminoJSONHandler) GetSignBytes(_ context.Context, _ signing.SignerData, _ signing.TxData) ([]byte, error) {

--- a/x/tx/signing/msg_extensions.go
+++ b/x/tx/signing/msg_extensions.go
@@ -1,0 +1,33 @@
+package signing
+
+import (
+	"google.golang.org/protobuf/runtime/protoimpl"
+	descriptorpb "google.golang.org/protobuf/types/descriptorpb"
+)
+
+// E_Service and E_Signer are protov2-compatible (protoimpl.ExtensionInfo)
+// definitions of the cosmos.msg.v1 proto extensions. Defining them here avoids
+// importing cosmossdk.io/api/cosmos/msg/v1 from x/tx/signing, which would
+// create the cycle x/tx/signing→types/msgservice→x/tx/signing.
+//
+// Field numbers and semantics are identical to the pulsar-generated versions.
+// The file descriptor is registered by the gogoproto types/msgservice init().
+var (
+	E_Service = &protoimpl.ExtensionInfo{
+		ExtendedType:  (*descriptorpb.ServiceOptions)(nil),
+		ExtensionType: (*bool)(nil),
+		Field:         11110000,
+		Name:          "cosmos.msg.v1.service",
+		Tag:           "varint,11110000,opt,name=service",
+		Filename:      "cosmos/msg/v1/msg.proto",
+	}
+
+	E_Signer = &protoimpl.ExtensionInfo{
+		ExtendedType:  (*descriptorpb.MessageOptions)(nil),
+		ExtensionType: (*[]string)(nil),
+		Field:         11110000,
+		Name:          "cosmos.msg.v1.signer",
+		Tag:           "bytes,11110000,rep,name=signer",
+		Filename:      "cosmos/msg/v1/msg.proto",
+	}
+)

--- a/x/tx/signing/sign_mode.go
+++ b/x/tx/signing/sign_mode.go
@@ -1,0 +1,35 @@
+package signing
+
+// SignMode represents a signing mode with its own security guarantees.
+// It is defined here as a standalone integer type (equivalent to the
+// gogoproto-generated cosmos.tx.signing.v1beta1.SignMode) so that x/tx
+// does not need to import cosmossdk.io/api/cosmos/tx/signing/v1beta1.
+//
+// Values are identical to the proto enum values; conversion to/from the
+// gogoproto type (types/tx/signing.SignMode) is a plain integer cast.
+type SignMode int32
+
+const (
+	SignMode_SIGN_MODE_UNSPECIFIED       SignMode = 0
+	SignMode_SIGN_MODE_DIRECT            SignMode = 1
+	SignMode_SIGN_MODE_TEXTUAL           SignMode = 2
+	SignMode_SIGN_MODE_DIRECT_AUX        SignMode = 3
+	SignMode_SIGN_MODE_LEGACY_AMINO_JSON SignMode = 127
+	SignMode_SIGN_MODE_EIP_191           SignMode = 191
+)
+
+var signModeNames = map[SignMode]string{
+	SignMode_SIGN_MODE_UNSPECIFIED:       "SIGN_MODE_UNSPECIFIED",
+	SignMode_SIGN_MODE_DIRECT:            "SIGN_MODE_DIRECT",
+	SignMode_SIGN_MODE_TEXTUAL:           "SIGN_MODE_TEXTUAL",
+	SignMode_SIGN_MODE_DIRECT_AUX:        "SIGN_MODE_DIRECT_AUX",
+	SignMode_SIGN_MODE_LEGACY_AMINO_JSON: "SIGN_MODE_LEGACY_AMINO_JSON",
+	SignMode_SIGN_MODE_EIP_191:           "SIGN_MODE_EIP_191",
+}
+
+func (s SignMode) String() string {
+	if name, ok := signModeNames[s]; ok {
+		return name
+	}
+	return "SIGN_MODE_UNKNOWN"
+}

--- a/x/tx/signing/sign_mode_handler.go
+++ b/x/tx/signing/sign_mode_handler.go
@@ -2,14 +2,12 @@ package signing
 
 import (
 	"context"
-
-	signingv1beta1 "cosmossdk.io/api/cosmos/tx/signing/v1beta1"
 )
 
 // SignModeHandler is the interface that handlers for each sign mode should implement to generate sign bytes.
 type SignModeHandler interface {
 	// Mode is the sign mode supported by this handler
-	Mode() signingv1beta1.SignMode
+	Mode() SignMode
 
 	// GetSignBytes returns the sign bytes for the provided SignerData and TxData, or an error.
 	GetSignBytes(ctx context.Context, signerData SignerData, txData TxData) ([]byte, error)

--- a/x/tx/signing/testutil/util.go
+++ b/x/tx/signing/testutil/util.go
@@ -2,17 +2,17 @@ package testutil
 
 import (
 	"github.com/cosmos/cosmos-proto/anyutil"
+	gogoproto "github.com/cosmos/gogoproto/proto"
+	gogotypes "github.com/cosmos/gogoproto/types/any"
 	"google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"cosmossdk.io/api/cosmos/crypto/secp256k1"
-	signingv1beta1 "cosmossdk.io/api/cosmos/tx/signing/v1beta1"
-	txv1beta1 "cosmossdk.io/api/cosmos/tx/v1beta1"
 
 	"github.com/cosmos/cosmos-sdk/x/tx/signing"
 )
 
+// HandlerArgumentOptions are options for MakeHandlerArguments.
 type HandlerArgumentOptions struct {
 	ChainID          string
 	Memo             string
@@ -21,10 +21,11 @@ type HandlerArgumentOptions struct {
 	AccSeq           uint64
 	Unordered        bool
 	Timeouttimestamp *timestamppb.Timestamp
-	Fee              *txv1beta1.Fee
+	Fee              *signing.TxFeeData
 	SignerAddress    string
 }
 
+// MakeHandlerArguments creates signing.SignerData and signing.TxData for use in tests.
 func MakeHandlerArguments(options HandlerArgumentOptions) (signing.SignerData, signing.TxData, error) {
 	pk := &secp256k1.PubKey{
 		Key: make([]byte, 256),
@@ -34,63 +35,108 @@ func MakeHandlerArguments(options HandlerArgumentOptions) (signing.SignerData, s
 		return signing.SignerData{}, signing.TxData{}, err
 	}
 
-	signerInfo := []*txv1beta1.SignerInfo{
-		{
-			PublicKey: anyPk,
-			ModeInfo: &txv1beta1.ModeInfo{
-				Sum: &txv1beta1.ModeInfo_Single_{
-					Single: &txv1beta1.ModeInfo_Single{
-						Mode: signingv1beta1.SignMode_SIGN_MODE_DIRECT_AUX,
-					},
-				},
-			},
-			Sequence: options.AccSeq,
-		},
-	}
-
 	anyMsg, err := anyutil.New(options.Msg)
 	if err != nil {
 		return signing.SignerData{}, signing.TxData{}, err
 	}
 
-	txBody := &txv1beta1.TxBody{
-		Messages:         []*anypb.Any{anyMsg},
+	txBodyData := &signing.TxBodyData{
+		Messages:         []signing.RawMsg{{TypeUrl: anyMsg.TypeUrl, Value: anyMsg.Value}},
 		Memo:             options.Memo,
 		Unordered:        options.Unordered,
 		TimeoutTimestamp: options.Timeouttimestamp,
 	}
 
-	authInfo := &txv1beta1.AuthInfo{
-		Fee:         options.Fee,
-		SignerInfos: signerInfo,
+	var feeData signing.TxFeeData
+	if options.Fee != nil {
+		feeData = *options.Fee
 	}
 
-	protov2MarshalOpts := proto.MarshalOptions{Deterministic: true}
-	bodyBz, err := protov2MarshalOpts.Marshal(txBody)
+	txAuthInfoData := &signing.TxAuthInfoData{Fee: feeData}
+
+	// Build raw bytes using minimal gogoproto-compatible structs.
+	// This avoids importing types/tx which creates an import cycle in tests.
+	bodyBz, err := gogoproto.Marshal(&rawTxBody{
+		Messages: []*gogotypes.Any{{TypeUrl: anyMsg.TypeUrl, Value: anyMsg.Value}},
+		Memo:     options.Memo,
+	})
 	if err != nil {
 		return signing.SignerData{}, signing.TxData{}, err
 	}
 
-	authInfoBz, err := protov2MarshalOpts.Marshal(authInfo)
+	authInfoBz, err := gogoproto.Marshal(&rawAuthInfo{
+		SignerInfos: []*rawSignerInfo{
+			{
+				PublicKey: &gogotypes.Any{TypeUrl: anyPk.TypeUrl, Value: anyPk.Value},
+				ModeInfo:  &rawModeInfo{Single: &rawModeInfoSingle{Mode: 3}},
+				Sequence:  options.AccSeq,
+			},
+		},
+	})
 	if err != nil {
 		return signing.SignerData{}, signing.TxData{}, err
 	}
 
 	txData := signing.TxData{
-		Body:          txBody,
-		AuthInfo:      authInfo,
+		Body:          txBodyData,
+		AuthInfo:      txAuthInfoData,
 		AuthInfoBytes: authInfoBz,
 		BodyBytes:     bodyBz,
 	}
 
-	signerAddress := options.SignerAddress
 	signerData := signing.SignerData{
 		ChainID:       options.ChainID,
 		AccountNumber: options.AccNum,
 		Sequence:      options.AccSeq,
-		Address:       signerAddress,
+		Address:       options.SignerAddress,
 		PubKey:        anyPk,
 	}
 
 	return signerData, txData, nil
 }
+
+// minimal gogoproto-compatible structs for marshaling TxBody and AuthInfo bytes
+// without importing github.com/cosmos/cosmos-sdk/types/tx (which creates cycles).
+
+type rawTxBody struct {
+	Messages []*gogotypes.Any `protobuf:"bytes,1,rep,name=messages,proto3"`
+	Memo     string           `protobuf:"bytes,2,opt,name=memo,proto3"`
+}
+
+func (*rawTxBody) Reset()         {}
+func (*rawTxBody) String() string { return "" }
+func (*rawTxBody) ProtoMessage()  {}
+
+type rawAuthInfo struct {
+	SignerInfos []*rawSignerInfo `protobuf:"bytes,1,rep,name=signer_infos,json=signerInfos,proto3"`
+}
+
+func (*rawAuthInfo) Reset()         {}
+func (*rawAuthInfo) String() string { return "" }
+func (*rawAuthInfo) ProtoMessage()  {}
+
+type rawSignerInfo struct {
+	PublicKey *gogotypes.Any `protobuf:"bytes,1,opt,name=public_key,json=publicKey,proto3"`
+	ModeInfo  *rawModeInfo   `protobuf:"bytes,2,opt,name=mode_info,json=modeInfo,proto3"`
+	Sequence  uint64         `protobuf:"varint,3,opt,name=sequence,proto3"`
+}
+
+func (*rawSignerInfo) Reset()         {}
+func (*rawSignerInfo) String() string { return "" }
+func (*rawSignerInfo) ProtoMessage()  {}
+
+type rawModeInfo struct {
+	Single *rawModeInfoSingle `protobuf:"bytes,1,opt,name=single,proto3,oneof"`
+}
+
+func (*rawModeInfo) Reset()         {}
+func (*rawModeInfo) String() string { return "" }
+func (*rawModeInfo) ProtoMessage()  {}
+
+type rawModeInfoSingle struct {
+	Mode int32 `protobuf:"varint,1,opt,name=mode,proto3,enum=cosmos.tx.signing.v1beta1.SignMode"`
+}
+
+func (*rawModeInfoSingle) Reset()         {}
+func (*rawModeInfoSingle) String() string { return "" }
+func (*rawModeInfoSingle) ProtoMessage()  {}

--- a/x/tx/signing/tx_data.go
+++ b/x/tx/signing/tx_data.go
@@ -1,14 +1,51 @@
 package signing
 
-import txv1beta1 "cosmossdk.io/api/cosmos/tx/v1beta1"
+import "google.golang.org/protobuf/types/known/timestamppb"
 
-// TxData is the data about a transaction that is necessary to generate sign bytes.
+// RawMsg is a raw protobuf message represented as TypeUrl + marshaled Value bytes.
+// It has the same structure as google.protobuf.Any but avoids import cycles by
+// not depending on any SDK module that transitively imports x/tx/signing.
+type RawMsg struct {
+	TypeUrl string
+	Value   []byte
+}
+
+// TxBodyData holds the body fields needed by sign mode handlers.
+type TxBodyData struct {
+	Messages                    []RawMsg
+	Memo                        string
+	TimeoutHeight               uint64
+	Unordered                   bool
+	TimeoutTimestamp            *timestamppb.Timestamp
+	ExtensionOptions            []RawMsg
+	NonCriticalExtensionOptions []RawMsg
+}
+
+// TxAuthInfoData holds the auth info fields needed by sign mode handlers.
+// SignerInfos is omitted — no handler reads it; the signer addresses are
+// pre-computed in TxData.Signers.
+type TxAuthInfoData struct {
+	Fee TxFeeData
+}
+
+// TxFeeData holds fee data used in amino signing.
+type TxFeeData struct {
+	Amount   []TxCoinData
+	GasLimit uint64
+	Payer    string
+	Granter  string
+}
+
+// TxCoinData is a denomination/amount pair for fee display in amino signing.
+type TxCoinData struct {
+	Denom  string
+	Amount string
+}
+
+// TxData is the data about a transaction necessary to generate sign bytes.
 type TxData struct {
-	// Body is the TxBody that will be part of the transaction.
-	Body *txv1beta1.TxBody
-
-	// AuthInfo is the AuthInfo that will be part of the transaction.
-	AuthInfo *txv1beta1.AuthInfo
+	Body     *TxBodyData
+	AuthInfo *TxAuthInfoData
 
 	// BodyBytes is the marshaled body bytes that will be part of TxRaw.
 	BodyBytes []byte

--- a/x/tx/signing/unknown_fields.go
+++ b/x/tx/signing/unknown_fields.go
@@ -1,0 +1,202 @@
+package signing
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"google.golang.org/protobuf/encoding/protowire"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protodesc"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/types/known/anypb"
+
+	errorsmod "cosmossdk.io/errors"
+)
+
+// ErrUnknownField is returned when unknown protobuf fields are encountered.
+var ErrUnknownField = errorsmod.Register("tx", 2, "unknown protobuf field")
+
+const bit11NonCritical = 1 << 10
+
+var (
+	anyDesc     = (&anypb.Any{}).ProtoReflect().Descriptor()
+	anyFullName = anyDesc.FullName()
+)
+
+// RejectUnknownFieldsStrict operates by the same rules as RejectUnknownFields, but returns an error if any unknown
+// non-critical fields are encountered.
+func RejectUnknownFieldsStrict(bz []byte, msg protoreflect.MessageDescriptor, resolver protodesc.Resolver) error {
+	_, err := RejectUnknownFields(bz, msg, false, resolver)
+	return err
+}
+
+// RejectUnknownFields rejects any bytes bz with an error that has unknown fields for the provided proto.Message type with an
+// option to allow non-critical fields (specified as those fields with bit 11) to pass through. In either case, the
+// hasUnknownNonCriticals will be set to true if non-critical fields were encountered during traversal. This flag can be
+// used to treat a message with non-critical field different in different security contexts (such as transaction signing).
+// This function traverses inside of messages nested via google.protobuf.Any. It does not do any deserialization of the proto.Message.
+// An AnyResolver must be provided for traversing inside google.protobuf.Any's.
+func RejectUnknownFields(bz []byte, desc protoreflect.MessageDescriptor, allowUnknownNonCriticals bool, resolver protodesc.Resolver) (hasUnknownNonCriticals bool, err error) {
+	// recursion limit with same default as https://github.com/protocolbuffers/protobuf-go/blob/v1.35.2/encoding/protowire/wire.go#L28
+	return doRejectUnknownFields(bz, desc, allowUnknownNonCriticals, resolver, 10_000)
+}
+
+func doRejectUnknownFields(
+	bz []byte,
+	desc protoreflect.MessageDescriptor,
+	allowUnknownNonCriticals bool,
+	resolver protodesc.Resolver,
+	recursionLimit int,
+) (hasUnknownNonCriticals bool, err error) {
+	if len(bz) == 0 {
+		return hasUnknownNonCriticals, nil
+	}
+	if recursionLimit == 0 {
+		return false, errors.New("recursion limit reached")
+	}
+
+	fields := desc.Fields()
+
+	for len(bz) > 0 {
+		tagNum, wireType, m := protowire.ConsumeTag(bz)
+		if m < 0 {
+			return hasUnknownNonCriticals, errors.New("invalid length")
+		}
+
+		fieldDesc := fields.ByNumber(tagNum)
+		if fieldDesc == nil {
+			isCriticalField := tagNum&bit11NonCritical == 0
+
+			if !isCriticalField {
+				hasUnknownNonCriticals = true
+			}
+
+			if isCriticalField || !allowUnknownNonCriticals {
+				// The tag is critical, so report it.
+				return hasUnknownNonCriticals, ErrUnknownField.Wrapf(
+					"%s: {TagNum: %d, WireType:%q}",
+					desc.FullName(), tagNum, WireTypeToString(wireType))
+			}
+		}
+
+		// Skip over the bytes that store fieldNumber and wireType bytes.
+		bz = bz[m:]
+		n := protowire.ConsumeFieldValue(tagNum, wireType, bz)
+		if n < 0 {
+			err = fmt.Errorf("could not consume field value for tagNum: %d, wireType: %q; %w",
+				tagNum, WireTypeToString(wireType), protowire.ParseError(n))
+			return hasUnknownNonCriticals, err
+		}
+		fieldBytes := bz[:n]
+		bz = bz[n:]
+
+		// An unknown but non-critical field
+		if fieldDesc == nil {
+			continue
+		}
+
+		fieldMessage := fieldDesc.Message()
+		// not message or group kind
+		if fieldMessage == nil {
+			continue
+		}
+		// if a message descriptor is a placeholder resolve it using the injected resolver.
+		// this can happen when a descriptor has been registered in the
+		// "google.golang.org/protobuf" registry but not in "github.com/cosmos/gogoproto".
+		// fixes: https://github.com/cosmos/cosmos-sdk/issues/22574
+		if fieldMessage.IsPlaceholder() {
+			gogoDesc, err := resolver.FindDescriptorByName(fieldMessage.FullName())
+			if err != nil {
+				return hasUnknownNonCriticals, fmt.Errorf("could not resolve placeholder descriptor: %v: %w", fieldMessage, err)
+			}
+			fieldMessage = gogoDesc.(protoreflect.MessageDescriptor)
+		}
+
+		// consume length prefix of nested message
+		_, o := protowire.ConsumeVarint(fieldBytes)
+		if o < 0 {
+			err = fmt.Errorf("could not consume length prefix fieldBytes for nested message: %v: %w",
+				fieldMessage, protowire.ParseError(o))
+			return hasUnknownNonCriticals, err
+		} else if o > len(fieldBytes) {
+			err = fmt.Errorf("length prefix > len(fieldBytes) for nested message: %v", fieldMessage)
+			return hasUnknownNonCriticals, err
+		}
+
+		fieldBytes = fieldBytes[o:]
+
+		var err error
+
+		if fieldMessage.FullName() == anyFullName {
+			// Firstly typecheck types.Any to ensure nothing snuck in.
+			hasUnknownNonCriticalsChild, err := doRejectUnknownFields(fieldBytes, anyDesc, allowUnknownNonCriticals, resolver, recursionLimit-1)
+			hasUnknownNonCriticals = hasUnknownNonCriticals || hasUnknownNonCriticalsChild
+			if err != nil {
+				return hasUnknownNonCriticals, err
+			}
+			var a anypb.Any
+			if err = proto.Unmarshal(fieldBytes, &a); err != nil {
+				return hasUnknownNonCriticals, err
+			}
+
+			msgName := protoreflect.FullName(strings.TrimPrefix(a.TypeUrl, "/"))
+			msgDesc, err := resolver.FindDescriptorByName(msgName)
+			if err != nil {
+				return hasUnknownNonCriticals, err
+			}
+
+			fieldMessage = msgDesc.(protoreflect.MessageDescriptor)
+			fieldBytes = a.Value
+		}
+
+		hasUnknownNonCriticalsChild, err := doRejectUnknownFields(fieldBytes, fieldMessage, allowUnknownNonCriticals, resolver, recursionLimit-1)
+		hasUnknownNonCriticals = hasUnknownNonCriticals || hasUnknownNonCriticalsChild
+		if err != nil {
+			return hasUnknownNonCriticals, err
+		}
+	}
+
+	return hasUnknownNonCriticals, nil
+}
+
+// errUnknownField represents an error indicating that we encountered
+// a field that isn't available in the target proto.Message.
+type errUnknownField struct {
+	Desc     protoreflect.MessageDescriptor
+	TagNum   protowire.Number
+	WireType protowire.Type
+}
+
+// String implements fmt.Stringer.
+func (twt *errUnknownField) String() string {
+	return fmt.Sprintf("errUnknownField %q: {TagNum: %d, WireType:%q}",
+		twt.Desc.FullName(), twt.TagNum, WireTypeToString(twt.WireType))
+}
+
+// Error implements the error interface.
+func (twt *errUnknownField) Error() string {
+	return twt.String()
+}
+
+var _ error = (*errUnknownField)(nil)
+
+// WireTypeToString returns a string representation of the given protowire.Type.
+func WireTypeToString(wt protowire.Type) string {
+	switch wt {
+	case 0:
+		return "varint"
+	case 1:
+		return "fixed64"
+	case 2:
+		return "bytes"
+	case 3:
+		return "start_group"
+	case 4:
+		return "end_group"
+	case 5:
+		return "fixed32"
+	default:
+		return fmt.Sprintf("unknown type: %d", wt)
+	}
+}

--- a/x/upgrade/autocli.go
+++ b/x/upgrade/autocli.go
@@ -1,15 +1,15 @@
 package upgrade
 
 import (
-	autocliv1 "cosmossdk.io/api/cosmos/autocli/v1"
 	upgradev1beta1 "cosmossdk.io/api/cosmos/upgrade/v1beta1"
+	autocli "cosmossdk.io/core/autocli"
 )
 
-func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
-	return &autocliv1.ModuleOptions{
-		Query: &autocliv1.ServiceCommandDescriptor{
+func (am AppModule) AutoCLIOptions() *autocli.ModuleOptions {
+	return &autocli.ModuleOptions{
+		Query: &autocli.ServiceCommandDescriptor{
 			Service: upgradev1beta1.Query_ServiceDesc.ServiceName,
-			RpcCommandOptions: []*autocliv1.RpcCommandOptions{
+			RpcCommandOptions: []*autocli.RpcCommandOptions{
 				{
 					RpcMethod: "CurrentPlan",
 					Use:       "plan",
@@ -21,7 +21,7 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					Use:       "applied [upgrade-name]",
 					Short:     "Query the block header for height at which a completed upgrade was applied",
 					Long:      "If upgrade-name was previously executed on the chain, this returns the header for the block at which it was applied. This helps a client determine which binary was valid over a given range of blocks, as well as more context to understand past migrations.",
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+					PositionalArgs: []*autocli.PositionalArgDescriptor{
 						{ProtoField: "name"},
 					},
 				},
@@ -31,7 +31,7 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					Alias:     []string{"module_versions"},
 					Short:     "Query the list of module versions",
 					Long:      "Gets a list of module names and their respective consensus versions. Following the command with a specific module name will return only that module's information.",
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+					PositionalArgs: []*autocli.PositionalArgDescriptor{
 						{ProtoField: "module_name", Optional: true},
 					},
 				},
@@ -46,9 +46,9 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 				},
 			},
 		},
-		Tx: &autocliv1.ServiceCommandDescriptor{
+		Tx: &autocli.ServiceCommandDescriptor{
 			Service: upgradev1beta1.Msg_ServiceDesc.ServiceName,
-			RpcCommandOptions: []*autocliv1.RpcCommandOptions{
+			RpcCommandOptions: []*autocli.RpcCommandOptions{
 				{
 					RpcMethod:   "CancelUpgrade",
 					Use:         "cancel-upgrade-proposal",


### PR DESCRIPTION
## Summary

Phases 1–3 of the pulsar (`cosmossdk.io/api`) removal project, rebased on main after #26456 merged.

### Phase 1 — Go-native AutoCLI types (`core/autocli`)

Introduces five Go-native structs in a new `cosmossdk.io/core/autocli` package that mirror the `autocliv1` proto messages 1:1. All 33 module `autocli.go` files now import `cosmossdk.io/core/autocli` instead of `cosmossdk.io/api/cosmos/autocli/v1`. Only `runtime/services/autocli.go` still imports `autocliv1` at the gRPC boundary — it converts Go-native options to proto via `toProtoModuleOptions()`.

**35 → 2 files** importing `cosmossdk.io/api/cosmos/autocli/v1`

### Phase 2 — Go-native `SignMode` type (`x/tx/signing`)

Defines `signing.SignMode` as a standalone `int32` type in `x/tx/signing` with identical values to the proto enum, avoiding a circular import (`x/tx/signing → types/tx/signing → codec/types → x/tx/signing`). All `SignModeHandler` implementations and the `HandlerMap` use the local type. The `x/auth/signing` conversion functions become plain integer casts.

**16 → 2 files** importing `cosmossdk.io/api/cosmos/tx/signing/v1beta1`
(remaining 2: `adapter.go` + `testutil/util.go` — deferred to Phase 4, use pulsar `ModeInfo_Single`)

### Phase 3 — Reflection gRPC stubs + msg/v1 extensions

- New `runtime/services/reflection` package hand-writes the `cosmos.reflection.v1.ReflectionService` gRPC stub without the pulsar dependency. **4 → 0 files** importing `cosmossdk.io/api/cosmos/reflection/v1`.
- `types/msgservice/extensions_v2.go` adds `*protoimpl.ExtensionInfo` instances (`E_ServiceV2`, `E_SignerV2`) compatible with the protov2 API. Used by `configurator.go`, `validate.go`, `autocli.go`, `builder.go`. **6 → 2 files** importing `cosmossdk.io/api/cosmos/msg/v1` (remaining 2: in `x/tx/signing` — cycle-blocked, Phase 4).

### Rebase note

Rebased on main after #26456 (remove `SIGN_MODE_TEXTUAL`) merged, which deleted `x/tx/signing/textual/`. This automatically removed 3 more `signingv1beta1` and 2 `txv1beta1` import sites.

### Deferred to Phase 4 (pulsar Tx type replacement)

`x/auth/tx/adapter.go`, `x/tx/decode/decode.go`, `x/tx/signing/direct/direct.go`, `x/tx/signing/directaux/direct_aux.go` — use `txv1beta1.SignDoc`, `txv1beta1.Tx`, `txv1beta1.SignDocDirectAux` for protov2 marshaling via `protoreflect`. Replacing these requires substituting the gogoproto Tx types throughout the signing path.

Issue: N/A