### PR TITLE
fix(staking): allow multiple history entires in genesis import, and fix labeling of historical entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (x/staking) [#26611](https://github.com/cosmos/cosmos-sdk/pull/26611) Fix missing key rotation type tags on genesis import.
 * (blockstm) [#26627](https://github.com/cosmos/cosmos-sdk/pull/26627) Guard against block-stm estimate panic.
 * (x/staking) [#26616](https://github.com/cosmos/cosmos-sdk/pull/26616) Expire historical cons addr lookups only once equivocation evidence is no longer admissible.
+* (x/staking) [#26641](https://github.com/cosmos/cosmos-sdk/pull/26641) Allow multiple history entires in genesis import, and fix labeling of historical entries.
 
 ### Deprecated
 

--- a/x/staking/genesis.go
+++ b/x/staking/genesis.go
@@ -134,11 +134,10 @@ type consKeyRotationValidatorIndexes struct {
 }
 
 // consKeyRotationHistoryIndexes tracks rotation history entries that should
-// continue locking old consensus keys during the unbonding window.
+// continue locking old consensus keys while evidence for them is admissible.
 type consKeyRotationHistoryIndexes struct {
 	byValidatorAddress                 map[string]struct{}
-	byConsensusAddress                 map[string]struct{}
-	consensusAddressByValidatorAddress map[string]string
+	validatorAddressByConsensusAddress map[string]string
 }
 
 // buildGenesisValidatorIndex creates a lookup of validators listed in the
@@ -171,9 +170,9 @@ func buildGenesisValidatorIndex(data *types.GenesisState) (consKeyRotationValida
 	return indexes, nil
 }
 
-// validateConsKeyRotationHistory validates already applied rotations that are
-// still inside the unbonding window and returns the old consensus key locks
-// restored from genesis.
+// validateConsKeyRotationHistory validates already applied rotations whose old
+// keys still admit evidence and returns the old consensus key locks restored
+// from genesis.
 func validateConsKeyRotationHistory(
 	data *types.GenesisState,
 	validatorIndexes consKeyRotationValidatorIndexes,
@@ -181,9 +180,9 @@ func validateConsKeyRotationHistory(
 	history := data.GetConsensusKeyRotationHistory()
 	indexes := consKeyRotationHistoryIndexes{
 		byValidatorAddress:                 make(map[string]struct{}, len(history)),
-		byConsensusAddress:                 make(map[string]struct{}, len(history)),
-		consensusAddressByValidatorAddress: make(map[string]string, len(history)),
+		validatorAddressByConsensusAddress: make(map[string]string, len(history)),
 	}
+	gatedValidators := make(map[string]struct{}, len(history))
 
 	for _, h := range history {
 		// decode both addresses before using them as canonical map keys
@@ -192,24 +191,30 @@ func validateConsKeyRotationHistory(
 			return consKeyRotationHistoryIndexes{}, err
 		}
 
-		// a validator can only have one history record inside the unbonding
-		// window, and history is only valid for validators present in genesis
-		if _, found := indexes.byValidatorAddress[string(valAddr)]; found {
-			return consKeyRotationHistoryIndexes{}, fmt.Errorf("duplicate consensus key rotation history for validator %s", h.ValidatorAddress)
-		}
+		// history is only valid for validators present in genesis
 		if _, found := validatorIndexes.byValidatorAddress[string(valAddr)]; !found {
 			return consKeyRotationHistoryIndexes{}, fmt.Errorf("consensus key rotation history for unknown validator %s", h.ValidatorAddress)
 		}
 		indexes.byValidatorAddress[string(valAddr)] = struct{}{}
 
-		// a rotated-away consensus address can only be locked by one history
+		// a validator can hold one record per rotated away key that still
+		// admits evidence, but only one of them carries its re rotation gate
+		// maturity, since a validator can have only a single rotation in
+		// progress at a time
+		if !h.MaturityTime.IsZero() {
+			if _, found := gatedValidators[string(valAddr)]; found {
+				return consKeyRotationHistoryIndexes{}, fmt.Errorf("duplicate consensus key rotation maturity time for validator %s", h.ValidatorAddress)
+			}
+			gatedValidators[string(valAddr)] = struct{}{}
+		}
+
+		// a rotated away consensus address can only be locked by one history
 		// entry
 		consAddrKey := string(oldConsAddr)
-		if _, found := indexes.byConsensusAddress[consAddrKey]; found {
+		if _, found := indexes.validatorAddressByConsensusAddress[consAddrKey]; found {
 			return consKeyRotationHistoryIndexes{}, fmt.Errorf("duplicate consensus key rotation old consensus address %s", h.OldConsensusAddress)
 		}
-		indexes.byConsensusAddress[consAddrKey] = struct{}{}
-		indexes.consensusAddressByValidatorAddress[string(valAddr)] = consAddrKey
+		indexes.validatorAddressByConsensusAddress[consAddrKey] = string(valAddr)
 	}
 
 	return indexes, nil
@@ -257,7 +262,7 @@ func validatePendingConsKeyRotations(
 		if _, found := validatorIndexes.validatorAddressByConsensusAddress[newConsAddrKey]; found {
 			return fmt.Errorf("pending consensus key rotation for validator %s targets a live consensus key", rotation.ValidatorAddress)
 		}
-		if _, found := historyIndexes.byConsensusAddress[newConsAddrKey]; found {
+		if _, found := historyIndexes.validatorAddressByConsensusAddress[newConsAddrKey]; found {
 			return fmt.Errorf("pending consensus key rotation for validator %s targets a consensus key in rotation history", rotation.ValidatorAddress)
 		}
 		pendingNewConsAddrs[newConsAddrKey] = struct{}{}
@@ -266,7 +271,7 @@ func validatePendingConsKeyRotations(
 	// history can lock a live key only while that same validator has a pending
 	// rotation. Once the rotation has applied, the old key should no longer be
 	// live in the validator set.
-	for valAddr, historyConsAddr := range historyIndexes.consensusAddressByValidatorAddress {
+	for historyConsAddr, valAddr := range historyIndexes.validatorAddressByConsensusAddress {
 		liveValAddr, found := validatorIndexes.validatorAddressByConsensusAddress[historyConsAddr]
 		if !found {
 			continue

--- a/x/staking/genesis_test.go
+++ b/x/staking/genesis_test.go
@@ -83,18 +83,54 @@ func TestValidateGenesis(t *testing.T) {
 				ApplyHeight:      10,
 			}}
 		}, true},
-		{"duplicate consensus key rotation history", func(data *types.GenesisState) {
+		{"consensus key rotation history with retired maturity gate", func(data *types.GenesisState) {
+			data.Validators = cloneValidators(genValidators1)
+			data.ConsensusKeyRotationHistory = []types.ConsensusKeyRotationHistory{{
+				ValidatorAddress:    valAddr,
+				OldConsensusAddress: sdk.ConsAddress(ed25519.GenPrivKey().PubKey().Address()).String(),
+			}}
+		}, false},
+		{"multiple consensus key rotation history for validator", func(data *types.GenesisState) {
 			data.Validators = cloneValidators(genValidators1)
 			data.ConsensusKeyRotationHistory = []types.ConsensusKeyRotationHistory{
 				{
 					ValidatorAddress:    valAddr,
-					OldConsensusAddress: oldConsAddr,
+					OldConsensusAddress: sdk.ConsAddress(ed25519.GenPrivKey().PubKey().Address()).String(),
 					MaturityTime:        maturity,
 				},
 				{
 					ValidatorAddress:    valAddr,
-					OldConsensusAddress: oldConsAddr,
+					OldConsensusAddress: sdk.ConsAddress(ed25519.GenPrivKey().PubKey().Address()).String(),
+				},
+			}
+		}, false},
+		{"duplicate consensus key rotation maturity time", func(data *types.GenesisState) {
+			data.Validators = cloneValidators(genValidators1)
+			data.ConsensusKeyRotationHistory = []types.ConsensusKeyRotationHistory{
+				{
+					ValidatorAddress:    valAddr,
+					OldConsensusAddress: sdk.ConsAddress(ed25519.GenPrivKey().PubKey().Address()).String(),
 					MaturityTime:        maturity,
+				},
+				{
+					ValidatorAddress:    valAddr,
+					OldConsensusAddress: sdk.ConsAddress(ed25519.GenPrivKey().PubKey().Address()).String(),
+					MaturityTime:        maturity,
+				},
+			}
+		}, true},
+		{"duplicate consensus key rotation old consensus address", func(data *types.GenesisState) {
+			data.Validators = cloneValidators(genValidators1)
+			dupConsAddr := sdk.ConsAddress(ed25519.GenPrivKey().PubKey().Address()).String()
+			data.ConsensusKeyRotationHistory = []types.ConsensusKeyRotationHistory{
+				{
+					ValidatorAddress:    valAddr,
+					OldConsensusAddress: dupConsAddr,
+					MaturityTime:        maturity,
+				},
+				{
+					ValidatorAddress:    valAddr,
+					OldConsensusAddress: dupConsAddr,
 				},
 			}
 		}, true},

--- a/x/staking/keeper/rotation.go
+++ b/x/staking/keeper/rotation.go
@@ -1,6 +1,7 @@
 package keeper
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -24,13 +25,20 @@ import (
 func (k Keeper) ImportConsKeyRotations(ctx context.Context, histories []types.ConsensusKeyRotationHistory, pending []types.PendingConsensusKeyRotation) error {
 	store := k.storeService.OpenKVStore(ctx)
 
-	hasPending := make(map[string]bool, len(pending))
+	// the live cons addr of each validator that has a rotation pending apply,
+	// used below to pick out which of its history records that rotation is
+	// moving away from. A nil value means the validator no longer exists.
+	pendingLiveConsAddr := make(map[string]sdk.ConsAddress, len(pending))
 	for _, rotation := range pending {
 		valAddr, err := k.validatorAddressCodec.StringToBytes(rotation.ValidatorAddress)
 		if err != nil {
 			return err
 		}
-		hasPending[string(valAddr)] = true
+		liveConsAddr, err := k.validatorConsAddr(ctx, valAddr)
+		if err != nil {
+			return err
+		}
+		pendingLiveConsAddr[string(valAddr)] = liveConsAddr
 
 		var newPubKey cryptotypes.PubKey
 		if err := k.cdc.UnpackAny(rotation.NewPubkey, &newPubKey); err != nil {
@@ -83,10 +91,31 @@ func (k Keeper) ImportConsKeyRotations(ctx context.Context, histories []types.Co
 				return err
 			}
 
-			// the lock is PendingFrom while a rotation for this validator is still
-			// pending apply, and RotatedFrom once it has been applied.
+			// a validator can hold both an applied rotation whose old key
+			// still admits evidence and a rotation that has not applied yet.
+
+			// pendingLiveConsAddr is populated when iterating over pending
+			// rotations, check this validator that has a historical rotation,
+			// also has a pending rotation.
+			liveConsAddr, hasPendingRotation := pendingLiveConsAddr[string(valAddr)]
+
+			// the pending rotation for this validator has not swapped the
+			// validator's key yet, so check if the key in this history entry is
+			// the one that is currently live.
+			//
+			// history records are written at rotation submit time, so this is
+			// true only for a record whose rotation was exported before it
+			// reached its apply height. It is false for the validator's other
+			// records, whose rotations already applied and moved the live key on.
+			isPendingRotationKey := hasPendingRotation && bytes.Equal(liveConsAddr, oldConsAddr)
+
+			// a validator removed before its rotation applied keeps its pending
+			// entry but has no live key left to compare against, so its records
+			// stay PendingFrom as they are in live state.
+			liveKeyUnknown := hasPendingRotation && liveConsAddr == nil
+
 			kind := types.ConsAddrLockRotatedFrom
-			if hasPending[string(valAddr)] {
+			if isPendingRotationKey || liveKeyUnknown {
 				kind = types.ConsAddrLockPendingFrom
 			}
 			if err := k.SetRotationLockedConsAddr(ctx, oldConsAddr, valAddr, kind); err != nil {
@@ -109,6 +138,19 @@ func (k Keeper) ImportConsKeyRotations(ctx context.Context, histories []types.Co
 	}
 
 	return nil
+}
+
+// validatorConsAddr returns the validator's live consensus address, or nil if
+// the validator no longer exists.
+func (k Keeper) validatorConsAddr(ctx context.Context, valAddr sdk.ValAddress) (sdk.ConsAddress, error) {
+	validator, err := k.GetValidator(ctx, valAddr)
+	if err != nil {
+		if errors.Is(err, types.ErrNoValidatorFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return validator.GetConsAddr()
 }
 
 // ExportConsKeyRotationHistory returns one record per rotated-away consensus key

--- a/x/staking/keeper/rotation.go
+++ b/x/staking/keeper/rotation.go
@@ -110,8 +110,14 @@ func (k Keeper) ImportConsKeyRotations(ctx context.Context, histories []types.Co
 			isPendingRotationKey := hasPendingRotation && bytes.Equal(liveConsAddr, oldConsAddr)
 
 			// a validator removed before its rotation applied keeps its pending
-			// entry but has no live key left to compare against, so its records
-			// stay PendingFrom as they are in live state.
+			// entry but has no live key left to compare against, so we cannot
+			// tell its records apart and mark them all PendingFrom.
+			//
+			// the kind is unobservable for a removed validator, since
+			// ValidatorByHistoricalConsAddr resolves the lock and then fails on
+			// the missing validator either way. PendingFrom is the safer of the
+			// two, as it cannot attribute an old key to a validator later
+			// recreated at the same operator address.
 			liveKeyUnknown := hasPendingRotation && liveConsAddr == nil
 
 			kind := types.ConsAddrLockRotatedFrom

--- a/x/staking/keeper/rotation_test.go
+++ b/x/staking/keeper/rotation_test.go
@@ -526,6 +526,60 @@ func (s *KeeperTestSuite) TestImportConsKeyRotationsRoundTrip() {
 	require.True(after.Tokens.LT(before.Tokens))
 }
 
+func (s *KeeperTestSuite) TestImportConsKeyRotationsAppliedAndPending() {
+	require := s.Require()
+	s.SetupTest()
+
+	pk0 := ed25519.GenPrivKey().PubKey()
+	pk1 := ed25519.GenPrivKey().PubKey()
+	pk2 := ed25519.GenPrivKey().PubKey()
+	_, valAddr := s.bondedValidator(pk0)
+	consAddr0 := sdk.ConsAddress(pk0.Address())
+	consAddr1 := sdk.ConsAddress(pk1.Address())
+	consAddr2 := sdk.ConsAddress(pk2.Address())
+
+	// rotate pk0 to pk1 and apply it, then queue pk1 to pk2 while the evidence
+	// lock on pk0 is still open, leaving the validator with two history records.
+	s.ctx = s.ctx.WithBlockHeight(100)
+	require.NoError(s.stakingKeeper.SetConsKeyRotation(s.ctx, valAddr, pk0, pk1))
+	s.ctx = s.ctx.WithBlockHeight(100 + stakingtypes.ConsensusUpdateDelay)
+	require.NoError(s.stakingKeeper.ApplyConsKeyRotations(s.ctx))
+	require.NoError(s.stakingKeeper.SetConsKeyRotation(s.ctx, valAddr, pk1, pk2))
+
+	histories, err := s.stakingKeeper.ExportConsKeyRotationHistory(s.ctx)
+	require.NoError(err)
+	require.Len(histories, 2)
+	pending, err := s.stakingKeeper.ExportPendingConsKeyRotations(s.ctx, s.ctx.BlockHeight())
+	require.NoError(err)
+	require.Len(pending, 1)
+
+	// restart from the export, the validator is live on pk1 as it was at export
+	s.SetupTest()
+	s.bondedValidatorWithConsKey(valAddr, pk1)
+	require.NoError(s.stakingKeeper.ImportConsKeyRotations(s.ctx, histories, pending))
+
+	// only the pending rotation's old key is PendingFrom, the applied rotation's
+	// old key stays RotatedFrom so evidence for it still resolves
+	kind, _, found, err := s.stakingKeeper.GetRotationLockedConsAddr(s.ctx, consAddr0)
+	require.NoError(err)
+	require.True(found)
+	require.Equal(stakingtypes.ConsAddrLockRotatedFrom, kind)
+
+	kind, _, found, err = s.stakingKeeper.GetRotationLockedConsAddr(s.ctx, consAddr1)
+	require.NoError(err)
+	require.True(found)
+	require.Equal(stakingtypes.ConsAddrLockPendingFrom, kind)
+
+	kind, _, found, err = s.stakingKeeper.GetRotationLockedConsAddr(s.ctx, consAddr2)
+	require.NoError(err)
+	require.True(found)
+	require.Equal(stakingtypes.ConsAddrLockPendingTo, kind)
+
+	validator, err := s.stakingKeeper.ValidatorByHistoricalConsAddr(s.ctx, consAddr0)
+	require.NoError(err)
+	require.Equal(valAddr.String(), validator.OperatorAddress)
+}
+
 func (s *KeeperTestSuite) TestValidatorByHistoricalConsAddr() {
 	require := s.Require()
 

--- a/x/staking/types/rotation.go
+++ b/x/staking/types/rotation.go
@@ -20,7 +20,7 @@ func (h ConsensusKeyRotationHistory) Validate() (sdk.ValAddress, sdk.ConsAddress
 		return nil, nil, fmt.Errorf("invalid consensus key rotation old consensus address %s: %w", h.OldConsensusAddress, err)
 	}
 
-	// NOTE: note validating maturity time is non zero since a zero maturity
+	// NOTE: not validating maturity time is non zero since a zero maturity
 	// time is valid. it marks a record whose re rotation gate has already been
 	// retired while its evidence lock is still open.
 	return valAddr, oldConsAddr, nil

--- a/x/staking/types/rotation.go
+++ b/x/staking/types/rotation.go
@@ -20,10 +20,9 @@ func (h ConsensusKeyRotationHistory) Validate() (sdk.ValAddress, sdk.ConsAddress
 		return nil, nil, fmt.Errorf("invalid consensus key rotation old consensus address %s: %w", h.OldConsensusAddress, err)
 	}
 
-	if h.MaturityTime.IsZero() {
-		return nil, nil, fmt.Errorf("consensus key rotation history for validator %s has zero maturity time", h.ValidatorAddress)
-	}
-
+	// NOTE: note validating maturity time is non zero since a zero maturity
+	// time is valid. it marks a record whose re rotation gate has already been
+	// retired while its evidence lock is still open.
 	return valAddr, oldConsAddr, nil
 }
 


### PR DESCRIPTION
# Description

Fix issue the parent PR is introducing where genesis import's were not properly updated to handle rotations having multiple history entires, as well as a maturity time of zero signaling that another historical entry is managing the maturity time of the rotation. Also fixes a bug where locked addr from genesis imports were being improperly labeled as `PendingFrom`, not `RotatedFrom`. This would cause `ValidatorByHistoricalConsAddr`, breaking historical evidence lookups. 

Closes: FOU-951, FOU-952

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->
