### PR TITLE
fix(store): bound decompressed snapshot chunk size to prevent decompression-bomb DoS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Bug Fixes
 
+* (store) [#26999](https://github.com/cosmos/cosmos-sdk/pull/26999) Bound the maximum decompressed size read per state-sync snapshot chunk to prevent a decompression-bomb style aggregate-work DoS during snapshot restore.
 * (client) [#26524](https://github.com/cosmos/cosmos-sdk/pull/26524) Fix file handle leak in the `snapshot dump` command where chunk files were deferred-closed inside the loop, keeping every chunk's handle open until the command returned (follow-up to #25811).
 * (x/distribution) [#26518](https://github.com/cosmos/cosmos-sdk/pull/26518) Return an error from internal historical rewards reads when the record is absent, preventing recovered reference-count panics during BlockSTM speculative execution.
 * (x/auth) [#26515](https://github.com/cosmos/cosmos-sdk/pull/26515) Bound the pubkey and signature indices in `ConsumeMultisignatureVerificationGas` and `VerifyMultisignature` so a multisig signature with a bit array larger than the key set, or with more set bits than supplied signatures, returns an error instead of panicking with index out of range.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Bug Fixes
 
-* (store) [#26999](https://github.com/cosmos/cosmos-sdk/pull/26999) Bound the maximum decompressed size read per state-sync snapshot chunk to prevent a decompression-bomb style aggregate-work DoS during snapshot restore.
+* (store) [#26586](https://github.com/cosmos/cosmos-sdk/pull/26586) Bound the maximum decompressed size read per state-sync snapshot chunk to prevent a decompression-bomb style aggregate-work DoS during snapshot restore.
 * (client) [#26524](https://github.com/cosmos/cosmos-sdk/pull/26524) Fix file handle leak in the `snapshot dump` command where chunk files were deferred-closed inside the loop, keeping every chunk's handle open until the command returned (follow-up to #25811).
 * (x/distribution) [#26518](https://github.com/cosmos/cosmos-sdk/pull/26518) Return an error from internal historical rewards reads when the record is absent, preventing recovered reference-count panics during BlockSTM speculative execution.
 * (x/auth) [#26515](https://github.com/cosmos/cosmos-sdk/pull/26515) Bound the pubkey and signature indices in `ConsumeMultisignatureVerificationGas` and `VerifyMultisignature` so a multisig signature with a bit array larger than the key set, or with more set bits than supplied signatures, returns an error instead of panicking with index out of range.

--- a/store/snapshots/chunk.go
+++ b/store/snapshots/chunk.go
@@ -108,8 +108,9 @@ func (w *ChunkWriter) Write(data []byte) (int, error) {
 
 // ChunkReader reads chunks from a channel of io.ReadClosers and outputs them as an io.Reader
 type ChunkReader struct {
-	ch     <-chan io.ReadCloser
-	reader io.ReadCloser
+	ch           <-chan io.ReadCloser
+	reader       io.ReadCloser
+	chunksOpened int // number of physical chunks opened so far; used to detect chunk boundaries
 }
 
 // NewChunkReader creates a new ChunkReader.
@@ -124,7 +125,15 @@ func (r *ChunkReader) next() error {
 		return io.EOF
 	}
 	r.reader = reader
+	r.chunksOpened++
 	return nil
+}
+
+// chunksOpenedCount returns the number of physical chunks opened for reading so far. The whole
+// snapshot is a single continuous compressed stream split into chunks only for storage/transport,
+// so this lets a decompressor detect chunk boundaries and bound decompressed output per chunk.
+func (r *ChunkReader) chunksOpenedCount() int {
+	return r.chunksOpened
 }
 
 // Close implements io.ReadCloser.

--- a/store/snapshots/chunk.go
+++ b/store/snapshots/chunk.go
@@ -110,7 +110,7 @@ func (w *ChunkWriter) Write(data []byte) (int, error) {
 type ChunkReader struct {
 	ch           <-chan io.ReadCloser
 	reader       io.ReadCloser
-	chunksOpened int // number of physical chunks opened so far; used to detect chunk boundaries
+	chunksOpened int // count of physical chunks opened; lets readers detect chunk boundaries
 }
 
 // NewChunkReader creates a new ChunkReader.
@@ -127,13 +127,6 @@ func (r *ChunkReader) next() error {
 	r.reader = reader
 	r.chunksOpened++
 	return nil
-}
-
-// chunksOpenedCount returns the number of physical chunks opened for reading so far. The whole
-// snapshot is a single continuous compressed stream split into chunks only for storage/transport,
-// so this lets a decompressor detect chunk boundaries and bound decompressed output per chunk.
-func (r *ChunkReader) chunksOpenedCount() int {
-	return r.chunksOpened
 }
 
 // Close implements io.ReadCloser.

--- a/store/snapshots/stream.go
+++ b/store/snapshots/stream.go
@@ -20,11 +20,8 @@ const (
 	// Do not change compression level without new snapshot format (must be uniform across nodes)
 	snapshotCompressionLevel = 7
 
-	// snapshotMaxDecompressedChunkSize bounds decompressed bytes read per physical chunk. The
-	// whole snapshot is one continuous zlib stream (only chunked for storage/transport), so
-	// without this a malicious state-sync peer could serve one small, highly-compressible
-	// chunk that decompresses into gigabytes of data, forcing large IAVL import work before the
-	// resulting app hash is ever checked against the trusted header.
+	// snapshotMaxDecompressedChunkSize bounds decompressed bytes per physical chunk, guarding
+	// against a decompression bomb since the whole snapshot is one continuous zlib stream.
 	snapshotMaxDecompressedChunkSize = 100 * snapshotChunkSize // 1 GB per chunk
 )
 
@@ -86,9 +83,8 @@ type StreamReader struct {
 	protoReader protoio.ReadCloser
 }
 
-// chunkBoundedReader wraps a decompressing reader and bounds how many bytes may be read from it
-// since the last physical chunk boundary observed via chunkReader. Enforces
-// snapshotMaxDecompressedChunkSize (see comment there for why).
+// chunkBoundedReader caps decompressed bytes read since the last physical chunk boundary,
+// enforcing snapshotMaxDecompressedChunkSize.
 type chunkBoundedReader struct {
 	r           io.Reader
 	chunkReader *ChunkReader

--- a/store/snapshots/stream.go
+++ b/store/snapshots/stream.go
@@ -9,6 +9,8 @@ import (
 	"github.com/cosmos/gogoproto/proto"
 
 	"cosmossdk.io/errors"
+
+	snapshottypes "github.com/cosmos/cosmos-sdk/store/v2/snapshots/types"
 )
 
 const (
@@ -17,6 +19,13 @@ const (
 	snapshotBufferSize = int(snapshotChunkSize)
 	// Do not change compression level without new snapshot format (must be uniform across nodes)
 	snapshotCompressionLevel = 7
+
+	// snapshotMaxDecompressedChunkSize bounds decompressed bytes read per physical chunk. The
+	// whole snapshot is one continuous zlib stream (only chunked for storage/transport), so
+	// without this a malicious state-sync peer could serve one small, highly-compressible
+	// chunk that decompresses into gigabytes of data, forcing large IAVL import work before the
+	// resulting app hash is ever checked against the trusted header.
+	snapshotMaxDecompressedChunkSize = 100 * snapshotChunkSize // 1 GB per chunk
 )
 
 // StreamWriter set up a stream pipeline to serialize snapshot nodes:
@@ -77,6 +86,44 @@ type StreamReader struct {
 	protoReader protoio.ReadCloser
 }
 
+// chunkBoundedReader wraps a decompressing reader and bounds how many bytes may be read from it
+// since the last physical chunk boundary observed via chunkReader. This is what enforces
+// snapshotMaxDecompressedChunkSize (see the decompression-bomb guard comment on that constant).
+type chunkBoundedReader struct {
+	r           io.Reader
+	chunkReader *ChunkReader
+	maxBytes    int64
+	remaining   int64
+	seenChunks  int
+}
+
+func newChunkBoundedReader(r io.Reader, chunkReader *ChunkReader, maxBytes int64) *chunkBoundedReader {
+	return &chunkBoundedReader{
+		r:           r,
+		chunkReader: chunkReader,
+		maxBytes:    maxBytes,
+		remaining:   maxBytes,
+		seenChunks:  chunkReader.chunksOpenedCount(),
+	}
+}
+
+// Read implements io.Reader.
+func (g *chunkBoundedReader) Read(p []byte) (int, error) {
+	if opened := g.chunkReader.chunksOpenedCount(); opened != g.seenChunks {
+		g.seenChunks = opened
+		g.remaining = g.maxBytes
+	}
+	if g.remaining <= 0 {
+		return 0, snapshottypes.ErrDecompressedChunkTooLarge
+	}
+	if int64(len(p)) > g.remaining {
+		p = p[:g.remaining]
+	}
+	n, err := g.r.Read(p)
+	g.remaining -= int64(n)
+	return n, err
+}
+
 // NewStreamReader set up a restore stream pipeline.
 func NewStreamReader(chunks <-chan io.ReadCloser) (*StreamReader, error) {
 	chunkReader := NewChunkReader(chunks)
@@ -84,7 +131,8 @@ func NewStreamReader(chunks <-chan io.ReadCloser) (*StreamReader, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "zlib failure")
 	}
-	protoReader := protoio.NewDelimitedReader(zReader, snapshotMaxItemSize)
+	boundedReader := newChunkBoundedReader(zReader, chunkReader, int64(snapshotMaxDecompressedChunkSize))
+	protoReader := protoio.NewDelimitedReader(boundedReader, snapshotMaxItemSize)
 	return &StreamReader{
 		chunkReader: chunkReader,
 		zReader:     zReader,

--- a/store/snapshots/stream.go
+++ b/store/snapshots/stream.go
@@ -87,8 +87,8 @@ type StreamReader struct {
 }
 
 // chunkBoundedReader wraps a decompressing reader and bounds how many bytes may be read from it
-// since the last physical chunk boundary observed via chunkReader. This is what enforces
-// snapshotMaxDecompressedChunkSize (see the decompression-bomb guard comment on that constant).
+// since the last physical chunk boundary observed via chunkReader. Enforces
+// snapshotMaxDecompressedChunkSize (see comment there for why).
 type chunkBoundedReader struct {
 	r           io.Reader
 	chunkReader *ChunkReader
@@ -103,24 +103,24 @@ func newChunkBoundedReader(r io.Reader, chunkReader *ChunkReader, maxBytes int64
 		chunkReader: chunkReader,
 		maxBytes:    maxBytes,
 		remaining:   maxBytes,
-		seenChunks:  chunkReader.chunksOpenedCount(),
+		seenChunks:  chunkReader.chunksOpened,
 	}
 }
 
 // Read implements io.Reader.
-func (g *chunkBoundedReader) Read(p []byte) (int, error) {
-	if opened := g.chunkReader.chunksOpenedCount(); opened != g.seenChunks {
-		g.seenChunks = opened
-		g.remaining = g.maxBytes
+func (c *chunkBoundedReader) Read(p []byte) (int, error) {
+	if opened := c.chunkReader.chunksOpened; opened != c.seenChunks {
+		c.seenChunks = opened
+		c.remaining = c.maxBytes
 	}
-	if g.remaining <= 0 {
+	if c.remaining <= 0 {
 		return 0, snapshottypes.ErrDecompressedChunkTooLarge
 	}
-	if int64(len(p)) > g.remaining {
-		p = p[:g.remaining]
+	if int64(len(p)) > c.remaining {
+		p = p[:c.remaining]
 	}
-	n, err := g.r.Read(p)
-	g.remaining -= int64(n)
+	n, err := c.r.Read(p)
+	c.remaining -= int64(n)
 	return n, err
 }
 

--- a/store/snapshots/stream_test.go
+++ b/store/snapshots/stream_test.go
@@ -1,0 +1,51 @@
+package snapshots
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	snapshottypes "github.com/cosmos/cosmos-sdk/store/v2/snapshots/types"
+)
+
+// TestChunkBoundedReader exercises chunkBoundedReader directly (white-box) rather than through
+// NewStreamReader, since the production constants (10MB chunks, 1GB budget) are too large to
+// drive through a fast unit test. chunkReader is only consulted for its opened-chunk count, so
+// it can be advanced independently of the bytes chunkBoundedReader actually reads.
+func TestChunkBoundedReader(t *testing.T) {
+	ch := make(chan io.ReadCloser, 2)
+	ch <- io.NopCloser(bytes.NewReader([]byte{1}))
+	ch <- io.NopCloser(bytes.NewReader([]byte{2}))
+	close(ch)
+	chunkReader := NewChunkReader(ch)
+
+	src := bytes.NewReader(bytes.Repeat([]byte{0xAA}, 100))
+	bounded := newChunkBoundedReader(src, chunkReader, 4)
+
+	buf := make([]byte, 4)
+	n, err := bounded.Read(buf)
+	require.NoError(t, err)
+	require.Equal(t, 4, n)
+
+	// Budget exhausted and no physical chunk boundary crossed yet: further reads must fail.
+	_, err = bounded.Read(buf)
+	require.ErrorIs(t, err, snapshottypes.ErrDecompressedChunkTooLarge)
+	_, err = bounded.Read(buf)
+	require.ErrorIs(t, err, snapshottypes.ErrDecompressedChunkTooLarge)
+
+	// Drive chunkReader across the boundary into the second physical chunk.
+	one := make([]byte, 1)
+	_, err = chunkReader.Read(one)
+	require.NoError(t, err)
+	require.Equal(t, 1, chunkReader.chunksOpened)
+	_, err = chunkReader.Read(one)
+	require.NoError(t, err)
+	require.Equal(t, 2, chunkReader.chunksOpened)
+
+	// The new chunk grants a fresh budget.
+	n, err = bounded.Read(buf)
+	require.NoError(t, err)
+	require.Equal(t, 4, n)
+}

--- a/store/snapshots/stream_test.go
+++ b/store/snapshots/stream_test.go
@@ -10,10 +10,6 @@ import (
 	snapshottypes "github.com/cosmos/cosmos-sdk/store/v2/snapshots/types"
 )
 
-// TestChunkBoundedReader exercises chunkBoundedReader directly (white-box) rather than through
-// NewStreamReader, since the production constants (10MB chunks, 1GB budget) are too large to
-// drive through a fast unit test. chunkReader is only consulted for its opened-chunk count, so
-// it can be advanced independently of the bytes chunkBoundedReader actually reads.
 func TestChunkBoundedReader(t *testing.T) {
 	ch := make(chan io.ReadCloser, 2)
 	ch <- io.NopCloser(bytes.NewReader([]byte{1}))
@@ -29,13 +25,13 @@ func TestChunkBoundedReader(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 4, n)
 
-	// Budget exhausted and no physical chunk boundary crossed yet: further reads must fail.
+	// budget exhausted, no boundary crossed yet
 	_, err = bounded.Read(buf)
 	require.ErrorIs(t, err, snapshottypes.ErrDecompressedChunkTooLarge)
 	_, err = bounded.Read(buf)
 	require.ErrorIs(t, err, snapshottypes.ErrDecompressedChunkTooLarge)
 
-	// Drive chunkReader across the boundary into the second physical chunk.
+	// cross into the second physical chunk
 	one := make([]byte, 1)
 	_, err = chunkReader.Read(one)
 	require.NoError(t, err)
@@ -44,7 +40,7 @@ func TestChunkBoundedReader(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 2, chunkReader.chunksOpened)
 
-	// The new chunk grants a fresh budget.
+	// new chunk grants a fresh budget
 	n, err = bounded.Read(buf)
 	require.NoError(t, err)
 	require.Equal(t, 4, n)

--- a/store/snapshots/types/errors.go
+++ b/store/snapshots/types/errors.go
@@ -17,8 +17,7 @@ var (
 	// ErrInvalidSnapshotVersion is returned when the snapshot version is invalid
 	ErrInvalidSnapshotVersion = errors.New("invalid snapshot version")
 
-	// ErrDecompressedChunkTooLarge is returned when a snapshot chunk decompresses into more
-	// bytes than allowed, guarding against a malicious peer forcing unbounded decompression
-	// work (a decompression bomb) before the resulting state root can be verified.
+	// ErrDecompressedChunkTooLarge guards against a decompression bomb: a chunk decompressing
+	// into more bytes than allowed before the state root can be verified.
 	ErrDecompressedChunkTooLarge = errors.New("decompressed snapshot chunk exceeds maximum allowed size: possible decompression bomb")
 )

--- a/store/snapshots/types/errors.go
+++ b/store/snapshots/types/errors.go
@@ -16,4 +16,9 @@ var (
 
 	// ErrInvalidSnapshotVersion is returned when the snapshot version is invalid
 	ErrInvalidSnapshotVersion = errors.New("invalid snapshot version")
+
+	// ErrDecompressedChunkTooLarge is returned when a snapshot chunk decompresses into more
+	// bytes than allowed, guarding against a malicious peer forcing unbounded decompression
+	// work (a decompression bomb) before the resulting state root can be verified.
+	ErrDecompressedChunkTooLarge = errors.New("decompressed snapshot chunk exceeds maximum allowed size: possible decompression bomb")
 )


### PR DESCRIPTION
### Problem

State-sync snapshot restore decompresses a zlib stream supplied by a peer with no limit on output size. A peer can serve one small, highly-compressible chunk that decompresses into gigabytes of data. Since the resulting bytes get fed straight into IAVL import before the final app hash is ever checked against the trusted header, a single malicious chunk can force a large amount of memory and CPU work on the restoring node before anything gets validated.

The snapshot format splits the export into fixed-size physical chunks (10MB each), but the whole snapshot is one continuous zlib stream — `NewStreamReader` builds a single `zlib.Reader` for the entire restore, not one per chunk. So a naive single "whole-restore" cap would either have to be too small (breaking legitimate large chain-state restores) or too large (defeating the point).

### Fix

- Add a `chunkBoundedReader` in `store/snapshots/stream.go` that wraps the zlib reader and tracks decompressed bytes, resetting its budget every time `ChunkReader` (in `store/snapshots/chunk.go`) opens a new physical chunk.
- Cap each physical chunk's decompressed output at `snapshotMaxDecompressedChunkSize = 100 * snapshotChunkSize` (1GB per 10MB chunk) — far above realistic legitimate export data (which typically compresses only 2-10x), but well below zlib's theoretical worst case (~1032x), so it meaningfully bounds attacker leverage without touching legitimate restores.
- Add a new sentinel error `ErrDecompressedChunkTooLarge` in `store/snapshots/types/errors.go`, distinguishable from `io.EOF` so callers can't mistake a tripped guard for a clean end of stream.
- Add `store/snapshots/stream_test.go` covering the budget-exceeded and reset-on-chunk-boundary paths directly (production constants are too large to drive through a normal roundtrip test).


#### PR checklist

- [x] Tests written/updated
- [x] Changelog entry added in `CHANGELOG.md`
- [x] Updated relevant documentation (`docs/` or `spec/`) and code comments