### PR TITLE
fix(tools/cosmovisor): publish v1.7.3 release artifacts

### DIFF
--- a/tools/cosmovisor/.goreleaser.yml
+++ b/tools/cosmovisor/.goreleaser.yml
@@ -2,6 +2,7 @@ project_name: cosmovisor
 
 release:
   disable: false
+  draft: true
   name_template: "{{.Tag}}"
 
 before:

--- a/tools/cosmovisor/CHANGELOG.md
+++ b/tools/cosmovisor/CHANGELOG.md
@@ -40,7 +40,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Improvements
 
-* Publish prebuilt artifacts for the Go 1.26 compatibility fix introduced in v1.7.2; the v1.7.2 GitHub release contained no downloadable binaries.
+* [#26780](https://github.com/cosmos/cosmos-sdk/pull/26780) Publish prebuilt artifacts for the Go 1.26 compatibility fix introduced in v1.7.2; the v1.7.2 GitHub release contained no downloadable binaries.
 
 ## v1.7.2 - 2026-08-26
 

--- a/tools/cosmovisor/CHANGELOG.md
+++ b/tools/cosmovisor/CHANGELOG.md
@@ -36,6 +36,12 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
+## v1.7.3 - 2026-08-26
+
+### Improvements
+
+* Publish prebuilt artifacts for the Go 1.26 compatibility fix introduced in v1.7.2; the v1.7.2 GitHub release contained no downloadable binaries.
+
 ## v1.7.2 - 2026-08-26
 
 ### Bug Fixes

--- a/tools/cosmovisor/README.md
+++ b/tools/cosmovisor/README.md
@@ -53,7 +53,7 @@ Release branches have the following format `release/cosmovisor/vA.B.x`, where A 
 
 ### Installation
 
-You can download Cosmovisor from the [GitHub releases](https://github.com/cosmos/cosmos-sdk/releases/tag/cosmovisor%2Fv1.7.2).
+You can download Cosmovisor from the [GitHub releases](https://github.com/cosmos/cosmos-sdk/releases/tag/cosmovisor%2Fv1.7.3).
 
 To install the latest version of `cosmovisor`, run the following command:
 
@@ -64,7 +64,7 @@ go install cosmossdk.io/tools/cosmovisor/cmd/cosmovisor@latest
 To install a specific version, you can specify the version:
 
 ```shell
-go install cosmossdk.io/tools/cosmovisor/cmd/cosmovisor@v1.7.2
+go install cosmossdk.io/tools/cosmovisor/cmd/cosmovisor@v1.7.3
 ```
 
 Run `cosmovisor version` to check the cosmovisor version.

--- a/tools/cosmovisor/RELEASE_NOTES.md
+++ b/tools/cosmovisor/RELEASE_NOTES.md
@@ -1,11 +1,11 @@
-# Cosmovisor v1.7.2 Release Notes
+# Cosmovisor v1.7.3 Release Notes
 
-Cosmovisor v1.7.2 fixes builds with Go 1.26 and later failing with `invalid reference to encoding/json.unquoteBytes`.
+Cosmovisor v1.7.3 makes prebuilt binaries available for the v1.7.2 fix for builds with Go 1.26 and later failing with `invalid reference to encoding/json.unquoteBytes`. The v1.7.2 GitHub release did not include those binaries.
 
-See the [CHANGELOG](https://github.com/cosmos/cosmos-sdk/blob/tools/cosmovisor/v1.7.2/tools/cosmovisor/CHANGELOG.md) for details on the changes in v1.7.2.
+See the [CHANGELOG](https://github.com/cosmos/cosmos-sdk/blob/tools/cosmovisor/v1.7.3/tools/cosmovisor/CHANGELOG.md) for details on the changes in v1.7.3.
 
 ## Installation instructions
 
 ```shell
-go install cosmossdk.io/tools/cosmovisor/cmd/cosmovisor@v1.7.2
+go install cosmossdk.io/tools/cosmovisor/cmd/cosmovisor@v1.7.3
 ```


### PR DESCRIPTION
## Summary

- publish v1.7.3 through a mutable draft so GoReleaser can upload assets before the release becomes immutable
- point installation documentation at v1.7.3
- explain that v1.7.3 carries the Go 1.26 compatibility fix because the v1.7.2 GitHub release has no downloadable binaries

## Release procedure

After the workflow uploads the artifacts, verify the four platform archives and checksum file in the draft, then publish it manually. Do not blindly rerun the workflow while a draft for the tag exists.

## Verification

- git diff --check