### PR TITLE
fix(crypto): validate secp256k1 pubkey SEC1 tag byte

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (x/staking) [#26460](https://github.com/cosmos/cosmos-sdk/pull/26460) Coalesce key rotation power updates to not emit duplicates.
 * (x/staking) [#26483](https://github.com/cosmos/cosmos-sdk/pull/26483) Block `MsgCreateValidator` from creating validators with cons addrs locked by key rotations.
 * (blockstm) [#25893](https://github.com/cosmos/cosmos-sdk/pull/25893) Fix CancelAll cancellation by clearing blocker ESTIMATE marks before waking suspended executors.
+* (crypto) [#26529](https://github.com/cosmos/cosmos-sdk/pull/26529) Validate the SEC1 tag byte (`0x02`/`0x03`) when unmarshaling a `secp256k1.PubKey`, rejecting malformed compressed keys that previously passed the length-only check.
 
 ### Deprecated
 

--- a/crypto/keys/secp256k1/secp256k1.go
+++ b/crypto/keys/secp256k1/secp256k1.go
@@ -192,6 +192,13 @@ func (pubKey *PubKey) UnmarshalAmino(bz []byte) error {
 	if len(bz) != PubKeySize {
 		return errorsmod.Wrap(errors.ErrInvalidPubKey, "invalid pubkey size")
 	}
+	// A compressed SEC1 point must start with a 0x02 or 0x03 tag byte. The
+	// length check alone lets keys with any other leading byte through even
+	// though they are not valid points (and can never verify a signature), so
+	// also reject an invalid tag here.
+	if bz[0] != 0x02 && bz[0] != 0x03 {
+		return errorsmod.Wrap(errors.ErrInvalidPubKey, "invalid pubkey SEC1 tag")
+	}
 	pubKey.Key = bz
 
 	return nil

--- a/crypto/keys/secp256k1/secp256k1_test.go
+++ b/crypto/keys/secp256k1/secp256k1_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
 	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
 
 type keyData struct {
@@ -393,6 +394,49 @@ func TestMarshalAmino(t *testing.T) {
 			require.NoError(t, err)
 
 			require.Equal(t, tc.msg, tc.typ)
+		})
+	}
+}
+
+func TestPubKeyUnmarshalAminoSEC1Tag(t *testing.T) {
+	validKey := secp256k1.GenPrivKey().PubKey().Bytes()
+	require.Len(t, validKey, secp256k1.PubKeySize)
+	require.Truef(t, validKey[0] == 0x02 || validKey[0] == 0x03,
+		"generated compressed key has unexpected tag byte %#x", validKey[0])
+
+	// 33-byte buffers whose only meaningful difference is the leading tag byte;
+	// the remaining bytes are arbitrary because UnmarshalAmino validates the tag,
+	// not the full point.
+	withTag := func(tag byte) []byte {
+		bz := make([]byte, secp256k1.PubKeySize)
+		bz[0] = tag
+		return bz
+	}
+
+	testCases := []struct {
+		name   string
+		bz     []byte
+		expErr bool
+	}{
+		{"valid generated key", validKey, false},
+		{"tag 0x02 accepted", withTag(0x02), false},
+		{"tag 0x03 accepted", withTag(0x03), false},
+		{"invalid tag 0x00", withTag(0x00), true},
+		{"invalid tag 0x04", withTag(0x04), true},
+		{"invalid tag 0x05", append([]byte{0x05}, validKey[1:]...), true},
+		{"wrong length", validKey[:secp256k1.PubKeySize-1], true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var pk secp256k1.PubKey
+			err := pk.UnmarshalAmino(tc.bz)
+			if tc.expErr {
+				require.ErrorIs(t, err, sdkerrors.ErrInvalidPubKey)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.bz, pk.Key)
 		})
 	}
 }


### PR DESCRIPTION
## Description

Closes: #20406

### Bug
`secp256k1.PubKey.UnmarshalAmino` ([secp256k1.go:191](crypto/keys/secp256k1/secp256k1.go#L191))
checks only that the key is 33 bytes, not that it starts with a valid SEC1
compressed-point tag (`0x02`/`0x03`). Keys with any other leading byte are
accepted even though they are not valid points and can never verify a signature.

### Proof (test fails on `main`, before the fix)
--- FAIL: TestPubKeyUnmarshalAminoSEC1Tag/invalid_tag_0x00 — Expected error but got nil.
--- FAIL: TestPubKeyUnmarshalAminoSEC1Tag/invalid_tag_0x04 — Expected error but got nil.
--- FAIL: TestPubKeyUnmarshalAminoSEC1Tag/invalid_tag_0x05 — Expected error but got nil.


i.e. malformed keys are silently accepted. With the fix they are rejected.

### Fix
Reject an invalid SEC1 tag byte in `UnmarshalAmino` in addition to the length
check. This only tightens acceptance of keys that could never verify a
signature, so no usable key is affected; valid keys decode unchanged (the
existing amino backwards-compatibility tests still pass).

### Test
`TestPubKeyUnmarshalAminoSEC1Tag` asserts `0x02`/`0x03` tags (and real generated
keys) are accepted, and that `0x00`/`0x04`/`0x05` tags and wrong length are
rejected with `ErrInvalidPubKey`.