### PR TITLE
fix(baseapp): protect name/version/appVersion with RWMutex on both readers and writers

### DIFF
--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -145,6 +145,9 @@ func (app *BaseApp) InitChain(req *abci.RequestInitChain) (*abci.ResponseInitCha
 }
 
 func (app *BaseApp) Info(_ *abci.RequestInfo) (*abci.ResponseInfo, error) {
+	app.mu.RLock()
+	defer app.mu.RUnlock()
+
 	lastCommitID := app.cms.LastCommitID()
 
 	return &abci.ResponseInfo{
@@ -1157,11 +1160,11 @@ func handleQueryApp(app *BaseApp, path []string, req *abci.RequestQuery) *abci.R
 				Value:     bz,
 			}
 
-		case "version":
+	case "version":
 			return &abci.ResponseQuery{
 				Codespace: sdkerrors.RootCodespace,
 				Height:    req.Height,
-				Value:     []byte(app.version),
+				Value:     []byte(app.Version()),
 			}
 
 		default:

--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -62,7 +62,7 @@ var _ servertypes.ABCI = (*BaseApp)(nil)
 // BaseApp reflects the ABCI application implementation.
 type BaseApp struct {
 	// initialized on creation
-	mu                sync.Mutex // mu protects the fields below.
+	mu                sync.RWMutex // mu protects concurrent access to name, version, appVersion.
 	logger            log.Logger
 	name              string                      // application name from abci.BlockInfo
 	db                dbm.DB                      // common DB backend
@@ -239,16 +239,22 @@ func NewBaseApp(
 
 // Name returns the name of the BaseApp.
 func (app *BaseApp) Name() string {
+	app.mu.RLock()
+	defer app.mu.RUnlock()
 	return app.name
 }
 
 // AppVersion returns the application's protocol version.
 func (app *BaseApp) AppVersion() uint64 {
+	app.mu.RLock()
+	defer app.mu.RUnlock()
 	return app.appVersion
 }
 
 // Version returns the application's version string.
 func (app *BaseApp) Version() string {
+	app.mu.RLock()
+	defer app.mu.RUnlock()
 	return app.version
 }
 

--- a/baseapp/options.go
+++ b/baseapp/options.go
@@ -164,6 +164,8 @@ func (app *BaseApp) SetName(name string) {
 		panic("SetName() on sealed BaseApp")
 	}
 
+	app.mu.Lock()
+	defer app.mu.Unlock()
 	app.name = name
 }
 
@@ -181,11 +183,15 @@ func (app *BaseApp) SetVersion(v string) {
 	if app.sealed {
 		panic("SetVersion() on sealed BaseApp")
 	}
+	app.mu.Lock()
+	defer app.mu.Unlock()
 	app.version = v
 }
 
 // SetProtocolVersion sets the application's protocol version
 func (app *BaseApp) SetProtocolVersion(v uint64) {
+	app.mu.Lock()
+	defer app.mu.Unlock()
 	app.appVersion = v
 }
 


### PR DESCRIPTION
## Description

Closes the data race identified in #26342 (review by @aljo242) with a complete fix that protects both reader and writer sides consistently.

## Problem

The existing sync.Mutex in BaseApp was documented as protecting fields like name, version, and appVersion, but:
- Only Info() acquired the lock (added in the previous, incomplete PR)
- All setters (SetName, SetVersion, SetProtocolVersion) wrote without the lock
- Other readers (Name(), Version(), AppVersion(), handleQueryApp) read without the lock
- SetProtocolVersion() has no sealed guard and can be called anytime by the upgrade keeper, creating a real race with Info()

## Fix

- Upgrade sync.Mutex to sync.RWMutex for concurrent reader support
- Add RLock to reader methods: Name(), Version(), AppVersion(), Info()
- Add Lock to writer methods: SetName(), SetVersion(), SetProtocolVersion()
- Route handleQueryApp version query through app.Version() accessor

## Files Changed

- baseapp/baseapp.go: struct field type + reader methods
- baseapp/abci.go: Info() + handleQueryApp()
- baseapp/options.go: setter methods

## Testing

- Run with Go race detector: go test -race ./baseapp/...
- No behavioral changes, purely adds synchronization

Replaces #26321 and #26342 (both closed due to incomplete mutex coverage).