### PR TITLE
fix(server): prevent goroutine leak on API and gRPC server shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (x/staking) [#26460](https://github.com/cosmos/cosmos-sdk/pull/26460) Coalesce key rotation power updates to not emit duplicates.
 * (x/staking) [#26483](https://github.com/cosmos/cosmos-sdk/pull/26483) Block `MsgCreateValidator` from creating validators with cons addrs locked by key rotations.
 * (blockstm) [#25893](https://github.com/cosmos/cosmos-sdk/pull/25893) Fix CancelAll cancellation by clearing blocker ESTIMATE marks before waking suspended executors.
+* (server) [#26538](https://github.com/cosmos/cosmos-sdk/pull/26538) Buffer the `errCh` channel in the API and gRPC server start routines so the serving goroutine does not leak when the server is stopped via context cancellation.
 * (crypto) [#26529](https://github.com/cosmos/cosmos-sdk/pull/26529) Validate the SEC1 tag byte (`0x02`/`0x03`) when unmarshaling a `secp256k1.PubKey`, rejecting malformed compressed keys that previously passed the length-only check.
 
 ### Deprecated

--- a/server/api/server.go
+++ b/server/api/server.go
@@ -155,7 +155,10 @@ func (s *Server) Start(ctx context.Context, cfg config.Config) error {
 	// register grpc-gateway routes (after grpc-web server as the first match is used)
 	s.Router.PathPrefix("/").Handler(s.GRPCGatewayRouter)
 
-	errCh := make(chan error)
+	// Buffered so the serving goroutine can always deliver Serve's result and
+	// exit: on the ctx.Done() shutdown path below the select returns without
+	// receiving from errCh, and an unbuffered channel would leak that goroutine.
+	errCh := make(chan error, 1)
 
 	// Start the API in an external goroutine as Serve is blocking and will return
 	// an error upon failure, which we'll send on the error channel that will be

--- a/server/grpc/server.go
+++ b/server/grpc/server.go
@@ -145,7 +145,10 @@ func StartGRPCServer(ctx context.Context, logger log.Logger, cfg config.GRPCConf
 		return fmt.Errorf("failed to listen on address %s: %w", cfg.Address, err)
 	}
 
-	errCh := make(chan error)
+	// Buffered so the serving goroutine can always deliver Serve's result and
+	// exit: on the ctx.Done() shutdown path below the select returns without
+	// receiving from errCh, and an unbuffered channel would leak that goroutine.
+	errCh := make(chan error, 1)
 
 	// Start the gRPC server in an external goroutine as Serve is blocking and will return
 	// an error upon failure, which we'll send on the error channel that will be


### PR DESCRIPTION
## Bug

In `server/api` and `server/grpc` the serving goroutine sends `Serve`'s result
on an unbuffered `errCh`. On the `ctx.Done()` shutdown path the `select` returns
after stopping the server without receiving from `errCh`. Once `Serve` unblocks
and returns, the goroutine blocks forever on the send, leaking it for the
lifetime of the process.

## Fix

Buffer `errCh` with capacity 1 in both start routines, so the serving goroutine
can always deliver its result and exit regardless of which `select` branch the
caller took. Same fix and pattern as #26526.

No unit test is added: reproducing the leak requires starting a real server and
asserting on goroutine state, which is flaky in CI — matching the precedent set
by #26526.
