### PR TITLE
feat(x/auth/tx): allow configuring aminojson encoder via ConfigOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (docs) [#25918](https://github.com/cosmos/cosmos-sdk/issues/25918) Regenerate Swagger API spec to reflect current proto state, including `authority` field on consensus params and removal of stale module-config definitions.
 * (baseapp) [#22368](https://github.com/cosmos/cosmos-sdk/issues/22368) Add `-race`-mode regression test (`TestABCI_Race_GRPC_Query_During_Commit`) covering concurrent `BaseApp.Query` and `FinalizeBlock`/`Commit`. Pins down the state-management mutex work added in #24655 and follow-ups so the data race reported against v0.50.x cannot regress silently.
 * (x/staking, x/slashing) [#26481](https://github.com/cosmos/cosmos-sdk/pull/26481) Resolve evidence against recently rotated consensus keys and migrate slashing signing state to the active consensus key.
+* (x/auth/tx) [#25221](https://github.com/cosmos/cosmos-sdk/issues/25221) Add `ConfigOptions.AminoJSONEncoder` so applications can configure a custom `aminojson.Encoder` (e.g. custom field encodings) for the `SIGN_MODE_LEGACY_AMINO_JSON` handler without replicating the SDK's `HandlerMap` construction.
 
 ### Bug Fixes
 

--- a/x/auth/tx/config.go
+++ b/x/auth/tx/config.go
@@ -41,6 +41,12 @@ type ConfigOptions struct {
 	SigningOptions *txsigning.Options
 	// CustomSignModes are the custom sign modes that will be added to the txsigning.HandlerMap.
 	CustomSignModes []txsigning.SignModeHandler
+	// AminoJSONEncoder is the encoder used by the SIGN_MODE_LEGACY_AMINO_JSON handler.
+	// This allows configuring custom field, message, scalar and type encodings (e.g. via
+	// aminojson.Encoder.DefineFieldEncoding) without replicating the SDK's HandlerMap construction.
+	// If nil, a default aminojson.Encoder is created using the FileResolver and TypeResolver
+	// derived from SigningOptions. See https://github.com/cosmos/cosmos-sdk/issues/25221.
+	AminoJSONEncoder *aminojson.Encoder
 	// ProtoDecoder is the decoder that will be used to decode protobuf transactions.
 	ProtoDecoder sdk.TxDecoder
 	// ProtoEncoder is the encoder that will be used to encode protobuf transactions.
@@ -133,6 +139,7 @@ func NewSigningHandlerMap(configOpts ConfigOptions) (*txsigning.HandlerMap, erro
 			handlers[i] = aminojson.NewSignModeHandler(aminojson.SignModeHandlerOptions{
 				FileResolver: signingOpts.FileResolver,
 				TypeResolver: signingOpts.TypeResolver,
+				Encoder:      configOpts.AminoJSONEncoder,
 			})
 		}
 	}

--- a/x/auth/tx/config_test.go
+++ b/x/auth/tx/config_test.go
@@ -1,6 +1,8 @@
 package tx_test
 
 import (
+	"context"
+	"io"
 	"testing"
 
 	gogoproto "github.com/cosmos/gogoproto/proto"
@@ -9,6 +11,7 @@ import (
 	protov2 "google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
 
+	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/codec/address"
 	"github.com/cosmos/cosmos-sdk/codec/testutil"
@@ -16,9 +19,13 @@ import (
 	"github.com/cosmos/cosmos-sdk/std"
 	"github.com/cosmos/cosmos-sdk/testutil/testdata"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	signingtypes "github.com/cosmos/cosmos-sdk/types/tx/signing"
+	authsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
 	"github.com/cosmos/cosmos-sdk/x/auth/tx"
 	txtestutil "github.com/cosmos/cosmos-sdk/x/auth/tx/testutil"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	txsigning "github.com/cosmos/cosmos-sdk/x/tx/signing"
+	"github.com/cosmos/cosmos-sdk/x/tx/signing/aminojson"
 )
 
 func TestGenerator(t *testing.T) {
@@ -95,4 +102,77 @@ func TestNewTxConfigWithExplicitSigningOptions(t *testing.T) {
 	require.NotSame(t, interfaceRegistry.SigningContext(), txConfig.SigningContext())
 	// FileResolver default came from the interface registry.
 	require.NotNil(t, signingOpts.FileResolver)
+}
+
+// TestConfigOptionsAminoJSONEncoder verifies that a custom aminojson.Encoder
+// supplied via ConfigOptions.AminoJSONEncoder is wired into the
+// SIGN_MODE_LEGACY_AMINO_JSON handler, so applications can configure custom
+// field encodings without replicating the SDK's HandlerMap construction.
+// Regression test for https://github.com/cosmos/cosmos-sdk/issues/25221.
+func TestConfigOptionsAminoJSONEncoder(t *testing.T) {
+	interfaceRegistry := testutil.CodecOptions{}.NewInterfaceRegistry()
+	std.RegisterInterfaces(interfaceRegistry)
+	banktypes.RegisterInterfaces(interfaceRegistry)
+	protoCodec := codec.NewProtoCodec(interfaceRegistry)
+
+	// Sentinel emitted by a custom encoder for the "legacy_coins" field encoding,
+	// which bank MsgSend amounts and tx fees are tagged with.
+	const sentinel = `"custom-amino-coins-encoding"`
+	customCoinsEncoder := func(_ *aminojson.Encoder, _ protoreflect.Value, w io.Writer) error {
+		_, err := w.Write([]byte(sentinel))
+		return err
+	}
+	enc := aminojson.NewEncoder(aminojson.EncoderOptions{
+		FileResolver: interfaceRegistry,
+	}).DefineFieldEncoding("legacy_coins", customCoinsEncoder)
+
+	signModes := []signingtypes.SignMode{signingtypes.SignMode_SIGN_MODE_LEGACY_AMINO_JSON}
+
+	// With the custom encoder, the sentinel must appear in the amino JSON sign bytes.
+	customConfig, err := tx.NewTxConfigWithOptions(protoCodec, tx.ConfigOptions{
+		EnabledSignModes: signModes,
+		AminoJSONEncoder: &enc,
+	})
+	require.NoError(t, err)
+	require.Contains(t, string(getAminoJSONSignBytes(t, customConfig)), sentinel)
+
+	// Without the option the default encoder is used, so the sentinel is absent.
+	defaultConfig, err := tx.NewTxConfigWithOptions(protoCodec, tx.ConfigOptions{
+		EnabledSignModes: signModes,
+	})
+	require.NoError(t, err)
+	require.NotContains(t, string(getAminoJSONSignBytes(t, defaultConfig)), sentinel)
+}
+
+// getAminoJSONSignBytes builds a bank MsgSend transaction with the given
+// TxConfig and returns its SIGN_MODE_LEGACY_AMINO_JSON sign bytes.
+func getAminoJSONSignBytes(t *testing.T, txConfig client.TxConfig) []byte {
+	t.Helper()
+
+	_, pubKey, fromAddr := testdata.KeyTestPubAddr()
+	_, _, toAddr := testdata.KeyTestPubAddr()
+	coins := sdk.NewCoins(sdk.NewInt64Coin("stake", 10))
+
+	builder := txConfig.NewTxBuilder()
+	require.NoError(t, builder.SetMsgs(banktypes.NewMsgSend(fromAddr, toAddr, coins)))
+	builder.SetFeeAmount(coins)
+	builder.SetGasLimit(10000)
+	builder.SetMemo("memo")
+
+	signerData := authsigning.SignerData{
+		Address:       fromAddr.String(),
+		ChainID:       "test-chain",
+		AccountNumber: 1,
+		Sequence:      1,
+		PubKey:        pubKey,
+	}
+	signBz, err := authsigning.GetSignBytesAdapter(
+		context.Background(),
+		txConfig.SignModeHandler(),
+		signingtypes.SignMode_SIGN_MODE_LEGACY_AMINO_JSON,
+		signerData,
+		builder.GetTx(),
+	)
+	require.NoError(t, err)
+	return signBz
 }


### PR DESCRIPTION
# Description

Closes: #25221

Adds `ConfigOptions.AminoJSONEncoder` so applications can supply a custom `aminojson.Encoder` (e.g. with custom field/message encodings registered via `DefineFieldEncoding`) for the `SIGN_MODE_LEGACY_AMINO_JSON` handler, without replicating the SDK's `HandlerMap` construction. This implements option (1) from the issue.

When `AminoJSONEncoder` is nil, behavior is unchanged: a default encoder is created from the `FileResolver`/`TypeResolver` derived from `SigningOptions`.

### Files to review
- `x/auth/tx/config.go` — new `AminoJSONEncoder` option, wired into the `SIGN_MODE_LEGACY_AMINO_JSON` handler
- `x/auth/tx/config_test.go` — `TestConfigOptionsAminoJSONEncoder`: registers a custom `legacy_coins` field encoder and asserts it reaches the amino JSON sign bytes (and is absent without the option)
- `CHANGELOG.md`

### Checks
- `go test ./x/auth/tx/...` passes
- `golangci-lint run ./x/auth/tx/...` — 0 issues
