### PR TITLE
fix(x/bank): scale amount when ResolveDenom converts base to display denom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Bug Fixes
 
+* (x/bank) [#26597](https://github.com/cosmos/cosmos-sdk/pull/26597) Fix `QueryAllBalances` with `ResolveDenom=true` returning unscaled base-unit amounts with the display denom. The response now correctly scales amounts (e.g. `100000000uatom` → `100atom`) and falls back to the base denom when the amount is not evenly divisible.
 * (client) [#26524](https://github.com/cosmos/cosmos-sdk/pull/26524) Fix file handle leak in the `snapshot dump` command where chunk files were deferred-closed inside the loop, keeping every chunk's handle open until the command returned (follow-up to #25811).
 * (x/distribution) [#26518](https://github.com/cosmos/cosmos-sdk/pull/26518) Return an error from internal historical rewards reads when the record is absent, preventing recovered reference-count panics during BlockSTM speculative execution.
 * (x/auth) [#26515](https://github.com/cosmos/cosmos-sdk/pull/26515) Bound the pubkey and signature indices in `ConsumeMultisignatureVerificationGas` and `VerifyMultisignature` so a multisig signature with a bit array larger than the key set, or with more set bits than supplied signatures, returns an error instead of panicking with index out of range.

--- a/x/bank/keeper/grpc_query.go
+++ b/x/bank/keeper/grpc_query.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	"context"
+	"math/big"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -66,7 +67,10 @@ func (k BaseKeeper) AllBalances(ctx context.Context, req *types.QueryAllBalances
 		func(key collections.Pair[sdk.AccAddress, string], value math.Int) (sdk.Coin, error) {
 			if req.ResolveDenom {
 				if metadata, ok := k.GetDenomMetaData(sdkCtx, key.K2()); ok {
-					return sdk.NewCoin(metadata.Display, value), nil
+					scaledValue, ok := scaleAmountToDisplay(value, metadata)
+					if ok {
+						return sdk.NewCoin(metadata.Display, scaledValue), nil
+					}
 				}
 			}
 			return sdk.NewCoin(key.K2(), value), nil
@@ -78,6 +82,55 @@ func (k BaseKeeper) AllBalances(ctx context.Context, req *types.QueryAllBalances
 	}
 
 	return &types.QueryAllBalancesResponse{Balances: balances, Pagination: pageRes}, nil
+}
+
+// scaleAmountToDisplay converts a base-unit amount to the display denomination
+// using the exponent from denom metadata. If the result would require a
+// fractional coin, it returns false to indicate the caller should keep the
+// base denom and amount unchanged.
+//
+// For example, given metadata:
+//
+//	base: uatom (exponent 0)
+//	display: atom (exponent 6)
+//
+// A value of 100000000 uatom is scaled to 100 atom.
+// A value of 1000001 uatom cannot be represented as an integer atom, so it
+// returns false.
+func scaleAmountToDisplay(value math.Int, metadata types.Metadata) (math.Int, bool) {
+	var baseExponent, displayExponent uint32
+
+	for _, du := range metadata.DenomUnits {
+		if du.Denom == metadata.Base {
+			baseExponent = du.Exponent
+		}
+		if du.Denom == metadata.Display {
+			displayExponent = du.Exponent
+		}
+	}
+
+	// If display exponent is not greater than base, no scaling is needed.
+	if displayExponent <= baseExponent {
+		return value, true
+	}
+
+	expDiff := displayExponent - baseExponent
+	divisor := math.NewIntFromBigInt(new(big.Int).Exp(
+		big.NewInt(10),
+		big.NewInt(int64(expDiff)),
+		nil,
+	))
+
+	scaledValue := value.Quo(divisor)
+	remainder := value.Mod(divisor)
+
+	// If there's a remainder, the amount cannot be represented as an integer
+	// in the display denomination; keep the base denom.
+	if !remainder.IsZero() {
+		return math.Int{}, false
+	}
+
+	return scaledValue, true
 }
 
 // SpendableBalances implements a gRPC query handler for retrieving an account's

--- a/x/bank/keeper/grpc_query.go
+++ b/x/bank/keeper/grpc_query.go
@@ -98,6 +98,11 @@ func (k BaseKeeper) AllBalances(ctx context.Context, req *types.QueryAllBalances
 // A value of 1000001 uatom cannot be represented as an integer atom, so it
 // returns false.
 func scaleAmountToDisplay(value math.Int, metadata types.Metadata) (math.Int, bool) {
+	// If base and display denoms are the same, no scaling is needed.
+	if metadata.Display == metadata.Base {
+		return value, true
+	}
+
 	var baseExponent, displayExponent uint32
 
 	for _, du := range metadata.DenomUnits {

--- a/x/bank/keeper/grpc_query_test.go
+++ b/x/bank/keeper/grpc_query_test.go
@@ -168,6 +168,73 @@ func (suite *KeeperTestSuite) TestQueryAllBalances() {
 	suite.Nil(res.Pagination.NextKey)
 }
 
+func (suite *KeeperTestSuite) TestQueryAllBalancesResolveDenom() {
+	ctx, queryClient := suite.ctx, suite.queryClient
+	_, _, addr := testdata.KeyTestPubAddr()
+
+	// Setup: uatom balance of 100_000_000 (100 atom with exponent 6)
+	uatomCoins := sdk.NewCoins(sdk.NewInt64Coin("uatom", 100_000_000))
+	suite.mockFundAccount(addr)
+	suite.Require().NoError(testutil.FundAccount(ctx, suite.bankKeeper, addr, uatomCoins))
+
+	// Set metadata: uatom (base, exponent 0) -> atom (display, exponent 6)
+	metadata := types.Metadata{
+		Description: "The native staking token of the Cosmos Hub.",
+		DenomUnits: []*types.DenomUnit{
+			{Denom: "uatom", Exponent: 0, Aliases: []string{"microatom"}},
+			{Denom: "atom", Exponent: 6, Aliases: []string{"ATOM"}},
+		},
+		Base:    "uatom",
+		Display: "atom",
+	}
+	suite.bankKeeper.SetDenomMetaData(ctx, metadata)
+
+	// Without ResolveDenom: should return base denom with base amount
+	req := types.NewQueryAllBalancesRequest(addr, nil, false)
+	res, err := queryClient.AllBalances(gocontext.Background(), req)
+	suite.Require().NoError(err)
+	suite.Require().Len(res.Balances, 1)
+	suite.Equal("uatom", res.Balances[0].Denom)
+	suite.Equal("100000000", res.Balances[0].Amount.String())
+
+	// With ResolveDenom: should return display denom with scaled amount
+	req = types.NewQueryAllBalancesRequest(addr, nil, true)
+	res, err = queryClient.AllBalances(gocontext.Background(), req)
+	suite.Require().NoError(err)
+	suite.Require().Len(res.Balances, 1)
+	suite.Equal("atom", res.Balances[0].Denom)
+	suite.Equal("100", res.Balances[0].Amount.String())
+}
+
+func (suite *KeeperTestSuite) TestQueryAllBalancesResolveDenomFractionalAmount() {
+	ctx, queryClient := suite.ctx, suite.queryClient
+	_, _, addr := testdata.KeyTestPubAddr()
+
+	// Setup: uatom balance of 1_000_001 (cannot be represented as integer atom)
+	uatomCoins := sdk.NewCoins(sdk.NewInt64Coin("uatom", 1_000_001))
+	suite.mockFundAccount(addr)
+	suite.Require().NoError(testutil.FundAccount(ctx, suite.bankKeeper, addr, uatomCoins))
+
+	metadata := types.Metadata{
+		Description: "The native staking token of the Cosmos Hub.",
+		DenomUnits: []*types.DenomUnit{
+			{Denom: "uatom", Exponent: 0, Aliases: []string{"microatom"}},
+			{Denom: "atom", Exponent: 6, Aliases: []string{"ATOM"}},
+		},
+		Base:    "uatom",
+		Display: "atom",
+	}
+	suite.bankKeeper.SetDenomMetaData(ctx, metadata)
+
+	// With ResolveDenom: amount doesn't divide evenly, should keep base denom
+	req := types.NewQueryAllBalancesRequest(addr, nil, true)
+	res, err := queryClient.AllBalances(gocontext.Background(), req)
+	suite.Require().NoError(err)
+	suite.Require().Len(res.Balances, 1)
+	suite.Equal("uatom", res.Balances[0].Denom)
+	suite.Equal("1000001", res.Balances[0].Amount.String())
+}
+
 func (suite *KeeperTestSuite) TestSpendableBalances() {
 	_, _, addr := testdata.KeyTestPubAddr()
 


### PR DESCRIPTION
## Summary

Fixes #26484

QueryAllBalances with `ResolveDenom=true` was returning the base-unit amount with the display denom. For example, a balance of `100000000uatom` was returned as `100000000atom` instead of `100atom`.

## Problem

In `x/bank/keeper/grpc_query.go`, the `AllBalances` handler changes only the denom name but keeps the base-unit amount unchanged when resolving denominations.

## Solution

Added `scaleAmountToDisplay` which uses the `DenomUnit` exponent to properly scale the amount when converting from base to display denomination. The helper function:
1. Finds the base and display denom exponents from `DenomUnits`
2. Calculates `divisor = 10^(displayExponent - baseExponent)`
3. Divides the base amount by the divisor
4. If there is a remainder (fractional result), returns false to fall back to the base denom

This means:
- `100000000uatom` -> `100atom` (clean division)
- `1000001uatom` -> `1000001uatom` (fractional, keeps base)

## Changes

- `x/bank/keeper/grpc_query.go`: Added `scaleAmountToDisplay` helper and updated the `AllBalances` callback to use it.
- `x/bank/keeper/grpc_query_test.go`: Added two new tests:
  - `TestQueryAllBalancesResolveDenom` - verifies correct scaling (100000000uatom -> 100atom)
  - `TestQueryAllBalancesResolveDenomFractionalAmount` - verifies fallback to base denom when amount does not divide evenly

## Testing

All existing tests pass. The new tests verify both the scaling and fallback behavior.
