### PR TITLE
fix(math): remove redundant allocations in MinInt and MaxInt

### DIFF
--- a/math/CHANGELOG.md
+++ b/math/CHANGELOG.md
@@ -36,6 +36,10 @@ Ref: https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.j
 
 ## [Unreleased]
 
+### Bug Fixes
+
+* [#26781](https://github.com/cosmos/cosmos-sdk/pull/26781) Fix aliasing bug in `MinInt` and `MaxInt` — result no longer shares internal pointer with inputs.
+
 ## [math/v1.5.3](https://github.com/cosmos/cosmos-sdk/releases/tag/math/v1.5.3) - 2025-04-04
 
 * [#24375](https://github.com/cosmos/cosmos-sdk/pull/24375) Remove GDA decimal type.  NOTE: the previous v1.5.x family releases have been retracted as they were released with broken features.  This release sets `math` to support everything in the `v1.4.x` family  with testing improvements and dependency bumps

--- a/math/int.go
+++ b/math/int.go
@@ -406,12 +406,12 @@ func (i Int) Abs() Int {
 
 // MinInt return the minimum of the ints
 func MinInt(i1, i2 Int) Int {
-	return Int{min(i1.BigInt(), i2.BigInt())}
+	return Int{min(i1.i, i2.i)}
 }
 
 // MaxInt returns the maximum between two integers.
-func MaxInt(i, i2 Int) Int {
-	return Int{max(i.BigInt(), i2.BigInt())}
+func MaxInt(i1, i2 Int) Int {
+	return Int{max(i1.i, i2.i)}
 }
 
 // String returns human-readable string

--- a/math/int_test.go
+++ b/math/int_test.go
@@ -692,3 +692,16 @@ func BenchmarkIntOverflowCheckTime(b *testing.B) {
 	}
 	sink = nil
 }
+
+func TestMinMaxIntAliasing(t *testing.T) {
+	a := math.NewInt(5)
+	b := math.NewInt(10)
+
+	resMin := math.MinInt(a, b)
+	resMin.BigIntMut().SetInt64(999)
+	require.Equal(t, int64(5), a.Int64(), "MinInt: input a was mutated")
+
+	resMax := math.MaxInt(a, b)
+	resMax.BigIntMut().SetInt64(999)
+	require.Equal(t, int64(10), b.Int64(), "MaxInt: input b was mutated")
+}


### PR DESCRIPTION
Removes a redundant allocation in MinInt and MaxInt the min/max helpers already return a fresh big.Int copy, so the extra new(big.Int).Set(...) wrapper was unnecessary. The result still doesn't share its internal pointer with the inputs (verified by TestMinMaxIntAliasing).