### PR TITLE
fix(store): delete stale commit-info metadata on prune (#26551)

### DIFF
--- a/store/rootmulti/store.go
+++ b/store/rootmulti/store.go
@@ -716,6 +716,18 @@ func (rs *Store) PruneStores(pruningHeight int64) (err error) {
 	if newEarliest > currentEarliest {
 		batch := rs.db.NewBatch()
 		defer batch.Close()
+
+		// Delete stale commit-info metadata (s/<version>) for the heights just
+		// pruned. This is symmetric with the IAVL version pruning above; without
+		// it the metadata DB grows unbounded, as one CommitInfo record is written
+		// per block and never removed. currentEarliest is the previously persisted
+		// earliest version, so lower keys were already deleted by earlier prunes.
+		for v := currentEarliest; v <= pruningHeight; v++ {
+			if err := batch.Delete([]byte(fmt.Sprintf(commitInfoKeyFmt, v))); err != nil {
+				rs.logger.Error("failed to delete stale commit info", "version", v, "err", err)
+			}
+		}
+
 		flushEarliestVersion(batch, newEarliest)
 		if err := batch.WriteSync(); err != nil {
 			rs.logger.Error("failed to persist earliest version", "err", err)

--- a/store/rootmulti/store_test.go
+++ b/store/rootmulti/store_test.go
@@ -1189,3 +1189,34 @@ func TestEarliestVersionPersistence(t *testing.T) {
 	require.Equal(t, earliestBeforeRestart, ms2.EarliestVersion(),
 		"earliest version should persist across restarts")
 }
+
+// TestPruningDeletesCommitInfo ensures that pruning removes the commit-info
+// metadata records (s/<version>) for pruned heights, not just the IAVL tree
+// versions. Without this, the metadata DB grows unbounded (one CommitInfo
+// record per block, forever) even on aggressively pruning nodes.
+func TestPruningDeletesCommitInfo(t *testing.T) {
+	db := dbm.NewMemDB()
+	ms := newMultiStoreWithMounts(db, pruningtypes.NewCustomPruningOptions(2, 1))
+	require.NoError(t, ms.LoadLatestVersion())
+
+	for i := 0; i < 10; i++ {
+		ms.Commit()
+	}
+
+	// Wait for pruning to advance the earliest available version.
+	require.Eventually(t, func() bool { return ms.EarliestVersion() > 1 },
+		time.Second, 10*time.Millisecond)
+
+	earliest := ms.EarliestVersion()
+	require.Greater(t, earliest, int64(1))
+
+	// Every pruned height's commit-info must be deleted.
+	for v := int64(1); v < earliest; v++ {
+		_, err := ms.GetCommitInfo(v)
+		require.Error(t, err, "commit info for pruned height %d should be deleted", v)
+	}
+
+	// Retained heights must still have their commit-info.
+	_, err := ms.GetCommitInfo(ms.LatestVersion())
+	require.NoError(t, err)
+}


### PR DESCRIPTION
# Description
Closes #26551

`rootmulti.PruneStores` deletes IAVL tree versions for pruned heights and
advances the `s/earliest` marker, but it never deletes the per-height commit
info records (`s/<version>`). One `CommitInfo` record is written to the
metadata DB on every block by `flushCommitInfo` and is never removed, so the
metadata DB grows unbounded on pruning nodes — proportional to total block
height — even though the corresponding IAVL history has been discarded.

### Root cause

In `store/rootmulti/store.go`, `PruneStores` (~L678) only calls
`DeleteVersionsTo(pruningHeight)` on each IAVL store and writes `s/earliest`.
The `s/<version>` keys written by `flushCommitInfo` (~L1268) have no
corresponding deletion path.

### Fix

Within the existing batch that advances `s/earliest`, also delete the commit
info records for the heights that were just pruned, using the previously
persisted earliest version as the lower bound so each prune only removes its
own increment. This is symmetric with the IAVL version pruning that already
happens above it.

Deleting these records is safe: a commit info at height `v` is only used to
serve state at `v` (`loadVersion`, query/proof paths, `GetCommitInfo`
callers). Once `v <= pruningHeight` the IAVL data for `v` is already gone, so
`v` is unservable regardless — its commit info is dead metadata.

### Testing

Added `TestPruningDeletesCommitInfo`, which fails before the change (commit
info for pruned heights is still present) and passes after. Existing pruning
and earliest-version tests continue to pass:
go test ./rootmulti/... && go vet ./rootmulti/...

### Note
On a node pruned for the first time after long unpruned operation, the initial
delete range (`1..pruningHeight`) is large — a one-time bulk delete. Steady
state only removes `interval`-sized ranges per prune.

