### PR TITLE
feat: Add consensus key algo to init and testnet commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (x/auth/tx) [#25221](https://github.com/cosmos/cosmos-sdk/issues/25221) Add `ConfigOptions.AminoJSONEncoder` so applications can configure a custom `aminojson.Encoder` (e.g. custom field encodings) for the `SIGN_MODE_LEGACY_AMINO_JSON` handler without replicating the SDK's `HandlerMap` construction.
 * chore(x/auth) [#26567](https://github.com/cosmos/cosmos-sdk/pull/26567): add a human-readable error
 * (blockstm) [#26592](https://github.com/cosmos/cosmos-sdk/pull/26592) Validate `ExecuteBlock` inputs (block size, store index mapping, and estimates) at the exported entry point so invalid input returns a descriptive error instead of an opaque "index out of range" panic.
+* (cli) [#26604](https://github.com/cosmos/cosmos-sdk/pull/26604) Add consensus key algo to init and testnet CLIs.
 
 ### Bug Fixes
 

--- a/simapp/simd/cmd/testnet.go
+++ b/simapp/simd/cmd/testnet.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	cmtconfig "github.com/cometbft/cometbft/config"
+	cmttypes "github.com/cometbft/cometbft/types"
 	cmttime "github.com/cometbft/cometbft/types/time"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -34,6 +35,7 @@ import (
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/cosmos/cosmos-sdk/x/genutil"
+	genutilcli "github.com/cosmos/cosmos-sdk/x/genutil/client/cli"
 	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 )
@@ -57,6 +59,7 @@ var (
 
 type initArgs struct {
 	algo              string
+	consensusKeyAlgo  string
 	chainID           string
 	keyringBackend    string
 	minGasPrices      string
@@ -71,17 +74,18 @@ type initArgs struct {
 }
 
 type startArgs struct {
-	algo          string
-	apiAddress    string
-	chainID       string
-	enableLogging bool
-	grpcAddress   string
-	minGasPrices  string
-	numValidators int
-	outputDir     string
-	printMnemonic bool
-	rpcAddress    string
-	timeoutCommit time.Duration
+	algo             string
+	consensusKeyAlgo string
+	apiAddress       string
+	chainID          string
+	enableLogging    bool
+	grpcAddress      string
+	minGasPrices     string
+	numValidators    int
+	outputDir        string
+	printMnemonic    bool
+	rpcAddress       string
+	timeoutCommit    time.Duration
 }
 
 func addTestnetFlagsToCmd(cmd *cobra.Command) {
@@ -90,6 +94,7 @@ func addTestnetFlagsToCmd(cmd *cobra.Command) {
 	cmd.Flags().String(flags.FlagChainID, "", "genesis file chain-id, if left blank will be randomly created")
 	cmd.Flags().String(server.FlagMinGasPrices, fmt.Sprintf("0.000006%s", sdk.DefaultBondDenom), "Minimum gas prices to accept for transactions; All fees in a tx must meet this minimum (e.g. 0.01photino,0.001stake)")
 	cmd.Flags().String(flags.FlagKeyType, string(hd.Secp256k1Type), "Key signing algorithm to generate keys for")
+	cmd.Flags().String(genutilcli.FlagConsensusKeyAlgo, cmttypes.ABCIPubKeyTypeEd25519, "algorithm for the validator consensus key (ed25519|secp256k1|bls12_381|ml_dsa_65)")
 
 	// support old flags name for backwards compatibility
 	cmd.Flags().SetNormalizeFunc(func(f *pflag.FlagSet, name string) pflag.NormalizedName {
@@ -156,6 +161,7 @@ Example:
 			args.algo, _ = cmd.Flags().GetString(flags.FlagKeyType)
 			args.bondTokenDenom, _ = cmd.Flags().GetString(flagStakingDenom)
 			args.singleMachine, _ = cmd.Flags().GetBool(flagSingleHost)
+			args.consensusKeyAlgo, _ = cmd.Flags().GetString(genutilcli.FlagConsensusKeyAlgo)
 			config.Consensus.TimeoutCommit, err = cmd.Flags().GetDuration(flagCommitTimeout)
 			if err != nil {
 				return err
@@ -203,6 +209,7 @@ Example:
 			args.grpcAddress, _ = cmd.Flags().GetString(flagGRPCAddress)
 			args.printMnemonic, _ = cmd.Flags().GetBool(flagPrintMnemonic)
 			args.timeoutCommit, _ = cmd.Flags().GetDuration(flagCommitTimeout)
+			args.consensusKeyAlgo, _ = cmd.Flags().GetString(genutilcli.FlagConsensusKeyAlgo)
 
 			return startTestnet(cmd, args)
 		},
@@ -298,7 +305,7 @@ func initTestnetFiles(
 			}
 		}
 
-		nodeIDs[i], valPubKeys[i], err = genutil.InitializeNodeValidatorFiles(nodeConfig)
+		nodeIDs[i], valPubKeys[i], err = genutil.InitializeNodeValidatorFilesFromMnemonicWithKeyType(nodeConfig, "", args.consensusKeyAlgo)
 		if err != nil {
 			_ = os.RemoveAll(args.outputDir)
 			return err
@@ -393,7 +400,7 @@ func initTestnetFiles(
 		srvconfig.WriteConfigFile(filepath.Join(nodeDir, "config", "app.toml"), appConfig)
 	}
 
-	if err := initGenFiles(clientCtx, mm, args.chainID, genAccounts, genBalances, genFiles, args.numValidators); err != nil {
+	if err := initGenFiles(clientCtx, mm, args.chainID, genAccounts, genBalances, genFiles, args.numValidators, args.consensusKeyAlgo); err != nil {
 		return err
 	}
 
@@ -413,7 +420,7 @@ func initTestnetFiles(
 func initGenFiles(
 	clientCtx client.Context, mm module.BasicManager, chainID string,
 	genAccounts []authtypes.GenesisAccount, genBalances []banktypes.Balance,
-	genFiles []string, numValidators int,
+	genFiles []string, numValidators int, consensusKeyAlgo string,
 ) error {
 	appGenState := mm.DefaultGenesis(clientCtx.Codec)
 
@@ -446,6 +453,8 @@ func initGenFiles(
 	}
 
 	appGenesis := genutiltypes.NewAppGenesisWithVersion(chainID, appGenStateJSON)
+	appGenesis.Consensus.Params = cmttypes.DefaultConsensusParams()
+	appGenesis.Consensus.Params.Validator.PubKeyTypes = []string{consensusKeyAlgo}
 	// generate empty genesis files for each validator and save
 	for i := 0; i < numValidators; i++ {
 		if err := appGenesis.SaveAs(genFiles[i]); err != nil {
@@ -577,6 +586,7 @@ func startTestnet(cmd *cobra.Command, args startArgs) error {
 		networkConfig.ChainID = args.chainID
 	}
 	networkConfig.SigningAlgo = args.algo
+	networkConfig.ValidatorConsensusKeyType = args.consensusKeyAlgo
 	networkConfig.MinGasPrices = args.minGasPrices
 	networkConfig.NumValidators = args.numValidators
 	networkConfig.EnableLogging = args.enableLogging

--- a/simapp/simd/cmd/testnet_test.go
+++ b/simapp/simd/cmd/testnet_test.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/spf13/viper"
@@ -67,4 +69,53 @@ func Test_TestnetCmd(t *testing.T) {
 
 	bankGenState := banktypes.GetGenesisStateFromAppState(encodingConfig.Codec, appState)
 	require.NotEmpty(t, bankGenState.Supply.String())
+}
+
+func Test_TestnetCmd_ConsensusKeyAlgo(t *testing.T) {
+	moduleBasic := module.NewBasicManager(
+		auth.AppModuleBasic{},
+		genutil.NewAppModuleBasic(genutiltypes.DefaultMessageValidator),
+		bank.AppModuleBasic{},
+		staking.AppModuleBasic{},
+		mint.AppModuleBasic{},
+		distribution.AppModuleBasic{},
+		consensus.AppModuleBasic{},
+	)
+
+	home := t.TempDir()
+	encodingConfig := moduletestutil.MakeTestEncodingConfig(auth.AppModuleBasic{}, staking.AppModuleBasic{})
+	logger := log.NewNopLogger()
+	cfg, err := genutiltest.CreateDefaultCometConfig(home)
+	require.NoError(t, err)
+
+	err = genutiltest.ExecInitCmd(moduleBasic, home, encodingConfig.Codec)
+	require.NoError(t, err)
+
+	serverCtx := server.NewContext(viper.New(), cfg, logger)
+	clientCtx := client.Context{}.
+		WithCodec(encodingConfig.Codec).
+		WithHomeDir(home).
+		WithTxConfig(encodingConfig.TxConfig)
+
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, server.ServerContextKey, serverCtx)
+	ctx = context.WithValue(ctx, client.ClientContextKey, &clientCtx)
+	cmd := testnetInitFilesCmd(moduleBasic, banktypes.GenesisBalancesIterator{})
+	cmd.SetArgs([]string{
+		fmt.Sprintf("--%s=test", flags.FlagKeyringBackend),
+		fmt.Sprintf("--output-dir=%s", home),
+		"--validator-count=1",
+		"--consensus-key-algo=ml_dsa_65",
+	})
+	require.NoError(t, cmd.ExecuteContext(ctx))
+
+	nodeDir := filepath.Join(home, "node0", "simd")
+
+	appGenesis, err := genutiltypes.AppGenesisFromFile(filepath.Join(nodeDir, "config", "genesis.json"))
+	require.NoError(t, err)
+	require.Equal(t, []string{"ml_dsa_65"}, appGenesis.Consensus.Params.Validator.PubKeyTypes)
+
+	pvKey, err := os.ReadFile(filepath.Join(nodeDir, "config", "priv_validator_key.json"))
+	require.NoError(t, err)
+	require.Contains(t, string(pvKey), "cometbft/PrivKeyMlDsa65")
 }

--- a/x/genutil/client/cli/init.go
+++ b/x/genutil/client/cli/init.go
@@ -119,7 +119,12 @@ func InitCmd(mbm module.BasicManager, defaultNodeHome string) *cobra.Command {
 				initHeight = 1
 			}
 
-			nodeID, _, err := genutil.InitializeNodeValidatorFilesFromMnemonic(config, mnemonic)
+			consensusKey, err := cmd.Flags().GetString(FlagConsensusKeyAlgo)
+			if err != nil {
+				return errorsmod.Wrap(err, "Failed to get consensus key algo")
+			}
+
+			nodeID, _, err := genutil.InitializeNodeValidatorFilesFromMnemonicWithKeyType(config, mnemonic, consensusKey)
 			if err != nil {
 				return err
 			}
@@ -167,11 +172,6 @@ func InitCmd(mbm module.BasicManager, defaultNodeHome string) *cobra.Command {
 			appGenesis.Consensus = &types.ConsensusGenesis{
 				Validators: nil,
 				Params:     cmttypes.DefaultConsensusParams(),
-			}
-
-			consensusKey, err := cmd.Flags().GetString(FlagConsensusKeyAlgo)
-			if err != nil {
-				return errorsmod.Wrap(err, "Failed to get consensus key algo")
 			}
 
 			appGenesis.Consensus.Params.Validator.PubKeyTypes = []string{consensusKey}


### PR DESCRIPTION
# Description

Adds `consensusKeyAlgo` to both `init` and `testnet` commands. 

In the case of `init`, the argument already existed in genutils it just wasn't being wired up.

In the case of `testnet` it is a net new flag on the command.
