### PR TITLE
fix(client/v2): avoid panic on missing positional signer argument

### DIFF
--- a/client/v2/CHANGELOG.md
+++ b/client/v2/CHANGELOG.md
@@ -34,6 +34,12 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 # Changelog
 
+## [Unreleased]
+
+### Bug Fixes
+
+* [#26540](https://github.com/cosmos/cosmos-sdk/pull/26540) Fail gracefully instead of panicking when a positional signer argument is omitted from a generated command.
+
 ## [v2.0.0-beta.11](https://github.com/cosmos/cosmos-sdk/tree/client/v2.0.0-beta.11) - 2025-05-30
 
 ### Bug Fixes

--- a/client/v2/autocli/common.go
+++ b/client/v2/autocli/common.go
@@ -87,7 +87,13 @@ func (b *Builder) buildMethodCommandCommon(descriptor protoreflect.MethodDescrip
 				}
 			} else {
 				// if the signer is not a flag, it is a positional argument
-				// we need to get the correct positional arguments
+				// we need to get the correct positional arguments.
+				// When the last positional argument is optional or varargs, cobra
+				// accepts a call with fewer arguments than the signer's index, so
+				// guard against an out-of-range access and fail gracefully.
+				if binder.SignerInfo.PositionalArgIndex >= len(args) {
+					return fmt.Errorf("expected %d positional arguments, got %d", binder.SignerInfo.PositionalArgIndex+1, len(args))
+				}
 				if err := cmd.Flags().Set(flags.FlagFrom, args[binder.SignerInfo.PositionalArgIndex]); err != nil {
 					return err
 				}

--- a/client/v2/autocli/msg_test.go
+++ b/client/v2/autocli/msg_test.go
@@ -217,6 +217,36 @@ func TestMsgOptionsError(t *testing.T) {
 	assert.ErrorContains(t, err, "invalid argument")
 }
 
+// TestMsgMissingPositionalSignerArg ensures that omitting a positional signer
+// argument fails gracefully instead of panicking with an index-out-of-range.
+// When the last positional argument is optional, cobra accepts a call with one
+// fewer argument than the signer's index, which previously caused
+// args[SignerInfo.PositionalArgIndex] to be accessed out of range.
+func TestMsgMissingPositionalSignerArg(t *testing.T) {
+	fixture := initFixture(t)
+
+	// from_address is the signer and is placed last as an optional positional
+	// argument, so a call with only the preceding arguments passes cobra's
+	// argument validation but leaves the signer argument unset.
+	_, err := runCmd(fixture, buildCustomModuleMsgCommand(&autocliv1.ServiceCommandDescriptor{
+		Service: bankv1beta1.Msg_ServiceDesc.ServiceName,
+		RpcCommandOptions: []*autocliv1.RpcCommandOptions{
+			{
+				RpcMethod: "Send",
+				PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+					{ProtoField: "to_address"},
+					{ProtoField: "amount"},
+					{ProtoField: "from_address", Optional: true},
+				},
+			},
+		},
+		EnhanceCustomCommand: true,
+	}), "send",
+		"cosmos1y74p8wyy4enfhfn342njve6cjmj5c8dtl6emdk", "1000stake",
+	)
+	assert.ErrorContains(t, err, "expected 3 positional arguments, got 2")
+}
+
 func TestHelpMsg(t *testing.T) {
 	fixture := initFixture(t)
 


### PR DESCRIPTION
## Bug

When a message's signer field is bound as a positional argument and the
last positional argument is optional or varargs, cobra accepts a call with
one fewer argument than the signer's index (`MinimumNArgs(totalArgs-1)` /
`RangeArgs(totalArgs-1, totalArgs)`). The signer handling in
`client/v2/autocli/common.go` then accesses
`args[binder.SignerInfo.PositionalArgIndex]` without a bounds check, panicking
with an index-out-of-range instead of failing with a validation error.

This is what #25837 reports for `ibc-transfer transfer` when invoked with fewer
than the required positional arguments.

## Fix

Bound the access by the length of `args`; if the signer positional argument is
missing, return a clear error instead of panicking.

## Test

`TestMsgMissingPositionalSignerArg` places the signer (`from_address`) as the
last, optional positional argument and invokes the command without it. Before
the fix the test panics with index-out-of-range; after, it fails with
`expected 3 positional arguments, got 2`. Full `autocli` package green,
`go vet` clean.

Closes #25837
