### PR TITLE
ci: bump go to 1.26.5 and ignore GO-2026-5932 in vulncheck

### DIFF
--- a/.github/workflows/dependencies-review.yml
+++ b/.github/workflows/dependencies-review.yml
@@ -38,7 +38,9 @@ jobs:
           # - GO-2025-3443: CometBFT v0.38.16, v1.0.0 (fixed in v0.38.17+, v1.0.1+)
           # - GO-2026-4479: pion/dtls/v2 AES GCM nonce reuse. No fix for v2 branch.
           #                 Pulled via libp2->pion/stun. Tracking: https://github.com/libp2p/go-libp2p/issues/3464
-          IGNORED_VULNS="GO-2025-3443 GO-2026-4479"
+          # - GO-2026-5932: golang.org/x/crypto openpgp armor. No fixed release yet,
+          #                 called from crypto/armor.go (key export/import armoring).
+          IGNORED_VULNS="GO-2025-3443 GO-2026-4479 GO-2026-5932"
 
           for vuln in $vulnerabilities; do
             if ! echo "$IGNORED_VULNS" | grep -qw "$vuln"; then

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 #
 # This image is pushed to the GHCR as https://ghcr.io/cosmos/simapp
 
-FROM golang:1.26.4-alpine AS build-env
+FROM golang:1.26.5-alpine AS build-env
 
 # Install minimum necessary dependencies
 ENV PACKAGES curl make git libc-dev bash gcc linux-headers eudev-dev

--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module cosmossdk.io/api
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/cosmos/cosmos-proto v1.0.0-beta.5

--- a/client/v2/go.mod
+++ b/client/v2/go.mod
@@ -1,6 +1,6 @@
 module cosmossdk.io/client/v2
 
-go 1.26.4
+go 1.26.5
 
 require (
 	cosmossdk.io/api v1.0.0

--- a/collections/go.mod
+++ b/collections/go.mod
@@ -1,6 +1,6 @@
 module cosmossdk.io/collections
 
-go 1.26.4
+go 1.26.5
 
 require (
 	cosmossdk.io/schema v1.1.0

--- a/contrib/devtools/Dockerfile
+++ b/contrib/devtools/Dockerfile
@@ -3,7 +3,7 @@
 # docker run --rm -v $(pwd):/workspace --workdir /workspace cosmossdk-proto sh ./scripts/protocgen.sh
 
 FROM bufbuild/buf:1.64 AS builder
-FROM golang:1.26.4-alpine
+FROM golang:1.26.5-alpine
 
 RUN apk add --no-cache \
   nodejs \

--- a/contrib/images/simd-dlv/Dockerfile
+++ b/contrib/images/simd-dlv/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.4-alpine AS build
+FROM golang:1.26.5-alpine AS build
 
 RUN apk add build-base git linux-headers libc-dev
 RUN go install github.com/go-delve/delve/cmd/dlv@latest

--- a/contrib/images/simd-env/Dockerfile
+++ b/contrib/images/simd-env/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.4-alpine AS build
+FROM golang:1.26.5-alpine AS build
 
 RUN apk add build-base git linux-headers
 

--- a/core/go.mod
+++ b/core/go.mod
@@ -1,6 +1,6 @@
 module cosmossdk.io/core
 
-go 1.26.4
+go 1.26.5
 
 require (
 	cosmossdk.io/api v1.0.0

--- a/depinject/go.mod
+++ b/depinject/go.mod
@@ -1,6 +1,6 @@
 module cosmossdk.io/depinject
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/cosmos/cosmos-proto v1.0.0-beta.5

--- a/enterprise/group/go.mod
+++ b/enterprise/group/go.mod
@@ -1,6 +1,6 @@
 module github.com/cosmos/cosmos-sdk/enterprise/group
 
-go 1.26.4
+go 1.26.5
 
 require (
 	cosmossdk.io/api v1.0.0

--- a/enterprise/group/simapp/go.mod
+++ b/enterprise/group/simapp/go.mod
@@ -1,6 +1,6 @@
 module github.com/cosmos/cosmos-sdk/enterprise/group/simapp
 
-go 1.26.4
+go 1.26.5
 
 require (
 	cosmossdk.io/api v1.0.0

--- a/enterprise/group/tests/systemtests/go.mod
+++ b/enterprise/group/tests/systemtests/go.mod
@@ -1,6 +1,6 @@
 module github.com/cosmos/cosmos-sdk/enterprise/group/tests/systemtests
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/cosmos/cosmos-sdk/tools/systemtests v0.0.0-00010101000000-000000000000

--- a/enterprise/poa/examples/migrate-from-pos/go.mod
+++ b/enterprise/poa/examples/migrate-from-pos/go.mod
@@ -1,6 +1,6 @@
 module github.com/cosmos/cosmos-sdk/enterprise/poa/examples/migrate-from-pos
 
-go 1.26.4
+go 1.26.5
 
 require (
 	cosmossdk.io/api v1.0.0

--- a/enterprise/poa/go.mod
+++ b/enterprise/poa/go.mod
@@ -1,6 +1,6 @@
 module github.com/cosmos/cosmos-sdk/enterprise/poa
 
-go 1.26.4
+go 1.26.5
 
 require (
 	cosmossdk.io/api v1.0.0

--- a/enterprise/poa/simapp/go.mod
+++ b/enterprise/poa/simapp/go.mod
@@ -1,6 +1,6 @@
 module github.com/cosmos/cosmos-sdk/enterprise/poa/simapp
 
-go 1.26.4
+go 1.26.5
 
 require (
 	cosmossdk.io/api v1.0.0

--- a/enterprise/poa/tests/systemtests/go.mod
+++ b/enterprise/poa/tests/systemtests/go.mod
@@ -1,6 +1,6 @@
 module github.com/cosmos/cosmos-sdk/enterprise/poa/tests/systemtests
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/cosmos/cosmos-sdk v0.54.0

--- a/errors/go.mod
+++ b/errors/go.mod
@@ -1,6 +1,6 @@
 module cosmossdk.io/errors
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/pkg/errors v0.9.1

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-go 1.26.4
+go 1.26.5
 
 module github.com/cosmos/cosmos-sdk
 

--- a/log/go.mod
+++ b/log/go.mod
@@ -1,6 +1,6 @@
 module cosmossdk.io/log/v2
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/bytedance/sonic v1.15.2

--- a/math/go.mod
+++ b/math/go.mod
@@ -1,6 +1,6 @@
 module cosmossdk.io/math
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -17,7 +17,7 @@ export CHAIN_ID=cosmoshub-1
 export DENOM=uatom
 export GH_URL=https://github.com/cosmos/gaia
 export BINARY_VERSION=v1.0.0
-export GO_VERSION=1.26.4
+export GO_VERSION=1.26.5
 export PRELAUNCH_GENESIS_URL=https://raw.githubusercontent.com/cosmos/mainnet/main/cosmoshub-1/genesis-prelaunch.json
 export GENTXS_DIR=~/go/src/github.com/cosmos/mainnet/$CHAIN_ID/gentxs
 ```

--- a/scripts/validate-gentxs.sh
+++ b/scripts/validate-gentxs.sh
@@ -12,7 +12,7 @@ CHAIN_ID= # ex: testnet-1
 DENOM= # ex: ustake
 GH_URL= # ex: https://github.com/cosmos/cosmos-sdk
 BINARY_VERSION= # ex :v0.44.0
-GO_VERSION=1.26.4
+GO_VERSION=1.26.5
 PRELAUNCH_GENESIS_URL= # ex: https://raw.githubusercontent.com/cosmos/cosmos-sdk/master/$CHAIN_ID/genesis-prelaunch.json
 GENTXS_DIR= # ex: $GOPATH/github.com/cosmos/mainnet/$CHAIN_ID/gentxs"
 echo

--- a/simapp/go.mod
+++ b/simapp/go.mod
@@ -1,6 +1,6 @@
 module cosmossdk.io/simapp
 
-go 1.26.4
+go 1.26.5
 
 require (
 	cosmossdk.io/api v1.0.0

--- a/store/go.mod
+++ b/store/go.mod
@@ -1,6 +1,6 @@
 module github.com/cosmos/cosmos-sdk/store/v2
 
-go 1.26.4
+go 1.26.5
 
 require (
 	cosmossdk.io/errors v1.1.0

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -1,6 +1,6 @@
 module github.com/cosmos/cosmos-sdk/tests
 
-go 1.26.4
+go 1.26.5
 
 require (
 	cosmossdk.io/api v1.0.0

--- a/tests/systemtests/go.mod
+++ b/tests/systemtests/go.mod
@@ -1,6 +1,6 @@
 module cosmossdk.io/tests/systemtests
 
-go 1.26.4
+go 1.26.5
 
 // always use latest versions in tests
 replace github.com/cosmos/cosmos-sdk => ../..

--- a/tools/confix/go.mod
+++ b/tools/confix/go.mod
@@ -1,6 +1,6 @@
 module cosmossdk.io/tools/confix
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/cosmos/cosmos-sdk v0.54.0

--- a/tools/cosmovisor/go.mod
+++ b/tools/cosmovisor/go.mod
@@ -1,6 +1,6 @@
 module cosmossdk.io/tools/cosmovisor
 
-go 1.26.4
+go 1.26.5
 
 require (
 	cosmossdk.io/log/v2 v2.1.0

--- a/tools/systemtests/go.mod
+++ b/tools/systemtests/go.mod
@@ -1,4 +1,4 @@
-go 1.26.4
+go 1.26.5
 
 module github.com/cosmos/cosmos-sdk/tools/systemtests
 


### PR DESCRIPTION
## Description

The `dependency-review` job is failing on every PR since two new advisories were published to the Go vulnerability database:

- **GO-2026-5856** (Encrypted Client Hello privacy leak in `crypto/tls`): present in the go1.26.4 stdlib, fixed in go1.26.5. Fixed here by bumping the `go` directive in all modules, the golang base image in Dockerfiles, and `GO_VERSION` in scripts.
- **GO-2026-5932** (`golang.org/x/crypto` openpgp armor): reached via `crypto/armor.go` (key export/import armoring). **No fixed x/crypto release exists yet**, so it is added to `IGNORED_VULNS` with a note, same treatment as GO-2026-4479 (pion/dtls). The entry should be removed once upstream ships a fix.