### PR TITLE
fix(baseapp): make BaseApp.Close idempotent (#26558)

### DIFF
--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -66,6 +66,7 @@ type BaseApp struct {
 	logger            log.Logger
 	name              string                      // application name from abci.BlockInfo
 	db                dbm.DB                      // common DB backend
+	closeOnce         sync.Once                   // ensures Close cleanup runs at most once
 	cms               storetypes.CommitMultiStore // Main (uncached) state
 	qms               storetypes.MultiStore       // Optional alternative multistore for querying only.
 	storeLoader       StoreLoader                 // function to handle store loading, may be overridden with SetStoreLoader()
@@ -1158,7 +1159,19 @@ func (app *BaseApp) StreamingManager() storetypes.StreamingManager {
 }
 
 // Close is called in start cmd to gracefully cleanup resources.
+// It is idempotent: cleanup runs at most once, so it is safe to call from
+// multiple shutdown paths (e.g. deferred cleanup and a signal handler).
+// Closing an already-closed backend such as PebbleDB otherwise panics
+// ("pebble: closed").
 func (app *BaseApp) Close() error {
+	var err error
+	app.closeOnce.Do(func() {
+		err = app.close()
+	})
+	return err
+}
+
+func (app *BaseApp) close() error {
 	var errs []error
 
 	// Close app.db (opened by cosmos-sdk/server/start.go call to openDB)

--- a/baseapp/baseapp_test.go
+++ b/baseapp/baseapp_test.go
@@ -1127,3 +1127,27 @@ func TestLoadVersionPruning(t *testing.T) {
 	require.Nil(t, err)
 	testLoadVersionHelper(t, app, int64(7), lastCommitID)
 }
+
+// closeCountingDB wraps a dbm.DB and panics on a second Close, mimicking
+// PebbleDB's "pebble: closed" behavior, to prove BaseApp.Close idempotency.
+type closeCountingDB struct {
+	dbm.DB
+	closeCount int
+}
+
+func (d *closeCountingDB) Close() error {
+	d.closeCount++
+	if d.closeCount > 1 {
+		panic("pebble: closed")
+	}
+	return nil
+}
+
+func TestBaseAppCloseIdempotent(t *testing.T) {
+	db := &closeCountingDB{DB: dbm.NewMemDB()}
+	app := baseapp.NewBaseApp(t.Name(), log.NewTestLogger(t), db, nil)
+
+	require.NoError(t, app.Close())
+	require.NotPanics(t, func() { _ = app.Close() }, "second Close must be idempotent")
+	require.Equal(t, 1, db.closeCount, "underlying db.Close must be called exactly once")
+}


### PR DESCRIPTION
# Description
Closes #26558

`BaseApp.Close` runs its cleanup (`app.db.Close()`, `app.snapshotManager.Close()`)
unconditionally with no guard against being called more than once. Several
shutdown paths in `server/start.go` can invoke `Close` twice (e.g. a deferred
cleanup plus a signal-driven cleanup), and closing an already-closed backend
such as PebbleDB panics with `pebble: closed`.

### Root cause

`baseapp/baseapp.go` `Close` (~L1160) had no `sync.Once`/closed flag, so a
second call re-invokes `db.Close()` on an already-closed handle.

### Fix

Guard the cleanup with a `sync.Once` (`closeOnce`) so it runs at most once.
`Close` now delegates to an internal `close()` via `closeOnce.Do`, making it
safe to call from multiple shutdown paths and concurrently. Subsequent calls
are no-ops and return nil.

### Testing

Added `TestBaseAppCloseIdempotent`, using a DB wrapper that panics on a second
`Close` (mimicking PebbleDB). It fails before the change (second `Close`
panics `pebble: closed`) and passes after (underlying `Close` is invoked
exactly once). Full package passes:
go test ./baseapp/ && go vet ./baseapp/