### PR TITLE
fix(types/module): prevent goroutine leak in ExportGenesis on error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (crypto) [#26529](https://github.com/cosmos/cosmos-sdk/pull/26529) Validate the SEC1 tag byte (`0x02`/`0x03`) when unmarshaling a `secp256k1.PubKey`, rejecting malformed compressed keys that previously passed the length-only check.
 * (x/auth/tx) [#26527](https://github.com/cosmos/cosmos-sdk/pull/26527) Fix nil pointer panic in `GetSigningTxData` when a `SignerInfo` has a nil `PublicKey`.
 * (x/auth/tx) [#26517](https://github.com/cosmos/cosmos-sdk/pull/26517) Return a decode error instead of panicking when a transaction's `SignerInfos` and `Signatures` counts disagree in `GetSignaturesV2`, or a multisig's `ModeInfos` and sub-signature counts disagree in `ModeInfoAndSigToSignatureData`.
+* (types/module) [#26525](https://github.com/cosmos/cosmos-sdk/pull/26525) Buffer the per-module result channels in `ExportGenesisForModules` so the export goroutines of not-yet-collected modules do not leak when the export aborts on the first module error.
 
 ### Deprecated
 

--- a/types/module/module.go
+++ b/types/module/module.go
@@ -556,12 +556,17 @@ func (m *Manager) ExportGenesisForModules(ctx sdk.Context, cdc codec.JSONCodec, 
 		err error
 	}
 
+	// Each per-module channel is buffered with capacity 1 so that an export
+	// goroutine can always deliver its single result and return, even if the
+	// collector loop below exits early on the first error. With an unbuffered
+	// channel the goroutines of not-yet-collected modules would block forever
+	// on send, leaking one goroutine per remaining module.
 	channels := make(map[string]chan genesisResult)
 	for _, moduleName := range modulesToExport {
 		mod := m.Modules[moduleName]
 		if module, ok := mod.(appmodule.HasGenesis); ok {
 			// core API genesis
-			channels[moduleName] = make(chan genesisResult)
+			channels[moduleName] = make(chan genesisResult, 1)
 			go func(module appmodule.HasGenesis, ch chan genesisResult) {
 				ctx := ctx.WithGasMeter(storetypes.NewInfiniteGasMeter()) // avoid race conditions
 				target := genesis.RawJSONTarget{}
@@ -580,13 +585,13 @@ func (m *Manager) ExportGenesisForModules(ctx sdk.Context, cdc codec.JSONCodec, 
 				ch <- genesisResult{rawJSON, nil}
 			}(module, channels[moduleName])
 		} else if module, ok := mod.(HasGenesis); ok {
-			channels[moduleName] = make(chan genesisResult)
+			channels[moduleName] = make(chan genesisResult, 1)
 			go func(module HasGenesis, ch chan genesisResult) {
 				ctx := ctx.WithGasMeter(storetypes.NewInfiniteGasMeter()) // avoid race conditions
 				ch <- genesisResult{module.ExportGenesis(ctx, cdc), nil}
 			}(module, channels[moduleName])
 		} else if module, ok := mod.(HasABCIGenesis); ok {
-			channels[moduleName] = make(chan genesisResult)
+			channels[moduleName] = make(chan genesisResult, 1)
 			go func(module HasABCIGenesis, ch chan genesisResult) {
 				ctx := ctx.WithGasMeter(storetypes.NewInfiniteGasMeter()) // avoid race conditions
 				ch <- genesisResult{module.ExportGenesis(ctx, cdc), nil}

--- a/types/module/module_test.go
+++ b/types/module/module_test.go
@@ -4,8 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
+	"runtime"
 	"testing"
+	"time"
 
 	abci "github.com/cometbft/cometbft/abci/types"
 	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
@@ -627,3 +630,44 @@ var (
 	_ appmodule.HasGenesis  = MockCoreAppModule{}
 	_ appmodule.HasServices = MockCoreAppModule{}
 )
+
+// failingCoreAppModule is a core appmodule whose ExportGenesis always returns an
+// error, used to exercise the early-return path of ExportGenesisForModules.
+type failingCoreAppModule struct {
+	MockCoreAppModule
+}
+
+func (failingCoreAppModule) ExportGenesis(context.Context, appmodule.GenesisTarget) error {
+	return errFoo
+}
+
+var _ appmodule.HasGenesis = failingCoreAppModule{}
+
+// TestManager_ExportGenesis_NoGoroutineLeakOnError verifies that when one module
+// fails during a concurrent export, the goroutines spawned for the remaining
+// modules do not leak. ExportGenesisForModules returns on the first error, so its
+// per-module result channels must be buffered for those goroutines to finish.
+func TestManager_ExportGenesis_NoGoroutineLeakOnError(t *testing.T) {
+	mods := map[string]appmodule.AppModule{"failing": failingCoreAppModule{}}
+	// Many healthy modules raise the odds that some are not collected before the
+	// failure aborts the loop; with unbuffered channels each of those leaks.
+	for i := 0; i < 50; i++ {
+		mods[fmt.Sprintf("ok%d", i)] = MockCoreAppModule{}
+	}
+	mm := module.NewManagerFromMap(mods)
+
+	ctx := sdk.NewContext(nil, cmtproto.Header{}, false, log.NewNopLogger())
+	cdc := codec.NewProtoCodec(types.NewInterfaceRegistry())
+
+	baseline := runtime.NumGoroutine()
+	_, err := mm.ExportGenesis(ctx, cdc)
+	require.ErrorIs(t, err, errFoo)
+
+	// Poll instead of relying on scheduling: every export goroutine must return.
+	deadline := time.Now().Add(5 * time.Second)
+	for runtime.NumGoroutine() > baseline && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	require.LessOrEqualf(t, runtime.NumGoroutine(), baseline,
+		"export goroutines leaked after the export aborted on error")
+}


### PR DESCRIPTION
## Description

`ExportGenesisForModules` exports modules concurrently: it spawns one
goroutine per module that delivers its result on a per-module channel,
then a collector loop reads them and returns on the first module error.

The per-module channels are unbuffered, so a goroutine blocks on send
until its result is received. When the collector returns early on an
error, every module that has not been collected yet (map iteration order
is random) is abandoned, and its goroutine blocks forever on the send —
leaking one goroutine per remaining module.

This fix buffers each per-module channel with capacity 1, so every export
goroutine can deliver its single result and return regardless of an early
collector exit.

## Test

Added `TestManager_ExportGenesis_NoGoroutineLeakOnError`: it exports many
healthy modules plus one failing module and asserts the goroutine count
returns to baseline after the export aborts. The test fails on the old
code (≈50 leaked goroutines) and passes with the fix.
