### PR TITLE
fix: Update poa to support mldsa validator keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (x/auth/tx) [#25221](https://github.com/cosmos/cosmos-sdk/issues/25221) Add `ConfigOptions.AminoJSONEncoder` so applications can configure a custom `aminojson.Encoder` (e.g. custom field encodings) for the `SIGN_MODE_LEGACY_AMINO_JSON` handler without replicating the SDK's `HandlerMap` construction.
 * chore(x/auth) [#26567](https://github.com/cosmos/cosmos-sdk/pull/26567): add a human-readable error
 * (blockstm) [#26592](https://github.com/cosmos/cosmos-sdk/pull/26592) Validate `ExecuteBlock` inputs (block size, store index mapping, and estimates) at the exported entry point so invalid input returns a descriptive error instead of an opaque "index out of range" panic.
-* (cli) [#26604](https://github.com/cosmos/cosmos-sdk/pull/26604) Add consensus key algo to init and testnet CLIs.
+* (poa) [#NNNNN](https://github.com/cosmos/cosmos-sdk/pull/NNNNN) Update poa to support mldsa65 validator keys.
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (staking) [#26471](https://github.com/cosmos/cosmos-sdk/pull/26471) Add genesis import/export support for validator consensus key rotation.
 * (crypto) [#26472](https://github.com/cosmos/cosmos-sdk/pull/26472) Add ML-DSA-65 (FIPS 204) support for user account keys: mnemonic-based keyring creation/recovery (`--algo ml_dsa_65`), transaction signing/verification, and an ante-handler signature-verification gas cost (`Params.SigVerifyCostMlDsa65`).
 * (enterprise/poa) [#26590](https://github.com/cosmos/cosmos-sdk/pull/26590) Add `MsgRotateConsPubKey` for POA validator consensus key rotation (operator self-service plus admin override).
+* (enterprise/poa) [#26614](https://github.com/cosmos/cosmos-sdk/pull/26614) Add ML-DSA-65 (mldsa65) validator key support to the PoA module via a `WithMlDsa65Support()` module option, raising `MaxPubKeyLength` to accommodate the larger keys.
 
 ### Improvements
 
@@ -70,7 +71,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (x/auth/tx) [#25221](https://github.com/cosmos/cosmos-sdk/issues/25221) Add `ConfigOptions.AminoJSONEncoder` so applications can configure a custom `aminojson.Encoder` (e.g. custom field encodings) for the `SIGN_MODE_LEGACY_AMINO_JSON` handler without replicating the SDK's `HandlerMap` construction.
 * chore(x/auth) [#26567](https://github.com/cosmos/cosmos-sdk/pull/26567): add a human-readable error
 * (blockstm) [#26592](https://github.com/cosmos/cosmos-sdk/pull/26592) Validate `ExecuteBlock` inputs (block size, store index mapping, and estimates) at the exported entry point so invalid input returns a descriptive error instead of an opaque "index out of range" panic.
-* (poa) [#26614](https://github.com/cosmos/cosmos-sdk/pull/26614) Update poa to support mldsa65 validator keys.
+* (cli) [#26604](https://github.com/cosmos/cosmos-sdk/pull/26604) Add consensus key algo to init and testnet CLIs.
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (x/auth/tx) [#25221](https://github.com/cosmos/cosmos-sdk/issues/25221) Add `ConfigOptions.AminoJSONEncoder` so applications can configure a custom `aminojson.Encoder` (e.g. custom field encodings) for the `SIGN_MODE_LEGACY_AMINO_JSON` handler without replicating the SDK's `HandlerMap` construction.
 * chore(x/auth) [#26567](https://github.com/cosmos/cosmos-sdk/pull/26567): add a human-readable error
 * (blockstm) [#26592](https://github.com/cosmos/cosmos-sdk/pull/26592) Validate `ExecuteBlock` inputs (block size, store index mapping, and estimates) at the exported entry point so invalid input returns a descriptive error instead of an opaque "index out of range" panic.
-* (poa) [#NNNNN](https://github.com/cosmos/cosmos-sdk/pull/NNNNN) Update poa to support mldsa65 validator keys.
+* (poa) [#26614](https://github.com/cosmos/cosmos-sdk/pull/26614) Update poa to support mldsa65 validator keys.
 
 ### Bug Fixes
 

--- a/enterprise/poa/simapp/app.go
+++ b/enterprise/poa/simapp/app.go
@@ -247,7 +247,12 @@ func NewSimApp(
 		bank.NewAppModule(appCodec, app.BankKeeper, app.AccountKeeper),
 		consensus.NewAppModule(appCodec, app.ConsensusParamsKeeper),
 		gov.NewAppModule(appCodec, app.GovKeeper, app.AccountKeeper, app.BankKeeper),
-		poa.NewAppModule(appCodec, app.POAKeeper, poa.WithSecp256k1Support()), // poa.WithSecp256k1Support() is an optional parameter to allow Secp256k1 keys as validators
+		poa.NewAppModule(
+			appCodec,
+			app.POAKeeper,
+			poa.WithSecp256k1Support(), // poa.WithSecp256k1Support() is an optional parameter to allow Secp256k1 keys as validators
+			poa.WithMlDsa65Support(),   // poa.WithMlDsa65Support() is an optional parameter to allow mldsa65 keys as validators
+		),
 	)
 
 	app.BasicModuleManager = module.NewBasicManagerFromManager(

--- a/enterprise/poa/x/poa/module.go
+++ b/enterprise/poa/x/poa/module.go
@@ -30,6 +30,7 @@ import (
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/cosmos/cosmos-sdk/crypto/hd"
 	"github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
+	"github.com/cosmos/cosmos-sdk/crypto/keys/mldsa65"
 	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
 	"github.com/cosmos/cosmos-sdk/enterprise/poa/x/poa/client/cli"
 	"github.com/cosmos/cosmos-sdk/enterprise/poa/x/poa/keeper"
@@ -119,6 +120,26 @@ type ModuleOption func(app *AppModule)
 func WithPubkeyFactory(f map[string]func(codec.Codec, []byte) *codectypes.Any) ModuleOption {
 	return func(app *AppModule) {
 		app.pubkeyFactory = f
+	}
+}
+
+// WithMlDsa65Support adds mldsa65 pubkey support to the PoA module.
+// This is needed when you want to create validators with mldsa65 keys.
+// IMPORTANT: You must also enable mldsa65 in the consensus params by setting
+// consensus.params.validator.pub_key_types to include "ml_dsa_65" in your genesis.
+func WithMlDsa65Support() ModuleOption {
+	return func(appModule *AppModule) {
+		appModule.pubkeyFactory[string(hd.MlDsa65Type)] = func(cdc codec.Codec, bz []byte) *codectypes.Any {
+			pubKey := &mldsa65.PubKey{
+				Key: bz,
+			}
+			anyPK, err := codectypes.NewAnyWithValue(pubKey)
+			if err != nil {
+				panic(err)
+			}
+
+			return anyPK
+		}
 	}
 }
 

--- a/enterprise/poa/x/poa/types/poa.go
+++ b/enterprise/poa/x/poa/types/poa.go
@@ -29,7 +29,7 @@ import (
 const MinPubKeyLength = 30
 
 // MaxPubKeyLength is the maximum allowed pubkey serialized length (includes proto overhead).
-const MaxPubKeyLength = 128
+const MaxPubKeyLength = 2048
 
 // ValidateBasic performs basic validation on a Validator.
 // It ensures that:


### PR DESCRIPTION
# Description

Updates poa module to support mldsa keys in both the constructor as well as updating the constant which bound pubkey length to be large enough for mldsa.