### PR TITLE
fix(client/v2): encode LegacyDec JSON arguments

### DIFF
--- a/client/v2/CHANGELOG.md
+++ b/client/v2/CHANGELOG.md
@@ -34,6 +34,12 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 # Changelog
 
+## Unreleased
+
+### Bug Fixes
+
+* (autocli) #26673 Correctly encode `cosmos.Dec` fields supplied in positional JSON arguments.
+
 ## [v2.0.0-beta.11](https://github.com/cosmos/cosmos-sdk/tree/client/v2.0.0-beta.11) - 2025-05-30
 
 ### Bug Fixes

--- a/client/v2/autocli/flag/json_message.go
+++ b/client/v2/autocli/flag/json_message.go
@@ -2,6 +2,7 @@ package flag
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -12,6 +13,7 @@ import (
 	"google.golang.org/protobuf/reflect/protoreflect"
 
 	"cosmossdk.io/client/v2/internal/util"
+	"cosmossdk.io/math"
 )
 
 var isJSONFileRegex = regexp.MustCompile(`\.json$`)
@@ -73,9 +75,136 @@ func (j *jsonMessageFlagValue) Set(s string) error {
 	} else {
 		messageBytes = []byte(s)
 	}
+	messageBytes, err := normalizeLegacyDecJSON(
+		j.messageType.Descriptor(),
+		messageBytes,
+	)
+	if err != nil {
+		return err
+	}
 	return j.jsonUnmarshalOptions.Unmarshal(messageBytes, j.message)
 }
 
 func (j *jsonMessageFlagValue) Type() string {
 	return fmt.Sprintf("%s (json)", j.messageType.Descriptor().FullName())
+}
+
+func normalizeLegacyDecJSON(
+	descriptor protoreflect.MessageDescriptor,
+	messageBytes []byte,
+) ([]byte, error) {
+	var value map[string]json.RawMessage
+	if err := json.Unmarshal(messageBytes, &value); err != nil {
+		return nil, err
+	}
+
+	if err := normalizeLegacyDecFields(descriptor, value); err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(value)
+}
+
+func normalizeLegacyDecFields(
+	descriptor protoreflect.MessageDescriptor,
+	value map[string]json.RawMessage,
+) error {
+	fields := descriptor.Fields()
+	for i := 0; i < fields.Len(); i++ {
+		field := fields.Get(i)
+		fieldValue, ok := value[field.JSONName()]
+		if !ok {
+			fieldValue, ok = value[string(field.Name())]
+		}
+		if !ok {
+			continue
+		}
+
+		normalized, err := normalizeLegacyDecField(field, fieldValue)
+		if err != nil {
+			return fmt.Errorf("invalid %s: %w", field.FullName(), err)
+		}
+		if _, hasJSONName := value[field.JSONName()]; hasJSONName {
+			value[field.JSONName()] = normalized
+		} else {
+			value[string(field.Name())] = normalized
+		}
+	}
+
+	return nil
+}
+
+func normalizeLegacyDecField(
+	field protoreflect.FieldDescriptor,
+	value json.RawMessage,
+) (json.RawMessage, error) {
+	if scalar, ok := GetScalarType(field); ok && scalar == DecScalarType {
+		if field.IsList() {
+			var values []json.RawMessage
+			if err := json.Unmarshal(value, &values); err != nil {
+				return nil, err
+			}
+			for i, item := range values {
+				normalized, err := normalizeLegacyDecValue(item)
+				if err != nil {
+					return nil, err
+				}
+				values[i] = normalized
+			}
+			return json.Marshal(values)
+		}
+
+		return normalizeLegacyDecValue(value)
+	}
+
+	if field.Kind() != protoreflect.MessageKind {
+		return value, nil
+	}
+
+	if field.IsMap() {
+		var values map[string]json.RawMessage
+		if err := json.Unmarshal(value, &values); err != nil {
+			return nil, err
+		}
+		for key, item := range values {
+			normalized, err := normalizeLegacyDecField(field.MapValue(), item)
+			if err != nil {
+				return nil, err
+			}
+			values[key] = normalized
+		}
+		return json.Marshal(values)
+	}
+
+	if field.IsList() {
+		var values []json.RawMessage
+		if err := json.Unmarshal(value, &values); err != nil {
+			return nil, err
+		}
+		for i, item := range values {
+			normalized, err := normalizeLegacyDecJSON(field.Message(), item)
+			if err != nil {
+				return nil, err
+			}
+			values[i] = normalized
+		}
+		return json.Marshal(values)
+	}
+
+	return normalizeLegacyDecJSON(field.Message(), value)
+}
+
+func normalizeLegacyDecValue(value json.RawMessage) (json.RawMessage, error) {
+	if len(value) == 0 || value[0] != '"' {
+		return value, nil
+	}
+	var text string
+	if err := json.Unmarshal(value, &text); err != nil {
+		return nil, err
+	}
+	dec, err := math.LegacyNewDecFromStr(text)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(dec.BigInt().String())
 }

--- a/client/v2/autocli/flag/json_message_test.go
+++ b/client/v2/autocli/flag/json_message_test.go
@@ -1,0 +1,57 @@
+package flag
+
+import (
+	"context"
+	"testing"
+
+	cosmos_proto "github.com/cosmos/cosmos-proto"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protodesc"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/reflect/protoregistry"
+	"google.golang.org/protobuf/types/descriptorpb"
+	"google.golang.org/protobuf/types/dynamicpb"
+)
+
+func TestJSONMessageFlagLegacyDec(t *testing.T) {
+	options := &descriptorpb.FieldOptions{}
+	proto.SetExtension(options, cosmos_proto.E_Scalar, DecScalarType)
+	file, err := protodesc.NewFile(&descriptorpb.FileDescriptorProto{
+		Syntax:  proto.String("proto3"),
+		Name:    proto.String("params.proto"),
+		Package: proto.String("cosmos.test.v1"),
+		MessageType: []*descriptorpb.DescriptorProto{{
+			Name: proto.String("Params"),
+			Field: []*descriptorpb.FieldDescriptorProto{{
+				Name:     proto.String("inflation_max"),
+				JsonName: proto.String("inflationMax"),
+				Number:   proto.Int32(1),
+				Label:    descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL.Enum(),
+				Type:     descriptorpb.FieldDescriptorProto_TYPE_STRING.Enum(),
+				Options:  options,
+			}},
+		}},
+	}, nil)
+	require.NoError(t, err)
+
+	descriptor := file.Messages().ByName("Params")
+	messageType := dynamicpb.NewMessageType(descriptor)
+	types := new(protoregistry.Types)
+	require.NoError(t, types.RegisterMessage(messageType))
+
+	ctx := context.Background()
+	value := jsonMessageFlagType{messageDesc: descriptor}.NewValue(
+		&ctx,
+		&Builder{TypeResolver: types},
+	)
+	require.NoError(t, value.Set(`{"inflationMax":"0.020000000000000000"}`))
+
+	got, err := value.Get(protoreflect.Value{})
+	require.NoError(t, err)
+	require.Equal(
+		t,
+		"20000000000000000",
+		got.Message().Get(descriptor.Fields().ByName("inflation_max")).String(),
+	)
+}


### PR DESCRIPTION
# Description

Closes: #26673

Normalize fields annotated as `cosmos.Dec` in AutoCLI positional JSON before passing the message to `protojson`. Human-readable decimal strings are converted to the atomics representation expected by the protobuf string field, including nested, repeated, and map message values.

The regression test builds a descriptor with a `cosmos.Dec` annotation, supplies `0.020000000000000000`, and verifies that the message receives `20000000000000000`.

## Testing

- `go test ./autocli/flag`

The client/v2 changelog includes an Unreleased bug-fix entry.
