### PR TITLE
fix(baseapp): clear stale OE after FinalizeBlock when ProcessProposal is skipped

### DIFF
--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -1003,7 +1003,7 @@ func (app *BaseApp) FinalizeBlock(req *abci.RequestFinalizeBlock) (res *abci.Res
 	if app.optimisticExec.Initialized() {
 		// check if the hash we got is the same as the one we are executing
 		ainStart := time.Now()
-		aborted := app.optimisticExec.AbortIfNeeded(req.Hash)
+		aborted := app.optimisticExec.AbortIfNeeded(req.Hash, req.Height)
 		measureSince(app.metricsCtx(), func() metric.Int64Histogram { return inst.OEAbortIfNeededTime }, ainStart)
 		if aborted {
 			if inst != nil {
@@ -1023,6 +1023,9 @@ func (app *BaseApp) FinalizeBlock(req *abci.RequestFinalizeBlock) (res *abci.Res
 				measureSince(app.metricsCtx(), func() metric.Int64Histogram { return inst.WorkingHashTime }, whStart)
 			}
 
+			// Clear OE after a successful consume so a skipped ProcessProposal for
+			// the next height cannot compare a leftover OE against FinalizeBlock.
+			app.optimisticExec.Reset()
 			return res, err
 		}
 

--- a/baseapp/abci_test.go
+++ b/baseapp/abci_test.go
@@ -2537,6 +2537,53 @@ func TestOptimisticExecution(t *testing.T) {
 	require.Equal(t, int64(50), suite.baseApp.LastBlockHeight())
 }
 
+// TestOptimisticExecutionSkipProcessProposal ensures that after OE successfully
+// finalizes height H, a FinalizeBlock for H+1 with no ProcessProposal does not
+// hit a leftover OE / spurious hash mismatch (issue #26766).
+func TestOptimisticExecutionSkipProcessProposal(t *testing.T) {
+	suite := NewBaseAppSuite(t, baseapp.SetOptimisticExecution())
+
+	_, err := suite.baseApp.InitChain(&abci.RequestInitChain{
+		ConsensusParams: &cmtproto.ConsensusParams{},
+	})
+	require.NoError(t, err)
+
+	runBlock := func(withProcessProposal bool) {
+		t.Helper()
+		tx := newTxCounter(t, suite.txConfig, 0, 1)
+		txBytes, err := suite.txConfig.TxEncoder()(tx)
+		require.NoError(t, err)
+
+		height := suite.baseApp.LastBlockHeight() + 1
+		hash := []byte("hash-" + strconv.FormatInt(height, 10))
+
+		if withProcessProposal {
+			respProcProp, err := suite.baseApp.ProcessProposal(&abci.RequestProcessProposal{
+				Txs:    [][]byte{txBytes},
+				Height: height,
+				Hash:   hash,
+			})
+			require.NoError(t, err)
+			require.Equal(t, abci.ResponseProcessProposal_ACCEPT, respProcProp.Status)
+		}
+
+		_, err = suite.baseApp.FinalizeBlock(&abci.RequestFinalizeBlock{
+			Height: height,
+			Txs:    [][]byte{txBytes},
+			Hash:   hash,
+		})
+		require.NoError(t, err)
+		_, err = suite.baseApp.Commit()
+		require.NoError(t, err)
+		require.Equal(t, height, suite.baseApp.LastBlockHeight())
+	}
+
+	// Height 2 runs with OE (height > initialHeight).
+	runBlock(true)
+	// Height 3: skip ProcessProposal, still finalize (OE must not be stale).
+	runBlock(false)
+}
+
 func TestABCI_Proposal_FailReCheckTx(t *testing.T) {
 	pool := mempool.NewPriorityMempool[int64](mempool.PriorityNonceMempoolConfig[int64]{
 		TxPriority:      mempool.NewDefaultTxPriority(),

--- a/baseapp/oe/optimistic_execution.go
+++ b/baseapp/oe/optimistic_execution.go
@@ -118,9 +118,11 @@ func (oe *OptimisticExecution) Execute(req *abci.RequestProcessProposal) {
 	}()
 }
 
-// AbortIfNeeded aborts the OE if the request hash is not the same as the one in
-// the running OE. Returns true if the OE was aborted.
-func (oe *OptimisticExecution) AbortIfNeeded(reqHash []byte) bool {
+// AbortIfNeeded aborts the OE if the incoming FinalizeBlock request does not
+// match the running OE. A height mismatch is treated as a stale OE (e.g.
+// ProcessProposal was skipped for the next height) and aborts without a hash
+// mismatch error. Returns true if the OE was aborted.
+func (oe *OptimisticExecution) AbortIfNeeded(reqHash []byte, reqHeight int64) bool {
 	if oe == nil {
 		return false
 	}
@@ -128,8 +130,16 @@ func (oe *OptimisticExecution) AbortIfNeeded(reqHash []byte) bool {
 	oe.mtx.Lock()
 	defer oe.mtx.Unlock()
 
+	// Prefer height check so a leftover OE from a prior height is not logged as
+	// a hash mismatch when ProcessProposal for the next height was skipped.
+	if oe.request.Height != reqHeight {
+		oe.logger.Info("OE aborted due to stale height", "oe_hash", hex.EncodeToString(oe.request.Hash), "req_hash", hex.EncodeToString(reqHash), "oe_height", oe.request.Height, "req_height", reqHeight)
+		oe.cancelFunc()
+		return true
+	}
+
 	if !bytes.Equal(oe.request.Hash, reqHash) {
-		oe.logger.Error("OE aborted due to hash mismatch", "oe_hash", hex.EncodeToString(oe.request.Hash), "req_hash", hex.EncodeToString(reqHash), "oe_height", oe.request.Height, "req_height", oe.request.Height)
+		oe.logger.Error("OE aborted due to hash mismatch", "oe_hash", hex.EncodeToString(oe.request.Hash), "req_hash", hex.EncodeToString(reqHash), "oe_height", oe.request.Height, "req_height", reqHeight)
 		oe.cancelFunc()
 		return true
 	} else if oe.abortRate > 0 && rand.Intn(100) < oe.abortRate {

--- a/baseapp/oe/optimistic_execution_test.go
+++ b/baseapp/oe/optimistic_execution_test.go
@@ -3,10 +3,13 @@ package oe
 import (
 	"context"
 	"errors"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	abci "github.com/cometbft/cometbft/abci/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"cosmossdk.io/log/v2"
 )
@@ -19,7 +22,8 @@ func TestOptimisticExecution(t *testing.T) {
 	oe := NewOptimisticExecution(log.NewNopLogger(), testFinalizeBlock)
 	assert.True(t, oe.Enabled())
 	oe.Execute(&abci.RequestProcessProposal{
-		Hash: []byte("test"),
+		Hash:   []byte("test"),
+		Height: 1,
 	})
 	assert.True(t, oe.Initialized())
 
@@ -27,8 +31,91 @@ func TestOptimisticExecution(t *testing.T) {
 	assert.Nil(t, resp)
 	assert.EqualError(t, err, "test error")
 
-	assert.False(t, oe.AbortIfNeeded([]byte("test")))
-	assert.True(t, oe.AbortIfNeeded([]byte("wrong_hash")))
+	assert.False(t, oe.AbortIfNeeded([]byte("test"), 1))
+	assert.True(t, oe.AbortIfNeeded([]byte("wrong_hash"), 1))
 
+	oe.Reset()
+}
+
+// TestAbortIfNeededStaleHeight covers the case where ProcessProposal for H+1 is
+// skipped and FinalizeBlock(H+1) arrives while OE still holds height H.
+// Abort must treat the height mismatch as stale instead of a hash mismatch.
+func TestAbortIfNeededStaleHeight(t *testing.T) {
+	oe := NewOptimisticExecution(log.NewNopLogger(), func(_ context.Context, _ *abci.RequestFinalizeBlock) (*abci.ResponseFinalizeBlock, error) {
+		return &abci.ResponseFinalizeBlock{}, nil
+	})
+
+	oe.Execute(&abci.RequestProcessProposal{
+		Hash:   []byte("hash-h"),
+		Height: 10,
+	})
+	_, err := oe.WaitResult()
+	require.NoError(t, err)
+	require.True(t, oe.Initialized())
+
+	// Same height, different hash → true hash mismatch abort.
+	assert.True(t, oe.AbortIfNeeded([]byte("other-hash"), 10))
+
+	// Re-execute for the stale-height path.
+	oe.Reset()
+	oe.Execute(&abci.RequestProcessProposal{
+		Hash:   []byte("hash-h"),
+		Height: 10,
+	})
+	_, err = oe.WaitResult()
+	require.NoError(t, err)
+
+	// Height H+1 with a different hash must abort as stale (not keep OE alive).
+	assert.True(t, oe.AbortIfNeeded([]byte("hash-h+1"), 11))
+}
+
+// TestResetAfterSuccessfulConsume mirrors FinalizeBlock consuming OE then
+// receiving FinalizeBlock for the next height without ProcessProposal.
+func TestResetAfterSuccessfulConsume(t *testing.T) {
+	var calls atomic.Int32
+	oe := NewOptimisticExecution(log.NewNopLogger(), func(_ context.Context, req *abci.RequestFinalizeBlock) (*abci.ResponseFinalizeBlock, error) {
+		calls.Add(1)
+		return &abci.ResponseFinalizeBlock{}, nil
+	})
+
+	oe.Execute(&abci.RequestProcessProposal{
+		Hash:   []byte("hash-10"),
+		Height: 10,
+	})
+	res, err := oe.WaitResult()
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	require.False(t, oe.AbortIfNeeded([]byte("hash-10"), 10))
+
+	// Successful FinalizeBlock path must clear OE (as baseapp now does).
+	oe.Reset()
+	assert.False(t, oe.Initialized())
+
+	// FinalizeBlock(H+1) with no ProcessProposal: OE is cleared, so no abort.
+	assert.False(t, oe.Initialized())
+	assert.Equal(t, int32(1), calls.Load())
+}
+
+func TestAbortIfNeededSameHeightWrongHash(t *testing.T) {
+	done := make(chan struct{})
+	oe := NewOptimisticExecution(log.NewNopLogger(), func(ctx context.Context, _ *abci.RequestFinalizeBlock) (*abci.ResponseFinalizeBlock, error) {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-done:
+			return &abci.ResponseFinalizeBlock{}, nil
+		case <-time.After(2 * time.Second):
+			return &abci.ResponseFinalizeBlock{}, nil
+		}
+	})
+
+	oe.Execute(&abci.RequestProcessProposal{
+		Hash:   []byte("hash-a"),
+		Height: 5,
+	})
+
+	assert.True(t, oe.AbortIfNeeded([]byte("hash-b"), 5))
+	close(done)
+	_, _ = oe.WaitResult()
 	oe.Reset()
 }


### PR DESCRIPTION
## Description

When ProcessProposal for H+1 is skipped (e.g. propose timeout), FinalizeBlock(H+1) could still see OE state from height H and log a misleading hash mismatch. Fallback still worked; this is a lifecycle / observability fix.

- Reset OE after a successful FinalizeBlock consume
- Treat height mismatch in `AbortIfNeeded` as stale OE (abort without hash-mismatch error)
- Log the incoming FinalizeBlock height as `req_height` (was duplicating `oe.request.Height`)

Fixes #26766

## Alternative Approaches

Only fixing the log would still leave a spurious abort/fallback on the next height. Resetting after consume plus a height check covers the skip-ProcessProposal path cleanly.

## Testing Checklist

- [x] Targeted unit/integration tests have been added.
- [ ] New code has comments documenting rationale.
- [x] Lint and unit tests (`make lint` & `make test`) have passed locally.
- [ ] Added corresponding changelog entry.

## Tests

```
go test ./baseapp/oe/ ./baseapp/ -count=1 -run 'TestOptimisticExecution|TestAbortIfNeeded|TestResetAfter'
```