### PR TITLE
fix(staking): bind key rotation fee denom to bond denom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (x/auth/tx) [#26517](https://github.com/cosmos/cosmos-sdk/pull/26517) Return a decode error instead of panicking when a transaction's `SignerInfos` and `Signatures` counts disagree in `GetSignaturesV2`, or a multisig's `ModeInfos` and sub-signature counts disagree in `ModeInfoAndSigToSignatureData`.
 * (x/auth/ante) [#26573](https://github.com/cosmos/cosmos-sdk/pull/26573) Reject tx with extra SignerInfos in SetPubKeyDecorator.
 * (blockstm) [#26591](https://github.com/cosmos/cosmos-sdk/pull/26591) normalize non-positive worker count in `STMRunner.Run`.
+* (x/staking) [#26613](https://github.com/cosmos/cosmos-sdk/pull/26613) Require `key_rotation_fee` denom to equal `bond_denom` in `Params.Validate` and derive the default fee denom from the configured bond denom.
 
 ### Deprecated
 

--- a/tests/integration/staking/keeper/cons_key_rotation_test.go
+++ b/tests/integration/staking/keeper/cons_key_rotation_test.go
@@ -53,7 +53,7 @@ func TestRotateConsPubKey_MsgServerQueuesAndEndBlockerApplies(t *testing.T) {
 
 	// fee debited from the operator account and burned (total supply
 	// decreases by exactly the fee)
-	fee := types.DefaultKeyRotationFee
+	fee := sdk.NewCoin(bondDenom, types.DefaultKeyRotationFeeAmount)
 	assert.DeepEqual(t, accBalBefore.Sub(fee), f.bankKeeper.GetBalance(f.sdkCtx, accAddr, bondDenom))
 	assert.DeepEqual(t, supplyBefore.Sub(fee), f.bankKeeper.GetSupply(f.sdkCtx, bondDenom))
 

--- a/x/staking/keeper/msg_server_test.go
+++ b/x/staking/keeper/msg_server_test.go
@@ -1112,7 +1112,7 @@ func (s *KeeperTestSuite) TestMsgUpdateParams() {
 					MaxEntries:        stakingtypes.DefaultMaxEntries,
 					HistoricalEntries: stakingtypes.DefaultHistoricalEntries,
 					BondDenom:         stakingtypes.BondStatusBonded,
-					KeyRotationFee:    stakingtypes.DefaultKeyRotationFee,
+					KeyRotationFee:    sdk.NewCoin(sdk.DefaultBondDenom, stakingtypes.DefaultKeyRotationFeeAmount),
 				},
 			},
 			expErr:    true,
@@ -1129,7 +1129,7 @@ func (s *KeeperTestSuite) TestMsgUpdateParams() {
 					MaxEntries:        stakingtypes.DefaultMaxEntries,
 					HistoricalEntries: stakingtypes.DefaultHistoricalEntries,
 					BondDenom:         stakingtypes.BondStatusBonded,
-					KeyRotationFee:    stakingtypes.DefaultKeyRotationFee,
+					KeyRotationFee:    sdk.NewCoin(sdk.DefaultBondDenom, stakingtypes.DefaultKeyRotationFeeAmount),
 				},
 			},
 			expErr:    true,
@@ -1146,7 +1146,7 @@ func (s *KeeperTestSuite) TestMsgUpdateParams() {
 					MaxEntries:        stakingtypes.DefaultMaxEntries,
 					HistoricalEntries: stakingtypes.DefaultHistoricalEntries,
 					BondDenom:         "",
-					KeyRotationFee:    stakingtypes.DefaultKeyRotationFee,
+					KeyRotationFee:    sdk.NewCoin(sdk.DefaultBondDenom, stakingtypes.DefaultKeyRotationFeeAmount),
 				},
 			},
 			expErr:    true,
@@ -1163,7 +1163,7 @@ func (s *KeeperTestSuite) TestMsgUpdateParams() {
 					MaxEntries:        stakingtypes.DefaultMaxEntries,
 					HistoricalEntries: stakingtypes.DefaultHistoricalEntries,
 					BondDenom:         "ghosttoken",
-					KeyRotationFee:    stakingtypes.DefaultKeyRotationFee,
+					KeyRotationFee:    sdk.NewInt64Coin("ghosttoken", 1000000),
 				},
 			},
 			expErr:    true,
@@ -1183,7 +1183,7 @@ func (s *KeeperTestSuite) TestMsgUpdateParams() {
 					MaxEntries:        stakingtypes.DefaultMaxEntries,
 					HistoricalEntries: stakingtypes.DefaultHistoricalEntries,
 					BondDenom:         stakingtypes.BondStatusBonded,
-					KeyRotationFee:    stakingtypes.DefaultKeyRotationFee,
+					KeyRotationFee:    sdk.NewCoin(sdk.DefaultBondDenom, stakingtypes.DefaultKeyRotationFeeAmount),
 				},
 			},
 			expErr:    true,
@@ -1200,7 +1200,7 @@ func (s *KeeperTestSuite) TestMsgUpdateParams() {
 					MaxEntries:        0,
 					HistoricalEntries: stakingtypes.DefaultHistoricalEntries,
 					BondDenom:         stakingtypes.BondStatusBonded,
-					KeyRotationFee:    stakingtypes.DefaultKeyRotationFee,
+					KeyRotationFee:    sdk.NewCoin(sdk.DefaultBondDenom, stakingtypes.DefaultKeyRotationFeeAmount),
 				},
 			},
 			expErr:    true,
@@ -1217,7 +1217,7 @@ func (s *KeeperTestSuite) TestMsgUpdateParams() {
 					HistoricalEntries: stakingtypes.DefaultHistoricalEntries,
 					MinCommissionRate: stakingtypes.DefaultMinCommissionRate,
 					BondDenom:         "denom",
-					KeyRotationFee:    stakingtypes.DefaultKeyRotationFee,
+					KeyRotationFee:    sdk.NewCoin(sdk.DefaultBondDenom, stakingtypes.DefaultKeyRotationFeeAmount),
 				},
 			},
 			expErr:    true,
@@ -1385,7 +1385,7 @@ func (s *KeeperTestSuite) TestMsgRotateConsPubKey() {
 			newRotateConsPubKeyMsg: func() *stakingtypes.MsgRotateConsPubKey {
 				// submit a valid rotation for valAddr
 				valAddr, _ := createValidator(stakingtypes.Bonded)
-				feeCoins := sdk.NewCoins(stakingtypes.DefaultKeyRotationFee)
+				feeCoins := sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, stakingtypes.DefaultKeyRotationFeeAmount))
 				s.bankKeeper.EXPECT().
 					SendCoinsFromAccountToModule(gomock.Any(), sdk.AccAddress(valAddr), stakingtypes.KeyRotationFeePoolName, feeCoins).
 					Return(nil)

--- a/x/staking/migrations/v6/migrate.go
+++ b/x/staking/migrations/v6/migrate.go
@@ -24,7 +24,7 @@ func Migrate(ctx context.Context, keeper paramsKeeper) error {
 	if isMissingKeyRotationFee(params.KeyRotationFee) {
 		params.KeyRotationFee = sdk.Coin{
 			Denom:  params.BondDenom,
-			Amount: types.DefaultKeyRotationFee.Amount,
+			Amount: types.DefaultKeyRotationFeeAmount,
 		}
 	}
 	if err := params.Validate(); err != nil {

--- a/x/staking/migrations/v6/migrate_test.go
+++ b/x/staking/migrations/v6/migrate_test.go
@@ -34,18 +34,18 @@ func TestMigrate(t *testing.T) {
 		k := &mockParamsKeeper{params: params}
 
 		require.NoError(t, Migrate(ctx, k))
-		require.Equal(t, sdk.NewCoin("uatom", types.DefaultKeyRotationFee.Amount), k.params.KeyRotationFee)
+		require.Equal(t, sdk.NewCoin("uatom", types.DefaultKeyRotationFeeAmount), k.params.KeyRotationFee)
 		require.NoError(t, k.params.Validate())
 	})
 
 	t.Run("preserves pre-existing key rotation fee", func(t *testing.T) {
 		params := types.DefaultParams()
 		params.BondDenom = "uatom"
-		params.KeyRotationFee = sdk.NewInt64Coin("oldfee", 42)
+		params.KeyRotationFee = sdk.NewInt64Coin("uatom", 42)
 		k := &mockParamsKeeper{params: params}
 
 		require.NoError(t, Migrate(ctx, k))
-		require.Equal(t, sdk.NewInt64Coin("oldfee", 42), k.params.KeyRotationFee)
+		require.Equal(t, sdk.NewInt64Coin("uatom", 42), k.params.KeyRotationFee)
 		require.NoError(t, k.params.Validate())
 	})
 

--- a/x/staking/simulation/genesis.go
+++ b/x/staking/simulation/genesis.go
@@ -53,7 +53,7 @@ func RandomizedGenState(simState *module.SimulationState) {
 	// NOTE: the slashing module need to be defined after the staking module on the
 	// NewSimulationManager constructor for this to work
 	simState.UnbondTime = unbondTime
-	keyRotationFee := sdk.NewCoin(simState.BondDenom, types.DefaultKeyRotationFee.Amount)
+	keyRotationFee := sdk.NewCoin(simState.BondDenom, types.DefaultKeyRotationFeeAmount)
 	params := types.NewParams(simState.UnbondTime, maxVals, 7, histEntries, simState.BondDenom, minCommissionRate, keyRotationFee)
 
 	// validators & delegations

--- a/x/staking/simulation/proposals.go
+++ b/x/staking/simulation/proposals.go
@@ -41,6 +41,7 @@ func SimulateMsgUpdateParams(r *rand.Rand, _ sdk.Context, _ []simtypes.Account) 
 
 	params := types.DefaultParams()
 	params.BondDenom = simtypes.RandStringOfLength(r, 10)
+	params.KeyRotationFee = sdk.NewCoin(params.BondDenom, types.DefaultKeyRotationFeeAmount)
 	params.HistoricalEntries = uint32(simtypes.RandIntBetween(r, 0, 1000))
 	params.MaxEntries = uint32(simtypes.RandIntBetween(r, 1, 1000))
 	params.MaxValidators = uint32(simtypes.RandIntBetween(r, 1, 1000))

--- a/x/staking/types/params.go
+++ b/x/staking/types/params.go
@@ -35,8 +35,10 @@ var (
 	// DefaultMinCommissionRate is set to 0%
 	DefaultMinCommissionRate = math.LegacyZeroDec()
 
-	// DefaultKeyRotationFee is the fee charged to rotate a validator's consensus key.
-	DefaultKeyRotationFee = sdk.NewInt64Coin(sdk.DefaultBondDenom, 1000000)
+	// DefaultKeyRotationFeeAmount is the default amount charged to rotate a
+	// validator's consensus key. The fee denom is always the bond denom, so only
+	// the amount has a fixed default; callers pair it with the active bond denom.
+	DefaultKeyRotationFeeAmount = math.NewInt(1000000)
 )
 
 // NewParams creates a new Params instance
@@ -67,7 +69,10 @@ func DefaultParams() Params {
 		DefaultHistoricalEntries,
 		sdk.DefaultBondDenom,
 		DefaultMinCommissionRate,
-		DefaultKeyRotationFee,
+		// Read the bond denom here so the fee tracks it even after
+		// sdk.DefaultBondDenom is overridden (e.g. init --default-denom);
+		// Validate requires the two denoms to match.
+		sdk.NewCoin(sdk.DefaultBondDenom, DefaultKeyRotationFeeAmount),
 	)
 }
 
@@ -119,6 +124,12 @@ func (p Params) Validate() error {
 
 	if err := validateKeyRotationFee(p.KeyRotationFee); err != nil {
 		return err
+	}
+
+	// The rotation fee is charged in this denom, so a validator can only pay it
+	// if it matches the staking denom they already hold.
+	if p.KeyRotationFee.Denom != p.BondDenom {
+		return fmt.Errorf("key rotation fee denom %q must match bond denom %q", p.KeyRotationFee.Denom, p.BondDenom)
 	}
 
 	return nil

--- a/x/staking/types/params_test.go
+++ b/x/staking/types/params_test.go
@@ -51,6 +51,13 @@ func TestValidateParams(t *testing.T) {
 	require.Error(t, params.Validate())
 
 	params = types.DefaultParams()
+	params.BondDenom = "uatom"
 	params.KeyRotationFee = sdk.NewInt64Coin("uatom", 1)
 	require.NoError(t, params.Validate())
+
+	// fee denom must match the bond denom
+	params = types.DefaultParams()
+	params.BondDenom = "uatom"
+	params.KeyRotationFee = sdk.NewInt64Coin(sdk.DefaultBondDenom, 1)
+	require.Error(t, params.Validate())
 }


### PR DESCRIPTION
# Description

Ensure that the key rotation fee denom is always the bond denom. When using the default bond denom, ensure that it is correctly bound to the overridden default denom set during init (e.g. not `stake`).

Closes: FOU-845

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->
