### PR TITLE
test(types): use Coins.Equal in TestQuoIntCoins (backport #25201)

### DIFF
--- a/types/coin_test.go
+++ b/types/coin_test.go
@@ -293,7 +293,7 @@ func (s *coinTestSuite) TestQuoIntCoins() {
 		} else {
 			res := tc.input.QuoInt(tc.divisor)
 			assert.Equal(tc.isValid, res.IsValid())
-			assert.Equal(tc.expected, res, "quotient of coins is incorrect, tc #%d", i)
+			assert.True(tc.expected.Equal(res), "quotient of coins is incorrect, tc #%d", i)
 		}
 	}
 }


### PR DESCRIPTION
## Description

`make test` fails on `release/v0.53.x` (including tags v0.53.7 / v0.53.8) when run with a **Go 1.25+** toolchain:

```
--- FAIL: TestCoinTestSuite/TestQuoIntCoins (0.00s)
    coin_test.go:296: quotient of coins is incorrect, tc #1
    -    abs: (big.nat) <nil>
    +    abs: (big.nat) {
    +    }
```

### Root cause
Go 1.25 reordered checks in `math/big`'s `nat.div` (golang/go commit `872496da2b`, [CL 650638](https://go-review.googlesource.com/c/go/+/650638)): a quotient that equals zero (e.g. `2atom / 4`) now goes through `divW` and carries an **empty non-nil** `abs` slice, while `big.NewInt(0)` has a **nil** one. The values are numerically equal — but `assert.Equal` compares via `reflect.DeepEqual`, which distinguishes nil from empty slices. Test-only brittleness; no runtime or consensus impact.

### Fix
Port the one-line assertion change from #25201 (already on `main`, where it was bundled with the CI Go 1.24→1.25 bump): compare with `Coins.Equal` instead of deep equality.

Verified locally: `go test ./types/ -run TestCoinTestSuite` passes under both go1.25.0 and go1.24.6 with this change; fails under go1.25.0 without it.

The corresponding `math/int_internal_test.go` fix from #25201 is already present on this branch, so this is the only file needing the port.

---

### Author Checklist

- [x] included the correct type prefix in the PR title
- [x] targeted the correct branch
- [x] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed