### PR TITLE
fix: bound multisig signature and pubkey indexing by slice lengths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 * (client) [#26524](https://github.com/cosmos/cosmos-sdk/pull/26524) Fix file handle leak in the `snapshot dump` command where chunk files were deferred-closed inside the loop, keeping every chunk's handle open until the command returned (follow-up to #25811).
 * (x/distribution) [#26518](https://github.com/cosmos/cosmos-sdk/pull/26518) Return an error from internal historical rewards reads when the record is absent, preventing recovered reference-count panics during BlockSTM speculative execution.
+* (x/auth) [#26515](https://github.com/cosmos/cosmos-sdk/pull/26515) Bound the pubkey and signature indices in `ConsumeMultisignatureVerificationGas` and `VerifyMultisignature` so a multisig signature with a bit array larger than the key set, or with more set bits than supplied signatures, returns an error instead of panicking with index out of range.
 * (x/distribution) [#26406](https://github.com/cosmos/cosmos-sdk/pull/26406) Add fallback paths (delegator/validator owner, then community pool) when withdrawing delegator rewards or validator commission to a blocked address during `Begin/EndBlockers`. user msg initiated paths still return `ErrUnauthorized` when withdrawing to blocked addresses.
 * (x/gov) [#26353](https://github.com/cosmos/cosmos-sdk/pull/26353) Fix leading comma in `proposal_messages` event attribute emitted by `SubmitProposal`.
 * (telemetry) [#26390](https://github.com/cosmos/cosmos-sdk/pull/26390) Fix env var for otel telemetry initialization.

--- a/crypto/keys/multisig/multisig.go
+++ b/crypto/keys/multisig/multisig.go
@@ -70,6 +70,9 @@ func (m *LegacyAminoPubKey) VerifyMultisignature(getSignBytes multisigtypes.GetS
 	sigIndex := 0
 	for i := range size {
 		if bitarray.GetIndex(i) {
+			if sigIndex >= len(sigs) {
+				return fmt.Errorf("signature size is incorrect %d", len(sigs))
+			}
 			si := sig.Signatures[sigIndex]
 			switch si := si.(type) {
 			case *signing.SingleSignatureData:

--- a/crypto/keys/multisig/multisig_test.go
+++ b/crypto/keys/multisig/multisig_test.go
@@ -318,6 +318,34 @@ func generatePubKeysAndSignatures(n int, msg []byte) (pubKeys []cryptotypes.PubK
 	return pubKeys, signatures
 }
 
+func TestVerifyMultisignatureMoreBitsThanSigs(t *testing.T) {
+	msg := []byte{1, 2, 3, 4}
+
+	// 2-of-3 multisig where the first two signatures are valid.
+	privKeys := []*secp256k1.PrivKey{secp256k1.GenPrivKey(), secp256k1.GenPrivKey(), secp256k1.GenPrivKey()}
+	pubKeys := make([]cryptotypes.PubKey, len(privKeys))
+	sigs := make([]signing.SignatureData, 0, len(privKeys))
+	for i, pk := range privKeys {
+		pubKeys[i] = pk.PubKey()
+		if i < 2 {
+			sig, err := pk.Sign(msg)
+			require.NoError(t, err)
+			sigs = append(sigs, &signing.SingleSignatureData{Signature: sig})
+		}
+	}
+
+	multisigKey := kmultisig.NewLegacyAminoPubKey(2, pubKeys)
+	bitArray := cryptotypes.NewCompactBitArray(3)
+	bitArray.SetIndex(0, true)
+	bitArray.SetIndex(1, true)
+	bitArray.SetIndex(2, true) // claims a third signer but only two signatures are supplied
+
+	sig := &signing.MultiSignatureData{BitArray: bitArray, Signatures: sigs}
+	getSignBytes := func(signing.SignMode) ([]byte, error) { return msg, nil }
+
+	require.Error(t, multisigKey.VerifyMultisignature(getSignBytes, sig))
+}
+
 func generateNestedMultiSignature(n int, msg []byte) (multisig.PubKey, *signing.MultiSignatureData) {
 	pubKeys := make([]cryptotypes.PubKey, n)
 	signatures := make([]signing.SignatureData, n)

--- a/x/auth/ante/sigverify.go
+++ b/x/auth/ante/sigverify.go
@@ -610,14 +610,23 @@ func ConsumeMultisignatureVerificationGas(
 	params types.Params, accSeq uint64,
 ) error {
 	size := sig.BitArray.Count()
-	sigIndex := 0
+	pubKeys := pubkey.GetPubKeys()
+	// the bit array is attacker-controlled and reaches this gas consumer before
+	// VerifyMultisignature runs its own checks, so bound it against the key set here.
+	if len(pubKeys) != size {
+		return fmt.Errorf("bit array size is incorrect, expecting: %d", len(pubKeys))
+	}
 
+	sigIndex := 0
 	for i := range size {
 		if !sig.BitArray.GetIndex(i) {
 			continue
 		}
+		if sigIndex >= len(sig.Signatures) {
+			return fmt.Errorf("signature size is incorrect %d", len(sig.Signatures))
+		}
 		sigV2 := signing.SignatureV2{
-			PubKey:   pubkey.GetPubKeys()[i],
+			PubKey:   pubKeys[i],
 			Data:     sig.Signatures[sigIndex],
 			Sequence: accSeq,
 		}

--- a/x/auth/ante/sigverify_test.go
+++ b/x/auth/ante/sigverify_test.go
@@ -157,6 +157,31 @@ func TestConsumeSignatureVerificationGas(t *testing.T) {
 	}
 }
 
+func TestConsumeMultisignatureVerificationGasMalformedBitArray(t *testing.T) {
+	params := types.DefaultParams()
+	pkSet, _ := generatePubKeysAndSignatures(3, []byte{1, 2, 3, 4}, false)
+	multisigKey := kmultisig.NewLegacyAminoPubKey(2, pkSet)
+
+	// more set bits than supplied signatures.
+	tooManyBits := multisig.NewMultisig(3)
+	tooManyBits.BitArray.SetIndex(0, true)
+	tooManyBits.BitArray.SetIndex(1, true)
+	tooManyBits.BitArray.SetIndex(2, true)
+
+	// bit array larger than the key set.
+	oversizedBits := &signing.MultiSignatureData{BitArray: cryptotypes.NewCompactBitArray(4)}
+	oversizedBits.BitArray.SetIndex(3, true)
+
+	for name, sig := range map[string]*signing.MultiSignatureData{
+		"more bits than signatures": tooManyBits,
+		"bit array exceeds key set": oversizedBits,
+	} {
+		t.Run(name, func(t *testing.T) {
+			require.Error(t, ante.ConsumeMultisignatureVerificationGas(storetypes.NewInfiniteGasMeter(), sig, multisigKey, params, 0))
+		})
+	}
+}
+
 func TestSigVerification(t *testing.T) {
 	suite := SetupTestSuite(t, true)
 	suite.txBankKeeper.EXPECT().DenomMetadata(gomock.Any(), gomock.Any()).Return(&banktypes.QueryDenomMetadataResponse{}, nil).AnyTimes()


### PR DESCRIPTION
# Description

Repro: submit a multisig tx whose `MultiSignatureData.BitArray` sets more bits than it supplies `Signatures`, or whose `Count()` exceeds the multisig key set.
Cause: `ConsumeMultisignatureVerificationGas` runs inside `SigGasConsumeDecorator`, which sits ahead of `SigVerificationDecorator` in the ante chain, so it executes before `VerifyMultisignature`'s size checks. It indexes `pubkey.GetPubKeys()[i]` and `sig.Signatures[sigIndex]` straight off the attacker-controlled bit array with no bounds, so a crafted signature panics with index out of range during gas consumption. `VerifyMultisignature` already guards the key-set size but still reads `sig.Signatures[sigIndex]` without bounding `sigIndex` against `len(sigs)`, so a signer supplying valid leading signatures plus an extra set bit panics it too.
Fix: bound the pubkey count and the signature index in the gas consumer, and add the same `sigIndex` bound in `VerifyMultisignature`.

Regression tests added in both packages; they panic on the current tree and pass with the change.