### PR TITLE
fix(cosmovisor): prevent goroutine leaks in WaitForUpgradeOrExit

### DIFF
--- a/tools/cosmovisor/CHANGELOG.md
+++ b/tools/cosmovisor/CHANGELOG.md
@@ -43,6 +43,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### Bug Fixes
 
 * [#23683](https://github.com/cosmos/cosmos-sdk/pull/23683) Replace `SigInt` with `SigTerm` to gracefully shutdown the process.
+* [#26526](https://github.com/cosmos/cosmos-sdk/pull/26526) Buffer the `cmdDone` and `psChan` channels in `WaitForUpgradeOrExit` so the `cmd.Wait` / `Process.Wait` goroutines do not leak on the upgrade and shutdown-grace-timeout paths.
 
 ## v1.7.1 - 2025-01-12
 

--- a/tools/cosmovisor/process.go
+++ b/tools/cosmovisor/process.go
@@ -270,7 +270,10 @@ func (l Launcher) WaitForUpgradeOrExit(cmd *exec.Cmd) (bool, error) {
 		currentUpgrade = upgradetypes.Plan{}
 	}
 
-	cmdDone := make(chan error)
+	// Buffered so the goroutine can always deliver cmd.Wait()'s result and
+	// return: on the upgrade path below the select picks MonitorUpdate and
+	// never receives from cmdDone, which would otherwise leak this goroutine.
+	cmdDone := make(chan error, 1)
 	go func() {
 		cmdDone <- cmd.Wait()
 	}()
@@ -285,8 +288,10 @@ func (l Launcher) WaitForUpgradeOrExit(cmd *exec.Cmd) (bool, error) {
 			l.logger.Info("sent interrupt to app, waiting for exit")
 			_ = cmd.Process.Signal(syscall.SIGTERM)
 
-			// Wait app exit
-			psChan := make(chan *os.ProcessState)
+			// Wait app exit. Buffered so the goroutine can always deliver the
+			// process state and return: on the ShutdownGrace timeout below the
+			// select stops receiving from psChan, which would otherwise leak it.
+			psChan := make(chan *os.ProcessState, 1)
 			go func() {
 				pstate, _ := cmd.Process.Wait()
 				psChan <- pstate


### PR DESCRIPTION
## Description

`WaitForUpgradeOrExit` launches a goroutine that delivers `cmd.Wait()`'s
result on `cmdDone`, then `select`s between the upgrade file watcher and
`cmdDone`:

- On the **upgrade path** the select receives from `MonitorUpdate` and
  never reads `cmdDone`. Once the app process exits (after being killed),
  that goroutine blocks forever on the unbuffered send — leaking one
  goroutine per upgrade cycle.
- The **shutdown-grace** branch has the same shape: it launches a goroutine
  that sends the process state on `psChan`, but on the `ShutdownGrace`
  timeout the select stops receiving from `psChan`, so after the process is
  killed that goroutine leaks too.

Both channels carry exactly one value, so buffering them with capacity 1
lets each goroutine always deliver its result and return regardless of
which select branch wins.

## Notes

No dedicated unit test: these goroutines are internal to
`WaitForUpgradeOrExit` and only reachable by driving a real subprocess
through the upgrade / shutdown-grace paths. The existing
`TestLaunchProcess` and `TestPlanShutdownGrace` already exercise those
paths; the change is a minimal buffering fix and the leak mechanism is
documented in the code comments.

