### PR TITLE
perf(types): memoize GetConfig registry-key fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Improvements
 
-* (types)[#26729](https://github.com/cosmos/cosmos-sdk/pull/26729) Memoize `GetConfig`'s "hostname|binary|pid" registry-key fallback, which derived 3 process-invariant syscalls on every call.
+* (types) [#26729](https://github.com/cosmos/cosmos-sdk/pull/26729) Memoize `GetConfig`'s "hostname|binary|pid" registry-key fallback, which derived the executable path, hostname, and PID on every call.
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Improvements
 
+* (types)[#26729](https://github.com/cosmos/cosmos-sdk/pull/26729) Memoize `GetConfig`'s "hostname|binary|pid" registry-key fallback, which derived 3 process-invariant syscalls on every call.
+
 ### Bug Fixes
 
 ### Deprecated

--- a/types/config.go
+++ b/types/config.go
@@ -39,7 +39,12 @@ func getConfigKey() string {
 	if id := os.Getenv(EnvConfigScope); id != "" {
 		return id
 	}
+	return defaultConfigKey()
+}
 
+// defaultConfigKey memoizes the "hostname|binary|pid" fallback: the three
+// syscalls behind it are process-invariant.
+var defaultConfigKey = sync.OnceValue(func() string {
 	exe, errExec := os.Executable()
 	host, errHost := os.Hostname()
 	pid := os.Getpid()
@@ -52,7 +57,7 @@ func getConfigKey() string {
 	}
 
 	return fmt.Sprintf("%s|%s|%d", host, exe, pid)
-}
+})
 
 // NewConfig returns a new Config with default values.
 func NewConfig() *Config {

--- a/types/config.go
+++ b/types/config.go
@@ -42,8 +42,7 @@ func getConfigKey() string {
 	return defaultConfigKey()
 }
 
-// defaultConfigKey memoizes the "hostname|binary|pid" fallback: the three
-// syscalls behind it are process-invariant.
+// defaultConfigKey freezes the fallback registry key for the process lifetime.
 var defaultConfigKey = sync.OnceValue(func() string {
 	exe, errExec := os.Executable()
 	host, errHost := os.Hostname()

--- a/types/config_test.go
+++ b/types/config_test.go
@@ -100,3 +100,9 @@ func (s *configTestSuite) TestConfig_ScopeKeyFormat() {
 	key := getConfigKey()
 	s.Require().True(strings.Count(key, "|") == 2, "scope key should have 2 pipe separators")
 }
+
+func BenchmarkGetConfig(b *testing.B) {
+	for b.Loop() {
+		GetConfig()
+	}
+}

--- a/types/config_test.go
+++ b/types/config_test.go
@@ -102,6 +102,7 @@ func (s *configTestSuite) TestConfig_ScopeKeyFormat() {
 }
 
 func BenchmarkGetConfig(b *testing.B) {
+	b.Setenv(EnvConfigScope, "")
 	for b.Loop() {
 		GetConfig()
 	}

--- a/types/config_test.go
+++ b/types/config_test.go
@@ -97,6 +97,7 @@ func (s *configTestSuite) TestConfig_ScopePerBinary_EnvRestoration() {
 }
 
 func (s *configTestSuite) TestConfig_ScopeKeyFormat() {
+	s.T().Setenv(EnvConfigScope, "")
 	key := getConfigKey()
 	s.Require().True(strings.Count(key, "|") == 2, "scope key should have 2 pipe separators")
 }


### PR DESCRIPTION
# Description

getConfigKey derived os.Executable, os.Hostname and os.Getpid on every call
compute fallback once via sync.OnceValue

```
benchstat /tmp/before.txt /tmp/after.txt 
goos: darwin
goarch: arm64
pkg: github.com/cosmos/cosmos-sdk/types
cpu: Apple M4 Max
             │ /tmp/before.txt │           /tmp/after.txt            │
             │     sec/op      │   sec/op     vs base                │
GetConfig-16      935.25n ± 1%   23.18n ± 2%  -97.52% (p=0.000 n=10)

```

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->
