### PR TITLE
test(log): reproduce data race in SetVerboseMode

### DIFF
--- a/log/race_test.go
+++ b/log/race_test.go
@@ -1,0 +1,31 @@
+package log_test
+
+import (
+	"io"
+	"testing"
+
+	log "cosmossdk.io/log/v2"
+)
+
+func TestSetVerboseModeRace(t *testing.T) {
+	logger := log.NewLogger(io.Discard, log.FilterOption(func(module, level string) bool {
+		return false
+	}))
+	vl := logger.(log.VerboseModeLogger)
+
+	done := make(chan struct{})
+
+	go func() {
+		for i := 0; i < 100000; i++ {
+			logger.Info("msg")
+		}
+		close(done)
+	}()
+
+	for i := 0; i < 100000; i++ {
+		vl.SetVerboseMode(true)
+		vl.SetVerboseMode(false)
+	}
+
+	<-done
+}


### PR DESCRIPTION
SetVerboseMode is not concurrency-safe: it performs unsynchronized writes to *zerolog.Logger and filterWriter.disableFilter while other goroutines concurrently read these fields during logging, which is reproducible with go test -race and reachable in production via x/upgrade/keeper.ApplyUpgrade.