### PR TITLE
fix(types): include full coin in Coins/DecCoins non-positive validation error

### DIFF
--- a/types/coin.go
+++ b/types/coin.go
@@ -274,7 +274,7 @@ func (coins Coins) Validate() error {
 				return fmt.Errorf("duplicate denomination %s", coin.Denom)
 			}
 			if !coin.IsPositive() {
-				return fmt.Errorf("coin %s amount is not positive", coin.Denom)
+				return fmt.Errorf("coin %s amount is not positive", coin)
 			}
 
 			// we compare each coin against the last denom

--- a/types/coin_test.go
+++ b/types/coin_test.go
@@ -915,6 +915,18 @@ func (s *coinTestSuite) TestCoins_Validate() {
 	}
 }
 
+func (s *coinTestSuite) TestCoins_Validate_NonPositiveErrorIncludesCoin() {
+	badCoin := sdk.Coin{Denom: "btree", Amount: math.ZeroInt()}
+	coins := sdk.Coins{
+		{Denom: "atree", Amount: math.OneInt()},
+		badCoin,
+	}
+	err := coins.Validate()
+	s.Require().Error(err)
+	// The error should name the offending coin (amount + denom), not the denom alone.
+	s.Require().Contains(err.Error(), badCoin.String())
+}
+
 func (s *coinTestSuite) TestMinMax() {
 	one := math.OneInt()
 	two := math.NewInt(2)

--- a/types/dec_coin.go
+++ b/types/dec_coin.go
@@ -546,7 +546,7 @@ func (coins DecCoins) Validate() error {
 				return fmt.Errorf("denomination %s is not sorted", coin.Denom)
 			}
 			if !coin.IsPositive() {
-				return fmt.Errorf("coin %s amount is not positive", coin.Denom)
+				return fmt.Errorf("coin %s amount is not positive", coin)
 			}
 
 			// we compare each coin against the last denom

--- a/types/dec_coin_test.go
+++ b/types/dec_coin_test.go
@@ -366,6 +366,18 @@ func (s *decCoinTestSuite) TestDecCoinsValidate() {
 	}
 }
 
+func (s *decCoinTestSuite) TestDecCoins_Validate_NonPositiveErrorIncludesCoin() {
+	badCoin := sdk.DecCoin{Denom: "btree", Amount: math.LegacyZeroDec()}
+	coins := sdk.DecCoins{
+		sdk.DecCoin{Denom: "atree", Amount: math.LegacyNewDec(1)},
+		badCoin,
+	}
+	err := coins.Validate()
+	s.Require().Error(err)
+	// The error should name the offending coin (amount + denom), not the denom alone.
+	s.Require().Contains(err.Error(), badCoin.String())
+}
+
 func (s *decCoinTestSuite) TestParseDecCoins() {
 	testCases := []struct {
 		input          string


### PR DESCRIPTION
## Description

In the multi-coin (`default`) branch of `Coins.Validate` and `DecCoins.Validate`, the "amount is not positive" error formats `coin.Denom` instead of the full `coin`, so the amount is dropped from the message:

```
coin atom amount is not positive      // current — denom only
coin 0atom amount is not positive     // expected — full coin
```

The single-coin branch in both functions already prints the full `coins[0]`; this aligns the loop branch with it (`coin.Denom` -> `coin` at `types/coin.go:277` and `types/dec_coin.go:549`).

Error-message only; no behavioral change. Added `TestCoins_Validate_NonPositiveErrorIncludesCoin` and `TestDecCoins_Validate_NonPositiveErrorIncludesCoin` asserting the offending coin's full string (amount + denom) appears in the error.

## Author Checklist

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] confirmed `!` in the type prefix if API or client breaking change
- [x] targeted the correct branch
- [x] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] included the necessary unit and integration tests
- [x] added a changelog entry to `CHANGELOG.md` (not required: error-message wording only, no user-facing behavior change)
- [x] confirmed all CI checks have passed