### PR TITLE
fix(store/rootmulti): prune stale commit-info records

### DIFF
--- a/store/CHANGELOG.md
+++ b/store/CHANGELOG.md
@@ -35,6 +35,8 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Bug Fixes
 
+* (store) [#26551](https://github.com/cosmos/cosmos-sdk/issues/26551) Prune stale rootmulti commit-info records when pruning stores.
+
 ## v2.0.0 (April 10, 2026)
 
 ### API Breaking

--- a/store/rootmulti/commit_info_prune_test.go
+++ b/store/rootmulti/commit_info_prune_test.go
@@ -1,0 +1,86 @@
+package rootmulti
+
+import (
+	"fmt"
+	"testing"
+
+	dbm "github.com/cosmos/cosmos-db"
+	"github.com/stretchr/testify/require"
+
+	pruningtypes "github.com/cosmos/cosmos-sdk/store/v2/pruning/types"
+)
+
+func countCommitInfoKeys(t *testing.T, db dbm.DB) int {
+	t.Helper()
+
+	iter, err := db.Iterator([]byte("s/0"), []byte("s/:"))
+	require.NoError(t, err)
+	defer iter.Close()
+
+	count := 0
+	for ; iter.Valid(); iter.Next() {
+		count++
+	}
+	require.NoError(t, iter.Error())
+
+	return count
+}
+
+func TestPruneCommitInfoDeletesStaleRecords(t *testing.T) {
+	db := dbm.NewMemDB()
+	ms := newMultiStoreWithMounts(db, pruningtypes.NewPruningOptions(pruningtypes.PruningNothing))
+	require.NoError(t, ms.LoadLatestVersion())
+
+	const versions = 50
+	for range versions {
+		ms.Commit()
+	}
+	require.Equal(t, versions, countCommitInfoKeys(t, db))
+
+	require.NoError(t, ms.pruneCommitInfo(40))
+
+	require.Equal(t, 11, countCommitInfoKeys(t, db))
+
+	for _, version := range []int64{1, 39} {
+		has, err := db.Has([]byte(fmt.Sprintf("s/%d", version)))
+		require.NoError(t, err)
+		require.False(t, has)
+	}
+	for _, version := range []int64{40, 50} {
+		has, err := db.Has([]byte(fmt.Sprintf("s/%d", version)))
+		require.NoError(t, err)
+		require.True(t, has)
+	}
+
+	has, err := db.Has([]byte(latestVersionKey))
+	require.NoError(t, err)
+	require.True(t, has)
+}
+
+func TestPruneCommitInfoRespectsBatchCapAndIgnoresOtherKeys(t *testing.T) {
+	db := dbm.NewMemDB()
+	ms := newMultiStoreWithMounts(db, pruningtypes.NewPruningOptions(pruningtypes.PruningNothing))
+
+	const total = commitInfoPruneBatch + 5000
+	for version := 1; version <= total; version++ {
+		require.NoError(t, db.Set([]byte(fmt.Sprintf("s/%d", version)), []byte{1}))
+	}
+
+	decoys := []string{latestVersionKey, earliestVersionKey, "s/k:bank/value", "s/_/value"}
+	for _, key := range decoys {
+		require.NoError(t, db.Set([]byte(key), []byte{9}))
+	}
+	require.Equal(t, total, countCommitInfoKeys(t, db))
+
+	require.NoError(t, ms.pruneCommitInfo(int64(total)+1))
+	require.Equal(t, total-commitInfoPruneBatch, countCommitInfoKeys(t, db))
+
+	require.NoError(t, ms.pruneCommitInfo(int64(total)+1))
+	require.Equal(t, 0, countCommitInfoKeys(t, db))
+
+	for _, key := range decoys {
+		has, err := db.Has([]byte(key))
+		require.NoError(t, err)
+		require.True(t, has)
+	}
+}

--- a/store/rootmulti/store.go
+++ b/store/rootmulti/store.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"math"
 	"sort"
+	"strconv"
 	"strings"
 	"sync/atomic"
 
@@ -722,7 +723,58 @@ func (rs *Store) PruneStores(pruningHeight int64) (err error) {
 		}
 	}
 
+	if err := rs.pruneCommitInfo(pruningHeight); err != nil {
+		rs.logger.Error("failed to prune commit-info", "prune_to", pruningHeight, "err", err)
+	}
+
 	return nil
+}
+
+const commitInfoPruneBatch = 20000
+
+func (rs *Store) pruneCommitInfo(pruningHeight int64) error {
+	if pruningHeight <= 1 {
+		return nil
+	}
+
+	iter, err := rs.db.Iterator([]byte("s/0"), []byte("s/:"))
+	if err != nil {
+		return err
+	}
+
+	keys := make([][]byte, 0, 1024)
+	for ; iter.Valid() && len(keys) < commitInfoPruneBatch; iter.Next() {
+		key := iter.Key()
+		suffix := key[len("s/"):]
+		version, perr := strconv.ParseInt(string(suffix), 10, 64)
+		if perr != nil || version >= pruningHeight {
+			continue
+		}
+
+		dk := make([]byte, len(key))
+		copy(dk, key)
+		keys = append(keys, dk)
+	}
+	iterErr := iter.Error()
+	if cerr := iter.Close(); cerr != nil && iterErr == nil {
+		iterErr = cerr
+	}
+	if iterErr != nil {
+		return iterErr
+	}
+	if len(keys) == 0 {
+		return nil
+	}
+
+	batch := rs.db.NewBatch()
+	defer batch.Close()
+	for _, key := range keys {
+		if err := batch.Delete(key); err != nil {
+			return err
+		}
+	}
+
+	return batch.WriteSync()
 }
 
 // GetStoreByName performs a lookup of a StoreKey given a store name typically


### PR DESCRIPTION
PruneStores currently removes stale IAVL versions and advances the earliest version pointer, but it leaves the corresponding rootmulti commit-info records (`s/<version>`) behind forever. Delete stale commit-info records in bounded batches so pruning reclaims the metadata written at each committed height.

# Description

Closes #26551

This PR updates `store/rootmulti/store.go` so `PruneStores` also prunes stale rootmulti commit-info records below the pruning height. The new helper scans only the numeric commit-info key range (`["s/0", "s/:")`), deletes at most 20000 records per prune pass, and closes the iterator before writing the delete batch.

The most critical files to review are:
- `store/rootmulti/store.go`
- `store/rootmulti/commit_info_prune_test.go`
- `store/CHANGELOG.md`

# Tests

```bash
cd store && go test ./rootmulti/...