### PR TITLE
fix(x/distribution): return errors for missing historical rewards internally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### Bug Fixes
 
 * (client) [#26524](https://github.com/cosmos/cosmos-sdk/pull/26524) Fix file handle leak in the `snapshot dump` command where chunk files were deferred-closed inside the loop, keeping every chunk's handle open until the command returned (follow-up to #25811).
-* (x/distribution) [#XXXX](https://github.com/cosmos/cosmos-sdk/pull/XXXX) Return an error from internal historical rewards reads when the record is absent, preventing recovered reference-count panics during BlockSTM speculative execution.
+* (x/distribution) [#26518](https://github.com/cosmos/cosmos-sdk/pull/26518) Return an error from internal historical rewards reads when the record is absent, preventing recovered reference-count panics during BlockSTM speculative execution.
 * (x/distribution) [#26406](https://github.com/cosmos/cosmos-sdk/pull/26406) Add fallback paths (delegator/validator owner, then community pool) when withdrawing delegator rewards or validator commission to a blocked address during `Begin/EndBlockers`. user msg initiated paths still return `ErrUnauthorized` when withdrawing to blocked addresses.
 * (x/gov) [#26353](https://github.com/cosmos/cosmos-sdk/pull/26353) Fix leading comma in `proposal_messages` event attribute emitted by `SubmitProposal`.
 * (telemetry) [#26390](https://github.com/cosmos/cosmos-sdk/pull/26390) Fix env var for otel telemetry initialization.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### Bug Fixes
 
 * (client) [#26524](https://github.com/cosmos/cosmos-sdk/pull/26524) Fix file handle leak in the `snapshot dump` command where chunk files were deferred-closed inside the loop, keeping every chunk's handle open until the command returned (follow-up to #25811).
+* (x/distribution) [#XXXX](https://github.com/cosmos/cosmos-sdk/pull/XXXX) Return an error from internal historical rewards reads when the record is absent, preventing recovered reference-count panics during BlockSTM speculative execution.
 * (x/distribution) [#26406](https://github.com/cosmos/cosmos-sdk/pull/26406) Add fallback paths (delegator/validator owner, then community pool) when withdrawing delegator rewards or validator commission to a blocked address during `Begin/EndBlockers`. user msg initiated paths still return `ErrUnauthorized` when withdrawing to blocked addresses.
 * (x/gov) [#26353](https://github.com/cosmos/cosmos-sdk/pull/26353) Fix leading comma in `proposal_messages` event attribute emitted by `SubmitProposal`.
 * (telemetry) [#26390](https://github.com/cosmos/cosmos-sdk/pull/26390) Fix env var for otel telemetry initialization.

--- a/tests/integration/blockstm/blockstm_fuzz_test.go
+++ b/tests/integration/blockstm/blockstm_fuzz_test.go
@@ -1,9 +1,11 @@
 package blockstm_test
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 
 	abci "github.com/cometbft/cometbft/abci/types"
@@ -27,6 +29,7 @@ import (
 	authsign "github.com/cosmos/cosmos-sdk/x/auth/signing"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
 	stakingtestutil "github.com/cosmos/cosmos-sdk/x/staking/testutil"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 )
@@ -59,6 +62,7 @@ const (
 	opUndelegate      operationKind = "undelegate"
 	opRedelegate      operationKind = "redelegate"
 	opCancelUnbonding operationKind = "cancel-unbonding"
+	opWithdrawReward  operationKind = "withdraw-reward"
 )
 
 type operation struct {
@@ -98,6 +102,87 @@ func TestBlockSTMDeterminism(t *testing.T) {
 		), maximumOperations)
 		runOperations(t, rt, genesisState, valSet, accounts, accountAddrs, validatorPubKeys, ops, 8)
 	})
+}
+
+func TestSequentialDistributionWithdrawRewardNoRecoveredPanic(t *testing.T) {
+	runDistributionWithdrawRewardNoRecoveredPanic(t, false, 0)
+}
+
+func TestBlockSTMDistributionWithdrawRewardNoRecoveredPanic(t *testing.T) {
+	runDistributionWithdrawRewardNoRecoveredPanic(t, true, 32)
+}
+
+func runDistributionWithdrawRewardNoRecoveredPanic(t *testing.T, enableBlockSTM bool, blockSTMExecutors int) {
+	accountCount := 32
+	validatorCount := 2
+	accounts := generateAccounts(accountCount)
+	accountAddrs := getAddrs(accounts)
+	validatorPubKeys := generateValidatorPubKeys(accountCount)
+	genesisState, valSet := buildGenesisState(t, accounts)
+
+	var logBuf bytes.Buffer
+	logger := log.NewLogger(&logBuf, log.OutputJSONOption())
+	blockSTMApp := newTestApplicationWithLogger(t, dbm.NewMemDB(), genesisState, valSet, enableBlockSTM, blockSTMExecutors, logger)
+	initTestApplication(t, blockSTMApp, accounts, accountAddrs, validatorPubKeys, validatorCount)
+
+	delegateOps := make([]operation, 0, accountCount-validatorCount)
+	for i := validatorCount; i < accountCount; i++ {
+		delegateOps = append(delegateOps, operation{
+			kind:      opDelegate,
+			account:   i,
+			validator: i % validatorCount,
+			amount:    10,
+		})
+	}
+
+	res, _ := finalizeAndCommitNextBlock(
+		t,
+		blockSTMApp.app,
+		buildTxs(
+			t,
+			blockSTMApp.app,
+			accounts,
+			accountAddrs,
+			validatorPubKeys,
+			blockSTMApp.app.LastBlockHeight()+1,
+			delegateOps,
+		),
+	)
+	requireSuccessfulTxResults(t, res.TxResults)
+
+	logBuf.Reset()
+	for block := 0; block < 300; block++ {
+		ops := make([]operation, 0, accountCount-validatorCount)
+		for i := validatorCount; i < accountCount; i++ {
+			ops = append(ops, operation{
+				kind:      opWithdrawReward,
+				account:   i,
+				validator: i % validatorCount,
+			})
+		}
+
+		height := blockSTMApp.app.LastBlockHeight() + 1
+		txBytes := buildTxs(t, blockSTMApp.app, accounts, accountAddrs, validatorPubKeys, height, ops)
+		res, _ := finalizeAndCommitNextBlock(t, blockSTMApp.app, txBytes)
+		requireSuccessfulTxResults(t, res.TxResults)
+
+		logOutput := logBuf.String()
+		if strings.Contains(logOutput, "cannot set negative reference count") {
+			t.Fatalf("recovered distribution negative reference-count panic at test block %d: %s", block, firstMatchingLine(logOutput, "cannot set negative reference count"))
+		}
+		if strings.Contains(logOutput, "panic recovered in runTx") {
+			t.Fatalf("unexpected recovered panic at test block %d: %s", block, firstMatchingLine(logOutput, "panic recovered in runTx"))
+		}
+	}
+}
+
+func firstMatchingLine(logOutput, substr string) string {
+	for _, line := range strings.Split(logOutput, "\n") {
+		if strings.Contains(line, substr) {
+			return line
+		}
+	}
+	return ""
 }
 
 func runOperations(
@@ -176,9 +261,19 @@ func newTestApplication(
 	enableBlockSTM bool,
 	blockSTMExecutors int,
 ) testApplication {
-	tb.Helper()
+	return newTestApplicationWithLogger(tb, db, genesisState, valSet, enableBlockSTM, blockSTMExecutors, log.NewNopLogger())
+}
 
-	logger := log.NewNopLogger()
+func newTestApplicationWithLogger(
+	tb testing.TB,
+	db dbm.DB,
+	genesisState []byte,
+	valSet *cmttypes.ValidatorSet,
+	enableBlockSTM bool,
+	blockSTMExecutors int,
+	logger log.Logger,
+) testApplication {
+	tb.Helper()
 
 	app := simapp.NewSimApp(
 		logger,
@@ -349,6 +444,11 @@ func generateOperations(rt *rapid.T, s state, maxOps int) []operation {
 				amount:    amount,
 			})
 
+		case opWithdrawReward:
+			delegations := positiveDelegations(s.delegations)
+			ref := rapid.SampledFrom(delegations).Draw(rt, opLabel(i, "delegation"))
+			ops = append(ops, operation{kind: kind, account: ref.delegator, validator: ref.validator})
+
 		default:
 			rt.Fatalf("unsupported operation kind %q", kind)
 		}
@@ -373,6 +473,7 @@ func availableOps(s state) []operationKind {
 
 	if len(positiveDelegations(s.delegations)) > 0 {
 		kinds = append(kinds, opUndelegate)
+		kinds = append(kinds, opWithdrawReward)
 	}
 
 	if len(redelegationSources(s)) > 0 {
@@ -563,6 +664,12 @@ func buildTxs(
 				sdk.ValAddress(accountAddrs[op.validator]).String(),
 				height,
 				sdk.NewInt64Coin(sdk.DefaultBondDenom, op.amount),
+			)
+
+		case opWithdrawReward:
+			msg = distrtypes.NewMsgWithdrawDelegatorReward(
+				accountAddrs[op.account].String(),
+				sdk.ValAddress(accountAddrs[op.validator]).String(),
 			)
 
 		default:

--- a/tests/integration/blockstm/blockstm_fuzz_test.go
+++ b/tests/integration/blockstm/blockstm_fuzz_test.go
@@ -113,6 +113,7 @@ func TestBlockSTMDistributionWithdrawRewardNoRecoveredPanic(t *testing.T) {
 }
 
 func runDistributionWithdrawRewardNoRecoveredPanic(t *testing.T, enableBlockSTM bool, blockSTMExecutors int) {
+	t.Helper()
 	accountCount := 32
 	validatorCount := 2
 	accounts := generateAccounts(accountCount)
@@ -261,6 +262,7 @@ func newTestApplication(
 	enableBlockSTM bool,
 	blockSTMExecutors int,
 ) testApplication {
+	tb.Helper()
 	return newTestApplicationWithLogger(tb, db, genesisState, valSet, enableBlockSTM, blockSTMExecutors, log.NewNopLogger())
 }
 

--- a/x/distribution/keeper/delegation.go
+++ b/x/distribution/keeper/delegation.go
@@ -67,12 +67,12 @@ func (k Keeper) calculateDelegationRewardsBetween(ctx context.Context, val staki
 	}
 
 	// return staking * (ending - starting)
-	starting, err := k.GetValidatorHistoricalRewards(ctx, valBz, startingPeriod)
+	starting, err := k.getValidatorHistoricalRewards(ctx, valBz, startingPeriod, true)
 	if err != nil {
 		return sdk.DecCoins{}, err
 	}
 
-	ending, err := k.GetValidatorHistoricalRewards(ctx, valBz, endingPeriod)
+	ending, err := k.getValidatorHistoricalRewards(ctx, valBz, endingPeriod, true)
 	if err != nil {
 		return sdk.DecCoins{}, err
 	}

--- a/x/distribution/keeper/msg_server.go
+++ b/x/distribution/keeper/msg_server.go
@@ -209,7 +209,7 @@ func (k msgServer) DepositValidatorRewardsPool(ctx context.Context, msg *types.M
 			return nil, err
 		}
 		current := rewards.Rewards
-		historical, err := k.GetValidatorHistoricalRewards(ctx, valAddr, rewards.Period-1)
+		historical, err := k.getValidatorHistoricalRewards(ctx, valAddr, rewards.Period-1, true)
 		if err != nil {
 			return nil, err
 		}

--- a/x/distribution/keeper/store.go
+++ b/x/distribution/keeper/store.go
@@ -129,10 +129,17 @@ func (k Keeper) IterateDelegatorStartingInfos(ctx context.Context, handler func(
 
 // GetValidatorHistoricalRewards gets historical rewards for a particular period
 func (k Keeper) GetValidatorHistoricalRewards(ctx context.Context, val sdk.ValAddress, period uint64) (rewards types.ValidatorHistoricalRewards, err error) {
+	return k.getValidatorHistoricalRewards(ctx, val, period, false)
+}
+
+func (k Keeper) getValidatorHistoricalRewards(ctx context.Context, val sdk.ValAddress, period uint64, strict bool) (rewards types.ValidatorHistoricalRewards, err error) {
 	store := k.storeService.OpenKVStore(ctx)
 	b, err := store.Get(types.GetValidatorHistoricalRewardsKey(val, period))
 	if err != nil {
 		return rewards, err
+	}
+	if strict && b == nil {
+		return rewards, types.ErrNoValidatorDistInfo.Wrapf("no historical rewards for validator %s period %d", val, period)
 	}
 
 	err = k.cdc.Unmarshal(b, &rewards)

--- a/x/distribution/keeper/validator.go
+++ b/x/distribution/keeper/validator.go
@@ -88,7 +88,7 @@ func (k Keeper) IncrementValidatorPeriod(ctx context.Context, val stakingtypes.V
 	}
 
 	// fetch historical rewards for last period
-	historical, err := k.GetValidatorHistoricalRewards(ctx, valBz, rewards.Period-1)
+	historical, err := k.getValidatorHistoricalRewards(ctx, valBz, rewards.Period-1, true)
 	if err != nil {
 		return 0, err
 	}
@@ -118,7 +118,7 @@ func (k Keeper) IncrementValidatorPeriod(ctx context.Context, val stakingtypes.V
 
 // incrementReferenceCount increments the reference count for a historical rewards value
 func (k Keeper) incrementReferenceCount(ctx context.Context, valAddr sdk.ValAddress, period uint64) error {
-	historical, err := k.GetValidatorHistoricalRewards(ctx, valAddr, period)
+	historical, err := k.getValidatorHistoricalRewards(ctx, valAddr, period, true)
 	if err != nil {
 		return err
 	}
@@ -133,7 +133,7 @@ func (k Keeper) incrementReferenceCount(ctx context.Context, valAddr sdk.ValAddr
 
 // decrementReferenceCount decrements the reference count for a historical rewards value, and delete if zero references remain
 func (k Keeper) decrementReferenceCount(ctx context.Context, valAddr sdk.ValAddress, period uint64) error {
-	historical, err := k.GetValidatorHistoricalRewards(ctx, valAddr, period)
+	historical, err := k.getValidatorHistoricalRewards(ctx, valAddr, period, true)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
# Description

Closes: #26518

This fixes a distribution state-transition path where missing validator historical
rewards can be unmarshaled as an empty value and later surface as a recovered
`cannot set negative reference count` panic under BlockSTM speculative execution.

The public `GetValidatorHistoricalRewards` query helper keeps its existing
behavior for absent records so historical reward queries continue to return an
empty response. Internal state-transition callers now use a strict helper that
returns `ErrNoValidatorDistInfo` when the historical rewards record is absent.
That turns the invalid execution path into a normal transaction error instead of
allowing an empty reward record to reach reference-count mutation.

The regression test first creates delegations, then repeatedly submits reward
withdrawals for many delegators in the same block. It is run in both sequential
and BlockSTM modes and fails if the app logger records either the historical
negative reference-count panic or any recovered `runTx` panic.

Validation:
- `go test ./integration/blockstm -run "Test(Sequential|BlockSTM)DistributionWithdrawRewardNoRecoveredPanic" -count=3 -v` from `tests/`
- `go test ./integration/blockstm -count=1 -v` from `tests/`
- `go test ./x/distribution/... -count=1`
- `git diff --check`

