### PR TITLE
fix: reject tx with mismatched signer info and signature counts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (blockstm) [#25893](https://github.com/cosmos/cosmos-sdk/pull/25893) Fix CancelAll cancellation by clearing blocker ESTIMATE marks before waking suspended executors.
 * (crypto) [#26529](https://github.com/cosmos/cosmos-sdk/pull/26529) Validate the SEC1 tag byte (`0x02`/`0x03`) when unmarshaling a `secp256k1.PubKey`, rejecting malformed compressed keys that previously passed the length-only check.
 * (x/auth/tx) [#26527](https://github.com/cosmos/cosmos-sdk/pull/26527) Fix nil pointer panic in `GetSigningTxData` when a `SignerInfo` has a nil `PublicKey`.
+* (x/auth/tx) [#26517](https://github.com/cosmos/cosmos-sdk/pull/26517) Return a decode error instead of panicking when a transaction's `SignerInfos` and `Signatures` counts disagree in `GetSignaturesV2`, or a multisig's `ModeInfos` and sub-signature counts disagree in `ModeInfoAndSigToSignatureData`.
 
 ### Deprecated
 

--- a/x/auth/tx/builder.go
+++ b/x/auth/tx/builder.go
@@ -252,6 +252,10 @@ func (w *wrapper) GetSignaturesV2() ([]signing.SignatureV2, error) {
 		return nil, err
 	}
 	n := len(signerInfos)
+	if len(sigs) != n {
+		return nil, errorsmod.Wrapf(sdkerrors.ErrTxDecode,
+			"expected %d signatures, got %d", n, len(sigs))
+	}
 	res := make([]signing.SignatureV2, n)
 
 	for i, si := range signerInfos {

--- a/x/auth/tx/sigs.go
+++ b/x/auth/tx/sigs.go
@@ -71,6 +71,10 @@ func ModeInfoAndSigToSignatureData(modeInfo *tx.ModeInfo, sig []byte) (signing.S
 			return nil, err
 		}
 
+		if len(multi.ModeInfos) != len(sigs) {
+			return nil, fmt.Errorf("expected %d multisig signatures, got %d", len(multi.ModeInfos), len(sigs))
+		}
+
 		sigv2s := make([]signing.SignatureData, len(sigs))
 		for i, mi := range multi.ModeInfos {
 			sigv2s[i], err = ModeInfoAndSigToSignatureData(mi, sigs[i])

--- a/x/auth/tx/sigs_test.go
+++ b/x/auth/tx/sigs_test.go
@@ -5,8 +5,12 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/cosmos/cosmos-sdk/codec"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/cosmos/cosmos-sdk/crypto/types"
 	"github.com/cosmos/cosmos-sdk/testutil/testdata"
+	txtypes "github.com/cosmos/cosmos-sdk/types/tx"
+	signingtypes "github.com/cosmos/cosmos-sdk/types/tx/signing"
 )
 
 func TestDecodeMultisignatures(t *testing.T) {
@@ -36,4 +40,55 @@ func TestDecodeMultisignatures(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, testSigs, decodedSigs)
+}
+
+func TestModeInfoAndSigToSignatureDataMultisigCountMismatch(t *testing.T) {
+	single := &txtypes.ModeInfo{Sum: &txtypes.ModeInfo_Single_{Single: &txtypes.ModeInfo_Single{Mode: signingtypes.SignMode_SIGN_MODE_DIRECT}}}
+	multi := &txtypes.ModeInfo{Sum: &txtypes.ModeInfo_Multi_{Multi: &txtypes.ModeInfo_Multi{
+		ModeInfos: []*txtypes.ModeInfo{single, single}, // two nested mode infos
+	}}}
+
+	// MultiSignature carries only one sub-signature, fewer than ModeInfos.
+	msig := types.MultiSignature{Signatures: [][]byte{[]byte("onesig")}}
+	bz, err := msig.Marshal()
+	require.NoError(t, err)
+
+	_, err = ModeInfoAndSigToSignatureData(multi, bz)
+	require.Error(t, err)
+}
+
+func TestGetSignaturesV2SignerSignatureCountMismatch(t *testing.T) {
+	registry := codectypes.NewInterfaceRegistry()
+	cdc := codec.NewProtoCodec(registry)
+	decoder := DefaultTxDecoder(cdc)
+
+	single := &txtypes.ModeInfo{Sum: &txtypes.ModeInfo_Single_{Single: &txtypes.ModeInfo_Single{Mode: signingtypes.SignMode_SIGN_MODE_DIRECT}}}
+	authInfo := &txtypes.AuthInfo{
+		SignerInfos: []*txtypes.SignerInfo{
+			{ModeInfo: single},
+			{ModeInfo: single},
+		},
+		Fee: &txtypes.Fee{GasLimit: 1},
+	}
+	authInfoBz, err := authInfo.Marshal()
+	require.NoError(t, err)
+
+	bodyBz, err := (&txtypes.TxBody{}).Marshal()
+	require.NoError(t, err)
+
+	raw := &txtypes.TxRaw{
+		BodyBytes:     bodyBz,
+		AuthInfoBytes: authInfoBz,
+		Signatures:    [][]byte{[]byte("onlyonesig")}, // one signature, two signer infos
+	}
+	txBz, err := raw.Marshal()
+	require.NoError(t, err)
+
+	decoded, err := decoder(txBz)
+	require.NoError(t, err)
+
+	_, err = decoded.(interface {
+		GetSignaturesV2() ([]signingtypes.SignatureV2, error)
+	}).GetSignaturesV2()
+	require.Error(t, err)
 }


### PR DESCRIPTION
# Description

`Repro:` decode a tx whose `AuthInfo.SignerInfos` outnumber its `Signatures` (each extra `SignerInfo` carrying a non-nil `ModeInfo`), then let the ante chain run; `SetPubKeyDecorator` calls `GetSignaturesV2` early, before the multisig guards.
`Cause:` `wrapper.GetSignaturesV2` ranges over `SignerInfos` but indexes the parallel `tx.Signatures` slice as `sigs[i]` with no length check, and the decoder never enforces equal counts, so the mismatch is an index-out-of-range panic. `ModeInfoAndSigToSignatureData` has the same shape inside a multisig `ModeInfo`: it ranges over `multi.ModeInfos` while indexing the decoded sub-signatures.
`Fix:` return `ErrTxDecode` when the counts disagree in `GetSignaturesV2`, and an error when `len(multi.ModeInfos) != len(sigs)` in `ModeInfoAndSigToSignatureData`.

Both sites are covered by a regression test in `x/auth/tx/sigs_test.go` that panics on the unpatched tree.
