### PR TITLE
fix(math): avoid nil internal big.Int when Unmarshal receives empty i…

### DIFF
--- a/math/CHANGELOG.md
+++ b/math/CHANGELOG.md
@@ -36,6 +36,10 @@ Ref: https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.j
 
 ## [Unreleased]
 
+### Bug Fixes
+
+* [#26536](https://github.com/cosmos/cosmos-sdk/pull/26536) Fix `LegacyDec`, `Int` and `Uint` `Unmarshal` leaving the receiver's internal `big.Int` nil on empty input (the previous code only nilled a local pointer copy), which made later methods such as `IsNegative` panic. Empty input now decodes to zero, matching `UnmarshalJSON`.
+
 ## [math/v1.5.3](https://github.com/cosmos/cosmos-sdk/releases/tag/math/v1.5.3) - 2025-04-04
 
 * [#24375](https://github.com/cosmos/cosmos-sdk/pull/24375) Remove GDA decimal type.  NOTE: the previous v1.5.x family releases have been retracted as they were released with broken features.  This release sets `math` to support everything in the `v1.4.x` family  with testing improvements and dependency bumps

--- a/math/int.go
+++ b/math/int.go
@@ -492,7 +492,11 @@ func (i *Int) MarshalTo(data []byte) (n int, err error) {
 // Unmarshal implements the gogo proto custom type interface.
 func (i *Int) Unmarshal(data []byte) error {
 	if len(data) == 0 {
-		i = nil
+		// Initialize to zero instead of leaving the receiver's internal big.Int
+		// nil (the previous `i = nil` only reassigned the local pointer copy).
+		// A nil internal value makes later methods panic; this mirrors the
+		// UnmarshalJSON path.
+		i.i = new(big.Int)
 		return nil
 	}
 

--- a/math/legacy_dec.go
+++ b/math/legacy_dec.go
@@ -867,7 +867,11 @@ func (d *LegacyDec) MarshalTo(data []byte) (n int, err error) {
 // Unmarshal implements the gogo proto custom type interface.
 func (d *LegacyDec) Unmarshal(data []byte) error {
 	if len(data) == 0 {
-		d = nil
+		// Initialize to zero instead of leaving the receiver's internal big.Int
+		// nil (the previous `d = nil` only reassigned the local pointer copy).
+		// A nil internal value makes later methods like IsNegative panic; this
+		// mirrors the UnmarshalJSON path.
+		d.i = new(big.Int)
 		return nil
 	}
 

--- a/math/uint.go
+++ b/math/uint.go
@@ -197,7 +197,11 @@ func (u *Uint) MarshalTo(data []byte) (n int, err error) {
 // Unmarshal implements the gogo proto custom type interface.
 func (u *Uint) Unmarshal(data []byte) error {
 	if len(data) == 0 {
-		u = nil
+		// Initialize to zero instead of leaving the receiver's internal big.Int
+		// nil (the previous `u = nil` only reassigned the local pointer copy).
+		// A nil internal value makes later methods panic; this mirrors the
+		// UnmarshalJSON path.
+		u.i = new(big.Int)
 		return nil
 	}
 

--- a/math/unmarshal_test.go
+++ b/math/unmarshal_test.go
@@ -35,3 +35,38 @@ func TestUnmarshalEmptyIsZeroNotNil(t *testing.T) {
 		require.True(t, u.IsZero()) // panicked before the fix
 	})
 }
+
+// TestUnmarshalZeroRoundTrip ensures a zero value survives a Marshal/Unmarshal
+// round trip as a usable (non-nil) zero, complementing the explicit empty-input
+// coverage in TestUnmarshalEmptyIsZeroNotNil.
+func TestUnmarshalZeroRoundTrip(t *testing.T) {
+	t.Run("LegacyDec", func(t *testing.T) {
+		bz, err := math.LegacyZeroDec().Marshal()
+		require.NoError(t, err)
+
+		var d math.LegacyDec
+		require.NoError(t, d.Unmarshal(bz))
+		require.False(t, d.IsNil())
+		require.True(t, d.IsZero())
+	})
+
+	t.Run("Int", func(t *testing.T) {
+		bz, err := math.ZeroInt().Marshal()
+		require.NoError(t, err)
+
+		var i math.Int
+		require.NoError(t, i.Unmarshal(bz))
+		require.False(t, i.IsNil())
+		require.True(t, i.IsZero())
+	})
+
+	t.Run("Uint", func(t *testing.T) {
+		bz, err := math.ZeroUint().Marshal()
+		require.NoError(t, err)
+
+		var u math.Uint
+		require.NoError(t, u.Unmarshal(bz))
+		require.False(t, u.IsNil())
+		require.True(t, u.IsZero())
+	})
+}

--- a/math/unmarshal_test.go
+++ b/math/unmarshal_test.go
@@ -1,0 +1,37 @@
+package math_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"cosmossdk.io/math"
+)
+
+// TestUnmarshalEmptyIsZeroNotNil ensures that unmarshaling empty bytes (e.g. a
+// zero-length protobuf custom-type field, which is decodable wire data) leaves a
+// usable zero value rather than a receiver whose internal big.Int is nil. A nil
+// internal value makes later methods such as IsZero / IsNegative panic.
+func TestUnmarshalEmptyIsZeroNotNil(t *testing.T) {
+	t.Run("LegacyDec", func(t *testing.T) {
+		var d math.LegacyDec
+		require.NoError(t, d.Unmarshal([]byte{}))
+		require.False(t, d.IsNil())
+		require.True(t, d.IsZero())      // panicked before the fix
+		require.False(t, d.IsNegative()) // panicked before the fix
+	})
+
+	t.Run("Int", func(t *testing.T) {
+		var i math.Int
+		require.NoError(t, i.Unmarshal([]byte{}))
+		require.False(t, i.IsNil())
+		require.True(t, i.IsZero()) // panicked before the fix
+	})
+
+	t.Run("Uint", func(t *testing.T) {
+		var u math.Uint
+		require.NoError(t, u.Unmarshal([]byte{}))
+		require.False(t, u.IsNil())
+		require.True(t, u.IsZero()) // panicked before the fix
+	})
+}


### PR DESCRIPTION
## Description

### Bug
`LegacyDec`, `Int` and `Uint` `Unmarshal` ([math/legacy_dec.go:868](math/legacy_dec.go#L868),
[int.go:493](math/int.go#L493), [uint.go:198](math/uint.go#L198)) return a nil error on
empty input while leaving the receiver's internal `big.Int` nil — the `d = nil`
statement only reassigns the function-local pointer copy, not the caller's
value. This is asymmetric with `UnmarshalJSON`, which sets `d.i = new(big.Int)`.
`IsZero`/`IsNegative` then dereference the nil internal value and panic.

### Reachability (untrusted protobuf)
A `DecCoin`/`Coin` with a zero-length `Amount` field is valid wire data: the
generated decoder ([coin.pb.go:596](types/coin.pb.go#L596)) calls
`m.Amount.Unmarshal(dAtA[iNdEx:iNdEx])` — an empty slice — so decode succeeds
with a nil-internal Amount. `DecCoin.Validate()` ([dec_coin.go:140](types/dec_coin.go#L140))
then calls `IsNegative()` with **no `IsNil` guard** → nil pointer panic.
Honest encoders never emit this (`MarshalTo` always writes ≥1 byte), so only
crafted/malformed input is affected.

### Fix
Initialize the internal `big.Int` to zero on empty input, matching
`UnmarshalJSON`. Empty input now decodes to a valid zero instead of a
panic-prone nil.

### Test
`TestUnmarshalEmptyIsZeroNotNil` (all three types): before — `IsZero`/`IsNegative`
panic on the nil internal value; after — empty input is a usable zero.
`TestUnmarshalZeroRoundTrip` (all three types): a zero value survives a
`Marshal`/`Unmarshal` round trip as a usable zero. Full `math` module suite
green, `go vet` clean.
