### PR TITLE
perf: speed up DecCoins.String() with a string builder

### DIFF
--- a/types/dec_coin.go
+++ b/types/dec_coin.go
@@ -201,14 +201,18 @@ func NewDecCoinsFromCoins(coins ...Coin) DecCoins {
 func (coins DecCoins) String() string {
 	if len(coins) == 0 {
 		return ""
+	} else if len(coins) == 1 {
+		return coins[0].String()
 	}
 
-	out := ""
-	for _, coin := range coins {
-		out += fmt.Sprintf("%v,", coin.String())
+	// Build the string with a string builder
+	var out strings.Builder
+	for _, coin := range coins[:len(coins)-1] {
+		out.WriteString(coin.String())
+		out.WriteByte(',')
 	}
-
-	return out[:len(out)-1]
+	out.WriteString(coins[len(coins)-1].String())
+	return out.String()
 }
 
 // TruncateDecimal returns the coins with truncated decimals and returns the


### PR DESCRIPTION
## Summary

`DecCoins.String()` built its output with `out += fmt.Sprintf("%v,", coin.String())`,
which reallocates and copies the whole accumulated string on every iteration. This
replaces it with a `strings.Builder`, matching what `Coins.String()` already does.
Output is byte for byte identical, including the single-coin case which now returns
early instead of appending a separator and slicing it back off.

## Why

`Coins.String()` got this treatment in #10076, back in 2021. `DecCoins.String()` has
the same shape and was left behind, so the two have been out of sync for four years.