### PR TITLE
chore(blockstm): validate ExecuteBlock inputs instead of panicking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (x/staking, x/slashing) [#26481](https://github.com/cosmos/cosmos-sdk/pull/26481) Resolve evidence against recently rotated consensus keys and migrate slashing signing state to the active consensus key.
 * (x/auth/tx) [#25221](https://github.com/cosmos/cosmos-sdk/issues/25221) Add `ConfigOptions.AminoJSONEncoder` so applications can configure a custom `aminojson.Encoder` (e.g. custom field encodings) for the `SIGN_MODE_LEGACY_AMINO_JSON` handler without replicating the SDK's `HandlerMap` construction.
 * chore(x/auth) [#26567](https://github.com/cosmos/cosmos-sdk/pull/26567): add a human-readable error
+* (blockstm) [#26592](https://github.com/cosmos/cosmos-sdk/pull/26592) Validate `ExecuteBlock` inputs (block size, store index mapping, and estimates) at the exported entry point so invalid input returns a descriptive error instead of an opaque "index out of range" panic.
 
 ### Bug Fixes
 

--- a/internal/blockstm/stm.go
+++ b/internal/blockstm/stm.go
@@ -35,8 +35,35 @@ func ExecuteBlockWithEstimates(
 	estimates []MultiLocations, // txn -> multi-locations
 	txExecutor TxExecutor,
 ) error {
+	if blockSize < 0 {
+		return fmt.Errorf("invalid block size: %d", blockSize)
+	}
 	if blockSize > math.MaxUint32 {
 		return fmt.Errorf("block size overflows uint32: %d", blockSize)
+	}
+
+	// Store indices are used directly as slice indices, so they must be a
+	// permutation of [0, len(stores)); duplicates would leave nil stores.
+	seen := make([]bool, len(stores))
+	for key, i := range stores {
+		if i < 0 || i >= len(stores) {
+			return fmt.Errorf("store index out of range for %q: %d not in [0, %d)", key.Name(), i, len(stores))
+		}
+		if seen[i] {
+			return fmt.Errorf("duplicate store index: %d", i)
+		}
+		seen[i] = true
+	}
+
+	if len(estimates) > blockSize {
+		return fmt.Errorf("estimates length %d exceeds block size %d", len(estimates), blockSize)
+	}
+	for txn, est := range estimates {
+		for store := range est {
+			if store < 0 || store >= len(stores) {
+				return fmt.Errorf("estimate for txn %d references store index out of range: %d not in [0, %d)", txn, store, len(stores))
+			}
+		}
 	}
 
 	if executors < 0 {

--- a/internal/blockstm/stm_test.go
+++ b/internal/blockstm/stm_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"math"
 	"math/rand"
 	"testing"
 	"time"
@@ -263,6 +264,93 @@ func TestSTMHighContentionStress(t *testing.T) {
 						"iteration %d: parallel != sequential for store %s", i, store.Name())
 				}
 			}
+		})
+	}
+}
+
+func TestValidateInputs(t *testing.T) {
+	stores := map[storetypes.StoreKey]int{StoreKeyAuth: 0, StoreKeyBank: 1}
+
+	testCases := []struct {
+		name      string
+		blockSize int
+		stores    map[storetypes.StoreKey]int
+		estimates []MultiLocations
+		errSubstr string // empty means expect no error
+	}{
+		{
+			name:      "valid, no estimates",
+			blockSize: 4,
+			stores:    stores,
+		},
+		{
+			name:      "valid with estimates",
+			blockSize: 4,
+			stores:    stores,
+			estimates: []MultiLocations{0: {1: Locations{Key([]byte("k"))}}},
+		},
+		{
+			name:      "zero block size is allowed",
+			blockSize: 0,
+			stores:    stores,
+		},
+		{
+			name:      "negative block size",
+			blockSize: -1,
+			stores:    stores,
+			errSubstr: "invalid block size",
+		},
+		{
+			name:      "block size overflows uint32",
+			blockSize: math.MaxUint32 + 1,
+			stores:    stores,
+			errSubstr: "overflows uint32",
+		},
+		{
+			name:      "store index out of range",
+			blockSize: 4,
+			stores:    map[storetypes.StoreKey]int{StoreKeyAuth: 0, StoreKeyBank: 2},
+			errSubstr: "store index out of range",
+		},
+		{
+			name:      "negative store index",
+			blockSize: 4,
+			stores:    map[storetypes.StoreKey]int{StoreKeyAuth: -1},
+			errSubstr: "store index out of range",
+		},
+		{
+			name:      "duplicate store index",
+			blockSize: 4,
+			stores:    map[storetypes.StoreKey]int{StoreKeyAuth: 0, StoreKeyBank: 0},
+			errSubstr: "duplicate store index",
+		},
+		{
+			name:      "estimates longer than block",
+			blockSize: 1,
+			stores:    stores,
+			estimates: make([]MultiLocations, 2),
+			errSubstr: "exceeds block size",
+		},
+		{
+			name:      "estimate store index out of range",
+			blockSize: 4,
+			stores:    stores,
+			estimates: []MultiLocations{0: {5: Locations{Key([]byte("k"))}}},
+			errSubstr: "references store index out of range",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			storage := NewMultiMemDB(stores)
+			noop := func(TxnIndex, MultiStore) {}
+			err := ExecuteBlockWithEstimates(context.Background(), tc.blockSize, tc.stores, storage, 1, tc.estimates, noop)
+			if tc.errSubstr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tc.errSubstr)
 		})
 	}
 }


### PR DESCRIPTION
# Description

`ExecuteBlockWithEstimates` only guarded against block sizes that overflow
uint32. Other caller-supplied values are used directly as slice lengths or
indices, so bad input surfaces as an opaque "index out of range" panic in
the scheduler or MVMemory rather than an error:

- a negative `blockSize` panics in `NewScheduler`'s `make([]T, blockSize)`
- store index values are used as slice indices, so any value outside
  `[0, len(stores))` panics, and a duplicate index silently leaves a nil
  store that nil-panics later during execution
- estimates are indexed by txn and store index, so an over-long estimates
  slice or an out-of-range store index panics in `InitWithEstimates`

These are unreachable from the current in-tree caller, which builds the
store map and estimates itself; this hardens the exported entry point so
future or downstream callers get a descriptive error instead of a panic.