### PR TITLE
fix(baseapp): make BaseApp.Close idempotent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * (blockstm) [#26772](https://github.com/cosmos/cosmos-sdk/pull/26772) Panic with a descriptive error when accessing an unregistered store instead of silently using store index zero.
 * (x/genutil) [#26741](https://github.com/cosmos/cosmos-sdk/issues/26741) Preserve vote extension enable height when exporting genesis state.
 * (baseapp) [#26738](https://github.com/cosmos/cosmos-sdk/pull/26738) Return genesis transaction events in the first block's `FinalizeBlock` response so block indexers can observe them.
+* (baseapp) [#26558](https://github.com/cosmos/cosmos-sdk/issues/26558) Make `BaseApp.Close` idempotent so the two deferred cleanups in `server/start.go` no longer close the application database twice, which panicked on pebble-backed nodes at the end of an otherwise clean shutdown.
 
 ### Deprecated
 

--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -89,6 +89,11 @@ type BaseApp struct {
 	// manages snapshots, i.e. dumps of app state at certain intervals
 	snapshotManager *snapshots.Manager
 
+	// closeOnce guarantees Close only ever closes the underlying resources once,
+	// and closeErr replays the result to any subsequent caller.
+	closeOnce sync.Once
+	closeErr  error
+
 	stateManager *state.Manager
 
 	// An inter-block write-through cache provided to the context during the ABCI
@@ -1164,8 +1169,21 @@ func (app *BaseApp) StreamingManager() storetypes.StreamingManager {
 	return app.streamingManager
 }
 
-// Close is called in start cmd to gracefully cleanup resources.
+// Close is called in start cmd to gracefully cleanup resources. It is safe to
+// call multiple times: the underlying resources are closed on the first call
+// only, and every later call replays that first result. Several shutdown paths
+// in server/start.go each defer a cleanup that calls Close, and some database
+// backends (pebble, for one) panic rather than return an error when closed
+// twice.
 func (app *BaseApp) Close() error {
+	app.closeOnce.Do(func() {
+		app.closeErr = app.close()
+	})
+
+	return app.closeErr
+}
+
+func (app *BaseApp) close() error {
 	var errs []error
 
 	// Close app.db (opened by cosmos-sdk/server/start.go call to openDB)

--- a/baseapp/close_test.go
+++ b/baseapp/close_test.go
@@ -1,0 +1,60 @@
+package baseapp_test
+
+import (
+	"errors"
+	"testing"
+
+	dbm "github.com/cosmos/cosmos-db"
+	"github.com/stretchr/testify/require"
+
+	"cosmossdk.io/log/v2"
+
+	"github.com/cosmos/cosmos-sdk/baseapp"
+)
+
+// closeCountingDB mimics the backends used in production: pebble panics when
+// Close is called on an already-closed database, and goleveldb returns an
+// error. Either way, the second Close must never reach the backend.
+type closeCountingDB struct {
+	dbm.DB
+	closes   int
+	closeErr error
+}
+
+func (db *closeCountingDB) Close() error {
+	db.closes++
+	if db.closes > 1 {
+		panic("pebble: closed")
+	}
+
+	if db.closeErr != nil {
+		return db.closeErr
+	}
+
+	return db.DB.Close()
+}
+
+// TestBaseAppCloseIsIdempotent covers the shutdown path in server/start.go,
+// where both startCmtNode's cleanup and startApp's cleanup are deferred and
+// each calls app.Close().
+func TestBaseAppCloseIsIdempotent(t *testing.T) {
+	db := &closeCountingDB{DB: dbm.NewMemDB()}
+	app := baseapp.NewBaseApp(t.Name(), log.NewTestLogger(t), db, nil)
+
+	require.NoError(t, app.Close())
+	require.NoError(t, app.Close())
+	require.NoError(t, app.Close())
+	require.Equal(t, 1, db.closes)
+}
+
+// TestBaseAppCloseReplaysError ensures a failure reported by the first Close is
+// not lost by the later, no-op calls.
+func TestBaseAppCloseReplaysError(t *testing.T) {
+	closeErr := errors.New("boom")
+	db := &closeCountingDB{DB: dbm.NewMemDB(), closeErr: closeErr}
+	app := baseapp.NewBaseApp(t.Name(), log.NewTestLogger(t), db, nil)
+
+	require.ErrorIs(t, app.Close(), closeErr)
+	require.ErrorIs(t, app.Close(), closeErr)
+	require.Equal(t, 1, db.closes)
+}


### PR DESCRIPTION
## Description

Closes #26558

`server/start.go` defers two cleanups that each call `app.Close()`:

- `startCmtNode` returns a `cleanupFn` that stops the CometBFT node and then calls `app.Close()` — deferred at [`server/start.go:352`](https://github.com/cosmos/cosmos-sdk/blob/main/server/start.go#L352)
- `startApp` returns an `appCleanupFn` that shuts telemetry down and then calls `app.Close()` — deferred at [`server/start.go:252`](https://github.com/cosmos/cosmos-sdk/blob/main/server/start.go#L252)

Defers run LIFO, so on the ordinary in-process shutdown path both fire and `Close` runs twice. `Close` closed `app.db` and `app.snapshotManager` unconditionally, so the second call re-closed an already-closed database.

Backends disagree about what that means. goleveldb returns an error, which is merely logged. **pebble panics** with `pebble: closed`, so a pebble-backed node panics at the tail end of an otherwise clean stop and exits non-zero.

## Fix

Guard the shutdown with a `sync.Once` and replay the first call's result. The underlying resources are closed once regardless of how many cleanup paths call `Close`, and a genuine close error is still surfaced to every caller rather than being swallowed.

This is deliberately fixed in `BaseApp.Close` rather than by deleting one of the two `defer`s: `Close` is exported, and the SDK itself calls it from four separate places (`server/start.go` lines 328, 424, 649, 830). Making the method idempotent fixes all of them, and any chain doing the same in its own start command.

## Testing

`baseapp/close_test.go` wraps a `dbm.DB` so the second `Close` panics the way pebble does, and asserts the backend is only closed once:

- `TestBaseAppCloseIsIdempotent` — three `Close` calls, one backend close, no panic
- `TestBaseAppCloseReplaysError` — an error from the first close is still returned by later calls, not lost

Both fail on `main` (`panic: pebble: closed`) and pass with this change. Full `./baseapp/` suite, `go vet`, and `gofmt` are clean.

---

### Author Checklist

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] confirmed `!` in the type prefix if API or client breaking change
- [x] targeted the correct branch
- [x] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
- [x] added a changelog entry to `CHANGELOG.md`
- [x] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
- [x] confirmed all CI checks have passed