### PR TITLE
fix(x/auth/ante): reject tx with extra SignerInfos in SetPubKeyDecorator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,7 +83,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (crypto) [#26529](https://github.com/cosmos/cosmos-sdk/pull/26529) Validate the SEC1 tag byte (`0x02`/`0x03`) when unmarshaling a `secp256k1.PubKey`, rejecting malformed compressed keys that previously passed the length-only check.
 * (x/auth/tx) [#26527](https://github.com/cosmos/cosmos-sdk/pull/26527) Fix nil pointer panic in `GetSigningTxData` when a `SignerInfo` has a nil `PublicKey`.
 * (x/auth/tx) [#26517](https://github.com/cosmos/cosmos-sdk/pull/26517) Return a decode error instead of panicking when a transaction's `SignerInfos` and `Signatures` counts disagree in `GetSignaturesV2`, or a multisig's `ModeInfos` and sub-signature counts disagree in `ModeInfoAndSigToSignatureData`.
-* (x/auth/ante) [#XXXX](https://github.com/cosmos/cosmos-sdk/pull/XXXX) Reject tx with extra SignerInfos in SetPubKeyDecorator.
+* (x/auth/ante) [#26573](https://github.com/cosmos/cosmos-sdk/pull/26573) Reject tx with extra SignerInfos in SetPubKeyDecorator.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (crypto) [#26529](https://github.com/cosmos/cosmos-sdk/pull/26529) Validate the SEC1 tag byte (`0x02`/`0x03`) when unmarshaling a `secp256k1.PubKey`, rejecting malformed compressed keys that previously passed the length-only check.
 * (x/auth/tx) [#26527](https://github.com/cosmos/cosmos-sdk/pull/26527) Fix nil pointer panic in `GetSigningTxData` when a `SignerInfo` has a nil `PublicKey`.
 * (x/auth/tx) [#26517](https://github.com/cosmos/cosmos-sdk/pull/26517) Return a decode error instead of panicking when a transaction's `SignerInfos` and `Signatures` counts disagree in `GetSignaturesV2`, or a multisig's `ModeInfos` and sub-signature counts disagree in `ModeInfoAndSigToSignatureData`.
+* (x/auth/ante) [#XXXX](https://github.com/cosmos/cosmos-sdk/pull/XXXX) Reject tx with extra SignerInfos in SetPubKeyDecorator.
 
 ### Deprecated
 

--- a/x/auth/ante/sigverify.go
+++ b/x/auth/ante/sigverify.go
@@ -76,6 +76,11 @@ func (spkd SetPubKeyDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate b
 		return sdk.Context{}, err
 	}
 
+	if len(pubkeys) != len(signers) {
+		return ctx, errorsmod.Wrapf(sdkerrors.ErrTxDecode,
+			"expected %d signer infos, got %d", len(signers), len(pubkeys))
+	}
+
 	signerStrs := make([]string, len(signers))
 	for i, pk := range pubkeys {
 		var err error

--- a/x/auth/ante/sigverify_test.go
+++ b/x/auth/ante/sigverify_test.go
@@ -9,6 +9,8 @@ import (
 	"go.uber.org/mock/gomock"
 
 	"github.com/cosmos/cosmos-sdk/codec"
+	txtypes "github.com/cosmos/cosmos-sdk/types/tx"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
 	"github.com/cosmos/cosmos-sdk/crypto/keys/mldsa65"
 	kmultisig "github.com/cosmos/cosmos-sdk/crypto/keys/multisig"
@@ -98,6 +100,40 @@ func TestSetPubKey_UnorderedNoEvents(t *testing.T) {
 		// transaction uses the same sequence number as another transaction from the same sender.
 		require.NotContains(t, event.Attributes, sdk.AttributeKeyAccountSequence)
 	}
+}
+
+func TestSetPubKey_SignerInfoCountMismatch(t *testing.T) {
+	suite := SetupTestSuite(t, true)
+
+	// Build a raw tx with 2 SignerInfos but an empty body (0 message signers).
+	// This mimics an attacker injecting extra SignerInfos to trigger an
+	// index-out-of-range panic in the pubkeys loop.
+	single := &txtypes.ModeInfo{Sum: &txtypes.ModeInfo_Single_{Single: &txtypes.ModeInfo_Single{Mode: signing.SignMode_SIGN_MODE_DIRECT}}}
+	authInfo := &txtypes.AuthInfo{
+		SignerInfos: []*txtypes.SignerInfo{{ModeInfo: single}, {ModeInfo: single}},
+		Fee:         &txtypes.Fee{GasLimit: 200000},
+	}
+	authInfoBz, err := authInfo.Marshal()
+	require.NoError(t, err)
+
+	bodyBz, err := (&txtypes.TxBody{}).Marshal()
+	require.NoError(t, err)
+
+	raw := &txtypes.TxRaw{
+		BodyBytes:     bodyBz,
+		AuthInfoBytes: authInfoBz,
+		Signatures:    [][]byte{[]byte("sig1"), []byte("sig2")},
+	}
+	txBz, err := raw.Marshal()
+	require.NoError(t, err)
+
+	decodedTx, err := suite.clientCtx.TxConfig.TxDecoder()(txBz)
+	require.NoError(t, err)
+
+	spkd := ante.NewSetPubKeyDecorator(suite.accountKeeper)
+	noopNext := func(ctx sdk.Context, _ sdk.Tx, _ bool) (sdk.Context, error) { return ctx, nil }
+	_, err = spkd.AnteHandle(suite.ctx, decodedTx, false, noopNext)
+	require.ErrorIs(t, err, sdkerrors.ErrTxDecode)
 }
 
 func TestConsumeSignatureVerificationGas(t *testing.T) {

--- a/x/auth/ante/sigverify_test.go
+++ b/x/auth/ante/sigverify_test.go
@@ -9,8 +9,6 @@ import (
 	"go.uber.org/mock/gomock"
 
 	"github.com/cosmos/cosmos-sdk/codec"
-	txtypes "github.com/cosmos/cosmos-sdk/types/tx"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
 	"github.com/cosmos/cosmos-sdk/crypto/keys/mldsa65"
 	kmultisig "github.com/cosmos/cosmos-sdk/crypto/keys/multisig"
@@ -21,6 +19,8 @@ import (
 	storetypes "github.com/cosmos/cosmos-sdk/store/v2/types"
 	"github.com/cosmos/cosmos-sdk/testutil/testdata"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	txtypes "github.com/cosmos/cosmos-sdk/types/tx"
 	"github.com/cosmos/cosmos-sdk/types/tx/signing"
 	"github.com/cosmos/cosmos-sdk/x/auth/ante"
 	"github.com/cosmos/cosmos-sdk/x/auth/migrations/legacytx"


### PR DESCRIPTION
### Problem

`SetPubKeyDecorator.AnteHandle` iterates over `pubkeys` (length = `len(SignerInfos)`) and indexes `signers[i]` (length = number of message signers) with no length guard. An attacker can craft a tx with 1 message, 1 raw signature (passes `ValidateBasic`), and 2+ `SignerInfos` — the loop panics at `signers[1]` before `SigVerificationDecorator` runs its count check.

This is the same count-mismatch class hardened in #26517, but on the `SetPubKeyDecorator` path.

### Fix

- Add `len(pubkeys) != len(signers)` guard returning `ErrTxDecode` before the loop in `SetPubKeyDecorator.AnteHandle`.
- Add `TestSetPubKey_SignerInfoCountMismatch`: builds a raw tx with 2 `SignerInfos` and an empty body (0 message signers), decodes it, and asserts `ErrTxDecode` instead of a panic.

---

#### PR checklist

- [x] Tests written/updated
- [x] Changelog entry added in `CHANGELOG.md`
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments