### PR TITLE
fix(client): parse raw debug bytes as unsigned values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Bug Fixes
 
+* (client) [#26549](https://github.com/cosmos/cosmos-sdk/pull/26549) Fix `debug raw-bytes` parsing so unsigned byte values such as `255` are accepted.
 * (client) [#26524](https://github.com/cosmos/cosmos-sdk/pull/26524) Fix file handle leak in the `snapshot dump` command where chunk files were deferred-closed inside the loop, keeping every chunk's handle open until the command returned (follow-up to #25811).
 * (x/distribution) [#26518](https://github.com/cosmos/cosmos-sdk/pull/26518) Return an error from internal historical rewards reads when the record is absent, preventing recovered reference-count panics during BlockSTM speculative execution.
 * (x/auth) [#26515](https://github.com/cosmos/cosmos-sdk/pull/26515) Bound the pubkey and signature indices in `ConsumeMultisignatureVerificationGas` and `VerifyMultisignature` so a multisig signature with a bit array larger than the key set, or with more set bits than supplied signatures, returns an error instead of panicking with index out of range.

--- a/client/debug/main.go
+++ b/client/debug/main.go
@@ -304,23 +304,31 @@ func RawBytesCmd() *cobra.Command {
 		Example: fmt.Sprintf("%s debug raw-bytes '[72 101 108 108 111 44 32 112 108 97 121 103 114 111 117 110 100]'", version.AppName),
 		Args:    cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
-			stringBytes := args[0]
-			stringBytes = strings.Trim(stringBytes, "[")
-			stringBytes = strings.Trim(stringBytes, "]")
-			spl := strings.Split(stringBytes, " ")
-
-			byteArray := []byte{}
-			for _, s := range spl {
-				b, err := strconv.ParseInt(s, 10, 8)
-				if err != nil {
-					return err
-				}
-				byteArray = append(byteArray, byte(b))
+			byteArray, err := parseRawBytes(args[0])
+			if err != nil {
+				return err
 			}
+
 			fmt.Printf("%X\n", byteArray)
 			return nil
 		},
 	}
+}
+
+func parseRawBytes(rawBytes string) ([]byte, error) {
+	stringBytes := strings.Trim(rawBytes, "[]")
+	parts := strings.Fields(stringBytes)
+
+	byteArray := make([]byte, 0, len(parts))
+	for _, s := range parts {
+		b, err := strconv.ParseUint(s, 10, 8)
+		if err != nil {
+			return nil, err
+		}
+		byteArray = append(byteArray, byte(b))
+	}
+
+	return byteArray, nil
 }
 
 func PrefixesCmd() *cobra.Command {

--- a/client/debug/main_test.go
+++ b/client/debug/main_test.go
@@ -1,0 +1,50 @@
+package debug
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseRawBytes(t *testing.T) {
+	testCases := []struct {
+		name    string
+		input   string
+		want    []byte
+		wantErr bool
+	}{
+		{
+			name:  "accepts unsigned byte values",
+			input: "[10 21 13 255]",
+			want:  []byte{10, 21, 13, 255},
+		},
+		{
+			name:  "accepts flexible whitespace",
+			input: "[72\t101\n108 108 111]",
+			want:  []byte("Hello"),
+		},
+		{
+			name:    "rejects negative values",
+			input:   "[-1]",
+			wantErr: true,
+		},
+		{
+			name:    "rejects values above byte range",
+			input:   "[256]",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseRawBytes(tc.input)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}


### PR DESCRIPTION
# Description

Fixes `debug raw-bytes` parsing so decimal byte values are treated as unsigned bytes.

The command help shows an example containing `255`, but the previous implementation used `strconv.ParseInt(..., 8)`, which rejects values above `127` because it parses a signed 8-bit integer. This switches parsing to `strconv.ParseUint(..., 8)` so the full byte range `0..255` is accepted, while negative values and values above `255` still fail.

This also uses `strings.Fields` so tabs, newlines, and repeated spaces are accepted between byte values.
