### PR TITLE
fix(math): report positive excess in LegacyNewDecFromStr precision error

### DIFF
--- a/math/legacy_dec.go
+++ b/math/legacy_dec.go
@@ -183,7 +183,7 @@ func LegacyNewDecFromStr(str string) (LegacyDec, error) {
 	}
 
 	if lenDecs > LegacyPrecision {
-		return LegacyDec{}, fmt.Errorf("value '%s' exceeds max precision by %d decimal places: max precision %d", str, LegacyPrecision-lenDecs, LegacyPrecision)
+		return LegacyDec{}, fmt.Errorf("value '%s' exceeds max precision by %d decimal places: max precision %d", str, lenDecs-LegacyPrecision, LegacyPrecision)
 	}
 
 	// add some extra zero's to correct to the Precision factor

--- a/math/legacy_dec_test.go
+++ b/math/legacy_dec_test.go
@@ -1414,6 +1414,9 @@ func TestLegacyNewDecFromStr_TooManyDecimals(t *testing.T) {
 	decStr := "1." + strings.Repeat("1", math.LegacyPrecision+1)
 	_, err := math.LegacyNewDecFromStr(decStr)
 	require.Error(t, err, "expected error when input has more than %d decimal places", math.LegacyPrecision)
+	// The reported excess must be the (positive) number of decimal places over
+	// the limit, not a negative value from subtracting in the wrong order.
+	require.Contains(t, err.Error(), "exceeds max precision by 1 decimal places")
 }
 
 func TestUnmarshalJSON_InvalidFormat(t *testing.T) {


### PR DESCRIPTION
## Description

`LegacyNewDecFromStr` rejects inputs with more fractional digits than `LegacyPrecision`. On that branch the error computes the excess as `LegacyPrecision - lenDecs`, but the branch is only reached when `lenDecs > LegacyPrecision`, so the value is always negative:

```
value '1.1111111111111111111' exceeds max precision by -1 decimal places: max precision 18
```

Swapping the operands to `lenDecs - LegacyPrecision` reports the actual positive number of decimal places over the limit:

```
value '1.1111111111111111111' exceeds max precision by 1 decimal places: max precision 18
```

Error-message only; no behavioral change. `TestLegacyNewDecFromStr_TooManyDecimals` is extended to assert the reported excess is positive.

## Author Checklist

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] confirmed `!` in the type prefix if API or client breaking change
- [x] targeted the correct branch
- [x] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] included the necessary unit and integration tests
- [x] added a changelog entry to `CHANGELOG.md` (not required: error-message wording only, no user-facing behavior change)
- [x] confirmed all CI checks have passed