### PR TITLE
fix(staking): missing key rotation type tags on genesis import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (x/auth/tx) [#26517](https://github.com/cosmos/cosmos-sdk/pull/26517) Return a decode error instead of panicking when a transaction's `SignerInfos` and `Signatures` counts disagree in `GetSignaturesV2`, or a multisig's `ModeInfos` and sub-signature counts disagree in `ModeInfoAndSigToSignatureData`.
 * (x/auth/ante) [#26573](https://github.com/cosmos/cosmos-sdk/pull/26573) Reject tx with extra SignerInfos in SetPubKeyDecorator.
 * (blockstm) [#26591](https://github.com/cosmos/cosmos-sdk/pull/26591) normalize non-positive worker count in `STMRunner.Run`.
+* (x/staking) [#26611](https://github.com/cosmos/cosmos-sdk/pull/26611) Fix missing key rotation type tags on genesis import.
 
 ### Deprecated
 

--- a/x/staking/keeper/rotation.go
+++ b/x/staking/keeper/rotation.go
@@ -40,7 +40,7 @@ func (k Keeper) ImportConsKeyRotations(ctx context.Context, histories []types.Co
 		if err := store.Set(types.GetValidatorConsKeyRotationKey(valAddr), []byte{}); err != nil {
 			return err
 		}
-		if err := store.Set(types.GetRotationLockedConsAddrIndexKey(oldConsAddr), valAddr); err != nil {
+		if err := k.SetRotationLockedConsAddr(ctx, oldConsAddr, valAddr, types.ConsAddrLockRotatedFrom); err != nil {
 			return err
 		}
 	}
@@ -60,9 +60,25 @@ func (k Keeper) ImportConsKeyRotations(ctx context.Context, histories []types.Co
 			return err
 		}
 
-		if err := store.Set(types.GetRotationLockedConsAddrIndexKey(sdk.ConsAddress(newPubKey.Address())), valAddr); err != nil {
+		if err := k.SetRotationLockedConsAddr(ctx, sdk.ConsAddress(newPubKey.Address()), valAddr, types.ConsAddrLockPendingTo); err != nil {
 			return err
 		}
+
+		// The live path also locks the old addr with PendingFrom to protect it
+		// if the validator is removed before apply. The rotation is still
+		// pending, so the validator's live cons addr is the old addr.
+		validator, err := k.GetValidator(ctx, valAddr)
+		if err != nil {
+			return err
+		}
+		oldConsAddr, err := validator.GetConsAddr()
+		if err != nil {
+			return err
+		}
+		if err := k.SetRotationLockedConsAddr(ctx, sdk.ConsAddress(oldConsAddr), valAddr, types.ConsAddrLockPendingFrom); err != nil {
+			return err
+		}
+
 		if err := store.Set(types.GetConsKeyRotationApplyQueueKey(rotation.ApplyHeight, valAddr), newPubKeyBz); err != nil {
 			return err
 		}

--- a/x/staking/keeper/rotation.go
+++ b/x/staking/keeper/rotation.go
@@ -24,6 +24,31 @@ import (
 func (k Keeper) ImportConsKeyRotations(ctx context.Context, histories []types.ConsensusKeyRotationHistory, pending []types.PendingConsensusKeyRotation) error {
 	store := k.storeService.OpenKVStore(ctx)
 
+	hasPending := make(map[string]bool, len(pending))
+	for _, rotation := range pending {
+		valAddr, err := k.validatorAddressCodec.StringToBytes(rotation.ValidatorAddress)
+		if err != nil {
+			return err
+		}
+		hasPending[string(valAddr)] = true
+
+		var newPubKey cryptotypes.PubKey
+		if err := k.cdc.UnpackAny(rotation.NewPubkey, &newPubKey); err != nil {
+			return err
+		}
+		newPubKeyBz, err := k.cdc.MarshalInterface(newPubKey)
+		if err != nil {
+			return err
+		}
+
+		if err := k.SetRotationLockedConsAddr(ctx, sdk.ConsAddress(newPubKey.Address()), valAddr, types.ConsAddrLockPendingTo); err != nil {
+			return err
+		}
+		if err := store.Set(types.GetConsKeyRotationApplyQueueKey(rotation.ApplyHeight, valAddr), newPubKeyBz); err != nil {
+			return err
+		}
+	}
+
 	for _, history := range histories {
 		valAddr, err := k.validatorAddressCodec.StringToBytes(history.ValidatorAddress)
 		if err != nil {
@@ -40,46 +65,12 @@ func (k Keeper) ImportConsKeyRotations(ctx context.Context, histories []types.Co
 		if err := store.Set(types.GetValidatorConsKeyRotationKey(valAddr), []byte{}); err != nil {
 			return err
 		}
-		if err := k.SetRotationLockedConsAddr(ctx, oldConsAddr, valAddr, types.ConsAddrLockRotatedFrom); err != nil {
-			return err
-		}
-	}
 
-	for _, rotation := range pending {
-		valAddr, err := k.validatorAddressCodec.StringToBytes(rotation.ValidatorAddress)
-		if err != nil {
-			return err
+		kind := types.ConsAddrLockRotatedFrom
+		if hasPending[string(valAddr)] {
+			kind = types.ConsAddrLockPendingFrom
 		}
-
-		var newPubKey cryptotypes.PubKey
-		if err := k.cdc.UnpackAny(rotation.NewPubkey, &newPubKey); err != nil {
-			return err
-		}
-		newPubKeyBz, err := k.cdc.MarshalInterface(newPubKey)
-		if err != nil {
-			return err
-		}
-
-		if err := k.SetRotationLockedConsAddr(ctx, sdk.ConsAddress(newPubKey.Address()), valAddr, types.ConsAddrLockPendingTo); err != nil {
-			return err
-		}
-
-		// The live path also locks the old addr with PendingFrom to protect it
-		// if the validator is removed before apply. The rotation is still
-		// pending, so the validator's live cons addr is the old addr.
-		validator, err := k.GetValidator(ctx, valAddr)
-		if err != nil {
-			return err
-		}
-		oldConsAddr, err := validator.GetConsAddr()
-		if err != nil {
-			return err
-		}
-		if err := k.SetRotationLockedConsAddr(ctx, sdk.ConsAddress(oldConsAddr), valAddr, types.ConsAddrLockPendingFrom); err != nil {
-			return err
-		}
-
-		if err := store.Set(types.GetConsKeyRotationApplyQueueKey(rotation.ApplyHeight, valAddr), newPubKeyBz); err != nil {
+		if err := k.SetRotationLockedConsAddr(ctx, oldConsAddr, valAddr, kind); err != nil {
 			return err
 		}
 	}

--- a/x/staking/keeper/rotation_test.go
+++ b/x/staking/keeper/rotation_test.go
@@ -360,28 +360,35 @@ func (s *KeeperTestSuite) TestImportConsKeyRotationsRoundTrip() {
 	s.ctx = s.ctx.WithBlockHeight(100 + stakingtypes.ConsensusUpdateDelay)
 	require.NoError(s.stakingKeeper.ApplyConsKeyRotations(s.ctx))
 
-	// validator B: rotate without applying, leaving a live pending entry
-	// (PendingFrom on the old addr, PendingTo on the new addr).
+	// validator B: rotate without applying, then remove the validator before
+	// apply. The live path keeps the PendingFrom lock for exactly this case, so
+	// the pending entry outlives the validator record and must still import.
 	oldPkB := ed25519.GenPrivKey().PubKey()
 	newPkB := ed25519.GenPrivKey().PubKey()
-	_, valAddrB := s.bondedValidator(oldPkB)
+	vB, valAddrB := s.bondedValidator(oldPkB)
 	oldConsAddrB := sdk.ConsAddress(oldPkB.Address())
 	newConsAddrB := sdk.ConsAddress(newPkB.Address())
 	require.NoError(s.stakingKeeper.SetConsKeyRotation(s.ctx, valAddrB, oldPkB, newPkB))
+
+	vB.Status = stakingtypes.Unbonded
+	vB.Tokens = math.ZeroInt()
+	vB.DelegatorShares = math.LegacyZeroDec()
+	require.NoError(s.stakingKeeper.SetValidator(s.ctx, vB))
+	require.NoError(s.stakingKeeper.RemoveValidator(s.ctx, valAddrB))
 
 	histories, err := s.stakingKeeper.ExportConsKeyRotationHistory(s.ctx)
 	require.NoError(err)
 	pending, err := s.stakingKeeper.ExportPendingConsKeyRotations(s.ctx, s.ctx.BlockHeight())
 	require.NoError(err)
 
-	// restart from the export: validator A is live on its post-rotation key,
-	// validator B is still live on its old key.
+	// restart from the export: validator A is live on its post-rotation key.
+	// validator B is gone, so only its rotation state is imported.
 	s.SetupTest()
 	s.bondedValidatorWithConsKey(valAddrA, newPkA)
-	s.bondedValidatorWithConsKey(valAddrB, oldPkB)
 	require.NoError(s.stakingKeeper.ImportConsKeyRotations(s.ctx, histories, pending))
 
-	// ensure pending locks survive the round trip with the correct kinds.
+	// the removed validator's pending locks still round trip with the correct
+	// kinds despite the missing validator record.
 	kindB, gotValB, found, err := s.stakingKeeper.GetRotationLockedConsAddr(s.ctx, oldConsAddrB)
 	require.NoError(err)
 	require.True(found)

--- a/x/staking/keeper/rotation_test.go
+++ b/x/staking/keeper/rotation_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	abci "github.com/cometbft/cometbft/abci/types"
+	"go.uber.org/mock/gomock"
 
 	"cosmossdk.io/math"
 
@@ -19,8 +20,15 @@ import (
 // bondedValidator stores and bonds a validator with the given consensus
 // pubkey, returns the validator record together with its operator address.
 func (s *KeeperTestSuite) bondedValidator(pk cryptotypes.PubKey) (stakingtypes.Validator, sdk.ValAddress) {
-	require := s.Require()
 	valAddr := sdk.ValAddress(pk.Address())
+	return s.bondedValidatorWithConsKey(valAddr, pk), valAddr
+}
+
+// bondedValidatorWithConsKey bonds a validator at an explicit operator address
+// with a consensus key that need not be derived from that address, as happens
+// after a consensus key rotation.
+func (s *KeeperTestSuite) bondedValidatorWithConsKey(valAddr sdk.ValAddress, pk cryptotypes.PubKey) stakingtypes.Validator {
+	require := s.Require()
 	v, err := stakingtypes.NewValidator(valAddr.String(), pk, stakingtypes.Description{Moniker: "v"})
 	require.NoError(err)
 	v.Status = stakingtypes.Bonded
@@ -28,7 +36,7 @@ func (s *KeeperTestSuite) bondedValidator(pk cryptotypes.PubKey) (stakingtypes.V
 	v.DelegatorShares = math.LegacyNewDecFromInt(v.Tokens)
 	require.NoError(s.stakingKeeper.SetValidator(s.ctx, v))
 	require.NoError(s.stakingKeeper.SetValidatorByConsAddr(s.ctx, v))
-	return v, valAddr
+	return v
 }
 
 func (s *KeeperTestSuite) TestConsKeyRotationUpdate() {
@@ -334,6 +342,84 @@ func (s *KeeperTestSuite) TestRotationLockedConsAddrIndex() {
 	_, _, found, err = s.stakingKeeper.GetRotationLockedConsAddr(s.ctx, newConsAddr)
 	require.NoError(err)
 	require.False(found)
+}
+
+func (s *KeeperTestSuite) TestImportConsKeyRotationsRoundTrip() {
+	require := s.Require()
+	s.SetupTest()
+
+	// validator A: rotate and apply, leaving a RotatedFrom history entry.
+	oldPkA := ed25519.GenPrivKey().PubKey()
+	newPkA := ed25519.GenPrivKey().PubKey()
+	_, valAddrA := s.bondedValidator(oldPkA)
+	oldConsAddrA := sdk.ConsAddress(oldPkA.Address())
+	newConsAddrA := sdk.ConsAddress(newPkA.Address())
+
+	s.ctx = s.ctx.WithBlockHeight(100)
+	require.NoError(s.stakingKeeper.SetConsKeyRotation(s.ctx, valAddrA, oldPkA, newPkA))
+	s.ctx = s.ctx.WithBlockHeight(100 + stakingtypes.ConsensusUpdateDelay)
+	require.NoError(s.stakingKeeper.ApplyConsKeyRotations(s.ctx))
+
+	// validator B: rotate without applying, leaving a live pending entry
+	// (PendingFrom on the old addr, PendingTo on the new addr).
+	oldPkB := ed25519.GenPrivKey().PubKey()
+	newPkB := ed25519.GenPrivKey().PubKey()
+	_, valAddrB := s.bondedValidator(oldPkB)
+	oldConsAddrB := sdk.ConsAddress(oldPkB.Address())
+	newConsAddrB := sdk.ConsAddress(newPkB.Address())
+	require.NoError(s.stakingKeeper.SetConsKeyRotation(s.ctx, valAddrB, oldPkB, newPkB))
+
+	histories, err := s.stakingKeeper.ExportConsKeyRotationHistory(s.ctx)
+	require.NoError(err)
+	pending, err := s.stakingKeeper.ExportPendingConsKeyRotations(s.ctx, s.ctx.BlockHeight())
+	require.NoError(err)
+
+	// restart from the export: validator A is live on its post-rotation key,
+	// validator B is still live on its old key.
+	s.SetupTest()
+	s.bondedValidatorWithConsKey(valAddrA, newPkA)
+	s.bondedValidatorWithConsKey(valAddrB, oldPkB)
+	require.NoError(s.stakingKeeper.ImportConsKeyRotations(s.ctx, histories, pending))
+
+	// ensure pending locks survive the round trip with the correct kinds.
+	kindB, gotValB, found, err := s.stakingKeeper.GetRotationLockedConsAddr(s.ctx, oldConsAddrB)
+	require.NoError(err)
+	require.True(found)
+	require.Equal(stakingtypes.ConsAddrLockPendingFrom, kindB)
+	require.Equal(valAddrB, gotValB)
+
+	kindBTo, _, found, err := s.stakingKeeper.GetRotationLockedConsAddr(s.ctx, newConsAddrB)
+	require.NoError(err)
+	require.True(found)
+	require.Equal(stakingtypes.ConsAddrLockPendingTo, kindBTo)
+
+	// Now exercise the evidence handling path against validator A's rotated-away key,
+	// mirroring handleEquivocationEvidence: the old cons addr no longer resolves
+	// live, so it must resolve through the historical lookup.
+	s.ctx = s.ctx.WithBlockHeight(200)
+	_, err = s.stakingKeeper.ValidatorByConsAddr(s.ctx, oldConsAddrA)
+	require.ErrorIs(err, stakingtypes.ErrNoValidatorFound)
+
+	validator, err := s.stakingKeeper.ValidatorByHistoricalConsAddr(s.ctx, oldConsAddrA)
+	require.NoError(err)
+	require.Equal(valAddrA.String(), validator.OperatorAddress)
+	currentConsAddr, err := validator.GetConsAddr()
+	require.NoError(err)
+	require.Equal(newConsAddrA.Bytes(), currentConsAddr)
+
+	before, err := s.stakingKeeper.GetValidator(s.ctx, valAddrA)
+	require.NoError(err)
+
+	// Ensure we are able to slash the rotated validator on their resolved
+	// current cons addr.
+	s.bankKeeper.EXPECT().BurnCoins(gomock.Any(), stakingtypes.BondedPoolName, gomock.Any()).Return(nil)
+	burned, err := s.stakingKeeper.Slash(s.ctx, currentConsAddr, s.ctx.BlockHeight(), 10, math.LegacyNewDecWithPrec(5, 1))
+	require.NoError(err)
+
+	require.True(burned.IsPositive())
+	after, err := s.stakingKeeper.GetValidator(s.ctx, valAddrA)
+	require.NoError(err)
+	require.True(after.Tokens.LT(before.Tokens))
 }
 
 func (s *KeeperTestSuite) TestValidatorByHistoricalConsAddr() {


### PR DESCRIPTION
# Description

Fix key rotations missing `RotatedFrom` type tags when importing historical rotations, as well as not locking via `PendingFrom` type tags for a validators current cons addr when they have a rotation in progress on genesis import.

Closes: FOU-843

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->
