### PR TITLE
fix(baseapp): sanitize ABCI query path used as telemetry key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (crypto) [#26529](https://github.com/cosmos/cosmos-sdk/pull/26529) Validate the SEC1 tag byte (`0x02`/`0x03`) when unmarshaling a `secp256k1.PubKey`, rejecting malformed compressed keys that previously passed the length-only check.
 * (x/auth/tx) [#26527](https://github.com/cosmos/cosmos-sdk/pull/26527) Fix nil pointer panic in `GetSigningTxData` when a `SignerInfo` has a nil `PublicKey`.
 * (x/auth/tx) [#26517](https://github.com/cosmos/cosmos-sdk/pull/26517) Return a decode error instead of panicking when a transaction's `SignerInfos` and `Signatures` counts disagree in `GetSignaturesV2`, or a multisig's `ModeInfos` and sub-signature counts disagree in `ModeInfoAndSigToSignatureData`.
+* (baseapp) [#26528](https://github.com/cosmos/cosmos-sdk/pull/26528) Sanitize the ABCI query path before using it as a telemetry key so a malformed `abci_query` path can no longer register an invalid Prometheus metric name and break the `/metrics` endpoint.
 
 ### Deprecated
 

--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -181,12 +181,17 @@ func (app *BaseApp) Query(ctx context.Context, req *abci.RequestQuery) (resp *ab
 		req.Height = app.LastBlockHeight()
 	}
 
+	// req.Path is client-controlled and is used below as a telemetry key. Sanitize
+	// it to the Prometheus metric-name charset first: emitting it verbatim lets a
+	// caller register a metric name containing characters Prometheus rejects (e.g.
+	// '<', '>'), which corrupts the whole /metrics endpoint until the node restarts.
+	queryPath := sanitizeQueryMetricKey(req.Path)
 	//nolint:staticcheck // TODO: switch to OpenTelemetry
 	telemetry.IncrCounter(1, "query", "count")
 	//nolint:staticcheck // TODO: switch to OpenTelemetry
-	telemetry.IncrCounter(1, "query", req.Path)
+	telemetry.IncrCounter(1, "query", queryPath)
 	//nolint:staticcheck // TODO: switch to OpenTelemetry
-	defer telemetry.MeasureSince(telemetry.Now(), req.Path)
+	defer telemetry.MeasureSince(telemetry.Now(), queryPath)
 
 	if req.Path == QueryPathBroadcastTx {
 		return sdkerrors.QueryResult(errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "can't route a broadcast tx message"), app.trace), nil
@@ -1160,7 +1165,7 @@ func handleQueryApp(app *BaseApp, path []string, req *abci.RequestQuery) *abci.R
 				Value:     bz,
 			}
 
-	case "version":
+		case "version":
 			return &abci.ResponseQuery{
 				Codespace: sdkerrors.RootCodespace,
 				Height:    req.Height,
@@ -1246,6 +1251,26 @@ func SplitABCIQueryPath(requestPath string) (path []string) {
 	}
 
 	return path
+}
+
+// sanitizeQueryMetricKey replaces every character that is not valid in a
+// Prometheus metric name with '_'. The ABCI query path is client-controlled
+// and is used as a telemetry key; characters outside [a-zA-Z0-9_:] would
+// otherwise produce a metric name Prometheus rejects, breaking the entire
+// /metrics endpoint until the node restarts. Valid paths are unaffected in
+// practice, as the metrics sink already maps '.'/'/' to '_'.
+func sanitizeQueryMetricKey(key string) string {
+	return strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z',
+			r >= 'A' && r <= 'Z',
+			r >= '0' && r <= '9',
+			r == '_', r == ':':
+			return r
+		default:
+			return '_'
+		}
+	}, key)
 }
 
 // FilterPeerByAddrPort filters peers by address/port.

--- a/baseapp/abci_internal_test.go
+++ b/baseapp/abci_internal_test.go
@@ -1,0 +1,39 @@
+package baseapp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSanitizeQueryMetricKey(t *testing.T) {
+	testCases := []struct {
+		name string
+		path string
+		exp  string
+	}{
+		{"empty", "", ""},
+		{"already safe", "query_count", "query_count"},
+		{"colon preserved", "store:acc", "store:acc"},
+		{"store path slashes", "store/acc/key", "store_acc_key"},
+		{"grpc path", "/cosmos.bank.v1beta1.Query/Balance", "_cosmos_bank_v1beta1_Query_Balance"},
+		// The reported repro: a path with angle brackets produced an invalid
+		// Prometheus metric name and broke /metrics. It must be neutralized.
+		{"angle brackets", "/cosmos/slashing/v1beta1/signing_infos/<addr>", "_cosmos_slashing_v1beta1_signing_infos__addr_"},
+		{"assorted forbidden chars", "a b=c.d-e/f<g>h{i}", "a_b_c_d_e_f_g_h_i_"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := sanitizeQueryMetricKey(tc.path)
+			require.Equal(t, tc.exp, got)
+			// Security property: the result never contains a character outside
+			// the Prometheus metric-name charset.
+			for _, r := range got {
+				valid := (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') ||
+					(r >= '0' && r <= '9') || r == '_' || r == ':'
+				require.Truef(t, valid, "unexpected character %q in sanitized key %q", r, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

Closes: #23472

`Query` emits telemetry keyed by the client-controlled `req.Path`
([baseapp/abci.go:184-186](baseapp/abci.go#L184)). The telemetry wrapper passes
keys straight to go-metrics, whose Prometheus sink only maps a small character
set, so a path with characters Prometheus disallows (e.g. `<`, `>`) registers an
invalid metric name and breaks the whole `/metrics` endpoint until restart — an
externally triggerable telemetry outage.

Sanitize the path to the Prometheus metric-name charset before using it as a key.
Valid paths are unaffected (the sink already maps `.`/`/` to `_`); only
previously-invalid names change. Unit test added.

> Note: this fixes the reported crash (invalid metric name). The unbounded
> cardinality of per-path query metrics (any distinct path = a new series) is a
> separate concern — happy to bucket unrouted paths under `unknown` in a
> follow-up if maintainers prefer.
