### PR TITLE
ci: use merge_group base/head for dependency-review comparison

### DIFF
--- a/.github/workflows/dependencies-review.yml
+++ b/.github/workflows/dependencies-review.yml
@@ -19,8 +19,8 @@ jobs:
       - name: "Dependency Review"
         uses: actions/dependency-review-action@v5
         with:
-          base-ref: ${{ github.event.pull_request.base.sha || 'main' }}
-          head-ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          base-ref: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || 'main' }}
+          head-ref: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha || github.ref }}
           fail-on-severity: high
       - name: "Dependency audit"
         run: ./scripts/dep-assert.sh


### PR DESCRIPTION
## Description

**TLDR:** `dependency-review` uses the wrong comparison base on `merge_group` events, which breaks merge queues on release branches.

The workflow sets:

```yaml
base-ref: ${{ github.event.pull_request.base.sha || 'main' }}
head-ref: ${{ github.event.pull_request.head.sha || github.ref }}
```

`merge_group` events carry no `pull_request` payload, so `base-ref` falls back to `'main'`. For main's own merge queue that's approximately right, but for a release-branch queue the action diffs the queue ref against main's fork point — i.e. every dependency change the release branch has accumulated since diverging. Any advisory published against that pre-existing state then fails the queue run even though the queued PR doesn't touch the flagged package.

First observed on the `release/v0.54.x` queue for #26671 ([failing run](https://github.com/cosmos/cosmos-sdk/actions/runs/30274798121/job/90006007384)): GHSA-hrxh-6v49-42gf flagged `api/go.mod » grpc@v1.79.3`, which that PR doesn't modify — the PR-level run on the same head passed.

Fix: prefer the merge group's own `base_sha`/`head_sha` so the comparison covers only the queued changes.

Same fix applied directly to `release/v0.54.x` as part of #26671; this PR aligns main so future backports don't reintroduce the bug.