### PR TITLE
fix(client): close snapshot dump chunk files per iteration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Bug Fixes
 
+* (client) [#26524](https://github.com/cosmos/cosmos-sdk/pull/26524) Fix file handle leak in the `snapshot dump` command where chunk files were deferred-closed inside the loop, keeping every chunk's handle open until the command returned (follow-up to #25811).
 * (x/distribution) [#26406](https://github.com/cosmos/cosmos-sdk/pull/26406) Add fallback paths (delegator/validator owner, then community pool) when withdrawing delegator rewards or validator commission to a blocked address during `Begin/EndBlockers`. user msg initiated paths still return `ErrUnauthorized` when withdrawing to blocked addresses.
 * (x/gov) [#26353](https://github.com/cosmos/cosmos-sdk/pull/26353) Fix leading comma in `proposal_messages` event attribute emitted by `SubmitProposal`.
 * (telemetry) [#26390](https://github.com/cosmos/cosmos-sdk/pull/26390) Fix env var for otel telemetry initialization.

--- a/client/snapshot/dump.go
+++ b/client/snapshot/dump.go
@@ -83,28 +83,37 @@ func DumpArchiveCmd() *cobra.Command {
 			}
 
 			for i := uint32(0); i < snapshot.Chunks; i++ {
-				path := snapshotStore.PathChunk(height, uint32(format), i)
-				file, err := os.Open(path)
-				if err != nil {
-					return fmt.Errorf("failed to open chunk file %s: %w", path, err)
-				}
-				defer file.Close()
+				// Wrap each chunk in a function so the file handle is closed at the
+				// end of every iteration instead of accumulating until the command
+				// returns (a snapshot can have a very large number of chunks).
+				if err := func() error {
+					path := snapshotStore.PathChunk(height, uint32(format), i)
+					file, err := os.Open(path)
+					if err != nil {
+						return fmt.Errorf("failed to open chunk file %s: %w", path, err)
+					}
+					defer file.Close()
 
-				st, err := file.Stat()
-				if err != nil {
-					return fmt.Errorf("failed to stat chunk file %s: %w", path, err)
-				}
+					st, err := file.Stat()
+					if err != nil {
+						return fmt.Errorf("failed to stat chunk file %s: %w", path, err)
+					}
 
-				if err := tarWriter.WriteHeader(&tar.Header{
-					Name: strconv.FormatUint(uint64(i), 10),
-					Mode: 0o644,
-					Size: st.Size(),
-				}); err != nil {
-					return fmt.Errorf("failed to write chunk header to tar: %w", err)
-				}
+					if err := tarWriter.WriteHeader(&tar.Header{
+						Name: strconv.FormatUint(uint64(i), 10),
+						Mode: 0o644,
+						Size: st.Size(),
+					}); err != nil {
+						return fmt.Errorf("failed to write chunk header to tar: %w", err)
+					}
 
-				if _, err := io.Copy(tarWriter, file); err != nil {
-					return fmt.Errorf("failed to write chunk to tar: %w", err)
+					if _, err := io.Copy(tarWriter, file); err != nil {
+						return fmt.Errorf("failed to write chunk to tar: %w", err)
+					}
+
+					return nil
+				}(); err != nil {
+					return err
 				}
 			}
 


### PR DESCRIPTION
# Description

The `snapshot dump` command opens every chunk file inside a loop with a deferred `Close`:

```go
for i := uint32(0); i < snapshot.Chunks; i++ {
    file, err := os.Open(path)
    ...
    defer file.Close() // runs only when RunE returns, not per iteration
    ...
}
```

Because `defer` runs at function return, every chunk's file handle stays open until the whole command finishes. A snapshot can contain a very large number of chunks, so on a large snapshot this can exhaust the process file-descriptor limit (`too many open files`) and fail the dump.

This wraps each chunk in a function literal so the deferred `Close` runs at the end of every iteration. No behavior change otherwise.

Follow-up to #25811, which fixed the same class of leak in the `snapshot load` command (`client/snapshot/load.go`); `dump.go` had the same pattern but inside a loop.

## Testing

`go build ./client/...` and `go vet ./client/snapshot/...` pass; `gofmt` clean.
